### PR TITLE
FIX: allow moderators to access /admin/customize/watched_words

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-customize-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-index.js
@@ -1,6 +1,10 @@
 import Route from "@ember/routing/route";
 export default Route.extend({
   beforeModel() {
-    this.transitionTo("adminCustomizeThemes");
+    if (this.currentUser.admin) {
+      this.transitionTo("adminCustomizeThemes");
+    } else {
+      this.transitionTo("adminWatchedWords");
+    }
   },
 });

--- a/app/assets/javascripts/admin/addon/templates/admin.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin.hbs
@@ -18,8 +18,8 @@
             {{nav-item route="adminEmail" label="admin.email.title"}}
           {{/if}}
           {{nav-item route="adminLogs" label="admin.logs.title"}}
+          {{nav-item route="adminCustomize" label="admin.customize.title"}}
           {{#if currentUser.admin}}
-            {{nav-item route="adminCustomize" label="admin.customize.title"}}
             {{nav-item route="adminApi" label="admin.api.title"}}
             {{#if siteSettings.enable_backups}}
               {{nav-item route="admin.backups" label="admin.backups.title"}}

--- a/app/assets/javascripts/admin/addon/templates/customize.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize.hbs
@@ -1,13 +1,15 @@
 {{#admin-nav}}
-  {{nav-item route="adminCustomizeThemes" label="admin.customize.theme.title" class="admin-customize-themes"}}
-  {{nav-item route="adminCustomize.colors" label="admin.customize.colors.title" class="admin-customize-colors"}}
-  {{nav-item route="adminSiteText" label="admin.site_text.title" class="admin-customize-site-text"}}
-  {{nav-item route="adminCustomizeEmailTemplates" label="admin.customize.email_templates.title" class="admin-customize-email-templates"}}
-  {{nav-item route="adminCustomizeEmailStyle" label="admin.customize.email_style.title" class="admin-customize-email-styles"}}
-  {{nav-item route="adminUserFields" label="admin.user_fields.title" class="admin-customize-user-fields"}}
-  {{nav-item route="adminEmojis" label="admin.emoji.title" class="admin-customize-emojis"}}
-  {{nav-item route="adminPermalinks" label="admin.permalink.title" class="admin-customize-permalinks"}}
-  {{nav-item route="adminEmbedding" label="admin.embedding.title" class="admin-customize-embedding"}}
+  {{#if currentUser.admin}}
+    {{nav-item route="adminCustomizeThemes" label="admin.customize.theme.title" class="admin-customize-themes"}}
+    {{nav-item route="adminCustomize.colors" label="admin.customize.colors.title" class="admin-customize-colors"}}
+    {{nav-item route="adminSiteText" label="admin.site_text.title" class="admin-customize-site-text"}}
+    {{nav-item route="adminCustomizeEmailTemplates" label="admin.customize.email_templates.title" class="admin-customize-email-templates"}}
+    {{nav-item route="adminCustomizeEmailStyle" label="admin.customize.email_style.title" class="admin-customize-email-styles"}}
+    {{nav-item route="adminUserFields" label="admin.user_fields.title" class="admin-customize-user-fields"}}
+    {{nav-item route="adminEmojis" label="admin.emoji.title" class="admin-customize-emojis"}}
+    {{nav-item route="adminPermalinks" label="admin.permalink.title" class="admin-customize-permalinks"}}
+    {{nav-item route="adminEmbedding" label="admin.embedding.title" class="admin-customize-embedding"}}
+  {{/if}}
   {{nav-item route="adminWatchedWords" label="admin.watched_words.title" class="admin-customize-watched-words"}}
 {{/admin-nav}}
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,8 +189,8 @@ Discourse::Application.routes.draw do
       get "/logs" => "staff_action_logs#index"
 
       # alias
-      get '/logs/watched_words', to: redirect(relative_url_root + 'admin/customize/watched_words'), constraints: AdminConstraint.new
-      get '/logs/watched_words/*path', to: redirect(relative_url_root + 'admin/customize/watched_words/%{path}'), constraints: AdminConstraint.new
+      get '/logs/watched_words', to: redirect(relative_url_root + 'admin/customize/watched_words')
+      get '/logs/watched_words/*path', to: redirect(relative_url_root + 'admin/customize/watched_words/%{path}')
 
       get "customize" => "color_schemes#index", constraints: AdminConstraint.new
       get "customize/themes" => "themes#index", constraints: AdminConstraint.new
@@ -239,7 +239,13 @@ Discourse::Application.routes.draw do
 
         resource :email_style, only: [:show, :update]
         get 'email_style/:field' => 'email_styles#show', constraints: { field: /html|css/ }
+      end
 
+      resources :embeddable_hosts, constraints: AdminConstraint.new
+      resources :color_schemes, constraints: AdminConstraint.new
+      resources :permalinks, constraints: AdminConstraint.new
+
+      scope "/customize" do
         resources :watched_words, only: [:index, :create, :update, :destroy] do
           collection do
             get "action/:id" => "watched_words#index"
@@ -249,11 +255,6 @@ Discourse::Application.routes.draw do
         end
         post "watched_words/upload" => "watched_words#upload"
       end
-
-      resources :embeddable_hosts, constraints: AdminConstraint.new
-      resources :color_schemes, constraints: AdminConstraint.new
-
-      resources :permalinks, constraints: AdminConstraint.new
 
       get "version_check" => "versions#show"
 


### PR DESCRIPTION
Moderators were unable to access `/admin/customize/watched_words` feature. This was regressed in https://github.com/discourse/discourse/commit/61860098d979933348dd95e144d1b9ccec1fcdd8