### PR TITLE
FIX: Remove GitHub avatars from emails

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -142,6 +142,7 @@ module Email
       style('.onebox-avatar-inline', ONEBOX_INLINE_AVATAR_STYLE)
 
       @fragment.css('.github-body-container .excerpt').remove
+      @fragment.css('.github-info .user img').remove
 
       @fragment.css('aside.quote blockquote > p').each do |p|
         p['style'] = 'padding: 0;'


### PR DESCRIPTION
Rationale:
1. these avatars are quite large (460x460px or so) and they end up being displayed in all their huge glory at the end of emails (in macOS Mail.app) when sent from a secure-uploads-enabled forum
2. they were displayed in the wrong spot (due to `float: left`) in some cases, depending on viewport size and the rendering engine

<details>
<summary>Examples (CW: huge joffrey 😄)</summary>
<img width="640" alt="huge avatar" src="https://user-images.githubusercontent.com/66961/123554428-37fc4f00-d780-11eb-9e23-6733e67b364a.png">

<img width="279" alt="invalid position on macOS" src="https://user-images.githubusercontent.com/66961/123554536-c2dd4980-d780-11eb-9f06-066f11af7c69.png">

<img src="https://user-images.githubusercontent.com/66961/123554347-d340f480-d77f-11eb-8018-943d39a0e193.jpeg" alt="invalid position on iOS" width="300">
</details>

Alternative solution:
Disable them only when secure-uploads are enabled, and fix the positioning so that it works on small screen sizes/webkit.