### PR TITLE
FIX: Clear appropriate cache when updating font settings

### DIFF
--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -27,7 +27,7 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
     end
   end
 
-  Stylesheet::Manager.clear_core_cache!(["desktop", "mobile"]) if [:base_font, :heading_font].include?(name)
+  Stylesheet::Manager.clear_color_scheme_cache! if [:base_font, :heading_font].include?(name)
 
   Report.clear_cache(:storage_stats) if [:backup_location, :s3_backup_bucket].include?(name)
 

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -502,6 +502,15 @@ describe Stylesheet::Manager do
       expect(stylesheet2).to include("--primary: #c00;")
     end
 
+    it "includes updated font definitions" do
+      details1 = manager.color_scheme_stylesheet_details(nil, "all")
+
+      SiteSetting.base_font = DiscourseFonts.fonts[2][:key]
+
+      details2 = manager.color_scheme_stylesheet_details(nil, "all")
+      expect(details1[:new_href]).not_to eq(details2[:new_href])
+    end
+
     context "theme colors" do
       let(:theme) { Fabricate(:theme).tap { |t|
         t.set_field(target: :common, name: "color_definitions", value: ':root {--special: rebeccapurple;}')


### PR DESCRIPTION
Fonts are now included with color definitions, and we need to clear the
correct cache when updating the setting.
