### PR TITLE
FIX: automatically expire bad push channels

### DIFF
--- a/app/models/push_subscription.rb
+++ b/app/models/push_subscription.rb
@@ -2,15 +2,21 @@
 
 class PushSubscription < ActiveRecord::Base
   belongs_to :user
+
+  def parsed_data
+    JSON.parse(data)
+  end
 end
 
 # == Schema Information
 #
 # Table name: push_subscriptions
 #
-#  id         :bigint           not null, primary key
-#  user_id    :integer          not null
-#  data       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id            :bigint           not null, primary key
+#  user_id       :integer          not null
+#  data          :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  error_count   :integer          default(0), not null
+#  first_error_at :datetime
 #

--- a/db/migrate/20210526053611_add_error_count_to_push_subscriptions.rb
+++ b/db/migrate/20210526053611_add_error_count_to_push_subscriptions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddErrorCountToPushSubscriptions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :push_subscriptions, :error_count, :integer, null: false, default: 0
+    add_column :push_subscriptions, :first_error_at, :datetime
+  end
+end


### PR DESCRIPTION
Previously we would retry push notifications indefinitely for all errors
except for ExpiredSubscription

Under certain conditions other persistent errors may arise such as a persistent
rate limit.

If we track more than 3 errors in a period of time longer than a day we will
delete the subscription

Also performs a bit of internal cleanup to ensure protected methods really
are private.
