### PR TITLE
fix badge wrapping in user summary

### DIFF
--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -247,6 +247,7 @@
   display: grid;
   grid: auto-flow / repeat(3, 1fr);
   grid-gap: 1em;
+  width: 100%;
   margin-bottom: 1.5em;
 
   @include breakpoint(medium) {


### PR DESCRIPTION
Minor follow-up to 15320d4

Sometimes the badges on the summary page have short content or they get scaled down in a theme, and this change prevents the "more badges" text from wrapping like this: 


Before:
![Screen Shot 2021-07-27 at 12 22 15 AM](https://user-images.githubusercontent.com/1681963/127094953-2f25a9fd-d757-4b74-bf76-1aa49af92344.png)

After:
![Screen Shot 2021-07-27 at 12 23 39 AM](https://user-images.githubusercontent.com/1681963/127095056-e2680610-53c8-42ed-8658-b50b6b942456.png)
