### PR TITLE
DEV: Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3095,7 +3095,7 @@ squoosh@discourse/squoosh#dc9649d:
   version "2.0.0"
   resolved "https://codeload.github.com/discourse/squoosh/tar.gz/dc9649d0a4d396d1251c22291b17d99f1716da44"
   dependencies:
-    wasm-feature-detect "^1.2.9"
+    wasm-feature-detect "^1.2.11"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -3415,7 +3415,7 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-wasm-feature-detect@^1.2.11:
+wasm-feature-detect@^1.2.9:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/wasm-feature-detect/-/wasm-feature-detect-1.2.11.tgz#e21992fd1f1d41a47490e392a5893cb39d81e29e"
   integrity sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w==


### PR DESCRIPTION
Running `yarn install` (no update) results in this diff

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
