### PR TITLE
DEV: Ignore the 2FA table when moving timestamps

### DIFF
--- a/script/db_timestamps_mover.rb
+++ b/script/db_timestamps_mover.rb
@@ -79,7 +79,7 @@ def is_date?(string)
 end
 
 def create_updater
-  ignore_tables = %w[application_requests user_visits]
+  ignore_tables = %w[application_requests user_second_factors user_visits]
   TimestampsUpdater.new "public", ignore_tables
 end
 


### PR DESCRIPTION
Or 2FA will be broken after moving. We use this script for moving timestamps when restoring Try.
