### PR TITLE
FIX: use `update_attribute` method to trigger callbacks.

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -690,7 +690,7 @@ class Group < ActiveRecord::Base
     has_webhooks = WebHook.active_web_hooks(:group_user)
     payload = WebHook.generate_payload(:group_user, group_user, WebHookGroupUserSerializer) if has_webhooks
     group_user.destroy
-    user.update_columns(primary_group_id: nil) if user.primary_group_id == self.id
+    user.update_attribute(:primary_group_id, nil) if user.primary_group_id == self.id
     DiscourseEvent.trigger(:user_removed_from_group, user, self)
     WebHook.enqueue_hooks(:group_user, :user_removed_from_group,
       id: group_user.id,

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -315,7 +315,7 @@ describe Group do
   end
 
   it "Correctly handles removal of primary group" do
-    group = Fabricate(:group)
+    group = Fabricate(:group, flair_icon: "icon")
     user = Fabricate(:user)
     group.add(user)
     group.save
@@ -330,6 +330,7 @@ describe Group do
 
     user.reload
     expect(user.primary_group).to eq nil
+    expect(user.flair_group_id).to eq nil
   end
 
   it "Can update moderator/staff/admin groups correctly" do


### PR DESCRIPTION
Group flair is not removed while removing a user from the group since the `before_save` callback methods are not triggered while using the `update_columns` method.
