### PR TITLE
DEV: No need to disable rate limiter after running tests

### DIFF
--- a/spec/components/auth/default_current_user_provider_spec.rb
+++ b/spec/components/auth/default_current_user_provider_spec.rb
@@ -195,10 +195,6 @@ describe Auth::DefaultCurrentUserProvider do
         RateLimiter.enable
       end
 
-      after do
-        RateLimiter.disable
-      end
-
       it "rate limits api requests per api key" do
         global_setting :max_admin_api_reqs_per_key_per_minute, 3
 
@@ -424,10 +420,6 @@ describe Auth::DefaultCurrentUserProvider do
       RateLimiter.enable
     end
 
-    after do
-      RateLimiter.disable
-    end
-
     it "can only try 10 bad cookies a minute" do
       token = UserAuthToken.generate!(user_id: user.id)
 
@@ -625,10 +617,6 @@ describe Auth::DefaultCurrentUserProvider do
 
       before do
         RateLimiter.enable
-      end
-
-      after do
-        RateLimiter.disable
       end
 
       it "rate limits api usage" do

--- a/spec/components/middleware/anonymous_cache_spec.rb
+++ b/spec/components/middleware/anonymous_cache_spec.rb
@@ -178,10 +178,6 @@ describe Middleware::AnonymousCache do
       RateLimiter.enable
     end
 
-    after do
-      RateLimiter.disable
-    end
-
     it 'will revert to anonymous once we reach the limit' do
 
       RateLimiter.clear_all!

--- a/spec/components/middleware/request_tracker_spec.rb
+++ b/spec/components/middleware/request_tracker_spec.rb
@@ -205,7 +205,6 @@ describe Middleware::RequestTracker do
     end
 
     after do
-      RateLimiter.disable
       Rails.logger = @old_logger
     end
 

--- a/spec/components/rate_limiter_spec.rb
+++ b/spec/components/rate_limiter_spec.rb
@@ -34,10 +34,6 @@ describe RateLimiter do
       rate_limiter.clear!
     end
 
-    after do
-      RateLimiter.disable
-    end
-
     context 'aggressive rate limiter' do
 
       it 'can operate correctly and totally stop limiting' do

--- a/spec/integration/rate_limiting_spec.rb
+++ b/spec/integration/rate_limiting_spec.rb
@@ -10,10 +10,6 @@ describe 'rate limiter integration' do
     RateLimiter.clear_all!
   end
 
-  after do
-    RateLimiter.disable
-  end
-
   it "will rate limit message bus requests once queueing" do
     freeze_time
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -875,10 +875,6 @@ describe Category do
   end
 
   describe 'auto bump' do
-    after do
-      RateLimiter.disable
-    end
-
     it 'should correctly automatically bump topics' do
       freeze_time
       category = Fabricate(:category_with_definition, created_at: 1.minute.ago)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -629,7 +629,6 @@ describe Topic do
 
       after do
         RateLimiter.clear_all!
-        RateLimiter.disable
       end
 
       it "rate limits topic invitations" do
@@ -2296,7 +2295,6 @@ describe Topic do
 
     after do
       RateLimiter.clear_all!
-      RateLimiter.disable
     end
 
     it "limits according to max_personal_messages_per_day" do

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -692,8 +692,6 @@ RSpec.describe ApplicationController do
         RateLimiter.enable
       end
 
-      after { RateLimiter.disable }
-
       it "serves a LimitExceeded error in the preferred locale" do
         SiteSetting.max_likes_per_day = 1
         post1 = Fabricate(:post)

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -320,8 +320,6 @@ describe InvitesController do
           .to change { RateLimiter.new(user, 'resend-invite-per-hour', 10, 1.hour).remaining }.by(-1)
         expect(response.status).to eq(200)
         expect(Jobs::InviteEmail.jobs.size).to eq(1)
-      ensure
-        RateLimiter.disable
       end
 
       it 'cannot create duplicated invites' do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -324,7 +324,6 @@ describe UsersController do
 
       context "rate limiting" do
         before { RateLimiter.clear_all!; RateLimiter.enable }
-        after  { RateLimiter.disable }
 
         it "rate limits reset passwords" do
           freeze_time

--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -134,7 +134,6 @@ describe UsersEmailController do
 
         context "rate limiting" do
           before { RateLimiter.clear_all!; RateLimiter.enable }
-          after  { RateLimiter.disable }
 
           it "rate limits by IP" do
             freeze_time


### PR DESCRIPTION
We disable rate limiter before running every test [here](https://github.com/discourse/discourse/blob/90ab3b1c7575772aed87755e302aea530909af9a/spec/rails_helper.rb#L109-L109). See also the [comment](https://github.com/discourse/discourse/pull/13090#discussion_r634940223) from @SamSaffron.


