### PR TITLE
FIX: correctly use timeouts in `FileHelper` and `FinalDestination`

### DIFF
--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -49,7 +49,8 @@ class FileHelper
       max_redirects: follow_redirect ? 5 : 0,
       skip_rate_limit: skip_rate_limit,
       verbose: verbose,
-      validate_uri: validate_uri
+      validate_uri: validate_uri,
+      timeout: read_timeout
     )
 
     fd.get do |response, chunk, uri|

--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -101,8 +101,7 @@ class FinalDestination
     status_code, response_headers = nil
 
     catch(:done) do
-      Net::HTTP.start(@uri.host, @uri.port, use_ssl: @uri.is_a?(URI::HTTPS)) do |http|
-        http.open_timeout = timeout
+      Net::HTTP.start(@uri.host, @uri.port, use_ssl: @uri.is_a?(URI::HTTPS), open_timeout: timeout) do |http|
         http.read_timeout = timeout
         http.request_get(@uri.request_uri, request_headers) do |resp|
           status_code = resp.code.to_i
@@ -431,9 +430,8 @@ class FinalDestination
   end
 
   def safe_session(uri)
-    Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == "https")) do |http|
+    Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == "https"), open_timeout: timeout) do |http|
       http.read_timeout = timeout
-      http.open_timeout = timeout
       yield http
     end
   end


### PR DESCRIPTION
Previous refactors have lost usage of read_timeout in `FileHelper.download` and `FinalDestination` was incorrectly using `Net::HTTP.start` by setting `open_timeout` in the block instead of directly during the invocation.

Couldn't figure how to write a good test for this without slowing the spec.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
