### PR TITLE
PERF: Avoid N+1 queries when generating `Stylesheet::Manager.stylesheet_details`

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -641,11 +641,6 @@ class Theme < ActiveRecord::Base
     contents
   end
 
-  def has_scss(target)
-    name = target == :embedded_theme ? :embedded_scss : :scss
-    list_baked_fields(target, name).count > 0
-  end
-
   def convert_settings
     settings.each do |setting|
       setting_row = ThemeSetting.where(theme_id: self.id, name: setting.name.to_s).first

--- a/app/services/theme/scss_checker.rb
+++ b/app/services/theme/scss_checker.rb
@@ -1,0 +1,32 @@
+class Theme
+  class ScssChecker
+    def initialize(target, theme_ids)
+      @target = target
+      @theme_ids = theme_ids
+    end
+
+    def has_scss(theme_id)
+      !!get_themes_with_scss[theme_id]
+    end
+
+    private
+
+    def get_themes_with_scss
+      @themes_with_scss ||= begin
+        theme_target = :mobile if @target == :mobile_theme
+        theme_target = :desktop if @target == :desktop_theme
+        name = @target == :embedded_theme ? :embedded_scss : :scss
+
+        Theme
+          .where(id: @theme_ids)
+          .left_joins(:theme_fields)
+          .where(theme_fields: {
+            target_id: [Theme.targets[theme_target], Theme.targets[:common]],
+            name: name
+          })
+          .group(:id)
+          .size
+      end
+    end
+  end
+end

--- a/spec/lib/theme/scss_checker_spec.rb
+++ b/spec/lib/theme/scss_checker_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Theme::ScssChecker do
+  fab!(:theme) { Fabricate(:theme) }
+
+  describe '#has_scss' do
+    it 'should return true when theme has scss' do
+      scss_theme = Fabricate(:theme, component: true)
+      scss_theme.set_field(target: :common, name: "scss", value: ".scss{color: red;}")
+      scss_theme.save!
+
+      embedded_scss_theme = Fabricate(:theme, component: true)
+      embedded_scss_theme.set_field(target: :common, name: "embedded_scss", value: ".scss{color: red;}")
+      embedded_scss_theme.save!
+
+      theme_ids = [scss_theme.id, embedded_scss_theme.id]
+
+      desktop_theme_checker = described_class.new(:desktop_theme, theme_ids)
+
+      expect(desktop_theme_checker.has_scss(scss_theme.id)).to eq(true)
+      expect(desktop_theme_checker.has_scss(embedded_scss_theme.id)).to eq(false)
+
+      embedded_theme_checker = described_class.new(:embedded_theme, theme_ids)
+
+      expect(embedded_theme_checker.has_scss(scss_theme.id)).to eq(false)
+      expect(embedded_theme_checker.has_scss(embedded_scss_theme.id)).to eq(true)
+    end
+
+    it 'should return false when theme does not have scss' do
+      expect(described_class.new(:desktop_theme, [theme.id]).has_scss(theme.id))
+        .to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Assets are served via the server in development and the default 20
traces is too little for the number of assets we load in development.