### PR TITLE
UX: Fix mobile alert spacing

### DIFF
--- a/app/assets/stylesheets/mobile/alert.scss
+++ b/app/assets/stylesheets/mobile/alert.scss
@@ -1,6 +1,4 @@
 .alert.alert-info {
-  margin-top: 1em;
-  margin-bottom: 0;
   &.clickable {
     // there are (n) new or updated topics, click to show
     margin-top: 0;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1681963/123147646-4ae3ec00-d42d-11eb-9ea2-1e628199ad7b.png)


After:
<img width="411" alt="Screen Shot 2021-06-23 at 1 58 36 PM" src="https://user-images.githubusercontent.com/1681963/123147677-51726380-d42d-11eb-97a6-5f674b3a5dd7.png">


Discussion here: https://meta.discourse.org/t/global-notice-margin-on-mobile/194405
