### PR TITLE
FIX: Ignore posts needing approval when calculating reviewable counts.

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -509,7 +509,8 @@ class TopicView
           reviewable_scores s ON reviewable_id = r.id
         WHERE
           r.target_id IN (:post_ids) AND
-          r.target_type = 'Post'
+          r.target_type = 'Post' AND
+          COALESCE(s.reason, '') != 'category'
         GROUP BY
           target_id
       SQL

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -922,4 +922,41 @@ describe TopicView do
       expect(topic_view.show_read_indicator?).to be_falsey
     end
   end
+
+  describe '#reviewable_counts' do
+    it 'exclude posts queued because the category needs approval' do
+      category = Fabricate.build(:category, user: admin)
+      category.custom_fields[Category::REQUIRE_TOPIC_APPROVAL] = true
+      category.save!
+      manager = NewPostManager.new(
+        user,
+        raw: 'to the handler I say enqueue me!',
+        title: 'this is the title of the queued post',
+        category: category.id
+      )
+      result = manager.perform
+      reviewable = result.reviewable
+      reviewable.perform(admin, :approve_post)
+
+      topic_view = TopicView.new(reviewable.topic, admin)
+
+      expect(topic_view.reviewable_counts).to be_empty
+    end
+
+    it 'include posts queued for other reasons' do
+      Fabricate(:watched_word, word: "darn", action: WatchedWord.actions[:require_approval])
+      manager = NewPostManager.new(
+        user,
+        raw: 'this is darn new post content',
+        title: 'this is the title of the queued post'
+      )
+      result = manager.perform
+      reviewable = result.reviewable
+      reviewable.perform(admin, :approve_post)
+
+      topic_view = TopicView.new(reviewable.topic, admin)
+
+      expect(topic_view.reviewable_counts.keys).to contain_exactly(reviewable.target_id)
+    end
+  end
 end


### PR DESCRIPTION
In #12841, we started setting the `ReviewableQueuedPost`'s target and topic after approving it instead of storing them in the payload. As a result, the reviewable_counts query started to include queued posts.

When a category is set to require approval, every post has an associated reviewable. Pointing that each post has an associated queued post is not necessary in this case, so I added a WHERE clause to skip them.

