### PR TITLE
DEV: Ember CLI postinstall hook and shortcut

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -15,6 +15,13 @@ PROXY =
     "http://localhost:#{PORT}"
   end
 
+command =
+  if ARGV.include?("--test")
+    "test"
+  else
+    "server"
+  end
+
 if ARGV.include?("-h") || ARGV.include?("--help")
   puts "ember-cli OPTIONS"
   puts "--try To proxy try.discourse.org", ""
@@ -22,7 +29,7 @@ if ARGV.include?("-h") || ARGV.include?("--help")
   exec "yarn --cwd #{yarn_dir} run ember server --help"
 end
 
-args = ["--cwd", yarn_dir, "run", "ember", "server"] + ARGV.reject { |a| a == "--try" }
+args = ["--cwd", yarn_dir, "run", "ember", command] + ARGV.reject { |a| a == "--try" || "--test" }
 
 if !args.include?("--proxy")
   args << "--proxy"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "sinon": "^9.0.2"
   },
   "scripts": {
-    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('NPM is not supported, please use Yarn instead. ')\""
+    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('NPM is not supported, please use Yarn instead. ')\"",
+    "postinstall": "yarn --cwd app/assets/javascripts/discourse"
   }
 }


### PR DESCRIPTION
Two separate changes:

- adds a postinstall hook so that when running `yarn install` in project root it also runs `yarn install` for Ember CLI 
- adds an option to run ember cli tests via `bin/ember-cli --test`