### PR TITLE
FIX: Use CDN path when redirecting SVG sprite path.

### DIFF
--- a/app/controllers/svg_sprite_controller.rb
+++ b/app/controllers/svg_sprite_controller.rb
@@ -12,10 +12,10 @@ class SvgSpriteController < ApplicationController
     no_cookies
 
     RailsMultisite::ConnectionManagement.with_hostname(params[:hostname]) do
-      theme_id = params[:theme_id].to_i
+      theme_id = params[:theme_id].to_i if params[:theme_id].present?
 
       if SvgSprite.version(theme_id) != params[:version]
-        return redirect_to path(SvgSprite.path(theme_id))
+        return redirect_to UrlHelper.absolute((SvgSprite.path(theme_id)))
       end
 
       svg_sprite = "window.__svg_sprite = #{SvgSprite.bundle(theme_id).inspect};"

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -24,8 +24,17 @@ describe SvgSpriteController do
       random_hash = Digest::SHA1.hexdigest("somerandomstring")
       get "/svg-sprite/#{Discourse.current_hostname}/svg--#{random_hash}.js"
 
-      expect(response.status).to eq(302)
-      expect(response.location).to include(SvgSprite.version)
+      expect(response).to redirect_to(
+        "/svg-sprite/test.localhost/svg--#{SvgSprite.version}.js"
+      )
+
+      set_cdn_url "//some-cdn.com/site"
+
+      get "/svg-sprite/#{Discourse.current_hostname}/svg--#{random_hash}.js"
+
+      expect(response).to redirect_to(
+        "https://some-cdn.com/site/svg-sprite/test.localhost/svg--#{SvgSprite.version}.js"
+      )
     end
   end
 


### PR DESCRIPTION
This ensures that CDN URLs with relative paths do not end up losing the
relative paths.