### PR TITLE
FIX: Do not check for duplicate links in Onebox

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -456,7 +456,7 @@ export default Controller.extend({
       $links.each((idx, l) => {
         const href = l.href;
         if (href && href.length) {
-          // skip links in quotes
+          // skip links in quotes and oneboxes
           for (let element = l; element; element = element.parentElement) {
             if (
               element.tagName === "DIV" &&

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -471,6 +471,14 @@ export default Controller.extend({
             ) {
               return true;
             }
+
+            if (
+              element.tagName === "ASIDE" &&
+              element.classList.contains("onebox") &&
+              href !== element.dataset["onebox-src"]
+            ) {
+              return true;
+            }
           }
 
           const [warn, info] = linkLookup.check(post, href);

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -324,8 +324,11 @@ module PrettyText
     links = []
     doc = Nokogiri::HTML5.fragment(html)
 
-    # remove href inside quotes & elided part
-    doc.css("aside.quote a, .elided a").each { |a| a["href"] = "" }
+    # extract onebox links
+    doc.css("aside.onebox").each { |onebox| links << DetectedLink.new(onebox["data-onebox-src"], false) }
+
+    # remove href inside quotes & oneboxes & elided part
+    doc.css("aside.quote a, aside.onebox a, .elided a").each { |a| a["href"] = "" }
 
     # extract all links
     doc.css("a").each do |a|

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -325,10 +325,10 @@ module PrettyText
     doc = Nokogiri::HTML5.fragment(html)
 
     # extract onebox links
-    doc.css("aside.onebox").each { |onebox| links << DetectedLink.new(onebox["data-onebox-src"], false) }
+    doc.css("aside.onebox[data-onebox-src]").each { |onebox| links << DetectedLink.new(onebox["data-onebox-src"], false) }
 
     # remove href inside quotes & oneboxes & elided part
-    doc.css("aside.quote a, aside.onebox a, .elided a").each { |a| a["href"] = "" }
+    doc.css("aside.quote a, aside.onebox a, .elided a").remove
 
     # extract all links
     doc.css("a").each do |a|

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -779,6 +779,22 @@ describe PrettyText do
       ].sort)
     end
 
+    it "should not extract links inside oneboxes" do
+      onebox = <<~EOF
+        <aside class="onebox twitterstatus" data-onebox-src="https://twitter.com/EDBPostgres/status/1402528437441634306">
+          <header class="source">
+            <a href="https://twitter.com/EDBPostgres/status/1402528437441634306" target="_blank" rel="noopener">twitter.com</a>
+            <a href="https://twitter.com/EDBPostgres/status/1402528437441634306" target="_blank" rel="noopener">twitter.com</a>
+          </header>
+          <article class="onebox-body">
+            <div class="tweet">Example URL: <a target="_blank" href="https://example.com" rel="noopener">example.com</a></div>
+          </article>
+        </aside>
+      EOF
+
+      expect(PrettyText.extract_links(onebox).map(&:url)).to contain_exactly("https://twitter.com/EDBPostgres/status/1402528437441634306")
+    end
+
     it "should not preserve tags in code blocks" do
       expect(PrettyText.excerpt("<pre><code class='handlebars'>&lt;h3&gt;Hours&lt;/h3&gt;</code></pre>", 100)).to eq("&lt;h3&gt;Hours&lt;/h3&gt;")
     end


### PR DESCRIPTION
If a user posted a URL that appeared inside a Onebox, then the user
got a duplicate link notice. This was fixed by skipping those links in
Ruby.

If a user posted a URL that was Oneboxes and contained other links that
appeared in previous posts, then the user got a duplicate link notice.
This was fixed by skipping those links in JavaScript.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
