### PR TITLE
DEV: Remove `ember_jquery` in most situations

### DIFF
--- a/app/assets/javascripts/discourse/tests/theme_qunit_ember_jquery.js
+++ b/app/assets/javascripts/discourse/tests/theme_qunit_ember_jquery.js
@@ -1,6 +1,0 @@
-// discourse-skip-module
-
-//= require env
-//= require jquery.debug
-//= require ember.debug
-//= require discourse-loader

--- a/app/assets/javascripts/vendor.js
+++ b/app/assets/javascripts/vendor.js
@@ -1,3 +1,5 @@
+//= require ember_jquery
+
 //= require logster
 
 //= require template_include.js

--- a/app/assets/javascripts/wizard-vendor.js
+++ b/app/assets/javascripts/wizard-vendor.js
@@ -1,3 +1,4 @@
+//= require ember_jquery
 //= require template_include.js
 //= require jquery.ui.widget.js
 //= require jquery.fileupload.js

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -709,6 +709,7 @@ class UsersController < ApplicationController
   def password_reset_show
     expires_now
     token = params[:token]
+
     password_reset_find_user(token, committing_change: false)
 
     if !@error

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,6 @@
     <%- if ExtraLocalesController.client_overrides_exist? %>
       <%= preload_script_url ExtraLocalesController.url('overrides') %>
     <%- end %>
-    <%= preload_script "ember_jquery" %>
     <%= preload_script "vendor" %>
     <%= preload_script "pretty-text-bundle" %>
     <%= preload_script "application" %>

--- a/app/views/qunit/theme.html.erb
+++ b/app/views/qunit/theme.html.erb
@@ -7,7 +7,6 @@
       <%= discourse_stylesheet_link_tag(:desktop, theme_ids: nil) %>
       <%= discourse_stylesheet_link_tag(:test_helper, theme_ids: nil) %>
       <%= preload_script "locales/en" %>
-      <%= preload_script "discourse/tests/theme_qunit_ember_jquery" %>
       <%= preload_script "vendor" %>
       <%= preload_script "discourse/tests/theme_qunit_vendor" %>
       <%= preload_script "pretty-text-bundle" %>

--- a/app/views/users/activate_account.html.erb
+++ b/app/views/users/activate_account.html.erb
@@ -10,7 +10,6 @@
 </div>
 
 <%- content_for(:no_ember_head) do %>
-  <%= preload_script "ember_jquery" %>
   <%= preload_script "vendor" %>
   <%= render_google_universal_analytics_code %>
   <%= tag.meta id: 'data-activate-account', data: { path: path('/session/hp') } %>

--- a/app/views/wizard/index.html.erb
+++ b/app/views/wizard/index.html.erb
@@ -6,7 +6,6 @@
     <%- if ExtraLocalesController.client_overrides_exist? %>
       <%= preload_script_url ExtraLocalesController.url('overrides') %>
     <%- end %>
-    <%= preload_script 'ember_jquery' %>
     <%= preload_script 'wizard-vendor' %>
     <%= preload_script 'wizard-application' %>
     <%= preload_script_url ExtraLocalesController.url('wizard') %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -175,7 +175,6 @@ module Discourse
       embed-application.js
       discourse/tests/theme_qunit_helper.js
       discourse/tests/theme_qunit_vendor.js
-      discourse/tests/theme_qunit_ember_jquery.js
       discourse/tests/test_starter.js
     }
 

--- a/spec/requests/qunit_controller_spec.rb
+++ b/spec/requests/qunit_controller_spec.rb
@@ -98,7 +98,6 @@ describe QunitController do
         expect(response.body).to include("/stylesheets/desktop_")
         expect(response.body).to include("/stylesheets/test_helper_")
         expect(response.body).to include("/assets/locales/en.js")
-        expect(response.body).to include("/assets/discourse/tests/theme_qunit_ember_jquery.js")
         expect(response.body).to include("/assets/vendor.js")
         expect(response.body).to include("/assets/discourse/tests/theme_qunit_vendor.js")
         expect(response.body).to include("/assets/pretty-text-bundle.js")


### PR DESCRIPTION
In Ember CLI, the vendor bundler includes Ember/jQuery, so this brings
our app closer to that configuration.

We have a couple pages (Reset Password / Confirm New Email) where we need
`ember_jquery` without vendor so the file still exists for those cases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
