### PR TITLE
DEV: Improve auto-restart parent process detection logic

### DIFF
--- a/bin/unicorn
+++ b/bin/unicorn
@@ -87,6 +87,8 @@ end
 # This is handy if you want to bind a key to restarting unicorn in dev
 
 if dev_mode
+  $unicorn_dev_supervisor_pid = Process.pid # rubocop:disable Style/GlobalVars
+
   restart = true
   while restart
     restart = false

--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -12,7 +12,8 @@ if Rails.env.development? && !Rails.configuration.cache_classes
   ]
 
   Listen.to(*paths, only: /\.rb$/) do |modified, added, removed|
-    auto_restart = ENV["AUTO_RESTART"] != "0"
+    supervisor_pid = $unicorn_dev_supervisor_pid # rubocop:disable Style/GlobalVars
+    auto_restart = supervisor_pid && ENV["AUTO_RESTART"] != "0"
 
     files = modified + added + removed
 
@@ -25,7 +26,7 @@ if Rails.env.development? && !Rails.configuration.cache_classes
       message = auto_restart ? "Restarting server..." : "Server restart required. Automate this by setting AUTO_RESTART=1."
       STDERR.puts "[DEV]: Edited files which are not autoloaded. #{message}"
       STDERR.puts not_autoloaded.map { |path| "- #{path}".indent(7) }.join("\n")
-      Process.kill("USR2", Process.ppid) if auto_restart
+      Process.kill("USR2", supervisor_pid) if auto_restart
     end
   end.start
 end


### PR DESCRIPTION
The auto restart logic was sending a USR2 to the parent process without checking what the parent process actually was. In some situations, it might not be the `bin/unicorn` supervisor.

This commit switches to use a global variable for the supervisor PID. This will be much less prone to unexpected behavior.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
