### PR TITLE
Add min-width rule to fix header display issues on the Android Gmail app

### DIFF
--- a/app/views/user_notifications/digest.html.erb
+++ b/app/views/user_notifications/digest.html.erb
@@ -5,7 +5,7 @@
 </span>
 
 <%- if I18n.t('user_notifications.digest.custom.html.header').present? %>
-  <table class="digest-header logo-header" dir="<%= rtl? ? 'rtl' : 'ltr' %>" style="width:100%;border-spacing:0;padding:0;">
+  <table class="digest-header logo-header" dir="<%= rtl? ? 'rtl' : 'ltr' %>" style="width:100%;min-width:100%;border-spacing:0;padding:0;">
     <tr>
       <td style="padding:0;">
         <%= raw(t 'user_notifications.digest.custom.html.header') %>
@@ -13,7 +13,7 @@
     </tr>
   </table>
 <%- else %>
-<table class="digest-header text-header with-dir" style="background-color:#<%= @header_bgcolor -%>;width:100%;">
+<table class="digest-header text-header with-dir" style="background-color:#<%= @header_bgcolor -%>;width:100%;min-width:100%;">
   <tr>
     <td align="center" style="text-align: center;padding: 20px 0; font-family:Arial,sans-serif;">
 
@@ -54,7 +54,7 @@
 
 
 
-<table class="header-stats with-dir" style="table-layout:fixed;margin:10px 0 20px 0;padding:0;vertical-align:top;width:100%">
+<table class="header-stats with-dir" style="table-layout:fixed;margin:10px 0 20px 0;padding:0;vertical-align:top;width:100%;min-width:100%;">
 <tbody>
   <tr class="header-stat-count">
     <%- @counts.each do |count| -%>


### PR DESCRIPTION
This is to fix a formatting issue in the summary email header that occurs on the Android Gmail app when the email's header contains more than a minimal amount of data. Based on my testing, the issue occurs if any of the counts that are displayed in the header contain more than a single digit.

Here's an example of the issue. This is far from the worst possible case. I can find instances of the issue with summary emails I've received from Discourse sites on my Android phone.

![image](https://user-images.githubusercontent.com/2975917/126712574-1671c688-3b59-477c-9baa-4a555f23ed4b.png)

Here's the same email with the fix. This is from my self-hosted Discourse site. I've made the changes directly to the `digest.html.erb` file on that site:

![image](https://user-images.githubusercontent.com/2975917/126712743-58a9c10e-5ea4-46b1-a4cf-1642f1c5d786.png)

The cause of the issue is that the Android Gmail app does not respect the `width:100%` rule. Adding a `min-width:100%` rule fixes the issue. I'm less clear than I'd like to be about why the issue only occurs when there's a certain amount of content in the header, but it explains why we've failed to catch the issue on previous testing.

I'm not finding any unwanted side effects from this change for other email clients.





