### PR TITLE
Update disable mailing list mode setting description

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2199,7 +2199,7 @@ en:
     default_email_messages_level: "Set default email notification level when someone messages user."
     default_email_mailing_list_mode: "Send an email for every new post by default."
     default_email_mailing_list_mode_frequency: "Users who enable mailing list mode will receive emails this often by default."
-    disable_mailing_list_mode: "Disallow users from enabling mailing list mode."
+    disable_mailing_list_mode: "Disallow users from enabling mailing list mode (prevents any mailing list emails from being sent.)"
     default_email_previous_replies: "Include previous replies in emails by default."
 
     default_email_in_reply_to: "Include excerpt of replied to post in emails by default."


### PR DESCRIPTION
This PR updates the copy of the `disable_mailing_list_mode` site setting. There has been some confusion about what that setting does: https://meta.discourse.org/t/restrict-mailing-list-mode-to-old-users/182804. This change is intended to make it clear that when enabled, the setting prevents all mailing list emails from being sent. 

The PR has no tests, because it is only changing copy on the site.
