### PR TITLE
FIX: granting beginners badges when user skipped new user tips

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -113,6 +113,7 @@ class Badge < ActiveRecord::Base
   validates :badge_type, presence: true
   validates :allow_title, inclusion: [true, false]
   validates :multiple_grant, inclusion: [true, false]
+  validates :for_beginners, inclusion: [true, false]
 
   scope :enabled, -> { where(enabled: true) }
 
@@ -337,6 +338,7 @@ end
 #  system            :boolean          default(FALSE), not null
 #  image             :string(255)
 #  long_description  :text
+#  for_beginners     :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/db/fixtures/006_badges.rb
+++ b/db/fixtures/006_badges.rb
@@ -74,6 +74,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.auto_revoke = false
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -87,6 +88,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::UserChange
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -100,6 +102,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::PostRevision
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -113,6 +116,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::PostRevision
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -126,6 +130,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::PostAction
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -140,6 +145,7 @@ Badge.seed do |b|
   b.trigger = Badge::Trigger::PostAction
   b.auto_revoke = false
   b.system = true
+  b.for_beginners = true
 end
 
 [
@@ -176,6 +182,7 @@ Badge.seed do |b|
   # don't trigger for now, its too expensive
   b.trigger = Badge::Trigger::None
   b.system = true
+  b.for_beginners = true
 end
 
 [
@@ -209,6 +216,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::Community
   b.trigger = Badge::Trigger::PostAction
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -220,6 +228,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::UserChange
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -231,6 +240,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::PostRevision
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -243,6 +253,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::PostRevision
   b.system = true
+  b.for_beginners = true
 end
 
 [
@@ -365,6 +376,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::PostRevision
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -378,6 +390,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::None
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -391,6 +404,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::None
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|
@@ -404,6 +418,7 @@ Badge.seed do |b|
   b.default_badge_grouping_id = BadgeGrouping::GettingStarted
   b.trigger = Badge::Trigger::None
   b.system = true
+  b.for_beginners = true
 end
 
 Badge.seed do |b|

--- a/db/migrate/20210420162326_add_for_beginners_to_badge.rb
+++ b/db/migrate/20210420162326_add_for_beginners_to_badge.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddForBeginnersToBadge < ActiveRecord::Migration[6.0]
+  def change
+    add_column :badges, :for_beginners, :boolean, null: false, default: false
+  end
+end

--- a/db/post_migrate/20210420162817_mark_badges_for_beginners.rb
+++ b/db/post_migrate/20210420162817_mark_badges_for_beginners.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class MarkBadgesForBeginners < ActiveRecord::Migration[6.0]
+  def up
+    execute <<~SQL
+      UPDATE badges
+      SET for_beginners = true
+      WHERE name IN (
+        'Autobiographer',
+        'Editor',
+        'First Like',
+        'First Share',
+        'First Flag',
+        'First Link',
+        'First Quote',
+        'Read Guidelines',
+        'Reader',
+        'First Mention',
+        'First Emoji',
+        'First Onebox',
+        'First Reply By Email',
+        'Wiki Editor',
+        'Certified',
+        'Licensed',
+        'First Reaction',
+        'Welcome'
+      )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/post_migrate/20210420162817_mark_badges_for_beginners.rb
+++ b/db/post_migrate/20210420162817_mark_badges_for_beginners.rb
@@ -5,25 +5,25 @@ class MarkBadgesForBeginners < ActiveRecord::Migration[6.0]
     execute <<~SQL
       UPDATE badges
       SET for_beginners = true
-      WHERE name IN (
-        'Autobiographer',
-        'Editor',
-        'First Like',
-        'First Share',
-        'First Flag',
-        'First Link',
-        'First Quote',
-        'Read Guidelines',
-        'Reader',
-        'First Mention',
-        'First Emoji',
-        'First Onebox',
-        'First Reply By Email',
-        'Wiki Editor',
-        'Certified',
-        'Licensed',
-        'First Reaction',
-        'Welcome'
+      WHERE id IN (
+        5,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        40,
+        41,
+        42,
+        43,
+        48,
+        100,
+        101,
+        102
       )
     SQL
   end

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -150,6 +150,18 @@ describe BadgeGranter do
       b.badge_id = Badge::FirstLike
     end
 
+    it 'should not grant badges "for beginners" when user skipped new user tips' do
+      user.user_option.update!(skip_new_user_tips: true)
+      post = Fabricate(:post)
+      PostActionCreator.like(user, post)
+
+      UserBadge.destroy_all
+      BadgeGranter.backfill(Badge.find(Badge::FirstLike))
+
+      b = UserBadge.find_by(user_id: user.id, badge_id: Badge::FirstLike)
+      expect(b).to be_nil
+    end
+
     it 'should grant missing badges' do
       nice_topic = Badge.find(Badge::NiceTopic)
       good_topic = Badge.find(Badge::GoodTopic)

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -155,11 +155,9 @@ describe BadgeGranter do
       post = Fabricate(:post)
       PostActionCreator.like(user, post)
 
-      UserBadge.destroy_all
-      BadgeGranter.backfill(Badge.find(Badge::FirstLike))
-
-      b = UserBadge.find_by(user_id: user.id, badge_id: Badge::FirstLike)
-      expect(b).to be_nil
+      expect {
+        BadgeGranter.backfill(Badge.find(Badge::FirstLike))
+      }.to_not change { UserBadge.count }
     end
 
     it 'should grant missing badges' do

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -222,10 +222,10 @@ describe BadgeGranter do
       expect(user_badge).to eq(nil)
     end
 
-    it "doesn't grant 'getting started' badges when user skipped new user tips" do
+    it "doesn't grant badges 'for beginners' when user skipped new user tips" do
       freeze_time
       user.user_option.update!(skip_new_user_tips: true)
-      badge = Fabricate(:badge, badge_grouping_id: BadgeGrouping::GettingStarted)
+      badge = Fabricate(:badge, for_beginners: true)
 
       user_badge = BadgeGranter.grant(badge, user, created_at: 1.year.ago)
       expect(user_badge).to eq(nil)


### PR DESCRIPTION
Unfortunately, badges for beginners weren't skipping when a user chose to skip "new user tips". We had a check [here](https://github.com/discourse/discourse/blob/d44deb45f34459f4653efc549579b6657edcf2fd/app/services/badge_granter.rb#L49). But the code that was actually granting badges in most cases is [here](https://github.com/discourse/discourse/blob/d44deb45f34459f4653efc549579b6657edcf2fd/app/services/badge_granter.rb#L335) and written in SQL.

This PR adds a field `for_beginners` to `Badge` and fixes the problem.
