### PR TITLE
FIX: Let user clear their flair group

### DIFF
--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -123,7 +123,8 @@ class UserUpdater
 
     if attributes[:flair_group_id] &&
       attributes[:flair_group_id] != user.flair_group_id &&
-      guardian.can_use_primary_group?(user, attributes[:flair_group_id])
+      (attributes[:flair_group_id].blank? ||
+        guardian.can_use_primary_group?(user, attributes[:flair_group_id]))
 
       user.flair_group_id = attributes[:flair_group_id]
     end

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -370,6 +370,21 @@ describe UserUpdater do
       end
     end
 
+    context 'when updating flair group' do
+      let(:group) { Fabricate(:group, name: "Group", flair_bg_color: "#111111", flair_color: "#999999", flair_icon: "icon") }
+      let(:user) { Fabricate(:user) }
+
+      it 'updates when setting is enabled' do
+        group.add(user)
+
+        UserUpdater.new(acting_user, user).update(flair_group_id: group.id)
+        expect(user.reload.flair_group_id).to eq(group.id)
+
+        UserUpdater.new(acting_user, user).update(flair_group_id: "")
+        expect(user.reload.flair_group_id).to eq(nil)
+      end
+    end
+
     context 'when update fails' do
       it 'returns false' do
         user = Fabricate(:user)


### PR DESCRIPTION
Users were able to select their flair, but were not able to clear it
by selecting (none).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
