### PR TITLE
FIX: Allow additional valid theme .git url formats

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
@@ -24,7 +24,7 @@ export default Controller.extend(ModalFunctionality, {
   keyGenUrl: "/admin/themes/generate_key_pair",
   importUrl: "/admin/themes/import",
   recordType: "theme",
-  checkPrivate: match("uploadUrl", /^git/),
+  checkPrivate: match("uploadUrl", /^.*[@].*[:].*\.git$/),
   localFile: null,
   uploadUrl: null,
   uploadName: null,

--- a/app/assets/javascripts/admin/tests/admin/acceptance/admin-install-theme-modal-test.js
+++ b/app/assets/javascripts/admin/tests/admin/acceptance/admin-install-theme-modal-test.js
@@ -9,6 +9,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
     const urlInput = ".install-theme-content .repo input";
     const branchInput = ".install-theme-content .branch input";
     const privateRepoCheckbox = ".install-theme-content .check-private input";
+    const publicKey = ".install-theme-content .public-key textarea";
 
     const themeUrl = "git@github.com:discourse/discourse.git";
     await visit("/admin/customize/themes");
@@ -29,6 +30,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
       query(privateRepoCheckbox).checked,
       "private repo checkbox is checked"
     );
+    assert.ok(query(publicKey), "shows public key");
 
     await click(".modal-footer .d-modal-cancel");
 
@@ -40,6 +42,33 @@ acceptance("Admin - Themes - Install modal", function (needs) {
       !query(privateRepoCheckbox).checked,
       "private repo checkbox unchecked"
     );
+    assert.notOk(query(publicKey), "hide public key");
+  });
+
+  test("show public key for valid ssh theme urls", async function (assert) {
+    const urlInput = ".install-theme-content .repo input";
+    const privateRepoCheckbox = ".install-theme-content .check-private input";
+    const publicKey = ".install-theme-content .public-key textarea";
+
+    // Supports backlog repo ssh url format
+    const themeUrl =
+      "discourse@discourse.git.backlog.com:/TEST_THEME/test-theme.git";
+    await visit("/admin/customize/themes");
+
+    await click(".create-actions .btn-primary");
+    await click("#remote");
+    await fillIn(urlInput, themeUrl);
+    await click(".install-theme-content .inputs .advanced-repo");
+    await click(privateRepoCheckbox);
+    assert.equal(query(urlInput).value, themeUrl, "url input is filled");
+    assert.ok(
+      query(privateRepoCheckbox).checked,
+      "private repo checkbox is checked"
+    );
+    assert.ok(query(publicKey), "shows public key");
+
+    await fillIn(urlInput, "https://github.com/discourse/discourse.git");
+    assert.notOk(query(publicKey), "does not shows public key for https urls");
   });
 
   test("modal can be auto-opened with the right query params", async function (assert) {


### PR DESCRIPTION
Some git repos have a different ssh url scheme than github and we should
support them.

This change updates our regex format to account for repos that don't
start with "git", but are still valid ssh urls.

Also I added some tests to account for the various formats and to ensure
we don't show the public key when using https urls.

See: https://meta.discourse.org/t/182668
