### PR TITLE
FEATURE: Use upgrade-insecure-requests CSP directive

### DIFF
--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -8,6 +8,7 @@ class ContentSecurityPolicy
     def initialize(base_url:)
       @base_url = base_url
       @directives = {}.tap do |directives|
+        directives[:upgrade_insecure_requests] = [] if SiteSetting.force_https
         directives[:base_uri] = [:none]
         directives[:object_src] = [:none]
         directives[:script_src] = script_src

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -32,6 +32,18 @@ describe ContentSecurityPolicy do
     end
   end
 
+  describe 'upgrade-insecure-requests' do
+    it 'is not included when force_https is off' do
+      SiteSetting.force_https = false
+      expect(parse(policy)['upgrade-insecure-requests']).to eq(nil)
+    end
+
+    it 'is included when force_https is on' do
+      SiteSetting.force_https = true
+      expect(parse(policy)['upgrade-insecure-requests']).to eq([])
+    end
+  end
+
   describe 'worker-src' do
     it 'has expected values' do
       worker_srcs = parse(policy)['worker-src']


### PR DESCRIPTION
The `upgrade-insecure-requests` directive tells browsers to treat all of a site's insecure URLs as though they have been replaced with secure URLs. This means that URLs to external images, videos, etc. using `http` will be loaded from `https`. The browser will no longer display a mixed content warning. Note also that if the asset is not available via `https`, the request will fail (should be quite rare). 

This directive will only apply if `force_https` is enabled. 
