### PR TITLE
FIX: Allow any other tag to be a synonym

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
@@ -59,7 +59,7 @@
         {{tag-chooser
           id="add-synonyms"
           tags=newSynonyms
-          blockedTags=tagInfo.name
+          blockedTags=(array tagInfo.name)
           everyTag=true
           excludeSynonyms=true
           excludeHasSynonyms=true


### PR DESCRIPTION
Tag-chooser component expects an array of blocked tags, but was passed
a string instead. That made tag-chooser to not allow any tags that were
a substring of the current one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
