### PR TITLE
UX: Improve quick search suggestions

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -73,10 +73,10 @@ import { replaceFormatter } from "discourse/lib/utilities";
 import { replaceTagRenderer } from "discourse/lib/render-tag";
 import { setNewCategoryDefaultColors } from "discourse/routes/new-category";
 import { addSearchResultsCallback } from "discourse/lib/search";
-import { addInSearchShortcut } from "discourse/widgets/search-menu-results";
+import { addSearchSuggestion } from "discourse/widgets/search-menu-results";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.11.6";
+const PLUGIN_API_VERSION = "0.11.7";
 
 class PluginApi {
   constructor(version, container) {
@@ -1301,12 +1301,12 @@ class PluginApi {
    * Add a in: shortcut to search menu panel.
    *
    * ```
-   * addInSearchShortcut("in:assigned");
+   * addSearchSuggestion("in:assigned");
    * ```
    *
    */
-  addInSearchShortcut(value) {
-    addInSearchShortcut(value);
+  addSearchSuggestion(value) {
+    addSearchSuggestion(value);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -1298,7 +1298,7 @@ class PluginApi {
   }
 
   /**
-   * Add a in: shortcut to search menu panel.
+   * Add a suggestion shortcut to search menu panel.
    *
    * ```
    * addSearchSuggestion("in:assigned");

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -403,7 +403,7 @@ createWidget("search-menu-assistant", {
         });
         break;
       default:
-        suggestionShortcuts.sort().map((item) => {
+        suggestionShortcuts.map((item) => {
           if (item.includes(suggestionKeyword)) {
             const slug = prefix ? `${prefix} ${item} ` : `${item} `;
             content.push(this.attach("search-menu-assistant-item", { slug }));
@@ -412,7 +412,7 @@ createWidget("search-menu-assistant", {
         break;
     }
 
-    return content.filter((c, i) => i <= 10);
+    return content.filter((c, i) => i <= 8);
   },
 });
 

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -10,30 +10,27 @@ import highlightSearch from "discourse/lib/highlight-search";
 import { iconNode } from "discourse-common/lib/icon-library";
 import renderTag from "discourse/lib/render-tag";
 
-const inSearchShortcuts = [
+const suggestionShortcuts = [
   "in:title",
   "in:personal",
   "in:seen",
   "in:likes",
   "in:bookmarks",
   "in:created",
-];
-const statusSearchShortcuts = [
+  "in:pinned",
   "status:open",
   "status:closed",
   "status:public",
   "status:noreplies",
-];
-const orderSearchShortcuts = [
   "order:latest",
   "order:views",
   "order:likes",
   "order:latest_topic",
 ];
 
-export function addInSearchShortcut(value) {
-  if (inSearchShortcuts.indexOf(value) === -1) {
-    inSearchShortcuts.push(value);
+export function addSearchSuggestion(value) {
+  if (suggestionShortcuts.indexOf(value) === -1) {
+    suggestionShortcuts.push(value);
   }
 }
 
@@ -361,7 +358,7 @@ createWidget("search-menu-assistant", {
 
   html(attrs) {
     if (this.siteSettings.tagging_enabled) {
-      addInSearchShortcut("in:tagged");
+      addSearchSuggestion("in:tagged");
     }
 
     const content = [];
@@ -399,22 +396,12 @@ createWidget("search-menu-assistant", {
           );
         });
         break;
-      case "in:":
-        inSearchShortcuts.map((item) => {
-          const slug = prefix ? `${prefix} ${item} ` : item;
-          content.push(this.attach("search-menu-assistant-item", { slug }));
-        });
-        break;
-      case "status:":
-        statusSearchShortcuts.map((item) => {
-          const slug = prefix ? `${prefix} ${item} ` : item;
-          content.push(this.attach("search-menu-assistant-item", { slug }));
-        });
-        break;
-      case "order:":
-        orderSearchShortcuts.map((item) => {
-          const slug = prefix ? `${prefix} ${item} ` : item;
-          content.push(this.attach("search-menu-assistant-item", { slug }));
+      default:
+        suggestionShortcuts.map((item) => {
+          if (item.startsWith(suggestionKeyword)) {
+            const slug = prefix ? `${prefix} ${item} ` : item;
+            content.push(this.attach("search-menu-assistant-item", { slug }));
+          }
         });
         break;
     }

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -12,11 +12,6 @@ import renderTag from "discourse/lib/render-tag";
 
 const suggestionShortcuts = [
   "in:title",
-  "in:personal",
-  "in:seen",
-  "in:likes",
-  "in:bookmarks",
-  "in:created",
   "in:pinned",
   "status:open",
   "status:closed",
@@ -357,8 +352,19 @@ createWidget("search-menu-assistant", {
   tagName: "ul.search-menu-assistant",
 
   html(attrs) {
+    if (this.currentUser) {
+      addSearchSuggestion("in:likes");
+      addSearchSuggestion("in:bookmarks");
+      addSearchSuggestion("in:mine");
+      addSearchSuggestion("in:personal");
+      addSearchSuggestion("in:seen");
+      addSearchSuggestion("in:tracking");
+      addSearchSuggestion("in:unseen");
+      addSearchSuggestion("in:watching");
+    }
     if (this.siteSettings.tagging_enabled) {
       addSearchSuggestion("in:tagged");
+      addSearchSuggestion("in:untagged");
     }
 
     const content = [];
@@ -397,16 +403,16 @@ createWidget("search-menu-assistant", {
         });
         break;
       default:
-        suggestionShortcuts.map((item) => {
-          if (item.startsWith(suggestionKeyword)) {
-            const slug = prefix ? `${prefix} ${item} ` : item;
+        suggestionShortcuts.sort().map((item) => {
+          if (item.includes(suggestionKeyword)) {
+            const slug = prefix ? `${prefix} ${item} ` : `${item} `;
             content.push(this.attach("search-menu-assistant-item", { slug }));
           }
         });
         break;
     }
 
-    return content;
+    return content.filter((c, i) => i <= 10);
   },
 });
 

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -373,7 +373,7 @@ createWidget("search-menu-assistant", {
 
     switch (suggestionKeyword) {
       case "#":
-        attrs.results.map((category) => {
+        attrs.results.forEach((category) => {
           const slug = prefix
             ? `${prefix} #${category.slug} `
             : `#${category.slug} `;
@@ -388,7 +388,7 @@ createWidget("search-menu-assistant", {
         });
         break;
       case "@":
-        attrs.results.map((user) => {
+        attrs.results.forEach((user) => {
           const slug = prefix
             ? `${prefix} @${user.username} `
             : `@${user.username} `;
@@ -403,7 +403,7 @@ createWidget("search-menu-assistant", {
         });
         break;
       default:
-        suggestionShortcuts.map((item) => {
+        suggestionShortcuts.forEach((item) => {
           if (item.includes(suggestionKeyword)) {
             const slug = prefix ? `${prefix} ${item} ` : `${item} `;
             content.push(this.attach("search-menu-assistant-item", { slug }));

--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -11,7 +11,7 @@ import userSearch from "discourse/lib/user-search";
 
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
 const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
-const SUGGESTIONS_REGEXP = /(in:|status:|order:)([a-zA-Z]*)$/gi;
+const SUGGESTIONS_REGEXP = /(in:|status:|order:|:)([a-zA-Z]*)$/gi;
 
 const searchData = {};
 

--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -11,9 +11,9 @@ import userSearch from "discourse/lib/user-search";
 
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
 const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
+const SUGGESTIONS_REGEXP = /(in:|status:|order:)([a-zA-Z]*)$/gi;
 
 const searchData = {};
-const suggestionTriggers = ["in:", "status:", "order:"];
 
 export function initSearchData() {
   searchData.loading = false;
@@ -53,47 +53,42 @@ const SearchHelper = {
       searchData.results = [];
       searchData.loading = false;
 
-      if (typeof matchSuggestions === "string") {
-        searchData.suggestionKeyword = matchSuggestions;
+      if (matchSuggestions.type === "category") {
+        const categorySearchTerm = matchSuggestions.categoriesMatch[0].replace(
+          "#",
+          ""
+        );
+
+        searchData.suggestionResults = Category.search(categorySearchTerm);
+        searchData.suggestionKeyword = "#";
         widget.scheduleRerender();
-        return;
-      } else {
-        if (matchSuggestions.type === "category") {
-          const categorySearchTerm = matchSuggestions.categoriesMatch[0].replace(
-            "#",
-            ""
-          );
-
-          searchData.suggestionResults = Category.search(categorySearchTerm);
-          searchData.suggestionKeyword = "#";
-          widget.scheduleRerender();
-          return;
+      } else if (matchSuggestions.type === "username") {
+        const userSearchTerm = matchSuggestions.usernamesMatch[0].replace(
+          "@",
+          ""
+        );
+        const opts = { includeGroups: true, limit: 6 };
+        if (userSearchTerm.length > 0) {
+          opts.term = userSearchTerm;
+        } else {
+          opts.lastSeenUsers = true;
         }
-        if (matchSuggestions.type === "username") {
-          const userSearchTerm = matchSuggestions.usernamesMatch[0].replace(
-            "@",
-            ""
-          );
-          const opts = { includeGroups: true, limit: 6 };
-          if (userSearchTerm.length > 0) {
-            opts.term = userSearchTerm;
+
+        userSearch(opts).then((result) => {
+          if (result?.users?.length > 0) {
+            searchData.suggestionResults = result.users;
+            searchData.suggestionKeyword = "@";
           } else {
-            opts.lastSeenUsers = true;
+            searchData.noResults = true;
+            searchData.suggestionKeyword = false;
           }
-
-          userSearch(opts).then((result) => {
-            if (result?.users?.length > 0) {
-              searchData.suggestionResults = result.users;
-              searchData.suggestionKeyword = "@";
-            } else {
-              searchData.noResults = true;
-              searchData.suggestionKeyword = false;
-            }
-            widget.scheduleRerender();
-          });
-          return;
-        }
+          widget.scheduleRerender();
+        });
+      } else {
+        searchData.suggestionKeyword = matchSuggestions[0];
+        widget.scheduleRerender();
       }
+      return;
     }
 
     searchData.suggestionKeyword = false;
@@ -142,14 +137,6 @@ const SearchHelper = {
       return false;
     }
 
-    const simpleSuggestion = suggestionTriggers.find(
-      (mod) => searchData.term === mod || searchData.term.endsWith(` ${mod}`)
-    );
-
-    if (simpleSuggestion) {
-      return simpleSuggestion;
-    }
-
     const categoriesMatch = searchData.term.match(CATEGORY_SLUG_REGEXP);
 
     if (categoriesMatch) {
@@ -159,6 +146,11 @@ const SearchHelper = {
     const usernamesMatch = searchData.term.match(USERNAME_REGEXP);
     if (usernamesMatch) {
       return { type: "username", usernamesMatch };
+    }
+
+    const suggestionsMatch = searchData.term.match(SUGGESTIONS_REGEXP);
+    if (suggestionsMatch) {
+      return suggestionsMatch;
     }
 
     return false;

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -343,6 +343,10 @@ acceptance("Search - assistant", function (needs) {
     await fillIn("#search-term", "sam in:");
     await triggerKeyEvent("#search-term", "keyup", 51);
     assert.equal(query(firstTarget).innerText, "sam in:title");
+
+    await fillIn("#search-term", "in:pers");
+    await triggerKeyEvent("#search-term", "keyup", 51);
+    assert.equal(query(firstTarget).innerText, "in:personal");
   });
 
   test("shows users when typing @", async function (assert) {

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -452,7 +452,7 @@ class Search
     posts.where("posts.user_id = #{@guardian.user.id}") if @guardian.user
   end
 
-  advanced_filter(/^in:created$/i) do |posts|
+  advanced_filter(/^in:(created|mine)$/i) do |posts|
     posts.where(user_id: @guardian.user.id, post_number: 1) if @guardian.user
   end
 


### PR DESCRIPTION
Several small improvements: 

- allows searching within the quick suggestions: 
<img width="537" alt="image" src="https://user-images.githubusercontent.com/368961/126507484-334d3a6f-779b-41fe-ad55-f37dbeb07286.png">

- adds more shortcuts (watching, tracked, untagged, etc.)
- makes some shortcuts visible to authed users only (personal, bookmarks, seen etc.) because they are not helpful for anonymous searches
- Adds `in:mine` as synonym for `in:created`
- Shortcuts can now be invoked by typing simply `:` 
<img width="538" alt="image" src="https://user-images.githubusercontent.com/368961/126508309-66477282-5741-41fe-ab41-1257368fb7d1.png">

- renames the API function to `addSearchSuggestion`