### PR TITLE
DEV: trigger new discourse events `after_create_dev_record` & `after_populate_dev_records`.

### DIFF
--- a/lib/discourse_dev/record.rb
+++ b/lib/discourse_dev/record.rb
@@ -46,12 +46,15 @@ module DiscourseDev
         puts "Creating #{@count} sample #{type} records"
       end
 
+      records = []
       @count.times do
-        create!
+        records << create!
         putc "."
       end
 
+      DiscourseEvent.trigger(:after_populate_dev_records, records, type)
       puts
+      records
     end
 
     def current_count

--- a/lib/discourse_dev/record.rb
+++ b/lib/discourse_dev/record.rb
@@ -18,7 +18,7 @@ module DiscourseDev
       end
 
       @model = model
-      @type = model.to_s.downcase
+      @type = model.to_s.downcase.to_sym
       @count = count
     end
 
@@ -26,6 +26,7 @@ module DiscourseDev
       record = model.create!(data)
       yield(record) if block_given?
       DiscourseEvent.trigger(:after_create_dev_record, record, type)
+      record
     end
 
     def populate!

--- a/lib/discourse_dev/record.rb
+++ b/lib/discourse_dev/record.rb
@@ -18,18 +18,19 @@ module DiscourseDev
       end
 
       @model = model
-      @type = model.to_s
+      @type = model.to_s.downcase
       @count = count
     end
 
     def create!
       record = model.create!(data)
       yield(record) if block_given?
+      DiscourseEvent.trigger(:after_create_dev_record, record, type)
     end
 
     def populate!
       if current_count >= @count
-        puts "Already have #{current_count} #{type.downcase} records"
+        puts "Already have #{current_count} #{type} records"
 
         Rake.application.top_level_tasks.each do |task_name|
           Rake::Task[task_name].reenable
@@ -39,9 +40,9 @@ module DiscourseDev
         return
       elsif current_count > 0
         @count -= current_count
-        puts "There are #{current_count} #{type.downcase} records. Creating #{@count} more."
+        puts "There are #{current_count} #{type} records. Creating #{@count} more."
       else
-        puts "Creating #{@count} sample #{type.downcase} records"
+        puts "Creating #{@count} sample #{type} records"
       end
 
       @count.times do


### PR DESCRIPTION
After every new random record created using the `dev:populate` rake task a new Discourse event `after_create_dev_record` will be triggered. So the plugins can modify the records if needed.