### PR TITLE
DEV: Revert production-only fix for dynamic DirectoryItemSerializer attributes

### DIFF
--- a/app/controllers/edit_directory_columns_controller.rb
+++ b/app/controllers/edit_directory_columns_controller.rb
@@ -30,16 +30,10 @@ class EditDirectoryColumnsController < ApplicationController
       end
     end
 
-    update_directory_item_serializer_attributes
-
     render json: success_json
   end
 
   private
-
-  def update_directory_item_serializer_attributes
-    ::DirectoryItemSerializer.attributes(*DirectoryColumn.active_column_names)
-  end
 
   def ensure_user_fields_have_columns
     user_fields_without_column =


### PR DESCRIPTION
Reverts commit https://github.com/discourse/discourse/commit/a9175b77057cfbf315d9be30b693253948f2a9a7 which did not work as expected. This was intended to fix a bug only seen in production, but that wasn't the case