### PR TITLE
FIX: Replace 'Chromebook' with 'Chrome OS'

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -853,7 +853,7 @@ en:
       unknown: "unknown browser"
     device:
       android: "Android Device"
-      chromebook: "Chromebook"
+      chromebook: "Chrome OS"
       ipad: "iPad"
       iphone: "iPhone"
       ipod: "iPod"
@@ -864,7 +864,7 @@ en:
       unknown: "unknown device"
     os:
       android: "Android"
-      chromeos: "ChromeOS"
+      chromeos: "Chrome OS"
       ios: "iOS"
       linux: "Linux"
       macos: "macOS"


### PR DESCRIPTION
There are many Chrome OS devices and no way to determine the exact device.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
