### PR TITLE
FIX: Required field for Name

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -74,7 +74,9 @@
               <div class="input name-input">
                 <label for="new-account-name">
                   {{i18n "invites.name_label"}}
-                  <span class="required">*</span>
+                  {{#if siteSettings.full_name_required}}
+                    <span class="required">*</span>
+                  {{/if}}
                 </label>
                 {{input value=accountName id="new-account-name" name="name"}}
                 <div class="instructions">{{nameInstructions}}</div>

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -147,6 +147,12 @@ acceptance("Invite accept", function (needs) {
       "submit is enabled"
     );
   });
+
+  test("invite name is required only if full name is required", async function (assert) {
+    preloadInvite();
+    await visit("/invites/myvalidinvitetoken");
+    assert.ok(exists(".name-input .required"), "Full name is required");
+  });
 });
 
 acceptance("Invite accept when local login is disabled", function (needs) {


### PR DESCRIPTION
Name must be a required field only if full name is required is enabled in the admin page.
The backend works fine, however, in UI the required red asterisk is displayed irrespective of the settings configured.

Fixes [188225](https://meta.discourse.org/t/full-name-required-ui-confusion-when-accepting-invites/188225)