### PR TITLE
DEV: Docker development improvements

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -60,6 +60,13 @@ while [ "${#@}" -ne "0" ]; do
     shift
 done
 
+if [[ $(docker info -f "{{.Architecture}}") != *x86_64* ]]; then
+    echo "WARNING: Docker architecture is not x86_64."
+    echo "Discourse development is unlikely to work using Docker's architecture emulation."
+    echo "Please try a native development installation."
+    sleep 1
+fi
+
 echo "Using source in: ${SOURCE_DIR}"
 echo "Using data in:   ${DATA_DIR}"
 

--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -86,6 +86,7 @@ docker pull discourse/discourse_dev:release
 docker run -d \
     -p $local_publish:1080:1080 \
     -p $local_publish:3000:3000 \
+    -p $local_publish:4200:4200 \
     -p $local_publish:9292:9292 \
     -p $local_publish:9405:9405 \
     -v "$DATA_DIR:/shared/postgres_data:delegated" \

--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -66,7 +66,7 @@ echo "Using data in:   ${DATA_DIR}"
 mkdir -p "${DATA_DIR}"
 
 mount_plugin_symlinks=""
-for symlink in $(find $PLUGINS_DIR -type l); do
+for symlink in $(find $PLUGINS_DIR -depth 1 -type l); do
     # `readlink -f` doesn't work on macOS, to fix it you need to override the `readlink` with `greadlink`
     # > brew install coreutils
     # > ln -s "$(which greadlink)" "$(dirname "$(which greadlink)")/readlink"

--- a/bin/docker/bundle
+++ b/bin/docker/bundle
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-PARAMS="$@"
-CMD="cd /src && USER=discourse RAILS_ENV=${RAILS_ENV:=development} bundle $PARAMS"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"
+exec "$(dirname "$0")/exec" bundle "$@"

--- a/bin/docker/discourse
+++ b/bin/docker/discourse
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-PARAMS="$@"
-CMD="cd /src && USER=discourse RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENV=${RAILS_ENV:=development} script/discourse $PARAMS"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"
+exec "$(dirname "$0")/exec" script/discourse "$@"

--- a/bin/docker/ember-cli
+++ b/bin/docker/ember-cli
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec "$(dirname "$0")/exec" bin/ember-cli "$@"

--- a/bin/docker/exec
+++ b/bin/docker/exec
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+exec docker exec \
+  -it \
+  -u discourse:discourse \
+  -w '/src' \
+  -e RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 \
+  -e LD_PRELOAD=/usr/lib/libjemalloc.so \
+  -e RAILS_ENV \
+  -e NO_EMBER_CLI \
+  -e QUNIT_RAILS_ENV \
+  discourse_dev \
+  "$@"

--- a/bin/docker/mailcatcher
+++ b/bin/docker/mailcatcher
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-CMD="USER=discourse mailcatcher --http-ip 0.0.0.0 -f"
-docker exec -it discourse_dev /bin/bash -c "$CMD"
+exec "$(dirname "$0")/exec" mailcatcher --http-ip 0.0.0.0 -f

--- a/bin/docker/migrate
+++ b/bin/docker/migrate
@@ -1,6 +1,5 @@
 #!/bin/bash
+set -e
 
-CMD="cd /src && USER=discourse RAILS_ENV=development rake db:migrate"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"
-CMD="cd /src && USER=discourse RAILS_ENV=test rake db:migrate"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"
+"$(dirname "$0")/exec" bin/rake db:migrate
+RAILS_ENV=test "$(dirname "$0")/exec" bin/rake db:migrate

--- a/bin/docker/psql
+++ b/bin/docker/psql
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-PARAMS="$@"
-CMD="USER=discourse psql $PARAMS"
-docker exec -it -u postgres discourse_dev /bin/bash -c "$CMD"
+exec "$(dirname "$0")/exec" psql "$@"

--- a/bin/docker/rails
+++ b/bin/docker/rails
@@ -1,10 +1,3 @@
 #!/bin/bash
 
-PARAMS="$@"
-if [[ $# = 1 ]] && [[ "$1" =~ "s" ]];
-then
-  PARAMS="$PARAMS -b 0.0.0.0"
-fi
-
-CMD="cd /src && USER=discourse RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 LD_PRELOAD=/usr/lib/libjemalloc.so RACK_HANDLER=puma RAILS_ENV=${RAILS_ENV:=development} rails $PARAMS"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"
+exec "$(dirname "$0")/exec" bin/rails "$@"

--- a/bin/docker/rake
+++ b/bin/docker/rake
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-PARAMS="$@"
-CMD="cd /src && USER=discourse RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENV=${RAILS_ENV:=development} bundle exec rake $PARAMS"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"
+exec "$(dirname "$0")/exec" bin/rake "$@"

--- a/bin/docker/rspec
+++ b/bin/docker/rspec
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-PARAMS="$@"
-CMD="cd /src && USER=discourse RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENV=${RAILS_ENV:=test} bin/rspec $PARAMS"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"
+exec "$(dirname "$0")/exec" bin/rspec "$@"

--- a/bin/docker/shell
+++ b/bin/docker/shell
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker exec -it -u discourse:discourse discourse_dev /bin/bash
+
+exec "$(dirname "$0")/exec" /bin/bash "$@"

--- a/bin/docker/shell_root
+++ b/bin/docker/shell_root
@@ -1,2 +1,3 @@
 #!/bin/bash
-docker exec -it discourse_dev /bin/bash
+
+exec docker exec -it discourse_dev /bin/bash

--- a/bin/docker/sidekiq
+++ b/bin/docker/sidekiq
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-PARAMS="$@"
-CMD="cd /src && USER=discourse RAILS_ENV=${RAILS_ENV:=development} bundle exec sidekiq -q critical -q low -q default -q ultra_low"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"

--- a/bin/docker/unicorn
+++ b/bin/docker/unicorn
@@ -1,10 +1,3 @@
 #!/bin/bash
 
-PARAMS="$@"
-if [[ $# = 1 ]] && [[ "$1" =~ "s" ]];
-then
-  PARAMS="$PARAMS -b 0.0.0.0"
-fi
-
-CMD="cd /src && USER=discourse RUBY_GLOBAL_METHOD_CACHE_SIZE=131072 LD_PRELOAD=/usr/lib/libjemalloc.so RAILS_ENV=${RAILS_ENV:=development} bin/unicorn $PARAMS"
-docker exec -it -u discourse:discourse discourse_dev /bin/bash -c "$CMD"
+exec "$(dirname "$0")/exec" bin/unicorn "$@"


### PR DESCRIPTION
- DEV: Only mount top-level plugin symlinks
    
    Sometimes plugins directories will end up with other symlinks (e.g. inside node_modules folders). This logic does not work with deeply nested symlinks, and they are unlikely to be necessary for the plugin to work. Therefore we should only look for symlinks in the top-level of the `plugins` directory

- DEV: Update docker development binstubs
    
    - Add `d/ember-cli`, and publish port 4200
    - Remove `d/sidekiq`. Sidekiq is now started with the rails server
    - Move all `docker exec` logic into a single place, so we have one place to set environment variable pass-throughs
    - Use `exec` for all bash scripts, so that return statuses are passed back correctly
    - Avoid using `bin/bash -c` unnecessarily, because it makes escaping arguments difficult

- DEV: Add non-x86_64 warning to `d/boot_dev`
    
    Running a development environment using Docker's qemu architecture emulation is currently not possible because `inotify` is not supported: https://github.com/docker/for-mac/issues/5321
