### PR TITLE
FIX: Ensure images in polls don't cause abrupt scrolling

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -25,9 +25,16 @@ div.poll {
   }
 
   img {
+    // TODO: remove once disable_image_size_calculations is removed
     // needed to override internal styles in image-sizing hack
     max-width: 100% !important;
     height: auto;
+    // Hacky way to stop images without width/height
+    // from causing abrupt unintended scrolling
+    &:not([width]):not([height]) {
+      height: 200px !important;
+      object-fit: contain;
+    }
   }
 
   .poll-info {

--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -31,7 +31,7 @@ div.poll {
     height: auto;
     // Hacky way to stop images without width/height
     // from causing abrupt unintended scrolling
-    &:not([width]):not([height]) {
+    &:not([width]), &:not([height]) {
       height: 200px !important;
       object-fit: contain;
     }

--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -31,7 +31,9 @@ div.poll {
     height: auto;
     // Hacky way to stop images without width/height
     // from causing abrupt unintended scrolling
-    &:not([width]), &:not([height]) {
+    &:not([width]),
+    &:not([height]) {
+      width: 200px !important;
       height: 200px !important;
       object-fit: contain;
     }


### PR DESCRIPTION
In some very rare cases, poll options can end up with images that have
no dimensions, in which case, navigating to replies in that post stream
might result in unexpected scrolling (as the browser loads the images
and adjusts its layout).

This ensures that if width/height attributes are missing from an image,
the image is forced to display at a height of 200 pixels.
