### PR TITLE
DEV: Add `session` to `before_auth` and `after_auth` hooks

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -33,10 +33,10 @@ class Users::OmniauthCallbacksController < ApplicationController
       Discourse.redis.setex "#{Users::AssociateAccountsController::REDIS_PREFIX}_#{current_user.id}_#{token}", 10.minutes, auth.to_json
       return redirect_to "#{Discourse.base_path}/associate/#{token}"
     else
-      DiscourseEvent.trigger(:before_auth, authenticator, auth)
+      DiscourseEvent.trigger(:before_auth, authenticator, auth, session)
       @auth_result = authenticator.after_authenticate(auth)
       @auth_result.user = nil if @auth_result&.user&.staged # Treat staged users the same as unregistered users
-      DiscourseEvent.trigger(:after_auth, authenticator, @auth_result)
+      DiscourseEvent.trigger(:after_auth, authenticator, @auth_result, session)
     end
 
     preferred_origin = request.env['omniauth.origin']


### PR DESCRIPTION
This allows plugins to store/modify things in the session (e.g. the destination_url). This change is backwards compatible with existing plugins. If they do not specify a third argument, they will just be passed the first two.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
