### PR TITLE
DEV: Don't force Ember CLI on proxied requests made by Ember CLI

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,7 +95,7 @@ class ApplicationController < ActionController::Base
   end
 
   def ember_cli_required?
-    ENV['NO_EMBER_CLI'] != '1' && Rails.env.development?
+    Rails.env.development? && ENV['NO_EMBER_CLI'] != '1' && request.headers['X-Discourse-Ember-CLI'] != 'true'
   end
 
   def application_layout


### PR DESCRIPTION
Ember CLI server makes requests to the Rails/Unicorn server, so we should exclude these requests from getting the "Ember CLI is required in dev mode" message.