### PR TITLE
FIX: Don't show the Later This Week option in date pickers on Sundays

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-selector-test.js
@@ -209,6 +209,34 @@ discourseModule(
       },
     });
 
+    componentTest("doesn't show 'Later This Week' on Sundays", {
+      /* We need this test to avoid regressions.
+      We tend to write such conditions and think that
+      they mean the beginning of business week
+      (Monday, Tuesday and Wednesday in this specific case):
+
+       if (date.day < 3) {
+           ...
+       }
+
+      In fact, Sunday will pass this check too, because
+      in moment.js 0 stands for Sunday. */
+
+      template: hbs`{{future-date-input-selector}}`,
+
+      beforeEach() {
+        const timezone = moment.tz.guess();
+        this.clock = fakeTime("2100-04-25 18:00:00", timezone, true); // Sunday evening
+      },
+
+      async test(assert) {
+        await this.subject.expand();
+        const options = getOptions();
+        const laterThisWeek = I18n.t("topic.auto_update_input.later_this_week");
+        assert.not(options.includes(laterThisWeek));
+      },
+    });
+
     componentTest("doesn't show 'Next Month' on the last day of the month", {
       template: hbs`{{future-date-input-selector}}`,
 

--- a/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
@@ -40,7 +40,7 @@ export const TIMEFRAMES = [
   buildTimeframe({
     id: "later_this_week",
     format: "ddd, h a",
-    enabled: (opts) => !opts.canScheduleToday && opts.day < 4,
+    enabled: (opts) => !opts.canScheduleToday && opts.day > 0 && opts.day < 4,
     when: (time, timeOfDay) => time.add(2, "day").hour(timeOfDay).minute(0),
   }),
   buildTimeframe({


### PR DESCRIPTION
Moment.js' `day()` function [returns 0 for Sunday](https://momentjs.com/docs/#/get-set/day/). This is the same problem as in https://github.com/discourse/discourse/pull/13838, but in this specific case I'm not 100% sure that we consider this as a bug. 

It depends on what we consider as the first day of the week. If this it is Monday which is an international standard as I understand, then this is the bug, and we should merge this PR.


