### PR TITLE
FIX: Adjust styling of first notification

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -531,7 +531,7 @@ table {
 
   .first-notification,
   .read-later {
-    display: inline-block;
+    display: block;
     margin-bottom: 36px;
   }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -527,7 +527,7 @@ class User < ActiveRecord::Base
   end
 
   def unread_high_priority_notifications
-    @unread_high_prios ||= unread_notifications_of_priority(high_priority: true)
+    1
   end
 
   # PERF: This safeguard is in place to avoid situations where
@@ -584,14 +584,7 @@ class User < ActiveRecord::Base
   TRACK_FIRST_NOTIFICATION_READ_DURATION = 1.week.to_i
 
   def read_first_notification?
-    if (trust_level > TrustLevel[1] ||
-        (first_seen_at.present? && first_seen_at < TRACK_FIRST_NOTIFICATION_READ_DURATION.seconds.ago) ||
-        user_option.skip_new_user_tips)
-
-      return true
-    end
-
-    self.seen_notification_id == 0 ? false : true
+    false
   end
 
   def publish_notifications_state

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -527,7 +527,7 @@ class User < ActiveRecord::Base
   end
 
   def unread_high_priority_notifications
-    1
+    @unread_high_prios ||= unread_notifications_of_priority(high_priority: true)
   end
 
   # PERF: This safeguard is in place to avoid situations where
@@ -584,7 +584,14 @@ class User < ActiveRecord::Base
   TRACK_FIRST_NOTIFICATION_READ_DURATION = 1.week.to_i
 
   def read_first_notification?
-    false
+    if (trust_level > TrustLevel[1] ||
+        (first_seen_at.present? && first_seen_at < TRACK_FIRST_NOTIFICATION_READ_DURATION.seconds.ago) ||
+        user_option.skip_new_user_tips)
+
+      return true
+    end
+
+    self.seen_notification_id == 0 ? false : true
   end
 
   def publish_notifications_state


### PR DESCRIPTION
### After
<img width="481" alt="Screen Shot 2021-06-11 at 2 46 16 PM" src="https://user-images.githubusercontent.com/30537603/121741577-539b0080-cac4-11eb-8577-a22c09f0e662.png">


### Before
<img width="468" alt="Screen Shot 2021-06-11 at 2 46 39 PM" src="https://user-images.githubusercontent.com/30537603/121741537-4847d500-cac4-11eb-8039-675737ffc25a.png">

