### PR TITLE
DEV: Fix release_note task warnings

### DIFF
--- a/lib/tasks/release_note.rake
+++ b/lib/tasks/release_note.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-DATE_REGEX = /\A\d{4}-\d{2}-\d{2}/
+DATE_REGEX ||= /\A\d{4}-\d{2}-\d{2}/
 
-CHANGE_TYPES = [
+CHANGE_TYPES ||= [
   { pattern: /^FEATURE:/, heading: "New Features" },
   { pattern: /^FIX:/, heading: "Bug Fixes" },
   { pattern: /^UX:/, heading: "UX Changes" },


### PR DESCRIPTION
There was a bunch of warnings repeated over and over during spec runs:

```
/var/www/discourse/lib/tasks/release_note.rake:3: warning: already initialized constant DATE_REGEX
/var/www/discourse/lib/tasks/release_note.rake:3: warning: previous definition of DATE_REGEX was here
/var/www/discourse/lib/tasks/release_note.rake:5: warning: already initialized constant CHANGE_TYPES
/var/www/discourse/lib/tasks/release_note.rake:5: warning: previous definition of CHANGE_TYPES was here
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
