### PR TITLE
FIX: delete post action from permanently deleted posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -34,7 +34,7 @@ class Post < ActiveRecord::Base
 
   has_many :post_replies
   has_many :replies, through: :post_replies
-  has_many :post_actions
+  has_many :post_actions, dependent: :destroy
   has_many :topic_links
   has_many :group_mentions, dependent: :destroy
 

--- a/db/migrate/20210308010745_delete_orphan_post_actions.rb
+++ b/db/migrate/20210308010745_delete_orphan_post_actions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DeleteOrphanPostActions < ActiveRecord::Migration[6.0]
+  def up
+    sql = <<~SQL
+      DELETE FROM post_actions
+      USING post_actions pa
+      LEFT JOIN posts ON posts.id = pa.post_id
+      WHERE posts.id IS NULL
+      AND post_actions.id = pa.id
+    SQL
+
+    execute(sql)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
When Post is permanently deleted, we should delete correlated PostAction as well.
