### PR TITLE
DEV: prevents test timeout

### DIFF
--- a/app/assets/javascripts/discourse/app/components/software-update-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/software-update-prompt.js
@@ -2,21 +2,18 @@ import getURL from "discourse-common/lib/get-url";
 import { cancel, later } from "@ember/runloop";
 import discourseComputed, { on } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
-import { not } from "@ember/object/computed";
 import { isTesting } from "discourse-common/config/environment";
 
 export default Component.extend({
   showPrompt: false,
 
   classNameBindings: ["getClassNames"],
-  attributeBindings: ["isHidden:aria-hidden"],
+  attributeBindings: ["showPrompt::aria-hidden"],
 
   @discourseComputed
   rootUrl() {
     return getURL("/");
   },
-
-  isHidden: not("showPrompt"),
 
   _timeoutHandler: null,
 

--- a/app/assets/javascripts/discourse/app/components/software-update-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/software-update-prompt.js
@@ -2,18 +2,21 @@ import getURL from "discourse-common/lib/get-url";
 import { cancel, later } from "@ember/runloop";
 import discourseComputed, { on } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
+import { not } from "@ember/object/computed";
 import { isTesting } from "discourse-common/config/environment";
 
 export default Component.extend({
   showPrompt: false,
 
   classNameBindings: ["getClassNames"],
-  attributeBindings: ["showPrompt::aria-hidden"],
+  attributeBindings: ["isHidden:aria-hidden"],
 
   @discourseComputed
   rootUrl() {
     return getURL("/");
   },
+
+  isHidden: not("showPrompt"),
 
   _timeoutHandler: null,
 


### PR DESCRIPTION
clock manipulation seems not reliable in component tests. This blog post does a great job of explaining it: https://dockyard.com/blog/2018/04/18/bending-time-in-ember-tests

Sadly, we don't have all the "recent" ember test helpers and can't use things like `getSettledState()`.

For now this pattern seems the most reliable and easy to apply, albeit not great.

Note if you wist to reproduce the current timeout, the following command should do it: `QUNIT_SEED=215263717493121190480103670124734840282 rake qunit:test`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
