### PR TITLE
UX: Ensure external login icons are visible on hover

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -178,6 +178,10 @@
     margin-right: 9px;
     font-size: $font-0;
   }
+  .d-icon,
+  &.btn:hover .d-icon {
+    color: #000;
+  }
   &.google_oauth2 {
     background: var(--google);
     color: #333;


### PR DESCRIPTION
Some authentication buttons (e.g. apple, oidc, oauth2, saml) do not have a specific color specified. Therefore they were taking the default button-with-icon color, and the icons would almost disappear on hover. This commit adds a default of `#000` for these buttons, so that the button hover looks similar to core auth buttons.

Hover state before:

<img width="215" alt="Screenshot 2021-08-02 at 13 43 51" src="https://user-images.githubusercontent.com/6270921/127864507-2dd05172-599f-47b9-a859-8313d21025bf.png">

Hover state after:

<img width="208" alt="Screenshot 2021-08-02 at 13 43 36" src="https://user-images.githubusercontent.com/6270921/127864523-692a1452-7db5-4a18-ab7f-b518e7ca6da5.png">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
