### PR TITLE
UX: Make search result styles more consistent

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -277,8 +277,9 @@
   }
 
   .topic-excerpt {
+    display: block;
     font-size: $font-down-1;
-    margin-top: 5px;
+    margin-top: 0.33em;
     color: var(--primary-high);
     word-wrap: break-word;
     line-height: $line-height-large;

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -66,16 +66,13 @@
         display: flex;
         flex-wrap: wrap;
         align-items: center;
+        margin-top: 0.15em;
 
         .discourse-tags {
           .discourse-tag {
             margin-right: 0.25em;
           }
         }
-      }
-
-      a.widget-link {
-        color: var(--tertiary);
       }
     }
 

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -148,6 +148,7 @@
       font-size: $font-up-1;
       background: var(--primary-low);
       padding: 0.358em 1em;
+      margin-bottom: 0;
       @include breakpoint(medium) {
         padding: 0.358em 0.5em;
       }
@@ -293,7 +294,7 @@
   }
   .search-link {
     .topic-title {
-      font-size: $font-up-2;
+      font-size: $font-up-1;
       line-height: $line-height-medium;
       color: var(--primary);
     }


### PR DESCRIPTION
Search dropdown:
  * Make topic titles use the --primary color like they do everywhere else 
  * add a little space between categories and the title (a better match to the main topic list)

Full search page: 
  * Reduce the size of topic titles to match the main topic lists
  * Remove a gap between the advanced search title and options below
  
 Misc:
  * Excerpts on the topic list were displayed as `inline`, so the top margin was being applied to every line of text. `display: block;` fixes this, so the margin is only at the top of the excerpt (and space between lines of text is controlled with `line-height`)
