### PR TITLE
UX: Use button instead of anchor in filtered replies bar

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -162,7 +162,7 @@ createWidget("filter-jump-to-post", {
 });
 
 createWidget("filter-show-all", {
-  tagName: "a.filtered-replies-show-all",
+  tagName: "button.filtered-replies-show-all",
   buildKey: (attrs) => `filtered-show-all-${attrs.id}`,
 
   buildClasses() {


### PR DESCRIPTION
Fixes a subtle issue on laptops with touchscreens where hovering over the button would look bad: 

![f2ccf8ca2e9a137732d59d955f7d37b645b870d8](https://user-images.githubusercontent.com/368961/122574086-48dcf000-d01d-11eb-98a1-c7c92bc13d42.gif)

The issue is that in our stylesheets we have a general hover style for anchors. That style gets overriden for button-like anchors (`a.btn` elements) but only for non-touch devices. 

This is a bit tricky to fix generally, so this commit sidesteps the problem and uses a button element instead of an anchor in this specific scenario. 