### PR TITLE
UX: implements empty state message for PMs

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/quick-access-messages.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-messages.js
@@ -1,6 +1,9 @@
+import RawHtml from "discourse/widgets/raw-html";
+import { h } from "virtual-dom";
 import QuickAccessPanel from "discourse/widgets/quick-access-panel";
-import { createWidgetFrom } from "discourse/widgets/widget";
+import { createWidget, createWidgetFrom } from "discourse/widgets/widget";
 import { postUrl } from "discourse/lib/utilities";
+import I18n from "I18n";
 
 const ICON = "notification.private_message";
 
@@ -20,9 +23,22 @@ function toItem(message) {
   };
 }
 
+createWidget("no-quick-access-messages", {
+  html() {
+    return h("div.empty-state", [
+      h("span.empty-state-title", I18n.t("user.no_messages_title")),
+      new RawHtml({
+        html: `<p class="empty-state-body">${I18n.t(
+          "user.no_messages_body"
+        ).htmlSafe()}</p>`,
+      }),
+    ]);
+  },
+});
+
 createWidgetFrom(QuickAccessPanel, "quick-access-messages", {
   buildKey: () => "quick-access-messages",
-  emptyStatePlaceholderItemKey: "choose_topic.none_found",
+  emptyStateWidget: "no-quick-access-messages",
 
   showAllHref() {
     return `${this.attrs.path}/messages`;

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
@@ -14,7 +14,8 @@ import { h } from "virtual-dom";
  */
 export default createWidget("quick-access-panel", {
   tagName: "div.quick-access-panel",
-  emptyStatePlaceholderItemKey: "",
+  emptyStatePlaceholderItemKey: null,
+  emptyStateWidget: null,
 
   buildKey: () => {
     throw Error('Cannot attach abstract widget "quick-access-panel".');
@@ -60,6 +61,8 @@ export default createWidget("quick-access-panel", {
   emptyStatePlaceholderItem() {
     if (this.emptyStatePlaceholderItemKey) {
       return h("li.read", I18n.t(this.emptyStatePlaceholderItemKey));
+    } else if (this.emptyStateWidget) {
+      return this.attach(this.emptyStateWidget);
     } else {
       return "";
     }

--- a/app/assets/stylesheets/common/base/_index.scss
+++ b/app/assets/stylesheets/common/base/_index.scss
@@ -16,6 +16,7 @@
 @import "discourse";
 @import "edit-category";
 @import "edit-topic-timer-modal";
+@import "empty-state";
 @import "ember-select";
 @import "emoji";
 @import "exception";

--- a/app/assets/stylesheets/common/base/empty-state.scss
+++ b/app/assets/stylesheets/common/base/empty-state.scss
@@ -1,0 +1,19 @@
+.empty-state {
+  background: var(--tertiary-low);
+  color: var(--primary);
+  margin: 0;
+  padding: 0.5em 2.5em 0.5em 1em;
+  display: flex;
+  flex-direction: column;
+
+  .empty-state-title {
+    font-weight: 700;
+    padding: 0 0 1em 0;
+    margin: 0;
+  }
+
+  .empty-state-body {
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1021,6 +1021,8 @@ en:
       dismiss: "Dismiss"
       dismiss_notifications: "Dismiss All"
       dismiss_notifications_tooltip: "Mark all unread notifications as read"
+      no_messages_title: "You don’t have any messages"
+      no_messages_body: "Personal messages are a great way to chat with a group or inidividual directly.\nGo ahead, <a href=\"%{base_path}/new-topic\">start your first one now!</a>"
       first_notification: "Your first notification! Select it to begin."
       dynamic_favicon: "Show counts on browser icon"
       skip_new_user_tips:


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
