### PR TITLE
FIX: Handle timeout errors when sending push notifications

### DIFF
--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -2,6 +2,7 @@
 
 class PushNotificationPusher
   TOKEN_VALID_FOR_SECONDS ||= 5 * 60
+  CONNECTION_TIMEOUT_SECONDS = 5
 
   def self.push(user, payload)
     I18n.with_locale(user.effective_locale) do
@@ -76,7 +77,7 @@ class PushNotificationPusher
   MAX_ERRORS ||= 3
   MIN_ERROR_DURATION ||= 86400 # 1 day
 
-  def self.handle_generic_error(subscription)
+  def self.handle_generic_error(subscription, error, user, endpoint, message)
     subscription.error_count += 1
     subscription.first_error_at ||= Time.zone.now
 
@@ -86,6 +87,16 @@ class PushNotificationPusher
     else
       subscription.save!
     end
+
+    Discourse.warn_exception(
+      error,
+      message: "Failed to send push notification",
+      env: {
+        user_id: user.id,
+        endpoint: endpoint,
+        message: message.to_json
+      }
+    )
   end
 
   def self.send_notification(user, subscription, message)
@@ -111,7 +122,10 @@ class PushNotificationPusher
           public_key: SiteSetting.vapid_public_key,
           private_key: SiteSetting.vapid_private_key,
           expiration: TOKEN_VALID_FOR_SECONDS
-        }
+        },
+        open_timeout: CONNECTION_TIMEOUT_SECONDS,
+        read_timeout: CONNECTION_TIMEOUT_SECONDS,
+        ssl_timeout: CONNECTION_TIMEOUT_SECONDS
       )
 
       if subscription.first_error_at || subscription.error_count != 0
@@ -123,17 +137,10 @@ class PushNotificationPusher
       if e.response.message == "MismatchSenderId"
         subscription.destroy!
       else
-        handle_generic_error(subscription)
-        Discourse.warn_exception(
-          e,
-          message: "Failed to send push notification",
-          env: {
-            user_id: user.id,
-            endpoint: endpoint,
-            message: message.to_json
-          }
-        )
+        handle_generic_error(subscription, e, user, endpoint, message)
       end
+    rescue Timeout::Error => e
+      handle_generic_error(subscription, e, user, endpoint, message)
     end
   end
 


### PR DESCRIPTION
Decreases the timeout from 60 to 5 seconds and counts timeouts as errors. It also refactors existing specs to reduce duplicate code.