### PR TITLE
UX: Update positioning of mobile post controls

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -561,11 +561,7 @@ export default createWidget("post-menu", {
 
     const repliesButton = this.attachButton("replies", attrs);
     if (repliesButton) {
-      if (!this.site.mobileView) {
-        postControls.push(repliesButton);
-      } else {
-        visibleButtons.splice(-1, 0, repliesButton);
-      }
+      postControls.push(repliesButton);
     }
 
     const extraPostControls = applyDecorators(

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -35,6 +35,7 @@ span.badge-posts {
     }
     .actions {
       display: flex;
+      justify-content: flex-end;
 
       // Handles the like and flag buttons in the post menu.
       .double-button {
@@ -88,7 +89,6 @@ span.badge-posts {
           .d-icon {
             color: var(--primary-high);
           }
-          margin-left: auto;
         }
         &.has-like {
           .d-icon {
@@ -106,14 +106,15 @@ span.badge-posts {
       display: flex;
       align-items: center;
       .show-replies {
-        margin-left: auto;
         display: flex;
         font-size: $font-up-1;
+        padding: 10px 8px;
         + .reply {
           margin-left: 0;
         }
         .d-icon {
           padding-left: 8px;
+          font-size: $font-down-1;
         }
       }
       .actions {


### PR DESCRIPTION
This update would make the buttons positions more consistent with desktop and easier to reach with one hand (if you're right-hand dominant, anyway)

Before:
![Screen Shot 2021-04-19 at 11 22 42 PM](https://user-images.githubusercontent.com/1681963/115332634-31d96900-a166-11eb-8a17-4b2f796f4e04.png)

After: 
![Screen Shot 2021-04-19 at 11 22 48 PM](https://user-images.githubusercontent.com/1681963/115332651-3b62d100-a166-11eb-935c-342dfe7cb3bb.png)


