### PR TITLE
FEATURE: adds bbcode tag autocomplete

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -85,6 +85,10 @@ export default function (options) {
     return this;
   }
 
+  if (options && typeof options.preserveKey === "undefined") {
+    options.preserveKey = true;
+  }
+
   const disabled = options && options.disabled;
   let wrap = null;
   let autocompleteOptions = null;
@@ -199,7 +203,7 @@ export default function (options) {
           let text = me.val();
           text =
             text.substring(0, completeStart) +
-            (options.key || "") +
+            (options.preserveKey ? options.key || "" : "") +
             term +
             " " +
             text.substring(completeEnd + 1, text.length);

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -50,7 +50,10 @@ import { addPostClassesCallback } from "discourse/widgets/post";
 import { addPostSmallActionIcon } from "discourse/widgets/post-small-action";
 import { addQuickAccessProfileItem } from "discourse/widgets/quick-access-profile";
 import { addTagsHtmlCallback } from "discourse/lib/render-tags";
-import { addToolbarCallback } from "discourse/components/d-editor";
+import {
+  addBbcodeTagAutocomplete,
+  addToolbarCallback,
+} from "discourse/components/d-editor";
 import { addTopicTitleDecorator } from "discourse/components/topic-title";
 import { addUserMenuGlyph } from "discourse/widgets/user-menu";
 import { addUsernameSelectorDecorator } from "discourse/helpers/decorate-username-selector";
@@ -72,7 +75,7 @@ import { replaceTagRenderer } from "discourse/lib/render-tag";
 import { setNewCategoryDefaultColors } from "discourse/routes/new-category";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.11.2";
+const PLUGIN_API_VERSION = "0.11.3";
 
 class PluginApi {
   constructor(version, container) {
@@ -1225,6 +1228,10 @@ class PluginApi {
   }
   addPluginReviewableParam(reviewableType, param) {
     addPluginReviewableParam(reviewableType, param);
+  }
+
+  addBbcodeTagAutocomplete(data = {}) {
+    addBbcodeTagAutocomplete(data);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/templates/bbcode-tag-autocomplete.hbr
+++ b/app/assets/javascripts/discourse/app/templates/bbcode-tag-autocomplete.hbr
@@ -1,0 +1,9 @@
+<div class='autocomplete bbcode-tag'>
+  <ul>
+    {{#each options as |option|}}
+      <li>
+        <a href>{{option.name}}</a>
+      </li>
+    {{/each}}
+  </ul>
+</div>

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -39,6 +39,7 @@ import { setTopicList } from "discourse/lib/topic-list-tracker";
 import sinon from "sinon";
 import siteFixtures from "discourse/tests/fixtures/site-fixtures";
 import { clearResolverOptions } from "discourse-common/resolver";
+import { resetBbcodeAutocompleteTags } from "discourse/components/d-editor";
 
 const LEGACY_ENV = !setupApplicationTest;
 
@@ -260,6 +261,7 @@ export function acceptance(name, optionsOrCallback) {
       resetUsernameDecorators();
       resetOneboxCache();
       resetCustomPostMessageCallbacks();
+      resetBbcodeAutocompleteTags();
       setTopicList(null);
       _clearSnapshots();
       setURLContainer(null);

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -109,6 +109,17 @@ export default {
       };
 
       withPluginApi("0.8.8", initializeDiscourseLocalDates);
+
+      withPluginApi("0.11.3", (api) => {
+        api.addBbcodeTagAutocomplete({
+          name: "discourse_local_dates.bbcode_autocomplete.name",
+          template: "discourse_local_dates.bbcode_autocomplete.template",
+          templateOptions: {
+            date: moment().add("1.day").format("YYYY-MM-DD"),
+            timezone: moment.tz.guess(),
+          },
+        });
+      });
     }
   },
 };

--- a/plugins/discourse-local-dates/config/locales/client.en.yml
+++ b/plugins/discourse-local-dates/config/locales/client.en.yml
@@ -1,6 +1,9 @@
 en:
   js:
     discourse_local_dates:
+      bbcode_autocomplete:
+        name: Date
+        template: '[date=%{date} timezone="%{timezone}"]'
       relative_dates:
         today: Today %{time}
         tomorrow: Tomorrow %{time}


### PR DESCRIPTION
Usage: when typing `!` in composer, an autocomplete menu with a list of bbcode tags to use will now show.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
