### PR TITLE
FIX: Show correct dates in topic timelines

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -608,7 +608,7 @@ class TopicView
       columns = [:id]
 
       if !is_mega_topic?
-        columns << 'EXTRACT(DAYS FROM CURRENT_TIMESTAMP - posts.created_at)::INT AS days_ago'
+        columns << '(EXTRACT(EPOCH FROM CURRENT_TIMESTAMP - posts.created_at) / 86400)::INT AS days_ago'
       end
 
       posts.pluck(*columns)

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -796,13 +796,13 @@ describe TopicView do
   end
 
   describe '#filtered_post_stream' do
-    let!(:post) { Fabricate(:post, topic: topic, user: first_poster) }
-    let!(:post2) { Fabricate(:post, topic: topic, user: evil_trout) }
+    let!(:post) { Fabricate(:post, topic: topic, user: first_poster, created_at: 18.hours.ago) }
+    let!(:post2) { Fabricate(:post, topic: topic, user: evil_trout, created_at: 6.hours.ago) }
     let!(:post3) { Fabricate(:post, topic: topic, user: first_poster) }
 
     it 'should return the right columns' do
       expect(topic_view.filtered_post_stream).to eq([
-        [post.id, 0],
+        [post.id, 1],
         [post2.id, 0],
         [post3.id, 0]
       ])


### PR DESCRIPTION
The date shown in topic timeline was one day later if the post at that
position was made near midnight. This happened because the days number
was rounded down.

Example:

![image](https://user-images.githubusercontent.com/23153890/124948212-28e78d80-e019-11eb-8506-3e2c69516402.png)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
