### PR TITLE
DEV: Add select-kit helper isDisabled

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
+++ b/app/assets/javascripts/discourse/tests/helpers/select-kit-helper.js
@@ -211,6 +211,10 @@ export default function selectKit(selector) {
       return queryAll(selector).hasClass("is-hidden");
     },
 
+    isDisabled() {
+      return queryAll(selector).hasClass("is-disabled");
+    },
+
     header() {
       return headerHelper(queryAll(selector).find(".select-kit-header"));
     },


### PR DESCRIPTION
In a qunit test for a plugin I need to be able to check if a select-kit
element is disabled or not. Adding this helper in core allows me to do that.

