### PR TITLE
FIX: Update digest when updating color definitions in theme component

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -371,7 +371,7 @@ class Theme < ActiveRecord::Base
   end
 
   def list_baked_fields(target, name)
-    theme_ids = Theme.transform_ids([id], extend: false)
+    theme_ids = Theme.transform_ids([id], extend: name == :color_definitions)
     self.class.list_baked_fields(theme_ids, target, name)
   end
 

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -233,8 +233,28 @@ describe Stylesheet::Manager do
       theme.save!
 
       digest2 = manager.color_scheme_digest
-
       expect(digest1).to_not eq(digest2)
+    end
+
+    it "updates digest when updating a theme component's color definitions" do
+      scheme = ColorScheme.base
+      manager = Stylesheet::Manager.new(:color_definitions, theme.id, scheme)
+      digest1 = manager.color_scheme_digest
+
+      child_theme = Fabricate(:theme, component: true)
+      child_theme.set_field(target: :common, name: "color_definitions", value: 'body {color: fuchsia}')
+      child_theme.save!
+      theme.add_relative_theme!(:child, child_theme)
+      theme.save!
+
+      digest2 = manager.color_scheme_digest
+      expect(digest1).to_not eq(digest2)
+
+      child_theme.set_field(target: :common, name: "color_definitions", value: 'body {color: blue}')
+      child_theme.save!
+      digest3 = manager.color_scheme_digest
+      expect(digest2).to_not eq(digest3)
+
     end
 
     it "updates digest when setting fonts" do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
