### PR TITLE
FIX: prevents exception when text input is nil

### DIFF
--- a/lib/text_sentinel.rb
+++ b/lib/text_sentinel.rb
@@ -68,7 +68,9 @@ class TextSentinel
   def seems_unpretentious?
     return true if skipped_locale.include?(SiteSetting.default_locale)
     # Don't allow super long words if there is a word length maximum
-    @opts[:max_word_length].blank? || @text.split(/\s|\/|-|\.|:/).map(&:size).max <= @opts[:max_word_length]
+
+    @opts[:max_word_length].blank? ||
+    (@text.split(/\s|\/|-|\.|:/).map(&:size).max || 0) <= @opts[:max_word_length]
   end
 
   def seems_quiet?

--- a/spec/components/text_sentinel_spec.rb
+++ b/spec/components/text_sentinel_spec.rb
@@ -61,6 +61,18 @@ describe TextSentinel do
       end
     end
 
+    it "uses a sensible min entropy value when min body length is less than min entropy" do
+      SiteSetting.min_post_length = 3
+      SiteSetting.body_min_entropy = 7
+      expect(TextSentinel.body_sentinel('Yup')).to be_valid
+    end
+
+    it "uses a sensible min entropy value when min pm body length is less than min entropy" do
+      SiteSetting.min_post_length = 5
+      SiteSetting.min_personal_message_post_length = 3
+      SiteSetting.body_min_entropy = 7
+      expect(TextSentinel.body_sentinel('Lol', private_message: true)).to be_valid
+    end
   end
 
   context "validity" do
@@ -144,19 +156,9 @@ describe TextSentinel do
 
   end
 
-  context 'body_sentinel' do
-
-    it "uses a sensible min entropy value when min body length is less than min entropy" do
-      SiteSetting.min_post_length = 3
-      SiteSetting.body_min_entropy = 7
-      expect(TextSentinel.body_sentinel('Yup')).to be_valid
-    end
-
-    it "uses a sensible min entropy value when min pm body length is less than min entropy" do
-      SiteSetting.min_post_length = 5
-      SiteSetting.min_personal_message_post_length = 3
-      SiteSetting.body_min_entropy = 7
-      expect(TextSentinel.body_sentinel('Lol', private_message: true)).to be_valid
+  context 'seems_unpretentious?' do
+    it 'works with nil title' do
+      expect(TextSentinel.title_sentinel(nil).seems_unpretentious?).to eq(true)
     end
   end
 


### PR DESCRIPTION
nil was converted to "" and the matching regex would return [] and then be converted to nil with max usage.

Example exception:

```
NoMethodError (undefined method `<=' for nil:NilClass)

lib/text_sentinel.rb:71:in `seems_unpretentious?'
lib/validators/quality_title_validator.rb:13:in `validate_each'
lib/topic_creator.rb:25:in `valid?'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
