### PR TITLE
FIX: problems with choosing favorite badges

### DIFF
--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -109,10 +109,13 @@ class UserBadgesController < ApplicationController
       return render json: failed_json, status: 400
     end
 
+    new_is_favorite_value = !user_badge.is_favorite
     UserBadge
       .where(user_id: user_badge.user_id, badge_id: user_badge.badge_id)
-      .update(is_favorite: !user_badge.is_favorite)
+      .update(is_favorite: new_is_favorite_value)
     UserBadge.update_featured_ranks!(user_badge.user_id)
+
+    user_badge.is_favorite = new_is_favorite_value
     render_serialized(user_badge, DetailedUserBadgeSerializer, root: :user_badge)
   end
 

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -112,7 +112,7 @@ class UserBadgesController < ApplicationController
     new_is_favorite_value = !user_badge.is_favorite
     UserBadge
       .where(user_id: user_badge.user_id, badge_id: user_badge.badge_id)
-      .update(is_favorite: new_is_favorite_value)
+      .update_all(is_favorite: new_is_favorite_value)
     UserBadge.update_featured_ranks!(user_badge.user_id)
 
     user_badge.is_favorite = new_is_favorite_value

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -294,7 +294,10 @@ describe UserBadgesController do
     it "favorites a badge" do
       sign_in(user)
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
+
       expect(response.status).to eq(200)
+      parsed = response.parsed_body
+      expect(parsed["user_badge"]["is_favorite"]).to be true
 
       user_badge = UserBadge.find_by(user: user, badge: badge)
       expect(user_badge.is_favorite).to be true
@@ -304,7 +307,10 @@ describe UserBadgesController do
       sign_in(user)
       user_badge.toggle!(:is_favorite)
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
+
       expect(response.status).to eq(200)
+      parsed = response.parsed_body
+      expect(parsed["user_badge"]["is_favorite"]).to be false
 
       user_badge = UserBadge.find_by(user: user, badge: badge)
       expect(user_badge.is_favorite).to be false
@@ -323,16 +329,22 @@ describe UserBadgesController do
 
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
       expect(response.status).to eq(200)
+      parsed = response.parsed_body
+      expect(parsed["user_badge"]["is_favorite"]).to be false
       expect(user_badge.reload.is_favorite).to eq(false)
       expect(user_badge2.reload.is_favorite).to eq(false)
 
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
       expect(response.status).to eq(200)
+      parsed = response.parsed_body
+      expect(parsed["user_badge"]["is_favorite"]).to be true
       expect(user_badge.reload.is_favorite).to eq(true)
       expect(user_badge2.reload.is_favorite).to eq(true)
 
       put "/user_badges/#{other_user_badge.id}/toggle_favorite.json"
       expect(response.status).to eq(200)
+      parsed = response.parsed_body
+      expect(parsed["user_badge"]["is_favorite"]).to be true
       expect(other_user_badge.reload.is_favorite).to eq(true)
     end
   end

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -297,10 +297,10 @@ describe UserBadgesController do
 
       expect(response.status).to eq(200)
       parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to be true
+      expect(parsed["user_badge"]["is_favorite"]).to eq(true)
 
       user_badge = UserBadge.find_by(user: user, badge: badge)
-      expect(user_badge.is_favorite).to be true
+      expect(user_badge.is_favorite).to eq(true)
     end
 
     it "unfavorites a badge" do
@@ -310,10 +310,10 @@ describe UserBadgesController do
 
       expect(response.status).to eq(200)
       parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to be false
+      expect(parsed["user_badge"]["is_favorite"]).to eq(false)
 
       user_badge = UserBadge.find_by(user: user, badge: badge)
-      expect(user_badge.is_favorite).to be false
+      expect(user_badge.is_favorite).to eq(false)
     end
 
     it "works with multiple grants" do
@@ -330,21 +330,21 @@ describe UserBadgesController do
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
       expect(response.status).to eq(200)
       parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to be false
+      expect(parsed["user_badge"]["is_favorite"]).to eq(false)
       expect(user_badge.reload.is_favorite).to eq(false)
       expect(user_badge2.reload.is_favorite).to eq(false)
 
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
       expect(response.status).to eq(200)
       parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to be true
+      expect(parsed["user_badge"]["is_favorite"]).to eq(true)
       expect(user_badge.reload.is_favorite).to eq(true)
       expect(user_badge2.reload.is_favorite).to eq(true)
 
       put "/user_badges/#{other_user_badge.id}/toggle_favorite.json"
       expect(response.status).to eq(200)
       parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to be true
+      expect(parsed["user_badge"]["is_favorite"]).to eq(true)
       expect(other_user_badge.reload.is_favorite).to eq(true)
     end
   end


### PR DESCRIPTION
Choosing favorite badges started [behaving strange](https://meta.discourse.org/t/failed-error-selecting-favorite-badges/195657) recently.

This PR fixes the problem.

I'm a bit concerned about API method, and I'd like to change it in subsequent PR if there are no objections. We have this method:
```
PUT user_badges/20/toggle_favorite
``` 
And here is JSON this method returns:
<img width="400" alt="Screenshot 2021-07-14 at 16 54 19" src="https://user-images.githubusercontent.com/1274517/125640390-0be207d6-9844-4dd9-ac75-6e12d262d7d8.png">

It's quite a lot. In fact, this method could be returning only status code. That would be enough to figure out everything on the client side. No need to serialize objects, no need to send them to the client. It'll be a bit more efficient, but I'm also concerned about clearness of API. Looks like there's no need to return anything from this method.

Even more, instead of `toggle_favorite` it can be an idempotent method that sets `is_favorite` to provided value, and returns only status code as well
```
PUT user_badges/20/favorite
{ true }

or

PUT user_badges/20/favorite
{ false }
``` 