### PR TITLE
DEV: Remove deprecated Sidekiq config

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,6 @@ Discourse::Application.routes.draw do
     post "webhooks/sparkpost" => "webhooks#sparkpost"
 
     scope path: nil, constraints: { format: /.*/ } do
-      Sidekiq::Web.set :sessions, Rails.application.config.session_options
       if Rails.env.development?
         mount Sidekiq::Web => "/sidekiq"
         mount Logster::Web => "/logs"


### PR DESCRIPTION
> WARNING: Sidekiq::Web.sessions= is no longer relevant and will be removed in Sidekiq 7.0.