### PR TITLE
DEV: ensures tree is present for traverseCustomWidgets

### DIFF
--- a/app/assets/javascripts/discourse/app/components/mount-widget.js
+++ b/app/assets/javascripts/discourse/app/components/mount-widget.js
@@ -124,9 +124,7 @@ export default Component.extend({
       newTree._emberView = this;
       const patches = diff(this._tree || this._rootNode, newTree);
 
-      if (this._tree) {
-        traverseCustomWidgets(this._tree, (w) => w.willRerenderWidget());
-      }
+      traverseCustomWidgets(this._tree, (w) => w.willRerenderWidget());
 
       this.beforePatch();
       this._rootNode = patch(this._rootNode, patches);

--- a/app/assets/javascripts/discourse/app/widgets/glue.js
+++ b/app/assets/javascripts/discourse/app/widgets/glue.js
@@ -47,9 +47,7 @@ export default class WidgetGlue {
     });
     const patches = diff(this._tree || this._rootNode, newTree);
 
-    if (this._tree) {
-      traverseCustomWidgets(this._tree, (w) => w.willRerenderWidget());
-    }
+    traverseCustomWidgets(this._tree, (w) => w.willRerenderWidget());
 
     newTree._rerenderable = this;
     this._rootNode = patch(this._rootNode, patches);

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -38,6 +38,10 @@ export function decorateWidget(widgetName, cb) {
 }
 
 export function traverseCustomWidgets(tree, callback) {
+  if (!tree) {
+    return;
+  }
+
   if (tree.__type === "CustomWidget") {
     callback(tree);
   }


### PR DESCRIPTION
We already had this check sometimes in code, it's just safer to have this responsibility baked in the function.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
