### PR TITLE
FIX: Assets for the theme tests page are not compressed

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,10 +75,17 @@ module ApplicationHelper
         path = "#{GlobalSetting.s3_cdn_url}#{path}"
       end
 
-      if is_brotli_req?
-        path = path.gsub(/\.([^.]+)$/, '.br.\1')
-      elsif is_gzip_req?
-        path = path.gsub(/\.([^.]+)$/, '.gz.\1')
+      # assets needed for theme testing are not compressed because they take a fair
+      # amount of time to compress (+30 seconds) during rebuilds/deploys when the
+      # vast majority of sites will never need them, so it makes more sense to serve
+      # them uncompressed instead of making everyone's rebuild/deploy take +30 more
+      # seconds.
+      if !script.start_with?("discourse/tests/")
+        if is_brotli_req?
+          path = path.gsub(/\.([^.]+)$/, '.br.\1')
+        elsif is_gzip_req?
+          path = path.gsub(/\.([^.]+)$/, '.gz.\1')
+        end
       end
 
     elsif GlobalSetting.cdn_url&.start_with?("https") && is_brotli_req? && Rails.env != "development"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -69,6 +69,12 @@ describe ApplicationHelper do
 
         expect(link).to eq(preload_link("https://s3cdn.com/assets/application.js"))
       end
+
+      it "gives s3 cdn but without brotli/gzip extensions for theme tests assets" do
+        helper.request.env["HTTP_ACCEPT_ENCODING"] = 'gzip, br'
+        link = helper.preload_script('discourse/tests/theme_qunit_ember_jquery')
+        expect(link).to eq(preload_link("https://s3cdn.com/assets/discourse/tests/theme_qunit_ember_jquery.js"))
+      end
     end
   end
 


### PR DESCRIPTION
A couple of weeks we made a change that skipped compressing assets used by the theme qunit page: https://github.com/discourse/discourse/pull/13619. This is a follow-up PR to stop the application helper from generating the assets for the theme qunit page with `.br` or `.gzip` extensions when a site uses S3 as a CDN.