### PR TITLE
FIX: Resend only pending invites

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -290,12 +290,8 @@ class InvitesController < ApplicationController
   def resend_all_invites
     guardian.ensure_can_resend_all_invites!(current_user)
 
-    Invite
-      .left_outer_joins(:invited_users)
-      .where(invited_by: current_user)
+    Invite.pending(current_user)
       .where('invites.email IS NOT NULL')
-      .where('invited_users.user_id IS NULL')
-      .group('invites.id')
       .find_each { |invite| invite.resend_invite }
 
     render json: success_json

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -744,6 +744,8 @@ describe InvitesController do
     it 'resends all non-redeemed invites by a user' do
       SiteSetting.invite_expiry_days = 30
 
+      freeze_time
+
       user = Fabricate(:admin)
       new_invite = Fabricate(:invite, invited_by: user)
       expired_invite = Fabricate(:invite, invited_by: user)
@@ -756,9 +758,9 @@ describe InvitesController do
       post '/invites/reinvite-all'
 
       expect(response.status).to eq(200)
-      expect(new_invite.reload.expires_at.to_date).to eq(30.days.from_now.to_date)
-      expect(expired_invite.reload.expires_at.to_date).to eq(30.days.from_now.to_date)
-      expect(redeemed_invite.reload.expires_at.to_date).to eq(5.days.ago.to_date)
+      expect(new_invite.reload.expires_at).to eq_time(30.days.from_now)
+      expect(expired_invite.reload.expires_at).to eq_time(2.days.ago)
+      expect(redeemed_invite.reload.expires_at).to eq_time(5.days.ago)
     end
   end
 


### PR DESCRIPTION
The Resend Invites button used to resend expired invites too, which was
unexpected because the button was on the Pending Invites page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
