### PR TITLE
FIX: Link notification to first unread post

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -178,12 +178,24 @@ class PostAlerter
                SELECT last_read_post_number FROM topic_users tu
                WHERE tu.user_id = ? AND tu.topic_id = ? ),0)',
                 user.id, topic.id)
-      .where('reply_to_user_id = ? OR exists(
-            SELECT 1 from topic_users tu
-            WHERE tu.user_id = ? AND
-              tu.topic_id = ? AND
-              notification_level = ?
-            )', user.id, user.id, topic.id, TopicUser.notification_levels[:watching])
+      .where('reply_to_user_id = ?
+        OR exists(SELECT 1 from topic_users tu
+                  WHERE tu.user_id = ? AND
+                    tu.topic_id = ? AND
+                    notification_level = ?)
+        OR exists(SELECT 1 from category_users cu
+                  WHERE cu.user_id = ? AND
+                    cu.category_id = ? AND
+                    notification_level = ?)
+        OR exists(SELECT 1 from tag_users tu
+                  WHERE tu.user_id = ? AND
+                    tu.tag_id IN (SELECT tag_id FROM topic_tags WHERE topic_id = ?) AND
+                    notification_level = ?)',
+        user.id,
+        user.id, topic.id, TopicUser.notification_levels[:watching],
+        user.id, topic.category_id, CategoryUser.notification_levels[:watching],
+        user.id, topic.id, TagUser.notification_levels[:watching]
+      )
       .where(topic_id: topic.id)
   end
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -178,23 +178,25 @@ class PostAlerter
                SELECT last_read_post_number FROM topic_users tu
                WHERE tu.user_id = ? AND tu.topic_id = ? ),0)',
                 user.id, topic.id)
-      .where('reply_to_user_id = ?
+      .where('reply_to_user_id = :user_id
         OR exists(SELECT 1 from topic_users tu
-                  WHERE tu.user_id = ? AND
-                    tu.topic_id = ? AND
-                    notification_level = ?)
+                  WHERE tu.user_id = :user_id AND
+                    tu.topic_id = :topic_id AND
+                    notification_level = :topic_level)
         OR exists(SELECT 1 from category_users cu
-                  WHERE cu.user_id = ? AND
-                    cu.category_id = ? AND
-                    notification_level = ?)
+                  WHERE cu.user_id = :user_id AND
+                    cu.category_id = :category_id AND
+                    notification_level = :category_level)
         OR exists(SELECT 1 from tag_users tu
-                  WHERE tu.user_id = ? AND
-                    tu.tag_id IN (SELECT tag_id FROM topic_tags WHERE topic_id = ?) AND
-                    notification_level = ?)',
-        user.id,
-        user.id, topic.id, TopicUser.notification_levels[:watching],
-        user.id, topic.category_id, CategoryUser.notification_levels[:watching],
-        user.id, topic.id, TagUser.notification_levels[:watching]
+                  WHERE tu.user_id = :user_id AND
+                    tu.tag_id IN (SELECT tag_id FROM topic_tags WHERE topic_id = :topic_id) AND
+                    notification_level = :tag_level)',
+        user_id: user.id,
+        topic_id: topic.id,
+        category_id: topic.category_id,
+        topic_level: TopicUser.notification_levels[:watching],
+        category_level: CategoryUser.notification_levels[:watching],
+        tag_level: TagUser.notification_levels[:watching]
       )
       .where(topic_id: topic.id)
   end


### PR DESCRIPTION
If a topic with a few posts was posted in a watched category, the
created notification would always point to the last post, instead of
pointing to the first one.

The root cause is that the query that fetched the first unread post
uses 'TopicUser' records and those are not created by default for
user watching the category. In this case, it should use the
'CategoryUser' record.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
