### PR TITLE
FEATURE: Add user_confirmed_email to user event webhook

### DIFF
--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -72,6 +72,7 @@ class EmailToken < ActiveRecord::Base
         user.save!
         user.create_reviewable unless skip_reviewable
         user.set_automatic_groups
+        DiscourseEvent.trigger(:user_confirmed_email, user)
       end
 
       if user

--- a/config/initializers/012-web_hook_events.rb
+++ b/config/initializers/012-web_hook_events.rb
@@ -41,6 +41,7 @@ end
   user_logged_in
   user_approved
   user_updated
+  user_confirmed_email
 ).each do |event|
   DiscourseEvent.on(event) do |user|
     WebHook.enqueue_object_hooks(:user, user, event)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3990,7 +3990,7 @@ en:
           details: "When there is a new reply, edit, deleted or recovered."
         user_event:
           name: "User Event"
-          details: "When a user logs in, logs out, is created, approved or updated."
+          details: "When a user logs in, logs out, confirms their email, is created, approved or updated."
         group_event:
           name: "Group Event"
           details: "When a group is created, updated or destroyed."

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -230,7 +230,7 @@ describe UsersController do
         end
 
         expect(events.map { |event| event[:event_name] }).to contain_exactly(
-          :user_logged_in, :user_first_logged_in
+          :user_logged_in, :user_first_logged_in, :user_confirmed_email
         )
 
         expect(response.status).to eq(200)


### PR DESCRIPTION
Requested by @coding-horror [in Sept 2016](https://meta.discourse.org/t/webhooks-feedback/49046/9) 😇

At the moment, a webhook is fired for `user_created` when a user signs up, but if you want to do anything with it, like keep another system in sync, you'd want to ensure the user is who they say they are first, which email confirmation provides.

I tried accomplishing this with a [plugin](https://github.com/29th/discourse-user-activated-webhook/), but because `EmailToken.atomic_confirm` uses `update_all`, ActiveRecord callbacks are skipped so I can't hook into it. The closest I got with a plugin was:

```ruby
  add_model_callback(User, :after_update) do
    if saved_change_to_active && email_confirmed?
      WebHook.enqueue_object_hooks(:user, self, "user_activated")
    end
  end
```

The plugin approach catches the initial activation, but doesn't catch a user changing their email (and confirming it) later.

This pull request triggers the user event webhook any time the user confirms their email.

You'll see in `web_hook_spec.rb:327` I removed `user.activate`. I assume this was in there because the original intention may have been to fire the `user_created` webhook _after_ a user is activated. In fact it fires immediately when the user is created/signs up, so this line is not necessary. But I removed it because `#activate` also confirms the user's email address, which triggers this webhook, therefore the most recent webhook would be `user_confirmed_email`.