### PR TITLE
FIX: Check type of existing reviewables when new reviewable is created

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -139,8 +139,8 @@ class Reviewable < ActiveRecord::Base
     )
     reviewable.created_new!
 
-    if target.blank? || !Reviewable.where(target: target, type: reviewable.type).exists?
-      # If there is no target there's no chance of a conflict
+    if target.blank? || !where(target: target, type: reviewable.type).exists?
+      # If there is no target, and no existing reviewable with matching target and type, there's no chance of a conflict
       reviewable.save!
     else
       # In this case, a reviewable might already exist for this (type, target_id) index.

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -139,7 +139,7 @@ class Reviewable < ActiveRecord::Base
     )
     reviewable.created_new!
 
-    if target.blank?
+    if target.blank? || !Reviewable.where(target: target, type: reviewable.type).exists?
       # If there is no target there's no chance of a conflict
       reviewable.save!
     else

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -140,7 +140,7 @@ class Reviewable < ActiveRecord::Base
     reviewable.created_new!
 
     if target.blank? || !where(target: target, type: reviewable.type).exists?
-      # If there is no target, and no existing reviewable with matching target and type, there's no chance of a conflict
+      # If there is no target, or no existing reviewable with matching target and type, there's no chance of a conflict
       reviewable.save!
     else
       # In this case, a reviewable might already exist for this (type, target_id) index.

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -139,7 +139,7 @@ class Reviewable < ActiveRecord::Base
     )
     reviewable.created_new!
 
-    if target.blank? || !where(target: target, type: reviewable.type).exists?
+    if target.blank? || !Reviewable.where(target: target, type: reviewable.type).exists?
       # If there is no target, or no existing reviewable with matching target and type, there's no chance of a conflict
       reviewable.save!
     else

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe Reviewable, type: :model do
       expect(r1.pending?).to eq(true)
       expect(r0.pending?).to eq(false)
     end
+
+    it "will create a new reviewable when an existing reviewable exists the same target with different type" do
+      r0 = Fabricate(:reviewable_queued_post)
+      r0.perform(admin, :approve_post)
+
+      r1 = ReviewableFlaggedPost.needs_review!(created_by: admin, target: r0.target)
+      expect(r1.pending?).to eq(true)
+    end
   end
 
   context ".list_for" do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
