### PR TITLE
UX: adds hover title with full date to admin users columns

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -72,7 +72,7 @@
               <div>{{format-duration user.time_read}}</div>
             </td>
 
-            <td class="created">
+            <td class="created" title={{raw-date user.created_at}}>
               <div class="label">{{i18n "created"}}</div>
               <div>{{format-duration user.created_at_age}}</div>
             </td>

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -51,11 +51,20 @@
             <td class="email {{if showEmails "" "hidden"}}">
               {{~user.email~}}
             </td>
-            <td class="last-emailed">
-              <div class="label">{{i18n "admin.users.last_emailed"}}</div>
-              <div>{{format-duration user.last_emailed_age}}</div>
-            </td>
-            <td class="last-seen">
+
+            {{#if user.last_emailed_at}}
+              <td class="last-emailed" title={{raw-date user.last_emailed_at}}>
+                <div class="label">{{i18n "admin.users.last_emailed"}}</div>
+                <div>{{format-duration user.last_emailed_age}}</div>
+              </td>
+            {{else}}
+              <td class="last-emailed">
+                <div class="label">{{i18n "admin.users.last_emailed"}}</div>
+                <div>{{format-duration user.last_emailed_age}}</div>
+              </td>
+            {{/if}}
+
+            <td class="last-seen" title={{raw-date user.last_seen_at}}>
               <div class="label">{{i18n "last_seen"}}</div>
               <div>{{format-duration user.last_seen_age}}</div>
             </td>


### PR DESCRIPTION
This PR adds a hover title a few columns on the admin users' page

`/admin/users/list/active`

The hover title will show the date in full format on those columns with shortened dates

<img src="https://user-images.githubusercontent.com/33972521/127863863-3cd267a2-bdaf-4e5c-a249-2d81d547cb84.png" width="200">

<img src="https://user-images.githubusercontent.com/33972521/127863999-26fa5436-3b1f-45e1-b14a-898cfb9ebca7.png" width="200">

<img src="https://user-images.githubusercontent.com/33972521/127852781-87a9089d-61ea-4a2e-9065-3394657d0419.png" width="200">
