### PR TITLE
FIX: incorrect URL for tag pages inside category in subfolder setup.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-drop-link.js
+++ b/app/assets/javascripts/discourse/app/components/tag-drop-link.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import DiscourseURL from "discourse/lib/url";
 import discourseComputed from "discourse-common/utils/decorators";
+import getURL from "discourse-common/lib/get-url";
 
 export default Component.extend({
   tagName: "a",
@@ -14,11 +15,15 @@ export default Component.extend({
 
   @discourseComputed("tagId", "category")
   href(tagId, category) {
+    let path;
+
     if (category) {
-      return "/tags" + category.url + "/" + tagId;
+      path = "/tags" + category.path + "/" + tagId;
     } else {
-      return "/tag/" + tagId;
+      path = "/tag/" + tagId;
     }
+
+    return getURL(path);
   },
 
   @discourseComputed("tagId")

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -498,7 +498,7 @@ export function getCategoryAndTagUrl(category, subcategories, tag) {
   let url;
 
   if (category) {
-    url = category.url;
+    url = category.path;
     if (!subcategories) {
       url += "/none";
     }
@@ -510,7 +510,7 @@ export function getCategoryAndTagUrl(category, subcategories, tag) {
       : "/tag/" + tag.toLowerCase();
   }
 
-  return url || "/";
+  return getURL(url || "/");
 }
 
 export default _urlInstance;

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -128,8 +128,13 @@ const Category = RestModel.extend({
   },
 
   @discourseComputed("name")
-  url() {
-    return getURL(`/c/${Category.slugFor(this)}/${this.id}`);
+  path() {
+    return `/c/${Category.slugFor(this)}/${this.id}`;
+  },
+
+  @discourseComputed("path")
+  url(path) {
+    return getURL(path);
   },
 
   @discourseComputed


### PR DESCRIPTION
Previously, we didn't use the `getURL` method to include the subfolder prefix in these places.