### PR TITLE
A11Y: Set an empty `alt` tag on category logos

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
@@ -10,6 +10,7 @@
                 class="logo"
                 width=c.uploaded_logo.width
                 height=c.uploaded_logo.height
+                alt=""
               }}
             {{/if}}
           {{/unless}}

--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
@@ -9,6 +9,7 @@
               class="logo"
               width=c.uploaded_logo.width
               height=c.uploaded_logo.height
+              alt=""
             }}
           {{/if}}
         </div>
@@ -59,7 +60,8 @@
                         src=sc.uploaded_logo.url
                         class="logo"
                         width=sc.uploaded_logo.width
-                        height=sc.uploaded_logo.height}}
+                        height=sc.uploaded_logo.height
+                        alt=""}}
                   </span>
                   {{category-link sc hideParent="true"}}
                 </a>

--- a/app/assets/javascripts/discourse/app/templates/components/category-title-link.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/category-title-link.hbs
@@ -11,6 +11,7 @@
       src=category.uploaded_logo.url
       class="category-logo"
       width=category.uploaded_logo.width
-      height=category.uploaded_logo.height}}
+      height=category.uploaded_logo.height
+      alt=""}}
   {{/if}}
 </a>

--- a/app/assets/javascripts/discourse/app/templates/components/cdn-img.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/cdn-img.hbs
@@ -1,5 +1,5 @@
 {{#if src}}
   <div class="{{class}} aspect-image" style={{style}}>
-    <img src={{cdnSrc}} width={{width}} height={{height}}>
+    <img src={{cdnSrc}} width={{width}} height={{height}} alt={{alt}}>
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -7,6 +7,7 @@
       class="category-logo"
       width=category.uploaded_logo.width
       height=category.uploaded_logo.height
+      alt=""
     }}
 
     {{#if category.description}}


### PR DESCRIPTION
We don't have the ability to set `alt` or `aria-` tags on category logos, and until we do we should consider the logo decorative. Here I'm setting an empty `alt` tag so screen readers ignore them. When an `alt` tag isn't set some screen readers simply read "graphic" to the user, which is useless in this context!

Some discussion here: https://meta.discourse.org/t/a11y-for-categories/187696/3?u=awesomerobot
