### PR TITLE
FIX: backtracking re-render assertion in future-date-input

### DIFF
--- a/app/assets/javascripts/discourse/app/components/future-date-input.js
+++ b/app/assets/javascripts/discourse/app/components/future-date-input.js
@@ -24,7 +24,6 @@ export default Component.extend({
         date: datetime.format("YYYY-MM-DD"),
         time: datetime.format("HH:mm"),
       });
-      this._updateInput();
     }
   },
 


### PR DESCRIPTION
> _Backtracking re-render_ refers to a scenario where, in the middle of the rendering process, you have modified something that has already been rendered. 

See more details from the Ember team [here](https://github.com/emberjs/ember.js/issues/13948).

We call `_updateInput` from `init`. `_updateInput` triggers `onChangeInput` which [mutates](https://github.com/discourse/discourse/blob/a24b6daa87d9f75c729dcdfd6d9e9270fa9971ae/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs#L16) a date that was given to `future-date-input` just a moment ago and a rendering cycle wasn't finished yet.

I ran into this assertion when modifying the Slow Mode dialog when working on [FIX: slow mode dialog doesn't remember Enabled Until value](https://github.com/discourse/discourse/pull/13076).

It didn't break any test so far and I didn't find regressions; I will deal with regressions it may cause.
