### PR TITLE
FEATURE: allow search engines to index tag pages.

### DIFF
--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -23,6 +23,7 @@ class RobotsTxtController < ApplicationController
     /u
     /my
     /search
+    /tag/*/l
     /g
     /t/*/*.rss
     /c/*.rss

--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -23,7 +23,6 @@ class RobotsTxtController < ApplicationController
     /u
     /my
     /search
-    /tag
     /g
     /t/*/*.rss
     /c/*.rss

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -23,8 +23,6 @@ class TagsController < ::ApplicationController
 
   before_action :fetch_tag, only: [:info, :create_synonyms, :destroy_synonym]
 
-  after_action :add_noindex_header
-
   def index
     @description_meta = I18n.t("tags.title")
     @title = @description_meta

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -23,6 +23,8 @@ class TagsController < ::ApplicationController
 
   before_action :fetch_tag, only: [:info, :create_synonyms, :destroy_synonym]
 
+  after_action :add_noindex_header, except: [:index, :show]
+
   def index
     @description_meta = I18n.t("tags.title")
     @title = @description_meta

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -29,7 +29,6 @@ describe TagsController do
         tags = response.parsed_body["tags"]
         expect(tags.length).to eq(1)
         expect(tags[0]['text']).to eq("topic-test")
-        expect(response.headers['X-Robots-Tag']).to eq('noindex')
       end
     end
 


### PR DESCRIPTION
Previously, we blocked search engines in tag pages since they may get marked as duplicate content.

It reverts the commit https://github.com/discourse/discourse/commit/c94e6a9a66757ea48d99e3ee8d880523871cb6f4