### PR TITLE
UX: fix positioning of back button on progress bar

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -84,7 +84,7 @@
   margin-bottom: 0px;
   position: absolute;
   right: 0;
-  top: -2em;
+  top: -120%; // above parent container + some extra space
   .btn {
     margin: 0;
   }

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -28,6 +28,10 @@
   }
 }
 
+.progress-back-container {
+  top: -100%; // above parent container + some extra space
+}
+
 #topic-progress-wrapper {
   position: fixed;
   right: 10px; // match 10px padding on .wrap


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/1681963/116173015-c9e0d080-a6d9-11eb-9e6f-6413ad5c58fe.png)

After:
![Screen Shot 2021-04-24 at 12 12 43 AM](https://user-images.githubusercontent.com/1681963/116172987-bfbed200-a6d9-11eb-833d-f249585dbdbb.png)
