### PR TITLE
PERF: Cache categories in Site model take 3.

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -91,6 +91,7 @@ class Category < ActiveRecord::Base
   after_commit :trigger_category_created_event, on: :create
   after_commit :trigger_category_updated_event, on: :update
   after_commit :trigger_category_destroyed_event, on: :destroy
+  after_commit :clear_site_cache
 
   after_save_commit :index_search
 
@@ -956,6 +957,14 @@ class Category < ActiveRecord::Base
       SQL
 
     result.map { |row| [row.group_id, row.permission_type] }
+  end
+
+  def clear_site_cache
+    Site.clear_cache
+  end
+
+  def on_custom_fields_change
+    clear_site_cache
   end
 end
 

--- a/app/models/category_tag.rb
+++ b/app/models/category_tag.rb
@@ -3,6 +3,10 @@
 class CategoryTag < ActiveRecord::Base
   belongs_to :category
   belongs_to :tag
+
+  after_commit do
+    Site.clear_cache
+  end
 end
 
 # == Schema Information

--- a/app/models/category_tag_group.rb
+++ b/app/models/category_tag_group.rb
@@ -3,6 +3,10 @@
 class CategoryTagGroup < ActiveRecord::Base
   belongs_to :category
   belongs_to :tag_group
+
+  after_commit do
+    Site.clear_cache
+  end
 end
 
 # == Schema Information

--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -142,6 +142,11 @@ module HasCustomFields
     super
   end
 
+  def on_custom_fields_change
+    # Callback when custom fields have changed
+    # Override in model
+  end
+
   def custom_fields_preloaded?
     !!@preloaded_custom_fields
   end
@@ -197,8 +202,11 @@ module HasCustomFields
       if row_count == 0
         _custom_fields.create!(name: k, value: v)
       end
+
       custom_fields[k.to_s] = v # We normalize custom_fields as strings
     end
+
+    on_custom_fields_change
   end
 
   def save_custom_fields(force = false)
@@ -253,6 +261,7 @@ module HasCustomFields
         end
       end
 
+      on_custom_fields_change
       refresh_custom_fields_from_db
     end
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -9,7 +9,6 @@ class Site
 
   def initialize(guardian)
     @guardian = guardian
-    Category.preload_custom_fields(categories, preloaded_category_custom_fields) if preloaded_category_custom_fields.present?
   end
 
   def site_setting
@@ -28,16 +27,49 @@ class Site
     UserField.order(:position).all
   end
 
-  def categories
-    @categories ||= begin
+  CATEGORIES_CACHE_KEY = "site_categories"
+
+  def self.clear_cache
+    Discourse.cache.delete(CATEGORIES_CACHE_KEY)
+  end
+
+  def self.all_categories_cache
+    # Categories do not change often so there is no need for us to run the
+    # same query and spend time creating ActiveRecord objects for every requests.
+    #
+    # Do note that any new association added to the eager loading needs a
+    # corresponding ActiveRecord callback to clear the categories cache.
+    Discourse.cache.fetch(CATEGORIES_CACHE_KEY, expires_in: 30.minutes) do
       categories = Category
-        .includes(:uploaded_logo, :uploaded_background, :tags, :tag_groups)
-        .secured(@guardian)
+        .includes(:uploaded_logo, :uploaded_background, :tags, :tag_groups, :required_tag_group)
         .joins('LEFT JOIN topics t on t.id = categories.topic_id')
         .select('categories.*, t.slug topic_slug')
         .order(:position)
+        .to_a
 
-      categories = categories.to_a
+      if preloaded_category_custom_fields.present?
+        Category.preload_custom_fields(
+          categories,
+          preloaded_category_custom_fields
+        )
+      end
+
+      ActiveModel::ArraySerializer.new(
+        categories,
+        each_serializer: SiteCategorySerializer
+      ).as_json
+    end
+  end
+
+  def categories
+    @categories ||= begin
+      categories = []
+
+      self.class.all_categories_cache.each do |category|
+        if @guardian.can_see_serialized_category?(category_id: category[:id], read_restricted: category[:read_restricted])
+          categories << OpenStruct.new(category)
+        end
+      end
 
       with_children = Set.new
       categories.each do |c|

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -30,10 +30,10 @@ class SiteSerializer < ApplicationSerializer
     :shared_drafts_category_id,
     :custom_emoji_translation,
     :watched_words_replace,
-    :watched_words_link
+    :watched_words_link,
+    :categories
   )
 
-  has_many :categories, serializer: SiteCategorySerializer, embed: :objects
   has_many :archetypes, embed: :objects, serializer: ArchetypeSerializer
   has_many :user_fields, embed: :objects, serializer: UserFieldSerializer
   has_many :auth_providers, embed: :objects, serializer: AuthProviderSerializer
@@ -188,6 +188,10 @@ class SiteSerializer < ApplicationSerializer
 
   def watched_words_link
     WordWatcher.word_matcher_regexps(:link)
+  end
+
+  def categories
+    object.categories.map { |c| c.to_h }
   end
 
   private

--- a/lib/guardian/category_guardian.rb
+++ b/lib/guardian/category_guardian.rb
@@ -46,6 +46,14 @@ module CategoryGuardian
     nil
   end
 
+  def can_see_serialized_category?(category_id:, read_restricted: true)
+    # Guard to ensure only a boolean is passed in
+    read_restricted = true unless !!read_restricted == read_restricted
+
+    return true if !read_restricted
+    secure_category_ids.include?(category_id)
+  end
+
   def can_see_category?(category)
     return false unless category
     return true if is_admin?

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -6,17 +6,43 @@ describe SiteSerializer do
   let(:guardian) { Guardian.new }
   let(:category) { Fabricate(:category) }
 
+  after do
+    Site.clear_cache
+  end
+
   it "includes category custom fields only if its preloaded" do
     category.custom_fields["enable_marketplace"] = true
     category.save_custom_fields
 
-    data = MultiJson.dump(described_class.new(Site.new(guardian), scope: guardian, root: false))
-    expect(data).not_to include("enable_marketplace")
+    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    c1 = serialized[:categories].find { |c| c[:id] == category.id }
+
+    expect(c1[:custom_fields]).to eq(nil)
 
     Site.preloaded_category_custom_fields << "enable_marketplace"
+    Site.clear_cache
 
-    data = MultiJson.dump(described_class.new(Site.new(guardian), scope: guardian, root: false))
-    expect(data).to include("enable_marketplace")
+    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    c1 = serialized[:categories].find { |c| c[:id] == category.id }
+
+    expect(c1[:custom_fields]["enable_marketplace"]).to eq("t")
+  end
+
+  it "includes category tags" do
+    tag = Fabricate(:tag)
+    tag_group = Fabricate(:tag_group)
+    tag_group_2 = Fabricate(:tag_group)
+
+    category.tags << tag
+    category.tag_groups << tag_group
+    category.update!(required_tag_group: tag_group_2)
+
+    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    c1 = serialized[:categories].find { |c| c[:id] == category.id }
+
+    expect(c1[:allowed_tags]).to contain_exactly(tag.name)
+    expect(c1[:allowed_tag_groups]).to contain_exactly(tag_group.name)
+    expect(c1[:required_tag_group_name]).to eq(tag_group_2.name)
   end
 
   it "returns correct notification level for categories" do


### PR DESCRIPTION
Previous attempt resulted in custom fields going missing in the
serialized output.

This reverts commit 83a6ad32ffe75ae222028feddeca169fc5be54ac.