### PR TITLE
DEV: Skip compressing theme test files

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -281,6 +281,8 @@ task 'assets:precompile' => 'assets:precompile:before' do
           max_compress = max_compress?(info["logical_path"], locales)
           if File.exists?(_path)
             STDERR.puts "Skipping: #{file} already compressed"
+          elsif file.include? "discourse/tests"
+            STDERR.puts "Skipping: #{file}"
           else
             proc.call do
               start = Process.clock_gettime(Process::CLOCK_MONOTONIC)


### PR DESCRIPTION
Doing this shaves off ~34 seconds on the rebuild time of a site in a self-hosted Digital Ocean droplet for me (5m31s vs 4m57s). 

Since these files are only used by developers, I think it's worth the tradeoff of uncompressed bundles in favor of saving on rebuild time.