### PR TITLE
FIX: Add migration to set correct redemption_count

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -212,7 +212,8 @@ class Invite < ActiveRecord::Base
       .joins("LEFT JOIN invited_users ON invites.id = invited_users.invite_id")
       .joins("LEFT JOIN users ON invited_users.user_id = users.id")
       .where(invited_by_id: inviter.id)
-      .where('redemption_count > max_redemptions_allowed OR expires_at < ?', Time.zone.now)
+      .where('redemption_count < max_redemptions_allowed')
+      .where('expires_at < ?', Time.zone.now)
       .order('invites.expires_at ASC')
   end
 

--- a/db/migrate/20210323142518_update_invites_redemption_count.rb
+++ b/db/migrate/20210323142518_update_invites_redemption_count.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UpdateInvitesRedemptionCount < ActiveRecord::Migration[6.0]
+  def change
+    execute <<~SQL
+      WITH invite_counts AS (
+        SELECT invite_id, COUNT(*) count
+        FROM invited_users
+        GROUP BY invite_id
+      )
+      UPDATE invites
+      SET redemption_count = GREATEST(redemption_count, count)
+      FROM invite_counts
+      WHERE invites.id = invite_counts.invite_id
+    SQL
+  end
+end


### PR DESCRIPTION
Redeeming email invites did not increase the redemption_count which let
those invites in a weird state were they were both pending and redeemed.