### PR TITLE
FIX: Do not treat code tag as block level element

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -416,7 +416,12 @@ export default Component.extend({
         loadScript("/javascripts/diffhtml.min.js").then(() => {
           window.diff.innerHTML(
             this.element.querySelector(".d-editor-preview"),
-            cookedElement.innerHTML
+            cookedElement.innerHTML,
+            {
+              parser: {
+                rawElements: ["script", "noscript", "style", "template"],
+              },
+            }
           );
         });
       }


### PR DESCRIPTION
When syncing code elements, the inner text used to be escaped, which
rendered the actual HTML code instead. This commit overwrites default
parser settings to fix the way code tags are handled.