### PR TITLE
FIX: Toggle search menu when clicking the same button

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -286,7 +286,7 @@ export default createWidget("search-menu", {
     });
   },
 
-  mouseDownOutside() {
+  clickOutside() {
     this.sendWidgetAction("toggleSearchMenu");
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -52,6 +52,22 @@ acceptance("Search - Anonymous", function (needs) {
     );
   });
 
+  test("search button toggles search menu", async function (assert) {
+    await visit("/");
+
+    await click("#search-button");
+    assert.ok(exists(".search-menu"));
+
+    await click(".d-header"); // click outside
+    assert.ok(!exists(".search-menu"));
+
+    await click("#search-button");
+    assert.ok(exists(".search-menu"));
+
+    await click("#search-button"); // toggle same button
+    assert.ok(!exists(".search-menu"));
+  });
+
   test("search for a tag", async function (assert) {
     await visit("/");
 


### PR DESCRIPTION
Need to use the `clickOutside` event here, otherwise the widget's action plus the `mouseDownOutside` event get both called and the second cancels the first.
