### PR TITLE
UX: Revert some search dropdown styles

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -277,10 +277,10 @@
     }
 
     .topic-title {
+      display: inline-block;
+      color: var(--tertiary);
       overflow-wrap: anywhere;
-      font-size: var(--font-up-1);
       line-height: $line-height-medium;
-
       @supports not (overflow-wrap: anywhere) {
         word-break: break-word;
       }

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -1,6 +1,5 @@
 .search-highlight {
   font-weight: bold;
-  background: var(--highlight-medium);
 }
 
 .search-container {


### PR DESCRIPTION
* Smaller titles
* Back to --tertiary for color
* Removed search term highlight, kept the bold
* Fixed line-height not being applied