### PR TITLE
DEV: Allow `Discourse::Utils.execute_command` timeout with `env`

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -96,13 +96,18 @@ module Discourse
       private
 
       def execute_command(*command, timeout: nil, failure_message: "", success_status_codes: [0], chdir: ".")
+        env = nil
+        env = command.shift if command[0].is_a?(Hash)
+
         if timeout
           # will send a TERM after timeout
           # will send a KILL after timeout * 2
           command = ["timeout", "-k", "#{timeout.to_f * 2}", timeout.to_s] + command
         end
 
-        stdout, stderr, status = Open3.capture3(*command, chdir: chdir)
+        args = command
+        args = [env] + command if env
+        stdout, stderr, status = Open3.capture3(*args, chdir: chdir)
 
         if !status.exited? || !success_status_codes.include?(status.exitstatus)
           failure_message = "#{failure_message}\n" if !failure_message.blank?

--- a/spec/components/discourse_spec.rb
+++ b/spec/components/discourse_spec.rb
@@ -402,6 +402,10 @@ describe Discourse do
       expect do
         Discourse::Utils.execute_command("sleep", "999999999999", timeout: 0.001)
       end.to raise_error(RuntimeError)
+
+      expect do
+        Discourse::Utils.execute_command({ "MYENV" => "MYVAL" }, "sleep", "999999999999", timeout: 0.001)
+      end.to raise_error(RuntimeError)
     end
 
     it "works with a block" do


### PR DESCRIPTION
Followup to 5deda5ef3ef8763dfe936a313e0dddaa279a1b04

The first argument to `Open3.capture3` can be an environment variable hash. In this case, we need to insert the `timeout` command after the env hash.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
