### PR TITLE
FIX: Show group Email settings if just SMTP enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-manage.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-manage.js
@@ -29,7 +29,7 @@ export default Controller.extend({
     });
 
     if (!automatic) {
-      if (this.siteSettings.enable_imap && this.siteSettings.enable_smtp) {
+      if (this.siteSettings.enable_smtp) {
         defaultTabs.splice(2, 0, {
           route: "group.manage.email",
           title: "groups.manage.email.title",

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
@@ -9,6 +9,10 @@ acceptance("Managing Group Email Settings - SMTP Disabled", function (needs) {
 
   test("When SiteSetting.enable_smtp is false", async function (assert) {
     await visit("/g/discourse/manage/email");
+    assert.notOk(
+      queryAll(".user-secondary-navigation").text().includes("Email"),
+      "email link is not shown in the sidebar"
+    );
     assert.equal(
       currentRouteName(),
       "group.manage.profile",
@@ -25,6 +29,10 @@ acceptance(
 
     test("When SiteSetting.enable_smtp is true but SiteSetting.enable_imap is false", async function (assert) {
       await visit("/g/discourse/manage/email");
+      assert.ok(
+        queryAll(".user-secondary-navigation").text().includes("Email"),
+        "email link is shown in the sidebar"
+      );
       assert.equal(
         currentRouteName(),
         "group.manage.email",
@@ -59,6 +67,10 @@ acceptance(
 
     test("enabling SMTP, testing, and saving", async function (assert) {
       await visit("/g/discourse/manage/email");
+      assert.ok(
+        queryAll(".user-secondary-navigation").text().includes("Email"),
+        "email link is shown in the sidebar"
+      );
       assert.ok(
         exists("#enable_imap:disabled"),
         "IMAP is disabled until SMTP settings are valid"


### PR DESCRIPTION
We previously only showed the link to the Email section
of group settings if both SMTP and IMAP were enabled for
a site, but this is not necessary now, only SMTP can be
enabled by itself so we should show the section if SMTP
is enabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
