### PR TITLE
DEV: Add primary group class to user summary page

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -154,6 +154,13 @@ export default Controller.extend(CanCheckEmails, {
     }
   },
 
+  @discourseComputed("model.primary_group_name")
+  primaryGroup(group) {
+    if (group) {
+      return `group-${group}`;
+    }
+  },
+
   userNotificationLevel: computed(
     "currentUser.ignored_ids",
     "model.ignored",

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -1,5 +1,5 @@
 {{plugin-outlet name="above-user-profile" tagName="" args=(hash model=model)}}
-<div class="container {{if viewingSelf "viewing-self"}} {{if model.profile_hidden "profile-hidden"}}">
+<div class="container {{if viewingSelf "viewing-self"}} {{if model.profile_hidden "profile-hidden"}} {{primaryGroup}}">
   {{#d-section class="user-main"}}
     <section class="{{if collapsedInfo "collapsed-info"}} about {{if hasProfileBackgroundUrl "has-background" "no-background"}}" >
       {{#unless collapsedInfo}}


### PR DESCRIPTION
Add one more primary group class to user summary page.

Follow up on e01d5f80b4dfa9b2bc4f074156e2f7e476bdbda7