### PR TITLE
UX: fix PM header title alignment

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -166,6 +166,10 @@
       color: var(--primary-medium);
     }
   }
+  .header-title .private-message-glyph-wrapper {
+    float: left;
+    margin-right: 0.25em;
+  }
 }
 
 a.badge-category {


### PR DESCRIPTION
Before:

<img width="425" alt="Screenshot 2021-06-01 at 14 07 16" src="https://user-images.githubusercontent.com/11170663/120293321-c3e69c80-c2e2-11eb-9318-ba56e23aa2a6.png">

After:

<img width="423" alt="Screenshot 2021-06-01 at 14 07 37" src="https://user-images.githubusercontent.com/11170663/120293324-c5b06000-c2e2-11eb-9939-daad8a39f95b.png">

Looks like it regressed in [this commit](https://github.com/discourse/discourse/commit/be92f4e959c21e0688c07f43e200e026c61c974e).