### PR TITLE
FIX: Shared drafts should be disabled if Uncategorized is selected.

### DIFF
--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -183,7 +183,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def include_shared_drafts_category_id?
-    scope.can_see_shared_draft?
+    scope.can_see_shared_draft? && SiteSetting.shared_drafts_enabled?
   end
 
   def watched_words_replace

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -237,7 +237,7 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def include_destination_category_id?
-    scope.can_see_shared_draft? && object.topic.shared_draft.present?
+    scope.can_see_shared_draft? && SiteSetting.shared_drafts_enabled? && object.topic.shared_draft.present?
   end
 
   def is_shared_draft

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -59,4 +59,14 @@ describe SiteSerializer do
     serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
     expect(serialized[:default_dark_color_scheme]).to eq(nil)
   end
+
+  it 'does not include shared_drafts_category_id if the category is Uncategorized' do
+    admin = Fabricate(:admin)
+    admin_guardian = Guardian.new(admin)
+
+    SiteSetting.shared_drafts_category = SiteSetting.uncategorized_category_id
+
+    serialized = described_class.new(Site.new(admin_guardian), scope: admin_guardian, root: false).as_json
+    expect(serialized[:shared_drafts_category_id]).to eq(nil)
+  end
 end


### PR DESCRIPTION
The site setting's default value is "", but it's set to "1" when Uncategorized is selected again. We need to check if shared drafts are enabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
