### PR TITLE
FIX: Make rake site:export_structure export uploads

### DIFF
--- a/lib/tasks/site.rake
+++ b/lib/tasks/site.rake
@@ -47,7 +47,7 @@ class ZippedSiteStructure
     puts "  - Exporting upload #{upload_or_id_or_url} to #{zip_path}"
     @zip.add(zip_path, local_path)
 
-    { filename: upload.original_filename, path: file_zip_path }
+    { filename: upload.original_filename, path: zip_path }
   end
 
   def get_upload(upload, opts = {})


### PR DESCRIPTION
It failed because of an undefined variable.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
