### PR TITLE
DEV: Plugin API to add card listener elements

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/group-card-contents.js
@@ -11,7 +11,7 @@ const maxMembersToDisplay = 10;
 
 export default Component.extend(CardContentsBase, CleansUp, {
   elementId: "group-card",
-  triggeringLinkClass: "mention-group",
+  mentionSelector: "a.mention-group",
   classNames: ["no-bg", "group-card"],
   classNameBindings: [
     "visible:show",

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -16,7 +16,9 @@ import { prioritizeNameInUx } from "discourse/lib/settings";
 export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
   elementId: "user-card",
   classNames: "user-card",
-  triggeringLinkClass: "mention",
+  avatarSelector: "[data-user-card]",
+  avatarDataAttrKey: "userCard",
+  mentionSelector: "a.mention",
   classNameBindings: [
     "visible:show",
     "showBadges",

--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -2,7 +2,8 @@ import DiscourseURL from "discourse/lib/url";
 
 export function wantsNewWindow(e) {
   return (
-    e.isDefaultPrevented() ||
+    e.defaultPrevented ||
+    (e.isDefaultPrevernted && e.isDefaultPrevented()) ||
     e.shiftKey ||
     e.metaKey ||
     e.ctrlKey ||

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -37,6 +37,7 @@ import DiscourseBanner from "discourse/components/discourse-banner";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
 import Sharing from "discourse/lib/sharing";
 import { addAdvancedSearchOptions } from "discourse/components/search-advanced-options";
+import { addCardClickListenerSelector } from "discourse/mixins/card-contents-base";
 import { addCategorySortCriteria } from "discourse/components/edit-category-settings";
 import { addDecorator } from "discourse/widgets/post-cooked";
 import { addDiscoveryQueryParam } from "discourse/controllers/discovery-sortable";
@@ -1082,6 +1083,14 @@ class PluginApi {
    */
   addCategorySortCriteria(criteria) {
     addCategorySortCriteria(criteria);
+  }
+
+  /**
+   * Card contents mixin will add a listener to elements matching this selector
+   * that will open card contents on click
+   */
+  addCardClickListenerSelector(selector) {
+    addCardClickListenerSelector(selector);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -1087,7 +1087,8 @@ class PluginApi {
 
   /**
    * Card contents mixin will add a listener to elements matching this selector
-   * that will open card contents on click
+   * that will open card contents when a mention of div with the correct data attribute
+   * is clicked
    */
   addCardClickListenerSelector(selector) {
     addCardClickListenerSelector(selector);

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -8,6 +8,11 @@ import headerOutletHeights from "discourse/lib/header-outlet-height";
 import { inject as service } from "@ember/service";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 
+let _cardClickListenerSelectors = ["#main-outlet"];
+export function addCardClickListenerSelector(selector) {
+  _cardClickListenerSelectors.push(selector);
+}
+
 export default Mixin.create({
   router: service(),
 
@@ -117,20 +122,22 @@ export default Mixin.create({
         return true;
       });
 
-    $("#main-outlet").on(clickDataExpand, `[data-${id}]`, (e) => {
-      if (wantsNewWindow(e)) {
-        return;
-      }
-      const $target = $(e.currentTarget);
-      return this._show($target.data(id), $target);
-    });
+    _cardClickListenerSelectors.forEach((selector) => {
+      $(selector).on(clickDataExpand, `[data-${id}]`, (e) => {
+        if (wantsNewWindow(e)) {
+          return;
+        }
+        const $target = $(e.currentTarget);
+        return this._show($target.data(id), $target);
+      });
 
-    $("#main-outlet").on(clickMention, `a.${triggeringLinkClass}`, (e) => {
-      if (wantsNewWindow(e)) {
-        return;
-      }
-      const $target = $(e.currentTarget);
-      return this._show($target.text().replace(/^@/, ""), $target);
+      $(selector).on(clickMention, `a.${triggeringLinkClass}`, (e) => {
+        if (wantsNewWindow(e)) {
+          return;
+        }
+        const $target = $(e.currentTarget);
+        return this._show($target.text().replace(/^@/, ""), $target);
+      });
     });
 
     this.appEvents.on(previewClickEvent, this, "_previewClick");

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -136,11 +136,15 @@ export default Mixin.create({
 
   _cardClickHandler(e) {
     if (this.avatarSelector) {
-      this._showCardOnClick(
+      let matched = this._showCardOnClick(
         e,
         this.avatarSelector,
         (el) => el.dataset[this.avatarDataAttrKey]
       );
+
+      if (matched) {
+        return; // Don't need to check for mention click; it's an avatar click
+      }
     }
 
     // Mention click

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -134,10 +134,10 @@ export default Mixin.create({
     );
   },
 
-  _cardClickHandler(e) {
+  _cardClickHandler(event) {
     if (this.avatarSelector) {
       let matched = this._showCardOnClick(
-        e,
+        event,
         this.avatarSelector,
         (el) => el.dataset[this.avatarDataAttrKey]
       );
@@ -148,7 +148,7 @@ export default Mixin.create({
     }
 
     // Mention click
-    this._showCardOnClick(e, this.mentionSelector, (el) =>
+    this._showCardOnClick(event, this.mentionSelector, (el) =>
       el.innerText.replace(/^@/, "")
     );
   },


### PR DESCRIPTION
If plugins add content outside of `#main-outlet`, mentions and divs with `data-user-card` that should pop up the user card, do not. This allows plugins to pass in selectors that need the same listeners that `#main-outlet` gets.

If anyone has better naming ideas, PLZ LMK am I right?!