### PR TITLE
FIX: Wrong default notification level shown for group

### DIFF
--- a/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.js
+++ b/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.js
@@ -66,10 +66,19 @@ export default Component.extend({
     "aliasLevelOptions.firstObject.value"
   ),
 
-  defaultNotificationLevel: or(
+  @discourseComputed(
     "model.default_notification_level",
     "watchingNotificationLevel"
-  ),
+  )
+  defaultNotificationLevel(
+    defaultNotificationLevel,
+    watchingNotificationLevel
+  ) {
+    if (Object.values(NotificationLevels).includes(defaultNotificationLevel)) {
+      return defaultNotificationLevel;
+    }
+    return watchingNotificationLevel;
+  },
 
   @discourseComputed(
     "siteSettings.email_in",

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
@@ -3,6 +3,7 @@ import {
   count,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 
@@ -90,3 +91,43 @@ acceptance("Managing Group Interaction Settings", function (needs) {
     );
   });
 });
+
+acceptance(
+  "Managing Group Interaction Settings - Notification Levels",
+  function (needs) {
+    needs.user({ admin: true });
+
+    test("For a group with a default_notification_level of 0", async function (assert) {
+      await visit("/g/alternative-group/manage/interaction");
+
+      await assert.ok(exists(".groups-form"), "should have the form");
+      await assert.equal(
+        selectKit(".groups-form-default-notification-level").header().value(),
+        "0",
+        "it should select Muted as the notification level"
+      );
+    });
+
+    test("For a group with a null default_notification_level", async function (assert) {
+      await visit("/g/discourse/manage/interaction");
+
+      await assert.ok(exists(".groups-form"), "should have the form");
+      await assert.equal(
+        selectKit(".groups-form-default-notification-level").header().value(),
+        "3",
+        "it should select Watching as the notification level"
+      );
+    });
+
+    test("For a group with a selected default_notification_level", async function (assert) {
+      await visit("/g/support/manage/interaction");
+
+      await assert.ok(exists(".groups-form"), "should have the form");
+      await assert.equal(
+        selectKit(".groups-form-default-notification-level").header().value(),
+        "2",
+        "it should select Tracking as the notification level"
+      );
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/fixtures/group-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/group-fixtures.js
@@ -58,6 +58,34 @@ export default {
       visible_group_names: ["discourse"]
     }
   },
+  "/groups/support.json": {
+    group: {
+      id: 55,
+      automatic: false,
+      name: "support",
+      full_name: "Awesome Support",
+      user_count: 8,
+      alias_level: 99,
+      visible: true,
+      public_admission: true,
+      public_exit: false,
+      flair_url: "fa-adjust",
+      is_group_owner: true,
+      mentionable: true,
+      messageable: true,
+      can_see_members: true,
+      has_messages: true,
+      message_count: 2,
+      default_notification_level: 2,
+      imap_mailboxes: [
+        "All Mail",
+        "Important"
+      ]
+    },
+    extras: {
+      visible_group_names: ["support"]
+    }
+  },
   "/topics/groups/discourse.json": {
     users: [
       {
@@ -1296,7 +1324,8 @@ export default {
       mentionable: true,
       messageable: true,
       can_see_members: true,
-      can_admin_group: true
+      can_admin_group: true,
+      default_notification_level: 0,
     },
     extras: {
       visible_group_names: ["alternative-group"]


### PR DESCRIPTION
In the group interaction UI, if the default_notification_level for
a group was set to 0 (muted) it incorrectly showed as Watching in
the UI because of the ember or() helper, using JS comparison, considered
0 to be a falsey value and always showed 3 (watching) instead.

