### PR TITLE
FIX: Composer save button should be ✏ Save Edit when editing a PM post

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -231,7 +231,7 @@ export default Controller.extend({
     if (isWhispering) {
       return "far-eye-slash";
     }
-    if (privateMessage) {
+    if (privateMessage && modelAction === Composer.REPLY) {
       return "envelope";
     }
 
@@ -249,7 +249,7 @@ export default Controller.extend({
       return "composer.overwrite_edit";
     } else if (isWhispering) {
       return "composer.create_whisper";
-    } else if (privateMessage) {
+    } else if (privateMessage && modelAction === Composer.REPLY) {
       return "composer.create_pm";
     }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -23,6 +23,9 @@ acceptance("Composer", function (needs) {
     server.post("/uploads/lookup-urls", () => {
       return helper.response([]);
     });
+    server.get("/posts/419", () => {
+      return helper.response({ id: 419 });
+    });
   });
 
   skip("Tests the Composer controls", async function (assert) {
@@ -813,6 +816,23 @@ acceptance("Composer", function (needs) {
       queryAll(".save-or-cancel button.create svg.d-icon-envelope").length ===
         1,
       "reply button has envelope icon"
+    );
+  });
+
+  test("edit button when editing a post in a PM", async function (assert) {
+    await visit("/t/34");
+    await click("article#post_3 button.show-more-actions");
+    await click("article#post_3 button.edit");
+
+    assert.equal(
+      queryAll(".save-or-cancel button.create").text().trim(),
+      I18n.t("composer.save_edit"),
+      "save button says Save Edit"
+    );
+    assert.ok(
+      queryAll(".save-or-cancel button.create svg.d-icon-pencil-alt").length ===
+        1,
+      "save button has pencil icon"
     );
   });
 


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/edits-on-private-messages-should-generate-a-notification/182370/4?u=osama.

