### PR TITLE
PERF: Perform user filtering in SQL

### DIFF
--- a/app/jobs/regular/notify_tag_change.rb
+++ b/app/jobs/regular/notify_tag_change.rb
@@ -7,23 +7,20 @@ module Jobs
 
       if post&.topic&.visible?
         post_alerter = PostAlerter.new
-        post_alerter.notify_post_users(post, excluded_users(args), include_topic_watchers: !post.topic.private_message?, include_category_watchers: false)
+        post_alerter.notify_post_users(post, User.where(id: args[:notified_user_ids]),
+          group_ids: all_tags_in_hidden_groups?(args) ? tag_group_ids(args) : nil,
+          include_topic_watchers: !post.topic.private_message?,
+          include_category_watchers: false
+        )
         post_alerter.notify_first_post_watchers(post, post_alerter.tag_watchers(post.topic))
       end
     end
 
     private
 
-    def excluded_users(args)
-      if !args[:diff_tags] || !all_tags_in_hidden_groups?(args)
-        return User.where(id: args[:notified_user_ids])
-      end
-      group_users_join = DB.sql_fragment("LEFT JOIN group_users ON group_users.user_id = users.id AND group_users.group_id IN (:group_ids)", group_ids: tag_group_ids(args))
-      condition = DB.sql_fragment("group_users.id IS NULL OR users.id IN (:notified_user_ids)", notified_user_ids: args[:notified_user_ids])
-      User.joins(group_users_join).where(condition)
-    end
-
     def all_tags_in_hidden_groups?(args)
+      return false if args[:diff_tags].blank?
+
       Tag
         .where(name: args[:diff_tags])
         .joins(tag_groups: :tag_group_permissions)


### PR DESCRIPTION
Notifying about a tag change sometimes resulted in loading a large
number of users in memory just to perform an exclusion. This commit
prefers to do inclusion (i.e. instead of exclude users X, do include
users in groups Y) and does it in SQL to avoid fetching unnecessary
data that is later discarded.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
