### PR TITLE
 FIX: Suggest current username for staged users

### DIFF
--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -137,9 +137,18 @@ class Auth::Result
       return result
     end
 
+    suggested_username = UserNameSuggester.suggest(username_suggester_attributes)
+    if email_valid && email.present?
+      if username.present? && User.username_available?(username, email)
+        suggested_username = username
+      elsif staged_user = User.where(staged: true).find_by_email(email)
+        suggested_username = staged_user.username
+      end
+    end
+
     result = {
       email: email,
-      username: UserNameSuggester.suggest(username_suggester_attributes),
+      username: suggested_username,
       auth_provider: authenticator_name,
       email_valid: !!email_valid,
       can_edit_username: can_edit_username,


### PR DESCRIPTION
If user had a staged account and logged in using a third party service
a different username was suggested. This change will try to use the
username given by the authentication provider first, then the current
staged username and last suggest a new one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
