### PR TITLE
FIX: add theme field errors

### DIFF
--- a/app/serializers/theme_serializer.rb
+++ b/app/serializers/theme_serializer.rb
@@ -79,6 +79,10 @@ class ThemeSerializer < BasicThemeSerializer
   def initialize(theme, options = {})
     super
     @errors = []
+
+    object.theme_fields.each do |o|
+      @errors << o.error if o.error
+    end
   end
 
   def child_themes

--- a/spec/fabricators/theme_field_fabricator.rb
+++ b/spec/fabricators/theme_field_fabricator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Fabricator(:theme_field) do
+  theme
+  target_id { 0 }
+  name { sequence(:name) { |i| "scss_#{i + 1}" } }
+  value { ".test {color: blue;}" }
+  error { nil }
+end

--- a/spec/serializers/theme_serializer_spec.rb
+++ b/spec/serializers/theme_serializer_spec.rb
@@ -4,13 +4,23 @@ require 'rails_helper'
 
 RSpec.describe ThemeSerializer do
   describe "load theme settings" do
-    it 'should add error message when having invalid format' do
+    it 'should add error message when settings format is invalid' do
       theme = Fabricate(:theme)
       Theme.any_instance.stubs(:settings).raises(ThemeSettingsParser::InvalidYaml, I18n.t("themes.settings_errors.invalid_yaml"))
       serialized = ThemeSerializer.new(theme).as_json[:theme]
       expect(serialized[:settings]).to be_nil
       expect(serialized[:errors].count).to eq(1)
       expect(serialized[:errors][0]).to eq(I18n.t("themes.settings_errors.invalid_yaml"))
+    end
+
+    it 'should add errors messages from theme fields' do
+      error = "error when compiling theme field"
+      theme = Fabricate(:theme)
+      theme_field = Fabricate(:theme_field, error: error, theme: theme)
+      serialized = ThemeSerializer.new(theme.reload).as_json[:theme]
+      puts serialized
+      expect(serialized[:errors].count).to eq(1)
+      expect(serialized[:errors][0]).to eq(error)
     end
   end
 end

--- a/spec/serializers/theme_serializer_spec.rb
+++ b/spec/serializers/theme_serializer_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe ThemeSerializer do
       theme = Fabricate(:theme)
       theme_field = Fabricate(:theme_field, error: error, theme: theme)
       serialized = ThemeSerializer.new(theme.reload).as_json[:theme]
-      puts serialized
       expect(serialized[:errors].count).to eq(1)
       expect(serialized[:errors][0]).to eq(error)
     end


### PR DESCRIPTION
Expose theme field errors on theme pages
Previously these errors were not being displayed on themes.