### PR TITLE
DEV: Add `annotate` rake tasks, and enforce via GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,13 @@ jobs:
       fail-fast: false
 
       matrix:
-        build_type: [backend, frontend]
+        build_type: [backend, frontend, annotations]
         target: [core, plugins]
         postgres: ["13"]
         redis: ["6.x"]
+        exclude:
+          - build_type: annotations
+            target: plugins
 
     services:
       postgres:
@@ -130,4 +133,21 @@ jobs:
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
         run: bin/rake plugin:qunit['*','1200000']
+        timeout-minutes: 30
+
+      - name: Check Annotations
+        if: matrix.build_type == 'annotations'
+        run: |
+          bin/rake annotate:ensure_all_indexes
+          bin/annotate --models --model-dir app/models
+
+          if [ ! -z "$(git status --porcelain app/models/)" ]; then
+            echo "Core annotations are not up to date. To resolve, run:"
+            echo "  bin/rake annotate:clean"
+            echo
+            echo "Or manually apply the diff printed below:"
+            echo "---------------------------------------------"
+            git -c color.ui=always diff app/models/
+            exit 1
+          fi
         timeout-minutes: 30

--- a/Gemfile
+++ b/Gemfile
@@ -165,6 +165,8 @@ group :test, :development do
   gem 'parallel_tests'
 
   gem 'rswag-specs'
+
+  gem 'annotate'
 end
 
 group :development do
@@ -173,7 +175,6 @@ group :development do
   gem 'better_errors', platform: :mri, require: !!ENV['BETTER_ERRORS']
   gem 'binding_of_caller'
   gem 'yaml-lint'
-  gem 'annotate'
   gem 'discourse_dev_assets'
   gem 'faker', "~> 2.16"
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1026,7 +1026,7 @@ end
 #  min_tags_from_required_group              :integer          default(1), not null
 #  read_only_banner                          :string
 #  default_list_filter                       :string(20)       default("all")
-#  allow_unlimited_owner_edits_on_first_post :boolean          default(FALSE)
+#  allow_unlimited_owner_edits_on_first_post :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/models/directory_column.rb
+++ b/app/models/directory_column.rb
@@ -50,3 +50,22 @@ class DirectoryColumn < ActiveRecord::Base
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: directory_columns
+#
+#  id                 :bigint           not null, primary key
+#  name               :string
+#  automatic_position :integer
+#  icon               :string
+#  user_field_id      :integer
+#  enabled            :boolean          not null
+#  position           :integer          not null
+#  created_at         :datetime
+#  type               :integer          default("automatic"), not null
+#
+# Indexes
+#
+#  directory_column_index  (enabled,position,user_field_id)
+#

--- a/app/models/do_not_disturb_timing.rb
+++ b/app/models/do_not_disturb_timing.rb
@@ -11,3 +11,21 @@ class DoNotDisturbTiming < ActiveRecord::Base
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: do_not_disturb_timings
+#
+#  id        :bigint           not null, primary key
+#  user_id   :integer          not null
+#  starts_at :datetime         not null
+#  ends_at   :datetime         not null
+#  scheduled :boolean          default(FALSE)
+#
+# Indexes
+#
+#  index_do_not_disturb_timings_on_ends_at    (ends_at)
+#  index_do_not_disturb_timings_on_scheduled  (scheduled)
+#  index_do_not_disturb_timings_on_starts_at  (starts_at)
+#  index_do_not_disturb_timings_on_user_id    (user_id)
+#

--- a/app/models/ignored_user.rb
+++ b/app/models/ignored_user.rb
@@ -17,7 +17,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  summarized_at   :datetime
-#  expiring_at     :datetime
+#  expiring_at     :datetime         not null
 #
 # Indexes
 #

--- a/app/models/incoming_email.rb
+++ b/app/models/incoming_email.rb
@@ -109,6 +109,7 @@ end
 #  imap_uid          :integer
 #  imap_sync         :boolean
 #  imap_group_id     :bigint
+#  imap_missing      :boolean          default(FALSE), not null
 #  created_via       :integer          default(0), not null
 #
 # Indexes

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -290,6 +290,7 @@ end
 #  max_redemptions_allowed :integer          default(1), not null
 #  redemption_count        :integer          default(0), not null
 #  expires_at              :datetime         not null
+#  email_token             :string
 #
 # Indexes
 #

--- a/app/models/post_custom_field.rb
+++ b/app/models/post_custom_field.rb
@@ -19,8 +19,7 @@ end
 #
 #  idx_post_custom_fields_akismet                (post_id) WHERE (((name)::text = 'AKISMET_STATE'::text) AND (value = 'needs_review'::text))
 #  index_post_custom_fields_on_name_and_value    (name, "left"(value, 200))
-#  index_post_custom_fields_on_notice_args       (post_id) UNIQUE WHERE ((name)::text = 'notice_args'::text)
-#  index_post_custom_fields_on_notice_type       (post_id) UNIQUE WHERE ((name)::text = 'notice_type'::text)
+#  index_post_custom_fields_on_notice            (post_id) UNIQUE WHERE ((name)::text = 'notice'::text)
 #  index_post_custom_fields_on_post_id           (post_id) UNIQUE WHERE ((name)::text = 'missing uploads'::text)
 #  index_post_custom_fields_on_post_id_and_name  (post_id,name)
 #  index_post_id_where_missing_uploads_ignored   (post_id) UNIQUE WHERE ((name)::text = 'missing uploads ignored'::text)

--- a/app/models/push_subscription.rb
+++ b/app/models/push_subscription.rb
@@ -12,11 +12,11 @@ end
 #
 # Table name: push_subscriptions
 #
-#  id            :bigint           not null, primary key
-#  user_id       :integer          not null
-#  data          :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  error_count   :integer          default(0), not null
+#  id             :bigint           not null, primary key
+#  user_id        :integer          not null
+#  data           :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  error_count    :integer          default(0), not null
 #  first_error_at :datetime
 #

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -352,6 +352,8 @@ end
 #  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  force_review            :boolean          default(FALSE), not null
+#  reject_reason           :text
 #
 # Indexes
 #

--- a/app/models/reviewable_post.rb
+++ b/app/models/reviewable_post.rb
@@ -109,3 +109,39 @@ class ReviewablePost < Reviewable
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: reviewables
+#
+#  id                      :bigint           not null, primary key
+#  type                    :string           not null
+#  status                  :integer          default(0), not null
+#  created_by_id           :integer          not null
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  reviewable_by_group_id  :integer
+#  category_id             :integer
+#  topic_id                :integer
+#  score                   :float            default(0.0), not null
+#  potential_spam          :boolean          default(FALSE), not null
+#  target_id               :integer
+#  target_type             :string
+#  target_created_by_id    :integer
+#  payload                 :json
+#  version                 :integer          default(0), not null
+#  latest_score            :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  force_review            :boolean          default(FALSE), not null
+#  reject_reason           :text
+#
+# Indexes
+#
+#  index_reviewables_on_reviewable_by_group_id                 (reviewable_by_group_id)
+#  index_reviewables_on_status_and_created_at                  (status,created_at)
+#  index_reviewables_on_status_and_score                       (status,score)
+#  index_reviewables_on_status_and_type                        (status,type)
+#  index_reviewables_on_target_id_where_post_type_eq_post      (target_id) WHERE ((target_type)::text = 'Post'::text)
+#  index_reviewables_on_topic_id_and_status_and_created_by_id  (topic_id,status,created_by_id)
+#  index_reviewables_on_type_and_target_id                     (type,target_id) UNIQUE
+#

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -181,6 +181,8 @@ end
 #  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  force_review            :boolean          default(FALSE), not null
+#  reject_reason           :text
 #
 # Indexes
 #

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -121,6 +121,8 @@ end
 #  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  force_review            :boolean          default(FALSE), not null
+#  reject_reason           :text
 #
 # Indexes
 #

--- a/app/models/screened_email.rb
+++ b/app/models/screened_email.rb
@@ -90,6 +90,6 @@ end
 #
 # Indexes
 #
-#  index_blocked_emails_on_email          (email) UNIQUE
-#  index_blocked_emails_on_last_match_at  (last_match_at)
+#  index_screened_emails_on_email          (email) UNIQUE
+#  index_screened_emails_on_last_match_at  (last_match_at)
 #

--- a/app/models/shelved_notification.rb
+++ b/app/models/shelved_notification.rb
@@ -7,3 +7,15 @@ class ShelvedNotification < ActiveRecord::Base
     NotificationEmailer.process_notification(notification, no_delay: true)
   end
 end
+
+# == Schema Information
+#
+# Table name: shelved_notifications
+#
+#  id              :bigint           not null, primary key
+#  notification_id :integer          not null
+#
+# Indexes
+#
+#  index_shelved_notifications_on_notification_id  (notification_id)
+#

--- a/app/models/theme_modifier_set.rb
+++ b/app/models/theme_modifier_set.rb
@@ -98,13 +98,12 @@ end
 #
 # Table name: theme_modifier_sets
 #
-#  id                               :bigint           not null, primary key
-#  theme_id                         :bigint           not null
-#  serialize_topic_excerpts         :boolean
-#  csp_extensions                   :string           is an Array
-#  svg_icons                        :string           is an Array
-#  discourse_teams_sidebar_disabled :boolean
-#  topic_thumbnail_sizes            :string           is an Array
+#  id                       :bigint           not null, primary key
+#  theme_id                 :bigint           not null
+#  serialize_topic_excerpts :boolean
+#  csp_extensions           :string           is an Array
+#  svg_icons                :string           is an Array
+#  topic_thumbnail_sizes    :string           is an Array
 #
 # Indexes
 #

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1826,13 +1826,15 @@ end
 #  reviewable_score          :float            default(0.0), not null
 #  image_upload_id           :bigint
 #  slow_mode_seconds         :integer          default(0), not null
+#  bannered_until            :datetime
 #
 # Indexes
 #
 #  idx_topics_front_page                   (deleted_at,visible,archetype,category_id,id)
 #  idx_topics_user_id_deleted_at           (user_id) WHERE (deleted_at IS NULL)
 #  idxtopicslug                            (slug) WHERE ((deleted_at IS NULL) AND (slug IS NOT NULL))
-#  index_forum_threads_on_bumped_at        (bumped_at)
+#  index_topics_on_bannered_until          (bannered_until) WHERE (bannered_until IS NOT NULL)
+#  index_topics_on_bumped_at               (bumped_at)
 #  index_topics_on_created_at_and_visible  (created_at,visible) WHERE ((deleted_at IS NULL) AND ((archetype)::text <> 'private_message'::text))
 #  index_topics_on_id_and_deleted_at       (id,deleted_at)
 #  index_topics_on_id_filtered_banner      (id) UNIQUE WHERE (((archetype)::text = 'banner'::text) AND (deleted_at IS NULL))
@@ -1840,6 +1842,7 @@ end
 #  index_topics_on_lower_title             (lower((title)::text))
 #  index_topics_on_pinned_at               (pinned_at) WHERE (pinned_at IS NOT NULL)
 #  index_topics_on_pinned_globally         (pinned_globally) WHERE pinned_globally
+#  index_topics_on_pinned_until            (pinned_until) WHERE (pinned_until IS NOT NULL)
 #  index_topics_on_timestamps_private      (bumped_at,created_at,updated_at) WHERE ((deleted_at IS NULL) AND ((archetype)::text = 'private_message'::text))
 #  index_topics_on_updated_at_public       (updated_at,visible,highest_staff_post_number,highest_post_number,category_id,created_at,id) WHERE (((archetype)::text <> 'private_message'::text) AND (deleted_at IS NULL))
 #

--- a/app/models/topic_custom_field.rb
+++ b/app/models/topic_custom_field.rb
@@ -17,8 +17,6 @@ end
 #
 # Indexes
 #
-#  idx_topic_custom_fields_accepted_answer         (topic_id) UNIQUE WHERE ((name)::text = 'accepted_answer_post_id'::text)
-#  index_topic_custom_fields_on_topic_id           (topic_id) UNIQUE WHERE ((name)::text = 'vote_count'::text)
 #  index_topic_custom_fields_on_topic_id_and_name  (topic_id,name)
 #  topic_custom_fields_value_key_idx               (value,name) WHERE ((value IS NOT NULL) AND (char_length(value) < 400))
 #

--- a/app/models/topic_link_click.rb
+++ b/app/models/topic_link_click.rb
@@ -128,5 +128,5 @@ end
 #
 # Indexes
 #
-#  index_forum_thread_link_clicks_on_forum_thread_link_id  (topic_link_id)
+#  by_link  (topic_link_id)
 #

--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -512,6 +512,6 @@ end
 #
 # Indexes
 #
-#  index_forum_thread_users_on_forum_thread_id_and_user_id  (topic_id,user_id) UNIQUE
-#  index_topic_users_on_user_id_and_topic_id                (user_id,topic_id) UNIQUE
+#  index_topic_users_on_topic_id_and_user_id  (topic_id,user_id) UNIQUE
+#  index_topic_users_on_user_id_and_topic_id  (user_id,topic_id) UNIQUE
 #

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -464,9 +464,9 @@ end
 #
 #  idx_unique_rows                                   (action_type,user_id,target_topic_id,target_post_id,acting_user_id) UNIQUE
 #  idx_user_actions_speed_up_user_all                (user_id,created_at,action_type)
-#  index_actions_on_acting_user_id                   (acting_user_id)
-#  index_actions_on_user_id_and_action_type          (user_id,action_type)
+#  index_user_actions_on_acting_user_id              (acting_user_id)
 #  index_user_actions_on_action_type_and_created_at  (action_type,created_at)
 #  index_user_actions_on_target_post_id              (target_post_id)
 #  index_user_actions_on_target_user_id              (target_user_id) WHERE (target_user_id IS NOT NULL)
+#  index_user_actions_on_user_id_and_action_type     (user_id,action_type)
 #

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -122,5 +122,4 @@ end
 #  index_user_badges_on_badge_id_and_user_id_and_post_id  (badge_id,user_id,post_id) UNIQUE WHERE (post_id IS NOT NULL)
 #  index_user_badges_on_badge_id_and_user_id_and_seq      (badge_id,user_id,seq) UNIQUE WHERE (post_id IS NULL)
 #  index_user_badges_on_user_id                           (user_id)
-#  index_user_badges_on_is_favorite                       (is_favorite)
 #

--- a/app/models/user_custom_field.rb
+++ b/app/models/user_custom_field.rb
@@ -19,8 +19,5 @@ end
 #
 # Indexes
 #
-#  idx_user_custom_fields_last_reminded_at          (name,user_id) UNIQUE WHERE ((name)::text = 'last_reminded_at'::text)
-#  idx_user_custom_fields_remind_assigns_frequency  (name,user_id) UNIQUE WHERE ((name)::text = 'remind_assigns_frequency'::text)
-#  idx_user_custom_fields_user_notes_count          (name,user_id) UNIQUE WHERE ((name)::text = 'user_notes_count'::text)
-#  index_user_custom_fields_on_user_id_and_name     (user_id,name)
+#  index_user_custom_fields_on_user_id_and_name  (user_id,name)
 #

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -308,10 +308,10 @@ end
 #
 # Indexes
 #
-#  index_staff_action_logs_on_action_and_id                        (action,id)
-#  index_staff_action_logs_on_subject_and_id                       (subject,id)
-#  index_staff_action_logs_on_target_user_id_and_id                (target_user_id,id)
 #  index_user_histories_on_acting_user_id_and_action_and_id        (acting_user_id,action,id)
+#  index_user_histories_on_action_and_id                           (action,id)
 #  index_user_histories_on_category_id                             (category_id)
+#  index_user_histories_on_subject_and_id                          (subject,id)
+#  index_user_histories_on_target_user_id_and_id                   (target_user_id,id)
 #  index_user_histories_on_topic_id_and_target_user_id_and_action  (topic_id,target_user_id,action)
 #

--- a/app/models/user_notification_schedule.rb
+++ b/app/models/user_notification_schedule.rb
@@ -47,3 +47,31 @@ class UserNotificationSchedule < ActiveRecord::Base
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: user_notification_schedules
+#
+#  id               :bigint           not null, primary key
+#  user_id          :integer          not null
+#  enabled          :boolean          default(FALSE), not null
+#  day_0_start_time :integer          not null
+#  day_0_end_time   :integer          not null
+#  day_1_start_time :integer          not null
+#  day_1_end_time   :integer          not null
+#  day_2_start_time :integer          not null
+#  day_2_end_time   :integer          not null
+#  day_3_start_time :integer          not null
+#  day_3_end_time   :integer          not null
+#  day_4_start_time :integer          not null
+#  day_4_end_time   :integer          not null
+#  day_5_start_time :integer          not null
+#  day_5_end_time   :integer          not null
+#  day_6_start_time :integer          not null
+#  day_6_end_time   :integer          not null
+#
+# Indexes
+#
+#  index_user_notification_schedules_on_enabled  (enabled)
+#  index_user_notification_schedules_on_user_id  (user_id)
+#

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -210,6 +210,7 @@ end
 #  external_links_in_new_tab        :boolean          default(FALSE), not null
 #  enable_quoting                   :boolean          default(TRUE), not null
 #  dynamic_favicon                  :boolean          default(FALSE), not null
+#  disable_jump_reply               :boolean          default(FALSE), not null
 #  automatically_unpin_topics       :boolean          default(TRUE), not null
 #  digest_after_minutes             :integer
 #  auto_track_topics_after_msecs    :integer

--- a/lib/tasks/annotate.rake
+++ b/lib/tasks/annotate.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+desc "ensure the asynchronously-created post_search_data index is present"
+task "annotate" => :environment do |task, args|
+  raise if !system "bin/annotate --models"
+  STDERR.puts "Annotate executed successfully"
+
+  non_core_plugins = Dir["plugins/*"].filter do |plugin_path|
+    `git check-ignore #{plugin_path}`.present?
+  end
+  if non_core_plugins.length > 0
+    STDERR.puts "Warning: you have non-core plugins installed which may affect the annotations"
+    STDERR.puts "For core annotations, consider running `bin/rake annotate:clean`"
+  end
+end
+
+desc "ensure the asynchronously-created post_search_data index is present"
+task "annotate:ensure_all_indexes" => :environment do |task, args|
+  # One of the indexes on post_search_data is created by a sidekiq job
+  # We need to do some acrobatics to create it on-demand
+  SeedData::Topics.with_default_locale.create(include_welcome_topics: true)
+  SiteSetting.search_enable_recent_regular_posts_offset_size = 1
+  Jobs::CreateRecentPostSearchIndexes.new.execute([])
+end
+
+desc "regenerate core model annotations using a temporary database"
+task "annotate:clean" => :environment do |task, args|
+  db = TemporaryDb.new
+  db.start
+  db.with_env do
+    raise if !system "RAILS_ENV=test LOAD_PLUGINS=0 bin/rake db:migrate"
+    raise if !system "RAILS_ENV=test LOAD_PLUGINS=0 bin/rake annotate:ensure_all_indexes"
+    raise if !system "RAILS_ENV=test LOAD_PLUGINS=0 bin/annotate --models --model-dir app/models"
+  end
+  STDERR.puts "Annotate executed successfully"
+ensure
+  db&.stop
+  db&.remove
+end

--- a/lib/temporary_db.rb
+++ b/lib/temporary_db.rb
@@ -99,6 +99,28 @@ class TemporaryDb
     `#{pg_ctl_path} -D '#{PG_TEMP_PATH}' stop`
   end
 
+  def with_env(&block)
+    old_host = ENV["PGHOST"]
+    old_user = ENV["PGUSER"]
+    old_port = ENV["PGPORT"]
+    old_dev_db = ENV["DISCOURSE_DEV_DB"]
+    old_rails_db = ENV["RAILS_DB"]
+
+    ENV["PGHOST"] = "localhost"
+    ENV["PGUSER"] = "discourse"
+    ENV["PGPORT"] = pg_port.to_s
+    ENV["DISCOURSE_DEV_DB"] = "discourse"
+    ENV["RAILS_DB"] = "discourse"
+
+    yield
+  ensure
+    ENV["PGHOST"] = old_host
+    ENV["PGUSER"] = old_user
+    ENV["PGPORT"] = old_port
+    ENV["DISCOURSE_DEV_DB"] = old_dev_db
+    ENV["RAILS_DB"] = old_rails_db
+  end
+
   def remove
     raise "Error: the database must be stopped before it can be removed" if @started
     FileUtils.rm_rf PG_TEMP_PATH


### PR DESCRIPTION
`bin/rake annotate` is an alias of `bin/annotate --models`
`bin/rake annotate:clean` generates annotations by using a temporary, freshly migrated database. This should help us to produce more consistent annotations, even if development databases have been polluted by plugin migrations.

A GitHub actions task is also added which generates annotations on a clean database, and raises an error if they differ from the committed annotations.

(commits to be rebased-and-merged)