### PR TITLE
FIX: only send user suspension emails if email message provided

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -124,12 +124,14 @@ class Admin::UsersController < Admin::AdminController
     end
     @user.logged_out
 
-    Jobs.enqueue(
-      :critical_user_email,
-      type: :account_suspended,
-      user_id: @user.id,
-      user_history_id: user_history.id
-    )
+    if message && !message.empty?
+      Jobs.enqueue(
+        :critical_user_email,
+        type: :account_suspended,
+        user_id: @user.id,
+        user_history_id: user_history.id
+      )
+    end
 
     DiscourseEvent.trigger(
       :user_suspended,

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -133,10 +133,13 @@ RSpec.describe Admin::UsersController do
 
     it "works properly" do
       expect(user).not_to be_suspended
-      put "/admin/users/#{user.id}/suspend.json", params: {
-        suspend_until: 5.hours.from_now,
-        reason: "because I said so"
-      }
+
+      expect do
+        put "/admin/users/#{user.id}/suspend.json", params: {
+          suspend_until: 5.hours.from_now,
+          reason: "because I said so"
+        }
+      end.to change { Jobs::CriticalUserEmail.jobs.size }.by(0)
 
       expect(response.status).to eq(200)
 


### PR DESCRIPTION
This makes behavior consistent with documentation:

API:

> Will send an email with this message when present

Web UI:

> Optionally, provide more information about the suspension and it will be emailed to the user

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
