### PR TITLE
FIX: Do not show duplicate_link notice for quotes

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -453,8 +453,25 @@ export default Controller.extend({
       const post = this.get("model.post");
       const $links = $("a[href]", $preview);
       $links.each((idx, l) => {
-        const href = $(l).prop("href");
+        const href = l.href;
         if (href && href.length) {
+          // skip links in quotes
+          for (let element = l; element; element = element.parentElement) {
+            if (
+              element.tagName === "DIV" &&
+              element.classList.contains("d-editor-preview")
+            ) {
+              break;
+            }
+
+            if (
+              element.tagName === "ASIDE" &&
+              element.classList.contains("quote")
+            ) {
+              return true;
+            }
+          }
+
           const [warn, info] = linkLookup.check(post, href);
 
           if (warn) {


### PR DESCRIPTION
Quoting a link from the topic would show a false duplicate_link notice.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
