### PR TITLE
DEV: Do not restart server on plugin.rb save

### DIFF
--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -11,7 +11,7 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
     "#{Rails.root}/plugins"
   ]
 
-  Listen.to(*paths, only: /\.rb$/) do |modified, added, removed|
+  Listen.to(*paths, only: /^((?!plugin.rb).)*\.rb$/) do |modified, added, removed|
     supervisor_pid = $unicorn_dev_supervisor_pid # rubocop:disable Style/GlobalVars
     auto_restart = supervisor_pid && ENV["AUTO_RESTART"] != "0"
 

--- a/lib/guardian/ensure_magic.rb
+++ b/lib/guardian/ensure_magic.rb
@@ -8,6 +8,9 @@ module EnsureMagic
       can_method = :"#{Regexp.last_match[1]}?"
 
       if respond_to?(can_method)
+        puts "#########"
+        puts can_method.inspect
+        puts "#########"
         raise Discourse::InvalidAccess.new("#{can_method} failed") unless send(can_method, *args, &block)
         return
       end

--- a/lib/guardian/ensure_magic.rb
+++ b/lib/guardian/ensure_magic.rb
@@ -8,9 +8,6 @@ module EnsureMagic
       can_method = :"#{Regexp.last_match[1]}?"
 
       if respond_to?(can_method)
-        puts "#########"
-        puts can_method.inspect
-        puts "#########"
         raise Discourse::InvalidAccess.new("#{can_method} failed") unless send(can_method, *args, &block)
         return
       end


### PR DESCRIPTION
We have plugin API methods to ensure that plugin code is auto-reloaded. If plugins are properly written, we do not need to restart the server. This will speed up my development greatly, and encourage plugins to be written properly (to reload locally)

My regex tests :)
![image](https://user-images.githubusercontent.com/16214023/124170723-63778600-da6d-11eb-8d1e-389779f98fa2.png)