### PR TITLE
UX: margin improvement for mobile alerts

### DIFF
--- a/app/assets/stylesheets/common/components/banner.scss
+++ b/app/assets/stylesheets/common/components/banner.scss
@@ -7,6 +7,7 @@
   background: var(--tertiary-low);
   color: var(--primary);
   z-index: z("base") + 1;
+  margin-bottom: 1em;
   overflow: auto;
 
   &.overlay {

--- a/app/assets/stylesheets/desktop/banner.scss
+++ b/app/assets/stylesheets/desktop/banner.scss
@@ -3,7 +3,6 @@
 // --------------------------------------------------
 
 #banner {
-  margin-bottom: 1em;
   max-width: 1090px;
   max-height: 250px;
 }

--- a/app/assets/stylesheets/mobile/alert.scss
+++ b/app/assets/stylesheets/mobile/alert.scss
@@ -1,7 +1,7 @@
 .alert.alert-info {
   &.clickable {
     // there are (n) new or updated topics, click to show
-    margin-top: 0;
+    margin: 0;
     padding: 1em;
   }
 }


### PR DESCRIPTION
Follow-up to 1702922, this fixes the margin on `#banner` and the `See N new or updated topics` banner on the topic list. 