### PR TITLE
FIX: Dismiss new keyboard shortcut not working

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -553,11 +553,7 @@ export default {
       // If there is more than one match for the selector, just click
       // the first one, we don't want to click multiple things from one
       // shortcut.
-      if ($sel.length > 1) {
-        $sel[0].click();
-      } else {
-        $sel.click();
-      }
+      $sel[0].click();
     });
   },
 

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -86,8 +86,8 @@ const DEFAULT_BINDINGS = {
   t: { postAction: "replyAsNewTopic" },
   u: { handler: "goBack", anonymous: true },
   "x r": {
-    click: "#dismiss-new,#dismiss-new-top,#dismiss-posts,#dismiss-posts-top",
-  }, // dismiss new/posts
+    click: "#dismiss-new-bottom,#dismiss-new-top",
+  }, // dismiss new
   "x t": { click: "#dismiss-topics-bottom,#dismiss-topics-top" }, // dismiss topics
 };
 
@@ -549,7 +549,15 @@ export default {
         // If effective, prevent default.
         e.preventDefault();
       }
-      $sel.click();
+
+      // If there is more than one match for the selector, just click
+      // the first one, we don't want to click multiple things from one
+      // shortcut.
+      if ($sel.length > 1) {
+        $sel[0].click();
+      } else {
+        $sel.click();
+      }
     });
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -82,6 +82,7 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
 
   test("dismiss unread from top and bottom button", async function (assert) {
     await visit("/unread");
+    assert.ok(exists("#dismiss-topics-top"));
     await triggerKeyEvent(document, "keypress", "x".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "t".charCodeAt(0));
     assert.ok(exists("#dismiss-read-confirm"));
@@ -98,7 +99,10 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
     let originalTopics = [...topicList.topic_list.topics];
     topicList.topic_list.topics = [topicList.topic_list.topics[0]];
 
+    // visit root first so topic list starts fresh
+    await visit("/");
     await visit("/unread");
+    assert.notOk(exists("#dismiss-topics-top"));
     await triggerKeyEvent(document, "keypress", "x".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "t".charCodeAt(0));
     assert.ok(exists("#dismiss-read-confirm"));
@@ -115,6 +119,7 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
 
   test("dismiss new from top and bottom button", async function (assert) {
     await visit("/new");
+    assert.ok(exists("#dismiss-new-top"));
     await triggerKeyEvent(document, "keypress", "x".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "r".charCodeAt(0));
     assert.equal(resetNewCalled, 1);
@@ -125,12 +130,26 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
     let originalTopics = [...topicList.topic_list.topics];
     topicList.topic_list.topics = [topicList.topic_list.topics[0]];
 
+    // visit root first so topic list starts fresh
+    await visit("/");
     await visit("/new");
+    assert.notOk(exists("#dismiss-new-top"));
     await triggerKeyEvent(document, "keypress", "x".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "r".charCodeAt(0));
     assert.equal(resetNewCalled, 2);
 
     // restore the original topic list
     topicList.topic_list.topics = originalTopics;
+  });
+
+  test("click event not fired twice when both dismiss buttons are present", async function (assert) {
+    await visit("/new");
+    assert.ok(exists("#dismiss-new-top"));
+    assert.ok(exists("#dismiss-new-bottom"));
+
+    await triggerKeyEvent(document, "keypress", "x".charCodeAt(0));
+    await triggerKeyEvent(document, "keypress", "r".charCodeAt(0));
+
+    assert.equal(resetNewCalled, 1);
   });
 });


### PR DESCRIPTION
The dismiss new keyboard shortcut (x,r) has been broken since
7a79bd7da3e0a59454a3c03f3be31e457d0b9fcc. A fix was done and JS
tests were added in 006d52f32b8d61449dcdd42fa09b06b1573091b0
and b01e4738abe206cd1d09db74acacc743c457c374 but the test was not
quite correct and so the bottom dismiss new button was not clicked.

This also fixes an issue with our keyboard shortcut click handling.
If multiple elements matched the selector they were all clicked. Now
we just click the first match.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
