### PR TITLE
FEATURE: Allow admins to pre-populate user fields

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/invites-show.js
+++ b/app/assets/javascripts/discourse/app/routes/invites-show.js
@@ -17,4 +17,16 @@ export default DiscourseRoute.extend({
       return {};
     }
   },
+
+  setupController(controller, model) {
+    this._super(...arguments);
+
+    if (model.user_fields) {
+      controller.userFields.forEach((userField) => {
+        if (model.user_fields[userField.field.id]) {
+          userField.value = model.user_fields[userField.field.id];
+        }
+      });
+    }
+  },
 });

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -40,12 +40,7 @@ class InvitesController < ApplicationController
       }
 
       if staged_user = User.where(staged: true).with_email(invite.email).first
-        staged_user.custom_fields.each do |key, value|
-          if key.starts_with?(User::USER_FIELD_PREFIX)
-            info[:user_fields] ||= {}
-            info[:user_fields][key.delete_prefix(User::USER_FIELD_PREFIX)] = value
-          end
-        end
+        info[:user_fields] = staged_user.user_fields
       end
 
       store_preloaded("invite_info", MultiJson.dump(info))

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 class InvitesController < ApplicationController
 
   requires_login only: [:create, :destroy, :destroy_all_expired, :resend_invite, :resend_all_invites, :upload_csv]
@@ -29,13 +31,24 @@ class InvitesController < ApplicationController
 
       hidden_email = email != invite.email
 
-      store_preloaded("invite_info", MultiJson.dump(
+      info = {
         invited_by: UserNameSerializer.new(invite.invited_by, scope: guardian, root: false),
         email: email,
         hidden_email: hidden_email,
         username: hidden_email ? '' : UserNameSuggester.suggest(invite.email),
         is_invite_link: invite.is_invite_link?
-      ))
+      }
+
+      if staged_user = User.where(staged: true).with_email(invite.email).first
+        staged_user.custom_fields.each do |key, value|
+          if key.starts_with?(User::USER_FIELD_PREFIX)
+            info[:user_fields] ||= {}
+            info[:user_fields][key.delete_prefix(User::USER_FIELD_PREFIX)] = value
+          end
+        end
+      end
+
+      store_preloaded("invite_info", MultiJson.dump(info))
 
       secure_session["invite-key"] = invite.invite_key
 
@@ -266,35 +279,44 @@ class InvitesController < ApplicationController
   end
 
   def upload_csv
-    require 'csv'
-
     guardian.ensure_can_bulk_invite_to_forum!(current_user)
 
     hijack do
       begin
         file = params[:file] || params[:files].first
 
-        count = 0
+        csv_header = nil
         invites = []
-        max_bulk_invites = SiteSetting.max_bulk_invites
-        CSV.foreach(file.tempfile) do |row|
-          count += 1
-          invites.push(email: row[0], groups: row[1], topic_id: row[2]) if row[0].present?
-          break if count >= max_bulk_invites
+
+        CSV.foreach(file.tempfile, encoding: "bom|utf-8") do |row|
+          # Try to extract a CSV header, if it exists
+          if csv_header.nil?
+            if row[0] == 'email'
+              csv_header = row
+              next
+            else
+              csv_header = ["email", "groups", "topic_id"]
+            end
+          end
+
+          if row[0].present?
+            invites.push(csv_header.zip(row).map.to_h.filter { |k, v| v.present? })
+          end
+
+          break if invites.count >= SiteSetting.max_bulk_invites
         end
 
         if invites.present?
           Jobs.enqueue(:bulk_invite, invites: invites, current_user_id: current_user.id)
-          if count >= max_bulk_invites
-            render json: failed_json.merge(errors: [I18n.t("bulk_invite.max_rows", max_bulk_invites: max_bulk_invites)]), status: 422
+
+          if invites.count >= SiteSetting.max_bulk_invites
+            render json: failed_json.merge(errors: [I18n.t("bulk_invite.max_rows", max_bulk_invites: SiteSetting.max_bulk_invites)]), status: 422
           else
             render json: success_json
           end
         else
           render json: failed_json.merge(errors: [I18n.t("bulk_invite.error")]), status: 422
         end
-      rescue
-        render json: failed_json.merge(errors: [I18n.t("bulk_invite.error")]), status: 422
       end
     end
   end

--- a/app/jobs/regular/bulk_invite.rb
+++ b/app/jobs/regular/bulk_invite.rb
@@ -90,11 +90,11 @@ module Jobs
     end
 
     def get_user_fields(fields)
-      user_fields = []
+      user_fields = {}
 
       fields.each do |key, value|
         @user_fields[key] ||= UserField.find_by(name: key)&.id || :nil
-        user_fields << [@user_fields[key], value] if @user_fields[key] != :nil
+        user_fields[@user_fields[key]] = value if @user_fields[key] != :nil
       end
 
       user_fields

--- a/app/jobs/regular/bulk_invite.rb
+++ b/app/jobs/regular/bulk_invite.rb
@@ -6,25 +6,27 @@ module Jobs
 
     def initialize
       super
-      @logs    = []
-      @sent    = 0
-      @failed  = 0
-      @groups = {}
+
+      @logs         = []
+      @sent         = 0
+      @failed       = 0
+      @groups       = {}
+      @user_fields  = {}
       @valid_groups = {}
     end
 
     def execute(args)
-      invites = args[:invites]
-      raise Discourse::InvalidParameters.new(:invites) if invites.blank?
+      @invites = args[:invites]
+      raise Discourse::InvalidParameters.new(:invites) if @invites.blank?
 
       @current_user = User.find_by(id: args[:current_user_id])
       raise Discourse::InvalidParameters.new(:current_user_id) unless @current_user
+
       @guardian = Guardian.new(@current_user)
-      @total_invites = invites.length
 
-      process_invites(invites)
+      process_invites(@invites)
 
-      if @total_invites > Invite::BULK_INVITE_EMAIL_LIMIT
+      if @invites.length > Invite::BULK_INVITE_EMAIL_LIMIT
         ::Jobs.enqueue(:process_bulk_invite_emails)
       end
     ensure
@@ -87,10 +89,22 @@ module Jobs
       topic
     end
 
+    def get_user_fields(fields)
+      user_fields = []
+
+      fields.each do |key, value|
+        @user_fields[key] ||= UserField.find_by(name: key)&.id || :nil
+        user_fields << [@user_fields[key], value] if @user_fields[key] != :nil
+      end
+
+      user_fields
+    end
+
     def send_invite(invite)
       email = invite[:email]
       groups = get_groups(invite[:groups])
       topic = get_topic(invite[:topic_id])
+      user_fields = get_user_fields(invite.except(:email, :groups, :topic_id))
 
       begin
         if user = Invite.find_user_by_email(email)
@@ -105,17 +119,35 @@ module Jobs
               end
             end
           end
-        else
-          if @total_invites > Invite::BULK_INVITE_EMAIL_LIMIT
-            invite = Invite.generate(@current_user,
-              email: email,
-              topic: topic,
-              group_ids: groups.map(&:id),
-              emailed_status: Invite.emailed_status_types[:bulk_pending]
-            )
-          else
-            Invite.generate(@current_user, email: email, topic: topic, group_ids: groups.map(&:id))
+
+          if user_fields.present?
+            user_fields.each do |user_field, value|
+              user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field}"] = value
+            end
+            user.save_custom_fields
           end
+        else
+          if user_fields.present?
+            user = User.where(staged: true).find_by_email(email)
+            user ||= User.new(username: UserNameSuggester.suggest(email), email: email, staged: true)
+            user.custom_fields['bulk_invited'] = true
+            user_fields.each do |user_field, value|
+              user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field}"] = value
+            end
+            user.save!
+          end
+
+          invite_opts = {
+            email: email,
+            topic: topic,
+            group_ids: groups.map(&:id),
+          }
+
+          if @invites.length > Invite::BULK_INVITE_EMAIL_LIMIT
+            invite_opts[:emailed_status] = Invite.emailed_status_types[:bulk_pending]
+          end
+
+          Invite.generate(@current_user, invite_opts)
         end
       rescue => e
         save_log "Error inviting '#{email}' -- #{Rails::Html::FullSanitizer.new.sanitize(e.message)}"
@@ -153,7 +185,7 @@ module Jobs
       group = @groups[group_name]
 
       unless group
-        group = Group.find_by("lower(name) = ?", group_name)
+        group = Group.find_by('lower(name) = ?', group_name)
         @groups[group_name] = group
       end
 

--- a/app/jobs/regular/bulk_invite.rb
+++ b/app/jobs/regular/bulk_invite.rb
@@ -122,7 +122,7 @@ module Jobs
 
           if user_fields.present?
             user_fields.each do |user_field, value|
-              user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field}"] = value
+              user.set_user_field(user_field, value)
             end
             user.save_custom_fields
           end
@@ -130,9 +130,8 @@ module Jobs
           if user_fields.present?
             user = User.where(staged: true).find_by_email(email)
             user ||= User.new(username: UserNameSuggester.suggest(email), email: email, staged: true)
-            user.custom_fields['bulk_invited'] = true
             user_fields.each do |user_field, value|
-              user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field}"] = value
+              user.set_user_field(user_field, value)
             end
             user.save!
           end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1173,6 +1173,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def set_user_field(field_id, value)
+    custom_fields["#{USER_FIELD_PREFIX}#{field_id}"] = value
+  end
+
   def number_of_deleted_posts
     Post.with_deleted
       .where(user_id: self.id)

--- a/spec/fixtures/csv/discourse_headers.csv
+++ b/spec/fixtures/csv/discourse_headers.csv
@@ -1,0 +1,3 @@
+﻿email,groups,location
+test@example.com,discourse;ubuntu,usa
+test2@example.com,discourse;ubuntu,europe

--- a/spec/jobs/bulk_invite_spec.rb
+++ b/spec/jobs/bulk_invite_spec.rb
@@ -95,10 +95,10 @@ describe Jobs::BulkInvite do
 
       expect(Invite.count).to eq(3)
       expect(User.where(staged: true).find_by_email('test@discourse.org')).to eq(nil)
-      expect(user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"]).to eq('value 1')
-      expect(staged_user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"]).to eq('value 2')
+      expect(user.user_fields[user_field.id.to_s]).to eq('value 1')
+      expect(staged_user.user_fields[user_field.id.to_s]).to eq('value 2')
       new_staged_user = User.where(staged: true).find_by_email('test2@discourse.org')
-      expect(new_staged_user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"]).to eq('value 3')
+      expect(new_staged_user.user_fields[user_field.id.to_s]).to eq('value 3')
     end
 
     context 'invites are more than 200' do

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -179,11 +179,11 @@ describe Invite do
     it 'keeps custom fields' do
       user_field = Fabricate(:user_field)
       staged_user = Fabricate(:user, staged: true, email: invite.email)
-      staged_user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"] = 'some value'
+      staged_user.set_user_field(user_field.id, 'some value')
       staged_user.save_custom_fields
 
       expect(invite.redeem).to eq(staged_user)
-      expect(staged_user.reload.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"]).to eq('some value')
+      expect(staged_user.reload.user_fields[user_field.id.to_s]).to eq('some value')
     end
 
     it 'creates a notification for the invitee' do

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -176,6 +176,16 @@ describe Invite do
       expect(invite.redeem).to be_blank
     end
 
+    it 'keeps custom fields' do
+      user_field = Fabricate(:user_field)
+      staged_user = Fabricate(:user, staged: true, email: invite.email)
+      staged_user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"] = 'some value'
+      staged_user.save_custom_fields
+
+      expect(invite.redeem).to eq(staged_user)
+      expect(staged_user.reload.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"]).to eq('some value')
+    end
+
     it 'creates a notification for the invitee' do
       expect { invite.redeem }.to change { Notification.count }
     end

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -30,7 +30,7 @@ describe InvitesController do
     it 'shows default user fields' do
       user_field = Fabricate(:user_field)
       staged_user = Fabricate(:user, staged: true, email: invite.email)
-      staged_user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"] = 'some value'
+      staged_user.set_user_field(user_field.id, 'some value')
       staged_user.save_custom_fields
 
       get "/invites/#{invite.invite_key}"
@@ -743,10 +743,10 @@ describe InvitesController do
         expect(response.status).to eq(200)
 
         user = User.where(staged: true).find_by_email('test@example.com')
-        expect(user.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"]).to eq('usa')
+        expect(user.user_fields[user_field.id.to_s]).to eq('usa')
 
         user2 = User.where(staged: true).find_by_email('test2@example.com')
-        expect(user2.custom_fields["#{User::USER_FIELD_PREFIX}#{user_field.id}"]).to eq('europe')
+        expect(user2.user_fields[user_field.id.to_s]).to eq('europe')
       end
     end
   end


### PR DESCRIPTION
Admins can use bulk invites to pre-populate user fields. The imported
CSV file must have a header with "email" column (first position) and
names of the user fields (exact match).

Under the hood, the bulk invite will create staged users and populate
the custom fields of those.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
