### PR TITLE
FIX: Use rem for font sizes in post headings

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -124,27 +124,27 @@ $quote-share-maxwidth: 150px;
   }
 
   h1 {
-    font-size: $font-up-3-rem;
+    font-size: var(--font-up-3-rem);
   }
 
   h2 {
-    font-size: $font-up-2-rem;
+    font-size: var(--font-up-2-rem);
   }
 
   h3 {
-    font-size: $font-up-1-rem;
+    font-size: var(--font-up-1-rem);
   }
 
   h4 {
-    font-size: $font-0-rem;
+    font-size: var(--font-0-rem);
   }
 
   h5 {
-    font-size: $font-down-1-rem;
+    font-size: var(--font-down-1-rem);
   }
 
   h6 {
-    font-size: $font-down-2-rem;
+    font-size: var(--font-down-2-rem);
   }
 
   a {

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -124,27 +124,27 @@ $quote-share-maxwidth: 150px;
   }
 
   h1 {
-    font-size: $font-up-3;
+    font-size: $font-up-3-rem;
   }
 
   h2 {
-    font-size: $font-up-2;
+    font-size: $font-up-2-rem;
   }
 
   h3 {
-    font-size: $font-up-1;
+    font-size: $font-up-1-rem;
   }
 
   h4 {
-    font-size: $font-0;
+    font-size: $font-0-rem;
   }
 
   h5 {
-    font-size: $font-down-1;
+    font-size: $font-down-1-rem;
   }
 
   h6 {
-    font-size: $font-down-2;
+    font-size: $font-down-2-rem;
   }
 
   a {

--- a/app/assets/stylesheets/common/font-variables.scss
+++ b/app/assets/stylesheets/common/font-variables.scss
@@ -20,6 +20,14 @@
   --font-down-5: 0.5em;
   --font-down-6: 0.4355em;
 
+  // Font-size definitions in rem used in cooked headings
+  --font-up-3-rem: 1.5157rem;
+  --font-up-2-rem: 1.3195rem;
+  --font-up-1-rem: 1.1487rem;
+  --font-0-rem: 1rem;
+  --font-down-1-rem: 0.8706rem;
+  --font-down-2-rem: 0.7579rem;
+
   // inputs/textareas in iOS need to be at least 16px to avoid triggering zoom on focus
   // with base at 15px, the below gives 16.05px
   --font-size-ios-input: 1.07em;

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -65,13 +65,6 @@ $font-down-4: var(--font-down-4) !default;
 $font-down-5: var(--font-down-5) !default;
 $font-down-6: var(--font-down-6) !default;
 
-$font-up-3-rem: var(--font-up-3-rem);
-$font-up-2-rem: var(--font-up-2-rem);
-$font-up-1-rem: var(--font-up-1-rem);
-$font-0-rem: var(--font-0-rem);
-$font-down-1-rem: var(--font-down-1-rem);
-$font-down-2-rem: var(--font-down-2-rem);
-
 $font-size-ios-input: var(--font-size-ios-input) !default;
 
 // Common line-heights

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -65,6 +65,13 @@ $font-down-4: var(--font-down-4) !default;
 $font-down-5: var(--font-down-5) !default;
 $font-down-6: var(--font-down-6) !default;
 
+$font-up-3-rem: var(--font-up-3-rem);
+$font-up-2-rem: var(--font-up-2-rem);
+$font-up-1-rem: var(--font-up-1-rem);
+$font-0-rem: var(--font-0-rem);
+$font-down-1-rem: var(--font-down-1-rem);
+$font-down-2-rem: var(--font-down-2-rem);
+
 $font-size-ios-input: var(--font-size-ios-input) !default;
 
 // Common line-heights


### PR DESCRIPTION
Size of headings increased proportionally with their nesting because
their size was relative to the parent element (used em). This commit
makes headings from posts use rem instead which are relative to the
root HTML element.

`<h1><div><h1>test</h1></div></h1>` looks the same as `<h1>test</h1>`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
