### PR TITLE
DEV: Oneboxer wildcard subdomains

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1518,7 +1518,6 @@ en:
     allowed_inline_onebox_domains: "A list of domains that will be oneboxed in miniature form if linked without a title"
     enable_inline_onebox_on_all_domains: "Ignore inline_onebox_domain_allowlist site setting and allow inline onebox on all domains."
     force_custom_user_agent_hosts: "Hosts for which to use the custom onebox user agent on all requests. (Especially useful for hosts that limit access by user agent)."
-    force_get_hosts: "Hosts for which to disable HEAD requests and only use GET requests."
     max_oneboxes_per_post: "Maximum number of oneboxes in a post."
     facebook_app_access_token: "A token generated from your Facebook app ID and secret. Used to generate Instagram oneboxes."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1518,6 +1518,7 @@ en:
     allowed_inline_onebox_domains: "A list of domains that will be oneboxed in miniature form if linked without a title"
     enable_inline_onebox_on_all_domains: "Ignore inline_onebox_domain_allowlist site setting and allow inline onebox on all domains."
     force_custom_user_agent_hosts: "Hosts for which to use the custom onebox user agent on all requests. (Especially useful for hosts that limit access by user agent)."
+    force_get_hosts: "Hosts for which to disable HEAD requests and only use GET requests."
     max_oneboxes_per_post: "Maximum number of oneboxes in a post."
     facebook_app_access_token: "A token generated from your Facebook app ID and secret. Used to generate Instagram oneboxes."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1640,6 +1640,7 @@ onebox:
   force_get_hosts:
     default: "us.battle.net|news.yahoo.com|*.medium.com"
     type: list
+    hidden: true
   facebook_app_access_token:
     default: ""
     secret: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1637,6 +1637,9 @@ onebox:
   force_custom_user_agent_hosts:
     default: "http://codepen.io"
     type: list
+  force_get_hosts:
+    default: "us.battle.net|news.yahoo.com|*.medium.com"
+    type: list
   facebook_app_access_token:
     default: ""
     secret: true

--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -300,7 +300,17 @@ class FinalDestination
 
   def hostname_matches?(url)
     url = uri(url)
-    @uri && url.present? && @uri.hostname == url&.hostname
+
+    if @uri&.hostname.present? && url&.hostname.present?
+      hostname_parts = url.hostname.split('.')
+      has_wildcard = hostname_parts.first == '*'
+
+      if has_wildcard
+        @uri.hostname.end_with?(hostname_parts[1..-1].join('.'))
+      else
+        @uri.hostname == url.hostname
+      end
+    end
   end
 
   def is_dest_valid?

--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -215,7 +215,7 @@ class FinalDestination
 
       @status = :resolved
       return @uri
-    when 400, 405, 406, 409, 501
+    when 400, 405, 406, 409, 500, 501
       response_status, small_headers = small_get(request_headers)
 
       if response_status == 200

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -32,7 +32,8 @@ module Oneboxer
   end
 
   def self.force_get_hosts
-    hosts = ['http://us.battle.net', 'https://news.yahoo.com']
+    hosts = []
+    hosts += SiteSetting.force_get_hosts.split('|').collect { |domain| "https://#{domain}" }
     hosts += SiteSetting.cache_onebox_response_body_domains.split('|').collect { |domain| "https://www.#{domain}" }
     hosts += amazon_domains
 

--- a/spec/components/final_destination_spec.rb
+++ b/spec/components/final_destination_spec.rb
@@ -9,7 +9,7 @@ describe FinalDestination do
     {
       ignore_redirects: ['https://ignore-me.com'],
 
-      force_get_hosts: ['https://force.get.com'],
+      force_get_hosts: ['https://force.get.com', 'https://*.ihaveawildcard.com/'],
 
       preserve_fragment_url_hosts: ['https://eviltrout.com'],
 
@@ -17,6 +17,7 @@ describe FinalDestination do
       lookup_ip: lambda do |host|
         case host
         when 'eviltrout.com' then '52.84.143.152'
+        when 'particularly.eviltrout.com' then '52.84.143.152'
         when 'codinghorror.com' then '91.146.108.148'
         when 'discourse.org' then '104.25.152.10'
         when 'some_thing.example.com' then '104.25.152.10'
@@ -24,6 +25,7 @@ describe FinalDestination do
         when 'internal-ipv6.com' then '2001:abc:de:01:3:3d0:6a65:c2bf'
         when 'ignore-me.com' then '53.84.143.152'
         when 'force.get.com' then '22.102.29.40'
+        when 'any-subdomain.ihaveawildcard.com' then '104.25.152.11'
         when 'wikipedia.com' then '1.2.3.4'
         else
           as_ip = IPAddr.new(host)
@@ -170,8 +172,11 @@ describe FinalDestination do
       before do
         stub_request(:head, 'https://force.get.com/posts?page=4')
         stub_request(:get, 'https://force.get.com/posts?page=4')
+        stub_request(:get, 'https://any-subdomain.ihaveawildcard.com/some/other/content')
         stub_request(:head, 'https://eviltrout.com/posts?page=2')
         stub_request(:get, 'https://eviltrout.com/posts?page=2')
+        stub_request(:head, 'https://particularly.eviltrout.com/has/a/secret/plan')
+        stub_request(:get, 'https://particularly.eviltrout.com/has/a/secret/plan')
       end
 
       it "will do a GET when forced" do
@@ -189,6 +194,23 @@ describe FinalDestination do
         expect(WebMock).to_not have_requested(:get, 'https://eviltrout.com/posts?page=2')
         expect(WebMock).to have_requested(:head, 'https://eviltrout.com/posts?page=2')
       end
+
+      it "will go a GET when forced on a wildcard subdomain" do
+        final = FinalDestination.new('https://any-subdomain.ihaveawildcard.com/some/other/content', opts)
+        expect(final.resolve.to_s).to eq('https://any-subdomain.ihaveawildcard.com/some/other/content')
+        expect(final.status).to eq(:resolved)
+        expect(WebMock).to have_requested(:get, 'https://any-subdomain.ihaveawildcard.com/some/other/content')
+        expect(WebMock).to_not have_requested(:head, 'https://any-subdomain.ihaveawildcard.com/some/other/content')
+      end
+
+      it "will go a HEAD if on a subdomain of a forced get domain without a wildcard" do
+        final = FinalDestination.new('https://particularly.eviltrout.com/has/a/secret/plan', opts)
+        expect(final.resolve.to_s).to eq('https://particularly.eviltrout.com/has/a/secret/plan')
+        expect(final.status).to eq(:resolved)
+        expect(WebMock).to_not have_requested(:get, 'https://particularly.eviltrout.com/has/a/secret/plan')
+        expect(WebMock).to have_requested(:head, 'https://particularly.eviltrout.com/has/a/secret/plan')
+      end
+
     end
 
     context "HEAD not supported" do

--- a/spec/components/final_destination_spec.rb
+++ b/spec/components/final_destination_spec.rb
@@ -195,7 +195,7 @@ describe FinalDestination do
         expect(WebMock).to have_requested(:head, 'https://eviltrout.com/posts?page=2')
       end
 
-      it "will go a GET when forced on a wildcard subdomain" do
+      it "will do a GET when forced on a wildcard subdomain" do
         final = FinalDestination.new('https://any-subdomain.ihaveawildcard.com/some/other/content', opts)
         expect(final.resolve.to_s).to eq('https://any-subdomain.ihaveawildcard.com/some/other/content')
         expect(final.status).to eq(:resolved)
@@ -203,7 +203,7 @@ describe FinalDestination do
         expect(WebMock).to_not have_requested(:head, 'https://any-subdomain.ihaveawildcard.com/some/other/content')
       end
 
-      it "will go a HEAD if on a subdomain of a forced get domain without a wildcard" do
+      it "will do a HEAD if on a subdomain of a forced get domain without a wildcard" do
         final = FinalDestination.new('https://particularly.eviltrout.com/has/a/secret/plan', opts)
         expect(final.resolve.to_s).to eq('https://particularly.eviltrout.com/has/a/secret/plan')
         expect(final.status).to eq(:resolved)

--- a/spec/components/oneboxer_spec.rb
+++ b/spec/components/oneboxer_spec.rb
@@ -355,6 +355,60 @@ describe Oneboxer do
     end
   end
 
+  context 'strategies' do
+    it "has a 'default' strategy" do
+      expect(Oneboxer.strategies.keys.first).to eq(:default)
+    end
+
+    it "has a strategy with overrides" do
+      strategy = Oneboxer.strategies.keys[1]
+      expect(Oneboxer.strategies[strategy].keys).not_to eq([])
+    end
+
+    context "using a non-default strategy" do
+      let(:hostname) { "my.interesting.site" }
+      let(:url) { "https://#{hostname}/cool/content" }
+      let(:html) do
+        <<~HTML
+          <html>
+          <head>
+            <meta property="og:title" content="Page Title">
+            <meta property="og:description" content="Here is some cool content">
+          </head>
+          <body>
+             <p>body</p>
+          </body>
+          <html>
+        HTML
+      end
+
+      before do
+        stub_request(:head, url).to_return(status: 500)
+        stub_request(:get, url).to_return(status: 200, body: html)
+      end
+
+      after do
+        Oneboxer.clear_preferred_strategy!(hostname)
+      end
+
+      it "uses mutiple strategies" do
+        default_ordered = Oneboxer.strategies.keys
+        custom_ordered = Oneboxer.ordered_strategies(hostname)
+        expect(custom_ordered).to eq(default_ordered)
+
+        expect(Oneboxer.preferred_strategy(hostname)).to eq(nil)
+        expect(Oneboxer.preview(url, invalidate_oneboxes: true)).to include("Here is some cool content")
+
+        custom_ordered = Oneboxer.ordered_strategies(hostname)
+
+        expect(custom_ordered.count).to eq(default_ordered.count)
+        expect(custom_ordered).not_to eq(default_ordered)
+
+        expect(Oneboxer.preferred_strategy(hostname)).not_to eq(:default)
+      end
+    end
+  end
+
   describe 'cache_onebox_response_body' do
     let(:html) do
       <<~HTML

--- a/spec/components/oneboxer_spec.rb
+++ b/spec/components/oneboxer_spec.rb
@@ -383,7 +383,7 @@ describe Oneboxer do
       end
 
       before do
-        stub_request(:head, url).to_return(status: 500)
+        stub_request(:head, url).to_return(status: 509)
         stub_request(:get, url).to_return(status: 200, body: html)
       end
 


### PR DESCRIPTION
Allows a wildcard to be used as a subdomain on Oneboxer-related SiteSettings, e.g.:

- `force_get_hosts`
- `cache_onebox_response_body_domains`
- `force_custom_user_agent_hosts`