### PR TITLE
FIX: Send a different message if export fails

### DIFF
--- a/app/jobs/regular/export_user_archive.rb
+++ b/app/jobs/regular/export_user_archive.rb
@@ -112,7 +112,7 @@ module Jobs
           if upload.persisted?
             user_export.update_columns(upload_id: upload.id)
           else
-            Rails.logger.warn("Failed to upload the file #{zip_filename}")
+            Rails.logger.warn("Failed to upload the file #{zip_filename}: #{upload.errors.full_messages}")
           end
         end
 
@@ -485,7 +485,7 @@ module Jobs
       post = nil
 
       if @current_user
-        post = if upload
+        post = if upload.persisted?
           SystemMessage.create_from_system_user(
             @current_user,
             :csv_export_succeeded,

--- a/spec/jobs/export_user_archive_spec.rb
+++ b/spec/jobs/export_user_archive_spec.rb
@@ -92,6 +92,19 @@ describe Jobs::ExportUserArchive do
       expect(files.find { |f| f == 'user_archive.csv' }).to_not be_nil
       expect(files.find { |f| f == 'category_preferences.csv' }).to_not be_nil
     end
+
+    it 'sends a message if it fails' do
+      SiteSetting.max_export_file_size_kb = 1
+
+      expect do
+        Jobs::ExportUserArchive.new.execute(
+          user_id: user.id,
+        )
+      end.to change { Upload.count }.by(0)
+
+      system_message = user.topics_allowed.last
+      expect(system_message.title).to eq(I18n.t("system_messages.csv_export_failed.subject_template"))
+    end
   end
 
   context 'user_archive posts' do


### PR DESCRIPTION
It used to check if an upload record exists, which is wrong because an
invalid upload record exists even if the upload was not created.

The other improvement is a better log message.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
