### PR TITLE
FIX: send notification in user's locale if available.

### DIFF
--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -4,25 +4,27 @@ class PushNotificationPusher
   TOKEN_VALID_FOR_SECONDS ||= 5 * 60
 
   def self.push(user, payload)
-    message = {
-      title: I18n.t(
-        "discourse_push_notifications.popup.#{Notification.types[payload[:notification_type]]}",
-        site_title: SiteSetting.title,
-        topic: payload[:topic_title],
-        username: payload[:username]
-      ),
-      body: payload[:excerpt],
-      badge: get_badge,
-      icon: ActionController::Base.helpers.image_url("push-notifications/#{Notification.types[payload[:notification_type]]}.png"),
-      tag: "#{Discourse.current_hostname}-#{payload[:topic_id]}",
-      base_url: Discourse.base_url,
-      url: payload[:post_url],
-      hide_when_active: true
-    }
+    I18n.with_locale(user.effective_locale) do
+      message = {
+        title: I18n.t(
+          "discourse_push_notifications.popup.#{Notification.types[payload[:notification_type]]}",
+          site_title: SiteSetting.title,
+          topic: payload[:topic_title],
+          username: payload[:username]
+        ),
+        body: payload[:excerpt],
+        badge: get_badge,
+        icon: ActionController::Base.helpers.image_url("push-notifications/#{Notification.types[payload[:notification_type]]}.png"),
+        tag: "#{Discourse.current_hostname}-#{payload[:topic_id]}",
+        base_url: Discourse.base_url,
+        url: payload[:post_url],
+        hide_when_active: true
+      }
 
-    subscriptions(user).each do |subscription|
-      subscription = JSON.parse(subscription.data)
-      send_notification(user, subscription, message)
+      subscriptions(user).each do |subscription|
+        subscription = JSON.parse(subscription.data)
+        send_notification(user, subscription, message)
+      end
     end
   end
 

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -16,4 +16,30 @@ RSpec.describe PushNotificationPusher do
       .to eq(UrlHelper.absolute(upload.url))
   end
 
+  it "sends notification in user's locale" do
+    SiteSetting.allow_user_locale = true
+    user = Fabricate(:user, locale: 'pt_BR')
+    PushSubscription.create!(user_id: user.id, data: "{\"endpoint\": \"endpoint\"}")
+
+    PushNotificationPusher.expects(:send_notification).with(user, { "endpoint" => "endpoint" }, {
+      title: "system mencionou você em \"Topic\" - Discourse",
+      body: "description",
+      badge: "/assets/push-notifications/discourse.png",
+      icon: "/assets/push-notifications/mentioned.png",
+      tag: "test.localhost-1",
+      base_url: "http://test.localhost",
+      url: "https://example.com/t/1/2",
+      hide_when_active: true
+    }).once
+
+    PushNotificationPusher.push(user, {
+      topic_title: 'Topic',
+      username: 'system',
+      excerpt: 'description',
+      topic_id: 1,
+      post_url: "https://example.com/t/1/2",
+      notification_type: 1
+    })
+  end
+
 end


### PR DESCRIPTION
Previously, it was sending notifications in the site's default locale.
