### PR TITLE
DEV: Remove depreciation warning in `user-topics-lists` controller.

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-private-messages-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-private-messages-route.js
@@ -41,7 +41,6 @@ export default (viewName, path, channel) => {
       this.controllerFor("user-topics-list").setProperties({
         hideCategory: true,
         showPosters: true,
-        canBulkSelect: true,
         tagsForUser: this.modelFor("user").get("username_lower"),
         selected: [],
         showToggleBulkSelect: true,


### PR DESCRIPTION
```
The <(unknown):ember849>#canBulkSelect computed property was just overriden. This removes the computed property and replaces it with a plain value, and has been deprecated.
```

Follow-up to 43058db3cae5f9a06e62204253a8be0404948425