### PR TITLE
FIX: Use the no-sandbox flag when running Ember CLI tests.

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -6,7 +6,7 @@ module.exports = {
   browser_args: {
     Chrome: [
       // --no-sandbox is needed when running Chrome inside a container
-      process.env.CI ? "--no-sandbox" : null,
+      process.env.CI || process.env.EMBER_CLI ? "--no-sandbox" : null,
       "--headless",
       "--disable-dev-shm-usage",
       "--disable-software-rasterizer",


### PR DESCRIPTION
Without this flag we get "Error: Browser exited unexpectedly" when trying to run tests. The `docker:test` task uses the `EMBER_CLI` env var to run these tests.
