### PR TITLE
PERF: Preload `JsLocaleHelper.load_translations` for default locale.

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -933,6 +933,8 @@ module Discourse
       # this will force Cppjieba to preload if any site has it
       # enabled allowing it to be reused between all child processes
       Search.prepare_data("test")
+
+      JsLocaleHelper.load_translations(SiteSetting.default_locale)
     end
 
     [


### PR DESCRIPTION
In production, each Unicorn child process will currently hold the
default locale in memory on first load. Instead, we should preload it in
the Unicorn master process so that the memory is immediately shared when
forking.