### PR TITLE
DEV: Do not install service workers in development

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/register-service-worker.js
+++ b/app/assets/javascripts/discourse/app/initializers/register-service-worker.js
@@ -4,9 +4,7 @@ export default {
   name: "register-service-worker",
 
   initialize(container) {
-    const isSecured =
-      document.location.protocol === "https:" ||
-      location.hostname === "localhost";
+    const isSecured = document.location.protocol === "https:";
 
     if (isSecured && "serviceWorker" in navigator) {
       let { serviceWorkerURL } = container.lookup("session:main");


### PR DESCRIPTION
As asked by @eviltrout.

Note that it won't unregister existing ones, but it's easy to manually remove the service worker from the DevTools.
