### PR TITLE
FIX: Set CSP base-uri to 'self'

### DIFF
--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -9,7 +9,7 @@ class ContentSecurityPolicy
       @base_url = base_url
       @directives = {}.tap do |directives|
         directives[:upgrade_insecure_requests] = [] if SiteSetting.force_https
-        directives[:base_uri] = [:none]
+        directives[:base_uri] = [:self]
         directives[:object_src] = [:none]
         directives[:script_src] = script_src
         directives[:worker_src] = worker_src

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -19,9 +19,9 @@ describe ContentSecurityPolicy do
   end
 
   describe 'base-uri' do
-    it 'is set to none' do
+    it 'is set to self' do
       base_uri = parse(policy)['base-uri']
-      expect(base_uri).to eq(["'none'"])
+      expect(base_uri).to eq(["'self'"])
     end
   end
 


### PR DESCRIPTION
This fixes an issue where selecting text in a post results in Javascript console errors like this one: 

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/368961/124687547-1ea38300-dea3-11eb-9ecd-ded0dfc1a135.png">

This happens because when parsing the selected text (to use when quoting or sharing) we use [jQuery.parseHTML](https://github.com/jquery/jquery/blob/main/src/core/parseHTML.js#L27-L32) which creates a temporary document and sets a base href for it so URLs in the parsed HTML are correct. 

In the long run, we should fix this by avoiding jQuery when parsing HTML, but for now, we can switch to setting CSP to `'self'`, which is still safe. 