### PR TITLE
FIX: usercard bg img class, remove old styles

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -20,7 +20,7 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
   classNameBindings: [
     "visible:show",
     "showBadges",
-    "user.card_background::no-bg",
+    "user.card_background_upload_url::no-bg",
     "isFixed:fixed",
     "usernameClass",
   ],

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -48,7 +48,6 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
   .card-content {
     padding: 10px;
     background: rgba(var(--secondary-rgb), 0.85);
-    margin-top: 80px;
     &:after {
       content: "";
       display: block;
@@ -59,11 +58,6 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
     }
     .bio {
       @include line-clamp(2);
-    }
-  }
-  &.no-bg {
-    .card-content {
-      margin-top: 0;
     }
   }
   .card-row:not(.first-row) {


### PR DESCRIPTION
We were at one point showing different styles for usercards with backgrounds. That hasn't been the case for some time (3-5 years as far as I can tell), but I'd still like the `no-bg` class to work. Currently `no-bg` is added to all usercards, this fix makes the class work again but retains the current styling. 