### PR TITLE
FIX: remove @discobot likes feature on public topics

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/track_selector.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/track_selector.rb
@@ -61,7 +61,7 @@ module DiscourseNarrativeBot
             klass.new.input(@input, @user, post: @post, skip: skip_track?)
           end
         elsif is_reply && (@is_pm_to_bot || public_reply?)
-          like_user_post
+          like_user_post if @is_pm_to_bot
           bot_commands
         end
       elsif data && data.dig(:state)&.to_sym != :end && is_topic_action?

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/track_selector_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/track_selector_spec.rb
@@ -475,6 +475,16 @@ describe DiscourseNarrativeBot::TrackSelector do
           expect(new_post.raw).to eq(random_mention_reply)
         end
 
+        it 'should not like the public post' do
+          post.update!(raw: 'thanks @discobot!')
+
+          expect { described_class.new(:reply, user, post_id: post.id).select }
+            .to change { PostAction.count }.by(0)
+
+          new_post = Post.last
+          expect(new_post.raw).to eq(random_mention_reply)
+        end
+
         describe 'rate limiting random reply message in public topic' do
           let(:topic) { Fabricate(:topic) }
           let(:other_post) { Fabricate(:post, raw: '@discobot show me something', topic: topic) }


### PR DESCRIPTION
https://meta.discourse.org/t/discobot-is-breaking-the-meaning-of-likes-on-my-community/183804/8?u=techapj
