### PR TITLE
FIX: TL4 users can see their deleted posts

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -233,9 +233,9 @@ module PostGuardian
     return true if is_admin?
     return false unless can_see_topic?(post.topic)
     return false unless post.user == @user || Topic.visible_post_types(@user).include?(post.post_type)
-    return false if !(is_moderator? || is_category_group_moderator?(post.topic.category)) && post.deleted_at.present?
-
-    true
+    return true if is_moderator? || is_category_group_moderator?(post.topic.category)
+    return true if post.deleted_at.blank? || (post.deleted_by_id == @user.id && @user.has_trust_level?(TrustLevel[4]))
+    false
   end
 
   def can_view_edit_history?(post)

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -902,6 +902,17 @@ describe Guardian do
         expect(Guardian.new(user_gm).can_see?(post)).to be_truthy
       end
 
+      it 'TL4 users can see their deleted posts' do
+        user = Fabricate(:user, trust_level: 4)
+        user2 = Fabricate(:user, trust_level: 4)
+        post = Fabricate(:post, user: user, topic: Fabricate(:post).topic)
+
+        expect(Guardian.new(user).can_see?(post)).to eq(true)
+        PostDestroyer.new(user, post).destroy
+        expect(Guardian.new(user).can_see?(post)).to eq(true)
+        expect(Guardian.new(user2).can_see?(post)).to eq(false)
+      end
+
       it 'respects whispers' do
         regular_post = post
         whisper_post = Fabricate.build(:post, post_type: Post.types[:whisper])


### PR DESCRIPTION
They were able to delete their posts, but then could not recover them because they did not have the permissions to see them.