### PR TITLE
FEATURE: add title tag for group detail page

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -121,6 +121,7 @@ class GroupsController < ApplicationController
 
       format.html do
         @title = group.full_name.present? ? group.full_name.capitalize : group.name
+        @full_title = "#{@title} - #{SiteSetting.title}"
         @description_meta = group.bio_cooked.present? ? PrettyText.excerpt(group.bio_cooked, 300) : @title
         render :show
       end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title do %><%= @full_title %><% end %>
+
 <% content_for :head do %>
   <%= raw crawlable_meta_data(title: @title, description: @description_meta) %>
 <% end %>

--- a/spec/components/retrieve_title_spec.rb
+++ b/spec/components/retrieve_title_spec.rb
@@ -33,7 +33,7 @@ describe RetrieveTitle do
       expect(title).to eq("Good Title")
     end
 
-    it "will prefer the title from an opengraph tag" do
+    it "will prefer the title over the opengraph tag" do
       title = RetrieveTitle.extract_title(<<~HTML
         <html>
           <title>Good Title</title>

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -411,6 +411,7 @@ describe GroupsController do
 
       expect(response.status).to eq(200)
 
+      expect(response.body).to have_tag "title", text: "#{group.name} - #{SiteSetting.title}"
       expect(response.body).to have_tag(:meta, with: {
         property: 'og:title', content: group.name
       })


### PR DESCRIPTION
Meta ref: https://meta.discourse.org/t/links-to-discourse-groups-should-say-the-name-of-the-group-and-not-just-the-name-of-the-site/195052