### PR TITLE
FIX: Do not call 'set' in destroyed directory table component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/directory-table.js
+++ b/app/assets/javascripts/discourse/app/components/directory-table.js
@@ -57,7 +57,11 @@ export default Component.extend({
 
   @action
   onHorizontalScroll(primary, replica) {
-    if (this.isDestroyed || this.lastScrollPosition === primary.scrollLeft) {
+    if (
+      this.isDestroying ||
+      this.isDestroyed ||
+      this.lastScrollPosition === primary.scrollLeft
+    ) {
       return;
     }
 
@@ -65,7 +69,7 @@ export default Component.extend({
 
     if (!this.ticking) {
       window.requestAnimationFrame(() => {
-        if (!this.isDestroyed) {
+        if (!this.isDestroying && !this.isDestroyed) {
           replica.scrollLeft = this.lastScrollPosition;
           this.set("ticking", false);
         }

--- a/app/assets/javascripts/discourse/app/components/directory-table.js
+++ b/app/assets/javascripts/discourse/app/components/directory-table.js
@@ -57,7 +57,7 @@ export default Component.extend({
 
   @action
   onHorizontalScroll(primary, replica) {
-    if (this.lastScrollPosition === primary.scrollLeft) {
+    if (this.isDestroyed || this.lastScrollPosition === primary.scrollLeft) {
       return;
     }
 
@@ -65,8 +65,10 @@ export default Component.extend({
 
     if (!this.ticking) {
       window.requestAnimationFrame(() => {
-        replica.scrollLeft = this.lastScrollPosition;
-        this.set("ticking", false);
+        if (!this.isDestroyed) {
+          replica.scrollLeft = this.lastScrollPosition;
+          this.set("ticking", false);
+        }
       });
 
       this.set("ticking", true);


### PR DESCRIPTION
If you go wild and toggle directory columns like crazy you can trigger functions after the component has been destroyed. Nothing breaks in the UI but you can get a couple JS errors because `set` is being called on a destroyed component.