### PR TITLE
PERF: Remove extra PG query.

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -395,8 +395,7 @@ class Stylesheet::Manager
 
   def theme_digest
     if [:mobile_theme, :desktop_theme].include?(@target)
-      scss_digest = theme.resolve_baked_field(:common, :scss)
-      scss_digest += theme.resolve_baked_field(@target.to_s.sub("_theme", ""), :scss)
+      scss_digest = theme.resolve_baked_field(@target.to_s.sub("_theme", ""), :scss)
     elsif @target == :embedded_theme
       scss_digest = theme.resolve_baked_field(:common, :embedded_scss)
     else


### PR DESCRIPTION
In `Theme.list_baked_fields`, common is always included as a target.

```
SELECT "theme_fields".* FROM "theme_fields" JOIN (
          SELECT 160 AS theme_id, 0 AS theme_sort_column
        ) as X ON X.theme_id = theme_fields.theme_id WHERE "theme_fields"."theme_id" = 160 AND "theme_fields"."target_id" IN (0, 0) AND "theme_fields"."name" = 'scss' ORDER BY theme_sort_column, "theme_fields"."target_id" ASC; 
```

```
SELECT "theme_fields".* FROM "theme_fields" JOIN (
          SELECT 160 AS theme_id, 0 AS theme_sort_column
        ) as X ON X.theme_id = theme_fields.theme_id WHERE "theme_fields"."theme_id" = 160 AND "theme_fields"."target_id" IN (1, 0) AND "theme_fields"."name" = 'scss' ORDER BY theme_sort_column, "theme_fields"."target_id" ASC; 
```

The latter query will return overlapping results as the query before so we only need the latter query.