### PR TITLE
FIX: Do not show invalid option in flair chooser

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/flair-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/flair-chooser.js
@@ -1,3 +1,4 @@
+import { computed } from "@ember/object";
 import ComboBoxComponent from "select-kit/components/combo-box";
 
 export default ComboBoxComponent.extend({
@@ -11,4 +12,22 @@ export default ComboBoxComponent.extend({
   modifyComponentForRow() {
     return "flair-row";
   },
+
+  selectedContent: computed(
+    "value",
+    "content.[]",
+    "selectKit.noneItem",
+    function () {
+      const content = (this.content || []).findBy(
+        this.selectKit.valueProperty,
+        this.value
+      );
+
+      if (content) {
+        return this.selectKit.modifySelection(content);
+      } else {
+        return this.selectKit.noneItem;
+      }
+    }
+  ),
 });

--- a/db/migrate/20210713092503_set_users_flair_group_id.rb
+++ b/db/migrate/20210713092503_set_users_flair_group_id.rb
@@ -5,7 +5,10 @@ class SetUsersFlairGroupId < ActiveRecord::Migration[6.1]
     execute <<~SQL
       UPDATE users
       SET flair_group_id = primary_group_id
-      WHERE flair_group_id IS NULL
+      FROM groups
+      WHERE users.primary_group_id = groups.id AND
+            users.flair_group_id IS NULL AND
+            (groups.flair_icon IS NOT NULL OR groups.flair_upload_id IS NOT NULL)
     SQL
   end
 end


### PR DESCRIPTION
Both of the commits in this PR are meant to fix the problem of invalid option being shown in the flair chooser. An invalid option can be shown if at some point it was a valid one - a group with a flair that was later changed by an admin and flair was removed. The other option an invalid option can be selected is if the user had a primary group when the migration ran and copied the same value to the flair_group_id column.