### PR TITLE
DEV: introduces {{not}} helper

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/not.js
+++ b/app/assets/javascripts/discourse/app/helpers/not.js
@@ -1,0 +1,14 @@
+// https://github.com/jmurphyau/ember-truth-helpers/blob/master/addon/helpers/not.js
+import Helper from "@ember/component/helper";
+import truthConvert from "discourse/lib/truth-convert";
+
+export function not(params) {
+  for (let i = 0, len = params.length; i < len; i++) {
+    if (truthConvert(params[i]) === true) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export default Helper.helper(not);

--- a/app/assets/javascripts/discourse/app/lib/truth-convert.js
+++ b/app/assets/javascripts/discourse/app/lib/truth-convert.js
@@ -1,0 +1,16 @@
+// https://github.com/jmurphyau/ember-truth-helpers/blob/master/addon/utils/truth-convert.js
+import { isArray } from "@ember/array";
+import { get } from "@ember/object";
+
+export default function truthConvert(result) {
+  const truthy = result && get(result, "isTruthy");
+  if (typeof truthy === "boolean") {
+    return truthy;
+  }
+
+  if (isArray(result)) {
+    return get(result, "length") !== 0;
+  } else {
+    return !!result;
+  }
+}

--- a/app/assets/javascripts/discourse/tests/unit/helpers/not-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/helpers/not-test.js
@@ -1,0 +1,33 @@
+// https://github.com/jmurphyau/ember-truth-helpers/blob/master/tests/unit/helpers/not-test.js
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+module("helper:not", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("simple test 1", async function (assert) {
+    await render(
+      hbs`[{{not true}}] [{{not false}}] [{{not null}}] [{{not undefined}}] [{{not ''}}] [{{not ' '}}]`
+    );
+
+    assert.equal(
+      this.element.textContent,
+      "[false] [true] [true] [true] [true] [false]",
+      'value should be "[false] [true] [true] [true] [true] [false]"'
+    );
+  });
+
+  test("simple test 2", async function (assert) {
+    await render(
+      hbs`[{{not true false}}] [{{not true false}}] [{{not null null false null}}] [{{not false null ' ' true}}]`
+    );
+
+    assert.equal(
+      this.element.textContent,
+      "[false] [false] [true] [false]",
+      'value should be "[false] [false] [true] [false]"'
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/unit/helpers/not-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/helpers/not-test.js
@@ -1,33 +1,34 @@
 // https://github.com/jmurphyau/ember-truth-helpers/blob/master/tests/unit/helpers/not-test.js
-import { module, test } from "qunit";
-import { setupRenderingTest } from "ember-qunit";
-import { render } from "@ember/test-helpers";
-import { hbs } from "ember-cli-htmlbars";
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
 
-module("Unit | Helper | not", function (hooks) {
+discourseModule("Unit | Helper | not", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("simple test 1", async function (assert) {
-    await render(
-      hbs`[{{not true}}] [{{not false}}] [{{not null}}] [{{not undefined}}] [{{not ''}}] [{{not ' '}}]`
-    );
+  componentTest("simple test 1", {
+    template: hbs`<div id="not-test">[{{not true}}] [{{not false}}] [{{not null}}] [{{not undefined}}] [{{not ''}}] [{{not ' '}}]</div>`,
 
-    assert.equal(
-      this.element.textContent,
-      "[false] [true] [true] [true] [true] [false]",
-      'value should be "[false] [true] [true] [true] [true] [false]"'
-    );
+    test(assert) {
+      assert.equal(
+        query("#not-test").textContent,
+        "[false] [true] [true] [true] [true] [false]",
+        'value should be "[false] [true] [true] [true] [true] [false]"'
+      );
+    },
   });
 
-  test("simple test 2", async function (assert) {
-    await render(
-      hbs`[{{not true false}}] [{{not true false}}] [{{not null null false null}}] [{{not false null ' ' true}}]`
-    );
+  componentTest("simple test 2", {
+    template: hbs`<div id="not-test">[{{not true false}}] [{{not true false}}] [{{not null null false null}}] [{{not false null ' ' true}}]</div>`,
 
-    assert.equal(
-      this.element.textContent,
-      "[false] [false] [true] [false]",
-      'value should be "[false] [false] [true] [false]"'
-    );
+    test(assert) {
+      assert.equal(
+        query("#not-test").textContent,
+        "[false] [false] [true] [false]",
+        'value should be "[false] [false] [true] [false]"'
+      );
+    },
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/helpers/not-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/helpers/not-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "ember-qunit";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 
-module("helper:not", function (hooks) {
+module("Unit | Helper | not", function (hooks) {
   setupRenderingTest(hooks);
 
   test("simple test 1", async function (assert) {


### PR DESCRIPTION
Code is coming from https://github.com/jmurphyau/ember-truth-helpers, for now I only ported {{not}} which would have tons of use cases in our code base.

We might want to use more helpers in the future, also Ember should have this kind of helpers natively in the future:

- https://github.com/cibernox/rfcs/blob/add-logical-operators-to-templates/text/0000-add-logical-operators.md
- https://github.com/cibernox/rfcs/blob/add-equality-operators-to-templates/text/0000-add-equality-operators.md
- https://github.com/cibernox/rfcs/blob/add-numeric-comparison-operators-to-templates/text/0561-add-numeric-comparison-operators.md