### PR TITLE
FIX: Kernel.open is deprecated

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -255,6 +255,9 @@ class TopicEmbed < ActiveRecord::Base
     end
   end
 
+  def self.open(uri, **kwargs)
+    URI.open(uri, **kwargs)
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
