### PR TITLE
DEV: Periodically delete old email change requests

### DIFF
--- a/app/jobs/scheduled/clean_up_email_change_requests.rb
+++ b/app/jobs/scheduled/clean_up_email_change_requests.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CleanUpEmailChangeRequests < ::Jobs::Scheduled
+    every 1.day
+
+    def execute(args)
+      EmailChangeRequest.where('updated_at < ?', 1.month.ago).delete_all
+    end
+  end
+end

--- a/spec/jobs/clean_up_email_change_requests_spec.rb
+++ b/spec/jobs/clean_up_email_change_requests_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Jobs::CleanUpEmailChangeRequests do
+  it "deletes records older than 1 month" do
+    very_old = Fabricate(:email_change_request, updated_at: 32.days.ago)
+    yesterday = Fabricate(:email_change_request, updated_at: 1.day.ago)
+    today = Fabricate(:email_change_request, updated_at: Time.zone.now)
+
+    expect { described_class.new.execute({}) }.to change { EmailChangeRequest.count }.by(-1)
+    expect { very_old.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect(yesterday.reload).to be_present
+    expect(today.reload).to be_present
+  end
+end


### PR DESCRIPTION
Email change requests are never deleted no matter if they completed
successfully or not. The abandoned requests have the disadvantage of
showing up as unconfirmed emails in user's preferences page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
