### PR TITLE
DEV: Update release notes output format, and add plugin task

### DIFF
--- a/lib/tasks/release_note.rake
+++ b/lib/tasks/release_note.rake
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 desc "generate a release note from the important commits"
-task "release_note:generate", :from, :to do |t, args|
-  from = args[:from] || `git describe --tags --abbrev=0`.strip
+task "release_note:generate", :from, :to, :repo do |t, args|
+  repo = args[:repo] || "."
+  from = args[:from] || `git -C #{repo} describe --tags --abbrev=0`.strip
   to = args[:to] || "HEAD"
 
   bug_fixes = Set.new
@@ -12,7 +13,10 @@ task "release_note:generate", :from, :to do |t, args|
   perf_changes = Set.new
   a11y_changes = Set.new
 
-  `git log --pretty="tformat:%s" #{from}..#{to}`.each_line do |comment|
+  out = `git -C #{repo} log --pretty="tformat:%s" '#{from}..#{to}'`
+  next "Status #{$?.exitstatus} running git log\n#{out}" if !$?.success?
+
+  out.each_line do |comment|
     next if comment =~ /^\s*Revert/
     split_comments(comment).each do |line|
       if line =~ /^FIX:/
@@ -31,19 +35,48 @@ task "release_note:generate", :from, :to do |t, args|
     end
   end
 
-  print_changes("NEW FEATURES", new_features)
-  print_changes("BUG FIXES", bug_fixes)
-  print_changes("UX CHANGES", ux_changes)
-  print_changes("SECURITY CHANGES", sec_changes)
-  print_changes("PERFORMANCE", perf_changes)
-  print_changes("ACCESSIBILITY", a11y_changes)
+  print_changes("New Features", new_features)
+  print_changes("Bug Fixes", bug_fixes)
+  print_changes("UX Changes", ux_changes)
+  print_changes("Security Changes", sec_changes)
+  print_changes("Performance", perf_changes)
+  print_changes("Accessibility", a11y_changes)
+
+  if [bug_fixes, new_features, ux_changes, sec_changes, perf_changes, a11y_changes].all?(&:empty?)
+    puts "(no changes)", ""
+  end
+end
+
+# To use with all-the-plugins:
+#  1. Make sure you have a local, up-to-date clone of https://github.com/discourse/all-the-plugins
+#  2. In all-the-plugins, `git submodule update --init --recursive --remote`
+#  3. Change back to your discourse directory
+#  4. rake "release_note:plugins:generate[ HEAD@{2021-06-01} , HEAD@{now} , /path/to/all-the-plugins/plugins/* , discourse ]"
+desc "generate release notes for all official plugins in a directory"
+task "release_note:plugins:generate", :from, :to, :plugin_glob, :org do |t, args|
+  from = args[:from]
+  to = args[:to]
+  plugin_glob = args[:plugin_glob] || "./plugins/*"
+  git_org = args[:org]
+
+  all_repos = Dir.glob(plugin_glob).filter { |f| File.directory?(f) && File.exists?("#{f}/.git")  }
+
+  if git_org
+    all_repos = all_repos.filter { |dir| `git -C #{dir} remote get-url origin`.match?(/github.com[\/:]#{git_org}\//) }
+  end
+
+  all_repos.each do |dir|
+    puts "## #{File.basename(dir)}\n\n"
+    Rake::Task["release_note:generate"].invoke(from, to, dir)
+    Rake::Task["release_note:generate"].reenable
+    puts "---", ""
+  end
 end
 
 def print_changes(heading, changes)
   return if changes.length == 0
 
-  puts heading
-  puts "-" * heading.length, ""
+  puts "### #{heading}", ""
   puts changes.to_a, ""
 end
 


### PR DESCRIPTION
Updates the release_note:generate task to output `###` level headings, and adds a task for generating plugin release notes.

For example:
```
rake "release_note:plugins:generate[ HEAD@{2021-07-01} , HEAD@{now} , ../all-the-plugins/plugins/* , discourse ]"
```


```
## discourse-encrypt

### New Features

- Ability to permanently destroy the encrypted message
- Decrypt notification titles before rendering

### Bug Fixes

- Do not allow encrypted PMs to be converted
- Use Ember's debounce on stable.
- Make all lookups by username case insensitive
- Decrypt small action widget
- Email annotation that message will be deleted
- Remove order when find_each in the timer job
- Timer look when long user title
- Make sure all user identity promises are eventually resolved
- Visual improvements for the timer
- Correct encrypted_post_timer_evaluator job definition
- Do not error timer when post is already deleted
- Correct order to delete the message
- Email about encrypted message contains the topic id
- Check if arguments are valid
- Encrypt works for a user who cannot edit posts
- Eager load encrypt tables in search
- Even admin does not see/like encrypted posts
- Move lightbox decorator to after-cooked
- Lightbox images only if bigger than max_image_width/height
- Decorate decrypted images with lightbox
- Remove double data-topic-id span in quick-access-item

### UX Changes

- Improve error messages if decryption fails
- Simplify key pair reset
- Make 'Disable' red in the preferences menu
- Revise styles for exploding messages
- Replace 'reset key pair' with 'disable encryption'
- Improve enable and activate processes

### Performance

- Do not wait for debounce call if user identity is cached

---

## discourse-saml

### New Features

- Add support for multiple IdP certificates.

---

## discourse-login-with-amazon

(no changes)
---

...

```