### PR TITLE
UX: more consistent mobile spacing

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -13,9 +13,6 @@ $mobile-breakpoint: 700px;
   height: auto;
   overflow: hidden;
   height: 100%;
-  .mobile-view & {
-    margin-top: 10px;
-  }
   @include breakpoint(tablet) {
     width: calc(100% + 10px);
     margin-left: -10px;
@@ -27,6 +24,7 @@ $mobile-breakpoint: 700px;
     flex-wrap: wrap;
     width: calc(100% - 10px);
     flex: 1 0 auto;
+    margin-top: 0;
     @include breakpoint(tablet) {
       white-space: nowrap;
       flex-wrap: nowrap;

--- a/app/assets/stylesheets/common/base/faqs.scss
+++ b/app/assets/stylesheets/common/base/faqs.scss
@@ -15,13 +15,12 @@
   }
   .mobile-view & {
     font-size: $font-0;
-    margin-top: 20px;
   }
   li {
     margin-bottom: 8px;
   }
   .nav-pills {
-    margin-bottom: 20px;
+    margin: 0 0 2em;
   }
   ul:not(.nav-pills),
   ol:not(.nav-pills) {

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -25,7 +25,7 @@
   }
 
   .nav-pills {
-    margin-bottom: 1em;
+    margin: 0 0 1em;
   }
 
   .reviewable-container {

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -348,6 +348,7 @@ body.tags-intersection {
 
 .tags-controls {
   display: flex;
+  margin: 0;
   h2 {
     order: -1;
     margin-right: auto;

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -213,6 +213,7 @@
     .controls {
       ul {
         list-style-type: none;
+        margin-top: 0;
       }
 
       .btn {

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -140,7 +140,7 @@ blockquote {
 // Special elements
 
 #main-outlet {
-  padding-top: 0.25em;
+  padding-top: 1.25em;
 }
 
 #main {

--- a/app/assets/stylesheets/mobile/group.scss
+++ b/app/assets/stylesheets/mobile/group.scss
@@ -1,5 +1,5 @@
 .group {
-  margin-top: 15px;
+  margin: 0;
 }
 
 .group-name {

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -30,6 +30,7 @@
   button {
     // accounts for menu "ears" 4px + border 1px
     padding: 0.75em calc(0.5em + 4px + 1px);
+    margin: 0.25em;
     @media screen and (max-height: 380px) {
       // reduce padding to avoid scroll
       padding-top: 0.5em;

--- a/app/assets/stylesheets/mobile/search.scss
+++ b/app/assets/stylesheets/mobile/search.scss
@@ -1,6 +1,6 @@
 .search-container {
   flex-direction: column;
-  margin-top: 0.5em;
+  margin: 0;
 
   .search-advanced {
     order: 1;

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -27,7 +27,7 @@
     display: flex;
     flex-wrap: wrap;
     width: 100%;
-    margin: 0.5em 0 0;
+    margin: 0;
 
     button {
       &.select-kit-header {
@@ -374,7 +374,7 @@ tr.category-topic-link {
   padding: 0.5em 0 0.25em;
   border-top: 1px solid var(--primary-low) !important;
   border-bottom: 1px solid var(--primary-low) !important;
-  margin-bottom: 2em;
+  margin: 1em 0 2em;
 }
 
 .category-box {

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -296,7 +296,7 @@ span.post-count {
 #topic-title {
   z-index: z("base") + 1;
   margin: 0;
-  padding: 0.75em 0;
+  padding: 0 0 1em;
 }
 
 .quote-button.visible {

--- a/app/assets/stylesheets/mobile/user.scss
+++ b/app/assets/stylesheets/mobile/user.scss
@@ -33,7 +33,6 @@
 }
 
 .user-main {
-  margin-top: 12px;
   padding-bottom: 60px; // slightly taller than .footer-nav
 
   .user-content {


### PR DESCRIPTION
Spacing between the header and content was very tight in some places, and generally not consistent. This increases the space a little and makes it more consistent. 

Before:
 
![Screen Shot 2021-06-04 at 6 13 00 PM](https://user-images.githubusercontent.com/1681963/120867809-b63e4a80-c560-11eb-82ab-e2df6f9c8d89.png)
![Screen Shot 2021-06-04 at 6 13 31 PM](https://user-images.githubusercontent.com/1681963/120867810-b63e4a80-c560-11eb-8343-786043608662.png)
![Screen Shot 2021-06-04 at 6 13 23 PM](https://user-images.githubusercontent.com/1681963/120867811-b63e4a80-c560-11eb-916b-6a9a99957f83.png)
![Screen Shot 2021-06-04 at 6 13 06 PM](https://user-images.githubusercontent.com/1681963/120867812-b6d6e100-c560-11eb-8c06-0aba3e6da2df.png)

After:

![Screen Shot 2021-06-04 at 6 10 32 PM](https://user-images.githubusercontent.com/1681963/120867897-da9a2700-c560-11eb-9c6a-a52da90fd82e.png)
![Screen Shot 2021-06-04 at 6 01 06 PM](https://user-images.githubusercontent.com/1681963/120867898-da9a2700-c560-11eb-9371-225f9f651ef9.png)
![Screen Shot 2021-06-04 at 6 00 58 PM](https://user-images.githubusercontent.com/1681963/120867899-da9a2700-c560-11eb-9832-3d4248b9fef0.png)
![Screen Shot 2021-06-04 at 6 00 49 PM](https://user-images.githubusercontent.com/1681963/120867895-da9a2700-c560-11eb-8b2e-83bd6fbf9947.png)


