### PR TITLE
DEV: Pass signup=true to auth providers when signup buttons used

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -359,7 +359,7 @@ export default Controller.extend(
 
     actions: {
       externalLogin(provider) {
-        this.login.send("externalLogin", provider);
+        this.login.send("externalLogin", provider, { signup: true });
       },
 
       createAccount() {

--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -233,6 +233,7 @@ export default Controller.extend(
 
       externalLogin(provider) {
         provider.doLogin({
+          signup: true,
           params: {
             origin: window.location.href,
           },

--- a/app/assets/javascripts/discourse/app/controllers/login.js
+++ b/app/assets/javascripts/discourse/app/controllers/login.js
@@ -267,13 +267,15 @@ export default Controller.extend(ModalFunctionality, {
       return false;
     },
 
-    externalLogin(loginMethod) {
+    externalLogin(loginMethod, { signup = false } = {}) {
       if (this.loginDisabled) {
         return;
       }
 
       this.set("loggingIn", true);
-      loginMethod.doLogin().catch(() => this.set("loggingIn", false));
+      loginMethod
+        .doLogin({ signup: signup })
+        .catch(() => this.set("loggingIn", false));
     },
 
     createAccount() {

--- a/app/assets/javascripts/discourse/app/models/login-method.js
+++ b/app/assets/javascripts/discourse/app/models/login-method.js
@@ -23,7 +23,7 @@ const LoginMethod = EmberObject.extend({
     return this.message_override || I18n.t(`login.${this.name}.message`);
   },
 
-  doLogin({ reconnect = false, params = {} } = {}) {
+  doLogin({ reconnect = false, signup = false, params = {} } = {}) {
     if (this.customLogin) {
       this.customLogin();
       return Promise.resolve();
@@ -38,6 +38,10 @@ const LoginMethod = EmberObject.extend({
 
     if (reconnect) {
       params["reconnect"] = true;
+    }
+
+    if (signup) {
+      params["signup"] = true;
     }
 
     const paramKeys = Object.keys(params);

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -258,15 +258,17 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       const returnPath = encodeURIComponent(window.location.pathname);
       window.location = getURL("/session/sso?return_path=" + returnPath);
     } else {
-      this._autoLogin("createAccount", "create-account");
+      this._autoLogin("createAccount", "create-account", { signup: true });
     }
   },
 
-  _autoLogin(modal, modalClass, notAuto) {
+  _autoLogin(modal, modalClass, notAuto, { signup = false } = {}) {
     const methods = findAll();
 
     if (!this.siteSettings.enable_local_logins && methods.length === 1) {
-      this.controllerFor("login").send("externalLogin", methods[0]);
+      this.controllerFor("login").send("externalLogin", methods[0], {
+        signup: signup,
+      });
     } else {
       showModal(modal);
       this.controllerFor("modal").set("modalClass", modalClass);


### PR DESCRIPTION
This allows auth provider plugins to behave differently for login / signup. Previously, there was no way for them to know which button had been used.

Unfortunately there are no existing tests for any of this code. It's very difficult to test in QUnit, because the flow involves redirecting the browser to new URLs. I have tested this extensively in my local environment, and I think the change is relatively low risk. After merging I will verify all external auth methods on Meta to be absolutely sure.

This change will be a no-op in the majority of cases. If auth plugins wish to make use of this new feature, they should check for `?signup=true` in the URL. For example: https://github.com/discourse/discourse-oauth2-basic/pull/34

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
