### PR TITLE
FIX: Get all groups for user directory dropdown

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/users.js
@@ -1,4 +1,5 @@
 import Controller, { inject as controller } from "@ember/controller";
+import Group from "discourse/models/group";
 import { action } from "@ember/object";
 import discourseDebounce from "discourse-common/lib/debounce";
 import showModal from "discourse/lib/show-modal";
@@ -58,11 +59,11 @@ export default Controller.extend({
   },
 
   loadGroups() {
-    return this.store.findAll("group").then((groups) => {
+    return Group.findAll({ ignore_automatic: true }).then((groups) => {
       const groupOptions = groups.map((group) => {
         return {
-          name: group.name,
-          id: group.id,
+          name: group.full_name || group.name,
+          id: group.name,
         };
       });
       this.set("groupOptions", groupOptions);
@@ -72,7 +73,7 @@ export default Controller.extend({
   @action
   groupChanged(_, groupAttrs) {
     // First param is the group name, which include none or 'all groups'. Ignore this and look at second param.
-    this.set("group", groupAttrs.id ? groupAttrs.name : null);
+    this.set("group", groupAttrs.id);
   },
 
   @action


### PR DESCRIPTION
Previously I used `this.store.findAll("group")` which is _always_ paginated, so it's possible that not all groups were returned. Using `Group.findAll({ ignore_automatic: true })` (maybe we want automatic trust levels??) is what we want to use here.

I also wasn't using `full_name` when it's present, and this fixes that.