### PR TITLE
UX: Fix "last visit" line overlap in Chrome

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -212,6 +212,7 @@
     }
 
     td span {
+      position: relative; // Chrome needs this, otherwise the line is above the text
       background-color: var(--secondary);
       color: var(--danger-medium);
       padding: 0 8px;


### PR DESCRIPTION
This is a chrome-specific issue, discussion here: https://meta.discourse.org/t/last-visit-line-strikes-through-text/192103