### PR TITLE
FIX: Detect decode failures earlier in image optimization pipeline

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/media-optimization-utils.js
+++ b/app/assets/javascripts/discourse/app/lib/media-optimization-utils.js
@@ -71,11 +71,7 @@ function jpegDecodeFailure(type, imageData) {
     return false;
   }
 
-  if (imageData.data[3] === 0) {
-    return true;
-  } else {
-    return false;
-  }
+  return imageData.data[3] === 0;
 }
 
 export async function fileToImageData(file) {

--- a/app/assets/javascripts/discourse/app/lib/media-optimization-utils.js
+++ b/app/assets/javascripts/discourse/app/lib/media-optimization-utils.js
@@ -66,12 +66,28 @@ function isTransparent(type, imageData) {
   return false;
 }
 
+function jpegDecodeFailure(type, imageData) {
+  if (!/(\.|\/)jpe?g$/i.test(type)) {
+    return false;
+  }
+
+  if (imageData.data[3] === 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 export async function fileToImageData(file) {
   const drawable = await fileToDrawable(file);
   const imageData = drawableToimageData(drawable);
 
   if (isTransparent(file.type, imageData)) {
     throw "Image has transparent pixels, won't convert to JPEG!";
+  }
+
+  if (jpegDecodeFailure(file.type, imageData)) {
+    throw "JPEG image has transparent pixel, decode failed!";
   }
 
   return imageData;


### PR DESCRIPTION
Follow up to 9b51b9b but also detects the bug earlier and backs off.

What iOS 15 is doing is returning all zeroes to `ctx.getImageData`,
so we don't have to wait until resize to detect the problem.
