### PR TITLE
FIX: tag control styles should apply to desktop

### DIFF
--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -314,3 +314,11 @@ body.tags-intersection {
     margin-right: auto;
   }
 }
+
+.tags-controls {
+  display: flex;
+  h2 {
+    order: -1;
+    margin-right: auto;
+  }
+}

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -410,14 +410,6 @@ tr.category-topic-link {
   opacity: 1;
 }
 
-.tags-controls {
-  display: flex;
-  h2 {
-    order: -1;
-    margin-right: auto;
-  }
-}
-
 .category-heading {
   p {
     font-size: $font-up-1;


### PR DESCRIPTION
This makes styles consistent between desktop and mobile... the before state was probably a regression. 

Before:
![Screen Shot 2021-04-30 at 11 55 04 PM](https://user-images.githubusercontent.com/1681963/116770144-7e972c80-aa0f-11eb-87b4-f73f477aaf02.png)



After:
![Screen Shot 2021-04-30 at 11 51 36 PM](https://user-images.githubusercontent.com/1681963/116770148-83f47700-aa0f-11eb-88af-14eef80af326.png)