### PR TITLE
UX: improve user delete error message & return correct post count.

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -420,7 +420,7 @@ class Admin::UsersController < Admin::AdminController
       rescue UserDestroyer::PostsExistError
         render json: {
           deleted: false,
-          message: "User #{user.username} has #{user.post_count} posts, so they can't be deleted."
+          message: I18n.t("user.cannot_delete_has_posts", username: user.username, post_count: user.posts.joins(:topic).count),
         }, status: 403
       end
     end

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -15,7 +15,7 @@ class UserDestroyer
   # Returns a frozen instance of the User if the delete succeeded.
   def destroy(user, opts = {})
     raise Discourse::InvalidParameters.new('user is nil') unless user && user.is_a?(User)
-    raise PostsExistError if !opts[:delete_posts] && user.posts.count != 0
+    raise PostsExistError if !opts[:delete_posts] && user.posts.joins(:topic).count != 0
     @guardian.ensure_can_delete_user!(user)
 
     # default to using a transaction

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2594,6 +2594,7 @@ en:
     email_in_spam_header: "User's first email was flagged as spam"
     already_silenced: "User was already silenced by %{staff} %{time_ago}."
     already_suspended: "User was already suspended by %{staff} %{time_ago}."
+    cannot_delete_has_posts: "User %{username} has %{post_count} posts(s), either public posts or personal messages, so they can't be deleted."
 
   reviewables_reminder:
     submitted:

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -630,6 +630,7 @@ RSpec.describe Admin::UsersController do
         expect(response.status).to eq(403)
         json = response.parsed_body
         expect(json['deleted']).to eq(false)
+        expect(json['message']).to eq(I18n.t("user.cannot_delete_has_posts", username: delete_me.username, post_count: delete_me.posts.joins(:topic).count))
       end
 
       it "doesn't return an error if delete_posts == true" do

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -626,11 +626,16 @@ RSpec.describe Admin::UsersController do
       let!(:post) { Fabricate(:post, topic: topic, user: delete_me) }
 
       it "returns an api response that the user can't be deleted because it has posts" do
+        post_count = delete_me.posts.joins(:topic).count
+        delete_me_topic = Fabricate(:topic)
+        Fabricate(:post, topic: delete_me_topic, user: delete_me)
+        PostDestroyer.new(admin, delete_me_topic.first_post, context: "Deleted by admin").destroy
+
         delete "/admin/users/#{delete_me.id}.json"
         expect(response.status).to eq(403)
         json = response.parsed_body
         expect(json['deleted']).to eq(false)
-        expect(json['message']).to eq(I18n.t("user.cannot_delete_has_posts", username: delete_me.username, post_count: delete_me.posts.joins(:topic).count))
+        expect(json['message']).to eq(I18n.t("user.cannot_delete_has_posts", username: delete_me.username, post_count: post_count))
       end
 
       it "doesn't return an error if delete_posts == true" do


### PR DESCRIPTION
While deleting a user in admin side currently it returns incorrect post count and the message is not clear.