### PR TITLE
DEV: Buttons were missing btn-default classes

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/badges.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges.hbs
@@ -7,7 +7,7 @@
         <span>{{i18n "admin.badges.new"}}</span>
       {{/link-to}}
 
-      {{#link-to "adminBadges.award" "new" class="btn"}}
+      {{#link-to "adminBadges.award" "new" class="btn btn-default"}}
         {{d-icon "upload"}}
         <span>{{i18n "admin.badges.mass_award.title"}}</span>
       {{/link-to}}

--- a/app/assets/javascripts/admin/addon/templates/components/dashboard-new-features.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/dashboard-new-features.hbs
@@ -14,6 +14,6 @@
         {{i18n "admin.dashboard.new_features.learn_more"}}
       </a>
     {{/if}}
-    {{d-button label="admin.dashboard.new_features.dismiss" class="new-features-dismiss" action=dismissNewFeatures }}
+    {{d-button label="admin.dashboard.new_features.dismiss" class="btn-default new-features-dismiss" action=dismissNewFeatures }}
   </div>
 {{/if}}

--- a/app/assets/javascripts/admin/addon/templates/components/tags-uploader.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/tags-uploader.hbs
@@ -1,4 +1,4 @@
-<label class="btn {{if addDisabled "disabled"}}">
+<label class="btn btn-default {{if addDisabled "disabled"}}">
   {{d-icon "upload"}}
   {{i18n "admin.watched_words.form.upload"}}
   <input class="hidden-upload-field" disabled={{addDisabled}} type="file" accept="text/plain,text/csv">

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -189,7 +189,7 @@
         {{i18n "badges.badge_count" count=model.badge_count}}
       </div>
       <div class="controls">
-        {{#link-to "adminUser.badges" model class="btn"}}
+        {{#link-to "adminUser.badges" model class="btn btn-default"}}
           {{d-icon "certificate"}}
           {{i18n "admin.badges.edit_badges"}}
         {{/link-to}}
@@ -316,8 +316,7 @@
         {{model.api_key_count}}
       </div>
       <div class="controls">
-        {{d-button href="/admin/api/keys" label="admin.api.manage_keys"}}
-
+        {{d-button class="btn-default" href="/admin/api/keys" label="admin.api.manage_keys"}}
       </div>
     </div>
   {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/badges/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/badges/show.hbs
@@ -52,7 +52,7 @@
       {{#unless canLoadMore}}
         {{#if canShowOthers}}
           <div class="clearfix">
-            <a id="show-others-with-badge-link" href={{model.url}} class="btn">{{i18n "badges.others_count" count=othersCount}}</a>
+            <a id="show-others-with-badge-link" href={{model.url}} class="btn btn-default">{{i18n "badges.others_count" count=othersCount}}</a>
           </div>
         {{/if}}
       {{/unless}}

--- a/app/assets/javascripts/discourse/app/templates/components/copy-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/copy-button.hbs
@@ -1,1 +1,1 @@
-{{d-button icon="copy" action=(action "copy")}}
+{{d-button class="btn-default" icon="copy" action=(action "copy")}}

--- a/app/assets/javascripts/discourse/app/templates/components/date-time-input.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/date-time-input.hbs
@@ -26,7 +26,7 @@
 
 {{#if clearable}}
   {{d-button
-    class="clear-date-time"
+    class="btn-default clear-date-time"
     icon="times"
     action=(action "onClear")
   }}

--- a/app/assets/javascripts/discourse/app/templates/components/group-membership-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-membership-button.hbs
@@ -1,6 +1,6 @@
 {{#if canJoinGroup}}
   {{d-button action=(action "joinGroup")
-      class="group-index-join"
+      class="btn-default group-index-join"
       icon="user-plus"
       label="groups.join"
       disabled=updatingMembership}}
@@ -12,7 +12,7 @@
       disabled=updatingMembership}}
 {{else if canRequestMembership}}
   {{d-button action=(action "showRequestMembershipForm")
-      class="group-index-request"
+      class="btn-default group-index-request"
       disabled=loading
       icon="user-plus"
       label="groups.request"}}

--- a/app/assets/javascripts/discourse/app/templates/components/topic-entrance.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-entrance.hbs
@@ -1,7 +1,7 @@
-{{#d-button action=(action "enterTop") class="full jump-top"}}
+{{#d-button action=(action "enterTop") class="btn-default full jump-top"}}
   {{d-icon "step-backward"}} {{html-safe topDate}}
 {{/d-button}}
 
-{{#d-button action=(action "enterBottom") class="full jump-bottom"}}
+{{#d-button action=(action "enterBottom") class="btn-default full jump-bottom"}}
   {{html-safe bottomDate}} {{d-icon "step-forward"}}
 {{/d-button}}

--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -14,7 +14,7 @@
         {{d-button icon="plus"
           action=(route-action "showAddMembersModal")
           label="groups.manage.add_members"
-        class="group-members-add"}}
+        class="btn-default group-members-add"}}
       {{/if}}
     </div>
   </div>

--- a/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
@@ -134,7 +134,7 @@
   {{#if hasAdvanced}}
     {{d-button
       action=(action "toggleAdvanced")
-      class="show-advanced"
+      class="btn-default show-advanced"
       icon="cog"
       title=(if showAdvanced "user.invited.invite.hide_advanced" "user.invited.invite.show_advanced")
     }}

--- a/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
@@ -14,7 +14,7 @@
     onChange=(action (mut model.user_option.timezone))
     class="input-xxlarge"
   }}
-  {{d-button icon="globe" label="user.use_current_timezone" action=(action "useCurrentTimezone") }}
+  {{d-button class="btn-default" icon="globe" label="user.use_current_timezone" action=(action "useCurrentTimezone") }}
 </div>
 
 {{#if model.can_change_location}}

--- a/app/assets/javascripts/discourse/app/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.hbs
@@ -88,7 +88,7 @@
       {{#if filterTopic}}
         <div class="reviewable-filter topic-filter">
           {{i18n "review.filtered_topic"}}
-          {{d-button label="review.show_all_topics" icon="times" action=(action "resetTopic")}}
+          {{d-button class="btn-default" label="review.show_all_topics" icon="times" action=(action "resetTopic")}}
         </div>
       {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
@@ -13,9 +13,9 @@
             </nav>
 
             <div class="pull-right">
-              {{d-button icon="plus" action=(action "createInvite") label="user.invited.create"}}
+              {{d-button class="btn-default" icon="plus" action=(action "createInvite") label="user.invited.create"}}
               {{#if canBulkInvite}}
-                {{d-button icon="upload" action=(action "createInviteCsv") label="user.invited.bulk_invite.text"}}
+                {{d-button class="btn-default" icon="upload" action=(action "createInviteCsv") label="user.invited.bulk_invite.text"}}
               {{/if}}
               {{#if showBulkActionButtons}}
                 {{#if inviteExpired}}
@@ -30,7 +30,7 @@
                   {{#if reinvitedAll}}
                     {{i18n "user.invited.reinvited_all"}}
                   {{else}}
-                    {{d-button icon="sync" action=(action "reinviteAll") label="user.invited.reinvite_all"}}
+                    {{d-button class="btn-default" icon="sync" action=(action "reinviteAll") label="user.invited.reinvite_all"}}
                   {{/if}}
                 {{/if}}
               {{/if}}
@@ -132,7 +132,7 @@
                     </td>
 
                     <td class="invite-actions">
-                      {{d-button icon="pencil-alt" action=(action "editInvite" invite) title="user.invited.edit"}}
+                      {{d-button class="btn-default" icon="pencil-alt" action=(action "editInvite" invite) title="user.invited.edit"}}
                       {{d-button icon="trash-alt" class="cancel" action=(action "destroyInvite" invite) title=(if invite.destroyed "user.invited.removed" "user.invited.remove")}}
                     </td>
                   </tr>

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -79,6 +79,7 @@
                   {{d-button
                     ariaExpanded=collapsedInfoState.isExpanded
                     ariaControls="collapsed-info-panel"
+                    class="btn-default"
                     label=(concat "user." collapsedInfoState.label)
                     icon=collapsedInfoState.icon
                     action=(action collapsedInfoState.action)

--- a/app/assets/javascripts/discourse/app/widgets/private-message-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/private-message-map.js
@@ -187,7 +187,7 @@ export default createWidget("private-message-map", {
         this.attach("button", {
           action: "showInvite",
           icon: "plus",
-          className: "btn.no-text.btn-icon",
+          className: "btn btn-default no-text btn-icon",
         })
       );
     }

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
@@ -140,7 +140,7 @@ export default createWidget("quick-access-panel", {
           title: "user.dismiss_notifications_tooltip",
           icon: "check",
           label: "user.dismiss",
-          className: "notifications-dismiss",
+          className: "btn btn-default notifications-dismiss",
           action: "dismissNotifications",
         })
       );

--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -52,7 +52,7 @@ createWidget("topic-admin-menu-button", {
       result.push(
         this.attach("button", {
           className:
-            "popup-menu-button toggle-admin-menu" +
+            "btn-default popup-menu-button toggle-admin-menu" +
             (attrs.addKeyboardTargetClass ? " keyboard-target-admin-menu" : ""),
           title: "topic_admin_menu",
           icon: "wrench",

--- a/plugins/poll/assets/javascripts/discourse/templates/modal/poll-ui-builder.hbs
+++ b/plugins/poll/assets/javascripts/discourse/templates/modal/poll-ui-builder.hbs
@@ -44,7 +44,7 @@
         {{/each}}
 
         <div class="poll-option-controls">
-          {{d-button icon="plus" label="poll.ui_builder.poll_options.add" action=(action "addOption" pollOptions.lastObject)}}
+          {{d-button class="btn-default" icon="plus" label="poll.ui_builder.poll_options.add" action=(action "addOption" pollOptions.lastObject)}}
           {{#if (and showMinNumOfOptionsValidation (not minNumOfOptionsValidation.ok))}}
             {{input-tip validation=minNumOfOptionsValidation}}
           {{/if}}
@@ -165,7 +165,7 @@
 
   {{d-button
     action=(action "toggleAdvanced")
-    class="show-advanced"
+    class="btn-default show-advanced"
     icon="cog"
     title=(if showAdvanced "poll.ui_builder.hide_advanced" "poll.ui_builder.show_advanced")}}
 </div>


### PR DESCRIPTION
All of these buttons are styled in the "default" way, so they should carry the `btn-default` class.

Because we use `btn` on all buttons, the `btn-default` class is useful while building themes because it provides a selector that can distinguish buttons from `btn-primary`, `btn-danger`, etc... 