### PR TITLE
FIX: Handle edge cases for group SMTP email job

### DIFF
--- a/app/models/skipped_email_log.rb
+++ b/app/models/skipped_email_log.rb
@@ -40,8 +40,8 @@ class SkippedEmailLog < ActiveRecord::Base
       sender_topic_deleted: 23,
       user_email_no_email: 24,
       group_smtp_post_deleted: 25,
-      group_smtp_topic_deleted: 25,
-      group_smtp_disabled_for_group: 25,
+      group_smtp_topic_deleted: 26,
+      group_smtp_disabled_for_group: 27,
       # you need to add the reason in server.en.yml below the "skipped_email_log" key
       # when you add a new enum value
     )

--- a/app/models/skipped_email_log.rb
+++ b/app/models/skipped_email_log.rb
@@ -39,6 +39,9 @@ class SkippedEmailLog < ActiveRecord::Base
       user_email_access_denied: 22,
       sender_topic_deleted: 23,
       user_email_no_email: 24,
+      group_smtp_post_deleted: 25,
+      group_smtp_topic_deleted: 25,
+      group_smtp_disabled_for_group: 25,
       # you need to add the reason in server.en.yml below the "skipped_email_log" key
       # when you add a new enum value
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,6 +193,10 @@ class User < ActiveRecord::Base
     joins(:user_emails).where("lower(user_emails.email) IN (?)", email)
   end
 
+  scope :with_primary_email, ->(email) do
+    joins(:user_emails).where("lower(user_emails.email) IN (?) AND user_emails.primary", email)
+  end
+
   scope :human_users, -> { where('users.id > 0') }
 
   # excluding fake users like the system user or anonymous users
@@ -386,8 +390,12 @@ class User < ActiveRecord::Base
     end
   end
 
-  def self.find_by_email(email)
-    self.with_email(Email.downcase(email)).first
+  def self.find_by_email(email, primary: false)
+    if primary
+      self.with_primary_email(Email.downcase(email)).first
+    else
+      self.with_email(Email.downcase(email)).first
+    end
   end
 
   def self.find_by_username(username)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4043,6 +4043,9 @@ en:
     sender_post_deleted: "post has been deleted"
     sender_message_to_invalid: "recipient has invalid email address"
     sender_topic_deleted: "topic has been deleted"
+    group_smtp_post_deleted: "post has been deleted"
+    group_smtp_topic_deleted: "topic has been deleted"
+    group_smtp_disabled_for_group: "smtp has been disabled for the group"
 
   color_schemes:
     base_theme_name: "Base"

--- a/spec/jobs/regular/group_smtp_email_spec.rb
+++ b/spec/jobs/regular/group_smtp_email_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
   it "creates an IncomingEmail record with the correct details to avoid double processing IMAP" do
     subject.execute(args)
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
     incoming_email = IncomingEmail.find_by(post_id: post.id, topic_id: post.topic_id, user_id: post.user.id)
     expect(incoming_email).not_to eq(nil)
     expect(incoming_email.message_id).to eq("topic/#{post.topic_id}/#{post.id}@test.localhost")
@@ -98,6 +99,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
   it "does not create a post reply key, it always replies to the group email_username" do
     subject.execute(args)
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     post_reply_key = PostReplyKey.where(user_id: recipient_user, post_id: post.id).first
     expect(post_reply_key).to eq(nil)
@@ -108,6 +110,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
   it "creates an EmailLog record with the correct details" do
     subject.execute(args)
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     expect(email_log).not_to eq(nil)
     expect(email_log.message_id).to eq("topic/#{post.topic_id}/#{post.id}@test.localhost")
@@ -116,6 +119,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
   it "creates an IncomingEmail record with the correct details to avoid double processing IMAP" do
     subject.execute(args)
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
     incoming_email = IncomingEmail.find_by(post_id: post.id, topic_id: post.topic_id, user_id: post.user.id)
     expect(incoming_email).not_to eq(nil)
     expect(incoming_email.message_id).to eq("topic/#{post.topic_id}/#{post.id}@test.localhost")
@@ -128,6 +132,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
   it "does not create a post reply key, it always replies to the group email_username" do
     subject.execute(args)
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     post_reply_key = PostReplyKey.where(user_id: recipient_user, post_id: post.id).first
     expect(post_reply_key).to eq(nil)
@@ -139,6 +144,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
     group.update(full_name: "")
     subject.execute(args)
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     expect(email_log.raw_headers).to include("From: support-group via Discourse <#{group.email_username}")
   end
@@ -146,6 +152,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
   it "has the group_smtp_id and the to_address filled in correctly" do
     subject.execute(args)
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     expect(email_log.to_address).to eq("test@test.com")
     expect(email_log.smtp_group_id).to eq(group.id)
@@ -155,6 +162,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
     it "has the cc_addresses and cc_user_ids filled in correctly" do
       subject.execute(args)
       expect(ActionMailer::Base.deliveries.count).to eq(1)
+      expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
       email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
       expect(email_log.cc_addresses).to eq("otherguy@test.com;cormac@lit.com")
       expect(email_log.cc_user_ids).to match_array([staged1.id, staged2.id])
@@ -210,6 +218,14 @@ RSpec.describe Jobs::GroupSmtpEmail do
   context "when disable_emails is yes" do
     it "returns without sending email" do
       SiteSetting.disable_emails = "yes"
+      subject.execute(args)
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+    end
+  end
+
+  context "group is deleted" do
+    it "returns without sending email" do
+      group.destroy
       subject.execute(args)
       expect(ActionMailer::Base.deliveries.count).to eq(0)
     end

--- a/spec/jobs/regular/group_smtp_email_spec.rb
+++ b/spec/jobs/regular/group_smtp_email_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
 
   it "creates an IncomingEmail record with the correct details to avoid double processing IMAP" do
     subject.execute(args)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
     incoming_email = IncomingEmail.find_by(post_id: post.id, topic_id: post.topic_id, user_id: post.user.id)
     expect(incoming_email).not_to eq(nil)
     expect(incoming_email.message_id).to eq("topic/#{post.topic_id}/#{post.id}@test.localhost")
@@ -96,6 +97,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
 
   it "does not create a post reply key, it always replies to the group email_username" do
     subject.execute(args)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     post_reply_key = PostReplyKey.where(user_id: recipient_user, post_id: post.id).first
     expect(post_reply_key).to eq(nil)
@@ -105,6 +107,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
 
   it "creates an EmailLog record with the correct details" do
     subject.execute(args)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     expect(email_log).not_to eq(nil)
     expect(email_log.message_id).to eq("topic/#{post.topic_id}/#{post.id}@test.localhost")
@@ -112,6 +115,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
 
   it "creates an IncomingEmail record with the correct details to avoid double processing IMAP" do
     subject.execute(args)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
     incoming_email = IncomingEmail.find_by(post_id: post.id, topic_id: post.topic_id, user_id: post.user.id)
     expect(incoming_email).not_to eq(nil)
     expect(incoming_email.message_id).to eq("topic/#{post.topic_id}/#{post.id}@test.localhost")
@@ -123,6 +127,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
 
   it "does not create a post reply key, it always replies to the group email_username" do
     subject.execute(args)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     post_reply_key = PostReplyKey.where(user_id: recipient_user, post_id: post.id).first
     expect(post_reply_key).to eq(nil)
@@ -133,12 +138,14 @@ RSpec.describe Jobs::GroupSmtpEmail do
   it "falls back to the group name if full name is blank" do
     group.update(full_name: "")
     subject.execute(args)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     expect(email_log.raw_headers).to include("From: support-group via Discourse <#{group.email_username}")
   end
 
   it "has the group_smtp_id and the to_address filled in correctly" do
     subject.execute(args)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     expect(email_log.to_address).to eq("test@test.com")
     expect(email_log.smtp_group_id).to eq(group.id)
@@ -147,6 +154,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
   context "when there are cc_addresses" do
     it "has the cc_addresses and cc_user_ids filled in correctly" do
       subject.execute(args)
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
       email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
       expect(email_log.cc_addresses).to eq("otherguy@test.com;cormac@lit.com")
       expect(email_log.cc_user_ids).to match_array([staged1.id, staged2.id])
@@ -157,6 +165,68 @@ RSpec.describe Jobs::GroupSmtpEmail do
     let(:post_id) { post.topic.posts.first.id }
     it "aborts and does not send a group SMTP email; the OP is the one that sent the email in the first place" do
       expect { subject.execute(args) }.not_to(change { EmailLog.count })
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+    end
+  end
+
+  context "when the post is deleted" do
+    it "aborts and adds a skipped email log" do
+      post.trash!
+      subject.execute(args)
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+      expect(SkippedEmailLog.exists?(
+        email_type: "group_smtp",
+        user: recipient_user,
+        post: nil,
+        to_address: recipient_user.email,
+        reason_type: SkippedEmailLog.reason_types[:group_smtp_post_deleted]
+      )).to eq(true)
+    end
+  end
+
+  context "when the topic is deleted" do
+    it "aborts and adds a skipped email log" do
+      post.topic.trash!
+      subject.execute(args)
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+      expect(SkippedEmailLog.exists?(
+        email_type: "group_smtp",
+        user: recipient_user,
+        post: post,
+        to_address: recipient_user.email,
+        reason_type: SkippedEmailLog.reason_types[:group_smtp_topic_deleted]
+      )).to eq(true)
+    end
+  end
+
+  context "when smtp is not enabled" do
+    it "returns without sending email" do
+      SiteSetting.enable_smtp = false
+      subject.execute(args)
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+    end
+  end
+
+  context "when disable_emails is yes" do
+    it "returns without sending email" do
+      SiteSetting.disable_emails = "yes"
+      subject.execute(args)
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+    end
+  end
+
+  context "when smtp is not enabled for the group" do
+    it "returns without sending email" do
+      group.update(smtp_enabled: false)
+      subject.execute(args)
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+      expect(SkippedEmailLog.exists?(
+        email_type: "group_smtp",
+        user: recipient_user,
+        post: post,
+        to_address: recipient_user.email,
+        reason_type: SkippedEmailLog.reason_types[:group_smtp_disabled_for_group]
+      )).to eq(true)
     end
   end
 end

--- a/spec/jobs/regular/group_smtp_email_spec.rb
+++ b/spec/jobs/regular/group_smtp_email_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
 
   context "when smtp is not enabled for the group" do
     it "returns without sending email" do
-      group.update(smtp_enabled: false)
+      group.update!(smtp_enabled: false)
       subject.execute(args)
       expect(ActionMailer::Base.deliveries.count).to eq(0)
       expect(SkippedEmailLog.exists?(


### PR DESCRIPTION
Skip group SMTP email (and add log) if:

* topic is deleted
* post is deleted
* smtp has been disabled for the group

Skip without log if:

* enable_smtp site setting is false
* disable_emails site setting is yes