### PR TITLE
FIX: can_admin_group should be true when creating a new group.

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/groups-new.js
+++ b/app/assets/javascripts/discourse/app/routes/groups-new.js
@@ -10,7 +10,11 @@ export default DiscourseRoute.extend({
   },
 
   model() {
-    return Group.create({ automatic: false, visibility_level: 0 });
+    return Group.create({
+      automatic: false,
+      visibility_level: 0,
+      can_admin_group: true,
+    });
   },
 
   setupController(controller, model) {


### PR DESCRIPTION
It looks like this regressed in #10432.

A user can create a group if they're an admin or if they're a mod **and** the `moderators_manage_categories_and_groups` setting is enabled, so it's safe to always set `can_admin_group` to true for new groups.

It will let us configure automatic membership, default title, and effects on create.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
