### PR TITLE
FIX: Keep filter bar after replying or editing

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -831,7 +831,10 @@ export default Controller.extend({
         const post = result.target;
 
         if (post && !staged && options.jump !== false) {
-          DiscourseURL.routeTo(post.url, { skipIfOnScreen: true });
+          DiscourseURL.routeTo(post.url, {
+            keepFilter: true,
+            skipIfOnScreen: true,
+          });
         }
       })
       .catch((error) => {


### PR DESCRIPTION
Bug report: https://meta.discourse.org/t/editing-a-post-in-filtered-topic-hides-the-show-all-button/185004 

In a filtered post stream (summary, user post or using the `filtered replies` setting), this ensures that the sticky bottom bar with the "Show All" button stays visible after replying or editing a post.