### PR TITLE
DEV: Show warning in admin UI for core SCSS color vars

### DIFF
--- a/app/assets/javascripts/admin/addon/components/ace-editor.js
+++ b/app/assets/javascripts/admin/addon/components/ace-editor.js
@@ -1,8 +1,11 @@
 import Component from "@ember/component";
 import getURL from "discourse-common/lib/get-url";
 import loadScript from "discourse/lib/load-script";
+import I18n from "I18n";
 import { observes } from "discourse-common/utils/decorators";
 import { on } from "@ember/object/evented";
+
+const COLOR_VARS_REGEX = /\$(primary|secondary|tertiary|quaternary|header_background|header_primary|highlight|danger|success|love)(\s|;|-(low|medium|high))/g;
 
 export default Component.extend({
   mode: "css",
@@ -117,12 +120,18 @@ export default Component.extend({
             bindKey: { mac: "cmd-s", win: "ctrl-s" },
           });
         }
+
+        editor.on("blur", () => {
+          this.warnSCSSDeprecations();
+        });
+
         editor.$blockScrolling = Infinity;
         editor.renderer.setScrollMargin(10, 10);
 
         this.element.setAttribute("data-editor", editor);
         this._editor = editor;
         this.changeDisabledState();
+        this.warnSCSSDeprecations();
 
         $(window)
           .off("ace:resize")
@@ -138,6 +147,40 @@ export default Component.extend({
         }
       });
     });
+  },
+
+  warnSCSSDeprecations() {
+    if (
+      this.mode !== "scss" ||
+      this.editorId.startsWith("color_definitions") ||
+      !this._editor
+    ) {
+      return;
+    }
+
+    if (this._editor) {
+      let lines = this.content.split("\n"),
+        warnings = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].match(COLOR_VARS_REGEX)) {
+          warnings.push({
+            row: i,
+            column: 0,
+            text: I18n.t("admin.customize.theme.scss_warning_inline"),
+            type: "warning",
+          });
+        }
+      }
+
+      this._editor.getSession().setAnnotations(warnings);
+
+      this.setWarning(
+        warnings.length
+          ? I18n.t("admin.customize.theme.scss_color_variables_warning")
+          : false
+      );
+    }
   },
 
   actions: {

--- a/app/assets/javascripts/admin/addon/components/ace-editor.js
+++ b/app/assets/javascripts/admin/addon/components/ace-editor.js
@@ -158,29 +158,27 @@ export default Component.extend({
       return;
     }
 
-    if (this._editor) {
-      let lines = this.content.split("\n"),
-        warnings = [];
-
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].match(COLOR_VARS_REGEX)) {
-          warnings.push({
-            row: i,
+    let warnings = this.content
+      .split("\n")
+      .map((line, row) => {
+        if (line.match(COLOR_VARS_REGEX)) {
+          return {
+            row,
             column: 0,
             text: I18n.t("admin.customize.theme.scss_warning_inline"),
             type: "warning",
-          });
+          };
         }
-      }
+      })
+      .filter(Boolean);
 
-      this._editor.getSession().setAnnotations(warnings);
+    this._editor.getSession().setAnnotations(warnings);
 
-      this.setWarning(
-        warnings.length
-          ? I18n.t("admin.customize.theme.scss_color_variables_warning")
-          : false
-      );
-    }
+    this.setWarning(
+      warnings.length
+        ? I18n.t("admin.customize.theme.scss_color_variables_warning")
+        : false
+    );
   },
 
   actions: {

--- a/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
+++ b/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
@@ -6,6 +6,8 @@ import { isDocumentRTL } from "discourse/lib/text-direction";
 import { next } from "@ember/runloop";
 
 export default Component.extend({
+  warning: null,
+
   @discourseComputed("theme.targets", "onlyOverridden", "showAdvanced")
   visibleTargets(targets, onlyOverridden, showAdvanced) {
     return targets.filter((target) => {
@@ -123,6 +125,10 @@ export default Component.extend({
 
     save() {
       this.attrs.save();
+    },
+
+    setWarning(message) {
+      this.set("warning", message);
     },
   },
 });

--- a/app/assets/javascripts/admin/addon/templates/components/admin-theme-editor.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-theme-editor.hbs
@@ -91,4 +91,13 @@
   <pre class="field-warning">{{html-safe warning}}</pre>
 {{/if}}
 
-{{ace-editor content=activeSection editorId=editorId mode=activeSectionMode autofocus="true" placeholder=placeholder htmlPlaceholder=true save=(action "save") setWarning=(action "setWarning")}}
+{{ace-editor
+  content=activeSection
+  editorId=editorId
+  mode=activeSectionMode
+  autofocus="true"
+  placeholder=placeholder
+  htmlPlaceholder=true
+  save=(action "save")
+  setWarning=(action "setWarning")
+}}

--- a/app/assets/javascripts/admin/addon/templates/components/admin-theme-editor.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-theme-editor.hbs
@@ -87,4 +87,8 @@
   <pre class="field-error">{{error}}</pre>
 {{/if}}
 
-{{ace-editor content=activeSection editorId=editorId mode=activeSectionMode autofocus="true" placeholder=placeholder htmlPlaceholder=true save=(action "save")}}
+{{#if warning}}
+  <pre class="field-warning">{{html-safe warning}}</pre>
+{{/if}}
+
+{{ace-editor content=activeSection editorId=editorId mode=activeSectionMode autofocus="true" placeholder=placeholder htmlPlaceholder=true save=(action "save") setWarning=(action "setWarning")}}

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -49,12 +49,17 @@
     }
   }
 
-  .field-error {
+  .field-error,
+  .field-warning {
     margin-top: 10px;
     margin-bottom: 10px;
     background-color: var(--quaternary-low);
-    padding: 5px;
+    padding: 10px;
     white-space: pre-wrap;
+  }
+
+  .field-warning {
+    background-color: var(--tertiary-low);
   }
 
   .admin-container {

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -53,13 +53,13 @@
   .field-warning {
     margin-top: 10px;
     margin-bottom: 10px;
-    background-color: var(--quaternary-low);
+    background-color: var(--danger-low-mid);
     padding: 10px;
     white-space: pre-wrap;
   }
 
   .field-warning {
-    background-color: var(--tertiary-low);
+    background-color: var(--highlight-low);
   }
 
   .admin-container {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4358,6 +4358,8 @@ en:
           yaml:
             text: "YAML"
             title: "Define theme settings in YAML format"
+          scss_color_variables_warning: "Using core SCSS color variables in themes is deprecated. Please use CSS custom properties instead. See <a href=\"https://meta.discourse.org/t/-/77551#color-variables-2\" target=\"_blank\">this guide</a> for more details."
+          scss_warning_inline: "Using core SCSS color variables in themes is deprecated."
         colors:
           select_base:
             title: "Select base color palette"


### PR DESCRIPTION
<img width="982" alt="image" src="https://user-images.githubusercontent.com/368961/117481707-56d52680-af31-11eb-88d4-ceb7671e7a86.png">

This is just a visual warning to direct theme maintainers towards CSS custom properties for colors. It's a small step today that will enable us to eventually compile theme stylesheets independently of color schemes in the future. 