### PR TITLE
UX: Make bulk select checkbox easier to target

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -2,7 +2,9 @@
 
 {{#if bulkSelectEnabled}}
   <td class="bulk-select">
-    <input type="checkbox" class="bulk-select">
+    <label for="bulk-select-{{topic.id}}">
+      <input type="checkbox" class="bulk-select" id="bulk-select-{{topic.id}}">
+    </label>
   </td>
 {{/if}}
 
@@ -23,8 +25,8 @@
     {{~topic-featured-link topic}}
     {{~/if}}
     {{~raw-plugin-outlet name="topic-list-after-title"}}
-    {{~raw "list/unread-indicator" includeUnreadIndicator=includeUnreadIndicator 
-                                   topicId=topic.id 
+    {{~raw "list/unread-indicator" includeUnreadIndicator=includeUnreadIndicator
+                                   topicId=topic.id
                                    unreadClass=unreadClass~}}
     {{~#if showTopicPostBadges}}
     {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -46,8 +46,13 @@
   }
 
   td.bulk-select {
-    padding: 10px;
+    padding: 0;
     width: 30px;
+    label {
+      margin: 0px;
+      padding: 12px 10px 16px 10px;
+      cursor: pointer;
+    }
     + .main-link {
       padding-left: 0;
     }


### PR DESCRIPTION
Adds a label element around the checkbox, so that user can more easily
hit the element. Quite useful when checking many items in topic list.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
