### PR TITLE
UX: spacing adjustments, mobile nav refactor

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -1,29 +1,35 @@
 {{#d-section class=sectionClass pageClass="user-messages"}}
   {{#if inboxes.length}}
+    <div class="inboxes-controls">
+      {{combo-box
+        content=inboxes
+        classNames="user-messages-inboxes-drop"
+        value=selectedInbox
+        onChange=(action "updateInbox")
+        options=(hash
+          filterable=true
+        )
+      }}
+      {{#if (and group site.mobileView)}}
+        {{group-notifications-button
+          value=group.group_user.notification_level
+          onChange=(action "changeGroupNotificationLevel")
+        }}
+      {{/if}}
+    </div>
+  {{/if}}
+
+  {{#if (and pmTaggingEnabled tagsContent)}}
     {{combo-box
-      content=inboxes
-      classNames="user-messages-inboxes-drop"
-      value=selectedInbox
-      onChange=(action "updateInbox")
+      content=tagsContent
+      value=tag
+      classNames="user-messages-tags-drop"
       options=(hash
         filterable=true
+        none="tagging.selector_all_tags"
       )
     }}
   {{/if}}
-
-  {{#unless site.mobileView}}
-    {{#if (and pmTaggingEnabled tagsContent)}}
-      {{combo-box
-        content=tagsContent
-        value=tag
-        classNames="user-messages-tags-drop"
-        options=(hash
-          filterable=true
-          none="tagging.selector_all_tags"
-        )
-      }}
-    {{/if}}
-  {{/unless}}
 
   {{#mobile-nav class="messages-nav" desktopClass="nav-stacked action-list"}}
     {{#if isAllInbox}}
@@ -105,25 +111,28 @@
         {{/link-to}}
       </li>
     {{/if}}
-
-    {{#unless mobileView}}
-      {{#if group}}
-        <li>
-          {{group-notifications-button
-            value=group.group_user.notification_level
-            onChange=(action "changeGroupNotificationLevel")
-          }}
-        </li>
-      {{/if}}
-
-      {{#if showNewPM}}
-        <li>
-          {{d-button class="btn-primary new-private-message" action=(route-action "composePrivateMessage") icon="envelope" label="user.new_private_message"}}
-        </li>
-      {{/if}}
-    {{/unless}}
   {{/mobile-nav}}
 {{/d-section}}
+
+{{#if site.mobileView}}
+  {{#if showNewPM}}
+    {{d-button class="btn-primary new-private-message" action=(route-action "composePrivateMessage") icon="envelope" label="user.new_private_message"}}
+  {{/if}}
+{{/if}}
+
+{{#unless site.mobileView}}
+  <section class="user-additional-controls">
+    {{#if group}}
+      {{group-notifications-button
+        value=group.group_user.notification_level
+        onChange=(action "changeGroupNotificationLevel")
+      }}
+    {{/if}}
+    {{#if showNewPM}}
+      {{d-button class="btn-primary new-private-message" action=(route-action "composePrivateMessage") icon="envelope" label="user.new_private_message"}}
+    {{/if}}
+  </section>
+{{/unless}}
 
 <section class="user-content">
   {{#if showWarningsWarning}}

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -114,10 +114,8 @@
   {{/mobile-nav}}
 {{/d-section}}
 
-{{#if site.mobileView}}
-  {{#if showNewPM}}
-    {{d-button class="btn-primary new-private-message" action=(route-action "composePrivateMessage") icon="envelope" label="user.new_private_message"}}
-  {{/if}}
+{{#if (and site.mobileView showNewPM)}}
+  {{d-button class="btn-primary new-private-message" action=(route-action "composePrivateMessage") icon="envelope" label="user.new_private_message"}}
 {{/if}}
 
 {{#unless site.mobileView}}

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -66,12 +66,10 @@
 .nav-stacked {
   @extend %nav;
   padding: 0;
-  overflow: hidden;
   background: var(--primary-low);
 
   li {
     border-bottom: 1px solid var(--primary-low);
-    position: relative;
 
     &:last-of-type {
       border-bottom: 0;
@@ -89,6 +87,7 @@
     line-height: $line-height-small;
     cursor: pointer;
     color: var(--primary);
+    @include ellipsis;
 
     &.active {
       color: var(--secondary);

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -22,11 +22,14 @@
 
   .combo-box {
     width: 100%;
-    margin-top: 1px;
+    &:not(:last-of-type) {
+      margin-bottom: 0.875em;
+    }
   }
 
   .nav-stacked {
     background-color: transparent;
+    margin: 0;
 
     li {
       border-bottom: none;
@@ -51,10 +54,23 @@
     }
   }
 
+  .select-kit + .messages-nav {
+    margin-top: 1em;
+  }
+
+  .inboxes-controls {
+    margin-bottom: 0.75em;
+  }
+
   &.user-messages {
+    --left-padding: 0.8em;
     .user-messages-inboxes-drop,
     .user-messages-tags-drop {
-      padding: 13px 13px 0 0;
+      padding: 0 1em 0 0;
+
+      .select-kit-header {
+        padding-left: var(--left-padding);
+      }
 
       .select-kit-selected-name {
         overflow: hidden;
@@ -63,13 +79,16 @@
 
     .nav-stacked {
       a {
-        padding-left: 0;
-      }
-
-      .new-private-message {
-        margin-top: 13px;
+        padding-left: calc(
+          var(--left-padding) - 1px
+        ); // 1px accounts for border on select-kit elements above
       }
     }
+  }
+}
+.user-additional-controls {
+  button {
+    margin-bottom: 1em;
   }
 }
 
@@ -247,6 +266,16 @@ table.user-invite-list {
 
   .public-user-fields {
     overflow: hidden;
+  }
+}
+
+.user-messages-page {
+  .topic-list th {
+    padding-top: 4px;
+  }
+
+  .show-mores {
+    position: absolute;
   }
 }
 

--- a/app/assets/stylesheets/mobile/user.scss
+++ b/app/assets/stylesheets/mobile/user.scss
@@ -4,8 +4,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: auto auto auto;
-  grid-row-gap: 20px;
-  grid-column-gap: 16px;
+  grid-gap: 16px;
   .user-primary-navigation {
     grid-column-start: 1;
     grid-row-start: 1;
@@ -31,37 +30,82 @@
     grid-column-start: 1;
   }
 
+  // specific to messages
+
   .user-messages.user-messages-inboxes {
     grid-row-start: 2;
-    grid-row-end: 3;
     grid-column-start: 1;
     grid-column-end: 3;
+
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto auto auto;
-    grid-column-gap: 16px;
+    gap: 16px;
 
-    .user-messages-inboxes-drop {
-      grid-row-start: 1;
-      grid-row-end: 2;
+    + .user-additional-controls {
+      grid-row-start: 2;
       grid-column-start: 1;
-      grid-column-end: 2;
+    }
+  }
 
-      .select-kit-header {
-        padding: 8px 10px;
+  .inboxes-controls {
+    display: flex;
+  }
 
-        .caret-icon {
-          color: var(--primary-medium);
-        }
+  .user-messages-inboxes-drop {
+    padding: 0;
+    flex: 1 1 auto;
+    .select-kit-header {
+      padding: 8px 10px;
+
+      .caret-icon {
+        color: var(--primary-medium);
       }
     }
+  }
 
-    .messages-nav {
-      grid-row-start: 1;
-      grid-row-end: 2;
-      grid-column-start: 2;
-      grid-column-end: 3;
+  .messages-nav {
+    grid-column-start: 2;
+    grid-column-end: 3;
+    grid-row-start: 1;
+  }
+
+  .user-messages-tags-drop {
+    justify-self: start;
+    margin-bottom: -1.5em; // pulls the topic list below closer
+    .select-kit-header {
+      border: none;
+      justify-self: start;
+      padding-left: 10px;
     }
+    &.single-select.is-expanded .select-kit-header {
+      outline: none;
+    }
+  }
+
+  .new-private-message {
+    grid-row-start: 1;
+    grid-column-start: 2;
+  }
+
+  .group-notifications-button {
+    margin-left: 8px;
+
+    .select-kit-header {
+      height: 100%;
+
+      .selected-name .name {
+        display: none;
+      }
+    }
+  }
+}
+
+.user-messages-page {
+  .paginated-topics-list {
+    margin-top: 0;
+  }
+  .show-mores {
+    margin-top: 0.5em;
   }
 }
 
@@ -199,6 +243,10 @@
       flex: 1 1 25%;
       margin-left: auto;
 
+      .btn {
+        margin-bottom: 16px;
+      }
+
       ul {
         margin: 0;
         display: flex;
@@ -256,6 +304,7 @@
 
 .user-main .collapsed-info.about .details {
   display: flex;
+  margin-bottom: 16px;
   .user-profile-avatar {
     margin: 0;
     flex: 0 0 auto;


### PR DESCRIPTION
On desktop I've adjusted the spacing a bit, and moved the tracking & new message buttons outside of the vertical `ul`, this matches what other user pages do and spaces things out a little more. I also fixed an issue where the tracking dropdown was cropped due to overflow being hidden. 

The tracking nav on mobile wasn't working in the dropdown, so I tried to restructure things in a reasonable way to avoid it... also trying to make tags visible because I know some admins use them a lot (the mobile user nav could probably use a total redesign soon... there's a lot going on).


Before/After

![Screen Shot 2021-07-28 at 2 32 30 PM](https://user-images.githubusercontent.com/1681963/127377063-760ebabf-75fb-4dd6-84a6-7b64488810b3.png)
![Screen Shot 2021-07-28 at 2 16 19 PM](https://user-images.githubusercontent.com/1681963/127377092-c5e3ed76-e18c-40ff-8d8e-68e8480a34c4.png)

![Screen Shot 2021-07-28 at 2 32 12 PM](https://user-images.githubusercontent.com/1681963/127377125-7efaf873-66da-4f78-a9fb-cd088d81c1bb.png)
![Screen Shot 2021-07-28 at 2 16 44 PM](https://user-images.githubusercontent.com/1681963/127377111-6e0e03b7-03db-43a8-b282-e8cd5284b5b3.png)

![Screen Shot 2021-07-28 at 2 31 43 PM](https://user-images.githubusercontent.com/1681963/127377188-c4324876-6805-40a2-8f61-b8468cc684c8.png) 
![Screen Shot 2021-07-28 at 2 17 24 PM](https://user-images.githubusercontent.com/1681963/127377219-57072796-18e7-4a0b-a0e9-1c3687a03642.png)

![Screen Shot 2021-07-28 at 2 31 54 PM](https://user-images.githubusercontent.com/1681963/127377562-a9178da1-c6e4-4145-9a23-2767c8f2ac5a.png)
![Screen Shot 2021-07-28 at 2 18 57 PM](https://user-images.githubusercontent.com/1681963/127377525-3ea33dbc-5fb0-4f67-b81e-98eb66b36295.png)


