### PR TITLE
DEV: Use filesystem-based SchemaCache in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ config/discourse.conf
 /db/*.sqlite3
 /db/structure.sql
 /db/schema.rb
+/db/schema_cache.yml
 
 # Ignore all logfiles and tempfiles.
 /log/*.log

--- a/config/application.rb
+++ b/config/application.rb
@@ -235,6 +235,9 @@ module Discourse
     # see: http://stackoverflow.com/questions/11894180/how-does-one-correctly-add-custom-sql-dml-in-migrations/11894420#11894420
     config.active_record.schema_format = :sql
 
+    # We use this in development-mode only (see development.rb)
+    config.active_record.use_schema_cache_dump = false
+
     # per https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet
     config.pbkdf2_iterations = 64000
     config.pbkdf2_algorithm = "sha256"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,9 @@ Discourse::Application.configure do
   # Log error messages when you accidentally call methods on nil.
   config.eager_load = false
 
+  # Use the schema_cache.yml file generated during db:migrate (via db:schema:cache:dump)
+  config.active_record.use_schema_cache_dump = true
+
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -221,6 +221,10 @@ task 'db:migrate' => ['load_config', 'environment', 'set_locale'] do |_, args|
   SeedFu.quiet = true
   SeedFu.seed(SeedHelper.paths, SeedHelper.filter)
 
+  if Rails.env.development?
+    Rake::Task['db:schema:cache:dump'].invoke
+  end
+
   if !Discourse.skip_post_deployment_migrations? && ENV['SKIP_OPTIMIZE_ICONS'] != '1'
     SiteIconManager.ensure_optimized!
   end


### PR DESCRIPTION
In development we regularly restart/reload Rails, which wipes out the schema cache. This then has to be regenerated using DDL queries on the database.

Instead, we can make use of the `rake db:schema:cache:dump` command. This will dump the schema cache to a YAML file, and then load it when needed. This is significantly faster than rebuilding the cache from DDL queries every time.

See also #12900 

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
