### PR TITLE
FIX: Regression in colors used by non-default theme

### DIFF
--- a/lib/stylesheet/importer.rb
+++ b/lib/stylesheet/importer.rb
@@ -135,9 +135,12 @@ module Stylesheet
         rescue
           ColorScheme.base_colors
         end
-      elsif (@theme_id && theme.color_scheme)
-        colors = theme.color_scheme.resolved_colors
+      elsif (@theme_id && !theme.component)
+        colors = theme&.color_scheme&.resolved_colors || ColorScheme.base_colors
       else
+        # this is a slightly ugly backwards compatibility fix,
+        # we shouldn't be using the default theme color scheme for components
+        # (most components use CSS custom properties which work fine without this)
         colors = Theme.find_by_id(SiteSetting.default_theme_id)&.color_scheme&.resolved_colors ||
           ColorScheme.base_colors
       end

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -331,6 +331,7 @@ describe Stylesheet::Manager do
 
     it "uses the correct color scheme when a non-default theme is selected and it uses the base 'Light' scheme" do
       cs = Fabricate(:color_scheme, name: 'Not This')
+      ColorSchemeRevisor.revise(cs, colors: [{ name: "primary", hex: "CC0000" }])
       default_theme = Fabricate(:theme, color_scheme_id: cs.id)
       SiteSetting.default_theme_id = default_theme.id
 
@@ -338,6 +339,10 @@ describe Stylesheet::Manager do
 
       link = Stylesheet::Manager.color_scheme_stylesheet_link_tag(nil, "all", [user_theme.id])
       expect(link).to include("/stylesheets/color_definitions_base_")
+
+      stylesheet = Stylesheet::Manager.new(:color_definitions, user_theme.id, nil).compile(force: true)
+      expect(stylesheet).not_to include("--primary: #c00;")
+      expect(stylesheet).to include("--primary: #222;") # from base scheme
     end
 
     it "uses the correct scheme when a valid scheme id is used" do


### PR DESCRIPTION
eb7f0ec is the source of this regression, where a non-default theme set to use
the base color scheme was resolving to the default theme's color scheme.