### PR TITLE
FIX: Typo in emoji path caused by 83f332b

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/settings.js
+++ b/app/assets/javascripts/discourse/app/lib/settings.js
@@ -12,6 +12,6 @@ export function emojiBasePath() {
   let siteSettings = helperContext().siteSettings;
 
   return siteSettings.external_emoji_url === ""
-    ? "/images/emojis"
+    ? "/images/emoji"
     : siteSettings.external_emoji_url;
 }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
