### PR TITLE
UX: Fix bulk-select icon and button alignment

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -42,7 +42,6 @@
 
   button.bulk-select {
     padding: 0;
-    vertical-align: middle;
   }
 
   td.bulk-select {
@@ -179,7 +178,8 @@
 
 #bulk-select {
   position: fixed;
-  right: 20px;
+  right: 10px; // match horizontal padding on .wrap
+  padding-top: 12px; // match .topic-list th padding
   background-color: var(--secondary);
   z-index: z("dropdown");
   @supports (position: sticky) {

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -42,6 +42,7 @@
 
   button.bulk-select {
     padding: 0;
+    line-height: $line-height-large;
   }
 
   td.bulk-select {


### PR DESCRIPTION
(Note: the button sticks as you scroll, which is why it's overlapping "Activity" here) 


Before:
![Screen Shot 2021-06-04 at 6 55 44 PM](https://user-images.githubusercontent.com/1681963/120870263-7aa67f00-c566-11eb-8893-14c9da9ea945.png)
![Screen Shot 2021-06-04 at 6 48 33 PM](https://user-images.githubusercontent.com/1681963/120870227-63679180-c566-11eb-80bd-215fb0d93c3f.png)


After:
![Screen Shot 2021-06-04 at 6 52 53 PM](https://user-images.githubusercontent.com/1681963/120870248-6febea00-c566-11eb-9070-cb3c20b5e89c.png)
![Screen Shot 2021-06-04 at 6 49 20 PM](https://user-images.githubusercontent.com/1681963/120870243-6c586300-c566-11eb-9a48-3e3db49334aa.png)
