### PR TITLE
DEV: Don't use chunked encoding in development mode

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/initializers/message-bus.js
@@ -86,7 +86,8 @@ export default {
     messageBus.baseUrl =
       siteSettings.long_polling_base_url.replace(/\/$/, "") + "/";
 
-    messageBus.enableChunkedEncoding = siteSettings.enable_chunked_encoding;
+    messageBus.enableChunkedEncoding =
+      isProduction() && siteSettings.enable_chunked_encoding;
 
     if (messageBus.baseUrl !== "/") {
       messageBus.ajax = function (opts) {


### PR DESCRIPTION
The express server and http-proxy seem to buffer quite a bit and that
slows down message bus.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
