### PR TITLE
FIX: Allow `file-change` events soon after reloading

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/initializers/live-development.js
@@ -8,6 +8,7 @@ export default {
   name: "live-development",
   initialize(container) {
     const messageBus = container.lookup("message-bus:main");
+    const session = container.lookup("session:main");
 
     // Preserve preview_theme_id=## and pp=async-flamegraph parameters across pages
     const params = new URLSearchParams(window.location.search);
@@ -48,32 +49,36 @@ export default {
     }
 
     // Observe file changes
-    messageBus.subscribe("/file-change", function (data) {
-      if (Handlebars.compile && !Ember.TEMPLATES.empty) {
-        // hbs notifications only happen in dev
-        Ember.TEMPLATES.empty = Handlebars.compile("<div></div>");
-      }
-      data.forEach((me) => {
-        if (me === "refresh") {
-          // Refresh if necessary
-          document.location.reload(true);
-        } else {
-          $("link").each(function () {
-            if (me.hasOwnProperty("theme_id") && me.new_href) {
-              const target = $(this).data("target");
-              const themeId = $(this).data("theme-id");
-              if (
-                target === me.target &&
-                (!themeId || themeId === me.theme_id)
-              ) {
-                refreshCSS(this, null, me.new_href);
-              }
-            } else if (this.href.match(me.name) && (me.hash || me.new_href)) {
-              refreshCSS(this, me.hash, me.new_href);
-            }
-          });
+    messageBus.subscribe(
+      "/file-change",
+      function (data) {
+        if (Handlebars.compile && !Ember.TEMPLATES.empty) {
+          // hbs notifications only happen in dev
+          Ember.TEMPLATES.empty = Handlebars.compile("<div></div>");
         }
-      });
-    });
+        data.forEach((me) => {
+          if (me === "refresh") {
+            // Refresh if necessary
+            document.location.reload(true);
+          } else {
+            $("link").each(function () {
+              if (me.hasOwnProperty("theme_id") && me.new_href) {
+                const target = $(this).data("target");
+                const themeId = $(this).data("theme-id");
+                if (
+                  target === me.target &&
+                  (!themeId || themeId === me.theme_id)
+                ) {
+                  refreshCSS(this, null, me.new_href);
+                }
+              } else if (this.href.match(me.name) && (me.hash || me.new_href)) {
+                refreshCSS(this, me.hash, me.new_href);
+              }
+            });
+          }
+        });
+      },
+      session.mbLastFileChangeId
+    );
   },
 };

--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -83,6 +83,10 @@ export default {
     session.disableCustomCSS = setupData.disableCustomCss === "true";
     session.markdownItURL = setupData.markdownItUrl;
 
+    if (setupData.mbLastFileChangeId) {
+      session.mbLastFileChangeId = parseInt(setupData.mbLastFileChangeId, 10);
+    }
+
     if (setupData.safeMode) {
       session.safe_mode = setupData.safeMode;
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -539,6 +539,7 @@ module ApplicationHelper
       if ENV['DEBUG_PRELOADED_APP_DATA']
         setup_data[:debug_preloaded_app_data] = true
       end
+      setup_data[:mb_last_file_change_id] = MessageBus.last_id('/file-change')
     end
 
     if guardian.can_enable_safe_mode? && params["safe_mode"]


### PR DESCRIPTION
This patch remembers the last id for the `file-change` event and uses it
to initialize the client side watcher. This should help fix the issue
where styles are not reloaded client side if the browser refreshed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
