### PR TITLE
FIX: Ignore max excerpt length for div excerpts too

### DIFF
--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -4,7 +4,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
 
   attr_reader :excerpt
 
-  CUSTOM_EXCERPT_REGEX = /<\s*[span|div][^>]*class\s*=\s*['|"]excerpt['|"][^>]*>/
+  CUSTOM_EXCERPT_REGEX = /<\s*(span|div)[^>]*class\s*=\s*['"]excerpt['"][^>]*>/
 
   def initialize(length, options = nil)
     @length = length

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -4,7 +4,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
 
   attr_reader :excerpt
 
-  SPAN_REGEX = /<\s*span[^>]*class\s*=\s*['|"]excerpt['|"][^>]*>/
+  CUSTOM_EXCERPT_REGEX = /<\s*[span|div][^>]*class\s*=\s*['|"]excerpt['|"][^>]*>/
 
   def initialize(length, options = nil)
     @length = length
@@ -29,7 +29,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
 
   def self.get_excerpt(html, length, options)
     html ||= ''
-    length = html.length if html.include?('excerpt') && SPAN_REGEX === html
+    length = html.length if html.include?('excerpt') && CUSTOM_EXCERPT_REGEX === html
     me = self.new(length, options)
     parser = Nokogiri::HTML::SAX::Parser.new(me)
     catch(:done) do

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -798,10 +798,24 @@ describe PrettyText do
       expect(post.excerpt).to eq("hello <a href=\"https://site.com\" rel=\"noopener nofollow ugc\">site</a>")
     end
 
+    it "handles div excerpt at the beginning of a post" do
+      expect(PrettyText.excerpt("<div class='excerpt'>hi</div> test", 100)).to eq('hi')
+      post = Fabricate(:post, raw: "<div class='excerpt'>hi</div> test")
+      expect(post.excerpt).to eq("hi")
+    end
+
     it "handles span excerpt at the beginning of a post" do
       expect(PrettyText.excerpt("<span class='excerpt'>hi</span> test", 100)).to eq('hi')
       post = Fabricate(:post, raw: "<span class='excerpt'>hi</span> test")
       expect(post.excerpt).to eq("hi")
+    end
+
+    it "ignores max excerpt length if a div excerpt is specified" do
+      two_hundred = "123456789 " * 20 + "."
+      text = two_hundred + "<div class='excerpt'>#{two_hundred}</div>" + two_hundred
+      expect(PrettyText.excerpt(text, 100)).to eq(two_hundred)
+      post = Fabricate(:post, raw: text)
+      expect(post.excerpt).to eq(two_hundred)
     end
 
     it "ignores max excerpt length if a span excerpt is specified" do

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -800,30 +800,22 @@ describe PrettyText do
 
     it "handles div excerpt at the beginning of a post" do
       expect(PrettyText.excerpt("<div class='excerpt'>hi</div> test", 100)).to eq('hi')
-      post = Fabricate(:post, raw: "<div class='excerpt'>hi</div> test")
-      expect(post.excerpt).to eq("hi")
     end
 
     it "handles span excerpt at the beginning of a post" do
       expect(PrettyText.excerpt("<span class='excerpt'>hi</span> test", 100)).to eq('hi')
-      post = Fabricate(:post, raw: "<span class='excerpt'>hi</span> test")
-      expect(post.excerpt).to eq("hi")
     end
 
     it "ignores max excerpt length if a div excerpt is specified" do
       two_hundred = "123456789 " * 20 + "."
       text = two_hundred + "<div class='excerpt'>#{two_hundred}</div>" + two_hundred
       expect(PrettyText.excerpt(text, 100)).to eq(two_hundred)
-      post = Fabricate(:post, raw: text)
-      expect(post.excerpt).to eq(two_hundred)
     end
 
     it "ignores max excerpt length if a span excerpt is specified" do
       two_hundred = "123456789 " * 20 + "."
       text = two_hundred + "<span class='excerpt'>#{two_hundred}</span>" + two_hundred
       expect(PrettyText.excerpt(text, 100)).to eq(two_hundred)
-      post = Fabricate(:post, raw: text)
-      expect(post.excerpt).to eq(two_hundred)
     end
 
     it "unescapes html entities when we want text entities" do


### PR DESCRIPTION
We support two [types](https://github.com/discourse/discourse/blob/b21f74060e865d809ba466cb52e6cb95c7b0cf1f/lib/excerpt_parser.rb#L120) of custom excerpts. It can be `<div class="excerpt">` or `<span class="excerpt">`. We also ignore max excerpt length for custom excerpts. But we forgot to process `div` when ignoring max length.