### PR TITLE
FIX: show sign up modal when local logins are disabled

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -97,6 +97,9 @@ export default Controller.extend(
       if (hasAtLeastOneLoginButton && !hasAuthOptions) {
         classes.push("has-alt-auth");
       }
+      if (!this.canCreateLocal) {
+        classes.push("no-local-logins");
+      }
       return classes.join(" ");
     },
 

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -7,17 +7,18 @@
         {{loading-spinner size="large"}}
       {{/if}}
 
-      {{#if showCreateForm}}
-        <div class="create-account-form">
-          <div class="login-welcome-header">
-            <h1 class="login-title">{{i18n "create_account.header_title"}}</h1> <img src={{wavingHandURL}} alt="" class="waving-hand">
-            <p class="login-subheader">{{i18n "create_account.subheader_title"}}</p>
+      <div class="create-account-form">
+        <div class="login-welcome-header">
+          <h1 class="login-title">{{i18n "create_account.header_title"}}</h1> <img src={{wavingHandURL}} alt="" class="waving-hand">
+          <p class="login-subheader">{{i18n "create_account.subheader_title"}}</p>
+        </div>
+        {{#unless hasAuthOptions}}
+          <div class="create-account-login-buttons">
+            {{login-buttons externalLogin=(action "externalLogin")}}
           </div>
-          {{#unless hasAuthOptions}}
-            <div class="create-account-login-buttons">
-              {{login-buttons externalLogin=(action "externalLogin")}}
-            </div>
-          {{/unless}}
+        {{/unless}}
+        {{#if showCreateForm}}
+
           <div class="login-form">
 
             <form>
@@ -147,29 +148,30 @@
               {{/if}}
             </form>
           </div>
-          {{#if showCreateForm}}
-            <div class="modal-footer">
-              {{d-button
-                class="btn-large btn-primary"
-                action=(action "createAccount")
-                disabled=submitDisabled
-                label="create_account.title"
-                isLoading=formSubmitted
-              }}
 
-              {{#unless hasAuthOptions}}
-                {{d-button class="btn-large" id="login-link" action=(route-action "showLogin") disabled=formSubmitted label="log_in"}}
-              {{/unless}}
+        {{/if}}
+        {{#if showCreateForm}}
+          <div class="modal-footer">
+            {{d-button
+              class="btn-large btn-primary"
+              action=(action "createAccount")
+              disabled=submitDisabled
+              label="create_account.title"
+              isLoading=formSubmitted
+            }}
 
-              <div class="disclaimer">
-                {{html-safe disclaimerHtml}}
-              </div>
+            {{#unless hasAuthOptions}}
+              {{d-button class="btn-large" id="login-link" action=(route-action "showLogin") disabled=formSubmitted label="log_in"}}
+            {{/unless}}
+
+            <div class="disclaimer">
+              {{html-safe disclaimerHtml}}
             </div>
+          </div>
 
-            {{plugin-outlet name="create-account-after-modal-footer" tagName=""}}
-          {{/if}}
-        </div>
-      {{/if}}
+          {{plugin-outlet name="create-account-after-modal-footer" tagName=""}}
+        {{/if}}
+      </div>
     {{/d-modal-body}}
   {{/unless}}
 {{/create-account}}

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -149,8 +149,6 @@
             </form>
           </div>
 
-        {{/if}}
-        {{#if showCreateForm}}
           <div class="modal-footer">
             {{d-button
               class="btn-large btn-primary"
@@ -170,6 +168,7 @@
           </div>
 
           {{plugin-outlet name="create-account-after-modal-footer" tagName=""}}
+
         {{/if}}
       </div>
     {{/d-modal-body}}

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -105,6 +105,14 @@
   &.awaiting-approval {
     display: none;
   }
+
+  .no-local-logins {
+    // when third-party auth is available, but not local logins
+    .login-left-side,
+    .login-welcome-header {
+      padding: 3em 1em 3em 3em;
+    }
+  }
 }
 
 // Login Form Styles


### PR DESCRIPTION
It looks like we lost a state in the new signup modal where third-party auth is enabled, but local auth is disabled. 

https://meta.discourse.org/t/login-modal-ui-black-fades-out/180492/4?u=awesomerobot

Before the redesign we had:

![Screen Shot 2021-04-05 at 6 46 20 PM](https://user-images.githubusercontent.com/1681963/113652306-86a6bb00-9661-11eb-879d-fd2e6b4d68a3.png)


Now we have:

![image](https://user-images.githubusercontent.com/1681963/113652083-231c8d80-9661-11eb-9a81-75b74b259fa8.png)

This fix does this:

![Screen Shot 2021-04-05 at 10 43 36 PM](https://user-images.githubusercontent.com/1681963/113652116-316aa980-9661-11eb-897d-09bde7539774.png)
