### PR TITLE
DEV: use Redis data for version check in DiscourseUpdates

### DIFF
--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -130,7 +130,7 @@ module DiscourseUpdates
       return nil if entries.nil?
 
       entries.select! do |item|
-        item["discourse_version"].nil? || Discourse.has_needed_version?(Discourse::VERSION::STRING, item["discourse_version"]) rescue nil
+        item["discourse_version"].nil? || Discourse.has_needed_version?(last_installed_version, item["discourse_version"]) rescue nil
       end
 
       entries.sort_by { |item| Time.zone.parse(item["created_at"]).to_i }.reverse


### PR DESCRIPTION
A version bump caused the specs to fail, this switches to using the version stored in Redis, which is also what is stubbed in the specs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
