### PR TITLE
FIX: Include watched topics from muted categories in digests

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -506,7 +506,7 @@ class Topic < ActiveRecord::Base
     end
     if remove_category_ids.present?
       remove_category_ids.uniq!
-      topics = topics.where("topics.category_id NOT IN (?)", remove_category_ids)
+      topics = topics.where("topic_users.notification_level != ? OR topics.category_id NOT IN (?)", TopicUser.notification_levels[:muted], remove_category_ids)
     end
 
     # Remove muted tags

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1952,6 +1952,17 @@ describe Topic do
         expect(Topic.for_digest(user, 1.year.ago)).to eq([])
       end
 
+      it "does return watched topics from muted categories" do
+        user = Fabricate(:user)
+        category = Fabricate(:category_with_definition, created_at: 2.minutes.ago)
+        topic = Fabricate(:topic, category: category, created_at: 1.minute.ago)
+
+        CategoryUser.set_notification_level_for_category(user, CategoryUser.notification_levels[:muted], category.id)
+        Fabricate(:topic_user, user: user, topic: topic, notification_level: TopicUser.notification_levels[:regular])
+
+        expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to eq([topic])
+      end
+
       it "doesn't return topics from suppressed categories" do
         user = Fabricate(:user)
         category = Fabricate(:category_with_definition, created_at: 2.minutes.ago)


### PR DESCRIPTION
Topic that are muted or from muted categories are not included in digests, but non-muted topics from muted categories should be included.