### PR TITLE
FIX: Ignore `allowlistgeneric` Onebox image sizes

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -770,7 +770,7 @@ export default Controller.extend({
 
     // TODO: This should not happen in model
     const imageSizes = {};
-    $("#reply-control .d-editor-preview img").each((i, e) => {
+    $("#reply-control .d-editor-preview img").not('.onebox.allowlistedgeneric img').each((i, e) => {
       const $img = $(e);
       const src = $img.prop("src");
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -770,14 +770,16 @@ export default Controller.extend({
 
     // TODO: This should not happen in model
     const imageSizes = {};
-    $("#reply-control .d-editor-preview img").not('.onebox.allowlistedgeneric img').each((i, e) => {
-      const $img = $(e);
-      const src = $img.prop("src");
+    $("#reply-control .d-editor-preview img")
+      .not(".onebox.allowlistedgeneric img")
+      .each((i, e) => {
+        const $img = $(e);
+        const src = $img.prop("src");
 
-      if (src && src.length) {
-        imageSizes[src] = { width: $img.width(), height: $img.height() };
-      }
-    });
+        if (src && src.length) {
+          imageSizes[src] = { width: $img.width(), height: $img.height() };
+        }
+      });
 
     const promise = composer
       .save({ imageSizes, editReason: this.editReason })

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -770,7 +770,8 @@ export default Controller.extend({
 
     // TODO: This should not happen in model
     const imageSizes = {};
-    document.querySelectorAll("#reply-control .d-editor-preview img:not(.onebox img)")
+    document
+      .querySelectorAll("#reply-control .d-editor-preview img:not(.onebox img)")
       .forEach((e) => {
         const src = e.src;
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -771,12 +771,11 @@ export default Controller.extend({
     // TODO: This should not happen in model
     const imageSizes = {};
     document.querySelectorAll("#reply-control .d-editor-preview img:not(.onebox img)")
-      .each((i, e) => {
-        const $img = $(e);
-        const src = $img.prop("src");
+      .forEach((e) => {
+        const src = e.src;
 
         if (src && src.length) {
-          imageSizes[src] = { width: $img.width(), height: $img.height() };
+          imageSizes[src] = { width: e.width, height: e.height };
         }
       });
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -770,8 +770,7 @@ export default Controller.extend({
 
     // TODO: This should not happen in model
     const imageSizes = {};
-    $("#reply-control .d-editor-preview img")
-      .not(".onebox.allowlistedgeneric img")
+    document.querySelectorAll("#reply-control .d-editor-preview img:not(.onebox img)")
       .each((i, e) => {
         const $img = $(e);
         const src = $img.prop("src");


### PR DESCRIPTION
The size of an image contained within the preview pane of a Composer window may vary depending on the configuration of the browser displaying the Composer (e.g., dimension of browser window, zoom level, etc.).

Presently, the dimensions of the images from the browser creating the post containing the Onebox will be used to render the Onebox to anyone who views the post. It is safer to let the backend figure out the dimensions of the images. Therefore, exclude `.onebox.allowlistedgeneric` images from the list of `image_sizes` sent to the backend.

