### PR TITLE
DEV: new plugin API to change default new category colors

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -68,9 +68,10 @@ import { registerHighlightJSLanguage } from "discourse/lib/highlight-syntax";
 import { registerTopicFooterButton } from "discourse/lib/register-topic-footer-button";
 import { replaceFormatter } from "discourse/lib/utilities";
 import { replaceTagRenderer } from "discourse/lib/render-tag";
+import { setNewCategoryDefaultColors } from "discourse/routes/new-category";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.11.1";
+const PLUGIN_API_VERSION = "0.11.2";
 
 class PluginApi {
   constructor(version, container) {
@@ -1220,6 +1221,22 @@ class PluginApi {
   }
   addSaveableUserOptionField(fieldName) {
     addSaveableUserOptionField(fieldName);
+  }
+
+  /**
+   * Change the default category background and text colors in the
+   * category creation modal.
+   *
+   * ```
+   * api.setNewCategoryDefaultColors(
+   *   'FFFFFF', // background color
+   *   '000000'  // text color
+   *  )
+   * ```
+   *
+   **/
+  setNewCategoryDefaultColors(backgroundColor, textColor) {
+    setNewCategoryDefaultColors(backgroundColor, textColor);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/routes/new-category.js
+++ b/app/assets/javascripts/discourse/app/routes/new-category.js
@@ -3,6 +3,14 @@ import I18n from "I18n";
 import { Promise } from "rsvp";
 import { SEARCH_PRIORITIES } from "discourse/lib/constants";
 
+let _newCategoryColor = "0088CC",
+  _newCategoryTextColor = "FFFFFF";
+
+export function setNewCategoryDefaultColors(backgroundColor, textColor) {
+  _newCategoryColor = backgroundColor;
+  _newCategoryTextColor = textColor;
+}
+
 export default DiscourseRoute.extend({
   model() {
     return Promise.resolve(this.groupPermissions())
@@ -16,8 +24,8 @@ export default DiscourseRoute.extend({
 
   newCategoryWithPermissions(group_permissions) {
     return this.store.createRecord("category", {
-      color: "0088CC",
-      text_color: "FFFFFF",
+      color: _newCategoryColor,
+      text_color: _newCategoryTextColor,
       group_permissions,
       available_groups: this.site.groups.map((g) => g.name),
       allow_badges: true,


### PR DESCRIPTION
```
api.setNewCategoryDefaultColors(
  'FFFFFF', // background color
  '000000'  // text color
)
```
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
