### PR TITLE
DEV: Fix a flaky/leaking test

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -2,7 +2,6 @@ import * as ajaxlib from "discourse/lib/ajax";
 import { module, test } from "qunit";
 import Group from "discourse/models/group";
 import User from "discourse/models/user";
-import pretender from "discourse/tests/helpers/create-pretender";
 import sinon from "sinon";
 
 module("Unit | Model | user", function () {
@@ -74,13 +73,11 @@ module("Unit | Model | user", function () {
   test("resolvedTimezone", function (assert) {
     const tz = "Australia/Brisbane";
     let user = User.create({ timezone: tz, username: "chuck", id: 111 });
-    let stub = sinon.stub(moment.tz, "guess").returns("America/Chicago");
 
-    pretender.put("/u/chuck.json", () => {
-      return [200, { "Content-Type": "application/json" }, {}];
-    });
-
+    sinon.stub(moment.tz, "guess").returns("America/Chicago");
+    sinon.stub(ajaxlib.ajax);
     let spy = sinon.spy(ajaxlib, "ajax");
+
     assert.equal(
       user.resolvedTimezone(user),
       tz,
@@ -119,8 +116,6 @@ module("Unit | Model | user", function () {
       }),
       "if the user has no timezone, and the user is not the current user, do NOT save it with an AJAX update"
     );
-
-    stub.restore();
   });
 
   test("muted ids", function (assert) {


### PR DESCRIPTION
* pretender wasn't catching the request because it ran after this test finished
* restore wasn't needed, we do `sinon.restore()` after each test

The error was:
```
↪ Unit | Model | user::resolvedTimezone [✔]
↪ Unit | Utility | url::routeTo with prefixUnhandled request in test environment: /forum/u/chuck.json (PUT)
Error: Unhandled request in test environment: /forum/u/chuck.json (PUT)
    at Pretender.server.unhandledRequest (discourse/tests/setup-tests:173:15)
    at Pretender.handleRequest (pretender:400:14)
    at FakeRequest.send (pretender:169:21)
    at Object.send (jquery:10100:10)
    at Function.ajax (jquery:9683:15)
    at performAjax (discourse/app/lib/ajax:174:19)
    at eval (discourse/app/lib/ajax:183:11)
    at invokeCallback (ember:63104:17)
    at publish (ember:63087:9)
    at eval (ember:57463:16)
 [✘]
```

A minimal reproduction:
`http://localhost:3001/qunit?seed=3&testId=da76996b&testId=e52a53e7`