### PR TITLE
FIX: Clientside validate min tags for required tag group

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1247,19 +1247,22 @@ export default Controller.extend({
   @discourseComputed("model.category", "model.tags", "lastValidatedAt")
   tagValidation(category, tags, lastValidatedAt) {
     const tagsArray = tags || [];
-    if (
-      this.site.can_tag_topics &&
-      !this.currentUser.staff &&
-      category &&
-      category.minimum_required_tags > tagsArray.length
-    ) {
-      return EmberObject.create({
-        failed: true,
-        reason: I18n.t("composer.error.tags_missing", {
-          count: category.minimum_required_tags,
-        }),
-        lastShownAt: lastValidatedAt,
-      });
+    if (this.site.can_tag_topics && !this.currentUser.staff && category) {
+      if (
+        category.minimum_required_tags > tagsArray.length ||
+        (category.required_tag_groups &&
+          category.min_tags_from_required_group > tagsArray.length)
+      ) {
+        return EmberObject.create({
+          failed: true,
+          reason: I18n.t("composer.error.tags_missing", {
+            count:
+              category.minimum_required_tags ||
+              category.min_tags_from_required_group,
+          }),
+          lastShownAt: lastValidatedAt,
+        });
+      }
     }
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
@@ -1,7 +1,9 @@
 import {
   acceptance,
+  queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
+import I18n from "I18n";
 import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
 import Category from "discourse/models/category";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -50,6 +52,45 @@ acceptance("Composer - Tags", function (needs) {
 
     await click("#reply-control button.create");
     assert.equal(currentURL(), "/");
+    assert.equal(
+      queryAll(".popup-tip.bad").text().trim(),
+      I18n.t("composer.error.tags_missing", { count: 1 }),
+      "it should display the right alert"
+    );
+
+    const tags = selectKit(".mini-tag-chooser");
+    await tags.expand();
+    await tags.selectRowByValue("monkey");
+
+    await click("#reply-control button.create");
+    assert.notEqual(currentURL(), "/");
+  });
+
+  test("users do not bypass min required tags in tag group validation rule", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+
+    await fillIn("#reply-title", "this is my new topic title");
+    await fillIn(".d-editor-input", "this is the *content* of a post");
+
+    Category.findById(2).setProperties({
+      required_tag_groups: ["support tags"],
+      min_tags_from_required_group: 1,
+    });
+
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
+
+    updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
+
+    await click("#reply-control button.create");
+    assert.equal(currentURL(), "/");
+    assert.equal(
+      queryAll(".popup-tip.bad").text().trim(),
+      I18n.t("composer.error.tags_missing", { count: 1 }),
+      "it should display the right alert"
+    );
 
     const tags = selectKit(".mini-tag-chooser");
     await tags.expand();


### PR DESCRIPTION
When the user has not selected any tags and minimum_required_tags
is specified for a category, they get a clientside validation error
to tell them this. We were not doing the same thing when
min_tags_from_required_group and required_tag_groups was specified.