### PR TITLE
FIX: Nav items not recomputing on query param change

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -79,10 +79,20 @@ export default Component.extend(FilterModeMixin, {
     return !additionalTags && !category && tagId !== "none";
   },
 
-  @discourseComputed("filterType", "category", "noSubcategories", "tag.id")
-  navItems(filterType, category, noSubcategories, tagId) {
-    const currentRouteQueryParams = this.get("router.currentRoute.queryParams");
-
+  @discourseComputed(
+    "filterType",
+    "category",
+    "noSubcategories",
+    "tag.id",
+    "router.currentRoute.queryParams"
+  )
+  navItems(
+    filterType,
+    category,
+    noSubcategories,
+    tagId,
+    currentRouteQueryParams
+  ) {
     return NavItem.buildList(category, {
       filterType,
       noSubcategories,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/920448/110721979-3b191100-825d-11eb-9de0-165f1ea268dc.png)


The recalculation of the `forceActive` function for the nav items was being run _before_ the querystring parameters are getting updated. For example for the Unassigned link:

```javascript
i.addNavigationBarItem({
  name: "unassigned",
  customFilter: (category) => {
    return category && category.enable_unassigned_filter;
  },
  customHref: (category) => {
    if (category) {
      return getURL(category.url) + "/l/latest?status=open&assigned=nobody";
    }
  },
  forceActive: (category, args, router) => {
    const queryParams = router.currentRoute.queryParams;

    return (
      queryParams &&
      Object.keys(queryParams).length === 2 &&
      queryParams["assigned"] === "nobody" &&
      queryParams["status"] === "open"
    );
  },
  before: "top",
});
```

When forceActive is hit going from e.g.`http://localhost:3000/c/some-category/5/l/top` to `http://localhost:3000/c/some-category/5/l/latest?assigned=nobody&status=open` the `queryParams` are empty and the URL does not seem to change until after the transition and so `active` ends up being false in this `navigation-item` function which controls whether or not to do the highlight:

```javascript
@discourseComputed("content.filterType", "filterType", "content.active")
active(contentFilterType, filterType, active) {
  if (active !== undefined) {
    return active;
  }
  return contentFilterType === filterType;
},
```

Also sometimes this is not even recalculated, for example going from `http://localhost:3000/c/some-category/5/l/latest?status=open` to `http://localhost:3000/c/some-category/5/l/latest?assigned=nobody&status=open`. This PR fixes the issue where the query parameters changing was not forcing this recalculation. This was especially noticable in conjunction with https://github.com/discourse/discourse-loading-slider.