### PR TITLE
UX: fix layout of group header buttons on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/group-membership-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-membership-button.hbs
@@ -6,7 +6,7 @@
       disabled=updatingMembership}}
 {{else if canLeaveGroup}}
   {{d-button action=(action "leaveGroup")
-      class="btn-default group-index-leave"
+      class="btn-danger group-index-leave"
       icon="user-times"
       label="groups.leave"
       disabled=updatingMembership}}

--- a/app/assets/javascripts/discourse/app/templates/components/group-membership-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-membership-button.hbs
@@ -6,7 +6,7 @@
       disabled=updatingMembership}}
 {{else if canLeaveGroup}}
   {{d-button action=(action "leaveGroup")
-      class="btn-danger group-index-leave"
+      class="btn-default group-index-leave"
       icon="user-times"
       label="groups.leave"
       disabled=updatingMembership}}

--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -33,15 +33,6 @@
           showLogin=(route-action "showLogin")
         }}
 
-        {{#if displayGroupMessageButton}}
-          {{d-button
-            action=(action "messageGroup")
-            class="btn-primary group-message-button"
-            icon="envelope"
-            label="groups.message"
-          }}
-        {{/if}}
-
         {{#if currentUser.admin}}
           {{#if model.automatic}}
             {{d-button
@@ -59,6 +50,15 @@
               label="admin.groups.delete"
             }}
           {{/if}}
+        {{/if}}
+
+        {{#if displayGroupMessageButton}}
+          {{d-button
+            action=(action "messageGroup")
+            class="btn-primary group-message-button"
+            icon="envelope"
+            label="groups.message"
+          }}
         {{/if}}
       </div>
 

--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -83,8 +83,10 @@ span.mention-group {
 
   .group-details-button {
     display: flex;
-    flex-shrink: 0;
-    gap: 10px;
+    flex-wrap: wrap;
+    button:not(:last-child) {
+      margin-right: 0.5em;
+    }
   }
 }
 

--- a/app/assets/stylesheets/mobile/group.scss
+++ b/app/assets/stylesheets/mobile/group.scss
@@ -43,4 +43,7 @@
 
 .group-info {
   flex-wrap: wrap;
+  .group-details-button button {
+    margin-top: 0.5em;
+  }
 }


### PR DESCRIPTION
Safari doesn't support `gap` for flexbox yet unfortunately. I also moved the message button to consistently be on the right and made sure these wrap well with longer translations.


Before:

![Screen Shot 2021-04-21 at 12 00 16 AM](https://user-images.githubusercontent.com/1681963/115495182-17ba8c00-a235-11eb-8317-445e9397266d.png)


After:

![Screen Shot 2021-04-21 at 12 02 39 AM](https://user-images.githubusercontent.com/1681963/115495184-19844f80-a235-11eb-8fc3-a57f67856e27.png)
