### PR TITLE
increase target usernames

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -283,14 +283,14 @@ class UserAction < ActiveRecord::Base
           update_like_count(user_id, hash[:action_type], 1)
         end
 
-        # move into Topic perhaps
         group_ids = nil
         if topic && topic.category && topic.category.read_restricted
-          group_ids = topic.category.groups.pluck("groups.id")
+          group_ids = [Group::AUTO_GROUPS[:admins]]
+          group_ids.concat(topic.category.groups.pluck("groups.id"))
         end
 
         if action.user
-          MessageBus.publish("/u/#{action.user.username.downcase}", action.id, user_ids: [user_id], group_ids: group_ids)
+          MessageBus.publish("/u/#{action.user.username_lower}", action.id, user_ids: [user_id], group_ids: group_ids)
         end
 
         action

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1405,10 +1405,7 @@ describe GroupsController do
       it "will invite the user if their username and email are both invited" do
         new_user = Fabricate(:user)
         put "/groups/#{group.id}/members.json", params: { usernames: new_user.username, emails: new_user.email }
-
         expect(response.status).to eq(200)
-        body = response.parsed_body
-
         expect(new_user.reload.group_ids.include?(group.id)).to eq(true)
       end
 
@@ -1471,8 +1468,6 @@ describe GroupsController do
 
       it "raises an error if user to be removed is not found" do
         delete "/groups/#{group.id}/members.json", params: { user_id: -10 }
-
-        response_body = response.parsed_body
         expect(response.status).to eq(400)
       end
 
@@ -1627,7 +1622,7 @@ describe GroupsController do
     end
 
     it "sends a private message when accepted" do
-      group_request = GroupRequest.create!(group: group, user: other_user)
+      GroupRequest.create!(group: group, user: other_user)
       expect { put "/groups/#{group.id}/handle_membership_request.json", params: { user_id: other_user.id, accept: true } }
         .to change { Topic.count }.by(1)
         .and change { Post.count }.by(1)


### PR DESCRIPTION
- FIX: Correctly publish messages unconditionally to admins
- FEATURE: allow for notification of up to 20 group owners
