### PR TITLE
DEV: Fix flaky specs

### DIFF
--- a/spec/lib/onebox/engine/instagram_onebox_spec.rb
+++ b/spec/lib/onebox/engine/instagram_onebox_spec.rb
@@ -31,16 +31,15 @@ describe Onebox::Engine::InstagramOnebox do
       stub_request(:get, api_link).to_return(status: 200, body: onebox_response("instagram"))
       stub_request(:get, "https://api.instagram.com/oembed/?url=https://www.instagram.com/p/CARbvuYDm3Q")
         .to_return(status: 200, body: onebox_response("instagram"))
+      @previous_options = Onebox.options.to_h
+      Onebox.options = { facebook_app_access_token: access_token }
     end
 
-    around do |example|
-      previous_options = Onebox.options.to_h
-      example.run
-      Onebox.options = previous_options
+    after do
+      Onebox.options = @previous_options
     end
 
     it "includes title" do
-      Onebox.options = { facebook_app_access_token: access_token }
       onebox = described_class.new(link)
       html = onebox.to_html
 
@@ -48,7 +47,6 @@ describe Onebox::Engine::InstagramOnebox do
     end
 
     it "includes image" do
-      Onebox.options = { facebook_app_access_token: access_token }
       onebox = described_class.new(link)
       html = onebox.to_html
 
@@ -62,6 +60,12 @@ describe Onebox::Engine::InstagramOnebox do
 
     before do
       stub_request(:get, api_link).to_return(status: 200, body: onebox_response("instagram_old_onebox"))
+      @previous_options = Onebox.options.to_h
+      Onebox.options = {}
+    end
+
+    after do
+      Onebox.options = @previous_options
     end
 
     it "includes title" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -153,6 +153,8 @@ describe User do
     let(:user) { Fabricate(:user) }
 
     it 'enqueues the system message' do
+      SiteSetting.send_welcome_message = true
+
       expect_enqueued_with(job: :send_system_message, args: { user_id: user.id, message_type: 'welcome_user' }) do
         user.enqueue_welcome_message('welcome_user')
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -64,6 +64,7 @@ describe UsersController do
     context 'valid token' do
       context 'welcome message' do
         it 'enqueues a welcome message if the user object indicates so' do
+          SiteSetting.send_welcome_message = true
           user.update(active: false)
           put "/u/activate-account/#{token}"
           expect(response.status).to eq(200)


### PR DESCRIPTION
Some specs failed when `LOAD_PLUGINS=1` was set while migrating the test DB and the narrative-bot plugin disabled the `send_welcome_message` site setting.

The Onebox specs sometimes failed on GitHub Actions, but I wasn't able to reproduce it locally. This should fix it.