### PR TITLE
DEV: Improve logging of errors in `Jobs::ProcessUserNotificationSchedules`

### DIFF
--- a/app/jobs/scheduled/process_user_notification_schedules.rb
+++ b/app/jobs/scheduled/process_user_notification_schedules.rb
@@ -8,8 +8,8 @@ module Jobs
       UserNotificationSchedule.enabled.includes(:user).each do |schedule|
         begin
           schedule.create_do_not_disturb_timings
-        rescue
-          Rails.logger.warn("Failed to process user_notification_schedule with ID #{schedule.id}")
+        rescue => e
+          Discourse.warn_exception(e, message: "Failed to process user_notification_schedule with ID #{schedule.id}")
         end
       end
     end


### PR DESCRIPTION
Gives us the actual error and backtrace to work with. Otherwise, the
logging of the error is not useful at all.