### PR TITLE
UX: Tweak the timestamp line in Twitter onebox

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -637,6 +637,28 @@ aside.onebox.twitterstatus .onebox-body {
       }
     }
   }
+
+  .date {
+    display: flex;
+    line-height: $line-height-small;
+
+    .timestamp {
+      color: var(--primary-medium);
+    }
+  }
+
+  .like,
+  .retweet {
+    align-items: center;
+    color: var(--primary-medium);
+    display: flex;
+    margin-left: 0.75em;
+
+    svg {
+      fill: currentColor;
+      margin-right: 0.25em;
+    }
+  }
 }
 
 // Onebox - Imgur/Flickr - Album
@@ -777,18 +799,6 @@ aside.onebox.xkcd .onebox-body img {
 .onebox.githubcommit {
   pre.message {
     padding: 0;
-  }
-}
-
-.onebox.twitterstatus {
-  .like,
-  .retweet {
-    color: var(--primary-med-or-secondary-med);
-    padding-left: 10px;
-    svg {
-      fill: currentColor;
-      vertical-align: middle;
-    }
   }
 }
 

--- a/lib/onebox/templates/twitterstatus.mustache
+++ b/lib/onebox/templates/twitterstatus.mustache
@@ -16,7 +16,7 @@
 </div>
 
 <div class="date">
-  <a href="{{link}}" target="_blank" rel="noopener">{{timestamp}}</a>
+  <a href="{{link}}" class="timestamp" target="_blank" rel="noopener">{{timestamp}}</a>
 
   {{#likes}}
     <span class="like">


### PR DESCRIPTION
Fixed alignment and made the color less intrusive to make the actual content pop out more.

Before/After

<img width="344" alt="before" src="https://user-images.githubusercontent.com/66961/123624058-6e80ab00-d80e-11eb-81b9-138fcc3740f4.png"> <img width="344" alt="after" src="https://user-images.githubusercontent.com/66961/123624064-70e30500-d80e-11eb-83b6-1ab2cd5c0659.png">
