### PR TITLE
FIX: Replace use of regular expression

### DIFF
--- a/lib/email.rb
+++ b/lib/email.rb
@@ -3,9 +3,6 @@
 require 'mail'
 
 module Email
-  # cute little guy ain't he?
-  MESSAGE_ID_REGEX = /<(.*@.*)+>/
-
   def self.is_valid?(email)
     return false unless String === email
     !!(EmailValidator.email_regex =~ email)
@@ -57,16 +54,18 @@ module Email
 
   # https://tools.ietf.org/html/rfc850#section-2.1.7
   def self.message_id_rfc_format(message_id)
-    return message_id if message_id =~ MESSAGE_ID_REGEX
-    "<#{message_id}>"
+    message_id.present? && !is_message_id_rfc?(message_id) ? "<#{message_id}>" : message_id
   end
 
   def self.message_id_clean(message_id)
-    return message_id if !(message_id =~ MESSAGE_ID_REGEX)
-    message_id.tr("<>", "")
+    message_id.present? && is_message_id_rfc?(message_id) ? message_id.gsub(/^<|>$/, "") : message_id
   end
 
   private
+
+  def self.is_message_id_rfc?(message_id)
+    message_id.start_with?('<') && message_id.include?('@') && message_id.end_with?('>')
+  end
 
   def self.obfuscate_part(part)
     if part.size < 3

--- a/spec/components/email/email_spec.rb
+++ b/spec/components/email/email_spec.rb
@@ -65,4 +65,29 @@ describe Email do
 
   end
 
+  describe "message_id_rfc_format" do
+
+    it "returns message ID in RFC format" do
+      expect(Email.message_id_rfc_format("test@test")).to eq("<test@test>")
+    end
+
+    it "returns input if already in RFC format" do
+      expect(Email.message_id_rfc_format("<test@test>")).to eq("<test@test>")
+    end
+
+  end
+
+  describe "message_id_clean" do
+
+    it "returns message ID if in RFC format" do
+      expect(Email.message_id_clean("<test@test>")).to eq("test@test")
+    end
+
+    it "returns input if a clean message ID is not in RFC format" do
+      message_id = "<" + "@" * 50
+      expect(Email.message_id_clean(message_id)).to eq(message_id)
+    end
+
+  end
+
 end


### PR DESCRIPTION
It used a regular expression to check if message IDs were in RFC format.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
