### PR TITLE
FEATURE: Navigate to an approved queued topic from the review queue.

### DIFF
--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -83,8 +83,10 @@ class ReviewableQueuedPost < Reviewable
       return create_result(:failure) { |r| r.errors = creator.errors }
     end
 
-    payload['created_post_id'] = created_post.id
-    payload['created_topic_id'] = created_post.topic_id unless topic_id
+    self.target = created_post
+    if topic_id.nil?
+      self.topic_id = created_post.topic_id
+    end
     save
 
     UserSilencer.unsilence(created_by, performed_by) if created_by.silenced?

--- a/db/migrate/20210426193009_move_approved_queued_posts_topic_and_post_data.rb
+++ b/db/migrate/20210426193009_move_approved_queued_posts_topic_and_post_data.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class MoveApprovedQueuedPostsTopicAndPostData < ActiveRecord::Migration[6.1]
+  def up
+    DB.query_single <<~SQL
+      UPDATE reviewables r
+      SET topic_id = (payload->>'created_topic_id')::int, target_id = (payload->>'created_post_id')::int, target_type = 'Post'
+      WHERE r.type = 'ReviewableQueuedPost' AND r.status = 1
+      AND (r.payload->>'created_topic_id') IS NOT NULL
+      AND (r.payload->>'created_post_id') IS NOT NULL
+      AND topic_id IS NULL
+      AND target_id IS NULL
+    SQL
+  end
+
+  def down
+  end
+end

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ReviewableQueuedPost, type: :model do
           expect(result.created_post.custom_fields['hello']).to eq('world')
           expect(result.created_post_topic).to eq(topic)
           expect(result.created_post.user).to eq(reviewable.created_by)
-          expect(reviewable.payload['created_post_id']).to eq(result.created_post.id)
+          expect(reviewable.target_id).to eq(result.created_post.id)
 
           expect(Topic.count).to eq(topic_count)
           expect(Post.count).to eq(post_count + 1)
@@ -183,8 +183,8 @@ RSpec.describe ReviewableQueuedPost, type: :model do
       expect(result.created_post).to be_valid
       expect(result.created_post_topic).to be_present
       expect(result.created_post_topic).to be_valid
-      expect(reviewable.payload['created_post_id']).to eq(result.created_post.id)
-      expect(reviewable.payload['created_topic_id']).to eq(result.created_post_topic.id)
+      expect(reviewable.target_id).to eq(result.created_post.id)
+      expect(reviewable.topic_id).to eq(result.created_post_topic.id)
 
       expect(Topic.count).to eq(topic_count + 1)
       expect(Post.count).to eq(post_count + 1)


### PR DESCRIPTION
Staff can visit an approved queued topic from the review queue by clicking their title. We no longer store the created post and topic ids in the reviewable's payload object. Instead, we set the `topic_id` and `target_id` attributes.

