### PR TITLE
FIX: Don’t display error if only error is a missing image

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -402,21 +402,25 @@ module Oneboxer
 
       # NOTE: Call r.errors after calling placeholder_html
       if r.errors.any?
-        missing_attributes = r.errors.keys.map(&:to_s).sort.join(I18n.t("word_connector.comma"))
-        error_message = I18n.t("errors.onebox.missing_data", missing_attributes: missing_attributes, count: r.errors.keys.size)
-        args = r.data.merge(error_message: error_message)
+        error_keys = r.errors.keys
+        skip_if_only_error = [:image]
+        unless error_keys.length == 1 && skip_if_only_error.include?(error_keys.first)
+          missing_attributes = error_keys.map(&:to_s).sort.join(I18n.t("word_connector.comma"))
+          error_message = I18n.t("errors.onebox.missing_data", missing_attributes: missing_attributes, count: error_keys.size)
+          args = r.data.merge(error_message: error_message)
 
-        if result[:preview].blank?
-          result[:preview] = preview_error_onebox(args)
-        else
-          doc = Nokogiri::HTML5::fragment(result[:preview])
-          aside = doc.at('aside')
+          if result[:preview].blank?
+            result[:preview] = preview_error_onebox(args)
+          else
+            doc = Nokogiri::HTML5::fragment(result[:preview])
+            aside = doc.at('aside')
 
-          if aside
-            # Add an error message to the preview that was returned
-            error_fragment = preview_error_onebox_fragment(args)
-            aside.add_child(error_fragment)
-            result[:preview] = doc.to_html
+            if aside
+              # Add an error message to the preview that was returned
+              error_fragment = preview_error_onebox_fragment(args)
+              aside.add_child(error_fragment)
+              result[:preview] = doc.to_html
+            end
           end
         end
       end

--- a/spec/components/oneboxer_spec.rb
+++ b/spec/components/oneboxer_spec.rb
@@ -272,6 +272,12 @@ describe Oneboxer do
       expect(Oneboxer.preview(url, invalidate_oneboxes: true)).to include("could not be found: description, image")
     end
 
+    it 'handles a missing image' do
+      # Note: If the only error is a missing image, we shouldn't return an error
+      stub_request(:get, url).to_return(body: response("missing_image"))
+      expect(Oneboxer.preview(url, invalidate_oneboxes: true)).not_to include("could not be found")
+    end
+
     it 'video with missing description returns a placeholder' do
       stub_request(:get, url).to_return(body: response("video_missing_description"))
       expect(Oneboxer.preview(url, invalidate_oneboxes: true)).to include("onebox-placeholder-container")

--- a/spec/fixtures/onebox/missing_image.response
+++ b/spec/fixtures/onebox/missing_image.response
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head prefix="og: http://ogp.me/ns#">
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title>Open Graph protocol examples</title>
+<meta property="og:type" content="website">
+<meta property="og:locale" content="en_US">
+<meta property="og:title" content="Open Graph protocol examples">
+<meta property="og:description" content="this is bodycontent">
+<meta property="og:site_name" content="Open Graph protocol examples">
+<meta property="og:determiner" content="the">
+<meta property="og:url" content="http://examples.opengraphprotocol.us/">
+<link rel="author" href="http://www.niallkennedy.com/">
+<link rel="icon shortcut" type="image/vnd.microsoft.icon" href="/favicon.ico" sizes="16x16">
+<link rel="icon" type="image/png" href="/media/images/icon.png" sizes="16x16">
+</head>
+<body itemscope itemtype="http://schema.org/WebPage">
+<header><h1 itemprop="name">Open Graph protocol examples</h1></header>
+<div role="main">
+<p itemprop="description">Examples of Open Graph protocol markup.</p>
+
+<section id="standard">
+<header><h2>Open Graph namespace</h2></header>
+<ul>
+<li><a href="/min.html">Missing required properties</a></li>
+<li><a href="/required.html">Required properties</a></li>
+<li><a href="/nomedia.html">Most properties, no media</a></li>
+<li><a href="/canadian.html">Canadian (en_CA)</a></li>
+<li>Images<ul>
+<li><a href="/image.html">Structured image</a></li>
+<li><a href="/image-url.html">Structured image w/ image:url</a></li>
+<li><a href="/image-array.html">Structured image array</a></li>
+<li><a href="/image-toosmall.html">One-pixel structured image</a></li></ul></li>
+<li>Audio<ul>
+<li><a href="/audio.html">Structured audio</a></li>
+<li><a href="/audio-url.html">Structured audio w/ audio:url</a></li>
+<li><a href="/audio-array.html">Structured audio array</a></li></ul></li>
+<li>Video<ul>
+<li><a href="/video.html">Structured video</a></li>
+<li><a href="/video-array.html">Structured video array</a></li></ul></li>
+</ul>
+</section>
+
+<section id="objects">
+<header><h2>Global object namespace</h2></header>
+<ul>
+<li><a href="/article.html">Article</a></li>
+<li><a href="/article-utc.html">Article w/ UTC datetime</a></li>
+<li><a href="/article-offset.html">Article w/ UTC offset</a></li>
+<li><a href="/book.html">Book</a></li>
+<li><a href="/book-isbn10.html">Book w/ ISBN-10</a></li>
+<li><a href="/profile.html">Profile</a></li>
+<li><a href="/video-movie.html">Video movie</a></li>
+</ul>
+</section>
+</div>
+<footer style="text-align:center">by <a rel="author" href="http://www.niallkennedy.com/">Niall Kennedy</a></footer>
+</body>
+</html>


### PR DESCRIPTION
`Onebox.preview` can return 0-to-n errors, where the errors are missing OpenGraph attributes (e.g. title, description, image, etc.). If any of these attributes are missing, we construct an error message and attach it to the Oneboxer preview HTML. The error message is something like:

 “Sorry, we were unable to generate a preview for this web page, because the following oEmbed / OpenGraph tags could not be found: description, image”

However, if the only missing tag is `image` we don’t need to display the error, as we have enough other data (title, description, etc.) to construct a useful/complete Onebox.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
