### PR TITLE
DEV: Require Ember CLI to be used in development mode

### DIFF
--- a/app/assets/stylesheets/ember_cli.scss
+++ b/app/assets/stylesheets/ember_cli.scss
@@ -1,0 +1,16 @@
+body.requires-ember-cli {
+  margin: 2rem;
+  font-family: Arial, Helvetica;
+  background-color: white;
+}
+
+pre {
+  background-color: lightgrey;
+}
+
+pre,
+code {
+  padding: 0;
+  margin: 0;
+  padding: 0.5rem;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,15 +94,23 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def ember_cli_required?
+    ENV['NO_EMBER_CLI'] != '1' && Rails.env.development?
+  end
+
+  def application_layout
+    ember_cli_required? ? "ember_cli" : "application"
+  end
+
   def set_layout
     case request.headers["Discourse-Render"]
     when "desktop"
-      return "application"
+      return application_layout
     when "crawler"
       return "crawler"
     end
 
-    use_crawler_layout? ? 'crawler' : 'application'
+    use_crawler_layout? ? 'crawler' : application_layout
   end
 
   class RenderEmpty < StandardError; end

--- a/app/views/layouts/ember_cli.html.erb
+++ b/app/views/layouts/ember_cli.html.erb
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title><%= content_for?(:title) ? yield(:title) : SiteSetting.title %></title>
+
+  <%= stylesheet_link_tag(:ember_cli) %>
+
+</head>
+<body class="requires-ember-cli">
+  <div class='warning'>
+    <h1>Ember CLI is Required in Development Mode</h1>
+
+    <p>To run Ember CLI in development mode, please do the following:</p>
+
+    <pre><code>$ bin/ember-cli</code></pre>
+
+    <p>If it's your first time starting Ember CLI you'll have to run yarn:</p>
+
+    <pre><code>$ cd app/assets/javascripts/discourse && yarn</code></pre>
+
+    <p>Then visit the following URL to use Discourse:</p>
+
+    <a href="http://localhost:4200/">http://localhost:4200</a>
+  </div>
+</body>
+</html>

--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -4,7 +4,7 @@
 require 'pathname'
 
 RAILS_ROOT = File.expand_path("../../", Pathname.new(__FILE__).realpath)
-PORT = ENV["UNICORN_PORT"] ||= "9292"
+PORT = ENV["UNICORN_PORT"] ||= "3000"
 
 Dir.chdir(RAILS_ROOT) # rubocop:disable Discourse/NoChdir
 Dir.chdir("app/assets/javascripts/discourse") # rubocop:disable Discourse/NoChdir

--- a/spec/components/stylesheet/compiler_spec.rb
+++ b/spec/components/stylesheet/compiler_spec.rb
@@ -6,6 +6,8 @@ require 'stylesheet/compiler'
 describe Stylesheet::Compiler do
   describe 'compilation' do
     Dir["#{Rails.root.join("app/assets/stylesheets")}/*.scss"].each do |path|
+      next if path =~ /ember_cli/
+
       path = File.basename(path, '.scss')
 
       it "can compile '#{path}' css" do


### PR DESCRIPTION
We really want to encourage all developers to use Ember CLI for local
development and testing. This will display an error page if they are not
with instructions on how to start the local server.

To disable it, you can set `NO_EMBER_CLI=1` as an ENV variable

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
