### PR TITLE
FIX: do not raise exception when svg path is nil

### DIFF
--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -180,10 +180,10 @@ class ThemeField < ActiveRecord::Base
       path = Discourse.store.path_for(upload)
     end
 
-    content = File.read(path)
     error = nil
 
     begin
+      content = File.read(path)
       svg_file = Nokogiri::XML(content) do |config|
         config.options = Nokogiri::XML::ParseOptions::NOBLANKS
       end

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -430,6 +430,11 @@ HTML
       theme_field.destroy!
       expect(SvgSprite.custom_svg_sprites(theme.id).size).to eq(0)
     end
+
+    it 'crashes gracefully when svg is invalid' do
+      FileStore::LocalStore.any_instance.stubs(:path_for).returns(nil)
+      expect(theme_field.validate_svg_sprite_xml).to match("Error with icons-sprite")
+    end
   end
 
 end


### PR DESCRIPTION
Bug was introduced here: https://github.com/discourse/discourse/commit/f7ab852e123afe22b9a594bd43af712b7cebd98b

If path is nil, it should not raise an exception and continue logging the error.