### PR TITLE
FIX: Build quote share URL using post number, not post ID

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -250,7 +250,9 @@ export default Component.extend({
 
   @discourseComputed("topic.{id,slug}", "quoteState")
   shareUrl(topic, quoteState) {
-    return getAbsoluteURL(postUrl(topic.slug, topic.id, quoteState.postId));
+    const postId = quoteState.postId;
+    const postNumber = topic.postStream.findLoadedPost(postId).post_number;
+    return getAbsoluteURL(postUrl(topic.slug, topic.id, postNumber));
   },
 
   @discourseComputed("topic.details.can_create_post", "composerVisible")


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
