### PR TITLE
DEV: Improve Ember CLI's bootstrap logic

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -172,6 +172,16 @@ module.exports = {
     let app = config.app;
     let options = config.options;
 
+    if (!proxy) {
+      // eslint-disable-next-line
+      console.error(`
+Discourse can't be run without a \`--proxy\` setting, because it needs a Rails application
+to serve API requests. For example:
+
+  yarn run ember serve --proxy "http://localhost:3000"\n`);
+      throw "--proxy argument is required";
+    }
+
     let watcher = options.watcher;
 
     let baseURL =

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -177,6 +177,7 @@ async function handleRequest(assetPath, proxy, req, res) {
         let get = bent("GET", [200, 404, 403, 500]);
         let response = await get(url, null, req.headers);
         if (response.headers["x-discourse-bootstrap-required"] === "true") {
+          req.headers["X-Discourse-Asset-Path"] = req.path;
           let json = await buildFromBootstrap(assetPath, proxy, req);
           return res.send(json);
         }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,9 +107,23 @@ class ApplicationController < ActionController::Base
 
   class RenderEmpty < StandardError; end
   class PluginDisabled < StandardError; end
+  class EmberCLIHijacked < StandardError; end
+
+  def catch_ember_cli_hijack
+    yield
+  rescue ActionView::Template::Error => ex
+    raise ex unless ex.cause.is_a?(EmberCLIHijacked)
+    send_ember_cli_bootstrap
+  end
 
   rescue_from RenderEmpty do
-    with_resolved_locale { render 'default/empty' }
+    catch_ember_cli_hijack do
+      with_resolved_locale { render 'default/empty' }
+    end
+  end
+
+  rescue_from EmberCLIHijacked do
+    send_ember_cli_bootstrap
   end
 
   rescue_from ArgumentError do |e|
@@ -286,11 +300,17 @@ class ApplicationController < ActionController::Base
       rescue Discourse::InvalidAccess
         return render plain: message, status: status_code
       end
-      with_resolved_locale do
-        error_page_opts[:layout] = opts[:include_ember] ? 'application' : 'no_ember'
-        render html: build_not_found_page(error_page_opts)
+      catch_ember_cli_hijack do
+        with_resolved_locale do
+          error_page_opts[:layout] = opts[:include_ember] ? 'application' : 'no_ember'
+          render html: build_not_found_page(error_page_opts)
+        end
       end
     end
+  end
+
+  def send_ember_cli_bootstrap
+    head 200, content_type: "text/html", "X-Discourse-Bootstrap-Required": true
   end
 
   # If a controller requires a plugin, it will raise an exception if that plugin is

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -591,4 +591,10 @@ module ApplicationHelper
       current_user ? nil : value
     end
   end
+
+  def hijack_if_ember_cli!
+    if request.headers["HTTP_X_DISCOURSE_EMBER_CLI"] == "true"
+      raise ApplicationController::EmberCLIHijacked.new
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,4 @@
+<%- hijack_if_ember_cli! -%>
 <!DOCTYPE html>
 <html lang="<%= html_lang %>" class="<%= html_classes %>">
   <head>

--- a/plugins/styleguide/plugin.rb
+++ b/plugins/styleguide/plugin.rb
@@ -15,7 +15,7 @@ Discourse::Application.routes.append do
 end
 
 after_initialize do
-  register_asset_filter do |type, request|
-    request&.fullpath&.start_with?('/styleguide')
+  register_asset_filter do |type, request, opts|
+    (opts[:path] || '').start_with?('/styleguide')
   end
 end

--- a/spec/components/discourse_spec.rb
+++ b/spec/components/discourse_spec.rb
@@ -65,6 +65,25 @@ describe Discourse do
     end
   end
 
+  context "asset_filter_options" do
+    it "obmits path if request is missing" do
+      opts = Discourse.asset_filter_options(:js, nil)
+      expect(opts[:path]).to be_blank
+    end
+
+    it "returns a hash with a path from the request" do
+      req = stub(fullpath: "/hello", headers: {})
+      opts = Discourse.asset_filter_options(:js, req)
+      expect(opts[:path]).to eq("/hello")
+    end
+
+    it "overwrites the path if the asset path is present" do
+      req = stub(fullpath: "/bootstrap.json", headers: { "HTTP_X_DISCOURSE_ASSET_PATH" => "/hello" })
+      opts = Discourse.asset_filter_options(:js, req)
+      expect(opts[:path]).to eq("/hello")
+    end
+  end
+
   context 'plugins' do
     let(:plugin_class) do
       Class.new(Plugin::Instance) do
@@ -107,7 +126,7 @@ describe Discourse do
 
       expect(Discourse.find_plugin_css_assets({}).length).to eq(2)
       expect(Discourse.find_plugin_js_assets({}).length).to eq(2)
-      plugin1.register_asset_filter do |type, request|
+      plugin1.register_asset_filter do |type, request, opts|
         false
       end
       expect(Discourse.find_plugin_css_assets({}).length).to eq(1)


### PR DESCRIPTION
Instead of having Ember CLI know which URLs to proxy or not, have it try
the URL with a special header `HTTP_X_DISCOURSE_EMBER_CLI`. If present,
and Discourse thinks we should bootstrap the application, it will
instead stop rendering and return a HTTP HEAD with a response header
telling Ember CLI to bootstrap.

In other words, any time Rails would otherwise serve up the HTML for the
Ember app, it stops and says "no, you do it."