### PR TITLE
FIX: flaky javascript tests with fake timers

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -76,6 +76,15 @@ export function fakeTime(timeString, timezone = null, advanceTime = false) {
   });
 }
 
+export function withFrozenTime(timeString, timezone, callback) {
+  const clock = fakeTime(timeString, timezone, false);
+  try {
+    callback();
+  } finally {
+    clock.restore();
+  }
+}
+
 let _pretenderCallbacks = {};
 
 export function resetSite(siteSettings, extras) {

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -34,11 +34,8 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     template,
 
     beforeEach() {
-      this.clock = fakeTime(
-        "2019-12-10T08:00:00",
-        this.currentUser._timezone,
-        true
-      );
+      const monday = "2100-06-07T08:00:00";
+      this.clock = fakeTime(monday, this.currentUser._timezone, true);
     },
 
     test(assert) {
@@ -52,11 +49,8 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
       template,
 
       beforeEach() {
-        this.clock = fakeTime(
-          "2019-12-13T08:00:00",
-          this.currentUser._timezone,
-          true
-        );
+        const thursday = "2100-06-10T08:00:00";
+        this.clock = fakeTime(thursday, this.currentUser._timezone, true);
       },
 
       test(assert) {
@@ -73,7 +67,7 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
     beforeEach() {
       this.clock = fakeTime(
-        "2019-12-11T22:00:00",
+        "2100-12-11T22:00:00",
         this.currentUser._timezone,
         true
       );
@@ -92,7 +86,7 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
     beforeEach() {
       this.clock = fakeTime(
-        "2019-12-11T14:30:00",
+        "2100-12-11T14:30:00",
         this.currentUser._timezone,
         true
       );
@@ -108,7 +102,7 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
     beforeEach() {
       this.clock = fakeTime(
-        "2019-12-11T17:00:00",
+        "2100-12-11T17:00:00",
         this.currentUser._timezone,
         true
       );
@@ -127,7 +121,7 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
     beforeEach() {
       this.clock = fakeTime(
-        "2019-12-11T13:00:00",
+        "2100-12-11T13:00:00",
         this.currentUser._timezone,
         true
       );

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -40,7 +40,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
   componentTest("show later this week option if today is < Thursday", {
     template,
-    skip: true,
 
     beforeEach() {
       mockMomentTz("2019-12-10T08:00:00", this.currentUser._timezone);
@@ -55,7 +54,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     "does not show later this week option if today is >= Thursday",
     {
       template,
-      skip: true,
 
       beforeEach() {
         mockMomentTz("2019-12-13T08:00:00", this.currentUser._timezone);
@@ -72,7 +70,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
   componentTest("later today does not show if later today is tomorrow", {
     template,
-    skip: true,
 
     beforeEach() {
       mockMomentTz("2019-12-11T22:00:00", this.currentUser._timezone);
@@ -88,7 +85,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
   componentTest("later today shows if it is after 5pm but before 6pm", {
     template,
-    skip: true,
 
     beforeEach() {
       mockMomentTz("2019-12-11T14:30:00", this.currentUser._timezone);
@@ -101,7 +97,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
   componentTest("later today does not show if it is after 5pm", {
     template,
-    skip: true,
 
     beforeEach() {
       mockMomentTz("2019-12-11T17:00:00", this.currentUser._timezone);
@@ -117,7 +112,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
   componentTest("later today does show if it is before the end of the day", {
     template,
-    skip: true,
 
     beforeEach() {
       mockMomentTz("2019-12-11T13:00:00", this.currentUser._timezone);
@@ -130,7 +124,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
   componentTest("prefills the custom reminder type date and time", {
     template,
-    skip: true,
 
     beforeEach() {
       let name = "test";
@@ -147,7 +140,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
   componentTest("defaults to 08:00 for custom time", {
     template,
-    skip: true,
 
     async test(assert) {
       await click("#tap_tile_custom");

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -6,13 +6,6 @@ import {
   fakeTime,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import sinon from "sinon";
-
-let clock = null;
-
-function mockMomentTz(dateString, timezone) {
-  clock = fakeTime(dateString, timezone, true);
-}
 
 discourseModule("Integration | Component | bookmark", function (hooks) {
   setupRenderingTest(hooks);
@@ -32,17 +25,20 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
   });
 
   hooks.afterEach(function () {
-    if (clock) {
-      clock.restore();
+    if (this.clock) {
+      this.clock.restore();
     }
-    sinon.restore();
   });
 
   componentTest("show later this week option if today is < Thursday", {
     template,
 
     beforeEach() {
-      mockMomentTz("2019-12-10T08:00:00", this.currentUser._timezone);
+      this.clock = fakeTime(
+        "2019-12-10T08:00:00",
+        this.currentUser._timezone,
+        true
+      );
     },
 
     test(assert) {
@@ -56,7 +52,11 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
       template,
 
       beforeEach() {
-        mockMomentTz("2019-12-13T08:00:00", this.currentUser._timezone);
+        this.clock = fakeTime(
+          "2019-12-13T08:00:00",
+          this.currentUser._timezone,
+          true
+        );
       },
 
       test(assert) {
@@ -72,7 +72,11 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     template,
 
     beforeEach() {
-      mockMomentTz("2019-12-11T22:00:00", this.currentUser._timezone);
+      this.clock = fakeTime(
+        "2019-12-11T22:00:00",
+        this.currentUser._timezone,
+        true
+      );
     },
 
     test(assert) {
@@ -87,7 +91,11 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     template,
 
     beforeEach() {
-      mockMomentTz("2019-12-11T14:30:00", this.currentUser._timezone);
+      this.clock = fakeTime(
+        "2019-12-11T14:30:00",
+        this.currentUser._timezone,
+        true
+      );
     },
 
     test(assert) {
@@ -99,7 +107,11 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     template,
 
     beforeEach() {
-      mockMomentTz("2019-12-11T17:00:00", this.currentUser._timezone);
+      this.clock = fakeTime(
+        "2019-12-11T17:00:00",
+        this.currentUser._timezone,
+        true
+      );
     },
 
     test(assert) {
@@ -114,7 +126,11 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     template,
 
     beforeEach() {
-      mockMomentTz("2019-12-11T13:00:00", this.currentUser._timezone);
+      this.clock = fakeTime(
+        "2019-12-11T13:00:00",
+        this.currentUser._timezone,
+        true
+      );
     },
 
     test(assert) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
@@ -27,7 +27,7 @@ discourseModule(
       template: hbs`{{future-date-input-selector}}`,
 
       beforeEach() {
-        const monday = fakeTime("2021-05-03T08:00:00", "UTC", true);
+        const monday = fakeTime("2100-06-07T08:00:00", "UTC", true);
         this.clock = monday;
       },
 
@@ -54,7 +54,7 @@ discourseModule(
       template: hbs`{{future-date-input-selector}}`,
 
       beforeEach() {
-        const sunday = fakeTime("2021-05-02T08:00:00", "UTC", true);
+        const sunday = fakeTime("2100-06-13T08:00:00", "UTC", true);
         this.clock = sunday;
       },
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
@@ -25,7 +25,6 @@ discourseModule(
     });
 
     componentTest("shows default options", {
-      skip: true,
       template: hbs`{{future-date-input-selector}}`,
 
       async test(assert) {
@@ -48,7 +47,6 @@ discourseModule(
     });
 
     componentTest("doesn't show 'Next Week' on Sundays", {
-      skip: true,
       template: hbs`{{future-date-input-selector}}`,
 
       beforeEach() {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
@@ -17,7 +17,6 @@ discourseModule(
 
     hooks.beforeEach(function () {
       this.set("subject", selectKit());
-      this.clock = fakeTime("2021-05-03T08:00:00", "UTC", true); // Monday
     });
 
     hooks.afterEach(function () {
@@ -26,6 +25,11 @@ discourseModule(
 
     componentTest("shows default options", {
       template: hbs`{{future-date-input-selector}}`,
+
+      beforeEach() {
+        const monday = fakeTime("2021-05-03T08:00:00", "UTC", true);
+        this.clock = monday;
+      },
 
       async test(assert) {
         await this.subject.expand();
@@ -50,7 +54,8 @@ discourseModule(
       template: hbs`{{future-date-input-selector}}`,
 
       beforeEach() {
-        this.clock = fakeTime("2021-05-02T08:00:00", "UTC", true); // Sunday
+        const sunday = fakeTime("2021-05-02T08:00:00", "UTC", true);
+        this.clock = sunday;
       },
 
       async test(assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
@@ -1,15 +1,14 @@
 import { module, test } from "qunit";
 import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import { formattedReminderTime } from "discourse/lib/bookmark";
-import sinon from "sinon";
 
 module("Unit | Utility | bookmark", function (hooks) {
   hooks.beforeEach(function () {
-    fakeTime("2020-04-11 08:00:00", "Australia/Brisbane");
+    this.clock = fakeTime("2020-04-11 08:00:00", "Australia/Brisbane");
   });
 
   hooks.afterEach(function () {
-    sinon.restore();
+    this.clock.restore();
   });
 
   test("formattedReminderTime works when the reminder time is tomorrow", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/time-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/time-utils-test.js
@@ -1,6 +1,6 @@
 import {
   discourseModule,
-  fakeTime,
+  withFrozenTime,
 } from "discourse/tests/helpers/qunit-helpers";
 
 import {
@@ -15,33 +15,29 @@ import { test } from "qunit";
 
 const timezone = "Australia/Brisbane";
 
-function mockMomentTz(dateString) {
-  fakeTime(dateString, timezone);
-}
-
 discourseModule("Unit | lib | timeUtils", function () {
   test("nextWeek gets next week correctly", function (assert) {
-    mockMomentTz("2019-12-11T08:00:00");
-
-    assert.equal(nextWeek(timezone).format("YYYY-MM-DD"), "2019-12-18");
+    withFrozenTime("2019-12-11T08:00:00", timezone, () => {
+      assert.equal(nextWeek(timezone).format("YYYY-MM-DD"), "2019-12-18");
+    });
   });
 
   test("nextMonth gets next month correctly", function (assert) {
-    mockMomentTz("2019-12-11T08:00:00");
-
-    assert.equal(nextMonth(timezone).format("YYYY-MM-DD"), "2020-01-11");
+    withFrozenTime("2019-12-11T08:00:00", timezone, () => {
+      assert.equal(nextMonth(timezone).format("YYYY-MM-DD"), "2020-01-11");
+    });
   });
 
   test("laterThisWeek gets 2 days from now", function (assert) {
-    mockMomentTz("2019-12-10T08:00:00");
-
-    assert.equal(laterThisWeek(timezone).format("YYYY-MM-DD"), "2019-12-12");
+    withFrozenTime("2019-12-10T08:00:00", timezone, () => {
+      assert.equal(laterThisWeek(timezone).format("YYYY-MM-DD"), "2019-12-12");
+    });
   });
 
   test("tomorrow gets tomorrow correctly", function (assert) {
-    mockMomentTz("2019-12-11T08:00:00");
-
-    assert.equal(tomorrow(timezone).format("YYYY-MM-DD"), "2019-12-12");
+    withFrozenTime("2019-12-11T08:00:00", timezone, () => {
+      assert.equal(tomorrow(timezone).format("YYYY-MM-DD"), "2019-12-12");
+    });
   });
 
   test("startOfDay changes the time of the provided date to 8:00am correctly", function (assert) {
@@ -54,54 +50,54 @@ discourseModule("Unit | lib | timeUtils", function () {
   });
 
   test("laterToday gets 3 hours from now and if before half-past, it rounds down", function (assert) {
-    mockMomentTz("2019-12-11T08:13:00");
-
-    assert.equal(
-      laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 11:00:00"
-    );
+    withFrozenTime("2019-12-11T08:13:00", timezone, () => {
+      assert.equal(
+        laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
+        "2019-12-11 11:00:00"
+      );
+    });
   });
 
   test("laterToday gets 3 hours from now and if after half-past, it rounds up to the next hour", function (assert) {
-    mockMomentTz("2019-12-11T08:43:00");
-
-    assert.equal(
-      laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 12:00:00"
-    );
+    withFrozenTime("2019-12-11T08:43:00", timezone, () => {
+      assert.equal(
+        laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
+        "2019-12-11 12:00:00"
+      );
+    });
   });
 
   test("laterToday is capped to 6pm. later today at 3pm = 6pm, 3:30pm = 6pm, 4pm = 6pm, 4:59pm = 6pm", function (assert) {
-    mockMomentTz("2019-12-11T15:00:00");
+    withFrozenTime("2019-12-11T15:00:00", timezone, () => {
+      assert.equal(
+        laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
+        "2019-12-11 18:00:00",
+        "3pm should max to 6pm"
+      );
+    });
 
-    assert.equal(
-      laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 18:00:00",
-      "3pm should max to 6pm"
-    );
+    withFrozenTime("2019-12-11T15:31:00", timezone, () => {
+      assert.equal(
+        laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
+        "2019-12-11 18:00:00",
+        "3:30pm should max to 6pm"
+      );
+    });
 
-    mockMomentTz("2019-12-11T15:31:00");
+    withFrozenTime("2019-12-11T16:00:00", timezone, () => {
+      assert.equal(
+        laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
+        "2019-12-11 18:00:00",
+        "4pm should max to 6pm"
+      );
+    });
 
-    assert.equal(
-      laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 18:00:00",
-      "3:30pm should max to 6pm"
-    );
-
-    mockMomentTz("2019-12-11T16:00:00");
-
-    assert.equal(
-      laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 18:00:00",
-      "4pm should max to 6pm"
-    );
-
-    mockMomentTz("2019-12-11T16:59:00");
-
-    assert.equal(
-      laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
-      "2019-12-11 18:00:00",
-      "4:59pm should max to 6pm"
-    );
+    withFrozenTime("2019-12-11T16:59:00", timezone, () => {
+      assert.equal(
+        laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
+        "2019-12-11 18:00:00",
+        "4:59pm should max to 6pm"
+      );
+    });
   });
 });


### PR DESCRIPTION
The [last commit](https://github.com/discourse/discourse/pull/13235/commits/b854b68d1fb2a9599889ecc97e9ad220533dd350) is the one that actually fixes flakiness.

The problem was happening in component integration tests on the [rendering stage](https://github.com/discourse/discourse/blob/fbfd54a9413fb66b5ef6e251a7ad7f89b2568874/app/assets/javascripts/discourse/tests/helpers/component-test.js#L128), sometimes the rendering would never finish.

Using time moments **in the future** when faking time solves the problem. Unfortunately, I don't know why exactly it helps. It was just a lucky guess after some hours I spent trying to figure out what's going on. But I've done a lot of testings, so looks like it really works. I'll be monitoring builds for some time after merging this anyway.

Unit tests seem to work alright with moments in the past. And we don't fake time in acceptance tests at the moment but I guess they would very likely be flaky with time moments from the past since they also do rendering.

I'm actually thinking of moving all fake time moments to the future (including moments in unit tests) to decrease the chances of flakiness. But I don't want to do everything in one PR, because I can accidentally introduce new flakiness.

A pretty easy way of picking time moments in the future for tests is to use the 2100 year. It has the same calendar as 2021. If a day is Monday in 2021 it's Monday in 2100 too.


