### PR TITLE
FIX: Use CDN urls for theme settings of type upload

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -128,7 +128,7 @@ class Theme < ActiveRecord::Base
     SvgSprite.expire_cache
   end
 
-  BASE_COMPILER_VERSION = 49
+  BASE_COMPILER_VERSION = 50
   def self.compiler_version
     get_set_cache "compiler_version" do
       dependencies = [

--- a/lib/theme_settings_manager.rb
+++ b/lib/theme_settings_manager.rb
@@ -173,5 +173,10 @@ class ThemeSettingsManager
   end
 
   class Upload < self
+    def value
+      val = super
+      Discourse.store.cdn_url(val)
+    end
+
   end
 end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -531,6 +531,24 @@ HTML
     expect(json["theme_uploads"]["bob"]).to eq("http://cdn.localhost#{upload.url}")
   end
 
+  it 'uses CDN url for settings of type upload' do
+    set_cdn_url("http://cdn.localhost")
+    Theme.destroy_all
+
+    upload = UploadCreator.new(file_from_fixtures("logo.png"), "logo.png").create_for(-1)
+    theme.set_field(target: :settings, name: "yaml", value: <<~YAML)
+      my_upload:
+        type: upload
+        default: ""
+    YAML
+
+    ThemeSetting.create!(theme: theme, data_type: ThemeSetting.types[:upload], value: upload.url, name: "my_upload")
+    theme.save!
+
+    json = JSON.parse(cached_settings(theme.id))
+    expect(json["my_upload"]).to eq("http://cdn.localhost#{upload.url}")
+  end
+
   it 'handles settings cache correctly' do
     Theme.destroy_all
 


### PR DESCRIPTION
Followup to d44deb45f34459f4653efc549579b6657edcf2fd (theme upload vars and upload type settings are separate things...) 
