### PR TITLE
FIX: `count` is not defined lint error

### DIFF
--- a/plugins/poll/test/javascripts/widgets/discourse-poll-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-test.js.es6
@@ -1,4 +1,5 @@
 import {
+  count,
   discourseModule,
   exists,
   queryAll,


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
