### PR TITLE
FIX: Add order to outputted stylesheet link tags

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -353,6 +353,9 @@ basic:
     default: "arial"
     enum: "BaseFontSetting"
     refresh: true
+  order_stylesheets:
+    default: false
+    hidden: true
 
 login:
   invite_only:

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -189,10 +189,9 @@ class Stylesheet::Manager
   def stylesheet_link_tag(target = :desktop, media = 'all')
     stylesheets = stylesheet_details(target, media)
     if !!(target.to_s =~ THEME_REGEX) && stylesheets.size > 1
-      stylesheets = stylesheets.sort_by { |sty| sty[:theme_name] }
-      stylesheets = stylesheets.sort_by.with_index do |s, i|
-        s[:theme_id] == @theme_id ? (stylesheets.length + i) : i
-      end
+      stylesheets = stylesheets.sort_by { |s|
+        [s[:remote] ? 0 : 1, s[:theme_id] == @theme_id ? 1 : 0, s[:theme_name]]
+      }
     end
     stylesheets.map do |stylesheet|
       href = stylesheet[:new_href]
@@ -224,7 +223,7 @@ class Stylesheet::Manager
         themes = load_themes(@theme_ids)
         themes.each do |theme|
           theme_id = theme&.id
-          data = { target: target, theme_id: theme_id, theme_name: theme&.name.downcase }
+          data = { target: target, theme_id: theme_id, theme_name: theme&.name.downcase, remote: theme.remote_theme_id? }
           builder = Builder.new(target: target, theme: theme, manager: self)
 
           next if builder.theme&.component && !scss_checker.has_scss(theme_id)

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -229,11 +229,11 @@ class Stylesheet::Manager
           stylesheets << data
         end
 
-        if stylesheets.size > 1
+        if SiteSetting.order_stylesheets && stylesheets.size > 1
           stylesheets = stylesheets.sort_by do |s|
             [
-              s[:remote] ? 0 : 1, 
-              s[:theme_id] == @theme_id ? 1 : 0, 
+              s[:remote] ? 0 : 1,
+              s[:theme_id] == @theme_id ? 1 : 0,
               s[:theme_name]
             ]
           end

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -188,11 +188,6 @@ class Stylesheet::Manager
 
   def stylesheet_link_tag(target = :desktop, media = 'all')
     stylesheets = stylesheet_details(target, media)
-    if !!(target.to_s =~ THEME_REGEX) && stylesheets.size > 1
-      stylesheets = stylesheets.sort_by { |s|
-        [s[:remote] ? 0 : 1, s[:theme_id] == @theme_id ? 1 : 0, s[:theme_name]]
-      }
-    end
     stylesheets.map do |stylesheet|
       href = stylesheet[:new_href]
       theme_id = stylesheet[:theme_id]
@@ -232,6 +227,12 @@ class Stylesheet::Manager
 
           data[:new_href] = href
           stylesheets << data
+        end
+
+        if stylesheets.size > 1
+          stylesheets = stylesheets.sort_by { |s|
+            [s[:remote] ? 0 : 1, s[:theme_id] == @theme_id ? 1 : 0, s[:theme_name]]
+          }
         end
       else
         builder = Builder.new(target: target, manager: self)

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -230,9 +230,13 @@ class Stylesheet::Manager
         end
 
         if stylesheets.size > 1
-          stylesheets = stylesheets.sort_by { |s|
-            [s[:remote] ? 0 : 1, s[:theme_id] == @theme_id ? 1 : 0, s[:theme_name]]
-          }
+          stylesheets = stylesheets.sort_by do |s|
+            [
+              s[:remote] ? 0 : 1, 
+              s[:theme_id] == @theme_id ? 1 : 0, 
+              s[:theme_name]
+            ]
+          end
         end
       else
         builder = Builder.new(target: target, manager: self)

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -188,12 +188,19 @@ class Stylesheet::Manager
 
   def stylesheet_link_tag(target = :desktop, media = 'all')
     stylesheets = stylesheet_details(target, media)
-
+    if !!(target.to_s =~ THEME_REGEX) && stylesheets.size > 1
+      stylesheets = stylesheets.sort_by { |sty| sty[:theme_name] }
+      stylesheets = stylesheets.sort_by.with_index do |s, i|
+        s[:theme_id] == @theme_id ? (stylesheets.length + i) : i
+      end
+    end
     stylesheets.map do |stylesheet|
       href = stylesheet[:new_href]
       theme_id = stylesheet[:theme_id]
       data_theme_id = theme_id ? "data-theme-id=\"#{theme_id}\"" : ""
-      %[<link href="#{href}" media="#{media}" rel="stylesheet" data-target="#{target}" #{data_theme_id}/>]
+      theme_name = stylesheet[:theme_name]
+      data_theme_name = theme_name ? "data-theme-name=\"#{theme_name}\"" : ""
+      %[<link href="#{href}" media="#{media}" rel="stylesheet" data-target="#{target}" #{data_theme_id} #{data_theme_name}/>]
     end.join("\n").html_safe
   end
 
@@ -211,43 +218,18 @@ class Stylesheet::Manager
 
     @@lock.synchronize do
       stylesheets = []
-      stale_theme_ids = []
-      theme_ids = is_theme_target ? @theme_ids : [nil]
-
-      theme_ids.each do |theme_id|
-        cache_key = "path_#{target}_#{theme_id}_#{current_hostname}"
-
-        if href = cache[cache_key]
-          stylesheets << {
-            target: target,
-            theme_id: theme_id,
-            new_href: href
-          }
-        else
-          stale_theme_ids << theme_id
-        end
-      end
-
-      scss_checker = ScssChecker.new(target, stale_theme_ids)
 
       if is_theme_target
-        themes = load_themes(stale_theme_ids)
-
+        scss_checker = ScssChecker.new(target, @theme_ids)
+        themes = load_themes(@theme_ids)
         themes.each do |theme|
           theme_id = theme&.id
-          data = { target: target, theme_id: theme_id }
+          data = { target: target, theme_id: theme_id, theme_name: theme&.name.downcase }
           builder = Builder.new(target: target, theme: theme, manager: self)
-          is_theme = builder.is_theme?
-          has_theme = builder.theme.present?
 
-          if is_theme && !has_theme
-            next
-          else
-            next if is_theme && builder.theme&.component && !scss_checker.has_scss(theme_id)
-            builder.compile unless File.exists?(builder.stylesheet_fullpath)
-            href = builder.stylesheet_path(current_hostname)
-            cache.defer_set("path_#{target}_#{theme_id}_#{current_hostname}", href)
-          end
+          next if builder.theme&.component && !scss_checker.has_scss(theme_id)
+          builder.compile unless File.exists?(builder.stylesheet_fullpath)
+          href = builder.stylesheet_path(current_hostname)
 
           data[:new_href] = href
           stylesheets << data
@@ -256,8 +238,6 @@ class Stylesheet::Manager
         builder = Builder.new(target: target, manager: self)
         builder.compile unless File.exists?(builder.stylesheet_fullpath)
         href = builder.stylesheet_path(current_hostname)
-
-        cache.defer_set("path_#{target}__#{current_hostname}", href)
 
         data = { target: target, new_href: href }
         stylesheets << data

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -164,13 +164,13 @@ describe Stylesheet::Manager do
         hrefs = manager.stylesheet_details(:desktop_theme, 'all')
 
         parent = hrefs.select { |href| href[:theme_id] == theme.id }.first
-        childA = hrefs.select { |href| href[:theme_id] == child_theme.id }.first
-        childZ = hrefs.select { |href| href[:theme_id] == z_child_theme.id }.first
-        childR = hrefs.select { |href| href[:theme_id] == child_remote.id }.first
+        child_a = hrefs.select { |href| href[:theme_id] == child_theme.id }.first
+        child_z = hrefs.select { |href| href[:theme_id] == z_child_theme.id }.first
+        child_r = hrefs.select { |href| href[:theme_id] == child_remote.id }.first
 
-        child_local_A = "<link href=\"#{childA[:new_href]}\" data-theme-id=\"#{childA[:theme_id]}\" data-theme-name=\"#{childA[:theme_name]}\"/>"
-        child_local_Z = "<link href=\"#{childZ[:new_href]}\" data-theme-id=\"#{childZ[:theme_id]}\" data-theme-name=\"#{childZ[:theme_name]}\"/>"
-        child_remote_R = "<link href=\"#{childR[:new_href]}\" data-theme-id=\"#{childR[:theme_id]}\" data-theme-name=\"#{childR[:theme_name]}\"/>"
+        child_local_A = "<link href=\"#{child_a[:new_href]}\" data-theme-id=\"#{child_a[:theme_id]}\" data-theme-name=\"#{child_a[:theme_name]}\"/>"
+        child_local_Z = "<link href=\"#{child_z[:new_href]}\" data-theme-id=\"#{child_z[:theme_id]}\" data-theme-name=\"#{child_z[:theme_name]}\"/>"
+        child_remote_R = "<link href=\"#{child_r[:new_href]}\" data-theme-id=\"#{child_r[:theme_id]}\" data-theme-name=\"#{child_r[:theme_name]}\"/>"
         parent_local = "<link href=\"#{parent[:new_href]}\" data-theme-id=\"#{parent[:theme_id]}\" data-theme-name=\"#{parent[:theme_name]}\"/>"
 
         link_hrefs = manager.stylesheet_link_tag(:desktop_theme).gsub('media="all" rel="stylesheet" data-target="desktop_theme" ', '')
@@ -191,13 +191,13 @@ describe Stylesheet::Manager do
         manager = manager(remote_main_theme.id)
         hrefs = manager.stylesheet_details(:desktop_theme, 'all')
 
-        parentR = hrefs.select { |href| href[:theme_id] == remote_main_theme.id }.first
-        childZ = hrefs.select { |href| href[:theme_id] == z_child_theme.id }.first
-        childR = hrefs.select { |href| href[:theme_id] == child_remote.id }.first
+        parent_r = hrefs.select { |href| href[:theme_id] == remote_main_theme.id }.first
+        child_z = hrefs.select { |href| href[:theme_id] == z_child_theme.id }.first
+        child_r = hrefs.select { |href| href[:theme_id] == child_remote.id }.first
 
-        parent_remote = "<link href=\"#{parentR[:new_href]}\" data-theme-id=\"#{parentR[:theme_id]}\" data-theme-name=\"#{parentR[:theme_name]}\"/>"
-        child_local = "<link href=\"#{childZ[:new_href]}\" data-theme-id=\"#{childZ[:theme_id]}\" data-theme-name=\"#{childZ[:theme_name]}\"/>"
-        child_remote = "<link href=\"#{childR[:new_href]}\" data-theme-id=\"#{childR[:theme_id]}\" data-theme-name=\"#{childR[:theme_name]}\"/>"
+        parent_remote = "<link href=\"#{parent_r[:new_href]}\" data-theme-id=\"#{parent_r[:theme_id]}\" data-theme-name=\"#{parent_r[:theme_name]}\"/>"
+        child_local = "<link href=\"#{child_z[:new_href]}\" data-theme-id=\"#{child_z[:theme_id]}\" data-theme-name=\"#{child_z[:theme_name]}\"/>"
+        child_remote = "<link href=\"#{child_r[:new_href]}\" data-theme-id=\"#{child_r[:theme_id]}\" data-theme-name=\"#{child_r[:theme_name]}\"/>"
 
         link_hrefs = manager.stylesheet_link_tag(:desktop_theme).gsub('media="all" rel="stylesheet" data-target="desktop_theme" ', '')
         expect(link_hrefs).to eq([child_remote, parent_remote, child_local].join("\n").html_safe)

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -135,8 +135,8 @@ describe Stylesheet::Manager do
       )
     end
 
-    context "stylesheet order " do
-      let(:z_child_theme) do 
+    context "stylesheet order" do
+      let(:z_child_theme) do
         Fabricate(:theme, component: true, name: "ze component").tap do |z|
           z.set_field(target: :desktop, name: "scss", value: ".child_desktop{.scss{color: red;}}")
           z.save!
@@ -145,11 +145,15 @@ describe Stylesheet::Manager do
 
       let(:remote) { RemoteTheme.create!(remote_url: "https://github.com/org/remote-theme1") }
 
-      let(:child_remote) do 
+      let(:child_remote) do
         Fabricate(:theme, remote_theme: remote, component: true).tap do |t|
           t.set_field(target: :desktop, name: "scss", value: ".child_desktop{.scss{color: red;}}")
           t.save!
         end
+      end
+
+      before do
+        SiteSetting.order_stylesheets = true
       end
 
       it 'output remote child, then sort children alphabetically, then local parent' do

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -176,10 +176,10 @@ describe Stylesheet::Manager do
 
       it "output remote child, remote parent, local child" do
         remote2 = RemoteTheme.create!(remote_url: "https://github.com/org/remote-theme2")
-        remote_main_theme = Fabricate(:theme, remote_theme: remote2, name: "remote main").tap { |t|
+        remote_main_theme = Fabricate(:theme, remote_theme: remote2, name: "remote main").tap do |t|
           t.set_field(target: :desktop, name: "scss", value: ".el{color: red;}")
           t.save!
-        }
+        end
 
         remote_main_theme.add_relative_theme!(:child, z_child_theme)
         remote_main_theme.add_relative_theme!(:child, child_remote)

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -145,10 +145,12 @@ describe Stylesheet::Manager do
 
       let(:remote) { RemoteTheme.create!(remote_url: "https://github.com/org/remote-theme1") }
 
-      let(:child_remote) { Fabricate(:theme, remote_theme: remote, component: true).tap { |t|
-        t.set_field(target: :desktop, name: "scss", value: ".child_desktop{.scss{color: red;}}")
-        t.save!
-      }}
+      let(:child_remote) do 
+        Fabricate(:theme, remote_theme: remote, component: true).tap do |t|
+          t.set_field(target: :desktop, name: "scss", value: ".child_desktop{.scss{color: red;}}")
+          t.save!
+        end
+      end
 
       it 'output remote child, then sort children alphabetically, then local parent' do
         theme.add_relative_theme!(:child, z_child_theme)

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -136,10 +136,12 @@ describe Stylesheet::Manager do
     end
 
     context "stylesheet order " do
-      let(:z_child_theme) { Fabricate(:theme, component: true, name: "ze component").tap { |z|
-        z.set_field(target: :desktop, name: "scss", value: ".child_desktop{.scss{color: red;}}")
-        z.save!
-      }}
+      let(:z_child_theme) do 
+        Fabricate(:theme, component: true, name: "ze component").tap do |z|
+          z.set_field(target: :desktop, name: "scss", value: ".child_desktop{.scss{color: red;}}")
+          z.save!
+        end
+      end
 
       let(:remote) { RemoteTheme.create!(remote_url: "https://github.com/org/remote-theme1") }
 


### PR DESCRIPTION
Theme and component stylesheets have so far been loaded without a specified order. This causes issues. Especially on sites with multiple themes and multiple components, styles from components would sometimes take precedence over the base theme and sometimes it would be the other way around. 

This PR orders the theme stylesheets thusly: 

- remote theme components (ordered alphabetically)
- remote main theme (if applicable)
- local theme components (ordered alphabetically)
- local main theme (if applicable)

Note that stylesheet ordering is **not yet** enabled by default, for now this behaviour is behind a hidden site setting: `order_stylesheets`. 

To use this, do the following in the Rails console: 

```bash
pry(main)> SiteSetting.order_stylesheets = true

pry(main)> Stylesheet::Manager.clear_theme_cache!
```

This PR also removes an extra layer of caching. We cache the full array of stylesheets for a specific target, and we also cached each stylesheet path, which is redundant. 