### PR TITLE
PERF: Make stylesheet max_file_mtime calculation more efficient

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -208,7 +208,7 @@ class Stylesheet::Manager
 
     Discourse.plugins.map { |plugin| File.dirname(plugin.path) }.each do |path|
       globs << "#{path}/plugin.rb"
-      globs << "#{path}/**/*.*css"
+      globs << "#{path}/assets/stylesheets/**/*.*css"
     end
 
     globs.map do |pattern|


### PR DESCRIPTION
Plugins always store their stylesheets under `/assets/stylesheets`, so we can make the glob pattern much more specific. In my local development environment, this increases the speed of `Stylesheet::Manager.max_file_mtime` from ~65ms to ~3ms (20x faster). This significantly improves stylesheet regeneration time, and the responsiveness of the theme admin UI.

Note that this will have negligible effect in production, because in production the value of `max_file_mtime` is aggressively cached.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
