### PR TITLE
FEATURE: Reduce invite key length

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -35,7 +35,7 @@ class Invite < ActiveRecord::Base
   validate :user_doesnt_already_exist
 
   before_create do
-    self.invite_key ||= SecureRandom.hex
+    self.invite_key ||= SecureRandom.base58(10)
     self.expires_at ||= SiteSetting.invite_expiry_days.days.from_now
   end
 


### PR DESCRIPTION
We used to generate invite keys that were 32-characters long which were
not very friendly and lead to very long links. This commit changes the
generation method to use almost all alphanumeric characters to produce
a 10-character long invite key.

This commit also introduces a rate limit for redeeming invites because
the probability of guessing an invite key has increased.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
