### PR TITLE
DEV: Fix a flaky spec

### DIFF
--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1736,7 +1736,9 @@ describe Post do
         version: post.version
       }
 
-      MessageBus.expects(:publish).with("/topic/#{topic.id}", message, user_ids: [user1.id, user2.id, user3.id]).once
+      MessageBus.expects(:publish).once.with("/topic/#{topic.id}", message, is_a(Hash)) do |_, _, options|
+        options[:user_ids].sort == [user1.id, user2.id, user3.id].sort
+      end
       post.publish_change_to_clients!(:created)
     end
   end


### PR DESCRIPTION
The error being:

```
1) Post#publish_changes_to_client! send message to all users participating in private conversation
     Failure/Error: MessageBus.publish(channel, message, opts)

     Mocha::ExpectationError:
       unexpected invocation: MessageBus.publish("/topic/93", {:id => 109, :post_number => 1, :updated_at => 2021-06-01 14:53:54.508794217 +0000 (1622559234.508794 secs), :user_id => 175, :last_editor_id => 175, :type => :created, :version => 1}, {:user_ids => [174, 172, 173]})
       unsatisfied expectations:
       - expected exactly once, invoked never: MessageBus.publish("/topic/93", {:id => 109, :post_number => 1, :updated_at => 2021-06-01 14:53:54.508794217 +0000 (1622559234.508794 secs), :user_id => 175, :last_editor_id => 175, :type => :created, :version => 1}, {:user_ids => [172, 174, 173]})
       satisfied expectations:
       - allowed any number of times, invoked never: Oneboxer.onebox(any_parameters)
       - allowed any number of times, invoked never: DateTime.now(any_parameters)
       - allowed any number of times, invoked 6 times: Time.now(any_parameters)
       - allowed any number of times, invoked never: Date.today(any_parameters)
       - allowed any number of times, invoked never: TrackTimeStub.stubbed(any_parameters)
     # ./app/models/post.rb:229:in `publish_message!'
     # ./app/models/post.rb:208:in `publish_change_to_clients!'
     # ./spec/models/post_spec.rb:1740:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:279:in `block (2 levels) in <top (required)>'
     # ./bundle/ruby/2.7.0/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```