### PR TITLE
UX: return correct error message if reviewable user is deleted  already.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4916,6 +4916,7 @@ en:
 
   reviewables:
     already_handled: "Thanks, but we've already reviewed that post and determined it does not need to be flagged again."
+    already_handled_and_user_not_exist: "Thanks, but we've already reviewed and that user is no longer exists."
     priorities:
       low: "Low"
       medium: "Medium"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4916,7 +4916,7 @@ en:
 
   reviewables:
     already_handled: "Thanks, but we've already reviewed that post and determined it does not need to be flagged again."
-    already_handled_and_user_not_exist: "Thanks, but we've already reviewed and that user is no longer exists."
+    already_handled_and_user_not_exist: "Thanks, but someone already reviewed and that user no longer exists."
     priorities:
       low: "Low"
       medium: "Medium"


### PR DESCRIPTION
Currently, when the target is not available we're returning the error message "`You are not permitted to view the requested resource`" which is not clear.