### PR TITLE
FIX: CSS tweaks so bookmark + timer modal work on mobile

### DIFF
--- a/app/assets/stylesheets/common/base/edit-topic-timer-modal.scss
+++ b/app/assets/stylesheets/common/base/edit-topic-timer-modal.scss
@@ -7,9 +7,18 @@
     border-top: 0;
     padding: 10px 0;
   }
+  .modal-inner-container {
+    box-sizing: border-box;
+    min-width: 310px;
+  }
   .modal-body {
     max-height: none;
     width: 375px;
+    box-sizing: border-box;
+
+    @media (max-width: 600px) {
+      width: 100% !important;
+    }
 
     .control-label {
       font-weight: 700;

--- a/app/assets/stylesheets/common/base/edit-topic-timer-modal.scss
+++ b/app/assets/stylesheets/common/base/edit-topic-timer-modal.scss
@@ -17,7 +17,7 @@
     box-sizing: border-box;
 
     @media (max-width: 600px) {
-      width: 100% !important;
+      width: 100%;
     }
 
     .control-label {

--- a/app/assets/stylesheets/common/components/bookmark-modal.scss
+++ b/app/assets/stylesheets/common/components/bookmark-modal.scss
@@ -1,6 +1,7 @@
 .bookmark-with-reminder.modal {
   .modal-inner-container {
     box-sizing: border-box;
+    min-width: 310px;
   }
   .modal-body {
     width: 375px;

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -204,21 +204,6 @@ sub sub {
   }
 }
 
-.edit-topic-timer-modal {
-  .future-date-input {
-    .alert-info {
-      margin: 0 -10px -10px -10px;
-      padding: 10px;
-    }
-  }
-  .btn.pull-right {
-    margin-right: 0;
-  }
-  .modal-body {
-    width: 375px;
-  }
-}
-
 .topic-footer-main-buttons {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Previously the timer modal was too wide and the bookmark modal too narrow.

This is what the timer modal looked like:

![image](https://user-images.githubusercontent.com/920448/109604599-85203980-7b6f-11eb-8372-fd13855e85bb.png)
