### PR TITLE
FIX: mention notification takes precedence over group

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -70,14 +70,14 @@ class PostAlerter
         mentioned_opts = { user_id: editor.id, original_username: editor.username, display_username: editor.username }
       end
 
-      expand_group_mentions(mentioned_groups, post) do |group, users|
-        users = only_allowed_users(users, post)
-        notified += notify_users(users - notified, :group_mentioned, post, mentioned_opts.merge(group: group))
-      end
-
       if mentioned_users
         mentioned_users = only_allowed_users(mentioned_users, post)
         notified += notify_users(mentioned_users - notified, :mentioned, post, mentioned_opts)
+      end
+
+      expand_group_mentions(mentioned_groups, post) do |group, users|
+        users = only_allowed_users(users, post)
+        notified += notify_users(users - notified, :group_mentioned, post, mentioned_opts.merge(group: group))
       end
     end
 

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -380,6 +380,13 @@ describe PostAlerter do
       expect(GroupMention.count).to eq(4)
     end
 
+    it 'takes private mention as precedence' do
+      expect {
+        create_post_with_alerts(raw: "Hello @group and @eviltrout, nice to meet you")
+      }.to change(evil_trout.notifications, :count).by(1)
+      expect(evil_trout.notifications.last.notification_type).to eq(Notification.types[:mentioned])
+    end
+
     it "triggers :before_create_notifications_for_users" do
       events = DiscourseEvent.track_events do
         post


### PR DESCRIPTION
When a specific user is mentioned and group to which this user belongs, a direct mention notification should take precedence.
