### PR TITLE
UX: show error message instead of disabling save button on tag groups page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-groups-form.js
+++ b/app/assets/javascripts/discourse/app/components/tag-groups-form.js
@@ -23,14 +23,12 @@ export default Component.extend(bufferedProperty("model"), {
   },
 
   @discourseComputed(
-    "buffered.isSaving",
     "buffered.name",
     "buffered.tag_names",
     "buffered.permissions"
   )
-  savingDisabled(isSaving, name, tagNames, permissions) {
+  cannotSave(name, tagNames, permissions) {
     return (
-      isSaving ||
       isEmpty(name) ||
       isEmpty(tagNames) ||
       (!this.everyoneSelected(permissions) &&
@@ -116,6 +114,11 @@ export default Component.extend(bufferedProperty("model"), {
     },
 
     save() {
+      if (this.cannotSave) {
+        bootbox.alert(I18n.t("tagging.groups.cannot_save"));
+        return false;
+      }
+
       const attrs = this.buffered.getProperties(
         "name",
         "tag_names",

--- a/app/assets/javascripts/discourse/app/templates/components/tag-groups-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-groups-form.hbs
@@ -93,7 +93,7 @@
     {{d-button
       class="btn-default"
       action=(action "save")
-      disabled=savingDisabled
+      disabled=buffered.isSaving
       label="tagging.groups.save"}}
 
     {{d-button

--- a/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tag-groups-test.js
@@ -66,8 +66,6 @@ acceptance("Tag Groups", function (needs) {
     await tags.selectRowByValue("monkey");
 
     await click("#visible-permission");
-    assert.ok(queryAll(".tag-group-content .btn.btn-default:disabled").length);
-
     await groups.expand();
     await groups.selectRowByIndex(1);
     await groups.selectRowByIndex(0);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3677,6 +3677,7 @@ en:
         everyone_can_use: "Tags can be used by everyone"
         usable_only_by_groups: "Tags are visible to everyone, but only the following groups can use them"
         visible_only_to_groups: "Tags are visible only to the following groups"
+        cannot_save: "Cannot save tag group. Make sure that there is at least one tag present, tag group name is not empty, and a group is selected for tags permission."
 
       topics:
         none:


### PR DESCRIPTION
https://meta.discourse.org/t/unable-to-rename-tag-groups-title-save-button-stays-grayed-out/172293/
