### PR TITLE
DEV: lazy-yt plugin should attempt to use `parse_embed_response`

### DIFF
--- a/plugins/lazy-yt/plugin.rb
+++ b/plugins/lazy-yt/plugin.rb
@@ -28,8 +28,10 @@ class Onebox::Engine::YoutubeOnebox
       video_height = (params['height'] && params['height'].to_i <= 500) ? params['height'] : 388 # embed height
       size_tags = ["width=\"#{video_width}\"", "height=\"#{video_height}\""]
 
-      og = get_opengraph.data
-      thumbnail_url = og[:image] || "https://img.youtube.com/vi/#{video_id}/hqdefault.jpg"
+      result = parse_embed_response
+      result ||= get_opengraph.data
+
+      thumbnail_url = result[:image] || "https://img.youtube.com/vi/#{video_id}/hqdefault.jpg"
 
       # Put in the LazyYT div instead of the iframe
       escaped_title = ERB::Util.html_escape(video_title)


### PR DESCRIPTION
This requires the `parse_embed_response` method, which should be available in the `onebox` gem, version 2.2.11 (or thereabouts).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
