### PR TITLE
DEV: Some select-box headers don't need a class

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -37,6 +37,7 @@ export default DropdownSelectBoxComponent.extend({
     filterable: false,
     showFullTitle: false,
     preventHeaderFocus: true,
+    customStyle: true,
   },
 
   @discourseComputed("isEditing", "action", "whisper", "noBump", "isInSlowMode")

--- a/app/assets/javascripts/select-kit/addon/components/dropdown-select-box/dropdown-select-box-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/dropdown-select-box/dropdown-select-box-header.js
@@ -18,7 +18,7 @@ export default SingleSelectHeaderComponent.extend({
   }),
 
   btnStyleClass: computed("customStyle", function () {
-    return `btn ${this.customStyle ? "" : "btn-default"}`;
+    return `${this.customStyle ? "" : "btn-default"}`;
   }),
 
   caretUpIcon: readOnly("selectKit.options.caretUpIcon"),

--- a/app/assets/javascripts/select-kit/addon/components/dropdown-select-box/dropdown-select-box-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/dropdown-select-box/dropdown-select-box-header.js
@@ -5,15 +5,20 @@ import { readOnly } from "@ember/object/computed";
 
 export default SingleSelectHeaderComponent.extend({
   layout,
-  classNames: ["btn-default", "dropdown-select-box-header"],
+  classNames: ["dropdown-select-box-header"],
   tagName: "button",
-  classNameBindings: ["btnClassName"],
+  classNameBindings: ["btnClassName", "btnStyleClass"],
   showFullTitle: readOnly("selectKit.options.showFullTitle"),
   attributeBindings: ["buttonType:type"],
   buttonType: "button",
+  customStyle: readOnly("selectKit.options.customStyle"),
 
   btnClassName: computed("showFullTitle", function () {
     return `btn ${this.showFullTitle ? "btn-icon-text" : "no-text btn-icon"}`;
+  }),
+
+  btnStyleClass: computed("customStyle", function () {
+    return `btn ${this.customStyle ? "" : "btn-default"}`;
   }),
 
   caretUpIcon: readOnly("selectKit.options.caretUpIcon"),

--- a/app/assets/javascripts/select-kit/addon/components/period-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/period-chooser.js
@@ -18,6 +18,7 @@ export default DropdownSelectBoxComponent.extend({
     filterable: false,
     autoFilterable: false,
     fullDay: "fullDay",
+    customStyle: true,
     headerComponent: "period-chooser/period-chooser-header",
   },
 

--- a/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options.js
+++ b/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options.js
@@ -10,6 +10,7 @@ export default DropdownSelectBoxComponent.extend({
     filterable: false,
     autoFilterable: false,
     preventHeaderFocus: true,
+    customStyle: true,
   },
 
   modifyContent(contents) {


### PR DESCRIPTION
The `dropdown-select-box-header` component adds a `btn-default` class to the button it creates... but not all the components that extend `dropdown-select-box-header` should have that class. 


This causes some minor annoyances in themes, for example if I do:

```css
.btn-default {
  background: salmon;
}
```

👍 most of the time I want this class's styles to apply to the `dropdown-select-box-header`... for example here:

![Screen Shot 2021-05-07 at 10 58 00 PM](https://user-images.githubusercontent.com/1681963/117523686-ad6d4f80-af87-11eb-9ff4-a95babb45b5d.png)


👎  but then I have to undo it here (and in a couple other places):

![Screen Shot 2021-05-07 at 10 59 08 PM](https://user-images.githubusercontent.com/1681963/117523711-d68de000-af87-11eb-8777-410aa4b646d6.png)


```css
.btn-default.period-chooser-header {
  background: transparent;
}
```



So what I'm adding in this PR is the ability to turn off that `btn-default` class selectively.