### PR TITLE
FIX: Update post's raw from server response

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -929,7 +929,6 @@ const Composer = RestModel.extend({
 
   editPost(opts) {
     const post = this.post;
-    const oldRaw = post.raw;
     const oldCooked = post.cooked;
     let promise = Promise.resolve();
 
@@ -971,14 +970,14 @@ const Composer = RestModel.extend({
     this.set("composeState", SAVING);
 
     const rollback = throwAjaxError((error) => {
-      post.setProperties({ raw: oldRaw, cooked: oldCooked });
+      post.setProperties("cooked", oldCooked);
       this.set("composeState", OPEN);
       if (error.jqXHR && error.jqXHR.status === 409) {
         this.set("editConflict", true);
       }
     });
 
-    post.setProperties({ raw: props.raw, cooked: props.cooked, staged: true });
+    post.setProperties({ cooked: props.cooked, staged: true });
     this.appEvents.trigger("post-stream:refresh", { id: post.id });
 
     return promise

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -247,7 +247,7 @@ class PostsController < ApplicationController
     return render_json_error(post) if post.errors.present?
     return render_json_error(topic) if topic.errors.present?
 
-    post_serializer = PostSerializer.new(post, scope: guardian, root: false)
+    post_serializer = PostSerializer.new(post, scope: guardian, root: false, add_raw: true)
     post_serializer.draft_sequence = DraftSequence.current(current_user, topic.draft_key)
     link_counts = TopicLink.counts_for(guardian, topic, [post])
     post_serializer.single_post_link_counts = link_counts[post.id] if link_counts.present?

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -415,10 +415,11 @@ describe PostsController do
       end
 
       it "updates post's raw attribute" do
-        put "/posts/#{post.id}.json", params: update_params
+        put "/posts/#{post.id}.json", params: { post: { raw: 'edited body   ' } }
 
         expect(response.status).to eq(200)
-        expect(post.reload.raw).to eq(update_params[:post][:raw])
+        expect(response.parsed_body['post']['raw']).to eq('edited body')
+        expect(post.reload.raw).to eq('edited body')
       end
 
       it "extracts links from the new body" do


### PR DESCRIPTION
The client used to update the raw, but sometimes the server changed the
raw text, which resulted in false edit conflicts.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
