### PR TITLE
FEATURE: Add tag-custom-settings plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
@@ -2,7 +2,10 @@
   {{#if tagInfo}}
     <div class="tag-name">
       {{discourse-tag tagInfo.name tagName="div" size="large"}}
+
       {{#if canAdminTag}}
+        {{plugin-outlet name="tag-custom-settings" args=(hash tag=tagInfo) connectorTagName="" tagName="section"}}
+
         {{d-button class="btn-default" action=(action "renameTag") icon="pencil-alt" label="tagging.rename_tag" id="rename-tag"}}
         {{d-button class="btn-default" action=(action "toggleEditControls") icon="cog" label="tagging.edit_synonyms" id="edit-synonyms"}}
         {{#if deleteAction}}


### PR DESCRIPTION
So plugin developers can add extra settings to the tag UI. Goes where the red square is in this screenshot:

![image](https://user-images.githubusercontent.com/920448/110744652-c27a7a80-8285-11eb-8155-e566a8a3f058.png)
