### PR TITLE
DEV: Add FAIL_ON_OUTPUT option for tests

### DIFF
--- a/spec/import_export/category_exporter_spec.rb
+++ b/spec/import_export/category_exporter_spec.rb
@@ -12,7 +12,7 @@ describe ImportExport::CategoryExporter do
   fab!(:user3) { Fabricate(:user) }
 
   before do
-    STDOUT.stubs(:write)
+    $stdout.stubs(:write)
   end
 
   context '.perform' do

--- a/spec/import_export/category_structure_exporter_spec.rb
+++ b/spec/import_export/category_structure_exporter_spec.rb
@@ -6,7 +6,7 @@ require "import_export/category_structure_exporter"
 describe ImportExport::CategoryStructureExporter do
 
   before do
-    STDOUT.stubs(:write)
+    $stdout.stubs(:write)
   end
 
   it 'export all the categories' do

--- a/spec/import_export/group_exporter_spec.rb
+++ b/spec/import_export/group_exporter_spec.rb
@@ -6,7 +6,7 @@ require "import_export/group_exporter"
 describe ImportExport::GroupExporter do
 
   before do
-    STDOUT.stubs(:write)
+    $stdout.stubs(:write)
   end
 
   it 'exports all the groups' do

--- a/spec/import_export/importer_spec.rb
+++ b/spec/import_export/importer_spec.rb
@@ -6,7 +6,7 @@ require "import_export"
 describe ImportExport::Importer do
 
   before do
-    STDOUT.stubs(:write)
+    $stdout.stubs(:write)
   end
 
   let(:import_data) do

--- a/spec/import_export/topic_exporter_spec.rb
+++ b/spec/import_export/topic_exporter_spec.rb
@@ -6,7 +6,7 @@ require "import_export"
 describe ImportExport::TopicExporter do
 
   before do
-    STDOUT.stubs(:write)
+    $stdout.stubs(:write)
   end
 
   fab!(:user) { Fabricate(:user) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -294,6 +294,14 @@ RSpec.configure do |config|
     ActiveRecord::Base.establish_connection
   end
 
+  RSpec::Matchers.define_negated_matcher :not_output, :output
+
+  if ENV['FAIL_ON_OUTPUT']
+    config.around(:each) do |example|
+      expect { example.run }.to not_output.to_stderr.and not_output.to_stdout
+    end
+  end
+
   class TestCurrentUserProvider < Auth::DefaultCurrentUserProvider
     def log_on_user(user, session, cookies, opts = {})
       session[:current_user_id] = user.id

--- a/spec/script/import_scripts/base_spec.rb
+++ b/spec/script/import_scripts/base_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../../script/import_scripts/base'
 
 describe ImportScripts::Base do
   before do
-    STDOUT.stubs(:write)
+    $stdout.stubs(:write)
   end
 
   class MockSpecImporter < ImportScripts::Base

--- a/spec/script/import_scripts/vanilla_body_parser_spec.rb
+++ b/spec/script/import_scripts/vanilla_body_parser_spec.rb
@@ -13,8 +13,8 @@ describe VanillaBodyParser do
   let(:user_id) { lookup.add_user('34567', user) }
 
   before do
-    STDOUT.stubs(:write)
-    STDERR.stubs(:write)
+    $stdout.stubs(:write)
+    $stderr.stubs(:write)
 
     VanillaBodyParser.configure(lookup: lookup, uploader: uploader, host: 'vanilla.sampleforum.org', uploads_path: uploads_path)
   end

--- a/spec/tasks/posts_spec.rb
+++ b/spec/tasks/posts_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Post rake tasks" do
   before do
     Rake::Task.clear
     Discourse::Application.load_tasks
-    STDOUT.stubs(:write)
+    $stdout.stubs(:write)
   end
 
   describe 'remap' do


### PR DESCRIPTION
This causes tests to fail when they output to stdout or stderr.

When the test output has been cleaned up, this can be enabled in CI to
keep it clean.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
