### PR TITLE
SECURITY: ensures timeouts are correctly used on connect

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -196,6 +196,7 @@ class FinalDestination
     response = Excon.public_send(@http_verb,
       @uri.to_s,
       read_timeout: timeout,
+      connect_timeout: timeout,
       headers: headers,
       middlewares: middlewares
     )

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -63,8 +63,7 @@ module Onebox
       end
 
       result = StringIO.new
-      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.normalized_scheme == 'https') do |http|
-        http.open_timeout = Onebox.options.connect_timeout
+      Net::HTTP.start(uri.host, uri.port, open_timeout: Onebox.options.connect_timeout, use_ssl: uri.normalized_scheme == 'https') do |http|
         http.read_timeout = Onebox.options.timeout
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE  # Work around path building bugs
 
@@ -118,8 +117,7 @@ module Onebox
     def self.fetch_content_length(location)
       uri = URI(location)
 
-      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.is_a?(URI::HTTPS)) do |http|
-        http.open_timeout = Onebox.options.connect_timeout
+      Net::HTTP.start(uri.host, uri.port, open_timeout: Onebox.options.connect_timeout, use_ssl: uri.is_a?(URI::HTTPS)) do |http|
         http.read_timeout = Onebox.options.timeout
         if uri.is_a?(URI::HTTPS)
           http.use_ssl = true

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -407,7 +407,8 @@ module Oneboxer
         ignore_hostnames: blocked_domains,
         force_get_hosts: force_get_hosts,
         force_custom_user_agent_hosts: force_custom_user_agent_hosts,
-        preserve_fragment_url_hosts: preserve_fragment_url_hosts
+        preserve_fragment_url_hosts: preserve_fragment_url_hosts,
+        timeout: 5
       }
 
       if strategy && Oneboxer.strategies[strategy][:force_get_host]


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
