### PR TITLE
DEV: Run `turbo_rspec` in the verbose mode on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'
-        run: bin/turbo_rspec
+        run: bin/turbo_rspec --verbose
 
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'


### PR DESCRIPTION
Output like this can help debug flaky specs (since it contains seeds):

```
Process 1: TEST_ENV_NUMBER=1 RSPEC_SILENCE_FILTER_ANNOUNCEMENTS=1 bundle exec rspec --tag ~type:multisite
--seed 22266 --format TurboTests::JsonRowsFormatter --out tmp/test-pipes/subprocess-1
--format ParallelTests::RSpec::RuntimeLogger --out tmp/turbo_rspec_runtime.log
spec/components/admin_user_index_query_spec.rb spec/components/auth/default_current_user_provider_spec.rb…
```