### PR TITLE
UX: Let users know they disabled discobot and they can't interact with it.

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -135,6 +135,7 @@ en:
 
           `@%{discobot_username} %{magic_8_ball_trigger}`
           > :crystal_ball: You may rely on it
+        discobot_disabled: You’ve disabled me in your preferences. You need to allow new user onboarding tips to interact with me.
 
       do_not_understand:
         first_response: |-

--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/track_selector.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/track_selector.rb
@@ -126,7 +126,9 @@ module DiscourseNarrativeBot
 
     def bot_commands(hint = true)
       raw =
-        if match_data = match_trigger?("#{self.class.dice_trigger} (\\d+)d(\\d+)")
+        if @user.manually_disabled_discobot?
+          I18n.t(self.class.i18n_key('random_mention.discobot_disabled'))
+        elsif match_data = match_trigger?("#{self.class.dice_trigger} (\\d+)d(\\d+)")
           DiscourseNarrativeBot::Dice.roll(match_data[1].to_i, match_data[2].to_i)
         elsif match_trigger?(self.class.quote_trigger)
           DiscourseNarrativeBot::QuoteGenerator.generate(@user)

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/track_selector_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/track_selector_spec.rb
@@ -19,6 +19,8 @@ describe DiscourseNarrativeBot::TrackSelector do
   before do
     stub_request(:get, "http://api.forismatic.com/api/1.0/?format=json&lang=en&method=getQuote").
       to_return(status: 200, body: "{\"quoteText\":\"Be Like Water\",\"quoteAuthor\":\"Bruce Lee\"}")
+
+      SiteSetting.discourse_narrative_bot_enabled = true
   end
 
   let(:help_message) do
@@ -464,6 +466,16 @@ describe DiscourseNarrativeBot::TrackSelector do
           described_class.new(:reply, user, post_id: post.id).select
           new_post = Post.last
           expect(new_post.raw).to eq(random_mention_reply)
+        end
+
+        it 'tells the user to enable the onboarding tips first' do
+          user.user_option.update!(skip_new_user_tips: true)
+          post.update!(raw: 'Show me what you can do @discobot')
+
+          described_class.new(:reply, user, post_id: post.id).select
+
+          new_post = Post.last
+          expect(new_post.raw).to eq(I18n.t('discourse_narrative_bot.track_selector.random_mention.discobot_disabled'))
         end
 
         it "should be case insensitive towards discobot's username" do

--- a/plugins/discourse-narrative-bot/spec/user_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/user_spec.rb
@@ -167,4 +167,12 @@ describe User do
       expect(DiscourseNarrativeBot::Store.get(user.id)).to eq(nil)
     end
   end
+
+  describe '#manually_disabled_discobot?' do
+    it 'returns true if the user manually disabled new user tips' do
+      user.user_option.skip_new_user_tips = true
+
+      expect(user.manually_disabled_discobot?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Discobot will reply to users they need to enable onboarding tips to interact with them when issued a command.