### PR TITLE
FIX: User fields are case insensitive in bulk CSV

### DIFF
--- a/app/jobs/regular/bulk_invite.rb
+++ b/app/jobs/regular/bulk_invite.rb
@@ -93,7 +93,7 @@ module Jobs
       user_fields = {}
 
       fields.each do |key, value|
-        @user_fields[key] ||= UserField.find_by(name: key)&.id || :nil
+        @user_fields[key] ||= UserField.where('name ILIKE ?', key).pluck_first(:id) || :nil
         user_fields[@user_fields[key]] = value if @user_fields[key] != :nil
       end
 

--- a/spec/jobs/bulk_invite_spec.rb
+++ b/spec/jobs/bulk_invite_spec.rb
@@ -82,14 +82,14 @@ describe Jobs::BulkInvite do
     end
 
     it 'can create staged users and prepulate user fields' do
-      user_field = Fabricate(:user_field)
+      user_field = Fabricate(:user_field, name: "Location")
       described_class.new.execute(
         current_user_id: admin.id,
         invites: [
           { email: 'test@discourse.org' }, # new user without user fields
-          { email: user.email, user_field.name => 'value 1' }, # existing user with user fields
-          { email: staged_user.email, user_field.name => 'value 2' }, # existing staged user with user fields
-          { email: 'test2@discourse.org', user_field.name => 'value 3' } # new staged user with user fields
+          { email: user.email, location: 'value 1' }, # existing user with user fields
+          { email: staged_user.email, location: 'value 2' }, # existing staged user with user fields
+          { email: 'test2@discourse.org', location: 'value 3' } # new staged user with user fields
         ]
       )
 


### PR DESCRIPTION
The CSV column title had to be case sensitive match with the name of
the user field which was unnecessary complex.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
