### PR TITLE
UX: Adjust list and onebox margins

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -95,7 +95,7 @@ a.loading-onebox {
 
 aside.onebox {
   border: 5px solid var(--primary-low);
-  margin-bottom: 1em;
+  margin: 1em 0;
   padding: 1em;
   font-size: $font-0;
   background: var(--secondary);

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -63,7 +63,7 @@ hr {
 
 ul,
 dd {
-  margin: 0 0 9px 25px;
+  margin: 1em 0 1em 1.25em;
   padding: 0;
 }
 
@@ -75,14 +75,15 @@ dd {
 
 .cooked ul,
 .d-editor-preview ul {
-  margin: 0;
-  padding-left: 40px;
+  padding-left: 1.25em;
 }
 
-li {
+li,
+.cooked li,
+.d-editor-preview li {
   > ul,
   > ol {
-    margin-bottom: 0;
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
Lists – made the indent smaller (helps on mobile), added vertical margin
Onebox – added top margin

before/after

<img width="376" alt="Screen Shot 2021-05-25 at 12 52 56" src="https://user-images.githubusercontent.com/66961/119486443-87ea8f00-bd58-11eb-9216-7e049e34ea6a.png"> <img width="376" alt="Screen Shot 2021-05-25 at 12 52 29" src="https://user-images.githubusercontent.com/66961/119486462-8ae57f80-bd58-11eb-8255-3ba3017d4e60.png">
