### PR TITLE
FIX: set a correct bump timestamp when updating timestamps on a topic

### DIFF
--- a/app/services/topic_timestamp_changer.rb
+++ b/app/services/topic_timestamp_changer.rb
@@ -29,6 +29,7 @@ class TopicTimestampChanger
         end
       end
 
+      @topic.reset_bumped_at
       update_topic(last_posted_at)
 
       yield(@topic) if block_given?
@@ -48,7 +49,6 @@ class TopicTimestampChanger
     @topic.update(
       created_at: @timestamp,
       updated_at: @timestamp,
-      bumped_at: @timestamp,
       last_posted_at: last_posted_at
     )
   end

--- a/spec/services/topic_timestamp_changer_spec.rb
+++ b/spec/services/topic_timestamp_changer_spec.rb
@@ -26,19 +26,20 @@ describe TopicTimestampChanger do
         TopicTimestampChanger.new(topic: topic, timestamp: new_timestamp.to_f).change!
 
         topic.reload
+        p1.reload
+        p2.reload
+        last_post_created_at = p2.created_at
+
         expect(topic.created_at).to eq_time(new_timestamp)
         expect(topic.updated_at).to eq_time(new_timestamp)
-        expect(topic.bumped_at).to eq_time(new_timestamp)
+        expect(topic.bumped_at).to eq_time(last_post_created_at)
+        expect(topic.last_posted_at).to eq_time(last_post_created_at)
 
-        p1.reload
         expect(p1.created_at).to eq_time(new_timestamp)
         expect(p1.updated_at).to eq_time(new_timestamp)
 
-        p2.reload
         expect(p2.created_at).to eq_time(new_timestamp + 1.day)
         expect(p2.updated_at).to eq_time(new_timestamp + 1.day)
-
-        expect(topic.last_posted_at).to eq_time(p2.reload.created_at)
       end
 
       describe 'when posts have timestamps in the future' do


### PR DESCRIPTION
There was a bug with changing timestamps using the topic wrench button:
<img width="175" alt="Screenshot 2021-07-15 at 20 18 08" src="https://user-images.githubusercontent.com/1274517/125823302-322d3058-7c5f-40ef-afd5-0b2ec37e9d3f.png">

Under some circumstances, a topic was disappearing from the top of the latest tab after changing timestamps. Steps to reproduce:
1. Choose a topic on the latest tab (the topic should be created some time ago, but has recent posts)
1. Change topic timestamps (for example, move them one day forward):
1. Go back to the latest tab and see that topic has disappeared.

This PR fixes this. We were setting `topic.bumped_at` to the timestamp user specified on the modal:

<img width="250" alt="Screenshot 2021-07-15 at 20 28 34" src="https://user-images.githubusercontent.com/1274517/125823896-001609cd-c358-4be4-87fc-68afb88d9416.png">

This is incorrect. Instead, we should be setting `topic.bumped_at` to the `created_at` timestamp of the last _regular_ (not a whisper and so on) post on the topic.



