### PR TITLE
FIX: errors that're triggering by too long excerpts

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -871,7 +871,6 @@ posting:
       zh_TW: 120
   topic_excerpt_maxlength:
     default: 220
-    max: 999
     locale_default:
       ja: 120
       zh_CN: 120

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -871,6 +871,7 @@ posting:
       zh_TW: 120
   topic_excerpt_maxlength:
     default: 220
+    max: 999
     locale_default:
       ja: 120
       zh_CN: 120

--- a/db/post_migrate/20210513125608_remove_length_constrain_from_topic_excerpt.rb
+++ b/db/post_migrate/20210513125608_remove_length_constrain_from_topic_excerpt.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveLengthConstrainFromTopicExcerpt < ActiveRecord::Migration[6.1]
+  def up
+    change_column :topics, :excerpt, :string, null: true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Sometimes users [get 500 errors](https://meta.discourse.org/t/500-error-community-forum-trial/190007) because of too long excerpts. 

The `excerpt` field in the database is constrained to 1000 chars in length. To support this constraint we [added](https://meta.discourse.org/t/500-error-while-posting-a-topic/159756/15?u=andrei) a restriction that the `topic_excerpt_maxlength` setting must be between 0 and 999.

Unfortunately, sometimes it doesn’t work because:
- `topic_excerpt_maxlength` restricts the length of a _visible to user_ excerpt. But we HTML-escape text before saving. If an excerpt contains `&` it’ll be `&amp;`. One character for the user but 5 characters to save to the database. So if `topic_excerpt_maxlength` is set to 999 it’s not so hard to have an excerpt of for example 1003 characters in length and run into this issue.
- It’s possible to define a [custom excerpt](https://meta.discourse.org/t/ability-to-custom-define-topic-preview-text/107455/11) for a topic. Such excerpts [bypass](https://github.com/discourse/discourse/blob/f05f5fde0ffa71e39ec75b4619fad77c8ed8f8ea/lib/excerpt_parser.rb#L32) check for a length. So if the user defines a too long custom excerpt he will run into this issue.

Removing the constraint on the database level solves the problem. But we still need the constraint for `topic_excerpt_maxlength` on the setting page, because too long excerpts would make UI wonky.

_There aren’t performance benefits in using length-constrained columns in Postgres, in fact, length-constrained columns need a few extra CPU cycles to check the length when storing data ([doc](https://www.postgresql.org/docs/9.3/datatype-character.html))._