### PR TITLE
FIX: Show plugin directory column attributes on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/directory-item-helpers.js
+++ b/app/assets/javascripts/discourse/app/helpers/directory-item-helpers.js
@@ -6,7 +6,9 @@ import I18n from "I18n";
 registerUnbound("mobile-directory-item-label", function (args) {
   // Args should include key/values { item, column }
   const count = args.item.get(args.column.name);
-  return htmlSafe(I18n.t(`directory.${args.column.name}`, { count }));
+  const translationPrefix =
+    args.column.type === "automatic" ? "directory." : "";
+  return htmlSafe(I18n.t(`${translationPrefix}${args.column.name}`, { count }));
 });
 
 registerUnbound("directory-item-value", function (args) {

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/directory-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/directory-item.hbs
@@ -1,7 +1,19 @@
 {{user-info user=item.user}}
 
 {{#each columns as |column|}}
-  {{#if (directory-column-is-automatic column=column)}}
+  {{#if (directory-column-is-user-field column=column)}}
+    {{#if (get item.user.user_fields column.user_field_id)}}
+      <div class="user-stat">
+        <span class="value user-field">
+          {{directory-item-user-field-value item=item column=column}}
+        </span>
+        <span class="label">
+          {{column.name}}
+        </span>
+      </div>
+    {{/if}}
+
+  {{else}}
     <div class="user-stat">
       <span class="value">
         {{directory-item-value item=item column=column}}
@@ -13,18 +25,6 @@
         {{mobile-directory-item-label item=item column=column}}
       </span>
     </div>
-
-  {{else}}
-    {{#if (get item.user.user_fields column.user_field_id)}}
-      <div class="user-stat">
-        <span class="value user-field">
-          {{directory-item-user-field-value item=item column=column}}
-        </span>
-        <span class="label">
-          {{column.name}}
-        </span>
-      </div>
-    {{/if}}
   {{/if}}
 {{/each}}
 


### PR DESCRIPTION
Right now plugin-added directory column attributes are not rendered on mobile. This swaps a bit of logic around in order to render plugin directory column attributes. 