### PR TITLE
FEATURE: Accept the flag modal on CTRL + ENTER and CMD + ENTER

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal-body.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal-body.js
@@ -3,6 +3,7 @@ import { scheduleOnce } from "@ember/runloop";
 export default Component.extend({
   classNames: ["modal-body"],
   fixed: false,
+  submitOnEnter: true,
   dismissable: true,
   autoFocus: true,
 
@@ -49,6 +50,7 @@ export default Component.extend({
         "fixed",
         "subtitle",
         "rawSubtitle",
+        "submitOnEnter",
         "dismissable",
         "headerClass",
         "autoFocus"

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -49,7 +49,7 @@ export default Component.extend({
   @on("didInsertElement")
   setUp() {
     $("html").on("keyup.discourse-modal", (e) => {
-      //only respond to events when the modal is visible
+      // only respond to events when the modal is visible
       if (!this.element.classList.contains("hidden")) {
         if (e.which === 27 && this.dismissable) {
           next(() => this.attrs.closeModal("initiatedByESC"));

--- a/app/assets/javascripts/discourse/app/components/d-modal.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal.js
@@ -19,6 +19,7 @@ export default Component.extend({
     "role",
     "ariaLabelledby:aria-labelledby",
   ],
+  submitOnEnter: true,
   dismissable: true,
   title: null,
   subtitle: null,
@@ -70,6 +71,10 @@ export default Component.extend({
   },
 
   triggerClickOnEnter(e) {
+    if (!this.submitOnEnter) {
+      return false;
+    }
+
     // skip when in a form or a textarea element
     if (
       e.target.closest("form") ||
@@ -122,6 +127,10 @@ export default Component.extend({
       // if no subtitle provided, makes sure the previous subtitle
       // of another modal is not used
       this.set("subtitle", null);
+    }
+
+    if ("submitOnEnter" in data) {
+      this.set("submitOnEnter", data.submitOnEnter);
     }
 
     if ("dismissable" in data) {

--- a/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
@@ -1,4 +1,4 @@
-{{#d-modal-body class="flag-modal-body" title=title}}
+{{#d-modal-body class="flag-modal-body" title=title submitOnEnter=false}}
   <form>
     {{#flag-selection nameKey=selected.name_key flags=flagsAvailable as |f|}}
       {{flag-action-type

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -2,17 +2,27 @@ import {
   acceptance,
   count,
   exists,
+  query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
+import { run } from "@ember/runloop";
 
 async function openFlagModal() {
   if (exists(".topic-post:first-child button.show-more-actions")) {
     await click(".topic-post:first-child button.show-more-actions");
   }
   await click(".topic-post:first-child button.create-flag");
+}
+
+function keyDown(element, keyCode, modifier) {
+  const event = document.createEvent("Event");
+  event.initEvent("keydown", true, true);
+  event.keyCode = 13;
+  event[modifier] = true;
+  run(() => element.dispatchEvent(event));
 }
 
 acceptance("flagging", function (needs) {
@@ -141,5 +151,37 @@ acceptance("flagging", function (needs) {
 
     await click(".modal-footer .btn-primary");
     assert.ok(!exists(".bootbox.modal:visible"));
+  });
+
+  test("CTRL + ENTER accepts the modal", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await openFlagModal();
+
+    const modal = query("#discourse-modal");
+    keyDown(modal, 13, "ctrlKey");
+    assert.ok(
+      exists("#discourse-modal:visible"),
+      "The modal wasn't closed because the accept button was disabled"
+    );
+
+    await click("#radio_inappropriate"); // this enables the accept button
+    keyDown(modal, 13, "ctrlKey");
+    assert.ok(!exists("#discourse-modal:visible"), "The modal was closed");
+  });
+
+  test("CMD or WINDOWS-KEY + ENTER accepts the modal", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await openFlagModal();
+
+    const modal = query("#discourse-modal");
+    keyDown(modal, 13, "metaKey");
+    assert.ok(
+      exists("#discourse-modal:visible"),
+      "The modal wasn't closed because the accept button was disabled"
+    );
+
+    await click("#radio_inappropriate"); // this enables the accept button
+    keyDown(modal, 13, "ctrlKey");
+    assert.ok(!exists("#discourse-modal:visible"), "The modal was closed");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -6,7 +6,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { test } from "qunit";
+import { skip, test } from "qunit";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
 import { run } from "@ember/runloop";
 
@@ -153,7 +153,7 @@ acceptance("flagging", function (needs) {
     assert.ok(!exists(".bootbox.modal:visible"));
   });
 
-  test("CTRL + ENTER accepts the modal", async function (assert) {
+  skip("CTRL + ENTER accepts the modal", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();
 
@@ -169,7 +169,7 @@ acceptance("flagging", function (needs) {
     assert.ok(!exists("#discourse-modal:visible"), "The modal was closed");
   });
 
-  test("CMD or WINDOWS-KEY + ENTER accepts the modal", async function (assert) {
+  skip("CMD or WINDOWS-KEY + ENTER accepts the modal", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();
 


### PR DESCRIPTION
We want to submit the flag modal on pressing <kbd>CTRL</kbd> + <kbd>ENTER</kbd> and <kbd>CMD</kbd> + <kbd>ENTER</kbd>.

Here's how our modals work:
- Every modal can be dismissed by pressing <kbd>ESC</kbd>. This behaviour can be disabled for a specific modal if we need to.
- Every modal can be submitted by pressing <kbd>ENTER</kbd> if the cursor wasn't on a text area or a form at the moment of pressing.

Now, the flag modal is actually a one big form and pressing <kbd>ENTER</kbd> doesn't submit it. I've added submitting by <kbd>CTRL</kbd>+<kbd>ENTER</kbd> but at first it was interfering with the basic modal submitting by <kbd>ENTER</kbd>. It's a pretty tricky thing to fix because we use the `keyup` event for submitting by <kbd>ENTER</kbd> and we need to use the `keydown` event for submitting with modifiers (because submitting by <kbd>CMD</kbd>+<kbd>ENTER</kbd> on Macs doesn't work with `keyup`).

Eventually, I fixed the problem just by adding a possibility to disable default submitting on <kbd>ENTER</kbd> (in the same way as we already have the possibility of disabling dismissing on <kbd>ESC</kbd>). Then I disabled default submitting for the flag form and implemented submitting by  <kbd>CTRL</kbd>+<kbd>ENTER</kbd> and <kbd>CMD</kbd>+<kbd>ENTER</kbd>. This way everything is simple and robust. I did it only for the flag modal but it'll be easy and safe to add the same behaviour to another modal.