### PR TITLE
PERF: Async notify users after inviting group

### DIFF
--- a/app/jobs/regular/group_pm_alert.rb
+++ b/app/jobs/regular/group_pm_alert.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Jobs
+  class GroupPmAlert < ::Jobs::Base
+    def execute(args)
+      return unless user = User.find_by(id: args[:user_id])
+      return unless group = Group.find_by(id: args[:group_id])
+      return unless post = Post.find_by(id: args[:post_id])
+      return unless topic = post.topic
+
+      group.set_message_default_notification_levels!(topic, ignore_existing: true)
+
+      alerter = PostAlerter.new
+
+      group.users.where(
+        "group_users.notification_level = :level",
+        level: NotificationLevels.all[:tracking]
+      ).find_each do |u|
+        alerter.notify_group_summary(u, post)
+      end
+
+      notification_data = {
+        notification_type: Notification.types[:invited_to_private_message],
+        topic_id: topic.id,
+        post_number: 1,
+        data: {
+          topic_title: topic.title,
+          display_username: user.username,
+          group_id: group.id
+        }.to_json
+      }
+
+      group.users.where(
+        "group_users.notification_level in (:levels) AND user_id != :id",
+        levels: [NotificationLevels.all[:watching], NotificationLevels.all[:watching_first_post]],
+        id: user.id
+      ).find_each do |u|
+        u.notifications.create!(notification_data)
+      end
+    end
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -982,6 +982,7 @@ describe Topic do
             set_state!(group, user_muted, :muted)
 
             Notification.delete_all
+            Jobs.run_immediately!
             topic.invite_group(topic.user, group)
 
             expect(Notification.count).to eq(3)

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -281,6 +281,7 @@ describe TopicUser do
           another_user = Fabricate(:user)
           group.add(another_user)
 
+          Jobs.run_immediately!
           topic.invite_group(target_user, group)
 
           expect(TopicUser.get(topic, another_user).notification_level)


### PR DESCRIPTION
Inviting a group generates a notification for each member. If this
happens synchronously it may take a while, leading to a poor user
experience.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
