### PR TITLE
DEV: reset plugin added directory columns in testing

### DIFF
--- a/app/models/directory_column.rb
+++ b/app/models/directory_column.rb
@@ -30,4 +30,8 @@ class DirectoryColumn < ActiveRecord::Base
   def self.plugin_directory_columns
     @@plugin_directory_columns
   end
+
+  def self.clear_plugin_directory_columns
+    @@plugin_directory_columns = []
+  end
 end

--- a/app/models/directory_item.rb
+++ b/app/models/directory_item.rb
@@ -34,6 +34,10 @@ class DirectoryItem < ActiveRecord::Base
     @@plugin_queries
   end
 
+  def self.clear_plugin_queries
+    @@plugin_queries = []
+  end
+
   def self.refresh_period!(period_type, force: false)
 
     Discourse.redis.set("directory_#{period_types[period_type]}", Time.zone.now.to_i)

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -613,7 +613,6 @@ describe Plugin::Instance do
       plugin.add_directory_column('random_c', query: "SELECT COUNT(*) FROM users", icon: 'recycle')
 
       expect(DirectoryColumn.find_by(name: 'random_c', icon: 'recycle', enabled: false).present?).to be(true)
-      DirectoryColumn
     end
 
     it 'errors when the column_name contains invalid characters' do

--- a/spec/components/plugin/instance_spec.rb
+++ b/spec/components/plugin/instance_spec.rb
@@ -604,10 +604,16 @@ describe Plugin::Instance do
   describe '#add_directory_column' do
     let!(:plugin) { Plugin::Instance.new }
 
+    after do
+      DirectoryItem.clear_plugin_queries
+      DirectoryColumn.clear_plugin_directory_columns
+    end
+
     it 'creates a directory column record' do
       plugin.add_directory_column('random_c', query: "SELECT COUNT(*) FROM users", icon: 'recycle')
 
       expect(DirectoryColumn.find_by(name: 'random_c', icon: 'recycle', enabled: false).present?).to be(true)
+      DirectoryColumn
     end
 
     it 'errors when the column_name contains invalid characters' do


### PR DESCRIPTION
Right now tests fail if plugin instance specs run before directory item specs. fix that!