### PR TITLE
FIX: Do not mark badge image uploads as secure

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -340,8 +340,8 @@ end
 #  trigger           :integer
 #  show_posts        :boolean          default(FALSE), not null
 #  system            :boolean          default(FALSE), not null
-#  image             :string(255)
 #  long_description  :text
+#  image_upload_id   :integer
 #
 # Indexes
 #

--- a/db/post_migrate/20210528003603_fix_badge_image_avatar_upload_security_and_acls.rb
+++ b/db/post_migrate/20210528003603_fix_badge_image_avatar_upload_security_and_acls.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class FixBadgeImageAvatarUploadSecurityAndAcls < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    upload_ids = DB.query_single(<<~SQL
+      SELECT image_upload_id
+      FROM badges
+      WHERE image_upload_id IS NOT NULL
+     SQL
+    )
+
+    if upload_ids.any?
+      reason = "badge_image fixup migration"
+      DB.exec(<<~SQL, upload_ids: upload_ids, reason: reason, now: Time.zone.now)
+        UPDATE uploads SET secure = false, security_last_changed_at = :now, updated_at = :now, security_last_changed_reason = :reason
+        WHERE id IN (:upload_ids) AND uploads.secure
+      SQL
+
+      if Discourse.store.external?
+        uploads = Upload.where(id: upload_ids, secure: false).where("updated_at = security_last_changed_at")
+        uploads.each do |upload|
+          Discourse.store.update_upload_ACL(upload)
+          upload.touch
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/post_migrate/20210528003603_fix_badge_image_avatar_upload_security_and_acls.rb
+++ b/db/post_migrate/20210528003603_fix_badge_image_avatar_upload_security_and_acls.rb
@@ -20,7 +20,7 @@ class FixBadgeImageAvatarUploadSecurityAndAcls < ActiveRecord::Migration[6.1]
       SQL
 
       if Discourse.store.external?
-        uploads = Upload.where(id: upload_ids, secure: false).where("updated_at = security_last_changed_at")
+        uploads = Upload.where(id: upload_ids)
         uploads.each do |upload|
           Discourse.store.update_upload_ACL(upload)
           upload.touch

--- a/lib/upload_security.rb
+++ b/lib/upload_security.rb
@@ -26,6 +26,7 @@ class UploadSecurity
     category_logo
     category_background
     group_flair
+    badge_image
   ]
 
   def self.register_custom_public_type(type)

--- a/spec/lib/upload_security_spec.rb
+++ b/spec/lib/upload_security_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe UploadSecurity do
       end
 
       context "when uploading in public context" do
+        describe "for a public type badge_image" do
+          let(:type) { 'badge_image' }
+          it "returns false" do
+            expect(subject.should_be_secure?).to eq(false)
+          end
+        end
         describe "for a public type group_flair" do
           let(:type) { 'group_flair' }
           it "returns false" do


### PR DESCRIPTION
We do not need badge_image upload types to be marked as secure.
Post migration is the same as
https://github.com/discourse/discourse/pull/12081.

See
https://meta.discourse.org/t/secure-media-uploads/140017/122?u=martin

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
