### PR TITLE
UX: displays a descriptive error when theme is not allowed

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -92,8 +92,12 @@ class Admin::ThemesController < Admin::AdminController
         render json: @theme.errors, status: :unprocessable_entity
       end
     elsif remote = params[:remote]
-
-      guardian.ensure_allowed_theme_repo_import!(remote.strip)
+      begin
+        guardian.ensure_allowed_theme_repo_import!(remote.strip)
+      rescue Discourse::InvalidAccess
+        render_json_error I18n.t("themes.import_error.not_allowed_theme", { repo: remote.strip }), status: :forbidden
+        return
+      end
 
       begin
         branch = params[:branch] ? params[:branch] : nil

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -78,6 +78,7 @@ en:
       unpack_failed: "Failed to unpack file"
       file_too_big: "The uncompressed file is too big."
       unknown_file_type: "The file you uploaded does not appear to be a valid Discourse theme."
+      not_allowed_theme: "`%{repo}` is not in the list of allowed themes (check `allowed_theme_repos` global setting)."
     errors:
       component_no_user_selectable: "Theme components can't be user-selectable"
       component_no_default: "Theme components can't be default theme"

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -119,13 +119,14 @@ describe Admin::ThemesController do
         expect(response.status).to eq(201)
       end
 
-      it "bans non whtielisted imports" do
+      it "bans non whitelisted imports" do
         RemoteTheme.stubs(:import_theme)
-        post "/admin/themes/import.json", params: {
-          remote: '    https://bad.com/discourse/discourse-brand-header       '
-        }
+        remote = '    https://bad.com/discourse/discourse-brand-header       '
+
+        post "/admin/themes/import.json", params: { remote: remote }
 
         expect(response.status).to eq(403)
+        expect(response.parsed_body['errors']).to include(I18n.t("themes.import_error.not_allowed_theme", { repo: remote.strip }))
       end
 
       it "bans json file import" do

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -119,7 +119,7 @@ describe Admin::ThemesController do
         expect(response.status).to eq(201)
       end
 
-      it "bans non whitelisted imports" do
+      it "prevents adding disallowed themes" do
         RemoteTheme.stubs(:import_theme)
         remote = '    https://bad.com/discourse/discourse-brand-header       '
 


### PR DESCRIPTION

<img width="777" alt="Capture d’écran 2021-04-20 à 10 29 31" src="https://user-images.githubusercontent.com/339945/115364588-d342d800-a1c3-11eb-8d44-8a3a58fe44be.png">
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
