### PR TITLE
FIX: Do not add CSS transition effect to animated images

### DIFF
--- a/app/assets/stylesheets/common/base/lightbox.scss
+++ b/app/assets/stylesheets/common/base/lightbox.scss
@@ -18,7 +18,7 @@ $meta-element-margin: 6px;
   border: 1px solid var(--primary-low);
 }
 
-.cooked img.d-lazyload {
+.cooked img.d-lazyload:not(.animated) {
   transition: opacity 0.4s 0.75s ease;
 }
 


### PR DESCRIPTION
Followup to c11d75da8783f3ded3338b13238646b49cfdcc64, the transition delays the pause/play action.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
