### PR TITLE
FIX: Ensure tag topic lists are not scrolled to an incorrect position

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -95,7 +95,7 @@ export default DiscourseRoute.extend(FilterModeMixin, {
     }
 
     return findTopicList(this.store, this.topicTrackingState, filter, params, {
-      cached: true,
+      cached: this.isPoppedState(transition),
     }).then((list) => {
       if (list.topic_list.tags && list.topic_list.tags.length === 1) {
         // Update name of tag (case might be different)


### PR DESCRIPTION
When navigating from a 'discovery' topic list to a 'tags' topic list, the scroll position from the 'discovery' list was being used by the tag list. That meant the user would be taken to a random point in the list, and not scrolled to the top.

Non-tag topic lists were working fine because we only apply the 'cached' logic (and by extension, the saved scroll location) when the user clicks 'back' in the browser. In the code, this is referred to as `isPoppedState`.

This commit takes the `isPoppedState` logic from the regular topic lists, and applies it to the tag topic lists.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
