### PR TITLE
FIX: Clear draft modal correctly when switching topics

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1105,7 +1105,7 @@ export default Controller.extend({
       cancel(this._saveDraftDebounce);
     }
 
-    let promise = new Promise((resolve) => {
+    let promise = new Promise((resolve, reject) => {
       if (this.get("model.hasMetaData") || this.get("model.replyDirty")) {
         const controller = showModal("discard-draft", {
           model: this.model,
@@ -1132,7 +1132,7 @@ export default Controller.extend({
             resolve();
           },
           // needed to resume saving drafts if composer stays open
-          onDismissModal: () => resolve(),
+          onDismissModal: () => reject(),
         });
       } else {
         // it is possible there is some sort of crazy draft with no body ... just give up on it

--- a/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
@@ -5,7 +5,7 @@
 {{/d-modal-body}}
 
 <div class="modal-footer">
-  {{d-button icon="far-trash-alt" label="post.cancel_composer.discard" class="btn-danger" action=(action "destroyDraft")}}
+  {{d-button icon="far-trash-alt" label="post.cancel_composer.discard" class="btn-danger discard-draft" action=(action "destroyDraft")}}
   {{d-button label="post.cancel_composer.save_draft" class="save-draft" action=(action "saveDraftAndClose")}}
   {{d-button label="post.cancel_composer.keep_editing" class="keep-editing" action=(action "dismissModal")}}
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -330,6 +330,37 @@ acceptance("Composer", function (needs) {
     );
   });
 
+  test("Discard draft modal works when switching topics", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-footer-buttons .btn.create");
+    await fillIn(".d-editor-input", "this is the content of the first reply");
+
+    await visit("/t/this-is-a-test-topic/9");
+    assert.equal(currentURL(), "/t/this-is-a-test-topic/9");
+    await click("#topic-footer-buttons .btn.create");
+    assert.ok(
+      exists(".discard-draft-modal.modal"),
+      "it pops up the discard drafts modal"
+    );
+
+    await click(".modal-footer button.keep-editing");
+
+    assert.ok(invisible(".discard-draft-modal.modal"));
+    await click("#topic-footer-buttons .btn.create");
+    assert.ok(
+      exists(".discard-draft-modal.modal"),
+      "it pops up the modal again"
+    );
+
+    await click(".modal-footer button.discard-draft");
+
+    assert.equal(
+      queryAll(".d-editor-input").val(),
+      "",
+      "discards draft and reset composer textarea"
+    );
+  });
+
   test("Create an enqueued Reply", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
@@ -423,7 +454,7 @@ acceptance("Composer", function (needs) {
       "it pops up a confirmation dialog"
     );
 
-    await click(".modal-footer button:nth-of-type(1)");
+    await click(".modal-footer button.discard-draft");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
@@ -580,7 +611,7 @@ acceptance("Composer", function (needs) {
       exists(".discard-draft-modal.modal"),
       "it pops up a confirmation dialog"
     );
-    await click(".modal-footer button:nth-of-type(1)");
+    await click(".modal-footer button.discard-draft");
     assert.equal(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,


### PR DESCRIPTION
Fixes an issue where the "Keep editing" button in the discard draft
modal wouldn't work when switching to a new topic with an open composer
and clicking Reply.

Followup to d470e4f

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
