### PR TITLE
FIX: Allow group owners manage group flair

### DIFF
--- a/app/assets/javascripts/discourse/app/components/groups-form-membership-fields.js
+++ b/app/assets/javascripts/discourse/app/components/groups-form-membership-fields.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import I18n from "I18n";
 import { computed } from "@ember/object";
+import { not } from "@ember/object/computed";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
@@ -20,6 +21,8 @@ export default Component.extend({
       { name: 4, value: 4 },
     ];
   },
+
+  canEdit: not("model.automatic"),
 
   groupTrustLevel: computed(
     "model.grant_trust_level",

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-membership-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-membership-fields.hbs
@@ -96,7 +96,9 @@
       {{i18n "admin.groups.default_title_description"}}
     </div>
   </div>
+{{/if}}
 
+{{#if canEdit}}
   <div class="control-group">
     {{group-flair-inputs model=model}}
   </div>


### PR DESCRIPTION
This was removed by accident during a reorganization.

Follow up to commit 901cee55cdeefa64cb65efa9a02a81297e416051.
