### PR TITLE
FEATURE: Allow a cluster_name to be configured and used for /srv/status

### DIFF
--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -9,6 +9,14 @@ class ForumsController < ActionController::Base
   after_action  :add_readonly_header
 
   def status
+    if params[:cluster]
+      if GlobalSetting.cluster_name.nil?
+        return render plain: "cluster name not configured", status: 500
+      elsif GlobalSetting.cluster_name != params[:cluster]
+        return render plain: "cluster name does not match", status: 500
+      end
+    end
+
     if $shutdown # rubocop:disable Style/GlobalVars
       render plain: "shutting down", status: (params[:shutdown_ok] ? 200 : 500)
     else

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -332,3 +332,7 @@ enable_email_sync_demon = false
 # this can easily lead to blocking sidekiq
 # on multisites we recommend a far lower number
 max_digests_enqueued_per_30_mins_per_site = 10000
+
+# This cluster name can be passed to the /srv/status route to verify
+# the application cluster is the same one you are expecting
+cluster_name =

--- a/spec/requests/forums_controller_spec.rb
+++ b/spec/requests/forums_controller_spec.rb
@@ -37,4 +37,31 @@ RSpec.describe ForumsController do
     end
   end
 
+  describe "cluster parameter" do
+    it "returns a 500 response if the cluster is not configured" do
+      get "/srv/status?cluster=abc"
+      expect(response.status).to eq(500)
+      expect(response.body).to include("not configured")
+    end
+
+    it "returns a 500 response if the cluster does not match" do
+      global_setting(:cluster_name, "mycluster")
+      get "/srv/status?cluster=abc"
+      expect(response.status).to eq(500)
+      expect(response.body).to include("not match")
+    end
+
+    it "returns a 200 response if the cluster does match" do
+      global_setting(:cluster_name, "mycluster")
+      get "/srv/status?cluster=abc"
+      expect(response.status).to eq(500)
+      expect(response.body).to include("not match")
+    end
+
+    it "returns a 200 response when given shutdown_ok" do
+      get "/srv/status?shutdown_ok=1"
+      expect(response.status).to eq(200)
+    end
+  end
+
 end


### PR DESCRIPTION
The cluster name can be configured by setting the `DISCOURSE_CLUSTER_NAME` environment variable. If set, you can then call /srv/status with a `?cluster=` parameter. If the cluster does not match, an error will be returned. This is useful if you need a load balancer to be able to verify the identity, as well as the presence, of an application container.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
