### PR TITLE
Support Fathom Analytics

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/page-tracking.js
+++ b/app/assets/javascripts/discourse/app/initializers/page-tracking.js
@@ -35,6 +35,15 @@ export default {
       });
       return;
     }
+    
+    // Use Fathom Analytics if it is present
+    if (typeof window.fathom !== "undefined") {
+      appEvents.on("page:changed", (data) => {
+        if (!data.replacedOnlyQueryParams) {
+          window.fathom.trackPageview({ url: data.url });
+        }
+      });
+    } 
 
     // Use Universal Analytics v3 if it is present
     if (


### PR DESCRIPTION
We've been flooded with support tickets over the last year with people who are wanting to use Discourse and have privacy-first analytics instead of Google Analytics. Fathom is the market leader, with companies such as Fastmail, GitHub, Buffer, Tailwind, Tuple and others using it.

This isn't a sales pitch though. My hope is that we can get this added in to have automatic Fathom support when someone adds our snippet in.

Thanks for your consideration :)