### PR TITLE
FEATURE: Filter reviewables by id.

### DIFF
--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -24,6 +24,7 @@ class ReviewablesController < ApplicationController
     custom_keys = Reviewable.custom_filters.map(&:first)
     additional_filters = JSON.parse(params.fetch(:additional_filters, {}), symbolize_names: true).slice(*custom_keys)
     filters = {
+      ids: params[:ids],
       status: status,
       category_id: category_id,
       topic_id: topic_id,

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -429,6 +429,7 @@ class Reviewable < ActiveRecord::Base
 
   def self.list_for(
     user,
+    ids: nil,
     status: :pending,
     category_id: nil,
     topic_id: nil,
@@ -465,6 +466,7 @@ class Reviewable < ActiveRecord::Base
     result = viewable_by(user, order: order)
 
     result = by_status(result, status)
+    result = result.where(id: ids) if ids
     result = result.where('reviewables.type = ?', type) if type
     result = result.where('reviewables.category_id = ?', category_id) if category_id
     result = result.where('reviewables.topic_id = ?', topic_id) if topic_id

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -223,6 +223,18 @@ describe ReviewablesController do
           expect(json['users'].any? { |u| u['id'] == reviewable.target_created_by_id && u['custom_fields']['private_field'] == 'private' }).to eq(false)
         end
       end
+
+      it 'supports filtering by id' do
+        reviewable_a = Fabricate(:reviewable)
+        reviewable_b = Fabricate(:reviewable)
+
+        get "/review.json?ids[]=#{reviewable_a.id}"
+
+        expect(response.code).to eq("200")
+        json = response.parsed_body
+        expect(json['reviewables']).to be_present
+        expect(json['reviewables'].size).to eq(1)
+      end
     end
 
     context "#show" do


### PR DESCRIPTION
The API now accepts an array called "ids" to select specific items. This filter is not present on the UI.

Example usage: "yoursite.com/review.json?ids[]=1&ids[]=2"

