### PR TITLE
UX: Don't show reply prompt if current topic is closed

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -710,7 +710,10 @@ export default Controller.extend({
     composer.set("disableDrafts", true);
 
     // for now handle a very narrow use case
-    // if we are replying to a topic AND not on the topic pop the window up
+    // if we are replying to a topic
+    // AND are on on a different topic
+    // AND topic is open (or we are staff)
+    // --> pop the window up
     if (!force && composer.replyingToTopic) {
       const currentTopic = this.topicModel;
 
@@ -719,7 +722,10 @@ export default Controller.extend({
         return;
       }
 
-      if (currentTopic.id !== composer.get("topic.id")) {
+      if (
+        currentTopic.id !== composer.get("topic.id") &&
+        (this.isStaffUser || !currentTopic.closed)
+      ) {
         const message =
           "<h1>" + I18n.t("composer.posting_not_on_topic") + "</h1>";
 

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -172,12 +172,7 @@ const Topic = RestModel.extend({
   @discourseComputed("related_messages")
   relatedMessages(relatedMessages) {
     if (relatedMessages) {
-      const store = this.store;
-
-      return this.set(
-        "related_messages",
-        relatedMessages.map((st) => store.createRecord("topic", st))
-      );
+      return relatedMessages.map((st) => this.store.createRecord("topic", st));
     }
   },
 


### PR DESCRIPTION
A non-staff user cannot post to a closed topic, so we should not show them the modal asking "Which topic do you want to reply to?"

This also fixes an issue I ran into while testing the above change, in Ember CLI an error was being raised because related messages were being set inside a computed property.
