### PR TITLE
FIX: Table header translations on admin users list

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -23,14 +23,14 @@
   {{#if model}}
     <table class="table users-list grid">
       <thead>
-        {{table-header-toggle field="username" labelKey="username" order=order asc=asc}}
-        {{table-header-toggle  class=(if showEmails "" "hidden") field="email" labelKey="email" order=order asc=asc}}
-        {{table-header-toggle field="last_emailed" labelKey="admin.users.last_emailed" order=order asc=asc}}
-        {{table-header-toggle field="seen" labelKey="last_seen" order=order asc=asc}}
-        {{table-header-toggle field="topics_viewed" labelKey="admin.user.topics_entered" order=order asc=asc}}
-        {{table-header-toggle field="posts_read" labelKey="admin.user.posts_read_count" order=order asc=asc}}
-        {{table-header-toggle field="read_time" labelKey="admin.user.time_read" order=order asc=asc}}
-        {{table-header-toggle field="created" labelKey="created" order=order asc=asc}}
+        {{table-header-toggle field="username" labelKey="username" order=order asc=asc automatic=true}}
+        {{table-header-toggle  class=(if showEmails "" "hidden") field="email" labelKey="email" order=order asc=asc automatic=true}}
+        {{table-header-toggle field="last_emailed" labelKey="admin.users.last_emailed" order=order asc=asc automatic=true}}
+        {{table-header-toggle field="seen" labelKey="last_seen" order=order asc=asc automatic=true}}
+        {{table-header-toggle field="topics_viewed" labelKey="admin.user.topics_entered" order=order asc=asc automatic=true}}
+        {{table-header-toggle field="posts_read" labelKey="admin.user.posts_read_count" order=order asc=asc automatic=true}}
+        {{table-header-toggle field="read_time" labelKey="admin.user.time_read" order=order asc=asc automatic=true}}
+        {{table-header-toggle field="created" labelKey="created" order=order asc=asc automatic=true}}
         {{#if siteSettings.must_approve_users}}
           <th>{{i18n "admin.users.approved"}}</th>
         {{/if}}


### PR DESCRIPTION
This is a change from my recent user directory changes. The problem is that I have been grepping in `jsapp` to find component uses and didn't catch this usage.

![image](https://user-images.githubusercontent.com/16214023/123146280-50d4cf80-d423-11eb-821c-91b2a1ee793d.png)

With change 

![image](https://user-images.githubusercontent.com/16214023/123146319-592d0a80-d423-11eb-8578-3bba6285da65.png)
