### PR TITLE
PERF: Preload `LetterAvatar.image_magick_version` in master process.

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -935,16 +935,25 @@ module Discourse
       Search.prepare_data("test")
     end
 
-    # router warm up
-    Rails.application.routes.recognize_path('abc') rescue nil
-
-    # preload discourse version
-    Discourse.git_version
-    Discourse.git_branch
-    Discourse.full_version
-
-    require 'actionview_precompiler'
-    ActionviewPrecompiler.precompile
+    [
+      Thread.new {
+        # router warm up
+        Rails.application.routes.recognize_path('abc') rescue nil
+      },
+      Thread.new {
+        # preload discourse version
+        Discourse.git_version
+        Discourse.git_branch
+        Discourse.full_version
+      },
+      Thread.new {
+        require 'actionview_precompiler'
+        ActionviewPrecompiler.precompile
+      },
+      Thread.new {
+        LetterAvatar.image_magick_version
+      }
+    ].each(&:join)
   ensure
     @preloaded_rails = true
   end


### PR DESCRIPTION
It is wasteful to run the clean up and command to generate the version
digest on every unicorn child process.

Flamegraph of a profile taken in one of our production instance. Around 31ms was spent generating the image magick verison.

![Screenshot from 2021-05-07 13-37-32](https://user-images.githubusercontent.com/4335742/117402654-66586d80-af39-11eb-88b4-f8883b26a3cd.png)
