### PR TITLE
FIX: Composer doesn't show an error message in case of a network issue and stops updating draft after

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/ajax.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax.js
@@ -54,7 +54,6 @@ export function updateCsrfToken() {
 
 export function ajax() {
   let url, args;
-  let ignoreUnsent = true;
   let ajaxObj;
 
   if (arguments.length === 1) {
@@ -69,10 +68,12 @@ export function ajax() {
   } else if (arguments.length === 2) {
     url = arguments[0];
     args = arguments[1];
-  } else if (arguments.length === 3) {
-    url = arguments[0];
-    args = arguments[1];
-    ignoreUnsent = arguments[2];
+  }
+
+  let ignoreUnsent = true;
+  if (args.ignoreUnsent !== undefined) {
+    ignoreUnsent = args.ignoreUnsent;
+    delete args.ignoreUnsent;
   }
 
   function performAjax(resolve, reject) {

--- a/app/assets/javascripts/discourse/app/lib/ajax.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax.js
@@ -54,6 +54,7 @@ export function updateCsrfToken() {
 
 export function ajax() {
   let url, args;
+  let ignoreUnsent = true;
   let ajaxObj;
 
   if (arguments.length === 1) {
@@ -68,6 +69,10 @@ export function ajax() {
   } else if (arguments.length === 2) {
     url = arguments[0];
     args = arguments[1];
+  } else if (arguments.length === 3) {
+    url = arguments[0];
+    args = arguments[1];
+    ignoreUnsent = arguments[2];
   }
 
   function performAjax(resolve, reject) {
@@ -112,7 +117,7 @@ export function ajax() {
 
     args.error = (xhr, textStatus, errorThrown) => {
       // 0 represents the `UNSENT` state
-      if (xhr.readyState === 0) {
+      if (ignoreUnsent && xhr.readyState === 0) {
         // Make sure we log pretender errors in test mode
         if (textStatus === "error" && isTesting()) {
           throw errorThrown;

--- a/app/assets/javascripts/discourse/app/models/draft.js
+++ b/app/assets/javascripts/discourse/app/models/draft.js
@@ -25,16 +25,20 @@ Draft.reopenClass({
 
   save(key, sequence, data, clientId, { forceSave = false } = {}) {
     data = typeof data === "string" ? data : JSON.stringify(data);
-    return ajax("/draft.json", {
-      type: "POST",
-      data: {
-        draft_key: key,
-        sequence,
-        data,
-        owner: clientId,
-        force_save: forceSave,
+    return ajax(
+      "/draft.json",
+      {
+        type: "POST",
+        data: {
+          draft_key: key,
+          sequence,
+          data,
+          owner: clientId,
+          force_save: forceSave,
+        },
       },
-    });
+      false
+    );
   },
 });
 

--- a/app/assets/javascripts/discourse/app/models/draft.js
+++ b/app/assets/javascripts/discourse/app/models/draft.js
@@ -25,20 +25,17 @@ Draft.reopenClass({
 
   save(key, sequence, data, clientId, { forceSave = false } = {}) {
     data = typeof data === "string" ? data : JSON.stringify(data);
-    return ajax(
-      "/draft.json",
-      {
-        type: "POST",
-        data: {
-          draft_key: key,
-          sequence,
-          data,
-          owner: clientId,
-          force_save: forceSave,
-        },
+    return ajax("/draft.json", {
+      type: "POST",
+      data: {
+        draft_key: key,
+        sequence,
+        data,
+        owner: clientId,
+        force_save: forceSave,
       },
-      false
-    );
+      ignoreUnsent: false,
+    });
   },
 });
 


### PR DESCRIPTION
When editing a draft we show a warning in case of a server error:
<img width="400" alt="Screenshot 2021-06-03 at 18 00 20" src="https://user-images.githubusercontent.com/1274517/120658560-98a4ae80-c496-11eb-9e4a-afb755402b59.png">

But in case of a network issue we don't do that, moreover draft saving stop working forever. The composer just looks like this, even if connection is restored:
<img width="250" alt="Screenshot 2021-06-03 at 18 01 11" src="https://user-images.githubusercontent.com/1274517/120658929-ef11ed00-c496-11eb-8688-1ddfb36a72f4.png">

This PR fixes both issues, adds a warning and makes the composer restore draft saving after issue.