### PR TITLE
DEV: Adds new plugin API support to always show the topic map

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -172,6 +172,7 @@ export default function transformPost(
   }
 
   const showTopicMap =
+    _additionalAttributes.indexOf("topicMap") !== -1 ||
     showPMMap ||
     (post.post_number === 1 &&
       topic.archetype === "regular" &&


### PR DESCRIPTION
You can enable this by using the `includePostAttributes` API call with
the value of `topicMap`. This will always show the topic map at the top
of a topic regardless of how many posts there are.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
