### PR TITLE
FIX: Remove additional setting check for uppy-upload

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -151,10 +151,8 @@ export default Mixin.create({
       this._reset();
     });
 
-    if (
-      this.siteSettings.enable_s3_uploads &&
-      this.siteSettings.enable_direct_s3_uploads // hidden setting like enable_experimental_image_uploader
-    ) {
+    // hidden setting like enable_experimental_image_uploader
+    if (this.siteSettings.enable_direct_s3_uploads) {
       this._useS3Uploads();
     } else {
       this._useXHRUploads();


### PR DESCRIPTION
Because the enable_s3_uploads setting may be false for
some sites but GlobalSetting.use_s3? is true, we need to
remove this additional check in uppy-upload. The hidden
enable_direct_s3_uploads setting is sufficient.
