### PR TITLE
FEATURE: Add last updated details to SMTP/IMAP group settings UI

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/group-imap-email-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-imap-email-settings.hbs
@@ -24,6 +24,7 @@
         {{#if mailboxes}}
           <label for="imap_mailbox_name">{{i18n "groups.manage.email.mailboxes.synchronized"}}</label>
           {{combo-box name="imap_mailbox_name"
+            id="imap_mailbox"
             value=group.imap_mailbox_name
             valueProperty="value"
             content=mailboxes
@@ -77,4 +78,13 @@
     </label>
     <p>{{i18n "groups.manage.email.settings.allow_unknown_sender_topic_replies_hint"}}</p>
   </div>
+
+  {{#if group.imap_updated_at}}
+    <div class="group-email-last-updated-details for-imap">
+      <small>
+        {{i18n "groups.manage.email.last_updated"}} <strong>{{format-date group.imap_updated_at leaveAgo="true"}}</strong>
+        {{i18n "groups.manage.email.last_updated_by"}} {{#link-to "user" group.imap_updated_by.username}}{{group.imap_updated_by.username}}{{/link-to}}
+      </small>
+    </div>
+  {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/group-smtp-email-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-smtp-email-settings.hbs
@@ -55,4 +55,13 @@
       </span>
     {{/if}}
   </div>
+
+  {{#if group.smtp_updated_at}}
+    <div class="group-email-last-updated-details for-smtp">
+      <small>
+        {{i18n "groups.manage.email.last_updated"}} <strong>{{format-date group.smtp_updated_at leaveAgo="true"}}</strong>
+        {{i18n "groups.manage.email.last_updated_by"}} {{#link-to "user" group.smtp_updated_by.username}}{{group.smtp_updated_by.username}}{{/link-to}}
+      </small>
+    </div>
+  {{/if}}
 </div>

--- a/app/assets/stylesheets/desktop/group.scss
+++ b/app/assets/stylesheets/desktop/group.scss
@@ -46,3 +46,10 @@
   width: 500px;
   max-width: 100%;
 }
+
+.group-smtp-email-settings,
+.group-imap-email-settings {
+  .group-email-last-updated-details {
+    text-align: right;
+  }
+}

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -98,6 +98,7 @@ class Group < ActiveRecord::Base
     "imap_server",
     "imap_port",
     "imap_ssl",
+    "imap_mailbox_name",
     "email_username",
     "email_password"
   ]

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -704,6 +704,8 @@ en:
           enable_imap: "Enable IMAP"
           test_settings: "Test Settings"
           save_settings: "Save Settings"
+          last_updated: "Last updated:"
+          last_updated_by: "by"
           settings_required: "All settings are required, please fill in all fields before validation."
           smtp_settings_valid: "SMTP settings valid."
           smtp_title: "SMTP"


### PR DESCRIPTION
Adds the last updated at and by SMTP/IMAP fields to the UI, we were already storing them in the DB:

![image](https://user-images.githubusercontent.com/920448/122155494-6dfd2180-ceaa-11eb-8385-a9cef3bb8f69.png)

Also makes sure that `imap_mailbox_name` being changed makes this field update.