### PR TITLE
FIX: Use correct property for jump-up embedded post link

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/embedded-post.js
+++ b/app/assets/javascripts/discourse/app/widgets/embedded-post.js
@@ -1,5 +1,4 @@
 import DecoratorHelper from "discourse/widgets/decorator-helper";
-import DiscourseURL from "discourse/lib/url";
 import PostCooked from "discourse/widgets/post-cooked";
 import { createWidget } from "discourse/widgets/widget";
 import { h } from "virtual-dom";
@@ -10,19 +9,15 @@ createWidget("post-link-arrow", {
 
   template: hbs`
     {{#if attrs.above}}
-      <a class="post-info arrow" title={{i18n "topic.jump_reply_up"}}>
+      <a href={{attrs.shareUrl}} class="post-info arrow" title={{i18n "topic.jump_reply_up"}}>
         {{d-icon "arrow-up"}}
       </a>
     {{else}}
-      <a class="post-info arrow" title={{i18n "topic.jump_reply_down"}}>
+      <a href={{attrs.shareUrl}} class="post-info arrow" title={{i18n "topic.jump_reply_down"}}>
         {{d-icon "arrow-down"}}
       </a>
     {{/if}}
   `,
-
-  click() {
-    DiscourseURL.routeTo(this.attrs.shareUrl);
-  },
 });
 
 export default createWidget("embedded-post", {
@@ -39,7 +34,7 @@ export default createWidget("embedded-post", {
               this.attach("poster-name", attrs),
               this.attach("post-link-arrow", {
                 above: state.above,
-                shareUrl: attrs.shareUrl,
+                shareUrl: attrs.customShare,
               }),
             ]),
             new PostCooked(attrs, new DecoratorHelper(this), this.currentUser),


### PR DESCRIPTION
Fixup for 77d33ebe21c #13320 which added the customShare property but did not update all uses

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
