### PR TITLE
FIX: blank avatar on user card if flair url is undefined

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-avatar-flair.js
+++ b/app/assets/javascripts/discourse/app/components/user-avatar-flair.js
@@ -15,7 +15,10 @@ export default MountWidget.extend({
       return;
     }
 
-    if (this.user.primary_group_flair_url) {
+    if (
+      this.user.primary_group_flair_url ||
+      this.user.primary_group_flair_bg_color
+    ) {
       return {
         primary_group_flair_url: this.user.primary_group_flair_url,
         primary_group_flair_bg_color: this.user.primary_group_flair_bg_color,


### PR DESCRIPTION
If creating a group avatar flair with no icon or image, the user card
was showing a blank circle.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
