### PR TITLE
FIX: When destroying a topic, destroy its associated published page.

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -165,6 +165,7 @@ class PostDestroyer
 
       if @post.topic && @post.is_first_post?
         permanent? ? @post.topic.destroy! : @post.topic.trash!(@user)
+        PublishedPage.unpublish!(@user, @post.topic) if @post.topic.published_page
       end
       update_associated_category_latest_topic
       update_user_counts

--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -439,6 +439,17 @@ describe PostDestroyer do
       expect(user2.user_stat.post_count).to eq(0)
     end
 
+    it 'deletes the published page associated with the topic' do
+      slug = 'my-published-page'
+      publish_result = PublishedPage.publish!(admin, post.topic, slug)
+      pp = publish_result.last
+      expect(publish_result.first).to eq(true)
+
+      PostDestroyer.new(admin, post).destroy
+
+      expect(PublishedPage.find_by(id: pp.id)).to be_nil
+    end
+
     it "accepts a delete_removed_posts_after option" do
       SiteSetting.delete_removed_posts_after = 0
 


### PR DESCRIPTION
Destroying a topic should remove the associated published page so another topic could re-use the slug.

