### PR TITLE
DEV: Add an option to skip a theme update from the themes:install task.

### DIFF
--- a/app/services/themes_install_task.rb
+++ b/app/services/themes_install_task.rb
@@ -2,14 +2,17 @@
 
 class ThemesInstallTask
   def self.install(themes)
-    counts = { installed: 0, updated: 0, errors: 0 }
+    counts = { installed: 0, updated: 0, errors: 0, skipped: 0 }
     log = []
     themes.each do |name, val|
       installer = new(val)
       next if installer.url.nil?
 
       if installer.theme_exists?
-        if installer.update
+        if installer.options.fetch(:skip_update, nil)
+          log << "#{name}: is already installed. Skipping update."
+          counts[:skipped] += 1
+        elsif installer.update
           log << "#{name}: is already installed. Updating from remote."
           counts[:updated] += 1
         else

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -45,6 +45,7 @@ task "themes:install" => :environment do |task, args|
   puts " Installed: #{counts[:installed]}"
   puts " Updated:   #{counts[:updated]}"
   puts " Errors:    #{counts[:errors]}"
+  puts " Skipped:   #{counts[:skipped]}"
 
   if counts[:errors] > 0
     exit 1


### PR DESCRIPTION
With this, a theme can now specify `skip_update: true` in the yml config for
update allowing for the theme to be installed only if it does not already
exist.