### PR TITLE
FIX: Update post's raw from server response

### DIFF
--- a/app/serializers/new_post_result_serializer.rb
+++ b/app/serializers/new_post_result_serializer.rb
@@ -13,7 +13,7 @@ class NewPostResultSerializer < ApplicationSerializer
   has_one :pending_post, serializer: TopicPendingPostSerializer, root: false, embed: :objects
 
   def post
-    post_serializer = PostSerializer.new(object.post, scope: scope, root: false)
+    post_serializer = PostSerializer.new(object.post, scope: scope, root: false, add_raw: true)
     post_serializer.draft_sequence = DraftSequence.current(scope.user, object.post.topic.draft_key)
     post_serializer.as_json
   end

--- a/spec/requests/api/schemas/json/topic_create_response.json
+++ b/spec/requests/api/schemas/json/topic_create_response.json
@@ -19,6 +19,9 @@
     "created_at": {
       "type": "string"
     },
+    "raw": {
+      "type": "string"
+    },
     "cooked": {
       "type": "string"
     },

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -989,7 +989,7 @@ describe PostsController do
 
       it "returns the nested post with a param" do
         post "/posts.json", params: {
-          raw: 'this is the test content',
+          raw: 'this is the test content  ',
           title: 'this is the test title for the topic',
           nested_post: true
         }
@@ -997,6 +997,7 @@ describe PostsController do
         expect(response.status).to eq(200)
         parsed = response.parsed_body
         expect(parsed['post']).to be_present
+        expect(parsed['post']['raw']).to eq('this is the test content')
         expect(parsed['post']['cooked']).to be_present
       end
 


### PR DESCRIPTION
This fix is similar to ea2833d0d89df9b48c4fc46e422f3e9b713cac00, but
this time raw text is updated after the post is created.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
