### PR TITLE
PERF: Update post uploads secure status in a job

### DIFF
--- a/app/jobs/regular/update_post_uploads_secure_status.rb
+++ b/app/jobs/regular/update_post_uploads_secure_status.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Jobs
+  class UpdatePostUploadsSecureStatus < ::Jobs::Base
+    def execute(args)
+      post = Post.find_by(id: args[:post_id])
+      return if post.blank?
+
+      post.uploads.each do |upload|
+        upload.update_secure_status(source: args[:source])
+      end
+    end
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -960,7 +960,7 @@ class Post < ActiveRecord::Base
 
   def update_uploads_secure_status(source:)
     if Discourse.store.external?
-      self.uploads.each { |upload| upload.update_secure_status(source: source) }
+      Jobs.enqueue(:update_post_uploads_secure_status, post_id: self.id, source: source)
     end
   end
 

--- a/spec/components/post_revisor_spec.rb
+++ b/spec/components/post_revisor_spec.rb
@@ -1119,6 +1119,7 @@ describe PostRevisor do
       context "secure media uploads" do
         let!(:image5) { Fabricate(:secure_upload) }
         before do
+          Jobs.run_immediately!
           setup_s3
           SiteSetting.authorized_extensions = "png|jpg|gif|mp4"
           SiteSetting.secure_media = true

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1481,6 +1481,8 @@ describe Post do
       end
 
       before do
+        Jobs.run_immediately!
+
         setup_s3
         SiteSetting.authorized_extensions = "pdf|png|jpg|csv"
         SiteSetting.secure_media = true


### PR DESCRIPTION
When secure uploads are enabled, editing a post with many uploads can
cause a timeout because the store has to be contacted for each upload.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
