### PR TITLE
UX: Remove theme-specific css, fix space

### DIFF
--- a/app/assets/stylesheets/common/select-kit/mini-tag-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/mini-tag-chooser.scss
@@ -68,10 +68,6 @@
           margin-right: 0.25em;
           margin-bottom: 0.25em;
 
-          .tag-icon {
-            margin-right: 0.25em;
-          }
-
           &.is-highlighted {
             box-shadow: 0 0 2px var(--danger), 0 1px 0 rgba(0, 0, 0, 0.05);
           }
@@ -79,6 +75,7 @@
           .d-icon {
             color: var(--primary-low-mid);
             vertical-align: middle;
+            margin-right: 0.25em;
           }
 
           &:hover .d-icon.d-icon-times {


### PR DESCRIPTION
Looks like the `.tag-icon` class is specific to https://meta.discourse.org/t/tag-icons-component/109757, using `.d-icon` removes that, still works for the theme, and also fixes this missing space issue

Before:
![Screen Shot 2021-07-27 at 5 28 13 PM](https://user-images.githubusercontent.com/1681963/127229880-f3bcf6d5-aae2-4a86-b8be-725aef9432a6.png)
After:
![Screen Shot 2021-07-27 at 5 30 37 PM](https://user-images.githubusercontent.com/1681963/127230164-82e49480-d7b4-44f9-9efa-6437f0e9fb33.png)
