### PR TITLE
FIX: Move allow_unknown_sender_topic_replies outside SMTP/IMAP box

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/group-imap-email-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-imap-email-settings.hbs
@@ -70,15 +70,6 @@
     {{/if}}
   </div>
 
-  <div class="control-group">
-    <h3>{{i18n "groups.manage.email.imap_additional_settings"}}</h3>
-    <label class="control-group-inline" for="allow_unknown_sender_topic_replies">
-      {{input type="checkbox" name="allow_unknown_sender_topic_replies" id="allow_unknown_sender_topic_replies" checked=group.allow_unknown_sender_topic_replies tabindex="13"}}
-      <span>{{i18n "groups.manage.email.settings.allow_unknown_sender_topic_replies"}}</span>
-    </label>
-    <p>{{i18n "groups.manage.email.settings.allow_unknown_sender_topic_replies_hint"}}</p>
-  </div>
-
   {{#if group.imap_updated_at}}
     <div class="group-email-last-updated-details for-imap">
       <small>

--- a/app/assets/javascripts/discourse/app/templates/components/group-manage-email-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-manage-email-settings.hbs
@@ -33,6 +33,17 @@
     </div>
   {{/if}}
 
+  <div class="group-manage-email-additional-settings-wrapper">
+    <div class="control-group">
+      <h3>{{i18n "groups.manage.email.imap_additional_settings"}}</h3>
+      <label class="control-group-inline" for="allow_unknown_sender_topic_replies">
+        {{input type="checkbox" name="allow_unknown_sender_topic_replies" id="allow_unknown_sender_topic_replies" checked=group.allow_unknown_sender_topic_replies tabindex="13"}}
+        <span>{{i18n "groups.manage.email.settings.allow_unknown_sender_topic_replies"}}</span>
+      </label>
+      <p>{{i18n "groups.manage.email.settings.allow_unknown_sender_topic_replies_hint"}}</p>
+    </div>
+  </div>
+
   <br>
   {{group-manage-save-button model=group disabled=(not emailSettingsValid) beforeSave=beforeSave afterSave=afterSave tabindex="14"}}
 </div>

--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -265,3 +265,7 @@ table.group-category-permissions {
     }
   }
 }
+
+.group-manage-email-additional-settings-wrapper {
+  margin-top: 1em;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -734,7 +734,7 @@ en:
           settings:
             title: "Settings"
             allow_unknown_sender_topic_replies: "Allow unknown sender topic replies."
-            allow_unknown_sender_topic_replies_hint: "Allows unknown senders to reply to group topics. If this is not enabled, replies from email addresses not already included on the IMAP email thread or invited to the topic will create a new topic."
+            allow_unknown_sender_topic_replies_hint: "Allows unknown senders to reply to group topics. If this is not enabled, replies from email addresses not already invited to the topic will create a new topic."
           mailboxes:
             synchronized: "Synchronized Mailbox"
             none_found: "No mailboxes were found in this email account."


### PR DESCRIPTION
This setting applies to both SMTP and IMAP for the group inbox,
so it should be outside those boxes in a standalone setting.

![image](https://user-images.githubusercontent.com/920448/122314532-b3c5f280-cf5b-11eb-9f56-8a93e6c59947.png)
