### PR TITLE
FIX: Set the "hasTargetGroups" attribute in the composer when clicking the message group button.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/group-card-contents.js
@@ -81,7 +81,10 @@ export default Component.extend(CardContentsBase, CleansUp, {
     },
 
     messageGroup() {
-      this.createNewMessageViaParams(this.get("group.name"));
+      this.createNewMessageViaParams({
+        recipients: this.get("group.name"),
+        hasGroups: true,
+      });
     },
 
     showGroup(group) {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1008,6 +1008,7 @@ export default Controller.extend({
       composerModel.setProperties({
         composeState: Composer.OPEN,
         isWarning: false,
+        hasTargetGroups: opts.hasGroups,
       });
 
       if (!this.model.targetRecipients) {

--- a/app/assets/javascripts/discourse/app/controllers/group.js
+++ b/app/assets/javascripts/discourse/app/controllers/group.js
@@ -132,7 +132,10 @@ export default Controller.extend({
 
   @action
   messageGroup() {
-    this.send("createNewMessageViaParams", this.get("model.name"));
+    this.send("createNewMessageViaParams", {
+      recipients: this.get("model.name"),
+      hasGroups: true,
+    });
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/mixins/open-composer.js
+++ b/app/assets/javascripts/discourse/app/mixins/open-composer.js
@@ -39,7 +39,12 @@ export default Mixin.create({
     });
   },
 
-  openComposerWithMessageParams(recipients, topicTitle, topicBody) {
+  openComposerWithMessageParams({
+    recipients = [],
+    topicTitle = "",
+    topicBody = "",
+    hasGroups = false,
+  } = {}) {
     this.controllerFor("composer").open({
       action: Composer.PRIVATE_MESSAGE,
       recipients,
@@ -47,6 +52,7 @@ export default Mixin.create({
       topicBody,
       archetypeId: "private_message",
       draftKey: Composer.NEW_PRIVATE_MESSAGE_KEY,
+      hasGroups: hasGroups,
     });
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -230,8 +230,18 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       );
     },
 
-    createNewMessageViaParams(recipients, title, body) {
-      this.openComposerWithMessageParams(recipients, title, body);
+    createNewMessageViaParams({
+      recipients = [],
+      topicTitle = "",
+      topicBody = "",
+      hasGroups = false,
+    } = {}) {
+      this.openComposerWithMessageParams({
+        recipients,
+        topicTitle,
+        topicBody,
+        hasGroups,
+      });
     },
   },
 

--- a/app/assets/javascripts/discourse/app/routes/new-message.js
+++ b/app/assets/javascripts/discourse/app/routes/new-message.js
@@ -20,12 +20,11 @@ export default DiscourseRoute.extend({
             .then((user) => {
               if (user.can_send_private_message_to_user) {
                 next(() =>
-                  e.send(
-                    "createNewMessageViaParams",
-                    user.username,
-                    params.title,
-                    params.body
-                  )
+                  e.send("createNewMessageViaParams", {
+                    recipients: user.username,
+                    topicTitle: params.title,
+                    topicBody: params.body,
+                  })
                 );
               } else {
                 bootbox.alert(
@@ -40,12 +39,11 @@ export default DiscourseRoute.extend({
             .then((result) => {
               if (result.messageable) {
                 next(() =>
-                  e.send(
-                    "createNewMessageViaParams",
-                    groupName,
-                    params.title,
-                    params.body
-                  )
+                  e.send("createNewMessageViaParams", {
+                    recipients: groupName,
+                    topicTitle: params.title,
+                    topicBody: params.body,
+                  })
                 );
               } else {
                 bootbox.alert(
@@ -55,7 +53,10 @@ export default DiscourseRoute.extend({
             })
             .catch(() => bootbox.alert(I18n.t("generic_error")));
         } else {
-          e.send("createNewMessageViaParams", null, params.title, params.body);
+          e.send("createNewMessageViaParams", {
+            topicTitle: params.title,
+            topicBody: params.body,
+          });
         }
       });
     } else {

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -219,6 +219,8 @@ acceptance("Group - Authenticated", function (needs) {
       "discourse",
       "it prefills the group name"
     );
+
+    assert.ok(!exists(".add-warning"), "groups can't receive warnings");
   });
 
   test("Admin viewing group messages when there are no messages", async function (assert) {


### PR DESCRIPTION
After clicking the message button on the group page, the composer shouldn't display the "official warning" checkbox. The discourse-bcc plugin also relies on this attribute to display an option in the composer.

