### PR TITLE
UX: Mobile consistency for topic status messages

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -861,6 +861,10 @@ blockquote > *:last-child {
     color: var(--primary-medium);
     min-width: 0; // Allows flex container to shrink
 
+    button {
+      align-self: flex-start;
+    }
+
     .custom-message {
       flex: 1 1 100%;
       text-transform: none;
@@ -883,6 +887,7 @@ blockquote > *:last-child {
 
     > p {
       margin: 0;
+      padding-right: 0.5em;
       line-height: $line-height-medium;
       flex: 1 1;
     }

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -117,6 +117,33 @@
   }
 }
 
+.topic-status-info,
+.topic-timer-info {
+  border-top: 1px solid var(--primary-low);
+  margin: 0;
+  &:empty {
+    padding: 0;
+  }
+  max-width: 758px;
+  .topic-timer-heading,
+  .slow-mode-heading {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    padding: var(--below-topic-margin) 0;
+  }
+  .slow-mode-remove,
+  .topic-timer-modify {
+    display: flex;
+    margin-left: auto;
+    align-self: flex-start;
+  }
+  button {
+    font-size: $font-down-2;
+    background: transparent;
+  }
+}
+
 .title-wrapper {
   display: flex;
   flex-wrap: wrap;

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -121,10 +121,13 @@
 .topic-timer-info {
   border-top: 1px solid var(--primary-low);
   margin: 0;
+  max-width: 758px;
   &:empty {
     padding: 0;
   }
-  max-width: 758px;
+  span .d-icon {
+    font-size: $font-down-1;
+  }
   .topic-timer-heading,
   .slow-mode-heading {
     display: flex;

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -59,31 +59,6 @@
   }
 }
 
-.topic-status-info,
-.topic-timer-info {
-  border-top: 1px solid var(--primary-low);
-  margin: 0;
-  &:empty {
-    padding: 0;
-  }
-  max-width: 758px;
-  .topic-timer-heading,
-  .slow-mode-heading {
-    display: flex;
-    align-items: center;
-    margin: 0;
-    padding: var(--below-topic-margin) 0;
-  }
-  .slow-mode-remove,
-  .topic-timer-modify {
-    margin-left: auto;
-  }
-  button {
-    font-size: $font-down-2;
-    background: transparent;
-  }
-}
-
 #topic-progress-wrapper {
   position: fixed;
   bottom: 0;

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -28,19 +28,6 @@
   }
 }
 
-.topic-timer-info {
-  padding-left: 10px;
-  border-top: 1px solid var(--primary-low);
-  padding-top: 10px;
-  h3 {
-    margin: 0;
-    display: flex;
-    button {
-      align-self: flex-start;
-    }
-  }
-}
-
 #topic-progress-wrapper {
   position: fixed;
   right: 10px; // match 10px padding on .wrap


### PR DESCRIPTION
Before: 
![Screen Shot 2021-04-23 at 7 05 11 PM](https://user-images.githubusercontent.com/1681963/115937846-e75a3400-a466-11eb-9378-9cd5f528769f.png)


After: 
![Screen Shot 2021-04-23 at 7 06 15 PM](https://user-images.githubusercontent.com/1681963/115937875-fd67f480-a466-11eb-9791-5ceb2b2f6a51.png)

(fixed that icon order issue in a different PR)
