### PR TITLE
FIX: when a flag is handled archive message for moderator group

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -89,6 +89,9 @@ class PostAction < ActiveRecord::Base
     I18n.with_locale(SiteSetting.default_locale) do
       related_post.topic.add_moderator_post(moderator, I18n.t(message_key))
     end
+
+    # archive message for moderators
+    GroupArchivedMessage.archive!(Group[:moderators].id, related_post.topic)
   end
 
   def staff_already_replied?(topic)

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -88,6 +88,7 @@ describe PostAction do
       topic.reload
       expect(topic.posts.count).to eq(2)
       expect(topic.posts.last.post_type).to eq(Post.types[:moderator_action])
+      expect(topic.message_archived?(mod)).to eq(true)
     end
 
   end


### PR DESCRIPTION
When a user flags a post with the “Something Else” option, a PM between the user and the moderators group is created. If no moderators reply to the PM, when the flag is handled at /review, an auto-reply is created for the PM. However, the PM is not archived, it stays in the inbox.

This commit ensures that the PM is archived for moderator group when no moderator has replied to that PM.
