### PR TITLE
FIX: `{{ace-editor}}` was buggy in Ember CLI release

### DIFF
--- a/app/assets/javascripts/admin/addon/components/ace-editor.js
+++ b/app/assets/javascripts/admin/addon/components/ace-editor.js
@@ -19,6 +19,10 @@ export default Component.extend({
     }
   },
 
+  didRender() {
+    this._skipContentChangeEvent = false;
+  },
+
   @observes("content")
   contentChanged() {
     const content = this.content || "";
@@ -103,7 +107,6 @@ export default Component.extend({
         editor.on("change", () => {
           this._skipContentChangeEvent = true;
           this.set("content", editor.getSession().getValue());
-          this._skipContentChangeEvent = false;
         });
         if (this.attrs.save) {
           editor.commands.addCommand({


### PR DESCRIPTION
This happened because observers now fire asynchronously in newer Ember releases for performance reasons. 
 
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
