### PR TITLE
FIX: Rename ninja edit terminology to grace period

### DIFF
--- a/spec/components/post_revisor_spec.rb
+++ b/spec/components/post_revisor_spec.rb
@@ -178,7 +178,7 @@ describe PostRevisor do
         expect(post.errors.messages[:base].first).to be I18n.t("cannot_edit_on_slow_mode")
       end
 
-      it 'ninja editing is allowed' do
+      it 'grace period editing is allowed' do
         SiteSetting.editing_grace_period = 1.minute
 
         subject.revise!(post.user, { raw: 'updated body' }, revised_at: post.updated_at + 10.seconds)
@@ -208,7 +208,7 @@ describe PostRevisor do
       end
     end
 
-    describe 'ninja editing' do
+    describe 'grace period editing' do
       it 'correctly applies edits' do
         SiteSetting.editing_grace_period = 1.minute
 
@@ -608,7 +608,7 @@ describe PostRevisor do
 
       context 'second poster posts again quickly' do
 
-        it 'is a ninja edit, because the second poster posted again quickly' do
+        it 'is a grace period edit, because the second poster posted again quickly' do
           SiteSetting.editing_grace_period = 1.minute
           subject.revise!(changed_by, { raw: 'yet another updated body' }, revised_at: post.updated_at + 10.seconds)
           post.reload
@@ -1178,7 +1178,7 @@ describe PostRevisor do
       expect { revisor.revise!(admin, { raw: 'updated body' }) }.to change(ReviewablePost, :count).by(0)
     end
 
-    it 'skips ninja edits' do
+    it 'skips grace period edits' do
       SiteSetting.editing_grace_period = 1.minute
 
       expect {

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -367,7 +367,7 @@ describe Group do
     expect(real_admins).to be_empty
     expect(real_staff).to eq []
 
-    # we need some ninja work to set min username to 6
+    # we need some work to set min username to 6
 
     User.where('length(username) < 6').each do |u|
       u.username = u.username + "ZZZZZZ"

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -692,7 +692,7 @@ describe Post do
 
     end
 
-    describe 'ninja editing & edit windows' do
+    describe 'grace period editing & edit windows' do
 
       before { SiteSetting.editing_grace_period = 1.minute.to_i }
 
@@ -700,7 +700,7 @@ describe Post do
         revised_at = post.updated_at + 2.minutes
         new_revised_at = revised_at + 2.minutes
 
-        # ninja edit
+        # grace period edit
         post.revise(post.user, { raw: 'updated body' }, revised_at: post.updated_at + 10.seconds)
         post.reload
         expect(post.version).to eq(1)
@@ -760,7 +760,7 @@ describe Post do
 
       context 'second poster posts again quickly' do
 
-        it 'is a ninja edit, because the second poster posted again quickly' do
+        it 'is a grace period edit, because the second poster posted again quickly' do
           SiteSetting.editing_grace_period = 1.minute.to_i
           post.revise(changed_by, { raw: 'yet another updated body' }, revised_at: post.updated_at + 10.seconds)
           post.reload


### PR DESCRIPTION
We renamed the site setting for this long ago, but there
were a few places left in the code base where "ninja edit"
needed to be turned into "grace period". Doing this here
to avoid combatative language.

