### PR TITLE
UX: consistent topic timer message button order

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/topic-timer-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-timer-info.hbs
@@ -4,15 +4,6 @@
       {{clockIcon}} {{notice}}
     </span>
     <div class="topic-timer-modify">
-      {{#if showTrashCan}}
-        {{d-button
-          ariaLabel="post.controls.remove_timer"
-          title="post.controls.remove_timer"
-          icon="trash-alt"
-          class="btn topic-timer-remove no-text"
-          action=removeTopicTimer
-        }}
-      {{/if}}
       {{#if showEdit}}
         {{d-button
           ariaLabel="post.controls.edit_timer"
@@ -20,6 +11,15 @@
           icon="pencil-alt"
           class="btn topic-timer-edit no-text"
           action=showTopicTimerModal
+        }}
+      {{/if}}
+      {{#if showTrashCan}}
+        {{d-button
+          ariaLabel="post.controls.remove_timer"
+          title="post.controls.remove_timer"
+          icon="trash-alt"
+          class="btn topic-timer-remove no-text"
+          action=removeTopicTimer
         }}
       {{/if}}
     </div>

--- a/app/assets/javascripts/discourse/app/templates/components/topic-timer-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-timer-info.hbs
@@ -5,22 +5,22 @@
     </span>
     <div class="topic-timer-modify">
       {{#if showEdit}}
-        {{d-button
+        {{~d-button
           ariaLabel="post.controls.edit_timer"
           title="post.controls.edit_timer"
           icon="pencil-alt"
           class="btn topic-timer-edit no-text"
           action=showTopicTimerModal
-        }}
+        ~}}
       {{/if}}
       {{#if showTrashCan}}
-        {{d-button
+        {{~d-button
           ariaLabel="post.controls.remove_timer"
           title="post.controls.remove_timer"
           icon="trash-alt"
           class="btn topic-timer-remove no-text"
           action=removeTopicTimer
-        }}
+        ~}}
       {{/if}}
     </div>
   </h3>


### PR DESCRIPTION
Before:
![Screen Shot 2021-04-23 at 6 40 28 PM](https://user-images.githubusercontent.com/1681963/115936592-a9a7dc00-a463-11eb-8aa5-355430d344f6.png)

After:
![Screen Shot 2021-04-23 at 6 44 35 PM](https://user-images.githubusercontent.com/1681963/115936695-f5f31c00-a463-11eb-85ef-a7dbe09d3483.png)
