### PR TITLE
DEV: bump `discourse_dev` gem to version `0.0.3`.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       railties (>= 3.1)
     discourse-ember-source (3.12.2.2)
     discourse-fonts (0.0.7)
-    discourse_dev (0.0.2)
+    discourse_dev (0.0.3)
       faker (~> 2.16)
     discourse_image_optim (0.26.2)
       exifr (~> 1.2, >= 1.2.2)


### PR DESCRIPTION
Added a commit to fix the issue in `bundle install`.