### PR TITLE
FIX: Pressing back from topic in bookmark list takes user to home

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/topic-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/topic-link.js
@@ -14,6 +14,7 @@ registerUnbound("topic-link", (topic, args) => {
 
   const result = `<a href='${url}'
                      class='${classes.join(" ")}'
-                     data-topic-id='${topic.id}'>${title}</a>`;
+                     data-topic-id='${topic.id}'
+                     data-auto-route="true">${title}</a>`;
   return htmlSafe(result);
 });

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -3,10 +3,10 @@ import I18n from "I18n";
 import { Promise } from "rsvp";
 import RestModel from "discourse/models/rest";
 import User from "discourse/models/user";
+import Topic from "discourse/models/topic";
 import { ajax } from "discourse/lib/ajax";
 import { computed } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
-import { fancyTitle } from "discourse/lib/topic-fancy-title";
 import { formattedReminderTime } from "discourse/lib/bookmark";
 import getURL from "discourse-common/lib/get-url";
 import { longDate } from "discourse/lib/formatter";
@@ -89,11 +89,6 @@ const Bookmark = RestModel.extend({
     });
   },
 
-  @discourseComputed("title")
-  fancyTitle(title) {
-    return fancyTitle(title, this.siteSettings.support_mixed_text_direction);
-  },
-
   @discourseComputed("created_at")
   createdAt(created_at) {
     return new Date(created_at);
@@ -128,6 +123,15 @@ const Bookmark = RestModel.extend({
       bookmarkReminderAt,
       currentUser.resolvedTimezone(currentUser)
     ).capitalize();
+  },
+
+  @discourseComputed("linked_post_number", "title", "topic_id")
+  topicLink(linked_post_number, title, topic_id) {
+    return Topic.create({
+      id: topic_id,
+      fancy_title: title,
+      linked_post_number,
+    });
   },
 
   loadItems(params) {

--- a/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
@@ -46,7 +46,7 @@
                     {{d-icon "thumbtack" class="bookmark-pinned"}}
                   {{/if}}
                   {{topic-status topic=bookmark.topicStatus}}
-                  {{topic-link bookmark}}
+                  {{topic-link bookmark.topicLink}}
                 </div>
               </span>
               {{#if bookmark.excerpt}}


### PR DESCRIPTION
See: https://meta.discourse.org/t/navigating-back-to-bookmarks/188912/4

Instead of taking the user back to the bookmark list after selecting
a topic and navigating back, the user was navigated back to the page
before that. This is because the topic-link component was missing
the data-auto-route attribute which tells the intercept-click library
not to use DiscourseURL.routeTo to handle the transition (so it is just
handled internally by Ember)
