### PR TITLE
FIX: Close hyperlink modal on pressing Esc

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
+++ b/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
@@ -22,7 +22,6 @@ export default Controller.extend(ModalFunctionality, {
 
     schedule("afterRender", () => {
       const element = document.querySelector(".insert-link");
-
       element.addEventListener("keydown", this.keyDown);
 
       element
@@ -57,6 +56,8 @@ export default Controller.extend(ModalFunctionality, {
           this.set("searchResults", []);
           event.preventDefault();
           event.stopPropagation();
+        } else {
+          this.send("closeModal");
         }
         break;
     }


### PR DESCRIPTION
The first input element of the hyperlink modal has a `keydown` event handler that is used to search posts. When there are results, pressing Esc dismisses the results. When there are no results, it will now dismiss the modal.