### PR TITLE
FIX: ensure plugin's gems are in the gem path

### DIFF
--- a/lib/plugin_gem.rb
+++ b/lib/plugin_gem.rb
@@ -5,21 +5,24 @@ module PluginGem
     opts ||= {}
 
     gems_path = File.dirname(path) + "/gems/#{RUBY_VERSION}"
+
     spec_path = gems_path + "/specifications"
-    spec_file = spec_path + "/#{name}-#{version}"
+
+    spec_file  = spec_path + "/#{name}-#{version}"
     spec_file += "-#{opts[:platform]}" if opts[:platform]
     spec_file += ".gemspec"
+
     unless File.exists? spec_file
-      command = "gem install #{name} -v #{version} -i #{gems_path} --no-document --ignore-dependencies --no-user-install"
-      if opts[:source]
-        command << " --source #{opts[:source]}"
-      end
+      command  = "gem install #{name} -v #{version} -i #{gems_path} --no-document --ignore-dependencies --no-user-install"
+      command += " --source #{opts[:source]}" if opts[:source]
       puts command
       puts `#{command}`
     end
+
     if File.exists? spec_file
-      spec = Gem::Specification.load spec_file
-      spec.activate
+      Gem.path << gems_path
+      Gem::Specification.load(spec_file).activate
+
       unless opts[:require] == false
         require opts[:require_name] ? opts[:require_name] : name
       end


### PR DESCRIPTION
Let's say you want to use a gem in a plugin that has a dependencie.

You would write something like this:

```ruby
gem 'dependency-gem', '1.2.3'
gem 'amazing-gem', '4.5.6'
```

However, since when we install a plugin gem we install it in the `gems`
directory created inside the plugins directory, when it comes the time
to install the `amazing-gem`, it won't be able to find the `dependency-gem`.

This fixes that issue by adding the `gems` plugins directory to the global gem path.

Also fixed a frozen string error when specifying a source.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
