### PR TITLE
FIX: Remove 'reply above line' marker

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -552,8 +552,13 @@ module Email
       @previous_replies_regex ||= /^--[- ]\n\*#{I18n.t("user_notifications.previous_discussion")}\*\n/im
     end
 
+    def reply_above_line_regex
+      @reply_above_line_regex ||= /\n#{I18n.t("user_notifications.reply_above_line")}\n/im
+    end
+
     def trim_discourse_markers(reply)
-      reply.split(previous_replies_regex)[0]
+      reply = reply.split(previous_replies_regex)[0]
+      reply.split(reply_above_line_regex)[0]
     end
 
     def parse_from_field(mail = nil)

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -412,6 +412,11 @@ describe Email::Receiver do
       expect(topic.posts.last.raw).to eq("This will not include the previous discussion that is present in this email.")
     end
 
+    it "removes the 'type reply above' marker" do
+      expect { process(:reply_above) }.to change { topic.posts.count }
+      expect(topic.posts.last.raw).to eq("This will not include the previous discussion that is present in this email.")
+    end
+
     it "handles multiple paragraphs" do
       expect { process(:paragraphs) }.to change { topic.posts.count }
       expect(topic.posts.last.raw).to eq("Do you like liquorice?\n\nI really like them. One could even say that I am *addicted* to liquorice. And if\nyou can mix it up with some anise, then I'm in heaven ;)")

--- a/spec/fixtures/emails/reply_above.eml
+++ b/spec/fixtures/emails/reply_above.eml
@@ -1,0 +1,15 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Fri, 15 Jan 2016 00:12:43 +0100
+Message-ID: <21@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+
+<p>This will not include the previous discussion that is present in this email.</p>
+
+<div>
+## Please type your reply above this line. ##
+</div>
+
+<div>previous discussion</div>


### PR DESCRIPTION
This marker is automatically added by Discourse's group SMTP mailer.
When user responded to emails sent by it, Discourse did not trim this
marker.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
