### PR TITLE
DEV: Remove `cache` option from `ajax()`

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report.js
@@ -366,7 +366,7 @@ export default Component.extend({
   },
 
   _buildPayload(facets) {
-    let payload = { data: { cache: true, facets } };
+    let payload = { data: { facets } };
 
     if (this.startDate) {
       payload.data.start_date = moment(this.startDate)

--- a/app/assets/javascripts/discourse/app/lib/ajax.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax.js
@@ -162,10 +162,6 @@ export function ajax() {
       args.headers["Discourse-Script"] = true;
     }
 
-    if (args.type === "GET" && args.cache !== true) {
-      args.cache = true; // Disable JQuery cache busting param, which was created to deal with IE8
-    }
-
     ajaxObj = $.ajax(getURL(url), args);
   }
 

--- a/app/assets/javascripts/discourse/app/lib/category-tag-search.js
+++ b/app/assets/javascripts/discourse/app/lib/category-tag-search.js
@@ -33,7 +33,6 @@ function searchTags(term, categories, limit) {
         function () {
           oldSearch = $.ajax(getURL("/tags/filter/search"), {
             type: "GET",
-            cache: true,
             data: { limit: limit, q },
           });
 

--- a/app/assets/javascripts/discourse/app/lib/load-script.js
+++ b/app/assets/javascripts/discourse/app/lib/load-script.js
@@ -99,7 +99,6 @@ export default function loadScript(url, opts) {
       ajax({
         url: fullUrl,
         dataType: "text",
-        cache: true,
       }).then(cb);
     } else {
       // Always load JavaScript with script tag to avoid Content Security Policy inline violations

--- a/app/assets/javascripts/discourse/app/lib/screen-track.js
+++ b/app/assets/javascripts/discourse/app/lib/screen-track.js
@@ -156,7 +156,6 @@ export default class {
 
     ajax("/topics/timings", {
       data,
-      cache: false,
       type: "POST",
       headers: {
         "X-SILENCE-LOGGER": "true",

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -141,7 +141,7 @@ const Bookmark = RestModel.extend({
       url += "?" + $.param(params);
     }
 
-    return ajax(url, { cache: "false" });
+    return ajax(url);
   },
 
   loadMore(additionalParams) {

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -172,7 +172,6 @@ const Post = RestModel.extend({
 
     return ajax(`/posts/${this.id}/recover`, {
       type: "PUT",
-      cache: false,
     })
       .then((data) => {
         this.setProperties({

--- a/app/assets/javascripts/discourse/app/models/user-drafts-stream.js
+++ b/app/assets/javascripts/discourse/app/models/user-drafts-stream.js
@@ -66,7 +66,7 @@ export default RestModel.extend({
 
     this.set("loading", true);
 
-    return ajax(findUrl, { cache: "false" })
+    return ajax(findUrl)
       .then((result) => {
         if (result && result.no_results_help) {
           this.set("noContentHelp", result.no_results_help);

--- a/app/assets/javascripts/discourse/app/models/user-posts-stream.js
+++ b/app/assets/javascripts/discourse/app/models/user-posts-stream.js
@@ -50,7 +50,7 @@ export default EmberObject.extend({
 
     this.set("loading", true);
 
-    return ajax(this.url, { cache: false })
+    return ajax(this.url)
       .then((result) => {
         if (result) {
           const posts = result.map((post) => UserAction.create(post));

--- a/app/assets/javascripts/discourse/app/models/user-stream.js
+++ b/app/assets/javascripts/discourse/app/models/user-stream.js
@@ -100,7 +100,7 @@ export default RestModel.extend({
     }
 
     this.set("loading", true);
-    return ajax(findUrl, { cache: "false" })
+    return ajax(findUrl)
       .then((result) => {
         if (result && result.no_results_help) {
           this.set("noContentHelp", result.no_results_help);

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -524,27 +524,23 @@ const User = RestModel.extend({
 
   loadUserAction(id) {
     const stream = this.stream;
-    return ajax(`/user_actions/${id}.json`, { cache: "false" }).then(
-      (result) => {
-        if (result && result.user_action) {
-          const ua = result.user_action;
+    return ajax(`/user_actions/${id}.json`).then((result) => {
+      if (result && result.user_action) {
+        const ua = result.user_action;
 
-          if (
-            (this.get("stream.filter") || ua.action_type) !== ua.action_type
-          ) {
-            return;
-          }
-          if (!this.get("stream.filter") && !this.inAllStream(ua)) {
-            return;
-          }
-
-          ua.title = emojiUnescape(escapeExpression(ua.title));
-          const action = UserAction.collapseStream([UserAction.create(ua)]);
-          stream.set("itemsLoaded", stream.get("itemsLoaded") + 1);
-          stream.get("content").insertAt(0, action[0]);
+        if ((this.get("stream.filter") || ua.action_type) !== ua.action_type) {
+          return;
         }
+        if (!this.get("stream.filter") && !this.inAllStream(ua)) {
+          return;
+        }
+
+        ua.title = emojiUnescape(escapeExpression(ua.title));
+        const action = UserAction.collapseStream([UserAction.create(ua)]);
+        stream.set("itemsLoaded", stream.get("itemsLoaded") + 1);
+        stream.get("content").insertAt(0, action[0]);
       }
-    );
+    });
   },
 
   inAllStream(ua) {

--- a/app/assets/javascripts/discourse/app/pre-initializers/theme-errors-handler.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/theme-errors-handler.js
@@ -29,7 +29,6 @@ function reportToLogster(name, error) {
   Ember.$.ajax(getURL("/logs/report_js_error"), {
     data,
     type: "POST",
-    cache: false,
   });
 }
 

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
@@ -63,24 +63,18 @@ createWidgetFrom(QuickAccessPanel, "quick-access-bookmarks", {
   },
 
   loadBookmarksWithReminders() {
-    return ajax(`/u/${this.currentUser.username}/bookmarks.json`, {
-      cache: "false",
-    }).then((result) => {
-      result = result.user_bookmark_list;
-      return result.bookmarks;
-    });
+    return ajax(`/u/${this.currentUser.username}/bookmarks.json`).then(
+      ({ user_bookmark_list }) => user_bookmark_list.bookmarks
+    );
   },
 
   loadUserActivityBookmarks() {
     return ajax("/user_actions.json", {
-      cache: "false",
       data: {
         username: this.currentUser.username,
         filter: UserAction.TYPES.bookmarks,
         no_results_help_key: "user_activity.no_bookmarks",
       },
-    }).then(({ user_actions }) => {
-      return user_actions;
-    });
+    }).then(({ user_actions }) => user_actions);
   },
 });

--- a/app/assets/javascripts/pretty-text/addon/oneboxer.js
+++ b/app/assets/javascripts/pretty-text/addon/oneboxer.js
@@ -71,7 +71,6 @@ function loadNext(ajax) {
       category_id: categoryId,
       topic_id: topicId,
     },
-    cache: true,
   })
     .then(
       (html) => {

--- a/app/assets/javascripts/select-kit/addon/mixins/tags.js
+++ b/app/assets/javascripts/select-kit/addon/mixins/tags.js
@@ -11,7 +11,6 @@ export default Mixin.create({
   searchTags(url, data, callback) {
     return ajax(getURL(url), {
       quietMillis: 200,
-      cache: true,
       dataType: "json",
       data,
     })


### PR DESCRIPTION
1. It defaults to `cache: true` already (in jQuery)
2. Setting it to `false` for non-GET request doesn't do anything
3. We were correcting `cache: false` GET requests to use `cache: true`

…so setting it to anything at all, for any type of request doesn't make sense (anymore)
