### PR TITLE
FIX: ensures validValues is an array

### DIFF
--- a/app/assets/javascripts/admin/addon/mixins/setting-object.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-object.js
@@ -50,7 +50,7 @@ export default Mixin.create({
     const vals = [],
       translateNames = this.translate_names;
 
-    validValues.forEach((v) => {
+    (validValues || []).forEach((v) => {
       if (v.name && v.name.length > 0 && translateNames) {
         vals.addObject({ name: I18n.t(v.name), value: v.value });
       } else {


### PR DESCRIPTION
Before this fix the setting object would have exceptions on 3 fields: computedNameProperty, computedValueProperty and validValues

```
TypeError: Cannot read property 'forEach' of undefined
    at Class.validValues (http://localhost:4200/assets/admin.js:10468:19)
    at Class.<anonymous> (http://localhost:4200/assets/vendor.js:82492:19)
    at http://localhost:4200/assets/vendor.js:28633:34
    at untrack (http://localhost:4200/assets/vendor.js:26641:7)
    at ComputedProperty.get (http://localhost:4200/assets/vendor.js:28632:13)
    at Class.CPGETTER_FUNCTION [as validValues] (http://localhost:4200/assets/vendor.js:26259:25)
    at Class.r (<anonymous>:1:83)
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
