### PR TITLE
FIX: TL4 users cannot unhide posts.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js
@@ -65,7 +65,7 @@ export function buildManageButtons(attrs, currentUser, siteSettings) {
     });
   }
 
-  if (attrs.canManage && attrs.hidden) {
+  if (currentUser.staff && attrs.hidden) {
     contents.push({
       icon: "far-eye",
       label: "post.controls.unhide",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -734,6 +734,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       {{mount-widget widget="post" args=args unhidePost=unhidePost}}
     `,
     beforeEach() {
+      this.currentUser.admin = true;
       this.set("args", { canManage: true, hidden: true });
       this.set("unhidePost", () => (this.unhidden = true));
     },


### PR DESCRIPTION
"PostsGuardian#can_unhide_post?" only returns true if the user is a staff member. We shouldn't let TL4 users see the Unhide post button.

