### PR TITLE
FIX: translations of table headers in group members directory

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -35,11 +35,11 @@
                 {{d-button action=(action "bulkClearAll") label="topics.bulk.clear_all"}}
               </th>
             {{/if}}
-            {{table-header-toggle order=order asc=asc field="username_lower" labelKey="username" class="username"}}
+            {{table-header-toggle order=order asc=asc field="username_lower" labelKey="username" class="username" automatic=true}}
             <th class="group-owner"></th>
-            {{table-header-toggle order=order asc=asc field="added_at" labelKey="groups.member_added"}}
-            {{table-header-toggle order=order asc=asc field="last_posted_at" labelKey="last_post"}}
-            {{table-header-toggle order=order asc=asc field="last_seen_at" labelKey="last_seen"}}
+            {{table-header-toggle order=order asc=asc field="added_at" labelKey="groups.member_added" automatic=true}}
+            {{table-header-toggle order=order asc=asc field="last_posted_at" labelKey="last_post" automatic=true}}
+            {{table-header-toggle order=order asc=asc field="last_seen_at" labelKey="last_seen" automatic=true}}
             <th>
               {{#if isBulk}}
                 {{group-member-dropdown

--- a/app/assets/javascripts/discourse/app/templates/group-requests.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-requests.hbs
@@ -12,8 +12,8 @@
     {{#load-more selector=".group-members tr" action=(action "loadMore")}}
       <table class="group-members">
         <thead>
-          {{table-header-toggle order=order asc=asc field="username_lower" labelKey="username"}}
-          {{table-header-toggle order=order asc=asc field="requested_at" labelKey="groups.member_requested"}}
+          {{table-header-toggle order=order asc=asc field="username_lower" labelKey="username" automatic=true}}
+          {{table-header-toggle order=order asc=asc field="requested_at" labelKey="groups.member_requested" automatic=true}}
           <th>{{i18n "groups.requests.reason"}}</th>
           <th></th>
           <th></th>


### PR DESCRIPTION
I previously made a change to the `table-header-toggle` component to determine if the key is automatically generated or if it's user created content. Add this key/value pair to uses outside user directory.