### PR TITLE
FEATURE: Add more columns to outbound EmailLog

### DIFF
--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -39,7 +39,7 @@ class EmailLog < ActiveRecord::Base
   end
 
   def topic
-    @topic ||= self.topic_id.present? ? Topic.find(self.topic_id) : self.post.topic
+    @topic ||= self.topic_id.present? ? Topic.find_by(id: self.topic_id) : self.post&.topic
   end
 
   def self.unique_email_per_post(post, user)
@@ -124,6 +124,6 @@ end
 #  index_email_logs_on_created_at  (created_at)
 #  index_email_logs_on_message_id  (message_id)
 #  index_email_logs_on_post_id     (post_id)
-#  index_email_logs_on_topic_id    (topic_id)
+#  index_email_logs_on_topic_id    (topic_id) WHERE (topic_id IS NOT NULL)
 #  index_email_logs_on_user_id     (user_id)
 #

--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -89,11 +89,11 @@ class EmailLog < ActiveRecord::Base
 
   def cc_users
     return [] if !self.cc_user_ids
-    User.where(id: self.cc_user_ids)
+    @cc_users ||= User.where(id: self.cc_user_ids)
   end
 
   def cc_addresses_split
-    self.cc_addresses&.split(";") || []
+    @cc_addresses_split ||= self.cc_addresses&.split(";") || []
   end
 end
 

--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -18,8 +18,6 @@ class EmailLog < ActiveRecord::Base
   belongs_to :post
   belongs_to :smtp_group, class_name: 'Group'
 
-  has_one :topic, through: :post
-
   validates :email_type, :to_address, presence: true
 
   scope :bounced, -> { where(bounced: true) }
@@ -38,6 +36,10 @@ class EmailLog < ActiveRecord::Base
   after_create do
     # Update last_emailed_at if the user_id is present and email was sent
     User.where(id: user_id).update_all("last_emailed_at = CURRENT_TIMESTAMP") if user_id.present?
+  end
+
+  def topic
+    @topic ||= self.topic_id.present? ? Topic.find(self.topic_id) : self.post.topic
   end
 
   def self.unique_email_per_post(post, user)
@@ -85,6 +87,14 @@ class EmailLog < ActiveRecord::Base
     super&.delete('-')
   end
 
+  def cc_users
+    return [] if !self.cc_user_ids
+    User.where(id: self.cc_user_ids)
+  end
+
+  def cc_addresses_split
+    self.cc_addresses&.split(";") || []
+  end
 end
 
 # == Schema Information
@@ -102,14 +112,18 @@ end
 #  bounced       :boolean          default(FALSE), not null
 #  message_id    :string
 #  smtp_group_id :integer
+#  cc_addresses  :text
+#  cc_user_ids   :integer          is an Array
+#  raw           :text
+#  topic_id      :integer
 #
 # Indexes
 #
-#  idx_email_logs_on_smtp_group_id  (smtp_group_id)
-#  index_email_logs_on_bounce_key   (bounce_key) UNIQUE WHERE (bounce_key IS NOT NULL)
-#  index_email_logs_on_bounced      (bounced)
-#  index_email_logs_on_created_at   (created_at)
-#  index_email_logs_on_message_id   (message_id)
-#  index_email_logs_on_post_id      (post_id)
-#  index_email_logs_on_user_id      (user_id)
+#  index_email_logs_on_bounce_key  (bounce_key) UNIQUE WHERE (bounce_key IS NOT NULL)
+#  index_email_logs_on_bounced     (bounced)
+#  index_email_logs_on_created_at  (created_at)
+#  index_email_logs_on_message_id  (message_id)
+#  index_email_logs_on_post_id     (post_id)
+#  index_email_logs_on_topic_id    (topic_id)
+#  index_email_logs_on_user_id     (user_id)
 #

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1216,6 +1216,9 @@ email:
     client: true
     default: true
     hidden: true
+  enable_raw_outbound_email_logging:
+    default: false
+    hidden: true
 
 files:
   max_image_size_kb:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1216,9 +1216,6 @@ email:
     client: true
     default: true
     hidden: true
-  enable_raw_outbound_email_logging:
-    default: false
-    hidden: true
 
 files:
   max_image_size_kb:

--- a/db/migrate/20210621002201_add_columns_to_email_log_to_match_incoming_for_smtp_imap.rb
+++ b/db/migrate/20210621002201_add_columns_to_email_log_to_match_incoming_for_smtp_imap.rb
@@ -7,7 +7,7 @@ class AddColumnsToEmailLogToMatchIncomingForSmtpImap < ActiveRecord::Migration[6
     add_column :email_logs, :raw, :text, null: true
     add_column :email_logs, :topic_id, :integer, null: true
 
-    add_index :email_logs, :topic_id
+    add_index :email_logs, :topic_id, where: 'topic_id IS NOT NULL'
   end
 
   def down

--- a/db/migrate/20210621002201_add_columns_to_email_log_to_match_incoming_for_smtp_imap.rb
+++ b/db/migrate/20210621002201_add_columns_to_email_log_to_match_incoming_for_smtp_imap.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddColumnsToEmailLogToMatchIncomingForSmtpImap < ActiveRecord::Migration[6.1]
+  def up
+    add_column :email_logs, :cc_addresses, :text, null: true
+    add_column :email_logs, :cc_user_ids, :integer, array: true, null: true
+    add_column :email_logs, :raw, :text, null: true
+    add_column :email_logs, :topic_id, :integer, null: true
+
+    add_index :email_logs, :topic_id
+  end
+
+  def down
+    remove_column :email_logs, :cc_addresses if column_exists?(:email_logs, :cc_addresses)
+    remove_column :email_logs, :cc_user_ids if column_exists?(:email_logs, :cc_user_ids)
+    remove_column :email_logs, :raw if column_exists?(:email_logs, :raw)
+    remove_column :email_logs, :topic_id if column_exists?(:email_logs, :topic_id)
+
+    remove_index :email_logs, :topic_id if index_exists?(:email_logs, [:topic_id])
+  end
+end

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -249,12 +249,14 @@ module Email
 
       # Log when a message is being sent from a group SMTP address, so we
       # can debug deliverability issues.
-      email_log.smtp_group_id = smtp_group_id
+      if smtp_group_id
+        email_log.smtp_group_id = smtp_group_id
 
-      # Store contents of all outgoing emails for greater visibility. Not
-      # really required by default, but a good idea to turn on for SMTP
-      # and IMAP sending.
-      if SiteSetting.enable_raw_outbound_email_logging
+        # Store contents of all outgoing emails using group SMTP
+        # for greater visibility and debugging. If the size of this
+        # gets out of hand, we should look into a group-level setting
+        # to enable this; size should be kept in check by regular purging
+        # of EmailLog though.
         email_log.raw = Email::Cleaner.new(@message).execute
       end
 

--- a/spec/components/email/sender_spec.rb
+++ b/spec/components/email/sender_spec.rb
@@ -339,12 +339,6 @@ describe Email::Sender do
         expect(email_log.raw).to eq(nil)
       end
 
-      it "logs raw of the email if enable_raw_outbound_email_logging" do
-        SiteSetting.enable_raw_outbound_email_logging = true
-        email_sender.send
-        expect(email_log.raw).to include("hello")
-      end
-
       context 'when the email is sent using group SMTP credentials' do
         let(:reply) { Fabricate(:post, topic: post.topic, reply_to_user: post.user, reply_to_post_number: post.post_number) }
         let(:notification) { Fabricate(:posted_notification, user: post.user, post: reply) }
@@ -362,7 +356,7 @@ describe Email::Sender do
           SiteSetting.enable_smtp = true
         end
 
-        it 'adds the group id to the email log' do
+        it 'adds the group id and raw content to the email log' do
           TopicAllowedGroup.create(topic: post.topic, group: group)
 
           email_sender.send
@@ -372,6 +366,7 @@ describe Email::Sender do
           expect(email_log.to_address).to eq(post.user.email)
           expect(email_log.user_id).to be_blank
           expect(email_log.smtp_group_id).to eq(group.id)
+          expect(email_log.raw).to include("Hello world")
         end
 
         it "does not add any of the mailing list headers" do

--- a/spec/models/email_log_spec.rb
+++ b/spec/models/email_log_spec.rb
@@ -110,4 +110,32 @@ describe EmailLog do
       expect(EmailLog.find(email_log.id).bounce_key).to eq(hex)
     end
   end
+
+  describe "#cc" do
+    let!(:email_log) { Fabricate(:email_log, user: user) }
+
+    describe "#cc_addresses_split" do
+      it "returns empty array if there are no cc addresses" do
+        expect(email_log.cc_addresses_split).to eq([])
+      end
+
+      it "returns array of cc addresses if there are any" do
+        email_log.update(cc_addresses: "test@test.com;test@test2.com")
+        expect(email_log.cc_addresses_split).to eq(["test@test.com", "test@test2.com"])
+      end
+    end
+
+    describe "#cc_users" do
+      it "returns empty array if there are no cc users" do
+        expect(email_log.cc_users).to eq([])
+      end
+
+      it "returns array of users if cc_user_ids is present" do
+        cc_user = Fabricate(:user, email: "test@test.com")
+        cc_user2 = Fabricate(:user, email: "test@test2.com")
+        email_log.update(cc_addresses: "test@test.com;test@test2.com", cc_user_ids: [cc_user.id, cc_user2.id])
+        expect(email_log.cc_users).to match_array([cc_user, cc_user2])
+      end
+    end
+  end
 end

--- a/spec/models/email_log_spec.rb
+++ b/spec/models/email_log_spec.rb
@@ -111,7 +111,7 @@ describe EmailLog do
     end
   end
 
-  describe "#cc" do
+  describe "cc addresses handling" do
     let!(:email_log) { Fabricate(:email_log, user: user) }
 
     describe "#cc_addresses_split" do


### PR DESCRIPTION
This adds the following columns to EmailLog:

* cc_addresses
* cc_user_ids
* topic_id
* raw

This is to bring the EmailLog table closer in parity to
IncomingEmail so it can be better utilized for Group SMTP
and IMAP mailing.

The raw column contains the full content of the outbound email,
but _only_ if the new hidden site setting
enable_raw_outbound_email_logging is enabled. Most sites do not
need it, and it's mostly required for IMAP and SMTP sending.

In the next pull request, there will be a migration to backfill
topic_id on the EmailLog table, at which point we can remove the
topic fallback method on EmailLog.
