### PR TITLE
FEATURE: Always show tag dropdown when tagging is enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -67,11 +67,6 @@ export default Controller.extend(BulkTopicSelection, FilterModeMixin, {
     });
   },
 
-  @discourseComputed("category")
-  showTagFilter() {
-    return this.siteSettings.show_filter_by_tag;
-  },
-
   loadMoreTopics() {
     return this.list.loadMore();
   },

--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -67,6 +67,11 @@ export default Controller.extend(BulkTopicSelection, FilterModeMixin, {
     });
   },
 
+  @discourseComputed("category")
+  showTagFilter() {
+    return true;
+  },
+
   loadMoreTopics() {
     return this.list.loadMore();
   },

--- a/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
@@ -15,23 +15,21 @@
 {{/each}}
 
 {{#if siteSettings.tagging_enabled}}
-  {{#if siteSettings.show_filter_by_tag}}
-    {{#if additionalTags}}
-      {{tags-intersection-chooser
-        currentCategory=category
-        mainTag=tag.id
-        additionalTags=additionalTags
-        options=(hash
-          categoryId=category.id
-        )
-      }}
-    {{else}}
-      {{tag-drop
-        currentCategory=category
-        noSubcategories=noSubcategories
-        tagId=tag.id
-      }}
-    {{/if}}
+  {{#if additionalTags}}
+    {{tags-intersection-chooser
+      currentCategory=category
+      mainTag=tag.id
+      additionalTags=additionalTags
+      options=(hash
+        categoryId=category.id
+      )
+    }}
+  {{else}}
+    {{tag-drop
+      currentCategory=category
+      noSubcategories=noSubcategories
+      tagId=tag.id
+    }}
   {{/if}}
 {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -1,4 +1,4 @@
-{{#d-section tagName="" pageClass="tags" bodyClass=(concat "tag-" tag.id (if category.slug (concat " category-" category.slug)) "")}}
+{{#d-section tagName="" pageClass="tags" bodyClass=(concat "tag-" tag.id (if category.slug (concat " category-" category.slug)) ""  (if additionalTags " tags-intersection"))}}
   <div class="container">
     {{discourse-banner user=currentUser banner=site.banner}}
   </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
@@ -36,7 +36,7 @@ acceptance("Tags intersection", function (needs) {
 
     assert.ok(exists(".mini-tag-chooser"), "The tag selector appears");
     assert.equal(
-      $(".mini-tag-chooser").text().trim(),
+      $(".composer-fields .mini-tag-chooser").text().trim(),
       "first, second",
       "populates the tags when clicking 'New topic'"
     );

--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -4,7 +4,6 @@ import ComboBoxComponent from "select-kit/components/combo-box";
 import DiscourseURL, { getCategoryAndTagUrl } from "discourse/lib/url";
 import TagsMixin from "select-kit/mixins/tags";
 import { computed } from "@ember/object";
-import { isEmpty } from "@ember/utils";
 import { makeArray } from "discourse-common/lib/helpers";
 
 export const NO_TAG_ID = "no-tags";
@@ -13,21 +12,13 @@ export const NONE_TAG_ID = "none";
 
 export default ComboBoxComponent.extend(TagsMixin, {
   pluginApiIdentifiers: ["tag-drop"],
-  classNameBindings: ["categoryStyle", "tagClass", "shouldHide:hidden"],
+  classNameBindings: ["categoryStyle", "tagClass"],
   classNames: ["tag-drop"],
   value: readOnly("tagId"),
   tagName: "li",
-  showFilterByTag: setting("show_filter_by_tag"),
   categoryStyle: setting("category_style"),
   maxTagSearchResults: setting("max_tag_search_results"),
   sortTagsAlphabetically: setting("tags_sort_alphabetically"),
-  shouldHide: computed("showFilterByTag", "content.[]", function () {
-    if (this.showFilterByTag && !isEmpty(this.content)) {
-      return false;
-    }
-
-    return true;
-  }),
 
   selectKitOptions: {
     allowAny: false,

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -307,3 +307,9 @@ section.tag-info {
     margin: 0 0.5em 0 0;
   }
 }
+
+body.tags-intersection {
+  .category-breadcrumb {
+    margin-right: auto;
+  }
+}

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -148,7 +148,7 @@ class Tag < ActiveRecord::Base
   end
 
   def self.include_tags?
-    SiteSetting.tagging_enabled && SiteSetting.show_filter_by_tag
+    SiteSetting.tagging_enabled
   end
 
   def full_url

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -240,7 +240,7 @@ class TopicTrackingState
   end
 
   def self.include_tags_in_report?
-    SiteSetting.tagging_enabled && (@include_tags_in_report || SiteSetting.show_filter_by_tag)
+    SiteSetting.tagging_enabled && @include_tags_in_report
   end
 
   def self.include_tags_in_report=(v)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2251,7 +2251,6 @@ en:
     max_tags_per_topic: "The maximum tags that can be applied to a topic."
     max_tag_length: "The maximum amount of characters that can be used in a tag."
     max_tag_search_results: "When searching for tags, the maximum number of results to show."
-    show_filter_by_tag: "Show a dropdown to filter a topic list by tag."
     max_tags_in_filter_list: "Maximum number of tags to show in the filter dropdown. The most used tags will be shown."
     tags_sort_alphabetically: "Show tags in alphabetical order. Default is to show in order of popularity."
     tags_listed_by_group: "List tags by tag group on the <a href='%{base_path}/tags' target='_blank'>Tags page</a>."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2373,10 +2373,6 @@ tags:
     client: true
     default: 5
     min: 1
-  show_filter_by_tag:
-    client: true
-    default: false
-    refresh: true
   max_tags_in_filter_list:
     client: true
     default: 30

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -636,14 +636,6 @@ describe TopicTrackingState do
       expect(row.tags).to contain_exactly("apples", "bananas")
 
       TopicTrackingState.include_tags_in_report = false
-      SiteSetting.show_filter_by_tag = true
-
-      report = TopicTrackingState.report(user)
-      expect(report.length).to eq(1)
-      row = report[0]
-      expect(row.tags).to contain_exactly("apples", "bananas")
-
-      SiteSetting.show_filter_by_tag = false
 
       report = TopicTrackingState.report(user)
       expect(report.length).to eq(1)


### PR DESCRIPTION
Removing the site setting and defaulting to the tag dropdown always being shown... this eliminates this static style of tag breadcrumb:

![image](https://user-images.githubusercontent.com/1681963/109102986-f7b89180-76f7-11eb-88bb-11ad2b8c31cc.png)
