### PR TITLE
FEATURE: Allow users to favorite badges

### DIFF
--- a/app/assets/javascripts/discourse/app/components/badge-card.js
+++ b/app/assets/javascripts/discourse/app/components/badge-card.js
@@ -1,6 +1,7 @@
 import { emojiUnescape, sanitize } from "discourse/lib/text";
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
+import { action } from "@ember/object";
 import { isEmpty } from "@ember/utils";
 
 export default Component.extend({
@@ -31,5 +32,10 @@ export default Component.extend({
       }
     }
     return sanitize(this.get("badge.description"));
+  },
+
+  @action
+  favorite() {
+    this.onClick();
   },
 });

--- a/app/assets/javascripts/discourse/app/components/badge-card.js
+++ b/app/assets/javascripts/discourse/app/components/badge-card.js
@@ -36,6 +36,6 @@ export default Component.extend({
 
   @action
   favorite() {
-    this.onClick();
+    this.onFavoriteClick();
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/user-badges.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-badges.js
@@ -7,11 +7,13 @@ export default Controller.extend({
   username: alias("user.model.username_lower"),
   sortedBadges: sort("model", "badgeSortOrder"),
   favoriteBadges: filterBy("model", "is_favorite", true),
-  favoriteCount: alias("favoriteBadges.length"),
-  maxFavorites: alias("model.meta.max_favorites"),
-  canFavorite: computed("favoriteCount", "maxFavorites", function () {
-    return this.favoriteCount < this.maxFavorites;
-  }),
+  canFavorite: computed(
+    "favoriteBadges.length",
+    "model.meta.max_favorites",
+    function () {
+      return this.favoriteBadges.length < this.model.meta.max_favorites;
+    }
+  ),
 
   init() {
     this._super(...arguments);

--- a/app/assets/javascripts/discourse/app/controllers/user-badges.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-badges.js
@@ -1,8 +1,6 @@
 import Controller, { inject as controller } from "@ember/controller";
-import { action } from "@ember/object";
-import { alias, filterBy, lt, sort } from "@ember/object/computed";
-
-const MAX_FAVORITES = 2;
+import { action, computed } from "@ember/object";
+import { alias, filterBy, sort } from "@ember/object/computed";
 
 export default Controller.extend({
   user: controller(),
@@ -10,12 +8,13 @@ export default Controller.extend({
   sortedBadges: sort("model", "badgeSortOrder"),
   favoriteBadges: filterBy("model", "is_favorite", true),
   favoriteCount: alias("favoriteBadges.length"),
-  canFavorite: lt("favoriteCount", MAX_FAVORITES),
+  maxFavorites: alias("model.meta.max_favorites"),
+  canFavorite: computed("favoriteCount", "maxFavorites", function () {
+    return this.favoriteCount < this.maxFavorites;
+  }),
 
   init() {
     this._super(...arguments);
-
-    this.maxFavorites = MAX_FAVORITES;
     this.badgeSortOrder = ["badge.badge_type.sort_order:desc", "badge.name"];
   },
 

--- a/app/assets/javascripts/discourse/app/controllers/user-badges.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-badges.js
@@ -1,4 +1,5 @@
 import Controller, { inject as controller } from "@ember/controller";
+import { action } from "@ember/object";
 import { alias, sort } from "@ember/object/computed";
 
 export default Controller.extend({
@@ -10,5 +11,10 @@ export default Controller.extend({
     this._super(...arguments);
 
     this.badgeSortOrder = ["badge.badge_type.sort_order:desc", "badge.name"];
+  },
+
+  @action
+  favorite(badge) {
+    return badge.favorite();
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/user-badges.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-badges.js
@@ -1,15 +1,21 @@
 import Controller, { inject as controller } from "@ember/controller";
 import { action } from "@ember/object";
-import { alias, sort } from "@ember/object/computed";
+import { alias, filterBy, lt, sort } from "@ember/object/computed";
+
+const MAX_FAVORITES = 2;
 
 export default Controller.extend({
   user: controller(),
   username: alias("user.model.username_lower"),
   sortedBadges: sort("model", "badgeSortOrder"),
+  favoriteBadges: filterBy("model", "is_favorite", true),
+  favoriteCount: alias("favoriteBadges.length"),
+  canFavorite: lt("favoriteCount", MAX_FAVORITES),
 
   init() {
     this._super(...arguments);
 
+    this.maxFavorites = MAX_FAVORITES;
     this.badgeSortOrder = ["badge.badge_type.sort_order:desc", "badge.name"];
   },
 

--- a/app/assets/javascripts/discourse/app/models/user-badge.js
+++ b/app/assets/javascripts/discourse/app/models/user-badge.js
@@ -7,6 +7,8 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseComputed from "discourse-common/utils/decorators";
 
+const DEFAULT_USER_BADGES_META = { max_favorites: 2 };
+
 const UserBadge = EmberObject.extend({
   @discourseComputed
   postUrl: function () {
@@ -96,11 +98,7 @@ UserBadge.reopenClass({
         userBadges.grant_count = json.user_badge_info.grant_count;
         userBadges.username = json.user_badge_info.username;
       }
-      if (json.meta) {
-        userBadges.meta = json.meta;
-      } else {
-        userBadges.meta = {};
-      }
+      userBadges.meta = json.meta || DEFAULT_USER_BADGES_META;
       return userBadges;
     }
   },

--- a/app/assets/javascripts/discourse/app/models/user-badge.js
+++ b/app/assets/javascripts/discourse/app/models/user-badge.js
@@ -24,7 +24,7 @@ const UserBadge = EmberObject.extend({
   },
 
   favorite() {
-    return ajax(`/user_badges/${this.id}/favorite`, { type: "PUT" })
+    return ajax(`/user_badges/${this.id}/toggle_favorite`, { type: "PUT" })
       .then((json) => {
         this.set("is_favorite", json.user_badge.is_favorite);
         return this;

--- a/app/assets/javascripts/discourse/app/models/user-badge.js
+++ b/app/assets/javascripts/discourse/app/models/user-badge.js
@@ -19,6 +19,20 @@ const UserBadge = EmberObject.extend({
       type: "DELETE",
     });
   },
+
+  favorite() {
+    return ajax("/user_badges/favorite", {
+      type: "PUT",
+      data: { id: this.id },
+    })
+      .then((json) => {
+        this.set("is_favorite", json.user_badge.is_favorite);
+        return this;
+      })
+      .catch((error) => {
+        throw new Error(error);
+      });
+  },
 });
 
 UserBadge.reopenClass({

--- a/app/assets/javascripts/discourse/app/models/user-badge.js
+++ b/app/assets/javascripts/discourse/app/models/user-badge.js
@@ -22,10 +22,7 @@ const UserBadge = EmberObject.extend({
   },
 
   favorite() {
-    return ajax("/user_badges/favorite", {
-      type: "PUT",
-      data: { id: this.id },
-    })
+    return ajax(`/user_badges/${this.id}/favorite`, { type: "PUT" })
       .then((json) => {
         this.set("is_favorite", json.user_badge.is_favorite);
         return this;
@@ -101,6 +98,8 @@ UserBadge.reopenClass({
       }
       if (json.meta) {
         userBadges.meta = json.meta;
+      } else {
+        userBadges.meta = {};
       }
       return userBadges;
     }

--- a/app/assets/javascripts/discourse/app/models/user-badge.js
+++ b/app/assets/javascripts/discourse/app/models/user-badge.js
@@ -4,6 +4,7 @@ import { Promise } from "rsvp";
 import Topic from "discourse/models/topic";
 import User from "discourse/models/user";
 import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseComputed from "discourse-common/utils/decorators";
 
 const UserBadge = EmberObject.extend({
@@ -29,9 +30,7 @@ const UserBadge = EmberObject.extend({
         this.set("is_favorite", json.user_badge.is_favorite);
         return this;
       })
-      .catch((error) => {
-        throw new Error(error);
-      });
+      .catch(popupAjaxError);
   },
 });
 

--- a/app/assets/javascripts/discourse/app/models/user-badge.js
+++ b/app/assets/javascripts/discourse/app/models/user-badge.js
@@ -100,6 +100,9 @@ UserBadge.reopenClass({
         userBadges.grant_count = json.user_badge_info.grant_count;
         userBadges.username = json.user_badge_info.username;
       }
+      if (json.meta) {
+        userBadges.meta = json.meta;
+      }
       return userBadges;
     }
   },

--- a/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
@@ -5,13 +5,17 @@
   <a href={{url}} class="check-display status-checked">{{d-icon "check"}}</a>
 {{/if}}
 {{#if isFavorite}}
-  <button class="favorite btn btn-default" {{action "favorite"}} type="button">
-    {{i18n "badges.unfavorite"}}
-  </button>
+  {{d-button
+    class="favorite btn btn-default"
+    action=(action "favorite")
+    type="button"
+    label="badges.unfavorite"}}
 {{else if canFavorite}}
-  <button class="favorite btn btn-default" {{action "favorite"}} type="button">
-    {{i18n "badges.favorite"}}
-  </button>
+  {{d-button
+    class="favorite btn btn-default"
+    action=(action "favorite")
+    type="button"
+    label="badges.favorite"}}
 {{/if}}
 <div class="badge-contents" >
   <div class="badge-icon {{badge.badgeTypeClassName}}">

--- a/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
@@ -4,7 +4,14 @@
 {{#if badge.has_badge}}
   <a href={{url}} class="check-display status-checked">{{d-icon "check"}}</a>
 {{/if}}
-<div class="badge-contents">
+<button class="favorite btn btn-default" {{action "favorite"}} type="button">
+  {{#if isFavorite}}
+    {{i18n "badges.unfavorite"}}
+  {{else}}
+    {{i18n "badges.favorite"}}
+  {{/if}}
+</button>
+<div class="badge-contents" >
   <div class="badge-icon {{badge.badgeTypeClassName}}">
     <a href={{url}}>{{icon-or-image badge}}</a>
   </div>

--- a/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
@@ -7,14 +7,14 @@
 {{#if isFavorite}}
   {{d-button
     icon="star"
-    class="favorite btn btn-default"
+    class="favorite"
     action=(action "favorite")
     type="button"
     label="badges.unfavorite"}}
 {{else if canFavorite}}
   {{d-button
     icon="far-star"
-    class="favorite btn btn-default"
+    class="favorite"
     action=(action "favorite")
     type="button"
     label="badges.favorite"}}

--- a/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
@@ -4,13 +4,15 @@
 {{#if badge.has_badge}}
   <a href={{url}} class="check-display status-checked">{{d-icon "check"}}</a>
 {{/if}}
-<button class="favorite btn btn-default" {{action "favorite"}} type="button">
-  {{#if isFavorite}}
+{{#if isFavorite}}
+  <button class="favorite btn btn-default" {{action "favorite"}} type="button">
     {{i18n "badges.unfavorite"}}
-  {{else}}
+  </button>
+{{else if canFavorite}}
+  <button class="favorite btn btn-default" {{action "favorite"}} type="button">
     {{i18n "badges.favorite"}}
-  {{/if}}
-</button>
+  </button>
+{{/if}}
 <div class="badge-contents" >
   <div class="badge-icon {{badge.badgeTypeClassName}}">
     <a href={{url}}>{{icon-or-image badge}}</a>

--- a/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
@@ -6,12 +6,14 @@
 {{/if}}
 {{#if isFavorite}}
   {{d-button
+    icon="star"
     class="favorite btn btn-default"
     action=(action "favorite")
     type="button"
     label="badges.unfavorite"}}
 {{else if canFavorite}}
   {{d-button
+    icon="far-star"
     class="favorite btn btn-default"
     action=(action "favorite")
     type="button"

--- a/app/assets/javascripts/discourse/app/templates/user/badges.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.hbs
@@ -1,6 +1,6 @@
 {{#d-section pageClass="user-badges" class="user-content user-badges-list"}}
   <p class="favorite-count">
-    {{i18n "badges.favorite_count" count=favoriteCount max=maxFavorites}}
+    {{i18n "badges.favorite_count" count=this.favoriteBadges.length max=model.meta.max_favorites}}
   </p>
   {{#each sortedBadges as |ub|}}
     {{badge-card

--- a/app/assets/javascripts/discourse/app/templates/user/badges.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.hbs
@@ -1,11 +1,15 @@
 {{#d-section pageClass="user-badges" class="user-content user-badges-list"}}
+  <p class="favorite-count">
+    {{i18n "badges.favorite_count" count=favoriteCount max=maxFavorites}} {{canFavorite}}
+  </p>
   {{#each sortedBadges as |ub|}}
     {{badge-card
       badge=ub.badge
       count=ub.count
-      username=username
       isFavorite=ub.is_favorite
-      onClick=(action "favorite" ub)
+      username=username
+      canFavorite=canFavorite
+      onFavoriteClick=(action "favorite" ub)
       filterUser="true"}}
   {{/each}}
 {{/d-section}}

--- a/app/assets/javascripts/discourse/app/templates/user/badges.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.hbs
@@ -4,6 +4,8 @@
       badge=ub.badge
       count=ub.count
       username=username
+      isFavorite=ub.is_favorite
+      onClick=(action "favorite" ub)
       filterUser="true"}}
   {{/each}}
 {{/d-section}}

--- a/app/assets/javascripts/discourse/app/templates/user/badges.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.hbs
@@ -1,6 +1,6 @@
 {{#d-section pageClass="user-badges" class="user-content user-badges-list"}}
   <p class="favorite-count">
-    {{i18n "badges.favorite_count" count=favoriteCount max=maxFavorites}} {{canFavorite}}
+    {{i18n "badges.favorite_count" count=favoriteCount max=maxFavorites}}
   </p>
   {{#each sortedBadges as |ub|}}
     {{badge-card

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -564,6 +564,7 @@ export function applyDefaultHandlers(pretender) {
     response(200, fixturesByUrl["/user_badges"])
   );
   pretender.delete("/user_badges/:badge_id", success);
+  pretender.put("/user_badges/:id/favorite", () => response(200, {user_badge: {is_favorite: true}}));
 
   pretender.post("/posts", function (request) {
     const data = parsePostData(request.requestBody);

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -564,7 +564,9 @@ export function applyDefaultHandlers(pretender) {
     response(200, fixturesByUrl["/user_badges"])
   );
   pretender.delete("/user_badges/:badge_id", success);
-  pretender.put("/user_badges/:id/favorite", () => response(200, {user_badge: {is_favorite: true}}));
+  pretender.put("/user_badges/:id/favorite", () =>
+    response(200, { user_badge: { is_favorite: true } })
+  );
 
   pretender.post("/posts", function (request) {
     const data = parsePostData(request.requestBody);

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -564,7 +564,7 @@ export function applyDefaultHandlers(pretender) {
     response(200, fixturesByUrl["/user_badges"])
   );
   pretender.delete("/user_badges/:badge_id", success);
-  pretender.put("/user_badges/:id/favorite", () =>
+  pretender.put("/user_badges/:id/toggle_favorite", () =>
     response(200, { user_badge: { is_favorite: true } })
   );
 

--- a/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
@@ -57,4 +57,10 @@ module("Unit | Model | user-badge", function () {
     const userBadge = UserBadge.create({ id: 1 });
     await userBadge.revoke();
   });
+
+  test("favorite", async function (assert) {
+    assert.expect(0);
+    const userBadge = UserBadge.create({ id: 1 });
+    await userBadge.favorite();
+  });
 });

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -143,6 +143,12 @@
     font-size: $font-up-2;
   }
 
+  .favorite {
+    position: absolute;
+    left: 5px;
+    top: 5px;
+  }
+
   .badge-contents {
     display: flex;
     min-height: 128px;

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -60,6 +60,10 @@
     flex-wrap: wrap;
   }
 
+  &.user-badges-list .favorite-count {
+    flex: 100%;
+  }
+
   .btn.right {
     float: right;
   }

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -98,8 +98,8 @@ class UserBadgesController < ApplicationController
   end
 
   def favorite
-    params.require(:id)
-    user_badge = UserBadge.find(params[:id])
+    params.require(:user_badge_id)
+    user_badge = UserBadge.find(params[:user_badge_id])
     user_badges = user_badge.user.user_badges
 
     unless can_favorite_badge?(user_badge)

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -37,8 +37,7 @@ class UserBadgesController < ApplicationController
     user_badges = user.user_badges
 
     if params[:grouped]
-      user_badges = user_badges.group(:badge_id)
-        .select(UserBadge.attribute_names.map { |x| "MAX(#{x}) AS #{x}" }, 'COUNT(*) AS "count"')
+      user_badges = user_badges.group(:badge_id).select_for_grouping
     end
 
     user_badges = user_badges.includes(badge: [:badge_grouping, :badge_type])

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -46,9 +46,12 @@ class UserBadgesController < ApplicationController
       .includes(post: :topic)
       .includes(:granted_by)
 
-    render_serialized(user_badges, DetailedUserBadgeSerializer, root: :user_badges, meta: {
-                                                                  max_favorites: MAX_FAVORITES,
-                                                                })
+    render_serialized(
+      user_badges,
+      DetailedUserBadgeSerializer,
+      root: :user_badges,
+      meta: { max_favorites: MAX_FAVORITES },
+    )
   end
 
   def create

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -74,7 +74,7 @@ class UserBadgesController < ApplicationController
 
     user_badge = BadgeGranter.grant(badge, user, granted_by: current_user, post_id: post_id)
 
-    render_serialized(user_badge, DetailedUserBadgeSerializer, root: "user_badge")
+    render_serialized(user_badge, DetailedUserBadgeSerializer, root: :user_badge)
   end
 
   def destroy
@@ -88,6 +88,16 @@ class UserBadgesController < ApplicationController
 
     BadgeGranter.revoke(user_badge, revoked_by: current_user)
     render json: success_json
+  end
+
+  def favorite
+    params.require(:id)
+    user_badge = UserBadge.find(params[:id])
+
+    user_badge.update_attribute(:is_favorite, !user_badge.is_favorite)
+    UserBadge.update_featured_ranks!(user_badge.user_id)
+
+    render_serialized(user_badge, DetailedUserBadgeSerializer, root: "user_badge")
   end
 
   private

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -2,6 +2,7 @@
 
 class UserBadgesController < ApplicationController
   MAX_FAVORITES = 2
+  MAX_BADGES = 96 # This was limited in PR#2360 to make it divisible by 8
 
   before_action :ensure_badges_enabled
 
@@ -9,7 +10,7 @@ class UserBadgesController < ApplicationController
     params.permit [:granted_before, :offset, :username]
 
     badge = fetch_badge_from_params
-    user_badges = badge.user_badges.order("granted_at DESC, id DESC").limit(96)
+    user_badges = badge.user_badges.order("granted_at DESC, id DESC").limit(MAX_BADGES)
     user_badges = user_badges.includes(:user, :granted_by, badge: :badge_type, post: :topic, user: :primary_group)
 
     grant_count = nil

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -9,7 +9,7 @@ class UserBadgesController < ApplicationController
     params.permit [:granted_before, :offset, :username]
 
     badge = fetch_badge_from_params
-    user_badges = badge.user_badges.order('granted_at DESC, id DESC').limit(96)
+    user_badges = badge.user_badges.order("granted_at DESC, id DESC").limit(96)
     user_badges = user_badges.includes(:user, :granted_by, badge: :badge_type, post: :topic, user: :primary_group)
 
     grant_count = nil
@@ -47,8 +47,8 @@ class UserBadgesController < ApplicationController
       .includes(:granted_by)
 
     render_serialized(user_badges, DetailedUserBadgeSerializer, root: :user_badges, meta: {
-      max_favorites: MAX_FAVORITES
-    })
+                                                                  max_favorites: MAX_FAVORITES,
+                                                                })
   end
 
   def create
@@ -64,7 +64,7 @@ class UserBadgesController < ApplicationController
 
     if params[:reason].present?
       unless is_badge_reason_valid? params[:reason]
-        return render json: failed_json.merge(message: I18n.t('invalid_grant_badge_reason_link')), status: 400
+        return render json: failed_json.merge(message: I18n.t("invalid_grant_badge_reason_link")), status: 400
       end
 
       if route = Discourse.route_for(params[:reason])
@@ -102,9 +102,9 @@ class UserBadgesController < ApplicationController
     if !user_badge.is_favorite && user_badges.where(is_favorite: true).count >= MAX_FAVORITES
       render json: failed_json, status: 403
     else
-      user_badge.update_attribute(:is_favorite, !user_badge.is_favorite)
+      user_badge.toggle!(:is_favorite)
       UserBadge.update_featured_ranks!(user_badge.user_id)
-      render_serialized(user_badge, DetailedUserBadgeSerializer, root: "user_badge")
+      render_serialized(user_badge, DetailedUserBadgeSerializer, root: :user_badge)
     end
   end
 
@@ -137,6 +137,6 @@ class UserBadgesController < ApplicationController
 
   def is_badge_reason_valid?(reason)
     route = Discourse.route_for(reason)
-    route && (route[:controller] == 'posts' || route[:controller] == 'topics')
+    route && (route[:controller] == "posts" || route[:controller] == "topics")
   end
 end

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -97,7 +97,7 @@ class UserBadgesController < ApplicationController
     render json: success_json
   end
 
-  def favorite
+  def toggle_favorite
     params.require(:user_badge_id)
     user_badge = UserBadge.find(params[:user_badge_id])
     user_badges = user_badge.user.user_badges

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -18,7 +18,7 @@ class UserBadge < ActiveRecord::Base
     select(
       UserBadge.attribute_names.map do |x|
         if x == 'is_favorite'
-          "BOOL_OR(user_badges.#{x})"
+          "BOOL_OR(user_badges.#{x}) AS is_favorite"
         else
           "MAX(user_badges.#{x}) AS #{x}"
         end
@@ -74,6 +74,7 @@ class UserBadge < ActiveRecord::Base
             PARTITION BY user_badges.user_id -- Do a separate rank for each user
             ORDER BY BOOL_OR(badges.enabled) DESC, -- Disabled badges last
                     MAX(featured_tl_badge.user_id) NULLS LAST, -- Best tl badge first
+                    BOOL_OR(user_badges.is_favorite) DESC NULLS LAST, -- Favorite badges next
                     CASE WHEN user_badges.badge_id IN (1,2,3,4) THEN 1 ELSE 0 END ASC, -- Non-featured tl badges last
                     MAX(badges.badge_type_id) ASC,
                     MAX(badges.grant_count) ASC,

--- a/app/serializers/detailed_user_badge_serializer.rb
+++ b/app/serializers/detailed_user_badge_serializer.rb
@@ -3,7 +3,7 @@
 class DetailedUserBadgeSerializer < BasicUserBadgeSerializer
   has_one :granted_by, serializer: UserBadgeSerializer::UserSerializer
 
-  attributes :post_number, :topic_id, :topic_title
+  attributes :post_number, :topic_id, :topic_title, :is_favorite
 
   def include_post_number?
     object.post

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3505,6 +3505,9 @@ en:
           name: Other
         posting:
           name: Posting
+      favorite: "Favorite"
+      unfavorite: "Unfavorite"
+      favorite_count: "%{count}/%{max} badges marked as favorite"
 
     tagging:
       all_tags: "All Tags"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -662,7 +662,7 @@ Discourse::Application.routes.draw do
     resources :badges, only: [:index]
     get "/badges/:id(/:slug)" => "badges#show", constraints: { format: /(json|html|rss)/ }
     resources :user_badges, only: [:index, :create, :destroy] do
-      put "favorite" => "user_badges#favorite", constraints: { format: :json }
+      put "toggle_favorite" => "user_badges#toggle_favorite", constraints: { format: :json }
     end
 
     get '/c', to: redirect(relative_url_root + 'categories')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -662,6 +662,7 @@ Discourse::Application.routes.draw do
     resources :badges, only: [:index]
     get "/badges/:id(/:slug)" => "badges#show", constraints: { format: /(json|html|rss)/ }
     resources :user_badges, only: [:index, :create, :destroy]
+    put "/user_badges/favorite" => "user_badges#favorite", constraints: { format: :json }
 
     get '/c', to: redirect(relative_url_root + 'categories')
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -662,7 +662,7 @@ Discourse::Application.routes.draw do
     resources :badges, only: [:index]
     get "/badges/:id(/:slug)" => "badges#show", constraints: { format: /(json|html|rss)/ }
     resources :user_badges, only: [:index, :create, :destroy]
-    put "/user_badges/favorite" => "user_badges#favorite", constraints: { format: :json }
+    put "/user_badges/:id/favorite" => "user_badges#favorite", constraints: { format: :json }
 
     get '/c', to: redirect(relative_url_root + 'categories')
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -661,8 +661,9 @@ Discourse::Application.routes.draw do
 
     resources :badges, only: [:index]
     get "/badges/:id(/:slug)" => "badges#show", constraints: { format: /(json|html|rss)/ }
-    resources :user_badges, only: [:index, :create, :destroy]
-    put "/user_badges/:id/favorite" => "user_badges#favorite", constraints: { format: :json }
+    resources :user_badges, only: [:index, :create, :destroy] do
+      put "favorite" => "user_badges#favorite", constraints: { format: :json }
+    end
 
     get '/c', to: redirect(relative_url_root + 'categories')
 

--- a/db/migrate/20210218144656_add_is_favorite_to_user_badge.rb
+++ b/db/migrate/20210218144656_add_is_favorite_to_user_badge.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIsFavoriteToUserBadge < ActiveRecord::Migration[6.0]
+  def change
+    add_column :user_badges, :is_favorite, :boolean
+    add_index :user_badges, :is_favorite
+  end
+end

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -110,6 +110,7 @@ module SvgSprite
     "far-moon",
     "far-smile",
     "far-square",
+    "far-star",
     "far-sun",
     "far-thumbs-down",
     "far-thumbs-up",

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -267,4 +267,41 @@ describe UserBadgesController do
       expect(events).to include(:user_badge_removed)
     end
   end
+
+  context 'favorite' do
+    let!(:user_badge) { UserBadge.create(badge: badge, user: user, granted_by: Discourse.system_user, granted_at: Time.now) }
+
+    it 'checks that the user is authorized to favorite the badge' do
+      sign_in(Fabricate(:admin))
+      put "/user_badges/#{user_badge.id}/favorite.json"
+      expect(response.status).to eq(403)
+    end
+
+    it 'checks that the user has less than two favorited badges' do
+      sign_in(user)
+      UserBadge.create(badge: Fabricate(:badge), user: user, granted_by: Discourse.system_user, granted_at: Time.now, is_favorite: true)
+      UserBadge.create(badge: Fabricate(:badge), user: user, granted_by: Discourse.system_user, granted_at: Time.now, is_favorite: true)
+      put "/user_badges/#{user_badge.id}/favorite.json"
+      expect(response.status).to eq(400)
+    end
+
+    it 'favorites a badge' do
+      sign_in(user)
+      put "/user_badges/#{user_badge.id}/favorite.json"
+      expect(response.status).to eq(200)
+
+      user_badge = UserBadge.find_by(user: user, badge: badge)
+      expect(user_badge.is_favorite).to be true
+    end
+
+    it 'unfavorites a badge' do
+      sign_in(user)
+      user_badge.toggle!(:is_favorite)
+      put "/user_badges/#{user_badge.id}/favorite.json"
+      expect(response.status).to eq(200)
+
+      user_badge = UserBadge.find_by(user: user, badge: badge)
+      expect(user_badge.is_favorite).to be false
+    end
+  end
 end


### PR DESCRIPTION
Right now, we select the best 3 badges for the user to be shown in their user card. But it’s not always the ones the users are most proud of. This features provides a way for users to select up to 2 badges that will be showcased in their user badge.

cc @ZogStriP 

![image](https://user-images.githubusercontent.com/3116474/109851717-4912d480-7c54-11eb-94d0-91de507efecf.png)

![image](https://user-images.githubusercontent.com/3116474/109851877-765f8280-7c54-11eb-96a9-220e8eb0c610.png)

![image](https://user-images.githubusercontent.com/3116474/111639837-e5fc7280-87fb-11eb-997b-85585f247dc3.png)

