### PR TITLE
FIX: redirect non-staff user to homepage when deleting own topic

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -20,7 +20,7 @@ import getURL from "discourse-common/lib/get-url";
 import { longDate } from "discourse/lib/formatter";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { resolveShareUrl } from "discourse/helpers/share-url";
-import { userPath } from "discourse/lib/url";
+import DiscourseURL, { userPath } from "discourse/lib/url";
 
 export function loadTopicView(topic, args) {
   const data = deepMerge({}, args);
@@ -424,6 +424,9 @@ const Topic = RestModel.extend({
           "details.can_delete": false,
           "details.can_recover": true,
         });
+        if (!deleted_by.staff) {
+          DiscourseURL.redirectTo("/");
+        }
       })
       .catch(popupAjaxError);
   },


### PR DESCRIPTION
When setting `delete removed posts after` is set to `0` and non-staff user self-deletes their own topic then we are showing them a blank page which is confusing. Now we'll redirect them to homepage instead of showing blank page.
