### PR TITLE
FIX: In components, fall back to default theme color variables

### DIFF
--- a/lib/stylesheet/importer.rb
+++ b/lib/stylesheet/importer.rb
@@ -135,8 +135,11 @@ module Stylesheet
         rescue
           ColorScheme.base_colors
         end
+      elsif (@theme_id && theme.color_scheme)
+        colors = theme.color_scheme.resolved_colors
       else
-        colors = (@theme_id && theme.color_scheme) ? theme.color_scheme.resolved_colors : ColorScheme.base_colors
+        colors = Theme.find_by_id(SiteSetting.default_theme_id)&.color_scheme&.resolved_colors ||
+          ColorScheme.base_colors
       end
 
       colors.each do |n, hex|


### PR DESCRIPTION
Component SCSS compilation should use the current theme's SCSS color
variables as a fallback before using the default core colors.

This is mostly a backwards-compatibility fix, new themes and components
should use CSS custom properties, which offer better support for on-the-fly
color scheme changes (dark mode support, etc.).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
