### PR TITLE
FIX: Dismiss topics keyboard shortcut not working

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -88,7 +88,7 @@ const DEFAULT_BINDINGS = {
   "x r": {
     click: "#dismiss-new,#dismiss-new-top,#dismiss-posts,#dismiss-posts-top",
   }, // dismiss new/posts
-  "x t": { click: "#dismiss-topics,#dismiss-topics-top" }, // dismiss topics
+  "x t": { click: "#dismiss-topics-bottom,#dismiss-topics-top" }, // dismiss topics
 };
 
 const animationDuration = 100;


### PR DESCRIPTION
This issue is a result of
https://github.com/discourse/discourse/commit/7a79bd7da3e0a59454a3c03f3be31e457d0b9fcc,
where the ID for the bottom Dismiss Topic buttons changed to
dismiss-topic-bottom.

This issue only occurs when you have a list of topics that is small enough to fit in the viewport, and thus not show the Dismiss Topics button at the top of the list.

![image](https://user-images.githubusercontent.com/920448/120566340-65403080-c452-11eb-8b6a-c7d872bdb254.png)


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
