### PR TITLE
DEV: Expire `cn` cookie at end of session

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
@@ -14,6 +14,7 @@ import { h } from "virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { isEmpty } from "@ember/utils";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
+import cookie from "discourse/lib/cookie";
 
 export const DefaultNotificationItem = createWidget(
   "default-notification-item",
@@ -147,11 +148,8 @@ export const DefaultNotificationItem = createWidget(
       this.attrs.set("read", true);
       const id = this.attrs.id;
       setTransientHeader("Discourse-Clear-Notifications", id);
-      if (document && document.cookie) {
-        document.cookie = `cn=${id}; path=${getURL(
-          "/"
-        )}; expires=Fri, 31 Dec 9999 23:59:59 GMT`;
-      }
+      cookie("cn", id, { path: getURL("/") });
+
       if (wantsNewWindow(e)) {
         return;
       }


### PR DESCRIPTION
This cookie is used to transmit notification read state to the server. It is always cleared by the server on the next page load, so there is no need for the expiry to be so long. This commit updates it to expire at the end of the session (the default), and replaces raw `document.cookie` usage with our `cookie` library.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
