### PR TITLE
FIX: Invite acceptance tests were broken in Ember CLI

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -22,7 +22,7 @@ function setAuthenticationData(hooks, json) {
   });
 }
 
-function preloadInvite({ link } = { link: false }) {
+function preloadInvite({ link = false } = {}) {
   const info = {
     invited_by: {
       id: 123,


### PR DESCRIPTION
They relied on old Ember behavior where the app does not boot until
`visit` is called and this is no longer true.

This refactors the test to DRY stuff up a bit, and modify the DOM where
necessary in `needs.hooks.beforeEach`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
