### PR TITLE
UX: daily automatic grouping for less than 34 days instead of 30

### DIFF
--- a/app/assets/javascripts/admin/addon/models/report.js
+++ b/app/assets/javascripts/admin/addon/models/report.js
@@ -504,7 +504,7 @@ const Report = EmberObject.extend({
 });
 
 export const WEEKLY_LIMIT_DAYS = 365;
-export const DAILY_LIMIT_DAYS = 30;
+export const DAILY_LIMIT_DAYS = 34;
 
 Report.reopenClass({
   groupingForDatapoints(count) {


### PR DESCRIPTION
30 days is too low and would force weekly mode

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
