### PR TITLE
Add category breadcrumbs to edit category page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bread-crumbs.js
+++ b/app/assets/javascripts/discourse/app/components/bread-crumbs.js
@@ -7,6 +7,8 @@ import { filter } from "@ember/object/computed";
 export default Component.extend({
   classNameBindings: ["hidden:hidden", ":category-breadcrumb"],
   tagName: "ol",
+  editingCategory: false,
+  editingCategoryTab: null,
 
   @discourseComputed("categories")
   filteredCategories(categories) {
@@ -45,6 +47,11 @@ export default Component.extend({
         hasOptions: options.length !== 0,
       };
     });
+  },
+
+  @discourseComputed("siteSettings.tagging_enabled", "editingCategory")
+  showTagsSection(taggingEnabled, editingCategory) {
+    return taggingEnabled && !editingCategory;
   },
 
   @discourseComputed("category")

--- a/app/assets/javascripts/discourse/app/components/bread-crumbs.js
+++ b/app/assets/javascripts/discourse/app/components/bread-crumbs.js
@@ -22,7 +22,7 @@ export default Component.extend({
   @discourseComputed(
     "category.ancestors",
     "filteredCategories",
-    "category.noSubcategories"
+    "noSubcategories"
   )
   categoryBreadcrumbs(categoryAncestors, filteredCategories, noSubcategories) {
     categoryAncestors = categoryAncestors || [];

--- a/app/assets/javascripts/discourse/app/components/bread-crumbs.js
+++ b/app/assets/javascripts/discourse/app/components/bread-crumbs.js
@@ -20,7 +20,7 @@ export default Component.extend({
   @discourseComputed(
     "category.ancestors",
     "filteredCategories",
-    "noSubcategories"
+    "category.noSubcategories"
   )
   categoryBreadcrumbs(categoryAncestors, filteredCategories, noSubcategories) {
     categoryAncestors = categoryAncestors || [];

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -30,6 +30,50 @@ export default Controller.extend({
     });
   },
 
+  @discourseComputed("site.categoriesList")
+  categories(categoriesList) {
+    return categoriesList;
+  },
+
+  @discourseComputed("categories")
+  filteredCategories(categories) {
+    return categories.filter(
+      (category) =>
+        this.siteSettings.allow_uncategorized_topics ||
+        category.id !== this.site.uncategorized_category_id
+    );
+  },
+
+  @discourseComputed(
+    "model.ancestors",
+    "filteredCategories",
+    "noSubcategories"
+  )
+  categoryBreadcrumbs(categoryAncestors, filteredCategories, noSubcategories) {
+    categoryAncestors = categoryAncestors || [];
+    const parentCategories = [undefined, ...categoryAncestors];
+    const categories = [...categoryAncestors, undefined];
+    const zipped = parentCategories.map((x, i) => [x, categories[i]]);
+
+    return zipped.map((record) => {
+      const [parentCategory, category] = record;
+
+      const options = filteredCategories.filter(
+        (c) =>
+          c.get("parentCategory.id") === (parentCategory && parentCategory.id)
+      );
+
+      return {
+        category,
+        parentCategory,
+        options,
+        isSubcategory: !!parentCategory,
+        noSubcategories: !category && noSubcategories,
+        hasOptions: options.length !== 0,
+      };
+    });
+  },
+
   @discourseComputed("saving", "model.name", "model.color", "deleting")
   disabled(saving, name, color, deleting) {
     if (saving || deleting) {

--- a/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-category-tabs.js
@@ -30,50 +30,6 @@ export default Controller.extend({
     });
   },
 
-  @discourseComputed("site.categoriesList")
-  categories(categoriesList) {
-    return categoriesList;
-  },
-
-  @discourseComputed("categories")
-  filteredCategories(categories) {
-    return categories.filter(
-      (category) =>
-        this.siteSettings.allow_uncategorized_topics ||
-        category.id !== this.site.uncategorized_category_id
-    );
-  },
-
-  @discourseComputed(
-    "model.ancestors",
-    "filteredCategories",
-    "noSubcategories"
-  )
-  categoryBreadcrumbs(categoryAncestors, filteredCategories, noSubcategories) {
-    categoryAncestors = categoryAncestors || [];
-    const parentCategories = [undefined, ...categoryAncestors];
-    const categories = [...categoryAncestors, undefined];
-    const zipped = parentCategories.map((x, i) => [x, categories[i]]);
-
-    return zipped.map((record) => {
-      const [parentCategory, category] = record;
-
-      const options = filteredCategories.filter(
-        (c) =>
-          c.get("parentCategory.id") === (parentCategory && parentCategory.id)
-      );
-
-      return {
-        category,
-        parentCategory,
-        options,
-        isSubcategory: !!parentCategory,
-        noSubcategories: !category && noSubcategories,
-        hasOptions: options.length !== 0,
-      };
-    });
-  },
-
   @discourseComputed("saving", "model.name", "model.color", "deleting")
   disabled(saving, name, color, deleting) {
     if (saving || deleting) {

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -522,7 +522,6 @@ export function getEditCategoryUrl(category, subcategories, tab) {
   if (tab) {
     url += `/${tab}`;
   }
-  console.log(url);
   return getURL(url);
 }
 

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -1,5 +1,6 @@
 import getURL, { withoutPrefix } from "discourse-common/lib/get-url";
 import { next, schedule } from "@ember/runloop";
+import Category from "discourse/models/category";
 import EmberObject from "@ember/object";
 import LockOn from "discourse/lib/lock-on";
 import Session from "discourse/models/session";
@@ -513,6 +514,16 @@ export function getCategoryAndTagUrl(category, subcategories, tag) {
   }
 
   return getURL(url || "/");
+}
+
+export function getEditCategoryUrl(category, subcategories, tab) {
+  let url = `/c/${Category.slugFor(category)}/edit`;
+
+  if (tab) {
+    url += `/${tab}`;
+  }
+  console.log(url);
+  return getURL(url);
 }
 
 export default _urlInstance;

--- a/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
@@ -4,6 +4,8 @@
       category=breadcrumb.category
       categories=breadcrumb.options
       tagId=tag.id
+      editingCategory=editingCategory
+      editingCategoryTab=editingCategoryTab
       options=(hash
         parentCategory=breadcrumb.parentCategory
         subCategory=breadcrumb.isSubcategory
@@ -14,7 +16,7 @@
   {{/if}}
 {{/each}}
 
-{{#if siteSettings.tagging_enabled}}
+{{#if showTagsSection}}
   {{#if additionalTags}}
     {{tags-intersection-chooser
       currentCategory=category

--- a/app/assets/javascripts/discourse/app/templates/edit-category-tabs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/edit-category-tabs.hbs
@@ -1,6 +1,24 @@
 <div class="edit-category {{if expandedMenu "expanded-menu"}}">
-  <div class="edit-category-title">
+  <div class="edit-category-title-bar">
+    <div class="edit-category-title">
     <h2>{{title}}</h2>
+      {{#each categoryBreadcrumbs as |breadcrumb|}}
+        {{#if breadcrumb.hasOptions}}
+          {{category-drop
+            category=breadcrumb.category
+            categories=breadcrumb.options
+            navigateToEdit=true
+            editCategoryTab=selectedTab
+            options=(hash
+              parentCategory=breadcrumb.parentCategory
+              subCategory=breadcrumb.isSubcategory
+              noSubcategories=breadcrumb.noSubcategories
+              autoFilterable=true
+            )
+            }}
+        {{/if}}
+      {{/each}}
+    </div>
     {{#unless mobileView}}
       {{#if model.id}}
         {{d-button

--- a/app/assets/javascripts/discourse/app/templates/edit-category-tabs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/edit-category-tabs.hbs
@@ -2,13 +2,15 @@
   <div class="edit-category-title-bar">
     <div class="edit-category-title">
       <h2>{{title}}</h2>
-      {{bread-crumbs
-        categories=site.categoriesList
-        category=model
-        noSubcategories=model.noSubcategories
-        editingCategory=true
-        editingCategoryTab=selectedTab
-      }}
+      {{#if model.id}}
+        {{bread-crumbs
+          categories=site.categoriesList
+          category=model
+          noSubcategories=model.noSubcategories
+          editingCategory=true
+          editingCategoryTab=selectedTab
+        }}
+      {{/if}}
     </div>
     {{#unless mobileView}}
       {{#if model.id}}

--- a/app/assets/javascripts/discourse/app/templates/edit-category-tabs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/edit-category-tabs.hbs
@@ -1,23 +1,14 @@
 <div class="edit-category {{if expandedMenu "expanded-menu"}}">
   <div class="edit-category-title-bar">
     <div class="edit-category-title">
-    <h2>{{title}}</h2>
-      {{#each categoryBreadcrumbs as |breadcrumb|}}
-        {{#if breadcrumb.hasOptions}}
-          {{category-drop
-            category=breadcrumb.category
-            categories=breadcrumb.options
-            navigateToEdit=true
-            editCategoryTab=selectedTab
-            options=(hash
-              parentCategory=breadcrumb.parentCategory
-              subCategory=breadcrumb.isSubcategory
-              noSubcategories=breadcrumb.noSubcategories
-              autoFilterable=true
-            )
-            }}
-        {{/if}}
-      {{/each}}
+      <h2>{{title}}</h2>
+      {{bread-crumbs
+        categories=site.categoriesList
+        category=model
+        noSubcategories=model.noSubcategories
+        editingCategory=true
+        editingCategoryTab=selectedTab
+      }}
     </div>
     {{#unless mobileView}}
       {{#if model.id}}

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -23,9 +23,19 @@ acceptance("Category Edit", function (needs) {
       "it jumps to the correct screen"
     );
 
-    assert.equal(queryAll(".badge-category").text(), "bug");
+    assert.equal(
+      queryAll(".category-breadcrumb .badge-category").text(),
+      "bug"
+    );
+    assert.equal(
+      queryAll(".category-color-editor .badge-category").text(),
+      "bug"
+    );
     await fillIn("input.category-name", "testing");
-    assert.equal(queryAll(".badge-category").text(), "testing");
+    assert.equal(
+      queryAll(".category-color-editor .badge-category").text(),
+      "testing"
+    );
 
     await fillIn(".edit-text-color input", "ff0000");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -1,4 +1,8 @@
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  exists,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
 import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
@@ -10,10 +14,9 @@ acceptance("Category New", function (needs) {
 
   test("Creating a new category", async function (assert) {
     await visit("/new-category");
-    assert.ok(queryAll(".badge-category"));
 
-    // Category breadcrumbs aren't rendered for new category
-    assert.notOk(queryAll(".category-breadcrumb"));
+    assert.ok(queryAll(".badge-category"));
+    assert.notOk(exists(".category-breadcrumb"));
 
     await fillIn("input.category-name", "testing");
     assert.equal(queryAll(".badge-category").text(), "testing");

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -12,6 +12,9 @@ acceptance("Category New", function (needs) {
     await visit("/new-category");
     assert.ok(queryAll(".badge-category"));
 
+    // Category breadcrumbs aren't rendered for new category
+    assert.notOk(queryAll(".category-breadcrumb"));
+
     await fillIn("input.category-name", "testing");
     assert.equal(queryAll(".badge-category").text(), "testing");
 

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -1,6 +1,6 @@
 import Category from "discourse/models/category";
 import ComboBoxComponent from "select-kit/components/combo-box";
-import DiscourseURL, { getCategoryAndTagUrl } from "discourse/lib/url";
+import DiscourseURL, { getCategoryAndTagUrl, getEditCategoryUrl } from "discourse/lib/url";
 import I18n from "I18n";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import { computed } from "@ember/object";
@@ -18,6 +18,8 @@ export default ComboBoxComponent.extend({
   tagName: "li",
   categoryStyle: readOnly("siteSettings.category_style"),
   noCategoriesLabel: I18n.t("categories.no_subcategory"),
+  navigateToEdit: false,
+  editCategoryTab: null,
 
   selectKitOptions: {
     filterable: true,
@@ -145,13 +147,19 @@ export default ComboBoxComponent.extend({
           ? this.selectKit.options.parentCategory
           : Category.findById(parseInt(categoryId, 10));
 
-      DiscourseURL.routeToUrl(
-        getCategoryAndTagUrl(
-          category,
-          categoryId !== NO_CATEGORIES_ID,
-          this.tagId
-        )
-      );
+      const route = this.navigateToEdit
+        ? getEditCategoryUrl(
+            category,
+            categoryId !== NO_CATEGORIES_ID,
+            this.editCategoryTab
+          )
+        : getCategoryAndTagUrl(
+            category,
+            categoryId !== NO_CATEGORIES_ID,
+            this.tagId
+          );
+
+      DiscourseURL.routeToUrl(route);
     },
   },
 

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -1,6 +1,9 @@
 import Category from "discourse/models/category";
 import ComboBoxComponent from "select-kit/components/combo-box";
-import DiscourseURL, { getCategoryAndTagUrl, getEditCategoryUrl } from "discourse/lib/url";
+import DiscourseURL, {
+  getCategoryAndTagUrl,
+  getEditCategoryUrl,
+} from "discourse/lib/url";
 import I18n from "I18n";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import { computed } from "@ember/object";
@@ -19,7 +22,8 @@ export default ComboBoxComponent.extend({
   categoryStyle: readOnly("siteSettings.category_style"),
   noCategoriesLabel: I18n.t("categories.no_subcategory"),
   navigateToEdit: false,
-  editCategoryTab: null,
+  editingCategory: false,
+  editingCategoryTab: null,
 
   selectKitOptions: {
     filterable: true,
@@ -59,14 +63,14 @@ export default ComboBoxComponent.extend({
       const shortcuts = [];
 
       if (
-        this.value ||
+        (this.value && !this.editingCategory) ||
         (this.selectKit.options.noSubcategories &&
           this.selectKit.options.subCategory)
       ) {
-        shortcuts.push({
-          id: ALL_CATEGORIES_ID,
-          name: this.allCategoriesLabel,
-        });
+        // shortcuts.push({
+        // id: ALL_CATEGORIES_ID,
+        // name: this.allCategoriesLabel,
+        // });
       }
 
       if (
@@ -112,6 +116,9 @@ export default ComboBoxComponent.extend({
     "parentCategoryName",
     "selectKit.options.subCategory",
     function () {
+      if (this.editingCategory) {
+        return this.noCategoriesLabel;
+      }
       if (this.selectKit.options.subCategory) {
         return I18n.t("categories.all_subcategories", {
           categoryName: this.parentCategoryName,
@@ -147,11 +154,11 @@ export default ComboBoxComponent.extend({
           ? this.selectKit.options.parentCategory
           : Category.findById(parseInt(categoryId, 10));
 
-      const route = this.navigateToEdit
+      const route = this.editingCategory
         ? getEditCategoryUrl(
             category,
             categoryId !== NO_CATEGORIES_ID,
-            this.editCategoryTab
+            this.editingCategoryTab
           )
         : getCategoryAndTagUrl(
             category,

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -67,10 +67,10 @@ export default ComboBoxComponent.extend({
         (this.selectKit.options.noSubcategories &&
           this.selectKit.options.subCategory)
       ) {
-        // shortcuts.push({
-        // id: ALL_CATEGORIES_ID,
-        // name: this.allCategoriesLabel,
-        // });
+        shortcuts.push({
+          id: ALL_CATEGORIES_ID,
+          name: this.allCategoriesLabel,
+        });
       }
 
       if (

--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -9,7 +9,7 @@ div.edit-category {
   grid-column-gap: 1.5em;
   grid-template-areas: "header header" "sidebar content" "sidebar warning" "sidebar footer";
 
-  .edit-category-title {
+  .edit-category-title-bar {
     grid-area: header;
     grid-column: 1 / span 2;
     display: flex;

--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -17,6 +17,11 @@ div.edit-category {
     align-self: start;
     background-color: var(--primary-very-low);
     padding: 20px;
+
+    .category-back {
+      height: 2em;
+      align-self: flex-end;
+    }
   }
 
   .edit-category-nav {

--- a/app/assets/stylesheets/mobile/edit-category.scss
+++ b/app/assets/stylesheets/mobile/edit-category.scss
@@ -39,7 +39,7 @@ div.edit-category {
     }
   }
 
-  .edit-category-title {
+  .edit-category-title-bar {
     justify-content: start;
     align-items: center;
     padding-bottom: 1em;


### PR DESCRIPTION
Currently, there is no easy way to switch between categories when editing one. This fixes that.

![image](https://user-images.githubusercontent.com/16214023/119400506-e869c580-bc9f-11eb-87b9-c4adfb7911c8.png)

![image](https://user-images.githubusercontent.com/16214023/119400520-f0296a00-bc9f-11eb-9c87-208c945b6ffc.png)

![image](https://user-images.githubusercontent.com/16214023/119400551-f7507800-bc9f-11eb-8232-f01f3640e11b.png)

![image](https://user-images.githubusercontent.com/16214023/119400580-fd465900-bc9f-11eb-908a-69882945412b.png)

![image](https://user-images.githubusercontent.com/16214023/119400604-046d6700-bca0-11eb-9453-4d400cae3abf.png)
