### PR TITLE
FEATURE: Stop checking referer for embeds

### DIFF
--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -44,6 +44,8 @@ class EmbeddableHost < ActiveRecord::Base
   end
 
   def self.url_allowed?(url)
+    return false if url.nil?
+
     # Work around IFRAME reload on WebKit where the referer will be set to the Forum URL
     return true if url&.starts_with?(Discourse.base_url) && EmbeddableHost.exists?
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1640,7 +1640,7 @@ security:
   content_security_policy_collect_reports:
     default: false
   content_security_policy_frame_ancestors:
-    default: false
+    default: true
   content_security_policy_script_src:
     type: simple_list
     default: ""

--- a/spec/components/topic_retriever_spec.rb
+++ b/spec/components/topic_retriever_spec.rb
@@ -36,9 +36,9 @@ describe TopicRetriever do
       end
     end
 
-    context "when host is not invalid" do
+    context "when host is valid" do
       before do
-        topic_retriever.stubs(:invalid_url?).returns(false)
+        Fabricate(:embeddable_host, host: 'http://eviltrout.com/')
       end
 
       context "when topics have been retrieved recently" do
@@ -61,6 +61,17 @@ describe TopicRetriever do
           topic_retriever.expects(:perform_retrieve).once
           topic_retriever.retrieve
         end
+      end
+    end
+
+    context "when host is invalid" do
+      before do
+        Fabricate(:embeddable_host, host: 'http://not-eviltrout.com/')
+      end
+
+      it "does not perform_retrieve" do
+        topic_retriever.expects(:perform_retrieve).never
+        topic_retriever.retrieve
       end
     end
 

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -150,9 +150,9 @@ describe EmbedController do
       Jobs.run_immediately!
     end
 
-    it "raises an error with no referer" do
+    it "doesn't raises an error with no referer" do
       get '/embed/comments', params: { embed_url: embed_url }
-      expect(response.body).to match(I18n.t('embed.error'))
+      expect(response.body).not_to match(I18n.t('embed.error'))
     end
 
     it "includes CSS from embedded_scss field" do
@@ -265,14 +265,6 @@ describe EmbedController do
           headers: { 'REFERER' => "https://example.com/some-other-path" }
 
         expect(response.body).to match('class="example"')
-      end
-
-      it "doesn't work with a made up host" do
-        get '/embed/comments',
-          params: { embed_url: embed_url },
-          headers: { 'REFERER' => "http://codinghorror.com/invalid-url" }
-
-        expect(response.body).to match(I18n.t('embed.error'))
       end
     end
 


### PR DESCRIPTION
Flips content_security_policy_frame_ancestors default to enabled, and
removes HTTP_REFERER checks on embed requests, as the new referer
privacy options made the check fragile.
