### PR TITLE
Post creator of a whisper post can be revealed to non-staff users.

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -258,6 +258,7 @@ class PostDestroyer
       .select(:created_at, :user_id, :post_number)
       .where("topic_id = ? and id <> ?", @post.topic_id, @post.id)
       .where.not(user_id: nil)
+      .where.not(post_type: Post.types[:whisper])
       .order('created_at desc')
       .limit(1)
       .first

--- a/spec/components/post_destroyer_spec.rb
+++ b/spec/components/post_destroyer_spec.rb
@@ -616,6 +616,22 @@ describe PostDestroyer do
     end
   end
 
+  describe "deleting a post directly after a whisper" do
+    before do
+      SiteSetting.enable_whispers = true
+    end
+
+    it 'should not set Topic#last_post_user_id to a whisperer' do
+      post_1 = create_post(topic: post.topic, user: moderator)
+      whisper_1 = create_post(topic: post.topic, user: Fabricate(:user), post_type: Post.types[:whisper])
+      whisper_2 = create_post(topic: post.topic, user: Fabricate(:user), post_type: Post.types[:whisper])
+
+      PostDestroyer.new(admin, whisper_2).destroy
+
+      expect(post.topic.reload.last_post_user_id).to eq(post_1.user.id)
+    end
+  end
+
   context 'deleting the second post in a topic' do
 
     fab!(:user) { Fabricate(:user) }


### PR DESCRIPTION
There are two bugs which led to the post creator of a whisper post being revealed to non-staff users.

Staff users that creates a whisper post in a personal message is revealed to non-staff participants of the personal message even though the whisper post cannot be seen by them.

When a whisper post is before the last post in a post stream, deleting the last post will result in the creator of the whisper post to be revealed to non-staff users as the last poster of the topic.