### PR TITLE
DEV: updates to onebox 2.2.14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
-    onebox (2.2.13)
+    onebox (2.2.14)
       addressable (~> 2.7.0)
       htmlentities (~> 4.3)
       multi_json (~> 1.11)

--- a/app/assets/javascripts/discourse/app/initializers/onebox-decorators.js
+++ b/app/assets/javascripts/discourse/app/initializers/onebox-decorators.js
@@ -4,7 +4,7 @@ let _showMoreClickPostsElements = [];
 
 function decorateGithubOneboxBody(element) {
   const containers = element.querySelectorAll(
-    ".onebox.githubpullrequest .show-more-container, .onebox.githubissue .show-more-container"
+    ".onebox.githubcommit .show-more-container, .onebox.githubpullrequest .show-more-container, .onebox.githubissue .show-more-container"
   );
 
   if (containers.length) {

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -161,26 +161,21 @@ aside.onebox {
       }
     }
 
-    .github-info + .github-body-container {
-      margin-top: 1em;
-    }
-
     .github-body-container {
-      margin: 0 0 0.5em 0;
-      padding: 0.5em;
+      margin: 1em 0 0 0;
       color: var(--primary-very-high);
-      background: var(--hljs-bg);
       max-height: 400px;
       white-space: pre-wrap;
       overflow-y: auto;
       word-break: break-word;
       font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono",
         "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace;
-      font-size: $font-down-1;
+      flex: 1 0 100%;
+      box-sizing: border-box;
 
       .show-more {
         // padding on right for larger hitzone
-        padding: 0.5em 1.5em 0.5em 0.25em;
+        padding: 0.5em 1.5em 0em 0.25em;
       }
     }
 


### PR DESCRIPTION
This commit also updates github’s body onebox styles in Discourse core:
- full width
- prevents show-more btn to trigger vertical scrolling
- makes text standout less and slightly bigger

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
