### PR TITLE
FEATURE: Make invites work with existing users

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -365,11 +365,16 @@ class InvitesController < ApplicationController
   end
 
   def ensure_not_logged_in
-    if current_user
-      flash[:error] = I18n.t("login.already_logged_in")
-      render layout: 'no_ember'
-      false
+    return if !current_user
+
+    if invite = Invite.find_by(invite_key: params[:id])
+      if topic = invite.topics.first
+        return redirect_to(topic.url) if guardian.can_see?(topic)
+      end
     end
+
+    flash[:error] = I18n.t("login.already_logged_in")
+    render layout: 'no_ember'
   end
 
   def post_process_invite(user)

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -79,6 +79,23 @@ describe InvitesController do
       expect(response).to redirect_to(topic.url)
     end
 
+    it 'adds logged in user to group and redirects them to invite topic' do
+      group = Fabricate(:group)
+      group.add_owner(invite.invited_by)
+      secured_category = Fabricate(:category)
+      secured_category.permissions = { group.name => :full }
+      secured_category.save!
+      topic = Fabricate(:topic, category: secured_category)
+      TopicInvite.create!(invite: invite, topic: topic)
+      InvitedGroup.create!(invite: invite, group: group)
+
+      sign_in(user)
+
+      get "/invites/#{invite.invite_key}"
+      expect(user.reload.groups).to include(group)
+      expect(response).to redirect_to(topic.url)
+    end
+
     it 'fails for logged in users' do
       sign_in(Fabricate(:user))
 

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -57,6 +57,16 @@ describe InvitesController do
       end
     end
 
+    it 'redirects logged in users to invite topic if they can see it' do
+      topic = Fabricate(:topic)
+      TopicInvite.create!(topic: topic, invite: invite)
+
+      sign_in(user)
+
+      get "/invites/#{invite.invite_key}"
+      expect(response).to redirect_to(topic.url)
+    end
+
     it 'fails for logged in users' do
       sign_in(Fabricate(:user))
 

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -57,6 +57,18 @@ describe InvitesController do
       end
     end
 
+    it 'adds logged in users to invite groups' do
+      group = Fabricate(:group)
+      group.add_owner(invite.invited_by)
+      InvitedGroup.create!(group: group, invite: invite)
+
+      sign_in(user)
+
+      get "/invites/#{invite.invite_key}"
+      expect(response).to redirect_to("/")
+      expect(user.reload.groups).to include(group)
+    end
+
     it 'redirects logged in users to invite topic if they can see it' do
       topic = Fabricate(:topic)
       TopicInvite.create!(topic: topic, invite: invite)


### PR DESCRIPTION
Users who were already logged in and were given an invite link used to
see an error message saying that they already have an account and
cannot redeem the invite.