### PR TITLE
DEV: Allow `transformed` values to be used in all widget hbs statements

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
@@ -262,6 +262,30 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
   });
 
+  componentTest("using transformed values in a subexpression", {
+    template: hbs`{{mount-widget widget="attach-test"}}`,
+
+    beforeEach() {
+      createWidget("testing", {
+        tagName: "span.value",
+        template: widgetHbs`{{attrs.value}}`,
+      });
+
+      createWidget("attach-test", {
+        transform() {
+          return { someValue: "world" };
+        },
+        tagName: "div.container",
+        template: widgetHbs`{{testing value=(concat "hello" " " transformed.someValue)}}`,
+      });
+    },
+
+    test(assert) {
+      assert.ok(queryAll(".container").length, "renders container");
+      assert.equal(queryAll(".container .value").text(), "hello world");
+    },
+  });
+
   componentTest("handlebars d-icon", {
     template: hbs`{{mount-widget widget="hbs-icon-test" args=args}}`,
 

--- a/lib/javascripts/widget-hbs-compiler.js
+++ b/lib/javascripts/widget-hbs-compiler.js
@@ -16,7 +16,7 @@ function sexpValue(value) {
   } else if (value.type === "SubExpression") {
     return sexp(value);
   }
-  return pValue;
+  return resolve(pValue);
 }
 
 function pairsToObj(pairs) {


### PR DESCRIPTION
Previously, the `transformed.blah` shortcut could only be used in top-level hbs statements like {{transformed.blah}}. When attempting to use it in a sub-expression like `{{concat "hello" transformed.world}}`, it would raise a "transformed is not defined" error.

This commit updates the shortcut logic to make `transformed.blah` and `attrs.blah` work consistently in all hbs expressions.

Co-authored-by: Jordan Vidrine <jordan@jordanvidrine.com>

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
