### PR TITLE
DEV: Increase number of mini-profiler traces in development.

### DIFF
--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -76,6 +76,8 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
 
   Rack::MiniProfiler.config.backtrace_includes = [/^\/?(app|config|lib|test|plugins)/]
 
+  Rack::MiniProfiler.config.max_traces_to_show = 100 if Rails.env.development?
+
   Rack::MiniProfiler.counter_method(Redis::Client, :call) { 'redis' }
   # Rack::MiniProfiler.counter_method(ActiveRecord::QueryMethods, 'build_arel')
   # Rack::MiniProfiler.counter_method(Array, 'uniq')


### PR DESCRIPTION
Assets are served via the server in development and the default 20
traces is too little for the number of assets we load in development.