### PR TITLE
DEV: ember-cli -u can be used to run a standalone dev discourse

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -64,7 +64,6 @@ if (ARGV - ["--unicorn", "-"]).length < 2
       end
     end
   end
-  # ember_pid = spawn("yarn", *args.to_a.flatten)
 
   trap("SIGINT") do
     # we got to swallow sigint to give time for

--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -30,18 +30,49 @@ end
 
 if ARGV.include?("-h") || ARGV.include?("--help")
   puts "ember-cli OPTIONS"
-  puts "#{"--try".cyan} To proxy try.discourse.org", ""
-  puts "#{"--test".cyan} To run the test suite", ""
+  puts "#{"--try".cyan} To proxy try.discourse.org"
+  puts "#{"--test".cyan} To run the test suite"
+  puts "#{"--unicorn, -u".cyan} To run a unicorn server as well"
   puts "The rest of the arguments are passed to ember server per:", ""
-  exec "yarn --cwd #{yarn_dir} run ember #{command} --help"
+  exec "yarn -s --cwd #{yarn_dir} run ember #{command} --help"
 end
 
-args = ["--cwd", yarn_dir, "run", "ember", command] + ARGV.reject { |a| a == "--try" || a == "--test" }
+args = ["-s", "--cwd", yarn_dir, "run", "ember", command] + ARGV.reject do |a|
+  ["--try", "--test", "--unicorn", "-u"].include?(a)
+end
 
 if !args.include?("--proxy")
   args << "--proxy"
   args << PROXY
 end
 
-system "yarn install --cwd #{yarn_dir}"
-exec "yarn", *args.to_a.flatten
+system "yarn -s install --cwd #{yarn_dir}"
+
+if (ARGV - ["--unicorn", "-"]).length < 2
+  unicorn_pid = spawn(__dir__ + "/unicorn")
+
+  Thread.new do
+    require 'open3'
+    Open3.popen2e("yarn", *args.to_a.flatten) do |i, oe, t|
+      puts "Ember CLI running on PID: #{t.pid}"
+      oe.each do |line|
+        if line.include?("\e[32m200\e") || line.include?("\e[36m304\e[0m") || line.include?("POST /message-bus")
+          # skip 200s and 304s and message bus
+        else
+          puts line
+        end
+      end
+    end
+  end
+  # ember_pid = spawn("yarn", *args.to_a.flatten)
+
+  trap("SIGINT") do
+    # we got to swallow sigint to give time for
+    # children to handle it
+  end
+
+  Process.wait(unicorn_pid)
+
+else
+  exec "yarn", *args.to_a.flatten
+end

--- a/bin/unicorn
+++ b/bin/unicorn
@@ -20,7 +20,7 @@ require 'fileutils'
 dev_mode = false
 
 def ensure_cache_clean!
-  all_plugin_directories = Pathname.new(RAILS_ROOT + '/plugins').children.select(&:directory?)
+  _all_plugin_directories = Pathname.new(RAILS_ROOT + '/plugins').children.select(&:directory?)
   core_git_sha = `git rev-parse HEAD`.strip
   plugins_combined_git_sha = `git ls-files -s plugins | git hash-object --stdin`.strip
   super_sha = Digest::SHA1.hexdigest(core_git_sha + plugins_combined_git_sha)


### PR DESCRIPTION
Previously we would need to launch unicorn separately this achieves
the same goal by making 2 modifications:

1. If -u is supplied ember-cli binary will launch and monitor ember cli and unicorn
2. We suppress 200 requests to keep console clean (we may consider moving to development rails logs)


Also cleans out output a bit by supplying silent flags to yarn.
