### PR TITLE
Plugin outlet for above the discovery list controls

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/discovery.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery.hbs
@@ -5,6 +5,8 @@
   {{/unless}}
 </div>
 
+{{plugin-outlet name="discovery-list-controls-above"}}
+
 <div class="list-controls">
   <div class="container">
     {{outlet "navigation-bar"}}


### PR DESCRIPTION
Hi, new to submitting PRs so hopefully I'm doing it right.

I would like to add some content here with a theme component: https://pasteboard.co/K1xxbPp.png I don't believe there's a way I can do it without overriding the discovery.hbs template in my theme.

My code doesn't include test coverage because I wouldn't think it's necessary for a plugin outlet :)

Thanks, please let me know if you need anything further or if I'm missing something here.