### PR TITLE
FEATURE: Obfuscate emails on invite show page

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -17,9 +17,19 @@ class InvitesController < ApplicationController
 
     invite = Invite.find_by(invite_key: params[:id])
     if invite.present? && !invite.expired? && !invite.redeemed?
+      email = Email.obfuscate(invite.email)
+
+      # Show email if the user already authenticated their email
+      if session[:authentication]
+        auth_result = Auth::Result.from_session_data(session[:authentication], user: nil)
+        if invite.email == auth_result.email
+          email = invite.email
+        end
+      end
+
       store_preloaded("invite_info", MultiJson.dump(
         invited_by: UserNameSerializer.new(invite.invited_by, scope: guardian, root: false),
-        email: invite.email,
+        email: email,
         username: UserNameSuggester.suggest(invite.email),
         is_invite_link: invite.is_invite_link?
       ))

--- a/lib/email.rb
+++ b/lib/email.rb
@@ -16,6 +16,20 @@ module Email
     email.downcase
   end
 
+  def self.obfuscate(email)
+    return email if !Email.is_valid?(email)
+
+    first, _, last = email.rpartition('@')
+
+    # Obfuscate each last part, except tld
+    last = last.split('.')
+    tld = last.pop
+    last.map! { |part| obfuscate_part(part) }
+    last << tld
+
+    "#{obfuscate_part(first)}@#{last.join('.')}"
+  end
+
   def self.cleanup_alias(name)
     name ? name.gsub(/[:<>,"]/, '') : name
   end
@@ -50,5 +64,17 @@ module Email
   def self.message_id_clean(message_id)
     return message_id if !(message_id =~ MESSAGE_ID_REGEX)
     message_id.tr("<>", "")
+  end
+
+  private
+
+  def self.obfuscate_part(part)
+    if part.size < 3
+      "*" * part.size
+    elsif part.size < 5
+      part[0] + "*" * (part.size - 1)
+    else
+      part[0] + "*" * (part.size - 2) + part[-1]
+    end
   end
 end

--- a/spec/components/email/email_spec.rb
+++ b/spec/components/email/email_spec.rb
@@ -44,4 +44,25 @@ describe Email do
 
   end
 
+  describe "obfuscate" do
+
+    it 'correctly obfuscates emails' do
+      expect(Email.obfuscate('a@b.com')).to eq('*@*.com')
+      expect(Email.obfuscate('test@test.co.uk')).to eq('t***@t***.**.uk')
+      expect(Email.obfuscate('simple@example.com')).to eq('s****e@e*****e.com')
+      expect(Email.obfuscate('very.common@example.com')).to eq('v*********n@e*****e.com')
+      expect(Email.obfuscate('disposable.style.email.with+symbol@example.com')).to eq('d********************************l@e*****e.com')
+      expect(Email.obfuscate('other.email-with-hyphen@example.com')).to eq('o*********************n@e*****e.com')
+      expect(Email.obfuscate('fully-qualified-domain@example.com')).to eq('f********************n@e*****e.com')
+      expect(Email.obfuscate('user.name+tag+sorting@example.com')).to eq('u*******************g@e*****e.com')
+      expect(Email.obfuscate('x@example.com')).to eq('*@e*****e.com')
+      expect(Email.obfuscate('example-indeed@strange-example.com')).to eq('e************d@s*************e.com')
+      expect(Email.obfuscate('example@s.example')).to eq('e*****e@*.example')
+      expect(Email.obfuscate('mailhost!username@example.org')).to eq('m***************e@e*****e.org')
+      expect(Email.obfuscate('user%example.com@example.org')).to eq('u**************m@e*****e.org')
+      expect(Email.obfuscate('user-@example.org')).to eq('u***-@e*****e.org')
+    end
+
+  end
+
 end


### PR DESCRIPTION
The email should not be ever displayed in clear text, except the case when the user authenticates using another service.