### PR TITLE
PERF: Improve theme stylesheet compilation performance

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -601,11 +601,12 @@ class Theme < ActiveRecord::Base
     find_disable_action_log&.created_at
   end
 
-  def scss_load_paths
-    return if self.extra_scss_fields.empty?
+  def with_scss_load_paths
+    return yield([]) if self.extra_scss_fields.empty?
 
-    @exporter ||= ThemeStore::ZipExporter.new(self)
-    ["#{@exporter.export_dir}/scss", "#{@exporter.export_dir}/stylesheets"]
+    ThemeStore::ZipExporter.new(self).with_export_dir(extra_scss_only: true) do |dir|
+      yield ["#{dir}/stylesheets"]
+    end
   end
 
   def scss_variables

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -375,11 +375,13 @@ class ThemeField < ActiveRecord::Base
   def compile_scss(prepended_scss = nil)
     prepended_scss ||= Stylesheet::Importer.new({}).prepended_scss
 
-    Stylesheet::Compiler.compile("#{prepended_scss} #{self.theme.scss_variables.to_s} #{self.value}",
-      "#{Theme.targets[self.target_id]}.scss",
-      theme: self.theme,
-      load_paths: self.theme.scss_load_paths
-    )
+    self.theme.with_scss_load_paths do |load_paths|
+      Stylesheet::Compiler.compile("#{prepended_scss} #{self.theme.scss_variables.to_s} #{self.value}",
+        "#{Theme.targets[self.target_id]}.scss",
+        theme: self.theme,
+        load_paths: load_paths
+      )
+    end
   end
 
   def compiled_css(prepended_scss)

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -246,7 +246,7 @@ class Stylesheet::Manager
     end
 
     rtl = @target.to_s =~ /_rtl$/
-    css, source_map = begin
+    css, source_map = with_load_paths do |load_paths|
       Stylesheet::Compiler.compile_asset(
         @target,
          rtl: rtl,
@@ -254,7 +254,7 @@ class Stylesheet::Manager
          theme_variables: theme&.scss_variables.to_s,
          source_map_file: source_map_filename,
          color_scheme_id: @color_scheme&.id,
-         load_paths: theme&.scss_load_paths
+         load_paths: load_paths
       )
     rescue SassC::SyntaxError => e
       if Stylesheet::Importer::THEME_TARGETS.include?(@target.to_s)
@@ -371,6 +371,14 @@ class Stylesheet::Manager
   def theme
     @theme ||= Theme.find_by(id: @theme_id) || :nil
     @theme == :nil ? nil : @theme
+  end
+
+  def with_load_paths
+    if theme
+      theme.with_scss_load_paths { |p| yield p }
+    else
+      yield nil
+    end
   end
 
   def theme_digest


### PR DESCRIPTION
When building the `scss_load_paths`, we were creating a full export of the theme (including uploads), and not cleaning it up. With many uploads, this can be extremely slow (because it downloads every upload from S3), and the lack of cleanup could cause a disk to fill up over time.

This commit updates the ZipExporter to provide a `with_export_dir` API, which takes care of cleanup. It also adds a kwarg which allows exporting only extra_scss fields. This should make things much faster for themes with many uploads.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
