### PR TITLE
FIX: Do not add mailing list headers to group SMTP emails

### DIFF
--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -366,6 +366,16 @@ describe Email::Sender do
           expect(email_log.user_id).to be_blank
           expect(email_log.smtp_group_id).to eq(group.id)
         end
+
+        it "does not add any of the mailing list headers" do
+          TopicAllowedGroup.create(topic: post.topic, group: group)
+          email_sender.send
+
+          expect(message.header['List-ID']).to eq(nil)
+          expect(message.header['List-Post']).to eq(nil)
+          expect(message.header['List-Archive']).to eq(nil)
+          expect(message.header['Precedence']).to eq(nil)
+        end
       end
     end
 


### PR DESCRIPTION
When we are emailing people from a group inbox, we are having
a PM conversation with them, as a support account would. In this
case mailing list headers do not make sense. It is not like a forum
topic where you may have tens or hundreds of participants -- it is a
conversation between the group and a small handful of people
directly contacting the group, often just one person.

The only header left in tact was List-Unsubscribe which is important
for letting people opt out to notifications.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
