### PR TITLE
UX: Show the `Dismiss New` button at the top of the topics.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/discovery/topics.hbs
@@ -1,3 +1,24 @@
+{{#if showDismissAtTop}}
+  <div class="row dismiss-container-top">
+    {{#if showDismissRead}}
+      {{d-button
+        class="btn-default dismiss-read"
+        id="dismiss-topics-top"
+        action=(action "dismissReadPosts")
+        title="topics.bulk.dismiss_tooltip"
+        label="topics.bulk.dismiss_button"}}
+    {{/if}}
+    {{#if showResetNew}}
+      {{d-button
+        class="btn-default dismiss-read"
+        id="dismiss-new-top"
+        action=(action "resetNew")
+        icon="check"
+        label="topics.bulk.dismiss_new"}}
+    {{/if}}
+  </div>
+{{/if}}
+
 {{#discovery-topics-list model=model refresh=(action "refresh") incomingCount=topicTrackingState.incomingCount as |discoveryTopicList|}}
   {{#if top}}
     <div class="top-lists">

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -428,7 +428,7 @@ tr.category-topic-link {
 }
 
 button.dismiss-read {
-  margin-right: 10px;
+  margin-bottom: 10px;
 }
 
 // base defines extra padding for easier click/top of title field


### PR DESCRIPTION
We want to be consistent across desktop and mobile.

