### PR TITLE
FIX: Let staged users choose their username

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -28,6 +28,7 @@ export default Controller.extend(
 
     invitedBy: readOnly("model.invited_by"),
     email: alias("model.email"),
+    accountEmail: alias("email"),
     hiddenEmail: alias("model.hidden_email"),
     emailVerifiedByLink: alias("model.email_verified_by_link"),
     accountUsername: alias("model.username"),

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -74,6 +74,7 @@ class InvitesController < ApplicationController
       }
 
       if staged_user = User.where(staged: true).with_email(invite.email).first
+        info[:username] = staged_user.username
         info[:user_fields] = staged_user.user_fields
       end
 

--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -13,16 +13,15 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
 
   # extracted from User cause it is very specific to invites
   def self.create_user_from_invite(email:, invite:, username: nil, name: nil, password: nil, user_custom_fields: nil, ip_address: nil, session: nil, email_token: nil)
-    user = User.where(staged: true).with_email(email.strip.downcase).first
-    user.unstage! if user
-
-    user ||= User.new
-
-    if username && UsernameValidator.new(username).valid_format? && User.username_available?(username)
+    if username && UsernameValidator.new(username).valid_format? && User.username_available?(username, email)
       available_username = username
     else
       available_username = UserNameSuggester.suggest(email)
     end
+
+    user = User.where(staged: true).with_email(email.strip.downcase).first
+    user.unstage! if user
+    user ||= User.new
 
     user.attributes = {
       email: email,


### PR DESCRIPTION
When a staged user tried to redeem an invite, a different username was
suggested and manually typing the staged username failed because the
username was not available.

There is still a problem left when a user attempts to redeem an invite
by email, without supplying the email token in the url (t query
parameter), because the email is redacted and it cannot be used when
checking availability of the username.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
