### PR TITLE
Penalty history improvements

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-penalty-history.js
+++ b/app/assets/javascripts/admin/addon/components/admin-penalty-history.js
@@ -1,0 +1,22 @@
+import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
+
+export default Component.extend({
+  classNames: ["penalty-history"],
+
+  @discourseComputed("user.penalty_counts.suspended")
+  suspendedCountClass(count) {
+    if (count > 0) {
+      return "danger";
+    }
+    return "";
+  },
+
+  @discourseComputed("user.penalty_counts.silenced")
+  silencedCountClass(count) {
+    if (count > 0) {
+      return "danger";
+    }
+    return "";
+  },
+});

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-silence-user.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-silence-user.js
@@ -2,6 +2,7 @@ import Controller from "@ember/controller";
 import PenaltyController from "admin/mixins/penalty-controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import { isEmpty } from "@ember/utils";
+import { later } from "@ember/runloop";
 
 export default Controller.extend(PenaltyController, {
   silenceUntil: null,
@@ -10,6 +11,14 @@ export default Controller.extend(PenaltyController, {
   onShow() {
     this.resetModal();
     this.setProperties({ silenceUntil: null, silencing: false });
+  },
+
+  @discourseComputed("user")
+  silenceUntilDefault() {
+    later(() => {
+      this.set("silenceUntil", this.user?.next_penalty);
+    });
+    return this.user?.next_penalty;
   },
 
   @discourseComputed("silenceUntil", "reason", "silencing")

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-silence-user.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-silence-user.js
@@ -21,6 +21,22 @@ export default Controller.extend(PenaltyController, {
     return silencing || isEmpty(silenceUntil) || !reason || reason.length < 1;
   },
 
+  @discourseComputed("user.penalty_counts.suspended")
+  suspendedCountClass(count) {
+    if (count > 0) {
+      return "danger";
+    }
+    return "";
+  },
+
+  @discourseComputed("user.penalty_counts.silenced")
+  silencedCountClass(count) {
+    if (count > 0) {
+      return "danger";
+    }
+    return "";
+  },
+
   actions: {
     silence() {
       if (this.submitDisabled) {

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-silence-user.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-silence-user.js
@@ -2,7 +2,6 @@ import Controller from "@ember/controller";
 import PenaltyController from "admin/mixins/penalty-controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import { isEmpty } from "@ember/utils";
-import { later } from "@ember/runloop";
 
 export default Controller.extend(PenaltyController, {
   silenceUntil: null,
@@ -13,12 +12,8 @@ export default Controller.extend(PenaltyController, {
     this.setProperties({ silenceUntil: null, silencing: false });
   },
 
-  @discourseComputed("user")
-  silenceUntilDefault() {
-    later(() => {
-      this.set("silenceUntil", this.user?.next_penalty);
-    });
-    return this.user?.next_penalty;
+  finishedSetup() {
+    this.set("silenceUntil", this.user?.next_penalty);
   },
 
   @discourseComputed("silenceUntil", "reason", "silencing")

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-silence-user.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-silence-user.js
@@ -21,22 +21,6 @@ export default Controller.extend(PenaltyController, {
     return silencing || isEmpty(silenceUntil) || !reason || reason.length < 1;
   },
 
-  @discourseComputed("user.penalty_counts.suspended")
-  suspendedCountClass(count) {
-    if (count > 0) {
-      return "danger";
-    }
-    return "";
-  },
-
-  @discourseComputed("user.penalty_counts.silenced")
-  silencedCountClass(count) {
-    if (count > 0) {
-      return "danger";
-    }
-    return "";
-  },
-
   actions: {
     silence() {
       if (this.submitDisabled) {

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-suspend-user.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-suspend-user.js
@@ -21,22 +21,6 @@ export default Controller.extend(PenaltyController, {
     return suspending || isEmpty(suspendUntil) || !reason || reason.length < 1;
   },
 
-  @discourseComputed("user.penalty_counts.suspended")
-  suspendedCountClass(count) {
-    if (count > 0) {
-      return "danger";
-    }
-    return "";
-  },
-
-  @discourseComputed("user.penalty_counts.silenced")
-  silencedCountClass(count) {
-    if (count > 0) {
-      return "danger";
-    }
-    return "";
-  },
-
   actions: {
     suspend() {
       if (this.submitDisabled) {

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-suspend-user.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-suspend-user.js
@@ -2,7 +2,6 @@ import Controller from "@ember/controller";
 import PenaltyController from "admin/mixins/penalty-controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import { isEmpty } from "@ember/utils";
-import { later } from "@ember/runloop";
 
 export default Controller.extend(PenaltyController, {
   suspendUntil: null,
@@ -13,12 +12,8 @@ export default Controller.extend(PenaltyController, {
     this.setProperties({ suspendUntil: null, suspending: false });
   },
 
-  @discourseComputed("user")
-  suspendUntilDefault() {
-    later(() => {
-      this.set("suspendUntil", this.user?.next_penalty);
-    });
-    return this.user?.next_penalty;
+  finishedSetup() {
+    this.set("suspendUntil", this.user?.next_penalty);
   },
 
   @discourseComputed("suspendUntil", "reason", "suspending")

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-suspend-user.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-suspend-user.js
@@ -21,6 +21,22 @@ export default Controller.extend(PenaltyController, {
     return suspending || isEmpty(suspendUntil) || !reason || reason.length < 1;
   },
 
+  @discourseComputed("user.penalty_counts.suspended")
+  suspendedCountClass(count) {
+    if (count > 0) {
+      return "danger";
+    }
+    return "";
+  },
+
+  @discourseComputed("user.penalty_counts.silenced")
+  silencedCountClass(count) {
+    if (count > 0) {
+      return "danger";
+    }
+    return "";
+  },
+
   actions: {
     suspend() {
       if (this.submitDisabled) {

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-suspend-user.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-suspend-user.js
@@ -2,6 +2,7 @@ import Controller from "@ember/controller";
 import PenaltyController from "admin/mixins/penalty-controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import { isEmpty } from "@ember/utils";
+import { later } from "@ember/runloop";
 
 export default Controller.extend(PenaltyController, {
   suspendUntil: null,
@@ -10,6 +11,14 @@ export default Controller.extend(PenaltyController, {
   onShow() {
     this.resetModal();
     this.setProperties({ suspendUntil: null, suspending: false });
+  },
+
+  @discourseComputed("user")
+  suspendUntilDefault() {
+    later(() => {
+      this.set("suspendUntil", this.user?.next_penalty);
+    });
+    return this.user?.next_penalty;
   },
 
   @discourseComputed("suspendUntil", "reason", "suspending")

--- a/app/assets/javascripts/admin/addon/services/admin-tools.js
+++ b/app/assets/javascripts/admin/addon/services/admin-tools.js
@@ -48,7 +48,6 @@ export default Service.extend({
 
   _showControlModal(type, user, opts) {
     opts = opts || {};
-
     let controller = showModal(`admin-${type}-user`, {
       admin: true,
       modalClass: `${type}-user-modal`,
@@ -65,6 +64,8 @@ export default Service.extend({
         before: opts.before,
         successCallback: opts.successCallback,
       });
+
+      controller.finishedSetup();
     });
   },
 

--- a/app/assets/javascripts/admin/addon/templates/components/admin-penalty-history.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-penalty-history.hbs
@@ -1,0 +1,8 @@
+<div class="suspended-count {{suspendedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
+  <label>{{i18n "admin.user.suspended_count"}}</label>
+  <span>{{user.penalty_counts.suspended}}</span>
+</div>
+<div class="silenced-count {{silencedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
+  <label>{{i18n "admin.user.silenced_count"}}</label>
+  <span>{{user.penalty_counts.silenced}}</span>
+</div>

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
@@ -21,6 +21,7 @@
           includeFarFuture=true
           clearable=false
           input=silenceUntil
+          initialInput=silenceUntilDefault
           onChangeInput=(action (mut silenceUntil))
         }}
       </label>

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
@@ -5,16 +5,7 @@
       <div class="alert alert-error">{{errorMessage}}</div>
     {{/if}}
 
-    <div class="penalty-history">
-      <div class="suspended-count {{suspendedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
-        <label>{{i18n "admin.user.suspended_count"}}</label>
-        <span>{{user.penalty_counts.suspended}}</span>
-      </div>
-      <div class="silenced-count {{silencedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
-        <label>{{i18n "admin.user.silenced_count"}}</label>
-        <span>{{user.penalty_counts.silenced}}</span>
-      </div>
-    </div>
+    {{admin-penalty-history user=user}}
 
     <div class="until-controls">
       <label>

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
@@ -6,11 +6,14 @@
     {{/if}}
 
     <div class="penalty-history">
-      <label>
-        {{i18n "admin.user.penalty_history"}}
-      </label>
-      <div class="suspended-count">{{i18n "admin.user.tl3_requirements.suspended"}}: {{user.penalty_counts.suspended}}</div>
-      <div class="silenced-count">{{i18n "admin.user.tl3_requirements.silenced"}}: {{user.penalty_counts.silenced}}</div>
+      <div class="suspended-count {{suspendedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
+        <label>{{i18n "admin.user.suspended_count"}}</label>
+        <span>{{user.penalty_counts.suspended}}</span>
+      </div>
+      <div class="silenced-count {{silencedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
+        <label>{{i18n "admin.user.silenced_count"}}</label>
+        <span>{{user.penalty_counts.silenced}}</span>
+      </div>
     </div>
 
     <div class="until-controls">

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
@@ -21,7 +21,6 @@
           includeFarFuture=true
           clearable=false
           input=silenceUntil
-          initialInput=silenceUntilDefault
           onChangeInput=(action (mut silenceUntil))
         }}
       </label>

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-silence-user.hbs
@@ -5,6 +5,14 @@
       <div class="alert alert-error">{{errorMessage}}</div>
     {{/if}}
 
+    <div class="penalty-history">
+      <label>
+        {{i18n "admin.user.penalty_history"}}
+      </label>
+      <div class="suspended-count">{{i18n "admin.user.tl3_requirements.suspended"}}: {{user.penalty_counts.suspended}}</div>
+      <div class="silenced-count">{{i18n "admin.user.tl3_requirements.silenced"}}: {{user.penalty_counts.silenced}}</div>
+    </div>
+
     <div class="until-controls">
       <label>
         {{future-date-input

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
@@ -22,7 +22,6 @@
             includeFarFuture=true
             clearable=false
             input=suspendUntil
-            initialInput=suspendUntilDefault
             onChangeInput=(action (mut suspendUntil))
           }}
         </label>

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
@@ -6,6 +6,14 @@
     {{/if}}
 
     {{#if user.canSuspend}}
+      <div class="penalty-history">
+        <label>
+          {{i18n "admin.user.penalty_history"}}
+        </label>
+        <div class="suspended-count">{{i18n "admin.user.tl3_requirements.suspended"}}: {{user.penalty_counts.suspended}}</div>
+        <div class="silenced-count">{{i18n "admin.user.tl3_requirements.silenced"}}: {{user.penalty_counts.silenced}}</div>
+      </div>
+
       <div class="until-controls">
         <label>
           {{future-date-input

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
@@ -6,16 +6,7 @@
     {{/if}}
 
     {{#if user.canSuspend}}
-      <div class="penalty-history">
-        <div class="suspended-count {{suspendedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
-          <label>{{i18n "admin.user.suspended_count"}}</label>
-          <span>{{user.penalty_counts.suspended}}</span>
-        </div>
-        <div class="silenced-count {{silencedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
-          <label>{{i18n "admin.user.silenced_count"}}</label>
-          <span>{{user.penalty_counts.silenced}}</span>
-        </div>
-      </div>
+      {{admin-penalty-history user=user}}
 
       <div class="until-controls">
         <label>

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
@@ -22,6 +22,7 @@
             includeFarFuture=true
             clearable=false
             input=suspendUntil
+            initialInput=suspendUntilDefault
             onChangeInput=(action (mut suspendUntil))
           }}
         </label>

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-suspend-user.hbs
@@ -7,11 +7,14 @@
 
     {{#if user.canSuspend}}
       <div class="penalty-history">
-        <label>
-          {{i18n "admin.user.penalty_history"}}
-        </label>
-        <div class="suspended-count">{{i18n "admin.user.tl3_requirements.suspended"}}: {{user.penalty_counts.suspended}}</div>
-        <div class="silenced-count">{{i18n "admin.user.tl3_requirements.silenced"}}: {{user.penalty_counts.silenced}}</div>
+        <div class="suspended-count {{suspendedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
+          <label>{{i18n "admin.user.suspended_count"}}</label>
+          <span>{{user.penalty_counts.suspended}}</span>
+        </div>
+        <div class="silenced-count {{silencedCountClass}}" title={{i18n "admin.user.last_six_months"}}>
+          <label>{{i18n "admin.user.silenced_count"}}</label>
+          <span>{{user.penalty_counts.silenced}}</span>
+        </div>
       </div>
 
       <div class="until-controls">

--- a/app/assets/javascripts/discourse/app/components/future-date-input.js
+++ b/app/assets/javascripts/discourse/app/components/future-date-input.js
@@ -14,20 +14,6 @@ export default Component.extend({
   displayLabel: null,
   labelClasses: null,
 
-  init() {
-    this._super(...arguments);
-
-    let initialInput = this.input || this.initialInput;
-    if (initialInput) {
-      const datetime = moment(initialInput);
-      this.setProperties({
-        selection: "pick_date_and_time",
-        date: datetime.format("YYYY-MM-DD"),
-        time: datetime.format("HH:mm"),
-      });
-    }
-  },
-
   timeInputDisabled: empty("date"),
 
   @observes("date", "time")
@@ -52,6 +38,15 @@ export default Component.extend({
 
     if (this.label) {
       this.set("displayLabel", I18n.t(this.label));
+    }
+
+    if (this.input) {
+      const datetime = moment(this.input);
+      this.setProperties({
+        selection: "pick_date_and_time",
+        date: datetime.format("YYYY-MM-DD"),
+        time: datetime.format("HH:mm"),
+      });
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/components/future-date-input.js
+++ b/app/assets/javascripts/discourse/app/components/future-date-input.js
@@ -16,6 +16,18 @@ export default Component.extend({
 
   timeInputDisabled: empty("date"),
 
+  init() {
+    this._super(...arguments);
+    if (this.input) {
+      const datetime = moment(this.input);
+      this.setProperties({
+        selection: "pick_date_and_time",
+        date: datetime.format("YYYY-MM-DD"),
+        time: datetime.format("HH:mm"),
+      });
+    }
+  },
+
   @observes("date", "time")
   _updateInput() {
     if (!this.date) {
@@ -38,15 +50,6 @@ export default Component.extend({
 
     if (this.label) {
       this.set("displayLabel", I18n.t(this.label));
-    }
-
-    if (this.input) {
-      const datetime = moment(this.input);
-      this.setProperties({
-        selection: "pick_date_and_time",
-        date: datetime.format("YYYY-MM-DD"),
-        time: datetime.format("HH:mm"),
-      });
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/components/future-date-input.js
+++ b/app/assets/javascripts/discourse/app/components/future-date-input.js
@@ -17,8 +17,9 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    if (this.input) {
-      const datetime = moment(this.input);
+    let initialInput = this.input || this.initialInput;
+    if (initialInput) {
+      const datetime = moment(initialInput);
       this.setProperties({
         selection: "pick_date_and_time",
         date: datetime.format("YYYY-MM-DD"),

--- a/app/assets/stylesheets/common/admin/suspend.scss
+++ b/app/assets/stylesheets/common/admin/suspend.scss
@@ -35,4 +35,9 @@
       height: 10em;
     }
   }
+  .penalty-history {
+    margin-bottom: 1em;
+    padding-bottom: 0.5em;
+    border-bottom: 1px solid var(--primary-low);
+  }
 }

--- a/app/assets/stylesheets/common/admin/suspend.scss
+++ b/app/assets/stylesheets/common/admin/suspend.scss
@@ -39,5 +39,20 @@
     margin-bottom: 1em;
     padding-bottom: 0.5em;
     border-bottom: 1px solid var(--primary-low);
+    display: flex;
+    & > * {
+      flex-basis: 100%;
+      text-align: center;
+      padding: 1em 0;
+      font-weight: 600;
+      label {
+        font-weight: 600;
+        justify-content: center;
+      }
+    }
+    .danger {
+      background-color: var(--danger);
+      color: var(--secondary);
+    }
   }
 }

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -22,6 +22,7 @@ class AdminDetailedUserSerializer < AdminUserSerializer
              :full_suspend_reason,
              :suspended_till,
              :silence_reason,
+             :penalty_counts,
              :primary_group_id,
              :badge_count,
              :warnings_received_count,
@@ -94,6 +95,10 @@ class AdminDetailedUserSerializer < AdminUserSerializer
 
   def silence_reason
     object.silence_reason
+  end
+
+  def penalty_counts
+    TrustLevel3Requirements.new(object).penalty_counts
   end
 
   def silenced_by

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -23,6 +23,7 @@ class AdminDetailedUserSerializer < AdminUserSerializer
              :suspended_till,
              :silence_reason,
              :penalty_counts,
+             :next_penalty,
              :primary_group_id,
              :badge_count,
              :warnings_received_count,
@@ -99,6 +100,20 @@ class AdminDetailedUserSerializer < AdminUserSerializer
 
   def penalty_counts
     TrustLevel3Requirements.new(object).penalty_counts
+  end
+
+  def next_penalty
+    next_penalty = nil
+    begin
+      step_number = penalty_counts.total
+      steps = SiteSetting.penalty_step_hours.split('|')
+      step_number = [step_number, steps.length].min
+      penalty_hours = steps[step_number]
+      next_penalty = Integer(penalty_hours, 10).hours.from_now
+    rescue
+      next_penalty = nil
+    end
+    next_penalty
   end
 
   def silenced_by

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -103,17 +103,13 @@ class AdminDetailedUserSerializer < AdminUserSerializer
   end
 
   def next_penalty
-    next_penalty = nil
-    begin
-      step_number = penalty_counts.total
-      steps = SiteSetting.penalty_step_hours.split('|')
-      step_number = [step_number, steps.length].min
-      penalty_hours = steps[step_number]
-      next_penalty = Integer(penalty_hours, 10).hours.from_now
-    rescue
-      next_penalty = nil
-    end
-    next_penalty
+    step_number = penalty_counts.total
+    steps = SiteSetting.penalty_step_hours.split('|')
+    step_number = [step_number, steps.length].min
+    penalty_hours = steps[step_number]
+    Integer(penalty_hours, 10).hours.from_now
+  rescue
+    nil
   end
 
   def silenced_by

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4998,6 +4998,9 @@ en:
         trust_level_unlocked_tip: "trust level is unlocked, system will may promote or demote user"
         lock_trust_level: "Lock Trust Level"
         unlock_trust_level: "Unlock Trust Level"
+        silenced_count: "Silenced"
+        suspended_count: "Suspended"
+        last_six_months: "Last 6 months"
         tl3_requirements:
           title: "Requirements for Trust Level 3"
           table_title:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4858,6 +4858,7 @@ en:
         penalty_post_edit: "Edit the post"
         penalty_post_none: "Do nothing"
         penalty_count: "Penalty Count"
+        penalty_history: "Penalty History"
         clear_penalty_history:
           title: "Clear Penalty History"
           description: "users with penalties cannot reach TL3"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2160,6 +2160,7 @@ en:
     share_anonymized_statistics: "Share anonymized usage statistics."
 
     auto_handle_queued_age: "Automatically handle records that are waiting to be reviewed after this many days. Flags will be ignored. Queued posts and users will be rejected. Set to 0 to disable this feature."
+    penalty_step_hours: "Default penalties for silencing or suspending users in hours. First offense defaults to the first value, second offense defaults to the second value, etc."
     svg_icon_subset: "Add additional FontAwesome 5 icons that you would like to include in your assets. Use prefix 'fa-' for solid icons, 'far-' for regular icons and 'fab-' for brand icons."
     max_prints_per_hour_per_user: "Maximum number of /print page impressions (set to 0 to disable)"
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2270,6 +2270,11 @@ uncategorized:
     default: 60
     min: 0
 
+  penalty_step_hours:
+    default: "24|72|168|720"
+    type: "list"
+    list_type: "compact"
+
   svg_icon_subset:
     default: ""
     type: "list"


### PR DESCRIPTION
Two features here:

1: Add a history count when applying penalties to give moderators context to the user they are penalizing.

2: Add a site setting that designates default penalty values in hours.

Silence/suspend modals will auto-fill in the default values, but otherwise
will still allow moderators to pick and overwrite values as normal.

First silence/suspend: first value
Second silence/suspend: second value
etc.

Penalty counts are forgiven at the same rate as tl3 promotion requirements do.

![Screenshot from 2021-06-10 17-51-22](https://user-images.githubusercontent.com/1322534/121614868-81c10780-ca14-11eb-942b-396181decaff.png)

![Screenshot from 2021-06-10 17-51-48](https://user-images.githubusercontent.com/1322534/121614897-900f2380-ca14-11eb-9670-7c4c39880987.png)

![Screenshot from 2021-06-10 17-52-31](https://user-images.githubusercontent.com/1322534/121614945-a74e1100-ca14-11eb-8749-ca0b79727d85.png)
