### PR TITLE
FIX: Automatically load more reviewable items.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -138,7 +138,10 @@ export default Component.extend({
 
           // "fast track" to update the current user's reviewable count before the message bus finds out.
           if (performResult.reviewable_count !== undefined) {
-            this.currentUser.set("reviewable_count", result.reviewable_count);
+            this.currentUser.set(
+              "reviewable_count",
+              performResult.reviewable_count
+            );
           }
 
           if (this.attrs.remove) {

--- a/app/assets/javascripts/discourse/app/controllers/review-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/review-index.js
@@ -102,7 +102,12 @@ export default Controller.extend({
       let newList = this.reviewables.reject((reviewable) => {
         return ids.indexOf(reviewable.id) !== -1;
       });
-      this.set("reviewables", newList);
+
+      if (newList.length === 0) {
+        this.send("refreshRoute");
+      } else {
+        this.set("reviewables", newList);
+      }
     },
 
     resetTopic() {


### PR DESCRIPTION
If you finished reviewing the initially loaded items, and there're more in the queue, load them.

Also, when fast-tracking the pending items updates, use the reviewable_count returned by the perform result. Calling "result.reviewable_count" returns undefined.


