### PR TITLE
FEATURE: Add disable_onebox_media_download_controls hidden site setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1592,6 +1592,9 @@ security:
   send_old_credential_reminder_days:
     default: 0
     hidden: true
+  disable_onebox_media_download_controls:
+    default: false
+    hidden: true
 
 onebox:
   enable_flash_video_onebox: false

--- a/lib/onebox/discourse_onebox_sanitize_config.rb
+++ b/lib/onebox/discourse_onebox_sanitize_config.rb
@@ -5,9 +5,14 @@ module Onebox
     module Config
       DISCOURSE_ONEBOX ||=
         Sanitize::Config.freeze_config(
-          Sanitize::Config.merge(Sanitize::Config::ONEBOX,
-                                 attributes: Sanitize::Config.merge(Sanitize::Config::ONEBOX[:attributes],
-                                                                    'aside' => [:data])))
+          Sanitize::Config.merge(
+            Sanitize::Config::ONEBOX,
+            attributes: Sanitize::Config.merge(
+              Sanitize::Config::ONEBOX[:attributes],
+              'aside' => [:data]
+            )
+          )
+        )
     end
   end
 end

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -221,18 +221,25 @@ module Oneboxer
   end
 
   def self.local_upload_html(url)
+    additional_controls = \
+      if SiteSetting.disable_onebox_media_download_controls
+        "controlslist='nodownload'"
+      else
+        ""
+      end
+
     case File.extname(URI(url).path || "")
     when VIDEO_REGEX
       <<~HTML
         <div class="onebox video-onebox">
-          <video width="100%" height="100%" controls="">
+          <video #{additional_controls} width="100%" height="100%" controls="">
             <source src='#{url}'>
             <a href='#{url}'>#{url}</a>
           </video>
         </div>
       HTML
     when AUDIO_REGEX
-      "<audio controls><source src='#{url}'><a href='#{url}'>#{url}</a></audio>"
+      "<audio #{additional_controls} controls><source src='#{url}'><a href='#{url}'>#{url}</a></audio>"
     end
   end
 
@@ -385,6 +392,7 @@ module Oneboxer
         allowed_iframe_origins: allowed_iframe_origins,
         hostname: GlobalSetting.hostname,
         facebook_app_access_token: SiteSetting.facebook_app_access_token,
+        disable_media_download_controls: SiteSetting.disable_onebox_media_download_controls
       }
 
       options[:cookie] = fd.cookie if fd.cookie


### PR DESCRIPTION
Uses https://github.com/discourse/onebox/commit/ff9ec90aec92fbd09fdc60c081a8e0c18a2b108b

Adds a hidden site setting called `disable_onebox_media_download_controls` which will add `controlslist="nodownload"` to video and audio oneboxes, and also to the local video and audio oneboxes within Discourse.