### PR TITLE
UX: stop imgur/google photo mobile onebox overflow

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -672,7 +672,7 @@ aside.onebox.twitterstatus .onebox-body {
     color: #fff;
     background-color: rgba(0, 0, 0, 0.6);
     @include ellipsis;
-    max-width: 690px;
+    max-width: 100%;
     padding: 5px 0;
 
     .inner-box {


### PR DESCRIPTION
The hardcoded width on `outer-box` was causing some overflow problems on mobile when below the set width, switching to `max-width: 100%;` fixes it. 

![image](https://user-images.githubusercontent.com/1681963/125709297-b9c2ce03-d353-426f-98f3-4e5740d9981a.png)
