### PR TITLE
FIX: Do not reload whole directory table on username input change

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/users.js
@@ -94,7 +94,10 @@ export default Controller.extend({
   },
 
   _setUsernameFilter(username) {
-    this.set("params.name", username);
+    this.setProperties({
+      name: username,
+      "params.name": username,
+    });
     this.loadUsers();
   },
 

--- a/app/assets/javascripts/discourse/app/controllers/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/users.js
@@ -20,27 +20,34 @@ export default Controller.extend({
   isLoading: false,
   columns: null,
   groupsOptions: null,
+  params: null,
 
   showTimeRead: equal("period", "all"),
 
-  loadUsers(params) {
-    this.set("isLoading", true);
+  loadUsers(params = null) {
+    if (params) {
+      this.set("params", params);
+    }
 
-    this.set("nameInput", params.name);
-    this.set("order", params.order);
+    this.setProperties({
+      isLoading: true,
+      nameInput: this.params.name,
+      order: this.params.order,
+    });
 
-    const userFieldColumns = this.columns.filter(
-      (c) => c.type === "user_field"
-    );
-    const userFieldIds = userFieldColumns.map((c) => c.user_field_id).join("|");
-
-    const pluginColumns = this.columns.filter((c) => c.type === "plugin");
-    const pluginColumnIds = pluginColumns.map((c) => c.id).join("|");
+    const userFieldIds = this.columns
+      .filter((c) => c.type === "user_field")
+      .map((c) => c.user_field_id)
+      .join("|");
+    const pluginColumnIds = this.columns
+      .filter((c) => c.type === "plugin")
+      .map((c) => c.id)
+      .join("|");
 
     return this.store
       .find(
         "directoryItem",
-        Object.assign(params, {
+        Object.assign(this.params, {
           user_field_ids: userFieldIds,
           plugin_column_ids: pluginColumnIds,
         })
@@ -50,7 +57,7 @@ export default Controller.extend({
         this.setProperties({
           model,
           lastUpdatedAt: lastUpdatedAt ? longDate(lastUpdatedAt) : null,
-          period: params.period,
+          period: this.params.period,
         });
       })
       .finally(() => {
@@ -83,11 +90,12 @@ export default Controller.extend({
 
   @action
   onUsernameFilterChanged(filter) {
-    discourseDebounce(this, this._setName, filter, 500);
+    discourseDebounce(this, this._setUsernameFilter, filter, 500);
   },
 
-  _setName(name) {
-    this.set("name", name);
+  _setUsernameFilter(username) {
+    this.set("params.name", username);
+    this.loadUsers();
   },
 
   @observes("model.canLoadMore")

--- a/app/assets/javascripts/discourse/app/routes/users.js
+++ b/app/assets/javascripts/discourse/app/routes/users.js
@@ -9,7 +9,7 @@ export default DiscourseRoute.extend({
     period: { refreshModel: true },
     order: { refreshModel: true },
     asc: { refreshModel: true },
-    name: { refreshModel: true, replace: true },
+    name: { refreshModel: false },
     group: { refreshModel: true },
     exclude_usernames: { refreshModel: true },
   },

--- a/app/assets/javascripts/discourse/app/routes/users.js
+++ b/app/assets/javascripts/discourse/app/routes/users.js
@@ -9,7 +9,7 @@ export default DiscourseRoute.extend({
     period: { refreshModel: true },
     order: { refreshModel: true },
     asc: { refreshModel: true },
-    name: { refreshModel: false },
+    name: { refreshModel: false, replace: true },
     group: { refreshModel: true },
     exclude_usernames: { refreshModel: true },
   },


### PR DESCRIPTION
The user directory table is currently being completely reloaded (directory columns + directory items) every time a new term is input in the username filter.

This stores the query params in the controller and does not refresh the model at the route level every time the username filter is changed.