### PR TITLE
Fixes for group names and group dropdown

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -62,7 +62,7 @@ acceptance("Group - Anonymous", function (needs) {
 
     assert.equal(
       groupDropdown.rowByIndex(0).name(),
-      I18n.t("groups.index.all").toLowerCase()
+      I18n.t("groups.index.all")
     );
 
     this.siteSettings.enable_group_directory = false;

--- a/app/assets/javascripts/select-kit/addon/components/group-dropdown.js
+++ b/app/assets/javascripts/select-kit/addon/components/group-dropdown.js
@@ -25,7 +25,7 @@ export default ComboBoxComponent.extend({
     const shortcuts = [];
 
     if (this.enableGroupDirectory || this.get("currentUser.staff")) {
-      shortcuts.push(I18n.t("groups.index.all").toLowerCase());
+      shortcuts.push(I18n.t("groups.index.all"));
     }
 
     return shortcuts.concat(this.groups);

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -437,7 +437,7 @@ class Group < ActiveRecord::Base
     end
 
     # don't allow shoddy localization to break this
-    localized_name = User.normalize_username(I18n.t("groups.default_names.#{name}", locale: SiteSetting.default_locale))
+    localized_name = I18n.t("groups.default_names.#{name}", locale: SiteSetting.default_locale)
     validator = UsernameValidator.new(localized_name)
 
     if validator.valid_format? && !User.username_exists?(localized_name)


### PR DESCRIPTION
Contains 2 small fixes:

* Allow uppercase letters in automatic group names. `User.username_exists?` always converts to lowercase during lookup, so this change should be safe.
* Don't downcase "all groups" in dropdown, because this doesn't make sense in languages other than English.