### PR TITLE
FIX: We should include resumable.js in the admin bundle

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -36,6 +36,10 @@ module.exports = function (defaults) {
   app.import(vendorJs + "jquery.fileupload.js");
   app.import(vendorJs + "jquery.autoellipsis-1.0.10.js");
 
+  let adminVendor = funnel(vendorJs, {
+    files: ["resumable.js"],
+  });
+
   return mergeTrees([
     discourseScss(`${discourseRoot}/app/assets/stylesheets`, "testem.scss"),
     createI18nTree(discourseRoot, vendorJs),
@@ -46,7 +50,7 @@ module.exports = function (defaults) {
       destDir: "assets/highlightjs",
     }),
     digest(
-      concat(app.options.adminTree, {
+      concat(mergeTrees([app.options.adminTree, adminVendor]), {
         outputFile: `assets/admin.js`,
       })
     ),


### PR DESCRIPTION
Normally we'd use `ember-auto-import` for this, but it's not run on
our admin tree due to the quirky way we load it conditionally.
Instead we'll append it at the bottom like our Rails app does.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
