### PR TITLE
FIX: Never display the invite show page form if DiscourseConnect enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -107,8 +107,9 @@ export default Controller.extend(
     )
     shouldDisplayForm(externalAuthsOnly, authOptions, emailValidationFailed) {
       return (
-        this.siteSettings.enable_local_logins ||
-        (externalAuthsOnly && authOptions && !emailValidationFailed)
+        (this.siteSettings.enable_local_logins ||
+          (externalAuthsOnly && authOptions && !emailValidationFailed)) &&
+        !this.siteSettings.enable_discourse_connect
       );
     },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -217,6 +217,23 @@ acceptance(
   }
 );
 
+acceptance(
+  "Invite accept when DiscourseConnect SSO is enabled and local login is enabled (bad config)",
+  function (needs) {
+    needs.settings({
+      enable_local_logins: true,
+      enable_discourse_connect: true,
+    });
+
+    test("invite link", async function (assert) {
+      preloadInvite({ link: true });
+
+      await visit("/invites/myvalidinvitetoken");
+      assert.ok(!exists("form"), "does not display the form");
+    });
+  }
+);
+
 acceptance("Invite link with authentication data", function (needs) {
   needs.settings({ enable_local_logins: false });
 


### PR DESCRIPTION
This form does not need to show if discourse connect is enabled
because generally the fields that would be filled in here are
filled in by the SSO provider. There is also an issue right now
where enable_local_logins and enable_discourse_connect can be
true at the same time which is not right.