### PR TITLE
FEATURE: Show stale reviewable to other clients

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -27,6 +27,11 @@ export default Component.extend({
   editing: false,
   _updates: null,
 
+  @discourseComputed("updating", "reviewable.updated")
+  disabled(updating, updated) {
+    return updating || updated;
+  },
+
   @discourseComputed(
     "reviewable.type",
     "siteSettings.blur_tl0_flagged_posts_media",

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -27,18 +27,18 @@ export default Component.extend({
   editing: false,
   _updates: null,
 
-  @discourseComputed("updating", "reviewable.updated")
-  disabled(updating, updated) {
-    return updating || updated;
-  },
-
   @discourseComputed(
     "reviewable.type",
+    "reviewable.stale",
     "siteSettings.blur_tl0_flagged_posts_media",
     "reviewable.target_created_by_trust_level"
   )
-  customClasses(type, blurEnabled, trustLevel) {
+  customClasses(type, stale, blurEnabled, trustLevel) {
     let classes = type.dasherize();
+
+    if (stale) {
+      classes = `${classes} reviewable-stale`;
+    }
 
     if (blurEnabled && trustLevel === 0) {
       classes = `${classes} blur-images`;

--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -57,14 +57,14 @@ export default DiscourseRoute.extend({
     });
 
     this.messageBus.subscribe("/reviewable_counts", (data) => {
-      if (data.remove_reviewable_ids) {
-        if (this.controller.filterStatus === data.status) {
-          this.controller.reviewables.forEach((reviewable) => {
-            if (data.remove_reviewable_ids.indexOf(reviewable.id) !== -1) {
-              reviewable.set("updated", true);
-            }
-          });
-        }
+      if (data.updates) {
+        this.controller.reviewables.forEach((reviewable) => {
+          const updates = data.updates[reviewable.id];
+          if (updates) {
+            reviewable.setProperties(updates);
+            reviewable.set("stale", true);
+          }
+        });
       }
     });
   },

--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -55,6 +55,18 @@ export default DiscourseRoute.extend({
         });
       }
     });
+
+    this.messageBus.subscribe("/reviewable_counts", (data) => {
+      if (data.remove_reviewable_ids) {
+        if (this.controller.filterStatus === data.status) {
+          this.controller.reviewables.forEach((reviewable) => {
+            if (data.remove_reviewable_ids.indexOf(reviewable.id) !== -1) {
+              reviewable.set("updated", true);
+            }
+          });
+        }
+      }
+    });
   },
 
   deactivate() {

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-item.hbs
@@ -44,42 +44,48 @@
     {{/if}}
   </div>
   <div class="reviewable-actions">
-    {{#if claimEnabled}}
-      <div class="claimed-actions">
-        <span class="help">{{html-safe claimHelp}}</span>
-        {{reviewable-claimed-topic topicId=topicId claimedBy=reviewable.claimed_by}}
+    {{#if reviewable.stale}}
+      <div class="reviewable-stale">
+        <span class="help">{{i18n "review.stale_help"}}</span>
       </div>
-    {{/if}}
+    {{else}}
+      {{#if claimEnabled}}
+        <div class="claimed-actions">
+          <span class="help">{{html-safe claimHelp}}</span>
+          {{reviewable-claimed-topic topicId=topicId claimedBy=reviewable.claimed_by}}
+        </div>
+      {{/if}}
 
-    {{#if canPerform}}
-      {{#if editing}}
-        {{d-button
-          class="btn-primary reviewable-action save-edit"
-          disabled=disabled
-          icon="check"
-          action=(action "saveEdit")
-          label="review.save"}}
-        {{d-button
-          class="btn-danger reviewable-action cancel-edit"
-          disabled=disabled
-          icon="times"
-          action=(action "cancelEdit")
-          label="review.cancel"}}
-      {{else}}
-        {{#each reviewable.bundled_actions as |bundle|}}
-          {{reviewable-bundled-action
-            bundle=bundle
-            performAction=(action "perform")
-            reviewableUpdating=disabled}}
-        {{/each}}
-
-        {{#if reviewable.can_edit}}
+      {{#if canPerform}}
+        {{#if editing}}
           {{d-button
-            class="reviewable-action edit"
+            class="btn-primary reviewable-action save-edit"
             disabled=disabled
-            icon="pencil-alt"
-            action=(action "edit")
-            label="review.edit"}}
+            icon="check"
+            action=(action "saveEdit")
+            label="review.save"}}
+          {{d-button
+            class="btn-danger reviewable-action cancel-edit"
+            disabled=disabled
+            icon="times"
+            action=(action "cancelEdit")
+            label="review.cancel"}}
+        {{else}}
+          {{#each reviewable.bundled_actions as |bundle|}}
+            {{reviewable-bundled-action
+              bundle=bundle
+              performAction=(action "perform")
+              reviewableUpdating=disabled}}
+          {{/each}}
+
+          {{#if reviewable.can_edit}}
+            {{d-button
+              class="reviewable-action edit"
+              disabled=disabled
+              icon="pencil-alt"
+              action=(action "edit")
+              label="review.edit"}}
+          {{/if}}
         {{/if}}
       {{/if}}
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-item.hbs
@@ -55,13 +55,13 @@
       {{#if editing}}
         {{d-button
           class="btn-primary reviewable-action save-edit"
-          disabled=updating
+          disabled=disabled
           icon="check"
           action=(action "saveEdit")
           label="review.save"}}
         {{d-button
           class="btn-danger reviewable-action cancel-edit"
-          disabled=updating
+          disabled=disabled
           icon="times"
           action=(action "cancelEdit")
           label="review.cancel"}}
@@ -70,13 +70,13 @@
           {{reviewable-bundled-action
             bundle=bundle
             performAction=(action "perform")
-            reviewableUpdating=updating}}
+            reviewableUpdating=disabled}}
         {{/each}}
 
         {{#if reviewable.can_edit}}
           {{d-button
             class="reviewable-action edit"
-            disabled=updating
+            disabled=disabled
             icon="pencil-alt"
             action=(action "edit")
             label="review.edit"}}

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-item.hbs
@@ -45,9 +45,7 @@
   </div>
   <div class="reviewable-actions">
     {{#if reviewable.stale}}
-      <div class="reviewable-stale">
-        <span class="help">{{i18n "review.stale_help"}}</span>
-      </div>
+      <div class="stale-help">{{i18n "review.stale_help"}}</div>
     {{else}}
       {{#if claimEnabled}}
         <div class="claimed-actions">

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -276,6 +276,10 @@
   padding-bottom: 1em;
 }
 
+.reviewable-stale {
+  opacity: 0.7;
+}
+
 .blur-images {
   img:not(.avatar):not(.emoji) {
     filter: blur(10px);

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -12,11 +12,11 @@ class ReviewablesController < ApplicationController
     offset = params[:offset].to_i
 
     if params[:type].present?
-      raise Discourse::InvalidParameter.new(:type) unless Reviewable.valid_type?(params[:type])
+      raise Discourse::InvalidParameters.new(:type) unless Reviewable.valid_type?(params[:type])
     end
 
     status = (params[:status] || 'pending').to_sym
-    raise Discourse::InvalidParameter.new(:status) unless allowed_statuses.include?(status)
+    raise Discourse::InvalidParameters.new(:status) unless allowed_statuses.include?(status)
 
     topic_id = params[:topic_id] ? params[:topic_id].to_i : nil
     category_id = params[:category_id] ? params[:category_id].to_i : nil

--- a/app/jobs/regular/notify_reviewable.rb
+++ b/app/jobs/regular/notify_reviewable.rb
@@ -15,28 +15,55 @@ class Jobs::NotifyReviewable < ::Jobs::Base
       counts[r.reviewable_by_group_id] += 1 if r.reviewable_by_group_id
     end
 
+    remove_reviewable_ids = Hash.new { |h, k| h[k] = [] }
+
+    if args[:remove_reviewable_ids].present?
+      Reviewable.where(id: args[:remove_reviewable_ids]).each do |r|
+        remove_reviewable_ids[:admins] << r.id
+        remove_reviewable_ids[:moderators] << r.id if r.reviewable_by_moderator?
+        remove_reviewable_ids[r.reviewable_by_group_id] << r.id if r.reviewable_by_group_id
+      end
+    end
+
     # admins
-    notify(counts[:admins], User.real.admins.pluck(:id))
+    notify(
+      User.real.admins.pluck(:id),
+      count: counts[:admins],
+      removed_ids: remove_reviewable_ids[:admins],
+      status: args[:status]
+    )
 
     # moderators
     if reviewable.reviewable_by_moderator?
-      notify(counts[:moderators], User.real.moderators.where("id NOT IN (?)", @contacted).pluck(:id))
+      notify(
+        User.real.moderators.where("id NOT IN (?)", @contacted).pluck(:id),
+        count: counts[:moderators],
+        removed_ids: remove_reviewable_ids[:moderators],
+        status: args[:status]
+      )
     end
 
     # category moderators
     if SiteSetting.enable_category_group_moderation? && (group = reviewable.reviewable_by_group)
       group.users.includes(:group_users).where("users.id NOT IN (?)", @contacted).find_each do |user|
         count = user.group_users.map { |gu| counts[gu.group_id] }.sum
-        notify(count, [user.id])
+        removed_ids = user.group_users.map { |gu| remove_reviewable_ids[gu.group_id] }.flatten.uniq
+        notify([user.id], count: count, removed_ids: removed_ids, status: args[:status])
       end
     end
   end
 
   protected
 
-  def notify(count, user_ids)
+  def notify(user_ids, count:, removed_ids:, status:)
     return if user_ids.blank?
+
     data = { reviewable_count: count }
+    if removed_ids.present?
+      data[:remove_reviewable_ids] = removed_ids
+      data[:status] = status
+    end
+
     MessageBus.publish("/reviewable_counts", data, user_ids: user_ids)
     @contacted += user_ids
   end

--- a/app/jobs/regular/notify_reviewable.rb
+++ b/app/jobs/regular/notify_reviewable.rb
@@ -15,13 +15,15 @@ class Jobs::NotifyReviewable < ::Jobs::Base
       counts[r.reviewable_by_group_id] += 1 if r.reviewable_by_group_id
     end
 
-    remove_reviewable_ids = Hash.new { |h, k| h[k] = [] }
+    all_updates = Hash.new { |h, k| h[k] = {} }
 
-    if args[:remove_reviewable_ids].present?
-      Reviewable.where(id: args[:remove_reviewable_ids]).each do |r|
-        remove_reviewable_ids[:admins] << r.id
-        remove_reviewable_ids[:moderators] << r.id if r.reviewable_by_moderator?
-        remove_reviewable_ids[r.reviewable_by_group_id] << r.id if r.reviewable_by_group_id
+    if args[:updated_reviewable_ids].present?
+      Reviewable.where(id: args[:updated_reviewable_ids]).each do |r|
+        payload = { status: r.status }
+
+        all_updates[:admins][r.id] = payload
+        all_updates[:moderators][r.id] = payload if r.reviewable_by_moderator?
+        all_updates[r.reviewable_by_group_id][r.id] = payload if r.reviewable_by_group_id
       end
     end
 
@@ -29,8 +31,7 @@ class Jobs::NotifyReviewable < ::Jobs::Base
     notify(
       User.real.admins.pluck(:id),
       count: counts[:admins],
-      removed_ids: remove_reviewable_ids[:admins],
-      status: args[:status]
+      updates: all_updates[:admins],
     )
 
     # moderators
@@ -38,31 +39,33 @@ class Jobs::NotifyReviewable < ::Jobs::Base
       notify(
         User.real.moderators.where("id NOT IN (?)", @contacted).pluck(:id),
         count: counts[:moderators],
-        removed_ids: remove_reviewable_ids[:moderators],
-        status: args[:status]
+        updates: all_updates[:moderators],
       )
     end
 
     # category moderators
     if SiteSetting.enable_category_group_moderation? && (group = reviewable.reviewable_by_group)
       group.users.includes(:group_users).where("users.id NOT IN (?)", @contacted).find_each do |user|
-        count = user.group_users.map { |gu| counts[gu.group_id] }.sum
-        removed_ids = user.group_users.map { |gu| remove_reviewable_ids[gu.group_id] }.flatten.uniq
-        notify([user.id], count: count, removed_ids: removed_ids, status: args[:status])
+        count = 0
+        updates = {}
+
+        user.group_users.each do |gu|
+          count += counts[gu.group_id] || 0
+          updates.merge!(all_updates[gu.group_id] || {})
+        end
+
+        notify([user.id], count: count, updates: updates)
       end
     end
   end
 
   protected
 
-  def notify(user_ids, count:, removed_ids:, status:)
+  def notify(user_ids, count:, updates:)
     return if user_ids.blank?
 
     data = { reviewable_count: count }
-    if removed_ids.present?
-      data[:remove_reviewable_ids] = removed_ids
-      data[:status] = status
-    end
+    data[:updates] = updates if updates.present?
 
     MessageBus.publish("/reviewable_counts", data, user_ids: user_ids)
     @contacted += user_ids

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -339,12 +339,6 @@ class Reviewable < ActiveRecord::Base
   # the result of the operation and whether the status of the reviewable changed.
   def perform(performed_by, action_id, args = nil)
     args ||= {}
-
-    # Store old status to remove reviewables only for users viewing reviewables
-    # of the same status. For example, if user views all reviewables, no
-    # reviewable should be removed.
-    status = self.status
-
     # Support this action or any aliases
     aliases = self.class.action_aliases
     valid = [ action_id, aliases.to_a.select { |k, v| v == action_id }.map(&:first) ].flatten
@@ -377,8 +371,7 @@ class Reviewable < ActiveRecord::Base
       Jobs.enqueue(
         :notify_reviewable,
         reviewable_id: self.id,
-        remove_reviewable_ids: result.remove_reviewable_ids,
-        status: Reviewable.statuses[status],
+        updated_reviewable_ids: result.remove_reviewable_ids,
       )
     end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -426,6 +426,7 @@ en:
         type_bonus:
           name: "type bonus"
           title: "Certain reviewable types can be assigned a bonus by staff to make them a higher priority."
+      stale_help: "This reviewable has been resolved by someone else."
       claim_help:
         optional: "You can claim this item to prevent others from reviewing it."
         required: "You must claim items before you can review them."

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -105,7 +105,7 @@ describe ReviewablesController do
 
       it "raises an error with an invalid type" do
         get "/review.json?type=ReviewableMadeUp"
-        expect(response.code).to eq("500")
+        expect(response.code).to eq("400")
       end
 
       it "supports filtering by status" do
@@ -135,7 +135,7 @@ describe ReviewablesController do
 
       it "raises an error with an invalid status" do
         get "/review.json?status=xyz"
-        expect(response.code).to eq("500")
+        expect(response.code).to eq("400")
       end
 
       it "supports filtering by category_id" do


### PR DESCRIPTION
We did not update other clients allowing multiple users to take action on a resolved reviewable (they were not informed of a change). This commit will continue removing the reviewable for the acting user, but the other users will see a greyed out reviewable, an updated status (i.e. Pending &rarr; Rejected) and a message at the bottom (instead of actions).

![image](https://user-images.githubusercontent.com/4147664/119147429-41451e00-ba54-11eb-8a30-d8ea9336bca4.png)
