### PR TITLE
UX: Align list-controls & topic-title top margins

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -1,8 +1,6 @@
 // Topic list navigation & controls
 
 .list-controls {
-  margin-bottom: 0.25em;
-
   .btn {
     &:not(:first-child) {
       margin-left: 0.5em;

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -668,7 +668,7 @@ table {
 // Special elements
 
 #main-outlet {
-  padding-top: 1.8em;
+  padding-top: 2.5em;
 }
 
 #main {

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -168,10 +168,6 @@
   }
 }
 
-h1 {
-  margin: 0 0 4px 0;
-}
-
 a.badge-category {
   margin-top: 5px;
 }
@@ -186,7 +182,7 @@ a.badge-category {
     }
   }
   h1 {
-    margin: 0 0 4px 0;
+    margin-bottom: 0;
     width: 100%;
   }
   a.badge-category {

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -16,8 +16,7 @@
 
 #topic-title {
   z-index: z("base");
-  padding-top: 14px;
-  margin-bottom: 10px;
+  margin-bottom: 1em;
 
   #edit-title,
   .category-chooser,

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -295,8 +295,8 @@ span.post-count {
 
 #topic-title {
   z-index: z("base") + 1;
-  margin: 0 0 0 0 !important;
-  padding: 15px 0;
+  margin: 0;
+  padding: 0.75em 0;
 }
 
 .quote-button.visible {

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -13,7 +13,6 @@
 }
 
 #topic-title {
-  margin: 0 60px 10px 0;
   h1 {
     font-size: $font-up-3;
     line-height: $line-height-medium;


### PR DESCRIPTION
before
<img width="342" alt="topic list, before" src="https://user-images.githubusercontent.com/66961/119562795-0d952b80-bda7-11eb-87e7-c8407d1c1926.png"> <img width="342" alt="topic, before" src="https://user-images.githubusercontent.com/66961/119562810-11c14900-bda7-11eb-8fd1-7a111d842656.png">

after
<img width="342" alt="topic list, after" src="https://user-images.githubusercontent.com/66961/119562831-1685fd00-bda7-11eb-9330-a7f44467407e.png"> <img width="342" alt="topic, after" src="https://user-images.githubusercontent.com/66961/119565156-e4c26580-bda9-11eb-8920-1290c2e50b4c.png">
