### PR TITLE
FIX: Replace censored watched word consistently

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/censored.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/censored.js
@@ -3,6 +3,10 @@ import { censorFn } from "pretty-text/censored-words";
 function recurse(tokens, apply) {
   let i;
   for (i = 0; i < tokens.length; i++) {
+    if (tokens[i].type === "html_raw" && tokens[i].onebox) {
+      continue;
+    }
+
     apply(tokens[i]);
     if (tokens[i].children) {
       recurse(tokens[i].children, apply);

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/onebox.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/onebox.js
@@ -81,6 +81,7 @@ function applyOnebox(state, silent) {
               child.type = "html_raw";
               child.content = cached;
               child.inline = true;
+              child.onebox = true;
 
               text.type = "html_raw";
               text.content = "";


### PR DESCRIPTION
Applying oneboxes and replacing censored watched words does not happen
in a strict order which often lead to inconsistencies. This commit
fixes the behavior and will never censor oneboxes.

To make it always censor oneboxes implies significant changes to the
PrettyText pipeline.