### PR TITLE
FIX: Show link in invite panel

### DIFF
--- a/app/assets/javascripts/discourse/app/components/invite-link-panel.js
+++ b/app/assets/javascripts/discourse/app/components/invite-link-panel.js
@@ -90,7 +90,7 @@ export default Component.extend({
         model.setProperties({
           saving: false,
           finished: true,
-          inviteLink: result,
+          inviteLink: result.link,
         });
 
         if (userInvitedController) {

--- a/app/assets/javascripts/discourse/app/components/invite-panel.js
+++ b/app/assets/javascripts/discourse/app/components/invite-panel.js
@@ -409,7 +409,7 @@ export default Component.extend({
         model.setProperties({
           saving: false,
           finished: true,
-          inviteLink: result,
+          inviteLink: result.link,
         });
 
         if (userInvitedController) {


### PR DESCRIPTION
Writing a test for this seems impossible at this moment because of many tiny problems. In fact, there is a test already for this, but it was disabled probably exactly because of this.