### PR TITLE
UX: Consistent emoji size for oneboxed GH issues.

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -509,6 +509,7 @@ pre.onebox code {
   .emoji {
     max-height: 15px;
     margin: 0.2em;
+    min-width: 15px;
   }
 }
 


### PR DESCRIPTION
Before:

<img width="636" alt="Screen Shot 2021-06-30 at 11 47 15" src="https://user-images.githubusercontent.com/5025816/123982271-440f2900-d999-11eb-8d5f-2da014cdef64.png">

After:

<img width="647" alt="Screen Shot 2021-06-30 at 11 46 58" src="https://user-images.githubusercontent.com/5025816/123982295-483b4680-d999-11eb-97be-e09ececc8582.png">
