### PR TITLE
FIX: Add amazon sites to force_get_hosts

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -27,7 +27,12 @@ module Oneboxer
   end
 
   def self.force_get_hosts
-    @force_get_hosts ||= ['http://us.battle.net', 'https://news.yahoo.com/']
+    @force_get_hosts ||= begin
+      hosts = ['http://us.battle.net', 'https://news.yahoo.com']
+      amazon_suffixes = %w(com com.br ca cn fr de in it co.jp com.mx nl pl sa sg es se com.tr ae co.uk)
+
+      hosts + amazon_suffixes.collect { |suffix| "https://www.amazon.#{suffix}" }
+    end
   end
 
   def self.force_custom_user_agent_hosts

--- a/spec/components/oneboxer_spec.rb
+++ b/spec/components/oneboxer_spec.rb
@@ -329,4 +329,10 @@ describe Oneboxer do
     end
   end
 
+  describe '#force_get_hosts' do
+    it "includes Amazon sites" do
+      expect(Oneboxer.force_get_hosts).to include('https://www.amazon.ca')
+    end
+  end
+
 end


### PR DESCRIPTION
It has been observed that doing a HEAD against an Amazon store URL may result in a 405 error being returned.

Skipping the HEAD request may result in an improved oneboxing experience when requesting these URLs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
