### PR TITLE
DEV: Retry-after header values should be strings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -166,7 +166,7 @@ class ApplicationController < ActionController::Base
         type: :rate_limit,
         status: 429,
         extras: { wait_seconds: retry_time_in_seconds },
-        headers: { 'Retry-After': retry_time_in_seconds }
+        headers: { 'Retry-After': retry_time_in_seconds.to_s }
       )
     end
   end

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -98,7 +98,7 @@ MessageBus.on_middleware_error do |env, e|
   if Discourse::InvalidAccess === e
     [403, {}, ["Invalid Access"]]
   elsif RateLimiter::LimitExceeded === e
-    [429, { 'Retry-After' => e.available_in }, [e.description]]
+    [429, { 'Retry-After' => e.available_in.to_s }, [e.description]]
   end
 end
 

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -166,7 +166,7 @@ class Middleware::RequestTracker
     if available_in = rate_limit(request)
       return [
         429,
-        { "Retry-After" => available_in },
+        { "Retry-After" => available_in.to_s },
         ["Slow down, too many requests from this IP address"]
       ]
     end

--- a/spec/components/middleware/request_tracker_spec.rb
+++ b/spec/components/middleware/request_tracker_spec.rb
@@ -16,6 +16,7 @@ describe Middleware::RequestTracker do
   end
 
   before do
+    ApplicationRequest.clear_cache!
     ApplicationRequest.enable
   end
 
@@ -69,7 +70,6 @@ describe Middleware::RequestTracker do
     end
 
     it "can log requests correctly" do
-
       data = Middleware::RequestTracker.get_data(env(
         "HTTP_USER_AGENT" => "AdsBot-Google (+http://www.google.com/adsbot.html)"
       ), ["200", { "Content-Type" => 'text/html' }], 0.1)
@@ -253,7 +253,7 @@ describe Middleware::RequestTracker do
 
       expect(Rails.logger.warnings).to eq(1)
       expect(status).to eq(429)
-      expect(headers["Retry-After"]).to eq(10)
+      expect(headers["Retry-After"]).to eq("10")
     end
 
     it "does warn if rate limiter is enabled" do
@@ -282,13 +282,13 @@ describe Middleware::RequestTracker do
       expect(status).to eq(200)
       status, headers = middleware.call(env1)
       expect(status).to eq(429)
-      expect(headers["Retry-After"]).to eq(10)
+      expect(headers["Retry-After"]).to eq("10")
 
       env2 = env("REMOTE_ADDR" => "1.1.1.1")
 
       status, headers = middleware.call(env2)
       expect(status).to eq(429)
-      expect(headers["Retry-After"]).to eq(10)
+      expect(headers["Retry-After"]).to eq("10")
     end
 
     it "does block if rate limiter is enabled" do
@@ -303,7 +303,7 @@ describe Middleware::RequestTracker do
 
       status, headers = middleware.call(env1)
       expect(status).to eq(429)
-      expect(headers["Retry-After"]).to eq(10)
+      expect(headers["Retry-After"]).to eq("10")
 
       status, _ = middleware.call(env2)
       expect(status).to eq(200)

--- a/spec/integration/rate_limiting_spec.rb
+++ b/spec/integration/rate_limiting_spec.rb
@@ -24,7 +24,7 @@ describe 'rate limiter integration' do
     }
 
     expect(response.status).to eq(429)
-    expect(response.headers['Retry-After']).to be > 29
+    expect(response.headers['Retry-After'].to_i).to be > 29
   end
 
   it "will not rate limit when all is good" do
@@ -76,7 +76,7 @@ describe 'rate limiter integration' do
 
     data = response.parsed_body
 
-    expect(response.headers['Retry-After']).to eq(60)
+    expect(response.headers["Retry-After"]).to eq("60")
     expect(data["extras"]["wait_seconds"]).to eq(60)
   end
 end


### PR DESCRIPTION
Fixes `Rack::Lint::LintError: a header value must be a String, but the value of 'Retry-After' is a Integer`. (see: https://github.com/rack/rack/blob/14a236b4f0899e46bc41c4f80dcff29159a59312/lib/rack/lint.rb#L676)

I found it when I got flooded by those warning a while back in a test-related accident 😉 (ember CLI tests were hitting a local rails server at a fast rate)