### PR TITLE
FEATURE: Add option to grant badge multiple times to users using Bulk Award

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-badges-award.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges-award.js
@@ -7,6 +7,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 export default Controller.extend({
   saving: false,
   replaceBadgeOwners: false,
+  grantExistingHolders: false,
 
   actions: {
     massAward() {
@@ -22,6 +23,10 @@ export default Controller.extend({
 
         options.data.append("file", file);
         options.data.append("replace_badge_owners", this.replaceBadgeOwners);
+        options.data.append(
+          "grant_existing_holders",
+          this.grantExistingHolders
+        );
 
         this.set("saving", true);
 

--- a/app/assets/javascripts/admin/addon/controllers/admin-badges-award.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges-award.js
@@ -14,6 +14,7 @@ export default Controller.extend({
   unmatchedEntries: null,
   resultsMessage: null,
   success: false,
+  unmatchedEntriesCount: 0,
 
   resetState() {
     this.setProperties({
@@ -21,15 +22,9 @@ export default Controller.extend({
       unmatchedEntries: null,
       resultsMessage: null,
       success: false,
+      unmatchedEntriesCount: 0,
     });
-    this.updateFileSelected();
-  },
-
-  updateFileSelected() {
-    this.set(
-      "fileSelected",
-      !!document.querySelector("#massAwardCSVUpload")?.files?.length
-    );
+    this.send("updateFileSelected");
   },
 
   @discourseComputed("fileSelected", "saving")
@@ -37,9 +32,17 @@ export default Controller.extend({
     return !fileSelected || saving;
   },
 
+  @discourseComputed("unmatchedEntriesCount", "unmatchedEntries.length")
+  unmatchedEntriesTruncated(unmatchedEntriesCount, length) {
+    return unmatchedEntriesCount && length && unmatchedEntriesCount > length;
+  },
+
   @action
-  onFileInputChange() {
-    this.updateFileSelected();
+  updateFileSelected() {
+    this.set(
+      "fileSelected",
+      !!document.querySelector("#massAwardCSVUpload")?.files?.length
+    );
   },
 
   @action
@@ -66,6 +69,7 @@ export default Controller.extend({
           ({
             matched_users_count: matchedCount,
             unmatched_entries: unmatchedEntries,
+            unmatched_entries_count: unmatchedEntriesCount,
           }) => {
             this.setProperties({
               resultsMessage: I18n.t("admin.badges.mass_award.success", {
@@ -74,7 +78,10 @@ export default Controller.extend({
               success: true,
             });
             if (unmatchedEntries.length) {
-              this.set("unmatchedEntries", unmatchedEntries);
+              this.setProperties({
+                unmatchedEntries,
+                unmatchedEntriesCount,
+              });
             }
           }
         )

--- a/app/assets/javascripts/admin/addon/controllers/admin-badges-award.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges-award.js
@@ -2,65 +2,91 @@ import Controller from "@ember/controller";
 import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import bootbox from "bootbox";
-import { popupAjaxError } from "discourse/lib/ajax-error";
-import { escapeExpression } from "discourse/lib/utilities";
+import { extractError } from "discourse/lib/ajax-error";
+import { action } from "@ember/object";
+import discourseComputed from "discourse-common/utils/decorators";
 
 export default Controller.extend({
   saving: false,
   replaceBadgeOwners: false,
   grantExistingHolders: false,
+  fileSelected: false,
+  unmatchedEntries: null,
+  resultsMessage: null,
+  success: false,
 
-  actions: {
-    massAward() {
-      const file = document.querySelector("#massAwardCSVUpload").files[0];
+  resetState() {
+    this.setProperties({
+      saving: false,
+      unmatchedEntries: null,
+      resultsMessage: null,
+      success: false,
+    });
+    this.updateFileSelected();
+  },
 
-      if (this.model && file) {
-        const options = {
-          type: "POST",
-          processData: false,
-          contentType: false,
-          data: new FormData(),
-        };
+  updateFileSelected() {
+    this.set(
+      "fileSelected",
+      !!document.querySelector("#massAwardCSVUpload")?.files?.length
+    );
+  },
 
-        options.data.append("file", file);
-        options.data.append("replace_badge_owners", this.replaceBadgeOwners);
-        options.data.append(
-          "grant_existing_holders",
-          this.grantExistingHolders
-        );
+  @discourseComputed("fileSelected", "saving")
+  massAwardButtonDisabled(fileSelected, saving) {
+    return !fileSelected || saving;
+  },
 
-        this.set("saving", true);
+  @action
+  onFileInputChange() {
+    this.updateFileSelected();
+  },
 
-        ajax(`/admin/badges/award/${this.model.id}`, options)
-          .then(
-            ({
-              matched_users_count: matchedCount,
-              unmatched_entries: unmatchedEntries,
-            }) => {
-              if (unmatchedEntries.length) {
-                const entriesToList = unmatchedEntries
-                  .map((entry) => `<li>${escapeExpression(entry)}</li>`)
-                  .join("");
-                bootbox.alert(
-                  I18n.t(
-                    "admin.badges.mass_award.success_with_unmatched_entries",
-                    { count: matchedCount, users: `<ul>${entriesToList}</ul>` }
-                  )
-                );
-              } else {
-                bootbox.alert(
-                  I18n.t("admin.badges.mass_award.success", {
-                    count: matchedCount,
-                  })
-                );
-              }
+  @action
+  massAward() {
+    const file = document.querySelector("#massAwardCSVUpload").files[0];
+
+    if (this.model && file) {
+      const options = {
+        type: "POST",
+        processData: false,
+        contentType: false,
+        data: new FormData(),
+      };
+
+      options.data.append("file", file);
+      options.data.append("replace_badge_owners", this.replaceBadgeOwners);
+      options.data.append("grant_existing_holders", this.grantExistingHolders);
+
+      this.resetState();
+      this.set("saving", true);
+
+      ajax(`/admin/badges/award/${this.model.id}`, options)
+        .then(
+          ({
+            matched_users_count: matchedCount,
+            unmatched_entries: unmatchedEntries,
+          }) => {
+            this.setProperties({
+              resultsMessage: I18n.t("admin.badges.mass_award.success", {
+                count: matchedCount,
+              }),
+              success: true,
+            });
+            if (unmatchedEntries.length) {
+              this.set("unmatchedEntries", unmatchedEntries);
             }
-          )
-          .catch(popupAjaxError)
-          .finally(() => this.set("saving", false));
-      } else {
-        bootbox.alert(I18n.t("admin.badges.mass_award.aborted"));
-      }
-    },
+          }
+        )
+        .catch((error) => {
+          this.setProperties({
+            resultsMessage: extractError(error),
+            success: false,
+          });
+        })
+        .finally(() => this.set("saving", false));
+    } else {
+      bootbox.alert(I18n.t("admin.badges.mass_award.aborted"));
+    }
   },
 });

--- a/app/assets/javascripts/admin/addon/controllers/admin-badges-award.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges-award.js
@@ -48,7 +48,11 @@ export default Controller.extend({
                   )
                 );
               } else {
-                bootbox.alert(I18n.t("admin.badges.mass_award.success"));
+                bootbox.alert(
+                  I18n.t("admin.badges.mass_award.success", {
+                    count: matchedCount,
+                  })
+                );
               }
             }
           )

--- a/app/assets/javascripts/admin/addon/routes/admin-badges-award.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-badges-award.js
@@ -9,4 +9,9 @@ export default Route.extend({
       );
     }
   },
+
+  setupController(controller) {
+    this._super(...arguments);
+    controller.resetState();
+  },
 });

--- a/app/assets/javascripts/admin/addon/templates/badges-award.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges-award.hbs
@@ -23,7 +23,7 @@
         </label>
         {{#if model.multiple_grant}}
           <label class="grant-existing-holders">
-            {{input type="checkbox" checked=grantExistingHolders class="grant-existing-holders"}}
+            {{input type="checkbox" checked=grantExistingHolders class="grant-existing-holders-checkbox"}}
             {{i18n "admin.badges.mass_award.grant_existing_holders"}}
           </label>
         {{/if}}

--- a/app/assets/javascripts/admin/addon/templates/badges-award.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges-award.hbs
@@ -14,7 +14,7 @@
       </div>
       <div>
         <h4>{{i18n "admin.badges.mass_award.upload_csv"}}</h4>
-        <input type="file" id="massAwardCSVUpload" accept=".csv" onchange={{action "onFileInputChange"}}>
+        <input type="file" id="massAwardCSVUpload" accept=".csv" onchange={{action "updateFileSelected"}}>
       </div>
       <div>
         <label>
@@ -55,7 +55,13 @@
       {{#if unmatchedEntries.length}}
         <p>
           {{d-icon "exclamation-triangle" class="bulk-award-status-icon failure"}}
-          {{i18n "admin.badges.mass_award.csv_has_unmatched_users"}}
+          <span>
+            {{#if unmatchedEntriesTruncated}}
+              {{i18n "admin.badges.mass_award.csv_has_unmatched_users_truncated_list" count=unmatchedEntriesCount}}
+            {{else}}
+              {{i18n "admin.badges.mass_award.csv_has_unmatched_users"}}
+            {{/if}}
+          </span>
         </p>
         <ul>
           {{#each unmatchedEntries as |entry|}}

--- a/app/assets/javascripts/admin/addon/templates/badges-award.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges-award.hbs
@@ -22,7 +22,7 @@
           {{i18n "admin.badges.mass_award.replace_owners"}}
         </label>
         {{#if model.multiple_grant}}
-          <label>
+          <label class="grant-existing-holders">
             {{input type="checkbox" checked=grantExistingHolders class="grant-existing-holders"}}
             {{i18n "admin.badges.mass_award.grant_existing_holders"}}
           </label>

--- a/app/assets/javascripts/admin/addon/templates/badges-award.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges-award.hbs
@@ -14,7 +14,7 @@
       </div>
       <div>
         <h4>{{i18n "admin.badges.mass_award.upload_csv"}}</h4>
-        <input type="file" id="massAwardCSVUpload" accept=".csv">
+        <input type="file" id="massAwardCSVUpload" accept=".csv" onchange={{action "onFileInputChange"}}>
       </div>
       <div>
         <label>
@@ -32,13 +32,38 @@
           class="btn-primary"
           action=(action "massAward")
           type="submit"
-          disabled=saving
+          disabled=massAwardButtonDisabled
+          icon="certificate"
           label="admin.badges.mass_award.perform"}}
-      {{#link-to "adminBadges.index" class="btn btn-danger"}}
+      {{#link-to "adminBadges.index" class="btn btn-normal"}}
         {{d-icon "times"}}
         <span>{{i18n "cancel"}}</span>
       {{/link-to}}
     </form>
+    {{#if saving}}
+      {{i18n "uploading"}}
+    {{/if}}
+    {{#if resultsMessage}}
+      <p>
+        {{#if success}}
+          {{d-icon "check" class="bulk-award-status-icon success"}}
+        {{else}}
+          {{d-icon "times" class="bulk-award-status-icon failure"}}
+        {{/if}}
+        {{resultsMessage}}
+      </p>
+      {{#if unmatchedEntries.length}}
+        <p>
+          {{d-icon "exclamation-triangle" class="bulk-award-status-icon failure"}}
+          {{i18n "admin.badges.mass_award.csv_has_unmatched_users"}}
+        </p>
+        <ul>
+          {{#each unmatchedEntries as |entry|}}
+            <li>{{entry}}</li>
+          {{/each}}
+        </ul>
+      {{/if}}
+    {{/if}}
   {{else}}
     <span class="badge-required">{{i18n "admin.badges.mass_award.no_badge_selected"}}</span>
   {{/if}}

--- a/app/assets/javascripts/admin/addon/templates/badges-award.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges-award.hbs
@@ -21,6 +21,12 @@
           {{input type="checkbox" checked=replaceBadgeOwners}}
           {{i18n "admin.badges.mass_award.replace_owners"}}
         </label>
+        {{#if model.multiple_grant}}
+          <label>
+            {{input type="checkbox" checked=grantExistingHolders class="grant-existing-holders"}}
+            {{i18n "admin.badges.mass_award.grant_existing_holders"}}
+          </label>
+        {{/if}}
       </div>
       {{d-button
           class="btn-primary"

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-badges-award-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-badges-award-test.js
@@ -1,0 +1,37 @@
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import I18n from "I18n";
+
+acceptance("Admin - Badges - Mass Award", function (needs) {
+  needs.user();
+  test("when the badge can be granted multiple times", async function (assert) {
+    await visit("/admin/badges/award/new");
+    await click(
+      query(
+        '.admin-badge-list-item span[data-badge-name="Both image and icon"]'
+      ).parentElement
+    );
+    assert.equal(
+      query(".grant-existing-holders").parentElement.textContent.trim(),
+      I18n.t("admin.badges.mass_award.grant_existing_holders"),
+      "checkbox for granting existing holders is displayed"
+    );
+  });
+
+  test("when the badge can be granted multiple times", async function (assert) {
+    await visit("/admin/badges/award/new");
+    await click(
+      query('.admin-badge-list-item span[data-badge-name="Only icon"]')
+        .parentElement
+    );
+    assert.ok(
+      !exists(".grant-existing-holders"),
+      "checkbox for granting existing holders is not displayed"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-badges-award-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-badges-award-test.js
@@ -12,23 +12,18 @@ acceptance("Admin - Badges - Mass Award", function (needs) {
   test("when the badge can be granted multiple times", async function (assert) {
     await visit("/admin/badges/award/new");
     await click(
-      query(
-        '.admin-badge-list-item span[data-badge-name="Both image and icon"]'
-      ).parentElement
+      '.admin-badge-list-item span[data-badge-name="Both image and icon"]'
     );
     assert.equal(
-      query(".grant-existing-holders").parentElement.textContent.trim(),
+      query("label.grant-existing-holders").textContent.trim(),
       I18n.t("admin.badges.mass_award.grant_existing_holders"),
       "checkbox for granting existing holders is displayed"
     );
   });
 
-  test("when the badge can be granted multiple times", async function (assert) {
+  test("when the badge can not be granted multiple times", async function (assert) {
     await visit("/admin/badges/award/new");
-    await click(
-      query('.admin-badge-list-item span[data-badge-name="Only icon"]')
-        .parentElement
-    );
+    await click('.admin-badge-list-item span[data-badge-name="Only icon"]');
     assert.ok(
       !exists(".grant-existing-holders"),
       "checkbox for granting existing holders is not displayed"

--- a/app/assets/javascripts/discourse/tests/fixtures/badges-fixture.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/badges-fixture.js
@@ -1726,6 +1726,7 @@ export default {
         name: "Both image and icon",
         icon: "fa-rocket",
         image_url: "/assets/some-image.png",
+        multiple_grant: true,
       },
     ]
   }

--- a/app/assets/stylesheets/common/admin/badges.scss
+++ b/app/assets/stylesheets/common/admin/badges.scss
@@ -134,6 +134,18 @@
 .award-badge {
   margin: 15px 0 0 15px;
   float: left;
+  max-width: 70%;
+
+  .bulk-award-status-icon {
+    margin-right: 3px;
+
+    &.success {
+      color: var(--success);
+    }
+    &.failure {
+      color: var(--danger);
+    }
+  }
 
   .badge-preview {
     min-height: 110px;

--- a/app/controllers/admin/badges_controller.rb
+++ b/app/controllers/admin/badges_controller.rb
@@ -63,8 +63,6 @@ class Admin::BadgesController < Admin::AdminController
       return
     end
 
-    BadgeGranter.revoke_all(badge) if replace_badge_owners
-
     line_number = 1
     entries = []
     File.open(csv_file) do |csv|
@@ -79,6 +77,8 @@ class Admin::BadgesController < Admin::AdminController
         end
       end
     end
+
+    BadgeGranter.revoke_all(badge) if replace_badge_owners
 
     usernames = []
     emails = []

--- a/app/controllers/admin/badges_controller.rb
+++ b/app/controllers/admin/badges_controller.rb
@@ -52,6 +52,15 @@ class Admin::BadgesController < Admin::AdminController
     end
 
     replace_badge_owners = params[:replace_badge_owners] == 'true'
+    grant_existing_holders = params[:grant_existing_holders] == 'true'
+    if !badge.multiple_grant? && grant_existing_holders
+      render_json_error(
+        I18n.t('badges.mass_award.errors.cant_grant_multiple_times', badge_name: badge.display_name),
+        status: 422
+      )
+      return
+    end
+
     BadgeGranter.revoke_all(badge) if replace_badge_owners
 
     batch_number = 1
@@ -62,12 +71,36 @@ class Admin::BadgesController < Admin::AdminController
       mode = Email.is_valid?(CSV.parse_line(csv.first).first) ? 'email' : 'username'
       csv.rewind
 
+      if grant_existing_holders
+        emails_or_usernames = []
+        csv.each_line do |line|
+          line = CSV.parse_line(line).first
+          line_number += 1
+          emails_or_usernames << line.strip.downcase if line.present?
+        end
+        csv.rewind
+
+        if mode == 'email'
+          sequence_map = User.with_email(emails_or_usernames)
+          emails_or_usernames_map_to_ids = sequence_map
+            .pluck('LOWER(user_emails.email)', :id)
+            .to_h
+        else
+          sequence_map = User.where(username_lower: emails_or_usernames)
+          emails_or_usernames_map_to_ids = sequence_map
+            .pluck(:username_lower, :id)
+            .to_h
+        end
+        sequence_map = sequence_map.joins(:user_badges).group(:id).maximum(:seq)
+      end
+
+      line_number = 1
       csv.each_line do |email_line|
         line = CSV.parse_line(email_line).first
+        line_number += 1
 
         if line.present?
-          batch << line
-          line_number += 1
+          batch << line.strip.downcase
         end
 
         # Split the emails in batches of 200 elements.
@@ -75,7 +108,26 @@ class Admin::BadgesController < Admin::AdminController
         last_batch_item = full_batch || csv.eof?
 
         if last_batch_item
-          Jobs.enqueue(:mass_award_badge, users_batch: batch, badge_id: badge.id, mode: mode)
+          if grant_existing_holders
+            batch_user_ids = emails_or_usernames_map_to_ids.slice(*batch).values
+            batch_sequence_map = sequence_map.slice(*batch_user_ids)
+            badge_count_per_user = {}
+            batch.each do |email_or_username|
+              user_id = emails_or_usernames_map_to_ids[email_or_username]
+              badge_count_per_user[user_id] ||= 0
+              badge_count_per_user[user_id] += 1
+              sequence_map[user_id] = (sequence_map[user_id] || -1) + 1
+            end
+          end
+
+          Jobs.enqueue(
+            :mass_award_badge,
+            users_batch: batch,
+            badge_id: badge.id,
+            mode: mode,
+            sequence_map: batch_sequence_map,
+            badge_count_per_user: badge_count_per_user
+          )
           batch = []
           batch_number += 1
         end
@@ -147,6 +199,7 @@ class Admin::BadgesController < Admin::AdminController
   end
 
   private
+
   def find_badge
     params.require(:id)
     Badge.find(params[:id])

--- a/app/jobs/regular/mass_award_badge.rb
+++ b/app/jobs/regular/mass_award_badge.rb
@@ -8,20 +8,39 @@ module Jobs
 
       users = User.select(:id, :username, :locale)
 
-      if mode == 'email'
+      email_mode = mode == 'email'
+      if email_mode
+        args[:users_batch].map!(&:downcase)
         users = users.with_email(args[:users_batch])
       else
-        users = users.where(username_lower: args[:users_batch].map!(&:downcase))
+        args[:users_batch].map! { |u| User.normalize_username(u) }
+        users = users.where(username_lower: args[:users_batch])
       end
 
-      return if users.empty? || badge.nil?
+      return if users.empty? || badge.nil? || !badge.enabled?
 
-      BadgeGranter.mass_grant(
-        badge,
-        users,
-        sequence_map: args[:sequence_map],
-        count_per_user: args[:badge_count_per_user]
-      )
+      if args[:grant_existing_holders] && (batch_number = args[:batch_number]) && (jobs_id = args[:jobs_id])
+        if email_mode
+          emails_or_usernames_map_to_ids = users.pluck('LOWER(user_emails.email)', :id).to_h
+        else
+          emails_or_usernames_map_to_ids = users.pluck(:username_lower, :id).to_h
+        end
+        count_per_user = {}
+        args[:users_batch].each do |email_or_username|
+          id = emails_or_usernames_map_to_ids[email_or_username]
+          next if id.blank?
+          count_per_user[id] ||= 0
+          count_per_user[id] += 1
+        end
+        BadgeGranter.mass_grant_existing_holders(
+          badge,
+          count_per_user,
+          jobs_id,
+          batch_number
+        )
+      else
+        BadgeGranter.mass_grant(badge, users)
+      end
     end
   end
 end

--- a/app/jobs/regular/mass_award_badge.rb
+++ b/app/jobs/regular/mass_award_badge.rb
@@ -3,45 +3,15 @@
 module Jobs
   class MassAwardBadge < ::Jobs::Base
     def execute(args)
-      return unless mode = args[:mode]
-      badge = Badge.find_by(id: args[:badge_id])
-      return if !badge&.enabled?
+      user = User.find_by(id: args[:user])
+      return if user.blank?
+      badge = Badge.find_by(enabled: true, id: args[:badge])
+      return if badge.blank?
 
-      users = User.select(:id, :username, :locale)
-
-      email_mode = mode == 'email'
-      if email_mode
-        args[:users_batch].map!(&:downcase)
-        users = users.with_email(args[:users_batch])
-      else
-        args[:users_batch].map! { |u| User.normalize_username(u) }
-        users = users.where(username_lower: args[:users_batch])
-      end
-
-      return if users.empty?
-
-      if args[:grant_existing_holders] && (batch_number = args[:batch_number]) && (jobs_id = args[:jobs_id])
-        if email_mode
-          emails_or_usernames_map_to_ids = users.pluck('LOWER(user_emails.email)', :id).to_h
-        else
-          emails_or_usernames_map_to_ids = users.pluck(:username_lower, :id).to_h
-        end
-        count_per_user = {}
-        args[:users_batch].each do |email_or_username|
-          id = emails_or_usernames_map_to_ids[email_or_username]
-          next if id.blank?
-          count_per_user[id] ||= 0
-          count_per_user[id] += 1
-        end
-        BadgeGranter.mass_grant_existing_holders(
-          badge,
-          count_per_user,
-          jobs_id,
-          batch_number
-        )
-      else
-        BadgeGranter.mass_grant(badge, users)
-      end
+      grant_existing_holders = args[:grant_existing_holders]
+      count = args[:count]
+      count = 1 if !grant_existing_holders
+      BadgeGranter.mass_grant(badge, user, count: count, allow_multiple_grants: grant_existing_holders)
     end
   end
 end

--- a/app/jobs/regular/mass_award_badge.rb
+++ b/app/jobs/regular/mass_award_badge.rb
@@ -5,6 +5,7 @@ module Jobs
     def execute(args)
       return unless mode = args[:mode]
       badge = Badge.find_by(id: args[:badge_id])
+      return if !badge&.enabled?
 
       users = User.select(:id, :username, :locale)
 
@@ -17,7 +18,7 @@ module Jobs
         users = users.where(username_lower: args[:users_batch])
       end
 
-      return if users.empty? || badge.nil? || !badge.enabled?
+      return if users.empty?
 
       if args[:grant_existing_holders] && (batch_number = args[:batch_number]) && (jobs_id = args[:jobs_id])
         if email_mode

--- a/app/jobs/regular/mass_award_badge.rb
+++ b/app/jobs/regular/mass_award_badge.rb
@@ -8,10 +8,7 @@ module Jobs
       badge = Badge.find_by(enabled: true, id: args[:badge])
       return if badge.blank?
 
-      grant_existing_holders = args[:grant_existing_holders]
-      count = args[:count]
-      count = 1 if !grant_existing_holders
-      BadgeGranter.mass_grant(badge, user, count: count, allow_multiple_grants: grant_existing_holders)
+      BadgeGranter.mass_grant(badge, user, count: args[:count])
     end
   end
 end

--- a/app/jobs/regular/mass_award_badge.rb
+++ b/app/jobs/regular/mass_award_badge.rb
@@ -16,7 +16,12 @@ module Jobs
 
       return if users.empty? || badge.nil?
 
-      BadgeGranter.mass_grant(badge, users)
+      BadgeGranter.mass_grant(
+        badge,
+        users,
+        sequence_map: args[:sequence_map],
+        count_per_user: args[:badge_count_per_user]
+      )
     end
   end
 end

--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -66,7 +66,7 @@ class BadgeGranter
           end
         end
       end
-    rescue PG::UniqueViolation => ex
+    rescue PG::UniqueViolation, PG::TRDeadlockDetected => ex
       if attempts < 10
         sleep(rand * 2)
         attempts += 1

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5251,6 +5251,7 @@ en:
           aborted: Please upload a CSV containing either user emails or usernames
           success: Your CSV was received and %{count} users will receive their badge shortly.
           csv_has_unmatched_users: "The following entries are in the CSV file but they couldn't be matched to existing users, and therefore won't receive the badge:"
+          csv_has_unmatched_users_truncated_list: "There were %{count} entries in the CSV file that couldn't be matched to existing users, and therefore won't receive the badge. Due to the large number of unmatched entries, only the first 100 are shown:"
           replace_owners: Remove the badge from previous owners
           grant_existing_holders: Grant additional badges to existing badge holders
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5250,9 +5250,7 @@ en:
           upload_csv: Upload a CSV with either user emails or usernames
           aborted: Please upload a CSV containing either user emails or usernames
           success: Your CSV was received and %{count} users will receive their badge shortly.
-          success_with_unmatched_entries: |
-            Your CSV file has been received and %{count} users will receive their badge shortly. However, the following user(s) could not be found, and therefore won't receive the badge:
-            %{users}
+          csv_has_unmatched_users: "The following entries are in the CSV file but they couldn't be matched to existing users, and therefore won't receive the badge:"
           replace_owners: Remove the badge from previous owners
           grant_existing_holders: Grant additional badges to existing badge holders
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5249,7 +5249,7 @@ en:
           perform: "Award Badge to Users"
           upload_csv: Upload a CSV with either user emails or usernames
           aborted: Please upload a CSV containing either user emails or usernames
-          success: Your CSV was received and users will receive their badge shortly.
+          success: Your CSV was received and %{count} users will receive their badge shortly.
           success_with_unmatched_entries: |
             Your CSV file has been received and %{count} users will receive their badge shortly. However, the following user(s) could not be found, and therefore won't receive the badge:
             %{users}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5250,6 +5250,9 @@ en:
           upload_csv: Upload a CSV with either user emails or usernames
           aborted: Please upload a CSV containing either user emails or usernames
           success: Your CSV was received and users will receive their badge shortly.
+          success_with_unmatched_entries: |
+            Your CSV file has been received and %{count} users will receive their badge shortly. However, the following user(s) could not be found, and therefore won't receive the badge:
+            %{users}
           replace_owners: Remove the badge from previous owners
           grant_existing_holders: Grant additional badges to existing badge holders
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5251,6 +5251,7 @@ en:
           aborted: Please upload a CSV containing either user emails or usernames
           success: Your CSV was received and users will receive their badge shortly.
           replace_owners: Remove the badge from previous owners
+          grant_existing_holders: Grant additional badges to existing badge holders
 
       emoji:
         title: "Emoji"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4450,6 +4450,7 @@ en:
       errors:
         invalid_csv: We encountered an error on line %{line_number}. Please confirm the CSV has one email per line.
         badge_disabled: Please enable the %{badge_name} badge first.
+        cant_grant_multiple_times: Can't grant the %{badge_name} badge multiple times to a single user.
     editor:
       name: Editor
       description: First post edit

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4449,6 +4449,7 @@ en:
     mass_award:
       errors:
         invalid_csv: We encountered an error on line %{line_number}. Please confirm the CSV has one email per line.
+        too_many_csv_entries: Too many entries in the CSV file. Please provide a CSV file with no more than %{count} entries.
         badge_disabled: Please enable the %{badge_name} badge first.
         cant_grant_multiple_times: Can't grant the %{badge_name} badge multiple times to a single user.
     editor:

--- a/spec/jobs/mass_award_badge_spec.rb
+++ b/spec/jobs/mass_award_badge_spec.rb
@@ -42,7 +42,7 @@ describe Jobs::MassAwardBadge do
       expect(instances.pluck(:seq).sort).to eq((0...4).to_a)
       notifications = Notification.where(user: user)
       expect(notifications.count).to eq(1)
-      expect(instances.map(&:notification_id).uniq).to eq([notifications.first.id])
+      expect(instances.map(&:notification_id).uniq).to contain_exactly(notifications.first.id)
     end
 
     def execute_job(user, count: 1, grant_existing_holders: false)

--- a/spec/jobs/mass_award_badge_spec.rb
+++ b/spec/jobs/mass_award_badge_spec.rb
@@ -9,22 +9,13 @@ describe Jobs::MassAwardBadge do
     let(:email_mode) { 'email' }
 
     it 'creates the badge for an existing user' do
-      execute_job([user.email])
+      execute_job(user)
 
       expect(UserBadge.where(user: user, badge: badge).exists?).to eq(true)
     end
 
-    it 'works with multiple users' do
-      user_2 = Fabricate(:user)
-
-      execute_job([user.email, user_2.email])
-
-      expect(UserBadge.exists?(user: user, badge: badge)).to eq(true)
-      expect(UserBadge.exists?(user: user_2, badge: badge)).to eq(true)
-    end
-
     it 'also creates a notification for the user' do
-      execute_job([user.email])
+      execute_job(user)
 
       expect(Notification.exists?(user: user)).to eq(true)
       expect(UserBadge.where.not(notification_id: nil).exists?(user: user, badge: badge)).to eq(true)
@@ -35,14 +26,26 @@ describe Jobs::MassAwardBadge do
 
       UserBadge.create!(badge_id: Badge::Member, user: user, granted_by: Discourse.system_user, granted_at: Time.now)
 
-      execute_job([user.email, user_2.email])
+      execute_job(user)
+      execute_job(user_2)
 
       expect(UserBadge.find_by(user: user, badge: badge).featured_rank).to eq(2)
       expect(UserBadge.find_by(user: user_2, badge: badge).featured_rank).to eq(1)
     end
 
-    def execute_job(emails)
-      subject.execute(users_batch: emails, badge_id:  badge.id, mode: 'email')
+    it 'grants a badge multiple times to a user' do
+      badge.update!(multiple_grant: true)
+      Notification.destroy_all
+      execute_job(user, count: 4, grant_existing_holders: true)
+      instances = UserBadge.where(user: user, badge: badge)
+      expect(instances.count).to eq(4)
+      notifications = Notification.where(user: user)
+      expect(notifications.count).to eq(1)
+      expect(instances.map(&:notification_id).uniq).to eq([notifications.first.id])
+    end
+
+    def execute_job(user, count: 1, grant_existing_holders: false)
+      subject.execute(user: user.id, badge:  badge.id, count: count, grant_existing_holders: grant_existing_holders)
     end
   end
 end

--- a/spec/jobs/mass_award_badge_spec.rb
+++ b/spec/jobs/mass_award_badge_spec.rb
@@ -39,6 +39,7 @@ describe Jobs::MassAwardBadge do
       execute_job(user, count: 4, grant_existing_holders: true)
       instances = UserBadge.where(user: user, badge: badge)
       expect(instances.count).to eq(4)
+      expect(instances.pluck(:seq).sort).to eq((0...4).to_a)
       notifications = Notification.where(user: user)
       expect(notifications.count).to eq(1)
       expect(instances.map(&:notification_id).uniq).to eq([notifications.first.id])

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -486,4 +486,18 @@ describe BadgeGranter do
       expect(BadgeGranter.notification_locale('pl_PL')).to eq('pl_PL')
     end
   end
+
+  describe '.mass_grant' do
+    it 'raises an error if the count argument is less than 1' do
+      expect do
+        BadgeGranter.mass_grant(badge, user, count: 0)
+      end.to raise_error(ArgumentError, "count can't be less than 1")
+    end
+
+    it 'raises an error if the count argument is larger than 1 and allow_multiple_grants is false' do
+      expect do
+        BadgeGranter.mass_grant(badge, user, count: 2, allow_multiple_grants: false)
+      end.to raise_error(ArgumentError, "count can't be larger than 1 when allow_multiple_grants is false.")
+    end
+  end
 end

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -494,10 +494,104 @@ describe BadgeGranter do
       end.to raise_error(ArgumentError, "count can't be less than 1")
     end
 
-    it 'raises an error if the count argument is larger than 1 and allow_multiple_grants is false' do
-      expect do
-        BadgeGranter.mass_grant(badge, user, count: 2, allow_multiple_grants: false)
-      end.to raise_error(ArgumentError, "count can't be larger than 1 when allow_multiple_grants is false.")
+    it 'grants the badge to the user as many times as the count argument' do
+      BadgeGranter.mass_grant(badge, user, count: 10)
+      sequence = UserBadge.where(badge: badge, user: user).pluck(:seq).sort
+      expect(sequence).to eq((0...10).to_a)
+
+      BadgeGranter.mass_grant(badge, user, count: 10)
+      sequence = UserBadge.where(badge: badge, user: user).pluck(:seq).sort
+      expect(sequence).to eq((0...20).to_a)
+    end
+  end
+
+  describe '.enqueue_mass_grant_for_users' do
+    before { Jobs.run_immediately! }
+
+    it 'returns a list of the entries that could not be matched to any users' do
+      results = BadgeGranter.enqueue_mass_grant_for_users(
+        badge,
+        emails: ['fakeemail@discourse.invalid', user.email],
+        usernames: [user.username, 'fakeusername'],
+      )
+      expect(results[:unmatched_entries]).to contain_exactly(
+        'fakeemail@discourse.invalid',
+        'fakeusername'
+      )
+      expect(results[:matched_users_count]).to eq(1)
+      expect(results[:unmatched_entries_count]).to eq(2)
+    end
+
+    context 'when ensure_users_have_badge_once is true' do
+      it 'ensures each user has the badge at least once and does not grant the badge multiple times to one user' do
+        BadgeGranter.grant(badge, user)
+        user_without_badge = Fabricate(:user)
+
+        Notification.destroy_all
+        results = BadgeGranter.enqueue_mass_grant_for_users(
+          badge,
+          usernames: [
+            user.username,
+            user.username,
+            user_without_badge.username,
+            user_without_badge.username
+          ],
+          ensure_users_have_badge_once: true
+        )
+        expect(results[:unmatched_entries]).to eq([])
+        expect(results[:matched_users_count]).to eq(2)
+        expect(results[:unmatched_entries_count]).to eq(0)
+
+        sequence = UserBadge.where(user: user, badge: badge).pluck(:seq)
+        expect(sequence).to contain_exactly(0)
+        # no new badge/notification because user already had the badge
+        # before enqueue_mass_grant_for_users was called
+        expect(user.reload.notifications.size).to eq(0)
+
+        sequence = UserBadge.where(user: user_without_badge, badge: badge)
+        expect(sequence.pluck(:seq)).to contain_exactly(0)
+        notifications = user_without_badge.reload.notifications
+        expect(notifications.size).to eq(1)
+        expect(sequence.first.notification_id).to eq(notifications.first.id)
+        expect(notifications.first.notification_type).to eq(Notification.types[:granted_badge])
+      end
+    end
+
+    context 'when ensure_users_have_badge_once is false' do
+      it 'grants the badge to the users as many times as they appear in the emails and usernames arguments' do
+        badge.update!(multiple_grant: true)
+        user_without_badge = Fabricate(:user)
+        user_with_badge = Fabricate(:user).tap { |u| BadgeGranter.grant(badge, u) }
+
+        Notification.destroy_all
+        emails = [user_with_badge.email.titlecase, user_without_badge.email.titlecase] * 20
+        usernames = [user_with_badge.username.titlecase, user_without_badge.username.titlecase] * 20
+
+        results = BadgeGranter.enqueue_mass_grant_for_users(
+          badge,
+          emails: emails,
+          usernames: usernames,
+          ensure_users_have_badge_once: false
+        )
+        expect(results[:unmatched_entries]).to eq([])
+        expect(results[:matched_users_count]).to eq(2)
+        expect(results[:unmatched_entries_count]).to eq(0)
+
+        sequence = UserBadge.where(user: user_with_badge, badge: badge).pluck(:seq)
+        expect(sequence.size).to eq(40 + 1)
+        expect(sequence.sort).to eq((0...(40 + 1)).to_a)
+        sequence = UserBadge.where(user: user_without_badge, badge: badge).pluck(:seq)
+        expect(sequence.size).to eq(40)
+        expect(sequence.sort).to eq((0...40).to_a)
+
+        # each user gets 1 notification no matter how many times
+        # they're repeated in the file.
+        [user_without_badge, user_with_badge].each do |u|
+          notifications = u.reload.notifications
+          expect(notifications.size).to eq(1)
+          expect(notifications.map(&:notification_type).uniq).to contain_exactly(Notification.types[:granted_badge])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Currently when bulk-awarding a badge that can be granted multiple times, users that appear multiple times in the CSV file are granted the badge only once if they have not been granted the badge before, and never if they already have the badge.

This PR adds a new option to the Badge Bulk Award feature so that it's possible to grant users a badge even if they already have the badge and as many times as they appear in the CSV file:

![image](https://user-images.githubusercontent.com/17474474/123868428-5b69fa00-d938-11eb-8976-7cd85d0b145c.png)

The way this feature works is when you upload a CSV file, the `Admin::BadgesController#mass_award` action looks up the current sequence numbers of the badge for all the users in the CSV file, and then passes this data to the instances of `MassAwardBadge` it enqueues.

The rationale behind making the controller action look up the current sequence numbers instead of the `MassAwardBadge` job is to make the job "crash safe". I.e., if the job looked up the current sequence numbers and it crashed midway through, Sidekiq would retry the job later and the job could potentially see new sequence numbers in the database and grant some users the badge more times than it should. In the current design we have no such problem because the controller passes the sequence numbers to the job and in the event it's retried it reuses the same sequence numbers.