### PR TITLE
FIX: Make search work with sub-sub-categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.js
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.js
@@ -263,33 +263,32 @@ export default Component.extend({
       const subcategories = match[0]
         .replace(REGEXP_CATEGORY_PREFIX, "")
         .split(":");
+
+      let userInput;
       if (subcategories.length > 1) {
-        const userInput = Category.findBySlug(
-          subcategories[1],
-          subcategories[0]
+        userInput = Category.list().find(
+          (category) =>
+            category.get("parentCategory.slug") === subcategories[0] &&
+            category.slug === subcategories[1]
         );
-        if (
-          (!existingInput && userInput) ||
-          (existingInput && userInput && existingInput.id !== userInput.id)
-        ) {
-          this.set("searchedTerms.category", userInput);
-        }
-      } else if (isNaN(subcategories)) {
-        const userInput = Category.findSingleBySlug(subcategories[0]);
-        if (
-          (!existingInput && userInput) ||
-          (existingInput && userInput && existingInput.id !== userInput.id)
-        ) {
-          this.set("searchedTerms.category", userInput);
-        }
       } else {
-        const userInput = Category.findById(subcategories[0]);
-        if (
-          (!existingInput && userInput) ||
-          (existingInput && userInput && existingInput.id !== userInput.id)
-        ) {
-          this.set("searchedTerms.category", userInput);
+        userInput = Category.list().find(
+          (category) =>
+            !category.parentCategory && category.slug === subcategories[0]
+        );
+
+        if (!userInput) {
+          userInput = Category.list().find(
+            (category) => category.slug === subcategories[0]
+          );
         }
+      }
+
+      if (
+        (!existingInput && userInput) ||
+        (existingInput && userInput && existingInput.id !== userInput.id)
+      ) {
+        this.set("searchedTerms.category", userInput);
       }
     } else {
       this.set("searchedTerms.category", null);

--- a/app/assets/javascripts/discourse/app/widgets/category-link.js
+++ b/app/assets/javascripts/discourse/app/widgets/category-link.js
@@ -4,7 +4,7 @@ import { categoryBadgeHTML } from "discourse/helpers/category-link";
 // Right now it's RawHTML. Eventually it should emit nodes
 export default class CategoryLink extends RawHtml {
   constructor(attrs) {
-    attrs.html = categoryBadgeHTML(attrs.category, attrs);
+    attrs.html = `<span>${categoryBadgeHTML(attrs.category, attrs)}</span>`;
     super(attrs);
   }
 }

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -374,9 +374,11 @@ createWidget("search-menu-assistant", {
     switch (suggestionKeyword) {
       case "#":
         attrs.results.forEach((category) => {
-          const slug = prefix
-            ? `${prefix} #${category.slug} `
-            : `#${category.slug} `;
+          const fullSlug = category.parentCategory
+            ? `#${category.parentCategory.slug}:${category.slug}`
+            : `#${category.slug}`;
+
+          const slug = prefix ? `${prefix} ${fullSlug} ` : `${fullSlug} `;
 
           content.push(
             this.attach("search-menu-assistant-item", {
@@ -433,6 +435,7 @@ createWidget("search-menu-assistant-item", {
           this.attach("category-link", {
             category: attrs.category,
             allowUncategorized: true,
+            recursive: true,
           }),
         ]
       );


### PR DESCRIPTION
Searching in a category looked only one level down, ignoring the site
setting max_category_nesting. The user interface did not support the
third level of categories and did not display them in the "Categorized"
input of the advanced search options.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
