### PR TITLE
FIX: Use Terser for minification even if uglify-js is not available

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -18,7 +18,7 @@ task 'assets:precompile:before' do
   # is recompiled
   Emoji.clear_cache
 
-  if !`which uglifyjs`.empty? && !ENV['SKIP_NODE_UGLIFY']
+  if (!`which terser`.empty? || !`which uglifyjs`.empty?) && !ENV['SKIP_NODE_UGLIFY']
     $node_uglify = true
   end
 

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -18,7 +18,7 @@ task 'assets:precompile:before' do
   # is recompiled
   Emoji.clear_cache
 
-  if (!`which terser`.empty? || !`which uglifyjs`.empty?) && !ENV['SKIP_NODE_UGLIFY']
+  if !`which terser`.empty? && !ENV['SKIP_NODE_UGLIFY']
     $node_uglify = true
   end
 
@@ -102,11 +102,8 @@ def compress_node(from, to)
   source_map_url = cdn_path "/assets/#{to}.map"
   base_source_map = assets_path + assets_additional_path
 
-  # TODO: Remove uglifyjs when base image only includes terser
-  js_compressor = `which terser`.empty? ? 'uglifyjs' : 'terser'
-
   cmd = <<~EOS
-    #{js_compressor} '#{assets_path}/#{from}' -m -c -o '#{to_path}' --source-map "base='#{base_source_map}',root='#{source_map_root}',url='#{source_map_url}'"
+    terser '#{assets_path}/#{from}' -m -c -o '#{to_path}' --source-map "base='#{base_source_map}',root='#{source_map_root}',url='#{source_map_url}'"
   EOS
 
   STDERR.puts cmd


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
In #12656, the default js minifier was switched to Terser from uglify-js, but in order for Terser to be used, uglify-js still has to be around. This fixes that.