### PR TITLE
UX: make poll content selectable

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -2,8 +2,6 @@ div.poll {
   margin: 1em 0;
   border: 1px solid var(--primary-low);
 
-  @include unselectable;
-
   ul,
   ol {
     margin: 0;


### PR DESCRIPTION
When initially released, the polls had a different design that didn't interact
well with the quote button - https://meta.discourse.org/t/31586

Now that the design has evolved, not being able to select text from inside a poll is
counter productive, so it's enabled again.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
