### PR TITLE
A11Y: Adjust heading rules on topic lists

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -40,8 +40,6 @@ export default Component.extend({
   classNameBindings: [":topic-list-item", "unboundClassNames", "topic.visited"],
   attributeBindings: ["data-topic-id", "role", "ariaLevel:aria-level"],
   "data-topic-id": alias("topic.id"),
-  role: "heading",
-  ariaLevel: "2",
 
   didReceiveAttrs() {
     this._super(...arguments);

--- a/app/assets/javascripts/discourse/app/helpers/topic-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/topic-link.js
@@ -16,6 +16,8 @@ registerUnbound("topic-link", (topic, args) => {
 
   return htmlSafe(
     `<a href='${url}'
+        role='heading'
+        level='2'
         class='${classes.join(" ")}'
         data-topic-id='${topic.id}'>${title}</a>`
   );

--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -13,7 +13,7 @@
   This causes the topic-post-badge to be considered the same word as "text"
   at the end of the link, preventing it from line wrapping onto its own line.
 --}}
-<td class='main-link clearfix' colspan="1" role="rowheader">
+<td class='main-link clearfix' colspan="1">
   {{~raw-plugin-outlet name="topic-list-before-link"}}
   <span class='link-top-line'>
     {{~raw-plugin-outlet name="topic-list-before-status"}}


### PR DESCRIPTION
Previously due to "rowheader" role we would read out topic titles twice.

This adjusts it so we apply the heading role only to the topic link.
In turn this makes navigation through topic lists more accurate (h) only
lands you on topic links. It also reduces the amount of duplicate reading
NVDA does.

Before:

Topic title link new topic link support link b481 link 19h link 2 button...

After:

Topic title link


This reduces noise, up and down once you land on a topic link can give you
more context.
