### PR TITLE
UX: New text and style for dominating topic message

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
@@ -1,0 +1,9 @@
+<a href {{action closeMessage message}} class="close">{{d-icon "times"}}</a>
+{{html-safe message.body}}
+
+{{d-button
+  class="btn-primary"
+  label="topic.invite_reply.title"
+  icon="user-friends"
+  action=(route-action "showInvite")
+}}

--- a/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
@@ -1,11 +1,13 @@
 <a href {{action closeMessage message}} class="close">{{d-icon "times"}}</a>
-{{html-safe message.body}}
+<div class="dominating-topic-content">
+  {{html-safe message.body}}
 
-{{#if currentUser.can_invite_to_forum}}
-  {{d-button
-    class="btn-primary"
-    label="topic.invite_reply.title"
-    icon="user-friends"
-    action=(route-action "showInvite")
-  }}
-{{/if}}
+  {{#if currentUser.can_invite_to_forum}}
+    {{d-button
+      class="btn-primary"
+      label="topic.invite_reply.title"
+      icon="user-friends"
+      action=(route-action "showInvite")
+    }}
+  {{/if}}
+</div>

--- a/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
@@ -1,9 +1,11 @@
 <a href {{action closeMessage message}} class="close">{{d-icon "times"}}</a>
 {{html-safe message.body}}
 
-{{d-button
-  class="btn-primary"
-  label="topic.invite_reply.title"
-  icon="user-friends"
-  action=(route-action "showInvite")
-}}
+{{#if currentUser.can_invite_to_forum}}
+  {{d-button
+    class="btn-primary"
+    label="topic.invite_reply.title"
+    icon="user-friends"
+    action=(route-action "showInvite")
+  }}
+{{/if}}

--- a/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
@@ -1,13 +1,11 @@
 <a href {{action closeMessage message}} class="close">{{d-icon "times"}}</a>
-<div class="dominating-topic-content">
-  {{html-safe message.body}}
+{{html-safe message.body}}
 
-  {{#if currentUser.can_invite_to_forum}}
-    {{d-button
-      class="btn-primary"
-      label="topic.invite_reply.title"
-      icon="user-friends"
-      action=(route-action "showInvite")
-    }}
-  {{/if}}
-</div>
+{{#if currentUser.can_invite_to_forum}}
+  {{d-button
+    class="btn-primary"
+    label="topic.invite_reply.title"
+    icon="user-friends"
+    action=(route-action "showInvite")
+  }}
+{{/if}}

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -322,7 +322,7 @@
     display: flex;
     align-items: center;
     margin-right: auto;
-    button {
+    .btn-primary {
       flex: 0 0 auto;
     }
     .cancel {

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -631,7 +631,9 @@
           &.single-tab {
             background: none;
             color: var(--primary);
-            padding: 4px 0;
+            padding: 0;
+            font-size: var(--font-up-3);
+            font-weight: bold;
           }
         }
       }

--- a/app/assets/stylesheets/common/components/share-and-invite-modal.scss
+++ b/app/assets/stylesheets/common/components/share-and-invite-modal.scss
@@ -2,11 +2,6 @@
   .modal-body {
     max-width: 475px;
     min-width: 320px;
-    padding: 0;
-  }
-
-  .modal-panel {
-    padding: 0.667em;
   }
 
   .modal-header {

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -85,16 +85,17 @@
 }
 
 .composer-popup {
+  box-sizing: border-box;
   position: absolute;
-  width: calc(50% - 45px);
+  width: calc(50% - 30px);
   max-width: 724px;
-  top: 20px;
+  top: 1.55em;
   bottom: 10px;
   left: 51%;
   overflow-y: auto;
   z-index: z("composer", "popover");
   padding: 10px 10px 35px 10px;
-  box-shadow: shadow("card");
+  box-shadow: shadow("dropdown");
   background: var(--highlight-medium);
   .hide-preview & {
     z-index: z("composer", "dropdown") + 1;
@@ -106,6 +107,18 @@
 
   &.education-message {
     background-color: var(--tertiary-low);
+  }
+
+  &.dominating-topic-message {
+    bottom: unset;
+    padding: 2.25em 6em 2.5em 2.25em;
+    p {
+      margin-top: 0;
+      font-size: var(--font-up-1);
+    }
+    button {
+      margin-top: 0.5em;
+    }
   }
 
   h3 {

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -89,7 +89,7 @@
   position: absolute;
   width: calc(50% - 30px);
   max-width: 724px;
-  top: 1.55em;
+  top: 21px; // grippie height + .reply-to margin-top + .reply-area padding-top
   bottom: 10px;
   left: 51%;
   overflow-y: auto;

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -523,12 +523,7 @@ en:
 
       It’s easier for everyone to read topics that have fewer in-depth replies versus lots of small, individual replies.
 
-    dominating_topic: |
-      ### Let others join the conversation
-
-      This topic is clearly important to you &ndash; you've posted more than %{percent}% of the replies here.
-
-      It could be even better if you gave other people space to share their points of view, too. Can you invite them over?
+    dominating_topic: You’ve posted more than %{percent}% of the replies here, is there anyone else you would like to hear from?
 
     get_a_room: |
       ### Encourage everyone to get involved in the conversation

--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -141,9 +141,9 @@ class ComposerMessagesFinder
 
     {
       id: 'dominating_topic',
-      templateName: 'education',
+      templateName: 'dominating-topic',
       wait_for_typing: true,
-      extraClass: 'education-message',
+      extraClass: 'education-message dominating-topic-message',
       body: PrettyText.cook(I18n.t('education.dominating_topic', percent: (ratio * 100).round))
     }
   end

--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -207,6 +207,7 @@ module SvgSprite
     "upload",
     "user",
     "user-edit",
+    "user-friends",
     "user-plus",
     "user-secret",
     "user-shield",


### PR DESCRIPTION
This shortens the text and (hopefully) makes the message sound less patronizing. It also adds an invite button to make including others easier. 

I'm also trying some new styling for shorter messages like this... more padding, larger text, shorter box:

![Screen Shot 2021-07-19 at 9 18 31 PM](https://user-images.githubusercontent.com/1681963/126248695-077d2de8-da44-4a68-b5ff-bff24119da5b.png)

I also made a couple small adjustments to this single-tab invite modal (made the title larger and bold when it's not used along with other tabs)

![Screen Shot 2021-07-19 at 9 18 23 PM](https://user-images.githubusercontent.com/1681963/126248722-86fb60b0-faea-4ca2-8a7e-f8c8b458cdc2.png)
