### PR TITLE
FEATURE: add support for like webhooks

### DIFF
--- a/app/jobs/regular/emit_web_hook_event.rb
+++ b/app/jobs/regular/emit_web_hook_event.rb
@@ -115,8 +115,8 @@ module Jobs
     end
 
     def group_webhook_invalid?
-      @web_hook.group_ids.present? && (@arguments[:group_id].present? ||
-        !@web_hook.group_ids.include?(@arguments[:group_id]))
+      @web_hook.group_ids.present? && (@arguments[:group_ids].blank? ||
+        (@web_hook.group_ids & @arguments[:group_ids]).blank?)
     end
 
     def category_webhook_invalid?

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -57,13 +57,14 @@ class WebHook < ActiveRecord::Base
     end
   end
 
-  def self.enqueue_object_hooks(type, object, event, serializer = nil)
+  def self.enqueue_object_hooks(type, object, event, serializer = nil, opts = {})
     if active_web_hooks(type).exists?
       payload = WebHook.generate_payload(type, object, serializer)
 
-      WebHook.enqueue_hooks(type, event,
-        id: object.id,
-        payload: payload
+      WebHook.enqueue_hooks(type, event, opts.merge(
+                              id: object.id,
+                              payload: payload
+                            )
       )
     end
   end

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -13,6 +13,7 @@ class WebHookEventType < ActiveRecord::Base
   ASSIGN = 12
   USER_BADGE = 13
   GROUP_USER = 14
+  LIKE = 15
 
   has_and_belongs_to_many :web_hooks
 

--- a/app/serializers/web_hook_like_serializer.rb
+++ b/app/serializers/web_hook_like_serializer.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 class WebHookLikeSerializer < ApplicationSerializer
-  attributes :post,
-             :user
-  def post
-    WebHookPostSerializer.new(object.post, scope: scope, root: false).as_json
-  end
-  def user
-    BasicUserSerializer.new(object.user, scope: scope, root: false).as_json
-  end
+  has_one :post, serializer: WebHookPostSerializer, embed: :objects
+  has_one :user, serializer: BasicUserSerializer, embed: :objects
 end

--- a/app/serializers/web_hook_like_serializer.rb
+++ b/app/serializers/web_hook_like_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class WebHookLikeSerializer < ApplicationSerializer
+  attributes :post,
+             :user
+  def post
+    WebHookPostSerializer.new(object.post, scope: scope, root: false).as_json
+  end
+  def user
+    BasicUserSerializer.new(object.user, scope: scope, root: false).as_json
+  end
+end

--- a/config/initializers/012-web_hook_events.rb
+++ b/config/initializers/012-web_hook_events.rb
@@ -106,3 +106,9 @@ DiscourseEvent.on(:user_added_to_group) do |user, group, options|
   group_user = GroupUser.find_by(user: user, group: group)
   WebHook.enqueue_object_hooks(:group_user, group_user, :user_added_to_group, WebHookGroupUserSerializer)
 end
+
+DiscourseEvent.on(:like_created) do |post_action|
+  user = post_action.user
+  group_ids = user.groups.map(&:id)
+  WebHook.enqueue_object_hooks(:like, post_action, :post_liked, WebHookLikeSerializer, group_ids: group_ids)
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4040,6 +4040,9 @@ en:
         group_user_event:
           name: "Group User Event"
           details: "When a user is added or removed in a group."
+        like_event:
+          name: "Like Event"
+          details: "When a user likes a post."
         delivery_status:
           title: "Delivery Status"
           inactive: "Inactive"

--- a/db/fixtures/007_web_hook_event_types.rb
+++ b/db/fixtures/007_web_hook_event_types.rb
@@ -59,3 +59,8 @@ WebHookEventType.seed do |b|
   b.id = WebHookEventType::GROUP_USER
   b.name = "group_user"
 end
+
+WebHookEventType.seed do |b|
+  b.id = WebHookEventType::LIKE
+  b.name = "like"
+end

--- a/spec/fabricators/web_hook_fabricator.rb
+++ b/spec/fabricators/web_hook_fabricator.rb
@@ -102,3 +102,11 @@ Fabricator(:group_user_web_hook, from: :web_hook) do
     web_hook.web_hook_event_types = [transients[:group_user_hook]]
   end
 end
+
+Fabricator(:like_web_hook, from: :web_hook) do
+  transient like_hook: WebHookEventType.find_by(name: 'like')
+
+  after_build do |web_hook, transients|
+    web_hook.web_hook_event_types = [transients[:like_hook]]
+  end
+end


### PR DESCRIPTION
Add support for like webhooks. Webhook events only send on user membership
in the defined webhook group filters.

This also fixes group webhook events, as before this was never used, and
the logic was not correct.