### PR TITLE
FIX: Update excerpt after process_post

### DIFF
--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -34,6 +34,7 @@ module Jobs
             Rails.logger.warn("Cooked post processor in FATAL state, bypassing. You need to urgently restart sidekiq\norig: #{orig_cooked}\nrecooked: #{recooked}\ncooked: #{cooked}\npost id: #{post.id}")
           else
             post.update_column(:cooked, cp.html)
+            post.topic.update_excerpt(post.excerpt_for_topic) if post.is_first_post?
             extract_links(post)
             auto_tag(post) if SiteSetting.tagging_enabled? && post.post_number == 1
             post.publish_change_to_clients! :revised

--- a/spec/jobs/process_post_spec.rb
+++ b/spec/jobs/process_post_spec.rb
@@ -78,6 +78,18 @@ describe Jobs::ProcessPost do
       expect(post.cooked).to eq(cooked)
     end
 
+    it "updates the topic excerpt when first post" do
+      post = Fabricate(:post, raw: "Some OP content", cooked: "")
+      post.topic.update_excerpt("Incorrect")
+
+      Jobs::ProcessPost.new.execute(post_id: post.id)
+      expect(post.topic.reload.excerpt).to eq("Some OP content")
+
+      post2 = Fabricate(:post, raw: "Some reply content", cooked: "", topic: post.topic)
+      Jobs::ProcessPost.new.execute(post_id: post2.id)
+      expect(post.topic.reload.excerpt).to eq("Some OP content")
+    end
+
     it "automatically tags first posts" do
       SiteSetting.tagging_enabled = true
 


### PR DESCRIPTION
Onebox content may only be resolved during the process_post job. Onebox content could change the content of the excerpt, so we need to make sure the excerpt is updated accordingly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
