### PR TITLE
DEV: Add more verbose logging for image uploads

### DIFF
--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -99,6 +99,10 @@ module Jobs
       begin
         retries ||= 3
 
+        if SiteSetting.verbose_upload_logging
+          Rails.logger.warn("Verbose Upload Logging: Downloading hotlinked image from #{src}")
+        end
+
         downloaded = FileHelper.download(
           src,
           max_file_size: @max_size,

--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -326,7 +326,7 @@ class OptimizedImage < ActiveRecord::Base
         error << " unknown reason"
       end
 
-      Discourse.warn(error, location: to, error_message: e.message)
+      Discourse.warn(error, location: to, error_message: e.message, instructions: instructions)
       false
     end
   end

--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -30,6 +30,10 @@ class UserAvatar < ActiveRecord::Base
         email_hash = @@custom_user_gravatar_email_hash[user_id] || user.email_hash
         gravatar_url = "https://#{SiteSetting.gravatar_base_url}/avatar/#{email_hash}.png?s=#{max}&d=404&reset_cache=#{SecureRandom.urlsafe_base64(5)}"
 
+        if SiteSetting.verbose_upload_logging
+          Rails.logger.warn("Verbose Upload Logging: Downloading gravatar from #{gravatar_url}")
+        end
+
         # follow redirects in case gravatar change rules on us
         tempfile = FileHelper.download(
           gravatar_url,
@@ -95,6 +99,10 @@ class UserAvatar < ActiveRecord::Base
   end
 
   def self.import_url_for_user(avatar_url, user, options = nil)
+    if SiteSetting.verbose_upload_logging
+      Rails.logger.warn("Verbose Upload Logging: Downloading sso-avatar from #{avatar_url}")
+    end
+
     tempfile = FileHelper.download(
       avatar_url,
       max_file_size: SiteSetting.max_image_size_kb.kilobytes,

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -74,6 +74,10 @@ class UserProfile < ActiveRecord::Base
   end
 
   def self.import_url_for_user(background_url, user, options = nil)
+    if SiteSetting.verbose_upload_logging
+      Rails.logger.warn("Verbose Upload Logging: Downloading profile background from #{background_url}")
+    end
+
     tempfile = FileHelper.download(
       background_url,
       max_file_size: SiteSetting.max_image_size_kb.kilobytes,

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -438,6 +438,9 @@ login:
   discourse_connect_allows_all_return_paths: false
   enable_discourse_connect_provider: false
   verbose_discourse_connect_logging: false
+  verbose_upload_logging:
+    hidden: true
+    default: false
   verbose_auth_token_logging:
     hidden: true
     default: true


### PR DESCRIPTION
Image optimization fails randomly (very rare) without a trace and it is
near impossible to find culprit image, reproduce the issue and attempt
to fix.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
