### PR TITLE
FIX: Don't proxy `/qunit` URL when using Ember CLI

### DIFF
--- a/app/controllers/qunit_controller.rb
+++ b/app/controllers/qunit_controller.rb
@@ -10,6 +10,7 @@ class QunitController < ApplicationController
 
   # only used in test / dev
   def index
+    raise Discourse::NotFound.new if request.headers["HTTP_X_DISCOURSE_EMBER_CLI"] == "true"
     raise Discourse::InvalidAccess.new if Rails.env.production?
   end
 


### PR DESCRIPTION
This is confusing because you're running the tests on the older version
of Ember. Use `/tests` for Ember CLI, and `/qunit` when using Rails'
asset pipeline (but only if REALLY necessary!)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
