### PR TITLE
FIX: De-prioritize composer category on navigation

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -202,6 +202,8 @@ export default (filterArg, params) => {
 
     deactivate() {
       this._super(...arguments);
+
+      this.controllerFor("composer").set("prioritizedCategoryId", null);
       this.searchService.set("searchContext", null);
     },
 


### PR DESCRIPTION
Not really a "fix", but better aligns the feature with my initial idea.