### PR TITLE
FIX: Allow add email to group if user can invite

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/group-add-members.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/group-add-members.hbs
@@ -2,7 +2,11 @@
   <form class="form-vertical group-add-members">
     <div class="control-group">
       <label class="control-label">
-        {{i18n "groups.add_members.usernames"}}
+        {{#if currentUser.can_invite_to_forum}}
+          {{i18n "groups.add_members.usernames_or_emails.title"}}
+        {{else}}
+          {{i18n "groups.add_members.usernames.title"}}
+        {{/if}}
       </label>
       <p class="description">
         {{i18n "groups.add_members.description"}}
@@ -14,8 +18,8 @@
         id="group-add-members-user-selector"
         onChange=(action (mut usernamesAndEmails))
         options=(hash
-          allowEmails=true
-          filterPlaceholder="groups.add_members.input_placeholder"
+          allowEmails=currentUser.can_invite_to_forum
+          filterPlaceholder=(if currentUser.can_invite_to_forum "groups.add_members.usernames_or_emails.input_placeholder" "groups.add_members.usernames.input_placeholder")
         )
       }}
     </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -660,8 +660,12 @@ en:
       add_members:
         title: "Add members to %{group_name}"
         description: "You can also paste in a comma separated list."
-        usernames: "Enter usernames or email addresses"
-        input_placeholder: "Usernames or emails"
+        usernames_or_emails:
+          title: "Enter usernames or email addresses"
+          input_placeholder: "Usernames or emails"
+        usernames:
+          title: "Enter usernames"
+          input_placeholder: "Usernames"
         notify_users: "Notify users"
       requests:
         title: "Requests"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -243,6 +243,9 @@ en:
     user_exists: "There's no need to invite <b>%{email}</b>, they <a href='%{base_path}/u/%{username}/summary'>already have an account!</a>"
     invite_exists: "You already invited <b>%{email}</b>."
     invalid_email: "%{email} isn't a valid email address."
+    rate_limit:
+      one: "You have already sent %{count} invite in the last day, please wait %{time_left} before trying again."
+      other: "You have already sent %{count} invites in the last day, please wait %{time_left} before trying again."
     confirm_email: "<p>You’re almost done! We sent an activation mail to your email address. Please follow the instructions in the mail to activate your account.</p><p>If it doesn’t arrive, check your spam folder.</p>"
     cant_invite_to_group: "You are not allowed to invite users to specified group(s). Make sure you are owner of the group(s) you are trying to invite to."
     disabled_errors:

--- a/lib/rate_limiter/limit_exceeded.rb
+++ b/lib/rate_limiter/limit_exceeded.rb
@@ -11,8 +11,8 @@ class RateLimiter
       @type = type
     end
 
-    def description
-      time_left =
+    def time_left
+      @time_left ||=
         if @available_in <= 3
           I18n.t("rate_limiter.short_time")
         elsif @available_in < 1.minute.to_i
@@ -22,7 +22,9 @@ class RateLimiter
         else
           I18n.t("rate_limiter.hours", count: (@available_in / 1.hour.to_i))
         end
+    end
 
+    def description
       if @type.present?
         type_key = @type.tr("-", "_")
         msg = I18n.t("rate_limiter.by_type.#{type_key}", time_left: time_left, default: "")


### PR DESCRIPTION
It used to allow adding email addresses to a group even if invites were
disabled for the site. This does not allow user to input email address
if they cannot invite.

The second thing this commit improves is the message that is displayed
to the user when they hit the invite rate limit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
