### PR TITLE
FIX: Remove hardcoded value when displaying incoming messages count.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/basic-topic-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/basic-topic-list.hbs
@@ -2,7 +2,7 @@
   {{#if hasIncoming}}
     <div class="show-mores">
       <a tabindex="0" href {{action showInserted}} class="alert alert-info clickable">
-        {{count-i18n key="topic_count_" suffix="latest" count=2}}
+        {{count-i18n key="topic_count_" suffix="latest" count=incomingCount}}
       </a>
     </div>
   {{/if}}


### PR DESCRIPTION
Follow-up to 902d0e1e3a61bc2d2d05c617a6e8e51aaaf42b30.

We probably should have test here but I'm in a hurry for a feature I'm building.