### PR TITLE
DEV: Add default `Accept-Language` to FinalDestination requests

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -89,6 +89,7 @@ class FinalDestination
     result = {
       "User-Agent" => @user_agent,
       "Accept" => "*/*",
+      "Accept-Language" => "*",
       "Host" => @uri.hostname
     }
 


### PR DESCRIPTION
Not specifying an `Accept-Language` should be equivalent to specifying an `Accept-Language` of `*`, however some webservers seem to prefer it if we are explicit about being able to handle a response of content in any language.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
