### PR TITLE
FIX: Make sure topic_user.bookmarked is synced in more places

### DIFF
--- a/app/jobs/regular/sync_topic_user_bookmarked.rb
+++ b/app/jobs/regular/sync_topic_user_bookmarked.rb
@@ -8,7 +8,9 @@ module Jobs
       DB.exec(<<~SQL, topic_id: topic_id)
         UPDATE topic_users SET bookmarked = true
         FROM bookmarks AS b
+        INNER JOIN posts ON posts.id = b.post_id
         WHERE NOT topic_users.bookmarked AND
+          posts.deleted_at IS NULL AND
           topic_users.topic_id = b.topic_id AND
           topic_users.user_id = b.user_id #{topic_id.present? ? "AND topic_users.topic_id = :topic_id" : ""}
       SQL
@@ -17,9 +19,12 @@ module Jobs
         UPDATE topic_users SET bookmarked = false
         WHERE topic_users.bookmarked AND
           (
-            SELECT COUNT(*) FROM bookmarks
-            WHERE topic_id = topic_users.topic_id
-            AND user_id = topic_users.user_id
+            SELECT COUNT(*)
+            FROM bookmarks
+            INNER JOIN posts ON posts.id = bookmarks.post_id
+            WHERE bookmarks.topic_id = topic_users.topic_id
+            AND bookmarks.user_id = topic_users.user_id
+            AND posts.deleted_at IS NULL
         ) = 0 #{topic_id.present? ? "AND topic_users.topic_id = :topic_id" : ""}
       SQL
     end

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -76,6 +76,7 @@ class PostDestroyer
 
     DiscourseEvent.trigger(:post_destroyed, @post, @opts, @user)
     WebHook.enqueue_post_hooks(:post_destroyed, @post, payload)
+    Jobs.enqueue(:sync_topic_user_bookmarked, topic_id: topic.id) if topic
 
     if is_first_post
       UserProfile.remove_featured_topic_from_all_profiles(@topic)
@@ -95,8 +96,11 @@ class PostDestroyer
     topic.update_column(:user_id, Discourse::SYSTEM_USER_ID) if !topic.user_id
     topic.recover!(@user) if @post.is_first_post?
     topic.update_statistics
+
     UserActionManager.post_created(@post)
     DiscourseEvent.trigger(:post_recovered, @post, @opts, @user)
+    Jobs.enqueue(:sync_topic_user_bookmarked, topic_id: topic.id) if topic
+
     if @post.is_first_post?
       UserActionManager.topic_created(topic)
       DiscourseEvent.trigger(:topic_recovered, topic, @user)

--- a/spec/jobs/sync_topic_user_bookmarked_spec.rb
+++ b/spec/jobs/sync_topic_user_bookmarked_spec.rb
@@ -27,6 +27,24 @@ RSpec.describe Jobs::SyncTopicUserBookmarked do
     expect(tu5.reload.bookmarked).to eq(false)
   end
 
+  it "does not consider topic as bookmarked if the bookmarked post is deleted" do
+    topic = Fabricate(:topic)
+    post1 = Fabricate(:post, topic: topic)
+
+    tu1 = Fabricate(:topic_user, topic: topic, bookmarked: false)
+    tu2 = Fabricate(:topic_user, topic: topic, bookmarked: true)
+
+    Fabricate(:bookmark, user: tu1.user, topic: topic, post: post1)
+    Fabricate(:bookmark, user: tu2.user, topic: topic, post: post1)
+
+    post1.trash!
+
+    subject.execute(topic_id: topic.id)
+
+    expect(tu1.reload.bookmarked).to eq(false)
+    expect(tu2.reload.bookmarked).to eq(false)
+  end
+
   it "works when no topic id is provided (runs for all topics)" do
     topic = Fabricate(:topic)
     Fabricate(:post, topic: topic)


### PR DESCRIPTION
When we call Bookmark.cleanup! we want to make sure that
topic_user.bookmarked is updated for topics linked to the
bookmarks that were deleted. Also when PostDestroyer calls
destroy and recover. We have a job for this already --
SyncTopicUserBookmarked -- so we just utilize that.