### PR TITLE
FEATURE: Show all categories in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -101,6 +101,7 @@ export default Controller.extend({
   showEditReason: false,
   editReason: null,
   scopedCategoryId: null,
+  prioritizedCategoryId: null,
   lastValidatedAt: null,
   isUploading: false,
   topic: null,
@@ -874,15 +875,22 @@ export default Controller.extend({
   },
 
   /**
-   Open the composer view
+    Open the composer view
 
-   @method open
-   @param {Object} opts Options for creating a post
-   @param {String} opts.action The action we're performing: edit, reply or createTopic
-   @param {Post} [opts.post] The post we're replying to
-   @param {Topic} [opts.topic] The topic we're replying to
-   @param {String} [opts.quote] If we're opening a reply from a quote, the quote we're making
-   **/
+    @method open
+    @param {Object} opts Options for creating a post
+      @param {String} opts.action The action we're performing: edit, reply, createTopic, createSharedDraft, privateMessage
+      @param {String} opts.draftKey
+      @param {Post} [opts.post] The post we're replying to
+      @param {Topic} [opts.topic] The topic we're replying to
+      @param {String} [opts.quote] If we're opening a reply from a quote, the quote we're making
+      @param {Boolean} [opts.ignoreIfChanged]
+      @param {Boolean} [opts.disableScopedCategory]
+      @param {Number} [opts.categoryId] Sets `scopedCategoryId` and `categoryId` on the Composer model
+      @param {Number} [opts.prioritizedCategoryId]
+      @param {String} [opts.draftSequence]
+      @param {Boolean} [opts.skipDraftCheck]
+  **/
   open(opts) {
     opts = opts || {};
 
@@ -904,6 +912,7 @@ export default Controller.extend({
       showEditReason: false,
       editReason: null,
       scopedCategoryId: null,
+      prioritizedCategoryId: null,
       skipAutoSave: true,
     });
 
@@ -912,6 +921,16 @@ export default Controller.extend({
       const category = this.site.categories.findBy("id", opts.categoryId);
       if (category) {
         this.set("scopedCategoryId", opts.categoryId);
+      }
+    }
+
+    if (opts.prioritizedCategoryId) {
+      const category = this.site.categories.findBy(
+        "id",
+        opts.prioritizedCategoryId
+      );
+      if (category) {
+        this.set("prioritizedCategoryId", opts.prioritizedCategoryId);
       }
     }
 

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1036,7 +1036,8 @@ export default Controller.extend(bufferedProperty("model"), {
         options = {
           action: Composer.CREATE_TOPIC,
           draftKey: post.topic.draft_key,
-          categoryId: this.get("model.category.id"),
+          topicCategoryId: this.get("model.category.id"),
+          prioritizedCategoryId: this.get("model.category.id"),
         };
       }
 

--- a/app/assets/javascripts/discourse/app/mixins/open-composer.js
+++ b/app/assets/javascripts/discourse/app/mixins/open-composer.js
@@ -14,7 +14,8 @@ export default Mixin.create({
     }
 
     this.controllerFor("composer").open({
-      categoryId,
+      prioritizedCategoryId: categoryId,
+      topicCategoryId: categoryId,
       action: Composer.CREATE_TOPIC,
       draftKey: controller.get("model.draft_key") || Composer.NEW_TOPIC_KEY,
       draftSequence: controller.get("model.draft_sequence") || 0,

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -693,15 +693,30 @@ const Composer = RestModel.extend({
     }
   },
 
-  /*
-     Open a composer
+  /**
+    Open a composer
 
-     opts:
-       action   - The action we're performing: edit, reply or createTopic
-       post     - The post we're replying to, if present
-       topic    - The topic we're replying to, if present
-       quote    - If we're opening a reply from a quote, the quote we're making
-  */
+    @method open
+    @param {Object} opts
+      @param {String} opts.action The action we're performing: edit, reply, createTopic, createSharedDraft, privateMessage
+      @param {String} opts.draftKey
+      @param {String} opts.draftSequence
+      @param {Post} [opts.post] The post we're replying to, if present
+      @param {Topic} [opts.topic] The topic we're replying to, if present
+      @param {String} [opts.quote] If we're opening a reply from a quote, the quote we're making
+      @param {String} [opts.reply]
+      @param {String} [opts.recipients]
+      @param {Number} [opts.composerTime]
+      @param {Number} [opts.typingTime]
+      @param {Boolean} [opts.whisper]
+      @param {Boolean} [opts.noBump]
+      @param {String} [opts.archetypeId] One of `site.archetypes` e.g. `regular` or `private_message`
+      @param {Object} [opts.metaData]
+      @param {Number} [opts.categoryId]
+      @param {Number} [opts.postId]
+      @param {Number} [opts.destinationCategoryId]
+      @param {String} [opts.title]
+  **/
   open(opts) {
     let promise = Promise.resolve();
 

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -80,6 +80,7 @@
                       isDisabled=disableCategoryChooser
                       options=(hash
                         scopedCategoryId=scopedCategoryId
+                        prioritizedCategoryId=prioritizedCategoryId
                       )
                     }}
                     {{popup-input-tip validation=categoryValidation}}

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -89,6 +89,44 @@ discourseModule(
       },
     });
 
+    componentTest("with prioritizedCategoryId", {
+      template: hbs`
+        {{category-chooser
+          value=value
+          options=(hash
+            prioritizedCategoryId=5
+          )
+        }}
+      `,
+
+      async test(assert) {
+        await this.subject.expand();
+
+        // The prioritized category
+        assert.equal(this.subject.rowByIndex(0).value(), 5);
+        // The prioritized category's child
+        assert.equal(this.subject.rowByIndex(1).value(), 22);
+        // Other categories in the default order
+        assert.equal(this.subject.rowByIndex(2).value(), 6);
+        assert.equal(this.subject.rowByIndex(3).value(), 21);
+        assert.equal(this.subject.rowByIndex(4).value(), 1);
+
+        assert.equal(
+          this.subject.rows().length,
+          20,
+          "all categories are visible"
+        );
+
+        await this.subject.fillInFilter("bug");
+
+        assert.equal(
+          this.subject.rowByIndex(0).name(),
+          "bug",
+          "search still finds categories"
+        );
+      },
+    });
+
     componentTest("with allowUncategorized=null", {
       template: hbs`
         {{category-chooser


### PR DESCRIPTION
…and just prioritize the current one, instead of hiding other categories.

Context: when you open the composer by clicking "New Topic" button when in a category, or by clicking "New Topic" in the share-popup, the category selector shows only the current category and its children (and "Uncategorized"). You can still find other categories, but you have to search by name.
This PR changes that, so you now can see all the categories in the dropdown, and those that are relevant (again: current, children and uncategorized) are displayed before all other categories.

tldr: don't make choosing other categories harder - make choosing relevant ones easier.

Before/After

<img width="290" alt="before" src="https://user-images.githubusercontent.com/66961/120215847-875d6700-c236-11eb-9e93-86a306dcde92.png"> <img width="290" alt="after" src="https://user-images.githubusercontent.com/66961/120215855-8a585780-c236-11eb-806c-1d81241e042f.png">

There are only exactly three categories in the first screenshot. The second one has all of them (notice the scroll)