### PR TITLE
FIX: Properly break overflowing long links in topic map

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -461,7 +461,7 @@ blockquote {
   td {
     vertical-align: top;
     padding: 1px;
-    word-wrap: anywhere;
+    word-break: break-all;
   }
 
   .topic-links {


### PR DESCRIPTION
`word-wrap: anywhere` had no effect, since `anywhere` is not a valid value.
