### PR TITLE
FIX: Change email from to not have via site_name for group SMTP

### DIFF
--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -48,7 +48,7 @@ class GroupSmtpMailer < ActionMailer::Base
       locale: SiteSetting.default_locale,
       delivery_method_options: delivery_options,
       from: from_group.email_username,
-      from_alias: I18n.t('email_from', user_name: group_name, site_name: Email.site_title),
+      from_alias: I18n.t('email_from_without_site', user_name: group_name),
       html_override: html_override(post),
       cc: cc_addresses
     )

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3458,6 +3458,7 @@ en:
   subject_re: "Re: "
   subject_pm: "[PM] "
   email_from: "%{user_name} via %{site_name}"
+  email_from_without_site: "%{user_name}"
 
   user_notifications:
     previous_discussion: "Previous Replies"

--- a/spec/jobs/regular/group_smtp_email_spec.rb
+++ b/spec/jobs/regular/group_smtp_email_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe Jobs::GroupSmtpEmail do
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     post_reply_key = PostReplyKey.where(user_id: recipient_user, post_id: post.id).first
     expect(post_reply_key).to eq(nil)
-    expect(email_log.raw_headers).not_to include("Reply-To: Support Group via Discourse <#{group.email_username}")
-    expect(email_log.raw_headers).to include("From: Support Group via Discourse <#{group.email_username}")
+    expect(email_log.raw_headers).not_to include("Reply-To: Support Group <#{group.email_username}")
+    expect(email_log.raw_headers).to include("From: Support Group <#{group.email_username}")
   end
 
   it "creates an EmailLog record with the correct details" do
@@ -136,8 +136,8 @@ RSpec.describe Jobs::GroupSmtpEmail do
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
     post_reply_key = PostReplyKey.where(user_id: recipient_user, post_id: post.id).first
     expect(post_reply_key).to eq(nil)
-    expect(email_log.raw).not_to include("Reply-To: Support Group via Discourse <#{group.email_username}")
-    expect(email_log.raw).to include("From: Support Group via Discourse <#{group.email_username}")
+    expect(email_log.raw).not_to include("Reply-To: Support Group <#{group.email_username}")
+    expect(email_log.raw).to include("From: Support Group <#{group.email_username}")
   end
 
   it "falls back to the group name if full name is blank" do
@@ -146,7 +146,7 @@ RSpec.describe Jobs::GroupSmtpEmail do
     expect(ActionMailer::Base.deliveries.count).to eq(1)
     expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
     email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
-    expect(email_log.raw_headers).to include("From: support-group via Discourse <#{group.email_username}")
+    expect(email_log.raw_headers).to include("From: support-group <#{group.email_username}")
   end
 
   it "has the group_smtp_id and the to_address filled in correctly" do


### PR DESCRIPTION
We now use the group's full name in group SMTP emails, so we are dropping the `via #{site_name}`. If group owners still want this they can just change the full name of the group.