### PR TITLE
FIX: light color scheme picker should default to user selection

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -237,9 +237,7 @@ export default Controller.extend({
       return value;
     },
     get() {
-      return this.currentSchemeCanBeSelected
-        ? this.session.userColorSchemeId
-        : null;
+      return this.session.userColorSchemeId;
     },
   }),
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -176,6 +176,21 @@ acceptance(
       );
     });
 
+    test("light color scheme defaults to custom scheme selected by user", async function (assert) {
+      let site = Site.current();
+      let session = Session.current();
+      session.userColorSchemeId = 2;
+      site.set("user_color_schemes", [{ id: 2, name: "Cool Breeze" }]);
+
+      await visit("/u/eviltrout/preferences/interface");
+      assert.ok(exists(".light-color-scheme"), "has light scheme dropdown");
+      assert.equal(
+        queryAll(".light-color-scheme .selected-name").data("value"),
+        session.userColorSchemeId,
+        "user's selected color scheme is selected value in light scheme dropdown"
+      );
+    });
+
     test("light and dark color scheme pickers", async function (assert) {
       let site = Site.current();
       let session = Session.current();


### PR DESCRIPTION
Fixes a bug in user preferences > interface, the light scheme dropdown
was defaulting to "Theme Default" even when the user had selected a
different scheme.
