### PR TITLE
DEV: Add performance warning message when running `rails s`

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -9,6 +9,18 @@ if !ENV["RAILS_ENV"] && (ARGV[0] == "s" || ARGV[0] == "server")
   end
 
   ENV["RAILS_LOGS_STDOUT"] ||= "1"
+
+  STDERR.puts <<~MESSAGE
+    --------
+    WARNING: Discourse uses `bin/unicorn` to start the web server.
+    For backwards compatibility, `rails s` will do this automatically.
+    For improved performance you should run `bin/unicorn` directly.
+
+    Running:
+    UNICORN_PORT=#{ENV["UNICORN_PORT"]} RAILS_LOGS_STDOUT=#{ENV["RAILS_LOGS_STDOUT"]} bin/unicorn
+    --------
+  MESSAGE
+
   exec File.expand_path("unicorn", __dir__)
 end
 


### PR DESCRIPTION
In Discourse, `rails s` ultimately launches the `bin/unicorn` script. However, the overhead of `rails` launching `bin/rails`, and then in turn `bin/unicorn` can be non-trivial. Therefore it is much better to run `bin/unicorn` directly.

This commit prints a warning message to STDERR when `rails s` is used. Functionality is unchanged.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
