### PR TITLE
changed private message -> personal message

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -337,7 +337,7 @@ en:
       remove: "Remove"
       remove_confirmation: "Are you sure you want to delete this draft?"
       new_topic: "New topic draft"
-      new_private_message: "New private message draft"
+      new_private_message: "New personal message draft"
       topic_reply: "Draft reply"
       abandon:
         confirm: "You have a draft in progress for this topic. What would you like to do with it?"


### PR DESCRIPTION
We are trying to not use "private message" in the UI, in favor of "personal message", because of course admins can read all messages so they are not really private unless encrypted messaging is turned on..

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
