### PR TITLE
FIX: mobile topic list number alignment

### DIFF
--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -442,8 +442,12 @@ td .main-link {
   }
 }
 .topic-list {
-  .posts-map {
-    font-size: $font-up-1;
+  .num.posts-map button {
+    font-size: $font-up-2;
+    padding: 0;
+  }
+  .num.activity a {
+    padding: 0;
   }
   // so the topic excerpt is full width
   // as the containing div is 80%


### PR DESCRIPTION
The switch to buttons in the layout on desktop messed up some padding on mobile

Before:
![Screen Shot 2021-04-07 at 4 32 48 PM](https://user-images.githubusercontent.com/1681963/113930129-e666a880-97be-11eb-82b8-b9c793752abb.png)

After:
![Screen Shot 2021-04-07 at 4 32 35 PM](https://user-images.githubusercontent.com/1681963/113930134-e9619900-97be-11eb-8e35-e4ebce0207b5.png)

