### PR TITLE
FIX: message bus when group private message

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -214,6 +214,7 @@ class Post < ActiveRecord::Base
       if topic.private_message?
         opts[:user_ids] = User.human_users.where("admin OR moderator").pluck(:id)
         opts[:user_ids] |= topic.allowed_users.pluck(:id)
+        opts[:user_ids] |= topic.allowed_group_users.pluck(:id)
       else
         opts[:group_ids] = topic.secure_group_ids
       end


### PR DESCRIPTION
When the private message was addressed to the group.
Group members didn't receive MessageBus messages about new posts.
To see content, they needed to refresh the page.

Meta: https://meta.discourse.org/t/group-private-message-message-bus-issue/181009/7
