### PR TITLE
FIX: Remove auto-route from topic-link

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/topic-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/topic-link.js
@@ -14,7 +14,6 @@ registerUnbound("topic-link", (topic, args) => {
 
   const result = `<a href='${url}'
                      class='${classes.join(" ")}'
-                     data-topic-id='${topic.id}'
-                     data-auto-route="true">${title}</a>`;
+                     data-topic-id='${topic.id}'>${title}</a>`;
   return htmlSafe(result);
 });


### PR DESCRIPTION
This was needed to fix a bookmark back button issue but it
broke category topic links, causing a full reload. Now it appears
something has changed in core and this is no longer necessary for
the bookmark back button to work, so I am removing it again.
