### PR TITLE
UX: pasting a twitter link into composer title will not set the title

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-title.js
+++ b/app/assets/javascripts/discourse/app/components/composer-title.js
@@ -153,10 +153,16 @@ export default Component.extend({
       this.set("composer.featuredLink", this.get("composer.title"));
 
       const $h = $(html),
-        heading = $h.find("h3").length > 0 ? $h.find("h3") : $h.find("h4"),
         composer = this.composer;
 
       composer.appendText(this.get("composer.title"), null, { block: true });
+
+      if ($h.hasClass("twitterstatus")) {
+        this.set("composer.title", "");
+        return;
+      }
+
+      const heading = $h.find("h3").length > 0 ? $h.find("h3") : $h.find("h4");
 
       if (heading.length > 0 && heading.text().length > 0) {
         this.changeTitle(heading.text());

--- a/app/assets/javascripts/discourse/app/components/composer-title.js
+++ b/app/assets/javascripts/discourse/app/components/composer-title.js
@@ -167,8 +167,10 @@ export default Component.extend({
       if (heading && heading.textContent) {
         this.changeTitle(heading.textContent);
       } else {
-        const firstTitle = frag.firstChild.attributes.title ||
-          (frag.querySelector("[title]") && frag.querySelector("[title]").attributes.title);
+        const firstTitle =
+          frag.firstChild.attributes.title ||
+          (frag.querySelector("[title]") &&
+            frag.querySelector("[title]").attributes.title);
 
         if (firstTitle) {
           this.changeTitle(firstTitle);

--- a/app/assets/javascripts/discourse/app/components/composer-title.js
+++ b/app/assets/javascripts/discourse/app/components/composer-title.js
@@ -149,11 +149,11 @@ export default Component.extend({
 
   _updatePost(html) {
     if (html) {
-      this.set("autoPosted", true);
-      this.set("composer.featuredLink", this.get("composer.title"));
-
       const frag = document.createRange().createContextualFragment(html),
         composer = this.composer;
+
+      this.set("autoPosted", true);
+      this.set("composer.featuredLink", this.get("composer.title"));
 
       composer.appendText(this.get("composer.title"), null, { block: true });
 
@@ -168,7 +168,9 @@ export default Component.extend({
         this.changeTitle(heading.textContent);
       } else {
         const firstTitle =
-          frag.firstChild.attributes.title ||
+          (frag.firstChild &&
+            frag.firstChild.attributes &&
+            frag.firstChild.attributes.title) ||
           (frag.querySelector("[title]") &&
             frag.querySelector("[title]").attributes.title);
 

--- a/app/assets/javascripts/discourse/app/components/composer-title.js
+++ b/app/assets/javascripts/discourse/app/components/composer-title.js
@@ -152,23 +152,25 @@ export default Component.extend({
       this.set("autoPosted", true);
       this.set("composer.featuredLink", this.get("composer.title"));
 
-      const $h = $(html),
+      const frag = document.createRange().createContextualFragment(html),
         composer = this.composer;
 
       composer.appendText(this.get("composer.title"), null, { block: true });
 
-      if ($h.hasClass("twitterstatus")) {
+      if (frag.querySelector(".twitterstatus")) {
         this.set("composer.title", "");
         return;
       }
 
-      const heading = $h.find("h3").length > 0 ? $h.find("h3") : $h.find("h4");
+      const heading = frag.querySelector("h3, h4");
 
-      if (heading.length > 0 && heading.text().length > 0) {
-        this.changeTitle(heading.text());
+      if (heading && heading.textContent) {
+        this.changeTitle(heading.textContent);
       } else {
-        const firstTitle = $h.attr("title") || $h.find("[title]").attr("title");
-        if (firstTitle && firstTitle.length > 0) {
+        const firstTitle = frag.firstChild.attributes.title ||
+          (frag.querySelector("[title]") && frag.querySelector("[title]").attributes.title);
+
+        if (firstTitle) {
           this.changeTitle(firstTitle);
         }
       }

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
@@ -135,6 +135,24 @@ acceptance("Composer topic featured links", function (needs) {
       "title is unchanged"
     );
   });
+
+  test("blank title for Twitter link", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    await fillIn(
+      "#reply-title",
+      "https://twitter.com/discourse/status/1357664660724482048"
+    );
+    assert.ok(
+      queryAll(".d-editor-preview").html().trim().indexOf("onebox") > 0,
+      "it pastes the link into the body and previews it"
+    );
+    assert.ok(
+      exists(".d-editor-textarea-wrapper .popup-tip.good"),
+      "the body is now good"
+    );
+    assert.blank(queryAll(".title-input input").val(), "title is blank");
+  });
 });
 
 acceptance(

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -864,6 +864,36 @@ export function applyDefaultHandlers(pretender) {
   `,
       ];
     }
+
+    if (
+      request.queryParams.url ===
+      "https://twitter.com/discourse/status/1357664660724482048"
+    ) {
+      return [
+        200,
+        { "Content-Type": "application/html" },
+        `
+        <aside class="onebox twitterstatus">
+          <header class="source">
+              <a href="https://twitter.com/discourse/status/1357664660724482048" target="_blank" rel="nofollow ugc noopener">twitter.com</a>
+          </header>
+          <article class="onebox-body">
+            <img src="https://pbs.twimg.com/media/EtdhY-ZXYAAKyvo.jpg:large" class="thumbnail onebox-avatar">
+        <h4><a href="https://twitter.com/discourse/status/1357664660724482048" target="_blank" rel="nofollow ugc noopener">Discourse (discourse)</a></h4>
+        <div class="tweet"> Too busy to keep up with release notes? https://t.co/FQtGI5VrMl</div>
+        <div class="date">
+          <a href="https://twitter.com/discourse/status/1357664660724482048" target="_blank" rel="nofollow ugc noopener">4:17 AM - 5 Feb 2021</a>
+            <span class="like">8</span>
+            <span class="retweet">1</span>
+        </div>
+          </article>
+          <div class="onebox-metadata"></div>
+          <div style="clear: both"></div>
+        </aside>
+        `,
+      ];
+    }
+
     return [404, { "Content-Type": "application/html" }, ""];
   });
 }


### PR DESCRIPTION
The title of Twitter oneboxes is always the name of the Twitter user,
which is not a descriptive topic title. Leave the title field blank so
that users must enter their own title.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
