### PR TITLE
FIX: title when YouTube is pasted as the title to composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-title.js
+++ b/app/assets/javascripts/discourse/app/components/composer-title.js
@@ -164,8 +164,12 @@ export default Component.extend({
 
       const heading = frag.querySelector("h3, h4");
 
-      if (heading && heading.textContent) {
-        this.changeTitle(heading.textContent);
+      const title =
+        (heading && heading.textContent) ||
+        (frag.firstElementChild && frag.firstElementChild.title);
+
+      if (title) {
+        this.changeTitle(title);
       } else {
         const firstTitle =
           (frag.firstChild &&

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
@@ -52,6 +52,17 @@ acceptance("Composer topic featured links", function (needs) {
     );
   });
 
+  test("YouTube onebox with title", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    await fillIn("#reply-title", "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    assert.equal(
+      queryAll(".title-input input").val(),
+      "Rick Astley - Never Gonna Give You Up (Video)",
+      "title is from the oneboxed article"
+    );
+  });
+
   test("no onebox result", async function (assert) {
     await visit("/");
     await click("#create-topic");

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -850,6 +850,16 @@ export function applyDefaultHandlers(pretender) {
       ];
     }
 
+    if (
+      request.queryParams.url === "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    ) {
+      return [
+        200,
+        { "Content-Type": "application/html" },
+        '<img src="https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg" width="480" height="360" title="Rick Astley - Never Gonna Give You Up (Video)">',
+      ];
+    }
+
     if (request.queryParams.url.indexOf("/internal-page.html") > -1) {
       return [
         200,


### PR DESCRIPTION
When the YouTube link is passed to the composer, it should extract the title.

https://meta.discourse.org/t/youtube-link-not-generate-title/183776
