### PR TITLE
FIX: Clear stale status of reloaded reviewables

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -29,14 +29,14 @@ export default Component.extend({
 
   @discourseComputed(
     "reviewable.type",
-    "reviewable.stale",
+    "reviewable.last_performing_username",
     "siteSettings.blur_tl0_flagged_posts_media",
     "reviewable.target_created_by_trust_level"
   )
-  customClasses(type, stale, blurEnabled, trustLevel) {
+  customClasses(type, lastPerformingUsername, blurEnabled, trustLevel) {
     let classes = type.dasherize();
 
-    if (stale) {
+    if (lastPerformingUsername) {
       classes = `${classes} reviewable-stale`;
     }
 

--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -39,6 +39,10 @@ export default DiscourseRoute.extend({
       sort_order: meta.sort_order,
       additionalFilters: meta.additional_filters || {},
     });
+
+    controller.reviewables.forEach((reviewable) => {
+      reviewable.set("stale", false);
+    });
   },
 
   activate() {

--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -41,7 +41,7 @@ export default DiscourseRoute.extend({
     });
 
     controller.reviewables.forEach((reviewable) => {
-      reviewable.set("stale", false);
+      reviewable.set("last_performing_username", null);
     });
   },
 
@@ -66,7 +66,6 @@ export default DiscourseRoute.extend({
           const updates = data.updates[reviewable.id];
           if (updates) {
             reviewable.setProperties(updates);
-            reviewable.set("stale", true);
           }
         });
       }

--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -40,9 +40,7 @@ export default DiscourseRoute.extend({
       additionalFilters: meta.additional_filters || {},
     });
 
-    controller.reviewables.forEach((reviewable) => {
-      reviewable.set("last_performing_username", null);
-    });
+    controller.reviewables.setEach("last_performing_username", null);
   },
 
   activate() {

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-item.hbs
@@ -44,8 +44,8 @@
     {{/if}}
   </div>
   <div class="reviewable-actions">
-    {{#if reviewable.stale}}
-      <div class="stale-help">{{i18n "review.stale_help"}}</div>
+    {{#if reviewable.last_performing_username}}
+      <div class="stale-help">{{html-safe (i18n "review.stale_help" username=reviewable.last_performing_username)}}</div>
     {{else}}
       {{#if claimEnabled}}
         <div class="claimed-actions">

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -197,7 +197,7 @@ acceptance("Review", function (needs) {
     publishToMessageBus("/reviewable_counts", {
       review_count: 1,
       updates: {
-        1234: { status: 1 },
+        1234: { last_performing_username: "foo", status: 1 },
       },
     });
 
@@ -206,6 +206,7 @@ acceptance("Review", function (needs) {
     assert.ok(reviewable.className.includes("reviewable-stale"));
     assert.equal(count("[data-reviewable-id=1234] .status .approved"), 1);
     assert.equal(count(".stale-help"), 1);
+    assert.ok(query(".stale-help").innerText.includes("foo"));
 
     await visit("/");
     await visit("/review"); // reload review

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -206,5 +206,10 @@ acceptance("Review", function (needs) {
     assert.ok(reviewable.className.includes("reviewable-stale"));
     assert.equal(count("[data-reviewable-id=1234] .status .approved"), 1);
     assert.equal(count(".stale-help"), 1);
+
+    await visit("/");
+    await visit("/review"); // reload review
+
+    assert.equal(count(".stale-help"), 0);
   });
 });

--- a/app/jobs/regular/notify_reviewable.rb
+++ b/app/jobs/regular/notify_reviewable.rb
@@ -19,7 +19,10 @@ class Jobs::NotifyReviewable < ::Jobs::Base
 
     if args[:updated_reviewable_ids].present?
       Reviewable.where(id: args[:updated_reviewable_ids]).each do |r|
-        payload = { status: r.status }
+        payload = {
+          last_performing_username: args[:performing_username],
+          status: r.status
+        }
 
         all_updates[:admins][r.id] = payload
         all_updates[:moderators][r.id] = payload if r.reviewable_by_moderator?

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -371,7 +371,8 @@ class Reviewable < ActiveRecord::Base
       Jobs.enqueue(
         :notify_reviewable,
         reviewable_id: self.id,
-        updated_reviewable_ids: result.remove_reviewable_ids,
+        performing_username: performed_by.username,
+        updated_reviewable_ids: result.remove_reviewable_ids
       )
     end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -426,7 +426,7 @@ en:
         type_bonus:
           name: "type bonus"
           title: "Certain reviewable types can be assigned a bonus by staff to make them a higher priority."
-      stale_help: "This reviewable has been resolved by someone else."
+      stale_help: "This reviewable has been resolved by <b>%{username}</b>."
       claim_help:
         optional: "You can claim this item to prevent others from reviewing it."
         required: "You must claim items before you can review them."


### PR DESCRIPTION
Navigating away from and back to the reviewables reloaded Reviewable
records, but did not clear the "stale" attribute.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
