### PR TITLE
UX: Adjust name alignment on email group chooser

### DIFF
--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -15,6 +15,10 @@
   box-shadow: -3px 0 0 var(--danger);
 }
 
+.tabLoc:focus {
+  outline: none;
+}
+
 .latest .featured-topic {
   padding-left: 4px;
 }

--- a/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
@@ -15,6 +15,7 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+      align-self: flex-end;
     }
     .avatar,
     .d-icon {

--- a/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
@@ -15,7 +15,7 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      // align-self: flex-end;
+      align-self: flex-end;
     }
     .avatar,
     .d-icon {

--- a/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
@@ -15,7 +15,7 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      align-self: flex-end;
+      // align-self: flex-end;
     }
     .avatar,
     .d-icon {


### PR DESCRIPTION
# Fix alignment on user name choice on messages

### After

<img width="234" alt="image" src="https://user-images.githubusercontent.com/30537603/127916034-6c752f67-4dee-4688-b933-a956af869a1c.png">


### Before

<img width="179" alt="image" src="https://user-images.githubusercontent.com/30537603/127916233-48e91543-9723-4061-81ab-543059ed7ecc.png">

# Fix dotted line appearing in FF when using j/k navigation

### After
<img width="135" alt="image" src="https://user-images.githubusercontent.com/30537603/127930232-c7c52e8d-9c8b-4c2f-ade7-d2463391165f.png">


### Before
<img width="210" alt="image" src="https://user-images.githubusercontent.com/30537603/127930193-533856a5-58fa-4ae9-b244-5f9dcf46e94d.png">

