### PR TITLE
UX: Add copy button to theme public key

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
@@ -78,7 +78,10 @@
           {{#if showPublicKey}}
             <div class="public-key">
               <div class="label">{{i18n "admin.customize.theme.public_key"}}</div>
-              {{textarea readonly=true value=publicKey}}
+              <div class="public-key-text-wrapper">
+                {{textarea class="public-key-value" readonly=true value=publicKey}}
+                {{copy-button selector="textarea.public-key-value"}}
+              </div>
             </div>
           {{else}}
             {{#if privateChecked}}

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -596,7 +596,6 @@
   }
   label input {
     width: auto;
-    margin: 3px 0;
   }
 }
 .public-key {
@@ -604,7 +603,17 @@
   textarea {
     cursor: auto;
     min-height: 220px;
+    margin-bottom: 0;
   }
+  button {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+}
+
+.public-key-text-wrapper {
+  position: relative;
 }
 
 .public-key-note {


### PR DESCRIPTION
Fixes a little spacing and adds a copy button to the public key

![Screen Shot 2021-07-10 at 12 31 11 AM](https://user-images.githubusercontent.com/1681963/125151766-84e40c00-e116-11eb-83a3-845001bacf04.png)