### PR TITLE
FIX: Email substution bug

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -27,7 +27,7 @@ module EmailHelper
 
   def email_html_template
     EmailStyle.new.html
-      .sub('%{email_content}', capture { yield })
+      .sub('%{email_content}') { capture { yield } }
       .gsub('%{html_lang}', html_lang)
       .html_safe
   end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
https://meta.discourse.org/t/regexp-escapes-interpreted-in-emails/184673



This changes from providing a string literal for the #sub replacement, to providing a block.
Because the block is provided the match object, it is presumed to have already performed all necessary backreferences.
This avoids any replacement of backreferences in the message body.

