### PR TITLE
FEATURE: Per-category default slow mode duration for topics.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-category-settings.js
+++ b/app/assets/javascripts/discourse/app/components/edit-category-settings.js
@@ -138,4 +138,10 @@ export default buildCategoryPanel("settings", {
     let hours = minutes ? minutes / 60 : null;
     this.set("category.auto_close_hours", hours);
   },
+
+  @action
+  onDefaultSlowModeDurationChange(minutes) {
+    let seconds = minutes ? minutes * 60 : null;
+    this.set("category.default_slow_mode_seconds", seconds);
+  },
 });

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -177,6 +177,11 @@ const Category = RestModel.extend({
     return topicCount;
   },
 
+  @discourseComputed("default_slow_mode_seconds")
+  defaultSlowModeMinutes(seconds) {
+    return seconds ? seconds / 60 : null;
+  },
+
   save() {
     const id = this.id;
     const url = id ? `/categories/${id}` : "/categories";
@@ -193,6 +198,7 @@ const Category = RestModel.extend({
         auto_close_based_on_last_post: this.get(
           "auto_close_based_on_last_post"
         ),
+        default_slow_mode_seconds: this.default_slow_mode_seconds,
         position: this.position,
         email_in: this.email_in,
         email_in_allow_strangers: this.email_in_allow_strangers,

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
@@ -116,6 +116,21 @@
     </label>
   </section>
 
+  <section class="field default-slow-mode">
+    <div class="control-group">
+      <label for="category-default-slow-mode">
+        {{i18n "category.default_slow_mode"}}
+      </label>
+      <div class="category-default-slow-mode-seconds">
+        {{relative-time-picker
+            id="category-default-slow-mode"
+            durationMinutes=category.defaultSlowModeMinutes
+            hiddenIntervals=hiddenRelativeIntervals
+            onChange=(action "onDefaultSlowModeDurationChange")}}
+      </div>
+    </div>
+  </section>
+
   <section class="field auto-close">
     <div class="control-group">
       <label for="topic-auto-close">

--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -158,7 +158,8 @@ div.edit-category {
     padding: 0 1.5em 2em 0;
   }
 
-  .category-topic-auto-close-hours {
+  .category-topic-auto-close-hours,
+  .category-default-slow-mode-seconds {
     width: 200px;
   }
 }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -298,6 +298,7 @@ class CategoriesController < ApplicationController
         :mailinglist_mirror,
         :all_topics_wiki,
         :allow_unlimited_owner_edits_on_first_post,
+        :default_slow_mode_seconds,
         :parent_category_id,
         :auto_close_hours,
         :auto_close_based_on_last_post,

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1027,6 +1027,7 @@ end
 #  read_only_banner                          :string
 #  default_list_filter                       :string(20)       default("all")
 #  allow_unlimited_owner_edits_on_first_post :boolean          default(FALSE), not null
+#  default_slow_mode_seconds                 :integer
 #
 # Indexes
 #

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -334,6 +334,7 @@ class Topic < ActiveRecord::Base
 
     if category_id_changed? || new_record?
       inherit_auto_close_from_category
+      inherit_slow_mode_from_category
     end
   end
 
@@ -1248,6 +1249,12 @@ class Topic < ActiveRecord::Base
     Topic.where('pinned_until < ?', Time.now).update_all(pinned_at: nil, pinned_globally: false, pinned_until: nil)
     Topic.where('bannered_until < ?', Time.now).find_each do |topic|
       topic.remove_banner!(Discourse.system_user)
+    end
+  end
+
+  def inherit_slow_mode_from_category
+    if self.category&.default_slow_mode_seconds
+      self.slow_mode_seconds = self.category&.default_slow_mode_seconds
     end
   end
 

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -20,7 +20,8 @@ class CategorySerializer < SiteCategorySerializer
              :custom_fields,
              :topic_featured_link_allowed,
              :search_priority,
-             :reviewable_by_group_name
+             :reviewable_by_group_name,
+             :default_slow_mode_seconds
 
   def reviewable_by_group_name
     object.reviewable_by_group.name

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3226,6 +3226,7 @@ en:
       position_disabled: "Categories will be displayed in order of activity. To control the order of categories in lists, "
       position_disabled_click: 'enable the "fixed category positions" setting.'
       minimum_required_tags: "Minimum number of tags required in a topic:"
+      default_slow_mode: 'Enable "Slow Mode" for new topics in this category.'
       parent: "Parent Category"
       num_auto_bump_daily: "Number of open topics to automatically bump daily:"
       navigate_to_first_post_after_read: "Navigate to first post after topics are read"

--- a/db/migrate/20210702204007_add_default_auto_close_seconds_to_category.rb
+++ b/db/migrate/20210702204007_add_default_auto_close_seconds_to_category.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultAutoCloseSecondsToCategory < ActiveRecord::Migration[6.1]
+  def change
+    add_column :categories, :default_slow_mode_seconds, :integer
+  end
+end

--- a/spec/requests/api/schemas/json/category_create_response.json
+++ b/spec/requests/api/schemas/json/category_create_response.json
@@ -170,6 +170,12 @@
         "allow_unlimited_owner_edits_on_first_post": {
           "type": "boolean"
         },
+        "default_slow_mode_seconds": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "group_permissions": {
           "type": "array",
           "items": [
@@ -274,6 +280,7 @@
         "auto_close_hours",
         "auto_close_based_on_last_post",
         "allow_unlimited_owner_edits_on_first_post",
+        "default_slow_mode_seconds",
         "group_permissions",
         "email_in",
         "email_in_allow_strangers",

--- a/spec/requests/api/schemas/json/category_update_response.json
+++ b/spec/requests/api/schemas/json/category_update_response.json
@@ -173,6 +173,12 @@
         "allow_unlimited_owner_edits_on_first_post": {
           "type": "boolean"
         },
+        "default_slow_mode_seconds": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "group_permissions": {
           "type": "array",
           "items": [
@@ -277,6 +283,7 @@
         "auto_close_hours",
         "auto_close_based_on_last_post",
         "allow_unlimited_owner_edits_on_first_post",
+        "default_slow_mode_seconds",
         "group_permissions",
         "email_in",
         "email_in_allow_strangers",


### PR DESCRIPTION
When configured, all topics in the category inherits the slow mode
duration from the category's default.

Note that currently there is no way to remove the slow mode from the
topics once it has been set.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
