### PR TITLE
UX: reduce opacity of code copy button

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -721,6 +721,7 @@ pre {
     font-size: $font-down-2;
     min-height: 0;
     font-size: $font-down-2;
+    opacity: 0.7;
 
     &.copied {
       .d-icon {

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -230,8 +230,11 @@ pre.copy-codeblocks .copy-cmd:not(.copied) {
 }
 
 pre.copy-codeblocks:hover .copy-cmd {
-  opacity: 1;
+  opacity: 0.7;
   visibility: visible;
+  &:hover {
+    opacity: 1;
+  }
 }
 
 .embedded-posts {


### PR DESCRIPTION
The goal is to make text that may fall under the button at least slightly visible. 