### PR TITLE
A11Y: Switch tabs using the keyboard

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -6,6 +6,7 @@ import PanEvents, {
 import { cancel, later, schedule } from "@ember/runloop";
 import Docking from "discourse/mixins/docking";
 import MountWidget from "discourse/components/mount-widget";
+import Mousetrap from "mousetrap";
 import RerenderOnDoNotDisturbChange from "discourse/mixins/rerender-on-do-not-disturb-change";
 import { observes } from "discourse-common/utils/decorators";
 import { topicTitleDecorators } from "discourse/components/topic-title";
@@ -25,6 +26,7 @@ const SiteHeaderComponent = MountWidget.extend(
     _scheduledMovingAnimation: null,
     _scheduledRemoveAnimate: null,
     _topic: null,
+    _mousetrap: null,
 
     @observes(
       "currentUser.unread_notifications",
@@ -209,6 +211,7 @@ const SiteHeaderComponent = MountWidget.extend(
       this.dispatch("notifications:changed", "user-notifications");
       this.dispatch("header:keyboard-trigger", "header");
       this.dispatch("search-autocomplete:after-complete", "search-term");
+      this.dispatch("user-menu:navigation", "user-menu");
 
       this.appEvents.on("dom:clean", this, "_cleanDom");
 
@@ -236,6 +239,26 @@ const SiteHeaderComponent = MountWidget.extend(
           once: true,
         });
       }
+
+      const header = document.querySelector("header.d-header");
+      const mousetrap = new Mousetrap(header);
+      mousetrap.bind(["right", "left"], (e) => {
+        const activeTab = document.querySelector(".glyphs .menu-link.active");
+
+        if (activeTab) {
+          let focusedTab = document.activeElement;
+          if (!focusedTab.dataset.tabNumber) {
+            focusedTab = activeTab;
+          }
+
+          this.appEvents.trigger("user-menu:navigation", {
+            key: e.key,
+            tabNumber: Number(focusedTab.dataset.tabNumber),
+          });
+        }
+      });
+
+      this.set("_mousetrap", mousetrap);
     },
 
     _cleanDom() {
@@ -256,6 +279,8 @@ const SiteHeaderComponent = MountWidget.extend(
 
       cancel(this._scheduledRemoveAnimate);
       window.cancelAnimationFrame(this._scheduledMovingAnimation);
+
+      this._mousetrap.unbind(["right", "left"]);
 
       document.removeEventListener("click", this._dismissFirstNotification);
     },

--- a/app/assets/javascripts/discourse/app/widgets/button.js
+++ b/app/assets/javascripts/discourse/app/widgets/button.js
@@ -28,6 +28,10 @@ export const ButtonClass = {
     return className;
   },
 
+  buildId(attrs) {
+    return attrs.id;
+  },
+
   buildAttributes() {
     const attrs = this.attrs;
     const attributes = {};
@@ -70,7 +74,7 @@ export const ButtonClass = {
     const icon = iconNode(attrs.icon, { class: attrs.iconClass });
     if (attrs["aria-label"]) {
       icon.properties.attributes["role"] = "img";
-      icon.properties.attributes["aria-hidden"] = false;
+      icon.properties.attributes["aria-hidden"] = true;
     }
     return icon;
   },

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
@@ -40,9 +40,13 @@ export default createWidget("quick-access-panel", {
     return Promise.resolve([]);
   },
 
+  buildId() {
+    return this.key;
+  },
+
   buildAttributes() {
     const attributes = this.attrs;
-    attributes["aria-labelledby"] = this.key;
+    attributes["aria-labelledby"] = attributes.currentQuickAccess;
     attributes["tabindex"] = "0";
     attributes["role"] = "tabpanel";
 

--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -1,7 +1,6 @@
-import { later, schedule } from "@ember/runloop";
+import { later } from "@ember/runloop";
 import { createWidget } from "discourse/widgets/widget";
 import { h } from "virtual-dom";
-import Mousetrap from "mousetrap";
 
 const UserMenuAction = {
   QUICK_ACCESS: "quickAccess",
@@ -60,9 +59,9 @@ createWidget("user-menu-links", {
   profileGlyph() {
     return {
       title: Titles["profile"],
-      className: "user-preferences-link",
+      className: "user-preferences-link menu-link",
       id: QuickAccess.PROFILE,
-      icon: "user menu-link",
+      icon: "user",
       action: UserMenuAction.QUICK_ACCESS,
       actionParam: QuickAccess.PROFILE,
       data: { url: `${this.attrs.path}/summary` },
@@ -156,30 +155,6 @@ createWidget("user-menu-links", {
 
     glyphs.push(this.profileGlyph());
 
-    schedule("afterRender", () => {
-      const tabList = document.querySelector(".glyphs");
-      const mousetrap = new Mousetrap(tabList);
-      const maxTabNumber = glyphs.length - 1;
-
-      mousetrap.bind(["right", "left"], (e) => {
-        const isLeft = e.key === "ArrowLeft";
-        const tabNumber = Number(e.target.dataset.tabNumber);
-        let nextTab = isLeft ? tabNumber - 1 : tabNumber + 1;
-
-        if (isLeft && nextTab < 0) {
-          nextTab = maxTabNumber;
-        }
-
-        if (!isLeft && nextTab > maxTabNumber) {
-          nextTab = 0;
-        }
-
-        document
-          .querySelector(`.menu-link[role='tab'][data-tab-number='${nextTab}']`)
-          .focus();
-      });
-    });
-
     return h("div.menu-links-row", [
       h(
         "div.glyphs",
@@ -223,6 +198,25 @@ export default createWidget("user-menu", {
   settings: {
     maxWidth: 320,
     showLogoutButton: true,
+  },
+
+  userMenuNavigation(nav) {
+    const maxTabNumber = document.querySelectorAll(".glyphs button").length - 1;
+    const isLeft = nav.key === "ArrowLeft";
+
+    let nextTab = isLeft ? nav.tabNumber - 1 : nav.tabNumber + 1;
+
+    if (isLeft && nextTab < 0) {
+      nextTab = maxTabNumber;
+    }
+
+    if (!isLeft && nextTab > maxTabNumber) {
+      nextTab = 0;
+    }
+
+    document
+      .querySelector(`.menu-link[role='tab'][data-tab-number='${nextTab}']`)
+      .focus();
   },
 
   defaultState() {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -414,6 +414,10 @@ div.menu-links-header {
         flex: 1 1 auto;
         padding: 0.65em 0.25em 0.75em;
         justify-content: center;
+
+        svg {
+          pointer-events: none;
+        }
       }
     }
 


### PR DESCRIPTION
According to the WAI-ARIA Authoring Practices, tabs should be navigable using the left/right arrow keys.

Additionally, the screen reader couldn't correctly announce that a tab was selected when clicking the tab icon. To fix this, we made the SVG icon non-clickable and set the "aria-hidden" attribute to true.

