### PR TITLE
DEV: ignore the given_daily_likes table when moving timestamps on Try

### DIFF
--- a/script/db_timestamps_mover.rb
+++ b/script/db_timestamps_mover.rb
@@ -79,7 +79,7 @@ def is_date?(string)
 end
 
 def create_updater
-  ignore_tables = %w[application_requests user_second_factors user_visits]
+  ignore_tables = %w[application_requests given_daily_likes user_second_factors user_visits]
   TimestampsUpdater.new "public", ignore_tables
 end
 


### PR DESCRIPTION
This will fix the try-reset build that failed today. Probably this going to happen again with other tables that have constraints on date columns. I'm going to modify the script to make it work without ignoring such tables. After that, the only table we're going to need to ignore will be the 2FA table.

Before I fixed that, don't hesitate to tag me if the try-reset build fail again.
