### PR TITLE
FEATURE: Show a notice if video cannot be rendered

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -114,7 +114,7 @@ export default {
               const video = videoContainer.getElementsByTagName("video")[0];
               video.addEventListener("loadeddata", () => {
                 later(() => {
-                  if (video.videoWidth === 0 && video.videoHeight === 0) {
+                  if (video.videoWidth === 0 || video.videoHeight === 0) {
                     const notice = document.createElement("div");
                     notice.className = "notice";
                     notice.innerHTML =

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -108,24 +108,25 @@ export default {
 
       api.decorateCookedElement(
         (element) => {
-          const containers = element.getElementsByClassName("video-container");
-          for (let i = 0; i < containers.length; ++i) {
-            const video = containers[i].getElementsByTagName("video")[0];
-            video.addEventListener("loadeddata", () => {
-              later(() => {
-                if (video.videoWidth === 0 && video.videoHeight === 0) {
-                  const notice = document.createElement("div");
-                  notice.className = "notice";
-                  notice.innerHTML =
-                    iconHTML("exclamation-triangle") +
-                    " " +
-                    I18n.t("cannot_render_video");
+          element
+            .querySelectorAll(".video-container")
+            .forEach((videoContainer) => {
+              const video = videoContainer.getElementsByTagName("video")[0];
+              video.addEventListener("loadeddata", () => {
+                later(() => {
+                  if (video.videoWidth === 0 && video.videoHeight === 0) {
+                    const notice = document.createElement("div");
+                    notice.className = "notice";
+                    notice.innerHTML =
+                      iconHTML("exclamation-triangle") +
+                      " " +
+                      I18n.t("cannot_render_video");
 
-                  containers[i].appendChild(notice);
-                }
-              }, 500);
+                    videoContainer.appendChild(notice);
+                  }
+                }, 500);
+              });
             });
-          }
         },
         { id: "discourse-video-codecs" }
       );

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -1,3 +1,5 @@
+import { later } from "@ember/runloop";
+import I18n from "I18n";
 import highlightSyntax from "discourse/lib/highlight-syntax";
 import lightbox from "discourse/lib/lightbox";
 import { iconHTML } from "discourse-common/lib/icon-library";
@@ -102,6 +104,30 @@ export default {
           });
         },
         { id: "onebox-source-icons" }
+      );
+
+      api.decorateCookedElement(
+        (element) => {
+          const containers = element.getElementsByClassName("video-container");
+          for (let i = 0; i < containers.length; ++i) {
+            const video = containers[i].getElementsByTagName("video")[0];
+            video.addEventListener("loadeddata", () => {
+              later(() => {
+                if (video.videoWidth === 0 && video.videoHeight === 0) {
+                  const notice = document.createElement("div");
+                  notice.className = "notice";
+                  notice.innerHTML =
+                    iconHTML("exclamation-triangle") +
+                    " " +
+                    I18n.t("cannot_render_video");
+
+                  containers[i].appendChild(notice);
+                }
+              }, 500);
+            });
+          }
+        },
+        { id: "discourse-video-codecs" }
       );
     });
   },

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -768,6 +768,26 @@ aside.onebox.stackexchange .onebox-body {
   }
 }
 
+.video-container {
+  .notice {
+    background-color: var(--highlight-medium);
+    padding: 10px 20px;
+    position: absolute;
+    width: calc(100% - 40px);
+    animation: 0.5s fadeIn;
+  }
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
 .onebox-placeholder-container {
   position: relative;
   width: 100%;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3461,6 +3461,8 @@ en:
       content_load_error: '<a href="%url%">The content</a> could not be loaded.'
       image_load_error: '<a href="%url%">The image</a> could not be loaded.'
 
+    cannot_render_video: This video cannot be rendered because your browser does not support the codec.
+
     keyboard_shortcuts_help:
       shortcut_key_delimiter_comma: ", "
       shortcut_key_delimiter_plus: "+"


### PR DESCRIPTION
Not all videos can be rendered everywhere because some browser may be
missing some codecs. This commit adds a notice on top of video to let
the user know about it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
