### PR TITLE
DEV: Use Terser for JS minification/compression if available

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -97,8 +97,11 @@ def compress_node(from, to)
   source_map_url = cdn_path "/assets/#{to}.map"
   base_source_map = assets_path + assets_additional_path
 
+  # TODO: Remove uglifyjs when base image only includes terser
+  js_compressor = `which terser`.empty? ? 'uglifyjs' : 'terser'
+
   cmd = <<~EOS
-    uglifyjs '#{assets_path}/#{from}' -m -c -o '#{to_path}' --source-map "base='#{base_source_map}',root='#{source_map_root}',url='#{source_map_url}'"
+    #{js_compressor} '#{assets_path}/#{from}' -m -c -o '#{to_path}' --source-map "base='#{base_source_map}',root='#{source_map_root}',url='#{source_map_url}'"
   EOS
 
   STDERR.puts cmd


### PR DESCRIPTION
Switches to Terser for JS compression, it is faster compared to uglify-js and supports more recent JS syntax (like the optional chaining operator). 

Uglify-js is still used if terser is unavailable, but it will be removed at the next base image bump. 
