### PR TITLE
FIX: active record annotation of topic model

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1813,7 +1813,7 @@ end
 #  deleted_by_id             :integer
 #  participant_count         :integer          default(1)
 #  word_count                :integer
-#  excerpt                   :string(1000)
+#  excerpt                   :string
 #  pinned_globally           :boolean          default(FALSE), not null
 #  pinned_until              :datetime
 #  fancy_title               :string(400)


### PR DESCRIPTION
I've removed constraint from the excerpt column in 00300b1, but I forgot to change the annotation
