### PR TITLE
FIX: Skip sending PM email for user silence

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -124,14 +124,12 @@ class Admin::UsersController < Admin::AdminController
     end
     @user.logged_out
 
-    if message.present?
-      Jobs.enqueue(
-        :critical_user_email,
-        type: :account_suspended,
-        user_id: @user.id,
-        user_history_id: user_history.id
-      )
-    end
+    Jobs.enqueue(
+      :critical_user_email,
+      type: :account_suspended,
+      user_id: @user.id,
+      user_history_id: user_history.id
+    )
 
     DiscourseEvent.trigger(
       :user_suspended,
@@ -345,7 +343,7 @@ class Admin::UsersController < Admin::AdminController
       keep_posts: true,
       post_id: params[:post_id]
     )
-    if silencer.silence && message.present?
+    if silencer.silence
       Jobs.enqueue(
         :critical_user_email,
         type: :account_silenced,

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -144,7 +144,6 @@ class UserNotifications < ActionMailer::Base
       template: "user_notifications.account_silenced",
       locale: user_locale(user),
       reason: user_history.details,
-      message: user_history.context,
       silenced_till: I18n.l(user.silenced_till, format: :long)
     )
   end
@@ -159,7 +158,6 @@ class UserNotifications < ActionMailer::Base
       template: "user_notifications.account_suspended",
       locale: user_locale(user),
       reason: user_history.details,
-      message: user_history.context,
       suspended_till: I18n.l(user.suspended_till, format: :long)
     )
   end

--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -61,6 +61,7 @@ class UserSilencer
           silence_message_params: silence_message_params
         )
 
+        silence_message_params.merge!(post_alert_options: { skip_send_email: true })
         SystemMessage.create(@user, message_type, silence_message_params)
         true
       end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3642,9 +3642,7 @@ en:
       text_body_template: |
         You have been suspended from the forum until %{suspended_till}.
 
-        %{reason}
-
-        %{message}
+        Reason - %{reason}
 
     account_silenced:
       title: "Account Silenced"
@@ -3652,9 +3650,7 @@ en:
       text_body_template: |
         You have been silenced from the forum until %{silenced_till}.
 
-        %{reason}
-
-        %{message}
+        Reason - %{reason}
 
     account_exists:
       title: "Account already exists"

--- a/lib/system_message.rb
+++ b/lib/system_message.rb
@@ -40,7 +40,7 @@ class SystemMessage
                        target_group_names: target_group_names,
                        subtype: TopicSubtype.system_message,
                        skip_validations: true,
-                       post_alert_options: { skip_send_email: true })
+                       post_alert_options: params[:post_alert_options])
 
     post = I18n.with_locale(@recipient.effective_locale) { creator.create }
 

--- a/lib/system_message.rb
+++ b/lib/system_message.rb
@@ -39,7 +39,8 @@ class SystemMessage
                        target_usernames: @recipient.username,
                        target_group_names: target_group_names,
                        subtype: TopicSubtype.system_message,
-                       skip_validations: true)
+                       skip_validations: true,
+                       post_alert_options: { skip_send_email: true })
 
     post = I18n.with_locale(@recipient.effective_locale) { creator.create }
 

--- a/spec/services/user_silencer_spec.rb
+++ b/spec/services/user_silencer_spec.rb
@@ -33,6 +33,13 @@ describe UserSilencer do
       expect(count).to eq(1)
     end
 
+    it "skips sending the email for the silence PM via post alert" do
+      NotificationEmailer.enable
+      Jobs.run_immediately!
+      UserSilencer.silence(user, admin)
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+
     it 'does not hide posts for tl1' do
       user.update!(trust_level: 1)
 


### PR DESCRIPTION
We were sending 2 emails for user silencing if a message was provided in the UI. Also always send email for user silence and user suspend with reason regardless of whether message provided.

`ref: t/42049`