### PR TITLE
FIX: Make sure reset-new for tracked is not limited by per_page count

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -968,7 +968,7 @@ class TopicsController < ApplicationController
         Topic.joins(:tags).where(tags: { name: params[:tag_id] })
       else
         if params[:tracked].to_s == "true"
-          TopicQuery.tracked_filter(TopicQuery.new(current_user).new_results, current_user.id)
+          TopicQuery.tracked_filter(TopicQuery.new(current_user).new_results(limit: false), current_user.id)
         else
           current_user.user_stat.update_column(:new_since, Time.zone.now)
           Topic

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -7,6 +7,7 @@
 
 class TopicQuery
   PG_MAX_INT ||= 2147483647
+  DEFAULT_PER_PAGE_COUNT ||= 30
 
   def self.validators
     @validators ||= begin
@@ -578,7 +579,7 @@ class TopicQuery
   protected
 
   def per_page_setting
-    30
+    DEFAULT_PER_PAGE_COUNT
   end
 
   def private_messages_for(user, type)
@@ -702,7 +703,7 @@ class TopicQuery
   # Create results based on a bunch of default options
   def default_results(options = {})
     options.reverse_merge!(@options)
-    options.reverse_merge!(per_page: per_page_setting)
+    options.reverse_merge!(per_page: per_page_setting) unless options[:limit] == false
 
     # Whether to return visible topics
     options[:visible] = true if @user.nil? || @user.regular?

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -749,16 +749,6 @@ HTML
 
   describe "automatic recompile" do
     it 'must recompile after bumping theme_field version' do
-      def stub_const(target, const, value)
-        old = target.const_get(const)
-        target.send(:remove_const, const)
-        target.const_set(const, value)
-        yield
-      ensure
-        target.send(:remove_const, const)
-        target.const_set(const, old)
-      end
-
       child.set_field(target: :common, name: "header", value: "World")
       child.set_field(target: :extra_js, name: "test.js.es6", value: "const hello = 'world';")
       child.save!

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -181,4 +181,14 @@ module Helpers
     `cd #{repo_dir} && git commit -am 'first commit'`
     repo_dir
   end
+
+  def stub_const(target, const, value)
+    old = target.const_get(const)
+    target.send(:remove_const, const)
+    target.const_set(const, value)
+    yield
+  ensure
+    target.send(:remove_const, const)
+    target.const_set(const, old)
+  end
 end


### PR DESCRIPTION
When dismissing new topics for the Tracked filter, the dismiss was
limited to 30 topics which is the default per page count for TopicQuery.
This happened even if you specified which topic IDs you were
selectively dismissing. This PR fixes that bug, and also moves
the per_page_count into a DEFAULT_PER_PAGE_COUNT for the TopicQuery
so it can be stubbed in tests.

Also moves the unused stub_const method into the spec helpers
for cases like this; it is much better to handle this in one place
with an ensure. In a follow up PR I will clean up other specs that
do the same thing and make them use stub_const.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
