### PR TITLE
SECURITY: Bump Rails to 6.1.3.2 (beta)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,13 +18,13 @@ else
   # this allows us to include the bits of rails we use without pieces we do not.
   #
   # To issue a rails update bump the version number here
-  gem 'actionmailer', '6.1.3.1'
-  gem 'actionpack', '6.1.3.1'
-  gem 'actionview', '6.1.3.1'
-  gem 'activemodel', '6.1.3.1'
-  gem 'activerecord', '6.1.3.1'
-  gem 'activesupport', '6.1.3.1'
-  gem 'railties', '6.1.3.1'
+  gem 'actionmailer', '6.1.3.2'
+  gem 'actionpack', '6.1.3.2'
+  gem 'actionview', '6.1.3.2'
+  gem 'activemodel', '6.1.3.2'
+  gem 'activerecord', '6.1.3.2'
+  gem 'activesupport', '6.1.3.2'
+  gem 'railties', '6.1.3.2'
   gem 'sprockets-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,22 +8,22 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (6.1.3.1)
-      actionpack (= 6.1.3.1)
-      actionview (= 6.1.3.1)
-      activejob (= 6.1.3.1)
-      activesupport (= 6.1.3.1)
+    actionmailer (6.1.3.2)
+      actionpack (= 6.1.3.2)
+      actionview (= 6.1.3.2)
+      activejob (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.1.3.1)
-      actionview (= 6.1.3.1)
-      activesupport (= 6.1.3.1)
+    actionpack (6.1.3.2)
+      actionview (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
       rack (~> 2.0, >= 2.0.9)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.1.3.1)
-      activesupport (= 6.1.3.1)
+    actionview (6.1.3.2)
+      activesupport (= 6.1.3.2)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
@@ -32,15 +32,15 @@ GEM
       actionview (>= 6.0.a)
     active_model_serializers (0.8.4)
       activemodel (>= 3.0)
-    activejob (6.1.3.1)
-      activesupport (= 6.1.3.1)
+    activejob (6.1.3.2)
+      activesupport (= 6.1.3.2)
       globalid (>= 0.3.6)
-    activemodel (6.1.3.1)
-      activesupport (= 6.1.3.1)
-    activerecord (6.1.3.1)
-      activemodel (= 6.1.3.1)
-      activesupport (= 6.1.3.1)
-    activesupport (6.1.3.1)
+    activemodel (6.1.3.2)
+      activesupport (= 6.1.3.2)
+    activerecord (6.1.3.2)
+      activemodel (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
+    activesupport (6.1.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -323,9 +323,9 @@ GEM
     rails_multisite (3.0.0)
       activerecord (> 5.0, < 7)
       railties (> 5.0, < 7)
-    railties (6.1.3.1)
-      actionpack (= 6.1.3.1)
-      activesupport (= 6.1.3.1)
+    railties (6.1.3.2)
+      actionpack (= 6.1.3.2)
+      activesupport (= 6.1.3.2)
       method_source
       rake (>= 0.8.7)
       thor (~> 1.0)
@@ -479,14 +479,14 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionmailer (= 6.1.3.1)
-  actionpack (= 6.1.3.1)
-  actionview (= 6.1.3.1)
+  actionmailer (= 6.1.3.2)
+  actionpack (= 6.1.3.2)
+  actionview (= 6.1.3.2)
   actionview_precompiler
   active_model_serializers (~> 0.8.3)
-  activemodel (= 6.1.3.1)
-  activerecord (= 6.1.3.1)
-  activesupport (= 6.1.3.1)
+  activemodel (= 6.1.3.2)
+  activerecord (= 6.1.3.2)
+  activesupport (= 6.1.3.2)
   addressable
   annotate
   aws-sdk-s3
@@ -566,7 +566,7 @@ DEPENDENCIES
   rack-protection
   rails_failover
   rails_multisite
-  railties (= 6.1.3.1)
+  railties (= 6.1.3.2)
   rake
   rb-fsevent
   rbtrace
@@ -606,4 +606,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.2.7
+   2.2.16


### PR DESCRIPTION
Includes fixes for

- CVE-2021-22902
- CVE-2021-22903
- CVE-2021-22904
- CVE-2021-22885

https://github.com/rails/rails/blob/v6.1.3.2/actionpack/CHANGELOG.md

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
