### PR TITLE
FIX: Improve handling when email is obfuscated

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -27,10 +27,13 @@ class InvitesController < ApplicationController
         end
       end
 
+      hidden_email = email != invite.email
+
       store_preloaded("invite_info", MultiJson.dump(
         invited_by: UserNameSerializer.new(invite.invited_by, scope: guardian, root: false),
         email: email,
-        username: UserNameSuggester.suggest(invite.email),
+        hidden_email: hidden_email,
+        username: hidden_email ? '' : UserNameSuggester.suggest(invite.email),
         is_invite_link: invite.is_invite_link?
       ))
 


### PR DESCRIPTION
This commit ensures that email validation is skipped when the email is
obfuscated, that the email is no longer send when it is not an invite
link and that no username is suggested if the email is hidden as that
may reveal the first part of the email.

Follow up to commit 033d6b64374dce833ecb073fbf824428d3a78bcd.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
