### PR TITLE
PERF: reduces rendering time of local-dates

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -45,6 +45,8 @@ export default {
   initialize(container) {
     const siteSettings = container.lookup("site-settings:main");
     if (siteSettings.discourse_local_dates_enabled) {
+      const currentUserTZ = moment.tz.guess();
+
       $.fn.applyLocalDates = function () {
         return this.each(function () {
           const opts = {};
@@ -67,7 +69,7 @@ export default {
 
           const localDateBuilder = new LocalDateBuilder(
             opts,
-            moment.tz.guess()
+            currentUserTZ
           ).build();
 
           const htmlPreviews = localDateBuilder.previews.map((preview) => {
@@ -96,7 +98,8 @@ export default {
             previewsNode.appendChild(htmlPreview)
           );
 
-          this.innerHTML = DATE_TEMPLATE;
+          this.innerText = "";
+          this.insertAdjacentHTML("beforeend", DATE_TEMPLATE);
           this.setAttribute("aria-label", localDateBuilder.textPreview);
           this.dataset.htmlTooltip = previewsNode.outerHTML;
           this.classList.add("cooked-date");

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -102,12 +102,12 @@ export default {
           this.insertAdjacentHTML("beforeend", DATE_TEMPLATE);
           this.setAttribute("aria-label", localDateBuilder.textPreview);
           this.dataset.htmlTooltip = previewsNode.outerHTML;
-          this.classList.add("cooked-date");
+
+          const classes = ["cooked-date"];
           if (localDateBuilder.pastEvent) {
-            this.classList.add("past");
+            classes.push("past");
           }
-          const relativeTime = this.querySelector(".relative-time");
-          relativeTime.innerText = localDateBuilder.formated;
+          this.classList.add(...classes);
         });
       };
 

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -2,15 +2,6 @@ import LocalDateBuilder from "../lib/local-date-builder";
 import showModal from "discourse/lib/show-modal";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
-const DATE_TEMPLATE = `
-  <span>
-    <svg class="fa d-icon d-icon-globe-americas svg-icon" xmlns="http://www.w3.org/2000/svg">
-      <use xlink:href="#globe-americas"></use>
-    </svg>
-    <span class="relative-time"></span>
-  </span>
-`;
-
 function initializeDiscourseLocalDates(api) {
   api.decorateCooked(
     ($elem) => $(".discourse-local-date", $elem).applyLocalDates(),
@@ -99,7 +90,15 @@ export default {
           );
 
           this.innerText = "";
-          this.insertAdjacentHTML("beforeend", DATE_TEMPLATE);
+          this.insertAdjacentHTML(
+            "beforeend",
+            `
+              <svg class="fa d-icon d-icon-globe-americas svg-icon" xmlns="http://www.w3.org/2000/svg">
+                <use xlink:href="#globe-americas"></use>
+              </svg>
+              <span class="relative-time">${localDateBuilder.formated}</span>
+            `
+          );
           this.setAttribute("aria-label", localDateBuilder.textPreview);
           this.dataset.htmlTooltip = previewsNode.outerHTML;
 

--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
@@ -1,5 +1,7 @@
 import { parseBBCodeTag } from "pretty-text/engines/discourse-markdown/bbcode-block";
 
+const timezoneNames = moment.tz.names();
+
 function addLocalDate(buffer, matches, state) {
   let token;
 
@@ -77,7 +79,7 @@ function addLocalDate(buffer, matches, state) {
 
   if (
     config.displayedTimezone &&
-    moment.tz.names().includes(config.displayedTimezone)
+    timezoneNames.includes(config.displayedTimezone)
   ) {
     token.attrs.push([
       "data-displayed-timezone",
@@ -87,7 +89,7 @@ function addLocalDate(buffer, matches, state) {
 
   if (config.timezones) {
     const timezones = config.timezones.split("|").filter((timezone) => {
-      return moment.tz.names().includes(timezone);
+      return timezoneNames.includes(timezone);
     });
 
     token.attrs.push([
@@ -96,7 +98,7 @@ function addLocalDate(buffer, matches, state) {
     ]);
   }
 
-  if (config.timezone && moment.tz.names().includes(config.timezone)) {
+  if (config.timezone && timezoneNames.includes(config.timezone)) {
     token.attrs.push([
       "data-timezone",
       state.md.utils.escapeHtml(config.timezone),


### PR DESCRIPTION
- prefers insertAdjacentHTML over innerHTML as it's much faster in this case (about 5x)
- memoizes tz.guess()
- memoizes list of timezones
- inlines template
- applies main element class in one pass

The perf profile for 78 dates before, notice the innerHTML timing:
![Capture d’écran 2021-08-03 à 18 25 28](https://user-images.githubusercontent.com/339945/128051589-8ae31930-184a-4f7e-abbe-06e4267ee912.png)


After:
![Capture d’écran 2021-08-03 à 18 17 50](https://user-images.githubusercontent.com/339945/128051155-0babd90b-f8ea-42f5-be19-16d6e63bc7f2.png)
