### PR TITLE
FIX: restore bulk select on full-page search

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/search-result-entries.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-result-entries.hbs
@@ -1,5 +1,5 @@
 <div class="fps-result-entries">
   {{#each posts as |post|}}
-    {{search-result-entry post=post}}
+    {{search-result-entry post=post bulkSelectEnabled=bulkSelectEnabled selected=selected}}
   {{/each}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -79,7 +79,7 @@
     {{else}}
       <div class="search-results">
         {{#load-more selector=".fps-result" action=(action "loadMore")}}
-          {{search-result-entries posts=model.posts}}
+          {{search-result-entries posts=model.posts bulkSelectEnabled=bulkSelectEnabled selected=selected}}
 
           {{#conditional-loading-spinner condition=loading }}
             {{#unless hasResults}}


### PR DESCRIPTION
This is a follow-up to 4dcdbd7; that refactor broke bulk selection on the search page. This fixes it 🎉 