### PR TITLE
FIX: Add suppress_anonymous_pageviews site setting

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -336,6 +336,3 @@ max_digests_enqueued_per_30_mins_per_site = 10000
 # This cluster name can be passed to the /srv/status route to verify
 # the application cluster is the same one you are expecting
 cluster_name =
-
-# Ignore anonymous page views for private sites
-ignore_anonymous_pageviews = true

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -336,3 +336,6 @@ max_digests_enqueued_per_30_mins_per_site = 10000
 # This cluster name can be passed to the /srv/status route to verify
 # the application cluster is the same one you are expecting
 cluster_name =
+
+# Ignore anonymous page views for private sites
+ignore_anonymous_pageviews = true

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -61,7 +61,7 @@ class Middleware::RequestTracker
       elsif data[:has_auth_cookie]
         ApplicationRequest.increment!(:page_view_logged_in)
         ApplicationRequest.increment!(:page_view_logged_in_mobile) if data[:is_mobile]
-      elsif !(GlobalSetting.try(:ignore_anonymous_pageviews) && SiteSetting.login_required)
+      elsif !SiteSetting.login_required
         ApplicationRequest.increment!(:page_view_anon)
         ApplicationRequest.increment!(:page_view_anon_mobile) if data[:is_mobile]
       end

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -61,7 +61,7 @@ class Middleware::RequestTracker
       elsif data[:has_auth_cookie]
         ApplicationRequest.increment!(:page_view_logged_in)
         ApplicationRequest.increment!(:page_view_logged_in_mobile) if data[:is_mobile]
-      else
+      elsif !(GlobalSetting.try(:ignore_anonymous_pageviews) && SiteSetting.login_required)
         ApplicationRequest.increment!(:page_view_anon)
         ApplicationRequest.increment!(:page_view_anon_mobile) if data[:is_mobile]
       end

--- a/spec/components/middleware/request_tracker_spec.rb
+++ b/spec/components/middleware/request_tracker_spec.rb
@@ -146,70 +146,34 @@ describe Middleware::RequestTracker do
         ), ["200", { "Content-Type" => 'text/html' }], 0.1)
       end
 
-      context "public sites" do
-        it "does not ignore anonymous requests if false" do
-          SiteSetting.login_required = false
-          GlobalSetting.stubs(:ignore_anonymous_pageviews).returns(false)
+      it "does not ignore anonymous requests for public sites" do
+        SiteSetting.login_required = false
 
-          Middleware::RequestTracker.log_request(anon_data)
-          Middleware::RequestTracker.log_request(logged_in_data)
+        Middleware::RequestTracker.log_request(anon_data)
+        Middleware::RequestTracker.log_request(logged_in_data)
 
-          ApplicationRequest.write_cache!
+        ApplicationRequest.write_cache!
 
-          expect(ApplicationRequest.http_total.first.count).to eq(2)
-          expect(ApplicationRequest.http_2xx.first.count).to eq(2)
+        expect(ApplicationRequest.http_total.first.count).to eq(2)
+        expect(ApplicationRequest.http_2xx.first.count).to eq(2)
 
-          expect(ApplicationRequest.page_view_logged_in.first.count).to eq(1)
-          expect(ApplicationRequest.page_view_anon.first.count).to eq(1)
-        end
-
-        it "does not ignore anonymous requests if true" do
-          SiteSetting.login_required = false
-
-          Middleware::RequestTracker.log_request(anon_data)
-          Middleware::RequestTracker.log_request(logged_in_data)
-
-          ApplicationRequest.write_cache!
-
-          expect(ApplicationRequest.http_total.first.count).to eq(2)
-          expect(ApplicationRequest.http_2xx.first.count).to eq(2)
-
-          expect(ApplicationRequest.page_view_logged_in.first.count).to eq(1)
-          expect(ApplicationRequest.page_view_anon.first.count).to eq(1)
-        end
+        expect(ApplicationRequest.page_view_logged_in.first.count).to eq(1)
+        expect(ApplicationRequest.page_view_anon.first.count).to eq(1)
       end
 
-      context "private sites" do
-        it "does not ignore anonymous requests if false" do
-          SiteSetting.login_required = true
-          GlobalSetting.stubs(:ignore_anonymous_pageviews).returns(false)
+      it "ignores anonymous requests for private sites" do
+        SiteSetting.login_required = true
 
-          Middleware::RequestTracker.log_request(anon_data)
-          Middleware::RequestTracker.log_request(logged_in_data)
+        Middleware::RequestTracker.log_request(anon_data)
+        Middleware::RequestTracker.log_request(logged_in_data)
 
-          ApplicationRequest.write_cache!
+        ApplicationRequest.write_cache!
 
-          expect(ApplicationRequest.http_total.first.count).to eq(2)
-          expect(ApplicationRequest.http_2xx.first.count).to eq(2)
+        expect(ApplicationRequest.http_total.first.count).to eq(2)
+        expect(ApplicationRequest.http_2xx.first.count).to eq(2)
 
-          expect(ApplicationRequest.page_view_logged_in.first.count).to eq(1)
-          expect(ApplicationRequest.page_view_anon.first.count).to eq(1)
-        end
-
-        it "ignores anonymous requests if true" do
-          SiteSetting.login_required = true
-
-          Middleware::RequestTracker.log_request(anon_data)
-          Middleware::RequestTracker.log_request(logged_in_data)
-
-          ApplicationRequest.write_cache!
-
-          expect(ApplicationRequest.http_total.first.count).to eq(2)
-          expect(ApplicationRequest.http_2xx.first.count).to eq(2)
-
-          expect(ApplicationRequest.page_view_logged_in.first.count).to eq(1)
-          expect(ApplicationRequest.page_view_anon.first).to eq(nil)
-        end
+        expect(ApplicationRequest.page_view_logged_in.first.count).to eq(1)
+        expect(ApplicationRequest.page_view_anon.first).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
For example, for sites with login_required set to true, counting
anonymous pageviews is confusing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
