### PR TITLE
FIX: ensure we dont collapse data multiple times

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report-chart.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-chart.js
@@ -1,3 +1,4 @@
+import Report from "admin/models/report";
 import Component from "@ember/component";
 import discourseDebounce from "discourse-common/lib/debounce";
 import loadScript from "discourse/lib/load-script";
@@ -179,52 +180,7 @@ export default Component.extend({
   },
 
   _applyChartGrouping(model, data, options) {
-    if (!options.chartGrouping || options.chartGrouping === "daily") {
-      return data;
-    }
-
-    if (
-      options.chartGrouping === "weekly" ||
-      options.chartGrouping === "monthly"
-    ) {
-      const isoKind = options.chartGrouping === "weekly" ? "isoWeek" : "month";
-      const kind = options.chartGrouping === "weekly" ? "week" : "month";
-      const startMoment = moment(model.start_date, "YYYY-MM-DD");
-
-      let currentIndex = 0;
-      let currentStart = startMoment.clone().startOf(isoKind);
-      let currentEnd = startMoment.clone().endOf(isoKind);
-      const transformedData = [
-        {
-          x: currentStart.format("YYYY-MM-DD"),
-          y: 0,
-        },
-      ];
-
-      data.forEach((d) => {
-        let date = moment(d.x, "YYYY-MM-DD");
-
-        if (!date.isBetween(currentStart, currentEnd)) {
-          currentIndex += 1;
-          currentStart = currentStart.add(1, kind).startOf(isoKind);
-          currentEnd = currentEnd.add(1, kind).endOf(isoKind);
-        }
-
-        if (transformedData[currentIndex]) {
-          transformedData[currentIndex].y += d.y;
-        } else {
-          transformedData[currentIndex] = {
-            x: d.x,
-            y: d.y,
-          };
-        }
-      });
-
-      return transformedData;
-    }
-
-    // ensure we return something if grouping is unknown
-    return data;
+    return Report.collapse(model, data, options.chartGrouping);
   },
 
   _unitForGrouping(options) {

--- a/app/assets/javascripts/admin/addon/components/admin-report-chart.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-chart.js
@@ -158,7 +158,7 @@ export default Component.extend({
               gridLines: { display: false },
               type: "time",
               time: {
-                unit: this._unitForGrouping(options),
+                unit: Report.unitForGrouping(options.chartGrouping),
               },
               ticks: {
                 sampleSize: 5,
@@ -181,16 +181,5 @@ export default Component.extend({
 
   _applyChartGrouping(model, data, options) {
     return Report.collapse(model, data, options.chartGrouping);
-  },
-
-  _unitForGrouping(options) {
-    switch (options.chartGrouping) {
-      case "monthly":
-        return "month";
-      case "weekly":
-        return "week";
-      default:
-        return "day";
-    }
   },
 });

--- a/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
@@ -137,7 +137,7 @@ export default Component.extend({
               gridLines: { display: false },
               type: "time",
               time: {
-                unit: this._unitForDatapoints(data.labels.length),
+                unit: Report.unitForDatapoints(data.labels.length),
               },
               ticks: {
                 sampleSize: 5,
@@ -149,16 +149,6 @@ export default Component.extend({
         },
       },
     };
-  },
-
-  _unitForDatapoints(count) {
-    if (count >= 366) {
-      return "month";
-    } else if (count >= 14 && count < 366) {
-      return "week";
-    } else {
-      return "day";
-    }
   },
 
   _resetChart() {

--- a/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
@@ -137,7 +137,7 @@ export default Component.extend({
               gridLines: { display: false },
               type: "time",
               time: {
-                unit: this._unitForGrouping(data.labels.length),
+                unit: this._unitForDatapoints(data.labels.length),
               },
               ticks: {
                 sampleSize: 5,
@@ -151,7 +151,7 @@ export default Component.extend({
     };
   },
 
-  _unitForGrouping(count) {
+  _unitForDatapoints(count) {
     if (count >= 366) {
       return "month";
     } else if (count >= 14 && count < 366) {

--- a/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
@@ -1,3 +1,4 @@
+import Report from "admin/models/report";
 import Component from "@ember/component";
 import discourseDebounce from "discourse-common/lib/debounce";
 import loadScript from "discourse/lib/load-script";
@@ -63,7 +64,7 @@ export default Component.extend({
         return {
           label: cd.label,
           stack: "pageviews-stack",
-          data: cd.data.map((d) => Math.round(parseFloat(d.y))),
+          data: Report.collapse(model, cd.data),
           backgroundColor: cd.color,
         };
       }),
@@ -129,15 +130,14 @@ export default Component.extend({
               },
             },
           ],
+
           xAxes: [
             {
               display: true,
               gridLines: { display: false },
               type: "time",
-              offset: true,
               time: {
-                parser: "YYYY-MM-DD",
-                minUnit: "day",
+                unit: this._unitForGrouping(data.labels.length),
               },
               ticks: {
                 sampleSize: 5,
@@ -149,6 +149,16 @@ export default Component.extend({
         },
       },
     };
+  },
+
+  _unitForGrouping(count) {
+    if (count >= 366) {
+      return "month";
+    } else if (count >= 14 && count < 366) {
+      return "week";
+    } else {
+      return "day";
+    }
   },
 
   _resetChart() {

--- a/app/assets/javascripts/admin/addon/components/admin-report.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report.js
@@ -162,7 +162,7 @@ export default Component.extend({
       isTesting() ? "start" : startDate.replace(/-/g, ""),
       isTesting() ? "end" : endDate.replace(/-/g, ""),
       "[:prev_period]",
-      this.get("options.table.limit"),
+      this.get("reportOptions.table.limit"),
       // Convert all filter values to strings to ensure unique serialization
       customFilters
         ? JSON.stringify(customFilters, (k, v) => (k ? `${v}` : v))
@@ -176,7 +176,7 @@ export default Component.extend({
     return reportKey;
   },
 
-  @discourseComputed("options.chartGrouping", "model.chartData.length")
+  @discourseComputed("reportOptions.chartGrouping", "model.chartData.length")
   chartGroupings(chartGrouping, count) {
     const options = ["daily", "weekly", "monthly"];
 
@@ -361,8 +361,8 @@ export default Component.extend({
         .split("T")[0];
     }
 
-    if (this.get("options.table.limit")) {
-      payload.data.limit = this.get("options.table.limit");
+    if (this.get("reportOptions.table.limit")) {
+      payload.data.limit = this.get("reportOptions.table.limit");
     }
 
     if (this.get("filters.customFilters")) {

--- a/app/assets/javascripts/admin/addon/components/admin-report.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report.js
@@ -79,7 +79,9 @@ export default Component.extend({
     }
     this.set("endDate", endDate);
 
-    this.set("currentMode", this.filters.mode);
+    if (this.filters) {
+      this.set("currentMode", this.filters.mode);
+    }
 
     if (this.report) {
       this._renderReport(this.report, this.forcedModes, this.currentMode);

--- a/app/assets/javascripts/admin/addon/components/admin-report.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report.js
@@ -180,7 +180,7 @@ export default Component.extend({
   chartGroupings(chartGrouping) {
     chartGrouping = chartGrouping || "daily";
 
-    let options = ["weekly", "monthly"];
+    const options = ["weekly", "monthly"];
     const distance = this.endDate.diff(this.startDate, "days");
     if (distance <= 30) {
       options.unshift("daily");

--- a/app/assets/javascripts/admin/addon/components/admin-report.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report.js
@@ -79,6 +79,8 @@ export default Component.extend({
     }
     this.set("endDate", endDate);
 
+    this.set("currentMode", this.filters.mode);
+
     if (this.report) {
       this._renderReport(this.report, this.forcedModes, this.currentMode);
     } else if (this.dataSourceName) {
@@ -127,7 +129,7 @@ export default Component.extend({
 
     return makeArray(modes).map((mode) => {
       const base = `btn-default mode-btn ${mode}`;
-      const cssClass = currentMode === mode ? `${base} is-current` : base;
+      const cssClass = currentMode === mode ? `${base} btn-primary` : base;
 
       return {
         mode,
@@ -176,8 +178,8 @@ export default Component.extend({
     return reportKey;
   },
 
-  @discourseComputed("reportOptions.chartGrouping", "model.chartData.length")
-  chartGroupings(chartGrouping, count) {
+  @discourseComputed("options.chartGrouping", "model.chartData.length")
+  chartGroupings(grouping, count) {
     const options = ["daily", "weekly", "monthly"];
 
     return options.map((id) => {
@@ -185,7 +187,7 @@ export default Component.extend({
         id,
         disabled: id === "daily" && count >= DAILY_LIMIT_DAYS,
         label: `admin.dashboard.reports.${id}`,
-        class: `chart-grouping ${chartGrouping === id ? "active" : "inactive"}`,
+        class: `chart-grouping ${grouping === id ? "active" : "inactive"}`,
       };
     });
   },
@@ -221,6 +223,7 @@ export default Component.extend({
 
     this.attrs.onRefresh({
       type: this.get("model.type"),
+      mode: this.currentMode,
       chartGrouping: options.chartGrouping,
       startDate:
         typeof options.startDate === "undefined"
@@ -252,7 +255,7 @@ export default Component.extend({
   },
 
   @action
-  changeMode(mode) {
+  onChangeMode(mode) {
     this.set("currentMode", mode);
 
     this.send("refreshReport", {

--- a/app/assets/javascripts/admin/addon/controllers/admin-reports-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-reports-show.js
@@ -2,7 +2,7 @@ import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export default Controller.extend({
-  queryParams: ["start_date", "end_date", "filters", "chart_grouping"],
+  queryParams: ["start_date", "end_date", "filters", "chart_grouping", "mode"],
   start_date: null,
   end_date: null,
   filters: null,

--- a/app/assets/javascripts/admin/addon/models/report.js
+++ b/app/assets/javascripts/admin/addon/models/report.js
@@ -503,21 +503,35 @@ const Report = EmberObject.extend({
   },
 });
 
+function computeGrouping(data, grouping) {
+  if (!grouping) {
+    if (data.length < 30) {
+      return "daily";
+    }
+
+    if (data.length >= 30 && data.length < 365) {
+      return "weekly";
+    }
+
+    if (data.length >= 365) {
+      return "monthly";
+    }
+  }
+
+  if (grouping === "daily" && data.length >= 30) {
+    return "weekly";
+  }
+
+  return grouping;
+}
+
 Report.reopenClass({
   collapse(model, data, grouping) {
-    if (!grouping) {
-      grouping = "daily";
-    }
+    grouping = computeGrouping(data, grouping);
 
-    if (data.length >= 30 && data.length < 366) {
-      grouping = "weekly";
-    } else if (data.length >= 366) {
-      grouping = "monthly";
-    } else {
+    if (grouping === "daily") {
       return data;
-    }
-
-    if (grouping === "weekly" || grouping === "monthly") {
+    } else if (grouping === "weekly" || grouping === "monthly") {
       const isoKind = grouping === "weekly" ? "isoWeek" : "month";
       const kind = grouping === "weekly" ? "week" : "month";
       const startMoment = moment(model.start_date, "YYYY-MM-DD");
@@ -533,7 +547,7 @@ Report.reopenClass({
       ];
 
       data.forEach((d) => {
-        let date = moment(d.x, "YYYY-MM-DD");
+        const date = moment(d.x, "YYYY-MM-DD");
 
         if (
           !date.isSame(currentStart) &&

--- a/app/assets/javascripts/admin/addon/models/report.js
+++ b/app/assets/javascripts/admin/addon/models/report.js
@@ -503,31 +503,47 @@ const Report = EmberObject.extend({
   },
 });
 
-function computeGrouping(data, grouping) {
-  if (!grouping) {
-    if (data.length < 30) {
+export const WEEKLY_LIMIT_DAYS = 365;
+export const DAILY_LIMIT_DAYS = 30;
+
+Report.reopenClass({
+  groupingForDatapoints(count) {
+    if (count < DAILY_LIMIT_DAYS) {
       return "daily";
     }
 
-    if (data.length >= 30 && data.length < 365) {
+    if (count >= DAILY_LIMIT_DAYS && count < WEEKLY_LIMIT_DAYS) {
       return "weekly";
     }
 
-    if (data.length >= 365) {
+    if (count >= WEEKLY_LIMIT_DAYS) {
       return "monthly";
     }
-  }
+  },
 
-  if (grouping === "daily" && data.length >= 30) {
-    return "weekly";
-  }
+  unitForDatapoints(count) {
+    if (count >= DAILY_LIMIT_DAYS && count < WEEKLY_LIMIT_DAYS) {
+      return "week";
+    } else if (count >= WEEKLY_LIMIT_DAYS) {
+      return "month";
+    } else {
+      return "day";
+    }
+  },
 
-  return grouping;
-}
+  unitForGrouping(grouping) {
+    switch (grouping) {
+      case "monthly":
+        return "month";
+      case "weekly":
+        return "week";
+      default:
+        return "day";
+    }
+  },
 
-Report.reopenClass({
   collapse(model, data, grouping) {
-    grouping = computeGrouping(data, grouping);
+    grouping = grouping || Report.groupingForDatapoints(data.length);
 
     if (grouping === "daily") {
       return data;

--- a/app/assets/javascripts/admin/addon/routes/admin-reports-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-reports-show.js
@@ -6,6 +6,7 @@ export default DiscourseRoute.extend({
     end_date: { refreshModel: true },
     filters: { refreshModel: true },
     chart_grouping: { refreshModel: true },
+    mode: { refreshModel: true },
   },
 
   model(params) {
@@ -27,6 +28,8 @@ export default DiscourseRoute.extend({
 
     params.chartGrouping = params.chart_grouping || "daily";
     delete params.chart_grouping;
+
+    params.mode = params.mode || "table";
 
     return params;
   },
@@ -55,6 +58,7 @@ export default DiscourseRoute.extend({
     onParamsChange(params) {
       const queryParams = {
         type: params.type,
+        mode: params.mode,
         start_date: params.startDate
           ? params.startDate.toISOString(true).split("T")[0]
           : null,

--- a/app/assets/javascripts/admin/addon/templates/components/admin-report.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-report.hbs
@@ -122,7 +122,7 @@
               <div class="modes">
                 {{#each displayedModes as |displayedMode|}}
                   {{d-button
-                    action=(action "changeMode")
+                    action=(action "onChangeMode")
                     actionParam=displayedMode.mode
                     class=displayedMode.cssClass
                     icon=displayedMode.icon}}

--- a/app/assets/javascripts/admin/addon/templates/components/admin-report.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-report.hbs
@@ -137,6 +137,7 @@
                     label=chartGrouping.label
                     action=(action "changeGrouping" chartGrouping.id)
                     class=chartGrouping.class
+                    disabled=chartGrouping.disabled
                   }}
                 {{/each}}
               </div>


### PR DESCRIPTION
Note that this commit will also disable daily grouping for datasets with more than 30 data points. This will also smartly do the grouping by month when grouping a full year.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
