### PR TITLE
DEV: Skip proxy argument for `bin/ember-cli --test`

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -41,7 +41,7 @@ args = ["-s", "--cwd", yarn_dir, "run", "ember", command] + ARGV.reject do |a|
   ["--try", "--test", "--unicorn", "-u"].include?(a)
 end
 
-if !args.include?("--proxy")
+if !args.include?("test") && !args.include?("--proxy")
   args << "--proxy"
   args << PROXY
 end


### PR DESCRIPTION
Avoids displaying the following warning:

```
The option '--proxy' is not registered with the 'test' command. Run `ember test --help` for a list of supported options.
```