### PR TITLE
FIX: Do not output empty style tags for components

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -615,6 +615,11 @@ class Theme < ActiveRecord::Base
     contents
   end
 
+  def has_scss(target)
+    name = target == :embedded_theme ? :embedded_scss : :scss
+    list_baked_fields(target, name).count > 0
+  end
+
   private
 
   def to_scss_variable(name, value)

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -83,6 +83,7 @@ class Stylesheet::Manager
           if is_theme && !has_theme
             next
           else
+            next if builder.theme&.component && !builder.theme&.has_scss(target)
             data[:theme_id] = builder.theme.id if has_theme && is_theme
             builder.compile unless File.exists?(builder.stylesheet_fullpath)
             href = builder.stylesheet_path(current_hostname)

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -105,7 +105,7 @@ describe Stylesheet::Manager do
       expect(hrefs[1][:theme_id]).to eq(child_theme.id)
     end
 
-    it 'does not output CSS for components with no styles' do
+    it 'does not output tags for component targets with no styles' do
       embedded_scss_child = Fabricate(:theme, component: true)
       embedded_scss_child.set_field(target: :common, name: "embedded_scss", value: ".scss{color: red;}")
       embedded_scss_child.save!

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -105,7 +105,21 @@ describe Stylesheet::Manager do
       expect(hrefs[1][:theme_id]).to eq(child_theme.id)
     end
 
-    it 'does not output multiple assets for non-themes' do
+    it 'does not output CSS for components with no styles' do
+      embedded_scss_child = Fabricate(:theme, component: true)
+      embedded_scss_child.set_field(target: :common, name: "embedded_scss", value: ".scss{color: red;}")
+      embedded_scss_child.save!
+
+      theme.add_relative_theme!(:child, embedded_scss_child)
+
+      hrefs = Stylesheet::Manager.stylesheet_details(:desktop_theme, 'all', [theme.id])
+      expect(hrefs.count).to eq(2) # theme + child_theme
+
+      hrefs = Stylesheet::Manager.stylesheet_details(:embedded_theme, 'all', [theme.id])
+      expect(hrefs.count).to eq(3) # theme + child_theme + embedded_scss_child
+    end
+
+    it 'does not output multiple assets for non-theme targets' do
       hrefs = Stylesheet::Manager.stylesheet_details(:admin, 'all', [theme.id])
       expect(hrefs.count).to eq(1)
 


### PR DESCRIPTION
Issue was introduced by component CSS debundling in aa1442f.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
