### PR TITLE
FIX: Don’t translate TrustLevel name when generating links

### DIFF
--- a/app/models/concerns/reports/users_by_trust_level.rb
+++ b/app/models/concerns/reports/users_by_trust_level.rb
@@ -24,7 +24,7 @@ module Reports::UsersByTrustLevel
       ]
 
       User.real.group('trust_level').count.sort.each do |level, count|
-        key = TrustLevel.name(level.to_i)
+        key = TrustLevel.levels.key(level.to_i)
         url = Proc.new { |k| "/admin/users/list/#{k}" }
         report.data << { url: url.call(key), key: key, x: level.to_i, y: count }
       end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -352,6 +352,8 @@ describe Report do
         expect(report.data.find { |d| d[:x] == TrustLevel[0] }[:y]).to eq 3
         expect(report.data.find { |d| d[:x] == TrustLevel[2] }[:y]).to eq 2
         expect(report.data.find { |d| d[:x] == TrustLevel[4] }[:y]).to eq 1
+
+        expect(report.data.find { |d| d[:x] == TrustLevel[0] }[:url]).to eq '/admin/users/list/newuser'
       end
     end
   end


### PR DESCRIPTION
We want to put the name of the trust level in to generated URLs, not the human-readable form.

i.e.:

`/admin/users/list/newuser`

rather than:

`/admin/users/list/new user`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
