### PR TITLE
DEV: Remove reference to very old plugin

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -86,10 +86,6 @@ class Plugin::Instance
     [].tap { |plugins|
       # also follows symlinks - http://stackoverflow.com/q/357754
       Dir["#{parent_path}/*/plugin.rb"].sort.each do |path|
-
-        # tagging is included in core, so don't load it
-        next if path =~ /discourse-tagging/
-
         source = File.read(path)
         metadata = Plugin::Metadata.parse(source)
         plugins << self.new(metadata, path)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
