### PR TITLE
UX: provide a region for various topic actions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
@@ -6,6 +6,10 @@ import { getTopicFooterButtons } from "discourse/lib/register-topic-footer-butto
 export default Component.extend({
   elementId: "topic-footer-buttons",
 
+  attributeBindings: ["role"],
+
+  role: "region",
+
   // Allow us to extend it
   layoutName: "components/topic-footer-buttons",
 


### PR DESCRIPTION
This makes it much easier to reply to topics / bookmark topics and so on

Previously topic buttons had no region
