### PR TITLE
FIX: Add users-directory-controls outlet to mobile template

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/users.hbs
@@ -33,6 +33,7 @@
             class="btn-default open-edit-columns-btn"
           }}
         {{/if}}
+        {{plugin-outlet name="users-directory-controls" connectorTagName="" tagName="" args=(hash model=model)}}
       </div>
 
       {{#conditional-loading-spinner condition=isLoading}}


### PR DESCRIPTION
This outlet was added to the desktop template in e1175f9f

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
