### PR TITLE
FIX: Show inviter name in email's from field

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -422,7 +422,7 @@ class UserNotifications < ActionMailer::Base
     user_name = notification_data[:original_username]
 
     if post && SiteSetting.enable_names && SiteSetting.display_name_on_email_from
-      name = User.where(id: post.user_id).pluck_first(:name)
+      name = User.where(id: notification_data[:original_user_id] || post.user_id).pluck_first(:name)
       user_name = name unless name.blank?
     end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1695,7 +1695,9 @@ class Topic < ActiveRecord::Base
       post_number: 1,
       data: {
         topic_title: self.title,
-        display_username: username
+        display_username: username,
+        original_user_id: user.id,
+        original_username: user.username
       }.to_json
     )
   end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -972,11 +972,52 @@ describe UserNotifications do
   end
 
   describe "user invited to a topic" do
+    let(:notification_type) { :invited_to_topic }
+
     include_examples "notification email building" do
-      let(:notification_type) { :invited_to_topic }
       include_examples "respect for private_email"
       include_examples "no reply by email"
       include_examples "sets user locale"
+    end
+
+    context "shows the right name in 'From' field" do
+      let(:inviter) { Fabricate(:user) }
+      let(:invitee) { Fabricate(:user) }
+
+      let(:notification) do
+        Fabricate(:notification,
+          notification_type: Notification.types[:invited_to_topic],
+          user: invitee,
+          topic: post.topic,
+          post_number: post.post_number,
+          data: {
+            topic_title: post.topic.title,
+            display_username: inviter.username,
+            original_user_id: inviter.id,
+            original_username: inviter.username
+          }.to_json
+        )
+      end
+
+      let(:mailer) do
+        UserNotifications.public_send(
+          "user_invited_to_topic",
+          invitee,
+          notification_type: Notification.types[notification.notification_type],
+          notification_data_hash: notification.data_hash,
+          post: notification.post
+        )
+      end
+
+      it "sends the email as the inviter" do
+        SiteSetting.enable_names = false
+
+        expect(mailer.message.to_s).to include("From: #{inviter.username} via #{SiteSetting.title} <#{SiteSetting.notification_email}>")
+      end
+
+      it "sends the email as the inviter" do
+        expect(mailer.message.to_s).to include("From: #{inviter.name} via #{SiteSetting.title} <#{SiteSetting.notification_email}>")
+      end
     end
   end
 


### PR DESCRIPTION
'From' field of the email contained the name of the user who posted the
shared post. Instead, it should contain the name of the inviter.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
