### PR TITLE
DEV: Make badges grid a `grid`

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/badge-card.hbs
@@ -23,10 +23,8 @@
   {{/if}}
 {{/if}}
 
-<div class="badge-contents" >
-  <div class="badge-icon {{badge.badgeTypeClassName}}">
-    <a href={{url}}>{{icon-or-image badge}}</a>
-  </div>
+<div class="badge-contents">
+  <a href={{url}} class="badge-icon {{badge.badgeTypeClassName}}">{{icon-or-image badge}}</a>
   <div class="badge-info">
     <div class="badge-info-item">
       <h3><a href={{url}} class="badge-link">{{badge.name}}</a></h3>

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -121,12 +121,9 @@
 }
 
 .badge-card {
-  position: relative;
-  display: inline-block;
   background-color: var(--primary-very-low);
   border: 1px solid var(--primary-low);
-  margin-bottom: 2vh;
-  transition: box-shadow 0.25s;
+  position: relative;
 
   .check-display {
     position: absolute;
@@ -151,9 +148,8 @@
 
   .badge-contents {
     display: flex;
-    min-height: 128px;
-    height: 100%;
-    padding: 0 10%;
+    min-height: 8em;
+    padding: 0 1.5em;
 
     .badge-link {
       color: var(--primary);
@@ -161,19 +157,20 @@
 
     .badge-icon {
       display: flex;
-      flex: 0 0 auto;
-      width: 1.23em;
-      margin-right: 5%;
+      flex-shrink: 0;
+      margin-right: 1.5em;
       align-items: center;
       justify-content: center;
-      font-size: 3.5em;
-      a {
-        width: 100%;
+      width: 64px;
+
+      svg {
+        font-size: 3.5em;
       }
+
       img {
         width: 100%;
-        max-width: 65px;
-        max-height: 80px;
+        max-width: 64px;
+        max-height: 64px;
       }
 
       &.badge-type-gold .fa {
@@ -193,11 +190,8 @@
       display: flex;
       flex: 1 1 auto;
       align-items: center;
-      padding: 1em 1.5em 1em 0;
+      padding: 1em 0;
       color: var(--primary);
-      @media screen and (max-width: 600px) {
-        padding-right: 0;
-      }
 
       h3 {
         margin-bottom: 0.25em;
@@ -209,38 +203,15 @@
     }
   }
 
-  &.medium {
-    flex: 0 0 auto;
-    width: 32%;
-    margin-right: 1.63%;
-    @media screen and (min-width: 851px) {
-      &:nth-of-type(3n) {
-        margin-right: 0;
-      }
-    }
-    @include breakpoint(medium) {
-      width: 48.5%;
-      &:nth-of-type(2n) {
-        margin-right: 0;
-      }
-    }
-    @include breakpoint(mobile-extra-large) {
-      flex: 0 0 100%;
-    }
-    &:hover {
-      box-shadow: shadow("card");
-    }
-    &:active {
-      box-shadow: none;
-    }
-  }
   &.large {
     width: 100%;
     align-self: flex-start;
+
     @media screen and (min-width: 767px) {
       max-width: calc(#{$large-width} / 2);
       margin-right: 1.5em;
     }
+
     .badge-contents {
       padding: 0 5%;
       h3 {
@@ -273,15 +244,20 @@
 }
 
 .badge-group-list {
+  display: grid;
+  grid: auto-flow / repeat(3, 1fr);
+  grid-gap: 1em;
   margin-bottom: 1.5em;
-  display: flex;
-  flex-wrap: wrap;
+
   @include breakpoint(medium) {
-    justify-content: space-between;
+    grid: auto-flow / repeat(2, 1fr);
+  }
+
+  @include breakpoint(mobile-large) {
+    grid: auto-flow / 1fr;
   }
 
   .title {
-    width: 100%;
     font-size: $font-up-1;
   }
 }

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -253,7 +253,7 @@
     grid: auto-flow / repeat(2, 1fr);
   }
 
-  @include breakpoint(mobile-large) {
+  @include breakpoint(mobile-extra-large) {
     grid: auto-flow / 1fr;
   }
 


### PR DESCRIPTION
Before / After (even grid gaps, more space for text, removed on-hover shadow)

<img width="400" alt="full before" src="https://user-images.githubusercontent.com/66961/125432329-c0817c1b-c908-452e-9dc7-e293c15434fe.png"> <img width="400" alt="full after" src="https://user-images.githubusercontent.com/66961/125432322-7c3177d3-0ea7-4d5f-a456-6441100614e8.png">

<img src="https://user-images.githubusercontent.com/66961/125432327-af38efde-f9bc-46d4-81e0-e870049733ec.png" alt="ipad before" width="400"> <img src="https://user-images.githubusercontent.com/66961/125432310-d1369255-798b-44ee-b18e-9d5aabc001b3.png" alt="ipad after" width="400">

<img src="https://user-images.githubusercontent.com/66961/125432325-bbe86ea8-b6b5-4c98-9d96-8206d5a72c6b.png" alt="iphone before" width="400"> <img src="https://user-images.githubusercontent.com/66961/125432317-bee4687b-f899-4a9d-a7be-103164797491.png" alt="iphone after" width="400">