### PR TITLE
DEV: Move autotag to topic creator

### DIFF
--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -36,7 +36,6 @@ module Jobs
             post.update_column(:cooked, cp.html)
             post.topic.update_excerpt(post.excerpt_for_topic) if post.is_first_post?
             extract_links(post)
-            auto_tag(post) if SiteSetting.tagging_enabled? && post.post_number == 1
             post.publish_change_to_clients! :revised
           end
         end
@@ -60,25 +59,6 @@ module Jobs
     def extract_links(post)
       TopicLink.extract_from(post)
       QuotedPost.extract_from(post)
-    end
-
-    def auto_tag(post)
-      word_watcher = WordWatcher.new("#{post.topic.title} #{post.raw}")
-
-      old_tags = post.topic.tags.pluck(:name).to_set
-      new_tags = old_tags.dup
-
-      WordWatcher.words_for_action(:tag).each do |word, tags|
-        new_tags += tags.split(",") if word_watcher.matches?(word)
-      end
-
-      if old_tags != new_tags
-        post.revise(
-          Discourse.system_user,
-          tags: new_tags.to_a,
-          edit_reason: I18n.t(:watched_words_auto_tag)
-        )
-      end
     end
   end
 

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -176,6 +176,16 @@ class TopicCreator
       topic.errors.add(:base, :unable_to_tag)
       rollback_from_errors!(topic)
     end
+
+    guardian = Guardian.new(Discourse.system_user)
+    word_watcher = WordWatcher.new("#{@opts[:title]} #{@opts[:raw]}")
+    word_watcher_tags = topic.tags.map(&:name)
+    WordWatcher.words_for_action(:tag).each do |word, tags|
+      if word_watcher.matches?(word)
+        word_watcher_tags += tags.split(",")
+      end
+    end
+    DiscourseTagging.tag_topic_by_names(topic, guardian, word_watcher_tags)
   end
 
   def setup_auto_close_time(topic)

--- a/spec/jobs/process_post_spec.rb
+++ b/spec/jobs/process_post_spec.rb
@@ -89,49 +89,6 @@ describe Jobs::ProcessPost do
       Jobs::ProcessPost.new.execute(post_id: post2.id)
       expect(post.topic.reload.excerpt).to eq("Some OP content")
     end
-
-    it "automatically tags first posts" do
-      SiteSetting.tagging_enabled = true
-
-      Fabricate(:watched_word, action: WatchedWord.actions[:tag], word: "Greetings?", replacement: "hello , world")
-
-      post = Fabricate(:post, raw: "Greeting", cooked: "")
-      Jobs::ProcessPost.new.execute(post_id: post.id)
-      expect(post.topic.reload.tags.pluck(:name)).to contain_exactly()
-
-      post = Fabricate(:post, raw: "Greetings", cooked: "")
-      Jobs::ProcessPost.new.execute(post_id: post.id)
-      expect(post.topic.reload.tags.pluck(:name)).to contain_exactly()
-
-      post = Fabricate(:post, raw: "Greetings?", cooked: "")
-      Jobs::ProcessPost.new.execute(post_id: post.id)
-      expect(post.topic.reload.tags.pluck(:name)).to contain_exactly("hello", "world")
-
-      topic = Fabricate(:topic, title: "Greetings? People")
-      post = Fabricate(:post, topic: topic, raw: "nothing yet", cooked: "")
-
-      Jobs::ProcessPost.new.execute(post_id: post.id)
-      expect(post.topic.reload.tags.pluck(:name)).to contain_exactly("hello", "world")
-    end
-
-    it "automatically tags first posts (regex)" do
-      SiteSetting.tagging_enabled = true
-      SiteSetting.watched_words_regular_expressions = true
-
-      Fabricate(:watched_word, action: WatchedWord.actions[:tag], word: "Greetings?", replacement: "hello , world")
-
-      post = Fabricate(:post, raw: "Greeting", cooked: "")
-      Jobs::ProcessPost.new.execute(post_id: post.id)
-      expect(post.topic.reload.tags.pluck(:name)).to contain_exactly("hello", "world")
-
-      post = Fabricate(:post, raw: "Greetings", cooked: "")
-      Jobs::ProcessPost.new.execute(post_id: post.id)
-      expect(post.topic.reload.tags.pluck(:name)).to contain_exactly("hello", "world")
-
-      post = Fabricate(:post, raw: "Greetings?", cooked: "")
-      Jobs::ProcessPost.new.execute(post_id: post.id)
-      expect(post.topic.reload.tags.pluck(:name)).to contain_exactly("hello", "world")
-    end
   end
 
 end


### PR DESCRIPTION
This move was necessary to automatically tag the topic with the right
tags from creation time. The process post job may be delayed for a
short time.

This also ensures that the tags will not be added over and over when
the post is edited.
