### PR TITLE
FIX: additionalOpts update and change to function

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timer-info.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timer-info.js
@@ -45,7 +45,6 @@ export default Component.extend({
     return canModifyTimer && showTopicTimerModal;
   },
 
-  @discourseComputed
   additionalOpts() {
     return {};
   },
@@ -98,7 +97,7 @@ export default Component.extend({
         );
       }
 
-      options = Object.assign(options, this.additionalOpts);
+      options = Object.assign(options, this.additionalOpts());
       this.setProperties({
         title: `${moment(this.executeAt).format("LLLL")}`.htmlSafe(),
         notice: `${I18n.t(this._noticeKey(), options)}`.htmlSafe(),

--- a/app/assets/javascripts/discourse/app/components/topic-timer-info.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timer-info.js
@@ -94,11 +94,11 @@ export default Component.extend({
             categoryName: category.get("slug"),
             categoryUrl: category.get("url"),
           },
-          options,
-          this.additionalOpts
+          options
         );
       }
 
+      options = Object.assign(options, this.additionalOpts);
       this.setProperties({
         title: `${moment(this.executeAt).format("LLLL")}`.htmlSafe(),
         notice: `${I18n.t(this._noticeKey(), options)}`.htmlSafe(),


### PR DESCRIPTION
@martin-brennan 
I made [this PR](https://github.com/discourse/discourse/pull/12519) a few days back. I encountered an issue there. The `additionalOpts` object is added to the options inside a conditional which isn't desired. This resolves the issue.