### PR TITLE
FIX: `this.loading` is undefined, it should be `state.loading`

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
@@ -79,7 +79,7 @@ export default createWidget("quick-access-panel", {
   },
 
   refreshNotifications(state) {
-    if (this.loading) {
+    if (state.loading) {
       return;
     }
 


### PR DESCRIPTION
This might prevent issues with double requests on the user notifications panel.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
