### PR TITLE
FIX: Downsize image last when saving uploads

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -59,13 +59,11 @@ class UploadCreator
           clean_svg!
         elsif !Rails.env.test? || @opts[:force_optimize]
           convert_to_jpeg! if convert_png_to_jpeg? || should_alter_quality?
-          downsize!        if should_downsize?
-
-          return @upload   if is_still_too_big?
-
           fix_orientation! if should_fix_orientation?
           crop!            if should_crop?
           optimize!        if should_optimize?
+          downsize!        if should_downsize?
+          return @upload   if is_still_too_big?
         end
 
         # conversion may have switched the type


### PR DESCRIPTION
The other processing operations, such as fixing orientation or cropping,
can in rare cases increase the size of the uploaded image. Running the
downsize step after all these operations should create the best image
possible.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
