### PR TITLE
FIX: Ensure group flair upload is present when deciding type

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -747,7 +747,7 @@ class Group < ActiveRecord::Base
 
   def flair_type
     return :icon if flair_icon.present?
-    return :image if flair_upload_id.present? && flair_upload.present?
+    return :image if flair_upload.present?
   end
 
   def flair_url

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -747,7 +747,7 @@ class Group < ActiveRecord::Base
 
   def flair_type
     return :icon if flair_icon.present?
-    return :image if flair_upload_id.present?
+    return :image if flair_upload_id.present? && flair_upload.present?
   end
 
   def flair_url


### PR DESCRIPTION
Previously, if the upload_id was present, but the upload was missing, the entire site would give a server error.

We have no foreign keys on this relation, so we have to be able to cope with the situation where the upload_id is present, but the actual upload has been deleted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
