### PR TITLE
DEV: Fix a flaky Onceoff spec

### DIFF
--- a/spec/integrity/onceoff_integrity_spec.rb
+++ b/spec/integrity/onceoff_integrity_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 describe ::Jobs::Onceoff do
   it "can run all once off jobs without errors" do
-    # load all once offs
-
+    # Load all once offs
     Dir[Rails.root + 'app/jobs/onceoff/*.rb'].each do |f|
       require_relative '../../app/jobs/onceoff/' + File.basename(f)
     end
-    ObjectSpace.each_object(Class).select { |klass| klass < ::Jobs::Onceoff }.each do |j|
-      j.new.execute_onceoff(nil)
-    end
+
+    ObjectSpace.each_object(Class)
+      .select { |klass| klass.superclass == ::Jobs::Onceoff }
+      .each { |job| job.new.execute_onceoff(nil) }
   end
 end


### PR DESCRIPTION
The error was:

```
Jobs::Onceoff can run all once off jobs without errors
     Failure/Error: j.new.execute_onceoff(nil)

     TypeError:
       can't create instance of singleton class
     # ./spec/integrity/onceoff_integrity_spec.rb:13:in `new'
     # ./spec/integrity/onceoff_integrity_spec.rb:13:in `block (3 levels) in <main>'
     # ./spec/integrity/onceoff_integrity_spec.rb:12:in `each'
     # ./spec/integrity/onceoff_integrity_spec.rb:12:in `block (2 levels) in <main>'
     # ./spec/rails_helper.rb:279:in `block (2 levels) in <top (required)>'
     # ./bundle/ruby/2.7.0/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

```

Sometimes the class found by `ObjectSpace.each_object(Class)` would be e.g:
`#<Class:#<Jobs::MigrateBadgeImageToUploads:0x00007f96f8277400>>`

…instead of e.g:
`#<Jobs::MigrateBadgeImageToUploads:0x00007f96ffa59540>`

This commit changes the `#select` to filter out those classes.