### PR TITLE
DEV: Move pretty-text into vendor and use that

### DIFF
--- a/app/assets/javascripts/discourse/tests/test_helper.js
+++ b/app/assets/javascripts/discourse/tests/test_helper.js
@@ -17,7 +17,6 @@
 // Our base application
 //= require vendor
 //= require discourse-shims
-//= require pretty-text-bundle
 //= require markdown-it-bundle
 //= require application
 //= require admin

--- a/app/assets/javascripts/vendor.js
+++ b/app/assets/javascripts/vendor.js
@@ -27,3 +27,4 @@
 //= require virtual-dom-amd
 //= require intersection-observer
 //= require discourse-shims
+//= require pretty-text-bundle

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,6 @@
       <%= preload_script_url ExtraLocalesController.url('overrides') %>
     <%- end %>
     <%= preload_script "vendor" %>
-    <%= preload_script "pretty-text-bundle" %>
     <%= preload_script "application" %>
     <%- Discourse.find_plugin_js_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, request: request).each do |file| %>
       <%= preload_script file %>

--- a/app/views/qunit/theme.html.erb
+++ b/app/views/qunit/theme.html.erb
@@ -9,7 +9,6 @@
       <%= preload_script "locales/en" %>
       <%= preload_script "vendor" %>
       <%= preload_script "discourse/tests/theme_qunit_vendor" %>
-      <%= preload_script "pretty-text-bundle" %>
       <%= preload_script "markdown-it-bundle" %>
       <%= preload_script "application" %>
       <%- Discourse.find_plugin_js_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, request: request).each do |file| %>

--- a/spec/requests/qunit_controller_spec.rb
+++ b/spec/requests/qunit_controller_spec.rb
@@ -100,7 +100,6 @@ describe QunitController do
         expect(response.body).to include("/assets/locales/en.js")
         expect(response.body).to include("/assets/vendor.js")
         expect(response.body).to include("/assets/discourse/tests/theme_qunit_vendor.js")
-        expect(response.body).to include("/assets/pretty-text-bundle.js")
         expect(response.body).to include("/assets/markdown-it-bundle.js")
         expect(response.body).to include("/assets/application.js")
         expect(response.body).to include("/assets/admin.js")


### PR DESCRIPTION
In Ember CLI addons get put into the vendor bundle, as opposed to their
own bundle like we're doing in the Rails app. We never use pretty-text
without our vendor bundle so this should have no difference on
performance.

We need to keep the pretty-text bundle for server side cooking.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
