### PR TITLE
DEV: suppress assets logs from qunit tests

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -25,7 +25,7 @@ end
 # feel free to point this anywhere accessible on the filesystem
 pid (ENV["UNICORN_PID_PATH"] || "#{discourse_path}/tmp/pids/unicorn.pid")
 
-if ENV["RAILS_ENV"] != "production"
+if ENV["RAILS_ENV"] == "development" || !ENV["RAILS_ENV"]
   logger Logger.new($stdout)
   # we want a longer timeout in dev cause first request can be really slow
   timeout (ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)


### PR DESCRIPTION
Partially reverts: https://github.com/discourse/discourse/commit/956f8492507f6004272b1e6900f3e56c5c0f41a1

Note that this way of running tests will soon be deprecated in favor of `ember test` and this shouldn’t matter anymore.