### PR TITLE
UX: Change color of focus & hover on user menu tabs

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -466,8 +466,11 @@ div.menu-links-header {
 
   button:hover,
   button:focus {
-    background-color: var(--highlight-medium);
+    background-color: var(--primary-low);
     outline: none;
+    &.active {
+      background-color: var(--primary-very-low);
+    }
   }
   button {
     padding: 0.3em 0.5em;


### PR DESCRIPTION
This PR changes the background color on the user menu buttons focused & hover state to better align the styling with other top / mid level menu item buttons.

### After

<img width="357" alt="image" src="https://user-images.githubusercontent.com/30537603/120004459-67ab1200-bf9c-11eb-8858-cd3187de4402.png">

### Before

<img width="355" alt="image" src="https://user-images.githubusercontent.com/30537603/120004505-77c2f180-bf9c-11eb-8a3b-74df8fc1d7bb.png">

