### PR TITLE
FIX: Do not redirect to a topic user cannot see

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -251,11 +251,19 @@ class InvitesController < ApplicationController
       topic = invite.topics.first
       response = {}
 
-      if user.present? && user.active?
-        response[:redirect_to] = topic.present? ? path(topic.relative_url) : path("/")
-      elsif user.present?
-        response[:message] = I18n.t('invite.confirm_email')
-        cookies[:destination_url] = path(topic.relative_url) if topic.present?
+      if user.present?
+        if user.active?
+          if user.guardian.can_see?(topic)
+            response[:redirect_to] = path(topic.relative_url)
+          else
+            response[:redirect_to] = path("/")
+          end
+        else
+          response[:message] = I18n.t('invite.confirm_email')
+          if user.guardian.can_see?(topic)
+            cookies[:destination_url] = path(topic.relative_url)
+          end
+        end
       end
 
       render json: success_json.merge(response)

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -686,9 +686,9 @@ describe InvitesController do
     end
 
     context 'topic invites' do
-      let(:invite) { Fabricate(:invite, email: 'test@example.com') }
+      fab!(:invite) { Fabricate(:invite, email: 'test@example.com') }
 
-      let(:secured_category) do
+      fab!(:secured_category) do
         secured_category = Fabricate(:category)
         secured_category.permissions = { staff: :full }
         secured_category.save!
@@ -698,26 +698,23 @@ describe InvitesController do
       it 'redirects user to topic if activated' do
         topic = Fabricate(:topic)
         TopicInvite.create!(invite: invite, topic: topic)
-        put "/invites/show/#{invite.invite_key}.json", params: { email_token: invite.email_token }
 
-        user = User.find_by_email('test@example.com')
+        put "/invites/show/#{invite.invite_key}.json", params: { email_token: invite.email_token }
         expect(response.parsed_body['redirect_to']).to eq(topic.relative_url)
       end
 
       it 'sets destination_url cookie if user is not activated' do
         topic = Fabricate(:topic)
         TopicInvite.create!(invite: invite, topic: topic)
-        put "/invites/show/#{invite.invite_key}.json"
 
-        user = User.find_by_email('test@example.com')
+        put "/invites/show/#{invite.invite_key}.json"
         expect(cookies['destination_url']).to eq(topic.relative_url)
       end
 
       it 'does not redirect user if they cannot see topic' do
         TopicInvite.create!(invite: invite, topic: Fabricate(:topic, category: secured_category))
-        put "/invites/show/#{invite.invite_key}.json", params: { email_token: invite.email_token }
 
-        user = User.find_by_email('test@example.com')
+        put "/invites/show/#{invite.invite_key}.json", params: { email_token: invite.email_token }
         expect(response.parsed_body['redirect_to']).to eq("/")
       end
     end


### PR DESCRIPTION
Inviting a user to a private topic used to redirect them to a 404 page
immediately after signup.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
