### PR TITLE
FEATURE: allow groups to have configurable css properties for primary groups

### DIFF
--- a/app/assets/javascripts/discourse/app/components/groups-form-membership-fields.js
+++ b/app/assets/javascripts/discourse/app/components/groups-form-membership-fields.js
@@ -54,12 +54,19 @@ export default Component.extend({
     return this.model.emailDomains.split(this.tokenSeparator).filter(Boolean);
   }),
 
+  cssProperties: computed("model.cssProperties", function () {
+    return this.model.cssProperties.split(this.tokenSeparator).filter(Boolean);
+  }),
+
   actions: {
     onChangeEmailDomainsSetting(value) {
       this.set(
         "model.automatic_membership_email_domains",
         value.join(this.tokenSeparator)
       );
+    },
+    onChangeCssProperties(value) {
+      this.set("model.css_properties", value.join(this.tokenSeparator));
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/group.js
+++ b/app/assets/javascripts/discourse/app/controllers/group.js
@@ -105,14 +105,22 @@ export default Controller.extend({
     "model.name",
     "model.flair_url",
     "model.flair_bg_color",
-    "model.flair_color"
+    "model.flair_color",
+    "model.css_properties"
   )
-  avatarFlairAttributes(groupName, flairURL, flairBgColor, flairColor) {
+  avatarFlairAttributes(
+    groupName,
+    flairURL,
+    flairBgColor,
+    flairColor,
+    cssProperties
+  ) {
     return {
       primary_group_flair_url: flairURL,
       primary_group_flair_bg_color: flairBgColor,
       primary_group_flair_color: flairColor,
       primary_group_name: groupName,
+      primary_group_css_properties: cssProperties,
     };
   },
 

--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -24,6 +24,7 @@ export function transformBasicPost(post) {
     primary_group_flair_url: post.primary_group_flair_url,
     primary_group_flair_bg_color: post.primary_group_flair_bg_color,
     primary_group_flair_color: post.primary_group_flair_color,
+    primary_group_css_properties: post.primary_group_css_properties,
     wiki: post.wiki,
     lastWikiEdit: post.last_wiki_edit,
     firstPost: post.post_number === 1,

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -29,6 +29,11 @@ const Group = RestModel.extend({
     return isEmpty(value) ? "" : value;
   },
 
+  @discourseComputed("css_properties")
+  cssProperties(value) {
+    return isEmpty(value) ? "" : value;
+  },
+
   @discourseComputed("automatic")
   type(automatic) {
     return automatic ? "automatic" : "custom";
@@ -237,6 +242,7 @@ const Group = RestModel.extend({
       publish_read_state: this.publish_read_state,
       allow_unknown_sender_topic_replies: this
         .allow_unknown_sender_topic_replies,
+      css_properties: this.cssProperties,
     };
 
     ["muted", "regular", "watching", "tracking", "watching_first_post"].forEach(

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-membership-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-membership-fields.hbs
@@ -96,6 +96,27 @@
       {{i18n "admin.groups.default_title_description"}}
     </div>
   </div>
+
+  <div class="control-group">
+    <label class="control-label">{{i18n "admin.groups.manage.membership.css_properties"}}</label>
+
+    <label for="css_properties">
+      {{i18n "admin.groups.manage.membership.css_properties_description"}}
+    </label>
+
+    {{list-setting
+        name="css_properties"
+        class="group-css-properties"
+        value=cssProperties
+        choices=cssProperties
+        settingName="name"
+        nameProperty=null
+        valueProperty=null
+        onChange=(action "onChangeCssProperties")
+        options=(hash allowAny=true)
+    }}
+  </div>
+
 {{/if}}
 
 {{#if canEdit}}

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -709,9 +709,20 @@ export default createWidget("post", {
   shadowTree: true,
 
   buildAttributes(attrs) {
-    return attrs.height
-      ? { style: `min-height: ${attrs.height}px` }
-      : undefined;
+    const styles = [];
+
+    if (attrs.primary_group_css_properties) {
+      const properties = attrs.primary_group_css_properties.split("|");
+      properties.forEach((property) => {
+        styles.push(`--${property}`);
+      });
+    }
+
+    if (attrs.height) {
+      styles.push(`min-height: ${attrs.height}px`);
+    }
+
+    return styles.length > 0 ? { style: `${styles.join("; ")};` } : undefined;
   },
 
   buildId(attrs) {

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -1053,4 +1053,17 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       assert.equal(link.attr("href"), "/g/testGroup/requests?filter=foo");
     },
   });
+
+  componentTest("contains primary group custom properties", {
+    template: hbs`{{mount-widget widget="post" args=args}}`,
+    beforeEach() {
+      this.set("args", {
+        primary_group_css_properties: "test1:value|test2:value2",
+      });
+    },
+    test(assert) {
+      const post = queryAll(".topic-post");
+      assert.equal(post.attr("style"), "--test1:value; --test2:value2;");
+    },
+  });
 });

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -175,7 +175,8 @@ class Admin::GroupsController < Admin::AdminController
       :owner_usernames,
       :usernames,
       :publish_read_state,
-      :notify_users
+      :notify_users,
+      :css_properties
     ]
     custom_fields = DiscoursePluginRegistry.editable_group_custom_fields
     permitted << { custom_fields: custom_fields } unless custom_fields.blank?

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -583,6 +583,7 @@ class GroupsController < ApplicationController
           flair_upload_id
           flair_bg_color
           flair_color
+          css_properties
         }
       else
         default_params = %i{
@@ -621,7 +622,8 @@ class GroupsController < ApplicationController
             :grant_trust_level,
             :automatic_membership_email_domains,
             :publish_read_state,
-            :allow_unknown_sender_topic_replies
+            :allow_unknown_sender_topic_replies,
+            :css_properties
           ])
 
           custom_fields = DiscoursePluginRegistry.editable_group_custom_fields

--- a/app/serializers/basic_group_serializer.rb
+++ b/app/serializers/basic_group_serializer.rb
@@ -31,7 +31,8 @@ class BasicGroupSerializer < ApplicationSerializer
              :members_visibility_level,
              :can_see_members,
              :can_admin_group,
-             :publish_read_state
+             :publish_read_state,
+             :css_properties
 
   def include_display_name?
     object.automatic

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -39,6 +39,7 @@ class PostSerializer < BasicPostSerializer
              :primary_group_flair_url,
              :primary_group_flair_bg_color,
              :primary_group_flair_color,
+             :primary_group_css_properties,
              :version,
              :can_edit,
              :can_delete,
@@ -198,6 +199,10 @@ class PostSerializer < BasicPostSerializer
 
   def primary_group_flair_color
     object.user&.primary_group&.flair_color
+  end
+
+  def primary_group_css_properties
+    object.user&.primary_group&.css_properties
   end
 
   def link_counts

--- a/app/serializers/web_hook_post_serializer.rb
+++ b/app/serializers/web_hook_post_serializer.rb
@@ -31,6 +31,7 @@ class WebHookPostSerializer < PostSerializer
     primary_group_flair_url
     primary_group_flair_bg_color
     primary_group_flair_color
+    primary_group_css_properties
     notice
   }.each do |attr|
     define_method("include_#{attr}?") do

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3879,6 +3879,8 @@ en:
               one: "%{count} user has the new email domains and will be added to the group."
               other: "%{count} users have the new email domains and will be added to the group."
             primary_group: "Automatically set as primary group"
+            css_properties: "CSS custom properties"
+            css_properties_description: "Custom css properties to be added to posts made by members of this group. Each entry should be of the form key:value. Alphanumeric characters and dashes only."
         name_placeholder: "Group name, no spaces, same as username rule"
         primary: "Primary Group"
         no_primary: "(no primary group)"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -454,6 +454,7 @@ en:
       usernames_or_emails_required: "Usernames or emails must be present"
       no_invites_with_discourse_connect: "You can invite only registered users when DiscourseConnect is enabled"
       no_invites_without_local_logins: "You can invite only registered users when local logins are disabled"
+      invalid_css_property: "'%{property}' is not a valid css property. Properties need to be of the form key:value"
     default_names:
       everyone: "everyone"
       admins: "admins"

--- a/db/migrate/20210418071027_add_css_properties_to_groups.rb
+++ b/db/migrate/20210418071027_add_css_properties_to_groups.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCssPropertiesToGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_column :groups, :css_properties, :text
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1194,4 +1194,34 @@ describe Group do
       expect(TagUser.lookup(user, :tracking).pluck(:tag_id)).to contain_exactly(tag1.id, tag2.id)
     end
   end
+
+  describe "css properties" do
+    it "should allow valid key:value groups with alphanumerics, separated by pipe" do
+      valid_property = "test:1|test2:valuevalue2|test3:test-number-three"
+      group = Fabricate(:group)
+      group.css_properties = valid_property
+      group.save!
+      expect(group.reload.css_properties).to eq(valid_property)
+    end
+    it "should require key:value pairs" do
+      group = Fabricate(:group)
+      group.css_properties = "test"
+      expect { group.save! }.to raise_error(ActiveRecord::RecordInvalid)
+      group.css_properties = "test:test2:test3"
+      expect { group.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+    it "should require key and value to be alphanumerics" do
+      group = Fabricate(:group)
+      group.css_properties = "test!:123"
+      expect { group.save! }.to raise_error(ActiveRecord::RecordInvalid)
+      group.css_properties = "test:123@"
+      expect { group.save! }.to raise_error(ActiveRecord::RecordInvalid)
+      group.css_properties = "test:123|test2:&"
+      expect { group.save! }.to raise_error(ActiveRecord::RecordInvalid)
+      group.css_properties = "-test:123"
+      expect { group.save! }.to raise_error(ActiveRecord::RecordInvalid)
+      group.css_properties = "test-:123"
+      expect { group.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end

--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -61,6 +61,7 @@ describe 'groups' do
                 membership_visibility_level: { type: :integer },
                 can_see_members: { type: :boolean },
                 publish_read_state: { type: :boolean },
+                css_properties: { type: :string, nullable: true },
               },
               required: ["id"]
             }

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -54,6 +54,7 @@ describe 'posts' do
                 primary_group_flair_url: { type: :string, nullable: true },
                 primary_group_flair_bg_color: { type: :string, nullable: true },
                 primary_group_flair_color: { type: :string, nullable: true },
+                primary_group_css_properties: { type: :string, nullable: true },
                 version: { type: :integer },
                 can_edit: { type: :boolean },
                 can_delete: { type: :boolean },

--- a/spec/requests/api/schemas/json/group_response.json
+++ b/spec/requests/api/schemas/json/group_response.json
@@ -30,61 +30,34 @@
           "type": "boolean"
         },
         "title": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "grant_trust_level": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "incoming_email": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "has_messages": {
           "type": "boolean"
         },
         "flair_url": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "flair_bg_color": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "flair_color": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "bio_raw": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "bio_cooked": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "bio_excerpt": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "public_admission": {
           "type": "boolean"
@@ -96,19 +69,13 @@
           "type": "boolean"
         },
         "full_name": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "default_notification_level": {
           "type": "integer"
         },
         "membership_request_template": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "is_group_user": {
           "type": "boolean"
@@ -135,85 +102,47 @@
           "type": "boolean"
         },
         "automatic_membership_email_domains": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "smtp_server": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "smtp_port": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "smtp_ssl": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "imap_server": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "imap_port": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "imap_ssl": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "imap_mailbox_name": {
           "type": "string"
         },
         "imap_mailboxes": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": []
         },
         "email_username": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "email_password": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "imap_last_error": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "imap_old_emails": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "imap_new_emails": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "message_count": {
           "type": "integer"
@@ -223,33 +152,26 @@
         },
         "watching_category_ids": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": []
         },
         "tracking_category_ids": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": []
         },
         "watching_first_post_category_ids": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": []
         },
         "regular_category_ids": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": []
         },
         "muted_category_ids": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": []
+        },
+        "css_properties": {
+          "type": ["string", "null"]
         }
       },
       "required": [
@@ -305,7 +227,8 @@
         "tracking_category_ids",
         "watching_first_post_category_ids",
         "regular_category_ids",
-        "muted_category_ids"
+        "muted_category_ids",
+        "css_properties"
       ]
     },
     "extras": {
@@ -314,18 +237,11 @@
       "properties": {
         "visible_group_names": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": []
         }
       },
-      "required": [
-        "visible_group_names"
-      ]
+      "required": ["visible_group_names"]
     }
   },
-  "required": [
-    "group",
-    "extras"
-  ]
+  "required": ["group", "extras"]
 }

--- a/spec/requests/api/schemas/json/groups_list_response.json
+++ b/spec/requests/api/schemas/json/groups_list_response.json
@@ -36,61 +36,34 @@
               "type": "boolean"
             },
             "title": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "grant_trust_level": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "incoming_email": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "has_messages": {
               "type": "boolean"
             },
             "flair_url": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "flair_bg_color": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "flair_color": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "bio_raw": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "bio_cooked": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "bio_excerpt": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "public_admission": {
               "type": "boolean"
@@ -102,19 +75,13 @@
               "type": "boolean"
             },
             "full_name": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "default_notification_level": {
               "type": "integer"
             },
             "membership_request_template": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "is_group_user": {
               "type": "boolean"
@@ -133,6 +100,9 @@
             },
             "publish_read_state": {
               "type": "boolean"
+            },
+            "css_properties": {
+              "type": ["string", "null"]
             }
           },
           "required": [
@@ -164,7 +134,8 @@
             "members_visibility_level",
             "can_see_members",
             "can_admin_group",
-            "publish_read_state"
+            "publish_read_state",
+            "css_properties"
           ]
         }
       ]
@@ -175,14 +146,10 @@
       "properties": {
         "type_filters": {
           "type": "array",
-          "items": [
-
-          ]
+          "items": []
         }
       },
-      "required": [
-        "type_filters"
-      ]
+      "required": ["type_filters"]
     },
     "total_rows_groups": {
       "type": "integer"
@@ -191,10 +158,5 @@
       "type": "string"
     }
   },
-  "required": [
-    "groups",
-    "extras",
-    "total_rows_groups",
-    "load_more_groups"
-  ]
+  "required": ["groups", "extras", "total_rows_groups", "load_more_groups"]
 }

--- a/spec/requests/api/schemas/json/topic_create_response.json
+++ b/spec/requests/api/schemas/json/topic_create_response.json
@@ -5,10 +5,7 @@
       "type": "integer"
     },
     "name": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "username": {
       "type": "string"
@@ -35,10 +32,7 @@
       "type": "integer"
     },
     "reply_to_post_number": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "quote_count": {
       "type": "integer"
@@ -65,34 +59,22 @@
       "type": "string"
     },
     "display_username": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "primary_group_name": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "primary_group_flair_url": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "primary_group_flair_bg_color": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "primary_group_flair_color": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
+    },
+    "primary_group_css_properties": {
+      "type": ["string", "null"]
     },
     "version": {
       "type": "integer"
@@ -110,10 +92,7 @@
       "type": "boolean"
     },
     "user_title": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "bookmarked": {
       "type": "boolean"
@@ -132,10 +111,7 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "id",
-            "can_act"
-          ]
+          "required": ["id", "can_act"]
         }
       ]
     },
@@ -161,19 +137,13 @@
       "type": "integer"
     },
     "deleted_at": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "user_deleted": {
       "type": "boolean"
     },
     "edit_reason": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "can_view_edit_history": {
       "type": "boolean"
@@ -182,10 +152,7 @@
       "type": "boolean"
     },
     "reviewable_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "reviewable_score_count": {
       "type": "integer"
@@ -219,6 +186,7 @@
     "primary_group_flair_url",
     "primary_group_flair_bg_color",
     "primary_group_flair_color",
+    "primary_group_css_properties",
     "version",
     "can_edit",
     "can_delete",

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -781,7 +781,8 @@ describe GroupsController do
             visibility_level: 1,
             members_visibility_level: 3,
             tracking_category_ids: [category.id],
-            tracking_tags: [tag.name]
+            tracking_tags: [tag.name],
+            css_properties: 'test1:testvalue|test2:test2'
           }
         }
 
@@ -798,6 +799,7 @@ describe GroupsController do
         expect(group.grant_trust_level).to eq(2)
         expect(group.group_category_notification_defaults.first&.category).to eq(category)
         expect(group.group_tag_notification_defaults.first&.tag).to eq(tag)
+        expect(group.css_properties).to eq('test1:testvalue|test2:test2')
 
         expect(Jobs::AutomaticGroupMembership.jobs.first["args"].first["group_id"])
           .to eq(group.id)
@@ -824,7 +826,8 @@ describe GroupsController do
             messageable_level: 1,
             default_notification_level: 1,
             tracking_category_ids: [category.id],
-            tracking_tags: [tag.name]
+            tracking_tags: [tag.name],
+            css_properties: 'test1:testvalue|test2:test2'
           }
         }
 
@@ -841,6 +844,7 @@ describe GroupsController do
         expect(group.default_notification_level).to eq(1)
         expect(group.group_category_notification_defaults.first&.category).to eq(category)
         expect(group.group_tag_notification_defaults.first&.tag).to eq(tag)
+        expect(group.css_properties).to eq('test1:testvalue|test2:test2')
       end
 
       it 'triggers a extensibility event' do
@@ -887,7 +891,8 @@ describe GroupsController do
             visibility_level: 1,
             members_visibility_level: 3,
             tracking_category_ids: [category.id],
-            tracking_tags: [tag.name]
+            tracking_tags: [tag.name],
+            css_properties: 'test1:testvalue|test2:test2',
           }
         }
 
@@ -904,6 +909,7 @@ describe GroupsController do
         expect(group.grant_trust_level).to eq(2)
         expect(group.group_category_notification_defaults.first&.category).to eq(category)
         expect(group.group_tag_notification_defaults.first&.tag).to eq(tag)
+        expect(group.css_properties).to eq('test1:testvalue|test2:test2')
 
         expect(Jobs::AutomaticGroupMembership.jobs.first["args"].first["group_id"])
           .to eq(group.id)

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -278,6 +278,24 @@ describe PostSerializer do
 
   end
 
+  context "post with a primary group" do
+    fab!(:current_user) { Fabricate(:user) }
+    fab!(:topic) { Fabricate(:topic) }
+    fab!(:group_user) { Fabricate(:group_user) }
+    fab!(:post) { Fabricate(:post, topic: topic, user: group_user.user) }
+    let(:css_properties) { "test:test-value" }
+
+    before do
+      group_user.group.update!(css_properties: css_properties)
+      group_user.user.update!(primary_group: group_user.group)
+    end
+
+    it "returns with the payload" do
+      expect(serialized_post_for_user(current_user)[:primary_group_css_properties]).to eq(css_properties)
+      expect(serialized_post_for_user(nil)[:primary_group_css_properties]).to eq(css_properties)
+    end
+  end
+
   def serialized_post(u)
     s = PostSerializer.new(post, scope: Guardian.new(u), root: false)
     s.add_raw = true


### PR DESCRIPTION
Allow primary groups to configure their own custom css properties.
CSS Properties are in the form my-key:my-custom-value
Properties are printed to primary group poster's style in posts.

This allows themes to implement custom styling that is able to be general
and leave specific styling details to each individual group.

eg:

A group with the following setting
```
important-group-image:background-image1-url
important-group-text:red
```

can be fed into a theme with the following styling:
```
.topic-post {
  color: var(--important-group-text);
  background-image: var(--important-group-image);
}
```

Then, later someone interested in creating a second group with similar styling
with different assets/colors is able to create a group with the following
css properties:

```
important-group-image: background-image2-url
important-group-text: blue
```

And posters with the new group set will automatically inherit styling from the
theme with the new properties without any additional changes to themes.

This allows us to easily apply group post styling without having to know which groups we need to style beforehand.

Some examples in screenshots:

![Screenshot from 2021-04-18 09-19-27](https://user-images.githubusercontent.com/1322534/115152754-4ebb5280-a027-11eb-814f-d547c1a13fdb.png)
![Screenshot from 2021-04-18 09-19-36](https://user-images.githubusercontent.com/1322534/115152755-4f53e900-a027-11eb-8e9a-15ae2b5d1520.png)
![Screenshot from 2021-04-18 09-19-45](https://user-images.githubusercontent.com/1322534/115152756-4f53e900-a027-11eb-9b20-9fae918fc441.png)
