### PR TITLE
DEV: fix joining in the script for moving timestamps

### DIFF
--- a/script/db_timestamps_mover.rb
+++ b/script/db_timestamps_mover.rb
@@ -53,6 +53,7 @@ class TimestampsUpdater
       JOIN information_schema.tables AS t
         ON c.table_name = t.table_name
       WHERE c.table_schema = '#{@schema}'
+        AND t.table_schema = '#{@schema}'
         AND c.data_type = '#{data_type}'
         AND t.table_type = 'BASE TABLE'
     SQL


### PR DESCRIPTION
Without checking if `t.table_schema = '#{@schema}'` the SELECT with JOIN in the script were returning every column twice in case there is a 'backup' scheme with exactly the same tables as in the 'public scheme'.
