### PR TITLE
FEATURE: Add assistant to quick search widget

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -216,7 +216,6 @@ const SiteHeaderComponent = MountWidget.extend(
 
       this.dispatch("notifications:changed", "user-notifications");
       this.dispatch("header:keyboard-trigger", "header");
-      this.dispatch("search-autocomplete:after-complete", "search-term");
       this.dispatch("user-menu:navigation", "user-menu");
 
       this.appEvents.on("dom:clean", this, "_cleanDom");

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -73,9 +73,10 @@ import { replaceFormatter } from "discourse/lib/utilities";
 import { replaceTagRenderer } from "discourse/lib/render-tag";
 import { setNewCategoryDefaultColors } from "discourse/routes/new-category";
 import { addSearchResultsCallback } from "discourse/lib/search";
+import { addInSearchShortcut } from "discourse/widgets/search-menu-results";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.11.5";
+const PLUGIN_API_VERSION = "0.11.6";
 
 class PluginApi {
   constructor(version, container) {
@@ -1294,6 +1295,18 @@ class PluginApi {
    */
   addSearchResultsCallback(callback) {
     addSearchResultsCallback(callback);
+  }
+
+  /**
+   * Add a in: shortcut to search menu panel.
+   *
+   * ```
+   * addInSearchShortcut("in:assigned");
+   * ```
+   *
+   */
+  addInSearchShortcut(value) {
+    addInSearchShortcut(value);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -206,53 +206,30 @@ export function isValidSearchTerm(searchTerm, siteSettings) {
   }
 }
 
-export function applySearchAutocomplete(
-  $input,
-  siteSettings,
-  appEvents,
-  options
-) {
-  const afterComplete = function () {
-    if (appEvents) {
-      appEvents.trigger("search-autocomplete:after-complete");
-    }
-  };
-
+export function applySearchAutocomplete($input, siteSettings) {
   $input.autocomplete(
-    deepMerge(
-      {
-        template: findRawTemplate("category-tag-autocomplete"),
-        key: "#",
-        width: "100%",
-        treatAsTextarea: true,
-        autoSelectFirstSuggestion: false,
-        transformComplete(obj) {
-          return obj.text;
-        },
-        dataSource(term) {
-          return searchCategoryTag(term, siteSettings);
-        },
-        afterComplete,
-      },
-      options
-    )
+    deepMerge({
+      template: findRawTemplate("category-tag-autocomplete"),
+      key: "#",
+      width: "100%",
+      treatAsTextarea: true,
+      autoSelectFirstSuggestion: false,
+      transformComplete: (obj) => obj.text,
+      dataSource: (term) => searchCategoryTag(term, siteSettings),
+    })
   );
 
   if (siteSettings.enable_mentions) {
     $input.autocomplete(
-      deepMerge(
-        {
-          template: findRawTemplate("user-selector-autocomplete"),
-          key: "@",
-          width: "100%",
-          treatAsTextarea: true,
-          autoSelectFirstSuggestion: false,
-          transformComplete: (v) => v.username || v.name,
-          dataSource: (term) => userSearch({ term, includeGroups: true }),
-          afterComplete,
-        },
-        options
-      )
+      deepMerge({
+        template: findRawTemplate("user-selector-autocomplete"),
+        key: "@",
+        width: "100%",
+        treatAsTextarea: true,
+        autoSelectFirstSuggestion: false,
+        transformComplete: (v) => v.username || v.name,
+        dataSource: (term) => userSearch({ term, includeGroups: true }),
+      })
     );
   }
 }

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -2,7 +2,6 @@ import DiscourseURL, { userPath } from "discourse/lib/url";
 import I18n from "I18n";
 import { addExtraUserClasses } from "discourse/helpers/user-avatar";
 import { ajax } from "discourse/lib/ajax";
-import { applySearchAutocomplete } from "discourse/lib/search";
 import { avatarImg } from "discourse/widgets/post";
 import { createWidget } from "discourse/widgets/widget";
 import { get } from "@ember/object";
@@ -484,17 +483,9 @@ export default createWidget("header", {
 
     if (this.state.searchVisible) {
       schedule("afterRender", () => {
-        const $searchInput = $("#search-term");
-        $searchInput.focus().select();
-
-        applySearchAutocomplete(
-          $searchInput,
-          this.siteSettings,
-          this.appEvents,
-          {
-            appendSelector: ".menu-panel",
-          }
-        );
+        const searchInput = document.querySelector("#search-term");
+        searchInput.focus();
+        searchInput.select();
       });
     }
   },

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-controls.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-controls.js
@@ -13,10 +13,6 @@ createWidget("search-term", {
     return { afterAutocomplete: false };
   },
 
-  searchAutocompleteAfterComplete() {
-    this.state.afterAutocomplete = true;
-  },
-
   buildAttributes(attrs) {
     return {
       type: "text",
@@ -28,12 +24,8 @@ createWidget("search-term", {
   },
 
   keyUp(e) {
-    if (e.which === 13) {
-      if (this.state.afterAutocomplete) {
-        this.state.afterAutocomplete = false;
-      } else {
-        return this.sendWidgetAction("fullSearch");
-      }
+    if (e.which === 13 && !this.state.afterAutocomplete) {
+      return this.sendWidgetAction("fullSearch");
     }
 
     const val = this.attrs.value;

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -13,7 +13,7 @@ import renderTag from "discourse/lib/render-tag";
 
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]+)$/gi;
 
-const searchAssistantTerms = ["#", "in:", "status:"];
+const searchAssistantTerms = ["#", "in:", "status:", "order:"];
 const inSearchShortcuts = [
   "in:title",
   "in:personal",
@@ -27,6 +27,12 @@ const statusSearchShortcuts = [
   "status:closed",
   "status:public",
   "status:noreplies",
+];
+const orderSearchShortcuts = [
+  "order:latest",
+  "order:views",
+  "order:likes",
+  "order:latest_topic",
 ];
 
 export function addInSearchShortcut(value) {
@@ -410,6 +416,13 @@ createWidget("search-menu-assistant", {
           const slug = prefix ? `${prefix} ${item} ` : item;
           content.push(this.attach("search-menu-assistant-item", { slug }));
         });
+        break;
+      case "order:":
+        orderSearchShortcuts.map((item) => {
+          const slug = prefix ? `${prefix} ${item} ` : item;
+          content.push(this.attach("search-menu-assistant-item", { slug }));
+        });
+        break;
     }
 
     return content;

--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -17,6 +17,7 @@ export function initSearchData() {
   searchData.typeFilter = null;
   searchData.invalidTerm = false;
   searchData.topicId = null;
+  searchData.afterAutocomplete = false;
 }
 
 initSearchData();
@@ -73,6 +74,7 @@ const SearchHelper = {
         .catch(popupAjaxError)
         .finally(() => {
           searchData.loading = false;
+          searchData.afterAutocomplete = false;
           widget.scheduleRerender();
         });
     }
@@ -132,10 +134,14 @@ export default createWidget("search-menu", {
   },
 
   panelContents() {
-    const contextEnabled = searchData.contextEnabled;
+    const { contextEnabled, afterAutocomplete } = searchData;
 
     let searchInput = [
-      this.attach("search-term", { value: searchData.term, contextEnabled }),
+      this.attach(
+        "search-term",
+        { value: searchData.term, contextEnabled },
+        { state: { afterAutocomplete } }
+      ),
     ];
     if (searchData.term && searchData.loading) {
       searchInput.push(h("div.searching", h("div.spinner")));
@@ -211,7 +217,7 @@ export default createWidget("search-menu", {
       return false;
     }
 
-    if (searchData.loading || searchData.noResults) {
+    if (searchData.loading) {
       return;
     }
 
@@ -304,6 +310,11 @@ export default createWidget("search-menu", {
     searchData.typeFilter = null;
     searchData.term = term;
     this.triggerSearch();
+  },
+
+  triggerAutocomplete(term) {
+    searchData.afterAutocomplete = true;
+    this.searchTermChanged(term);
   },
 
   fullSearch() {

--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -10,7 +10,9 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import userSearch from "discourse/lib/user-search";
 
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
-const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
+// The backend user search query returns zero results for a term-free search
+// so the regexp below only matches @ followed by a valid character
+const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]+)$/gi;
 
 const searchData = {};
 const suggestionTriggers = ["in:", "status:", "order:"];
@@ -74,11 +76,14 @@ const SearchHelper = {
             term: matchSuggestions.usernamesMatch[0],
             includeGroups: true,
           }).then((result) => {
-            if (result?.users) {
+            if (result?.users.length > 0) {
               searchData.suggestionResults = result.users;
               searchData.suggestionKeyword = "@";
-              widget.scheduleRerender();
+            } else {
+              searchData.noResults = true;
+              searchData.suggestionKeyword = false;
             }
+            widget.scheduleRerender();
           });
           return;
         }

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -2,6 +2,7 @@ import {
   acceptance,
   count,
   exists,
+  query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
@@ -245,5 +246,44 @@ acceptance("Search - with tagging enabled", function (needs) {
       .trim();
 
     assert.equal(tags, "dev slow");
+  });
+});
+
+acceptance("Search - assistant", function (needs) {
+  needs.user();
+
+  test("shows category shortcuts when typing #", async function (assert) {
+    await visit("/");
+
+    await click("#search-button");
+
+    await fillIn("#search-term", "#");
+    await triggerKeyEvent("#search-term", "keyup", 51);
+
+    const firstCategory =
+      ".search-menu .results ul.search-menu-assistant .search-link";
+    assert.ok(exists(query(firstCategory)));
+
+    const firstResultSlug = query(
+      `${firstCategory} .category-name`
+    ).innerText.trim();
+
+    await click(firstCategory);
+    assert.equal(query("#search-term").value, `#${firstResultSlug} `);
+  });
+
+  test("shows in: shortcuts", async function (assert) {
+    await visit("/");
+    await click("#search-button");
+
+    await fillIn("#search-term", "in:");
+    await triggerKeyEvent("#search-term", "keyup", 51);
+
+    assert.equal(
+      query(
+        ".search-menu .results ul.search-menu-assistant .search-link .in-modifier-slug"
+      ).innerText,
+      "in:title"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -270,20 +270,35 @@ acceptance("Search - assistant", function (needs) {
 
     await click(firstCategory);
     assert.equal(query("#search-term").value, `#${firstResultSlug} `);
+
+    await fillIn("#search-term", "sam #");
+    await triggerKeyEvent("#search-term", "keyup", 51);
+
+    assert.ok(exists(query(firstCategory)));
+    assert.equal(
+      query(
+        ".search-menu .results ul.search-menu-assistant .search-item-prefix"
+      ).innerText,
+      "sam"
+    );
+
+    await click(firstCategory);
+    assert.equal(query("#search-term").value, `sam #${firstResultSlug} `);
   });
 
   test("shows in: shortcuts", async function (assert) {
     await visit("/");
     await click("#search-button");
 
+    const firstTarget =
+      ".search-menu .results ul.search-menu-assistant .search-link .search-item-slug";
+
     await fillIn("#search-term", "in:");
     await triggerKeyEvent("#search-term", "keyup", 51);
+    assert.equal(query(firstTarget).innerText, "in:title");
 
-    assert.equal(
-      query(
-        ".search-menu .results ul.search-menu-assistant .search-link .in-modifier-slug"
-      ).innerText,
-      "in:title"
-    );
+    await fillIn("#search-term", "sam in:");
+    await triggerKeyEvent("#search-term", "keyup", 51);
+    assert.equal(query(firstTarget).innerText, "sam in:title");
   });
 });

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -251,6 +251,24 @@
         }
       }
     }
+
+    .search-menu-assistant {
+      min-width: 100%;
+      margin-top: -1em;
+
+      .assistant-description {
+        color: var(--primary-low-mid);
+        padding: var(--search-padding);
+      }
+
+      .in-modifier-slug {
+        display: inline-block;
+        width: 125px;
+      }
+      .in-modifier-description {
+        color: var(--primary-low-mid);
+      }
+    }
   }
 
   .searching {

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -256,16 +256,18 @@
       min-width: 100%;
       margin-top: -1em;
 
-      .assistant-description {
-        color: var(--primary-low-mid);
-        padding: var(--search-padding);
+      .search-menu-assistant-item {
+        > span {
+          vertical-align: baseline;
+          display: inline-block;
+        }
       }
 
-      .in-modifier-slug {
-        display: inline-block;
-        width: 125px;
+      .search-item-prefix {
+        margin-right: 0.5em;
       }
-      .in-modifier-description {
+
+      .search-item-everything {
         color: var(--primary-low-mid);
       }
     }

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -263,14 +263,9 @@
         }
       }
 
+      .search-item-user .avatar,
       .search-item-prefix {
         margin-right: 0.5em;
-      }
-
-      .search-item-user {
-        .avatar {
-          margin-right: 0.5em;
-        }
       }
     }
   }

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -267,8 +267,10 @@
         margin-right: 0.5em;
       }
 
-      .search-item-everything {
-        color: var(--primary-low-mid);
+      .search-item-user {
+        .avatar {
+          margin-right: 0.5em;
+        }
       }
     }
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2267,15 +2267,6 @@ en:
       search_google: "Try searching with Google instead:"
       search_google_button: "Google"
       search_button: "Search"
-      assistant:
-        category_description: "Filter search results by category:"
-        in_modifiers_description: "Use these special keywords to further filter the results:"
-      in:
-        title: "Matching in title only"
-        personal: "In personal messages"
-        seen: "In topics I have read"
-        likes: "In posts I have liked"
-
 
       context:
         user: "Search posts by @%{username}"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2267,6 +2267,15 @@ en:
       search_google: "Try searching with Google instead:"
       search_google_button: "Google"
       search_button: "Search"
+      assistant:
+        category_description: "Filter search results by category:"
+        in_modifiers_description: "Use these special keywords to further filter the results:"
+      in:
+        title: "Matching in title only"
+        personal: "In personal messages"
+        seen: "In topics I have read"
+        likes: "In posts I have liked"
+
 
       context:
         user: "Search posts by @%{username}"


### PR DESCRIPTION
https://user-images.githubusercontent.com/368961/125479173-a0bca3c0-302a-4e1a-b35c-ad8174487a87.mp4

This replaces the autocomplete dropdown for categories and usernames on the search input and insteads adds suggestions for the filters as items in the search results. 

As seen in the screencast, typing a partial category name, i.e.`shows #do` will return autocomplete suggestions in the main results space that the user can select and search for. 

The PR adds the same behaviour for `@mentions` as well as `in: status: order:` keywords. The following suggestions are included: 

```
in:title
in:personal
in:seen
in:likes
in:bookmarks
in:created

status:open
status:closed
status:public
status:noreplies

order:latest
order:views
order:likes
order:latest_topic
```

An API function has also been included so that plugins can extend the `in:` shortcuts. For example, `addInSearchShortcut("in:assigned")` should allow the assign plugin to show its search filter when it is enabled. 