### PR TITLE
FIX: Update upload secure status when revising posts

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -226,6 +226,11 @@ class PostRevisor
     # it can fire events in sidekiq before the post is done saving
     # leading to corrupt state
     QuotedPost.extract_from(@post)
+
+    # This must be done before post_process_post, because that uses
+    # post upload security status to cook URLs.
+    @post.update_uploads_secure_status(source: "post revisor")
+
     post_process_post
 
     update_topic_word_counts


### PR DESCRIPTION
When uploads are created from the composer (editing or creating a post),
for sites with secure uploads enabled we assume security by default and
that new upload is set to secure. When the post is created, we then
check whether the post uploads _actually_ need to be secure and adjust
accordingly.

We were not doing this when revising a post, so when a new upload was
created when editing a post in a public topic, the secure status stayed
true erroneously causing issues with image previews, among other things.