### PR TITLE
FIX: Manually update DirectoryItemSerializer attributes on directory column change

### DIFF
--- a/app/controllers/edit_directory_columns_controller.rb
+++ b/app/controllers/edit_directory_columns_controller.rb
@@ -38,7 +38,7 @@ class EditDirectoryColumnsController < ApplicationController
   private
 
   def update_directory_item_serializer_attributes
-    ::DirectoryItemSerializer::UserSerializer.attributes(*DirectoryColumn.active_column_names)
+    ::DirectoryItemSerializer.attributes(*DirectoryColumn.active_column_names)
   end
 
   def ensure_user_fields_have_columns

--- a/app/controllers/edit_directory_columns_controller.rb
+++ b/app/controllers/edit_directory_columns_controller.rb
@@ -30,10 +30,16 @@ class EditDirectoryColumnsController < ApplicationController
       end
     end
 
+    update_directory_item_serializer_attributes
+
     render json: success_json
   end
 
   private
+
+  def update_directory_item_serializer_attributes
+    ::DirectoryItemSerializer::UserSerializer.attributes(*DirectoryColumn.active_column_names)
+  end
 
   def ensure_user_fields_have_columns
     user_fields_without_column =


### PR DESCRIPTION
https://github.com/discourse/discourse/blob/6e1fa7b08258d1a4d8fa9492e9b1e782e240c47a/app/serializers/directory_item_serializer.rb#L32

DirectoryItemSerializer attributes are being eval'd on boot in production, so when `DirectoryColumn.active_column_names` changes, the attributes in DirectoryItemSerializer do not change.

This PR adds a manual call to set DirectoryItemSerializer attributes after directory columns are changed.
 