### PR TITLE
FEATURE: Enable contact picker on new invite modal

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-invite.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-invite.js
@@ -5,6 +5,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { extractError } from "discourse/lib/ajax-error";
 import { bufferedProperty } from "discourse/mixins/buffered-content";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
+import { getNativeContact } from "discourse/lib/pwa-utils";
 import Group from "discourse/models/group";
 import Invite from "discourse/models/invite";
 import I18n from "I18n";
@@ -160,6 +161,13 @@ export default Controller.extend(
       this.appEvents.trigger("modal-body:clearFlash");
 
       this.save({ sendEmail });
+    },
+
+    @action
+    searchContact() {
+      getNativeContact(this.capabilities, ["email"], false).then((result) => {
+        this.set("buffered.email", result[0].email[0]);
+      });
     },
   }
 );

--- a/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
@@ -44,6 +44,13 @@
           value=buffered.email
           placeholderKey="topic.invite_reply.email_placeholder"
         }}
+        {{#if capabilities.hasContactPicker}}
+          {{d-button
+            icon="address-book"
+            action=(action "searchContact")
+            class="btn-primary open-contact-picker"
+          }}
+        {{/if}}
       </div>
     {{/if}}
 

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -856,7 +856,8 @@
     input[type="text"] {
       width: 100%;
 
-      &.invite-link {
+      &.invite-link,
+      &#invite-email {
         width: 85%;
       }
     }


### PR DESCRIPTION
The new invite modal removed this feature in the rewrite. This re-adds it using the existing methods and feature detection.

![image](https://user-images.githubusercontent.com/1385470/110844133-cd360f00-8287-11eb-95f2-5a3221870028.png)
