### PR TITLE
FIX: Validate upload is still valid after calling the "before_upload_creation" event

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -153,9 +153,10 @@ class UploadCreator
         @upload.assign_attributes(attrs)
       end
 
-      return @upload unless @upload.save(validate: @opts[:validate])
-
-      DiscourseEvent.trigger(:before_upload_creation, @file, is_image, @opts[:for_export])
+      # Callbacks using this event to validate the upload or the file must add errors to the
+      # upload errors object.
+      DiscourseEvent.trigger(:before_upload_creation, @file, is_image, @upload, @opts[:validate])
+      return @upload unless @upload.errors.empty? && @upload.save(validate: @opts[:validate])
 
       # store the file and update its url
       File.open(@file.path) do |f|


### PR DESCRIPTION
Since we use the event to perform additional validations on the file, we should check if it added any errors to the upload before saving it. This change makes the UploadCreator more consistent since we no longer have to rely on exceptions.

