### PR TITLE
DEV: Switch off of our image_optim fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,9 +90,7 @@ gem 'unf', require: false
 
 gem 'email_reply_trimmer'
 
-# Forked until https://github.com/toy/image_optim/pull/162 is merged
-# https://github.com/discourse/image_optim
-gem 'discourse_image_optim', require: 'image_optim'
+gem 'image_optim'
 gem 'multi_json'
 gem 'mustache'
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,12 +117,6 @@ GEM
     discourse-fonts (0.0.8)
     discourse_dev (0.2.1)
       faker (~> 2.16)
-    discourse_image_optim (0.26.2)
-      exifr (~> 1.2, >= 1.2.2)
-      fspath (~> 3.0)
-      image_size (~> 1.5)
-      in_threads (~> 1.3)
-      progress (~> 3.0, >= 3.0.1)
     docile (1.4.0)
     ecma-re-validator (0.3.0)
       regexp_parser (~> 2.0)
@@ -168,7 +162,13 @@ GEM
     http_accept_language (2.1.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    image_size (1.5.0)
+    image_optim (0.30.0)
+      exifr (~> 1.2, >= 1.2.2)
+      fspath (~> 3.0)
+      image_size (>= 1.5, < 3)
+      in_threads (~> 1.3)
+      progress (~> 3.0, >= 3.0.1)
+    image_size (2.1.0)
     in_threads (1.5.4)
     jmespath (1.4.0)
     jquery-rails (4.4.0)
@@ -508,7 +508,6 @@ DEPENDENCIES
   discourse-ember-source (~> 3.12.2)
   discourse-fonts
   discourse_dev
-  discourse_image_optim
   email_reply_trimmer
   ember-handlebars-template (= 0.8.0)
   excon
@@ -522,6 +521,7 @@ DEPENDENCIES
   highline
   htmlentities
   http_accept_language
+  image_optim
   json
   json_schemer
   listen

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -424,8 +424,6 @@ class UploadCreator
     OptimizedImage.ensure_safe_paths!(@file.path)
     FileHelper.optimize_image!(@file.path)
     extract_image_info!
-  rescue ImageOptim::TimeoutExceeded
-    Rails.logger.warn("ImageOptim timed out while optimizing #{@filename}")
   end
 
   def filesize


### PR DESCRIPTION
The main image_optim gem now includes the timeout feature
that we had in our fork. So it is now safe to switch off of our fork and
back to the image_optim gem.

This is the link to the commit in the image_optim repo that adds the
timeout option:

https://github.com/toy/image_optim/commit/ec3767dde0d9f9f3d18bd688645583d847ba2e13

One difference with the new timeout implementation is that image_optim
now handles the timeout exceptions instead of bubbling them up:

https://github.com/toy/image_optim/blob/1ed03285873078185c129c66007231469461e429/lib/image_optim.rb#L128-L129

```
 rescue Errors::TimeoutExceeded
   handler.result
```

So a timeout will just return `nil`, which is the same response if it
couldn't optimize an image. I don't think we were really watching for
or doing anything about these timeout warnings in our logs so I think
this is an okay change to have and we will have less warnings in our
logs now too.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
