### PR TITLE
UX: improve the link to the preferences page on the new and unread tabs

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -179,7 +179,7 @@ const controllerOpts = {
 
     return I18n.t("topics.none.educate." + tab, {
       userPrefsUrl: userPath(
-        `${this.currentUser.get("username_lower")}/preferences`
+        `${this.currentUser.get("username_lower")}/preferences/notifications`
       ),
     });
   },


### PR DESCRIPTION
When the <kbd>New</kbd> tab and the <kbd>Unread</kbd> tab are empty we show educational messages with links to the preferences page:

<img width="650" alt="Screenshot 2021-07-10 at 11 40 18" src="https://user-images.githubusercontent.com/1274517/125273053-95b29e80-e31d-11eb-9da8-8b9435b34684.png">

<img width="750" alt="Screenshot 2021-07-10 at 11 40 27" src="https://user-images.githubusercontent.com/1274517/125273134-a8c56e80-e31d-11eb-9c28-1f1512197656.png">

Both links lead to `preferences/account` page. In fact, settings that changes behaviour of the New and the Unread tab are on the `preferences/notifications` page:
<img width="500" alt="Screenshot 2021-07-12 at 14 31 57" src="https://user-images.githubusercontent.com/1274517/125274032-9a2b8700-e31e-11eb-896b-ecb2993b27de.png">

This PR makes links lead there.

