### PR TITLE
FIX: Clear state after creating new topic

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -805,6 +805,10 @@ export default Controller.extend({
           this.appEvents.trigger("post:highlight", result.payload.post_number);
         }
 
+        if (this.get("model.draftKey") === Composer.NEW_TOPIC_KEY) {
+          this.currentUser.set("has_topic_draft", false);
+        }
+
         if (result.responseJson.route_to) {
           this.destroyDraft();
           if (result.responseJson.message) {


### PR DESCRIPTION
Fixes an issue where the "Open Draft" button would be stuck after a topic was successfully created.

Reported in https://meta.discourse.org/t/open-draft-button-stuck-after-the-topic-created/185314