### PR TITLE
FIX: Set user flair group to primary group

### DIFF
--- a/db/migrate/20210713092503_set_users_flair_group_id.rb
+++ b/db/migrate/20210713092503_set_users_flair_group_id.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SetUsersFlairGroupId < ActiveRecord::Migration[6.1]
+  def change
+    execute <<~SQL
+      UPDATE users
+      SET flair_group_id = primary_group_id
+      WHERE flair_group_id IS NULL
+    SQL
+  end
+end


### PR DESCRIPTION
This is a follow up to commit 87c1e98571631d83e0d9f0846bd95a2c7e9bce87
which introduced different fields for primary and flair groups. Before
that, primary group was used as a flair group too.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
