### PR TITLE
updated copy for reply_as_new_group_message

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2132,7 +2132,7 @@ en:
           confirm: You have a new topic draft saved, which will be overwritten if you create a linked topic.
         reply_as_new_group_message:
           label: Reply as new group message
-          desc: Create a new private message with the same recipients
+          desc: Create new message starting with same recipients
         reply_as_private_message:
           label: New message
           desc: Create a new personal message


### PR DESCRIPTION
I changed from "Create a new private message with the same recipients" to "Create new message starting with same recipients". 

Wanting to remove "private" because these messages are not private (admins can read them unless encrypted messaging is in use). Also want to communicate that this is a way to expand the conversation to new people without having to explicitly invite them to the current message, or give them access to the past discussions. 

ref: https://dev.discourse.org/t/bring-invite-to-message-in-line-with-new-invite-system/49578/12?u=tobiaseigen

ref: https://meta.discourse.org/t/how-do-you-add-another-person-to-a-private-message-when-its-already-sent/43357/8?u=tobiaseigen

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
