### PR TITLE
FIX: limit visible revisions history to last 100 

### DIFF
--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -195,7 +195,7 @@ class PostRevisionSerializer < ApplicationSerializer
 
     post_revisions = post_revisions
       .order(number: :desc)
-      .limit(100)
+      .limit(99)
       .to_a
       .reverse
 

--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -184,16 +184,14 @@ class PostRevisionSerializer < ApplicationSerializer
   end
 
   def revisions
+    @revisions ||= all_revisions.select { |r| scope.can_view_hidden_post_revisions? || !r["hidden"] }
+  end
+
+  def all_revisions
     return @all_revisions if @all_revisions
 
     post_revisions = PostRevision
       .where(post_id: object.post_id)
-
-    if !scope.can_view_hidden_post_revisions?
-      post_revisions = post_revisions.where(hidden: false)
-    end
-
-    post_revisions = post_revisions
       .order(number: :desc)
       .limit(99)
       .to_a

--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -184,13 +184,20 @@ class PostRevisionSerializer < ApplicationSerializer
   end
 
   def revisions
-    @revisions ||= all_revisions.select { |r| scope.can_view_hidden_post_revisions? || !r["hidden"] }
-  end
-
-  def all_revisions
     return @all_revisions if @all_revisions
 
-    post_revisions = PostRevision.where(post_id: object.post_id).order(:number).to_a
+    post_revisions = PostRevision
+      .where(post_id: object.post_id)
+
+    if !scope.can_view_hidden_post_revisions?
+      post_revisions = post_revisions.where(hidden: false)
+    end
+
+    post_revisions = post_revisions
+      .order(number: :desc)
+      .limit(100)
+      .to_a
+      .reverse
 
     latest_modifications = {
       "raw" => [post.raw],

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3374,7 +3374,7 @@ en:
       one: "user"
       other: "users"
     category_title: "Category"
-    history: "History"
+    history: "History, last 100 revisions"
     changed_by: "by %{author}"
 
     raw_email:


### PR DESCRIPTION
This is done to prevent spike memory usage when the number of revisions is very large (thousands) and the post has a significant length.