### PR TITLE
DEV: Give callback listeners access to the request object.

### DIFF
--- a/app/controllers/users/associate_accounts_controller.rb
+++ b/app/controllers/users/associate_accounts_controller.rb
@@ -23,9 +23,9 @@ class Users::AssociateAccountsController < ApplicationController
     authenticator = Discourse.enabled_authenticators.find { |a| a.name == provider_name }
     raise Discourse::InvalidAccess.new(I18n.t('authenticator_not_found')) if authenticator.nil?
 
-    DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies)
+    DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies, request)
     auth_result = authenticator.after_authenticate(auth, existing_account: current_user)
-    DiscourseEvent.trigger(:after_auth, authenticator, auth_result, session, cookies)
+    DiscourseEvent.trigger(:after_auth, authenticator, auth_result, session, cookies, request)
 
     render json: success_json
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -33,10 +33,10 @@ class Users::OmniauthCallbacksController < ApplicationController
       Discourse.redis.setex "#{Users::AssociateAccountsController::REDIS_PREFIX}_#{current_user.id}_#{token}", 10.minutes, auth.to_json
       return redirect_to "#{Discourse.base_path}/associate/#{token}"
     else
-      DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies)
+      DiscourseEvent.trigger(:before_auth, authenticator, auth, session, cookies, request)
       @auth_result = authenticator.after_authenticate(auth)
       @auth_result.user = nil if @auth_result&.user&.staged # Treat staged users the same as unregistered users
-      DiscourseEvent.trigger(:after_auth, authenticator, @auth_result, session, cookies)
+      DiscourseEvent.trigger(:after_auth, authenticator, @auth_result, session, cookies, request)
     end
 
     preferred_origin = request.env['omniauth.origin']


### PR DESCRIPTION
Plugins listening on the `before_auth` callback can interact with the request object and access data like the user agent or the remote IP address. We'll later store this data in the user record, but it might not exist at this point if we're authenticating a new account.