### PR TITLE
FIX: Components mobile-specific CSS was missing

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -356,6 +356,8 @@ class Theme < ActiveRecord::Base
     if target == :translations
       fields = ThemeField.find_first_locale_fields(theme_ids, I18n.fallbacks[name])
     else
+      target = :mobile if target == :mobile_theme
+      target = :desktop if target == :desktop_theme
       fields = ThemeField.find_by_theme_ids(theme_ids)
         .where(target_id: [Theme.targets[target], Theme.targets[:common]])
       fields = fields.where(name: name.to_s) unless name.nil?

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -119,6 +119,17 @@ describe Stylesheet::Manager do
       expect(hrefs.count).to eq(3) # theme + child_theme + embedded_scss_child
     end
 
+    it '.stylesheet_details can find components mobile SCSS when target is `:mobile_theme`' do
+      child_with_mobile_scss = Fabricate(:theme, component: true)
+      child_with_mobile_scss.set_field(target: :mobile, name: :scss, value: "body { color: red; }")
+      child_with_mobile_scss.save!
+      theme.add_relative_theme!(:child, child_with_mobile_scss)
+
+      hrefs = Stylesheet::Manager.stylesheet_details(:mobile_theme, 'all', [theme.id])
+      expect(hrefs.find { |h| h[:theme_id] == child_with_mobile_scss.id }).to be_present
+      expect(hrefs.count).to eq(3)
+    end
+
     it 'does not output multiple assets for non-theme targets' do
       hrefs = Stylesheet::Manager.stylesheet_details(:admin, 'all', [theme.id])
       expect(hrefs.count).to eq(1)


### PR DESCRIPTION
This fixes an old hidden bug that was exposed in https://github.com/discourse/discourse/commit/cf0192018ed7cd5cb4bc3526be583396c64cd4f7. The bug is that we call the `Stylesheet::Manager.stylesheet_details` method with the `target` arg as `:mobile_theme` when we want to retrieve a theme component's mobile CSS. The problem is that this `target` value will at some point be looked up in the `Theme.targets` enum which doesn't have a `:mobile_theme` key, instead it has `:mobile` key.

This PR removes the `_theme` suffix in the `Theme.list_baked_fields` method like we do here:

https://github.com/discourse/discourse/blob/31f3563f2d7ad81645c94acd69810823d363c869/lib/stylesheet/importer.rb#L188-L189

I don't see a better way to fix this because our theme code is very sensitive and we need this bug fixed ASAP because it impacts theme components that have mobile CSS.

cc @pmusaraj 