### PR TITLE
FEATURE: Allow linking an existing account during external-auth signup

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-account.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-account.js
@@ -407,6 +407,17 @@ export default Controller.extend(
       }
     },
 
+    @discourseComputed("authOptions.associate_url", "authOptions.auth_provider")
+    associateHtml(url, provider) {
+      if (!url) {
+        return;
+      }
+      return I18n.t("create_account.associate", {
+        associate_link: url,
+        provider: I18n.t(`login.${provider}.name`),
+      });
+    },
+
     actions: {
       externalLogin(provider) {
         this.login.send("externalLogin", provider, { signup: true });

--- a/app/assets/javascripts/discourse/app/routes/associate-account.js
+++ b/app/assets/javascripts/discourse/app/routes/associate-account.js
@@ -3,9 +3,14 @@ import { ajax } from "discourse/lib/ajax";
 import { next } from "@ember/runloop";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import showModal from "discourse/lib/show-modal";
+import cookie from "discourse/lib/cookie";
 
 export default DiscourseRoute.extend({
-  beforeModel() {
+  beforeModel(transition) {
+    if (!this.currentUser) {
+      cookie("destination_url", transition.intent.url);
+      return this.replaceWith("login");
+    }
     const params = this.paramsFor("associate-account");
     this.replaceWith(`preferences.account`, this.currentUser).then(() =>
       next(() =>

--- a/app/assets/javascripts/discourse/app/templates/modal/associate-account-confirm.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/associate-account-confirm.hbs
@@ -10,14 +10,24 @@
     </div>
   {{/if}}
 
-  {{#if model.account_description}}
-    {{i18n "user.associated_accounts.confirm_description.account_specific"
-        provider=(i18n (concat "login." model.provider_name ".name"))
-        account_description=model.account_description}}
-  {{else}}
-    {{i18n "user.associated_accounts.confirm_description.generic"
-        provider=(i18n (concat "login." model.provider_name ".name"))}}
+  {{#if model.existing_account_description}}
+    <p>
+      {{i18n "user.associated_accounts.confirm_description.disconnect"
+          provider=(i18n (concat "login." model.provider_name ".name"))
+          account_description=model.existing_account_description}}
+    </p>
   {{/if}}
+
+  <p>
+    {{#if model.account_description}}
+      {{i18n "user.associated_accounts.confirm_description.account_specific"
+          provider=(i18n (concat "login." model.provider_name ".name"))
+          account_description=model.account_description}}
+    {{else}}
+      {{i18n "user.associated_accounts.confirm_description.generic"
+          provider=(i18n (concat "login." model.provider_name ".name"))}}
+    {{/if}}
+  </p>
 {{/d-modal-body}}
 
 <div class="modal-footer">

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -16,6 +16,11 @@
 
           <div class="login-form">
             <form>
+              {{#if associateHtml}}
+                <div class="input-group create-account-associate-link">
+                  <span>{{html-safe associateHtml}}</span>
+                </div>
+              {{/if}}
               <div class="input-group create-account-email">
                 {{input type="email" disabled=emailDisabled value=accountEmail id="new-account-email" name="email" class=(value-entered accountEmail) autofocus="autofocus" focusOut=(action "checkEmailAvailability")}}
                 <label class="alt-placeholder" for="new-account-email">

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-external-test.js
@@ -2,17 +2,24 @@ import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 
+function setupAuthData(data) {
+  data = {
+    auth_provider: "test",
+    email: "blah@example.com",
+    can_edit_username: true,
+    can_edit_name: true,
+    ...data,
+  };
+
+  const node = document.createElement("meta");
+  node.dataset.authenticationData = JSON.stringify(data);
+  node.id = "data-authentication";
+  document.querySelector("head").appendChild(node);
+}
+
 acceptance("Create Account - external auth", function (needs) {
   needs.hooks.beforeEach(() => {
-    const node = document.createElement("meta");
-    node.dataset.authenticationData = JSON.stringify({
-      auth_provider: "test",
-      email: "blah@example.com",
-      can_edit_username: true,
-      can_edit_name: true,
-    });
-    node.id = "data-authentication";
-    document.querySelector("head").appendChild(node);
+    setupAuthData();
   });
   needs.hooks.afterEach(() => {
     document
@@ -29,6 +36,11 @@ acceptance("Create Account - external auth", function (needs) {
     );
 
     assert.ok(exists("#new-account-username"), "it shows the fields");
+
+    assert.notOk(
+      exists(".create-account-associate-link"),
+      "it does not show the associate link"
+    );
   });
 
   test("when skip is enabled", async function (assert) {
@@ -41,5 +53,30 @@ acceptance("Create Account - external auth", function (needs) {
     );
 
     assert.not(exists("#new-account-username"), "it does not show the fields");
+  });
+});
+
+acceptance("Create account - with associate link", function (needs) {
+  needs.hooks.beforeEach(() => {
+    setupAuthData({ associate_url: "/associate/abcde" });
+  });
+  needs.hooks.afterEach(() => {
+    document
+      .querySelector("head")
+      .removeChild(document.getElementById("data-authentication"));
+  });
+
+  test("displays associate link when allowed", async function (assert) {
+    await visit("/");
+
+    assert.ok(
+      exists("#discourse-modal div.create-account-body"),
+      "it shows the registration modal"
+    );
+    assert.ok(exists("#new-account-username"), "it shows the fields");
+    assert.ok(
+      exists(".create-account-associate-link"),
+      "it shows the associate link"
+    );
   });
 });

--- a/app/controllers/users/associate_accounts_controller.rb
+++ b/app/controllers/users/associate_accounts_controller.rb
@@ -22,7 +22,7 @@ class Users::AssociateAccountsController < ApplicationController
     end
 
     DiscourseEvent.trigger(:before_auth, authenticator, auth_hash, session, cookies, request)
-    auth_result = authenticator.after_authenticate(auth, existing_account: current_user)
+    auth_result = authenticator.after_authenticate(auth_hash, existing_account: current_user)
     DiscourseEvent.trigger(:after_auth, authenticator, auth_result, session, cookies, request)
 
     secure_session[self.class.key(params[:token])] = nil

--- a/app/controllers/users/associate_accounts_controller.rb
+++ b/app/controllers/users/associate_accounts_controller.rb
@@ -3,41 +3,51 @@
 class Users::AssociateAccountsController < ApplicationController
   SECURE_SESSION_PREFIX ||= "omniauth_reconnect"
 
+  before_action :ensure_logged_in
+
   def connect_info
-    auth = get_auth_hash
-
-    provider_name = auth.provider
-    authenticator = Discourse.enabled_authenticators.find { |a| a.name == provider_name }
-    raise Discourse::InvalidAccess.new(I18n.t('authenticator_not_found')) if authenticator.nil?
-
-    account_description = authenticator.description_for_auth_hash(auth)
-
-    render json: { token: params[:token], provider_name: provider_name, account_description: account_description }
+    account_description = authenticator.description_for_auth_hash(auth_hash)
+    existing_account_description = authenticator.description_for_user(current_user).presence
+    render json: {
+      token: params[:token],
+      provider_name: auth_hash.provider,
+      account_description: account_description,
+      existing_account_description: existing_account_description
+    }
   end
 
   def connect
-    auth = get_auth_hash
-    secure_session[self.class.key(params[:token])] = nil
+    if authenticator.description_for_user(current_user).present? && authenticator.can_revoke?
+      authenticator.revoke(current_user)
+    end
 
-    provider_name = auth.provider
-    authenticator = Discourse.enabled_authenticators.find { |a| a.name == provider_name }
-    raise Discourse::InvalidAccess.new(I18n.t('authenticator_not_found')) if authenticator.nil?
-
-    DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies, request)
+    DiscourseEvent.trigger(:before_auth, authenticator, auth_hash, session, cookies, request)
     auth_result = authenticator.after_authenticate(auth, existing_account: current_user)
     DiscourseEvent.trigger(:after_auth, authenticator, auth_result, session, cookies, request)
+
+    secure_session[self.class.key(params[:token])] = nil
 
     render json: success_json
   end
 
   private
 
-  def get_auth_hash
-    token = params[:token]
-    json = secure_session[self.class.key(token)]
-    raise Discourse::NotFound if json.nil?
+  def auth_hash
+    @auth_hash ||= begin
+      token = params[:token]
+      json = secure_session[self.class.key(token)]
+      raise Discourse::NotFound if json.nil?
 
-    OmniAuth::AuthHash.new(JSON.parse(json))
+      OmniAuth::AuthHash.new(JSON.parse(json))
+    end
+  end
+
+  def authenticator
+    provider_name = auth_hash.provider
+    authenticator = Discourse.enabled_authenticators.find { |a| a.name == provider_name }
+    raise Discourse::InvalidAccess.new(I18n.t('authenticator_not_found')) if authenticator.nil?
+    raise Discourse::InvalidAccess.new(I18n.t('authenticator_no_connect')) if !authenticator.can_connect_existing_user?
+    authenticator
   end
 
   def self.key(token)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -28,10 +28,8 @@ class Users::OmniauthCallbacksController < ApplicationController
     authenticator = self.class.find_authenticator(params[:provider])
 
     if session.delete(:auth_reconnect) && authenticator.can_connect_existing_user? && current_user
-      # Save to redis, with a secret token, then redirect to confirmation screen
-      token = SecureRandom.hex
-      secure_session.set "#{Users::AssociateAccountsController.key(token)}", auth.to_json, expires: 10.minutes
-      return redirect_to "#{Discourse.base_path}/associate/#{token}"
+      path = persist_auth_token(auth)
+      return redirect_to path
     else
       DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies, request)
       @auth_result = authenticator.after_authenticate(auth)
@@ -76,9 +74,16 @@ class Users::OmniauthCallbacksController < ApplicationController
 
     return render_auth_result_failure if @auth_result.failed?
 
+    client_hash = @auth_result.to_client_hash
+    if authenticator.can_connect_existing_user? &&
+      (SiteSetting.enable_local_logins || Discourse.enabled_authenticators.count > 1)
+      # There is more than one login method, and users are allowed to manage associations themselves
+      client_hash[:associate_url] = persist_auth_token(auth)
+    end
+
     cookies['_bypass_cache'] = true
     cookies[:authentication_data] = {
-      value: @auth_result.to_client_hash.to_json,
+      value: client_hash.to_json,
       path: Discourse.base_path("/")
     }
     redirect_to @origin
@@ -180,4 +185,9 @@ class Users::OmniauthCallbacksController < ApplicationController
     end
   end
 
+  def persist_auth_token(auth)
+    secret = SecureRandom.hex
+    secure_session.set "#{Users::AssociateAccountsController.key(secret)}", auth.to_json, expires: 10.minutes
+    "#{Discourse.base_path}/associate/#{secret}"
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -30,7 +30,7 @@ class Users::OmniauthCallbacksController < ApplicationController
     if session.delete(:auth_reconnect) && authenticator.can_connect_existing_user? && current_user
       # Save to redis, with a secret token, then redirect to confirmation screen
       token = SecureRandom.hex
-      Discourse.redis.setex "#{Users::AssociateAccountsController::REDIS_PREFIX}_#{current_user.id}_#{token}", 10.minutes, auth.to_json
+      secure_session.set "#{Users::AssociateAccountsController.key(token)}", auth.to_json, expires: 10.minutes
       return redirect_to "#{Discourse.base_path}/associate/#{token}"
     else
       DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies, request)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1359,6 +1359,7 @@ en:
         not_connected: "(not connected)"
         confirm_modal_title: "Connect %{provider} Account"
         confirm_description:
+          disconnect: "Your existing %{provider} account '%{account_description}' will be disconnected."
           account_specific: "Your %{provider} account '%{account_description}' will be used for authentication."
           generic: "Your %{provider} account will be used for authentication."
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1795,6 +1795,7 @@ en:
       disclaimer: "By registering, you agree to the <a href='%{privacy_link}' target='blank'>privacy policy</a> and <a href='%{tos_link}' target='blank'>terms of service</a>."
       title: "Create your account"
       failed: "Something went wrong, perhaps this email is already registered, try the forgot password link"
+      associate: "Already have an account? <a href='%{associate_link}'>Log In</a> to link your %{provider} account."
 
     forgot_password:
       title: "Password Reset"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -286,6 +286,7 @@ en:
   not_found: "The requested URL or resource could not be found."
   invalid_access: "You are not permitted to view the requested resource."
   authenticator_not_found: "Authentication method does not exist, or has been disabled."
+  authenticator_no_connect: "This authentication provider does not allow connection to an existing forum account."
   invalid_api_credentials: "You are not permitted to view the requested resource. The API username or key is invalid."
   provider_not_enabled: "You are not permitted to view the requested resource. The authentication provider is not enabled."
   provider_not_found: "You are not permitted to view the requested resource. The authentication provider does not exist."

--- a/spec/requests/associate_accounts_controller_spec.rb
+++ b/spec/requests/associate_accounts_controller_spec.rb
@@ -96,11 +96,19 @@ RSpec.describe Users::AssociateAccountsController do
     end
 
     it "returns the correct response for non-existent tokens" do
+      sign_in(user)
+
       get "/associate/12345678901234567890123456789012.json"
       expect(response.status).to eq(404)
 
       get "/associate/shorttoken.json"
       expect(response.status).to eq(404)
+    end
+
+    it "requires login" do
+      # XHR should 403
+      get "/associate/#{SecureRandom.hex}.json"
+      expect(response.status).to eq(403)
     end
   end
 end

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -246,6 +246,19 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(data["destination_url"]).to eq(destination_url)
       end
 
+      it 'should return an associate url when multiple login methods are enabled' do
+        get "/auth/google_oauth2/callback.json"
+        expect(response.status).to eq(302)
+
+        data = JSON.parse(cookies[:authentication_data])
+        expect(data["associate_url"]).to start_with('/associate/')
+
+        SiteSetting.enable_local_logins = false
+        get "/auth/google_oauth2/callback.json"
+        data = JSON.parse(cookies[:authentication_data])
+        expect(data["associate_url"]).to eq(nil)
+      end
+
       describe 'when site is invite_only' do
         before do
           SiteSetting.invite_only = true


### PR DESCRIPTION
FEATURE: Allow linking an existing account during external-auth signup

When a user signs up via an external auth method, a new link is added to the signup modal which allows them to connect an existing Discourse account. This will only happen if:

- There is at least 1 other auth method available

and
- The current auth method permits users to disconnect/reconnect their accounts themselves

![image](https://user-images.githubusercontent.com/6270921/128398748-46ef422b-84ff-4f07-8057-45d8e6a46eca.png)


---

This PR contains two other commits which clean up the backend implementation to make this possible.  This PR is intended to be rebased & merged.