### PR TITLE
DEV: Add output_sql_to_stderr! to MethodProfiler

### DIFF
--- a/lib/method_profiler.rb
+++ b/lib/method_profiler.rb
@@ -2,8 +2,6 @@
 
 # see https://samsaffron.com/archive/2017/10/18/fastest-way-to-profile-a-method-in-ruby
 class MethodProfiler
-  DEBUG_SQL_QUERY_LIMIT = 500
-
   def self.patch(klass, methods, name, no_recurse: false)
     patches = methods.map do |method_name|
 

--- a/lib/method_profiler.rb
+++ b/lib/method_profiler.rb
@@ -123,7 +123,7 @@ class MethodProfiler
   #
   # filter_transactions - When true, we do not record timings of transaction
   # related commits (BEGIN, COMMIT, ROLLBACK)
-  def self.debug_sql_instrumentation!(filter_transactions: false)
+  def self.output_sql_to_stderr!(filter_transactions: false)
     Rails.logger.warn("Stop! This instrumentation is not intended for use in production outside of debugging scenarios. Please be sure you know what you are doing when enabling this instrumentation.")
     @@instrumentation_debug_sql_filter_transactions = filter_transactions
     @@instrumentation_setup_debug_sql ||= begin


### PR DESCRIPTION
This PR adds `debug_sql_instrumentation!` to `MethodProfiler` for easier debugging of SQL queries and their timings from the console.

This is almost the same as ensure_discourse_instrumentation! but should not
be used in production (save for debugging in the console), and is only instrumenting
PostgresSQL queries.

This is almost the same as ensure_discourse_instrumentation! but should not
be used in production. This logs all SQL queries run and their durations
between start and stop.

It also works for super long running queries. If you interrupt the long-running
query the latest query data will still be logged after stopping the profiler.

Usage:

```ruby
MethodProfiler.output_sql_to_stderr!(filter_transactions: true)
MethodProfiler.start

# some code that runs queries

timings = MethodProfiler.stop
```

The result looks like this:

![image](https://user-images.githubusercontent.com/920448/111732620-a4ce9600-88c1-11eb-97fd-fc13772edd4f.png)
