### PR TITLE
UX: Fix the PM title icon alignment

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -224,11 +224,6 @@ a.badge-category {
   height: 0.95em;
 }
 
-.private-message-glyph-wrapper {
-  float: left;
-  margin-right: 0.25em;
-}
-
 .private_message {
   #topic-title {
     .edit-topic-title {
@@ -236,7 +231,7 @@ a.badge-category {
       .private-message-glyph {
         position: absolute;
         left: 0.75em;
-        top: 6px;
+        top: 7px;
       }
       #edit-title {
         width: calc(100% - 50px);


### PR DESCRIPTION
Before/After

<img width="200" alt="before" src="https://user-images.githubusercontent.com/66961/120222298-00ad8780-c240-11eb-9912-e19ea234f22d.png"> <img width="200" alt="after" src="https://user-images.githubusercontent.com/66961/120222305-03a87800-c240-11eb-94f3-a8dce16ec6a4.png">

(no extra margin to the left of the input, and the icon is one pixel lower)