### PR TITLE
DEV: Remove ScrollTop mixin

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/scroll-top.js
+++ b/app/assets/javascripts/discourse/app/mixins/scroll-top.js
@@ -1,6 +1,4 @@
 import DiscourseURL from "discourse/lib/url";
-import Mixin from "@ember/object/mixin";
-import { deprecated } from "discourse/mixins/scroll-top";
 import { isTesting } from "discourse-common/config/environment";
 import { scheduleOnce } from "@ember/runloop";
 
@@ -19,15 +17,5 @@ function scrollTop() {
   }
   scheduleOnce("afterRender", context, context._scrollTop);
 }
-
-export default Mixin.create({
-  didInsertElement() {
-    deprecated(
-      "The `ScrollTop` mixin is deprecated. Replace it with a `{{d-section}}` component"
-    );
-    this._super(...arguments);
-    scrollTop();
-  },
-});
 
 export { scrollTop };


### PR DESCRIPTION
It was deprecated (incorrectly! see the import 😅) 5 years ago. No references found anymore in core and all-the-plugins.
