### PR TITLE
REFACTOR: Consistency, A11Y, and less text for composer toggles

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/composer-toggles.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-toggles.hbs
@@ -2,24 +2,27 @@
   {{plugin-outlet name="before-composer-toggles"}}
 
   {{#if site.mobileView}}
-    {{flat-button
-      class="toggle-toolbar"
+    {{d-button
+      class="btn-flat toggle-toolbar btn-mini-toggle"
       icon="bars"
       action=toggleToolbar
-      title=toggleToolbarTitle}}
+      title=toggleToolbarTitle
+      ariaLabel=toggleToolbarTitle}}
   {{/if}}
 
-  {{flat-button
-    class="toggler"
+  {{d-button
+    class="btn-flat toggler toggle-minimize btn-mini-toggle"
     icon=toggleIcon
     action=toggleComposer
-    title=toggleTitle}}
+    title=toggleTitle
+    ariaLabel=toggleTitle}}
 
   {{#unless site.mobileView}}
-    {{flat-button
-      class="toggle-fullscreen"
+    {{d-button
+      class="btn-flat toggle-fullscreen btn-mini-toggle"
       icon=fullscreenIcon
       action=toggleFullscreen
-      title=fullscreenTitle}}
+      title=fullscreenTitle
+      ariaLabel=fullscreenTitle}}
   {{/unless}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -207,7 +207,13 @@
               {{d-button action=(action "togglePreview") class="hide-preview" ariaLabel="composer.hide_preview" icon="pencil-alt"}}
             {{/if}}
           {{else}}
-            <a href {{action "togglePreview"}} class="toggle-preview">{{html-safe toggleText}}</a>
+            {{d-button
+              action=(action "togglePreview")
+              translatedTitle=toggleText
+              translatedAriaLabel=toggleText
+              icon="angle-double-left"
+              class=(concat "btn-flat btn-mini-toggle toggle-preview " (unless showPreview "active"))
+              }}
           {{/if}}
 
         </div>

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -83,7 +83,7 @@
     .saving-text {
       display: none;
     }
-    .toggler {
+    .toggle-minimize {
       order: 2;
     }
   }
@@ -97,9 +97,7 @@
     margin: 5px 0 10px 0;
     display: flex;
     align-items: center;
-    .d-icon {
-      color: var(--primary-high);
-    }
+
     .reply-details {
       max-width: calc(100% - 175px);
       flex: 1 1 auto;
@@ -108,7 +106,7 @@
       white-space: nowrap;
 
       .d-icon {
-        opacity: 0.8;
+        color: var(--primary-medium);
       }
     }
     .composer-action-title {
@@ -152,11 +150,8 @@
     .composer-controls {
       display: flex;
       margin-left: auto;
-      button {
-        padding: 5px 7px;
-        &.toggler {
-          order: 2;
-        }
+      .toggle-minimize {
+        order: 2;
       }
     }
   }
@@ -536,5 +531,12 @@ body:not(.ios-safari-composer-hacks) {
     .d-editor-button-bar {
       font-size: $font-down-1;
     }
+  }
+}
+
+.toggle-preview {
+  transition: all 0.33s ease-out;
+  &.active {
+    transform: rotate(180deg);
   }
 }

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -264,6 +264,9 @@
   line-height: $line-height-small;
 }
 
+// Bonus Buttons
+// --------------------------------------------------
+
 .btn-flat {
   background: transparent;
   border: 0;
@@ -308,4 +311,23 @@
   border: 0;
   padding: 0;
   color: var(--tertiary);
+}
+
+.btn-mini-toggle {
+  padding: 0.4em 0.467em;
+  .d-icon {
+    color: var(--primary-high);
+  }
+  @include hover {
+    background: transparent;
+    .d-icon {
+      color: var(--primary);
+    }
+  }
+  &:focus {
+    background: var(--primary-low);
+    .d-icon {
+      color: var(--primary);
+    }
+  }
 }

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -56,7 +56,7 @@
     }
   }
 
-  .toggler {
+  .toggle-minimize {
     .d-icon-chevron-down {
       vertical-align: text-top;
     }
@@ -67,7 +67,7 @@
     padding-bottom: env(safe-area-inset-bottom);
 
     .toggle-toolbar,
-    .toggler {
+    .toggle-minimize {
       top: 8px;
     }
     .draft-text {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2028,8 +2028,8 @@ en:
       saved: "Saved!"
       saved_draft: "Post draft in progress. Tap to resume."
       uploading: "Uploading..."
-      show_preview: "show preview &raquo;"
-      hide_preview: "&laquo; hide preview"
+      show_preview: "show preview"
+      hide_preview: "hide preview"
 
       quote_post_title: "Quote whole post"
       bold_label: "B"


### PR DESCRIPTION
This does a few main things:

* Removes "show/hide preview" text from the composer (the button in the lower right). 

![Screen Shot 2021-04-07 at 12 56 25 AM](https://user-images.githubusercontent.com/1681963/113812488-2e90b700-973c-11eb-9194-ca2b210d2fb0.png)

![Screen Shot 2021-04-07 at 12 56 19 AM](https://user-images.githubusercontent.com/1681963/113812492-2f294d80-973c-11eb-8612-bc8e1eec8a95.png)

* creates a consistent `.btn-mini-toggle` style for all the toggles in the composer (preview, minimize, full-screen)

* adds aria-labels to all the toggles in the composer (preview, minimize, full-screen)