### PR TITLE
DEV: extract join_group method from groups#add_members method

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-membership-button.js
+++ b/app/assets/javascripts/discourse/app/components/group-membership-button.js
@@ -50,13 +50,13 @@ export default Component.extend({
     joinGroup() {
       if (this.currentUser) {
         this.set("updatingMembership", true);
-        const model = this.model;
+        const group = this.model;
 
-        model
-          .addMembers(this.currentUser.get("username"))
+        group
+          .join()
           .then(() => {
-            model.set("is_group_user", true);
-            this.appEvents.trigger("group:join", model);
+            group.set("is_group_user", true);
+            this.appEvents.trigger("group:join", group);
           })
           .catch(popupAjaxError)
           .finally(() => {

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -127,6 +127,14 @@ const Group = RestModel.extend({
     });
   },
 
+  join() {
+    return ajax(`/groups/${this.id}/join.json`, {
+      type: "PUT",
+    }).then(() => {
+      this.findMembers();
+    });
+  },
+
   addOwners(usernames, filter, notifyUsers) {
     return ajax(`/admin/groups/${this.id}/owners.json`, {
       type: "PUT",

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -130,7 +130,9 @@ const Group = RestModel.extend({
   join() {
     return ajax(`/groups/${this.id}/join.json`, {
       type: "PUT",
-    }).then(() => this.findMembers());
+    }).then(() => {
+      this.findMembers();
+    });
   },
 
   addOwners(usernames, filter, notifyUsers) {

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -130,9 +130,7 @@ const Group = RestModel.extend({
   join() {
     return ajax(`/groups/${this.id}/join.json`, {
       type: "PUT",
-    }).then(() => {
-      this.findMembers();
-    });
+    }).then(() => this.findMembers());
   },
 
   addOwners(usernames, filter, notifyUsers) {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -410,78 +410,24 @@ class GroupsController < ApplicationController
 
   def join
     group = Group.find(params[:id])
-    group.public_admission ? ensure_logged_in : guardian.ensure_can_edit!(group)
-    users = users_from_params.to_a
+    ensure_logged_in
 
-    if group.public_admission
-      if !guardian.can_log_group_changes?(group) && current_user != users.first
-        raise Discourse::InvalidAccess
-      end
+    raise Discourse::InvalidAccess unless group.public_admission
 
-      unless current_user.staff?
-        RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
-      end
+    unless current_user.staff?
+      RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
     end
 
-    emails = []
-    if params[:emails]
-      params[:emails].split(",").each do |email|
-        existing_user = User.find_by_email(email)
-        existing_user.present? ? users.push(existing_user) : emails.push(email)
-      end
-    end
+    already_in_group = group.users.exists?(id: current_user.id)
+    return if already_in_group
 
-    guardian.ensure_can_invite_to_forum!([group]) if emails.present?
-
-    if users.empty? && emails.empty?
-      raise Discourse::InvalidParameters.new(I18n.t("groups.errors.usernames_or_emails_required"))
-    end
-
-    if users.length > ADD_MEMBERS_LIMIT
-      return render_json_error(
-        I18n.t("groups.errors.adding_too_many_users", count: ADD_MEMBERS_LIMIT)
-      )
-    end
-
-    usernames_already_in_group = group.users.where(id: users.map(&:id)).pluck(:username)
-    if usernames_already_in_group.present? &&
-      usernames_already_in_group.length == users.length &&
-      emails.blank?
-      render_json_error(I18n.t(
-        "groups.errors.member_already_exist",
-        username: usernames_already_in_group.sort.join(", "),
-        count: usernames_already_in_group.size
-      ))
-    else
-      uniq_users = users.uniq
-      uniq_users.each do |user|
-        begin
-          group.add(user)
-          GroupActionLogger.new(current_user, group).log_add_user_to_group(user)
-          group.notify_added_to_group(user) if params[:notify_users]&.to_s == "true"
-        rescue ActiveRecord::RecordNotUnique
-          # Under concurrency, we might attempt to insert two records quickly and hit a DB
-          # constraint. In this case we can safely ignore the error and act as if the user
-          # was added to the group.
-        end
-      end
-
-      emails.each do |email|
-        begin
-          Invite.generate(current_user, email: email, group_ids: [group.id])
-        rescue RateLimiter::LimitExceeded => e
-          return render_json_error(I18n.t(
-            "invite.rate_limit",
-            count: SiteSetting.max_invites_per_day,
-            time_left: e.time_left
-          ))
-        end
-      end
-
-      render json: success_json.merge!(
-        usernames: uniq_users.map(&:username),
-        emails: emails
-      )
+    begin
+      group.add(current_user)
+      GroupActionLogger.new(current_user, group).log_add_user_to_group(current_user)
+    rescue ActiveRecord::RecordNotUnique
+      # Under concurrency, we might attempt to insert two records quickly and hit a DB
+      # constraint. In this case we can safely ignore the error and act as if the user
+      # was added to the group.
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -648,15 +648,13 @@ class GroupsController < ApplicationController
   private
 
   def add_user_to_group(group, user, notify = false)
-    begin
-      group.add(user)
-      GroupActionLogger.new(current_user, group).log_add_user_to_group(user)
-      group.notify_added_to_group(user) if notify
-    rescue ActiveRecord::RecordNotUnique
-      # Under concurrency, we might attempt to insert two records quickly and hit a DB
-      # constraint. In this case we can safely ignore the error and act as if the user
-      # was added to the group.
-    end
+    group.add(user)
+    GroupActionLogger.new(current_user, group).log_add_user_to_group(user)
+    group.notify_added_to_group(user) if notify
+  rescue ActiveRecord::RecordNotUnique
+    # Under concurrency, we might attempt to insert two records quickly and hit a DB
+    # constraint. In this case we can safely ignore the error and act as if the user
+    # was added to the group.
   end
 
   def group_params(automatic: false)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -333,19 +333,9 @@ class GroupsController < ApplicationController
 
   def add_members
     group = Group.find(params[:id])
-    group.public_admission ? ensure_logged_in : guardian.ensure_can_edit!(group)
+    guardian.ensure_can_edit!(group)
+
     users = users_from_params.to_a
-
-    if group.public_admission
-      if !guardian.can_log_group_changes?(group) && current_user != users.first
-        raise Discourse::InvalidAccess
-      end
-
-      unless current_user.staff?
-        RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
-      end
-    end
-
     emails = []
     if params[:emails]
       params[:emails].split(",").each do |email|

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -367,7 +367,8 @@ class GroupsController < ApplicationController
       ))
     else
       notify = params[:notify_users]&.to_s == "true"
-      users.uniq.each do |user|
+      uniq_users = users.uniq
+      uniq_users.each do |user|
         add_user_to_group(group, user, notify)
       end
 
@@ -384,7 +385,7 @@ class GroupsController < ApplicationController
       end
 
       render json: success_json.merge!(
-        usernames: users.uniq.map(&:username),
+        usernames: uniq_users.map(&:username),
         emails: emails
       )
     end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -409,14 +409,13 @@ class GroupsController < ApplicationController
   end
 
   def join
-    group = Group.find(params[:id])
     ensure_logged_in
-
-    raise Discourse::InvalidAccess unless group.public_admission
-
     unless current_user.staff?
       RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
     end
+
+    group = Group.find(params[:id])
+    raise Discourse::InvalidAccess unless group.public_admission
 
     already_in_group = group.users.exists?(id: current_user.id)
     return if already_in_group

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -400,8 +400,7 @@ class GroupsController < ApplicationController
     group = Group.find(params[:id])
     raise Discourse::InvalidAccess unless group.public_admission
 
-    already_in_group = group.users.exists?(id: current_user.id)
-    return if already_in_group
+    return if group.users.exists?(id: current_user.id)
     add_user_to_group(group, current_user)
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -602,6 +602,7 @@ Discourse::Application.routes.draw do
 
           get "permissions" => "groups#permissions"
           put "members" => "groups#add_members"
+          put "join" => "groups#join"
           delete "members" => "groups#remove_member"
           post "request_membership" => "groups#request_membership"
           put "handle_membership_request" => "groups#handle_membership_request"


### PR DESCRIPTION
We wanted to do a simple refactoring in `groups#add_members` method – we wanted to extract the code in the beginning of the method into the guardian. But looking into this, I've found out that actually all checks already extracted into guardians and the reason we have so many lines of checking code is that actually  the `groups#add_members` method serve two different purposes:
1. We use it when a user joins a public group:
    <img width="250" alt="Screenshot 2021-07-21 at 13 03 30" src="https://user-images.githubusercontent.com/1274517/126462672-9e948877-b738-4a80-bbeb-b1aa1961026b.png">
2. We use it when an admin wants to add users to a group:
    <img width="400" alt="Screenshot 2021-07-21 at 13 03 56" src="https://user-images.githubusercontent.com/1274517/126462699-43aa1cc2-35a1-4896-83e0-b5f8b8ef8b4a.png">

It's better to split this logic into two methods, instead of moving this mix deeper into the guardian, and this PR does this.

It's not like these two operations are completely different, but when a user (probably unprivileged) joins a public group and an admin adds users to a group, it isn't the same. Mixing it together makes code harder to follow and support. If I were to make some changes to joining logic, I need to read the code for bulk adding users to groups too. If I change the first logic, I risk breaking the second logic. Taking into account that the second logic here is for privileged users, it increases risk of security bugs.

Additionally, the `join` method can be more lightweight. It needs fewer checks on the server side. There is no need to return data from the server. It can be just idempotent PUT that returns a status code. The profiler doesn't show a very big increase in speed, though. Before:

<img width="400" alt="Screenshot 2021-07-20 at 22 06 57" src="https://user-images.githubusercontent.com/1274517/126466809-75e4984e-547a-4b51-bf29-72e31ebfa657.png">

After:

<img width="400" alt="Screenshot 2021-07-20 at 22 11 13" src="https://user-images.githubusercontent.com/1274517/126466830-1280c795-88f0-4e0c-89e2-da570e4d9fc6.png">
