### PR TITLE
upload_creator: ask ImageMagick to use internal SVG code to determine size

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -127,10 +127,14 @@ class UploadCreator
         if @image_info.type.to_s == 'svg'
           w, h = [0, 0]
 
+          # identify can behave differently depending on how it's compiled and
+          # what programs (e.g. inkscape) are installed on your system.
+          # 'MSVG:' forces ImageMagick to use internal routines and behave
+          # consistently whether it's running from our docker container or not
           begin
             w, h = Discourse::Utils
-              .execute_command("identify", "-ping", "-format", "%w %h", @file.path, timeout: Upload::MAX_IDENTIFY_SECONDS)
-              .split(' ')
+              .execute_command("identify", "-ping", "-format", "%w %h", "MSVG:#{@file.path}", timeout: Upload::MAX_IDENTIFY_SECONDS)
+              .split(' ').map(&:to_i)
           rescue
             # use default 0, 0
           end


### PR DESCRIPTION
This change largely targets dev users, but it could potentially change
behaviour in production.

Jamie Wilson & I debugged a problem where "should not be larger than the
maximum thumbnail size" would fail due to timeouts.

On our systems, on ImageMagick 7.1.0-2, with inkscape installed, IM would
attempt to rasterise the svg then check the resulting filesize, causing the
test to timeout.

As of now, we haven't found a way to cause this to behave better, but have a
workaround in that forcing IM to use the internal renderer (`MSVG:`) would
perform quickly, but error out on more complex files. We can at least try the
fast path before falling back to the potentially slower method.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
