### PR TITLE
FEATURE: enable tagging by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2389,7 +2389,7 @@ user_api:
 tags:
   tagging_enabled:
     client: true
-    default: false
+    default: true
     refresh: true
   tag_style:
     client: true

--- a/db/migrate/20210527114834_set_tagging_enabled.rb
+++ b/db/migrate/20210527114834_set_tagging_enabled.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SetTaggingEnabled < ActiveRecord::Migration[6.1]
+  def up
+    result = execute('SELECT COUNT(*) FROM topics')
+
+    # keep tagging disabled for existent sites
+    if result.first['count'] > 0
+      execute <<~SQL
+        INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+        VALUES('tagging_enabled', 5, 'f', NOW(), NOW())
+        ON CONFLICT (name) DO NOTHING
+      SQL
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20210527114834_set_tagging_enabled.rb
+++ b/db/migrate/20210527114834_set_tagging_enabled.rb
@@ -9,7 +9,7 @@ class SetTaggingEnabled < ActiveRecord::Migration[6.1]
       LIMIT 1
     SQL
 
-    # keep tagging disabled for existent sites
+    # keep tagging disabled for existing sites
     if result.first['created_at'].to_datetime < 1.hour.ago
       execute <<~SQL
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)

--- a/db/migrate/20210527114834_set_tagging_enabled.rb
+++ b/db/migrate/20210527114834_set_tagging_enabled.rb
@@ -2,10 +2,15 @@
 
 class SetTaggingEnabled < ActiveRecord::Migration[6.1]
   def up
-    result = execute('SELECT COUNT(*) FROM topics')
+    result = execute <<~SQL
+      SELECT created_at
+      FROM schema_migration_details
+      ORDER BY created_at
+      LIMIT 1
+    SQL
 
     # keep tagging disabled for existent sites
-    if result.first['count'] > 0
+    if result.first['created_at'].to_datetime < 1.hour.ago
       execute <<~SQL
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
         VALUES('tagging_enabled', 5, 'f', NOW(), NOW())

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -106,6 +106,7 @@ describe Search do
 
     it "includes custom tables" do
       begin
+        SiteSetting.tagging_enabled = false
         expect(Search.execute("test").posts[0].topic.association(:category).loaded?).to be true
         expect(Search.execute("test").posts[0].topic.association(:tags).loaded?).to be false
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,7 +86,6 @@ end
 SeedFu.quiet = true if SeedFu.respond_to? :quiet
 
 SiteSetting.automatically_download_gravatars = false
-SiteSetting.tagging_enabled = false
 
 SeedFu.seed
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,6 +86,7 @@ end
 SeedFu.quiet = true if SeedFu.respond_to? :quiet
 
 SiteSetting.automatically_download_gravatars = false
+SiteSetting.tagging_enabled = false
 
 SeedFu.seed
 

--- a/spec/requests/api/schemas/json/group_response.json
+++ b/spec/requests/api/schemas/json/group_response.json
@@ -250,6 +250,36 @@
           "items": [
 
           ]
+        },
+        "watching_tags": {
+          "type": "array",
+          "items": [
+
+          ]
+        },
+        "watching_first_post_tags": {
+          "type": "array",
+          "items": [
+
+          ]
+        },
+        "tracking_tags": {
+          "type": "array",
+          "items": [
+
+          ]
+        },
+        "regular_tags": {
+          "type": "array",
+          "items": [
+
+          ]
+        },
+        "muted_tags": {
+          "type": "array",
+          "items": [
+
+          ]
         }
       },
       "required": [

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -196,8 +196,6 @@ describe TopicViewSerializer do
     fab!(:staff_tag_group) { Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name]) }
 
     before do
-      SiteSetting.tagging_enabled = true
-      hidden_tag.tag_groups << staff_tag_group
       topic.tags << hidden_tag
     end
 
@@ -218,7 +216,6 @@ describe TopicViewSerializer do
     fab!(:tag3) { Fabricate(:tag, name: 'atag', topic_count: 3) }
 
     before do
-      SiteSetting.tagging_enabled = true
       topic.tags << tag1
       topic.tags << tag2
       topic.tags << tag3


### PR DESCRIPTION
Over the years we have found that a few communities never discovered tags.

Instead of having them default off we now have them default on, ensuring
that everyone finds out about them.
