### PR TITLE
FIX: Bug when scrolling in iOS Safari with composer open

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -164,7 +164,7 @@ export default Component.extend(KeyEnterEscape, {
     const viewportWindowDiff =
       this.windowInnerHeight - window.visualViewport.height;
 
-    viewportWindowDiff
+    viewportWindowDiff > 0
       ? doc.classList.add("keyboard-visible")
       : doc.classList.remove("keyboard-visible");
 


### PR DESCRIPTION
Regression was introduced in c54609b.

This ensures the full height composer styling only applies when (window height - viewport height > 0). Previously it was being wronglytriggered when that calculation returned a negative number.

