### PR TITLE
DEV: removes comment about disable_jump_reply

### DIFF
--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -200,8 +200,6 @@ class UserOption < ActiveRecord::Base
 
 end
 
-# TODO: Drop disable_jump_reply column. Functionality removed April 2019
-
 # == Schema Information
 #
 # Table name: user_options
@@ -212,7 +210,6 @@ end
 #  external_links_in_new_tab        :boolean          default(FALSE), not null
 #  enable_quoting                   :boolean          default(TRUE), not null
 #  dynamic_favicon                  :boolean          default(FALSE), not null
-#  disable_jump_reply               :boolean          default(FALSE), not null
 #  automatically_unpin_topics       :boolean          default(TRUE), not null
 #  digest_after_minutes             :integer
 #  auto_track_topics_after_msecs    :integer


### PR DESCRIPTION
This has been removed in https://github.com/discourse/discourse/commit/40fa96777ddad4698df20d6b8a61afcf87743ed7

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
