### PR TITLE
UX: Add notice when watched words are regexes

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/watched-words-action.hbs
+++ b/app/assets/javascripts/admin/addon/templates/watched-words-action.hbs
@@ -26,6 +26,10 @@
 
 <p class="about">{{actionDescription}}</p>
 
+{{#if siteSettings.watched_words_regular_expressions}}
+  <p>{{html-safe (i18n "admin.watched_words.regex_warning" basePath=(base-path))}}</p>
+{{/if}}
+
 {{watched-word-form
   actionKey=actionNameKey
   action=(action "recordAdded")

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4761,7 +4761,7 @@ en:
         clear_all: Clear All
         clear_all_confirm: "Are you sure you want to clear all watched words for the %{action} action?"
         invalid_regex: 'The watched word "%{word}" is an invalid regular expression.'
-        regex_warning: '<a href="%{basePath}/admin/site_settings/category/all_results?filter=watched%20words%20regular%20expressions%20">Watched words are regular expressions</a> and they do not automatically include word boundaries. If you want the regular expression to match whole words, include <code>\b</code> in the beggining and ending of your regular expression.'
+        regex_warning: '<a href="%{basePath}/admin/site_settings/category/all_results?filter=watched%20words%20regular%20expressions%20">Watched words are regular expressions</a> and they do not automatically include word boundaries. If you want the regular expression to match whole words, include <code>\b</code> at the start and end of your regular expression.'
         actions:
           block: "Block"
           censor: "Censor"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4761,6 +4761,7 @@ en:
         clear_all: Clear All
         clear_all_confirm: "Are you sure you want to clear all watched words for the %{action} action?"
         invalid_regex: 'The watched word "%{word}" is an invalid regular expression.'
+        regex_warning: '<a href="%{basePath}/admin/site_settings/category/all_results?filter=watched%20words%20regular%20expressions%20">Watched words are regular expressions</a> and they do not automatically include word boundaries. If you want the regular expression to match whole words, include <code>\b</code> in the beggining and ending of your regular expression.'
         actions:
           block: "Block"
           censor: "Censor"


### PR DESCRIPTION
There is a big difference between regular watched words and regular
expressions and this has been confusing in the past. This notice adds
an explanation.

This commit also reorganizes the code of the test modal.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
