### PR TITLE
FIX: Include user_field_ids in pagination URL for directory items

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -75,7 +75,7 @@ class DirectoryItemsController < ApplicationController
     result_count = result.count
     result = result.limit(PAGE_SIZE).offset(PAGE_SIZE * page).to_a
 
-    more_params = params.slice(:period, :order, :asc, :group).permit!
+    more_params = params.slice(:period, :order, :asc, :group, :user_field_ids).permit!
     more_params[:page] = page + 1
     load_more_uri = URI.parse(directory_items_path(more_params))
     load_more_directory_items_json = "#{load_more_uri.path}.json?#{load_more_uri.query}"

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -54,11 +54,12 @@ describe DirectoryItemsController do
     end
 
     it "respects more_params in load_more_directory_items" do
-      get '/directory_items.json', params: { period: 'all', order: "likes_given", group: group.name }
+      get '/directory_items.json', params: { period: 'all', order: "likes_given", group: group.name, user_field_ids: "1|2" }
       expect(response.status).to eq(200)
       json = response.parsed_body
 
       expect(json['meta']['load_more_directory_items']).to include("group=#{group.name}")
+      expect(json['meta']['load_more_directory_items']).to include("user_field_ids=#{CGI.escape('1|2')}")
       expect(json['meta']['load_more_directory_items']).to include("order=likes_given")
       expect(json['meta']['load_more_directory_items']).to include("period=all")
     end


### PR DESCRIPTION
Custom user fields are empty on pagination currently. That is because the `user_field_ids` param is not being passed into the load more url. This just forwards the param along and fixes the issue. I tested locally by making the `PAGE_SIZE` only 20 and so I have pagination with less than 50 (default `PAGE_SIZE` value) users.