### PR TITLE
DEV: Skip CSS watcher when running QUnit tests and expose more Chrome logs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,7 +84,7 @@ Discourse::Application.configure do
     config.developer_emails = emails.split(",").map(&:downcase).map(&:strip)
   end
 
-  if defined?(Rails::Server) || defined?(Puma) || defined?(Unicorn)
+  if ENV["DISCOURSE_SKIP_CSS_WATCHER"] != "1" && (defined?(Rails::Server) || defined?(Puma) || defined?(Unicorn))
     require 'stylesheet/watcher'
     STDERR.puts "Starting CSS change watcher"
     @watcher = Stylesheet::Watcher.watch

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -49,7 +49,8 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
       "SKIP_ENFORCE_HOSTNAME" => "1",
       "UNICORN_PID_PATH" => "#{Rails.root}/tmp/pids/unicorn_test_#{port}.pid", # So this can run alongside development
       "UNICORN_PORT" => port.to_s,
-      "UNICORN_SIDEKIQS" => "0"
+      "UNICORN_SIDEKIQS" => "0",
+      "DISCOURSE_SKIP_CSS_WATCHER" => "1"
     },
     "#{Rails.root}/bin/unicorn -c config/unicorn.conf.rb",
     pgroup: true

--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -75,7 +75,19 @@ async function runAllTests() {
     }
   }
 
-  const { Inspector, Page, Runtime } = protocol;
+  const { Inspector, Page, Runtime, Log } = protocol;
+
+  // Documentation https://chromedevtools.github.io/devtools-protocol/tot/Log/#type-LogEntry
+  Log.enable();
+  Log.entryAdded(({ entry }) => {
+    let message = `${new Date(entry.timestamp).toISOString()} - (type: ${
+      entry.source
+    }/${entry.level}) message: ${entry.text}`;
+    if (entry.url) {
+      message += `, url: ${entry.url}`;
+    }
+    console.log(message);
+  });
 
   // eslint-disable-next-line
   await Promise.all([Inspector.enable(), Page.enable(), Runtime.enable()]);


### PR DESCRIPTION
There are 2 changes in this PR:

1) Add a new environment variable called `DISCOURSE_SKIP_CSS_WATCHER` to disable our stylesheet watcher, and make the `qunit:test` rake task set this variable on the Unicorn/Rails server it spins up to disable our stylesheet watcher when running the tests because it doesn't really need it.

2) Print more Chrome logs (such as network/security errors) to the console. 