### PR TITLE
FIX: post merging was failing silently

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -400,7 +400,7 @@ Post.reopenClass({
     return ajax("/posts/merge_posts", {
       type: "PUT",
       data: { post_ids },
-    });
+    }).catch(popupAjaxError);
   },
 
   loadRevision(postId, version) {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -363,6 +363,8 @@ class PostsController < ApplicationController
     raise Discourse::InvalidParameters.new(:post_ids) if posts.pluck(:id) == params[:post_ids]
     PostMerger.new(current_user, posts).merge
     render body: nil
+  rescue PostMerger::CannotMergeError => e
+    render_json_error(e.message)
   end
 
   # Direct replies to this post

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2382,6 +2382,7 @@ en:
     errors:
       different_topics: "Posts belonging to different topics cannot be merged."
       different_users: "Posts belonging to different users cannot be merged."
+      max_post_length: "Posts cannot be merged because the combined post length is more than allowed."
 
   move_posts:
     new_topic_moderator_post:

--- a/lib/validators/stripped_length_validator.rb
+++ b/lib/validators/stripped_length_validator.rb
@@ -3,13 +3,7 @@
 class StrippedLengthValidator < ActiveModel::EachValidator
   def self.validate(record, attribute, value, range)
     if !value.nil?
-      value = value.dup
-      value.gsub!(/<!--(.*?)-->/, '') # strip HTML comments
-      value.gsub!(/:\w+(:\w+)?:/, "X") # replace emojis with a single character
-      value.gsub!(/\.{2,}/, '…') # replace multiple ... with …
-      value.gsub!(/\,{2,}/, ',') # replace multiple ,,, with ,
-      value.strip!
-
+      value = get_sanitized_value(value)
       record.errors.add attribute, (I18n.t('errors.messages.too_short', count: range.begin)) if value.length < range.begin
       record.errors.add attribute, (I18n.t('errors.messages.too_long_validation', max: range.end, length: value.length)) if value.length > range.end
     else
@@ -21,5 +15,14 @@ class StrippedLengthValidator < ActiveModel::EachValidator
     # the `in` parameter might be a lambda when the range is dynamic
     range = options[:in].lambda? ? options[:in].call : options[:in]
     self.class.validate(record, attribute, value, range)
+  end
+
+  def self.get_sanitized_value(value)
+    value = value.dup
+    value.gsub!(/<!--(.*?)-->/, '') # strip HTML comments
+    value.gsub!(/:\w+(:\w+)?:/, "X") # replace emojis with a single character
+    value.gsub!(/\.{2,}/, '…') # replace multiple ... with …
+    value.gsub!(/\,{2,}/, ',') # replace multiple ,,, with ,
+    value.strip
   end
 end

--- a/spec/components/post_merger_spec.rb
+++ b/spec/components/post_merger_spec.rb
@@ -66,5 +66,18 @@ describe PostMerger do
         PostMerger::CannotMergeError, I18n.t("merge_posts.errors.different_users")
       )
     end
+
+    it "should not allow posts with length greater than max_post_length" do
+      SiteSetting.max_post_length = 60
+
+      reply1 = create_post(topic: topic, raw: 'The first reply', post_number: 2, user: user)
+      reply2 = create_post(topic: topic, raw: "The second reply\nSecond line", post_number: 3, user: user)
+      reply3 = create_post(topic: topic, raw: 'The third reply', post_number: 4, user: user)
+      replies = [reply3, reply2, reply1]
+
+      expect { PostMerger.new(admin, replies).merge }.to raise_error(
+        PostMerger::CannotMergeError, I18n.t("merge_posts.errors.max_post_length")
+      )
+    end
   end
 end


### PR DESCRIPTION
https://meta.discourse.org/t/merging-very-long-posts-removes-them/183597

We will now show an error bootbox when the merged post length is greater than allowed.

This commit also updates client side to show all raised errors instead of failing silently.