### PR TITLE
FIX: Do not prevent other topic timers running on error

### DIFF
--- a/app/jobs/scheduled/topic_timer_enqueuer.rb
+++ b/app/jobs/scheduled/topic_timer_enqueuer.rb
@@ -19,7 +19,7 @@ module Jobs
         begin
           timer.enqueue_typed_job
         rescue => err
-          Rails.logger.error("Error when attempting to enqueue topic timer job for timer #{timer.id}: #{err.class} #{err.message}: #{err.backtrace.join("\n")}")
+          Discourse.warn_exception(err, message: "Error when attempting to enqueue topic timer job for timer #{timer.id}")
         end
       end
     end

--- a/app/jobs/scheduled/topic_timer_enqueuer.rb
+++ b/app/jobs/scheduled/topic_timer_enqueuer.rb
@@ -12,13 +12,15 @@ module Jobs
     every 1.minute
 
     def execute(_args = nil)
-      timers = TopicTimer.pending_timers
-
-      timers.find_each do |timer|
+      TopicTimer.pending_timers.find_each do |timer|
 
         # the typed job may not enqueue if it has already
         # been scheduled with enqueue_at
-        timer.enqueue_typed_job
+        begin
+          timer.enqueue_typed_job
+        rescue => err
+          Rails.logger.error("Error when attempting to enqueue topic timer job for timer #{timer.id}: #{err.class} #{err.message}: #{err.backtrace.join("\n")}")
+        end
       end
     end
   end

--- a/spec/jobs/topic_timer_enqueuer_spec.rb
+++ b/spec/jobs/topic_timer_enqueuer_spec.rb
@@ -47,4 +47,9 @@ RSpec.describe Jobs::TopicTimerEnqueuer do
     Jobs.enqueue_at(1.hours.from_now, :close_topic, topic_timer_id: timer1.id)
     subject.execute
   end
+
+  it "does not fail to enqueue other timers just because one timer errors" do
+    TopicTimer.any_instance.stubs(:enqueue_typed_job).raises(StandardError).then.returns(true)
+    expect { subject.execute }.not_to raise_error
+  end
 end


### PR DESCRIPTION
There was an issue with the TopicTimerEnqueuer where any timer
that failed to enqueue_typed_job with an error would prevent
all other pending timers after the one that errored from running.

To mitigate this we just capture the error and log it (so we can
still fix it if needed for bug crushing) and proceed with the
rest of the timer enqueues.

The commit https://github.com/discourse/discourse/pull/13544 highlighted
this issue originally in hosted sites.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
