### PR TITLE
FIX: use search message context on group message page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-group-messages-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-group-messages-route.js
@@ -31,10 +31,21 @@ export default (type) => {
         hideCategory: true,
         showPosters: true,
       });
+
+      const currentUser = this.currentUser;
+      this.searchService.set("searchContext", {
+        type: "private_messages",
+        id: currentUser.get("username_lower"),
+        user: currentUser,
+      });
     },
 
     _isArchive() {
       return type === "archive";
+    },
+
+    deactivate() {
+      this.searchService.set("searchContext", null);
     },
   });
 };

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -241,6 +241,12 @@ acceptance("Group - Authenticated", function (needs) {
       "This is a private message 1",
       "it should display the list of group topics"
     );
+
+    await click("#search-button");
+    assert.ok(
+      exists(".search-context input:checked"),
+      "scope to message checkbox is checked"
+    );
   });
 
   test("Admin Viewing Group", async function (assert) {


### PR DESCRIPTION
Meta ref: https://meta.discourse.org/t/search-on-message-list-pages-should-include-messages/170482/