### PR TITLE
FIX: Already sent headers error in Ember CLI

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -180,6 +180,7 @@ module.exports = {
         : cleanBaseURL(options.rootURL || options.baseURL);
 
     app.use(async (req, res, next) => {
+      let sentTemplate = false;
       try {
         const results = await watcher;
         if (this.shouldHandleRequest(req, options)) {
@@ -210,11 +211,14 @@ module.exports = {
                 </html>
               `;
             }
+            sentTemplate = true;
             return res.send(template);
           }
         }
       } finally {
-        next();
+        if (!sentTemplate) {
+          return next();
+        }
       }
     });
   },


### PR DESCRIPTION
If we are sending a custom template, we shouldn't do a `next()`,
we should halt middleware.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
