### PR TITLE
FIX: allow webp format on themes by default as well

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1233,7 +1233,7 @@ files:
     default: 50000
     max: 1024000
   theme_authorized_extensions:
-    default: "jpg|jpeg|png|woff|woff2|svg|eot|ttf|otf|gif|js"
+    default: "jpg|jpeg|png|woff|woff2|svg|eot|ttf|otf|gif|webp|js"
     type: list
     list_type: compact
   authorized_extensions:


### PR DESCRIPTION
webp was already supported and authorized for user uploads, allow themes to
use webp as well.