### PR TITLE
PERF: Preload client settings json while booting app.

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -942,6 +942,14 @@ module Discourse
       JsLocaleHelper.load_translations(SiteSetting.default_locale)
       Site.json_for(Guardian.new)
       SvgSprite.preload
+
+      begin
+        SiteSetting.client_settings_json
+      rescue => e
+        # Rescue from Redis related errors so that we can still boot the
+        # application even if Redis is down.
+        warn_exception(e, message: "Error while preloading client settings json")
+      end
     end
 
     [


### PR DESCRIPTION
Generating the client settings json involves santizing all string based
site settings. This is expensive as per our profile in production (~120ms) and one request after each deploy has
to pay this penalty.