### PR TITLE
FIX: perform `agree_and_keep` action only if possible.

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -124,8 +124,9 @@ class UserDestroyer
   end
 
   def agree_with_flags(user)
+    guardian = Guardian.new(Discourse.system_user)
     ReviewableFlaggedPost.where(target_created_by: user).find_each do |reviewable|
-      reviewable.perform(@actor, :agree_and_keep)
+      reviewable.perform(@actor, :agree_and_keep) if reviewable.actions_for(guardian).has?(:agree_and_keep)
     end
   end
 

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -124,9 +124,8 @@ class UserDestroyer
   end
 
   def agree_with_flags(user)
-    guardian = Guardian.new(Discourse.system_user)
     ReviewableFlaggedPost.where(target_created_by: user).find_each do |reviewable|
-      reviewable.perform(@actor, :agree_and_keep) if reviewable.actions_for(guardian).has?(:agree_and_keep)
+      reviewable.perform(@actor, :agree_and_keep) if reviewable.actions_for(@guardian).has?(:agree_and_keep)
     end
   end
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -645,6 +645,16 @@ RSpec.describe Admin::UsersController do
         expect(Topic.where(id: topic.id).count).to eq(0)
         expect(User.where(id: delete_me.id).count).to eq(0)
       end
+
+      context "user has reviewable flagged post which was handled" do
+        let!(:reviewable) { Fabricate(:reviewable_flagged_post, created_by: admin, target_created_by: delete_me, target: post, topic: topic, status: 4) }
+
+        it "deletes the user record" do
+          delete "/admin/users/#{delete_me.id}.json", params: { delete_posts: true, delete_as_spammer: true }
+          expect(response.status).to eq(200)
+          expect(User.where(id: delete_me.id).count).to eq(0)
+        end
+      end
     end
 
     it "deletes the user record" do


### PR DESCRIPTION
While deleting spammers from flag modal it's trying to perform `agree_and_keep` action where it's not possible (or already performed).
