### PR TITLE
FIX: Sort filelists to ensure consistant asset precompilation hash

### DIFF
--- a/lib/i18n/backend/discourse_i18n.rb
+++ b/lib/i18n/backend/discourse_i18n.rb
@@ -38,7 +38,7 @@ module I18n
       end
 
       def self.sort_locale_files(files)
-        files.sort_by do |filename|
+        files.sort.sort_by do |filename|
           matches = /(?:client|server)-([1-9]|[1-9][0-9]|100)\..+\.yml/.match(filename)
           matches&.[](1)&.to_i || 0
         end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -755,7 +755,7 @@ class Plugin::Instance
       root_path = "#{File.dirname(@path)}/assets/javascripts"
       admin_path = "#{File.dirname(@path)}/admin/assets/javascripts"
 
-      Dir.glob(["#{root_path}/**/*", "#{admin_path}/**/*"]) do |f|
+      Dir.glob(["#{root_path}/**/*", "#{admin_path}/**/*"]).sort.each do |f|
         f_str = f.to_s
         if File.directory?(f)
           yield [f, true]


### PR DESCRIPTION
Dir.glob and certain other filesystem commands do not guarantee file order and can change their output when ran on different machines.
This means that running asset precompilation on the exact same codebase will output
different content hashes.

This issue is difficult to reproduce because it depends on how the source files are stored in the filesystem. There are no tests included with this PR for this reason.

In the future, Ruby 3 provides `:sort` options that are enabled by default and would fix this issue. https://ruby-doc.org/core-3.0.1/Dir.html#method-c-glob

CONTEXT:

When our company built discourse on different machines, we noticed the asset files would be different. This was causing issues for us. Inspecting the compiled asset files didn't appear to show any differences, other than a few file lists (plugins, etc.) being in a different order. After diving into the code, we realized that this appeared to be caused by file globbing. We know that Sprockets will sort files [1][2] so this could only be caused by custom file lists within the Discourse application. 

We have been using this code change as a patch and have not seen this issue since we started using it 3 months ago.

[[1]](https://github.com/rails/sprockets/blob/2c38d99930421c22896a65e1d384edf90830f4c3/lib/sprockets/path_utils.rb#L64)[[2]](https://github.com/rails/sprockets/blob/2c38d99930421c22896a65e1d384edf90830f4c3/lib/sprockets/path_utils.rb#L327)
