### PR TITLE
DEV: add group-post-additional-member-info plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/group-post.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-post.hbs
@@ -16,6 +16,7 @@
       <div class="group-member-info names">
         <span class="name">{{name}}</span>
         {{#if post.user.title}}<span class="user-title">{{post.user.title}}</span>{{/if}}
+        {{plugin-outlet name="group-post-additional-member-info" noTags=true args=(hash user=post.user)}}
       </div>
     {{/if}}
   </div>


### PR DESCRIPTION
Add plugin outlet in group-member-info area within group-post