### PR TITLE
FIX: prevents exception when overriding models attribute

### DIFF
--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -71,6 +71,22 @@ describe TranslationOverride do
         end
       end
 
+      describe 'model attribute override' do
+        before do
+          SiteSetting.allow_uncategorized_topics = false
+        end
+
+        it 'applies the override' do
+          translation_override = TranslationOverride.upsert!(I18n.locale, 'activerecord.attributes.topic.category_id', 'foo')
+          topic = Fabricate.build(:topic)
+          topic.category = nil
+
+          expect(topic).not_to be_valid
+          error = I18n.t('errors.format', { attribute: 'foo', message: I18n.t('errors.messages.blank') })
+          expect(topic.errors.full_messages.first).to eq(error)
+        end
+      end
+
       describe 'pluralized keys' do
         describe 'valid keys' do
           it 'converts zero to other' do


### PR DESCRIPTION
eg: overriding `activerecord.attributes.topic.category_id` would currently lead to an exception when the key is used.

Our code currently thinks that the last part of the key is dedicated to pluralization.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
