### PR TITLE
UX: Improve style of GitHub PR body in emails

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -140,8 +140,9 @@ module Email
       style('.github-icon-container', 'float: left;')
       style('.github-icon-container *', 'fill: #646464; width: 40px; height: 40px;')
       style('.github-body-container', 'font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace; margin-top: 1em !important;')
-      style('.github-body-container .excerpt', 'display: none;')
       style('.onebox-avatar-inline', ONEBOX_INLINE_AVATAR_STYLE)
+
+      @fragment.css('.github-body-container .excerpt').remove
 
       @fragment.css('aside.quote blockquote > p').each do |p|
         p['style'] = 'padding: 0;'

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -139,6 +139,8 @@ module Email
       style('.github-info div', "display: inline; margin-right: 10px;")
       style('.github-icon-container', 'float: left;')
       style('.github-icon-container *', 'fill: #646464; width: 40px; height: 40px;')
+      style('.github-body-container', 'font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace; margin-top: 1em !important;')
+      style('.github-body-container .excerpt', 'display: none;')
       style('.onebox-avatar-inline', ONEBOX_INLINE_AVATAR_STYLE)
 
       @fragment.css('aside.quote blockquote > p').each do |p|

--- a/spec/components/email/styles_spec.rb
+++ b/spec/components/email/styles_spec.rb
@@ -185,6 +185,15 @@ describe Email::Styles do
       fragment = html_fragment('<aside class="quote"> <div class="title"> <div class="quote-controls"> <i class="fa fa-chevron-down" title="expand/collapse"></i><a href="/t/xyz/123" title="go to the quoted post" class="back"></a> </div> <img alt="" width="20" height="20" src="https://cdn-enterprise.discourse.org/boingboing/user_avatar/bbs.boingboing.net/techapj/40/54379_1.png" class="avatar">techAPJ: </div> <blockquote> <p>lorem ipsum</p> </blockquote> </aside>')
       expect(fragment.to_s.squish).to match(/^<blockquote.+<\/blockquote>$/)
     end
+
+    it "removes GitHub excerpts" do
+      stub_request(:head, "https://github.com/discourse/discourse/pull/1253").to_return(status: 200, body: "", headers: {})
+      stub_request(:get, "https://api.github.com/repos/discourse/discourse/pulls/1253").to_return(status: 200, body: onebox_response("githubpullrequest"))
+
+      onebox = Oneboxer.onebox("https://github.com/discourse/discourse/pull/1253")
+      fragment = html_fragment(onebox)
+      expect(fragment.css(".github-body-container .excerpt")).to be_empty
+    end
   end
 
   context "replace_secure_media_urls" do


### PR DESCRIPTION
On web, we display only an excerpt in a monospace font and the email did
not use the same style.

![image](https://user-images.githubusercontent.com/4147664/120018138-68b95f00-bfef-11eb-8837-bd047b6b70f2.png)
