### PR TITLE
DEV: Pass the cookie jar to the :after_auth event

### DIFF
--- a/app/controllers/users/associate_accounts_controller.rb
+++ b/app/controllers/users/associate_accounts_controller.rb
@@ -27,9 +27,9 @@ class Users::AssociateAccountsController < ApplicationController
     authenticator = Discourse.enabled_authenticators.find { |a| a.name == provider_name }
     raise Discourse::InvalidAccess.new(I18n.t('authenticator_not_found')) if authenticator.nil?
 
-    DiscourseEvent.trigger(:before_auth, authenticator, auth)
+    DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies)
     auth_result = authenticator.after_authenticate(auth, existing_account: current_user)
-    DiscourseEvent.trigger(:after_auth, authenticator, auth_result)
+    DiscourseEvent.trigger(:after_auth, authenticator, auth_result, session, cookies)
 
     render json: success_json
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -33,10 +33,10 @@ class Users::OmniauthCallbacksController < ApplicationController
       Discourse.redis.setex "#{Users::AssociateAccountsController::REDIS_PREFIX}_#{current_user.id}_#{token}", 10.minutes, auth.to_json
       return redirect_to "#{Discourse.base_path}/associate/#{token}"
     else
-      DiscourseEvent.trigger(:before_auth, authenticator, auth, session)
+      DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies)
       @auth_result = authenticator.after_authenticate(auth)
       @auth_result.user = nil if @auth_result&.user&.staged # Treat staged users the same as unregistered users
-      DiscourseEvent.trigger(:after_auth, authenticator, @auth_result, session)
+      DiscourseEvent.trigger(:after_auth, authenticator, @auth_result, session, cookies)
     end
 
     preferred_origin = request.env['omniauth.origin']


### PR DESCRIPTION
Plugins can add custom cookies by hooking to this event. The auth result is also included in this event so they can know if auth was successful.

