### PR TITLE
Update class names to avoid ad blocker

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/share-popup.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/share-popup.hbs
@@ -14,11 +14,11 @@
   }}
 </div>
 
-<div class="share-link-container">
+<div class="link-share-container">
   <input class="share-link-input" type="text" aria-label={{i18n "share.url"}}> {{copy-button selector="input.share-link-input"}}
 </div>
 
-<div class="share-link-actions">
+<div class="link-share-actions">
   <div class="sources">
     {{#each sources as |s|}}
       {{share-source source=s title=model.title action=(action "share")}}

--- a/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
@@ -2,7 +2,7 @@
   <form>
     <div class="input-group invite-link">
       <label for="invite-link">{{i18n "user.invited.invite.instructions"}}</label>
-      <div class="share-link-container">
+      <div class="link-share-container">
         {{input
           name="invite-link"
           class="invite-link"

--- a/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
@@ -2,7 +2,7 @@
   <form>
     <div class="input-group invite-link">
       <label for="invite-link">{{i18n "topic.share.instructions"}}</label>
-      <div class="share-link-container">
+      <div class="link-share-container">
         {{input
           name="invite-link"
           class="invite-link"
@@ -12,7 +12,7 @@
         {{copy-button selector="input.invite-link"}}
       </div>
     </div>
-    <div class="share-link-actions">
+    <div class="link-share-actions">
       <div class="sources">
         {{#each sources as |s|}}
           {{share-source source=s title=topic.title action=(action "share")}}

--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -1,6 +1,6 @@
 // styles that apply to the "share" modal & popup when sharing a link to a post or topic
 
-.share-link-container {
+.link-share-container {
   display: flex;
   button {
     transition-property: background-color, color; // don't transition outline
@@ -15,7 +15,7 @@
   }
 }
 
-.share-link-actions {
+.link-share-actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;


### PR DESCRIPTION
Minor follow-up to 8de8989, the optional `fanboy-social` blocklist that comes with uBlock Origin blocks anything starting with `share-link`, and that blocks the share link input in addition to the social links. I've updated to `link-share` instead to avoid the issue. 