### PR TITLE
UX: icon instead of text for hiding mobile preview

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -199,7 +199,7 @@
             </a>
 
             {{#if showPreview}}
-              {{d-button action=(action "togglePreview") class="hide-preview" icon="pencil-alt"}}
+              {{d-button action=(action "togglePreview") class="hide-preview" ariaLabel="composer.hide_preview" icon="pencil-alt"}}
             {{/if}}
           {{else}}
             <a href {{action "togglePreview"}} class="toggle-preview">{{html-safe toggleText}}</a>

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -199,7 +199,7 @@
             </a>
 
             {{#if showPreview}}
-              {{d-button action=(action "togglePreview") class="hide-preview" label="composer.hide_preview"}}
+              {{d-button action=(action "togglePreview") class="hide-preview" icon="pencil-alt"}}
             {{/if}}
           {{else}}
             <a href {{action "togglePreview"}} class="toggle-preview">{{html-safe toggleText}}</a>


### PR DESCRIPTION
The translations of "hide preview" are quite long in some languages! not great for small mobile devices

![image](https://user-images.githubusercontent.com/1681963/113784393-5a437b00-9703-11eb-9881-78694e3329cb.png)


Switching to the edit icon to get back: 
![Screen Shot 2021-04-06 at 6 11 13 PM](https://user-images.githubusercontent.com/1681963/113784458-79daa380-9703-11eb-858e-cb0c175f153d.png)
