### PR TITLE
DEV: add tag-navigation plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -21,6 +21,12 @@
           changeTagNotificationLevel=(action "changeTagNotificationLevel")
           toggleInfo=(action "toggleInfo")
           }}
+
+          {{plugin-outlet
+            name="tag-navigation"
+            args=(hash category=category tag=tag)
+            tagName=""
+          }}
       </section>
     </div>
   </div>


### PR DESCRIPTION
Adds a plugin outlet to the tag template to match the `category-navigation` outlet on category pages (using this for a customer theme component). 