### PR TITLE
DEV: Drop user_options.disable_jump_reply column

### DIFF
--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class UserOption < ActiveRecord::Base
+  self.ignored_columns = [
+    "disable_jump_reply", # Remove once 20210706091905 is promoted from post_deploy to regular migration
+  ]
+
   self.primary_key = :user_id
   belongs_to :user
   before_create :set_defaults
@@ -210,7 +214,6 @@ end
 #  external_links_in_new_tab        :boolean          default(FALSE), not null
 #  enable_quoting                   :boolean          default(TRUE), not null
 #  dynamic_favicon                  :boolean          default(FALSE), not null
-#  disable_jump_reply               :boolean          default(FALSE), not null
 #  automatically_unpin_topics       :boolean          default(TRUE), not null
 #  digest_after_minutes             :integer
 #  auto_track_topics_after_msecs    :integer

--- a/db/post_migrate/20210706091905_drop_disable_jump_reply_column_from_user_options.rb
+++ b/db/post_migrate/20210706091905_drop_disable_jump_reply_column_from_user_options.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DropDisableJumpReplyColumnFromUserOptions < ActiveRecord::Migration[6.1]
+  DROPPED_COLUMNS ||= {
+    user_options: %i{disable_jump_reply}
+  }
+
+  def up
+    DROPPED_COLUMNS.each do |table, columns|
+      Migration::ColumnDropper.execute_drop(table, columns)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
24ef4f7b removed the use of this column in 2019

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
