### PR TITLE
UX: better position for search bulk select button

### DIFF
--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -81,8 +81,25 @@
       justify-content: flex-start;
       align-items: stretch;
       flex-wrap: wrap;
+      padding-right: 2.6em; // placeholder for fixed position bulk search button
       button {
         margin: 0 0.5em 0.5em 0;
+      }
+
+      .bulk-select-container {
+        order: 2; // last button
+        margin-left: auto;
+        z-index: z("dropdown"); // below composer
+      }
+
+      #bulk-select {
+        position: fixed;
+        right: unset;
+        margin: 0;
+        button {
+          margin: 0;
+          box-shadow: 0 0 0.4em 0.45em var(--secondary); // slight fade behind the button, because it can overlay content
+        }
       }
     }
 


### PR DESCRIPTION
This improves the position of the button for bulk controls...

Before you could run into this situation:

![Screen Shot 2021-04-03 at 12 35 21 AM](https://user-images.githubusercontent.com/1681963/113468520-9b424380-9414-11eb-8d2b-b321704b118a.png)



After:

![Screen Shot 2021-04-03 at 12 26 26 AM](https://user-images.githubusercontent.com/1681963/113468525-a4331500-9414-11eb-80f4-3140f5c16f77.png)

and then while scrolling it's closer to the actual topic:

 
![Screen Shot 2021-04-03 at 12 26 38 AM](https://user-images.githubusercontent.com/1681963/113468530-abf2b980-9414-11eb-91b5-b89a914126c5.png)


