### PR TITLE
FIX: Avoid creating a post revision when topic tags have not changed.

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -372,6 +372,11 @@ class TopicsController < ApplicationController
     changes.delete(:title) if topic.title == changes[:title]
     changes.delete(:category_id) if topic.category_id.to_i == changes[:category_id].to_i
 
+    if Tag.include_tags?
+      topic_tags = topic.tags.map(&:name).sort
+      changes.delete(:tags) if changes[:tags]&.sort == topic_tags
+    end
+
     success = true
 
     if changes.length > 0

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1470,6 +1470,18 @@ RSpec.describe TopicsController do
             expect(response.status).to eq(200)
             expect(topic.tags).to eq([])
           end
+
+          it 'does not cause a revision when tags have not changed' do
+            topic.tags << tag
+
+            expect do
+              put "/t/#{topic.slug}/#{topic.id}.json", params: {
+                tags: [tag.name]
+              }
+            end.to change { topic.reload.first_post.revisions.count }.by(0)
+
+            expect(response.status).to eq(200)
+          end
         end
 
         context 'when topic is private' do


### PR DESCRIPTION
Co-authored-by: jmperez127 <jmperez127@gmail.com>