### PR TITLE
UX: Show a "Summarize" button in topic timeline

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -148,6 +148,7 @@
             jumpToPostPrompt=(action "jumpToPostPrompt")
             jumpToIndex=(action "jumpToIndex")
             replyToPost=(action "replyToPost")
+            showSummary=(action "showSummary")
             toggleMultiSelect=(action "toggleMultiSelect")
             showTopicSlowModeUpdate=(route-action "showTopicSlowModeUpdate")
             deleteTopic=(action "deleteTopic")

--- a/app/assets/javascripts/discourse/app/widgets/toggle-topic-summary.js
+++ b/app/assets/javascripts/discourse/app/widgets/toggle-topic-summary.js
@@ -38,7 +38,8 @@ export default createWidget("toggle-topic-summary", {
       this.attach("toggle-summary-description", attrs),
       this.attach("button", {
         className: "btn btn-primary",
-        icon: "layer-group",
+        icon: attrs.topicSummaryEnabled ? null : "layer-group",
+        title: attrs.topicSummaryEnabled ? null : "summary.short_title",
         label: attrs.topicSummaryEnabled ? "summary.disable" : "summary.enable",
         action: attrs.topicSummaryEnabled ? "cancelFilter" : "showSummary",
       }),

--- a/app/assets/javascripts/discourse/app/widgets/toggle-topic-summary.js
+++ b/app/assets/javascripts/discourse/app/widgets/toggle-topic-summary.js
@@ -38,6 +38,7 @@ export default createWidget("toggle-topic-summary", {
       this.attach("toggle-summary-description", attrs),
       this.attach("button", {
         className: "btn btn-primary",
+        icon: "layer-group",
         label: attrs.topicSummaryEnabled ? "summary.disable" : "summary.enable",
         action: attrs.topicSummaryEnabled ? "cancelFilter" : "showSummary",
       }),

--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -351,6 +351,17 @@ createWidget("timeline-footer-controls", {
     const controls = [];
     const { currentUser, fullScreen, topic, notificationLevel } = attrs;
 
+    if (!fullScreen && topic.has_summary && !topic.postStream.summary) {
+      controls.push(
+        this.attach("button", {
+          className: "show-summary",
+          label: "summary.short_label",
+          title: "summary.short_title",
+          action: "showSummary",
+        })
+      );
+    }
+
     if (currentUser && !fullScreen) {
       if (topic.get("details.can_create_post")) {
         controls.push(

--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -351,10 +351,15 @@ createWidget("timeline-footer-controls", {
     const controls = [];
     const { currentUser, fullScreen, topic, notificationLevel } = attrs;
 
-    if (!fullScreen && topic.has_summary && !topic.postStream.summary) {
+    if (
+      this.siteSettings.summary_timeline_button &&
+      !fullScreen &&
+      topic.has_summary &&
+      !topic.postStream.summary
+    ) {
       controls.push(
         this.attach("button", {
-          className: "show-summary",
+          className: "show-summary btn-small",
           label: "summary.short_label",
           title: "summary.short_title",
           action: "showSummary",

--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -360,6 +360,7 @@ createWidget("timeline-footer-controls", {
       controls.push(
         this.attach("button", {
           className: "show-summary btn-small",
+          icon: "layer-group",
           label: "summary.short_label",
           title: "summary.short_title",
           action: "showSummary",

--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -186,6 +186,8 @@
       margin-top: 1.5em;
       transition: opacity 0.2s ease-in;
       display: flex;
+      flex-wrap: wrap;
+      max-width: 9em;
 
       .reply-to-post {
         margin-right: 0.5em;
@@ -194,6 +196,9 @@
       button:last-child {
         margin-right: 0;
       }
+    }
+    .show-summary {
+      margin-bottom: 0.5em;
     }
 
     .start-date {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1819,6 +1819,8 @@ en:
       description_time_MF: "There {replyCount, plural, one {is <b>#</b> reply} other {are <b>#</b> replies}} with an estimated read time of <b>{readingTime, plural, one {# minute} other {# minutes}}</b>."
       enable: "Summarize This Topic"
       disable: "Show All Posts"
+      short_label: "Summarize"
+      short_title: "Show a summary of this topic as determined by the community"
 
     deleted_filter:
       enabled_description: "This topic contains deleted posts, which have been hidden."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1820,7 +1820,7 @@ en:
       enable: "Summarize This Topic"
       disable: "Show All Posts"
       short_label: "Summarize"
-      short_title: "Show a summary of this topic as determined by the community"
+      short_title: "Show a summary of this topic: the most interesting posts as determined by the community"
 
     deleted_filter:
       enabled_description: "This topic contains deleted posts, which have been hidden."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1545,11 +1545,13 @@ en:
     enforce_second_factor: "Forces users to enable two-factor authentication. Select 'all' to enforce it to all users. Select 'staff' to enforce it to staff users only."
     force_https: "Force your site to use HTTPS only. WARNING: do NOT enable this until you verify HTTPS is fully set up and working absolutely everywhere! Did you check your CDN, all social logins, and any external logos / dependencies to make sure they are all HTTPS compatible, too?"
     same_site_cookies: "Use same site cookies, they eliminate all Cross Site Request Forgery vectors on supported browsers (Lax or Strict). Warning: Strict will only work on sites that force login and use an external auth method."
+
     summary_score_threshold: "The minimum score required for a post to be included in 'Summarize This Topic'"
     summary_posts_required: "Minimum posts in a topic before 'Summarize This Topic' is enabled. Changes to this setting will be applied retroactively within a week."
     summary_likes_required: "Minimum likes in a topic before 'Summarize This Topic' is enabled. Changes to this setting will be applied retroactively within a week."
     summary_percent_filter: "When a user clicks 'Summarize This Topic', show the top % of posts"
     summary_max_results: "Maximum posts returned by 'Summarize This Topic'"
+    summary_timeline_button: "Show a 'Summarize' button in the timeline"
 
     enable_personal_messages: "Allow trust level 1 (configurable via min trust level to send messages) users to create messages and reply to messages. Note that staff can always send messages no matter what."
     enable_system_message_replies: "Allows users to reply to system messages, even if personal messages are disabled"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2100,6 +2100,9 @@ uncategorized:
   summary_likes_required: 1
   summary_percent_filter: 20
   summary_max_results: 100
+  summary_timeline_button:
+    client: true
+    default: false
 
   automatic_topic_heat_values: true
 

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -141,6 +141,7 @@ module SvgSprite
     "info-circle",
     "italic",
     "key",
+    "layer-group",
     "link",
     "list",
     "list-ol",


### PR DESCRIPTION
Makes it a little easy to access the summary feature of large topics,
given that the existing button at the bottom of the OP is easy to miss.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/123475972-2113fc00-d5ca-11eb-9285-0285bffcce1a.png">

This is behind a site setting (default off). 