### PR TITLE
FIX: Core templates should never overwrite theme/plugins

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/raw-templates.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/raw-templates.js
@@ -2,7 +2,11 @@ import { getResolverOption } from "discourse-common/resolver";
 
 export const __DISCOURSE_RAW_TEMPLATES = {};
 
-export function addRawTemplate(name, template) {
+export function addRawTemplate(name, template, opts = {}) {
+  // Core templates should never overwrite themes / plugins
+  if (opts.core && __DISCOURSE_RAW_TEMPLATES[name]) {
+    return;
+  }
   __DISCOURSE_RAW_TEMPLATES[name] = template;
 }
 

--- a/app/assets/javascripts/discourse-hbr/raw-handlebars-compiler.js
+++ b/app/assets/javascripts/discourse-hbr/raw-handlebars-compiler.js
@@ -143,7 +143,7 @@ TemplateCompiler.prototype.processString = function (string, relativePath) {
     ");\n\n" +
     'addRawTemplate("' +
     filename +
-    '", template);\n' +
+    '", template, { core: true });\n' +
     "export default template;"
   );
 };


### PR DESCRIPTION
This happened in Ember CLI due to a different script load order.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
