### PR TITLE
DEV: Plugin outlet in topic-status component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-status.js
+++ b/app/assets/javascripts/discourse/app/components/topic-status.js
@@ -12,8 +12,6 @@ export default Component.extend({
       const topic = this.topic;
       topic.get("pinned") ? topic.clearPin() : topic.rePin();
     }
-
-    return false;
   },
 
   @discourseComputed("disableActions")

--- a/app/assets/javascripts/discourse/app/components/topic-status.js
+++ b/app/assets/javascripts/discourse/app/components/topic-status.js
@@ -11,6 +11,7 @@ export default Component.extend({
     if (this.canAct && $(e.target).hasClass("d-icon-thumbtack")) {
       const topic = this.topic;
       topic.get("pinned") ? topic.clearPin() : topic.rePin();
+      return false;
     }
   },
 

--- a/app/assets/javascripts/discourse/app/templates/components/topic-status.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-status.hbs
@@ -30,3 +30,5 @@
 {{~#if topicInvisible~}}
   <span title={{invisibleTitle}} class="topic-status">{{invisibleIcon}}</span>
 {{~/if~}}
+{{plugin-outlet name="after-topic-status" tagName="" args=(hash topic=topic)}}
+

--- a/app/assets/javascripts/discourse/app/templates/components/topic-status.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-status.hbs
@@ -31,4 +31,3 @@
   <span title={{invisibleTitle}} class="topic-status">{{invisibleIcon}}</span>
 {{~/if~}}
 {{plugin-outlet name="after-topic-status" tagName="" args=(hash topic=topic)}}
-


### PR DESCRIPTION
You'll notice I moved the `return false;` inside `click` function to only the pin logic path. When `click` returns false, the event is not propogated to children of the component. This is problematic if you want to use the `plugin-outlet` and have a click event inside of it. I don't see any reason why removing the `return false` would cause an error.