### PR TITLE
FIX: Allow CodeCommit-style theme .git url format

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
@@ -24,7 +24,7 @@ export default Controller.extend(ModalFunctionality, {
   keyGenUrl: "/admin/themes/generate_key_pair",
   importUrl: "/admin/themes/import",
   recordType: "theme",
-  checkPrivate: match("uploadUrl", /^.*[@].*[:].*\.git$/),
+  checkPrivate: match("uploadUrl", /^ssh\:\/\/.*\@.*\.git$|.*\@.*\:.*\.git$/),
   localFile: null,
   uploadUrl: null,
   uploadName: null,

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
@@ -80,6 +80,10 @@
               <div class="label">{{i18n "admin.customize.theme.public_key"}}</div>
               {{textarea readonly=true value=publicKey}}
             </div>
+          {{else}}
+            {{#if privateChecked}}
+              <div class="public-key-note">{{i18n "admin.customize.theme.public_key_note"}}</div>
+            {{/if}}
           {{/if}}
         {{/if}}
       </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
@@ -67,8 +67,15 @@ acceptance("Admin - Themes - Install modal", function (needs) {
     );
     assert.ok(query(publicKey), "shows public key");
 
+    // Supports AWS CodeCommit style repo URLs
+    await fillIn(
+      urlInput,
+      "ssh://someID@git-codecommit.us-west-2.amazonaws.com/v1/repos/test-repo.git"
+    );
+    assert.ok(query(publicKey), "shows public key");
+
     await fillIn(urlInput, "https://github.com/discourse/discourse.git");
-    assert.notOk(query(publicKey), "does not shows public key for https urls");
+    assert.notOk(query(publicKey), "does not show public key for https urls");
   });
 
   test("modal can be auto-opened with the right query params", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
@@ -76,6 +76,9 @@ acceptance("Admin - Themes - Install modal", function (needs) {
 
     await fillIn(urlInput, "https://github.com/discourse/discourse.git");
     assert.notOk(query(publicKey), "does not show public key for https urls");
+
+    await fillIn(urlInput, "git@github.com:discourse/discourse.git");
+    assert.ok(query(publicKey), "shows public key for valid github repo url");
   });
 
   test("modal can be auto-opened with the right query params", async function (assert) {

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -593,16 +593,19 @@
     width: auto;
     margin: 3px 0;
   }
-
-  .public-key {
-    margin-top: 10px;
-    textarea {
-      cursor: auto;
-      height: 150px;
-    }
+}
+.public-key {
+  margin-top: 1em;
+  textarea {
+    cursor: auto;
+    min-height: 220px;
   }
 }
 
+.public-key-note {
+  margin-top: 1em;
+  color: var(--primary-medium);
+}
 // Permalinks
 .permalinks {
   .url,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4265,6 +4265,7 @@ en:
           is_private: "Theme is in a private git repository"
           remote_branch: "Branch name (optional)"
           public_key: "Grant the following public key access to the repo:"
+          public_key_note: "After entering a valid private repository URL above, an SSH key will be generated and displayed here."
           install: "Install"
           installed: "Installed"
           install_popular: "Popular"


### PR DESCRIPTION
This also adds a note in the UI to let users know that the SSH key will
be displayed once a valid repo URL is entered.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/368961/115048052-29073f80-9ea7-11eb-9468-6bf23b168e1e.png">
