### PR TITLE
DEV: freeze time when running rate limiter tests

### DIFF
--- a/spec/components/middleware/request_tracker_spec.rb
+++ b/spec/components/middleware/request_tracker_spec.rb
@@ -151,6 +151,10 @@ describe Middleware::RequestTracker do
 
       @old_logger = Rails.logger
       Rails.logger = TestLogger.new
+
+      # rate limiter tests depend on checks for retry-after
+      # they can be sensitive to clock skew during test runs
+      freeze_time DateTime.parse('2021-01-01 01:00')
     end
 
     after do


### PR DESCRIPTION
This avoids issues around clock skew making retry-after return 9 instead of
10
