### PR TITLE
FIX: allow adding user to PM when inviter is in allowed list (even though other participants are not in allowed list)

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1047,14 +1047,6 @@ class Topic < ActiveRecord::Base
         raise NotAllowed.new(I18n.t("topic_invite.sender_does_not_allow_pm"))
       end
 
-      if !target_user.staff? && target_user&.user_option&.enable_allowed_pm_users
-        topic_users = self.topic_allowed_users.pluck(:user_id)
-        allowed_users = AllowedPmUser.where(user: target_user.id, allowed_pm_user_id: topic_users)
-        if (allowed_users - topic_users).size > 0
-          raise NotAllowed.new(I18n.t("topic_invite.receiver_does_not_allow_other_user_pm"))
-        end
-      end
-
       if private_message?
         !!invite_to_private_message(invited_by, target_user, guardian)
       else

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -260,7 +260,6 @@ en:
     muted_topic: "Sorry, that user muted this topic."
     receiver_does_not_allow_pm: "Sorry, that user does not allow you to send them private messages."
     sender_does_not_allow_pm: "Sorry, you do not allow that user to send you private messages."
-    receiver_does_not_allow_other_user_pm: "Sorry, that user does not allow an existing participant to send them private messages."
 
   backup:
     operation_already_running: "An operation is currently running. Can't start a new job right now."

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -728,13 +728,16 @@ describe Topic do
             Fabricate.build(:topic_allowed_user, user: user2)
           ]) }
 
+          before do
+            another_user.user_option.update!(enable_allowed_pm_users: true)
+          end
+
           it 'succeeds when inviter is in allowed list' do
             AllowedPmUser.create!(user: another_user, allowed_pm_user: user)
             expect(topic.invite(user, another_user.username)).to eq(true)
           end
 
           it 'should raise error when inviter not in allowed list' do
-            another_user.user_option.update!(enable_allowed_pm_users: true)
             AllowedPmUser.create!(user: another_user, allowed_pm_user: user2)
             expect { topic.invite(user, another_user.username) }
               .to raise_error(Topic::NotAllowed)
@@ -742,27 +745,21 @@ describe Topic do
           end
 
           it 'should succeed for staff even when not allowed' do
-            another_user.user_option.update!(enable_allowed_pm_users: true)
             AllowedPmUser.create!(user: another_user, allowed_pm_user: user2)
             expect(topic.invite(another_user, admin.username)).to eq(true)
           end
 
           it 'should raise error when target_user is not in inviters allowed list' do
             user.user_option.update!(enable_allowed_pm_users: true)
-            another_user.user_option.update!(enable_allowed_pm_users: true)
             AllowedPmUser.create!(user: another_user, allowed_pm_user: user)
             expect { topic.invite(user, another_user.username) }
               .to raise_error(Topic::NotAllowed)
               .with_message(I18n.t("topic_invite.sender_does_not_allow_pm"))
           end
 
-          it 'should raise error if target_user has not allowed any of the other participants' do
-            another_user.user_option.update!(enable_allowed_pm_users: true)
+          it 'succeeds when inviter is in allowed list even though other participants are not in allowed list' do
             AllowedPmUser.create!(user: another_user, allowed_pm_user: user)
-
-            expect { pm.invite(user, another_user.username) }
-              .to raise_error(Topic::NotAllowed)
-              .with_message(I18n.t("topic_invite.receiver_does_not_allow_other_user_pm"))
+            expect(pm.invite(user, another_user.username)).to eq(true)
           end
         end
       end


### PR DESCRIPTION
If you create an allowlist of users who can PM you, and use the function “Only specific users can send me private messages”, then you can’t be added to group messages unless everyone in that message is already in your allow list.

This commit allows user to be added to a group message even when other participants are not in allowed list.
