### PR TITLE
DEV: extract leave_group method from the group#remove_member method

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-membership-button.js
+++ b/app/assets/javascripts/discourse/app/components/group-membership-button.js
@@ -37,7 +37,7 @@ export default Component.extend({
   removeFromGroup() {
     const model = this.model;
     model
-      .removeMember(this.currentUser)
+      .leave()
       .then(() => {
         model.set("is_group_user", false);
         this.appEvents.trigger("group:leave", model);

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -114,6 +114,12 @@ const Group = RestModel.extend({
     }).then(() => this.findMembers(params, true));
   },
 
+  leave() {
+    return ajax(`/groups/${this.id}/leave.json`, {
+      type: "DELETE",
+    }).then(() => this.findMembers({}, true));
+  },
+
   addMembers(usernames, filter, notifyUsers, emails = []) {
     return ajax(`/groups/${this.id}/members.json`, {
       type: "PUT",

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -507,14 +507,14 @@ class GroupsController < ApplicationController
   end
 
   def leave
-    group = Group.find_by(id: params[:id])
-    raise Discourse::NotFound unless group
     ensure_logged_in
-    raise Discourse::InvalidAccess unless group.public_exit
-
     unless current_user.staff?
       RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
     end
+
+    group = Group.find_by(id: params[:id])
+    raise Discourse::NotFound unless group
+    raise Discourse::InvalidAccess unless group.public_exit
 
     if group.remove(current_user)
       GroupActionLogger.new(current_user, group).log_remove_user_from_group(current_user)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -463,7 +463,7 @@ class GroupsController < ApplicationController
   def remove_member
     group = Group.find_by(id: params[:id])
     raise Discourse::NotFound unless group
-    group.public_exit ? ensure_logged_in : guardian.ensure_can_edit!(group)
+    guardian.ensure_can_edit!(group)
 
     # Maintain backwards compatibility
     params[:usernames] = params[:username] if params[:username].present?
@@ -473,16 +473,6 @@ class GroupsController < ApplicationController
     raise Discourse::InvalidParameters.new(
       'user_ids or usernames or user_emails must be present'
     ) if users.empty?
-
-    if group.public_exit
-      if !guardian.can_log_group_changes?(group) && current_user != users.first
-        raise Discourse::InvalidAccess
-      end
-
-      unless current_user.staff?
-        RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
-      end
-    end
 
     removed_users = []
     skipped_users = []

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -509,47 +509,16 @@ class GroupsController < ApplicationController
   def leave
     group = Group.find_by(id: params[:id])
     raise Discourse::NotFound unless group
-    group.public_exit ? ensure_logged_in : guardian.ensure_can_edit!(group)
+    ensure_logged_in
+    raise Discourse::InvalidAccess unless group.public_exit
 
-    # Maintain backwards compatibility
-    params[:usernames] = params[:username] if params[:username].present?
-    params[:user_emails] = params[:user_email] if params[:user_email].present?
-
-    users = users_from_params
-    raise Discourse::InvalidParameters.new(
-      'user_ids or usernames or user_emails must be present'
-    ) if users.empty?
-
-    if group.public_exit
-      if !guardian.can_log_group_changes?(group) && current_user != users.first
-        raise Discourse::InvalidAccess
-      end
-
-      unless current_user.staff?
-        RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
-      end
+    unless current_user.staff?
+      RateLimiter.new(current_user, "public_group_membership", 3, 1.minute).performed!
     end
 
-    removed_users = []
-    skipped_users = []
-
-    users.each do |user|
-      if group.remove(user)
-        removed_users << user.username
-        GroupActionLogger.new(current_user, group).log_remove_user_from_group(user)
-      else
-        if group.users.exclude? user
-          skipped_users << user.username
-        else
-          raise Discourse::InvalidParameters
-        end
-      end
+    if group.remove(current_user)
+      GroupActionLogger.new(current_user, group).log_remove_user_from_group(current_user)
     end
-
-    render json: success_json.merge!(
-      usernames: removed_users,
-      skipped_usernames: skipped_users
-    )
   end
 
   MAX_NOTIFIED_OWNERS ||= 20

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -604,6 +604,7 @@ Discourse::Application.routes.draw do
           put "members" => "groups#add_members"
           put "join" => "groups#join"
           delete "members" => "groups#remove_member"
+          delete "leave" => "groups#leave"
           post "request_membership" => "groups#request_membership"
           put "handle_membership_request" => "groups#handle_membership_request"
           post "notifications" => "groups#set_notifications"


### PR DESCRIPTION
Exactly the same fix as the fix with extracting the `join` method from the `group#add_memebers` method. See description of that fix - https://github.com/discourse/discourse/pull/13807.
