### PR TITLE
DEV: Fix an `ActiveModel::Errors` deprecation

### DIFF
--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -516,7 +516,7 @@ after_initialize do
       result = NewPostResult.new(:poll, false)
 
       post.errors.full_messages.each do |message|
-        result.errors[:base] << message
+        result.add_error(message)
       end
 
       result


### PR DESCRIPTION
The warning was:

```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array
in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.
(called from block (3 levels) in activate! at discourse/plugins/poll/plugin.rb:519)
```