### PR TITLE
FIX: simplify and improve choosing favorite badges

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user-badge.js
+++ b/app/assets/javascripts/discourse/app/models/user-badge.js
@@ -22,12 +22,14 @@ const UserBadge = EmberObject.extend({
   },
 
   favorite() {
-    return ajax(`/user_badges/${this.id}/toggle_favorite`, { type: "PUT" })
-      .then(() => {
-        this.set("is_favorite", !this.is_favorite);
-        return this;
-      })
-      .catch(popupAjaxError);
+    this.toggleProperty("is_favorite");
+    return ajax(`/user_badges/${this.id}/toggle_favorite`, {
+      type: "PUT",
+    }).catch((e) => {
+      // something went wrong, switch the UI back:
+      this.toggleProperty("is_favorite");
+      popupAjaxError(e);
+    });
   },
 });
 

--- a/app/assets/javascripts/discourse/app/models/user-badge.js
+++ b/app/assets/javascripts/discourse/app/models/user-badge.js
@@ -23,8 +23,8 @@ const UserBadge = EmberObject.extend({
 
   favorite() {
     return ajax(`/user_badges/${this.id}/toggle_favorite`, { type: "PUT" })
-      .then((json) => {
-        this.set("is_favorite", json.user_badge.is_favorite);
+      .then(() => {
+        this.set("is_favorite", !this.is_favorite);
         return this;
       })
       .catch(popupAjaxError);

--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -109,14 +109,10 @@ class UserBadgesController < ApplicationController
       return render json: failed_json, status: 400
     end
 
-    new_is_favorite_value = !user_badge.is_favorite
     UserBadge
       .where(user_id: user_badge.user_id, badge_id: user_badge.badge_id)
-      .update_all(is_favorite: new_is_favorite_value)
+      .update_all(is_favorite: !user_badge.is_favorite)
     UserBadge.update_featured_ranks!(user_badge.user_id)
-
-    user_badge.is_favorite = new_is_favorite_value
-    render_serialized(user_badge, DetailedUserBadgeSerializer, root: :user_badge)
   end
 
   private

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -288,17 +288,14 @@ describe UserBadgesController do
       SiteSetting.max_favorite_badges = 3
 
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
-      expect(response.status).to eq(200)
+      expect(response.status).to eq(204)
     end
 
     it "favorites a badge" do
       sign_in(user)
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
 
-      expect(response.status).to eq(200)
-      parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to eq(true)
-
+      expect(response.status).to eq(204)
       user_badge = UserBadge.find_by(user: user, badge: badge)
       expect(user_badge.is_favorite).to eq(true)
     end
@@ -308,10 +305,7 @@ describe UserBadgesController do
       user_badge.toggle!(:is_favorite)
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
 
-      expect(response.status).to eq(200)
-      parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to eq(false)
-
+      expect(response.status).to eq(204)
       user_badge = UserBadge.find_by(user: user, badge: badge)
       expect(user_badge.is_favorite).to eq(false)
     end
@@ -328,23 +322,17 @@ describe UserBadgesController do
       other_user_badge = UserBadge.create(badge: other_badge, user: user, granted_by: Discourse.system_user, granted_at: Time.now)
 
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
-      expect(response.status).to eq(200)
-      parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to eq(false)
+      expect(response.status).to eq(204)
       expect(user_badge.reload.is_favorite).to eq(false)
       expect(user_badge2.reload.is_favorite).to eq(false)
 
       put "/user_badges/#{user_badge.id}/toggle_favorite.json"
-      expect(response.status).to eq(200)
-      parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to eq(true)
+      expect(response.status).to eq(204)
       expect(user_badge.reload.is_favorite).to eq(true)
       expect(user_badge2.reload.is_favorite).to eq(true)
 
       put "/user_badges/#{other_user_badge.id}/toggle_favorite.json"
-      expect(response.status).to eq(200)
-      parsed = response.parsed_body
-      expect(parsed["user_badge"]["is_favorite"]).to eq(true)
+      expect(response.status).to eq(204)
       expect(other_user_badge.reload.is_favorite).to eq(true)
     end
   end


### PR DESCRIPTION
This is a subsequent PR to the bug fix https://github.com/discourse/discourse/pull/13731

In fact, this would fix that problem too, I just had already finished PR and decided to merge it, so users have a bug fixed, and we can discuss this PR in case we need to. Improvements are pretty straightforward, though. It fixes two things:
1. There is no need to return anything from the server method `PUT user_badges/{id}/toggle_favorite`. This PR makes this method return a response with an empty body and status code 204 (which is the default status code for a PUT method without body in Rails)
2. It changes the flow on the client side. Now when the user clicks on a star to favorite a badge, the UI on the client updates immediately, then it sends a request to the server to save that information. If there is an error, we roll back the UI. This will be more robust. For example, users have no chances to fast mark as favorite more badges than they're allowed. Thanks to @ZogStriP for advice.
