### PR TITLE
FIX: Remove button to dismiss theme error messages

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -16,10 +16,7 @@
   </div>
 
   {{#each model.errors as |error|}}
-    <div class="alert alert-error">
-      <button type="button" class="close" data-dismiss="alert" aria-label={{i18n "modal.dismiss_error"}}>×</button>
-      {{error}}
-    </div>
+    <div class="alert alert-error">{{error}}</div>
   {{/each}}
 
   {{#unless model.supported}}


### PR DESCRIPTION
<img width="793" alt="image" src="https://user-images.githubusercontent.com/368961/125673110-6d96f29b-8494-4764-b563-741c3fd9f126.png">

The "x" in the screenshot doesn't work (it relies on an event that is available only on modals). It's not worth fixing either, I think, admins should fix the errors at the source, instead of dismissing the alert. 