### PR TITLE
DEV: Default to `development` RAILS_ENV when running theme tests

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -114,6 +114,7 @@ task "themes:qunit", :type, :value do |t, args|
     MSG
   end
   ENV["THEME_#{type.upcase}"] = value.to_s
+  ENV["QUNIT_RAILS_ENV"] ||= 'development' # qunit:test will switch to `test` by default
   Rake::Task["qunit:test"].reenable
   Rake::Task["qunit:test"].invoke(1200000, "/theme-qunit")
 end


### PR DESCRIPTION
When testing theme components in development, it doesn't make sense to use the `test` environment. The `test` environment almost certainly has 0 themes installed.

This change still works fine when using the `themes:install_and_test` rake task, because that rake task explicitly specifies environment/database-config.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
