### PR TITLE
FIX: Truncate badge timestamps derived from non-public data

### DIFF
--- a/lib/badge_queries.rb
+++ b/lib/badge_queries.rb
@@ -55,7 +55,7 @@ module BadgeQueries
   SQL
 
   FirstShare = <<~SQL
-    SELECT views.user_id, i2.post_id, i2.created_at granted_at
+    SELECT views.user_id, i2.post_id, date_trunc('hour', i2.created_at) granted_at
     FROM
     (
       SELECT i.user_id, MIN(i.id) i_id
@@ -68,7 +68,7 @@ module BadgeQueries
   SQL
 
   FirstFlag = <<~SQL
-    SELECT pa1.user_id, pa1.created_at granted_at, pa1.post_id
+    SELECT pa1.user_id, date_trunc('month', pa1.created_at) granted_at, pa1.post_id
     FROM (
       SELECT pa.user_id, min(pa.id) id
       FROM post_actions pa


### PR DESCRIPTION
Link shares are truncated to the top of the hour, and flagging is truncated to the beginning of the month.

https://meta.discourse.org/t/first-flag-badge-has-precise-public-timestamps-that-could-be-correlated-with-flagged-posts/187710

Test failures in `UsersController#perform_account_activation` and `User.enqueue_welcome_message` happen on master

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
