### PR TITLE
FIX: Show user filter hints when typing `@` in search 

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -10,8 +10,6 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import userSearch from "discourse/lib/user-search";
 
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
-// The backend user search query returns zero results for a term-free search
-// so the regexp below only matches @ followed by a valid character
 const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
 
 const searchData = {};

--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -12,7 +12,7 @@ import userSearch from "discourse/lib/user-search";
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
 // The backend user search query returns zero results for a term-free search
 // so the regexp below only matches @ followed by a valid character
-const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]+)$/gi;
+const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
 
 const searchData = {};
 const suggestionTriggers = ["in:", "status:", "order:"];
@@ -72,11 +72,19 @@ const SearchHelper = {
           return;
         }
         if (matchSuggestions.type === "username") {
-          userSearch({
-            term: matchSuggestions.usernamesMatch[0],
-            includeGroups: true,
-          }).then((result) => {
-            if (result?.users.length > 0) {
+          const userSearchTerm = matchSuggestions.usernamesMatch[0].replace(
+            "@",
+            ""
+          );
+          const opts = { includeGroups: true, limit: 6 };
+          if (userSearchTerm.length > 0) {
+            opts.term = userSearchTerm;
+          } else {
+            opts.lastSeenUsers = true;
+          }
+
+          userSearch(opts).then((result) => {
+            if (result?.users?.length > 0) {
               searchData.suggestionResults = result.users;
               searchData.suggestionKeyword = "@";
             } else {

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -268,6 +268,33 @@ acceptance("Search - with tagging enabled", function (needs) {
 acceptance("Search - assistant", function (needs) {
   needs.user();
 
+  needs.pretender((server, helper) => {
+    server.get("/u/search/users", () => {
+      return helper.response({
+        users: [
+          {
+            username: "TeaMoe",
+            name: "TeaMoe",
+            avatar_template:
+              "https://avatars.discourse.org/v3/letter/t/41988e/{size}.png",
+          },
+          {
+            username: "TeamOneJ",
+            name: "J Cobb",
+            avatar_template:
+              "https://avatars.discourse.org/v3/letter/t/3d9bf3/{size}.png",
+          },
+          {
+            username: "kudos",
+            name: "Team Blogeto.com",
+            avatar_template:
+              "/user_avatar/meta.discourse.org/kudos/{size}/62185_1.png",
+          },
+        ],
+      });
+    });
+  });
+
   test("shows category shortcuts when typing #", async function (assert) {
     await visit("/");
 
@@ -316,5 +343,22 @@ acceptance("Search - assistant", function (needs) {
     await fillIn("#search-term", "sam in:");
     await triggerKeyEvent("#search-term", "keyup", 51);
     assert.equal(query(firstTarget).innerText, "sam in:title");
+  });
+
+  test("shows users when typing @", async function (assert) {
+    await visit("/");
+
+    await click("#search-button");
+
+    await fillIn("#search-term", "@");
+    await triggerKeyEvent("#search-term", "keyup", 51);
+
+    const firstUser =
+      ".search-menu .results ul.search-menu-assistant .search-item-user";
+    const firstUsername = query(firstUser).innerText.trim();
+    assert.equal(firstUsername, "TeaMoe");
+
+    await click(query(firstUser));
+    assert.equal(query("#search-term").value, `@${firstUsername} `);
   });
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1079,6 +1079,8 @@ class UsersController < ApplicationController
     }
 
     options[:include_staged_users] = !!ActiveModel::Type::Boolean.new.cast(params[:include_staged_users])
+    options[:last_seen_users] = !!ActiveModel::Type::Boolean.new.cast(params[:last_seen_users])
+    options[:limit] = params[:limit].to_i if params[:limit].present?
     options[:topic_id] = topic_id if topic_id
     options[:category_id] = category_id if category_id
 

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -12,6 +12,7 @@ class UserSearch
     @topic_allowed_users = opts[:topic_allowed_users]
     @searching_user = opts[:searching_user]
     @include_staged_users = opts[:include_staged_users] || false
+    @last_seen_users = opts[:last_seen_users] || false
     @limit = opts[:limit] || 20
     @groups = opts[:groups]
 
@@ -156,6 +157,15 @@ class UserSearch
     # 4. global matches
     if @term.present?
       filtered_by_term_users
+        .order('last_seen_at DESC NULLS LAST')
+        .limit(@limit - users.size)
+        .pluck(:id)
+        .each { |id| users << id }
+    end
+
+    # 5. last seen users (for search auto-suggestions)
+    if @last_seen_users
+      scoped_users
         .order('last_seen_at DESC NULLS LAST')
         .limit(@limit - users.size)
         .pluck(:id)

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -238,5 +238,14 @@ describe UserSearch do
       results = search_for("", topic_id: topic.id, searching_user: mr_b)
       expect(results).to eq [mr_pink, mr_orange].map(&:username)
     end
+
+    it "works with last_seen_users option" do
+      results = search_for("", last_seen_users: true)
+
+      expect(results).not_to be_blank
+      expect(results[0]).to eq("mrbrown")
+      expect(results[1]).to eq("mrpink")
+      expect(results[2]).to eq("mrorange")
+    end
   end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4022,6 +4022,24 @@ describe UsersController do
         expect(json["users"].map { |u| u["name"] }).not_to include(staged_user.name)
       end
     end
+
+    context '`last_seen_users`' do
+      it "returns results when the param is true" do
+        get "/u/search/users.json", params: { last_seen_users: true }
+
+        json = response.parsed_body
+        expect(json["users"]).not_to be_empty
+      end
+
+      it "respects limit parameter at the same time" do
+        limit = 3
+        get "/u/search/users.json", params: { last_seen_users: true, limit: limit }
+
+        json = response.parsed_body
+        expect(json["users"]).not_to be_empty
+        expect(json["users"].size).to eq(limit)
+      end
+    end
   end
 
   describe '#email_login' do


### PR DESCRIPTION
Will show the last 6 seen users as filtering suggestions when typing `@` in quick search. (Previously the user suggestion required a character after the `@`.)

This also adds a default limit of 6 results to the user search query, previously the backend was returning 20 results but a maximum of 6 results was being shown (set [here](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/user-search.js#L121)). 