### PR TITLE
FIX: flaky specs after topic view custom filters

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -781,7 +781,7 @@ class TopicView
       @contains_gaps = true
     end
 
-    if @filter.present? && @filter != 'summary' && TopicView.custom_filters[@filter].present?
+    if @filter.present? && @filter.to_s != 'summary' && TopicView.custom_filters[@filter].present?
       @filtered_posts = TopicView.custom_filters[@filter].call(@filtered_posts, self)
     end
 

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -74,7 +74,7 @@ describe TopicView do
       expect(tv.filter_posts).to eq([p0, p1])
 
       ensure
-        TopicView.instance_variable_set(:@custom_filters, [])
+        TopicView.instance_variable_set(:@custom_filters, {})
     end
   end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2456,7 +2456,7 @@ RSpec.describe TopicsController do
 
           expect(body["post_stream"]["posts"].map { |p| p["id"] }).to eq([post3.id])
         ensure
-          TopicView.instance_variable_set(:@custom_filters, [])
+          TopicView.instance_variable_set(:@custom_filters, {})
         end
       end
     end


### PR DESCRIPTION
When ensuring TopicView class variables return to the original state it should use empty Hash instead of empty Array. That

https://github.com/discourse/discourse/blob/master/lib/topic_view.rb#L60