### PR TITLE
DEV: Remove broken associations on `Invite` model.

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -18,8 +18,6 @@ class Invite < ActiveRecord::Base
 
   rate_limit :limit_invites_per_day
 
-  belongs_to :user
-  belongs_to :topic
   belongs_to :invited_by, class_name: 'User'
 
   has_many :invited_users


### PR DESCRIPTION
No relevant foreign keys exists on the invites table for the
associations to even work.