### PR TITLE
FIX: Hide image resize controls in staged edit content

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -650,6 +650,10 @@ blockquote {
   // a deeply nested blockquote, and so on.. you get the idea.
   .cooked {
     overflow: hidden;
+
+    .button-wrapper {
+      display: none;
+    }
   }
   .group-request {
     border-top: 1px solid var(--primary-low);


### PR DESCRIPTION
The content from the preview is used to stage post changes immediately, but sometimes it is different than the cooked content. One such difference is the image resize controls which are present only in the preview.