### PR TITLE
FIX: do not respond to pressing ESC and ENTER if we're NOT on the modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -48,8 +48,11 @@ export default Component.extend({
   @on("didInsertElement")
   setUp() {
     $("html").on("keyup.discourse-modal", (e) => {
-      //only respond to events when the modal is visible
-      if (!this.element.classList.contains("hidden")) {
+      // only respond to events when we're on a modal and the modal is visible
+      if (
+        e.target.closest("#discourse-modal") &&
+        !this.element.classList.contains("hidden")
+      ) {
         if (e.which === 27 && this.dismissable) {
           next(() => this.attrs.closeModal("initiatedByESC"));
         }


### PR DESCRIPTION
Our modals always respond to pressing ESC and ENTER (we handle the `keyUp` event). The problem is that sometimes some code can handle the `keyDown` event (for Ctrl+Enter for example) and close the modal _before_ handling the `keyUp` event in the modal. With the current implementation, it leads to one more accepting or dismissing of the modal.

This PR fixes this problem, we'll be responding to pressing ESC or ENTER only when we're _on_ the modal.
