### PR TITLE
UX: Improve copy when a group member search returns no results

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/group-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-index.js
@@ -83,6 +83,17 @@ export default Controller.extend({
     }
   },
 
+  @discourseComputed("filter", "members", "model.can_see_members")
+  emptyMessageKey(filter, members, canSeeMembers) {
+    if (!canSeeMembers) {
+      return "groups.members.forbidden";
+    } else if (filter) {
+      return "groups.members.no_filter_matches";
+    } else {
+      return "groups.empty.members";
+    }
+  },
+
   @action
   loadMore() {
     this.findMembers();

--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -111,13 +111,9 @@
     {{/load-more}}
 
     {{conditional-loading-spinner condition=loading}}
-  {{else if model.can_see_members}}
-    <br>
-
-    <div>{{i18n "groups.empty.members"}}</div>
   {{else}}
     <br>
 
-    <div>{{i18n "groups.members.forbidden"}}</div>
+    <div>{{i18n emptyMessageKey}}</div>
   {{/if}}
 </section>

--- a/app/assets/javascripts/discourse/app/templates/mobile/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/group-index.hbs
@@ -49,13 +49,9 @@
     {{/load-more}}
 
     {{conditional-loading-spinner condition=loading}}
-  {{else if model.can_see_members}}
-    <br>
-
-    <div>{{i18n "groups.empty.members"}}</div>
   {{else}}
     <br>
 
-    <div>{{i18n "groups.members.forbidden"}}</div>
+    <div>{{i18n emptyMessageKey}}</div>
   {{/if}}
 </section>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -850,6 +850,7 @@ en:
         owner: "Owner"
         primary: "Primary"
         forbidden: "You're not allowed to view the members."
+        no_filter_matches: "No members match that search."
       topics: "Topics"
       posts: "Posts"
       mentions: "Mentions"


### PR DESCRIPTION
Previously it would say "There are no members in this group". Now it says "No members match that search."

https://meta.discourse.org/t/group-username-search-empty-search-message-is-wrong/198609

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
