### PR TITLE
UX: Consistent padding on mobile & desktop `.wrap`

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -349,7 +349,7 @@ table {
   @extend .clearfix;
   margin-right: auto;
   margin-left: auto;
-  padding: 0 8px;
+  padding: 0 10px;
 
   .contents {
     position: relative;

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -14,7 +14,7 @@
   backface-visibility: hidden; /** do magic for scrolling performance **/
 
   > .wrap {
-    width: calc(100% - 16px); // accommodates for 8px vertical padding
+    width: calc(100% - 20px); // accommodates for 10px vertical padding
     height: 100%;
     .contents {
       display: flex;

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -28,8 +28,8 @@
   > .row {
     grid-area: posts;
     max-width: calc(
-      100vw - 16px
-    ); // 16px is the left + right padding on .wrap in common/base/discourse.scss
+      100vw - 20px
+    ); // 20px is the left + right padding on .wrap in common/base/discourse.scss
   }
 
   .timeline-container {

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -54,10 +54,6 @@ blockquote {
 }
 
 // Common classes
-.wrap {
-  padding: 0 10px;
-}
-
 .boxed {
   .contents {
     padding: 10px 0 0 0;


### PR DESCRIPTION
Due to padding on `.wrap`, we were calculating with `16px` on desktop, but mobile has slightly more padding so the `16px` wasn't enough. This caused the space on the right of the page to be 4px too small within topics on mobile.

The little extra padding on mobile is nice, but I don't want to add more mobile-specific styles... so I gave desktop a little more padding instead and making everything consistent. 