### PR TITLE
FIX: QUnit tests could time out based on load order

### DIFF
--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -244,6 +244,9 @@ function setupTestsCommon(application, container, config) {
   let pluginPath = getUrlParameter("qunit_single_plugin")
     ? "/" + getUrlParameter("qunit_single_plugin") + "/"
     : "/plugins/";
+  if (getUrlParameter("qunit_disable_auto_start") === "1") {
+    QUnit.config.autostart = false;
+  }
 
   Object.keys(requirejs.entries).forEach(function (entry) {
     let isTest = /\-test/.test(entry);

--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -106,8 +106,9 @@ async function runAllTests() {
     }
   });
 
-  console.log("navigate to " + args[0]);
-  Page.navigate({ url: args[0] });
+  let url = args[0] + "&qunit_disable_auto_start=1";
+  console.log("navigate to ", url);
+  Page.navigate({ url });
 
   Page.loadEventFired(async () => {
     let qff = process.env.QUNIT_FAIL_FAST;
@@ -281,6 +282,7 @@ function logQUnit() {
 
     window.qunitDone = context;
   });
+  QUnit.start();
 }
 let qunit_script = logQUnit.toString();
 


### PR DESCRIPTION
By default our QUnit test runner starts automatically. This is normally
fine but for our `run-qunit.js` script we add a bunch of QUnit events
using `eval` and sometimes those events were added after the tests
already started/finished resulting in a hang.

This adds a new parameter that will cause QUnit not to run
automatically, which the runner uses, then triggers a `start()` when it
knows it's ready.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
