### PR TITLE
REFACTOR: removes unused code

### DIFF
--- a/app/assets/javascripts/discourse/app/models/store.js
+++ b/app/assets/javascripts/discourse/app/models/store.js
@@ -1,5 +1,4 @@
 import EmberObject, { set } from "@ember/object";
-import Category from "discourse/models/category";
 import { Promise } from "rsvp";
 import RestModel from "discourse/models/rest";
 import ResultSet from "discourse/models/result-set";
@@ -278,14 +277,6 @@ export default EmberObject.extend({
   },
 
   _lookupSubType(subType, type, id, root) {
-    // cheat: we know we already have categories in memory
-    // TODO: topics do their own resolving of `category_id`
-    // to category. That should either respect this or be
-    // removed.
-    if (subType === "category" && type !== "topic") {
-      return Category.findById(id);
-    }
-
     if (root.meta && root.meta.types) {
       subType = root.meta.types[subType] || subType;
     }

--- a/app/assets/javascripts/discourse/tests/unit/services/store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/store-test.js
@@ -142,8 +142,6 @@ module("Unit | Service | store", function () {
     assert.equal(fruitCols.length, 2);
     assert.equal(fruitCols[0].get("id"), 1);
     assert.equal(fruitCols[1].get("id"), 2);
-
-    assert.ok(fruit.get("category"), "categories are found automatically");
   });
 
   test("embedded records can be cleared", async function (assert) {


### PR DESCRIPTION
This has been fully useless since this fix https://github.com/discourse/discourse/pull/12865

The removed test is due to the fact that it's not actually testing a real life thing. A fruit object is not supposed to have a category so there's not point in testing this, the Topic object will do it's own logic by itself and shouldn't need this.


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
