### PR TITLE
DEV: Don't resetSite() more often than needed

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -1,6 +1,7 @@
 import {
   acceptance,
   count,
+  exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -1,5 +1,6 @@
 import {
   acceptance,
+  exists,
   queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -219,9 +219,7 @@ export function acceptance(name, optionsOrCallback) {
       clearOutletCache();
       clearHTMLCache();
 
-      if (siteChanges) {
-        resetSite(currentSettings(), siteChanges);
-      }
+      resetSite(currentSettings(), siteChanges);
 
       if (LEGACY_ENV) {
         getApplication().__registeredObjects__ = false;
@@ -253,7 +251,6 @@ export function acceptance(name, optionsOrCallback) {
       flushMap();
       localStorage.clear();
       User.resetCurrent();
-      resetSite(currentSettings());
       resetExtraClasses();
       clearOutletCache();
       clearHTMLCache();


### PR DESCRIPTION
Avoid calling `resetSite()` twice per test in certain situations.