### PR TITLE
FIX: Long poll if window becomes active

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/initializers/message-bus.js
@@ -56,11 +56,7 @@ export default {
     // When 20 minutes pass we stop long polling due to "shouldLongPollCallback".
     onPresenceChange({
       unseenTime: LONG_POLL_AFTER_UNSEEN_TIME,
-      callback: () => {
-        if (messageBus.onVisibilityChange) {
-          messageBus.onVisibilityChange();
-        }
-      },
+      callback: () => document.dispatchEvent(new Event("visibilitychange")),
     });
 
     if (siteSettings.login_required && !user) {

--- a/app/assets/javascripts/discourse/app/lib/user-presence.js
+++ b/app/assets/javascripts/discourse/app/lib/user-presence.js
@@ -44,11 +44,11 @@ export function seenUser() {
 }
 
 // register a callback for cases where presence changed
-export function onPresenceChange(maxUnseenTime, callback) {
-  if (maxUnseenTime < MIN_DELTA) {
+export function onPresenceChange({ unseenTime, callback }) {
+  if (unseenTime < MIN_DELTA) {
     throw "unseenTime is too short";
   }
-  callbacks.push({ unseenTime: maxUnseenTime, callback: callback });
+  callbacks.push({ unseenTime, callback });
 }
 
 // We could piggieback on the Scroll mixin, but it is not applied


### PR DESCRIPTION
This commit fixes two bugs. The first one is that onPresenceChange was
called with invalid arguments and it did not register a callback. The
second bug is that it triggered the wrong visibilitychange event. The
function it tried to call does not exist in all versions of MessageBus.
It is safer to trigger an event instead because that exists in all
versions.

The test was intentionally omitted because we do not test MessageBus and it requires a lot of stubs which do not make the test useful anymore.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
