### PR TITLE
FIX: Fall back to hardcoded version when period check disabled

### DIFF
--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -115,6 +115,10 @@ module DiscourseUpdates
       keys.present? ? keys.map { |k| Discourse.redis.hgetall(k) } : []
     end
 
+    def current_version
+      last_installed_version || Discourse::VERSION::STRING
+    end
+
     def new_features_payload
       response = Excon.new(new_features_endpoint).request(expects: [200], method: :Get)
       response.body
@@ -130,7 +134,7 @@ module DiscourseUpdates
       return nil if entries.nil?
 
       entries.select! do |item|
-        item["discourse_version"].nil? || Discourse.has_needed_version?(last_installed_version, item["discourse_version"]) rescue nil
+        item["discourse_version"].nil? || Discourse.has_needed_version?(current_version, item["discourse_version"]) rescue nil
       end
 
       entries.sort_by { |item| Time.zone.parse(item["created_at"]).to_i }.reverse


### PR DESCRIPTION
When `SiteSetting.version_checks?` is disabled, the Discourse version is
not stored in Redis, so we need to fall back to the hardcoded value.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
