### PR TITLE
FIX: Do not add same email multiple times

### DIFF
--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -41,10 +41,10 @@ class EmailUpdater
       UserHistory.create!(action: UserHistory.actions[:add_email], acting_user_id: @user.id)
     end
 
-    change_req = EmailChangeRequest.find_or_initialize_by(
-      user_id: @user.id, new_email: email, requested_by: @guardian.user
-    )
+    change_req = EmailChangeRequest.find_or_initialize_by(user_id: @user.id, new_email: email)
+
     if change_req.new_record?
+      change_req.requested_by = @guardian.user
       change_req.old_email = old_email
       change_req.new_email = email
     end

--- a/spec/components/email_updater_spec.rb
+++ b/spec/components/email_updater_spec.rb
@@ -17,6 +17,15 @@ describe EmailUpdater do
     expect(updater.errors.messages[:base].first).to be I18n.t("change_email.error_staged")
   end
 
+  it "does not create multiple email change requests" do
+    user = Fabricate(:user)
+
+    EmailUpdater.new(guardian: Fabricate(:admin).guardian, user: user).change_to(new_email)
+    EmailUpdater.new(guardian: Fabricate(:admin).guardian, user: user).change_to(new_email)
+
+    expect(user.email_change_requests.count).to eq(1)
+  end
+
   context "when an admin is changing the email of another user" do
     let(:admin) { Fabricate(:admin) }
     let(:updater) { EmailUpdater.new(guardian: admin.guardian, user: user) }

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2852,6 +2852,18 @@ describe UsersController do
       expect(event[:event_name]).to eq(:user_updated)
       expect(event[:params].first).to eq(user)
     end
+
+    it "can destroy duplicate emails" do
+      EmailChangeRequest.create!(
+        user: user,
+        new_email: user.email,
+        change_state: EmailChangeRequest.states[:authorizing_new]
+      )
+
+      delete "/u/#{user.username}/preferences/email.json", params: { email: user_email.email }
+
+      expect(user.email_change_requests).to be_empty
+    end
   end
 
   describe '#is_local_username' do


### PR DESCRIPTION
The user and an admin could create multiple email change requests for
the same user. If any of the requests was validated and it became
primary, the other request could not be deleted anymore.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
