### PR TITLE
FIX: Make autotag watched words case insensitive

### DIFF
--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -6,7 +6,9 @@ class Admin::WatchedWordsController < Admin::AdminController
   skip_before_action :check_xhr, only: [:download]
 
   def index
-    render_json_dump WatchedWordListSerializer.new(WatchedWord.by_action, scope: guardian, root: false)
+    watched_words = WatchedWord.by_action
+    watched_words = watched_words.where.not(action: WatchedWord.actions[:tag]) if !SiteSetting.tagging_enabled
+    render_json_dump WatchedWordListSerializer.new(watched_words, scope: guardian, root: false)
   end
 
   def create

--- a/app/serializers/watched_word_list_serializer.rb
+++ b/app/serializers/watched_word_list_serializer.rb
@@ -4,9 +4,8 @@ class WatchedWordListSerializer < ApplicationSerializer
   attributes :actions, :words, :regular_expressions, :compiled_regular_expressions
 
   def actions
-    WatchedWord.actions.keys.filter do |key|
-      SiteSetting.tagging_enabled || key != :tag
-    end
+    SiteSetting.tagging_enabled ? WatchedWord.actions.keys
+                                : WatchedWord.actions.keys.filter { |k| k != :tag }
   end
 
   def words

--- a/app/serializers/watched_word_list_serializer.rb
+++ b/app/serializers/watched_word_list_serializer.rb
@@ -4,7 +4,9 @@ class WatchedWordListSerializer < ApplicationSerializer
   attributes :actions, :words, :regular_expressions, :compiled_regular_expressions
 
   def actions
-    WatchedWord.actions.keys
+    WatchedWord.actions.keys.filter do |key|
+      SiteSetting.tagging_enabled || key != :tag
+    end
   end
 
   def words
@@ -21,7 +23,7 @@ class WatchedWordListSerializer < ApplicationSerializer
 
   def compiled_regular_expressions
     expressions = {}
-    WatchedWord.actions.keys.each do |action|
+    actions.each do |action|
       expressions[action] = WordWatcher.word_matcher_regexp(action)&.source
     end
     expressions

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -111,11 +111,7 @@ class WordWatcher
     end
   end
 
-  def matches?(word)
-    if SiteSetting.watched_words_regular_expressions?
-      Regexp.new(word).match?(@raw)
-    else
-      @raw.include?(word)
-    end
+  def word_matches?(word)
+    Regexp.new(WordWatcher.word_to_regexp(word), Regexp::IGNORECASE).match?(@raw)
   end
 end

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -169,23 +169,23 @@ class TopicCreator
   end
 
   def setup_tags(topic)
-    return if @opts[:tags].blank?
-
-    valid_tags = DiscourseTagging.tag_topic_by_names(topic, @guardian, @opts[:tags])
-    unless valid_tags
-      topic.errors.add(:base, :unable_to_tag)
-      rollback_from_errors!(topic)
-    end
-
-    guardian = Guardian.new(Discourse.system_user)
-    word_watcher = WordWatcher.new("#{@opts[:title]} #{@opts[:raw]}")
-    word_watcher_tags = topic.tags.map(&:name)
-    WordWatcher.words_for_action(:tag).each do |word, tags|
-      if word_watcher.matches?(word)
-        word_watcher_tags += tags.split(",")
+    if @opts[:tags].present?
+      valid_tags = DiscourseTagging.tag_topic_by_names(topic, @guardian, @opts[:tags])
+      unless valid_tags
+        topic.errors.add(:base, :unable_to_tag)
+        rollback_from_errors!(topic)
       end
     end
-    DiscourseTagging.tag_topic_by_names(topic, guardian, word_watcher_tags)
+
+    watched_words = WordWatcher.words_for_action(:tag)
+    if watched_words.present?
+      word_watcher = WordWatcher.new("#{@opts[:title]} #{@opts[:raw]}")
+      word_watcher_tags = topic.tags.map(&:name)
+      watched_words.each do |word, tags|
+        word_watcher_tags += tags.split(",") if word_watcher.word_matches?(word)
+      end
+      DiscourseTagging.tag_topic_by_names(topic, Discourse.system_user.guardian, word_watcher_tags)
+    end
   end
 
   def setup_auto_close_time(topic)

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -503,10 +503,10 @@ describe PostCreator do
 
             context "without regular expressions" do
               it "works" do
-                Fabricate(:watched_word, action: WatchedWord.actions[:tag], word: "hello", replacement: "greetings , hey")
+                Fabricate(:watched_word, action: WatchedWord.actions[:tag], word: "HELLO", replacement: "greetings , hey")
 
-                @post = creator_with_tags.create
-                expect(@post.topic.tags.map(&:name)).to match_array(tag_names + ['greetings', 'hey'])
+                @post = creator.create
+                expect(@post.topic.tags.map(&:name)).to match_array(['greetings', 'hey'])
               end
 
               it "does not treat as regular expressions" do


### PR DESCRIPTION
The 'autotag' words were shown even if tagging was disabled.

This commit also fixes the bug when no tag was applied if no other tag
was already present.