### PR TITLE
FIX: Exclude emoji images from JS sizing

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/ensure-max-image-dimensions.js
+++ b/app/assets/javascripts/discourse/app/initializers/ensure-max-image-dimensions.js
@@ -27,7 +27,7 @@ export default {
 
     const styleTag = document.createElement("style");
     styleTag.id = "image-sizing-hack";
-    styleTag.innerHTML = `#reply-control .d-editor-preview img:not(.thumbnail):not(.ytp-thumbnail-image), .cooked img:not(.thumbnail):not(.ytp-thumbnail-image) {${styles}}`;
+    styleTag.innerHTML = `#reply-control .d-editor-preview img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji), .cooked img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji) {${styles}}`;
     document.head.appendChild(styleTag);
   },
 };


### PR DESCRIPTION
Should remove jumpiness when using the experimental `disable_image_size_calculations` site setting.
