### PR TITLE
FIX: avatar flair wasn't displaying on the user summary page

### DIFF
--- a/app/serializers/user_summary_serializer.rb
+++ b/app/serializers/user_summary_serializer.rb
@@ -43,7 +43,7 @@ class UserSummarySerializer < ApplicationSerializer
     end
 
     def primary_group_flair_url
-      object.primary_group&.flair_icon
+      object.primary_group&.flair_url
     end
 
     def primary_group_flair_bg_color


### PR DESCRIPTION
It's an additional fix for [FEATURE: include avatar flair on the avatars listed in a user summary’s “Most…” sections](https://github.com/discourse/discourse/pull/12858).

Avatar flair on the user summary page was displaying when it was an icon and wasn't displaying when it was an image. On `g/team/manage/membership`:

<img width="348" alt="Screenshot 2021-04-28 at 12 58 45" src="https://user-images.githubusercontent.com/1274517/116376645-82fdf280-a821-11eb-9123-46e6fdbec1a7.png">

