### PR TITLE
UX: unconditionally focus modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -141,6 +141,10 @@ export default Component.extend({
         focusTarget = this.element.querySelector(
           ".modal-body input, .modal-body button, .modal-footer input, .modal-footer button"
         );
+
+        if (!focusTarget) {
+          focusTarget = this.element.querySelector(".modal-header button");
+        }
       }
       if (focusTarget) {
         afterTransition(() => focusTarget.focus());


### PR DESCRIPTION
Previously auto focus would only work on modals that include buttons or
inputs.

To avoid a situation where information modals such as keyboard shortcuts
do not get focus, simply focus on the close button as a fallback.
