### PR TITLE
DEV: Use appEvents instead of jQuery for composer resizing progress

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -112,6 +112,7 @@ export default Component.extend(KeyEnterEscape, {
 
     const performDrag = (event) => {
       $composer.trigger("div-resizing");
+      this.appEvents.trigger("composer:div-resizing");
       $composer.addClass("clear-transitions");
       const currentMousePos = mouseYPos(event);
       let size = origComposerSize + (lastMousePos - currentMousePos);
@@ -142,6 +143,7 @@ export default Component.extend(KeyEnterEscape, {
       lastMousePos = mouseYPos(event);
       $document.on(DRAG_EVENTS, throttledPerformDrag);
       $document.on(END_EVENTS, endDrag);
+      this.appEvents.trigger("composer:resize-started");
     });
 
     if (iOSWithVisualViewport()) {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

This event was needed for plugin work, and I'd rather not add new jQuery dependencies. Not sure which plugins currently use this event?