### PR TITLE
DEV: add an option in user-chooser to list staged users

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -21,6 +21,7 @@ function performSearch(
   includeMessageableGroups,
   allowedUsers,
   groupMembersOf,
+  includeStagedUsers,
   resultsFn
 ) {
   let cached = cache[term];
@@ -49,6 +50,7 @@ function performSearch(
       include_messageable_groups: includeMessageableGroups,
       groups: groupMembersOf,
       topic_allowed_users: allowedUsers,
+      include_staged_users: includeStagedUsers,
     },
   });
 
@@ -90,6 +92,7 @@ let debouncedSearch = function (
   includeMessageableGroups,
   allowedUsers,
   groupMembersOf,
+  includeStagedUsers,
   resultsFn
 ) {
   discourseDebounce(
@@ -103,6 +106,7 @@ let debouncedSearch = function (
     includeMessageableGroups,
     allowedUsers,
     groupMembersOf,
+    includeStagedUsers,
     resultsFn,
     300
   );
@@ -189,7 +193,8 @@ export default function userSearch(options) {
     allowedUsers = options.allowedUsers,
     topicId = options.topicId,
     categoryId = options.categoryId,
-    groupMembersOf = options.groupMembersOf;
+    groupMembersOf = options.groupMembersOf,
+    includeStagedUsers = options.includeStagedUsers;
 
   if (oldSearch) {
     oldSearch.abort();
@@ -226,6 +231,7 @@ export default function userSearch(options) {
       includeMessageableGroups,
       allowedUsers,
       groupMembersOf,
+      includeStagedUsers,
       function (r) {
         cancel(clearPromise);
         resolve(organizeResults(r, options));

--- a/app/assets/javascripts/select-kit/addon/components/user-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/user-chooser.js
@@ -75,6 +75,7 @@ export default MultiSelectComponent.extend({
       includeMessageableGroups: options.includeMessageableGroups,
       groupMembersOf: options.groupMembersOf,
       allowEmails: options.allowEmails,
+      includeStagedUsers: this.includeStagedUsers,
     }).then((result) => {
       if (typeof result === "string") {
         // do nothing promise probably got cancelled

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1074,7 +1074,7 @@ class UsersController < ApplicationController
      groups: @groups
     }
 
-    options[:include_staged_users] = params[:include_staged_users] || false
+    options[:include_staged_users] = ActiveModel::Type::Boolean.new.cast(params[:include_staged_users])
     options[:topic_id] = topic_id if topic_id
     options[:category_id] = category_id if category_id
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1074,6 +1074,7 @@ class UsersController < ApplicationController
      groups: @groups
     }
 
+    options[:include_staged_users] = params[:include_staged_users] || false
     options[:topic_id] = topic_id if topic_id
     options[:category_id] = category_id if category_id
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1074,7 +1074,7 @@ class UsersController < ApplicationController
      groups: @groups
     }
 
-    options[:include_staged_users] = ActiveModel::Type::Boolean.new.cast(params[:include_staged_users])
+    options[:include_staged_users] = !!ActiveModel::Type::Boolean.new.cast(params[:include_staged_users])
     options[:topic_id] = topic_id if topic_id
     options[:category_id] = category_id if category_id
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3731,6 +3731,7 @@ describe UsersController do
     fab!(:topic) { Fabricate :topic }
     let(:user)  { Fabricate :user, username: "joecabot", name: "Lawrence Tierney" }
     let(:post1) { Fabricate(:post, user: user, topic: topic) }
+    let(:staged_user) { Fabricate(:user, staged: true) }
 
     before do
       SearchIndexer.enable
@@ -3998,6 +3999,26 @@ describe UsersController do
         def users_found
           response.parsed_body['users'].map { |u| u['username'] }
         end
+      end
+    end
+
+    context '`include_staged_users`' do
+      it "includes staged users when the param is true" do
+        get "/u/search/users.json", params: { term: staged_user.name, include_staged_users: true }
+        json = response.parsed_body
+        expect(json["users"].map { |u| u["name"] }).to include(staged_user.name)
+      end
+
+      it "doesn't include staged users when the param is not passed" do
+        get "/u/search/users.json", params: { term: staged_user.name }
+        json = response.parsed_body
+        expect(json["users"].map { |u| u["name"] }).not_to include(staged_user.name)
+      end
+
+      it "doesn't include staged users when the param explicitly set to false" do
+        get "/u/search/users.json", params: { term: staged_user.name, include_staged_users: false }
+        json = response.parsed_body
+        expect(json["users"].map { |u| u["name"] }).not_to include(staged_user.name)
       end
     end
   end


### PR DESCRIPTION
Use Case:
`UserSearch` class already has this option `include_staged_users` which is used in the `directory_items_controller`.
It would make sense to take advantage of that from the frontend `user-search` function via a param.
