### PR TITLE
DEV: Do not prompt to run `yarn` in dev env

### DIFF
--- a/app/views/layouts/ember_cli.html.erb
+++ b/app/views/layouts/ember_cli.html.erb
@@ -15,13 +15,9 @@
 
     <pre><code>$ bin/ember-cli</code></pre>
 
-    <p>If it's your first time starting Ember CLI you'll have to run yarn:</p>
-
-    <pre><code>$ cd app/assets/javascripts/discourse && yarn</code></pre>
-
     <p>Then visit the following URL to use Discourse:</p>
 
-    <a href="http://localhost:4200/">http://localhost:4200</a>
+   <h3><a href="http://localhost:4200/">http://localhost:4200</a></h3>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Since https://github.com/discourse/discourse/pull/13102, a separate `yarn install` is no longer needed (it's run in `bin/ember-cli`. 