### PR TITLE
UX: Remove background image after image has loaded

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -18,7 +18,7 @@ export function nativeLazyLoading(api) {
           if (!img.complete) {
             if (!img.onload) {
               img.onload = () => {
-                img.style = '';
+                img.style = "";
               };
             }
 

--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -15,7 +15,15 @@ export function nativeLazyLoading(api) {
       forEachImage(post, (img) => {
         img.loading = "lazy";
         if (img.dataset.smallUpload) {
-          img.style = `background-image: url(${img.dataset.smallUpload}); background-size: cover;`;
+          if (!img.complete) {
+            if (!img.onload) {
+              img.onload = () => {
+                img.style = '';
+              };
+            }
+
+            img.style = `background-image: url(${img.dataset.smallUpload}); background-size: cover;`;
+          }
         }
       }),
     {

--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -18,7 +18,7 @@ export function nativeLazyLoading(api) {
           if (!img.complete) {
             if (!img.onload) {
               img.onload = () => {
-                img.style = "";
+                img.removeAttribute("style");
               };
             }
 


### PR DESCRIPTION
If an image has a `smallUpload`, that may be set as the `background-image` on the `img` element, and the `img` element set to use `lazy` loading. When the browser decides to load the `src` of the image element, it is rendered on top of the existing background image.

However, if the image proper has a transparent background, the background image may be partially visible through the transparent portions of the image.

This change creates an `onload` event that removes the background image when the image proper has completed loading.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
