### PR TITLE
FIX: Remove duplicate add_unsubscribe_link hash key

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -692,7 +692,7 @@ class UserNotifications < ActionMailer::Base
       context: context,
       username: username,
       group_name: group_name,
-      add_unsubscribe_link: !user.staged,
+      add_unsubscribe_link: !user.staged && !using_group_smtp,
       mailing_list_mode: user.user_option.mailing_list_mode,
       unsubscribe_url: post.unsubscribe_url(user),
       allow_reply_by_email: allow_reply_by_email,
@@ -713,8 +713,7 @@ class UserNotifications < ActionMailer::Base
       locale: locale,
       delivery_method_options: delivery_method_options,
       use_from_address_for_reply_to: use_from_address_for_reply_to,
-      from: from_address,
-      add_unsubscribe_link: !using_group_smtp
+      from: from_address
     }
 
     unless translation_override_exists


### PR DESCRIPTION
This double key was introduced in
https://github.com/discourse/discourse/commit/f0c10edd2813abc5afd7247fe2b348ec61065891

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
