### PR TITLE
FIX: Do not block `uploads` path in robots.txt

### DIFF
--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -20,7 +20,7 @@ class RobotsTxtController < ApplicationController
 
   DISALLOWED_WITH_HEADER_PATHS ||= %w{
     /badges
-    /u
+    /u/
     /my
     /search
     /tag/*/l


### PR DESCRIPTION
The `/u` rule also matches the `/uploads` path, which prevents Twitter from showing the site logo in its link previews.

Warning: This PR is untested. I only tested the rule change using the `robots.txt` override feature in a production discourse instance.

See https://meta.discourse.org/t/default-robots-txt-blocks-twitter-card-images/181762

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
