### PR TITLE
FIX: Do not offer to save draft if invalid

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1189,9 +1189,6 @@ export default Controller.extend({
           },
           onSaveDraft: () => {
             this._saveDraft();
-            if (this.model.draftKey === Composer.NEW_TOPIC_KEY) {
-              this.currentUser.set("has_topic_draft", true);
-            }
             this.model.clearState();
             this.close();
             resolve();
@@ -1242,10 +1239,12 @@ export default Controller.extend({
           );
         }
       } else {
-        this._saveDraftPromise = model.saveDraft().finally(() => {
-          this._lastDraftSaved = Date.now();
-          this._saveDraftPromise = null;
-        });
+        this._saveDraftPromise = model
+          .saveDraft(this.currentUser)
+          .finally(() => {
+            this._lastDraftSaved = Date.now();
+            this._saveDraftPromise = null;
+          });
       }
     }
   },

--- a/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/discard-draft.hbs
@@ -6,6 +6,8 @@
 
 <div class="modal-footer">
   {{d-button icon="far-trash-alt" label="post.cancel_composer.discard" class="btn-danger discard-draft" action=(action "destroyDraft")}}
-  {{d-button label="post.cancel_composer.save_draft" class="save-draft" action=(action "saveDraftAndClose")}}
+  {{#if model.canSaveDraft}}
+    {{d-button label="post.cancel_composer.save_draft" class="save-draft" action=(action "saveDraftAndClose")}}
+  {{/if}}
   {{d-button label="post.cancel_composer.keep_editing" class="keep-editing" action=(action "dismissModal")}}
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -22,7 +22,7 @@ import LinkLookup from "discourse/lib/link-lookup";
 
 acceptance("Composer", function (needs) {
   needs.user();
-  needs.settings({ enable_whispers: true });
+  needs.settings({ enable_whispers: true, min_first_post_length: 20 });
   needs.site({ can_tag_topics: true });
   needs.pretender((server, helper) => {
     server.post("/uploads/lookup-urls", () => {
@@ -998,5 +998,14 @@ acceptance("Composer", function (needs) {
 
     await fillIn(".d-editor-input", "@staff");
     assert.ok(exists(".composer-popup"), "Shows the 'group_mentioned' notice");
+  });
+
+  test("Does not save invalid draft", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    await fillIn("#reply-title", "Something");
+    await fillIn(".d-editor-input", "Something");
+    await click(".save-or-cancel .cancel");
+    assert.notOk(exists(".discard-draft-modal .save-draft"));
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -22,7 +22,7 @@ import LinkLookup from "discourse/lib/link-lookup";
 
 acceptance("Composer", function (needs) {
   needs.user();
-  needs.settings({ enable_whispers: true, min_first_post_length: 20 });
+  needs.settings({ enable_whispers: true });
   needs.site({ can_tag_topics: true });
   needs.pretender((server, helper) => {
     server.post("/uploads/lookup-urls", () => {
@@ -1001,6 +1001,8 @@ acceptance("Composer", function (needs) {
   });
 
   test("Does not save invalid draft", async function (assert) {
+    this.siteSettings.min_first_post_length = 20;
+
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "Something");


### PR DESCRIPTION
An invalid draft is the draft of a topic with a short title or body.
The client does not save these, but it will ask the client if they want
to save it. Even if the answer is 'yes', the draft is discarded. This
commit skips Save button for small drafts.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
