### PR TITLE
DEV: Make `dockcontainer` and `hidepassed` the defaults

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -30,6 +30,9 @@ module.exports = function (defaults) {
 
   let app = new EmberApp(defaults, {
     autoRun: false,
+    "ember-qunit": {
+      insertContentForTestBody: false,
+    },
   });
 
   // WARNING: We should only import scripts here if they are not in NPM.

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -81,6 +81,13 @@ function createApplication(config, settings) {
 }
 
 function setupTestsCommon(application, container, config) {
+  QUnit.config.hidepassed = true;
+
+  // Let's customize QUnit options a bit
+  QUnit.config.urlConfig = QUnit.config.urlConfig.filter(
+    (c) => ["dockcontainer", "nocontainer"].indexOf(c.id) === -1
+  );
+
   application.rootElement = "#ember-testing";
   application.setupForTesting();
   application.injectTestHelpers();

--- a/app/assets/javascripts/discourse/tests/test-helper.js
+++ b/app/assets/javascripts/discourse/tests/test-helper.js
@@ -8,6 +8,15 @@ document.addEventListener("discourse-booted", () => {
   let setupTests = require("discourse/tests/setup-tests").default;
   Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION = false;
 
+  document.write(`
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+
+    <div id="ember-testing-container" style='position: fixed'>
+      <div id="ember-testing"></div>
+    </div>
+  `);
+
   setupTests(config.APP);
-  start();
+  start({ setupTestContainer: false });
 });


### PR DESCRIPTION
This makes running qunit tests in a browser much simpler

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
