### PR TITLE
UX: Fix broken styling on login modal when local login is disabled.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/login.hbs
@@ -73,13 +73,16 @@
       </div>
     {{/if}}
     {{#if showLoginButtons}}
-      <div class="login-right-side">
-        {{#if noLoginLocal}}
+      {{#if noLoginLocal}}
+        <div class="login-left-side">
           <div class="login-welcome-header">
             <h1 class="login-title">{{i18n "login.header_title"}}</h1> <img src={{wavingHandURL}} alt="" class="waving-hand">
             <p class="login-subheader">{{i18n "login.subheader_title"}}</p>
           </div>
-        {{/if}}
+        </div>
+      {{/if}}
+
+      <div class="login-right-side">
         {{login-buttons externalLogin=(action "externalLogin")}}
       </div>
     {{/if}}


### PR DESCRIPTION
## Before
![Screenshot from 2021-03-10 15-47-16](https://user-images.githubusercontent.com/4335742/110594546-e7082100-81b7-11eb-8d25-2c3461e1f642.png)

## After
![Screenshot from 2021-03-10 15-46-00](https://user-images.githubusercontent.com/4335742/110594550-e7a0b780-81b7-11eb-8929-50e620efd765.png)
