### PR TITLE
DEV: Drop duration column from topic timers

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1319,19 +1319,13 @@ class Topic < ActiveRecord::Base
   #  * by_user: User who is setting the topic's status update.
   #  * based_on_last_post: True if time should be based on timestamp of the last post.
   #  * category_id: Category that the update will apply to.
-  #  * duration: TODO(2021-06-01): DEPRECATED - do not use
   #  * duration_minutes: The duration of the timer in minutes, which is used if the timer is based
   #                      on the last post or if the timer type is delete_replies.
   #  * silent: Affects whether the close topic timer status change will be silent or not.
-  def set_or_create_timer(status_type, time, by_user: nil, based_on_last_post: false, category_id: SiteSetting.uncategorized_category_id, duration: nil, duration_minutes: nil, silent: nil)
-    return delete_topic_timer(status_type, by_user: by_user) if time.blank? && duration_minutes.blank? && duration.blank?
+  def set_or_create_timer(status_type, time, by_user: nil, based_on_last_post: false, category_id: SiteSetting.uncategorized_category_id, duration_minutes: nil, silent: nil)
+    return delete_topic_timer(status_type, by_user: by_user) if time.blank? && duration_minutes.blank?
 
     duration_minutes = duration_minutes ? duration_minutes.to_i : 0
-
-    # TODO(2021-06-01): deprecated - remove this when plugins calling set_or_create_timer
-    # have been fixed to use duration_minutes
-    duration = duration ? duration.to_i : 0
-
     public_topic_timer = !!TopicTimer.public_types[status_type]
     topic_timer_options = { topic: self, public_type: public_topic_timer }
     topic_timer_options.merge!(user: by_user) unless public_topic_timer
@@ -1347,29 +1341,15 @@ class Topic < ActiveRecord::Base
     end
 
     if topic_timer.based_on_last_post
-      if duration > 0 || duration_minutes > 0
+      if duration_minutes > 0
         last_post_created_at = self.ordered_posts.last.present? ? self.ordered_posts.last.created_at : time_now
-
-        # TODO(2021-06-01): deprecated - remove this when plugins calling set_or_create_timer
-        # have been fixed to use duration_minutes
-        if duration > 0
-          duration_minutes = duration * 60
-        end
-
         topic_timer.duration_minutes = duration_minutes
         topic_timer.execute_at = last_post_created_at + duration_minutes.minutes
         topic_timer.created_at = last_post_created_at
       end
     elsif topic_timer.status_type == TopicTimer.types[:delete_replies]
-      if duration > 0 || duration_minutes > 0
+      if duration_minutes > 0
         first_reply_created_at = (self.ordered_posts.where("post_number > 1").minimum(:created_at) || time_now)
-
-        # TODO(2021-06-01): deprecated - remove this when plugins calling set_or_create_timer
-        # have been fixed to use duration_minutes
-        if duration > 0
-          duration_minutes = duration * 60 * 24
-        end
-
         topic_timer.duration_minutes = duration_minutes
         topic_timer.execute_at = first_reply_created_at + duration_minutes.minutes
         topic_timer.created_at = first_reply_created_at

--- a/db/post_migrate/20210628035905_drop_duration_column_from_topic_timers.rb
+++ b/db/post_migrate/20210628035905_drop_duration_column_from_topic_timers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DropDurationColumnFromTopicTimers < ActiveRecord::Migration[6.1]
+  DROPPED_COLUMNS ||= {
+    topic_timers: %i{duration}
+  }
+
+  def up
+    DROPPED_COLUMNS.each do |table, columns|
+      Migration::ColumnDropper.execute_drop(table, columns)
+    end
+  end
+
+  def down
+    add_column :topic_timers, :duration, :string
+  end
+end


### PR DESCRIPTION
The duration column has been ignored since the commit
https://github.com/discourse/discourse/commit/4af77f1e3854c564c8404e08b83e786fd25a7bfe
for topic_timers, we use duration_minutes instead.

Also removing the duration key from Topic.set_or_create_timer. The only
plugin to use this was discourse-solved, which doesn't use it any
longer
since
https://github.com/discourse/discourse-solved/commit/c722b94a97b9710b9e43b40cd879c0af605085bd

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
