### PR TITLE
FIX: Sort user bookmarks by reminder date

### DIFF
--- a/lib/bookmark_query.rb
+++ b/lib/bookmark_query.rb
@@ -28,7 +28,7 @@ class BookmarkQuery
 
   def list_all
     results = user_bookmarks.order(
-      '(CASE WHEN bookmarks.pinned THEN 0 ELSE 1 END), bookmarks.updated_at DESC'
+      '(CASE WHEN bookmarks.pinned THEN 0 ELSE 1 END), bookmarks.reminder_at ASC, bookmarks.updated_at DESC'
     )
 
     topics = Topic.listable_topics.secured(@guardian)


### PR DESCRIPTION
With this change, bookmarks will be ordered thusly:

- pinned
- reminder date (ascending)
- updated date (descending)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
