### PR TITLE
FIX: Ensure software-update banner is only shown after 24 hours

### DIFF
--- a/app/assets/javascripts/discourse/app/components/software-update-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/software-update-prompt.js
@@ -43,7 +43,7 @@ export default Component.extend({
       }
 
       if (!this._timeoutHandler && this.session.requiresRefresh) {
-        if (isTesting) {
+        if (isTesting()) {
           this.set("showPrompt", true);
         } else {
           // Since we can do this transparently for people browsing the forum


### PR DESCRIPTION
`isTesting` is a function, so `if(isTesting)` was only checking for the presence of the function. We need to actually evaluate it. Followup to 68a032a7348dbf264f4d2db5f5dae5d0ecfdb7bd

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
