### PR TITLE
DEV: correctly defines focusComposer shortcut as shift+c

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -20,7 +20,7 @@ const DEFAULT_BINDINGS = {
   ".": { click: ".alert.alert-info.clickable", anonymous: true }, // show incoming/updated topics
   b: { handler: "toggleBookmark" },
   c: { handler: "createTopic" },
-  C: { handler: "focusComposer" },
+  "shift+c": { handler: "focusComposer" },
   "ctrl+f": { handler: "showPageSearch", anonymous: true },
   "command+f": { handler: "showPageSearch", anonymous: true },
   "command+left": { handler: "webviewKeyboardBack" },


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
