### PR TITLE
FIX: Detect resize failures in the client size image optimization

### DIFF
--- a/public/javascripts/media-optimization-worker.js
+++ b/public/javascripts/media-optimization-worker.js
@@ -74,6 +74,9 @@ async function optimize(imageData, fileName, width, height, settings) {
         settings.resize_pre_multiply,
         settings.resize_linear_rgb
       );
+      if (resizeResult[3] !== 255) {
+        throw "Image corrupted during resize. Falling back to the original for encode"
+      }
       maybeResized = new ImageData(
         resizeResult,
         target_dimensions.width,
@@ -102,6 +105,10 @@ async function optimize(imageData, fileName, width, height, settings) {
   const finalSize = result.byteLength
   logIfDebug(`Worker post reencode file: ${finalSize}`);
   logIfDebug(`Reduction: ${(initialSize / finalSize).toFixed(1)}x speedup`);
+
+  if (finalSize < 20000) {
+    throw "Final size suspciously small, discarding optimizations"
+  }
 
   let transferrable = Uint8Array.from(result).buffer; // decoded was allocated inside WASM so it **cannot** be transfered to another context, need to copy by value
 


### PR DESCRIPTION
On iOS 15 beta, if you select the camera app when uploading an image
and try to upload a freshly taken picture, from the second picture
onwards the resize WASM operation will return an array filled with
zeroes.

Since every 4th byte is alpha, and at this step we are only dealing with
non-transparent images this a O(1) way to detect that the bug was hit.
(On normal images, all 4th bytes are 255 at this point)

Also adds a "catch-all" when the original image became too small to try
to accomodate other bugs of the same type. By default we only trigger
this whole operation on images over 1MB, so if the end result is <20KB
something weird did happen. Throwing here will let the upload continue
using the original file, so nothing is lost and the user can continue.
