### PR TITLE
Revert "FIX: Ignore `allowlistgeneric` Onebox image sizes (#13240)"

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -770,15 +770,14 @@ export default Controller.extend({
 
     // TODO: This should not happen in model
     const imageSizes = {};
-    document
-      .querySelectorAll("#reply-control .d-editor-preview img:not(.onebox img)")
-      .forEach((e) => {
-        const src = e.src;
+    $("#reply-control .d-editor-preview img").each((i, e) => {
+      const $img = $(e);
+      const src = $img.prop("src");
 
-        if (src && src.length) {
-          imageSizes[src] = { width: e.width, height: e.height };
-        }
-      });
+      if (src && src.length) {
+        imageSizes[src] = { width: $img.width(), height: $img.height() };
+      }
+    });
 
     const promise = composer
       .save({ imageSizes, editReason: this.editReason })


### PR DESCRIPTION
This reverts commit abac61449282cce61886fb1b50a3587a579e6406.

The CSS selector I was trying to use does not appear to be widely supported.
