### PR TITLE
Revert "DEV: suppress assets logs from qunit tests (#13871)"

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -25,7 +25,7 @@ end
 # feel free to point this anywhere accessible on the filesystem
 pid (ENV["UNICORN_PID_PATH"] || "#{discourse_path}/tmp/pids/unicorn.pid")
 
-if ENV["RAILS_ENV"] == "development" || !ENV["RAILS_ENV"]
+if ENV["RAILS_ENV"] != "production"
   logger Logger.new($stdout)
   # we want a longer timeout in dev cause first request can be really slow
   timeout (ENV["UNICORN_TIMEOUT"] && ENV["UNICORN_TIMEOUT"].to_i || 60)


### PR DESCRIPTION
This reverts commit 1b649016d91737ec666f73418ed4229bcbb24601.

Test is failing with the following message:

```
navigate to  http://localhost:60099/qunit?hidepassed=1&seed=312984199721107128645754962579661839397&qunit_disable_auto_start=1
2021-07-29T02:57:13.303Z - (type: network/error) message: Failed to load resource: the server responded with a status of 403 (Forbidden), url: http://localhost:60099/extra-locales/admin?v=eeeea38a700966a1a7fb600b23f3a222
2021-07-29T02:57:43.823Z - (type: network/error) message: Failed to load resource: net::ERR_EMPTY_RESPONSE, url: http://localhost:60099/assets/discourse/tests/test_helper.js
ReferenceError: define is not defined
    at eval (discourse/tests/acceptance/about-test:1:1)
    at http://localhost:60099/assets/discourse/tests/core_plugins_tests.js:1:1
ReferenceError: require is not defined
    at eval (discourse/tests/test_starter:5:24)
    at http://localhost:60099/assets/discourse/tests/test_starter.js:1:1
2021-07-29T02:57:43.891Z - (type: network/error) message: Failed to load resource: the server responded with a status of 403 (Forbidden), url: http://localhost:60099/extra-locales/admin?v=eeeea38a700966a1a7fb600b23f3a222

Tests timed out
```