### PR TITLE
FIX: Make diffHTML handle external changes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -422,6 +422,9 @@ export default Component.extend({
         );
 
         loadScript("/javascripts/diffhtml.min.js").then(() => {
+          // changing the contents of the preview element between two uses of
+          // diff.innerHTML did not apply the diff correctly
+          window.diff.release(this.element.querySelector(".d-editor-preview"));
           window.diff.innerHTML(
             this.element.querySelector(".d-editor-preview"),
             cookedElement.innerHTML,


### PR DESCRIPTION
Changing the contents of the preview element between two uses of
diff.innerHTML did not apply the diff correctly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
