### PR TITLE
DEV: Always run all linting tests in GitHub actions, even on failure

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -57,15 +57,19 @@ jobs:
         run: yarn install
 
       - name: Rubocop
+        if: ${{ always() }}
         run: bundle exec rubocop .
 
       - name: ESLint (core)
+        if: ${{ always() }}
         run: yarn eslint --ext .js,.js.es6 --no-error-on-unmatched-pattern app/assets/javascripts
 
       - name: ESLint (core plugins)
+        if: ${{ always() }}
         run: yarn eslint --ext .js,.js.es6 --no-error-on-unmatched-pattern plugins/**/{test,assets}/javascripts
 
       - name: Prettier
+        if: ${{ always() }}
         run: |
           yarn prettier -v
           yarn prettier --list-different \
@@ -75,13 +79,16 @@ jobs:
             "plugins/**/assets/javascripts/**/*.{js,es6}"
 
       - name: Ember template lint
+        if: ${{ always() }}
         run: |
           yarn ember-template-lint \
             app/assets/javascripts \
             plugins/**/assets/javascripts
 
       - name: English locale lint (core)
+        if: ${{ always() }}
         run: bundle exec ruby script/i18n_lint.rb "config/**/locales/{client,server}.en.yml"
 
       - name: English locale lint (core plugins)
+        if: ${{ always() }}
         run: bundle exec ruby script/i18n_lint.rb "plugins/**/locales/{client,server}.en.yml"


### PR DESCRIPTION
This means that if you have multiple failures, they can all be seen in a single run

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
