### PR TITLE
UX: Prevent topic progress bar from overlapping

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -151,10 +151,7 @@ export default Component.extend({
 
     const $html = $("html");
     const offset = window.pageYOffset || $html.scrollTop();
-    const progressHeight = this.site.mobileView
-      ? 0
-      : $("#topic-progress").outerHeight();
-    const maximumOffset = $("#topic-bottom").offset().top + progressHeight;
+    const maximumOffset = $("#topic-bottom").offset().top;
     const windowHeight = $(window).height();
     let composerHeight = $("#reply-control").height() || 0;
     const isDocked = offset >= maximumOffset - windowHeight + composerHeight;

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -87,7 +87,7 @@
 
 #topic-progress-wrapper {
   display: flex;
-  right: 9px;
+  right: 9px; // 8px padding on #main-outlet + 1px right border
   .topic-admin-menu-button-container {
     display: flex;
     > span {

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -62,6 +62,13 @@
   }
 }
 
+@media screen and (max-width: 924px) {
+  .post-stream {
+    // make space for the topic progress bar to dock
+    padding-bottom: 2em;
+  }
+}
+
 .progress-back-container {
   z-index: z("dropdown");
   margin-right: 0;
@@ -80,6 +87,7 @@
 
 #topic-progress-wrapper {
   display: flex;
+  right: 9px;
   .topic-admin-menu-button-container {
     display: flex;
     > span {

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -85,7 +85,6 @@
 
 #topic-progress-wrapper {
   position: fixed;
-  right: 2em;
   bottom: 0;
   left: 0;
   margin: 0 auto;

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -14,10 +14,6 @@
   padding: 15px 0 8px 0;
 }
 
-.post-stream {
-  padding-bottom: 3em;
-}
-
 span.badge-posts {
   margin-right: 5px;
 }

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -43,6 +43,7 @@
 
 #topic-progress-wrapper {
   position: fixed;
+  right: 10px; // match 10px padding on .wrap
   bottom: 0;
   z-index: z("timeline");
   &:not(.docked) {

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -43,7 +43,6 @@
 
 #topic-progress-wrapper {
   position: fixed;
-  right: 1em;
   bottom: 0;
   z-index: z("timeline");
   &:not(.docked) {


### PR DESCRIPTION
On small desktop screens the topic progress bar would overlap various elements, this makes some space for it when needed. I also finessed the right alignment a little bit. 

Before:
![Screen Shot 2021-04-20 at 10 43 46 PM](https://user-images.githubusercontent.com/1681963/115489526-4ed77000-a22a-11eb-9288-6d33fcfe4da6.png)


After:
![Screen Shot 2021-04-20 at 10 40 27 PM](https://user-images.githubusercontent.com/1681963/115489554-5a2a9b80-a22a-11eb-9c32-7812d4d27196.png)


