### PR TITLE
FIX: 100% Width for logout button

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -362,6 +362,8 @@
       }
       ul button {
         line-height: 1.4; // match 'ul a' link height
+        width: 100%;
+        display: flex;
       }
       @media screen and (max-height: 360px) {
         // two column grid to avoid scroll


### PR DESCRIPTION
This commit sets the width for the logout button to be 100% to allow for clicking outside of the text to still work as expected.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

### New
The button now fills the width of the `li` element it is contained in.
![image](https://user-images.githubusercontent.com/30537603/109528420-42c90080-7a7a-11eb-9ed0-8d91a1ab10a3.png)

### Old
The button did not fill in the width of the `li` element it was contained in.
![image](https://user-images.githubusercontent.com/30537603/109528506-5c6a4800-7a7a-11eb-9e9a-d3d93acd015d.png)

