### PR TITLE
FIX: Hide Uncategorized unless allow_uncategorized_topics

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -144,7 +144,7 @@ class CategoryList
 
   def prune_empty
     return if SiteSetting.allow_uncategorized_topics
-    @categories.delete_if { |c| c.uncategorized? && c.displayable_topics.blank? }
+    @categories.delete_if { |c| c.uncategorized? }
   end
 
   # Attach some data for serialization to each topic

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -67,6 +67,19 @@ describe CategoriesController do
         SiteSetting.get(:uncategorized_category_id), category.id
       )
     end
+
+    it 'does not show uncategorized unless allow_uncategorized_topics' do
+      SiteSetting.desktop_category_page_style = "categories_boxes_with_topics"
+
+      uncategorized = Category.find(SiteSetting.uncategorized_category_id)
+      Fabricate(:topic, category: uncategorized)
+      CategoryFeaturedTopic.feature_topics
+
+      SiteSetting.allow_uncategorized_topics = false
+
+      get "/categories.json"
+      expect(response.parsed_body["category_list"]["categories"].map { |x| x['id'] }).not_to include(uncategorized.id)
+    end
   end
 
   context 'extensibility event' do
@@ -521,6 +534,17 @@ describe CategoriesController do
       json = response.parsed_body
       expect(json['category_list']['categories'].size).to eq(4)
       expect(json['topic_list']['topics'].size).to eq(6)
+    end
+
+    it 'does not show uncategorized unless allow_uncategorized_topics' do
+      uncategorized = Category.find(SiteSetting.uncategorized_category_id)
+      Fabricate(:topic, category: uncategorized)
+      CategoryFeaturedTopic.feature_topics
+
+      SiteSetting.allow_uncategorized_topics = false
+
+      get "/categories_and_latest.json"
+      expect(response.parsed_body["category_list"]["categories"].map { |x| x['id'] }).not_to include(uncategorized.id)
     end
   end
 end


### PR DESCRIPTION
Uncategorized was sometimes visible even if allow_uncategorized_topics
was false. This was especially happening on mobile, if at least one
topic was uncategorized.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
