### PR TITLE
FIX: Add appropriate classes to `html` element including `lang`

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
@@ -242,6 +242,10 @@
         head.append(theme_ids);
       }
 
+      let htmlElement = document.getElementsByTagName("html")[0];
+      htmlElement.classList = bootstrap.html_classes;
+      htmlElement.setAttribute("lang", bootstrap.html_lang);
+
       let themeHtml = bootstrap.theme_html;
       let html = bootstrap.html;
 

--- a/app/controllers/bootstrap_controller.rb
+++ b/app/controllers/bootstrap_controller.rb
@@ -60,6 +60,8 @@ class BootstrapController < ApplicationController
       preloaded: @preloaded,
       html: create_html,
       theme_html: create_theme_html,
+      html_classes: html_classes,
+      html_lang: html_lang
     }
     bootstrap[:extra_locales] = extra_locales if extra_locales.present?
     bootstrap[:csrf_token] = form_authenticity_token if current_user

--- a/spec/requests/bootstrap_controller_spec.rb
+++ b/spec/requests/bootstrap_controller_spec.rb
@@ -41,6 +41,9 @@ describe BootstrapController do
     expect(preloaded['siteSettings']).to be_present
     expect(preloaded['currentUser']).to be_blank
     expect(preloaded['topicTrackingStates']).to be_blank
+
+    expect(bootstrap['html_classes']).to eq("desktop-view not-mobile-device text-size-normal anon")
+    expect(bootstrap['html_lang']).to eq('en')
   end
 
   it "returns user data when authenticated" do


### PR DESCRIPTION
This was not working in the Ember CLI version of the application.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
