### PR TITLE
FIX: moderator actions and small actions shouldn't prevent fully merged topics from closing

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -66,8 +66,6 @@ class PostMover
     Guardian.new(user).ensure_can_see! topic
     @destination_topic = topic
 
-    moving_all_posts = (@original_topic.posts.pluck(:id).sort == @post_ids.sort)
-
     create_temp_table
     delete_invalid_post_timings
     move_each_post
@@ -78,7 +76,11 @@ class PostMover
     update_upload_security_status
     update_bookmarks
 
-    if moving_all_posts
+    posts_left = @original_topic.posts
+      .where("post_type = ? or (post_type = ? and action_code != 'split_topic')", Post.types[:regular], Post.types[:whisper])
+      .count
+
+    if posts_left == 1
       close_topic_and_schedule_deletion
     end
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -58,6 +58,14 @@ describe PostMover do
         @like = PostActionCreator.like(another_user, p4)
       end
 
+      def add_moderator_post_to(topic, post_type)
+        topic.add_moderator_post(
+          user,
+          "message",
+          post_type: post_type,
+          action_code: "split_topic")
+      end
+
       context 'success' do
 
         it "correctly handles notifications and bread crumbs" do
@@ -662,6 +670,18 @@ describe PostMover do
 
             timer = topic.topic_timers.find_by(status_type: TopicTimer.types[:delete])
             expect(timer).to be_nil
+          end
+
+          it "ignores moderator posts and closes the topic if all regular posts were moved" do
+            add_moderator_post_to topic, Post.types[:moderator_action]
+            add_moderator_post_to topic, Post.types[:small_action]
+
+            posts_to_move = [p1.id, p2.id, p3.id, p4.id]
+            moved_to = topic.move_posts(user, posts_to_move, destination_topic_id: destination_topic.id)
+            expect(moved_to).to be_present
+
+            topic.reload
+            expect(topic).to be_closed
           end
 
           it "does not try to move small action posts" do


### PR DESCRIPTION
When a topic is fully merged into another topic we close it and schedule its deleting. But if the merged topic contains some moderator actions or small actions it won't be merged. This change fixes this problem.
