### PR TITLE
DEV: Fix incorrect optimization in SvgSprite.

### DIFF
--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -322,22 +322,20 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
       end
     end
 
-    if theme_ids.present?
-      custom_svg_sprites(theme_ids).each do |fname|
-        svg_file = Nokogiri::XML(File.open(fname)) do |config|
-          config.options = Nokogiri::XML::ParseOptions::NOBLANKS
-        end
+    custom_svg_sprites(theme_ids).each do |fname|
+      svg_file = Nokogiri::XML(File.open(fname)) do |config|
+        config.options = Nokogiri::XML::ParseOptions::NOBLANKS
+      end
 
-        svg_filename = "#{File.basename(fname, ".svg")}"
+      svg_filename = "#{File.basename(fname, ".svg")}"
 
-        svg_file.css("symbol").each do |sym|
-          icon_id = prepare_symbol(sym, svg_filename)
+      svg_file.css("symbol").each do |sym|
+        icon_id = prepare_symbol(sym, svg_filename)
 
-          if icons.include? icon_id
-            sym.attributes['id'].value = icon_id
-            sym.css('title').each(&:remove)
-            svg_subset << sym.to_xml
-          end
+        if icons.include? icon_id
+          sym.attributes['id'].value = icon_id
+          sym.css('title').each(&:remove)
+          svg_subset << sym.to_xml
         end
       end
     end


### PR DESCRIPTION
`SvgSprite.custom_sprite_paths` does not just fetch custom SVG sprite
from themes. It also picks up any custom svg icons from a pre-defined
plugin folder.

Follow-up to 0700e9382d551e4948b493e1219f3119e52bcae4