### PR TITLE
FIX: display warning when SSO email is different from invite email

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -31,6 +31,7 @@ export default Controller.extend(
     accountEmail: alias("email"),
     hiddenEmail: alias("model.hidden_email"),
     emailVerifiedByLink: alias("model.email_verified_by_link"),
+    differentExternalEmail: alias("model.different_external_email"),
     accountUsername: alias("model.username"),
     passwordRequired: notEmpty("accountPassword"),
     successMessage: null,
@@ -130,7 +131,8 @@ export default Controller.extend(
       "authOptions.email",
       "authOptions.email_valid",
       "hiddenEmail",
-      "emailVerifiedByLink"
+      "emailVerifiedByLink",
+      "differentExternalEmail"
     )
     emailValidation(
       email,
@@ -138,9 +140,10 @@ export default Controller.extend(
       externalAuthEmail,
       externalAuthEmailValid,
       hiddenEmail,
-      emailVerifiedByLink
+      emailVerifiedByLink,
+      differentExternalEmail
     ) {
-      if (hiddenEmail) {
+      if (hiddenEmail && !differentExternalEmail) {
         return EmberObject.create({
           ok: true,
           reason: I18n.t("user.email.ok"),

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -50,10 +50,13 @@ class InvitesController < ApplicationController
       email = Email.obfuscate(invite.email)
 
       # Show email if the user already authenticated their email
+      different_external_email = false
       if session[:authentication]
         auth_result = Auth::Result.from_session_data(session[:authentication], user: nil)
         if invite.email == auth_result.email
           email = invite.email
+        else
+          different_external_email = true
         end
       end
 
@@ -72,6 +75,10 @@ class InvitesController < ApplicationController
         is_invite_link: invite.is_invite_link?,
         email_verified_by_link: email_verified_by_link
       }
+
+      if different_external_email
+        info[:different_external_email] = true
+      end
 
       if staged_user = User.where(staged: true).with_email(invite.email).first
         info[:username] = staged_user.username


### PR DESCRIPTION
In this commit, we skipped frontend validation when email is obfuscated:
https://github.com/discourse/discourse/commit/534008ba24c

However, if email from SSO is different from email from invite, we should still display warning.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
