### PR TITLE
DEV: Deprecate `message` parameter in auth provider plugin API

### DIFF
--- a/app/assets/javascripts/discourse/app/models/login-method.js
+++ b/app/assets/javascripts/discourse/app/models/login-method.js
@@ -18,11 +18,6 @@ const LoginMethod = EmberObject.extend({
     return this.pretty_name_override || I18n.t(`login.${this.name}.name`);
   },
 
-  @discourseComputed
-  message() {
-    return this.message_override || I18n.t(`login.${this.name}.message`);
-  },
-
   doLogin({ reconnect = false, signup = false, params = {} } = {}) {
     if (this.customLogin) {
       this.customLogin();

--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -576,7 +576,6 @@ export default {
           custom_url: null,
           pretty_name_override: null,
           title_override: null,
-          message_override: null,
           frame_width: 580,
           frame_height: 400,
           can_connect: true,

--- a/app/serializers/auth_provider_serializer.rb
+++ b/app/serializers/auth_provider_serializer.rb
@@ -2,7 +2,7 @@
 
 class AuthProviderSerializer < ApplicationSerializer
 
-  attributes :name, :custom_url, :pretty_name_override, :title_override, :message_override,
+  attributes :name, :custom_url, :pretty_name_override, :title_override,
              :frame_width, :frame_height, :can_connect, :can_revoke,
              :icon
 
@@ -14,10 +14,6 @@ class AuthProviderSerializer < ApplicationSerializer
   def pretty_name_override
     return SiteSetting.get(object.pretty_name_setting) if object.pretty_name_setting
     object.pretty_name
-  end
-
-  def message_override
-    object.message
   end
 
 end

--- a/lib/auth/auth_provider.rb
+++ b/lib/auth/auth_provider.rb
@@ -8,7 +8,7 @@ class Auth::AuthProvider
   end
 
   def self.auth_attributes
-    [:pretty_name, :title, :message, :frame_width, :frame_height, :authenticator,
+    [:authenticator, :pretty_name, :title, :message, :frame_width, :frame_height,
      :pretty_name_setting, :title_setting, :enabled_setting, :full_screen_login, :full_screen_login_setting,
      :custom_url, :background_color, :icon]
   end
@@ -30,6 +30,10 @@ class Auth::AuthProvider
 
   def full_screen_login_setting=(val)
     Discourse.deprecate("(#{authenticator.name}) full_screen_login is now forced. The full_screen_login_setting parameter can be removed from the auth_provider.")
+  end
+
+  def message=(val)
+    Discourse.deprecate("(#{authenticator.name}) message is no longer used because all logins are full screen. It should be removed from the auth_provider")
   end
 
   def name

--- a/spec/fixtures/plugins/my_plugin/plugin.rb
+++ b/spec/fixtures/plugins/my_plugin/plugin.rb
@@ -6,10 +6,7 @@
 # authors: Frank Zappa
 
 auth_provider title: 'with Ubuntu',
-              authenticator: Auth::FacebookAuthenticator.new,
-              message: 'Authenticating with Ubuntu (make sure pop up blockers are not enbaled)',
-              frame_width: 1000,   # the frame size used for the pop up window, overrides default
-              frame_height: 800
+              authenticator: Auth::FacebookAuthenticator.new
 
 register_javascript <<JS
   console.log("Hello world")


### PR DESCRIPTION
This has been unused since d2bceff133ac152678a1407d45fea260a0fe8536

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
