### PR TITLE
A11Y: Fix post control and user-menu focus styles

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -284,10 +284,21 @@
         }
       }
 
-      &:hover,
-      &:focus {
+      &:hover {
         background-color: var(--highlight-medium);
         outline: none;
+      }
+
+      &:focus-within {
+        background: var(--highlight-medium);
+        a {
+          // we don't need the link focus because we're styling the parent
+          outline: 0;
+        }
+        .btn-flat:focus {
+          // undo default btn-flat style
+          background: transparent;
+        }
       }
 
       a {

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -299,10 +299,9 @@
 
   &:focus {
     outline: none;
-    background: var(--primary-medium);
-    color: var(--secondary);
+    background: var(--primary-low);
     .d-icon {
-      color: var(--primary-low);
+      color: var(--primary);
     }
   }
 }


### PR DESCRIPTION
This fixes focus styles in the user menu and in post controls.

Before:

![Screen Shot 2021-05-21 at 6 30 01 PM](https://user-images.githubusercontent.com/1681963/119204087-8ff9b480-ba62-11eb-8e88-1646774ab5eb.png)
![Screen Shot 2021-05-21 at 6 29 57 PM](https://user-images.githubusercontent.com/1681963/119204105-938d3b80-ba62-11eb-811a-720b0df8c636.png)

After:

![Screen Shot 2021-05-21 at 6 26 22 PM](https://user-images.githubusercontent.com/1681963/119204038-7c4e4e00-ba62-11eb-811a-fa6b1b26fa51.png)
![Screen Shot 2021-05-21 at 6 26 10 PM](https://user-images.githubusercontent.com/1681963/119204040-7e181180-ba62-11eb-9d3b-e1c66b56980b.png)
