### PR TITLE
FIX: rake db:validate_indexes was broken

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -327,7 +327,7 @@ end
 desc 'Validate indexes'
 task 'db:validate_indexes', [:arg] => ['db:ensure_post_migrations', 'environment'] do |_, args|
 
-  db = TemporaryDB.new
+  db = TemporaryDb.new
   db.start
 
   ActiveRecord::Base.establish_connection(

--- a/lib/temporary_db.rb
+++ b/lib/temporary_db.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TemporaryDB
+class TemporaryDb
   PG_TEMP_PATH = "/tmp/pg_schema_tmp"
   PG_CONF = "#{PG_TEMP_PATH}/postgresql.conf"
   PG_SOCK_PATH = "#{PG_TEMP_PATH}/sockets"


### PR DESCRIPTION
A file was moved, but zeitwerk can not find it due to custom inflection.

Renamed so it can be properly found.
