### PR TITLE
Fix label for visibility

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
@@ -1,7 +1,7 @@
 {{#if canAdminGroup}}
   <div class="control-group">
     <label class="control-label">{{i18n "admin.groups.manage.interaction.visibility"}}</label>
-    <label for="visiblity">{{i18n "admin.groups.manage.interaction.visibility_levels.title"}}</label>
+    <label for="visibility">{{i18n "admin.groups.manage.interaction.visibility_levels.title"}}</label>
 
     {{combo-box
       name="alias"
@@ -19,7 +19,7 @@
   </div>
 
   <div class="control-group">
-    <label for="visiblity">{{i18n "admin.groups.manage.interaction.members_visibility_levels.title"}}</label>
+    <label for="visibility">{{i18n "admin.groups.manage.interaction.members_visibility_levels.title"}}</label>
 
     {{combo-box name="alias"
       valueProperty="value"


### PR DESCRIPTION
Note: This is a placeholder. As noted in #12779, these the current draft of changes are incorrect

@gschlager https://github.com/discourse/discourse/pull/12779#discussion_r617273469

https://github.com/discourse/discourse/pull/12779#discussion_r617326801:
Wearing a different hat (one that I haven't used in a while)...

https://html.spec.whatwg.org/multipage/forms.html#the-label-element

`<label for=...>` is an id-ref, and there is no obvious sign of an `id=` attribute in the subsequent content:
https://github.com/discourse/discourse/blob/838fa12f14afadd3e01434ba6c2cb54d2afda0e8/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs#L6-L14

Yes, `for="visibility"` while the obvious typo fix is not the correct fix for this, assuming that the goal is to reference the highlighted `combo-box` (which seems likely).

I suspect that a correct fix to this is beyond the scope of this PR (it's huge already). I can drop this correction and split it off into an issue for someone else to fix (possibly me, but, likely not me in the near future -- I'm trying to make a release myself). (Or I can leave this spelling correction in and still split off an issue for someone to investigate all `<label for=...>` tags.)

I could eventually try to run a screen reader and test things, but, I think it's best for me to suggest that discourse do a11y testing w/ one instead.

