### PR TITLE
FIX: Don't show the get a room composer message in private categories

### DIFF
--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -151,6 +151,7 @@ class ComposerMessagesFinder
   def check_get_a_room(min_users_posted: 5)
     return unless educate_reply?(:notified_about_get_a_room)
     return unless @details[:post_id].present?
+    return if @topic.category&.read_restricted
 
     reply_to_user_id = Post.where(id: @details[:post_id]).pluck(:user_id)[0]
 

--- a/spec/components/composer_messages_finder_spec.rb
+++ b/spec/components/composer_messages_finder_spec.rb
@@ -343,6 +343,13 @@ describe ComposerMessagesFinder do
       expect(ComposerMessagesFinder.new(user, composer_action: 'reply').check_get_a_room(min_users_posted: 2)).to be_blank
     end
 
+    it "does not give a message if the topic's category is read_restricted" do
+      topic.category.update(read_restricted: true)
+      finder = ComposerMessagesFinder.new(user, composer_action: 'reply', topic_id: topic.id, post_id: op.id)
+      finder.check_get_a_room(min_users_posted: 2)
+      expect(UserHistory.exists_for_user?(user, :notified_about_get_a_room)).to eq(false)
+    end
+
     context "reply" do
       let(:finder) { ComposerMessagesFinder.new(user, composer_action: 'reply', topic_id: topic.id, post_id: op.id) }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16214023/114750638-d0ef0280-9d19-11eb-9d08-085a54b25251.png)

We show this message regardless of category currently. In an internal instance™️ we decided to not show this message on read_restricted categories.

