### PR TITLE
FIX: If we want a `.json` path, don't bootstrap

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -237,6 +237,10 @@ module.exports = {
       return false;
     }
 
+    if (req.path.endsWith(".json")) {
+      return false;
+    }
+
     let baseURL =
       options.rootURL === ""
         ? "/"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
