### PR TITLE
UX: more consistent user control button width

### DIFF
--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -180,9 +180,29 @@ table.user-invite-list {
       padding: 0 0 12px 0;
       float: right;
       text-align: right;
+      max-width: 13.5em;
+      overflow: hidden;
 
+      li > div, // select-kit
       .btn {
-        min-width: 140px;
+        min-width: 9.5em;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      li > div {
+        .name {
+          @include ellipsis;
+        }
+      }
+
+      .d-button-label {
+        @include ellipsis;
+      }
+
+      .selected-name {
+        // select-kit
+        overflow: hidden;
       }
     }
 
@@ -192,6 +212,7 @@ table.user-invite-list {
       }
       .controls {
         width: auto;
+        max-width: unset;
 
         > ul {
           display: inline-flex;


### PR DESCRIPTION
This fixes a width inconsistency for user profile buttons with long text in some languages:


Before: 
![image](https://user-images.githubusercontent.com/1681963/112934074-fca1a400-90ee-11eb-9f73-59ce529a1f8c.png)

After (ignore the color difference):
![Screen Shot 2021-03-30 at 12 31 06 AM](https://user-images.githubusercontent.com/1681963/112934190-3a063180-90ef-11eb-9c3f-93e0a23a18db.png)


It also truncates button text if it's very long.  