### PR TITLE
DEV: ensure state is clean prior to spec

### DIFF
--- a/spec/components/discourse_spec.rb
+++ b/spec/components/discourse_spec.rb
@@ -78,8 +78,14 @@ describe Discourse do
     let(:plugin1) { plugin_class.new.tap { |p| p.enabled = true; p.path = "my-plugin-1" } }
     let(:plugin2) { plugin_class.new.tap { |p| p.enabled = false; p.path = "my-plugin-1" } }
 
-    before { Discourse.plugins.append(plugin1, plugin2) }
-    after { Discourse.plugins.clear }
+    before do
+      Discourse.plugins.clear
+      Discourse.plugins.append(plugin1, plugin2)
+    end
+
+    after do
+      Discourse.plugins.clear
+    end
 
     before do
       plugin_class.any_instance.stubs(:css_asset_exists?).returns(true)

--- a/spec/components/discourse_spec.rb
+++ b/spec/components/discourse_spec.rb
@@ -79,12 +79,12 @@ describe Discourse do
     let(:plugin2) { plugin_class.new.tap { |p| p.enabled = false; p.path = "my-plugin-1" } }
 
     before do
-      Discourse.plugins.clear
       Discourse.plugins.append(plugin1, plugin2)
     end
 
     after do
-      Discourse.plugins.clear
+      Discourse.plugins.delete plugin1
+      Discourse.plugins.delete plugin2
     end
 
     before do
@@ -93,13 +93,13 @@ describe Discourse do
     end
 
     it 'can find plugins correctly' do
-      expect(Discourse.plugins).to contain_exactly(plugin1, plugin2)
+      expect(Discourse.plugins).to include(plugin1, plugin2)
 
       # Exclude disabled plugins by default
-      expect(Discourse.find_plugins({})).to contain_exactly(plugin1)
+      expect(Discourse.find_plugins({})).to include(plugin1)
 
       # Include disabled plugins when requested
-      expect(Discourse.find_plugins(include_disabled: true)).to contain_exactly(plugin1, plugin2)
+      expect(Discourse.find_plugins(include_disabled: true)).to include(plugin1, plugin2)
     end
 
     it 'can find plugin assets' do

--- a/spec/components/stylesheet/compiler_spec.rb
+++ b/spec/components/stylesheet/compiler_spec.rb
@@ -28,14 +28,20 @@ describe Stylesheet::Compiler do
     end
 
     context "with a plugin" do
-      before do
+      let :plugin1 do
         plugin1 = Plugin::Instance.new
         plugin1.path = "#{Rails.root}/spec/fixtures/plugins/my_plugin/plugin.rb"
         plugin1.register_css "body { background: $primary }"
+        plugin1
+      end
 
+      let :plugin2 do
         plugin2 = Plugin::Instance.new
         plugin2.path = "#{Rails.root}/spec/fixtures/plugins/scss_plugin/plugin.rb"
+        plugin2
+      end
 
+      before do
         Discourse.plugins << plugin1
         Discourse.plugins << plugin2
         plugin1.activate!
@@ -44,7 +50,8 @@ describe Stylesheet::Compiler do
       end
 
       after do
-        Discourse.plugins.pop
+        Discourse.plugins.delete plugin1
+        Discourse.plugins.delete plugin2
         Stylesheet::Importer.register_imports!
         DiscoursePluginRegistry.reset!
       end


### PR DESCRIPTION
Corrects flaky spec

Previously we were only clearing state after our spec ran, leaving possible
edge cases where `Discourse.plugins` had data.
