### PR TITLE
UX: Add success state to copy button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/copy-button.js
+++ b/app/assets/javascripts/discourse/app/components/copy-button.js
@@ -1,8 +1,11 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import discourseDebounce from "discourse-common/lib/debounce";
 
 export default Component.extend({
   tagName: "",
+  copyIcon: "copy",
+  copyClass: "btn-primary",
 
   @action
   copy() {
@@ -14,6 +17,17 @@ export default Component.extend({
       if (this.copied) {
         this.copied();
       }
+
+      this.set("copyIcon", "check");
+      this.set("copyClass", "btn-primary ok");
+
+      discourseDebounce(() => {
+        if (this.isDestroying || this.isDestroyed) {
+          return;
+        }
+        this.set("copyIcon", "copy");
+        this.set("copyClass", "btn-primary");
+      }, 3000);
     } catch (err) {}
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/share-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/share-topic.js
@@ -40,14 +40,6 @@ export default Controller.extend(
     },
 
     @action
-    copied() {
-      return this.appEvents.trigger("modal-body:flash", {
-        text: I18n.t("topic.share.copied"),
-        messageClass: "success",
-      });
-    },
-
-    @action
     onChangeUsers(usernames) {
       this.set("users", usernames.uniq());
     },

--- a/app/assets/javascripts/discourse/app/templates/components/copy-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/copy-button.hbs
@@ -1,1 +1,1 @@
-{{d-button class="btn-default" icon="copy" action=(action "copy")}}
+{{d-button class=copyClass icon=copyIcon action=(action "copy")}}

--- a/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
@@ -9,7 +9,7 @@
           value=topicUrl
           readonly=true
         }}
-        {{copy-button selector="input.invite-link" copied=(action "copied")}}
+        {{copy-button selector="input.invite-link"}}
       </div>
     </div>
 


### PR DESCRIPTION
Before:
![Screen Shot 2021-07-10 at 12 38 45 AM](https://user-images.githubusercontent.com/1681963/125151892-79451500-e117-11eb-9cfc-b5840723c677.png)

After:
![Kapture 2021-07-10 at 00 37 29](https://user-images.githubusercontent.com/1681963/125151896-7ea25f80-e117-11eb-8d30-c6e65a8690ce.gif)
