### PR TITLE
PostMover performance improvements

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -418,8 +418,8 @@ class PostMover
   def update_statistics
     destination_topic.update_statistics
     original_topic.update_statistics
-    TopicUser.update_post_action_cache(topic_id: original_topic.id)
-    TopicUser.update_post_action_cache(topic_id: destination_topic.id)
+    TopicUser.update_post_action_cache(topic_id: original_topic.id, post_id: @post_ids, following_move: true)
+    TopicUser.update_post_action_cache(topic_id: destination_topic.id, post_id: @post_ids, following_move: true)
   end
 
   def update_user_actions

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -79,7 +79,6 @@ class PostMover
     moving_all_posts = original_topic_posts_count == posts.length
 
     create_temp_table
-    delete_invalid_post_timings
     move_each_post
     create_moderator_post_in_original_topic
     update_statistics
@@ -146,6 +145,7 @@ class PostMover
     update_quotes
     move_first_post_replies
     delete_post_replies
+    delete_invalid_post_timings
     copy_first_post_timings
     move_post_timings
     copy_topic_users
@@ -318,16 +318,12 @@ class PostMover
   end
 
   def delete_invalid_post_timings
-    DB.exec(<<~SQL, topid_id: destination_topic.id)
+    DB.exec <<~SQL
       DELETE
       FROM post_timings pt
-      WHERE pt.topic_id = :topid_id
-        AND NOT EXISTS(
-          SELECT 1
-          FROM posts p
-          WHERE p.topic_id = pt.topic_id
-            AND p.post_number = pt.post_number
-        )
+      USING moved_posts mp
+      WHERE pt.topic_id = mp.new_topic_id
+        AND pt.post_number = mp.new_post_number
     SQL
   end
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -769,6 +769,19 @@ describe PostMover do
             end
           end
 
+          it "updates topic_user.liked values for both source and destination topics" do
+            expect(TopicUser.find_by(topic: topic, user: user).liked).to eq(false)
+
+            like = Fabricate(:post_action, post: p3, user: user, post_action_type_id: PostActionType.types[:like])
+            expect(TopicUser.find_by(topic: topic, user: user).liked).to eq(true)
+
+            expect(TopicUser.find_by(topic: destination_topic, user: user)).to eq(nil)
+            topic.move_posts(user, [p3.id], destination_topic_id: destination_topic.id)
+
+            expect(TopicUser.find_by(topic: topic, user: user).liked).to eq(false)
+            expect(TopicUser.find_by(topic: destination_topic, user: user).liked).to eq(true)
+          end
+
           context "read state and other stats per user" do
             def create_topic_user(user, topic, opts = {})
               notification_level = opts.delete(:notification_level) || :regular


### PR DESCRIPTION
(Commits to be rebased-and-merged)

**PERF: Improve post_timing performance when moving posts**

Scanning for all possible invalid post_timing records in the destination topics can be a very expensive operation. The main aim is to avoid the data clashing with soon-to-be-moved posts, so we can reduce the scope of the query by targeting only rows which would actually cause a clash. post_timings has an index on (topic_id, post_number), so this is very fast.

On an example site, this reduced the query from ~6s to <10ms

---
**PERF: Improve topic_user.liked update performance when moving posts**

Previously we would re-calculate topic_user.liked for all users who have ever viewed the source or destination topic. This can be very expensive on large sites. Instead, we can use the array of moved post ids to find which users are actually affected by the move, and restrict the update query to only check/update their records.

On an example site this reduced the `update_post_action_cache` time from ~27s to 300ms