### PR TITLE
UX: add ARIA region role to posts

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -596,6 +596,10 @@ createWidget("post-article", {
 
   buildAttributes(attrs) {
     return {
+      "aria-label": I18n.t("share.post", {
+        postNumber: attrs.post_number,
+      }),
+      role: "region",
       "data-post-id": attrs.id,
       "data-topic-id": attrs.topicId,
       "data-user-id": attrs.user_id,


### PR DESCRIPTION
NVDA does not detect HTML5 articles as regions. This explicitly sets a
region with an aria-label denoting post numbers making it much easier to
know where you are in a topic.

Note role: article which is more semantically correct is not respected by
NVDA d/D shortcut, hence the much more generic "region" role.
