### PR TITLE
DEV: Update server startup warning to be more specific

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -10,17 +10,6 @@ if !ENV["RAILS_ENV"] && (ARGV[0] == "s" || ARGV[0] == "server")
 
   ENV["RAILS_LOGS_STDOUT"] ||= "1"
 
-  STDERR.puts <<~MESSAGE
-    --------
-    WARNING: Discourse uses `bin/unicorn` to start the web server.
-    For backwards compatibility, `rails s` will do this automatically.
-    For improved performance you should run `bin/unicorn` directly.
-
-    Running:
-    UNICORN_PORT=#{ENV["UNICORN_PORT"]} RAILS_LOGS_STDOUT=#{ENV["RAILS_LOGS_STDOUT"]} bin/unicorn
-    --------
-  MESSAGE
-
   exec File.expand_path("unicorn", __dir__)
 end
 

--- a/bin/unicorn
+++ b/bin/unicorn
@@ -6,6 +6,12 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 RAILS_ROOT = File.expand_path("../../", Pathname.new(__FILE__).realpath)
 
+if defined? Bundler
+  STDERR.puts <<~MESSAGE
+    WARNING: Using `bundle exec` to start the server is unnecessary, and will make startup slower. Use `bin/rails s` or `bin/unicorn`.
+  MESSAGE
+end
+
 require 'rubygems'
 require 'bundler/setup'
 require 'digest'


### PR DESCRIPTION
Using `bundle exec` will slow down server startup by at least 0.5s. `bin/unicorn` has built-in handling of bundler dependencies, so it is better to launch `bin/rails s` or `bin/unicorn` directly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
