### PR TITLE
Revert "FIX: excludes .svg-as-img from JS sizing (#12906)"

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/ensure-max-image-dimensions.js
+++ b/app/assets/javascripts/discourse/app/initializers/ensure-max-image-dimensions.js
@@ -27,7 +27,7 @@ export default {
 
     const styleTag = document.createElement("style");
     styleTag.id = "image-sizing-hack";
-    styleTag.innerHTML = `#reply-control .d-editor-preview img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji), .cooked img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji):not(.svg-as-img) {${styles}}`;
+    styleTag.innerHTML = `#reply-control .d-editor-preview img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji), .cooked img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji) {${styles}}`;
     document.head.appendChild(styleTag);
   },
 };


### PR DESCRIPTION
This reverts commit 2f0205e5c850e40c278a0854c1cb121fdd175cbd.

Issue is handled in https://github.com/discourse/discourse-icon/pull/3
