### PR TITLE
FIX: Update raw and cooked immediate after edit

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -929,6 +929,7 @@ const Composer = RestModel.extend({
 
   editPost(opts) {
     const post = this.post;
+    const oldRaw = post.raw;
     const oldCooked = post.cooked;
     let promise = Promise.resolve();
 
@@ -970,14 +971,14 @@ const Composer = RestModel.extend({
     this.set("composeState", SAVING);
 
     const rollback = throwAjaxError((error) => {
-      post.set("cooked", oldCooked);
+      post.setProperties({ raw: oldRaw, cooked: oldCooked });
       this.set("composeState", OPEN);
       if (error.jqXHR && error.jqXHR.status === 409) {
         this.set("editConflict", true);
       }
     });
 
-    post.setProperties({ cooked: props.cooked, staged: true });
+    post.setProperties({ raw: props.raw, cooked: props.cooked, staged: true });
     this.appEvents.trigger("post-stream:refresh", { id: post.id });
 
     return promise

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -970,9 +970,7 @@ const Composer = RestModel.extend({
     this.set("composeState", SAVING);
 
     const rollback = throwAjaxError((error) => {
-      post.setProperties({ cooked: oldCooked, staged: false });
-      this.appEvents.trigger("post-stream:refresh", { id: post.id });
-
+      post.set("cooked", oldCooked);
       this.set("composeState", OPEN);
       if (error.jqXHR && error.jqXHR.status === 409) {
         this.set("editConflict", true);

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
@@ -14,26 +14,23 @@ acceptance("Composer - Edit conflict", function (needs) {
     });
   });
 
-  QUnit.skip(
-    "Edit a post that causes an edit conflict",
-    async function (assert) {
-      await visit("/t/internationalization-localization/280");
-      await click(".topic-post:nth-of-type(1) button.show-more-actions");
-      await click(".topic-post:nth-of-type(1) button.edit");
-      await fillIn(".d-editor-input", "this will 409");
-      await click("#reply-control button.create");
-      assert.equal(
-        queryAll("#reply-control button.create").text().trim(),
-        I18n.t("composer.overwrite_edit"),
-        "it shows the overwrite button"
-      );
-      assert.ok(
-        queryAll("#draft-status .d-icon-user-edit"),
-        "error icon should be there"
-      );
-      await click(".modal .btn-primary");
-    }
-  );
+  test("Edit a post that causes an edit conflict", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.edit");
+    await fillIn(".d-editor-input", "this will 409");
+    await click("#reply-control button.create");
+    assert.equal(
+      queryAll("#reply-control button.create").text().trim(),
+      I18n.t("composer.overwrite_edit"),
+      "it shows the overwrite button"
+    );
+    assert.ok(
+      queryAll("#draft-status .d-icon-user-edit"),
+      "error icon should be there"
+    );
+    await click(".modal .btn-primary");
+  });
 
   test("Should not send originalText when posting a new reply", async function (assert) {
     await visit("/t/internationalization-localization/280");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -348,7 +348,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  QUnit.skip("Editing a post stages new content", async function (assert) {
+  test("Editing a post stages new content", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post:nth-of-type(1) button.show-more-actions");
     await click(".topic-post:nth-of-type(1) button.edit");
@@ -367,26 +367,23 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  QUnit.skip(
-    "Editing a post can rollback to old content",
-    async function (assert) {
-      await visit("/t/internationalization-localization/280");
-      await click(".topic-post:nth-of-type(1) button.show-more-actions");
-      await click(".topic-post:nth-of-type(1) button.edit");
+  test("Editing a post can rollback to old content", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click(".topic-post:nth-of-type(1) button.show-more-actions");
+    await click(".topic-post:nth-of-type(1) button.edit");
 
-      await fillIn(".d-editor-input", "this will 409");
-      await fillIn("#reply-title", "This is the new text for the title");
-      await click("#reply-control button.create");
+    await fillIn(".d-editor-input", "this will 409");
+    await fillIn("#reply-title", "This is the new text for the title");
+    await click("#reply-control button.create");
 
-      assert.ok(!exists(".topic-post.staged"));
-      assert.equal(
-        find(".topic-post .cooked")[0].innerText,
-        "Any plans to support localization of UI elements, so that I (for example) could set up a completely German speaking forum?"
-      );
+    assert.ok(!exists(".topic-post.staged"));
+    assert.equal(
+      find(".topic-post .cooked")[0].innerText,
+      "Any plans to support localization of UI elements, so that I (for example) could set up a completely German speaking forum?"
+    );
 
-      await click(".bootbox.modal .btn-primary");
-    }
-  );
+    await click(".bootbox.modal .btn-primary");
+  });
 
   test("Composer can switch between edits", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -1,6 +1,7 @@
 import Pretender from "pretender";
 import User from "discourse/models/user";
 import getURL from "discourse-common/lib/get-url";
+import { Promise } from "rsvp";
 
 export function parsePostData(query) {
   const result = {};
@@ -479,12 +480,15 @@ export function applyDefaultHandlers(pretender) {
   pretender.put("/posts/:post_id/recover", success);
   pretender.get("/posts/:post_id/expand-embed", success);
 
-  pretender.put("/posts/:post_id", (request) => {
+  pretender.put("/posts/:post_id", async (request) => {
     const data = parsePostData(request.requestBody);
     if (data.post.raw === "this will 409") {
       return response(409, { errors: ["edit conflict"] });
     } else if (data.post.raw === "will return empty json") {
-      return response(200, {});
+      window.resolveLastPromise();
+      return new Promise((resolve) => {
+        window.resolveLastPromise = resolve;
+      }).then(() => response(200, {}));
     }
     data.post.id = request.params.post_id;
     data.post.version = 2;


### PR DESCRIPTION
Cooked field used to be updated immediately, but raw was updated by other means. The post stream was refreshed twice, once after saving and another one after the whole process almost finished.