### PR TITLE
FIX: add toggle-link to intercept click

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -38,6 +38,7 @@ export default function interceptClick(e) {
       !currentTarget.dataset.userCard &&
       currentTarget.classList.contains("ember-view")) ||
     currentTarget.classList.contains("lightbox") ||
+    currentTarget.classList.contains("toggle-link") ||
     href.indexOf("mailto:") === 0 ||
     (href.match(/^http[s]?:\/\//i) &&
       !href.match(new RegExp("^https?:\\/\\/" + window.location.hostname, "i")))


### PR DESCRIPTION
For some reason dropping jQuery in 8a36b91 broke the mobile dropdown nav? adding the `toggle-link` to the intercept fixes it... 