### PR TITLE
FIX: Improve error messages if user cannot send PM emails

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
@@ -7,7 +7,7 @@
     topicId=topicId
     filterPlaceholder="composer.users_placeholder"
     includeMessageableGroups=true
-    allowEmails=true
+    allowEmails=currentUser.can_send_private_email_messages
     autoWrap=true
   )
 }}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -568,6 +568,7 @@ en:
               cant_send_pm: "Sorry, you cannot send a personal message to that user."
               no_user_selected: "You must select a valid user."
               reply_by_email_disabled: "Reply by email has been disabled."
+              send_to_email_disabled: "Sorry, you cannot send personal messages to email."
               target_user_not_found: "One of the users you are sending this message to could not be found."
               unable_to_update: "There was an error updating that topic."
               unable_to_tag: "There was an error tagging the topic."

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -193,7 +193,7 @@ class TopicCreator
     end
 
     if @opts[:target_emails].present? && !@guardian.can_send_private_messages_to_email? then
-      rollback_with!(topic, :reply_by_email_disabled)
+      rollback_with!(topic, :send_to_email_disabled)
     end
 
     add_users(topic, @opts[:target_usernames])

--- a/spec/components/topic_creator_spec.rb
+++ b/spec/components/topic_creator_spec.rb
@@ -245,6 +245,17 @@ describe TopicCreator do
           end.to raise_error(ActiveRecord::Rollback)
         end
       end
+
+      context 'to emails' do
+        it 'works for staff' do
+          expect(TopicCreator.create(admin, Guardian.new(admin), pm_valid_attrs.merge(target_emails: 'test@example.com'))).to be_valid
+        end
+
+        it 'does not work for non-staff' do
+          user.update!(trust_level: TrustLevel[4])
+          expect { TopicCreator.create(user, Guardian.new(user), pm_valid_attrs.merge(target_emails: 'test@example.com')) }.to raise_error(ActiveRecord::Rollback)
+        end
+      end
     end
 
     context 'setting timestamps' do


### PR DESCRIPTION
It used to say that the user could not replace by email when creating new email PMs. This is no longer the case.

The composer will no longer allow entering email address if the user cannot send email PMs in order to prevent the error.