### PR TITLE
FIX: new topic indicator on the mobile categories page

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -63,9 +63,13 @@ class CategoryList < DraftableList
 
     @all_topics = Topic.where(id: category_featured_topics.map(&:topic_id))
     @all_topics = @all_topics.includes(:last_poster) if @options[:include_topics]
+
+    @dismissed_topic_users_lookup = DismissedTopicUser.lookup_for(@guardian.current_user, @all_topics) if @guardian.current_user
+
     @all_topics.each do |t|
       # hint for the serializer
       t.include_last_poster = true if @options[:include_topics]
+      t.dismissed = @guardian.current_user && @dismissed_topic_users_lookup.include?(t.id)
       @topics_by_id[t.id] = t
     end
 

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -63,28 +63,25 @@ class CategoryList < DraftableList
 
     @all_topics = Topic.where(id: category_featured_topics.map(&:topic_id))
     @all_topics = @all_topics.includes(:last_poster) if @options[:include_topics]
-
-    @dismissed_topic_users_lookup = DismissedTopicUser.lookup_for(@guardian.current_user, @all_topics) if @guardian.current_user
-
     @all_topics.each do |t|
       # hint for the serializer
       t.include_last_poster = true if @options[:include_topics]
-t.dismissed = dismissed_topic?(topic)
-
-def dismissed_topic?(topic)
-  if @guardian.current_user
-    @dismissed_topic_users_lookup ||= DismissedTopicUser.lookup_for(@guardian.current_user, @all_topics)
-    @dismissed_topic_users_lookup.include?(topic.id)
-  else
-    false
-  end
-end
+      t.dismissed = dismissed_topic?(t)
       @topics_by_id[t.id] = t
     end
 
     category_featured_topics.each do |cft|
       @topics_by_category_id[cft.category_id] ||= []
       @topics_by_category_id[cft.category_id] << cft.topic_id
+    end
+  end
+
+  def dismissed_topic?(topic)
+    if @guardian.current_user
+      @dismissed_topic_users_lookup ||= DismissedTopicUser.lookup_for(@guardian.current_user, @all_topics)
+      @dismissed_topic_users_lookup.include?(topic.id)
+    else
+      false
     end
   end
 

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -69,7 +69,16 @@ class CategoryList < DraftableList
     @all_topics.each do |t|
       # hint for the serializer
       t.include_last_poster = true if @options[:include_topics]
-      t.dismissed = @guardian.current_user && @dismissed_topic_users_lookup.include?(t.id)
+t.dismissed = dismissed_topic?(topic)
+
+def dismissed_topic?(topic)
+  if @guardian.current_user
+    @dismissed_topic_users_lookup ||= DismissedTopicUser.lookup_for(@guardian.current_user, @all_topics)
+    @dismissed_topic_users_lookup.include?(topic.id)
+  else
+    false
+  end
+end
       @topics_by_id[t.id] = t
     end
 

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -95,18 +95,22 @@ describe CategoryList do
       let!(:topic2) { Fabricate(:topic, category: topic_category, bumped_at: 5.minutes.ago) }
       let!(:topic3) { Fabricate(:topic, category: topic_category, bumped_at: 2.minutes.ago) }
       let!(:pinned) { Fabricate(:topic, category: topic_category, pinned_at: 10.minutes.ago, bumped_at: 10.minutes.ago) }
+      let!(:dismissed_topic_user) { Fabricate(:dismissed_topic_user, topic: topic2, user: user) }
 
       def displayable_topics
         category_list = CategoryList.new(Guardian.new(user), include_topics: true)
-        category_list.categories.find { |c| c.id == topic_category.id }.displayable_topics.map(&:id)
+        category_list.categories.find { |c| c.id == topic_category.id }.displayable_topics
       end
 
       it "returns pinned topic first" do
-        expect(displayable_topics).to eq([pinned.id, topic3.id])
+        expect(displayable_topics.map(&:id)).to eq([pinned.id, topic3.id])
 
         TopicUser.change(user.id, pinned.id, cleared_pinned_at: pinned.pinned_at + 10)
 
-        expect(displayable_topics).to eq([topic3.id, topic2.id])
+        expect(displayable_topics[0].dismissed).to eq(false)
+        expect(displayable_topics[1].dismissed).to eq(true)
+
+        expect(displayable_topics.map(&:id)).to eq([topic3.id, topic2.id])
       end
     end
 


### PR DESCRIPTION
Regression with new dismiss button. We need the same solution to indicate if the topic was seen for category_list as done for topic_list:
https://github.com/discourse/discourse/blob/master/app/models/topic_list.rb#L123

Meta: https://meta.discourse.org/t/dismissed-new-topics-still-show-blue-dots-in-categories-view/181596
