### PR TITLE
UX: Hide email columns when `Hide Emails` is selected

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -19,7 +19,6 @@
   {{text-field value=listFilter placeholder=searchHint}}
 </div>
 
-{{!-- <div class="users-list-container"> --}}
 {{#load-more class="users-list-container" selector=".users-list tr" action=(action "loadMore")}}
   {{#if model}}
     <table class="table users-list grid">

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -19,12 +19,13 @@
   {{text-field value=listFilter placeholder=searchHint}}
 </div>
 
-{{#load-more selector=".users-list tr" action=(action "loadMore")}}
+{{!-- <div class="users-list-container"> --}}
+{{#load-more class="users-list-container" selector=".users-list tr" action=(action "loadMore")}}
   {{#if model}}
     <table class="table users-list grid">
       <thead>
         {{table-header-toggle field="username" labelKey="username" order=order asc=asc}}
-        {{table-header-toggle field="email" labelKey="email" order=order asc=asc}}
+        {{table-header-toggle  class=(if showEmails "" "hidden") field="email" labelKey="email" order=order asc=asc}}
         {{table-header-toggle field="last_emailed" labelKey="admin.users.last_emailed" order=order asc=asc}}
         {{table-header-toggle field="seen" labelKey="last_seen" order=order asc=asc}}
         {{table-header-toggle field="topics_viewed" labelKey="admin.user.topics_entered" order=order asc=asc}}
@@ -48,7 +49,7 @@
                 {{d-icon "far-envelope" title="user.staged" }}
               {{/if}}
             </td>
-            <td class="email">
+            <td class="email {{if showEmails "" "hidden"}}">
               {{~user.email~}}
             </td>
             <td class="last-emailed">
@@ -98,7 +99,6 @@
       </tbody>
     </table>
     {{conditional-loading-spinner condition=refreshing}}
-
   {{else}}
     <p>{{i18n "search.no_results"}}</p>
   {{/if}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -427,7 +427,7 @@ $mobile-breakpoint: 700px;
   }
   .users-list-container {
     overflow-x: auto;
-  }  
+  }
 }
 
 .admin-title {

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -425,6 +425,9 @@ $mobile-breakpoint: 700px;
   .controls {
     @include clearfix;
   }
+  .users-list-container {
+    overflow-x: auto;
+  }  
 }
 
 .admin-title {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
This PR adds an auto scroll for the users table container. It also hides the email column when `Hide Emails` is toggled.


https://user-images.githubusercontent.com/30537603/123123724-abaefc80-d40c-11eb-91fe-188fc5c4611e.mp4


