### PR TITLE
DEV: Fix another flaky spec

### DIFF
--- a/spec/models/trust_level_and_staff_setting_spec.rb
+++ b/spec/models/trust_level_and_staff_setting_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 describe TrustLevelAndStaffSetting do
   describe ".values" do
+    after do
+      I18n.reload!
+    end
+
     it "returns translated names" do
       TranslationOverride.upsert!(I18n.locale, "js.trust_levels.names.newuser", "New Member")
       TranslationOverride.upsert!(I18n.locale, "trust_levels.admin", "Hero")


### PR DESCRIPTION
The error was:

```
  1) ExtraLocalesController.client_overrides_exist? returns true if there are client-side translation overrides
     Failure/Error: expect(ExtraLocalesController.client_overrides_exist?).to eq(false)

       expected: false
            got: true

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -false
       +true

     # ./spec/requests/extra_locales_controller_spec.rb:162:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:279:in `block (2 levels) in <top (required)>'
     # .gem/ruby/2.7.3/gems/webmock-3.13.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

Minimal repro:

```
bin/rspec './spec/models/trust_level_and_staff_setting_spec.rb[1:1:1]' './spec/requests/extra_locales_controller_spec.rb[1:3:2]' --tag ~type:multisite --seed 33616
```
