### PR TITLE
FEATURE: Enable pausing images from Giphy and Tenor

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -7,6 +7,7 @@ class CookedPostProcessor
   LIGHTBOX_WRAPPER_CSS_CLASS = "lightbox-wrapper"
   LOADING_SIZE = 10
   LOADING_COLORS = 32
+  GIF_SOURCES_REGEXP = /(giphy|tenor)\.com\//
 
   attr_reader :cooking_options, :doc
 
@@ -320,7 +321,7 @@ class CookedPostProcessor
 
     upload = Upload.get_from_url(src)
 
-    if upload.present? && upload.animated?
+    if (upload.present? && upload.animated?) || src.match?(GIF_SOURCES_REGEXP)
       img.add_class("animated")
     end
 

--- a/spec/components/cooked_post_processor_spec.rb
+++ b/spec/components/cooked_post_processor_spec.rb
@@ -990,6 +990,31 @@ describe CookedPostProcessor do
       expect(doc.css('img.animated').size).to eq(1)
     end
 
+    context "giphy/tenor images" do
+      before do
+        CookedPostProcessor.any_instance.stubs(:get_size).with("https://media2.giphy.com/media/7Oifk90VrCdNe/giphy.webp").returns([311, 280])
+        CookedPostProcessor.any_instance.stubs(:get_size).with("https://media1.tenor.com/images/20c7ddd5e84c7427954f430439c5209d/tenor.gif").returns([833, 104])
+      end
+
+      it "marks giphy images as animated" do
+        post = Fabricate(:post, raw: "![tennis-gif|311x280](https://media2.giphy.com/media/7Oifk90VrCdNe/giphy.webp)")
+        cpp = CookedPostProcessor.new(post, disable_loading_image: true)
+        cpp.post_process
+
+        doc = Nokogiri::HTML5::fragment(cpp.html)
+        expect(doc.css('img.animated').size).to eq(1)
+      end
+
+      it "marks giphy images as animated" do
+        post = Fabricate(:post, raw: "![cat](https://media1.tenor.com/images/20c7ddd5e84c7427954f430439c5209d/tenor.gif)")
+        cpp = CookedPostProcessor.new(post, disable_loading_image: true)
+        cpp.post_process
+
+        doc = Nokogiri::HTML5::fragment(cpp.html)
+        expect(doc.css('img.animated').size).to eq(1)
+      end
+    end
+
     it "optimizes images in quotes" do
       post = Fabricate(:post, raw: <<~MD)
         [quote]


### PR DESCRIPTION
As requested in https://meta.discourse.org/t/allow-pause-for-animated-images-from-certain-domains/191728. This will be most helpful on sites where `download remote images to local` has been disabled. 