### PR TITLE
DEV: referencing global exists is deprecated

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -3,6 +3,7 @@ import componentTest, {
 } from "discourse/tests/helpers/component-test";
 import {
   discourseModule,
+  exists,
   fakeTime,
   query,
   queryAll,


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
