### PR TITLE
DEV: small refactor of the category_moderators method

### DIFF
--- a/app/models/about.rb
+++ b/app/models/about.rb
@@ -106,7 +106,7 @@ class About
     mods = User.where(id: results.map(&:user_ids).flatten.uniq).index_by(&:id)
 
     results.map do |row|
-      CategoryMods.new(row.category_id, row.user_ids.map { |id| mods[id] })
+      CategoryMods.new(row.category_id, mods.values_at(row.user_ids))
     end
   end
 

--- a/app/models/about.rb
+++ b/app/models/about.rb
@@ -106,7 +106,7 @@ class About
     mods = User.where(id: results.map(&:user_ids).flatten.uniq).index_by(&:id)
 
     results.map do |row|
-      CategoryMods.new(row.category_id, mods.values_at(row.user_ids))
+      CategoryMods.new(row.category_id, mods.values_at(*row.user_ids))
     end
   end
 

--- a/app/models/about.rb
+++ b/app/models/about.rb
@@ -103,10 +103,10 @@ class About
       ORDER BY c.position
     SQL
 
-    moderators = User.where(id: results.map(&:user_ids).flatten.uniq).map { |u| [u.id, u] }.to_h
+    mods = User.where(id: results.map(&:user_ids).flatten.uniq).index_by(&:id)
 
     results.map do |row|
-      CategoryMods.new(row.category_id, row.user_ids.map { |id| moderators[id] })
+      CategoryMods.new(row.category_id, row.user_ids.map { |id| mods[id] })
     end
   end
 


### PR DESCRIPTION
Used `index_by(&:id)` instead of `map { |u| [u.id, u] }.to_h` thanks to @cvx's recommendation.

Also renamed the `moderators` variable to not clash with method of the same name.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
