### PR TITLE
FIX: Do not block SVG sprite bundle if a file is missing

### DIFF
--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -330,6 +330,11 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     end
 
     custom_svg_sprites(theme_ids).each do |fname|
+      if !File.exist?(fname)
+        cache.delete("custom_svg_sprites_#{Theme.transform_ids(theme_ids).join(',')}")
+        next
+      end
+
       svg_file = Nokogiri::XML(File.open(fname)) do |config|
         config.options = Nokogiri::XML::ParseOptions::NOBLANKS
       end
@@ -475,6 +480,8 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     # Automatically register icons in sprites added via themes or plugins
     icons = []
     custom_svg_sprites(theme_ids).each do |fname|
+      next if !File.exist?(fname)
+
       svg_file = Nokogiri::XML(File.open(fname))
 
       svg_file.css('symbol').each do |sym|

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -359,6 +359,8 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     searched_icon = process(searched_icon.dup)
 
     sprite_sources([SiteSetting.default_theme_id]).each do |fname|
+      next if !File.exist?(fname)
+
       svg_file = Nokogiri::XML(File.open(fname))
       svg_filename = "#{File.basename(fname, ".svg")}"
 
@@ -380,6 +382,8 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     results = Set.new
 
     sprite_sources([SiteSetting.default_theme_id]).each do |fname|
+      next if !File.exist?(fname)
+
       svg_file = Nokogiri::XML(File.open(fname))
       svg_filename = "#{File.basename(fname, ".svg")}"
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
