### PR TITLE
FIX: Allow group invites when local login is disabled.

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -339,8 +339,6 @@ class GroupsController < ApplicationController
     if emails.any?
       if SiteSetting.enable_discourse_connect?
         raise Discourse::InvalidParameters.new(I18n.t("groups.errors.no_invites_with_discourse_connect"))
-      elsif !SiteSetting.enable_local_logins?
-        raise Discourse::InvalidParameters.new(I18n.t("groups.errors.no_invites_without_local_logins"))
       end
     end
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1383,14 +1383,6 @@ describe GroupsController do
         expect(response.parsed_body["error_type"]).to eq("invalid_parameters")
       end
 
-      it "rejects unknown emails when local logins are disabled" do
-        SiteSetting.enable_local_logins = false
-        put "/groups/#{group.id}/members.json", params: { emails: "newuser@example.com" }
-
-        expect(response.status).to eq(400)
-        expect(response.parsed_body["error_type"]).to eq("invalid_parameters")
-      end
-
       it "will find users by email, and invite the correct user" do
         new_user = Fabricate(:user)
         expect(new_user.group_ids.include?(group.id)).to eq(false)


### PR DESCRIPTION
Redemption of invites via OAuth providers is now supported.

Follow-up to ce04db861033c906830fd07ae98b3d0cb375c753