### PR TITLE
Revert "PERF: Cache categories in Site model take 2."

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -91,7 +91,6 @@ class Category < ActiveRecord::Base
   after_commit :trigger_category_created_event, on: :create
   after_commit :trigger_category_updated_event, on: :update
   after_commit :trigger_category_destroyed_event, on: :destroy
-  after_commit :clear_site_cache
 
   after_save_commit :index_search
 
@@ -957,10 +956,6 @@ class Category < ActiveRecord::Base
       SQL
 
     result.map { |row| [row.group_id, row.permission_type] }
-  end
-
-  def clear_site_cache
-    Site.clear_cache
   end
 end
 

--- a/app/models/category_tag.rb
+++ b/app/models/category_tag.rb
@@ -3,10 +3,6 @@
 class CategoryTag < ActiveRecord::Base
   belongs_to :category
   belongs_to :tag
-
-  after_commit do
-    Site.clear_cache
-  end
 end
 
 # == Schema Information

--- a/app/models/category_tag_group.rb
+++ b/app/models/category_tag_group.rb
@@ -3,10 +3,6 @@
 class CategoryTagGroup < ActiveRecord::Base
   belongs_to :category
   belongs_to :tag_group
-
-  after_commit do
-    Site.clear_cache
-  end
 end
 
 # == Schema Information

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -28,42 +28,16 @@ class Site
     UserField.order(:position).all
   end
 
-  CATEGORIES_CACHE_KEY = "site_categories"
-
-  def self.clear_cache
-    Discourse.cache.delete(CATEGORIES_CACHE_KEY)
-  end
-
-  def self.all_categories_cache
-    # Categories do not change often so there is no need for us to run the
-    # same query and spend time creating ActiveRecord objects for every requests.
-    #
-    # Do note that any new association added to the eager loading needs a
-    # corresponding ActiveRecord callback to clear the categories cache.
-    Discourse.cache.fetch(CATEGORIES_CACHE_KEY, expires_in: 30.minutes) do
+  def categories
+    @categories ||= begin
       categories = Category
-        .includes(:uploaded_logo, :uploaded_background, :tags, :tag_groups, :required_tag_group)
+        .includes(:uploaded_logo, :uploaded_background, :tags, :tag_groups)
+        .secured(@guardian)
         .joins('LEFT JOIN topics t on t.id = categories.topic_id')
         .select('categories.*, t.slug topic_slug')
         .order(:position)
-        .to_a
 
-      ActiveModel::ArraySerializer.new(
-        categories,
-        each_serializer: SiteCategorySerializer
-      ).as_json
-    end
-  end
-
-  def categories
-    @categories ||= begin
-      categories = []
-
-      self.class.all_categories_cache.each do |category|
-        if @guardian.can_see_serialized_category?(category_id: category[:id], read_restricted: category[:read_restricted])
-          categories << OpenStruct.new(category)
-        end
-      end
+      categories = categories.to_a
 
       with_children = Set.new
       categories.each do |c|

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -30,10 +30,10 @@ class SiteSerializer < ApplicationSerializer
     :shared_drafts_category_id,
     :custom_emoji_translation,
     :watched_words_replace,
-    :watched_words_link,
-    :categories
+    :watched_words_link
   )
 
+  has_many :categories, serializer: SiteCategorySerializer, embed: :objects
   has_many :archetypes, embed: :objects, serializer: ArchetypeSerializer
   has_many :user_fields, embed: :objects, serializer: UserFieldSerializer
   has_many :auth_providers, embed: :objects, serializer: AuthProviderSerializer
@@ -188,10 +188,6 @@ class SiteSerializer < ApplicationSerializer
 
   def watched_words_link
     WordWatcher.word_matcher_regexps(:link)
-  end
-
-  def categories
-    object.categories.map { |c| c.to_h }
   end
 
   private

--- a/lib/guardian/category_guardian.rb
+++ b/lib/guardian/category_guardian.rb
@@ -46,14 +46,6 @@ module CategoryGuardian
     nil
   end
 
-  def can_see_serialized_category?(category_id:, read_restricted: true)
-    # Guard to ensure only a boolean is passed in
-    read_restricted = true unless !!read_restricted == read_restricted
-
-    return true if !read_restricted
-    secure_category_ids.include?(category_id)
-  end
-
   def can_see_category?(category)
     return false unless category
     return true if is_admin?

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -10,34 +10,13 @@ describe SiteSerializer do
     category.custom_fields["enable_marketplace"] = true
     category.save_custom_fields
 
-    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-    c1 = serialized[:categories].find { |c| c[:id] == category.id }
-
-    expect(c1[:preloaded_custom_fields]).to eq(nil)
+    data = MultiJson.dump(described_class.new(Site.new(guardian), scope: guardian, root: false))
+    expect(data).not_to include("enable_marketplace")
 
     Site.preloaded_category_custom_fields << "enable_marketplace"
 
-    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-    c1 = serialized[:categories].find { |c| c[:id] == category.id }
-
-    expect(c1[:preloaded_custom_fields]["enable_marketplace"]).to eq("t")
-  end
-
-  it "includes category tags" do
-    tag = Fabricate(:tag)
-    tag_group = Fabricate(:tag_group)
-    tag_group_2 = Fabricate(:tag_group)
-
-    category.tags << tag
-    category.tag_groups << tag_group
-    category.update!(required_tag_group: tag_group_2)
-
-    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-    c1 = serialized[:categories].find { |c| c[:id] == category.id }
-
-    expect(c1[:allowed_tags]).to contain_exactly(tag.name)
-    expect(c1[:allowed_tag_groups]).to contain_exactly(tag_group.name)
-    expect(c1[:required_tag_group_name]).to eq(tag_group_2.name)
+    data = MultiJson.dump(described_class.new(Site.new(guardian), scope: guardian, root: false))
+    expect(data).to include("enable_marketplace")
   end
 
   it "returns correct notification level for categories" do


### PR DESCRIPTION
This reverts commit 06fa1efd3d8a935a5ae3e7876dbbaa3193316d7c.

Breakage in solved plugin

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
