### PR TITLE
DEV: upgrade mini_sql

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       libv8 (~> 8.4.255)
     mini_scheduler (0.13.0)
       sidekiq (>= 4.2.3)
-    mini_sql (1.0.1)
+    mini_sql (1.1.1)
     mini_suffix (0.3.2)
       ffi (~> 1.9)
     minitest (5.14.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
       libv8 (~> 8.4.255)
     mini_scheduler (0.13.0)
       sidekiq (>= 4.2.3)
-    mini_sql (1.1.1)
+    mini_sql (1.1.3)
     mini_suffix (0.3.2)
       ffi (~> 1.9)
     minitest (5.14.4)

--- a/lib/mini_sql_multisite_connection.rb
+++ b/lib/mini_sql_multisite_connection.rb
@@ -82,6 +82,20 @@ class MiniSqlMultisiteConnection < MiniSql::Postgres::Connection
     ActiveRecord::Base.connection.raw_connection
   end
 
+  # make for a multisite friendly prepared statement cache
+  def prepared(condition = true)
+    if condition
+      conn = raw_connection.instance_variable_get(:@mini_sql_prepared_connection)
+      if !conn
+        conn = MiniSql::Postgres::PreparedConnection.new(self)
+        raw_connection.instance_variable_set(:@mini_sql_prepared_connection, conn)
+      end
+      conn
+    else
+      self
+    end
+  end
+
   def build(sql)
     CustomBuilder.new(self, sql)
   end

--- a/spec/lib/mini_sql_multisite_connection_spec.rb
+++ b/spec/lib/mini_sql_multisite_connection_spec.rb
@@ -73,6 +73,11 @@ describe MiniSqlMultisiteConnection do
       expect(outputString).to eq("123")
     end
 
+    it "supports prepared statements" do
+      DB.prepared.query("SELECT ?", 1)
+      DB.prepared.query("SELECT ?", 2)
+    end
+
   end
 
 end


### PR DESCRIPTION
Even though we are not planning on using this quite yet, mini_sql now supports
prepared statements.

Would like this upgrade merged so we can do some benchmarking.

Note, this will not work with pg_bouncer, but sites that are not using it
may benefit from the feature.
