### PR TITLE
FIX: errors loading secure uploads when secure media is disabled

### DIFF
--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -77,15 +77,16 @@ class UrlHelper
   end
 
   def self.cook_url(url, secure: false, local: nil)
+    is_secure = SiteSetting.secure_media && secure
     local = is_local(url) if local.nil?
     return url if !local
 
-    url = secure ? secure_proxy_without_cdn(url) : absolute_without_cdn(url)
+    url = is_secure ? secure_proxy_without_cdn(url) : absolute_without_cdn(url)
 
     # we always want secure media to come from
     # Discourse.base_url_no_prefix/secure-media-uploads
     # to avoid asset_host mixups
-    return schemaless(url) if secure
+    return schemaless(url) if is_secure
 
     # PERF: avoid parsing url excpet for extreme conditions
     # this is a hot path used on home page

--- a/spec/components/url_helper_spec.rb
+++ b/spec/components/url_helper_spec.rb
@@ -170,6 +170,8 @@ describe UrlHelper do
       Rails.configuration.action_controller.asset_host = "https://test.some-cdn.com/dev"
 
       FileStore::S3Store.any_instance.stubs(:has_been_uploaded?).returns(true)
+
+      SiteSetting.secure_media = true
     end
 
     def cooked
@@ -183,6 +185,16 @@ describe UrlHelper do
         expect(cooked).to eq(
           "//test.localhost/secure-media-uploads/dev/original/3X/2/e/2e6f2ef81b6910ea592cd6d21ee897cd51cf72e4.jpeg"
         )
+      end
+
+      context "and secure_media setting is disabled" do
+        before { SiteSetting.secure_media = false }
+
+        it "returns the local_cdn_url" do
+          expect(cooked).to eq(
+            "//s3bucket.s3.dualstack.us-west-1.amazonaws.com/dev/original/3X/2/e/2e6f2ef81b6910ea592cd6d21ee897cd51cf72e4.jpeg"
+          )
+        end
       end
     end
 


### PR DESCRIPTION
After restoring a database from a site that had secure media configured and disabling the secure_media setting, any page with an upload will raise errors. This change will allow the uploads to be loaded from the local files. I'm not sure if this is the correct fix, so someone who knows more about secure media should review.