### PR TITLE
FEATURE: Add input name so 1Password doesn't autocomplete 

### DIFF
--- a/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-filter.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-filter.hbs
@@ -1,4 +1,5 @@
 {{#unless isHidden}}
+  {{!-- filter-input-search prevents 1password from attempting autocomplete --}}
   {{input
     tabindex=-1
     class="filter-input"
@@ -6,6 +7,7 @@
     autocomplete="discourse"
     autocorrect="off"
     autocapitalize="off"
+    name="filter-input-search"
     autofocus=selectKit.options.autofocus
     spellcheck=false
     value=(readonly selectKit.filter)


### PR DESCRIPTION
Follow-up to https://meta.discourse.org/t/conflicts-with-discourse-and-1password-7-beta-in-safari/160066/11?u=awesomerobot

1Password will ignore this filter input if we add the word "search" to the name. 

