### PR TITLE
FIX: Show Uncategorized when unsubscribing

### DIFF
--- a/app/views/email/unsubscribe.html.erb
+++ b/app/views/email/unsubscribe.html.erb
@@ -37,7 +37,7 @@
           <p>
           <label>
             <%= check_box_tag 'unwatch_category' %>
-            <%= t('unsubscribe.unwatch_category', category: category_badge(@topic.category)).html_safe %>
+            <%= t('unsubscribe.unwatch_category', category: category_badge(@topic.category, show_uncategorized: true)).html_safe %>
           </label>
           </p>
         <% end %>

--- a/spec/requests/email_controller_spec.rb
+++ b/spec/requests/email_controller_spec.rb
@@ -273,6 +273,8 @@ RSpec.describe EmailController do
 
         navigate_to_unsubscribe
         expect(response.body).to include("unwatch_category")
+        doc = Nokogiri::HTML5::fragment(response.body)
+        expect(doc.css('a.badge-wrapper[href="/c/uncategorized/1"]').size).to eq(1)
 
         cu.destroy!
 


### PR DESCRIPTION
If user tried to unsubscribe from a post from category Uncategorized,
the category name was not displayed. It said only "Stop watching all
topics in".

![image](https://user-images.githubusercontent.com/23153890/126792652-4dadf9b0-73d6-4c9b-be3f-d85b7b3258b3.png)