### PR TITLE
FEATURE: Automatically timed delete stub topics after entire topic is merged into another topic

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2183,6 +2183,7 @@ en:
     show_create_topics_notice: "If the site has fewer than 5 public topics, show a notice asking admins to create some topics."
 
     delete_drafts_older_than_n_days: "Delete drafts older than (n) days."
+    days_to_wait_before_deleting_fully_merged_stub_topics: "Number of days to wait before automatically deleting fully merged stub topics. Set to 0 to never delete stub topics."
 
     bootstrap_mode_min_users: "Minimum number of users required to disable bootstrap mode (set to 0 to disable)"
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2146,6 +2146,10 @@ uncategorized:
     default: 180
     max: 36500
 
+  days_to_wait_before_deleting_fully_merged_stub_topics:
+    default: 7
+    min: 0
+
   backup_drafts_to_pm_length:
     default: 0
     hidden: true


### PR DESCRIPTION
In the past, we were only closing fully merged topics. Now we start setting a timer for deletion on them. By default, stub topics will be deleted in 7 days. Users can change this period or disable this feature by setting the period to 0.
