### PR TITLE
DEV: Update script/promote_migrations

### DIFF
--- a/script/promote_migrations
+++ b/script/promote_migrations
@@ -14,8 +14,19 @@ require 'open3'
 require 'fileutils'
 
 VERSION_REGEX = %r{\/(\d+)_}
-DRY_RUN = ARGV.include? '--dry-run'
-PLUGINS = ARGV.include? '--plugins'
+
+DRY_RUN = !!ARGV.delete('--dry-run')
+
+if i = ARGV.find_index('--plugins-base')
+  ARGV.delete_at(i)
+  PLUGINS = true
+  PLUGINS_BASE = ARGV.delete_at(i)
+elsif ARV.delete('--plugins-base')
+  PLUGINS = true
+  PLUGINS_BASE = 'plugins'
+end
+
+raise "Unknown arguments: #{ARGV.join(', ')}" if ARGV.length > 0
 
 def run(*args, capture: true)
   out, s = Open3.capture2(*args)
@@ -60,7 +71,7 @@ promote_threshold = latest_stable_post_migration[VERSION_REGEX, 1].to_i
 current_post_migrations =
   if PLUGINS
     puts 'Looking in plugins...'
-    Dir.glob('plugins/*/db/post_migrate/*')
+    Dir.glob("#{PLUGINS_BASE}/**/db/post_migrate/*")
   else
     Dir.glob('db/post_migrate/*')
   end

--- a/script/promote_migrations
+++ b/script/promote_migrations
@@ -21,7 +21,7 @@ if i = ARGV.find_index('--plugins-base')
   ARGV.delete_at(i)
   PLUGINS = true
   PLUGINS_BASE = ARGV.delete_at(i)
-elsif ARV.delete('--plugins-base')
+elsif ARV.delete('--plugins')
   PLUGINS = true
   PLUGINS_BASE = 'plugins'
 end


### PR DESCRIPTION
Introduces the --plugins-base flag for updating plugins in a different directory. Followup to 49f39434c48c6f05ab2037f0f31c9da521401cfb

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
