### PR TITLE
DEV: Allow us to use Ember CLI assets in production

### DIFF
--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -28,8 +28,7 @@
     <bootstrap-content key="hidden-login-form">
     <bootstrap-content key="preloaded">
 
-    <script src="{{rootURL}}assets/scripts/start-app.js"></script>
-    <script src="{{rootURL}}assets/scripts/discourse-boot.js"></script>
+    <script src="{{rootURL}}assets/start-discourse.js"></script>
 
     <bootstrap-content key="body-footer">
     {{content-for "body-footer"}}

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -19,6 +19,12 @@ module.exports = function (defaults) {
     "ember-qunit": {
       insertContentForTestBody: false,
     },
+    sourcemaps: {
+      // There seems to be a bug with brocolli-concat when sourcemaps are disabled
+      // that causes the `app.import` statements below to fail in production mode.
+      // This forces the use of `fast-sourcemap-concat` which works in production.
+      enabled: true,
+    },
   });
 
   // Ember CLI does this by default for the app tree, but for our extra bundles we
@@ -60,5 +66,12 @@ module.exports = function (defaults) {
       })
     ),
     digest(prettyTextEngine(vendorJs, "discourse-markdown")),
+    digest(
+      concat("public/assets/scripts", {
+        outputFile: `assets/start-discourse.js`,
+        headerFiles: [`start-app.js`],
+        inputFiles: [`discourse-boot.js`],
+      })
+    ),
   ]);
 };

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,28 @@ module ApplicationHelper
     @extra_body_classes ||= Set.new
   end
 
+  def discourse_config_environment
+    # TODO: Can this come from Ember CLI somehow?
+    { modulePrefix: "discourse",
+      environment: Rails.env,
+      rootURL: Discourse.base_path,
+      locationType: "auto",
+      historySupportMiddleware: false,
+      EmberENV: {
+        FEATURES: {},
+        EXTEND_PROTOTYPES: { "Date": false },
+        _APPLICATION_TEMPLATE_WRAPPER: false,
+        _DEFAULT_ASYNC_OBSERVERS: true,
+        _JQUERY_INTEGRATION: true
+      },
+      APP: {
+        name: "discourse",
+        version: "#{Discourse::VERSION::STRING} #{Discourse.git_version}",
+        exportApplicationGlobal: true
+      }
+    }.to_json
+  end
+
   def google_universal_analytics_json(ua_domain_name = nil)
     result = {}
     if ua_domain_name

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,6 +59,7 @@
 
     <%= tag.meta id: 'data-discourse-setup', data: client_side_setup_data %>
 
+    <meta name="discourse/config/environment" content="<%=u discourse_config_environment %>" />
     <%- if authentication_data %>
       <meta id="data-authentication" data-authentication-data="<%= authentication_data %>">
     <%- end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -197,9 +197,11 @@ module Discourse
       app.config.assets.precompile += ['application.js']
 
       start_path = ::Rails.root.join("app/assets").to_s
-      exclude = ['.es6', '.hbs', '.hbr', '.js', '.css', '']
+      exclude = ['.es6', '.hbs', '.hbr', '.js', '.css', '.lock', '.json', '.log', '.html', '']
       app.config.assets.precompile << lambda do |logical_path, filename|
         filename.start_with?(start_path) &&
+        !filename.include?("/node_modules/") &&
+        !filename.include?("/dist/") &&
         !exclude.include?(File.extname(logical_path))
       end
     end


### PR DESCRIPTION
This adds an optional ENV variable, `EMBER_CLI_PROD_ASSETS`. If truthy,
compiling production assets will be done via Ember CLI and will replace
the assets Rails would otherwise use.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
