### PR TITLE
Improve details_enabled site setting description copy

### DIFF
--- a/plugins/discourse-details/config/locales/server.en.yml
+++ b/plugins/discourse-details/config/locales/server.en.yml
@@ -1,5 +1,5 @@
 en:
   site_settings:
-    details_enabled: 'Enable the details feature. If you change this, you must rebake all posts with: "rake posts:rebake".'
+    details_enabled: 'Include the ability to add expandable details to a post. This feature can be found in the toolbar popup menu of the composer. You must rebake all posts with "rake posts:rebake" if you change this setting.'
   details:
     excerpt_details: "(click for more details)"


### PR DESCRIPTION
The `details_enabled` site setting description did not clearly convey what it controls.

The copy change was discussed here: https://meta.discourse.org/t/183923

I restructured the last sentence slightly to avoid wrapping the rake task between two lines.

Final result:

<img width="693" alt="Screen Shot 2021-03-30 at 12 58 55 PM" src="https://user-images.githubusercontent.com/22733864/113049796-ecbeaa00-9158-11eb-8536-9db8dde20931.png">
