### PR TITLE
DEV: Set DISCOURSE_PORT when spawning unicorn via `ember-cli -u`

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -49,7 +49,8 @@ end
 system "yarn -s install --cwd #{yarn_dir}"
 
 if ARGV.include?("-u") || ARGV.include?("--unicorn")
-  unicorn_pid = spawn(__dir__ + "/unicorn")
+  unicorn_env = { "DISCOURSE_PORT" => ENV["DISCOURSE_PORT"] || "4200" }
+  unicorn_pid = spawn(unicorn_env, __dir__ + "/unicorn")
 
   Thread.new do
     require 'open3'


### PR DESCRIPTION
This means that Discourse will use the ember-cli proxy's port number in various places like auth redirects and emails

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
