### PR TITLE
DEV: Return a non-zero exit code when `discourse remap` is aborted

### DIFF
--- a/script/discourse
+++ b/script/discourse
@@ -43,7 +43,7 @@ class DiscourseCLI < Thor
     text = STDIN.gets
     if text.strip != "YES"
       puts "aborting."
-      exit
+      exit 1
     end
 
     if options[:global]


### PR DESCRIPTION
This makes it much easier to integrate the script with external tools

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
