### PR TITLE
DEV: resets user search cache between tests

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -12,6 +12,14 @@ let cache = {},
   currentTerm,
   oldSearch;
 
+export function resetUserSearchCache() {
+  cache = {};
+  cacheKey = null;
+  cacheTime = null;
+  currentTerm = null;
+  oldSearch = null;
+}
+
 function performSearch(
   term,
   topicId,

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -34,6 +34,7 @@ import { resetDecorators as resetPostCookedDecorators } from "discourse/widgets/
 import { resetTopicTitleDecorators } from "discourse/components/topic-title";
 import { resetUsernameDecorators } from "discourse/helpers/decorate-username-selector";
 import { resetWidgetCleanCallbacks } from "discourse/components/mount-widget";
+import { resetUserSearchCache } from "discourse/lib/user-search";
 import sessionFixtures from "discourse/tests/fixtures/session-fixtures";
 import { setTopicList } from "discourse/lib/topic-list-tracker";
 import sinon from "sinon";
@@ -272,6 +273,7 @@ export function acceptance(name, optionsOrCallback) {
       resetUsernameDecorators();
       resetOneboxCache();
       resetCustomPostMessageCallbacks();
+      resetUserSearchCache();
       clearCustomNavItemHref();
       setTopicList(null);
       _clearSnapshots();


### PR DESCRIPTION
The current behaviour was producing random tests failures which where consistently reproducible using `seed=32037592518471299633729129648744282271`

```
Test Errors
----------------------------------------------
  Test Failed: it returns cancel when eager completing with no results
    Assertion Failed:
      Expected: __CANCELLED, Actual: [object Object],[object Object],[object Object]    
    Assertion Failed:
      Expected: __CANCELLED, Actual: [object Object],[object Object],[object Object]
    at Object.eval (discourse/tests/unit/lib/user-search-test:87:21)
    at processModule (qunit:1192:16)
    at module$1 (qunit:1217:4)
    at eval (discourse/tests/unit/lib/user-search-test:4:21)
    at obj (discourse-loader:366:31)
    at tryFinally (discourse-loader:190:14)
    at require (discourse-loader:363:5)
```

The cause of this error, is the test not giving any topicId or categoryId resulting in a cache key "undefined-undefined", just like a possibly previous test. Reseting cache between tests, seems the most straightforward and future proof solution

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
