### PR TITLE
FEATURE: Import and export watched word

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/watched-word-uploader.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/watched-word-uploader.hbs
@@ -1,5 +1,5 @@
 <label class="btn btn-default {{if addDisabled "disabled"}}">
   {{d-icon "upload"}}
   {{i18n "admin.watched_words.form.upload"}}
-  <input class="hidden-upload-field" disabled={{addDisabled}} type="file" accept="text/plain">
+  <input class="hidden-upload-field" disabled={{addDisabled}} type="file">
 </label>

--- a/app/models/watched_word.rb
+++ b/app/models/watched_word.rb
@@ -46,6 +46,10 @@ class WatchedWord < ActiveRecord::Base
     w
   end
 
+  def self.has_replacement?(action)
+    action == :replace || action == :tag
+  end
+
   def action_key=(arg)
     self.action = self.class.actions[arg.to_sym]
   end

--- a/app/serializers/watched_word_serializer.rb
+++ b/app/serializers/watched_word_serializer.rb
@@ -8,6 +8,6 @@ class WatchedWordSerializer < ApplicationSerializer
   end
 
   def include_replacement?
-    action == :replace || action == :tag
+    WatchedWord.has_replacement?(action)
   end
 end

--- a/spec/fixtures/csv/words_tag.csv
+++ b/spec/fixtures/csv/words_tag.csv
@@ -1,0 +1,11 @@
+hello,"tag1,tag2"
+
+,"tag1,tag3"
+
+
+world,"tag2,tag3"
+
+
+
+test,
+


### PR DESCRIPTION
Find & Replace and Autotag watched words were not completely exported
and import did not work with these either. This commit changes the
input and output format to CSV, which allows for a secondary column.

This change is backwards compatible because a CSV file with only one
column has one value per line.