### PR TITLE
FIX: Update max-width of staff log cells

### DIFF
--- a/app/assets/stylesheets/common/admin/staff_logs.scss
+++ b/app/assets/stylesheets/common/admin/staff_logs.scss
@@ -132,7 +132,7 @@
   }
   td.subject,
   td.details {
-    max-width: 20vw;
+    max-width: 10vw;
     > div {
       max-height: 100px;
       overflow-y: auto;


### PR DESCRIPTION
This commit adjusts the max-width of cells in the staff logs to make up for the new word wrap rules in place.

### Before
![image](https://user-images.githubusercontent.com/30537603/116613708-a3e84580-a8fe-11eb-8f55-7c3c5789a3f9.png)

### After

![image](https://user-images.githubusercontent.com/30537603/116613874-d2662080-a8fe-11eb-88d4-861c4571de27.png)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
