### PR TITLE
DEV: Skip looking for svgo, gifsicle binaries

### DIFF
--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -124,6 +124,9 @@ class FileHelper
         jpegoptim: { strip: strip_image_metadata ? "all" : "none" },
         jpegtran: false,
         jpegrecompress: false,
+        # Skip looking for gifsicle, svgo binaries
+        gifsicle: false,
+        svgo: false
       )
     end
   end


### PR DESCRIPTION
We don't use these binaries, yet image_optim automatically looks for them when initializing. Skipping avoids some unnecessary work and removes this warning message when running specs: 

```
gifsicle worker: `gifsicle` not found; please provide proper binary or disable this worker (--no-gifsicle argument or `:gifsicle => false` through options)
svgo worker: `svgo` not found; please provide proper binary or disable this worker (--no-svgo argument or `:svgo => false` through options)
```

See also [this PR](https://github.com/discourse/discourse_docker/pull/533), it removes svgo binary from the base image.