### PR TITLE
FIX: allows to use icon-picker in wizard

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/icon-picker.js
+++ b/app/assets/javascripts/select-kit/addon/components/icon-picker.js
@@ -4,10 +4,10 @@ import {
   enableMissingIconWarning,
 } from "discourse-common/lib/icon-library";
 import MultiSelectComponent from "select-kit/components/multi-select";
-import { ajax } from "discourse/lib/ajax";
 import { computed } from "@ember/object";
 import { isDevelopment } from "discourse-common/config/environment";
 import { makeArray } from "discourse-common/lib/helpers";
+import { ajax } from "select-kit/lib/ajax-helper";
 
 export default MultiSelectComponent.extend({
   pluginApiIdentifiers: ["icon-picker"],

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
@@ -69,6 +69,10 @@ export default Component.extend(UtilsMixin, {
     );
   }),
 
+  dasherizedTitle: computed("title", function () {
+    return (this.title || "").replace(".", "-").dasherize();
+  }),
+
   label: computed("rowLabel", "item.label", "title", "rowName", function () {
     const label =
       this.rowLabel ||

--- a/app/assets/javascripts/select-kit/addon/lib/ajax-helper.js
+++ b/app/assets/javascripts/select-kit/addon/lib/ajax-helper.js
@@ -1,0 +1,8 @@
+let ajax;
+if (window.Discourse) {
+  ajax = requirejs("discourse/lib/ajax").ajax;
+} else {
+  ajax = requirejs("wizard/lib/ajax").ajax;
+}
+
+export { ajax };

--- a/app/assets/javascripts/select-kit/addon/mixins/tags.js
+++ b/app/assets/javascripts/select-kit/addon/mixins/tags.js
@@ -1,6 +1,6 @@
 import I18n from "I18n";
 import Mixin from "@ember/object/mixin";
-import { ajax } from "discourse/lib/ajax";
+import { ajax } from "select-kit/lib/ajax-helper";
 import getURL from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
 import { makeArray } from "discourse-common/lib/helpers";

--- a/app/assets/javascripts/select-kit/addon/templates/components/multi-select.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/multi-select.hbs
@@ -10,7 +10,9 @@
   {{#select-kit/select-kit-body selectKit=selectKit id=(concat selectKit.uniqueID "-body")}}
     {{#if selectKit.isLoading}}
       <span class="is-loading">
-        {{loading-spinner size="small"}}
+        {{#if site}}
+          {{loading-spinner size="small"}}
+        {{/if}}
       </span>
     {{else}}
       {{#if selectKit.filter}}

--- a/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-row.hbs
@@ -1,5 +1,5 @@
 {{#each icons as |icon|}}
-  {{d-icon icon translatedtitle=(dasherize title)}}
+  {{d-icon icon translatedtitle=dasherizedTitle}}
 {{/each}}
 
 <span class="name">

--- a/app/assets/javascripts/wizard/lib/ajax.js
+++ b/app/assets/javascripts/wizard/lib/ajax.js
@@ -14,11 +14,20 @@ export function getToken() {
 }
 
 export function ajax(args) {
+  let url;
+
+  if (arguments.length === 2) {
+    url = arguments[0];
+    args = arguments[1];
+  } else {
+    url = args.url;
+  }
+
   return new Promise((resolve, reject) => {
     args.headers = { "X-CSRF-Token": getToken() };
     args.success = (data) => run(null, resolve, data);
     args.error = (xhr) => run(null, reject, xhr);
-    args.url = getUrl(args.url);
+    args.url = getUrl(url);
     jQuery.ajax(args);
   });
 }


### PR DESCRIPTION
- inlines dasherize helper in sk
- uses an ajax helper to load wizard's ajax lib when in wizard
- amends wizard's ajax lib to work with string as first arg
- disabled loading spinner in wizard as it's not available

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
