### PR TITLE
FIX: no error when double save post with poll

### DIFF
--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -467,7 +467,7 @@ after_initialize do
 
       after_save do
         polls = self.extracted_polls
-        self.extracted_polls = []
+        self.extracted_polls = nil
         next if polls.blank? || !polls.is_a?(Hash)
         post = self
 

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -486,6 +486,7 @@ after_initialize do
   end
 
   validate(:post, :validate_polls) do |force = nil|
+    self.extracted_polls = []
     return unless self.raw_changed? || force
 
     validator = DiscoursePoll::PollsValidator.new(self)

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -467,6 +467,7 @@ after_initialize do
 
       after_save do
         polls = self.extracted_polls
+        self.extracted_polls = []
         next if polls.blank? || !polls.is_a?(Hash)
         post = self
 
@@ -486,7 +487,6 @@ after_initialize do
   end
 
   validate(:post, :validate_polls) do |force = nil|
-    self.extracted_polls = []
     return unless self.raw_changed? || force
 
     validator = DiscoursePoll::PollsValidator.new(self)

--- a/plugins/poll/spec/models/poll_spec.rb
+++ b/plugins/poll/spec/models/poll_spec.rb
@@ -85,7 +85,6 @@ describe ::DiscoursePoll::Poll do
 
   it "is not throwing an error when double save" do
     post = Fabricate(:post, raw: "[poll]\n- A\n- B\n[/poll]")
-    post.custom_fields["expert"] = true
     expect { post.save! }.not_to raise_error
   end
 end

--- a/plugins/poll/spec/models/poll_spec.rb
+++ b/plugins/poll/spec/models/poll_spec.rb
@@ -81,6 +81,11 @@ describe ::DiscoursePoll::Poll do
 
       expect(poll.post).to eq(post)
     end
+  end
 
+  it "is not throwing an error when double save" do
+    post = Fabricate(:post, raw: "[poll]\n- A\n- B\n[/poll]")
+    post.custom_fields["expert"] = true
+    expect { post.save! }.not_to raise_error
   end
 end


### PR DESCRIPTION
Some plugins hook into Post after save to set custom fields and save again.

For example: https://github.com/discourse/discourse-category-experts/blob/main/lib/category_experts/post_handler.rb#L27

Problem is that in case like that `raw_changed?` is false but all callback are triggered. `extracted_polls` is class attribute therefore that should be reset with each attempt.

That was causing an error:
```
#<ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint 
"index_polls_on_post_id_and_name" DETAIL:  Key (post_id, name)=(8967, poll) already exists.

```
