### PR TITLE
FEATURE: Allow using 'top' view for topic list embed

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -56,7 +56,14 @@ class EmbedController < ApplicationController
     end
 
     topic_query = TopicQuery.new(current_user, list_options)
-    @list = topic_query.list_latest
+    top_period = params[:top_period]&.to_sym
+    valid_top_period = TopTopic.periods.include?(top_period)
+
+    @list = if valid_top_period
+      topic_query.list_top_for(top_period)
+    else
+      topic_query.list_latest
+    end
   end
 
   def comments

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -100,6 +100,22 @@ describe EmbedController do
         expect(response.body).to match("data-referer=\"https://example.com/evil-trout\"")
       end
 
+      it "returns a list of topics" do
+        bad_topic = Fabricate(:topic)
+        good_topic = Fabricate(:topic, like_count: 1000, posts_count: 100)
+        TopTopic.refresh!
+
+        get '/embed/topics?discourse_embed_id=de-1234&top_period=yearly', headers: {
+          'REFERER' => 'https://example.com/evil-trout'
+        }
+        expect(response.status).to eq(200)
+        expect(response.headers['X-Frame-Options']).to be_nil
+        expect(response.body).to match("data-embed-id=\"de-1234\"")
+        expect(response.body).to match("data-topic-id=\"#{good_topic.id}\"")
+        expect(response.body).not_to match("data-topic-id=\"#{bad_topic.id}\"")
+        expect(response.body).to match("data-referer=\"https://example.com/evil-trout\"")
+      end
+
       it "returns no referer if not supplied" do
         get '/embed/topics?discourse_embed_id=de-1234'
         expect(response.status).to eq(200)


### PR DESCRIPTION
With this users can add a `top-period` attribute to `d-topic-list` element to get a top list instead of latest.

Example:

```html
<d-topics-list discourse-url="http://localhost:9292/" top-period="yearly"></d-topics-list>
```

Not sure exactly how to add tests as this just piggybacks on the existing infrastructure from the TopicQuery model.