### PR TITLE
FIX: Do not keep old URL in history

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/topic-by-slug-or-id.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-by-slug-or-id.js
@@ -12,6 +12,17 @@ export default DiscourseRoute.extend({
   },
 
   afterModel(result) {
-    DiscourseURL.routeTo(result.url, { replaceURL: true });
+    // Using { replaceURL: true } to replace the current incomplete URL with
+    // the complete one is working incorrectly.
+    //
+    // Let's consider an example where the user is at /t/-/1. If they click on
+    // a link to /t/2 the expected behavior is to take the user to /t/2 that
+    // will redirect to /t/-/2 and generate a history with two entries: /t/-/1
+    // followed by /t/-/2.
+    //
+    // When { replaceURL: true } is present, the history contains a single
+    // entry /t/-/2. This suggests that `afterModel` is called in the context
+    // of the referrer replacing its entry with the new one.
+    DiscourseURL.routeTo(result.url);
   },
 });


### PR DESCRIPTION
Clicking on an incomplete link to a topic (/t/ID or /t/SLUG) from
another post could replace current history entry or create two: one for
the incomplete URL and another one for the correct one. Going back was
either impossible or took the user to a redirect loop, redirected back
to /t/ID which redirected them again to /t/SLUG/ID.
