### PR TITLE
FIX: Prevent double slashes in Ember templates paths

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -128,7 +128,7 @@ class Theme < ActiveRecord::Base
     SvgSprite.expire_cache
   end
 
-  BASE_COMPILER_VERSION = 45
+  BASE_COMPILER_VERSION = 46
   def self.compiler_version
     get_set_cache "compiler_version" do
       dependencies = [

--- a/lib/theme_javascript_compiler.rb
+++ b/lib/theme_javascript_compiler.rb
@@ -183,7 +183,11 @@ class ThemeJavascriptCompiler
 
   # TODO Error handling for handlebars templates
   def append_ember_template(name, hbs_template)
-    name = "javascripts/#{name}" if !name.start_with?("javascripts/")
+    if !name.start_with?("javascripts/")
+      prefix = "javascripts"
+      prefix += "/" if !name.start_with?("/")
+      name = prefix + name
+    end
     name = name.inspect
     compiled = EmberTemplatePrecompiler.new(@theme_id).compile(hbs_template)
     # the `'Ember' in window` check is needed for no_ember pages

--- a/spec/lib/theme_javascript_compiler_spec.rb
+++ b/spec/lib/theme_javascript_compiler_spec.rb
@@ -127,4 +127,18 @@ describe ThemeJavascriptCompiler do
       expect(compiler.content.to_s).to include("addRawTemplate(\"#{name}.hbs\"")
     end
   end
+
+  describe "#append_ember_template" do
+    let(:compiler) { ThemeJavascriptCompiler.new(1, 'marks') }
+    it 'prepends `javascripts/` to template name if it is not prepended' do
+      compiler.append_ember_template("/connectors/blah-1", "{{var}}")
+      expect(compiler.content.to_s).to include('Ember.TEMPLATES["javascripts/connectors/blah-1"]')
+
+      compiler.append_ember_template("connectors/blah-2", "{{var}}")
+      expect(compiler.content.to_s).to include('Ember.TEMPLATES["javascripts/connectors/blah-2"]')
+
+      compiler.append_ember_template("javascripts/connectors/blah-3", "{{var}}")
+      expect(compiler.content.to_s).to include('Ember.TEMPLATES["javascripts/connectors/blah-3"]')
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/12517

Some themes add a leading slash to the names of the Ember templates they define/override, e.g.:

```html
<script type='text/x-handlebars' data-template-name='/connectors/above-site-header/brand-header'>
```

So we need to add a check here to not break themes that do this.