### PR TITLE
Import of mbox: handle charset=windows-1252

### DIFF
--- a/script/import_scripts/mbox/support/indexer.rb
+++ b/script/import_scripts/mbox/support/indexer.rb
@@ -160,9 +160,7 @@ module ImportScripts::Mbox
       last_line_number = 0
 
       each_line(filename) do |line|
-        line = line.scrub
-
-        if line =~ @split_regex
+        if line.scrub =~ @split_regex
           if last_line_number > 0
             yield raw_message, first_line_number, last_line_number
             raw_message = +''


### PR DESCRIPTION
When importing the mbox containing this [message](https://github.com/discourse/discourse/files/6373458/windows.txt), it shows like this: 
> ![fail](https://user-images.githubusercontent.com/1356830/116013871-b0387e00-a632-11eb-84cf-07769d9dcb8d.png)

This issue has been reported [here](https://meta.discourse.org/t/import-mbox-maps-charset-windows-1252-to/168908) by Loic who proposed this patch (but who [doesn't have a GitHub account](https://blog.dachary.org/2018/07/29/why-i-deleted-my-github-account/)).

About this patch, @gschlager [stated](https://meta.discourse.org/t/import-mbox-maps-charset-windows-1252-to/168908/14):
> Looks like a perfect way of fixing the problem.