### PR TITLE
DEV: Remove unused `disabled_plugins` checks

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
@@ -1,4 +1,3 @@
-import Site from "discourse/models/site";
 import { buildRawConnectorCache } from "discourse-common/lib/raw-templates";
 import deprecated from "discourse-common/lib/deprecated";
 
@@ -26,17 +25,8 @@ const DefaultConnectorClass = {
 };
 
 function findOutlets(collection, callback) {
-  const disabledPlugins = Site.currentProp("disabled_plugins") || [];
-
   Object.keys(collection).forEach(function (res) {
     if (res.indexOf("/connectors/") !== -1) {
-      // Skip any disabled plugins
-      for (let i = 0; i < disabledPlugins.length; i++) {
-        if (res.indexOf("/" + disabledPlugins[i] + "/") !== -1) {
-          return;
-        }
-      }
-
       const segments = res.split("/");
       let outletName = segments[segments.length - 2];
       const uniqueName = segments[segments.length - 1];

--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -4,7 +4,6 @@ export default {
   "site.json": {
     site: {
       default_archetype: "regular",
-      disabled_plugins: [],
       shared_drafts_category_id: 24,
       notification_types: NOTIFICATION_TYPES,
       post_types: {

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -12,7 +12,6 @@ class SiteSerializer < ApplicationSerializer
     :top_menu_items,
     :anonymous_top_menu_items,
     :uncategorized_category_id, # this is hidden so putting it here
-    :disabled_plugins,
     :user_field_max_length,
     :post_action_types,
     :topic_flag_types,
@@ -116,10 +115,6 @@ class SiteSerializer < ApplicationSerializer
 
   def uncategorized_category_id
     SiteSetting.uncategorized_category_id
-  end
-
-  def disabled_plugins
-    Discourse.disabled_plugin_names
   end
 
   def user_field_max_length

--- a/plugins/styleguide/assets/javascripts/discourse/styleguide-route-map.js.es6
+++ b/plugins/styleguide/assets/javascripts/discourse/styleguide-route-map.js.es6
@@ -1,10 +1,4 @@
 export default function () {
-  const { disabled_plugins = [] } = this.site;
-
-  if (disabled_plugins.indexOf("styleguide") !== -1) {
-    return;
-  }
-
   this.route("styleguide", function () {
     this.route("show", { path: ":category/:section" });
   });


### PR DESCRIPTION
We now bundle Javascript for each theme/plugin separately, and only ship bundles for enabled plugins to the client. Therefore, these disabled_plugins checks are now redundant, and can be removed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
