### PR TITLE
DEV: Replace Rails ends_with? with Ruby end_with?

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -748,9 +748,9 @@ class Plugin::Instance
         f_str = f.to_s
         if File.directory?(f)
           yield [f, true]
-        elsif f_str.ends_with?(".js.es6") || f_str.ends_with?(".hbs") || f_str.ends_with?(".hbr")
+        elsif f_str.end_with?(".js.es6") || f_str.end_with?(".hbs") || f_str.end_with?(".hbr")
           yield [f, false]
-        elsif transpile_js && f_str.ends_with?(".js")
+        elsif transpile_js && f_str.end_with?(".js")
           yield [f, false]
         end
       end


### PR DESCRIPTION
ActiveSupport is no longer available in application.rb starting from Ruby 6.1, but application.rb calls the plugin API that uses ends_with? and it causes problems. This commit uses Ruby's end_with? instead.