### PR TITLE
DEV: raises a GrantError instead of a log and a variable exception

### DIFF
--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class BadgeGranter
+  class GrantError < StandardError; end
 
   def self.disable_queue
     @queue_disabled = true
@@ -390,8 +391,7 @@ class BadgeGranter
 
     badge.reset_grant_count!
   rescue => e
-    Rails.logger.error("Failed to backfill '#{badge.name}' badge: #{opts}")
-    raise e
+    raise GrantError, "Failed to backfill '#{badge.name}' badge: #{opts}. Reason: #{e.message}"
   end
 
   def self.revoke_ungranted_titles!


### PR DESCRIPTION
The message in logs will now look like:

```
BadgeGranter::GrantError: Failed to backfill 'Some Badge' badge: {:post_ids=>[]}. Reason: ERROR:  column "email" does not exist
LINE 6: ...t id as user_id, current_timestamp as granted_at, email from...
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
