### PR TITLE
DEV: add `discourse_dev` gem in development dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ copyright
 
 yarn-error.log
 tags
+
+# file used with `discourse_dev` gem in development environment.
+config/dev.yml

--- a/Gemfile
+++ b/Gemfile
@@ -177,6 +177,7 @@ group :development do
   gem 'binding_of_caller'
   gem 'yaml-lint'
   gem 'annotate'
+  gem 'discourse_dev'
 end
 
 # this is an optional gem, it provides a high performance replacement

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       railties (>= 3.1)
     discourse-ember-source (3.12.2.2)
     discourse-fonts (0.0.7)
-    discourse_dev (0.0.1)
+    discourse_dev (0.0.2)
       faker (~> 2.16)
     discourse_image_optim (0.26.2)
       exifr (~> 1.2, >= 1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       railties (>= 3.1)
     discourse-ember-source (3.12.2.2)
     discourse-fonts (0.0.7)
+    discourse_dev (0.0.1)
+      faker (~> 2.16)
     discourse_image_optim (0.26.2)
       exifr (~> 1.2, >= 1.2.2)
       fspath (~> 3.0)
@@ -135,6 +137,8 @@ GEM
     execjs (2.7.0)
     exifr (1.3.9)
     fabrication (2.21.1)
+    faker (2.16.0)
+      i18n (>= 1.6, < 2)
     fakeweb (1.3.0)
     faraday (1.3.0)
       faraday-net_http (~> 1.0)
@@ -499,6 +503,7 @@ DEPENDENCIES
   discourse-ember-rails (= 0.18.6)
   discourse-ember-source (~> 3.12.2)
   discourse-fonts
+  discourse_dev
   discourse_image_optim
   email_reply_trimmer
   ember-handlebars-template (= 0.8.0)

--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -54,6 +54,11 @@ module I18n
         # load it
         I18n.backend.load_translations(I18n.load_path.grep(/\.#{Regexp.escape locale}\.yml$/))
 
+        if Rails.env.development?
+          I18n.backend.load_translations(I18n.load_path.grep(/.*faker.*\/#{Regexp.escape locale}\.yml$/))
+          I18n.backend.load_translations(I18n.load_path.grep(/.*faker.*\/#{Regexp.escape locale}\/.*\.yml$/))
+        end
+
         @loaded_locales << locale
       end
     end


### PR DESCRIPTION
For more details visit https://github.com/discourse/discourse_dev
