### PR TITLE
DEV: add timezone to user fixtures

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/user-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/user-fixtures.js
@@ -294,6 +294,7 @@ export default {
         day_6_start_time: 480,
         day_6_end_time: 1020,
       },
+      timezone: "Australia/Brisbane",
     },
   },
   "/u/eviltrout/card.json": {
@@ -2680,6 +2681,7 @@ export default {
         text_size: "normal",
         text_size_seq: 0,
       },
+      timezone: "America/Los_Angeles",
     },
   },
   "/u/charlie/card.json": {
@@ -2994,6 +2996,7 @@ export default {
         text_size_seq: 0,
         title_count_mode: "notifications",
       },
+      timezone: "Asia/Tokyo",
     },
   },
   "/u/%E3%83%A9%E3%82%A4%E3%82%AA%E3%83%B3/summary.json": {


### PR DESCRIPTION
Lack of this field made problems when writing tests for things dependant on time. 

The server returns this field. [Here](https://github.com/discourse/discourse/blob/130160537c9f40a5012715435e579b2c1441604b/app/serializers/user_card_serializer.rb#L66) is the field in `UserCardSerializer` and `UserSerializer` [inherits](https://github.com/discourse/discourse/blob/130160537c9f40a5012715435e579b2c1441604b/app/serializers/user_serializer.rb#L3) `UserCardSerializer`.