### PR TITLE
FIX: Only refresh the review count when the user can see the review queue.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
@@ -129,9 +129,7 @@ export default createWidget("hamburger-menu", {
         count: this.lookupCount("unread"),
       });
 
-      // Staff always see the review link.
-      // Non-staff will see it if there are items to review
-      if (currentUser.staff || currentUser.reviewable_count) {
+      if (currentUser.can_review) {
         links.push({
           route: siteSettings.reviewable_default_topics
             ? "review.topics"
@@ -341,7 +339,7 @@ export default createWidget("hamburger-menu", {
   refreshReviewableCount(state) {
     const { currentUser } = this;
 
-    if (state.loading || !currentUser) {
+    if (state.loading || !currentUser || !currentUser.can_review) {
       return;
     }
 

--- a/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
@@ -31,7 +31,8 @@ export default {
       akismet_review_count: 0,
       title_count_mode: "notifications",
       timezone: "Australia/Brisbane",
-      skip_new_user_tips: false
+      skip_new_user_tips: false,
+      can_review: true
     }
   }
 };

--- a/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
@@ -63,6 +63,7 @@ discourseModule(
 
       beforeEach() {
         this.currentUser.set("moderator", true);
+        this.currentUser.set("can_review", true);
       },
 
       test(assert) {

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -52,6 +52,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :skip_new_user_tips,
              :do_not_disturb_until,
              :has_topic_draft,
+             :can_review
 
   def groups
     object.visible_groups.pluck(:id, :name).map { |id, name| { id: id, name: name } }
@@ -210,6 +211,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def reviewable_count
     Reviewable.list_for(object).count
+  end
+
+  def can_review
+    scope.can_see_review_queue?
   end
 
   def mailing_list_mode

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -166,4 +166,24 @@ RSpec.describe CurrentUserSerializer do
     end
 
   end
+
+  context '#can_review' do
+    it 'return false for regular users' do
+      serializer = serializer(Fabricate(:user))
+      payload = serializer.as_json
+
+      expect(payload[:can_review]).to eq(false)
+    end
+
+    it 'returns trus for staff' do
+      serializer = serializer(Fabricate(:admin))
+      payload = serializer.as_json
+
+      expect(payload[:can_review]).to eq(true)
+    end
+
+    def serializer(user)
+      CurrentUserSerializer.new(user, scope: Guardian.new(user), root: false)
+    end
+  end
 end


### PR DESCRIPTION
We currently make an AJAX request every time someone opens the hamburger menu, resulting in a forbidden response when a user can't see the review queue.

