### PR TITLE
DEV: Do not re-throw in popupAjaxError

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/ajax-error.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax-error.js
@@ -64,10 +64,5 @@ export function throwAjaxError(undoCallback) {
 }
 
 export function popupAjaxError(error) {
-  if (error && error._discourse_displayed) {
-    return;
-  }
   bootbox.alert(extractError(error));
-
-  error._discourse_displayed = true;
 }

--- a/app/assets/javascripts/discourse/app/lib/ajax-error.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax-error.js
@@ -70,7 +70,4 @@ export function popupAjaxError(error) {
   bootbox.alert(extractError(error));
 
   error._discourse_displayed = true;
-
-  // We re-throw in a catch to not swallow the exception
-  throw error;
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
@@ -333,38 +333,38 @@ acceptance(
   }
 );
 
-// acceptance(
-//   "Managing Group Email Settings - SMTP and IMAP Enabled - Email Test Invalid",
-//   function (needs) {
-//     needs.user();
-//     needs.settings({ enable_smtp: true, enable_imap: true });
+acceptance(
+  "Managing Group Email Settings - SMTP and IMAP Enabled - Email Test Invalid",
+  function (needs) {
+    needs.user();
+    needs.settings({ enable_smtp: true, enable_imap: true });
 
-//     needs.pretender((server, helper) => {
-//       server.post("/groups/47/test_email_settings", () => {
-//         return helper.response(400, {
-//           success: false,
-//           errors: [
-//             "There was an issue with the SMTP credentials provided, check the username and password and try again.",
-//           ],
-//         });
-//       });
-//     });
+    needs.pretender((server, helper) => {
+      server.post("/groups/47/test_email_settings", () => {
+        return helper.response(400, {
+          success: false,
+          errors: [
+            "There was an issue with the SMTP credentials provided, check the username and password and try again.",
+          ],
+        });
+      });
+    });
 
-//     test("enabling IMAP, testing, and saving", async function (assert) {
-//       await visit("/g/discourse/manage/email");
+    test("enabling IMAP, testing, and saving", async function (assert) {
+      await visit("/g/discourse/manage/email");
 
-//       await click("#enable_smtp");
-//       await click("#prefill_smtp_gmail");
-//       await fillIn('input[name="username"]', "myusername@gmail.com");
-//       await fillIn('input[name="password"]', "password@gmail.com");
-//       await click(".test-smtp-settings");
+      await click("#enable_smtp");
+      await click("#prefill_smtp_gmail");
+      await fillIn('input[name="username"]', "myusername@gmail.com");
+      await fillIn('input[name="password"]', "password@gmail.com");
+      await click(".test-smtp-settings");
 
-//       assert.equal(
-//         query(".modal-body").innerText,
-//         "There was an issue with the SMTP credentials provided, check the username and password and try again.",
-//         "shows a dialogue with the error message from the server"
-//       );
-//       await click(".modal-footer .btn.btn-primary");
-//     });
-//   }
-// );
+      assert.equal(
+        query(".modal-body").innerText,
+        "There was an issue with the SMTP credentials provided, check the username and password and try again.",
+        "shows a dialogue with the error message from the server"
+      );
+      await click(".modal-footer .btn.btn-primary");
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
@@ -341,7 +341,7 @@ acceptance(
 
     needs.pretender((server, helper) => {
       server.post("/groups/47/test_email_settings", () => {
-        return helper.response(400, {
+        return helper.response(422, {
           success: false,
           errors: [
             "There was an issue with the SMTP credentials provided, check the username and password and try again.",


### PR DESCRIPTION
Effectively reverts https://github.com/discourse/discourse/commit/3ddc33b07c8b5e6e68b4d0ba92f60a8d4663341a

Makes the failure states testable; see the uncommented test.

I don't think we're re-catching these errors anyway?

_update:_
We did in a single instance in discourse-code-review but it wasn't really intentional and I fixed it in https://github.com/discourse/discourse-code-review/pull/73