### PR TITLE
DEV: Return 400 instead of 500 for invalid top period

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -259,11 +259,8 @@ class ListController < ApplicationController
     options ||= {}
     period = params[:period]
     period ||= ListController.best_period_for(current_user.try(:previous_visit_at), options[:category])
-    if TopTopic.periods.include?(period.to_sym)
-      public_send("top_#{period}", options)
-    else
-      raise Discourse::InvalidParameters.new("Invalid period. Valid periods are #{TopTopic.periods.join(", ")}")
-    end
+    TopTopic.validate_period(period)
+    public_send("top_#{period}", options)
   end
 
   def category_top

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -259,7 +259,7 @@ class ListController < ApplicationController
     options ||= {}
     period = params[:period]
     period ||= ListController.best_period_for(current_user.try(:previous_visit_at), options[:category])
-    if ListController.action_methods.include? "top_#{period}"
+    if TopTopic.periods.include?(period.to_sym)
       public_send("top_#{period}", options)
     else
       raise Discourse::InvalidParameters.new("Invalid period. Valid periods are #{TopTopic.periods.join(", ")}")

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -259,9 +259,9 @@ class ListController < ApplicationController
     options ||= {}
     period = params[:period]
     period ||= ListController.best_period_for(current_user.try(:previous_visit_at), options[:category])
-    begin
+    if ListController.action_methods.include? "top_#{period}"
       public_send("top_#{period}", options)
-    rescue NoMethodError
+    else
       raise Discourse::InvalidParameters.new("Invalid period. Valid periods are #{TopTopic.periods.join(", ")}")
     end
   end

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -259,7 +259,11 @@ class ListController < ApplicationController
     options ||= {}
     period = params[:period]
     period ||= ListController.best_period_for(current_user.try(:previous_visit_at), options[:category])
-    public_send("top_#{period}", options)
+    begin
+      public_send("top_#{period}", options)
+    rescue NoMethodError
+      raise Discourse::InvalidParameters.new("Invalid period. Valid periods are #{TopTopic.periods.join(", ")}")
+    end
   end
 
   def category_top

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -424,6 +424,23 @@ RSpec.describe ListController do
     end
   end
 
+  describe 'Top' do
+    it 'renders top' do
+      get "/top"
+      expect(response.status).to eq(200)
+    end
+
+    it 'renders top with a period' do
+      get "/top?period=weekly"
+      expect(response.status).to eq(200)
+    end
+
+    it 'errors for invalid periods on top' do
+      get "/top?period=decadely"
+      expect(response.status).to eq(400)
+    end
+  end
+
   describe 'category' do
     context 'in a category' do
       let(:category) { Fabricate(:category_with_definition) }


### PR DESCRIPTION
This change will prevent a fatal 500 error when passing in an invalid
period param value to the `/top` route.
