### PR TITLE
UX: Fix theme upload width, remove class clash, prettier

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
@@ -1,10 +1,30 @@
-{{#d-modal-body class="upload-selector install-theme" title="admin.customize.theme.install"}}
+{{#d-modal-body
+  class="theme-upload-selector install-theme"
+  title="admin.customize.theme.install"
+}}
   {{#unless directRepoInstall}}
     <div class="install-theme-items">
-      {{install-theme-item value="popular" selection=selection label="admin.customize.theme.install_popular"}}
-      {{install-theme-item value="local" selection=selection label="admin.customize.theme.install_upload"}}
-      {{install-theme-item value="remote" selection=selection label="admin.customize.theme.install_git_repo"}}
-      {{install-theme-item value="create" selection=selection label="admin.customize.theme.install_create" showIcon=true}}
+      {{install-theme-item
+        value="popular"
+        selection=selection
+        label="admin.customize.theme.install_popular"
+      }}
+      {{install-theme-item
+        value="local"
+        selection=selection
+        label="admin.customize.theme.install_upload"
+      }}
+      {{install-theme-item
+        value="remote"
+        selection=selection
+        label="admin.customize.theme.install_git_repo"
+      }}
+      {{install-theme-item
+        value="create"
+        selection=selection
+        label="admin.customize.theme.install_create"
+        showIcon=true
+      }}
     </div>
   {{/unless}}
   <div class="install-theme-content">
@@ -13,9 +33,16 @@
         {{#each themes as |theme|}}
           <div class="popular-theme-item" data-name={{theme.name}}>
             <div class="popular-theme-name">
-              <a href={{theme.meta_url}} rel="noopener noreferrer" target="_blank">
+              <a
+                href={{theme.meta_url}}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
                 {{#if theme.component}}
-                  {{d-icon "puzzle-piece" title="admin.customize.theme.component"}}
+                  {{d-icon
+                    "puzzle-piece"
+                    title="admin.customize.theme.component"
+                  }}
                 {{/if}}
                 {{theme.name}}
               </a>
@@ -28,14 +55,21 @@
               {{#if theme.installed}}
                 <span>{{i18n "admin.customize.theme.installed"}}</span>
               {{else}}
-                {{d-button class="btn-small"
+                {{d-button
+                  class="btn-small"
                   label="admin.customize.theme.install"
                   disabled=installDisabled
                   icon="upload"
-                  action=(action "installThemeFromList" theme.value)}}
+                  action=(action "installThemeFromList" theme.value)
+                }}
 
                 {{#if theme.preview}}
-                  <a href={{theme.preview}} rel="noopener noreferrer" target="_blank">{{d-icon "desktop"}} {{i18n "admin.customize.theme.preview"}}</a>
+                  <a
+                    href={{theme.preview}}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >{{d-icon "desktop"}}
+                    {{i18n "admin.customize.theme.preview"}}</a>
                 {{/if}}
               {{/if}}
             </div>
@@ -46,26 +80,38 @@
 
     {{#if local}}
       <div class="inputs">
-        <input onchange={{action "uploadLocaleFile"}} type="file" id="file-input" accept=".dcstyle.json,application/json,.tar.gz,application/x-gzip,.zip,application/zip"><br>
-        <span class="description">{{i18n "admin.customize.theme.import_file_tip"}}</span>
+        <input
+          onchange={{action "uploadLocaleFile"}}
+          type="file"
+          id="file-input"
+          accept=".dcstyle.json,application/json,.tar.gz,application/x-gzip,.zip,application/zip"
+        /><br />
+        <span class="description">{{i18n
+            "admin.customize.theme.import_file_tip"
+          }}</span>
       </div>
     {{/if}}
 
     {{#if remote}}
       <div class="inputs">
         <div class="repo">
-          <div class="label">{{i18n "admin.customize.theme.import_web_tip"}}</div>
+          <div class="label">{{i18n
+              "admin.customize.theme.import_web_tip"
+            }}</div>
           {{input value=uploadUrl placeholder=urlPlaceholder}}
         </div>
 
         {{d-button
           class="btn-small advanced-repo"
           action=(action "toggleAdvanced")
-          label="admin.customize.theme.import_web_advanced"}}
+          label="admin.customize.theme.import_web_advanced"
+        }}
 
         {{#if advancedVisible}}
           <div class="branch">
-            <div class="label">{{i18n "admin.customize.theme.remote_branch"}}</div>
+            <div class="label">{{i18n
+                "admin.customize.theme.remote_branch"
+              }}</div>
             {{input value=branch placeholder="master"}}
           </div>
 
@@ -77,12 +123,16 @@
           </div>
           {{#if showPublicKey}}
             <div class="public-key">
-              <div class="label">{{i18n "admin.customize.theme.public_key"}}</div>
+              <div class="label">{{i18n
+                  "admin.customize.theme.public_key"
+                }}</div>
               {{textarea readonly=true value=publicKey}}
             </div>
           {{else}}
             {{#if privateChecked}}
-              <div class="public-key-note">{{i18n "admin.customize.theme.public_key_note"}}</div>
+              <div class="public-key-note">{{i18n
+                  "admin.customize.theme.public_key_note"
+                }}</div>
             {{/if}}
           {{/if}}
         {{/if}}
@@ -106,7 +156,9 @@
 
     {{#if directRepoInstall}}
       <div class="repo">
-        <div class="label">{{html-safe (i18n "admin.customize.theme.direct_install_tip" name=uploadName)}}</div>
+        <div class="label">{{html-safe
+            (i18n "admin.customize.theme.direct_install_tip" name=uploadName)
+          }}</div>
         <pre><code>{{uploadUrl}}</code></pre>
       </div>
     {{/if}}
@@ -118,10 +170,16 @@
   <div class="modal-footer">
     {{#if duplicateRemoteThemeWarning}}
       <div class="install-theme-warning">
-        ⚠️ {{duplicateRemoteThemeWarning}}
+        ⚠️
+        {{duplicateRemoteThemeWarning}}
       </div>
     {{/if}}
-    {{d-button action=(action "installTheme") disabled=installDisabled class="btn btn-primary" label=submitLabel}}
+    {{d-button
+      action=(action "installTheme")
+      disabled=installDisabled
+      class="btn btn-primary"
+      label=submitLabel
+    }}
     {{d-modal-cancel close=(route-action "closeModal")}}
   </div>
 {{/unless}}

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
@@ -1,7 +1,4 @@
-{{#d-modal-body
-  class="theme-upload-selector install-theme"
-  title="admin.customize.theme.install"
-}}
+{{#d-modal-body class="install-theme" title="admin.customize.theme.install"}}
   {{#unless directRepoInstall}}
     <div class="install-theme-items">
       {{install-theme-item

--- a/app/assets/stylesheets/desktop/upload.scss
+++ b/app/assets/stylesheets/desktop/upload.scss
@@ -39,8 +39,7 @@
       }
     }
   }
-  .radios:last-child:not(:nth-child(2)) {
-    // last child for composer modal, but not theme import modal
+  .radios:last-child {
     min-height: 20px;
   }
 }


### PR DESCRIPTION
Minor class clash here, the composer file modal & theme upload modal used to be similar... but the theme uploader has diverged, so I'm removing the old class to fix this issue:

Before:

![Screen Shot 2021-05-14 at 5 32 11 PM](https://user-images.githubusercontent.com/1681963/118333805-611b9580-b4da-11eb-8ac3-81516b7519b3.png)

After:

![Screen Shot 2021-05-14 at 5 31 58 PM](https://user-images.githubusercontent.com/1681963/118333811-64af1c80-b4da-11eb-9f70-39096deca15e.png)
