### PR TITLE
UX: Make discobot flag tutorial copy clearer

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -293,11 +293,11 @@ en:
 
       flag:
         instructions: |-
-          We like our discussions friendly, and we need your help to [keep things civilized](%{guidelines_url}). If you see a problem, please flag to privately let the author, or [our helpful staff](%{about_url}), know about it.
+          We like our discussions friendly, and we need your help to [keep things civilized](%{guidelines_url}). If you see a problem, please flag to privately let the author or [our helpful staff](%{about_url}) know about it. There are many reasons you might want to flag a post, ranging from an inocuous topic-splitting suggestion to a clear-cut community standards violation. If you select **Something Else**, you'll start a private message discussion with the moderators where you can ask further questions.
 
           > :imp: I wrote something nasty here
 
-          I guess you know what to do. Go ahead and **flag this post** <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-flag.png" width="16" height="16"> as inappropriate!
+          Go ahead and **flag this post** <img src="%{base_uri}/plugins/discourse-narrative-bot/images/font-awesome-flag.png" width="16" height="16"> and select **It's Inappropriate** as the reason!
         reply: |-
           [Our staff](%{base_uri}/groups/staff) will be privately notified about your flag. If enough community members flag a post, it will also be automatically hidden as a precaution. (Since I didn’t actually write a nasty post :angel:, I’ve gone ahead and removed the flag for now.)
         not_found: |-


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

Per https://meta.discourse.org/t/-/186896, this is a simple copy change to help curb users from sending messages to the moderators via flagging the Discobot tutorial. 