### PR TITLE
FIX: Do not dump schema during production database migrations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,3 @@
 require File.expand_path('../config/application', __FILE__)
 
 Discourse::Application.load_tasks
-
-# this prevents crashes when migrating a database in production in certain
-# PostgreSQL configuations when trying to create structure.sql
-Rake::Task["db:structure:dump"].clear if Rails.env.production?

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,4 +67,5 @@ Discourse::Application.configure do
     config.developer_emails = emails.split(",").map(&:downcase).map(&:strip)
   end
 
+  config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
It's important that we don't perform pg_dumps against databases
running behind pgbouncer.

We had an old monkey-patch to prevent this, but following some [recent
internal rails refactoring](https://github.com/rails/rails/commit/5488686851978c64346a0c03d2b6541cf2a94879),
the patch no longer works. Instead, we can use the official
`config.active_record.dump_schema_after_migration` option.

Setting this to false in production is recommended by Rails, and is the
default for newly generated Rails applications.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
