### PR TITLE
FIX: Render detailed_404 page from 403 responses

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/exception.js
+++ b/app/assets/javascripts/discourse/app/controllers/exception.js
@@ -51,6 +51,9 @@ export default Controller.extend({
   isServer: gte("thrown.status", 500),
   isUnknown: none("isNetwork", "isServer"),
 
+  // Handling for the detailed_404 setting (which actually creates 403s)
+  errorHtml: alias("thrown.responseJSON.extras.html"),
+
   // TODO
   // make ajax requests to /srv/status with exponential backoff
   // if one succeeds, set networkFixed to true, which puts a "Fixed!" message on the page

--- a/app/assets/javascripts/discourse/app/controllers/exception.js
+++ b/app/assets/javascripts/discourse/app/controllers/exception.js
@@ -1,5 +1,6 @@
 import { alias, equal, gte, none } from "@ember/object/computed";
 import discourseComputed, { on } from "discourse-common/utils/decorators";
+import DiscourseURL from "discourse/lib/url";
 import Controller from "@ember/controller";
 import I18n from "I18n";
 import { schedule } from "@ember/runloop";
@@ -31,15 +32,15 @@ export default Controller.extend({
   thrown: null,
   lastTransition: null,
 
-  @discourseComputed
-  isNetwork() {
+  @discourseComputed("thrown")
+  isNetwork(thrown) {
     // never made it on the wire
-    if (this.get("thrown.readyState") === 0) {
+    if (thrown && thrown.readyState === 0) {
       return true;
     }
 
     // timed out
-    if (this.get("thrown.jqTextStatus") === "timeout") {
+    if (thrown && thrown.jqTextStatus === "timeout") {
       return true;
     }
 
@@ -65,16 +66,18 @@ export default Controller.extend({
     this.set("loading", false);
   },
 
-  @discourseComputed("isNetwork", "isServer", "isUnknown")
-  reason() {
-    if (this.isNetwork) {
+  @discourseComputed("isNetwork", "thrown.status", "thrown")
+  reason(isNetwork, thrownStatus, thrown) {
+    if (isNetwork) {
       return I18n.t("errors.reasons.network");
-    } else if (this.isServer) {
+    } else if (thrownStatus >= 500) {
       return I18n.t("errors.reasons.server");
-    } else if (this.isNotFound) {
+    } else if (thrownStatus === 404) {
       return I18n.t("errors.reasons.not_found");
-    } else if (this.isForbidden) {
+    } else if (thrownStatus === 403) {
       return I18n.t("errors.reasons.forbidden");
+    } else if (thrown === null) {
+      return I18n.t("errors.reasons.unknown");
     } else {
       // TODO
       return I18n.t("errors.reasons.unknown");
@@ -83,30 +86,42 @@ export default Controller.extend({
 
   requestUrl: alias("thrown.requestedUrl"),
 
-  @discourseComputed("networkFixed", "isNetwork", "isServer", "isUnknown")
-  desc() {
-    if (this.networkFixed) {
+  @discourseComputed(
+    "networkFixed",
+    "isNetwork",
+    "thrown.status",
+    "thrown.statusText",
+    "thrown"
+  )
+  desc(networkFixed, isNetwork, thrownStatus, thrownStatusText, thrown) {
+    if (networkFixed) {
       return I18n.t("errors.desc.network_fixed");
-    } else if (this.isNetwork) {
+    } else if (isNetwork) {
       return I18n.t("errors.desc.network");
-    } else if (this.isNotFound) {
+    } else if (thrownStatus === 404) {
       return I18n.t("errors.desc.not_found");
-    } else if (this.isServer) {
+    } else if (thrownStatus === 403) {
+      return I18n.t("errors.desc.forbidden");
+    } else if (thrownStatus >= 500) {
       return I18n.t("errors.desc.server", {
-        status: this.get("thrown.status") + " " + this.get("thrown.statusText"),
+        status: thrownStatus + " " + thrownStatusText,
       });
+    } else if (thrown === null) {
+      return I18n.t("errors.desc.unknown");
     } else {
       // TODO
       return I18n.t("errors.desc.unknown");
     }
   },
 
-  @discourseComputed("networkFixed", "isNetwork", "isServer", "isUnknown")
-  enabledButtons() {
-    if (this.networkFixed) {
+  @discourseComputed("networkFixed", "isNetwork", "lastTransition")
+  enabledButtons(networkFixed, isNetwork, lastTransition) {
+    if (networkFixed) {
       return [ButtonLoadPage];
-    } else if (this.isNetwork) {
+    } else if (isNetwork) {
       return [ButtonBackDim, ButtonTryAgain];
+    } else if (!lastTransition) {
+      return [ButtonBackBright];
     } else {
       return [ButtonBackBright, ButtonTryAgain];
     }
@@ -114,14 +129,25 @@ export default Controller.extend({
 
   actions: {
     back() {
-      window.history.back();
+      // Strip off subfolder
+      const currentURL = DiscourseURL.router.location.getURL();
+      if (this.lastTransition && currentURL !== "/exception") {
+        this.lastTransition.abort();
+        this.setProperties({ lastTransition: null, thrown: null });
+        // Can't use routeTo because it handles navigation to the same page
+        DiscourseURL.handleURL(currentURL);
+      } else {
+        window.history.back();
+      }
     },
 
     tryLoading() {
       this.set("loading", true);
 
       schedule("afterRender", () => {
-        this.lastTransition.retry();
+        const transition = this.lastTransition;
+        this.setProperties({ lastTransition: null, thrown: null });
+        transition.retry();
         this.set("loading", false);
       });
     },

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -483,6 +483,7 @@ const DiscourseURL = EmberObject.extend({
 
     transition._discourse_intercepted = true;
     transition._discourse_anchor = elementId;
+    transition._discourse_original_url = path;
 
     const promise = transition.promise || transition;
     promise.then(() => jumpToElement(elementId));

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -94,13 +94,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
     },
 
     error(err, transition) {
-      let xhr = {};
-      if (err.jqXHR) {
-        xhr = err.jqXHR;
-      }
-
-      const xhrOrErr = err.jqXHR ? xhr : err;
-
+      const xhrOrErr = err.jqXHR ? err.jqXHR : err;
       const exceptionController = this.controllerFor("exception");
 
       const c = window.console;

--- a/app/assets/javascripts/discourse/app/templates/exception.hbs
+++ b/app/assets/javascripts/discourse/app/templates/exception.hbs
@@ -5,9 +5,11 @@
     <div class="error-page">
       <div class="face">:(</div>
       <div class="reason">{{reason}}</div>
-      <div class="url">
-        {{i18n "errors.prev_page"}} <a href={{requestUrl}} data-auto-route="true">{{requestUrl}}</a>
-      </div>
+      {{#if requestUrl}}
+        <div class="url">
+          {{i18n "errors.prev_page"}} <a href={{requestUrl}} data-auto-route="true">{{requestUrl}}</a>
+        </div>
+      {{/if}}
       <div class="desc">
         {{#if networkFixed}}
           {{d-icon "check-circle"}}

--- a/app/assets/javascripts/discourse/app/templates/exception.hbs
+++ b/app/assets/javascripts/discourse/app/templates/exception.hbs
@@ -1,22 +1,26 @@
 <div class="container">
-  <div class="error-page">
-    <div class="face">:(</div>
-    <div class="reason">{{reason}}</div>
-    <div class="url">
-      {{i18n "errors.prev_page"}} <a href={{requestUrl}} data-auto-route="true">{{requestUrl}}</a>
-    </div>
-    <div class="desc">
-      {{#if networkFixed}}
-        {{d-icon "check-circle"}}
-      {{/if}}
+  {{#if (and this.errorHtml this.isForbidden)}}
+    <div class="not-found">{{html-safe this.errorHtml}}</div>
+  {{else}}
+    <div class="error-page">
+      <div class="face">:(</div>
+      <div class="reason">{{reason}}</div>
+      <div class="url">
+        {{i18n "errors.prev_page"}} <a href={{requestUrl}} data-auto-route="true">{{requestUrl}}</a>
+      </div>
+      <div class="desc">
+        {{#if networkFixed}}
+          {{d-icon "check-circle"}}
+        {{/if}}
 
-      {{desc}}
+        {{desc}}
+      </div>
+      <div class="buttons">
+        {{#each enabledButtons as |buttonData|}}
+          {{d-button icon=buttonData.icon action=buttonData.action label=buttonData.key class=buttonData.classes}}
+        {{/each}}
+        {{conditional-loading-spinner condition=loading}}
+      </div>
     </div>
-    <div class="buttons">
-      {{#each enabledButtons as |buttonData|}}
-        {{d-button icon=buttonData.icon action=buttonData.action label=buttonData.key class=buttonData.classes}}
-      {{/each}}
-      {{conditional-loading-spinner condition=loading}}
-    </div>
-  </div>
+  {{/if}}
 </div>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -299,7 +299,7 @@ class ApplicationController < ActionController::Base
       with_resolved_locale(check_current_user: false) do
         # Include error in HTML format for topics#show.
         if (request.params[:controller] == 'topics' && request.params[:action] == 'show') || (request.params[:controller] == 'categories' && request.params[:action] == 'find_by_slug')
-          opts[:extras] = { html: build_not_found_page(error_page_opts) }
+          opts[:extras] = { html: build_not_found_page(error_page_opts), group: error_page_opts[:group] }
         end
       end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -214,6 +214,7 @@ class CategoriesController < ApplicationController
           'not in group',
           @category,
           custom_message: 'not_in_group.title_category',
+          custom_message_params: { group: group.name },
           group: group
         )
       else

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -294,7 +294,7 @@ en:
   invalid_whisper_access: "Either whispers are not enabled or you do not have access to create whisper posts"
   not_in_group:
     title_topic: "You need to request membership to the '%{group}' group to see this topic."
-    title_category: "You must be in a group to see this category."
+    title_category: "You need to request membership to the '%{group}' group to see this category."
     request_membership: "Request Membership"
     join_group: "Join Group"
   deleted_topic: "Oops! This topic has been deleted and is no longer available."


### PR DESCRIPTION
https://meta.discourse.org/t/detailled-404-for-category-page/171444/

This was previously broken by 59ef48c0b9d70a6639a545d1c96f3cc6f93ebf2c (#11425, #11424, https://meta.discourse.org/t/error-page-appears-repeatedly-after-you-try-accessing-a-private-page/170557/).

Centralize the logic into the exception controller, which avoids the problematic bug and makes it easy to add additional detailed 404 pages in the future.

:warning: This commit is a localization break. Translators should copy the `not_in_group.title_topic` key to the `not_in_group.title_category` key, changing "topic" to "category".

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
