### PR TITLE
FIX: Remove user's associated invite objects

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -85,6 +85,13 @@ class UserDestroyer
           end
         end
 
+        Invite.where(email: user_emails).each do |invite|
+          # invited_users will be removed by dependent destroy association when user is destroyed
+          invite.invited_groups.destroy_all
+          invite.topic_invites.destroy_all
+          invite.destroy
+        end
+
         unless opts[:quiet]
           if @actor == user
             deleted_by = Discourse.system_user

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -221,6 +221,22 @@ describe UserDestroyer do
       end
     end
 
+    context 'user was invited' do
+      it "should delete the invite of user" do
+        invite = Fabricate(:invite)
+        topic_invite = invite.topic_invites.create!(topic: Fabricate(:topic))
+        invited_group = invite.invited_groups.create!(group: Fabricate(:group))
+        user = Fabricate(:user)
+        user.user_emails.create!(email: invite.email)
+
+        UserDestroyer.new(admin).destroy(user)
+
+        expect(Invite.exists?(invite.id)).to eq(false)
+        expect(InvitedGroup.exists?(invited_group.id)).to eq(false)
+        expect(TopicInvite.exists?(topic_invite.id)).to eq(false)
+      end
+    end
+
     context 'user created category' do
       let!(:topic) { Fabricate(:topic, user: user) }
       let!(:first_post) { Fabricate(:post, user: user, topic: topic) }


### PR DESCRIPTION
Issue: Getting 422 response when trying to create invite for a deleted user.

Steps to reproduce:
1. Invite a user through API
2. Accept the invite
3. Delete the user from admin settings
4. Create an invite with the same email

This will result in 422 because there will be an existing invite for the same email. The fix is to remove the invite based relations of a user when the user is destroyed.

Fixes [188105](https://meta.discourse.org/t/invite-deleted-user-again/188105)