### PR TITLE
FIX: Make truth-helpers work in Ember CLI

### DIFF
--- a/app/assets/javascripts/discourse-common/package.json
+++ b/app/assets/javascripts/discourse-common/package.json
@@ -18,7 +18,8 @@
     "ember-cli-babel": "^7.13.0",
     "ember-cli-htmlbars": "^4.2.0",
     "ember-auto-import": "^1.5.3",
-    "handlebars": "^4.7.0"
+    "handlebars": "^4.7.0",
+    "truth-helpers": "^1.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.1.0",

--- a/app/assets/javascripts/package.json
+++ b/app/assets/javascripts/package.json
@@ -1,4 +1,3 @@
-
 {
   "private": true,
   "workspaces": [
@@ -8,6 +7,7 @@
     "discourse-hbr",
     "discourse-widget-hbs",
     "pretty-text",
-    "select-kit"
+    "select-kit",
+    "truth-helpers"
   ]
 }

--- a/app/assets/javascripts/truth-helpers/package.json
+++ b/app/assets/javascripts/truth-helpers/package.json
@@ -15,9 +15,9 @@
     "start": "ember serve"
   },
   "dependencies": {
+    "ember-auto-import": "^1.5.3",
     "ember-cli-babel": "^7.13.0",
-    "ember-cli-htmlbars": "^4.2.0",
-    "ember-auto-import": "^1.5.3"
+    "ember-cli-htmlbars": "^4.2.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.1.0",


### PR DESCRIPTION
The addon wasn't included at all 😃