### PR TITLE
FIX: dismiss new button for tags on top

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -110,6 +110,15 @@ export default Controller.extend(BulkTopicSelection, FilterModeMixin, {
     return this.isFilterPage(filter, "new") && topicsLength > 0;
   },
 
+  @discourseComputed("list.filter", "list.topics.length")
+  showDismissAtTop(filter, topicsLength) {
+    return (
+      (this.isFilterPage(filter, "new") ||
+        this.isFilterPage(filter, "unread")) &&
+      topicsLength >= 15
+    );
+  },
+
   actions: {
     dismissReadPosts() {
       showModal("dismiss-read", { title: "topics.bulk.dismiss_read" });

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -49,7 +49,7 @@
             id="dismiss-new"
             icon="check"
             label="topics.bulk.dismiss_new"}}
-          {{/if}}
+        {{/if}}
     </div>
   {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -2,7 +2,6 @@
   <div class="container">
     {{discourse-banner user=currentUser banner=site.banner}}
   </div>
-
   <div class="list-controls">
     <div class="container">
       <section class="navigation-container tag-navigation">
@@ -31,6 +30,28 @@
   {{/if}}
 
   {{plugin-outlet name="discovery-list-container-top" args=(hash category=category)}}
+
+  {{#if showDismissAtTop}}
+    <div class="row dismiss-container-top">
+      {{#if showDismissRead}}
+        {{d-button
+          class="btn-default dismiss-read"
+          id="dismiss-topics"
+          action=(action "dismissReadPosts")
+          title="topics.bulk.dismiss_tooltip"
+          label="topics.bulk.dismiss_button"}}
+        {{/if}}
+
+        {{#if showResetNew}}
+          {{d-button
+            class="btn-default dismiss-read"
+            action=(action "resetNew")
+            id="dismiss-new"
+            icon="check"
+            label="topics.bulk.dismiss_new"}}
+          {{/if}}
+    </div>
+  {{/if}}
 
   <div class="container list-container">
     <div class="row">


### PR DESCRIPTION
Currently, new topics for specific tags can be dismissed with the button at the bottom of the page.

When there are more than 15 new topics, we should display the same button at the top as well. It already works in the same manner for categories.
