### PR TITLE
FIX: `Topic#invite_group` failed to notify users on newly created topic

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -930,6 +930,7 @@ class Topic < ActiveRecord::Base
       group_user = topic_allowed_groups.find_by(group_id: group.id)
       if group_user
         group_user.destroy
+        allowed_groups.reload
         add_small_action(removed_by, "removed_group", group.name)
         return true
       end
@@ -968,6 +969,7 @@ class Topic < ActiveRecord::Base
 
   def invite_group(user, group)
     TopicAllowedGroup.create!(topic_id: id, group_id: group.id)
+    allowed_groups.reload
 
     last_post = posts.order('post_number desc').where('not hidden AND posts.deleted_at IS NULL').first
     if last_post

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -909,7 +909,15 @@ describe Topic do
   context 'private message' do
     let(:coding_horror) { Fabricate(:coding_horror) }
     fab!(:evil_trout) { Fabricate(:evil_trout) }
-    let(:topic) { Fabricate(:private_message_topic, recipient: coding_horror) }
+    let(:topic) do
+      PostCreator.new(
+        Fabricate(:user),
+        title: "This is a private message",
+        raw: "This is my message to you-ou-ou",
+        archetype: Archetype.private_message,
+        target_usernames: coding_horror.username
+      ).create!.topic
+    end
 
     it "should integrate correctly" do
       expect(Guardian.new(topic.user).can_see?(topic)).to eq(true)


### PR DESCRIPTION
Creating a new topic with `PostCreator` loads the topic's `allowed_groups` association. `Topic#invite_group` added a new record to that association without reloading. A subsequent call to `PostAlerter#notify_group_summary` didn't work because it didn't find the invited group in the topic's `allowed_groups` association.