### PR TITLE
FIX: Always render topic counts

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -142,7 +142,8 @@ export default class PostCooked {
           const $onebox = $link.closest(".onebox");
           if (
             $onebox.length === 0 ||
-            (bestElements[$onebox[0]] && bestElements[$onebox[0]] === $link[0])
+            !bestElements[$onebox[0]] ||
+            bestElements[$onebox[0]] === $link[0]
           ) {
             const title = I18n.t("topic_map.clicks", { count: lc.clicks });
             $link.append(


### PR DESCRIPTION
A post is rendered multiple times when it is being loaded. Sometimes,
not all information is available and the best link in the Onebox cannot
be found.

I could not write a test because I think the bug is caused by a race condition. The new condition should "fail" more gracefully, until the next render happens.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
