### PR TITLE
DEV: allow `dev:populate` rake task in production environment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,8 +179,12 @@ end
 
 if ENV["ALLOW_DEV_POPULATE"] == "1"
   gem 'discourse_dev_assets'
+  gem 'faker', "~> 2.16"
 else
-  gem 'discourse_dev_assets', :group => :development
+  group :development do
+    gem 'discourse_dev_assets'
+    gem 'faker', "~> 2.16"
+  end
 end
 
 # this is an optional gem, it provides a high performance replacement

--- a/Gemfile
+++ b/Gemfile
@@ -175,8 +175,12 @@ group :development do
   gem 'better_errors', platform: :mri, require: !!ENV['BETTER_ERRORS']
   gem 'binding_of_caller'
   gem 'yaml-lint'
+end
+
+if ENV["ALLOW_DEV_POPULATE"] == "1"
   gem 'discourse_dev_assets'
-  gem 'faker', "~> 2.16"
+else
+  gem 'discourse_dev_assets', :group => :development
 end
 
 # this is an optional gem, it provides a high performance replacement

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -1003,6 +1003,10 @@ module Discourse
     headers['Access-Control-Allow-Methods'] = CDN_REQUEST_METHODS.join(", ")
     headers
   end
+
+  def self.allow_dev_populate?
+    Rails.env.development? || ENV["ALLOW_DEV_POPULATE"] == "1"
+  end
 end
 
 # rubocop:enable Style/GlobalVars

--- a/lib/discourse_dev/record.rb
+++ b/lib/discourse_dev/record.rb
@@ -30,6 +30,10 @@ module DiscourseDev
     end
 
     def populate!(ignore_current_count: false)
+      unless Discourse.allow_dev_populate?
+        raise 'To run this rake task in a production site, set the value of `ALLOW_DEV_POPULATE` environment variable to "1"'
+      end
+
       unless ignore_current_count
         if current_count >= @count
           puts "Already have #{current_count} #{type} records"

--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -55,7 +55,7 @@ module I18n
         # load it
         I18n.backend.load_translations(I18n.load_path.grep(/\.#{Regexp.escape locale}\.yml$/))
 
-        if Rails.env.development?
+        if Discourse.allow_dev_populate?
           I18n.backend.load_translations(I18n.load_path.grep(/.*faker.*\/#{Regexp.escape locale}\.yml$/))
           I18n.backend.load_translations(I18n.load_path.grep(/.*faker.*\/#{Regexp.escape locale}\/.*\.yml$/))
         end


### PR DESCRIPTION
To use this rake task in production `ALLOW_DEV_POPULATE` environment variable should be set to "1".