### PR TITLE
UX: Fix styling for long label in multi-select choices

### DIFF
--- a/app/assets/stylesheets/common/select-kit/multi-select.scss
+++ b/app/assets/stylesheets/common/select-kit/multi-select.scss
@@ -145,6 +145,11 @@
         align-items: center;
         display: flex;
         justify-content: space-between;
+        max-width: calc(100% - 5px);
+
+        .name {
+          @include ellipsis;
+        }
 
         .d-icon {
           color: var(--primary-low-mid);


### PR DESCRIPTION
Before: 

<img width="730" alt="image" src="https://user-images.githubusercontent.com/368961/116447060-93b06780-a825-11eb-83b7-8068a18b5520.png">

After: 

<img width="719" alt="image" src="https://user-images.githubusercontent.com/368961/116447001-872c0f00-a825-11eb-9170-90852d39c52f.png">
