### PR TITLE
FIX: Trust level when inviting users to group

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -322,6 +322,8 @@ class GroupsController < ApplicationController
       unless current_user.staff?
         RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
       end
+    elsif !current_user.has_trust_level?(SiteSetting.min_trust_level_to_allow_invite.to_i)
+      raise Discourse::InvalidAccess
     end
 
     emails = []

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1211,6 +1211,16 @@ describe GroupsController do
         expect(Topic.last.topic_users.map(&:user_id)).to include(Discourse::SYSTEM_USER_ID, user2.id)
       end
 
+      it 'does not add users without sufficient permission' do
+        sign_in(user)
+        SiteSetting.min_trust_level_to_allow_invite = user.trust_level + 1
+        user2 = Fabricate(:user)
+
+        put "/groups/#{group.id}/members.json", params: { usernames: user2.username }
+
+        expect(response.status).to eq(403)
+      end
+
       context "is able to add several members to a group" do
         fab!(:user1) { Fabricate(:user) }
         fab!(:user2) { Fabricate(:user, username: "UsEr2") }


### PR DESCRIPTION
Bug reproduction steps:
1. In admin trust level settings, set `min trust level to allow invite` to 2
2. Login with a user belonging to a group and having trust level 1
3. Select `Add Members` and invite new users

The invite is successfully sent despite the logged-in user not having sufficient privilege.

Fix is to check the current user's trust level when adding new members of a group.

Fixes [189357](https://meta.discourse.org/t/group-owners-can-invite-users-regardless-of-trust-level/189357)