### PR TITLE
DEV: Incorrect name in precompile output.

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -76,10 +76,11 @@ class Stylesheet::Manager
             compiled << "#{target}_#{theme.id}"
           end
         else
-          $stderr.puts "precompile target: #{target} #{name}"
+          theme = manager.get_theme(theme_id)
+          $stderr.puts "precompile target: #{target} #{theme&.name}"
 
           Stylesheet::Manager::Builder.new(
-            target: target, theme: manager.get_theme(theme_id), manager: manager
+            target: target, theme: theme, manager: manager
           ).compile(force: true)
         end
       end


### PR DESCRIPTION
Follow-up to c54d58e28f9d026a1d9076e1740983d406c1bf79