### PR TITLE
UX: User bookmark page style adjustments

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
@@ -52,7 +52,7 @@
               {{/if}}
             </td>
             {{#unless site.mobileView}}
-              <td>  
+              <td>
                 {{#if bookmark.post_user_avatar_template}}
                   <a href={{bookmark.postUser.path}} data-user-card={{bookmark.post_user_username}} class="avatar">
                     {{avatar bookmark.postUser avatarTemplatePath="avatar_template" usernamePath="username" namePath="name" imageSize="small"}}

--- a/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
@@ -2,66 +2,59 @@
   {{#load-more selector=".bookmark-list .bookmark-list-item" action=loadMore}}
     <table class="topic-list bookmark-list">
       <thead>
-        {{#if site.mobileView}}
-          <th>&nbsp;</th>
-          <th>{{i18n "topic.title"}}</th>
-          <th>&nbsp;</th>
-        {{else}}
+        {{#unless site.mobileView}}
           <th>{{i18n "topic.title"}}</th>
           <th>&nbsp;</th>
           <th class="post-metadata">{{i18n "post.bookmarks.updated"}}</th>
           <th class="post-metadata">{{i18n "activity"}}</th>
           <th>&nbsp;</th>
-        {{/if}}
+        {{/unless}}
       </thead>
       <tbody>
         {{#each content as |bookmark|}}
           <tr class="topic-list-item bookmark-list-item">
-            {{#if site.mobileView}}
-              <td>
-                {{#if bookmark.post_user_avatar_template}}
-                  <a href={{bookmark.postUser.path}} data-user-card={{bookmark.post_user_username}}>
-                    {{avatar bookmark.postUser avatarTemplatePath="avatar_template" usernamePath="username" namePath="name" imageSize="small"}}
-                  </a>
-                {{/if}}
-              </td>
-            {{/if}}
             <td class="main-link" role="rowheader">
               <span class="link-top-line">
                 <div class="bookmark-metadata">
-                  {{#if bookmark.name}}
-                    <span class="bookmark-metadata-item">
-                      {{d-icon "info-circle"}}{{bookmark.name}}
-                    </span>
-                  {{/if}}
                   {{#if bookmark.reminder_at}}
                     <span class="bookmark-metadata-item">
                       {{d-icon "far-clock"}}{{bookmark.formattedReminder}}
                     </span>
                   {{/if}}
+                  {{#if bookmark.name}}
+                    <span class="bookmark-metadata-item">
+                      {{d-icon "info-circle"}}<span>{{bookmark.name}}</span>
+                    </span>
+                  {{/if}}
                 </div>
-
                 <div class="bookmark-status-with-link">
                   {{#if bookmark.pinned}}
                     {{d-icon "thumbtack" class="bookmark-pinned"}}
                   {{/if}}
-                  {{topic-status topic=bookmark.topicStatus}}
+                  {{~topic-status topic=bookmark.topicStatus~}}
                   {{topic-link bookmark.topicLink}}
                 </div>
               </span>
-              {{#if bookmark.excerpt}}
-                {{!-- template-lint-disable  --}}
-                <p class="post-excerpt" {{on "click" this.screenExcerptForExternalLink}}>{{html-safe bookmark.excerpt}}</p>
-              {{/if}}
               <div class="link-bottom-line">
                 {{category-link bookmark.category}}
                 {{discourse-tags bookmark mode="list" tagsForUser=tagsForUser}}
               </div>
+              {{#if bookmark.excerpt}}
+                {{#if site.mobileView}}
+                  {{#if bookmark.post_user_avatar_template}}
+                    <a href={{bookmark.postUser.path}} data-user-card={{bookmark.post_user_username}} class="avatar">
+                      {{avatar bookmark.postUser avatarTemplatePath="avatar_template" usernamePath="username" namePath="name" imageSize="small"}}
+                    </a>
+                  {{/if}}
+                {{/if}}
+                {{!-- template-lint-disable --}}
+                <p class="post-excerpt" {{on "click" this.screenExcerptForExternalLink}}>{{html-safe bookmark.excerpt}}</p>
+              {{/if}}
             </td>
             {{#unless site.mobileView}}
-              <td>
+              <td>  
                 {{#if bookmark.post_user_avatar_template}}
-                  <a href={{bookmark.postUser.path}} data-user-card={{bookmark.post_user_username}}>
+                  <a href={{bookmark.postUser.path}} data-user-card={{bookmark.post_user_username}} class="avatar">
                     {{avatar bookmark.postUser avatarTemplatePath="avatar_template" usernamePath="username" namePath="name" imageSize="small"}}
                   </a>
                 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark-list.hbs
@@ -39,14 +39,10 @@
                 {{category-link bookmark.category}}
                 {{discourse-tags bookmark mode="list" tagsForUser=tagsForUser}}
               </div>
-              {{#if bookmark.excerpt}}
-                {{#if site.mobileView}}
-                  {{#if bookmark.post_user_avatar_template}}
-                    <a href={{bookmark.postUser.path}} data-user-card={{bookmark.post_user_username}} class="avatar">
-                      {{avatar bookmark.postUser avatarTemplatePath="avatar_template" usernamePath="username" namePath="name" imageSize="small"}}
-                    </a>
-                  {{/if}}
-                {{/if}}
+              {{#if (and site.mobileView bookmark.excerpt bookmark.post_user_avatar_template)}}
+                <a href={{bookmark.postUser.path}} data-user-card={{bookmark.post_user_username}} class="avatar">
+                  {{avatar bookmark.postUser avatarTemplatePath="avatar_template" usernamePath="username" namePath="name" imageSize="small"}}
+                </a>
                 {{!-- template-lint-disable --}}
                 <p class="post-excerpt" {{on "click" this.screenExcerptForExternalLink}}>{{html-safe bookmark.excerpt}}</p>
               {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/topic-status.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-status.hbs
@@ -30,4 +30,4 @@
 {{~#if topicInvisible~}}
   <span title={{invisibleTitle}} class="topic-status">{{invisibleIcon}}</span>
 {{~/if~}}
-{{plugin-outlet name="after-topic-status" tagName="" args=(hash topic=topic)}}
+{{plugin-outlet name="after-topic-status" tagName="" args=(hash topic=topic)~}}

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -57,12 +57,14 @@
 
 <section class="user-content">
   <div class="list-actions">
-    {{#if (and site.mobileView showNewPM)}}
-      {{d-button
-        class="btn-primary new-private-message"
-        action=(route-action "composePrivateMessage")
-        icon="envelope"
-        label="user.new_private_message"}}
+    {{#if site.mobileView}}
+      {{#if showNewPM}}
+        {{d-button
+          class="btn-primary new-private-message"
+          action=(route-action "composePrivateMessage")
+          icon="envelope"
+          label="user.new_private_message"}}
+      {{/if}}
     {{/if}}
 
     {{#if isGroup}}

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -57,14 +57,12 @@
 
 <section class="user-content">
   <div class="list-actions">
-    {{#if site.mobileView}}
-      {{#if showNewPM}}
-        {{d-button
-          class="btn-primary new-private-message"
-          action=(route-action "composePrivateMessage")
-          icon="envelope"
-          label="user.new_private_message"}}
-      {{/if}}
+    {{#if (and site.mobileView showNewPM)}}
+      {{d-button
+        class="btn-primary new-private-message"
+        action=(route-action "composePrivateMessage")
+        icon="envelope"
+        label="user.new_private_message"}}
     {{/if}}
 
     {{#if isGroup}}

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -160,6 +160,7 @@
     margin-top: 0.5em;
     margin-bottom: 0.5em;
     font-size: $font-down-2;
+    word-break: break-word;
   }
 }
 

--- a/app/assets/stylesheets/common/components/bookmark-list.scss
+++ b/app/assets/stylesheets/common/components/bookmark-list.scss
@@ -28,7 +28,6 @@ $mobile-breakpoint: 700px;
   }
   @media (max-width: $mobile-breakpoint) {
     .main-link {
-      padding-left: 0.5em;
       padding-right: 0.5em;
     }
   }
@@ -45,27 +44,25 @@ $mobile-breakpoint: 700px;
   }
   .bookmark-metadata {
     font-size: $font-down-2;
-    display: flex;
-    margin-bottom: 0.2em;
+    margin-bottom: 0.35em;
 
     &-item {
-      margin-right: 0.5em;
-      display: flex;
-      align-items: center;
+      display: inline-block;
+      margin-right: 1em;
+      margin-bottom: 0.25em;
+      line-height: $line-height-medium;
+      span {
+        word-break: break-word;
+      }
     }
 
     .d-icon {
-      // not aligning center because of multi-line notes
-      align-self: flex-start;
-      margin-right: 0.2em;
-      padding-top: 0.12em;
+      margin-right: 0.25em;
     }
 
     @media (max-width: $mobile-breakpoint) {
-      flex-direction: column;
       &-item {
         display: block;
-        margin-bottom: 0.2em;
       }
     }
   }
@@ -74,8 +71,27 @@ $mobile-breakpoint: 700px;
     flex-direction: row;
     align-items: center;
 
+    .mobile-view & {
+      margin-bottom: 0.15em;
+    }
     .topic-statuses {
       float: none;
+      &:empty {
+        // avoids extra margin
+        display: none;
+      }
+    }
+  }
+
+  .post-excerpt {
+    overflow: hidden;
+    padding-right: 1em;
+  }
+
+  .mobile-view & {
+    .avatar {
+      float: left;
+      margin: 0.27em 0.27em 0 0;
     }
   }
 }

--- a/app/assets/stylesheets/common/components/bookmark-list.scss
+++ b/app/assets/stylesheets/common/components/bookmark-list.scss
@@ -44,7 +44,7 @@ $mobile-breakpoint: 700px;
   }
   .bookmark-metadata {
     font-size: $font-down-2;
-    margin-bottom: 0.35em;
+    margin-bottom: 0.25em;
 
     &-item {
       display: inline-block;
@@ -58,12 +58,6 @@ $mobile-breakpoint: 700px;
 
     .d-icon {
       margin-right: 0.25em;
-    }
-
-    @media (max-width: $mobile-breakpoint) {
-      &-item {
-        display: block;
-      }
     }
   }
   .bookmark-status-with-link {


### PR DESCRIPTION
* Updated the mobile layout to utilize space better, also removed the superfluous table header
* Fixed an issue where long words would break the mobile layout 
* Fixed some cross-browser icon alignment inconsistencies (the 🕐 and ℹ️ )
* Some general spacing adjustments between elements 
* Removed some extra white space in the topic-status container 
* Moved the category/tag line back under the title, to be consistent with topic lists everywhere else 

Before/After

![Screen Shot 2021-07-27 at 10 28 11 PM](https://user-images.githubusercontent.com/1681963/127254061-ef524f49-e795-4dc1-bfff-a5b4ad5da622.png)
![Screen Shot 2021-07-27 at 10 37 27 PM](https://user-images.githubusercontent.com/1681963/127254858-0c3cd162-1905-4890-b577-180f23733281.png)




![Screen Shot 2021-07-27 at 10 28 20 PM](https://user-images.githubusercontent.com/1681963/127254062-8996a262-b67e-400a-9fd9-e9ec41c86c23.png)
![Screen Shot 2021-07-27 at 10 39 21 PM](https://user-images.githubusercontent.com/1681963/127254937-a54c3b2b-adaf-4655-abe6-910f5a050124.png)
