### PR TITLE
FIX: Reintroduce add group user by email

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/group-add-members.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/group-add-members.hbs
@@ -4,15 +4,22 @@
 
     <div class="input-group">
       {{email-group-user-chooser
-        value=usernames
-        onChange=(action (mut usernames))
+        value=usernamesAndEmails
+        onChange=(action "setUsernamesAndEmails")
+        options=(hash
+          allowEmails=currentUser.can_invite_to_forum
+          filterPlaceholder=(if currentUser.can_invite_to_forum
+                             "groups.add_members.usernames_or_emails_placeholder"
+                             "groups.add_members.usernames_placeholder"
+                            )
+        )
       }}
     </div>
 
     {{#if model.can_admin_group}}
       <div class="input-group">
         <label>
-          {{input id="set-owner" type="checkbox" checked=setOwner disabled=emailsPresent}}
+          {{input id="set-owner" type="checkbox" checked=setOwner disabled=emails}}
           {{i18n "groups.add_members.set_owner"}}
         </label>
       </div>
@@ -20,7 +27,7 @@
 
     <div class="input-group">
       <label>
-        {{input type="checkbox"  checked=notifyUsers}}
+        {{input type="checkbox" checked=notifyUsers disabled=(and (not usernames) emails)}}
         {{i18n "groups.add_members.notify_users"}}
       </label>
     </div>
@@ -31,6 +38,6 @@
   {{d-button action=(action "addMembers")
       class="add btn-primary"
       icon="plus"
-      disabled=(or loading (not usernames))
+      disabled=(or loading (not usernamesAndEmails))
       label="groups.add"}}
 </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -668,6 +668,8 @@ en:
       add_members:
         title: "Add Users to %{group_name}"
         description: "Enter a list of users you want to invite to the group or paste in a comma separated list:"
+        usernames_placeholder: "usernames"
+        usernames_or_emails_placeholder: "usernames or emails"
         notify_users: "Notify users"
         set_owner: "Set users as owners of this group"
       requests:


### PR DESCRIPTION
This feature was removed when the modal for adding and inviting members
was split in two modals.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
