### PR TITLE
FIX: Disable lightboxing of animated images

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -353,13 +353,13 @@ class CookedPostProcessor
       unless @disable_loading_image
         upload.create_thumbnail!(LOADING_SIZE, LOADING_SIZE, format: 'png', colors: LOADING_COLORS)
       end
-    end
 
-    if img.ancestors('.onebox, .onebox-body, .quote').blank? && !img.classes.include?("onebox")
-      add_lightbox!(img, original_width, original_height, upload, cropped: crop)
-    end
+      return if upload.animated?
 
-    if upload.present?
+      if img.ancestors('.onebox, .onebox-body, .quote').blank? && !img.classes.include?("onebox")
+        add_lightbox!(img, original_width, original_height, upload, cropped: crop)
+      end
+
       optimize_image!(img, upload, cropped: crop)
     end
   end
@@ -390,7 +390,7 @@ class CookedPostProcessor
     w, h = img["width"].to_i, img["height"].to_i
 
     # note: optimize_urls cooks the src and data-small-upload further after this
-    thumbnail = !upload.animated && upload.thumbnail(w, h)
+    thumbnail = upload.thumbnail(w, h)
     if thumbnail && thumbnail.filesize.to_i < upload.filesize
       img["src"] = thumbnail.url
 

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -973,7 +973,10 @@ describe CookedPostProcessor do
       expect(doc.css('img').first['srcset']).to_not eq(nil)
     end
 
-    it "does not optimize animated images but adds a class so animated images can be identified" do
+    it "processes animated images correctly" do
+      # skips optimization
+      # skips lightboxing
+      # adds "animated" class to element
       upload.update!(animated: true)
       post = Fabricate(:post, raw: "![image|1024x768, 50%](#{upload.short_url})")
 
@@ -981,7 +984,7 @@ describe CookedPostProcessor do
       cpp.post_process
 
       doc = Nokogiri::HTML5::fragment(cpp.html)
-      expect(doc.css('.lightbox-wrapper').size).to eq(1)
+      expect(doc.css('.lightbox-wrapper').size).to eq(0)
       expect(doc.css('img').first['src']).to include(upload.url)
       expect(doc.css('img').first['srcset']).to eq(nil)
       expect(doc.css('img.animated').size).to eq(1)

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -241,7 +241,7 @@ describe SearchIndexer do
       post.rebake!
       post.reload
 
-      expect(post.cooked).to include(
+      expect(post.cooked).not_to include(
         CookedPostProcessor::LIGHTBOX_WRAPPER_CSS_CLASS
       )
 


### PR DESCRIPTION
Pausing animated images was clashing with lightboxing, both actions were being invoked on click. I can't think of any scenarios where lightboxing animated images is useful, hence this disables lightboxing of all animated images.