### PR TITLE
UX: stop presence indicator hop, space consistency

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -293,7 +293,7 @@
                 </div>
               {{/if}}
 
-              {{slow-mode-info topic=model user=currentUser}}
+              {{slow-mode-info topic=model user=currentUser tagName=""}}
 
               {{topic-timer-info
                   topicClosed=model.closed

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1137,7 +1137,8 @@ a.mention-group {
 }
 
 #topic-footer-buttons {
-  padding: 1.5em 0 0.75em 0;
+  margin: var(--below-topic-margin) 0;
+  padding: 0;
 
   .topic-footer-main-buttons {
     display: flex;

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -16,10 +16,15 @@
   }
 }
 
+[class*="archetype-"] {
+  --below-topic-margin: 0.75em;
+}
+
 .container.posts {
   display: grid;
   grid-template-areas: "posts timeline";
   grid-template-columns: auto auto;
+  margin-bottom: var(--below-topic-margin);
   > .row {
     grid-area: posts;
     max-width: calc(

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -455,8 +455,8 @@ pre.copy-codeblocks:hover .copy-cmd {
 }
 
 .suggested-topics {
-  clear: left;
-  padding: 20px 0 15px 0;
+  margin: 4.5em 0 1em;
+
   table {
     margin-top: 10px;
   }

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -59,9 +59,10 @@
   }
 }
 
+.topic-status-info,
 .topic-timer-info {
   border-top: 1px solid var(--primary-low);
-  padding: 10px 0;
+  margin: 0;
   &:empty {
     padding: 0;
   }
@@ -70,14 +71,14 @@
   .slow-mode-heading {
     display: flex;
     align-items: center;
-    margin: 0px;
+    margin: 0;
+    padding: var(--below-topic-margin) 0;
   }
+  .slow-mode-remove,
   .topic-timer-modify {
     margin-left: auto;
   }
-  .topic-timer-remove,
-  .slow-mode-remove,
-  .topic-timer-edit {
+  button {
     font-size: $font-down-2;
     background: transparent;
   }

--- a/plugins/discourse-presence/assets/stylesheets/presence.scss
+++ b/plugins/discourse-presence/assets/stylesheets/presence.scss
@@ -1,3 +1,8 @@
+.topic-above-footer-buttons-outlet.presence {
+  min-height: 1.8em; // height of the avatars, prevents layout shift
+  margin: var(--below-topic-margin) 0;
+}
+
 .presence-users {
   background-color: var(--secondary, $secondary);
   color: var(--primary-medium, $primary-medium);


### PR DESCRIPTION
This eliminates the page jump that happens when presence indicators appear below a topic by reserving some space for them (may have been a regression that I caused recently?).

 I also cleaned up spacing of items at the bottom of topics and fixed a consistency issue with the slow mode delete button. 


Before:

![jump](https://user-images.githubusercontent.com/1681963/115647121-439b4780-a2f1-11eb-8db9-33fab691a8fc.gif)


After:

![nojump](https://user-images.githubusercontent.com/1681963/115647133-4b5aec00-a2f1-11eb-830f-7e771eb5a941.gif)