### PR TITLE
DEV: Cleanup after remote update check

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -125,6 +125,11 @@ class RemoteTheme < ActiveRecord::Base
       self.last_error_text = nil
     ensure
       self.save!
+      begin
+        importer.cleanup!
+      rescue => e
+        Rails.logger.warn("Failed cleanup remote git #{e}")
+      end
     end
   end
 


### PR DESCRIPTION
Checking for remote should cleanup after itself. Currently each check litters
the /tmp filesystem with checkouts. This patch ensures that update checks
keep the system a bit tidier.