### PR TITLE
UX: group dropdown filter height should match

### DIFF
--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -21,6 +21,10 @@
   &:last-child {
     margin-right: auto;
   }
+
+  .select-kit-header {
+    height: 100%;
+  }
 }
 
 .groups-boxes {


### PR DESCRIPTION
Before: 
![Screen Shot 2021-06-04 at 10 56 54 PM](https://user-images.githubusercontent.com/1681963/120878094-2d3b0980-c588-11eb-804d-656605948729.png)

After:
![Screen Shot 2021-06-04 at 9 19 27 PM](https://user-images.githubusercontent.com/1681963/120878081-1ac0d000-c588-11eb-9bde-990bda295a93.png)
