### PR TITLE
Revert "A11Y: Do not use positive tabindex in composer (#12563)"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-save-button.js
+++ b/app/assets/javascripts/discourse/app/components/composer-save-button.js
@@ -1,6 +1,7 @@
 import Button from "discourse/components/d-button";
 
 export default Button.extend({
+  tabindex: 5,
   classNameBindings: [":btn-primary", ":create", "disableSubmit:disabled"],
   title: "composer.title",
 });

--- a/app/assets/javascripts/discourse/app/templates/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-editor.hbs
@@ -1,4 +1,5 @@
 {{d-editor
+  tabindex="4"
   value=composer.reply
   placeholder=replyPlaceholder
   previewUpdated=(action "previewUpdated")

--- a/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
@@ -1,4 +1,5 @@
 {{text-field value=composer.title
+             tabindex="2"
              id="reply-title"
              maxLength=titleMaxLength
              placeholderKey=composer.titlePlaceholder

--- a/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-user-selector.hbs
@@ -1,5 +1,6 @@
 {{email-group-user-chooser
   id="private-message-users"
+  tabindex="1"
   value=splitRecipients
   onChange=(action "updateRecipients")
   options=(hash

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -20,7 +20,8 @@
                   model=model
                   openComposer=(action "openComposer")
                   closeComposer=(action "closeComposer")
-                  canWhisper=canWhisper}}
+                  canWhisper=canWhisper
+                  tabindex=8}}
                 {{plugin-outlet name="composer-action-after" noTags=true args=(hash model=model)}}
 
                 {{#unless site.mobileView}}
@@ -36,7 +37,7 @@
 
                 {{#if canEdit}}
                   {{#link-to-input onClick=(action "displayEditReason") showInput=showEditReason icon="info-circle" class="display-edit-reason"}}
-                    {{text-field value=editReason id="edit-reason" maxlength="255" placeholderKey="composer.edit_reason_placeholder"}}
+                    {{text-field value=editReason tabindex="7" id="edit-reason" maxlength="255" placeholderKey="composer.edit_reason_placeholder"}}
                   {{/link-to-input}}
                 {{/if}}
               </div>
@@ -59,7 +60,7 @@
                   }}
                   {{#if showWarning}}
                     <label class="add-warning">
-                      {{input type="checkbox" checked=model.isWarning}}
+                      {{input type="checkbox" checked=model.isWarning tabindex="3"}}
                       {{i18n "composer.add_warning"}}
                     </label>
                   {{/if}}
@@ -74,6 +75,7 @@
                   <div class="category-input">
                     {{category-chooser
                       value=model.categoryId
+                      tabindex="3"
                       onChange=(action (mut model.categoryId))
                       isDisabled=disableCategoryChooser
                       options=(hash
@@ -86,6 +88,7 @@
                 {{#if canEditTags}}
                   {{mini-tag-chooser
                     value=model.tags
+                    tabindex=4
                     isDisabled=disableTagsChooser
                     onChange=(action (mut model.tags))
                     options=(hash
@@ -137,7 +140,7 @@
                                      disableSubmit=disableSubmit}}
 
               {{#if site.mobileView}}
-                <a href {{action "cancel"}} title={{i18n "cancel"}} class="cancel">
+                <a href {{action "cancel"}} tabindex="6" title={{i18n "cancel"}} class="cancel">
                   {{#if canEdit}}
                     {{d-icon "times"}}
                   {{else}}
@@ -145,7 +148,7 @@
                   {{/if}}
                 </a>
               {{else}}
-                <a href {{action "cancel"}} class="cancel" >{{i18n "cancel"}}</a>
+                <a href {{action "cancel"}} tabindex="6" class="cancel" >{{i18n "cancel"}}</a>
               {{/if}}
             {{/unless}}
 


### PR DESCRIPTION
This reverts commit af879b7851e3c26b9a612dc7d76ca02c80a619c6.

The reverted commit made keyboard focusable content in the preview interrupt tab order, we'll need to do something more complex here... like adding `tabindex="-1"` to all preview content. 