### PR TITLE
DEV: Set disable_mailing_list_mode automatically

### DIFF
--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -141,7 +141,8 @@ module Jobs
           email_args[:notification_type] = email_args[:notification_type].to_s
         end
 
-        if user.user_option.mailing_list_mode? &&
+        if !SiteSetting.disable_mailing_list_mode &&
+           user.user_option.mailing_list_mode? &&
            user.user_option.mailing_list_mode_frequency > 0 && # don't catch notifications for users on daily mailing list mode
            (!post.try(:topic).try(:private_message?)) &&
            NOTIFICATIONS_SENT_BY_MAILING_LIST.include?(email_args[:notification_type])

--- a/db/migrate/20210315173137_set_disable_mailing_list_mode.rb
+++ b/db/migrate/20210315173137_set_disable_mailing_list_mode.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class SetDisableMailingListMode < ActiveRecord::Migration[6.0]
+  def up
+    result = execute "SELECT COUNT(*) FROM user_options WHERE mailing_list_mode"
+    if result.first['count'] > 0
+      execute <<~SQL
+        INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+        VALUES('disable_mailing_list_mode', 5, 'f', NOW(), NOW())
+        ON CONFLICT (name) DO UPDATE SET value = 'f'
+      SQL
+    end
+  end
+
+  def down
+    result = execute "SELECT COUNT(*) FROM user_options WHERE mailing_list_mode"
+    if result.first['count'] == 0
+      execute "DELETE FROM site_settings WHERE name = 'disable_mailing_list_mode'"
+    end
+  end
+end

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -483,6 +483,19 @@ describe Jobs::UserEmail do
         )
       end
 
+      it "sends the mail if the user enabled mailing list mode, but mailing list mode is disabled globally" do
+        user.user_option.update(mailing_list_mode: true, mailing_list_mode_frequency: 1)
+
+        Jobs::UserEmail.new.execute(
+          type: :user_mentioned,
+          user_id: user.id,
+          post_id: post.id,
+          notification_id: notification.id
+        )
+
+        expect(ActionMailer::Base.deliveries.first.to).to contain_exactly(user.email)
+      end
+
       context "recently seen" do
         it "doesn't send an email to a user that's been recently seen" do
           user.update!(last_seen_at: 9.minutes.ago)
@@ -618,6 +631,8 @@ describe Jobs::UserEmail do
       end
 
       it "doesn't send the mail if the user is using individual mailing list mode" do
+        SiteSetting.disable_mailing_list_mode = false
+
         user.user_option.update(mailing_list_mode: true, mailing_list_mode_frequency: 1)
         # sometimes, we pass the notification_id
         Jobs::UserEmail.new.execute(type: :user_mentioned, user_id: user.id, notification_id: notification.id, post_id: post.id)
@@ -634,6 +649,8 @@ describe Jobs::UserEmail do
       end
 
       it "doesn't send the mail if the user is using individual mailing list mode with no echo" do
+        SiteSetting.disable_mailing_list_mode = false
+
         user.user_option.update(mailing_list_mode: true, mailing_list_mode_frequency: 2)
         # sometimes, we pass the notification_id
         Jobs::UserEmail.new.execute(type: :user_mentioned, user_id: user.id, notification_id: notification.id, post_id: post.id)


### PR DESCRIPTION
This fixes the problem where disable_mailing_list_mode was set to true
and caused users who already used the mailing list mode to no longer
receive emails.