### PR TITLE
DEV: Clean up state leak in BootstrapController spec.

### DIFF
--- a/spec/requests/bootstrap_controller_spec.rb
+++ b/spec/requests/bootstrap_controller_spec.rb
@@ -14,6 +14,7 @@ describe BootstrapController do
 
   after do
     DiscoursePluginRegistry.reset!
+    ExtraLocalesController.clear_cache!
   end
 
   it "returns data as anonymous" do


### PR DESCRIPTION
The state leak was causing `ExtraLocalesController.client_overrides_exist?` specs to fail randomly.

Follow-up to 19763065394e09de2c162a869aa953c7cd4e6fa3