### PR TITLE
DEV: Remove leftover reference to intersection-observer

### DIFF
--- a/app/assets/javascripts/discourse/tests/theme_qunit_vendor.js
+++ b/app/assets/javascripts/discourse/tests/theme_qunit_vendor.js
@@ -32,6 +32,5 @@
 //= require jquery.autoellipsis-1.0.10
 //= require virtual-dom
 //= require virtual-dom-amd
-//= require intersection-observer
 //= require discourse-shims
 //= require pretty-text-bundle


### PR DESCRIPTION
Followup to f343cfd, should fix the build.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
