### PR TITLE
FIX: Ensure the signup boolean is passed when started via _autoLogin

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -247,9 +247,9 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       const returnPath = encodeURIComponent(window.location.pathname);
       window.location = getURL("/session/sso?return_path=" + returnPath);
     } else {
-      this._autoLogin("login", "login-modal", () =>
-        this.controllerFor("login").resetForm()
-      );
+      this._autoLogin("login", "login-modal", {
+        notAuto: () => this.controllerFor("login").resetForm(),
+      });
     }
   },
 
@@ -262,7 +262,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
     }
   },
 
-  _autoLogin(modal, modalClass, notAuto, { signup = false } = {}) {
+  _autoLogin(modal, modalClass, { notAuto = null, signup = false } = {}) {
     const methods = findAll();
 
     if (!this.siteSettings.enable_local_logins && methods.length === 1) {


### PR DESCRIPTION
The signup boolean was being passed in the third _autoLogin argument, when it should have been the fourth. The third parameter to _autoLogin was optional, which is confusing. This commit cleans things up so both optional arguments are supplied via keywords.

Followup to cbef2ba151a2617271e3af1514d07c06de34f309

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
