### PR TITLE
DEV: make font sizing and ratios default

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -51,28 +51,28 @@ $base-font-family: var(--font-family) !default;
 $heading-font-family: var(--heading-font-family) !default;
 
 // Font-size defintions, multiplier ^ (step / interval)
-$font-up-6: 2.296em;
-$font-up-5: 2em;
-$font-up-4: 1.7511em;
-$font-up-3: 1.5157em;
-$font-up-2: 1.3195em;
-$font-up-1: 1.1487em; // 2^(1/5)
+$font-up-6: 2.296em !default;
+$font-up-5: 2em !default;
+$font-up-4: 1.7511em !default;
+$font-up-3: 1.5157em !default;
+$font-up-2: 1.3195em !default;
+$font-up-1: 1.1487em !default; // 2^(1/5)
 $font-0: 1em;
-$font-down-1: 0.8706em; // 2^(-1/5)
-$font-down-2: 0.7579em; // Smallest size we use based on the 1em base
-$font-down-3: 0.6599em;
-$font-down-4: 0.5745em;
-$font-down-5: 0.5em;
-$font-down-6: 0.4355em;
+$font-down-1: 0.8706em !default; // 2^(-1/5)
+$font-down-2: 0.7579em !default; // Smallest size we use based on the 1em base
+$font-down-3: 0.6599em !default;
+$font-down-4: 0.5745em !default;
+$font-down-5: 0.5em !default;
+$font-down-6: 0.4355em !default;
 
 // inputs/textareas in iOS need to be at least 16px to avoid triggering zoom on focus
 // with base at 15px, the below gives 16.05px
-$font-size-ios-input: 1.07em;
+$font-size-ios-input: 1.07em !default;
 
 // Common line-heights
-$line-height-small: 1;
-$line-height-medium: 1.2; // Headings or large text
-$line-height-large: 1.4; // Normal or small text
+$line-height-small: 1 !default;
+$line-height-medium: 1.2 !default; // Headings or large text
+$line-height-large: 1.4 !default; // Normal or small text
 
 @import "common/foundation/math";
 


### PR DESCRIPTION
Make it easier for themes/plugins to use Discourse's built in font sizing
and override font ratios