### PR TITLE
FIX: Make sure tag-based topic list uses its own preload key

### DIFF
--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -69,6 +69,9 @@ class TopicList < DraftableList
       else
         "topic_list_#{@category.url.sub(/^\//, '')}/l/#{@filter}"
       end
+    elsif @tags
+      tag = @tags.first
+      "topic_list_tag/#{tag.name}/l/#{@filter}"
     else
       "topic_list_#{@filter}"
     end

--- a/spec/models/topic_list_spec.rb
+++ b/spec/models/topic_list_spec.rb
@@ -93,6 +93,7 @@ describe TopicList do
 
   describe "#preload_key" do
     let(:category) { Fabricate(:category) }
+    let(:tag) { Fabricate(:tag) }
 
     it "generates correct key for categories" do
       topic_list = TopicList.new('latest', nil, nil, category: category, category_id: category.id)
@@ -102,6 +103,11 @@ describe TopicList do
     it "generates correct key for 'no subcategories' option" do
       topic_list = TopicList.new('latest', nil, nil, category: category, category_id: category.id, no_subcategories: true)
       expect(topic_list.preload_key).to eq("topic_list_c/#{category.slug}/#{category.id}/none/l/latest")
+    end
+
+    it "generates correct key for tag" do
+      topic_list = TopicList.new('latest', nil, nil, tags: [tag])
+      expect(topic_list.preload_key).to eq("topic_list_tag/#{tag.name}/l/latest")
     end
   end
 end


### PR DESCRIPTION
When transitioning from a tag topic list e.g. /tag/alerts
to the / route the topic list was not reloaded because the
same preload key was used for both lists (topic_list_latest).
The topic list was only reloaded when clicking on the / route
a second time because then it is forced to reload.

In the topic list adapter, we call `PreloadStore.getAndRemove` to
get the topic lists:

https://github.com/discourse/discourse/blob/534777f5fdbf48a6a77a362636cc936a19c17c43/app/assets/javascripts/discourse/app/adapters/topic-list.js#L34-L41

Now instead of both / and /tag/alerts sharing the same preload
key of `topic_list_latest`, the tag has a key of `topic_list_tag/alerts/l/latest`