### PR TITLE
FIX: use correct URL in schema markup for post images.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1087,7 +1087,8 @@ class Post < ActiveRecord::Base
   end
 
   def image_url
-    image_upload&.url
+    raw_url = image_upload&.url
+    UrlHelper.cook_url(raw_url, secure: image_upload&.secure?, local: true) if raw_url
   end
 
   private

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -62,7 +62,7 @@
           <link itemprop="mainEntityOfPage" href="<%= post.topic.url %>">
 
           <% if post.image_url %>
-            <link itemprop="image" href="<%= Discourse.base_url %><%= post.image_url %>">
+            <link itemprop="image" href="<%= post.image_url %>">
           <% end %>
 
           <span class="crawler-post-infos">

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2438,6 +2438,17 @@ RSpec.describe TopicsController do
         body = response.body
         expect(body).to have_tag(:meta, with: { name: 'description', content: '[image_description]' })
       end
+
+      it "uses image cdn url for schema markup" do
+        set_cdn_url("http://cdn.localhost")
+        post = Fabricate(:post_with_uploaded_image)
+        cpp = CookedPostProcessor.new(post).update_post_image
+
+        get post.topic.url
+
+        body = response.body
+        expect(body).to have_tag(:link, with: { itemprop: 'image', href: post.image_url })
+      end
     end
   end
 


### PR DESCRIPTION
Currently, it wrongly adds Discourse base URL in prefix even for CDN URLs.