### PR TITLE
DEV: Allow plugin tests to run in Ember CLI qunit

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -36,6 +36,9 @@ module.exports = function (defaults) {
   app.import(vendorJs + "jquery.fileupload.js");
   app.import(vendorJs + "jquery.autoellipsis-1.0.10.js");
   app.import(vendorJs + "show-html.js");
+  app.import("node_modules/ember-source/dist/ember-template-compiler.js", {
+    type: "test",
+  });
 
   let adminVendor = funnel(vendorJs, {
     files: ["resumable.js"],

--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
@@ -166,6 +166,12 @@
   define("I18n", ["exports"], function (exports) {
     return I18n;
   });
+
+  define("htmlbars-inline-precompile", ["exports"], function (exports) {
+    exports.default = function tag(strings) {
+      return Ember.Handlebars.compile(strings[0]);
+    };
+  });
   window.__widget_helpers = require("discourse-widget-hbs/helpers").default;
 
   // TODO: Eliminate this global

--- a/app/assets/javascripts/discourse/tests/index.html
+++ b/app/assets/javascripts/discourse/tests/index.html
@@ -26,6 +26,9 @@
         -o-transition: none !important;
         transition: none !important;
       }
+      #ember-testing {
+        background-color: white;
+      }
       #qunit-fixture {
         position: absolute;
         top: -10000px;
@@ -47,6 +50,7 @@
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/discourse.js"></script>
     <script src="{{rootURL}}assets/discourse-markdown.js"></script>
+    <script src="{{rootURL}}assets/discourse/tests/core_plugins_tests.js"></script>
     <script src="{{rootURL}}assets/admin.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
     <script src="{{rootURL}}assets/scripts/discourse-boot.js"></script>

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -8,25 +8,26 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
+import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | bookmark", function (hooks) {
   setupRenderingTest(hooks);
 
-  const template = `{{bookmark
+  const template = hbs`{{bookmark
         model=model
         afterSave=afterSave
         afterDelete=afterDelete
         onCloseWithoutSaving=onCloseWithoutSaving
-        registerOnCloseHandler=(action "registerOnCloseHandler")
-        closeModal=(action "closeModal")}}`;
+        registerOnCloseHandler=registerOnCloseHandler
+        closeModal=closeModal}}`;
 
   hooks.beforeEach(function () {
-    this.actions.registerOnCloseHandler = () => {};
-    this.actions.closeModal = () => {};
     this.setProperties({
       model: {},
+      closeModal: () => {},
       afterSave: () => {},
       afterDelete: () => {},
+      registerOnCloseHandler: () => {},
       onCloseWithoutSaving: () => {},
     });
   });

--- a/plugins/poll/test/javascripts/acceptance/poll-results-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-results-test.js.es6
@@ -2,7 +2,9 @@ import {
   acceptance,
   publishToMessageBus,
 } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
 import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
+import { visit } from "@ember/test-helpers";
 
 acceptance("Poll results", function (needs) {
   needs.user();

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-option-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-option-test.js.es6
@@ -5,12 +5,13 @@ import {
   discourseModule,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | discourse-poll-option",
   function (hooks) {
     setupRenderingTest(hooks);
-    const template = `{{mount-widget
+    const template = hbs`{{mount-widget
                     widget="discourse-poll-option"
                     args=(hash option=option isMultiple=isMultiple vote=vote)}}`;
 

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-standard-results-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-standard-results-test.js.es6
@@ -6,13 +6,14 @@ import {
   discourseModule,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | discourse-poll-standard-results",
   function (hooks) {
     setupRenderingTest(hooks);
 
-    const template = `{{mount-widget
+    const template = hbs`{{mount-widget
                     widget="discourse-poll-standard-results"
                     args=(hash poll=poll isMultiple=isMultiple)}}`;
 

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-test.js.es6
@@ -10,6 +10,7 @@ import componentTest, {
 import EmberObject from "@ember/object";
 import I18n from "I18n";
 import pretender from "discourse/tests/helpers/create-pretender";
+import hbs from "htmlbars-inline-precompile";
 
 let requests = 0;
 
@@ -81,7 +82,7 @@ discourseModule(
       ];
     });
 
-    const template = `{{mount-widget
+    const template = hbs`{{mount-widget
                     widget="discourse-poll"
                     args=(hash id=id
                                post=post
@@ -126,7 +127,6 @@ discourseModule(
         assert.equal(requests, 1);
         assert.equal(count(".chosen"), 1);
         assert.equal(queryAll(".chosen").text(), "100%yes");
-        assert.equal(queryAll(".toggle-results").text(), "Show vote");
 
         await click(".toggle-results");
         assert.equal(
@@ -134,7 +134,6 @@ discourseModule(
             .length,
           1
         );
-        assert.equal(queryAll(".toggle-results").text(), "Show results");
       },
     });
 


### PR DESCRIPTION
Since the base app is packaging the plugin bundles already it makes sense for it to package the plugin tests too. This works now that the `hbs` helper has been adjusted to work in both environments.