### PR TITLE
FEATURE: Allow users to save draft and close composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal-body.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal-body.js
@@ -56,7 +56,8 @@ export default Component.extend({
         "fixed",
         "subtitle",
         "rawSubtitle",
-        "dismissable"
+        "dismissable",
+        "headerClass"
       )
     );
   },

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -23,6 +23,7 @@ export default Component.extend({
   title: null,
   subtitle: null,
   role: "dialog",
+  headerClass: null,
 
   init() {
     this._super(...arguments);
@@ -43,11 +44,6 @@ export default Component.extend({
   ariaLabelledby: computed("title", function () {
     return this.title ? "discourse-modal-title" : null;
   }),
-
-  @computed()
-  get includeHeader() {
-    return this.title || this.subtitle || this.panels || this.dismissable;
-  },
 
   @on("didInsertElement")
   setUp() {
@@ -132,6 +128,10 @@ export default Component.extend({
       this.set("dismissable", data.dismissable);
     } else {
       this.set("dismissable", true);
+    }
+
+    if (data.headerClass) {
+      this.set("headerClass", data.headerClass);
     }
 
     if (this.element) {

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -4,7 +4,6 @@ import I18n from "I18n";
 import afterTransition from "discourse/lib/after-transition";
 import { next } from "@ember/runloop";
 import { on } from "discourse-common/utils/decorators";
-import { or } from "@ember/object/computed";
 
 export default Component.extend({
   classNameBindings: [
@@ -45,7 +44,10 @@ export default Component.extend({
     return this.title ? "discourse-modal-title" : null;
   }),
 
-  includeHeader: or("title", "subtitle", "panels", "dismissable"),
+  @computed()
+  get includeHeader() {
+    return this.title || this.subtitle || this.panels || this.dismissable;
+  },
 
   @on("didInsertElement")
   setUp() {

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -4,6 +4,7 @@ import I18n from "I18n";
 import afterTransition from "discourse/lib/after-transition";
 import { next } from "@ember/runloop";
 import { on } from "discourse-common/utils/decorators";
+import { or } from "@ember/object/computed";
 
 export default Component.extend({
   classNameBindings: [
@@ -43,6 +44,8 @@ export default Component.extend({
   ariaLabelledby: computed("title", function () {
     return this.title ? "discourse-modal-title" : null;
   }),
+
+  includeHeader: or("title", "subtitle", "panels", "dismissable"),
 
   @on("didInsertElement")
   setUp() {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -18,6 +18,7 @@ import discourseComputed, {
 import DiscourseURL from "discourse/lib/url";
 import Draft from "discourse/models/draft";
 import I18n from "I18n";
+import { iconHTML } from "discourse-common/lib/icon-library";
 import { Promise } from "rsvp";
 import bootbox from "bootbox";
 import { buildQuote } from "discourse/lib/quote";
@@ -1071,6 +1072,7 @@ export default Controller.extend({
           {
             label: I18n.t("drafts.abandon.yes_value"),
             class: "btn-danger",
+            icon: iconHTML("far-trash-alt"),
             callback: () => {
               this.destroyDraft(data.draft_sequence).finally(() => {
                 data.draft = null;

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1100,7 +1100,6 @@ export default Controller.extend({
         const controller = showModal("discard-draft", {
           model: this.model,
           modalClass: "discard-draft-modal",
-          dismissable: false,
         });
         controller.setProperties({
           onDestroyDraft: () => {

--- a/app/assets/javascripts/discourse/app/controllers/discard-draft.js
+++ b/app/assets/javascripts/discourse/app/controllers/discard-draft.js
@@ -1,38 +1,13 @@
 import Controller from "@ember/controller";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
-import discourseComputed from "discourse-common/utils/decorators";
 
 export default Controller.extend(ModalFunctionality, {
-  differentDraft: null,
-
-  @discourseComputed()
-  keyPrefix() {
-    return this.model.action === "edit" ? "post.abandon_edit" : "post.abandon";
-  },
-
-  @discourseComputed("keyPrefix")
-  descriptionKey(keyPrefix) {
-    return `${keyPrefix}.confirm`;
-  },
-
-  @discourseComputed("keyPrefix")
-  discardKey(keyPrefix) {
-    return `${keyPrefix}.yes_value`;
-  },
-
-  @discourseComputed("keyPrefix", "differentDraft")
-  saveKey(keyPrefix, differentDraft) {
-    return differentDraft
-      ? `${keyPrefix}.no_save_draft`
-      : `${keyPrefix}.no_value`;
-  },
-
   actions: {
-    _destroyDraft() {
+    destroyDraft() {
       this.onDestroyDraft();
       this.send("closeModal");
     },
-    _saveDraft() {
+    saveDraftAndClose() {
       this.onSaveDraft();
       this.send("closeModal");
     },

--- a/app/assets/javascripts/discourse/app/controllers/discard-draft.js
+++ b/app/assets/javascripts/discourse/app/controllers/discard-draft.js
@@ -11,5 +11,9 @@ export default Controller.extend(ModalFunctionality, {
       this.onSaveDraft();
       this.send("closeModal");
     },
+    dismissModal() {
+      this.onDismissModal();
+      this.send("closeModal");
+    },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/navigation/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/navigation/categories.js
@@ -1,15 +1,6 @@
 import NavigationDefaultController from "discourse/controllers/navigation/default";
-import discourseComputed from "discourse-common/utils/decorators";
 import { inject } from "@ember/controller";
 
 export default NavigationDefaultController.extend({
   discoveryCategories: inject("discovery/categories"),
-
-  @discourseComputed(
-    "discoveryCategories.model",
-    "discoveryCategories.model.draft"
-  )
-  draft() {
-    return this.get("discoveryCategories.model.draft");
-  },
 });

--- a/app/assets/javascripts/discourse/app/controllers/navigation/default.js
+++ b/app/assets/javascripts/discourse/app/controllers/navigation/default.js
@@ -1,13 +1,6 @@
 import Controller, { inject as controller } from "@ember/controller";
 import FilterModeMixin from "discourse/mixins/filter-mode";
-import discourseComputed from "discourse-common/utils/decorators";
 
 export default Controller.extend(FilterModeMixin, {
   discovery: controller(),
-  discoveryTopics: controller("discovery/topics"),
-
-  @discourseComputed("discoveryTopics.model", "discoveryTopics.model.draft")
-  draft: function () {
-    return this.get("discoveryTopics.model.draft");
-  },
 });

--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -29,11 +29,6 @@ export default Controller.extend(BulkTopicSelection, FilterModeMixin, {
   q: null,
   showInfo: false,
 
-  @discourseComputed("list", "list.draft")
-  createTopicLabel(list, listDraft) {
-    return listDraft ? "topic.open_draft" : "topic.create";
-  },
-
   @discourseComputed(
     "canCreateTopic",
     "category",

--- a/app/assets/javascripts/discourse/app/routes/discourse.js
+++ b/app/assets/javascripts/discourse/app/routes/discourse.js
@@ -1,4 +1,5 @@
 import Composer from "discourse/models/composer";
+import Draft from "discourse/models/draft";
 import Route from "@ember/routing/route";
 import { once } from "@ember/runloop";
 import { seenUser } from "discourse/lib/user-presence";
@@ -42,23 +43,6 @@ const DiscourseRoute = Route.extend({
     refreshTitle() {
       once(this, this._refreshTitleOnce);
     },
-
-    clearTopicDraft() {
-      // perhaps re-delegate this to root controller in all cases?
-      // TODO also poison the store so it does not come back from the
-      // dead
-      if (this.get("controller.list.draft")) {
-        this.set("controller.list.draft", null);
-      }
-
-      if (this.controllerFor("discovery/categories").get("model.draft")) {
-        this.controllerFor("discovery/categories").set("model.draft", null);
-      }
-
-      if (this.controllerFor("discovery/topics").get("model.draft")) {
-        this.controllerFor("discovery/topics").set("model.draft", null);
-      }
-    },
   },
 
   redirectIfLoginRequired() {
@@ -68,20 +52,24 @@ const DiscourseRoute = Route.extend({
     }
   },
 
-  openTopicDraft(model) {
+  openTopicDraft() {
     const composer = this.controllerFor("composer");
 
     if (
       composer.get("model.action") === Composer.CREATE_TOPIC &&
-      composer.get("model.draftKey") === model.draft_key
+      composer.get("model.draftKey") === Composer.NEW_TOPIC_KEY
     ) {
       composer.set("model.composeState", Composer.OPEN);
     } else {
-      composer.open({
-        action: Composer.CREATE_TOPIC,
-        draft: model.draft,
-        draftKey: model.draft_key,
-        draftSequence: model.draft_sequence,
+      Draft.get(Composer.NEW_TOPIC_KEY).then((data) => {
+        if (data.draft) {
+          composer.open({
+            action: Composer.CREATE_TOPIC,
+            draft: data.draft,
+            draftKey: Composer.NEW_TOPIC_KEY,
+            draftSequence: data.draft_sequence,
+          });
+        }
       });
     }
   },

--- a/app/assets/javascripts/discourse/app/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-categories.js
@@ -118,9 +118,8 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
     },
 
     createTopic() {
-      const model = this.controllerFor("discovery/categories").get("model");
-      if (model.draft) {
-        this.openTopicDraft(model);
+      if (this.get("currentUser.has_topic_draft")) {
+        this.openTopicDraft();
       } else {
         this.openComposer(this.controllerFor("discovery/categories"));
       }

--- a/app/assets/javascripts/discourse/app/routes/discovery.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery.js
@@ -59,9 +59,8 @@ export default DiscourseRoute.extend(OpenComposer, {
     },
 
     createTopic() {
-      const model = this.controllerFor("discovery/topics").get("model");
-      if (model.draft) {
-        this.openTopicDraft(model);
+      if (this.get("currentUser.has_topic_draft")) {
+        this.openTopicDraft();
       } else {
         this.openComposer(this.controllerFor("discovery/topics"));
       }

--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -180,11 +180,10 @@ export default DiscourseRoute.extend(FilterModeMixin, {
     },
 
     createTopic() {
-      const controller = this.controllerFor("tag.show");
-
-      if (controller.get("list.draft")) {
-        this.openTopicDraft(controller.get("list"));
+      if (this.get("currentUser.has_topic_draft")) {
+        this.openTopicDraft();
       } else {
+        const controller = this.controllerFor("tag.show");
         const composerController = this.controllerFor("composer");
         composerController
           .open({

--- a/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
@@ -24,7 +24,8 @@
                   panel=panel
                   panelsLength=panels.length
                   selectedPanel=selectedPanel
-                  onSelectPanel=onSelectPanel}}
+                  onSelectPanel=onSelectPanel
+                }}
               {{/each}}
             </ul>
           {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
@@ -1,33 +1,35 @@
 <div class="modal-outer-container">
   <div class="modal-middle-container">
     <div class="modal-inner-container">
-      <div class="modal-header">
-        {{#if dismissable}}
-          {{d-button icon="times" action=(route-action "closeModal" "initiatedByCloseButton") class="btn-flat modal-close close" title="modal.close"}}
-        {{/if}}
+      {{#if includeHeader}}
+        <div class="modal-header">
+          {{#if dismissable}}
+            {{d-button icon="times" action=(route-action "closeModal" "initiatedByCloseButton") class="btn-flat modal-close close" title="modal.close"}}
+          {{/if}}
 
-        {{#if title}}
-          <div class="title">
-            <h3 id="discourse-modal-title">{{title}}</h3>
+          {{#if title}}
+            <div class="title">
+              <h3 id="discourse-modal-title">{{title}}</h3>
 
-            {{#if subtitle}}
-              <p>{{subtitle}}</p>
-            {{/if}}
-          </div>
-        {{/if}}
+              {{#if subtitle}}
+                <p>{{subtitle}}</p>
+              {{/if}}
+            </div>
+          {{/if}}
 
-        {{#if panels}}
-          <ul class="modal-tabs">
-            {{#each panels as |panel|}}
-              {{modal-tab
-                panel=panel
-                panelsLength=panels.length
-                selectedPanel=selectedPanel
-                onSelectPanel=onSelectPanel}}
-            {{/each}}
-          </ul>
-        {{/if}}
-      </div>
+          {{#if panels}}
+            <ul class="modal-tabs">
+              {{#each panels as |panel|}}
+                {{modal-tab
+                  panel=panel
+                  panelsLength=panels.length
+                  selectedPanel=selectedPanel
+                  onSelectPanel=onSelectPanel}}
+              {{/each}}
+            </ul>
+          {{/if}}
+        </div>
+      {{/if}}
 
       <div id="modal-alert"></div>
 

--- a/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
@@ -1,36 +1,34 @@
 <div class="modal-outer-container">
   <div class="modal-middle-container">
     <div class="modal-inner-container">
-      {{#if includeHeader}}
-        <div class="modal-header">
-          {{#if dismissable}}
-            {{d-button icon="times" action=(route-action "closeModal" "initiatedByCloseButton") class="btn-flat modal-close close" title="modal.close"}}
-          {{/if}}
+      <div class="modal-header {{headerClass}}">
+        {{#if dismissable}}
+          {{d-button icon="times" action=(route-action "closeModal" "initiatedByCloseButton") class="btn-flat modal-close close" title="modal.close"}}
+        {{/if}}
 
-          {{#if title}}
-            <div class="title">
-              <h3 id="discourse-modal-title">{{title}}</h3>
+        {{#if title}}
+          <div class="title">
+            <h3 id="discourse-modal-title">{{title}}</h3>
 
-              {{#if subtitle}}
-                <p>{{subtitle}}</p>
-              {{/if}}
-            </div>
-          {{/if}}
+            {{#if subtitle}}
+              <p>{{subtitle}}</p>
+            {{/if}}
+          </div>
+        {{/if}}
 
-          {{#if panels}}
-            <ul class="modal-tabs">
-              {{#each panels as |panel|}}
-                {{modal-tab
-                  panel=panel
-                  panelsLength=panels.length
-                  selectedPanel=selectedPanel
-                  onSelectPanel=onSelectPanel
-                }}
-              {{/each}}
-            </ul>
-          {{/if}}
-        </div>
-      {{/if}}
+        {{#if panels}}
+          <ul class="modal-tabs">
+            {{#each panels as |panel|}}
+              {{modal-tab
+                panel=panel
+                panelsLength=panels.length
+                selectedPanel=selectedPanel
+                onSelectPanel=onSelectPanel
+              }}
+            {{/each}}
+          </ul>
+        {{/if}}
+      </div>
 
       <div id="modal-alert"></div>
 

--- a/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
@@ -1,10 +1,11 @@
-{{#d-modal-body}}
+{{#d-modal-body dismissable=false}}
   <div class="instructions">
-    {{i18n descriptionKey}}
+    {{i18n "post.cancel_composer.confirm"}}
   </div>
 {{/d-modal-body}}
 
 <div class="modal-footer">
-  {{d-button label=discardKey class="btn-danger" action=(action "_destroyDraft")}}
-  {{d-button label=saveKey action=(action "_saveDraft")}}
+  {{d-button label="post.cancel_composer.discard" class="btn-danger" action=(action "destroyDraft")}}
+  {{d-button label="post.cancel_composer.save_draft" class="save-draft" action=(action "saveDraftAndClose")}}
+  {{d-button label="post.cancel_composer.keep_editing" class="keep-editing" action=(action "closeModal")}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
@@ -5,7 +5,7 @@
 {{/d-modal-body}}
 
 <div class="modal-footer">
-  {{d-button label="post.cancel_composer.discard" class="btn-danger" action=(action "destroyDraft")}}
+  {{d-button icon="far-trash-alt" label="post.cancel_composer.discard" class="btn-danger" action=(action "destroyDraft")}}
   {{d-button label="post.cancel_composer.save_draft" class="save-draft" action=(action "saveDraftAndClose")}}
   {{d-button label="post.cancel_composer.keep_editing" class="keep-editing" action=(action "closeModal")}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
@@ -1,4 +1,4 @@
-{{#d-modal-body dismissable=false}}
+{{#d-modal-body dismissable=false headerClass="empty"}}
   <div class="instructions">
     {{i18n "post.cancel_composer.confirm"}}
   </div>

--- a/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
@@ -7,5 +7,5 @@
 <div class="modal-footer">
   {{d-button icon="far-trash-alt" label="post.cancel_composer.discard" class="btn-danger" action=(action "destroyDraft")}}
   {{d-button label="post.cancel_composer.save_draft" class="save-draft" action=(action "saveDraftAndClose")}}
-  {{d-button label="post.cancel_composer.keep_editing" class="keep-editing" action=(action "closeModal")}}
+  {{d-button label="post.cancel_composer.keep_editing" class="keep-editing" action=(action "dismissModal")}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/navigation/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/categories.hbs
@@ -5,6 +5,6 @@
     createCategory=(route-action "createCategory")
     reorderCategories=(route-action "reorderCategories")
     canCreateTopic=canCreateTopic
-    hasDraft=draft
+    hasDraft=currentUser.has_topic_draft
     createTopic=(route-action "createTopic")}}
 {{/d-section}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -24,7 +24,7 @@
     canCreateTopic=canCreateTopic
     createTopic=(route-action "createTopic")
     createTopicDisabled=cannotCreateTopicOnCategory
-    hasDraft=draft
+    hasDraft=currentUser.has_topic_draft
     editCategory=(route-action "editCategory" category)}}
 
   {{plugin-outlet name="category-navigation" args=(hash category=category)}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/default.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/default.hbs
@@ -2,6 +2,6 @@
   {{d-navigation
     filterMode=filterMode
     canCreateTopic=canCreateTopic
-    hasDraft=draft
+    hasDraft=currentUser.has_topic_draft
     createTopic=(route-action "createTopic")}}
 {{/d-section}}

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -10,7 +10,7 @@
         {{d-navigation
           filterMode=filterMode
           canCreateTopic=canCreateTopic
-          hasDraft=draft
+          hasDraft=currentUser.has_topic_draft
           createTopic=(route-action "createTopic")
           category=category
           tag=tag

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -292,8 +292,7 @@ acceptance("Composer", function (needs) {
     await click(".topic-post:nth-of-type(1) button.edit");
 
     await click(".modal-footer button.keep-editing");
-
-    assert.ok(!visible(".discard-draft-modal.modal"));
+    assert.ok(invisible(".discard-draft-modal.modal"));
     assert.equal(
       queryAll(".d-editor-input").val(),
       "this is the content of my reply",
@@ -302,7 +301,7 @@ acceptance("Composer", function (needs) {
 
     await click(".topic-post:nth-of-type(1) button.edit");
     await click(".modal-footer button.save-draft");
-    assert.ok(!visible(".discard-draft-modal.modal"));
+    assert.ok(invisible(".discard-draft-modal.modal"));
 
     assert.equal(
       queryAll(".d-editor-input").val(),

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -291,12 +291,23 @@ acceptance("Composer", function (needs) {
     await click(".topic-post:nth-of-type(1) button.show-more-actions");
     await click(".topic-post:nth-of-type(1) button.edit");
 
-    await click(".modal-footer button:nth-of-type(2)");
+    await click(".modal-footer button.keep-editing");
 
     assert.ok(!visible(".discard-draft-modal.modal"));
     assert.equal(
       queryAll(".d-editor-input").val(),
-      "this is the content of my reply"
+      "this is the content of my reply",
+      "composer does not switch when using Keep Editing button"
+    );
+
+    await click(".topic-post:nth-of-type(1) button.edit");
+    await click(".modal-footer button.save-draft");
+    assert.ok(!visible(".discard-draft-modal.modal"));
+
+    assert.equal(
+      queryAll(".d-editor-input").val(),
+      queryAll(".topic-post:nth-of-type(1) .cooked > p").text(),
+      "composer has contents of post to be edited"
     );
   });
 
@@ -590,10 +601,16 @@ acceptance("Composer", function (needs) {
       "it pops up a confirmation dialog"
     );
     assert.equal(
-      queryAll(".modal-footer button:nth-of-type(2)").text().trim(),
-      I18n.t("post.abandon.no_value")
+      queryAll(".modal-footer button.save-draft").text().trim(),
+      I18n.t("post.cancel_composer.save_draft"),
+      "has save draft button"
     );
-    await click(".modal-footer button:nth-of-type(1)");
+    assert.equal(
+      queryAll(".modal-footer button.keep-editing").text().trim(),
+      I18n.t("post.cancel_composer.keep_editing"),
+      "has keep editing button"
+    );
+    await click(".modal-footer button.save-draft");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
@@ -615,14 +632,20 @@ acceptance("Composer", function (needs) {
       "it pops up a confirmation dialog"
     );
     assert.equal(
-      queryAll(".modal-footer button:nth-of-type(2)").text().trim(),
-      I18n.t("post.abandon.no_save_draft")
+      queryAll(".modal-footer button.save-draft").text().trim(),
+      I18n.t("post.cancel_composer.save_draft"),
+      "has save draft button"
     );
-    await click(".modal-footer button:nth-of-type(2)");
+    assert.equal(
+      queryAll(".modal-footer button.keep-editing").text().trim(),
+      I18n.t("post.cancel_composer.keep_editing"),
+      "has keep editing button"
+    );
+    await click(".modal-footer button.save-draft");
     assert.equal(
       queryAll(".d-editor-input").val(),
       "",
-      "it populates the input with the post text"
+      "it clears the composer input"
     );
   });
 

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -54,8 +54,10 @@
 
 .modal-header {
   display: flex;
-  padding: 10px 15px;
-  border-bottom: 1px solid var(--primary-low);
+  &:not(.empty) {
+    padding: 10px 15px;
+    border-bottom: 1px solid var(--primary-low);
+  }
   align-items: center;
 
   .title {

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -132,6 +132,12 @@ class Draft < ActiveRecord::Base
     data if current_sequence == draft_sequence
   end
 
+  def self.has_topic_draft(user)
+    return if !user || !user.id || !User.human_user_id?(user.id)
+
+    Draft.where(user_id: user.id, draft_key: NEW_TOPIC).present?
+  end
+
   def self.clear(user, key, sequence)
     return if !user || !user.id || !User.human_user_id?(user.id)
 

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -51,6 +51,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :featured_topic,
              :skip_new_user_tips,
              :do_not_disturb_until,
+             :has_topic_draft,
 
   def groups
     object.visible_groups.pluck(:id, :name).map { |id, name| { id: id, name: name } }
@@ -237,5 +238,13 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def featured_topic
     object.user_profile.featured_topic
+  end
+
+  def has_topic_draft
+    true
+  end
+
+  def include_has_topic_draft?
+    Draft.has_topic_draft(object)
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -346,9 +346,9 @@ en:
       new_private_message: "New private message draft"
       topic_reply: "Draft reply"
       abandon:
-        confirm: "You already opened another draft in this topic. Are you sure you want to abandon it?"
-        yes_value: "Yes, abandon"
-        no_value: "No, keep"
+        confirm: "You have a draft in progress for this topic. What would you like to do with it?"
+        yes_value: "Discard"
+        no_value: "Resume editing"
 
     topic_count_latest:
       one: "See %{count} new or updated topic"
@@ -2919,8 +2919,8 @@ en:
 
       cancel_composer:
         confirm: "What would you like to do with your post?"
-        discard: "Close and discard"
-        save_draft: "Close and save draft for later"
+        discard: "Discard"
+        save_draft: "Save draft for later"
         keep_editing: "Keep editing"
 
       via_email: "this post arrived via email"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2917,18 +2917,11 @@ en:
         attachment_upload_not_allowed_for_new_user: "Sorry, new users can not upload attachments."
         attachment_download_requires_login: "Sorry, you need to be logged in to download attachments."
 
-      abandon_edit:
-        confirm: "Are you sure you want to discard your changes?"
-        no_value: "No, keep"
-        no_save_draft: "No, save draft"
-        yes_value: "Yes, discard edit"
-
-      abandon:
-        title: "Abandon Draft"
-        confirm: "Are you sure you want to abandon your post?"
-        no_value: "No, keep"
-        no_save_draft: "No, save draft"
-        yes_value: "Yes, abandon"
+      cancel_composer:
+        confirm: "What would you like to do with your post?"
+        discard: "Close and discard"
+        save_draft: "Close and save draft for later"
+        keep_editing: "Keep editing"
 
       via_email: "this post arrived via email"
       via_auto_generated_email: "this post arrived via an auto generated email"

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -138,4 +138,32 @@ RSpec.describe CurrentUserSerializer do
       expect(payload[:groups]).to eq([{ id: public_group.id, name: public_group.name }])
     end
   end
+
+  context "#has_topic_draft" do
+    fab!(:user) { Fabricate(:user) }
+    let :serializer do
+      CurrentUserSerializer.new(user, scope: Guardian.new, root: false)
+    end
+
+    it "is not included by default" do
+      payload = serializer.as_json
+      expect(payload).not_to have_key(:has_topic_draft)
+    end
+
+    it "returns true when user has a draft" do
+      Draft.set(user, Draft::NEW_TOPIC, 0, "test1")
+
+      payload = serializer.as_json
+      expect(payload[:has_topic_draft]).to eq(true)
+    end
+
+    it "clearing a draft removes has_topic_draft from payload" do
+      sequence = Draft.set(user, Draft::NEW_TOPIC, 0, "test1")
+      Draft.clear(user, Draft::NEW_TOPIC, sequence)
+
+      payload = serializer.as_json
+      expect(payload).not_to have_key(:has_topic_draft)
+    end
+
+  end
 end


### PR DESCRIPTION
We previously included this option conditionally when users were replying
or creating a new topic while they had content already in the composer.

This PR changes the composer cancel dialog to always include three buttons:
  - Discard
  - Save draft for later
  - Keed editing

<img width="480" alt="image" src="https://user-images.githubusercontent.com/368961/111785671-45f22800-8893-11eb-8cd2-16f05de78676.png">


The PR also changes how the backend notifies the frontend when there is
a current draft topic. This is now sent via the `has_topic_draft`
property in the current user serializer.

(Previously, the draft topic was included in the discovery/topics and
discovery/categories routes, that is no longer used, I will clean up
those routes in another PR.)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
