### PR TITLE
FIX: prevents malformed href to crash TopicEmbed

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -165,7 +165,7 @@ class TopicEmbed < ActiveRecord::Base
             uri.host = original_uri.host
             node[url_param] = uri.to_s
           end
-        rescue URI::Error
+        rescue URI::Error, Addressable::URI::InvalidURIError
           # If there is a mistyped URL, just do nothing
         end
       end

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -343,6 +343,22 @@ describe TopicEmbed do
         expect(response.body).to have_tag('a', with: { href: 'mailto:bar@example.com' })
       end
     end
+
+    context "malformed href" do
+      let(:url) { 'http://example.com/foo' }
+      let(:contents) { '<p><a href="(http://foo.bar)">Baz</a></p>' }
+      let!(:file) { StringIO.new }
+
+      before do
+        file.stubs(:read).returns contents
+        TopicEmbed.stubs(:open).returns file
+      end
+
+      it "doesn’t raise an exception" do
+        stub_request(:head, url)
+        expect { TopicEmbed.find_remote(url) }.not_to raise_error
+      end
+    end
   end
 
   describe '.absolutize_urls' do


### PR DESCRIPTION
If the associated page of a remote url passed to `TopicEmber.new(remote_url)` contained a malformed link like: `<a href="(http://foo.bar)">Baz</a>` it would raise an uncaught exception:

```
Job exception: Invalid scheme format: (http
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
