### PR TITLE
DEV: Clear filters when navigating to a post

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -370,7 +370,7 @@ const DiscourseURL = EmberObject.extend({
           opts.nearPost = topicController.get("model.highest_post_number");
         }
 
-        opts.cancelSummary = true;
+        opts.cancelFilter = true;
 
         postStream.refresh(opts).then(() => {
           const closest = postStream.closestPostNumberFor(opts.nearPost || 1);

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -311,9 +311,9 @@ export default RestModel.extend({
     opts = opts || {};
     opts.nearPost = parseInt(opts.nearPost, 10);
 
-    if (opts.cancelSummary) {
-      this.set("summary", false);
-      delete opts.cancelSummary;
+    if (opts.cancelFilter) {
+      this.cancelFilter();
+      delete opts.cancelFilter;
     }
 
     const topic = this.topic;


### PR DESCRIPTION
The issue was that when navigating to a post that was hidden by a filter, the post stayed hidden (and the navigation would highlight the nearest post). This was most noticeable when filtered replies were enabled.

Reported in: https://meta.discourse.org/t/links-to-hidden-messages-dont-clear-filters/184491

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
