### PR TITLE
FIX: Group inbox new filter not accounting for dismissed topics.

### DIFF
--- a/lib/topic_query/private_message_lists.rb
+++ b/lib/topic_query/private_message_lists.rb
@@ -104,6 +104,7 @@ class TopicQuery
 
     def list_private_messages_group_new(user)
       list = filter_private_message_new(user, :group)
+      list = remove_dismissed(list, user)
       publish_read_state = !!group.publish_read_state
       list = append_read_state(list, group) if publish_read_state
       create_list(:private_messages, { publish_read_state: publish_read_state }, list)

--- a/spec/lib/topic_query/private_message_lists_spec.rb
+++ b/spec/lib/topic_query/private_message_lists_spec.rb
@@ -203,6 +203,16 @@ describe TopicQuery::PrivateMessageLists do
 
       expect(topics).to contain_exactly(group_message)
     end
+
+    it 'returns a list of new private messages for a group accounting for dismissed topics' do
+      Fabricate(:dismissed_topic_user, topic: group_message, user: user_2)
+
+      topics = TopicQuery.new(nil, group_name: group.name)
+        .list_private_messages_group_new(user_2)
+        .topics
+
+      expect(topics).to eq([])
+    end
   end
 
   describe '#list_private_messages_group_unread' do


### PR DESCRIPTION
Follow-up to 2c046cc670161e3b9f998edcc7500d18bcfd8f9a