### PR TITLE
UX: Align the bulk-select icon

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -42,6 +42,7 @@
 
   button.bulk-select {
     padding: 0;
+    vertical-align: middle;
   }
 
   td.bulk-select {


### PR DESCRIPTION
Before / After

<img width="304" alt="bulk select icon before" src="https://user-images.githubusercontent.com/66961/120173055-f372a780-c203-11eb-8454-f81425905c5e.png"> <img width="304" alt="bulk select icon after" src="https://user-images.githubusercontent.com/66961/120173094-fb324c00-c203-11eb-9778-74a18c525f6d.png">

