### PR TITLE
FEATURE: Treat emoji or similar characters as one

### DIFF
--- a/lib/validators/stripped_length_validator.rb
+++ b/lib/validators/stripped_length_validator.rb
@@ -3,14 +3,15 @@
 class StrippedLengthValidator < ActiveModel::EachValidator
   def self.validate(record, attribute, value, range)
     if !value.nil?
-      html_comments_regexp = /<!--(.*?)-->/
-      stripped_length = value.gsub(html_comments_regexp, '')
-      stripped_length = stripped_length.strip.length
+      value = value.dup
+      value.gsub!(/<!--(.*?)-->/, '') # strip HTML comments
+      value.gsub!(/:\w+(:\w+)?:/, "X") # replace emojis with a single character
+      value.gsub!(/\.{2,}/, '…') # replace multiple ... with …
+      value.gsub!(/\,{2,}/, ',') # replace multiple ,,, with ,
+      value.strip!
 
-      record.errors.add attribute, (I18n.t('errors.messages.too_short', count: range.begin)) unless
-          stripped_length >= range.begin
-      record.errors.add attribute, (I18n.t('errors.messages.too_long_validation', max: range.end, length: stripped_length)) unless
-          stripped_length <= range.end
+      record.errors.add attribute, (I18n.t('errors.messages.too_short', count: range.begin)) if value.length < range.begin
+      record.errors.add attribute, (I18n.t('errors.messages.too_long_validation', max: range.end, length: value.length)) if value.length > range.end
     else
       record.errors.add attribute, (I18n.t('errors.messages.blank'))
     end

--- a/spec/components/validators/post_validator_spec.rb
+++ b/spec/components/validators/post_validator_spec.rb
@@ -52,6 +52,33 @@ describe PostValidator do
       expect(post.errors.count).to eq(1)
     end
 
+    it "counts emoji as a single character" do
+      post.raw = ":smiling_face_with_three_hearts:" * (SiteSetting.min_post_length - 1)
+      validator.stripped_length(post)
+      expect(post.errors.count).to eq(1)
+
+      post = build(:post, topic: topic)
+      post.raw = ":smiling_face_with_three_hearts:" * SiteSetting.min_post_length
+      validator.stripped_length(post)
+      expect(post.errors.count).to eq(0)
+    end
+
+    it "counts multiple characters as a single character" do
+      post.raw = "." * SiteSetting.min_post_length
+      validator.stripped_length(post)
+      expect(post.errors.count).to eq(1)
+
+      post = build(:post, topic: topic)
+      post.raw = "," * SiteSetting.min_post_length
+      validator.stripped_length(post)
+      expect(post.errors.count).to eq(1)
+
+      post = build(:post, topic: topic)
+      post.raw = "<!-- #{'very long comment' * SiteSetting.min_post_length} -->"
+      validator.stripped_length(post)
+      expect(post.errors.count).to eq(1)
+    end
+
     it "adds no error for long raw" do
       post.raw = "this is a long topic body testing 123"
       validator.stripped_length(post)


### PR DESCRIPTION
Long messages consisting only of emojis, dots or commas used to be
valid because character-wise they were over the limit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
