### PR TITLE
FIX: Keep current filter while navigating posts in a topic

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -754,6 +754,7 @@ export default Controller.extend(bufferedProperty("model"), {
     jumpTop() {
       DiscourseURL.routeTo(this.get("model.firstPostUrl"), {
         skipIfOnScreen: false,
+        keepFilter: true,
       });
     },
 
@@ -764,6 +765,7 @@ export default Controller.extend(bufferedProperty("model"), {
       DiscourseURL.routeTo(this.get("model.lastPostUrl"), {
         skipIfOnScreen: false,
         jumpEnd,
+        keepFilter: true,
       });
     },
 
@@ -774,6 +776,7 @@ export default Controller.extend(bufferedProperty("model"), {
       );
       DiscourseURL.routeTo(this.get("model.lastPostUrl"), {
         jumpEnd: true,
+        keepFilter: true,
       });
     },
 
@@ -1163,11 +1166,18 @@ export default Controller.extend(bufferedProperty("model"), {
     const post = postStream.findLoadedPost(postId);
 
     if (post) {
-      DiscourseURL.routeTo(topic.urlForPostNumber(post.get("post_number")));
+      DiscourseURL.routeTo(topic.urlForPostNumber(post.get("post_number")), {
+        keepFilter: true,
+      });
     } else {
       // need to load it
       postStream.findPostsByIds([postId]).then((arr) => {
-        DiscourseURL.routeTo(topic.urlForPostNumber(arr[0].get("post_number")));
+        DiscourseURL.routeTo(
+          topic.urlForPostNumber(arr[0].get("post_number")),
+          {
+            keepFilter: true,
+          }
+        );
       });
     }
   },

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -370,7 +370,9 @@ const DiscourseURL = EmberObject.extend({
           opts.nearPost = topicController.get("model.highest_post_number");
         }
 
-        opts.cancelFilter = true;
+        if (!routeOpts.keepFilter) {
+          opts.cancelFilter = true;
+        }
 
         postStream.refresh(opts).then(() => {
           const closest = postStream.closestPostNumberFor(opts.nearPost || 1);

--- a/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
@@ -223,7 +223,9 @@ export default createWidget("header-topic-info", {
   jumpToTopPost() {
     const topic = this.attrs.topic;
     if (topic) {
-      DiscourseURL.routeTo(topic.get("firstPostUrl"));
+      DiscourseURL.routeTo(topic.get("firstPostUrl"), {
+        keepFilter: true,
+      });
     }
   },
 });


### PR DESCRIPTION
Reported in: https://meta.discourse.org/t/user-posts-in-a-topic/185247

This fixes a regression introduced in https://github.com/discourse/discourse/pull/12557. In some cases, we want to clear the filters when navigating to a specific route (for example, when clicking on a notification). In other cases, though, we want to keep the filters as they are. 

This PR adds a `keepFilter` option and uses it when: 

- navigating using the topic timeline (jumping to top, jumping to bottom or jumping to a specific post)
- clicking on the header title to jump to the OP