### PR TITLE
FIX: increase max favorite badges to 6

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -311,7 +311,7 @@ basic:
     client: true
     default: 2
     min: 0
-    max: 5
+    max: 6
   enable_whispers:
     client: true
     default: false


### PR DESCRIPTION
Limit was 5 with the assumption that trust level badge
will be the 6th badge. With trust level badges disabled,
it should be possible to increase this to 6, or even more imo.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
