### PR TITLE
FEATURE: Admins can flag posts so they can review them later.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flag-selection.js
+++ b/app/assets/javascripts/discourse/app/components/flag-selection.js
@@ -12,7 +12,10 @@ export default Component.extend({
       return;
     }
 
-    this.element.querySelector("#radio_" + nameKey).checked = "true";
+    const selector = this.element.querySelector("#radio_" + nameKey);
+    if (selector) {
+      selector.checked = "true";
+    }
   },
 
   @observes("nameKey")

--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -266,6 +266,17 @@ export default Controller.extend(ModalFunctionality, {
       this.set("model.hidden", true);
     },
 
+    flagForReview() {
+      const notifyModeratorsID = 7;
+      const notifyModerators = this.flagsAvailable.find(
+        (f) => f.id === notifyModeratorsID
+      );
+      this.set("selected", notifyModerators);
+
+      this.send("createFlag", { queue_for_review: true });
+      this.set("model.hidden", true);
+    },
+
     changePostActionType(action) {
       this.set("selected", action);
     },

--- a/app/assets/javascripts/discourse/app/models/action-summary.js
+++ b/app/assets/javascripts/discourse/app/models/action-summary.js
@@ -53,6 +53,7 @@ export default RestModel.extend({
         message: opts.message,
         is_warning: opts.isWarning,
         take_action: opts.takeAction,
+        queue_for_review: opts.queue_for_review,
         flag_topic: this.flagTopic ? true : false,
       },
       returnXHR: true,

--- a/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
@@ -40,6 +40,13 @@
         performAction=(action "takeAction")
         reviewableUpdating=submitDisabled
     }}
+
+    {{d-button
+      class="btn-danger"
+      action=(action "flagForReview")
+      icon="exclamation-triangle"
+      label="flagging.flag_for_review"
+    }}
   {{/if}}
 
   {{#if showDeleteSpammer}}

--- a/app/controllers/post_actions_controller.rb
+++ b/app/controllers/post_actions_controller.rb
@@ -16,7 +16,8 @@ class PostActionsController < ApplicationController
       is_warning: params[:is_warning],
       message: params[:message],
       take_action: params[:take_action] == 'true',
-      flag_topic: params[:flag_topic] == 'true'
+      flag_topic: params[:flag_topic] == 'true',
+      queue_for_review: params[:queue_for_review] == 'true'
     )
     result = creator.perform
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -521,7 +521,7 @@ class Post < ActiveRecord::Base
       (topic.present? && (topic.private_message? || topic.category&.read_restricted))
   end
 
-  def hide!(post_action_type_id, reason = nil)
+  def hide!(post_action_type_id, reason = nil, custom_message: nil)
     return if hidden?
 
     reason ||= hidden_at ?
@@ -553,11 +553,16 @@ class Post < ActiveRecord::Base
         )
       }
 
+      message = custom_message
+      if message.nil?
+        message = hiding_again ? :post_hidden_again : :post_hidden
+      end
+
       Jobs.enqueue_in(
         5.seconds,
         :send_system_message,
         user_id: user.id,
-        message_type: hiding_again ? :post_hidden_again : :post_hidden,
+        message_type: message,
         message_options: options
       )
     end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3242,6 +3242,7 @@ en:
       notify_action: "Message"
       official_warning: "Official Warning"
       delete_spammer: "Delete Spammer"
+      flag_for_review: "Flag Post"
 
       # keys ending with _MF use message format, see https://meta.discourse.org/t/message-format-support-for-localization/7035 for details
       delete_confirm_MF: "You are about to delete {POSTS, plural, one {<b>#</b> post} other {<b>#</b> posts}} and {TOPICS, plural, one {<b>#</b> topic} other {<b>#</b> topics}} from this user, remove their account, block signups from their IP address <b>{ip_address}</b>, and add their email address <b>{email}</b> to a permanent block list. Are you sure this user is really a spammer?"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2824,6 +2824,20 @@ en:
         The community flagged this post and now it is hidden. **Because this post has been hidden more than once, your post will now remain hidden until it is handled by a staff member.**
 
         For additional guidance, please refer to our [community guidelines](%{base_url}/guidelines).
+    
+    queued_by_staff:
+      title: "Post Needs Approval"
+      subject_template: "Post hidden by staff, awaiting approval"
+      text_body_template: |
+        Hello,
+
+        This is an automated message from %{site_name} to let you know that your post was hidden.
+        
+        <%{base_url}%{url}>
+
+        Your post will remain hidden until a staff member reviews it.
+
+        For additional guidance, please refer to our [community guidelines](%{base_url}/guidelines).
 
     flags_disagreed:
       title: "Flagged post restored by staff"
@@ -4911,6 +4925,7 @@ en:
       email_spam: "This email was flagged as spam by the header defined in `email_in_spam_header`."
       suspect_user: "This new user entered profile information without reading any topics or posts, which strongly suggests they may be a spammer. See `approve_suspect_users`."
       contains_media: "This post includes embedded media. See `review_media_unless_trust_level`."
+      queued_by_staff: "A staff member thinks this post needs review. It'll remain hidden until then."
 
     actions:
       agree:


### PR DESCRIPTION
Staff can send a post to the review queue by clicking the "Flag Post" button next to "Take Action...". Clicking it flags the post using the "Notify moderators" score type and hides it. A custom message will be sent to the user.
