### PR TITLE
DEV: Remove autoloading in initializers depreciation message.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -111,7 +111,6 @@ module Discourse
     config.autoload_paths += Dir["#{config.root}/app/jobs"]
     config.autoload_paths += Dir["#{config.root}/app/serializers"]
     config.autoload_paths += Dir["#{config.root}/lib"]
-    config.autoload_paths += Dir["#{config.root}/lib/active_record/connection_adapters"]
     config.autoload_paths += Dir["#{config.root}/lib/common_passwords"]
     config.autoload_paths += Dir["#{config.root}/lib/highlight_js"]
     config.autoload_paths += Dir["#{config.root}/lib/i18n"]

--- a/config/initializers/100-logster.rb
+++ b/config/initializers/100-logster.rb
@@ -19,13 +19,15 @@ if Rails.env.development? && RUBY_VERSION.match?(/^2\.5\.[23]/)
 end
 
 if Rails.env.development? && !Sidekiq.server? && ENV["RAILS_LOGS_STDOUT"] == "1"
-  console = ActiveSupport::Logger.new(STDOUT)
-  original_logger = Rails.logger.chained.first
-  console.formatter = original_logger.formatter
-  console.level = original_logger.level
+  Rails.application.config.after_initialize do
+    console = ActiveSupport::Logger.new(STDOUT)
+    original_logger = Rails.logger.chained.first
+    console.formatter = original_logger.formatter
+    console.level = original_logger.level
 
-  unless ActiveSupport::Logger.logger_outputs_to?(original_logger, STDOUT)
-    original_logger.extend(ActiveSupport::Logger.broadcast(console))
+    unless ActiveSupport::Logger.logger_outputs_to?(original_logger, STDOUT)
+      original_logger.extend(ActiveSupport::Logger.broadcast(console))
+    end
   end
 end
 


### PR DESCRIPTION
This was printing the following depreciation message in dev:

```
DEPRECATION WARNING: Initialization autoloaded the constants SiteSettings, SiteSettings::DeprecatedSettings, SiteSettingExtension, SiteSettings::YamlLoader, SiteSettings::DefaultsProvider, SiteSettings::Validations, SiteSettings::TypeSupervisor, Enum, RegexSettingValidation, StringSettingValidator, EmailSettingValidator, UsernameSettingValidator, GroupSettingValidator, AllowUserLocaleEnabledValidator, CategoriesTopicsValidator, IntegerSettingValidator, RegexPresenceValidator, CategoryPageStyle, ColorSchemeSetting, BaseFontSetting, EnableInviteOnlyValidator, EnableLocalLoginsViaEmailValidator, EnableSsoValidator, SsoOverridesEmailValidator, MinUsernameLengthValidator, MaxUsernameLengthValidator, UnicodeUsernameValidator, UnicodeUsernameAllowlistValidator, TrustLevelSetting, TrustLevelAndStaffSetting, MarkdownTypographerQuotationMarksValidator, EmojiSetSiteSetting, ReplyByEmailEnabledValidator, ReplyByEmailAddressValidator, AlternativeReplyByEmailAddressesValidator, POP3PollingEnabledSettingValidator, S3RegionSiteSetting, ExternalSystemAvatarsValidator, ColorListValidator, SelectableAvatarsEnabledValidator, ReviewableSensitivitySetting, ReviewablePrioritySetting, BackupLocationSiteSetting, CategorySearchPriorityWeightsValidator, SlugSetting, DigestEmailSiteSetting, EmailLevelSiteSetting, MailingListModeSiteSetting, PreviousRepliesSiteSetting, NewTopicDurationSiteSetting, AutoTrackDurationSiteSetting, NotificationLevelWhenReplyingSiteSetting, LikeNotificationFrequencySiteSetting, RemoveMutedTagsFromLatestSiteSetting, SiteSetting, SiteSettings::DbProvider, Site, Searchable, Roleable, HasCustomFields, SecondFactorManager, HasDestroyedWebHook, UserFullNameValidator, AllowedIpAddressValidator, User, MobileDetection, CrawlerDetection, Guardian, HttpLanguageParser, TwitterApi, Email, and Email::BuildEmailHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload SiteSettings, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
```