### PR TITLE
DEV: Run `yarn install` when running `bin/ember-cli`

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -43,4 +43,5 @@ if !args.include?("--proxy")
   args << PROXY
 end
 
+system "yarn install --cwd #{yarn_dir}"
 exec "yarn", *args.to_a.flatten


### PR DESCRIPTION
Some people have noticed that if we change the packages in package.json
that they have to manually run `yarn install` or Discourse won't work.

This adds `yarn install` to the `bin/ember-cli` helper we run. It seems
quite fast if there is nothing to install so it shouldn't hurt to do
this every time we start the server.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
