### PR TITLE
FIX: Ascending/descending sorting in the group membership requests page

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-requests.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-requests.js
@@ -7,10 +7,10 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 export default Controller.extend({
   application: controller(),
 
-  queryParams: ["order", "desc", "filter"],
+  queryParams: ["order", "asc", "filter"],
 
   order: "",
-  desc: null,
+  asc: null,
   filter: null,
   filterInput: null,
 
@@ -27,7 +27,7 @@ export default Controller.extend({
     );
   },
 
-  @observes("order", "desc", "filter")
+  @observes("order", "asc", "filter")
   _filtersChanged() {
     this.findRequesters(true);
   },
@@ -57,9 +57,9 @@ export default Controller.extend({
     });
   },
 
-  @discourseComputed("order", "desc", "filter")
-  memberParams(order, desc, filter) {
-    return { order, desc, filter };
+  @discourseComputed("order", "asc", "filter")
+  memberParams(order, asc, filter) {
+    return { order, asc, filter };
   },
 
   @discourseComputed("model.requesters.[]")


### PR DESCRIPTION
The `GroupsController#members` endpoint accepts a `desc` parameter to determine how members are sorted, but it's been deprecated in favor of a boolean `asc` parameter. However, in the frontend, specifically the group membership requests page was not updated entirely to use the `asc` param and it still passes a `desc` param when changing how group requests are sorted.

This PR updates the `group-requests` Ember controller so it passes a boolean `asc` param and removes all references of `desc`. The controller view/template has already been updated to use `asc`:

https://github.com/discourse/discourse/blob/207c3085fc377e5f08c1002c9913eed3c4debdd6/app/assets/javascripts/discourse/app/templates/group-requests.hbs#L15-L16