### PR TITLE
FIX: Search menu regression

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -161,7 +161,9 @@ createSearchResult({
         this.siteSettings.use_pg_headlines_for_excerpt &&
           result.topic_title_headline
           ? new RawHtml({
-              html: emojiUnescape(result.topic_title_headline),
+              html: `<span>${emojiUnescape(
+                result.topic_title_headline
+              )}</span>`,
             })
           : new Highlighted(topic.fancyTitle, term)
       ),


### PR DESCRIPTION
Turns out the extra `<span>` is crucial. (TODO: this codepath needs tests…)

Thanks @techAPJ for the report