### PR TITLE
FIX: Giphy oneboxing when the response is an image

### DIFF
--- a/lib/onebox/engine/animated_image_onebox.rb
+++ b/lib/onebox/engine/animated_image_onebox.rb
@@ -11,7 +11,12 @@ module Onebox
 
       def to_html
         og = get_opengraph
-        "<img src='#{og.image}' width='#{og.image_width}' height='#{og.image_height}' class='animated onebox' #{og.title_attr}>"
+        if og.image
+          "<img src='#{og.image}' width='#{og.image_width}' height='#{og.image_height}' class='animated onebox' #{og.title_attr}>"
+        else
+          escaped_url = ::Onebox::Helpers.normalize_url_for_output(@url)
+          "<img src='#{escaped_url}' class='animated onebox'>"
+        end
       end
     end
   end

--- a/spec/lib/onebox/engine/animated_image_onebox_spec.rb
+++ b/spec/lib/onebox/engine/animated_image_onebox_spec.rb
@@ -4,12 +4,14 @@ require "rails_helper"
 
 describe Onebox::Engine::AnimatedImageOnebox do
   let(:giphy) { "http://gph.is/15bRbWf" }
+  let(:direct_gif) { "https://media4.giphy.com/media/Zatyu5LBO2zCyhiAAs/giphy.gif" }
   let(:tenor) { "https://tenor.com/bb3fQ.gif" }
 
   before do
     @previous_options = Onebox.options.to_h
     Onebox.options = { redirect_limit: 0 }
     stub_request(:get, giphy).to_return(status: 200, body: onebox_response("giphy"))
+    stub_request(:get, direct_gif).to_return(status: 200, body: file_from_fixtures("animated.webp"))
     stub_request(:get, tenor).to_return(status: 200, body: onebox_response("tenor"))
   end
 
@@ -20,6 +22,13 @@ describe Onebox::Engine::AnimatedImageOnebox do
   it "works for giphy short URLs" do
     html = described_class.new(giphy).to_html
     expect(html).to include("img")
+    expect(html).to include("class='animated onebox'")
+  end
+
+  it "works when the response is the image asset itself" do
+    html = described_class.new(direct_gif).to_html
+    expect(html).to include("img")
+    expect(html).to include("src='#{direct_gif}'")
     expect(html).to include("class='animated onebox'")
   end
 


### PR DESCRIPTION
Most Giphy URLs return an HTML document with opengraph tags, but some URLs return the actual image file. In those cases, we can pass the URL to the `img` element. 