### PR TITLE
FIX: user group message route should not be case-sensitive

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -153,7 +153,7 @@ class ListController < ApplicationController
       end
     when :private_messages_group, :private_messages_group_archive
       define_method("#{action}") do
-        group = Group.find_by(name: params[:group_name])
+        group = Group.find_by("LOWER(name) = ?", params[:group_name].downcase)
         raise Discourse::NotFound if !group
         raise Discourse::NotFound unless guardian.can_see_group_messages?(group)
 

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ListController do
   fab!(:user) { Fabricate(:user) }
   fab!(:topic) { Fabricate(:topic, user: user) }
-  fab!(:group) { Fabricate(:group) }
+  fab!(:group) { Fabricate(:group, name: "AwesomeGroup") }
   fab!(:admin) { Fabricate(:admin) }
 
   before do
@@ -247,7 +247,7 @@ RSpec.describe ListController do
 
       it 'should return the right response' do
         topic = Fabricate(:private_message_topic, allowed_groups: [group])
-        get "/topics/private-messages-group/#{user.username}/#{group.name}.json"
+        get "/topics/private-messages-group/#{user.username}/awesomegroup.json"
 
         expect(response.status).to eq(200)
 


### PR DESCRIPTION
Meta reference: https://meta.discourse.org/t/route-capitalization-error-in-private-messages-group/171028