### PR TITLE
DEV: Pass a list of tag group names when using the search endpoint.

### DIFF
--- a/app/controllers/tag_groups_controller.rb
+++ b/app/controllers/tag_groups_controller.rb
@@ -67,8 +67,8 @@ class TagGroupsController < ApplicationController
       matches = matches.where('lower(name) ILIKE ?', "%#{params[:q].strip}%")
     end
 
-    if params[:ids].present?
-      matches = matches.where(id: params[:ids])
+    if params[:names].present?
+      matches = matches.where(name: params[:names].map(&:downcase))
     end
 
     matches = matches.order('name').limit(params[:limit] || 5)

--- a/spec/requests/tag_groups_controller_spec.rb
+++ b/spec/requests/tag_groups_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe TagGroupsController do
       it 'returns the tag group with the associated tag names' do
         tag_group = tag_group_with_permission(everyone, readonly)
 
-        get '/tag_groups/filter/search.json', params: { ids: [tag_group.id] }
+        get '/tag_groups/filter/search.json', params: { names: [tag_group.name] }
         expect(response.status).to eq(200)
 
         results = JSON.parse(response.body, symbolize_names: true).fetch(:results)
@@ -95,7 +95,7 @@ RSpec.describe TagGroupsController do
       it 'returns an empty array if the tag group is private' do
         tag_group = tag_group_with_permission(staff, full)
 
-        get '/tag_groups/filter/search.json', params: { ids: [tag_group.id] }
+        get '/tag_groups/filter/search.json', params: { names: [tag_group.name] }
         expect(response.status).to eq(200)
 
         results = JSON.parse(response.body, symbolize_names: true).fetch(:results)


### PR DESCRIPTION
Accepting a list of names instead of ids is more convenient when searching for tag groups using data from the `category.allowed_tag_groups` method.

