### PR TITLE
DEV: Fix stylesheet manager flaky spec

### DIFF
--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -53,7 +53,7 @@ class StylesheetsController < ApplicationController
     # Security note, safe due to route constraint
     underscore_digest = digest ? "_" + digest : ""
 
-    cache_path = "#{Rails.root}/#{Stylesheet::Manager::CACHE_PATH}"
+    cache_path = Stylesheet::Manager.cache_fullpath
     location = "#{cache_path}/#{target}#{underscore_digest}#{extension}"
 
     stylesheet_time = query.pluck_first(:created_at)

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -135,7 +135,9 @@ class Stylesheet::Manager
   end
 
   def self.cache_fullpath
-    "#{Rails.root}/#{CACHE_PATH}"
+    path = "#{Rails.root}/#{CACHE_PATH}"
+    return path if !Rails.env.test?
+    File.join(path, "test_#{ENV['TEST_ENV_NUMBER'].presence || '0'}")
   end
 
   attr_reader :theme_ids


### PR DESCRIPTION
The cache_fullpath for the Stylesheet::Manager was the same for
every test runner in a parallel test environment, so when other
specs or other places e.g. the stylesheets_controller_spec ran
rm -rf Stylesheet::Manager.cache_fullpath this caused errors
for other specs running that went through the
Stylesheet::Manager::Builder#compile path, causing the error

```
Errno::ENOENT:
       No such file or directory @ rb_sysopen
```
