### PR TITLE
FIX: Link notification to first unread post

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -178,13 +178,8 @@ class PostAlerter
                SELECT last_read_post_number FROM topic_users tu
                WHERE tu.user_id = ? AND tu.topic_id = ? ),0)',
                 user.id, topic.id)
-      .where('reply_to_user_id = ? OR exists(
-            SELECT 1 from topic_users tu
-            WHERE tu.user_id = ? AND
-              tu.topic_id = ? AND
-              notification_level = ?
-            )', user.id, user.id, topic.id, TopicUser.notification_levels[:watching])
       .where(topic_id: topic.id)
+      .where.not(user_id: user.id)
   end
 
   def first_unread_post(user, topic)


### PR DESCRIPTION
If a topic and a few posts were posted in a watched category, the
created notification would always point to the last post, instead of
pointing to the first (unread) one.

The root cause is that the query that fetched the first unread post
uses 'TopicUser' records and those are not created by default for
user watching the category.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
