### PR TITLE
DEV: Prevent npm usage

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/.npmrc
+++ b/app/assets/javascripts/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/admin/.npmrc
+++ b/app/assets/javascripts/admin/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -46,7 +46,9 @@
     "loader.js": "^4.7.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -48,7 +48,7 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/discourse-common/.npmrc
+++ b/app/assets/javascripts/discourse-common/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/discourse-common/package.json
+++ b/app/assets/javascripts/discourse-common/package.json
@@ -46,7 +46,9 @@
     "loader.js": "^4.7.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/discourse-common/package.json
+++ b/app/assets/javascripts/discourse-common/package.json
@@ -48,7 +48,7 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/discourse-hbr/.npmrc
+++ b/app/assets/javascripts/discourse-hbr/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/discourse-hbr/package.json
+++ b/app/assets/javascripts/discourse-hbr/package.json
@@ -46,7 +46,9 @@
     "loader.js": "^4.7.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/discourse-hbr/package.json
+++ b/app/assets/javascripts/discourse-hbr/package.json
@@ -48,7 +48,7 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/discourse-widget-hbs/.npmrc
+++ b/app/assets/javascripts/discourse-widget-hbs/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/discourse-widget-hbs/package.json
+++ b/app/assets/javascripts/discourse-widget-hbs/package.json
@@ -46,7 +46,9 @@
     "loader.js": "^4.7.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/discourse-widget-hbs/package.json
+++ b/app/assets/javascripts/discourse-widget-hbs/package.json
@@ -48,7 +48,7 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/discourse/.npmrc
+++ b/app/assets/javascripts/discourse/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/.npmrc
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/package.json
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/package.json
@@ -9,5 +9,10 @@
       "history-support-middleware",
       "proxy-server-middleware"
     ]
+  },
+  "engines": {
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   }
 }

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/package.json
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/package.json
@@ -13,6 +13,6 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   }
 }

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -66,7 +66,7 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -64,7 +64,9 @@
     "virtual-dom": "^2.1.1"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   },
   "ember": {
     "edition": "default"

--- a/app/assets/javascripts/pretty-text/.npmrc
+++ b/app/assets/javascripts/pretty-text/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/pretty-text/package.json
+++ b/app/assets/javascripts/pretty-text/package.json
@@ -47,7 +47,7 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/pretty-text/package.json
+++ b/app/assets/javascripts/pretty-text/package.json
@@ -45,7 +45,9 @@
     "loader.js": "^4.7.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/select-kit/.npmrc
+++ b/app/assets/javascripts/select-kit/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/select-kit/package.json
+++ b/app/assets/javascripts/select-kit/package.json
@@ -46,7 +46,7 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/select-kit/package.json
+++ b/app/assets/javascripts/select-kit/package.json
@@ -44,7 +44,9 @@
     "loader.js": "^4.7.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/truth-helpers/.npmrc
+++ b/app/assets/javascripts/truth-helpers/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/app/assets/javascripts/truth-helpers/package.json
+++ b/app/assets/javascripts/truth-helpers/package.json
@@ -46,7 +46,7 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   },
   "ember": {
     "edition": "octane"

--- a/app/assets/javascripts/truth-helpers/package.json
+++ b/app/assets/javascripts/truth-helpers/package.json
@@ -44,7 +44,9 @@
     "loader.js": "^4.7.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,11 @@
     "lodash": "4.17.21"
   },
   "scripts": {
-    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('NPM is not supported, please use Yarn instead. ')\"",
     "postinstall": "yarn --cwd app/assets/javascripts/discourse"
+  },
+  "engines": {
+    "node": ">= 12.*",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
   "engines": {
     "node": ">= 12.*",
     "npm": "please-use-yarn",
-    "yarn": ">= 1.22.11"
+    "yarn": ">= 1.21.1"
   }
 }


### PR DESCRIPTION
We rely on yarn workspaces so we don't want people using npm in the repo by accident.

Also updated the required node version to 12+.

~~Not sure about the min yarn version – the latest one could be missing in various CI-like envs, so I might change it yet.~~
Downgraded yarn to ">= 1.21.1" (the oldest of "current" versions, tagged "legacy")