### PR TITLE
UX: Fix focus style for post edit history button

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -706,6 +706,10 @@ blockquote {
           }
         }
       }
+      &:focus {
+        @include default-focus;
+        background: transparent;
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes the focus style due to this now being a button

Before:
![Screen Shot 2021-04-19 at 5 11 17 PM](https://user-images.githubusercontent.com/1681963/115303945-4996fa00-a132-11eb-979b-cbde6d5ebe7f.png)


After: 
![Screen Shot 2021-04-19 at 5 10 42 PM](https://user-images.githubusercontent.com/1681963/115303940-4865cd00-a132-11eb-8a93-208ce1b2941b.png)

