### PR TITLE
FIX: Remove extra margin from share topic modal

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -856,8 +856,7 @@
     .group-chooser,
     .user-chooser,
     .future-date-input-selector {
-      margin-left: 25px;
-      width: calc(100% - 25px);
+      width: 100%;
     }
 
     &.invite-to-topic input[type="radio"] {
@@ -953,6 +952,19 @@
   .show-advanced {
     margin-left: auto;
     margin-right: 0;
+  }
+}
+
+.create-invite-modal {
+  .input-group {
+    textarea#invite-message,
+    &.invite-to-topic input[type="text"],
+    .group-chooser,
+    .user-chooser,
+    .future-date-input-selector {
+      margin-left: 25px;
+      width: calc(100% - 25px);
+    }
   }
 }
 


### PR DESCRIPTION
The same margin used in invite modals was present, but it is not needed here. In the invite modal it is used because all inputs are organized in a list.