### PR TITLE
DEV: don't swallow a promise from group.findMembers method and switch to using async/await

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/group-card-contents.js
@@ -51,7 +51,7 @@ export default Component.extend(CardContentsBase, CleansUp, {
         }
         return group.can_see_members &&
           group.members.length < maxMembersToDisplay
-          ? group.findMembers({ limit: maxMembersToDisplay }, true)
+          ? group.reloadMembers({ limit: maxMembersToDisplay }, true)
           : Promise.resolve();
       })
       .catch(() => this._close())

--- a/app/assets/javascripts/discourse/app/controllers/group-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-index.js
@@ -35,10 +35,10 @@ export default Controller.extend({
 
   @observes("order", "asc", "filter")
   _filtersChanged() {
-    this.findMembers(true);
+    this.reloadMembers(true);
   },
 
-  findMembers(refresh) {
+  reloadMembers(refresh) {
     if (this.loading || !this.model) {
       return;
     }
@@ -49,7 +49,7 @@ export default Controller.extend({
     }
 
     this.set("loading", true);
-    this.model.findMembers(this.memberParams, refresh).finally(() => {
+    this.model.reloadMembers(this.memberParams, refresh).finally(() => {
       this.setProperties({
         "application.showFooter":
           this.model.members.length >= this.model.user_count,
@@ -85,7 +85,7 @@ export default Controller.extend({
 
   @action
   loadMore() {
-    this.findMembers();
+    this.reloadMembers();
   },
 
   @action
@@ -128,7 +128,7 @@ export default Controller.extend({
           type: "DELETE",
           data: { user_ids: selection.map((u) => u.id).join(",") },
         }).then(() => {
-          this.model.findMembers(this.memberParams, true);
+          this.model.reloadMembers(this.memberParams, true);
           this.set("isBulk", false);
         });
 

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -34,9 +34,9 @@ const Group = RestModel.extend({
     return automatic ? "automatic" : "custom";
   },
 
-  findMembers(params, refresh) {
+  async findMembers(params, refresh) {
     if (isEmpty(this.name) || !this.can_see_members) {
-      return Promise.reject();
+      return;
     }
 
     if (refresh) {
@@ -48,25 +48,24 @@ const Group = RestModel.extend({
       params
     );
 
-    return Group.loadMembers(this.name, params).then((result) => {
-      const ownerIds = new Set();
-      result.owners.forEach((owner) => ownerIds.add(owner.id));
+    const response = await Group.loadMembers(this.name, params);
+    const ownerIds = new Set();
+    response.owners.forEach((owner) => ownerIds.add(owner.id));
 
-      const members = refresh ? [] : this.members;
-      members.pushObjects(
-        result.members.map((member) => {
-          member.owner = ownerIds.has(member.id);
-          member.primary = member.primary_group_name === this.name;
-          return User.create(member);
-        })
-      );
+    const members = refresh ? [] : this.members;
+    members.pushObjects(
+      response.members.map((member) => {
+        member.owner = ownerIds.has(member.id);
+        member.primary = member.primary_group_name === this.name;
+        return User.create(member);
+      })
+    );
 
-      this.setProperties({
-        members,
-        user_count: result.meta.total,
-        limit: result.meta.limit,
-        offset: result.meta.offset,
-      });
+    this.setProperties({
+      members,
+      user_count: response.meta.total,
+      limit: response.meta.limit,
+      offset: response.meta.offset,
     });
   },
 
@@ -100,56 +99,59 @@ const Group = RestModel.extend({
     });
   },
 
-  removeOwner(member) {
-    return ajax(`/admin/groups/${this.id}/owners.json`, {
+  async removeOwner(member) {
+    await ajax(`/admin/groups/${this.id}/owners.json`, {
       type: "DELETE",
       data: { user_id: member.id },
-    }).then(() => this.findMembers({}, true));
+    });
+    await this.findMembers({}, true);
   },
 
-  removeMember(member, params) {
-    return ajax(`/groups/${this.id}/members.json`, {
+  async removeMember(member, params) {
+    await ajax(`/groups/${this.id}/members.json`, {
       type: "DELETE",
       data: { user_id: member.id },
-    }).then(() => this.findMembers(params, true));
+    });
+    await this.findMembers(params, true);
   },
 
-  leave() {
-    return ajax(`/groups/${this.id}/leave.json`, {
+  async leave() {
+    await ajax(`/groups/${this.id}/leave.json`, {
       type: "DELETE",
-    }).then(() => this.findMembers({}, true));
+    });
+    await this.findMembers({}, true);
   },
 
-  addMembers(usernames, filter, notifyUsers, emails = []) {
-    return ajax(`/groups/${this.id}/members.json`, {
+  async addMembers(usernames, filter, notifyUsers, emails = []) {
+    const response = await ajax(`/groups/${this.id}/members.json`, {
       type: "PUT",
       data: { usernames, emails, notify_users: notifyUsers },
-    }).then((response) => {
-      if (filter) {
-        return this._filterMembers(response.usernames);
-      } else {
-        return this.findMembers();
-      }
     });
+    if (filter) {
+      await this._filterMembers(response.usernames);
+    } else {
+      await this.findMembers();
+    }
   },
 
-  join() {
-    return ajax(`/groups/${this.id}/join.json`, {
+  async join() {
+    await ajax(`/groups/${this.id}/join.json`, {
       type: "PUT",
-    }).then(() => this.findMembers({}, true));
+    });
+    await this.findMembers({}, true);
   },
 
-  addOwners(usernames, filter, notifyUsers) {
-    return ajax(`/admin/groups/${this.id}/owners.json`, {
+  async addOwners(usernames, filter, notifyUsers) {
+    const response = await ajax(`/admin/groups/${this.id}/owners.json`, {
       type: "PUT",
       data: { group: { usernames, notify_users: notifyUsers } },
-    }).then((response) => {
-      if (filter) {
-        return this._filterMembers(response.usernames);
-      } else {
-        return this.findMembers({}, true);
-      }
     });
+
+    if (filter) {
+      await this._filterMembers(response.usernames);
+    } else {
+      await this.findMembers({}, true);
+    }
   },
 
   _filterMembers(usernames) {
@@ -289,19 +291,19 @@ const Group = RestModel.extend({
     return attrs;
   },
 
-  create() {
-    return ajax("/admin/groups", {
+  async create() {
+    const response = await ajax("/admin/groups", {
       type: "POST",
       data: { group: this.asJSON() },
-    }).then((resp) => {
-      this.setProperties({
-        id: resp.basic_group.id,
-        usernames: null,
-        ownerUsernames: null,
-      });
-
-      return this.findMembers();
     });
+
+    this.setProperties({
+      id: response.basic_group.id,
+      usernames: null,
+      ownerUsernames: null,
+    });
+
+    await this.findMembers();
   },
 
   save(opts = {}) {

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -126,9 +126,9 @@ const Group = RestModel.extend({
       data: { usernames, emails, notify_users: notifyUsers },
     }).then((response) => {
       if (filter) {
-        this._filterMembers(response.usernames);
+        return this._filterMembers(response.usernames);
       } else {
-        this.findMembers();
+        return this.findMembers();
       }
     });
   },
@@ -136,9 +136,7 @@ const Group = RestModel.extend({
   join() {
     return ajax(`/groups/${this.id}/join.json`, {
       type: "PUT",
-    }).then(() => {
-      this.findMembers({}, true);
-    });
+    }).then(() => this.findMembers({}, true));
   },
 
   addOwners(usernames, filter, notifyUsers) {
@@ -147,9 +145,9 @@ const Group = RestModel.extend({
       data: { group: { usernames, notify_users: notifyUsers } },
     }).then((response) => {
       if (filter) {
-        this._filterMembers(response.usernames);
+        return this._filterMembers(response.usernames);
       } else {
-        this.findMembers({}, true);
+        return this.findMembers({}, true);
       }
     });
   },
@@ -302,7 +300,7 @@ const Group = RestModel.extend({
         ownerUsernames: null,
       });
 
-      this.findMembers();
+      return this.findMembers();
     });
   },
 

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -34,7 +34,7 @@ const Group = RestModel.extend({
     return automatic ? "automatic" : "custom";
   },
 
-  async findMembers(params, refresh) {
+  async reloadMembers(params, refresh) {
     if (isEmpty(this.name) || !this.can_see_members) {
       return;
     }
@@ -104,7 +104,7 @@ const Group = RestModel.extend({
       type: "DELETE",
       data: { user_id: member.id },
     });
-    await this.findMembers({}, true);
+    await this.reloadMembers({}, true);
   },
 
   async removeMember(member, params) {
@@ -112,14 +112,14 @@ const Group = RestModel.extend({
       type: "DELETE",
       data: { user_id: member.id },
     });
-    await this.findMembers(params, true);
+    await this.reloadMembers(params, true);
   },
 
   async leave() {
     await ajax(`/groups/${this.id}/leave.json`, {
       type: "DELETE",
     });
-    await this.findMembers({}, true);
+    await this.reloadMembers({}, true);
   },
 
   async addMembers(usernames, filter, notifyUsers, emails = []) {
@@ -130,7 +130,7 @@ const Group = RestModel.extend({
     if (filter) {
       await this._filterMembers(response.usernames);
     } else {
-      await this.findMembers();
+      await this.reloadMembers();
     }
   },
 
@@ -138,7 +138,7 @@ const Group = RestModel.extend({
     await ajax(`/groups/${this.id}/join.json`, {
       type: "PUT",
     });
-    await this.findMembers({}, true);
+    await this.reloadMembers({}, true);
   },
 
   async addOwners(usernames, filter, notifyUsers) {
@@ -150,12 +150,12 @@ const Group = RestModel.extend({
     if (filter) {
       await this._filterMembers(response.usernames);
     } else {
-      await this.findMembers({}, true);
+      await this.reloadMembers({}, true);
     }
   },
 
   _filterMembers(usernames) {
-    return this.findMembers({ filter: usernames.join(",") });
+    return this.reloadMembers({ filter: usernames.join(",") });
   },
 
   @discourseComputed("display_name", "name")
@@ -303,7 +303,7 @@ const Group = RestModel.extend({
       ownerUsernames: null,
     });
 
-    await this.findMembers();
+    await this.reloadMembers();
   },
 
   save(opts = {}) {

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -126,7 +126,7 @@ const Group = RestModel.extend({
       data: { usernames, emails, notify_users: notifyUsers },
     }).then((response) => {
       if (filter) {
-        this._filterMembers(response);
+        this._filterMembers(response.usernames);
       } else {
         this.findMembers();
       }
@@ -147,15 +147,15 @@ const Group = RestModel.extend({
       data: { group: { usernames, notify_users: notifyUsers } },
     }).then((response) => {
       if (filter) {
-        this._filterMembers(response);
+        this._filterMembers(response.usernames);
       } else {
         this.findMembers({}, true);
       }
     });
   },
 
-  _filterMembers(response) {
-    return this.findMembers({ filter: response.usernames.join(",") });
+  _filterMembers(usernames) {
+    return this.findMembers({ filter: usernames.join(",") });
   },
 
   @discourseComputed("display_name", "name")

--- a/app/assets/javascripts/discourse/app/routes/group-index.js
+++ b/app/assets/javascripts/discourse/app/routes/group-index.js
@@ -20,7 +20,7 @@ export default DiscourseRoute.extend({
       showing: "members",
     });
 
-    controller.findMembers(true);
+    controller.reloadMembers(true);
   },
 
   @action


### PR DESCRIPTION
We found this problem when working on improving methods for adding and removing users from groups (see https://github.com/discourse/discourse/pull/13807#discussion_r674167047).

This PR removes swallowing promises, switch some functions to using `async / await` and renames functions  from`findMembers` to `reloadMembers`.
