### PR TITLE
UX: disable "Queue For Review" button if user can't perform action.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -181,6 +181,17 @@ export default Controller.extend(ModalFunctionality, {
 
   submitDisabled: not("submitEnabled"),
 
+  @discourseComputed("notifyModeratorsFlag")
+  cantFlagForReview(notifyModeratorsFlag) {
+    return !notifyModeratorsFlag;
+  },
+
+  @discourseComputed("flagsAvailable")
+  notifyModeratorsFlag(flagsAvailable) {
+    const notifyModeratorsID = 7;
+    return flagsAvailable.find((f) => f.id === notifyModeratorsID);
+  },
+
   // Staff accounts can "take action"
   @discourseComputed("flagTopic", "selected.is_custom_flag")
   canTakeAction(flagTopic, isCustomFlag) {
@@ -289,12 +300,7 @@ export default Controller.extend(ModalFunctionality, {
     },
 
     flagForReview() {
-      const notifyModeratorsID = 7;
-      const notifyModerators = this.flagsAvailable.find(
-        (f) => f.id === notifyModeratorsID
-      );
-      this.set("selected", notifyModerators);
-
+      this.set("selected", this.get("notifyModeratorsFlag"));
       this.send("createFlag", { queue_for_review: true });
       this.set("model.hidden", true);
     },

--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -180,11 +180,7 @@ export default Controller.extend(ModalFunctionality, {
   },
 
   submitDisabled: not("submitEnabled"),
-
-  @discourseComputed("notifyModeratorsFlag")
-  cantFlagForReview(notifyModeratorsFlag) {
-    return !notifyModeratorsFlag;
-  },
+  cantFlagForReview: not("notifyModeratorsFlag"),
 
   @discourseComputed("flagsAvailable")
   notifyModeratorsFlag(flagsAvailable) {

--- a/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
@@ -44,6 +44,7 @@
     {{d-button
       class="btn-danger"
       action=(action "flagForReview")
+      disabled=cantFlagForReview
       icon="exclamation-triangle"
       label="flagging.flag_for_review"
     }}


### PR DESCRIPTION
Currently, it's returning JS error when the action is already performed by the same staff user.
