### PR TITLE
Color scheme optional defer publish

### DIFF
--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -242,6 +242,7 @@ class ColorScheme < ActiveRecord::Base
     end if params[:colors]
 
     new_color_scheme.colors = colors
+    new_color_scheme.skip_publish if params[:skip_publish]
     new_color_scheme.save
     new_color_scheme
   end

--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -162,8 +162,8 @@ class ColorScheme < ActiveRecord::Base
   alias_method :colors, :color_scheme_colors
 
   before_save :bump_version
-  after_save :publish_discourse_stylesheet, unless: :skip_publish
-  after_save :dump_caches
+  after_save_commit :publish_discourse_stylesheet, unless: :skip_publish
+  after_save_commit :dump_caches
   after_destroy :dump_caches
   belongs_to :theme
 

--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -155,13 +155,14 @@ class ColorScheme < ActiveRecord::Base
   end
 
   attr_accessor :is_base
+  attr_accessor :skip_publish
 
   has_many :color_scheme_colors, -> { order('id ASC') }, dependent: :destroy
 
   alias_method :colors, :color_scheme_colors
 
   before_save :bump_version
-  after_save :publish_discourse_stylesheet
+  after_save :publish_discourse_stylesheet, unless: :skip_publish
   after_save :dump_caches
   after_destroy :dump_caches
   belongs_to :theme
@@ -303,18 +304,27 @@ class ColorScheme < ActiveRecord::Base
 
   def publish_discourse_stylesheet
     if self.id
-      Stylesheet::Manager.clear_color_scheme_cache!
+      self.class.publish_discourse_stylesheets!(self.id)
+    end
+  end
 
-      theme_ids = Theme.where(color_scheme_id: self.id).pluck(:id)
-      if theme_ids.present?
-        Stylesheet::Manager.cache.clear
-        Theme.notify_theme_change(
-          theme_ids,
-          with_scheme: true,
-          clear_manager_cache: false,
-          all_themes: true
-        )
-      end
+  def self.publish_discourse_stylesheets!(id = nil)
+    Stylesheet::Manager.clear_color_scheme_cache!
+
+    theme_ids = []
+    if id
+      theme_ids = Theme.where(color_scheme_id: id).pluck(:id)
+    else
+      theme_ids = Theme.all.pluck(:id)
+    end
+    if theme_ids.present?
+      Stylesheet::Manager.cache.clear
+      Theme.notify_theme_change(
+        theme_ids,
+        with_scheme: true,
+        clear_manager_cache: false,
+        all_themes: true
+      )
     end
   end
 


### PR DESCRIPTION
Allow a hook to color scheme changes to skip and defer publishing stylesheets until `ColorScheme.publish_discourse_stylesheets!` is called.

This is useful for when you are altering or updating multiple stylesheets at once.