### PR TITLE
FIX: Remove unused JS from "finish installation" page

### DIFF
--- a/app/views/layouts/finish_installation.html.erb
+++ b/app/views/layouts/finish_installation.html.erb
@@ -3,8 +3,6 @@
     <%= discourse_stylesheet_link_tag 'wizard', theme_ids: nil %>
     <%= discourse_color_scheme_stylesheets %>
 
-    <%= preload_script 'ember_jquery' %>
-    <%= preload_script 'wizard-vendor' %>
     <%= render partial: "layouts/head" %>
     <title><%= t 'wizard.title' %></title>
   </head>


### PR DESCRIPTION
This fixes the following error: "Uncaught ReferenceError: I18n is not defined"
The alternative would be to add `locales/#{I18n.locale}`, but the pages do not use any JS.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
