### PR TITLE
FIX: ensures successive topic hydrates doesn't override category

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -614,6 +614,12 @@ Topic.reopenClass({
     MUTED: 0,
   },
 
+  munge(json) {
+    // ensure we are not overriding category computed property
+    delete json.category;
+    return json;
+  },
+
   createActionSummary(result) {
     if (result.actions_summary) {
       const lookup = EmberObject.create();


### PR DESCRIPTION
This bug has first been seen when loading similar topics, minimum repro:

- Have a topic named "Something Foo Bar" with a category.

- Call this in console:
```
Discourse.currentUser.store.find("similar-topic", { title: "Something foo bar", raw: "" })
```

- Navigate to latest (no full refresh)

- The category from the topic should have disappeared

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
