### PR TITLE
DEV: improve error message for invalid setting’s value

### DIFF
--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -204,7 +204,7 @@ class SiteSettings::TypeSupervisor
   def validate_value(name, type, val)
     if type == self.class.types[:enum]
       if enum_class(name)
-        raise Discourse::InvalidParameters.new(:value) unless enum_class(name).valid_value?(val)
+        raise Discourse::InvalidParameters.new("Invalid `#{val}` value for `#{name}`") unless enum_class(name).valid_value?(val)
       else
         unless (choice = @choices[name])
           raise Discourse::InvalidParameters.new(name)

--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -204,7 +204,7 @@ class SiteSettings::TypeSupervisor
   def validate_value(name, type, val)
     if type == self.class.types[:enum]
       if enum_class(name)
-        raise Discourse::InvalidParameters.new("Invalid `#{val}` value for `#{name}`") unless enum_class(name).valid_value?(val)
+        raise Discourse::InvalidParameters.new("Invalid value `#{val}` for `#{name}`") unless enum_class(name).valid_value?(val)
       else
         unless (choice = @choices[name])
           raise Discourse::InvalidParameters.new(name)


### PR DESCRIPTION
Before this fix we would display this exception:

```
Discourse::InvalidParameters:
  value
```

After this fix we will display:

```
Discourse::InvalidParameters:
  Invalid `x` value for `s3_region`
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
