### PR TITLE
FIX: Wizard locale change wasn't applying to some elements

### DIFF
--- a/app/assets/javascripts/wizard/controllers/step.js
+++ b/app/assets/javascripts/wizard/controllers/step.js
@@ -1,4 +1,6 @@
+import getUrl from "discourse-common/lib/get-url";
 import Controller from "@ember/controller";
+
 export default Controller.extend({
   wizard: null,
   step: null,
@@ -7,7 +9,12 @@ export default Controller.extend({
     goNext(response) {
       const next = this.get("step.next");
       if (response.refresh_required) {
-        this.send("refresh");
+        if (this.get("step.id") === "locale") {
+          document.location = getUrl(`/wizard/steps/${next}`);
+          return;
+        } else {
+          this.send("refresh");
+        }
       }
       this.transitionToRoute("step", next);
     },


### PR DESCRIPTION
Since 0e303c7f5d2767c37b9078226b5ce1d20fa3678e, wizards steps that required a refresh were loading data via Ajax. But this doesn't update the extra locale strings, so when changing locale in the first step of the wizard, the footer buttons were "stuck" using the previous locale.

This forces a full reload when the locale is changed in the wizard.