### PR TITLE
FIX: Reload messages after a bulk operation

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic-bulk-actions.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic-bulk-actions.js
@@ -253,7 +253,7 @@ export default Controller.extend(ModalFunctionality, {
       if (this.isGroup) {
         params.group = this.groupFilter;
       }
-      this.forEachPerformed(params, (t) => t.set("archived", true));
+      this.performAndRefresh(params);
     },
 
     moveMessagesToInbox() {
@@ -261,7 +261,7 @@ export default Controller.extend(ModalFunctionality, {
       if (this.isGroup) {
         params.group = this.groupFilter;
       }
-      this.forEachPerformed(params, (t) => t.set("archived", false));
+      this.performAndRefresh(params);
     },
 
     unlistTopics() {

--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -55,6 +55,7 @@ export default Controller.extend({
 
   @action
   toggleBulkSelect() {
+    this.selected.clear();
     this.toggleProperty("bulkSelectEnabled");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages.js
@@ -29,6 +29,10 @@ export default DiscourseRoute.extend({
   },
 
   actions: {
+    refresh() {
+      this.refresh();
+    },
+
     willTransition: function () {
       this._super(...arguments);
       this.controllerFor("user").set("pmView", null);

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -60,7 +60,7 @@
     {{#unless site.mobileView}}
       {{#if showToggleBulkSelect}}
         {{d-button icon="list" class="btn-default bulk-select" title="topics.bulk.toggle" action=(action "toggleBulkSelect")}}
-        {{bulk-select-button selected=selected}}
+        {{bulk-select-button selected=selected action=(route-action "refresh")}}
       {{/if}}
     {{/unless}}
 


### PR DESCRIPTION
It did not show the updated state of the topic until user refreshed the
page.