### PR TITLE
FIX: Ensure the top 6 categories are shown in the user summary

### DIFF
--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -145,7 +145,7 @@ class UserSummary
 
     top_categories = {}
 
-    Category.where(id: post_count_query.limit(MAX_SUMMARY_RESULTS).pluck('category_id'))
+    Category.where(id: post_count_query.order("count(*) DESC").limit(MAX_SUMMARY_RESULTS).pluck('category_id'))
       .pluck(:id, :name, :color, :text_color, :slug, :read_restricted, :parent_category_id)
       .each do |c|
         top_categories[c[0].to_i] = CategoryWithCounts.new(

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -58,4 +58,24 @@ describe UserSummary do
     users = UserSummary.new(user, Guardian.new).most_liked_users
     expect(users).to eq([])
   end
+
+  it "includes ordered top categories" do
+    u = Fabricate(:user)
+
+    UserSummary::MAX_SUMMARY_RESULTS.times do
+      c = Fabricate(:category)
+      t = Fabricate(:topic, category: c, user: u)
+      Fabricate(:post, user: u, topic: t)
+    end
+
+    top_category = Fabricate(:category)
+    t = Fabricate(:topic, category: top_category, user: u)
+    Fabricate(:post, user: u, topic: t)
+    Fabricate(:post, user: u, topic: t)
+
+    summary = UserSummary.new(u, Guardian.new)
+
+    expect(summary.top_categories.length).to eq(UserSummary::MAX_SUMMARY_RESULTS)
+    expect(summary.top_categories.first[:id]).to eq(top_category.id)
+  end
 end


### PR DESCRIPTION
Previously it would pluck 6 categories which the user had posted in, **then** order them. To select the **top 6** categories, we need to perform the ordering in the SQL query before the LIMIT

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
