### PR TITLE
Spelling db migrate

### DIFF
--- a/db/migrate/20120806030641_add_new_password_new_salt_email_token_to_users.rb
+++ b/db/migrate/20120806030641_add_new_password_new_salt_email_token_to_users.rb
@@ -4,7 +4,7 @@ class AddNewPasswordNewSaltEmailTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :new_salt, :string, limit: 32
     add_column :users, :new_password_hash, :string, limit: 64
-    # email token is more flexible, can be used for both intial activation AND password change confirmation
+    # email token is more flexible, can be used for both initial activation AND password change confirmation
     add_column :users, :email_token, :string, limit: 32
     remove_column :users, :activation_key
   end

--- a/db/migrate/20120807223020_create_actions.rb
+++ b/db/migrate/20120807223020_create_actions.rb
@@ -7,7 +7,7 @@ class CreateActions < ActiveRecord::Migration[4.2]
       # I elected for multiple ids as opposed to using :as cause it makes the table
       # thinner, and the joining semantics much simpler (a simple multiple left join will do)
       #
-      # There is a notificiation table as well that covers much of this,
+      # There is a notification table as well that covers much of this,
       # but this table is wider and is intended for non-notifying actions as well
 
       t.integer :action_type, null: false

--- a/db/migrate/20130615073305_remove_topic_id_from_uploads.rb
+++ b/db/migrate/20130615073305_remove_topic_id_from_uploads.rb
@@ -6,6 +6,6 @@ class RemoveTopicIdFromUploads < ActiveRecord::Migration[4.2]
   end
 
   def down
-    add_column :uploads, :topic_id, :interger, null: false, default: -1
+    add_column :uploads, :topic_id, :integer, null: false, default: -1
   end
 end

--- a/db/migrate/20151117165756_add_automatically_unpin_topics_to_users.rb
+++ b/db/migrate/20151117165756_add_automatically_unpin_topics_to_users.rb
@@ -2,6 +2,6 @@
 
 class AddAutomaticallyUnpinTopicsToUsers < ActiveRecord::Migration[4.2]
   def change
-    add_column :users, :automatically_unpin_topics, :boolean, nullabe: false, default: true
+    add_column :users, :automatically_unpin_topics, :boolean, nullable: false, default: true
   end
 end

--- a/db/migrate/20151117165756_add_automatically_unpin_topics_to_users.rb
+++ b/db/migrate/20151117165756_add_automatically_unpin_topics_to_users.rb
@@ -2,6 +2,6 @@
 
 class AddAutomaticallyUnpinTopicsToUsers < ActiveRecord::Migration[4.2]
   def change
-    add_column :users, :automatically_unpin_topics, :boolean, nullable: false, default: true
+    add_column :users, :automatically_unpin_topics, :boolean, null: false, default: true
   end
 end

--- a/db/migrate/20160108051129_fix_incorrect_user_history.rb
+++ b/db/migrate/20160108051129_fix_incorrect_user_history.rb
@@ -9,7 +9,7 @@ class FixIncorrectUserHistory < ActiveRecord::Migration[4.2]
     #
     # This migration hunts for date stuff started going wrong and date it started being good and corrects the data
 
-    # this is a :auto_trust_level_change mislabled as :check_email
+    # this is a :auto_trust_level_change mislabeled as :check_email
     # impersonate that was actually delete topic
     condition = <<CLAUSE
 (action = 16 AND previous_value in ('0','1','2','3','4')) OR

--- a/db/migrate/20160112025852_remove_users_from_topic_allowed_users.rb
+++ b/db/migrate/20160112025852_remove_users_from_topic_allowed_users.rb
@@ -3,7 +3,7 @@
 class RemoveUsersFromTopicAllowedUsers < ActiveRecord::Migration[4.2]
 
   # historically we added admins automatically to a message if they
-  # responded, despite them being in the group the message is targetted at
+  # responded, despite them being in the group the message is targeted at
   # this causes inbox bloat for pretty much no reason
   def up
     sql = <<SQL

--- a/db/migrate/20170313192741_add_themes.rb
+++ b/db/migrate/20170313192741_add_themes.rb
@@ -73,6 +73,6 @@ SQL
   end
 
   def down
-    raise IrriversibleMigration
+    raise IrreversibleMigration
   end
 end

--- a/db/migrate/20200429095034_add_topic_thumbnail_information.rb
+++ b/db/migrate/20200429095034_add_topic_thumbnail_information.rb
@@ -41,6 +41,6 @@ class AddTopicThumbnailInformation < ActiveRecord::Migration[6.0]
   end
 
   def down
-    raise IrriversibleMigration
+    raise IrreversibleMigration
   end
 end

--- a/db/migrate/20210201034048_move_category_last_seen_at_to_new_table.rb
+++ b/db/migrate/20210201034048_move_category_last_seen_at_to_new_table.rb
@@ -32,6 +32,6 @@ class MoveCategoryLastSeenAtToNewTable < ActiveRecord::Migration[6.0]
   end
 
   def down
-    raise IrriversibleMigration
+    raise IrreversibleMigration
   end
 end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
This is split from #12779

@gschlager https://github.com/discourse/discourse/pull/12779#pullrequestreview-640718293:

> I like these changes. A lot. But I agree, splitting it into 2 PRs would be best.
We will need to check if the corrections in the DB migrations need a follow-up migration.