### PR TITLE
SECURITY: Sanitize d-popover attributes

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/d-popover.js
+++ b/app/assets/javascripts/discourse/app/lib/d-popover.js
@@ -16,8 +16,7 @@ const D_ARROW_HEIGHT = 10;
 
 const D_HORIZONTAL_MARGIN = 5;
 
-export const POPOVER_SELECTORS =
-  "[data-html-popover], [data-html-tooltip], [data-popover], [data-tooltip]";
+export const POPOVER_SELECTORS = "[data-popover], [data-tooltip]";
 
 export function hidePopover() {
   getPopover().fadeOut().remove();
@@ -55,11 +54,6 @@ export function showPopover(event, options = {}) {
 }
 
 function setPopoverHtmlContent($enteredElement, content) {
-  content =
-    content ||
-    $enteredElement.attr("data-html-popover") ||
-    $enteredElement.attr("data-html-tooltip");
-
   replaceHtmlContent($enteredElement, content);
 }
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/sanitizer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/sanitizer-test.js
@@ -136,6 +136,11 @@ module("Unit | Utility | sanitizer", function () {
     );
 
     cooked(`<div dir="rtl">RTL text</div>`, `<div dir="rtl">RTL text</div>`);
+
+    cooked(
+      `<div data-value="<something>" data-html-value="<something>"></div>`,
+      `<div data-value="&lt;something&gt;"></div>`
+    );
   });
 
   test("ids on headings", function (assert) {

--- a/app/assets/javascripts/pretty-text/addon/sanitizer.js
+++ b/app/assets/javascripts/pretty-text/addon/sanitizer.js
@@ -75,7 +75,9 @@ export function sanitize(text, allowLister) {
         if (
           (forAttr &&
             (forAttr.indexOf("*") !== -1 || forAttr.indexOf(value) !== -1)) ||
-          (name.indexOf("data-") === 0 && forTag["data-*"]) ||
+          (name.indexOf("data-html-") === -1 &&
+            name.indexOf("data-") === 0 &&
+            forTag["data-*"]) ||
           (tag === "a" &&
             name === "href" &&
             hrefAllowed(value, extraHrefMatchers)) ||


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
