### PR TITLE
Oneboxer cache response body

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1638,6 +1638,13 @@ onebox:
   facebook_app_access_token:
     default: ""
     secret: true
+  cache_onebox_response_body:
+    default: false
+  cache_onebox_response_body_domains:
+    default: ""
+    type: list
+  cache_onebox_user_agent:
+    default: ""
 spam:
   add_rel_nofollow_to_user_content: true
   hide_post_sensitivity:

--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -16,7 +16,7 @@ class FinalDestination
 
   def self.cache_https_domain(domain)
     key = redis_https_key(domain)
-    Discourse.redis.without_namespace.setex(key, "1", 1.day.to_i).present?
+    Discourse.redis.without_namespace.setex(key, 1.day.to_i, "1").present?
   end
 
   def self.is_https_domain?(domain)


### PR DESCRIPTION
Some oneboxes may fail if when making excessive and/or odd requests against the target domains. This change provides a simple mechanism to cache the results of succesful GET requests as part of the oneboxing process, with the goal of reducing repeated requests and ultimately improving the rate of successful oneboxing.

To enable:

Set `SiteSetting.cache_onebox_response_body` to `true`

Add the domains you’re interesting in caching to `SiteSetting. cache_onebox_response_body_domains` e.g. `example.com|example.org|example.net`

Optionally set `SiteSetting.cache_onebox_user_agent` to a user agent string of your choice to use when making requests against domains in the above list.