### PR TITLE
UX: Make it easier to hide the emoji on signup

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -73,6 +73,7 @@
     }
     .login-subheader {
       align-self: start;
+      grid-row-start: 2;
       margin: 0;
     }
     .waving-hand {


### PR DESCRIPTION
Using `display: none;` on the waving hand would break the subheader and cause it to be on the same line as the headline... this makes it less fragile. Discussion here: https://meta.discourse.org/t/how-do-i-remove-the-hand-wave-emoji-from-the-login-ui/194589/5