### PR TITLE
FIX: Don't show the This Weekend option in date pickers on Sundays

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
@@ -168,6 +168,41 @@ discourseModule(
       },
     });
 
+    componentTest("doesn't show 'This Weekend' on Sundays", {
+      /*
+        We need this test to avoid regressions.
+        We tend to write such conditions and think that
+        they mean the beginning of work week
+        (Monday, Tuesday and Wednesday in this specific case):
+
+         if (date.day <= 3) {
+             ...
+         }
+
+        In fact, Sunday will pass this check too, because
+        in moment.js 0 stands for Sunday.
+      */
+
+      template: hbs`
+        {{future-date-input-selector
+          includeWeekend=true
+        }}
+      `,
+
+      beforeEach() {
+        const timezone = moment.tz.guess();
+        this.clock = fakeTime("2100-04-25 18:00:00", timezone, true); // Sunday
+      },
+
+      async test(assert) {
+        await this.subject.expand();
+        const options = getOptions();
+        const thisWeekend = I18n.t("topic.auto_update_input.this_weekend");
+
+        assert.not(options.includes(thisWeekend));
+      },
+    });
+
     componentTest(
       "shows 'Later This Week' instead of 'Later Today' at the end of the day",
       {

--- a/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
@@ -46,7 +46,7 @@ export const TIMEFRAMES = [
   buildTimeframe({
     id: "this_weekend",
     format: "ddd, h a",
-    enabled: (opts) => opts.day < 5 && opts.includeWeekend,
+    enabled: (opts) => opts.day > 0 && opts.day < 5 && opts.includeWeekend,
     when: (time, timeOfDay) => time.day(6).hour(timeOfDay).minute(0),
     icon: "bed",
   }),


### PR DESCRIPTION
We fixed a similar problem in https://github.com/discourse/discourse/pull/12918. Moment.js' `day()` function [returns 0 for Sunday](https://momentjs.com/docs/#/get-set/day/).
