### PR TITLE
SECURITY: XSS in bookmarks list

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/topic-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/topic-link.js
@@ -3,17 +3,20 @@ import { registerUnbound } from "discourse-common/lib/helpers";
 
 registerUnbound("topic-link", (topic, args) => {
   const title = topic.get("fancyTitle");
+
   const url = topic.linked_post_number
     ? topic.urlForPostNumber(topic.linked_post_number)
     : topic.get("lastUnreadUrl");
 
   const classes = ["title"];
+
   if (args.class) {
     args.class.split(" ").forEach((c) => classes.push(c));
   }
 
-  const result = `<a href='${url}'
-                     class='${classes.join(" ")}'
-                     data-topic-id='${topic.id}'>${title}</a>`;
-  return htmlSafe(result);
+  return htmlSafe(
+    `<a href='${url}'
+        class='${classes.join(" ")}'
+        data-topic-id='${topic.id}'>${title}</a>`
+  );
 });

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -125,13 +125,9 @@ const Bookmark = RestModel.extend({
     ).capitalize();
   },
 
-  @discourseComputed("linked_post_number", "title", "topic_id")
-  topicLink(linked_post_number, title, topic_id) {
-    return Topic.create({
-      id: topic_id,
-      fancy_title: title,
-      linked_post_number,
-    });
+  @discourseComputed("linked_post_number", "fancy_title", "topic_id")
+  topicLink(linked_post_number, fancy_title, id) {
+    return Topic.create({ id, fancy_title, linked_post_number });
   },
 
   loadItems(params) {

--- a/app/serializers/user_bookmark_serializer.rb
+++ b/app/serializers/user_bookmark_serializer.rb
@@ -16,6 +16,7 @@ class UserBookmarkSerializer < ApplicationSerializer
              :reminder_at,
              :pinned,
              :title,
+             :fancy_title,
              :deleted,
              :hidden,
              :category_id,
@@ -51,6 +52,10 @@ class UserBookmarkSerializer < ApplicationSerializer
 
   def title
     topic.title
+  end
+
+  def fancy_title
+    topic.fancy_title
   end
 
   def deleted


### PR DESCRIPTION
We should use `fancy_title` instead of `title` when displaying a topic title to ensure only the allowed html is not escaped.