### PR TITLE
UX: smoother timeline footer animation, padding fix

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1103,7 +1103,7 @@ a.mention-group {
 }
 
 #topic-footer-buttons {
-  padding: 0.75em 0;
+  padding: 1.5em 0 0.75em 0;
 
   .topic-footer-main-buttons {
     display: flex;

--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -6,13 +6,14 @@
   box-sizing: border-box;
   z-index: z("timeline");
   -webkit-transform: translate3d(0, 0, 0);
+  transition: margin 0.25s ease-in-out;
 
   &.timeline-docked-bottom {
+    margin-bottom: -2em; // animate out footer button height
     .timeline-footer-controls {
       opacity: 0;
       pointer-events: none;
       cursor: default;
-      height: 0px;
     }
   }
 

--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -6,10 +6,11 @@
   box-sizing: border-box;
   z-index: z("timeline");
   -webkit-transform: translate3d(0, 0, 0);
-  transition: margin 0.25s ease-in-out;
-
+  transition: margin-bottom 0.25s ease-in;
   &.timeline-docked-bottom {
-    margin-bottom: -2em; // animate out footer button height
+    @media screen and (prefers-reduced-motion: no-preference) {
+      margin-bottom: -1.75em; // animate out footer button height
+    }
     .timeline-footer-controls {
       opacity: 0;
       pointer-events: none;

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -62,6 +62,9 @@
 .topic-timer-info {
   border-top: 1px solid var(--primary-low);
   padding: 10px 0;
+  &:empty {
+    padding: 0;
+  }
   max-width: 758px;
   .topic-timer-heading,
   .slow-mode-heading {


### PR DESCRIPTION
This animates the timeline docking without impacting button height. I also fixed an issue with some extra padding from an empty topic timer div.

Before:
![rough](https://user-images.githubusercontent.com/1681963/115101884-918d0580-9f15-11eb-84a9-24af67d4f83e.gif)

After:
![smooth](https://user-images.githubusercontent.com/1681963/115101882-8d60e800-9f15-11eb-9599-6b917493d6bc.gif)



