### PR TITLE
DEV: Update `i18n:check` rake task to detect invalid Markdown links

### DIFF
--- a/lib/tasks/i18n.rake
+++ b/lib/tasks/i18n.rake
@@ -6,15 +6,19 @@ require 'seed_data/topics'
 require 'colored2'
 
 desc "Checks locale files for errors"
-task "i18n:check", [:locale] => [:environment] do |_, args|
+task "i18n:check" => [:environment] do |_, args|
   failed_locales = []
 
-  if args[:locale].present?
-    if LocaleSiteSetting.valid_value?(args[:locale])
-      locales = [args[:locale]]
-    else
-      puts "ERROR: #{locale} is not a valid locale"
-      exit 1
+  if args.extras.present?
+    locales = []
+
+    args.extras.each do |locale|
+      if LocaleSiteSetting.valid_value?(locale)
+        locales << locale
+      else
+        puts "ERROR: #{locale} is not a valid locale"
+        exit 1
+      end
     end
   else
     locales = LocaleSiteSetting.supported_locales
@@ -44,8 +48,10 @@ task "i18n:check", [:locale] => [:environment] do |_, args|
             "Missing plural keys".magenta
           when LocaleFileChecker::TYPE_INVALID_MESSAGE_FORMAT
             "Invalid message format".yellow
+          when LocaleFileChecker::TYPE_INVALID_MARKDOWN_LINK
+            "Invalid markdown links".yellow
           end
-        details = error[:details] ? ": #{error[:details]}" : ""
+        details = error[:details].present? ? ": #{error[:details]}" : ""
 
         puts error[:key] << " -- " << message << details
       end


### PR DESCRIPTION
In addition to that it fixes a problem where the check failed on empty locale files and allows calling the rake task with multiple locales.