### PR TITLE
FEATURE: Retrieve an existing link only invite

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -835,6 +835,7 @@ Discourse::Application.routes.draw do
     post "invites/reinvite-all" => "invites#resend_all_invites"
     delete "invites" => "invites#destroy"
     put "invites/show/:id" => "invites#perform_accept_invitation", as: 'perform_accept_invite'
+    get "invites/retrieve" => "invites#retrieve"
 
     resources :export_csv do
       collection do

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -252,6 +252,36 @@ describe InvitesController do
     end
   end
 
+  context '#retrieve' do
+    it 'requires to be logged in' do
+      get '/invites/retrieve.json', params: { email: 'test@example.com' }
+      expect(response.status).to eq(403)
+    end
+
+    context 'while logged in' do
+      before do
+        sign_in(user)
+      end
+
+      fab!(:invite) { Fabricate(:invite, invited_by: user, email: 'test@example.com') }
+
+      it 'raises an error when the email is missing' do
+        get '/invites/retrieve.json'
+        expect(response.status).to eq(400)
+      end
+
+      it 'raises an error when the email cannot be found' do
+        get '/invites/retrieve.json', params: { email: 'test2@example.com' }
+        expect(response.status).to eq(400)
+      end
+
+      it 'can retrieve the invite' do
+        get '/invites/retrieve.json', params: { email: 'test@example.com' }
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
   context '#update' do
     fab!(:invite) { Fabricate(:invite, invited_by: admin, email: 'test@example.com') }
 


### PR DESCRIPTION
In Improve invite system, a newly created link only invite cannot be retrieved via API with the invitee's email once created. A new route, /invites/retrieve, is introduced to fetch an already created invite by email address.
