### PR TITLE
FIX: Add topic_diff to PostRevisor

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -530,6 +530,10 @@ class PostRevisor
     @post.previous_changes.slice(*POST_TRACKED_FIELDS)
   end
 
+  def topic_diff
+    @topic_changes.diff
+  end
+
   def perform_edit
     return if bypass_rate_limiter?
     EditRateLimiter.new(@editor).performed!


### PR DESCRIPTION
The instance of the PostRevisor is passed to the post_edited
event. It is useful to know what has happened to the topic in
this event (we already pass a boolean for topic_changed? but that
is not so helpful by itself).

```ruby
DiscourseEvent.trigger(:post_edited, @post, self.topic_changed?, self)
```