### PR TITLE
UX: prioritize moderator bg color in PMs 

### DIFF
--- a/app/assets/stylesheets/common/base/personal-message.scss
+++ b/app/assets/stylesheets/common/base/personal-message.scss
@@ -27,14 +27,14 @@
       .topic-body .cooked {
         background: var(--tertiary-very-low);
       }
+      .topic-body.highlighted {
+        .cooked {
+          animation: current-user-background-fade-highlight 2.5s ease-out;
+        }
+      }
     }
     .topic-body .cooked {
       border: 1px solid transparent;
-    }
-    .topic-body.highlighted {
-      .cooked {
-        animation: current-user-background-fade-highlight 2.5s ease-out;
-      }
     }
     .embedded-posts {
       .topic-body .cooked {

--- a/app/assets/stylesheets/common/base/personal-message.scss
+++ b/app/assets/stylesheets/common/base/personal-message.scss
@@ -23,9 +23,13 @@
   }
 
   .current-user-post {
+    &:not(.moderator) {
+      .topic-body .cooked {
+        background: var(--tertiary-very-low);
+      }
+    }
     .topic-body .cooked {
       border: 1px solid transparent;
-      background: var(--tertiary-very-low);
     }
     .topic-body.highlighted {
       .cooked {


### PR DESCRIPTION
follow up to aa6daea

The background for your own posts is taking priority over the staff bg color, which could add some confusion. This ensures the moderator color takes precedence. 