### PR TITLE
DEV: Clear all `navItem` information between tests

### DIFF
--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -301,8 +301,10 @@ export function customNavItemHref(cb) {
   NavItem.customNavItemHrefs.push(cb);
 }
 
-export function clearCustomNavItemHref() {
+export function clearNavItems() {
   NavItem.customNavItemHrefs.clear();
+  NavItem.extraArgsCallbacks.clear();
+  NavItem.extraNavItemDescriptors.clear();
 }
 
 export function addNavItem(item) {

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -40,7 +40,7 @@ import { setTopicList } from "discourse/lib/topic-list-tracker";
 import sinon from "sinon";
 import siteFixtures from "discourse/tests/fixtures/site-fixtures";
 import { clearResolverOptions } from "discourse-common/resolver";
-import { clearCustomNavItemHref } from "discourse/models/nav-item";
+import { clearNavItems } from "discourse/models/nav-item";
 import {
   cleanUpComposerUploadHandler,
   cleanUpComposerUploadMarkdownResolver,
@@ -274,7 +274,7 @@ export function acceptance(name, optionsOrCallback) {
       resetOneboxCache();
       resetCustomPostMessageCallbacks();
       resetUserSearchCache();
-      clearCustomNavItemHref();
+      clearNavItems();
       setTopicList(null);
       _clearSnapshots();
       setURLContainer(null);


### PR DESCRIPTION
Expands the original `clearCustomNavItemHref` from #13025. Fixes issues with discourse-assign tests.