### PR TITLE
DEV: ensures stylesheet watcher isn't crashing with gems plugins

### DIFF
--- a/lib/stylesheet/watcher.rb
+++ b/lib/stylesheet/watcher.rb
@@ -25,8 +25,8 @@ module Stylesheet
           @default_paths << File.dirname(plugin.path).sub(Rails.root.to_s, '').sub(/^\//, '')
         else
           # if plugin doesn’t seem to be in our app, consider it as outside of the app
-          # and use full path, this is the case for plugins coming from a gem
-          @default_paths << File.dirname(plugin.path)
+          # and ignore it
+          warn("[stylesheet watcher] Ignoring outside of rails root plugin: #{plugin.path.to_s}")
         end
       end
       @default_paths

--- a/lib/stylesheet/watcher.rb
+++ b/lib/stylesheet/watcher.rb
@@ -20,8 +20,14 @@ module Stylesheet
       return @default_paths if @default_paths
 
       @default_paths = ["app/assets/stylesheets"]
-      Discourse.plugins.each do |p|
-        @default_paths << File.dirname(p.path).sub(Rails.root.to_s, '').sub(/^\//, '')
+      Discourse.plugins.each do |plugin|
+        if plugin.path.to_s.include?(Rails.root.to_s)
+          @default_paths << File.dirname(plugin.path).sub(Rails.root.to_s, '').sub(/^\//, '')
+        else
+          # if plugin doesn’t seem to be in our app, consider it as outside of the app
+          # and use full path, this is the case for plugins coming from a gem
+          @default_paths << File.dirname(plugin.path)
+        end
       end
       @default_paths
     end


### PR DESCRIPTION
This bug has been exhibited since discourse_dev is now including an auth plugin which was loaded as a relative path instead of an absolute path, eg:

`Users/bob/.gem/ruby/2.6.6/gems/discourse_dev-0.1.0/auth/plugin.rb`

Instead of

`/Users/bob/.gem/ruby/2.6.6/gems/discourse_dev-0.1.0/auth/plugin.rb`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
