### PR TITLE
DEV: do not process composer preview when collapsed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -74,6 +74,7 @@ export default Component.extend(ComposerUpload, {
 
   shouldBuildScrollMap: true,
   scrollMap: null,
+  processPreview: true,
 
   uploadMarkdownResolvers,
   uploadProcessorActions,

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -252,6 +252,7 @@ export default Component.extend({
   emojiPickerIsActive: false,
   emojiStore: service("emoji-store"),
   isEditorFocused: false,
+  processPreview: false,
 
   @discourseComputed("placeholder")
   placeholderTranslated(placeholder) {
@@ -387,7 +388,7 @@ export default Component.extend({
   },
 
   _updatePreview() {
-    if (this._state !== "inDOM") {
+    if (this._state !== "inDOM" || !this.processPreview) {
       return;
     }
 
@@ -453,7 +454,7 @@ export default Component.extend({
     });
   },
 
-  @observes("ready", "value")
+  @observes("ready", "value", "processPreview")
   _watchForChanges() {
     if (!this.ready) {
       return;

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -252,7 +252,7 @@ export default Component.extend({
   emojiPickerIsActive: false,
   emojiStore: service("emoji-store"),
   isEditorFocused: false,
-  processPreview: false,
+  processPreview: true,
 
   @discourseComputed("placeholder")
   placeholderTranslated(placeholder) {

--- a/app/assets/javascripts/discourse/app/templates/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-editor.hbs
@@ -8,6 +8,7 @@
   importQuote=(action "importQuote")
   showUploadModal=showUploadModal
   togglePreview=(action "togglePreview")
+  processPreview=processPreview
   validation=validation
   loading=composer.loading
   forcePreview=forcePreview

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -127,6 +127,7 @@
                           cannotSeeMention=(action "cannotSeeMention")
                           importQuote=(action "importQuote")
                           togglePreview=(action "togglePreview")
+                          processPreview=showPreview
                           showToolbar=showToolbar
                           afterRefresh=(action "afterRefresh")
                           focusTarget=focusTarget}}


### PR DESCRIPTION
Note that I would prefer to not use the observer but that would end up being a way bigger and risky refactor.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
