### PR TITLE
FIX: flaky topic_view_serializer_spec

### DIFF
--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -58,7 +58,7 @@ describe TopicViewSerializer do
       end
 
       it 'should have thumbnails' do
-        SiteSetting.create_thumbnails = true
+        SiteSetting.stubs(:create_thumbnails).returns(true)
 
         Discourse.redis.del(topic.thumbnail_job_redis_key(Topic.thumbnail_sizes))
         json = nil


### PR DESCRIPTION
Thumbnails may not be created when SiteSetting is reset in parallel spec. For example:

https://github.com/discourse/discourse/blob/master/spec/models/upload_spec.rb#L26

Therefore, stubbing setting should increase consistency.