### PR TITLE
FIX: Do not show In Reply To for group SMTP emails

### DIFF
--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -64,7 +64,7 @@ class GroupSmtpMailer < ActionMailer::Base
         context_posts: nil,
         reached_limit: nil,
         post: post,
-        in_reply_to_post: post.reply_to_post,
+        in_reply_to_post: nil,
         classes: Rtl.new(nil).css_class,
         first_footer_classes: '',
         reply_above_line: true
@@ -82,13 +82,13 @@ class GroupSmtpMailer < ActionMailer::Base
     post.topic.allowed_users.each do |u|
       if SiteSetting.prioritize_username_in_ux?
         if u.staged?
-          list.push("[#{u.email}](#{Discourse.base_url}/u/#{u.username_lower})")
+          list.push("#{u.email}")
         else
           list.push("[#{u.username}](#{Discourse.base_url}/u/#{u.username_lower})")
         end
       else
         if u.staged?
-          list.push("[#{u.email}](#{Discourse.base_url}/u/#{u.username_lower})")
+          list.push("#{u.email}")
         else
           list.push("[#{u.name.blank? ? u.username : u.name}](#{Discourse.base_url}/u/#{u.username_lower})")
         end


### PR DESCRIPTION
We do not want to show the In Reply To section of the
group SMTP email template, it is similar to Context Posts
which we removed and is unnecessary.

This PR also removes the link to staged user profiles in
the email; their email addresses will just be converted
to regular mailto: links.

![image](https://user-images.githubusercontent.com/920448/123572440-958bac80-d80f-11eb-8856-d9dfed0ed156.png)

