### PR TITLE
FIX: do not close the merged topic if the first post wasn't merged

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -66,6 +66,11 @@ class PostMover
     Guardian.new(user).ensure_can_see! topic
     @destination_topic = topic
 
+    original_topic_posts_count = @original_topic.posts
+      .where("post_type = ? or (post_type = ? and action_code != 'split_topic')", Post.types[:regular], Post.types[:whisper])
+      .count
+    moving_all_posts = original_topic_posts_count == posts.length
+
     create_temp_table
     delete_invalid_post_timings
     move_each_post
@@ -76,11 +81,7 @@ class PostMover
     update_upload_security_status
     update_bookmarks
 
-    posts_left = @original_topic.posts
-      .where("post_type = ? or (post_type = ? and action_code != 'split_topic')", Post.types[:regular], Post.types[:whisper])
-      .count
-
-    if posts_left == 1
+    if moving_all_posts
       close_topic_and_schedule_deletion
     end
 

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -66,6 +66,13 @@ class PostMover
     Guardian.new(user).ensure_can_see! topic
     @destination_topic = topic
 
+    # when a topic contains some posts after moving posts to another topic we shouldn't close it
+    # two types of posts should prevent a topic from closing:
+    #   1. regular posts
+    #   2. almost all whispers
+    # we should only exclude whispers with action_code: 'split_topic'
+    # because we use such whispers as a small-action posts when moving posts to the secret message
+    # (in this case we don't want everyone to see that posts were moved, that's why we use whispers)
     original_topic_posts_count = @original_topic.posts
       .where("post_type = ? or (post_type = ? and action_code != 'split_topic')", Post.types[:regular], Post.types[:whisper])
       .count

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -626,7 +626,17 @@ describe PostMover do
 
           it "doesn't close the topic when not all posts were moved" do
             topic.expects(:add_moderator_post).once
-            posts_to_move = [p1.id, p2.id, p3.id]
+            posts_to_move = [p2.id, p3.id]
+            moved_to = topic.move_posts(user, posts_to_move, destination_topic_id: destination_topic.id)
+            expect(moved_to).to be_present
+
+            topic.reload
+            expect(topic).to_not be_closed
+          end
+
+          it "doesn't close the topic when all posts except the first one were moved" do
+            topic.expects(:add_moderator_post).once
+            posts_to_move = [p2.id, p3.id, p4.id]
             moved_to = topic.move_posts(user, posts_to_move, destination_topic_id: destination_topic.id)
             expect(moved_to).to be_present
 


### PR DESCRIPTION
When a topic is fully merged into another topic we close it and schedule it for deleting. But last time I changed this place I added a bug – when merging all posts in topic except the first one the topic was closing too. 

If the OP is not merged into another topic, the original topic shouldn't be closed and marked for delition. This PR fixes this.
