### PR TITLE
DEV: Remove super old code comment TODO

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -749,7 +749,6 @@ class TopicView
   end
 
   def filter_posts_by_ids(post_ids)
-    # TODO: Sort might be off
     @posts = Post.where(id: post_ids, topic_id: @topic.id)
       .includes(
         { user: :primary_group },


### PR DESCRIPTION
This TODO comment has existed for 8 years. Sort must be working just
fine or we would have prioritized fixing it.

Removing this comment as a tiny step toward keeping our codebase nice
and tidy.