### PR TITLE
Group posts adhere to prioritize name in UX option

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-post.js
+++ b/app/assets/javascripts/discourse/app/components/group-post.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 import getURL from "discourse-common/lib/get-url";
+import { prioritizeNameInUx } from "discourse/lib/settings";
 import { propertyEqual } from "discourse/lib/computed";
 
 export default Component.extend({
@@ -14,4 +15,12 @@ export default Component.extend({
     "post.post_type",
     "site.post_types.moderator_action"
   ),
+
+  @discourseComputed("post.user")
+  name() {
+    if (prioritizeNameInUx(this.post.user.name)) {
+      return this.post.user.name;
+    }
+    return this.post.user.username;
+  },
 });

--- a/app/assets/javascripts/discourse/app/templates/components/group-post.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-post.hbs
@@ -12,10 +12,10 @@
       </span>
     </div>
     <div class="group-post-category">{{category-link post.category}}</div>
-    {{#if post.user.name}}
-      <div class="group-member-info">
-        <span class="name">{{post.user.name}}</span>
-        {{#if post.user.title}}<span class="title">, {{post.user.title}}</span>{{/if}}
+    {{#if post.user}}
+      <div class="group-member-info names">
+        <span class="name">{{name}}</span>
+        {{#if post.user.title}}<span class="user-title">{{post.user.title}}</span>{{/if}}
       </div>
     {{/if}}
   </div>


### PR DESCRIPTION
Displays either username or name on the group activity page.
Removes hardcoded comma, and adds classes to share padding styling

Before:
![Screenshot from 2021-04-21 10-08-00](https://user-images.githubusercontent.com/1322534/115593568-80cbef00-a289-11eb-846a-e19cf84e67f8.png)


After:

With Prioritize username in UX enabled:
![Screenshot from 2021-04-21 10-07-41](https://user-images.githubusercontent.com/1322534/115593590-86293980-a289-11eb-9df4-d685a65cb11e.png)

With Prioritize username in UX disabled:
![Screenshot from 2021-04-21 10-07-19](https://user-images.githubusercontent.com/1322534/115593587-8590a300-a289-11eb-867a-de4a49bad28d.png)
