### PR TITLE
FIX: refresh post stream after in-place post updates

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -992,6 +992,7 @@ const Composer = RestModel.extend({
       .catch(rollback)
       .finally(() => {
         post.set("staged", false);
+        this.appEvents.trigger("post-stream:refresh", { id: post.id });
       });
   },
 


### PR DESCRIPTION
Changing the staged attribute on a post means we also need to re-render.

Previously certain edits would not issue a refresh leaving a post greyed out.
