### PR TITLE
UX: Move the skip auth confirmation spinner inside the create account form.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -2,11 +2,6 @@
   {{#unless complete}}
     {{plugin-outlet name="create-account-before-modal-body"}}
     {{#d-modal-body class=modalBodyClasses}}
-
-      {{#if skipConfirmation}}
-        {{loading-spinner size="large"}}
-      {{/if}}
-
       <div class="create-account-form">
         <div class="login-welcome-header">
           <h1 class="login-title">{{i18n "create_account.header_title"}}</h1> <img src={{wavingHandURL}} alt="" class="waving-hand">
@@ -169,6 +164,10 @@
 
           {{plugin-outlet name="create-account-after-modal-footer" tagName=""}}
 
+        {{/if}}
+
+        {{#if skipConfirmation}}
+          {{loading-spinner size="large"}}
         {{/if}}
       </div>
     {{/d-modal-body}}


### PR DESCRIPTION
Before:

<img width="865" alt="Screen Shot 2021-07-12 at 17 30 49" src="https://user-images.githubusercontent.com/5025816/125352166-4d07df00-e337-11eb-967b-97200a465284.png">


After:

<img width="904" alt="Screen Shot 2021-07-12 at 17 30 04" src="https://user-images.githubusercontent.com/5025816/125352138-47aa9480-e337-11eb-9cd2-b4e39b59c15d.png">
