### PR TITLE
FIX: subfolder prefix should work even if url starts with the prefix

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-url.js
@@ -3,8 +3,7 @@ let S3BaseUrl, S3CDN;
 
 export default function getURL(url) {
   if (baseUri === undefined) {
-    baseUri = $('meta[name="discourse-base-uri"]').attr("content") || "";
-    baseUriMatcher = new RegExp(`^${baseUri}`);
+    setPrefix($('meta[name="discourse-base-uri"]').attr("content") || "");
   }
 
   if (!url) {
@@ -16,7 +15,7 @@ export default function getURL(url) {
     return url;
   }
 
-  const found = url.startsWith(baseUri);
+  const found = baseUriMatcher.test(url);
 
   if (found) {
     return url;
@@ -51,20 +50,19 @@ export function withoutPrefix(path) {
   if (!baseUri) {
     return path;
   } else {
-    return path.replace(baseUriMatcher, "");
+    return path.replace(baseUriMatcher, "$1");
   }
 }
 
 export function setPrefix(configBaseUri) {
   baseUri = configBaseUri;
-  baseUriMatcher = new RegExp(`^${baseUri}`);
+  baseUriMatcher = new RegExp(`^${baseUri}(/|$)`);
 }
 
 export function setupURL(configCdn, configBaseUrl, configBaseUri) {
   cdn = configCdn;
   baseUrl = configBaseUrl;
-  baseUri = configBaseUri;
-  baseUriMatcher = new RegExp(`^${baseUri}`);
+  setPrefix(configBaseUri);
 }
 
 export function setupS3CDN(configS3BaseUrl, configS3CDN) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
@@ -37,6 +37,11 @@ module("Unit | Utility | get-url", function () {
     assert.equal(withoutPrefix("/eviltrout/hello"), "/eviltrout/hello");
     assert.equal(withoutPrefix("/eviltrout"), "/eviltrout");
     assert.equal(withoutPrefix("/"), "/");
+
+    setPrefix("/f");
+    assert.equal(withoutPrefix("/faq"), "/faq");
+    assert.equal(withoutPrefix("/f/faq"), "/faq");
+    assert.equal(withoutPrefix("/f"), "");
   });
 
   test("withoutPrefix called multiple times on the same path", function (assert) {
@@ -118,6 +123,18 @@ module("Unit | Utility | get-url", function () {
     assert.equal(
       getURL("/forum/t/123"),
       "/forum/t/123",
+      "does not prefix if the URL is already prefixed"
+    );
+
+    setPrefix("/f");
+    assert.equal(
+      getURL("/faq"),
+      "/f/faq",
+      "relative path has subfolder even if it starts with the prefix without trailing slash"
+    );
+    assert.equal(
+      getURL("/f/faq"),
+      "/f/faq",
       "does not prefix if the URL is already prefixed"
     );
   });


### PR DESCRIPTION
Issue was reported on https://meta.discourse.org/t/-/181798

DEV: test getURL for urls starting with the prefix without trailing slash

I tried to avoid more friction so `withoutPrefix(prefix)` now returns "/" instead of "", which is consistent to other results – but it can be addressed if needed.