### PR TITLE
FIX: CSS for collapsed table cells when showing insertion in Raw mode

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -16,6 +16,7 @@
   .revision-content {
     width: 47.5%;
     float: left;
+    min-height: 1px;
 
     &:nth-of-type(2) {
       margin-left: 5%;


### PR DESCRIPTION
More details here: https://meta.discourse.org/t/broken-css-when-displaying-insertions-in-raw-mode/177839
