### PR TITLE
DEV: uses vanilla js and DOM to replace link mentions

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/link-mentions.js
+++ b/app/assets/javascripts/discourse/app/lib/link-mentions.js
@@ -6,32 +6,40 @@ import { userPath } from "discourse/lib/url";
 let maxGroupMention;
 
 function replaceSpan($e, username, opts) {
-  let extra = "";
-  let extraClass = "";
+  let extra = {};
+  let extraClass = [];
+  const element = $e[0];
+  const a = document.createElement("a");
 
   if (opts && opts.group) {
     if (opts.mentionable) {
-      extra = `data-name='${username}' data-mentionable-user-count='${opts.mentionable.user_count}' data-max-mentions='${maxGroupMention}'`;
-      extraClass = "notify";
+      extra = {
+        name: username,
+        mentionableUserCount: opts.mentionable.user_count,
+        maxMentions: maxGroupMention,
+      };
+      extraClass.push("notify");
     }
-    $e.replaceWith(
-      `<a href='${
-        getURL("/g/") + username
-      }' class='mention-group ${extraClass}' ${extra}>@${username}</a>`
-    );
+
+    a.setAttribute("href", getURL("/g/") + username);
+    a.classList.add("mention-group", ...extraClass);
+    a.innerText = `@${username}`;
   } else {
     if (opts && opts.cannot_see) {
-      extra = `data-name='${username}'`;
-      extraClass = "cannot-see";
+      extra = { name: username };
+      extraClass.push("cannot-see");
     }
-    $e.replaceWith(
-      `<a href='${userPath(
-        username.toLowerCase()
-      )}' class='mention ${extraClass}' ${extra}>@${formatUsername(
-        username
-      )}</a>`
-    );
+
+    a.href = userPath(username.toLowerCase());
+    a.classList.add("mention", ...extraClass);
+    a.innerText = `@${formatUsername(username)}`;
   }
+
+  Object.keys(extra).forEach((key) => {
+    a.dataset[key] = extra[key];
+  });
+
+  element.replaceWith(a);
 }
 
 const found = {};


### PR DESCRIPTION
- uses DOM apis
- do not concat strings
- ensures string is set as innerText and not HTML
- do not work on jquery objects

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
