### PR TITLE
A11Y: Do not use positive tabindex in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-save-button.js
+++ b/app/assets/javascripts/discourse/app/components/composer-save-button.js
@@ -1,7 +1,6 @@
 import Button from "discourse/components/d-button";
 
 export default Button.extend({
-  tabindex: 5,
   classNameBindings: [":btn-primary", ":create", "disableSubmit:disabled"],
   title: "composer.title",
 });

--- a/app/assets/javascripts/discourse/app/templates/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-editor.hbs
@@ -1,5 +1,4 @@
 {{d-editor
-  tabindex="4"
   value=composer.reply
   placeholder=replyPlaceholder
   previewUpdated=(action "previewUpdated")

--- a/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
@@ -1,5 +1,4 @@
 {{text-field value=composer.title
-             tabindex="2"
              id="reply-title"
              maxLength=titleMaxLength
              placeholderKey=composer.titlePlaceholder

--- a/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
@@ -1,6 +1,5 @@
 {{email-group-user-chooser
   id="private-message-users"
-  tabindex="1"
   value=splitRecipients
   onChange=(action "updateRecipients")
   options=(hash

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -20,8 +20,7 @@
                   model=model
                   openComposer=(action "openComposer")
                   closeComposer=(action "closeComposer")
-                  canWhisper=canWhisper
-                  tabindex=8}}
+                  canWhisper=canWhisper}}
                 {{plugin-outlet name="composer-action-after" noTags=true args=(hash model=model)}}
 
                 {{#unless site.mobileView}}
@@ -37,7 +36,7 @@
 
                 {{#if canEdit}}
                   {{#link-to-input onClick=(action "displayEditReason") showInput=showEditReason icon="info-circle" class="display-edit-reason"}}
-                    {{text-field value=editReason tabindex="7" id="edit-reason" maxlength="255" placeholderKey="composer.edit_reason_placeholder"}}
+                    {{text-field value=editReason id="edit-reason" maxlength="255" placeholderKey="composer.edit_reason_placeholder"}}
                   {{/link-to-input}}
                 {{/if}}
               </div>
@@ -60,7 +59,7 @@
                   }}
                   {{#if showWarning}}
                     <label class="add-warning">
-                      {{input type="checkbox" checked=model.isWarning tabindex="3"}}
+                      {{input type="checkbox" checked=model.isWarning}}
                       {{i18n "composer.add_warning"}}
                     </label>
                   {{/if}}
@@ -75,7 +74,6 @@
                   <div class="category-input">
                     {{category-chooser
                       value=model.categoryId
-                      tabindex="3"
                       onChange=(action (mut model.categoryId))
                       isDisabled=disableCategoryChooser
                       options=(hash
@@ -88,7 +86,6 @@
                 {{#if canEditTags}}
                   {{mini-tag-chooser
                     value=model.tags
-                    tabindex=4
                     isDisabled=disableTagsChooser
                     onChange=(action (mut model.tags))
                     options=(hash
@@ -140,7 +137,7 @@
                                      disableSubmit=disableSubmit}}
 
               {{#if site.mobileView}}
-                <a href {{action "cancel"}} tabindex="6" title={{i18n "cancel"}} class="cancel">
+                <a href {{action "cancel"}} title={{i18n "cancel"}} class="cancel">
                   {{#if canEdit}}
                     {{d-icon "times"}}
                   {{else}}
@@ -148,7 +145,7 @@
                   {{/if}}
                 </a>
               {{else}}
-                <a href {{action "cancel"}} tabindex="6" class="cancel" >{{i18n "cancel"}}</a>
+                <a href {{action "cancel"}} class="cancel" >{{i18n "cancel"}}</a>
               {{/if}}
             {{/unless}}
 


### PR DESCRIPTION
From our audit:

>Because positive number tabindex values have been used on the textarea, category and tags comboboxes, create topic button, cancel button, and Create a new Topic button, they have been forced to the start of the keyboard focus order on any page they’re on. The editor toolbar buttons, the fullscreen button, the minimize button, and the hide preview link do not have positive tab index values, but are at the end of the document and therefore last in the focus order. 

> In practical terms, this means that all of the focusable elements on the page are between the textarea and the editor toolbar buttons, making it a practical impossibility for a keyboard user to interact with these buttons. As screen reader users will enter forms mode while interacting with the textarea and other form elements, they are likely to be using the TAB key to navigate the composer widget just like other keyboard users. Unless they are aware of the editor toolbar buttons and other controls, screen reader users may not find them either. 

> **Positive tabindex values should be avoided, instead allow the order of elements within the DOM determine the tab order.**