### PR TITLE
FIX: Unsubscribe from topic presence when navigating between topics

### DIFF
--- a/plugins/discourse-presence/assets/javascripts/discourse/components/topic-presence-display.js.es6
+++ b/plugins/discourse-presence/assets/javascripts/discourse/components/topic-presence-display.js.es6
@@ -1,7 +1,4 @@
-import discourseComputed, {
-  observes,
-  on,
-} from "discourse-common/utils/decorators";
+import discourseComputed, { on } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import { TOPIC_TYPE } from "discourse/plugins/discourse-presence/discourse/lib/presence";
 import { gt } from "@ember/object/computed";
@@ -19,8 +16,8 @@ export default Component.extend({
 
   shouldDisplay: gt("users.length", 0),
 
-  @observes("topic.id")
-  _unsubscribe() {
+  didReceiveAttrs() {
+    this._super(...arguments);
     if (this.topicId) {
       this.presenceManager.unsubscribe(this.topicId, TOPIC_TYPE);
     }

--- a/plugins/discourse-presence/assets/javascripts/discourse/components/topic-presence-display.js.es6
+++ b/plugins/discourse-presence/assets/javascripts/discourse/components/topic-presence-display.js.es6
@@ -1,4 +1,7 @@
-import discourseComputed, { on } from "discourse-common/utils/decorators";
+import discourseComputed, {
+  observes,
+  on,
+} from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import { TOPIC_TYPE } from "discourse/plugins/discourse-presence/discourse/lib/presence";
 import { gt } from "@ember/object/computed";
@@ -6,6 +9,7 @@ import { inject as service } from "@ember/service";
 
 export default Component.extend({
   topic: null,
+  topicId: null,
   presenceManager: service(),
 
   @discourseComputed("topic.id")
@@ -15,8 +19,17 @@ export default Component.extend({
 
   shouldDisplay: gt("users.length", 0),
 
+  @observes("topic.id")
+  _unsubscribe() {
+    if (this.topicId) {
+      this.presenceManager.unsubscribe(this.topicId, TOPIC_TYPE);
+    }
+    this.set("topicId", this.get("topic.id"));
+  },
+
   @on("didInsertElement")
   subscribe() {
+    this.set("topicId", this.get("topic.id"));
     this.presenceManager.subscribe(this.get("topic.id"), TOPIC_TYPE);
   },
 


### PR DESCRIPTION
This PR fixes a bug where if you navigate from topic to another one (via suggested topics, notifications etc.), the previous topic is not unsubscribed from presence manager, which means if you visit lots of topics all the subscriptions will accumulate and can cause rate limit errors.

This bug is exposed by the loading slider we're currently experimenting with on Meta because we no longer have an intermediate state when navigating between topics which means the `willDestroyElement` hook (line 23 in `topic-presence-display.js.es6`) that's responsible for unsubscribing is not called.

I tried to avoid adding an observer here, but I couldn't find a way to fix this issue without adding one.