### PR TITLE
DEV: Move chrome binary check into a shared lib

### DIFF
--- a/lib/autospec/qunit_runner.rb
+++ b/lib/autospec/qunit_runner.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "demon/rails_autospec"
-require 'rbconfig'
+require "chrome_installed_checker"
 
 module Autospec
 
@@ -38,10 +38,8 @@ module Autospec
 
     require "socket"
 
-    class ChromeNotInstalled < StandardError; end
-
     def initialize
-      ensure_chrome_is_installed
+      ChromeInstalledChecker.run
     end
 
     def start
@@ -116,21 +114,6 @@ module Autospec
     end
 
     private
-
-    def ensure_chrome_is_installed
-      if RbConfig::CONFIG['host_os'][/darwin|mac os/]
-        binary = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
-      elsif system("command -v google-chrome-stable >/dev/null;")
-        binary = "google-chrome-stable"
-      end
-      binary ||= "google-chrome" if system("command -v google-chrome >/dev/null;")
-
-      raise ChromeNotInstalled.new if !binary
-
-      if Gem::Version.new(`\"#{binary}\" --version`.match(/[\d\.]+/)[0]) < Gem::Version.new("59")
-        raise "Chrome 59 or higher is required"
-      end
-    end
 
     def port_available?(port)
       TCPServer.open(port).close

--- a/lib/chrome_installed_checker.rb
+++ b/lib/chrome_installed_checker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+class ChromeInstalledChecker
+  class ChromeNotInstalled < StandardError; end
+  class ChromeVersionTooLow < StandardError; end
+
+  def self.run
+    if RbConfig::CONFIG['host_os'][/darwin|mac os/]
+      binary = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
+    elsif system("command -v google-chrome-stable >/dev/null;")
+      binary = "google-chrome-stable"
+    end
+    binary ||= "google-chrome" if system("command -v google-chrome >/dev/null;")
+
+    if !binary
+      raise ChromeNotInstalled.new("Chrome is not installed. Download from https://www.google.com/chrome/browser/desktop/index.html")
+    end
+
+    if Gem::Version.new(`\"#{binary}\" --version`.match(/[\d\.]+/)[0]) < Gem::Version.new("59")
+      raise ChromeVersionTooLow.new("Chrome 59 or higher is required")
+    end
+  end
+end

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -4,20 +4,12 @@ desc "Runs the qunit test suite"
 
 task "qunit:test", [:timeout, :qunit_path] do |_, args|
   require "socket"
-  require 'rbconfig'
+  require "chrome_installed_checker"
 
-  if RbConfig::CONFIG['host_os'][/darwin|mac os/]
-    google_chrome_cli = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
-  else
-    google_chrome_cli = "google-chrome"
-  end
-
-  unless system("command -v \"#{google_chrome_cli}\" >/dev/null")
-    abort "Chrome is not installed. Download from https://www.google.com/chrome/browser/desktop/index.html"
-  end
-
-  if Gem::Version.new(`\"#{google_chrome_cli}\" --version`.match(/[\d\.]+/)[0]) < Gem::Version.new("59")
-    abort "Chrome 59 or higher is required to run tests in headless mode."
+  begin
+    ChromeInstalledChecker.run
+  rescue ChromeNotInstalled, ChromeVersionTooLow => err
+    abort err.message
   end
 
   unless system("command -v yarn >/dev/null;")

--- a/lib/tasks/smoke_test.rake
+++ b/lib/tasks/smoke_test.rake
@@ -2,18 +2,12 @@
 
 desc "run chrome headless smoke tests on current build"
 task "smoke:test" do
-  if RbConfig::CONFIG['host_os'][/darwin|mac os/]
-    google_chrome_cli = "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
-  else
-    google_chrome_cli = "google-chrome"
-  end
+  require "chrome_installed_checker"
 
-  unless system("command -v \"#{google_chrome_cli}\" >/dev/null")
-    abort "Chrome is not installed. Download from https://www.google.com/chrome/browser/desktop/index.html"
-  end
-
-  if Gem::Version.new(`\"#{google_chrome_cli}\" --version`.match(/[\d\.]+/)[0]) < Gem::Version.new("59")
-    abort "Chrome 59 or higher is required to run tests in headless mode."
+  begin
+    ChromeInstalledChecker.run
+  rescue ChromeNotInstalled, ChromeVersionTooLow => err
+    abort err.message
   end
 
   system("yarn install")


### PR DESCRIPTION
We had checks for the chrome binary in 3 different places
for tests and only one of them checked for google-chrome-stable,
which is problematic for Arch linux users (there are dozens of us!)

This PR moves all the code to one place and references it instead
of copying and pasting.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
