### PR TITLE
FIX: Don't attempt to delete non-existent bookmark

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -383,6 +383,10 @@ export default Component.extend({
 
   @action
   delete() {
+    if (!this.model.id) {
+      return;
+    }
+
     this._deleting = true;
     let deleteAction = () => {
       this._closeWithoutSaving = true;


### PR DESCRIPTION
Could happen when using the keyboard shortcut. (<kbd>d</kbd> <kbd>d</kbd>)
