### PR TITLE
DEV: Add `users-directory-controls` outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/users.hbs
@@ -41,6 +41,7 @@
                 class="btn-default open-edit-columns-btn"
               }}
             {{/if}}
+            {{plugin-outlet name="users-directory-controls" connectorTagName="" tagName="" args=(hash model=model)}}
           </div>
         </div>
 


### PR DESCRIPTION
This can be used by themes/plugins to add additional buttons to the user directory controls

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
