### PR TITLE
FIX: follow redirects for inline/mini onebox

### DIFF
--- a/spec/components/retrieve_title_spec.rb
+++ b/spec/components/retrieve_title_spec.rb
@@ -89,5 +89,16 @@ describe RetrieveTitle do
       IPSocket.stubs(:getaddress).returns('100.2.3.4')
       expect(RetrieveTitle.crawl("https://brelksdjflaskfj.com/amazing")).to eq("japanese こんにちは website")
     end
+
+    it "can follow redirect" do
+      stub_request(:get, "http://foobar.com/amazing").
+        to_return(status: 301, body: "", headers: { "location" => "https://wikipedia.com/amazing" })
+
+      stub_request(:get, "https://wikipedia.com/amazing").
+        to_return(status: 200, body: "<html><title>very amazing</title>", headers: {})
+
+      IPSocket.stubs(:getaddress).returns('100.2.3.4')
+      expect(RetrieveTitle.crawl("http://foobar.com/amazing")).to eq("very amazing")
+    end
   end
 end


### PR DESCRIPTION
By default `final_destination` library allows upto 5 redirects but this was not happening for inline oneboxes. This commit fixes inline oneboxes to allow upto 5 redirects.

Meta ref: https://meta.discourse.org/t/inline-oneboxing-doesnt-follow-redirects/194184/4