### PR TITLE
DEV: Move color definition functions to mixins

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -2,24 +2,6 @@
 // It is compiled to CSS separately from the rest of the app.
 // The source variables come from color_transformations.scss and variables.scss
 
-// this converts HEX colors to RGBs so they can be used in vanilla CSS
-// i.e.: rgba(var(--primary-low-rgb), 0.5)
-//
-// Note that "rgba(var(--primary-low), 0.5)" will not work,
-// because --primary-low has a HEX color value
-
-@function hexToRGB($hex) {
-  @return red($hex), green($hex), blue($hex);
-}
-
-@function schemeType() {
-  @if is-light-color-scheme() {
-    @return "light";
-  } @else {
-    @return "dark";
-  }
-}
-
 :root {
   --scheme-type: #{schemeType()};
   --primary: #{$primary};

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -174,3 +174,23 @@ $breakpoints: (
 
   @return $string;
 }
+
+// SCSS accepts HEX or RGB colors for rgba($color, 0.5)
+// CSS custom properties only accept RGB
+// Example usage:
+
+// --primary-rgb: #{hexToRGB($primary)};
+// ...
+// rgba(var(--primary-low-rgb), 0.5)
+
+@function hexToRGB($hex) {
+  @return red($hex), green($hex), blue($hex);
+}
+
+@function schemeType() {
+  @if is-light-color-scheme() {
+    @return "light";
+  } @else {
+    @return "dark";
+  }
+}

--- a/spec/components/stylesheet/importer_spec.rb
+++ b/spec/components/stylesheet/importer_spec.rb
@@ -77,7 +77,7 @@ describe Stylesheet::Importer do
 
   context "#import_color_definitions" do
     let(:scss) { ":root{--custom-color: green}" }
-    let(:scss_child) { ":root{--custom-color: red; --custom-color-rgb: \#{hexToRGB($quaternary)};}" }
+    let(:scss_child) { "$navy: #000080; :root{--custom-color: red; --custom-color-rgb: \#{hexToRGB($navy)}}" }
 
     let(:theme) do
       Fabricate(:theme).tap do |t|
@@ -103,7 +103,8 @@ describe Stylesheet::Importer do
       styles = Stylesheet::Importer.new({ theme_id: theme.id }).import_color_definitions
       expect(styles).to include("Color definitions from Child Theme")
       expect(styles).to include("--custom-color: red")
-      expect(styles).to include("--custom-color-rgb: 228,87,53")
+      expect(styles).to include("--custom-color-rgb: 0,0,128")
+
     end
 
     it "should include default theme color definitions" do

--- a/spec/components/stylesheet/importer_spec.rb
+++ b/spec/components/stylesheet/importer_spec.rb
@@ -77,7 +77,7 @@ describe Stylesheet::Importer do
 
   context "#import_color_definitions" do
     let(:scss) { ":root{--custom-color: green}" }
-    let(:scss_child) { ":root{--custom-color: red}" }
+    let(:scss_child) { ":root{--custom-color: red; --custom-color-rgb: \#{hexToRGB($quaternary)};}" }
 
     let(:theme) do
       Fabricate(:theme).tap do |t|
@@ -101,8 +101,9 @@ describe Stylesheet::Importer do
       theme.save!
 
       styles = Stylesheet::Importer.new({ theme_id: theme.id }).import_color_definitions
-      expect(styles).to include(scss_child)
       expect(styles).to include("Color definitions from Child Theme")
+      expect(styles).to include("--custom-color: red")
+      expect(styles).to include("--custom-color-rgb: 228,87,53")
     end
 
     it "should include default theme color definitions" do


### PR DESCRIPTION
So they can be used in themes, plugins, etc. Also adds a test to prevent regressions.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
