### PR TITLE
UX: Show first unique letters in invite link

### DIFF
--- a/app/assets/javascripts/discourse/app/models/invite.js
+++ b/app/assets/javascripts/discourse/app/models/invite.js
@@ -34,6 +34,11 @@ const Invite = EmberObject.extend({
       .catch(popupAjaxError);
   },
 
+  @discourseComputed("invite_key")
+  shortKey(key) {
+    return key.substr(0, 4) + "...";
+  },
+
   @discourseComputed("groups")
   groupIds(groups) {
     return groups ? groups.map((group) => group.id) : [];

--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
@@ -107,7 +107,7 @@
                       {{#if invite.email}}
                         {{invite.email}}
                       {{else}}
-                        {{i18n "user.invited.invited_via_link" count=invite.redemption_count max=invite.max_redemptions_allowed}}
+                        {{i18n "user.invited.invited_via_link" key=invite.shortKey count=invite.redemption_count max=invite.max_redemptions_allowed}}
                       {{/if}}
                     </td>
                     {{#if currentUser.staff}}

--- a/app/serializers/invite_serializer.rb
+++ b/app/serializers/invite_serializer.rb
@@ -2,6 +2,7 @@
 
 class InviteSerializer < ApplicationSerializer
   attributes :id,
+             :invite_key,
              :link,
              :email,
              :emailed,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1448,7 +1448,7 @@ en:
         redeemed_tab: "Redeemed"
         redeemed_tab_with_count: "Redeemed (%{count})"
         invited_via: "Invitation"
-        invited_via_link: "link (%{count} / %{max} redeemed)"
+        invited_via_link: "link %{key} (%{count} / %{max} redeemed)"
         groups: "Groups"
         topic: "Topic"
         sent: "Created/Last Sent"


### PR DESCRIPTION
This will show the first letters of the invite key for invites of type 'link'. Where it used to say "link (0 / 1 redeemed)" it will say "link abcd... (0 / 1 redeemed)" to make it easier to identify links.