### PR TITLE
FEATURE: Flag to disable DiscourseConnect CSRF protection

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -475,6 +475,9 @@ login:
   discourse_connect_overrides_website: false
   discourse_connect_overrides_card_background: false
   discourse_connect_not_approved_url: ""
+  discourse_connect_csrf_protection:
+    default: true
+    hidden: true
   blocked_email_domains:
     default: "mailinator.com"
     type: list

--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -375,10 +375,27 @@ describe DiscourseSingleSignOn do
     sso = DiscourseSingleSignOn.parse(payload, secure_session: secure_session)
     expect(sso.nonce_valid?).to eq true
 
+    other_session_sso = DiscourseSingleSignOn.parse(payload, secure_session: SecureSession.new("differentsession"))
+    expect(other_session_sso.nonce_valid?).to eq false
+
     sso.expire_nonce!
 
     expect(sso.nonce_valid?).to eq false
+  end
 
+  it "allows disabling CSRF protection" do
+    SiteSetting.discourse_connect_csrf_protection = false
+    _ , payload = DiscourseSingleSignOn.generate_url(secure_session: secure_session).split("?")
+
+    sso = DiscourseSingleSignOn.parse(payload, secure_session: secure_session)
+    expect(sso.nonce_valid?).to eq true
+
+    other_session_sso = DiscourseSingleSignOn.parse(payload, secure_session: SecureSession.new("differentsession"))
+    expect(other_session_sso.nonce_valid?).to eq true
+
+    sso.expire_nonce!
+
+    expect(sso.nonce_valid?).to eq false
   end
 
   it "generates a correct sso url" do


### PR DESCRIPTION
This is not recommended. But if you have other protections in place for CSRF mitigation, you may wish to disable Discourse's implementation. This site setting is not visible in the UI, and must be changed via the console.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
