### PR TITLE
FIX: Remove list double padding

### DIFF
--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -55,10 +55,18 @@
 // This is for the support_mixed_text_direction setting
 .cooked ul[dir="ltr"],
 .d-editor-preview ul[dir="ltr"],
-.cooked ul[dir="rtl"],
-.d-editor-preview ul[dir="rtl"] {
-  padding-right: 40px;
+.rtl .cooked ul[dir="rtl"],
+.rtl .d-editor-preview ul[dir="rtl"] {
   padding-left: 40px;
+  padding-right: 0;
+}
+
+.cooked ul[dir="rtl"],
+.d-editor-preview ul[dir="rtl"],
+.rtl .cooked ul[dir="ltr"],
+.rtl .d-editor-preview ul[dir="ltr"] {
+  padding-left: 0;
+  padding-right: 40px;
 }
 
 // Fixes github oneboxes for RTL sites


### PR DESCRIPTION
Enabling support_mixed_text_direction added both left-side and
right-side padding.

Follow up to 4bee7fb458532d95d2ef49dde976a9f06dbce3da.