### PR TITLE
UX: more consistent setting/edit buttons

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tags-admin-dropdown.js
+++ b/app/assets/javascripts/discourse/app/components/tags-admin-dropdown.js
@@ -8,7 +8,7 @@ export default DropdownSelectBoxComponent.extend({
   actionsMapping: null,
 
   selectKitOptions: {
-    icons: ["bars", "caret-down"],
+    icons: ["wrench", "caret-down"],
     showFullTitle: false,
   },
 
@@ -18,7 +18,7 @@ export default DropdownSelectBoxComponent.extend({
         id: "manageGroups",
         name: I18n.t("tagging.manage_groups"),
         description: I18n.t("tagging.manage_groups_description"),
-        icon: "wrench",
+        icon: "tags",
       },
       {
         id: "uploadTags",

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -24,14 +24,14 @@
           class="btn-default edit-category"
           action=editCategory
           icon="wrench"
-          label="category.edit"}}
+          ariaLabel="category.edit"}}
       {{/if}}
     {{/unless}}
   {{/if}}
 
   {{#if tag}}
     {{#if showToggleInfo}}
-      {{d-button icon="tag" class="btn-default" label="tagging.info" action=toggleInfo id="show-tag-info"}}
+      {{d-button icon="wrench" class="btn-default" ariaLabel="tagging.info" action=toggleInfo id="show-tag-info"}}
     {{/if}}
   {{/if}}
 

--- a/app/assets/javascripts/select-kit/addon/components/categories-admin-dropdown.js
+++ b/app/assets/javascripts/select-kit/addon/components/categories-admin-dropdown.js
@@ -9,7 +9,7 @@ export default DropdownSelectBoxComponent.extend({
   fixedCateoryPositions: setting("fixed_category_positions"),
 
   selectKitOptions: {
-    icon: "wrench",
+    icons: ["wrench", "caret-down"],
     showFullTitle: false,
     autoFilterable: false,
     filterable: false,

--- a/app/assets/stylesheets/common/select-kit/dropdown-select-box.scss
+++ b/app/assets/stylesheets/common/select-kit/dropdown-select-box.scss
@@ -29,7 +29,6 @@
           flex: 0 0 100%;
           overflow: hidden;
           font-size: $font-up-2;
-          align-self: center;
           margin-right: 0;
         }
       }

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -188,6 +188,7 @@ module SvgSprite
     "sync",
     "table",
     "tag",
+    "tags",
     "tasks",
     "thermometer-three-quarters",
     "thumbs-down",


### PR DESCRIPTION
Sometimes we have a hamburger, sometimes a wrench, sometimes a caret, sometimes text... this update establishes some rules:

* Always wrench
* No text
* If a dropdown, show a caret 

Before:
![Screen Shot 2021-06-03 at 6 09 11 PM](https://user-images.githubusercontent.com/1681963/120718217-efaa8380-c496-11eb-9466-80da58ed39d6.png)
![Screen Shot 2021-06-03 at 6 09 04 PM](https://user-images.githubusercontent.com/1681963/120718222-f2a57400-c496-11eb-8e5a-14e91b72240e.png)
![Screen Shot 2021-06-03 at 6 08 48 PM](https://user-images.githubusercontent.com/1681963/120718232-f76a2800-c496-11eb-9709-ea4b91b2df2c.png)


After:
![Screen Shot 2021-06-03 at 5 46 13 PM](https://user-images.githubusercontent.com/1681963/120718248-ffc26300-c496-11eb-9270-7ec574f53d58.png)
![Screen Shot 2021-06-03 at 6 05 34 PM](https://user-images.githubusercontent.com/1681963/120718277-0d77e880-c497-11eb-8c13-04502c5d212e.png)
![Screen Shot 2021-06-03 at 6 05 13 PM](https://user-images.githubusercontent.com/1681963/120718289-15d02380-c497-11eb-9781-c51ea84fa5d8.png)
