### PR TITLE
FIX: do not convert image format for site setting uploads

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -203,6 +203,7 @@ class UploadCreator
   MIN_CONVERT_TO_JPEG_SAVING_RATIO = 0.70
 
   def convert_to_jpeg!
+    return if @opts[:for_site_setting]
     return if filesize < MIN_CONVERT_TO_JPEG_BYTES_SAVED
 
     jpeg_tempfile = Tempfile.new(["image", ".jpg"])

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe UploadCreator do
         # pngquant will lose some colors causing some extra size reduction
         expect(thumbnail_size).to be < 7500
       end
-
     end
 
     describe 'converting to jpeg' do
@@ -148,7 +147,6 @@ RSpec.describe UploadCreator do
       end
 
       it 'should not store file as jpeg if it does not meet absolute byte saving requirements' do
-
         # logo.png is 2297 bytes, converting to jpeg saves 30% but does not meet
         # the absolute savings required of 25_000 bytes, if you save less than that
         # skip this
@@ -165,7 +163,6 @@ RSpec.describe UploadCreator do
         expect(upload.extension).to eq('png')
         expect(File.extname(upload.url)).to eq('.png')
         expect(upload.original_filename).to eq('logo.png')
-
       end
 
       it 'should store the upload with the right extension' do
@@ -181,6 +178,14 @@ RSpec.describe UploadCreator do
         expect(upload.extension).to eq('jpeg')
         expect(File.extname(upload.url)).to eq('.jpeg')
         expect(upload.original_filename).to eq('should_be_jpeg.jpg')
+      end
+
+      it "should not convert to jpeg when the image is uploaded from site setting" do
+        upload = UploadCreator.new(large_file, large_filename, for_site_setting: true, force_optimize: true).create_for(user.id)
+
+        expect(upload.extension).to eq('png')
+        expect(File.extname(upload.url)).to eq('.png')
+        expect(upload.original_filename).to eq('large_and_unoptimized.png')
       end
 
       context "jpeg image quality settings" do
@@ -229,7 +234,6 @@ RSpec.describe UploadCreator do
             expect(File.extname(upload.url)).to eq('.png')
             expect(upload.original_filename).to eq('large_and_unoptimized.png')
           end
-
         end
 
         it 'should not convert animated WEBP images' do


### PR DESCRIPTION
Meta reference: https://meta.discourse.org/t/png-converts-to-jpg-no-matter-what/183209/10?u=techapj