### PR TITLE
PERF: Add scheduled job to delete old stylesheet cache rows

### DIFF
--- a/app/jobs/scheduled/clean_up_stylesheet_cache.rb
+++ b/app/jobs/scheduled/clean_up_stylesheet_cache.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CleanUpStylesheetCache < ::Jobs::Scheduled
+    every 1.week
+
+    def execute(args)
+      StylesheetCache.clean_up
+    end
+  end
+end

--- a/app/models/stylesheet_cache.rb
+++ b/app/models/stylesheet_cache.rb
@@ -4,6 +4,7 @@ class StylesheetCache < ActiveRecord::Base
   self.table_name = 'stylesheet_cache'
 
   MAX_TO_KEEP = 50
+  CLEANUP_AFTER_DAYS = 150
 
   def self.add(target, digest, content, source_map, max_to_keep: nil)
     max_to_keep ||= MAX_TO_KEEP
@@ -43,7 +44,7 @@ class StylesheetCache < ActiveRecord::Base
   end
 
   def self.clean_up
-    StylesheetCache.where('created_at < ?', 150.days.ago).delete_all
+    StylesheetCache.where('created_at < ?', CLEANUP_AFTER_DAYS.days.ago).delete_all
   end
 
 end

--- a/app/models/stylesheet_cache.rb
+++ b/app/models/stylesheet_cache.rb
@@ -42,6 +42,10 @@ class StylesheetCache < ActiveRecord::Base
     end
   end
 
+  def self.clean_up
+    StylesheetCache.where('created_at < TIMESTAMP ?', 150.days.ago).delete_all
+  end
+
 end
 
 # == Schema Information

--- a/app/models/stylesheet_cache.rb
+++ b/app/models/stylesheet_cache.rb
@@ -43,7 +43,7 @@ class StylesheetCache < ActiveRecord::Base
   end
 
   def self.clean_up
-    StylesheetCache.where('created_at < TIMESTAMP ?', 150.days.ago).delete_all
+    StylesheetCache.where('created_at < ?', 150.days.ago).delete_all
   end
 
 end

--- a/spec/models/stylesheet_cache_spec.rb
+++ b/spec/models/stylesheet_cache_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe StylesheetCache do
 
-  describe "add" do
+  describe ".add" do
     it "correctly cycles once MAX_TO_KEEP is hit" do
       StylesheetCache.destroy_all
 
@@ -40,16 +40,20 @@ describe StylesheetCache do
   end
 
   describe ".clean_up" do
-    it "removes items older than 1 year" do
+    it "removes items older than threshold" do
       StylesheetCache.destroy_all
 
       StylesheetCache.add("a", "b", "c", "map")
       StylesheetCache.add("d", "e", "f", "map")
 
+      above_threshold = StylesheetCache::CLEANUP_AFTER_DAYS - 1
+      StylesheetCache.first.update!(created_at: above_threshold.days.ago)
+
       StylesheetCache.clean_up
       expect(StylesheetCache.all.size).to eq(2)
 
-      StylesheetCache.first.update!(created_at: 151.days.ago)
+      below_threshold = StylesheetCache::CLEANUP_AFTER_DAYS + 1
+      StylesheetCache.first.update!(created_at: below_threshold.days.ago)
 
       StylesheetCache.clean_up
       expect(StylesheetCache.all.size).to eq(1)

--- a/spec/models/stylesheet_cache_spec.rb
+++ b/spec/models/stylesheet_cache_spec.rb
@@ -39,7 +39,7 @@ describe StylesheetCache do
     end
   end
 
-  describe "clean_up" do
+  describe ".clean_up" do
     it "removes items older than 1 year" do
       StylesheetCache.destroy_all
 

--- a/spec/models/stylesheet_cache_spec.rb
+++ b/spec/models/stylesheet_cache_spec.rb
@@ -37,6 +37,24 @@ describe StylesheetCache do
 
       expect(StylesheetCache.order(:id).pluck(:target)).to eq(["desktop", "desktop", "mobile", "mobile"])
     end
+  end
 
+  describe "clean_up" do
+    it "removes items older than 1 year" do
+      StylesheetCache.destroy_all
+
+      StylesheetCache.add("a", "b", "c", "map")
+      StylesheetCache.add("d", "e", "f", "map")
+
+      StylesheetCache.clean_up
+      expect(StylesheetCache.all.size).to eq(2)
+
+      first = StylesheetCache.first
+      first.created_at = 151.days.ago
+      first.save
+
+      StylesheetCache.clean_up
+      expect(StylesheetCache.all.size).to eq(1)
+    end
   end
 end

--- a/spec/models/stylesheet_cache_spec.rb
+++ b/spec/models/stylesheet_cache_spec.rb
@@ -49,9 +49,7 @@ describe StylesheetCache do
       StylesheetCache.clean_up
       expect(StylesheetCache.all.size).to eq(2)
 
-      first = StylesheetCache.first
-      first.created_at = 151.days.ago
-      first.save
+      StylesheetCache.first.update!(created_at: 151.days.ago)
 
       StylesheetCache.clean_up
       expect(StylesheetCache.all.size).to eq(1)


### PR DESCRIPTION
Old stylesheet cache entries stick around for too long. We currently keep a maximum of 50 entries per target. Plus, any changes in target names (due to refactors) leave redundant entries in the table.

This adds a job that removes stylesheet cache entries older than 150 days. This is a long timeframe to account for Discourse sites that update only a few times a year. (We could also easily cleanup entries that are 50 or 100 days old.)

The `stylesheet_cache` table can be quite large. On review.discourse.org, for example, it is the largest table: 

```
# rake db:stats

table_name                           | row_estimate | table_size | index_size | total_size
-----------------------------------------------------------------------------------
stylesheet_cache                     | 6176         | 264 MB     | 936 kB     | 265 MB
```

1573 rows are over 150 days old, 5238 are over 100 days old. 