### PR TITLE
FIX: uses this.attrs to check for deprecations

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1045,7 +1045,7 @@ export default Component.extend(
             `The \`${from}\` attribute is deprecated. Use \`${to}\` instead`
           );
 
-          this.set(to, this.get(from));
+          this.set(to, this.attrs[from]);
         }
       });
     },

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1040,7 +1040,7 @@ export default Component.extend(
 
       Object.keys(migrations).forEach((from) => {
         const to = migrations[from];
-        if (this.get(from) && !this.get(to)) {
+        if (isPresent(this.attrs[from]) && !isPresent(this.attrs[to])) {
           this._deprecated(
             `The \`${from}\` attribute is deprecated. Use \`${to}\` instead`
           );

--- a/app/assets/javascripts/select-kit/addon/components/tag-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/tag-drop.js
@@ -33,6 +33,7 @@ export default ComboBoxComponent.extend(TagsMixin, {
 
   selectKitOptions: {
     allowAny: false,
+    autoFilterable: false,
     caretDownIcon: "caret-right",
     caretUpIcon: "caret-down",
     fullWidthOnMobile: true,


### PR DESCRIPTION
This is more accurate and prevents false positives where a property with the same name than deprecated is present in the component.