### PR TITLE
DEV: Remove JoyPixels emoji set

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -13,7 +13,7 @@ acceptance("Emoji", function (needs) {
     await fillIn(".d-editor-input", "this is an emoji :blonde_woman:");
     assert.equal(
       queryAll(".d-editor-preview:visible").html().trim(),
-      `<p>this is an emoji <img src="/images/emoji/emoji_one/blonde_woman.png?v=${v}" title=":blonde_woman:" class="emoji" alt=":blonde_woman:"></p>`
+      `<p>this is an emoji <img src="/images/emoji/google_classic/blonde_woman.png?v=${v}" title=":blonde_woman:" class="emoji" alt=":blonde_woman:"></p>`
     );
   });
 
@@ -24,7 +24,7 @@ acceptance("Emoji", function (needs) {
     await fillIn(".d-editor-input", "this is an emoji :blonde_woman:t5:");
     assert.equal(
       queryAll(".d-editor-preview:visible").html().trim(),
-      `<p>this is an emoji <img src="/images/emoji/emoji_one/blonde_woman/5.png?v=${v}" title=":blonde_woman:t5:" class="emoji" alt=":blonde_woman:t5:"></p>`
+      `<p>this is an emoji <img src="/images/emoji/google_classic/blonde_woman/5.png?v=${v}" title=":blonde_woman:t5:" class="emoji" alt=":blonde_woman:t5:"></p>`
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -181,7 +181,7 @@ acceptance("Topic", function (needs) {
 
     assert.equal(
       queryAll(".fancy-title").html().trim(),
-      `emojis title <img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/bike.png?v=${v}" title="bike" alt="bike" class="emoji"> <img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/blonde_woman/6.png?v=${v}" title="blonde_woman:t6" alt="blonde_woman:t6" class="emoji">`,
+      `emojis title <img width=\"20\" height=\"20\" src="/images/emoji/google_classic/bike.png?v=${v}" title="bike" alt="bike" class="emoji"> <img width=\"20\" height=\"20\" src="/images/emoji/google_classic/blonde_woman/6.png?v=${v}" title="blonde_woman:t6" alt="blonde_woman:t6" class="emoji">`,
       "it displays the new title with emojis"
     );
   });
@@ -196,7 +196,7 @@ acceptance("Topic", function (needs) {
 
     assert.equal(
       queryAll(".fancy-title").html().trim(),
-      `emojis title <img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/man_farmer.png?v=${v}" title="man_farmer" alt="man_farmer" class="emoji"><img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/pray.png?v=${v}" title="pray" alt="pray" class="emoji">`,
+      `emojis title <img width=\"20\" height=\"20\" src="/images/emoji/google_classic/man_farmer.png?v=${v}" title="man_farmer" alt="man_farmer" class="emoji"><img width=\"20\" height=\"20\" src="/images/emoji/google_classic/pray.png?v=${v}" title="pray" alt="pray" class="emoji">`,
       "it displays the new title with escaped unicode emojis"
     );
   });
@@ -212,7 +212,7 @@ acceptance("Topic", function (needs) {
 
     assert.equal(
       queryAll(".fancy-title").html().trim(),
-      `Test<img width=\"20\" height=\"20\" src="/images/emoji/emoji_one/slightly_smiling_face.png?v=${v}" title="slightly_smiling_face" alt="slightly_smiling_face" class="emoji">Title`,
+      `Test<img width=\"20\" height=\"20\" src="/images/emoji/google_classic/slightly_smiling_face.png?v=${v}" title="slightly_smiling_face" alt="slightly_smiling_face" class="emoji">Title`,
       "it displays the new title with escaped unicode emojis"
     );
   });

--- a/app/assets/javascripts/discourse/tests/helpers/site-settings.js
+++ b/app/assets/javascripts/discourse/tests/helpers/site-settings.js
@@ -89,7 +89,7 @@ const ORIGINAL_SETTINGS = {
     "apache|bash|cs|cpp|css|coffeescript|diff|xml|http|ini|json|java|javascript|makefile|markdown|nginx|objectivec|ruby|perl|php|python|sql|handlebars",
   enable_emoji: true,
   enable_emoji_shortcuts: true,
-  emoji_set: "emoji_one",
+  emoji_set: "google_classic",
   enable_emoji_shortcuts: true,
   enable_inline_emoji_translation: false,
   desktop_category_page_style: "categories_and_latest_topics",

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
@@ -32,12 +32,12 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "emoticons :)",
-      `emoticons <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'>`,
+      `emoticons <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'>`,
       "emoticons are still supported"
     );
     testUnescape(
       "With emoji :O: :frog: :smile:",
-      `With emoji <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/o.png?v=${v}' title='O' alt='O' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/frog.png?v=${v}' title='frog' alt='frog' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
+      `With emoji <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/o.png?v=${v}' title='O' alt='O' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/frog.png?v=${v}' title='frog' alt='frog' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "title with emoji"
     );
     testUnescape(
@@ -47,27 +47,27 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "(:frog:) :)",
-      `(<img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/frog.png?v=${v}' title='frog' alt='frog' class='emoji'>) <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'>`,
+      `(<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/frog.png?v=${v}' title='frog' alt='frog' class='emoji'>) <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'>`,
       "non-word characters allowed next to emoji"
     );
     testUnescape(
       ":smile: hi",
-      `<img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/smile.png?v=${v}' title='smile' alt='smile' class='emoji'> hi`,
+      `<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'> hi`,
       "start of line"
     );
     testUnescape(
       "hi :smile:",
-      `hi <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
+      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "end of line"
     );
     testUnescape(
       "hi :blonde_woman:t4:",
-      `hi <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/blonde_woman/4.png?v=${v}' title='blonde_woman:t4' alt='blonde_woman:t4' class='emoji'>`,
+      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_woman/4.png?v=${v}' title='blonde_woman:t4' alt='blonde_woman:t4' class='emoji'>`,
       "support for skin tones"
     );
     testUnescape(
       "hi :blonde_woman:t4: :blonde_man:t6:",
-      `hi <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/blonde_woman/4.png?v=${v}' title='blonde_woman:t4' alt='blonde_woman:t4' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/blonde_man/6.png?v=${v}' title='blonde_man:t6' alt='blonde_man:t6' class='emoji'>`,
+      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_woman/4.png?v=${v}' title='blonde_woman:t4' alt='blonde_woman:t4' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_man/6.png?v=${v}' title='blonde_man:t6' alt='blonde_man:t6' class='emoji'>`,
       "support for multiple skin tones"
     );
     testUnescape(
@@ -95,7 +95,7 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "Hello 😊 World",
-      `Hello <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/blush.png?v=${v}' title='blush' alt='blush' class='emoji'> World`,
+      `Hello <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blush.png?v=${v}' title='blush' alt='blush' class='emoji'> World`,
       "emoji from Unicode emoji"
     );
     testUnescape(
@@ -108,7 +108,7 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "Hello😊World",
-      `Hello<img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/blush.png?v=${v}' title='blush' alt='blush' class='emoji'>World`,
+      `Hello<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blush.png?v=${v}' title='blush' alt='blush' class='emoji'>World`,
       "emoji from Unicode emoji when inline translation enabled",
       {
         enable_inline_emoji_translation: true,
@@ -124,7 +124,7 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "hi:smile:",
-      `hi<img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
+      `hi<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "emoji when inline translation enabled",
       { enable_inline_emoji_translation: true }
     );

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -16,7 +16,7 @@ const rawOpts = {
     enable_emoji: true,
     enable_emoji_shortcuts: true,
     enable_mentions: true,
-    emoji_set: "emoji_one",
+    emoji_set: "google_classic",
     highlighted_languages: "json|ruby|javascript",
     default_code_lang: "auto",
     enable_markdown_linkify: true,
@@ -1485,15 +1485,15 @@ var bar = 'bar';
   test("emoji", function (assert) {
     assert.cooked(
       ":smile:",
-      `<p><img src="/images/emoji/emoji_one/smile.png?v=${v}" title=":smile:" class="emoji only-emoji" alt=":smile:"></p>`
+      `<p><img src="/images/emoji/google_classic/smile.png?v=${v}" title=":smile:" class="emoji only-emoji" alt=":smile:"></p>`
     );
     assert.cooked(
       ":(",
-      `<p><img src="/images/emoji/emoji_one/frowning.png?v=${v}" title=":frowning:" class="emoji only-emoji" alt=":frowning:"></p>`
+      `<p><img src="/images/emoji/google_classic/frowning.png?v=${v}" title=":frowning:" class="emoji only-emoji" alt=":frowning:"></p>`
     );
     assert.cooked(
       "8-)",
-      `<p><img src="/images/emoji/emoji_one/sunglasses.png?v=${v}" title=":sunglasses:" class="emoji only-emoji" alt=":sunglasses:"></p>`
+      `<p><img src="/images/emoji/google_classic/sunglasses.png?v=${v}" title=":sunglasses:" class="emoji only-emoji" alt=":sunglasses:"></p>`
     );
   });
 
@@ -1507,7 +1507,7 @@ var bar = 'bar';
     assert.cookedOptions(
       "test:smile:test",
       { siteSettings: { enable_inline_emoji_translation: true } },
-      `<p>test<img src="/images/emoji/emoji_one/smile.png?v=${v}" title=":smile:" class="emoji" alt=":smile:">test</p>`
+      `<p>test<img src="/images/emoji/google_classic/smile.png?v=${v}" title=":smile:" class="emoji" alt=":smile:">test</p>`
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -129,7 +129,7 @@ discourseModule("Unit | Model | topic", function () {
 
     assert.equal(
       topic.get("fancyTitle"),
-      `<img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/smile.png?v=${v}' title='smile' alt='smile' class='emoji'> with all <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'> the emojis <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/pear.png?v=${v}' title='pear' alt='pear' class='emoji'><img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/peach.png?v=${v}' title='peach' alt='peach' class='emoji'>`,
+      `<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'> with all <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'> the emojis <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/pear.png?v=${v}' title='pear' alt='pear' class='emoji'><img width=\"20\" height=\"20\" src='/images/emoji/google_classic/peach.png?v=${v}' title='peach' alt='peach' class='emoji'>`,
       "supports emojis"
     );
   });
@@ -159,7 +159,7 @@ discourseModule("Unit | Model | topic", function () {
 
     assert.equal(
       topic.get("escapedExcerpt"),
-      `This is a test topic <img width=\"20\" height=\"20\" src='/images/emoji/emoji_one/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
+      `This is a test topic <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "supports emojis"
     );
   });

--- a/app/models/emoji_set_site_setting.rb
+++ b/app/models/emoji_set_site_setting.rb
@@ -13,7 +13,6 @@ class EmojiSetSiteSetting < EnumSiteSetting
       { name: 'emoji_set.apple_international', value: 'apple' },
       { name: 'emoji_set.google', value: 'google' },
       { name: 'emoji_set.twitter', value: 'twitter' },
-      { name: 'emoji_set.emoji_one', value: 'emoji_one' },
       { name: 'emoji_set.win10', value: 'win10' },
       { name: 'emoji_set.google_classic', value: 'google_classic' },
       { name: 'emoji_set.facebook_messenger', value: 'facebook_messenger' },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1818,7 +1818,6 @@ en:
       apple_international: "Apple/International"
       google: "Google"
       twitter: "Twitter"
-      emoji_one: "JoyPixels (formerly EmojiOne)"
       win10: "Win10"
       google_classic: "Google Classic"
       facebook_messenger: "Facebook Messenger"

--- a/db/migrate/20210224162050_remove_emoji_one_from_emoji_set_site_setting.rb
+++ b/db/migrate/20210224162050_remove_emoji_one_from_emoji_set_site_setting.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RemoveEmojiOneFromEmojiSetSiteSetting < ActiveRecord::Migration[6.0]
+  def up
+    result = execute("SELECT value FROM site_settings WHERE name='emoji_set' and value='emoji_one'")
+    return unless result.count > 0
+
+    execute "DELETE FROM site_settings where name='emoji_set' and value='emoji_one'"
+    execute "UPDATE posts SET baked_version = 0 WHERE cooked LIKE '%/images/emoji/emoji_one%'"
+  end
+
+  def down
+    # Cannot undo
+  end
+end

--- a/lib/tasks/emoji.rake
+++ b/lib/tasks/emoji.rake
@@ -262,7 +262,6 @@ DEFAULT_SET ||= "twitter"
 # Replace the platform by another when downloading the image (accepts names or categories)
 EMOJI_IMAGES_PATCH ||= {
   "apple" => { "snowboarder" => "twitter" },
-  "emoji_one" => { "country-flag" => "twitter" },
   "windows" => { "country-flag" => "twitter" }
 }
 
@@ -272,7 +271,6 @@ EMOJI_SETS ||= {
   "google_blob" => "google_classic",
   "facebook" => "facebook_messenger",
   "twitter" => "twitter",
-  "emoji_one" => "emoji_one",
   "windows" => "win10",
 }
 
@@ -537,7 +535,7 @@ class TestEmojiUpdate < MiniTest::Test
     assert_equal File.size(original_image), File.size(alias_image)
 
     original_image = image_path("twitter", "macau")
-    alias_image = image_path("emoji_one", "macau")
+    alias_image = image_path("win10", "macau")
     assert_equal File.size(original_image), File.size(alias_image)
   end
 end

--- a/plugins/discourse-details/test/javascripts/lib/details-cooked-test.js.es6
+++ b/plugins/discourse-details/test/javascripts/lib/details-cooked-test.js.es6
@@ -5,7 +5,7 @@ module("lib:details-cooked-test");
 const defaultOpts = buildOptions({
   siteSettings: {
     enable_emoji: true,
-    emoji_set: "emoji_one",
+    emoji_set: "google_classic",
     highlighted_languages: "json|ruby|javascript",
     default_code_lang: "auto",
   },

--- a/spec/components/email/styles_spec.rb
+++ b/spec/components/email/styles_spec.rb
@@ -159,14 +159,14 @@ describe Email::Styles do
 
   context "strip_avatars_and_emojis" do
     it "works for lonesome emoji with no title" do
-      emoji = "<img src='/images/emoji/emoji_one/crying_cat_face.png'>"
+      emoji = "<img src='/images/emoji/twitter/crying_cat_face.png'>"
       style = Email::Styles.new(emoji)
       style.strip_avatars_and_emojis
       expect(style.to_html).to match_html(emoji)
     end
 
     it "works for lonesome emoji with title" do
-      emoji = "<img title='cry_cry' src='/images/emoji/emoji_one/crying_cat_face.png'>"
+      emoji = "<img title='cry_cry' src='/images/emoji/twitter/crying_cat_face.png'>"
       style = Email::Styles.new(emoji)
       style.strip_avatars_and_emojis
       expect(style.to_html).to match_html("cry_cry")


### PR DESCRIPTION
- removes the option from the `emoji_set` site setting
- deletes the site setting on existing sites
- marks posts using emojis from this set as requiring a rebake

Note that the actual image files are not removed here, the plan is to remove them in a few weeks/months (when presumably the rebaking of old posts has been completed).
