### PR TITLE
UX: restore autofocus on login inputs

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
@@ -13,7 +13,7 @@
       <form id="login-form" method="post">
         <div id="credentials" class={{credentialsClass}}>
           <div class="input-group">
-            {{input value=loginName class=(value-entered loginName)type="email" id="login-account-name" autocorrect="off" autocapitalize="off" disabled=showSecondFactor}}
+            {{input value=loginName class=(value-entered loginName) type="email" id="login-account-name" autocorrect="off" autocapitalize="off" disabled=showSecondFactor autofocus="autofocus"}}
             <label class="alt-placeholder" for="login-account-name">{{i18n "login.email_placeholder"}}</label>
             {{#if showLoginWithEmailLink}}
               <a href id="email-login-link" {{action (unless processingEmailLink "emailLogin")}}>

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -25,7 +25,7 @@
                 {{#if emailValidated}}
                   <span class="value">{{accountEmail}}</span>
                 {{else}}
-                  {{input type="email" value=accountEmail id="new-account-email" name="email" class=(value-entered accountEmail)}}
+                  {{input type="email" value=accountEmail id="new-account-email" name="email" class=(value-entered accountEmail) autofocus="autofocus"}}
                   <label class="alt-placeholder" for="new-account-email">
                     {{i18n "user.email.title"}}
                     {{~#if userFields~}}

--- a/app/assets/javascripts/discourse/app/templates/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/login.hbs
@@ -11,7 +11,7 @@
         <form id="login-form" method="post">
           <div id="credentials" class={{credentialsClass}}>
             <div class="input-group">
-              {{input value=loginName type="email" id="login-account-name" class=(value-entered loginName) autocomplete="username" autocorrect="off" autocapitalize="off" disabled=showSecondFactor}}
+              {{input value=loginName type="email" id="login-account-name" class=(value-entered loginName) autocomplete="username" autocorrect="off" autocapitalize="off" disabled=showSecondFactor autofocus="autofocus"}}
               <label class="alt-placeholder" for="login-account-name">{{i18n "login.email_placeholder"}}</label>
               {{#if showLoginWithEmailLink}}
                 <a href id="email-login-link" {{action (unless processingEmailLink "emailLogin")}}>


### PR DESCRIPTION
Our modals don't capture focus so without autofocus on the first input users end up tabbing around on content under the modal until they can reach login. This restores the previous functionality. We can remove once we capture modal focus. 