### PR TITLE
FIX: Load Oneboxes when diffhtml is enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -1,3 +1,4 @@
+import { ajax } from "discourse/lib/ajax";
 import {
   caretPosition,
   clipboardHelpers,
@@ -404,7 +405,7 @@ export default Component.extend({
         resolveCachedShortUrls(this.siteSettings, cookedElement);
         loadOneboxes(
           cookedElement,
-          null,
+          ajax,
           null,
           null,
           this.siteSettings.max_oneboxes_per_post,

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -977,7 +977,6 @@ posting:
     default: false
     client: true
   enable_diffhtml_preview:
-    hidden: true
     default: false
     client: true
   old_post_notice_days:


### PR DESCRIPTION
When enable_diffhtml_preview is true, oneboxes failed to load because a
wrong ajax function was passed.

This commit also unhides enable_diffhtml_preview.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
