### PR TITLE
DEV: Tests can reset a single registry

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -227,4 +227,11 @@ class DiscoursePluginRegistry
     end
   end
 
+  def self.reset_register!(register_name)
+    found_register = @@register_names.detect { |name| name == register_name }
+
+    if found_register
+      instance_variable_set(:"@#{found_register}", nil)
+    end
+  end
 end


### PR DESCRIPTION
Plugins can use this method to reset their specific registries without touching the ones defined in core.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
