### PR TITLE
FIX: Mobile app notification urls w/ subfolder

### DIFF
--- a/app/jobs/regular/push_notification.rb
+++ b/app/jobs/regular/push_notification.rb
@@ -4,7 +4,7 @@ module Jobs
   class PushNotification < ::Jobs::Base
     def execute(args)
       notification = args["payload"]
-      notification["url"] = UrlHelper.absolute_without_cdn(notification["post_url"])
+      notification["url"] = UrlHelper.absolute_without_cdn(Discourse.base_path + notification["post_url"])
       notification.delete("post_url")
 
       payload = {

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1645,7 +1645,7 @@ RSpec.describe TopicsController do
       end
     end
 
-    it 'correctly renders canoicals' do
+    it 'correctly renders canonicals' do
       get "/t/#{topic.id}", params: { slug: topic.slug }
 
       expect(response.status).to eq(200)

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -768,6 +768,7 @@ describe PostAlerter do
           { status: 200, body: "OK" }
         end
 
+      set_subfolder "/subpath"
       payload = {
         "secret_key" => SiteSetting.push_api_secret_key,
         "url" => Discourse.base_url,
@@ -781,7 +782,7 @@ describe PostAlerter do
           'topic_id' => topic.id,
           'excerpt' => 'Hello @eviltrout ❤',
           'username' => user.username,
-          'url' => UrlHelper.absolute(mention_post.url),
+          'url' => UrlHelper.absolute(Discourse.base_path + mention_post.url),
           'client_id' => 'xxx0'
         },
         {
@@ -791,7 +792,7 @@ describe PostAlerter do
           'topic_id' => topic.id,
           'excerpt' => 'Hello @eviltrout ❤',
           'username' => user.username,
-          'url' => UrlHelper.absolute(mention_post.url),
+          'url' => UrlHelper.absolute(Discourse.base_path + mention_post.url),
           'client_id' => 'xxx1'
         }
         ]
@@ -815,7 +816,7 @@ describe PostAlerter do
         "post_number" => new_post.post_number,
         "username" => new_post.user.username,
         "excerpt" => new_post.raw,
-        "url" => UrlHelper.absolute(new_post.url)
+        "url" => UrlHelper.absolute(Discourse.base_path + new_post.url)
       }
 
       payload["notifications"][0].merge! changes
@@ -829,7 +830,7 @@ describe PostAlerter do
         "post_number" => new_post.post_number,
         "username" => new_post.user.username,
         "excerpt" => new_post.raw,
-        "url" => UrlHelper.absolute(new_post.url)
+        "url" => UrlHelper.absolute(Discourse.base_path + new_post.url)
       }
 
       payload["notifications"][0].merge! changes


### PR DESCRIPTION
The urls that we generate for mobile post notifications don't take into
account the subfolder url if a site happens to have one configured. When
this happens when you tap on a new mobile notification it takes you to
a url that doesn't work because it is missing the subfolder portion.

I honestly think this should be handled in the Post model like we do
with the Topic model. `Post.url` should know how to handle subfolder
installs, but that seemed like a very risky change because there are
lots of other places in the codebase where we tack on the base_path and
I didn't want to risk duplicating it.

I also found a small typo in the topics controller spec.
