### PR TITLE
PERF: Switch ActiveRecord PG connection active check to use empty query.

### DIFF
--- a/lib/freedom_patches/active_record_postgresql_adapter.rb
+++ b/lib/freedom_patches/active_record_postgresql_adapter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Pulls in https://github.com/rails/rails/pull/42368 early since the query is
+# definitely more efficient as it does not involved the PG planner.
+# Remove once Rails 7 has been released.
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      def active?
+        @lock.synchronize do
+          @connection.query ";"
+        end
+        true
+      rescue PG::Error
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
See https://github.com/rails/rails/pull/42368

The impact is not quantifiable at the time of this writing but
prelimary investigation shows that `SELECT 1` accounts for 0.09 of CPU
time on a database. Note that Discourse runs thousands of databases so
the small impact may be amplified by the large number of databases that
we run.