### PR TITLE
FIX: "staff" and "admin" wasn't translatable in site settings

### DIFF
--- a/app/models/trust_level_and_staff_setting.rb
+++ b/app/models/trust_level_and_staff_setting.rb
@@ -18,4 +18,12 @@ class TrustLevelAndStaffSetting < TrustLevelSetting
   def self.special_groups
     ['staff', 'admin']
   end
+
+  def self.translation(value)
+    if special_group?(value)
+      I18n.t("trust_levels.#{value}")
+    else
+      super
+    end
+  end
 end

--- a/app/models/trust_level_setting.rb
+++ b/app/models/trust_level_setting.rb
@@ -8,18 +8,23 @@ class TrustLevelSetting < EnumSiteSetting
   end
 
   def self.values
-    levels = TrustLevel.all
-    valid_values.map { |x|
-      {
-        name: x.is_a?(Integer) ? "#{x}: #{levels[x.to_i].name}" : x,
-        value: x
-      }
-    }
+    valid_values.map do |value|
+      { name: translation(value), value: value }
+    end
   end
 
   def self.valid_values
     TrustLevel.valid_range.to_a
   end
 
+  def self.translation(value)
+    I18n.t(
+      "trust_levels.setting_label",
+      level: value,
+      title: I18n.t("trust_levels.#{TrustLevel.levels[value]}.title")
+    )
+  end
+
   private_class_method :valid_values
+  private_class_method :translation
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -727,7 +727,10 @@ en:
       title: "regular"
     leader:
       title: "leader"
+    admin: "admin"
+    staff: "staff"
     change_failed_explanation: "You attempted to demote %{user_name} to '%{new_trust_level}'. However their trust level is already '%{current_trust_level}'. %{user_name} will remain at '%{current_trust_level}' - if you wish to demote user lock trust level first"
+    setting_label: "%{level}: %{title}"
 
   post:
     image_placeholder:
@@ -994,7 +997,7 @@ en:
     imap_authentication_error: "There was an issue with the IMAP credentials provided, check the username and password and try again."
     imap_no_response_error: "An error occurred when communicating with the IMAP server. %{message}"
     smtp_authentication_error: "There was an issue with the SMTP credentials provided, check the username and password and try again."
-    authentication_error_gmail_app_password: "Application-specific password required. Learn more at <a target=\"_blank\" href=\"https://support.google.com/accounts/answer/185833\">this Google Help article</a>"
+    authentication_error_gmail_app_password: 'Application-specific password required. Learn more at <a target="_blank" href="https://support.google.com/accounts/answer/185833">this Google Help article</a>'
     smtp_server_busy_error: "The SMTP server is currently busy, try again later."
     smtp_unhandled_error: "There was an unhandled error when communicating with the SMTP server. %{message}"
     imap_unhandled_error: "There was an unhandled error when communicating with the IMAP server. %{message}"


### PR DESCRIPTION
It also replaces the concatenated string with a translation.