### PR TITLE
FIX: Serialize flair group ID for preferences page

### DIFF
--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -59,6 +59,7 @@ class UserCardSerializer < BasicUserSerializer
              :recent_time_read,
              :primary_group_id,
              :primary_group_name,
+             :flair_group_id,
              :flair_name,
              :flair_url,
              :flair_bg_color,

--- a/spec/serializers/web_hook_user_serializer_spec.rb
+++ b/spec/serializers/web_hook_user_serializer_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe WebHookUserSerializer do
       :recent_time_read,
       :primary_group_id,
       :primary_group_name,
+      :flair_group_id,
       :flair_name,
       :flair_url,
       :flair_bg_color,


### PR DESCRIPTION
Staff viewing the user preferences page of other users did not see the
selected flair because that information was not serialized for them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
