### PR TITLE
FIX: Ignore missing uploads in theme settings

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -527,7 +527,9 @@ class Theme < ActiveRecord::Base
 
     theme_uploads = {}
     upload_fields.each do |field|
-      theme_uploads[field.name] = Discourse.store.cdn_url(field.upload.url)
+      if field.upload&.url
+        theme_uploads[field.name] = Discourse.store.cdn_url(field.upload.url)
+      end
     end
     hash['theme_uploads'] = theme_uploads if theme_uploads.present?
 

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -504,6 +504,20 @@ HTML
     expect(json["theme_uploads"]["bob"]).to eq(upload.url)
   end
 
+  it 'does not break on missing uploads in settings' do
+    Theme.destroy_all
+
+    upload = UploadCreator.new(file_from_fixtures("logo.png"), "logo.png").create_for(-1)
+    theme.set_field(type: :theme_upload_var, target: :common, name: "bob", upload_id: upload.id)
+    theme.save!
+
+    Upload.find(upload.id).destroy
+    theme.clear_cached_settings!
+
+    json = JSON.parse(cached_settings(theme.id))
+    expect(json).to be_empty
+  end
+
   it 'uses CDN url for theme_uploads in settings' do
     set_cdn_url("http://cdn.localhost")
     Theme.destroy_all


### PR DESCRIPTION
In some rare cases, this could prevent the site from bootstrapping, because theme settings are invoked early in the application.