### PR TITLE
FIX: Previewing themes didn't work in Ember CLI

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -162,7 +162,13 @@ function buildFromBootstrap(assetPath, proxy, baseURL, req, headers) {
       path.join(process.cwd(), "dist", assetPath),
       "utf8",
       (err, template) => {
-        getJSON(`${proxy}${baseURL}bootstrap.json`, null, req.headers)
+        let url = `${proxy}${baseURL}bootstrap.json`;
+        let queryLoc = req.url.indexOf("?");
+        if (queryLoc !== -1) {
+          url += req.url.substr(queryLoc);
+        }
+
+        getJSON(url, null, req.headers)
           .then((json) => {
             resolve(applyBootstrap(json.bootstrap, template, headers));
           })
@@ -194,7 +200,7 @@ async function handleRequest(assetPath, proxy, baseURL, req, res) {
         }
 
         req.headers["X-Discourse-Ember-CLI"] = "true";
-        let get = bent("GET", [200, 404, 403, 500]);
+        let get = bent("GET", [200, 301, 302, 303, 307, 308, 404, 403, 500]);
         let response = await get(url, null, req.headers);
         res.set(response.headers);
         if (response.headers["x-discourse-bootstrap-required"] === "true") {


### PR DESCRIPTION
This is two fixes:

1. Ember CLI's proxy did not support 3xx redirects so a redirect was
   failing.

2. We were not passing query parameters to the `bootstrap.json` endpoint
   to correctly handle previewing themes (and other occasional options.)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
