### PR TITLE
FIX: with vanilla js .href and getAttribute("href") are not equal

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -22,7 +22,7 @@ export default function interceptClick(e) {
   }
 
   const currentTarget = e.currentTarget;
-  const href = currentTarget.href;
+  const href = currentTarget.getAttribute("href");
 
   if (
     !href ||


### PR DESCRIPTION
With a link having an empty href: `<a href>foo</a>` doing
`element.href` will give you the URL of the document, to get the same behavior than `$(element).attr("href")` and get "" you need to do `element.getAttribute("href")`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
