### PR TITLE
FIX: Hide a post's pending flag count from TL4 users.

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -17,9 +17,15 @@ module TopicGuardian
     return false if anonymous? || topic.nil?
     return true if is_staff?
 
+    is_category_group_moderator?(topic.category)
+  end
+
+  def can_moderate_topic?(topic)
+    return false if anonymous? || topic.nil?
+    return true if is_staff?
+
     can_perform_action_available_to_group_moderators?(topic)
   end
-  alias :can_moderate_topic? :can_review_topic?
 
   def can_create_shared_draft?
     SiteSetting.shared_drafts_enabled? && can_see_shared_draft?

--- a/spec/components/guardian/topic_guardian_spec.rb
+++ b/spec/components/guardian/topic_guardian_spec.rb
@@ -112,4 +112,13 @@ describe TopicGuardian do
       end
     end
   end
+
+  describe '#can_review_topic?' do
+    it 'returns false for TL4 users' do
+      tl4_user = Fabricate(:user, trust_level: TrustLevel[4])
+      topic = Fabricate(:topic)
+
+      expect(Guardian.new(tl4_user).can_review_topic?(topic)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
They can't see the review queue, so there's no reason to show a button with the post's pending flag count in the post controls.

