### PR TITLE
FIX: Review Queue Query parameters were not refreshing in Ember CLI

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/review-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/review-index.js
@@ -2,6 +2,7 @@ import Controller from "@ember/controller";
 import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
 import { isPresent } from "@ember/utils";
+import { next } from "@ember/runloop";
 
 export default Controller.extend({
   queryParams: [
@@ -93,6 +94,10 @@ export default Controller.extend({
     this.setProperties(range);
   },
 
+  refreshModel() {
+    next(() => this.send("refreshRoute"));
+  },
+
   actions: {
     remove(ids) {
       if (!ids) {
@@ -104,7 +109,7 @@ export default Controller.extend({
       });
 
       if (newList.length === 0) {
-        this.send("refreshRoute");
+        this.refreshModel();
       } else {
         this.set("reviewables", newList);
       }
@@ -112,7 +117,7 @@ export default Controller.extend({
 
     resetTopic() {
       this.set("topic_id", null);
-      this.send("refreshRoute");
+      this.refreshModel();
     },
 
     refresh() {
@@ -165,7 +170,7 @@ export default Controller.extend({
         additional_filters: JSON.stringify(this.additionalFilters),
       });
 
-      this.send("refreshRoute");
+      this.refreshModel();
     },
 
     loadMore() {


### PR DESCRIPTION
The problem was we were setting the properties then immediately calling
`refreshRoute` which was being executed before the properties were
settled via the runloop.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
