### PR TITLE
Fix the URL of comment for image_optim fork [skip ci]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem 'unf', require: false
 
 gem 'email_reply_trimmer'
 
-# Forked until https://github.com/toy/image_optim/pull/162 is merged
+# Forked until https://github.com/toy/image_optim/pull/189 is merged
 # https://github.com/discourse/image_optim
 gem 'discourse_image_optim', require: 'image_optim'
 gem 'multi_json'


### PR DESCRIPTION
The previous PR https://github.com/toy/image_optim/pull/162 was closed and a new PR https://github.com/toy/image_optim/pull/189 has been submitted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
