### PR TITLE
UX: Translate the action type in watched words regex error

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -233,7 +233,8 @@ class AdminDashboardData
       begin
         WordWatcher.word_matcher_regexp(action, raise_errors: true)
       rescue RegexpError => e
-        return I18n.t('dashboard.watched_word_regexp_error', base_path: Discourse.base_path, action: action)
+        translated_action = I18n.t("admin_js.admin.watched_words.actions.#{action}")
+        I18n.t('dashboard.watched_word_regexp_error', base_path: Discourse.base_path, action: translated_action)
       end
     end
     nil

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1459,7 +1459,7 @@ en:
     force_https_warning: "Your website is using SSL. But `<a href='%{base_path}/admin/site_settings/category/all_results?filter=force_https'>force_https</a>` is not yet enabled in your site settings."
     out_of_date_themes: "Updates are available for the following themes:"
     unreachable_themes: "We were unable to check for updates on the following themes:"
-    watched_word_regexp_error: "The regular expression for %{action} watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
+    watched_word_regexp_error: "The regular expression for '%{action}' watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
 
   site_settings:
     display_local_time_in_user_card: "Display the local time based on a user's timezone when their user card is opened."


### PR DESCRIPTION
Previously we were using the untranslated key from the code

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
