### PR TITLE
FIX: Delete old reminder topic timers

### DIFF
--- a/db/migrate/20210701233509_delete_old_reminder_topic_timers.rb
+++ b/db/migrate/20210701233509_delete_old_reminder_topic_timers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DeleteOldReminderTopicTimers < ActiveRecord::Migration[6.1]
+  def up
+    # following up from MigrateUserTopicTimersToBookmarkReminders,
+    # these status type 5 topic timers are the reminder type which
+    # have long been migrated to bookmark reminders
+    DB.exec("DELETE FROM topic_timers WHERE status_type = 5")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Following up from 5268568d23d6243a24db9f0f40eaca53c375540f
these status type 5 topic timers are the reminder type which
have long been migrated to bookmark reminders

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
