### PR TITLE
FIX: Respect personal_email_time_window_seconds in group SMTP

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -658,7 +658,11 @@ class PostAlerter
     # Send a single email using group SMTP settings to cut down on the
     # number of emails sent via SMTP, also to replicate how support systems
     # and group inboxes generally work in other systems.
-    Jobs.enqueue(
+    #
+    # We need to send this on a delay to allow for editing and finalising
+    # posts, the same way we do for private_message user emails/notifications.
+    Jobs.enqueue_in(
+      SiteSetting.personal_email_time_window_seconds,
       :group_smtp_email,
       group_id: group.id,
       post_id: post.id,

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1369,6 +1369,7 @@ describe PostAlerter do
     end
 
     it "sends the group smtp email job with a delay of personal_email_time_window_seconds" do
+      freeze_time
       incoming_email_post = create_post_with_incoming
       topic = incoming_email_post.topic
       post = Fabricate(:post, topic: topic)

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1368,6 +1368,23 @@ describe PostAlerter do
       expect { PostAlerter.new.after_save_post(post, true) }.to change { ActionMailer::Base.deliveries.size }.by(0)
     end
 
+    it "sends the group smtp email job with a delay of personal_email_time_window_seconds" do
+      incoming_email_post = create_post_with_incoming
+      topic = incoming_email_post.topic
+      post = Fabricate(:post, topic: topic)
+      PostAlerter.new.after_save_post(post, true)
+      job_enqueued?(
+        job: :group_smtp_email,
+        args: {
+          group_id: group.id,
+          post_id: post.id,
+          email: topic.reload.topic_allowed_users.order(:created_at).first.user.email,
+          cc_emails: ["bar@discourse.org", "jim@othersite.com"]
+        },
+        at: Time.zone.now + SiteSetting.personal_email_time_window_seconds.seconds
+      )
+    end
+
     it "skips sending a notification email to the group and all other email addresses that are _not_ members of the group,
     sends a group_smtp_email instead" do
       NotificationEmailer.enable


### PR DESCRIPTION
For other private messages we have the site setting
personal_email_time_window_seconds (default 20s) which allows
people to edit their post etc. before the email is sent.

This PR makes the Jobs::GroupSmtpEmail enqueuer in the
PostAlerter use the same delay.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
