### PR TITLE
PERF: Avoid running a pointless PG query when theme has no variables.

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -434,7 +434,18 @@ class Stylesheet::Manager
   end
 
   def uploads_digest
-    Digest::SHA1.hexdigest(ThemeField.joins(:upload).where(id: theme&.all_theme_variables).pluck(:sha1).join(","))
+    sha1s =
+      if (theme_ids = theme&.all_theme_variables).present?
+        ThemeField
+          .joins(:upload)
+          .where(id: theme_ids)
+          .pluck(:sha1)
+          .join(",")
+      else
+        ""
+      end
+
+      Digest::SHA1.hexdigest(sha1s)
   end
 
   def color_scheme_digest


### PR DESCRIPTION
When `Theme#all_theme_variables` returns an empty array, we were running
a pointless query in `StyleSheet::Manager#uploads_digest`.

`SELECT "sha1" FROM "theme_fields" INNER JOIN "uploads" ON
"uploads"."id" = "theme_fields"."upload_id" WHERE 1=0`