### PR TITLE
FEATURE: Attach backup log as upload

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2998,11 +2998,7 @@ en:
       text_body_template: |
         The restore was successful.
 
-        Here's the log:
-
-        ``` text
-        %{logs}
-        ```
+        Here's the log: %{logs}
 
     restore_failed:
       title: "Restore Failed"
@@ -3010,11 +3006,7 @@ en:
       text_body_template: |
         The restore has failed.
 
-        Here's the log:
-
-        ``` text
-        %{logs}
-        ```
+        Here's the log: %{logs}
 
     bulk_invite_succeeded:
       title: "Bulk Invite Succeeded"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2982,11 +2982,7 @@ en:
 
         Visit the [admin > backup section](%{base_url}/admin/backups) to download your new backup.
 
-        Here's the log:
-
-        ``` text
-        %{logs}
-        ```
+        Here's the log: %{logs}
 
     backup_failed:
       title: "Backup Failed"
@@ -2994,11 +2990,7 @@ en:
       text_body_template: |
         The backup has failed.
 
-        Here's the log:
-
-        ``` text
-        %{logs}
-        ```
+        Here's the log: %{logs}
 
     restore_succeeded:
       title: "Restore Succeeded"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2982,7 +2982,9 @@ en:
 
         Visit the [admin > backup section](%{base_url}/admin/backups) to download your new backup.
 
-        Here's the log: %{logs}
+        Here's the log:
+
+        %{logs}
 
     backup_failed:
       title: "Backup Failed"
@@ -2990,7 +2992,9 @@ en:
       text_body_template: |
         The backup has failed.
 
-        Here's the log: %{logs}
+        Here's the log:
+
+        %{logs}
 
     restore_succeeded:
       title: "Restore Succeeded"
@@ -2998,7 +3002,9 @@ en:
       text_body_template: |
         The restore was successful.
 
-        Here's the log: %{logs}
+        Here's the log:
+
+        %{logs}
 
     restore_failed:
       title: "Restore Failed"
@@ -3006,7 +3012,9 @@ en:
       text_body_template: |
         The restore has failed.
 
-        Here's the log: %{logs}
+        Here's the log:
+
+        %{logs}
 
     bulk_invite_succeeded:
       title: "Bulk Invite Succeeded"

--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -321,18 +321,7 @@ module BackupRestore
       log "Notifying '#{@user.username}' of the end of the backup..."
       status = @success ? :backup_succeeded : :backup_failed
 
-      upload = Logger.save_log_to_upload(user: @user, logs: @logs)
-      if upload.persisted?
-        logs = UploadMarkdown.new(upload).attachment_markdown
-      else
-        Rails.logger.warn("Failed to upload the backup logs file: #{upload.errors.full_messages}")
-        logs = <<~RAW
-          ```text
-          #{upload.errors.full_messages}
-          ```
-        RAW
-      end
-
+      logs = Discourse::Utils.logs_markdown(@logs, user: @user)
       post = SystemMessage.create_from_system_user(@user, status, logs: logs)
 
       if @user.id == Discourse::SYSTEM_USER_ID

--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -321,28 +321,7 @@ module BackupRestore
       log "Notifying '#{@user.username}' of the end of the backup..."
       status = @success ? :backup_succeeded : :backup_failed
 
-      upload = Dir.mktmpdir do |dir|
-        logfile = File.new(File.join(dir, 'log.txt'), 'w')
-        logfile.write(Discourse::Utils.pretty_logs(@logs))
-        logfile.close
-
-        zipfile = Compression::Zip.new.compress(dir, 'log.txt')
-        File.open(zipfile) do |file|
-          upload = UploadCreator.new(
-            file,
-            File.basename(zipfile),
-            type: 'backup_logs',
-            for_export: 'true'
-          ).create_for(@user.id)
-        end
-
-        if !upload.persisted?
-          Rails.logger.warn("Failed to upload the backup logs file #{zipfile}")
-        end
-
-        upload
-      end
-
+      upload = Logger.save_log_to_upload(user: @user, logs: @logs)
       post = SystemMessage.create_from_system_user(
         @user, status, logs: UploadMarkdown.new(upload).attachment_markdown
       )

--- a/lib/backup_restore/logger.rb
+++ b/lib/backup_restore/logger.rb
@@ -27,24 +27,6 @@ module BackupRestore
       end
     end
 
-    def self.save_log_to_upload(user:, filename: 'log.txt', logs:)
-      Dir.mktmpdir do |dir|
-        logfile = File.new(File.join(dir, filename), 'w')
-        logfile.write(Discourse::Utils.pretty_logs(logs))
-        logfile.close
-
-        zipfile = Compression::Zip.new.compress(dir, filename)
-        File.open(zipfile) do |file|
-          UploadCreator.new(
-            file,
-            File.basename(zipfile),
-            type: 'backup_logs',
-            for_export: 'true'
-          ).create_for(user.id)
-        end
-      end
-    end
-
     protected
 
     def publish_log(message, timestamp)

--- a/lib/backup_restore/logger.rb
+++ b/lib/backup_restore/logger.rb
@@ -34,7 +34,7 @@ module BackupRestore
         logfile.close
 
         zipfile = Compression::Zip.new.compress(dir, filename)
-        upload = File.open(zipfile) do |file|
+        File.open(zipfile) do |file|
           UploadCreator.new(
             file,
             File.basename(zipfile),
@@ -42,12 +42,6 @@ module BackupRestore
             for_export: 'true'
           ).create_for(user.id)
         end
-
-        if !upload.persisted?
-          Rails.logger.warn("Failed to upload the backup logs file #{zipfile}")
-        end
-
-        upload
       end
     end
 

--- a/lib/backup_restore/logger.rb
+++ b/lib/backup_restore/logger.rb
@@ -27,6 +27,30 @@ module BackupRestore
       end
     end
 
+    def self.save_log_to_upload(user:, filename: 'log.txt', logs:)
+      Dir.mktmpdir do |dir|
+        logfile = File.new(File.join(dir, filename), 'w')
+        logfile.write(Discourse::Utils.pretty_logs(logs))
+        logfile.close
+
+        zipfile = Compression::Zip.new.compress(dir, filename)
+        upload = File.open(zipfile) do |file|
+          UploadCreator.new(
+            file,
+            File.basename(zipfile),
+            type: 'backup_logs',
+            for_export: 'true'
+          ).create_for(user.id)
+        end
+
+        if !upload.persisted?
+          Rails.logger.warn("Failed to upload the backup logs file #{zipfile}")
+        end
+
+        upload
+      end
+    end
+
     protected
 
     def publish_log(message, timestamp)

--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -149,9 +149,9 @@ module BackupRestore
         log "Notifying '#{user.username}' of the end of the restore..."
         status = @success ? :restore_succeeded : :restore_failed
 
-        SystemMessage.create_from_system_user(
-          user, status,
-          logs: Discourse::Utils.pretty_logs(@logger.logs)
+        upload = Logger.save_log_to_upload(user: user, logs: @logger.logs)
+        post = SystemMessage.create_from_system_user(
+          user, status, logs: UploadMarkdown.new(upload).attachment_markdown
         )
       else
         log "Could not send notification to '#{@user_info[:username]}' " \

--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -149,18 +149,7 @@ module BackupRestore
         log "Notifying '#{user.username}' of the end of the restore..."
         status = @success ? :restore_succeeded : :restore_failed
 
-        upload = Logger.save_log_to_upload(user: user, logs: @logger.logs)
-        if upload.persisted?
-          logs = UploadMarkdown.new(upload).attachment_markdown
-        else
-          Rails.logger.warn("Failed to upload the backup logs file: #{upload.errors.full_messages}")
-          logs = <<~RAW
-            ```
-            #{upload.errors.full_messages}
-            ```
-          RAW
-        end
-
+        logs = Discourse::Utils.logs_markdown(@logger.logs, user: user)
         post = SystemMessage.create_from_system_user(user, status, logs: logs)
       else
         log "Could not send notification to '#{@user_info[:username]}' " \

--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -150,9 +150,18 @@ module BackupRestore
         status = @success ? :restore_succeeded : :restore_failed
 
         upload = Logger.save_log_to_upload(user: user, logs: @logger.logs)
-        post = SystemMessage.create_from_system_user(
-          user, status, logs: UploadMarkdown.new(upload).attachment_markdown
-        )
+        if upload.persisted?
+          logs = UploadMarkdown.new(upload).attachment_markdown
+        else
+          Rails.logger.warn("Failed to upload the backup logs file: #{upload.errors.full_messages}")
+          logs = <<~RAW
+            ```
+            #{upload.errors.full_messages}
+            ```
+          RAW
+        end
+
+        post = SystemMessage.create_from_system_user(user, status, logs: logs)
       else
         log "Could not send notification to '#{@user_info[:username]}' " \
           "(#{@user_info[:email]}), because the user does not exist."

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -58,10 +58,7 @@ module Discourse
 
       # Try to create an upload for the logs
       upload = Dir.mktmpdir do |dir|
-        logfile = File.new(File.join(dir, filename), 'w')
-        logfile.write(pretty_logs)
-        logfile.close
-
+        File.write(File.join(dir, filename), pretty_logs)
         zipfile = Compression::Zip.new.compress(dir, filename)
         File.open(zipfile) do |file|
           UploadCreator.new(
@@ -82,6 +79,7 @@ module Discourse
       # If logs are long and upload cannot be created, show trimmed logs
       <<~TEXT
       ```text
+      ...
       #{pretty_logs.last(max_logs_length)}
       ```
       TEXT

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -42,6 +42,51 @@ module Discourse
       logs.join("\n")
     end
 
+    def self.logs_markdown(logs, user:, filename: 'log.txt')
+      # Reserve 250 characters for the rest of the text
+      max_logs_length = SiteSetting.max_post_length - 250
+      pretty_logs = Discourse::Utils.pretty_logs(logs)
+
+      # If logs are short, try to inline them
+      if pretty_logs.size < max_logs_length
+        return <<~TEXT
+        ```text
+        #{pretty_logs}
+        ```
+        TEXT
+      end
+
+      # Try to create an upload for the logs
+      upload = Dir.mktmpdir do |dir|
+        logfile = File.new(File.join(dir, filename), 'w')
+        logfile.write(pretty_logs)
+        logfile.close
+
+        zipfile = Compression::Zip.new.compress(dir, filename)
+        File.open(zipfile) do |file|
+          UploadCreator.new(
+            file,
+            File.basename(zipfile),
+            type: 'backup_logs',
+            for_export: 'true'
+          ).create_for(user.id)
+        end
+      end
+
+      if upload.persisted?
+        return UploadMarkdown.new(upload).attachment_markdown
+      else
+        Rails.logger.warn("Failed to upload the backup logs file: #{upload.errors.full_messages}")
+      end
+
+      # If logs are long and upload cannot be created, show trimmed logs
+      <<~TEXT
+      ```text
+      #{pretty_logs.last(max_logs_length)}
+      ```
+      TEXT
+    end
+
     def self.atomic_write_file(destination, contents)
       begin
         return if File.read(destination) == contents

--- a/spec/lib/backup_restore/backuper_spec.rb
+++ b/spec/lib/backup_restore/backuper_spec.rb
@@ -18,23 +18,57 @@ describe BackupRestore::Backuper do
   end
 
   describe '#notify_user' do
-    before { STDOUT.stubs(:write) }
-
-    it 'include upload' do
-      backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
-      expect { backuper.send(:notify_user) }
-        .to change { Topic.private_messages.count }.by(1)
-        .and change { Upload.where(original_filename: "log.txt.zip").count }.by(1)
+    before do
+      freeze_time Time.zone.parse('2010-01-01 12:00')
     end
 
-    it 'includes upload error if cannot save upload' do
+    it 'includes logs if short' do
       SiteSetting.max_export_file_size_kb = 1
       SiteSetting.export_authorized_extensions = "tar.gz"
 
-      backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
-      expect { backuper.send(:notify_user) }
-        .to change { Topic.private_messages.count }.by(1)
-        .and change { Upload.count }.by(0)
+      silence_stdout do
+        backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
+
+        expect { backuper.send(:notify_user) }
+          .to change { Topic.private_messages.count }.by(1)
+          .and change { Upload.count }.by(0)
+      end
+
+      expect(Topic.last.first_post.raw).to include("```text\n[2010-01-01 12:00:00] Notifying 'system' of the end of the backup...\n```")
+    end
+
+    it 'include upload if log is long' do
+      SiteSetting.max_post_length = 250
+
+      silence_stdout do
+        backuper = silence_stdout { BackupRestore::Backuper.new(Discourse.system_user.id) }
+
+        expect { backuper.send(:notify_user) }
+          .to change { Topic.private_messages.count }.by(1)
+          .and change { Upload.where(original_filename: "log.txt.zip").count }.by(1)
+      end
+
+      expect(Topic.last.first_post.raw).to include("[log.txt.zip|attachment]")
+    end
+
+    it 'includes trimmed logs if log is long and upload cannot be saved' do
+      SiteSetting.max_post_length = 348
+      SiteSetting.max_export_file_size_kb = 1
+      SiteSetting.export_authorized_extensions = "tar.gz"
+
+      silence_stdout do
+        backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
+
+        1.upto(10).each do |i|
+          backuper.send(:log, "Line #{i}")
+        end
+
+        expect { backuper.send(:notify_user) }
+          .to change { Topic.private_messages.count }.by(1)
+          .and change { Upload.count }.by(0)
+      end
+
+      expect(Topic.last.first_post.raw).to include("```text\n[2010-01-01 12:00:00] Line 10\n[2010-01-01 12:00:00] Notifying 'system' of the end of the backup...\n```")
     end
   end
 end

--- a/spec/lib/backup_restore/backuper_spec.rb
+++ b/spec/lib/backup_restore/backuper_spec.rb
@@ -16,4 +16,13 @@ describe BackupRestore::Backuper do
 
     expect(backuper.send(:get_parameterized_title)).to eq("coding-horror")
   end
+
+  describe '#notify_user' do
+    it 'include upload' do
+      backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
+      expect { backuper.send(:notify_user) }
+        .to change { Topic.private_messages.count }.by(1)
+        .and change { Upload.count }.by(1)
+    end
+  end
 end

--- a/spec/lib/backup_restore/backuper_spec.rb
+++ b/spec/lib/backup_restore/backuper_spec.rb
@@ -18,11 +18,23 @@ describe BackupRestore::Backuper do
   end
 
   describe '#notify_user' do
+    before { STDOUT.stubs(:write) }
+
     it 'include upload' do
       backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
       expect { backuper.send(:notify_user) }
         .to change { Topic.private_messages.count }.by(1)
-        .and change { Upload.count }.by(1)
+        .and change { Upload.where(original_filename: "log.txt.zip").count }.by(1)
+    end
+
+    it 'includes upload error if cannot save upload' do
+      SiteSetting.max_export_file_size_kb = 1
+      SiteSetting.export_authorized_extensions = "tar.gz"
+
+      backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
+      expect { backuper.send(:notify_user) }
+        .to change { Topic.private_messages.count }.by(1)
+        .and change { Upload.count }.by(0)
     end
   end
 end

--- a/spec/lib/backup_restore/backuper_spec.rb
+++ b/spec/lib/backup_restore/backuper_spec.rb
@@ -68,7 +68,7 @@ describe BackupRestore::Backuper do
           .and change { Upload.count }.by(0)
       end
 
-      expect(Topic.last.first_post.raw).to include("```text\n[2010-01-01 12:00:00] Line 10\n[2010-01-01 12:00:00] Notifying 'system' of the end of the backup...\n```")
+      expect(Topic.last.first_post.raw).to include("```text\n...\n[2010-01-01 12:00:00] Line 10\n[2010-01-01 12:00:00] Notifying 'system' of the end of the backup...\n```")
     end
   end
 end


### PR DESCRIPTION
Discourse automatically sends a private message after backup or
restore finished. The private message used to contain the log inline
even when it was very long. A very long log can create issues because
the length of the post will be over the maximum allowed length of a
post. When that happens, Discourse will try to create an upload with
the logs. If that fails, it will trim the log and inline it.