### PR TITLE
FIX: Add platforms to stable Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,11 @@ GEM
     jwt (2.2.2)
     kgio (2.11.3)
     libv8 (8.4.255.0)
+    libv8 (8.4.255.0-universal-darwin-20)
+    libv8 (8.4.255.0-x86_64-darwin-18)
+    libv8 (8.4.255.0-x86_64-darwin-19)
+    libv8 (8.4.255.0-x86_64-darwin-20)
+    libv8 (8.4.255.0-x86_64-linux)
     listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -430,7 +435,12 @@ GEM
     zeitwerk (2.4.1)
 
 PLATFORMS
+  arm64-darwin-20
   ruby
+  x86_64-darwin-18
+  x86_64-darwin-19
+  x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   actionmailer (= 6.0.3.3)
@@ -558,4 +568,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.1.4
+   2.2.15


### PR DESCRIPTION
There are a few issues which require us to do this:
 - We install the latest version of bundler on every rebuild. Therefore we're running 2.2.15 everywhere, even for 'stable' clusters
 - Bundler has changed how gem platforms are managed. That meant that on the stable branch we were building libv8 from source via the 'ruby' package, rather than using the precompiled x86_64-linux binary
 - Building the libv8 from source is currently failing

 Together, these things mean that builds of `stable` are currently failing. Each of the above issues should likely be fixed, but this commit provides the quickest route to get things working again. Note that despite the Gemfile.lock update, no gem versions have changed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
