### PR TITLE
FIX: Make avatar-flair component fail gracefully group info missing

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/avatar-flair.js
+++ b/app/assets/javascripts/discourse/app/lib/avatar-flair.js
@@ -52,7 +52,7 @@ function initializeAutoGroupFlair(site) {
     "trust_level_3",
     "trust_level_4",
   ].forEach((groupName) => {
-    const group = site.groups.findBy("name", groupName);
+    const group = site.groups?.findBy("name", groupName);
     if (group && group.flair_url) {
       _noAutoFlair = false;
       _autoGroupFlair[groupName] = {

--- a/app/assets/javascripts/discourse/tests/integration/components/user-avatar-flair-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-avatar-flair-test.js
@@ -147,6 +147,26 @@ discourseModule(
       },
     });
 
+    componentTest("avatar flair for login-required site, before login", {
+      template: hbs`{{user-avatar-flair user=args}}`,
+      beforeEach() {
+        resetFlair();
+        this.set("args", {
+          admin: false,
+          moderator: false,
+          trust_level: 3,
+        });
+        // Groups not serialized for anon on login_required
+        this.site.groups = undefined;
+      },
+      afterEach() {
+        resetFlair();
+      },
+      test(assert) {
+        assert.ok(!exists(".avatar-flair"), "it does not render a flair");
+      },
+    });
+
     componentTest("avatar flair for primary group flair", {
       template: hbs`{{user-avatar-flair user=args}}`,
       beforeEach() {


### PR DESCRIPTION
This can happen when an avatar-flair component is rendered to an anonymous user on a login_required site (e.g. when they are redeeming an invite). The lack of group information was causing an error to be raised. With this commit, it now simple skips rendering the flair.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
