### PR TITLE
FIX: Ensure UserField changes are reflected instantly in webhooks

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -110,7 +110,7 @@ class WebHook < ActiveRecord::Base
   private
 
   def self.guardian
-    @guardian ||= Guardian.new(Discourse.system_user)
+    Guardian.new(Discourse.system_user)
   end
 end
 

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -377,6 +377,14 @@ describe WebHook do
       payload = JSON.parse(job_args["payload"])
       expect(payload["id"]).to eq(user.id)
       expect(payload["email"]).to eq(email)
+
+      # Reflects runtime change to user field
+      user_field = Fabricate(:user_field, show_on_profile: true)
+      user.logged_in
+      job_args = Jobs::EmitWebHookEvent.jobs.last["args"].first
+      expect(job_args["event_name"]).to eq("user_logged_in")
+      payload = JSON.parse(job_args["payload"])
+      expect(payload["user_fields"].size).to eq(1)
     end
 
     it 'should enqueue the right hooks for category events' do


### PR DESCRIPTION
The Guardian object memoizes a list of allowed user fields. Normally this is fine because Guardian objects only persist for a single request. However, the WebHook class was memoizing a guardian at the class level. This meant that an app restart was required for changes to be reflected. Plus, the Guardian was being shared across all sites in a multisite instance.

Initializing a guardian is cheap, so we can manage without memoization here.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
