### PR TITLE
FIX: Show bulk button on PMs for all users

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs
@@ -1,6 +1,6 @@
 {{#unless site.mobileView}}
   {{#if showToggleBulkSelect}}
-    {{bulk-select-button selected=selected action=(route-action "refresh")}}
+    {{bulk-select-button canDoBulkActions=true selected=selected action=(route-action "refresh")}}
   {{/if}}
 {{/unless}}
 


### PR DESCRIPTION
`canDoBulkActions: reads("currentUser.staff")` was added to the bulk button when adding the ability for all users to individually dismiss topics on `/new` and `/unread` but it locked out access for non-staff on their PM topic list (`/my/messages`). 

Discussion: https://meta.discourse.org/t/i-can-select-messages-but-no-actions-appear/197682