### PR TITLE
Revert search title change to fix topic statuses

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -277,7 +277,6 @@
     }
 
     .topic-title {
-      display: inline-block;
       color: var(--tertiary);
       overflow-wrap: anywhere;
       line-height: $line-height-medium;


### PR DESCRIPTION
This is a follow-up to e3b0abc, I had used `display: inline-block` so the line height could be adjusted, but it forces the topic status onto its own line if the title wraps:

Before:
![Screen Shot 2021-06-04 at 6 39 37 PM](https://user-images.githubusercontent.com/1681963/120869401-6792af80-c564-11eb-8d05-b7baa8c5ca78.png)

After:
![Screen Shot 2021-06-04 at 6 39 44 PM](https://user-images.githubusercontent.com/1681963/120869410-6bbecd00-c564-11eb-8c05-3cfff575b6a1.png)
