### PR TITLE
FIX: Do not cut off long polls

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -161,9 +161,6 @@ div.poll {
 div.poll.pie {
   .poll-container {
     display: inline-block;
-    height: 340px;
-    max-height: 340px;
-    overflow-y: auto;
   }
   .poll-info {
     display: inline-block;


### PR DESCRIPTION
Some polls with images can be very long. Those which showed a pie chart
for the results had a fixed height set, which meant that some images
could be cut off.

Example of cut off poll:

![image](https://user-images.githubusercontent.com/23153890/116262691-6a3e0000-a781-11eb-8887-0418061e79fe.png)
