### PR TITLE
UX: clean up tag styles to improve alignment

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -242,7 +242,6 @@
               align-items: center;
             }
             .discourse-tags {
-              display: inline-block;
               font-size: $font-down-1;
             }
           }

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -68,8 +68,6 @@
         align-items: center;
 
         .discourse-tags {
-          display: flex;
-          flex-wrap: wrap;
           .discourse-tag {
             margin-right: 0.25em;
           }

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -88,7 +88,6 @@
   &.simple,
   &.simple:visited,
   &.simple:hover {
-    margin-right: 0;
     color: var(--primary-high);
   }
 
@@ -123,11 +122,18 @@
 
 .d-header .topic-header-extra {
   .discourse-tags {
-    display: inline-block;
     font-size: $font-down-1;
   }
   .discourse-tags + .topic-featured-link {
     margin-left: 8px;
+  }
+}
+
+.discourse-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  a {
+    margin-right: 0.25em;
   }
 }
 
@@ -137,14 +143,9 @@
 
 .topic-list-item {
   .discourse-tags {
-    display: inline-flex;
     font-weight: normal;
     font-size: $font-down-1;
   }
-}
-
-.categories-list .topic-list-latest .discourse-tags {
-  display: inline-block;
 }
 
 .mobile-view .topic-list-item .discourse-tags {

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -143,7 +143,6 @@
   }
 
   .discourse-tags {
-    display: inline-block;
     .discourse-tag {
       font-size: $font-down-1;
     }

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -210,7 +210,6 @@
         align-items: center;
 
         .discourse-tags {
-          flex-wrap: wrap;
           font-size: $font-down-1;
         }
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1681963/110179934-e72ea800-7dd6-11eb-8c1d-c16bcdc8729b.png)

We're handling tags in a bunch of different ways, here I'm centralizing the styles a bit more (specifically `display`) so they align more consistently throughout. This fixes the above issue along with a similar alignment issue on some category page styles.  