### PR TITLE
PERF: Memoize core svgs in memory to avoid expensive XML parsing.

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -920,9 +920,9 @@ module Discourse
 
     schema_cache = ActiveRecord::Base.connection.schema_cache
 
-    # load up schema cache for all multisite assuming all dbs have
-    # an identical schema
     RailsMultisite::ConnectionManagement.safe_each_connection do
+      # load up schema cache for all multisite assuming all dbs have
+      # an identical schema
       dup_cache = schema_cache.dup
       # this line is not really needed, but just in case the
       # underlying implementation changes lets give it a shot
@@ -954,6 +954,9 @@ module Discourse
       },
       Thread.new {
         LetterAvatar.image_magick_version
+      },
+      Thread.new {
+        SvgSprite.core_svgs
       }
     ].each(&:join)
   ensure


### PR DESCRIPTION
The XML parsing of SVGs is done whenever the cache expires or on the
first load after a reboot. In one of our production instance, parsing
ranges from 30ms to 70ms which is not ideal. Instead, we've decided to
make a small memory trade off here by memoizing the core SVGs once on
boot to avoid parsing of the SVG files during the duration of a request.
The memozied hash will take up 57440 bytes or 0.05744 megabytes in size.