### PR TITLE
FIX: An unresolved blank uri should attempt an alternate Oneboxing strategy, if available

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -427,12 +427,10 @@ module Oneboxer
         args = { link: url }
         if fd.status == :invalid_address
           args[:error_message] = I18n.t("errors.onebox.invalid_address", hostname: fd.hostname)
-        elsif fd.status_code
+        elsif (fd.status_code || uri.nil?) && available_strategies.present?
           # Try a different oneboxing strategy, if we have any options left:
-          if available_strategies.present?
-            return external_onebox(url, available_strategies)
-          end
-
+          return external_onebox(url, available_strategies)
+        elsif fd.status_code
           args[:error_message] = I18n.t("errors.onebox.error_response", status_code: fd.status_code)
         end
 

--- a/spec/components/oneboxer_spec.rb
+++ b/spec/components/oneboxer_spec.rb
@@ -391,7 +391,7 @@ describe Oneboxer do
         Oneboxer.clear_preferred_strategy!(hostname)
       end
 
-      it "uses mutiple strategies" do
+      it "uses multiple strategies" do
         default_ordered = Oneboxer.strategies.keys
         custom_ordered = Oneboxer.ordered_strategies(hostname)
         expect(custom_ordered).to eq(default_ordered)


### PR DESCRIPTION
A timeout when calling FinalDestination may result in a status of `:ready` with a resolved uri of `nil`.

This should result in the next alternate Oneboxing strategy being used, if there are any left.