### PR TITLE
FEATURE: Change "Preformatted text" shortcut

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -129,7 +129,7 @@ class Toolbar {
     this.addButton({
       id: "code",
       group: "insertions",
-      shortcut: "Shift+C",
+      shortcut: "E",
       preventFocus: true,
       trimLeading: true,
       action: (...args) => this.context.send("formatCode", args),


### PR DESCRIPTION
Cmd/Ctrl+Shift+C was conflicting with browsers' "inspect element" keyboard shortcuts. Cmd/Ctrl-E was chosen because it's the same one that GitHub is now using: https://github.blog/changelog/2021-04-09-new-codeblock-shortcut/
