### PR TITLE
Adding after-groups-index-container plugin-outlet 

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.hbs
@@ -103,4 +103,4 @@
 
 {{/d-section}}
 
-{{plugin-outlet name=“after-groups-index-container” tagName=""}}
+{{plugin-outlet name="after-groups-index-container" tagName=""}}

--- a/app/assets/javascripts/discourse/app/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.hbs
@@ -102,3 +102,5 @@
   {{/conditional-loading-spinner}}
 
 {{/d-section}}
+
+{{plugin-outlet name=“after-groups-index-container” tagName=""}}


### PR DESCRIPTION
on the groups index template
