### PR TITLE
FIX: Do not require trust level to invite to group

### DIFF
--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1212,12 +1212,18 @@ describe GroupsController do
       end
 
       it 'does not add users without sufficient permission' do
+        group.add_owner(user)
         sign_in(user)
-        SiteSetting.min_trust_level_to_allow_invite = user.trust_level + 1
-        user2 = Fabricate(:user)
 
-        put "/groups/#{group.id}/members.json", params: { usernames: user2.username }
+        put "/groups/#{group.id}/members.json", params: { usernames: Fabricate(:user).username }
+        expect(response.status).to eq(200)
+      end
 
+      it 'does not send invites if user cannot invite' do
+        group.add_owner(user)
+        sign_in(user)
+
+        put "/groups/#{group.id}/members.json", params: { emails: "test@example.com" }
         expect(response.status).to eq(403)
       end
 


### PR DESCRIPTION
It used to require SiteSetting.min_trust_level_to_allow_invite to
invite a user to a group, even if the user existed and the inviter was
a group owner.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
