### PR TITLE
FIX: Missing iframe closing tag in discobot certificate

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/base.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/base.rb
@@ -137,7 +137,7 @@ module DiscourseNarrativeBot
       src = Discourse.base_url + DiscourseNarrativeBot::Engine.routes.url_helpers.certificate_path(options)
       alt = CGI.escapeHTML(I18n.t("#{self.class::I18N_KEY}.certificate.alt"))
 
-      "<iframe class='discobot-certificate' src='#{src}' width='650' height='464' alt='#{alt}'>"
+      "<iframe class='discobot-certificate' src='#{src}' width='650' height='464' alt='#{alt}'></iframe>"
     end
 
     protected

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -715,7 +715,7 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
         end
       end
 
-      it 'should create the right reply' do
+      it 'should create the right reply and issue the discobot certificate' do
         post.update!(raw: "[details=\"This is a test\"]\nwooohoo\n[/details]")
         narrative.input(:reply, user, post: post)
 
@@ -729,6 +729,12 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
 
         expect(user.badges.where(name: DiscourseNarrativeBot::AdvancedUserNarrative.badge_name).exists?)
           .to eq(true)
+
+        expect(topic.ordered_posts.last.cooked).to include("<iframe")
+        expect(Nokogiri::HTML5(topic.ordered_posts.last.cooked).at("iframe").text).not_to include(
+          "Bye for now"
+        )
+        expect(topic.ordered_posts.last.cooked).to include("</iframe>")
       end
     end
   end


### PR DESCRIPTION
When issuing the discobot certificate, we were not closing the
iframe tag, which meant that the final message instruction to
the user was swallowed up.

Before:

![image](https://user-images.githubusercontent.com/920448/118082948-6ce75900-b401-11eb-98fe-2311c55df4db.png)

After:

![image](https://user-images.githubusercontent.com/920448/118082985-796bb180-b401-11eb-87dc-94c33ff57e8c.png)
