### PR TITLE
DEV: Add `GeoList2-ASN.mmdb` and `.bundle` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /log
 /tmp
 
-/.bundle/config
+/.bundle
 /.env
 /.procfile
 /dump.rdb

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /log
 /tmp
 
+/.bundle/config
 /.env
 /.procfile
 /dump.rdb
@@ -46,6 +47,7 @@
 
 /vendor/bundle/*
 /vendor/data/GeoLite2-City.mmdb
+/vendor/data/GeoLite2-ASN.mmdb
 
 # Front-end
 dist


### PR DESCRIPTION
`GeoList2-ASN.mmdb` is one of the MaxMind databases we use for geolocation
`.bundle/` is created when you run something like `bundle config set --local ...`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
