### PR TITLE
FIX: Correctly use invite to topic email templates

### DIFF
--- a/app/jobs/regular/invite_email.rb
+++ b/app/jobs/regular/invite_email.rb
@@ -11,7 +11,7 @@ module Jobs
       invite = Invite.find_by(id: args[:invite_id])
       return unless invite.present?
 
-      message = InviteMailer.send_invite(invite)
+      message = InviteMailer.send_invite(invite, invite_to_topic: args[:invite_to_topic])
       Email::Sender.new(message, :invite).send
 
       if invite.emailed_status != Invite.emailed_status_types[:not_required]

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -5,7 +5,7 @@ class InviteMailer < ActionMailer::Base
 
   layout 'email_template'
 
-  def send_invite(invite)
+  def send_invite(invite, invite_to_topic: false)
     # Find the first topic they were invited to
     first_topic = invite.topics.order(:created_at).first
 
@@ -19,7 +19,7 @@ class InviteMailer < ActionMailer::Base
       ActionView::Base.full_sanitizer.sanitize(invite.custom_message.gsub(/\n+/, " ").strip) : nil
 
     # If they were invited to a topic
-    if first_topic.present?
+    if invite_to_topic && first_topic.present?
       # get topic excerpt
       topic_excerpt = ""
       if first_topic.excerpt

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -156,7 +156,7 @@ class Invite < ActiveRecord::Base
 
     if emailed_status == emailed_status_types[:pending]
       invite.update_column(:emailed_status, emailed_status_types[:sending])
-      Jobs.enqueue(:invite_email, invite_id: invite.id)
+      Jobs.enqueue(:invite_email, invite_id: invite.id, invite_to_topic: opts[:invite_to_topic])
     end
 
     invite.reload

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1059,7 +1059,8 @@ class Topic < ActiveRecord::Base
         email: username_or_email,
         topic: self,
         group_ids: group_ids,
-        custom_message: custom_message
+        custom_message: custom_message,
+        invite_to_topic: true
       )
     end
   end

--- a/spec/jobs/invite_email_spec.rb
+++ b/spec/jobs/invite_email_spec.rb
@@ -17,7 +17,7 @@ describe Jobs::InviteEmail do
 
       it 'delegates to the test mailer' do
         Email::Sender.any_instance.expects(:send)
-        InviteMailer.expects(:send_invite).with(invite, nil).returns(mailer)
+        InviteMailer.expects(:send_invite).with(invite, anything).returns(mailer)
         Jobs::InviteEmail.new.execute(invite_id: invite.id)
       end
 

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -90,7 +90,7 @@ describe InviteMailer do
           Invite.find_by(invited_by_id: topic.user.id)
         end
 
-        let(:invite_mail) { InviteMailer.send_invite(invite) }
+        let(:invite_mail) { InviteMailer.send_invite(invite, invite_to_topic: true) }
 
         it 'renders the invitee email' do
           expect(invite_mail.to).to eql(['name@example.com'])

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -894,12 +894,14 @@ describe Topic do
           before { user.update!(trust_level: TrustLevel[2]) }
 
           it 'should create an invite' do
+            Jobs.run_immediately!
             expect(topic.invite(user, 'test@email.com')).to eq(true)
 
             invite = Invite.last
 
             expect(invite.email).to eq('test@email.com')
             expect(invite.invited_by).to eq(user)
+            expect(ActionMailer::Base.deliveries.last.body).to include(topic.title)
           end
         end
       end


### PR DESCRIPTION
It was used both when inviting from a topic page and when creating
invites with "Send to topic on first login", while it should be used
only in the former case.