### PR TITLE
FIX: Skip upload if HTML cannot be parsed

### DIFF
--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -200,7 +200,7 @@ class InlineUploads
   def self.match_img(markdown, external_src: false, uploads: nil)
     markdown.scan(/(<(?!img)[^<>]+\/?>)?(\s*)(<img [^>\n]+>)/i) do |match|
       node = Nokogiri::HTML5::fragment(match[2].strip).children[0]
-      src =  node.attributes["src"]&.value
+      src = node&.attributes&.[]("src")&.value
 
       if src && (matched_uploads(src).present? || external_src)
         upload = uploads&.[](src)

--- a/spec/services/inline_uploads_spec.rb
+++ b/spec/services/inline_uploads_spec.rb
@@ -54,6 +54,11 @@ RSpec.describe InlineUploads do
         MD
       end
 
+      it "should work with invalid img tags" do
+        md = '<img data-id="<>">'
+        expect(InlineUploads.process(md)).to eq(md)
+      end
+
       it "should not correct code blocks" do
         md = "`<a class=\"attachment\" href=\"#{upload2.url}\">In Code Block</a>`"
 


### PR DESCRIPTION
Nokogiri cannot parse "<img data-id=\"<>" and returns an empty fragment, with no children.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
