### PR TITLE
FIX: Allow dismissing Discard Drafts modal via Esc key

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -51,7 +51,7 @@ export default Component.extend({
       //only respond to events when the modal is visible
       if (!this.element.classList.contains("hidden")) {
         if (e.which === 27 && this.dismissable) {
-          next(() => $(".modal-header button.modal-close").click());
+          next(() => this.attrs.closeModal("initiatedByESC"));
         }
 
         if (e.which === 13 && this.triggerClickOnEnter(e)) {
@@ -130,9 +130,7 @@ export default Component.extend({
       this.set("dismissable", true);
     }
 
-    if (data.headerClass) {
-      this.set("headerClass", data.headerClass);
-    }
+    this.set("headerClass", data.headerClass || null);
 
     if (this.element) {
       const autofocusInputs = this.element.querySelectorAll(

--- a/app/assets/javascripts/discourse/app/mixins/key-enter-escape.js
+++ b/app/assets/javascripts/discourse/app/mixins/key-enter-escape.js
@@ -3,6 +3,10 @@ import { isiPad } from "discourse/lib/utilities";
 // A mixin where hitting ESC calls `cancelled` and ctrl+enter calls `save.
 export default {
   keyDown(e) {
+    if (document.body.classList.contains("modal-open")) {
+      return;
+    }
+
     if (e.which === 27) {
       this.cancelled();
       return false;

--- a/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
@@ -1,4 +1,4 @@
-{{#d-modal-body dismissable=false headerClass="empty"}}
+{{#d-modal-body headerClass="hidden"}}
   <div class="instructions">
     {{i18n "post.cancel_composer.confirm"}}
   </div>

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -54,10 +54,8 @@
 
 .modal-header {
   display: flex;
-  &:not(.empty) {
-    padding: 10px 15px;
-    border-bottom: 1px solid var(--primary-low);
-  }
+  padding: 10px 15px;
+  border-bottom: 1px solid var(--primary-low);
   align-items: center;
 
   .title {


### PR DESCRIPTION
A few small adjustments: 
- pressing `ESC` while on the Discard Drafts modal will now dismiss and return the user to the composer
- composer keyboard shortcuts will be paused while a modal is visible
- modal header classes are reset correctly (to avoid the property from _sticking_ if switching between modals)