### PR TITLE
FIX: Delete internal links when moderator deletes a post

### DIFF
--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -108,7 +108,7 @@ class TopicLink < ActiveRecord::Base
   end
 
   def self.extract_from(post)
-    return if post.blank? || post.whisper? || post.user_id.blank?
+    return if post.blank? || post.whisper? || post.user_id.blank? || post.deleted_at.present?
 
     current_urls = []
     reflected_ids = []

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -168,6 +168,7 @@ class PostDestroyer
         permanent? ? @post.topic.destroy! : @post.topic.trash!(@user)
         PublishedPage.unpublish!(@user, @post.topic) if @post.topic.published_page
       end
+      TopicLink.where(link_post_id: @post.id).destroy_all
       update_associated_category_latest_topic
       update_user_counts
       TopicUser.update_post_action_cache(post_id: @post.id)


### PR DESCRIPTION
See https://meta.discourse.org/t/topic-replies-referencing-other-topics-are-still-visible-in-the-gutter-of-the-referenced-topic-after-the-referring-topic-reply-is-deleted/192064/6 for repro steps. 

It looks like this has been a longstanding issue. In `PostDestroyer` we have two separate methods when deleting depending on whether the action is taken by the post owner or by a moderator. There was no cleanup taking place in the case of moderators deleting posts. (And even after adding the cleanup, we need to ensure that `TopicLink.extract_from` does not wrongly extract links from deleted posts.)