### PR TITLE
UI: Make sure staff logs don't break the layout

### DIFF
--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -138,6 +138,9 @@
       overflow-y: auto;
     }
   }
+  td.context {
+    word-break: break-all;
+  }
 }
 
 .staff-action-logs-controls {


### PR DESCRIPTION
Prevents accidental layout stretching in `/admin/logs/staff_action_logs`

<img width="468" alt="Screen Shot 2021-03-23 at 19 45 04" src="https://user-images.githubusercontent.com/66961/112207050-f7d48000-8c16-11eb-9bee-e62ae5cd7c95.png">
