### PR TITLE
UX: Search result link title color change

### DIFF
--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -289,12 +289,13 @@
   }
 
   a.search-link:visited .topic-title {
-    color: var(--tertiary-high);
+    color: var(--primary-medium);
   }
   .search-link {
     .topic-title {
       font-size: $font-up-2;
       line-height: $line-height-medium;
+      color: var(--primary);
     }
     .topic-statuses {
       display: inline-block;


### PR DESCRIPTION
This changes the topic link title color to match how it looks on all other topic lists within Discourse.

## After
<img width="820" alt="image" src="https://user-images.githubusercontent.com/30537603/119560723-47980a80-bd72-11eb-9d3d-a742a8bfd5b9.png">


## Before
<img width="823" alt="image" src="https://user-images.githubusercontent.com/30537603/119560684-36e79480-bd72-11eb-86f2-c3e1885d3b5e.png">

