### PR TITLE
FIX: Retain tags with class='moz-txt-link...'

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -480,8 +480,12 @@ module Email
 
     def extract_from_mozilla(doc)
       # Mozilla (Thunderbird ?) properly identifies signature and forwarded emails
-      # Remove them and anything that comes after
-      elided = doc.css("*[class^='moz-'], *[class^='moz-'] ~ *").remove
+      # Remove them and anything that comes after. Leave in moz-txt-link- classes as they're links.
+      elided = doc.css("*[@class]:mozfilter", Class.new {
+        def mozfilter node_set
+          node_set.find_all { |node| node["class"] !~ /^moz-txt-link\b/ and node["class"] =~ /^moz-/ }
+        end
+      }.new).remove
       to_markdown(doc.to_html, elided.to_html)
     end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
Apologies, current workload does not permit me to write tests.  This is a fairly simple fix for
https://meta.discourse.org/t/urls-being-dropped-from-thunderbird-generated-replies/163751
where instead of all tags with class="moz-..." being elided, the ones with class="moz-txt-link..." are retained (these are links inserted by Thunderbird).