### PR TITLE
FIX: Replace use of auto_silence_first_post_regex with watched words

### DIFF
--- a/app/assets/javascripts/admin/addon/components/watched-word-form.js
+++ b/app/assets/javascripts/admin/addon/components/watched-word-form.js
@@ -16,8 +16,8 @@ export default Component.extend({
   actionKey: null,
   showMessage: false,
 
-  canReplace: equal("actionKey", "replace"),
-  canTag: equal("actionKey", "tag"),
+  isReplace: equal("actionKey", "replace"),
+  isTag: equal("actionKey", "tag"),
 
   @discourseComputed("regularExpressions")
   placeholderKey(regularExpressions) {
@@ -58,13 +58,15 @@ export default Component.extend({
       if (!this.formSubmitted) {
         this.set("formSubmitted", true);
 
-        const watchedWord = WatchedWord.create({
-          word: this.word,
-          replacement: this.canReplace || this.canTag ? this.replacement : null,
-          action: this.actionKey,
-        });
+        const attributes = { word: this.word, action: this.actionKey };
+        if (this.isReplace || this.isTag) {
+          attributes.replacement = this.replacement;
+        }
+        if (!this.isTag && this.firstPostOnly) {
+          attributes.first_post_only = this.firstPostOnly;
+        }
 
-        watchedWord
+        WatchedWord.create(attributes)
           .save()
           .then((result) => {
             this.setProperties({

--- a/app/assets/javascripts/admin/addon/components/watched-word-form.js
+++ b/app/assets/javascripts/admin/addon/components/watched-word-form.js
@@ -73,6 +73,7 @@ export default Component.extend({
             this.setProperties({
               word: "",
               replacement: "",
+              firstPostOnly: false,
               formSubmitted: false,
               showMessage: true,
               message: I18n.t("admin.watched_words.form.success"),

--- a/app/assets/javascripts/admin/addon/components/watched-word-form.js
+++ b/app/assets/javascripts/admin/addon/components/watched-word-form.js
@@ -16,6 +16,7 @@ export default Component.extend({
   actionKey: null,
   showMessage: false,
 
+  isRequireApproval: equal("actionKey", "require_approval"),
   isReplace: equal("actionKey", "replace"),
   isTag: equal("actionKey", "tag"),
 
@@ -62,7 +63,7 @@ export default Component.extend({
         if (this.isReplace || this.isTag) {
           attributes.replacement = this.replacement;
         }
-        if (!this.isTag && this.firstPostOnly) {
+        if (this.isRequireApproval) {
           attributes.first_post_only = this.firstPostOnly;
         }
 

--- a/app/assets/javascripts/admin/addon/controllers/admin-watched-words-action.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-watched-words-action.js
@@ -35,7 +35,12 @@ export default Controller.extend({
 
   @discourseComputed("currentAction.words.[]", "adminWatchedWords.model")
   filteredContent(words) {
-    return words || [];
+    return words ? words.filter((word) => !word.first_post_only) : [];
+  },
+
+  @discourseComputed("currentAction.words.[]", "adminWatchedWords.model")
+  filteredFirstPostContent(words) {
+    return words ? words.filter((word) => word.first_post_only) : [];
   },
 
   @discourseComputed("actionNameKey")

--- a/app/assets/javascripts/admin/addon/models/watched-word.js
+++ b/app/assets/javascripts/admin/addon/models/watched-word.js
@@ -14,6 +14,7 @@ const WatchedWord = EmberObject.extend({
           word: this.word,
           replacement: this.replacement,
           action_key: this.action,
+          first_post_only: this.first_post_only,
         },
         dataType: "json",
       }

--- a/app/assets/javascripts/admin/addon/templates/components/watched-word-form.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/watched-word-form.hbs
@@ -17,12 +17,12 @@
   </div>
 {{/if}}
 
-{{#unless isTag}}
+{{#if isRequireApproval}}
   <label class="watched-word-input">
     {{input type="checkbox" checked=firstPostOnly}}
     {{i18n "admin.watched_words.form.first_post_only" count=wordCount}}
   </label>
-{{/unless}}
+{{/if}}
 
 {{d-button class="btn-default" action=(action "submit") disabled=formSubmitted label="admin.watched_words.form.add"}}
 

--- a/app/assets/javascripts/admin/addon/templates/components/watched-word-form.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/watched-word-form.hbs
@@ -3,19 +3,26 @@
   {{text-field id="watched-word" value=word disabled=formSubmitted class="watched-word-input" autocorrect="off" autocapitalize="off" placeholderKey=placeholderKey title=(i18n placeholderKey)}}
 </div>
 
-{{#if canReplace}}
+{{#if isReplace}}
   <div class="watched-word-input">
     <label for="watched-replacement">{{i18n "admin.watched_words.form.replacement_label"}}</label>
     {{text-field id="watched-replacement" value=replacement disabled=formSubmitted class="watched-word-input" autocorrect="off" autocapitalize="off" placeholderKey="admin.watched_words.form.replacement_placeholder"}}
   </div>
 {{/if}}
 
-{{#if canTag}}
+{{#if isTag}}
   <div class="watched-word-input">
     <label for="watched-tag">{{i18n "admin.watched_words.form.tag_label"}}</label>
     {{text-field id="watched-tag" value=replacement disabled=formSubmitted class="watched-word-input" autocorrect="off" autocapitalize="off" placeholderKey="admin.watched_words.form.tag_placeholder"}}
   </div>
 {{/if}}
+
+{{#unless isTag}}
+  <label class="watched-word-input">
+    {{input type="checkbox" checked=firstPostOnly}}
+    {{i18n "admin.watched_words.form.first_post_only" count=wordCount}}
+  </label>
+{{/unless}}
 
 {{d-button class="btn-default" action=(action "submit") disabled=formSubmitted label="admin.watched_words.form.add"}}
 

--- a/app/assets/javascripts/admin/addon/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/addon/templates/watched-words-action.hbs
@@ -24,7 +24,7 @@
 {{watched-word-form
   actionKey=actionNameKey
   action=(action "recordAdded")
-  filteredContent=filteredContent
+  filteredContent=currentAction.words
   regularExpressions=adminWatchedWords.regularExpressions}}
 
 {{#if wordCount}}

--- a/app/assets/javascripts/admin/addon/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/addon/templates/watched-words-action.hbs
@@ -40,4 +40,14 @@
       <div class="watched-word-box">{{admin-watched-word word=word action=(action "recordRemoved")}}</div>
     {{/each}}
   </div>
+
+  {{#if filteredFirstPostContent}}
+    <p class="about">{{i18n "admin.watched_words.first_post_only_words"}}</p>
+
+    <div class="watched-words-list">
+      {{#each filteredFirstPostContent as |word| }}
+        <div class="watched-word-box">{{admin-watched-word word=word action=(action "recordRemoved")}}</div>
+      {{/each}}
+    </div>
+  {{/if}}
 {{/if}}

--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -85,7 +85,7 @@ class Admin::WatchedWordsController < Admin::AdminController
   private
 
   def watched_words_params
-    params.permit(:id, :word, :replacement, :action_key)
+    params.permit(:id, :word, :replacement, :action_key, :first_post_only)
   end
 
 end

--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -28,7 +28,7 @@ class Admin::WatchedWordsController < Admin::AdminController
   def upload
     file = params[:file] || params[:files].first
     action_key = params[:action_key].to_sym
-    has_replacement = WatchedWord.has_replacement?(action_key)
+    has_replacement = WatchedWord.has_replacement?(WatchedWord.actions[action_key])
 
     Scheduler::Defer.later("Upload watched words") do
       begin
@@ -59,7 +59,7 @@ class Admin::WatchedWordsController < Admin::AdminController
     raise Discourse::NotFound if !action
 
     content = WatchedWord.where(action: action)
-    if WatchedWord.has_replacement?(name)
+    if WatchedWord.has_replacement?(action)
       content = content.pluck(:word, :replacement).map(&:to_csv).join
     else
       content = content.pluck(:word).join("\n")

--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -68,7 +68,7 @@ module Jobs
       old_tags = post.topic.tags.pluck(:name).to_set
       new_tags = old_tags.dup
 
-      WordWatcher.words_for_action(:tag).each do |word, tags|
+      WordWatcher.get_cached_words(:tag).each do |word, tags|
         new_tags += tags.split(",") if word_watcher.matches?(word)
       end
 

--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -63,12 +63,15 @@ module Jobs
     end
 
     def auto_tag(post)
+      watched_words = WordWatcher.get_cached_words(:tag)
+      return if watched_words.blank?
+
       word_watcher = WordWatcher.new(post.raw)
 
       old_tags = post.topic.tags.pluck(:name).to_set
       new_tags = old_tags.dup
 
-      WordWatcher.get_cached_words(:tag).each do |word, tags|
+      watched_words.each do |word, tags|
         new_tags += tags.split(",") if word_watcher.matches?(word)
       end
 

--- a/app/models/watched_word.rb
+++ b/app/models/watched_word.rb
@@ -43,13 +43,17 @@ class WatchedWord < ActiveRecord::Base
     w.action_key = params[:action_key] if params[:action_key]
     w.action = params[:action] if params[:action]
     w.replacement = params[:replacement] if has_replacement?(w.action) && params[:replacement]
-    w.first_post_only = true if params[:first_post_only].present?
+    w.first_post_only = true if can_apply_to_first_post_only?(w.action) && params[:first_post_only].present?
     w.save
     w
   end
 
   def self.has_replacement?(action)
     action == WatchedWord.actions[:replace] || action == WatchedWord.actions[:tag]
+  end
+
+  def self.can_apply_to_first_post_only?(action)
+    action == WatchedWord.actions[:require_approval]
   end
 
   def action_key=(arg)
@@ -66,12 +70,13 @@ end
 #
 # Table name: watched_words
 #
-#  id          :integer          not null, primary key
-#  word        :string           not null
-#  action      :integer          not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  replacement :string
+#  id              :integer          not null, primary key
+#  word            :string           not null
+#  action          :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  replacement     :string
+#  first_post_only :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/models/watched_word.rb
+++ b/app/models/watched_word.rb
@@ -43,7 +43,7 @@ class WatchedWord < ActiveRecord::Base
     w.action_key = params[:action_key] if params[:action_key]
     w.action = params[:action] if params[:action]
     w.replacement = params[:replacement] if has_replacement?(w.action) && params[:replacement]
-    w.first_post_only = true if can_apply_to_first_post_only?(w.action) && params[:first_post_only].present?
+    w.first_post_only = params[:first_post_only].present? if can_apply_to_first_post_only?(w.action)
     w.save
     w
   end

--- a/app/serializers/watched_word_serializer.rb
+++ b/app/serializers/watched_word_serializer.rb
@@ -10,4 +10,8 @@ class WatchedWordSerializer < ApplicationSerializer
   def include_replacement?
     WatchedWord.has_replacement?(object.action)
   end
+
+  def include_first_post_only?
+    WatchedWord.can_apply_to_first_post_only?(object.action)
+  end
 end

--- a/app/serializers/watched_word_serializer.rb
+++ b/app/serializers/watched_word_serializer.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class WatchedWordSerializer < ApplicationSerializer
-  attributes :id, :word, :replacement, :action
+  attributes :id, :word, :replacement, :action, :first_post_only
 
   def action
     WatchedWord.actions[object.action]
   end
 
   def include_replacement?
-    WatchedWord.has_replacement?(action)
+    WatchedWord.has_replacement?(object.action)
   end
 end

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -7,7 +7,9 @@ class WordWatcher
   end
 
   def self.words_for_action(action, first_post_only: false)
-    words = WatchedWord.where(action: WatchedWord.actions[action.to_sym]).where(first_post_only: first_post_only).limit(1000)
+    words = WatchedWord.where(action: WatchedWord.actions[action.to_sym])
+    words = words.where(first_post_only: false) if !first_post_only
+    words = words.limit(1000)
     if action.to_sym == :replace || action.to_sym == :tag
       words.pluck(:word, :replacement).to_h
     else
@@ -66,7 +68,7 @@ class WordWatcher
 
   def self.clear_cache!
     WatchedWord.actions.each do |a, i|
-      Discourse.cache.delete word_matcher_regexp_key(a)
+      Discourse.cache.delete word_matcher_regexp_key(a, first_post_only: false)
       Discourse.cache.delete word_matcher_regexp_key(a, first_post_only: true)
     end
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4666,6 +4666,7 @@ en:
         show_words:
           one: "show %{count} word"
           other: "show %{count} words"
+        first_post_only_words: "Apply to first post only:"
         download: Download
         clear_all: Clear All
         clear_all_confirm: "Are you sure you want to clear all watched words for the %{action} action?"
@@ -4691,6 +4692,7 @@ en:
           replacement_placeholder: "example or https://example.com"
           tag_label: "Tag"
           tag_placeholder: "tag1,tag2,tag3"
+          first_post_only: "Apply to first post only"
           add: "Add"
           success: "Success"
           exists: "Already exists"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1949,7 +1949,6 @@ en:
     min_first_post_typing_time: "Minimum amount of time in milliseconds a user must type during first post, if threshold is not met post will automatically enter the needs approval queue. Set to 0 to disable (not recommended)"
     auto_silence_fast_typers_on_first_post: "Automatically silence users that do not meet min_first_post_typing_time"
     auto_silence_fast_typers_max_trust_level: "Maximum trust level to auto silence fast typers"
-    auto_silence_first_post_regex: "Case insensitive regex that if passed will cause first post by user to be silenced and sent to approval queue. Example: raging|a[bc]a , will cause all posts containing raging or aba or aca to be silenced on first. Only applies to first post."
     reviewable_claiming: "Does reviewable content need to be claimed before it can be acted upon?"
     reviewable_default_topics: "Show reviewable content grouped by topic by default"
     reviewable_default_visibility: "Don't show reviewable items unless they meet this priority"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1684,7 +1684,6 @@ spam:
   min_first_post_typing_time: 3000
   auto_silence_fast_typers_on_first_post: true
   auto_silence_fast_typers_max_trust_level: 0
-  auto_silence_first_post_regex: ""
   high_trust_flaggers_auto_hide_posts: true
   cooldown_hours_until_reflag:
     default: 24

--- a/db/migrate/20210331141224_add_first_post_only_to_watched_words.rb
+++ b/db/migrate/20210331141224_add_first_post_only_to_watched_words.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFirstPostOnlyToWatchedWords < ActiveRecord::Migration[6.0]
+  def change
+    add_column :watched_words, :first_post_only, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20210331165936_move_auto_silence_first_post_regex_to_watched_words.rb
+++ b/db/migrate/20210331165936_move_auto_silence_first_post_regex_to_watched_words.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MoveAutoSilenceFirstPostRegexToWatchedWords < ActiveRecord::Migration[6.0]
+  def up
+    execute <<~SQL
+      INSERT INTO watched_words (word, action, first_post_only, created_at, updated_at)
+      SELECT value, 3, true, created_at, updated_at
+      FROM site_settings
+      WHERE name = 'auto_silence_first_post_regex'
+    SQL
+
+    execute "DELETE FROM site_settings WHERE name = 'auto_silence_first_post_regex'"
+  end
+
+  def down
+    execute <<~SQL
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      SELECT 'auto_silence_first_post_regex', 3, word, created_at, updated_at
+      FROM watched_words
+      WHERE action = 3 AND first_post_only
+      LIMIT 1
+    SQL
+
+    execute "DELETE FROM watched_words WHERE action = 3 AND first_post_only"
+  end
+end

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -55,22 +55,9 @@ class NewPostManager
   end
 
   def self.matches_auto_silence_regex?(manager)
-    args = manager.args
-
-    pattern = SiteSetting.auto_silence_first_post_regex
-
-    return false unless pattern.present?
-    return false unless is_first_post?(manager)
-
-    begin
-      regex = Regexp.new(pattern, Regexp::IGNORECASE)
-    rescue => e
-      Rails.logger.warn "Invalid regex in auto_silence_first_post_regex #{e}"
-      return false
-    end
-
-    "#{args[:title]} #{args[:raw]}" =~ regex
-
+    return false if !is_first_post?(manager)
+    word_watcher = WordWatcher.new("#{manager.args[:title]} #{manager.args[:raw]}")
+    word_watcher.word_matches_for_action?(:require_approval, first_post_only: true)
   end
 
   def self.exempt_user?(user)

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -46,6 +46,7 @@ class TopicsBulkAction
     group = find_group
     topics.each do |t|
       if guardian.can_see?(t) && t.private_message?
+        @changed_ids << t.id
         if group
           GroupArchivedMessage.move_to_inbox!(group.id, t)
         else
@@ -59,6 +60,7 @@ class TopicsBulkAction
     group = find_group
     topics.each do |t|
       if guardian.can_see?(t) && t.private_message?
+        @changed_ids << t.id
         if group
           GroupArchivedMessage.archive!(group.id, t)
         else

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -46,7 +46,6 @@ class TopicsBulkAction
     group = find_group
     topics.each do |t|
       if guardian.can_see?(t) && t.private_message?
-        @changed_ids << t.id
         if group
           GroupArchivedMessage.move_to_inbox!(group.id, t)
         else
@@ -60,7 +59,6 @@ class TopicsBulkAction
     group = find_group
     topics.each do |t|
       if guardian.can_see?(t) && t.private_message?
-        @changed_ids << t.id
         if group
           GroupArchivedMessage.archive!(group.id, t)
         else

--- a/lib/validators/censored_words_validator.rb
+++ b/lib/validators/censored_words_validator.rb
@@ -3,7 +3,7 @@
 class CensoredWordsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     words_regexp = censored_words_regexp
-    if WordWatcher.words_for_action(:censor).present? && !words_regexp.nil?
+    if WordWatcher.get_cached_words(:censor).present? && !words_regexp.nil?
       censored_words = censor_words(value, words_regexp)
       return if censored_words.blank?
       record.errors.add(

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -888,7 +888,9 @@ describe PostsController do
       end
 
       it 'silences correctly based on auto_silence_first_post_regex' do
-        SiteSetting.auto_silence_first_post_regex = "I love candy|i eat s[1-5]"
+        SiteSetting.watched_words_regular_expressions = true
+        WatchedWord.create!(action: WatchedWord.actions[:require_approval], word: 'I love candy', first_post_only: true)
+        WatchedWord.create!(action: WatchedWord.actions[:require_approval], word: 'i eat s[1-5]', first_post_only: true)
 
         post "/posts.json", params: {
           raw: 'this is the test content',


### PR DESCRIPTION
This is another attempt at moving auto_silence_first_post_regex to watched words page. We tried to do this before in another tab, but the user experience was not great. This tries to use existing logic and add a 'first_post_only' flag to watched words.

For now, this flag can be used only for 'require approval' watched words.