### PR TITLE
Revert "REFACTOR: removes unused code"

### DIFF
--- a/app/assets/javascripts/discourse/app/models/store.js
+++ b/app/assets/javascripts/discourse/app/models/store.js
@@ -1,4 +1,5 @@
 import EmberObject, { set } from "@ember/object";
+import Category from "discourse/models/category";
 import { Promise } from "rsvp";
 import RestModel from "discourse/models/rest";
 import ResultSet from "discourse/models/result-set";
@@ -277,6 +278,14 @@ export default EmberObject.extend({
   },
 
   _lookupSubType(subType, type, id, root) {
+    // cheat: we know we already have categories in memory
+    // TODO: topics do their own resolving of `category_id`
+    // to category. That should either respect this or be
+    // removed.
+    if (subType === "category" && type !== "topic") {
+      return Category.findById(id);
+    }
+
     if (root.meta && root.meta.types) {
       subType = root.meta.types[subType] || subType;
     }

--- a/app/assets/javascripts/discourse/tests/unit/services/store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/store-test.js
@@ -142,6 +142,8 @@ module("Unit | Service | store", function () {
     assert.equal(fruitCols.length, 2);
     assert.equal(fruitCols[0].get("id"), 1);
     assert.equal(fruitCols[1].get("id"), 2);
+
+    assert.ok(fruit.get("category"), "categories are found automatically");
   });
 
   test("embedded records can be cleared", async function (assert) {


### PR DESCRIPTION
Reverts discourse/discourse#13412.

The store code is used by the reviewable. Will remove the test assertion in a follow-up commit.