### PR TITLE
UX: Add class to email div on login

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -21,7 +21,7 @@
           <div class="login-form">
 
             <form>
-              <div class="input-group">
+              <div class="input-group create-account-email">
                 {{#if emailValidated}}
                   <span class="value">{{accountEmail}}</span>
                 {{else}}


### PR DESCRIPTION
This commit adds a `create-account-email` class to the email div of the create account modal.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
