### PR TITLE
FIX: Remapping of uploads could fail during restore of backup

### DIFF
--- a/lib/backup_restore/restorer.rb
+++ b/lib/backup_restore/restorer.rb
@@ -52,7 +52,6 @@ module BackupRestore
 
       reload_site_settings
 
-      @system.unpause_sidekiq
       @system.disable_readonly_mode
 
       clear_category_cache


### PR DESCRIPTION
Sidekiq should be paused until the end of the restore, otherwise it might interfere (deadlock) with the remap of upload URLs in posts.