### PR TITLE
FIX: Add check for if element doesnt exist on ensureDropClosed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -52,6 +52,10 @@ export default Component.extend(FilterModeMixin, {
   },
 
   ensureDropClosed() {
+    if (!this.element || this.isDestroying || this.isDestroyed) {
+      return;
+    }
+
     if (this.expanded) {
       this.set("expanded", false);
     }
@@ -75,17 +79,13 @@ export default Component.extend(FilterModeMixin, {
             this.element.querySelector(".drop").style.display = "none";
 
             next(() => {
-              if (!this.element || this.isDestroying || this.isDestroyed) {
-                return;
-              }
-              this.set("expanded", false);
+              this.ensureDropClosed();
             });
-
             return true;
           });
 
           $(window).on("click.navigation-bar", () => {
-            this.set("expanded", false);
+            this.ensureDropClosed();
             return true;
           });
         });


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
This PR addresses an issue where sometimes the `navigation-bar` component would try to set the `expanded` property after the element no longer existed, resulting in an error. This commit adds a check to make sure the element exists before trying to set the `expanded` property to `false`. I also refactor the `next` and `window.onClick` to make a call to `this.ensureDropClosed()` instead of duplicating the functionality internally.
