### PR TITLE
UX: Add class to body on first unread notification

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -419,23 +419,6 @@ const SiteHeaderComponent = MountWidget.extend(
 
 export default SiteHeaderComponent.extend({
   classNames: ["d-header-wrap"],
-  classNameBindings: ["readFirstNorification:first-notification"],
-  readFirstNotification: null,
-
-  init() {
-    this._super(...arguments);
-
-    if (
-      this.currentUser &&
-      !this.get("currentUser.read_first_notification") &&
-      !this.get("currentUser.enforcedSecondFactor")
-    ) {
-      this.set("readFirstNotification", false);
-    } else {
-      this.set("readFirstNotification", true);
-    }
-
-  }
 });
 
 export function headerHeight() {

--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -215,6 +215,10 @@ const SiteHeaderComponent = MountWidget.extend(
 
       this.appEvents.on("dom:clean", this, "_cleanDom");
 
+      if (!this.get("currentUser.read_first_notification")) {
+        document.body.classList.add("unread-first-notification");
+      }
+
       // Allow first notification to be dismissed on a click anywhere
       if (
         this.currentUser &&
@@ -415,6 +419,23 @@ const SiteHeaderComponent = MountWidget.extend(
 
 export default SiteHeaderComponent.extend({
   classNames: ["d-header-wrap"],
+  classNameBindings: ["readFirstNorification:first-notification"],
+  readFirstNotification: null,
+
+  init() {
+    this._super(...arguments);
+
+    if (
+      this.currentUser &&
+      !this.get("currentUser.read_first_notification") &&
+      !this.get("currentUser.enforcedSecondFactor")
+    ) {
+      this.set("readFirstNotification", false);
+    } else {
+      this.set("readFirstNotification", true);
+    }
+
+  }
 });
 
 export function headerHeight() {

--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -229,6 +229,9 @@ const SiteHeaderComponent = MountWidget.extend(
         !this.get("currentUser.enforcedSecondFactor")
       ) {
         this._dismissFirstNotification = (e) => {
+          if (document.body.classList.contains("unread-first-notification")) {
+            document.body.classList.remove("unread-first-notification");
+          }
           if (
             !e.target.closest("#current-user") &&
             !e.target.closest(".ring-backdrop") &&

--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -215,7 +215,10 @@ const SiteHeaderComponent = MountWidget.extend(
 
       this.appEvents.on("dom:clean", this, "_cleanDom");
 
-      if (!this.get("currentUser.read_first_notification")) {
+      if (
+        this.currentUser &&
+        !this.get("currentUser.read_first_notification")
+      ) {
         document.body.classList.add("unread-first-notification");
       }
 

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -94,7 +94,6 @@ createWidget("header-notifications", {
           !user.get("enforcedSecondFactor")
         ) {
           if (!attrs.active && attrs.ringBackdrop) {
-            document.body.classList.add("first-notification");
             contents.push(h("span.ring"));
             contents.push(h("span.ring-backdrop-spotlight"));
             contents.push(
@@ -117,10 +116,6 @@ createWidget("header-notifications", {
                 ])
               )
             );
-          } else {
-            if (document.body.classList.contains("first-notification")) {
-              document.body.classList.remove("first-notification");
-            }
           }
         }
 
@@ -591,6 +586,9 @@ export default createWidget("header", {
 
   headerDismissFirstNotificationMask() {
     // Dismiss notifications
+    if (document.body.classList.contains("unread-first-notification")) {
+      document.body.classList.remove("unread-first-notification")
+    }
     this.store
       .findStale(
         "notification",

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -94,6 +94,7 @@ createWidget("header-notifications", {
           !user.get("enforcedSecondFactor")
         ) {
           if (!attrs.active && attrs.ringBackdrop) {
+            document.body.classList.add("first-notification");
             contents.push(h("span.ring"));
             contents.push(h("span.ring-backdrop-spotlight"));
             contents.push(

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -587,7 +587,7 @@ export default createWidget("header", {
   headerDismissFirstNotificationMask() {
     // Dismiss notifications
     if (document.body.classList.contains("unread-first-notification")) {
-      document.body.classList.remove("unread-first-notification")
+      document.body.classList.remove("unread-first-notification");
     }
     this.store
       .findStale(

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -117,6 +117,10 @@ createWidget("header-notifications", {
                 ])
               )
             );
+          } else {
+            if (document.body.classList.contains("first-notification")) {
+              document.body.classList.remove("first-notification");
+            }
           }
         }
 


### PR DESCRIPTION
This commit adds `first-notification` class to the body element when there is a first unread notification. This will fix any issues with certain themes who use custom headers where z-index issues sometimes cause those custom headers to not be hidden by the transparent shadow over the page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
