### PR TITLE
FIX: update the list of users after user joined group

### DIFF
--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -131,7 +131,7 @@ const Group = RestModel.extend({
     return ajax(`/groups/${this.id}/join.json`, {
       type: "PUT",
     }).then(() => {
-      this.findMembers();
+      this.findMembers({}, true);
     });
   },
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -398,6 +398,7 @@ class GroupsController < ApplicationController
     end
 
     group = Group.find(params[:id])
+    raise Discourse::NotFound unless group
     raise Discourse::InvalidAccess unless group.public_admission
 
     return if group.users.exists?(id: current_user.id)


### PR DESCRIPTION
A super tiny fix to the UI for joining a public group. This makes the list of users update when a user clicks the join button:
<img width="750" alt="Screenshot 2021-07-22 at 17 16 19" src="https://user-images.githubusercontent.com/1274517/126645579-4024ce0f-d47d-4947-989c-2a966bcd9329.png">

The PR also adds a check if a group exists to the `group#join` method.
