### PR TITLE
FIX: excludes .svg-as-img from JS sizing

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/ensure-max-image-dimensions.js
+++ b/app/assets/javascripts/discourse/app/initializers/ensure-max-image-dimensions.js
@@ -27,7 +27,7 @@ export default {
 
     const styleTag = document.createElement("style");
     styleTag.id = "image-sizing-hack";
-    styleTag.innerHTML = `#reply-control .d-editor-preview img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji), .cooked img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji) {${styles}}`;
+    styleTag.innerHTML = `#reply-control .d-editor-preview img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji), .cooked img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji):not(.svg-as-img) {${styles}}`;
     document.head.appendChild(styleTag);
   },
 };


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
