### PR TITLE
FEATURE: Treat site settings as plain text and add a new HTML type.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ gem 'discourse_image_optim', require: 'image_optim'
 gem 'multi_json'
 gem 'mustache'
 gem 'nokogiri'
+gem 'loofah'
 gem 'css_parser', require: false
 
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -525,6 +525,7 @@ DEPENDENCIES
   logstash-event
   logstash-logger
   logster
+  loofah
   lru_redux
   lz4-ruby
   mail!

--- a/app/assets/javascripts/admin/addon/templates/components/site-settings/html.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/site-settings/html.hbs
@@ -1,0 +1,2 @@
+{{text-field value=(html-safe value) classNames="input-setting-string"}}
+<div class="desc">{{html-safe setting.description}}</div>

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -6,7 +6,10 @@ class Admin::SiteSettingsController < Admin::AdminController
   end
 
   def index
-    render_json_dump(site_settings: SiteSetting.all_settings, diags: SiteSetting.diags)
+    render_json_dump(
+      site_settings: SiteSetting.all_settings(sanitize_plain_text_settings: true),
+      diags: SiteSetting.diags
+    )
   end
 
   def update

--- a/app/services/site_settings_task.rb
+++ b/app/services/site_settings_task.rb
@@ -2,7 +2,7 @@
 
 class SiteSettingsTask
   def self.export_to_hash(include_defaults: false, include_hidden: false)
-    site_settings = SiteSetting.all_settings(include_hidden)
+    site_settings = SiteSetting.all_settings(include_hidden: include_hidden)
     h = {}
     site_settings.each do |site_setting|
       next if site_setting[:default] == site_setting[:value] if !include_defaults

--- a/app/services/user_merger.rb
+++ b/app/services/user_merger.rb
@@ -148,7 +148,7 @@ class UserMerger
   def update_site_settings
     ::MessageBus.publish '/merge_user', { message: I18n.t("admin.user.merge_user.updating_site_settings") }, user_ids: [@acting_user.id] if @acting_user
 
-    SiteSetting.all_settings(true).each do |setting|
+    SiteSetting.all_settings(include_hidden: true).each do |setting|
       if setting[:type] == "username" && setting[:value] == @source_user.username
         SiteSetting.set_and_log(setting[:setting], @target_user.username)
       end

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -19,6 +19,7 @@
 # type: username - Must match the username of an existing user.
 # type: list     - A list of values, chosen from a set of valid values defined in the choices option.
 # type: enum     - A single value, chosen from a set of valid values in the choices option.
+# type: html     - A single value. It could contain HTML.
 #
 # A type:list setting with the word 'colors' in its name will make color values have a bold line of the corresponding color
 #

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -208,14 +208,20 @@ module SiteSettingExtension
   def client_settings_json_uncached
     MultiJson.dump(Hash[*@client_settings.map do |name|
       value = self.public_send(name)
-      value = value.to_s if type_supervisor.get_type(name) == :upload
-      value = value.map(&:to_s).join("|") if type_supervisor.get_type(name) == :uploaded_image_list
+      type = type_supervisor.get_type(name)
+      value = value.to_s if type == :upload
+      value = value.map(&:to_s).join("|") if type == :uploaded_image_list
+
+      if should_sanitize?(value, type)
+        value = sanitize(value)
+      end
+
       [name, value]
     end.flatten])
   end
 
   # Retrieve all settings
-  def all_settings(include_hidden = false)
+  def all_settings(include_hidden: false, sanitize_plain_text_settings: false)
 
     locale_setting_hash =
     {
@@ -244,6 +250,8 @@ module SiteSettingExtension
          default.to_i < Upload::SEEDED_ID_THRESHOLD
 
         default = default_uploads[default.to_i]
+      elsif sanitize_plain_text_settings && should_sanitize?(value, type_hash[:type].to_s)
+        value = sanitize(value)
       end
 
       opts = {
@@ -572,6 +580,14 @@ module SiteSettingExtension
     if (type_supervisor.get_type(name) == :upload || type_supervisor.get_type(name) == :uploaded_image_list) && uploads.has_key?(name)
       uploads.delete(name)
     end
+  end
+
+  def should_sanitize?(value, type)
+    value.is_a?(String) && type.to_s != 'html'
+  end
+
+  def sanitize(value)
+    CGI.unescapeHTML(Loofah.scrub_fragment(value, :strip).to_s)
   end
 
   def logger

--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -36,7 +36,8 @@ class SiteSettings::TypeSupervisor
       tag_list: 21,
       color: 22,
       simple_list: 23,
-      emoji_list: 24
+      emoji_list: 24,
+      html: 25
     )
   end
 

--- a/spec/components/site_settings/type_supervisor_spec.rb
+++ b/spec/components/site_settings/type_supervisor_spec.rb
@@ -94,6 +94,9 @@ describe SiteSettings::TypeSupervisor do
       it "'emoji_list' should be at the right position" do
         expect(SiteSettings::TypeSupervisor.types[:emoji_list]).to eq(24)
       end
+      it "'html' should be at the right position" do
+        expect(SiteSettings::TypeSupervisor.types[:html]).to eq(25)
+      end
     end
   end
 


### PR DESCRIPTION
To add an extra layer of security, we sanitize settings before shipping them to the client. We don't sanitize those that have the "html" type.

The CookedPostProcessor already uses Loofah for sanitization, so I chose to also use it for this. I added it to our gemfile since we installed it as a transitive dependency.
