### PR TITLE
FIX: don't update `allow_title` column of  existing badges in seed.

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -249,6 +249,7 @@ class Badge < ActiveRecord::Base
   end
 
   def default_allow_title=(val)
+    return unless self.new_record?
     self.allow_title ||= val
   end
 

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -213,4 +213,18 @@ describe Badge do
       expect(UserBadge.where(user_id: post.user.id, badge_id: Badge::PopularLink).count).to eq(0)
     end
   end
+
+  context "#seed" do
+
+    let(:regular_badge) do
+      Badge.find(Badge::Regular)
+    end
+
+    it "`allow_title` is not updated for existing records" do
+      regular_badge.update(allow_title: false)
+      SeedFu.seed
+      regular_badge.reload
+      expect(regular_badge.allow_title).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
The default `allow_title` column value is "true" for regular and leader badges. After we disable it on the admin side the seed method enabling it again while upgrading. So we shouldn't do it for existing badges.
