### PR TITLE
FIX: Add word boundaries to replace and tag watched words

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -118,7 +118,6 @@ acceptance("Admin - Watched Words - Bad regular expressions", function (needs) {
             action: "block",
           },
         ],
-        regular_expressions: true,
         compiled_regular_expressions: {
           block: null,
           censor: null,

--- a/app/assets/javascripts/discourse/tests/fixtures/watched-words-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/watched-words-fixtures.js
@@ -11,14 +11,14 @@ export default {
       {
         id: 7,
         word: "hi",
-        regexp: "hi",
+        regexp: "(hi)",
         replacement: "hello",
         action: "replace",
       },
       {
         id: 8,
         word: "hello",
-        regexp: "hello",
+        regexp: "(hello)",
         replacement: "greeting",
         action: "tag",
       },

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1675,21 +1675,21 @@ var bar = 'bar';
 
   test("watched words replace", function (assert) {
     const opts = {
-      watchedWordsReplace: { fun: "times" },
+      watchedWordsReplace: { "(?:\\W|^)(fun)(?=\\W|$)": "times" },
     };
 
-    assert.cookedOptions("test fun", opts, "<p>test times</p>");
+    assert.cookedOptions("test fun funny", opts, "<p>test times funny</p>");
   });
 
   test("watched words link", function (assert) {
     const opts = {
-      watchedWordsLink: { fun: "https://discourse.org" },
+      watchedWordsLink: { "(?:\\W|^)(fun)(?=\\W|$)": "https://discourse.org" },
     };
 
     assert.cookedOptions(
-      "test fun",
+      "test fun funny",
       opts,
-      '<p>test <a href="https://discourse.org">fun</a></p>'
+      '<p>test <a href="https://discourse.org">fun</a> funny</p>'
     );
   });
 
@@ -1697,7 +1697,7 @@ var bar = 'bar';
     const maxMatches = 100; // same limit as MD watched-words-replace plugin
     const opts = {
       siteSettings: { watched_words_regular_expressions: true },
-      watchedWordsReplace: { "\\bu?\\b": "you" },
+      watchedWordsReplace: { "(\\bu?\\b)": "you" },
     };
 
     assert.cookedOptions(

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
@@ -20,8 +20,8 @@ function findAllMatches(text, matchers) {
       count++ < MAX_MATCHES
     ) {
       matches.push({
-        index: match.index,
-        text: match[0],
+        index: match.index + match[0].indexOf(match[1]),
+        text: match[1],
         replacement: matcher.replacement,
         link: matcher.link,
       });

--- a/app/serializers/watched_word_serializer.rb
+++ b/app/serializers/watched_word_serializer.rb
@@ -4,7 +4,7 @@ class WatchedWordSerializer < ApplicationSerializer
   attributes :id, :word, :regexp, :replacement, :action
 
   def regexp
-    WordWatcher.word_to_regexp(word)
+    WordWatcher.word_to_regexp(word, whole: true)
   end
 
   def action

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -502,11 +502,19 @@ describe PostCreator do
             end
 
             context "without regular expressions" do
-              it "works" do
+              it "works with many tags" do
                 Fabricate(:watched_word, action: WatchedWord.actions[:tag], word: "HELLO", replacement: "greetings , hey")
 
                 @post = creator.create
                 expect(@post.topic.tags.map(&:name)).to match_array(['greetings', 'hey'])
+              end
+
+              it "works with overlapping words" do
+                Fabricate(:watched_word, action: WatchedWord.actions[:tag], word: "art", replacement: "about-art")
+                Fabricate(:watched_word, action: WatchedWord.actions[:tag], word: "artist*", replacement: "about-artists")
+
+                post = PostCreator.new(user, title: "hello world topic", raw: "this is topic abour artists", archetype_id: 1).create
+                expect(post.topic.tags.map(&:name)).to match_array(['about-artists'])
               end
 
               it "does not treat as regular expressions" do

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -1420,6 +1420,10 @@ HTML
       expect(PrettyText.cook("Lorem ipsum dolor sittt amet")).to match_html(<<~HTML)
         <p>Lorem ipsum something else amet</p>
       HTML
+
+      expect(PrettyText.cook("Lorem ipsum xdolor sit amet")).to match_html(<<~HTML)
+        <p>Lorem ipsum xdolor sit amet</p>
+      HTML
     end
 
     it "replaces words with links" do


### PR DESCRIPTION
The generated regular expressions did not contain \b which matched
every text that contained the word, even if it was only a substring of
a word.

For example, if "art" was a watched word a post containing word
"artist" matched.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
