### PR TITLE
FIX: Docking mixin was not cleaning up timers

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/docking.js
+++ b/app/assets/javascripts/discourse/app/mixins/docking.js
@@ -1,6 +1,6 @@
 import Mixin from "@ember/object/mixin";
 import discourseDebounce from "discourse-common/lib/debounce";
-import { later } from "@ember/runloop";
+import { cancel, later } from "@ember/runloop";
 
 const helper = {
   offset() {
@@ -12,11 +12,13 @@ const helper = {
 
 export default Mixin.create({
   queueDockCheck: null,
+  _initialTimer: null,
+  _queuedTimer: null,
 
   init() {
     this._super(...arguments);
     this.queueDockCheck = () => {
-      discourseDebounce(this, this.safeDockCheck, 5);
+      this._queuedTimer = discourseDebounce(this, this.safeDockCheck, 5);
     };
   },
 
@@ -34,11 +36,17 @@ export default Mixin.create({
     $(document).bind("touchmove.discourse-dock", this.queueDockCheck);
 
     // dockCheck might happen too early on full page refresh
-    later(this, this.safeDockCheck, 50);
+    this._initialTimer = later(this, this.safeDockCheck, 50);
   },
 
   willDestroyElement() {
     this._super(...arguments);
+
+    if (this._queuedTimer) {
+      cancel(this._queuedTimer);
+    }
+
+    cancel(this._initialTimer);
     $(window).unbind("scroll.discourse-dock", this.queueDockCheck);
     $(document).unbind("touchmove.discourse-dock", this.queueDockCheck);
   },


### PR DESCRIPTION
I noticed this while trying to debug slow performing ember tests.
Our docking mixin sometimes sets timers but never cancels them when
removed. I'm not sure of any errors this causes but we should be tidying
up whenever the component is removed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
