### PR TITLE
DEV: Stubbing "Rails.env.production?" introduces a lot of flakiness.

### DIFF
--- a/spec/requests/qunit_controller_spec.rb
+++ b/spec/requests/qunit_controller_spec.rb
@@ -33,16 +33,21 @@ describe QunitController do
 
     context "non-admin users on production" do
       before do
+        # We need to call sign_in before stubbing the method because SessionController#become
+        # checks for the current env when the file is loaded.
+        # We need to make sure become is called once before stubbing, or the method
+        # wont'be available for future tests if this one runs first.
+        sign_in(Fabricate(:user))
         Rails.env.stubs(:production?).returns(true)
       end
 
-      it "anons cannot see the page" do
+      it "regular users cannot see the page" do
         get '/theme-qunit'
         expect(response.status).to eq(404)
       end
 
-      it "regular users cannot see the page" do
-        sign_in(Fabricate(:user))
+      it "anons cannot see the page" do
+        sign_out
         get '/theme-qunit'
         expect(response.status).to eq(404)
       end


### PR DESCRIPTION
We need to be careful when stubbing this method. SessionController#become won't be defined if production is set to true, so if these tests run first, calling #sign_in will fail for other tests.

Calling sign_in before stubbing guarantees the method is defined because the check happens when the class is loaded.

