### PR TITLE
FIX: Destroy invites of anonymized emails

### DIFF
--- a/app/jobs/regular/anonymize_user.rb
+++ b/app/jobs/regular/anonymize_user.rb
@@ -16,6 +16,7 @@ module Jobs
     def make_anonymous
       anonymize_ips(@anonymize_ip) if @anonymize_ip
 
+      Invite.where(email: @prev_email).destroy_all
       InvitedUser.where(user_id: @user_id).destroy_all
       EmailToken.where(user_id: @user_id).destroy_all
       EmailLog.where(user_id: @user_id).delete_all

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -368,4 +368,17 @@ describe UserAnonymizer do
 
   end
 
+  describe "anonymize_emails" do
+    it "destroys all associated invites" do
+      invite = Fabricate(:invite, email: 'test@example.com')
+      user = invite.redeem
+
+      Jobs.run_immediately!
+      described_class.make_anonymous(user, admin)
+
+      expect(user.email).not_to eq('test@example.com')
+      expect { invite.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
 end

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -377,7 +377,7 @@ describe UserAnonymizer do
       described_class.make_anonymous(user, admin)
 
       expect(user.email).not_to eq('test@example.com')
-      expect { invite.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(Invite.exists?(id: invite.id)).to eq(false)
     end
   end
 


### PR DESCRIPTION
Anonymizing a user changed their email address, destroyed all
associated InvitedUser records, but did not destroy the invites
associated to the user.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
