### PR TITLE
FIX: Update draft count when sequence is increased

### DIFF
--- a/app/models/draft_sequence.rb
+++ b/app/models/draft_sequence.rb
@@ -23,6 +23,8 @@ class DraftSequence < ActiveRecord::Base
 
     DB.exec("DELETE FROM drafts WHERE user_id = :user_id AND draft_key = :draft_key AND sequence < :sequence", draft_key: key, user_id: user_id, sequence: sequence)
 
+    UserStat.update_draft_count(user_id)
+
     sequence
   end
 

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -229,7 +229,6 @@ class PostCreator
       @post.topic.reload
 
       publish
-      UserStat.update_draft_count(@user.id)
 
       track_latest_on_category
       enqueue_jobs unless @opts[:skip_jobs]

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -167,6 +167,7 @@ describe PostCreator do
             "/topic/#{created_post.topic_id}",
             "/topic/#{created_post.topic_id}",
             "/user",
+            "/user",
             "/user"
           ].sort
         )
@@ -196,7 +197,10 @@ describe PostCreator do
         user_action = messages.find { |m| m.channel == "/u/#{p.user.username}" }
         expect(user_action).not_to eq(nil)
 
-        expect(messages.filter { |m| m.channel != "/distributed_hash" }.length).to eq(6)
+        draft_count = messages.find { |m| m.channel == "/user" }
+        expect(draft_count).not_to eq(nil)
+
+        expect(messages.filter { |m| m.channel != "/distributed_hash" }.length).to eq(7)
       end
 
       it 'extracts links from the post' do

--- a/spec/models/draft_sequence_spec.rb
+++ b/spec/models/draft_sequence_spec.rb
@@ -15,6 +15,13 @@ describe DraftSequence do
       user.id = -99999
       2.times { expect(DraftSequence.next!(user, 'test')).to eq(0) }
     end
+
+    it 'updates draft count' do
+      Draft.create!(user: user, draft_key: 'test', data: {})
+      expect(user.reload.user_stat.draft_count).to eq(1)
+      expect(DraftSequence.next!(user, 'test')).to eq 1
+      expect(user.reload.user_stat.draft_count).to eq(0)
+    end
   end
 
   describe '.current' do


### PR DESCRIPTION
Sometimes users ended up having a draft count higher than the actual
number of drafts.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
