### PR TITLE
FIX: remove Nokogumbo references

### DIFF
--- a/lib/html_to_markdown.rb
+++ b/lib/html_to_markdown.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "nokogumbo"
 require "securerandom"
 
 class HtmlToMarkdown

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -145,7 +145,7 @@ describe SearchIndexer do
     end
 
     it 'should work with invalid HTML' do
-      post.update!(cooked: "<FD>" * Nokogumbo::DEFAULT_MAX_TREE_DEPTH)
+      post.update!(cooked: "<FD>" * Nokogiri::Gumbo::DEFAULT_MAX_TREE_DEPTH)
 
       SearchIndexer.update_posts_index(
         post_id: post.id,


### PR DESCRIPTION
Specs broken after https://github.com/discourse/discourse/commit/f4720205c0c2ceabc9a277ab957f0374ab154e8c
