### PR TITLE
FIX: do not validate uploads when running `uploads:fix_missing_s3` task

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -1036,7 +1036,8 @@ def fix_missing_s3
       else
         # we do not fix sha, it may be wrong for arbitrary reasons, if we correct it
         # we may end up breaking posts
-        upload.update!(etag: fixed_upload.etag, url: fixed_upload.url, verification_status: Upload.verification_statuses[:unchecked])
+        upload.assign_attributes(etag: fixed_upload.etag, url: fixed_upload.url, verification_status: Upload.verification_statuses[:unchecked])
+        upload.save!(validate: false)
 
         OptimizedImage.where(upload_id: upload.id).destroy_all
         rebake_ids = PostUpload.where(upload_id: upload.id).pluck(:post_id)


### PR DESCRIPTION
in reference to: https://github.com/discourse/discourse/commit/130160537c9f40a5012715435e579b2c1441604b