### PR TITLE
DEV: pass more arguments to `before-create-topic-button`

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -39,7 +39,10 @@
     args=(hash
       canCreateTopic=canCreateTopic
       createTopicDisabled=createTopicDisabled
-      createTopicLabel=createTopicLabel)
+      createTopicLabel=createTopicLabel
+      additionalTags=additionalTags
+      category=category
+      tag=tag)
   }}
 
   {{create-topic-button


### PR DESCRIPTION
This PR passes a few more arguments to the `before-create-topic-button` outlet. 

We need these arguments to avoid template overrides in themes. 