### PR TITLE
FIX: Don't swallow an error if we can't run `yarn ember build`

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -229,7 +229,15 @@ def copy_ember_cli_assets
   assets = {}
   files = {}
 
-  system("yarn --cwd #{ember_dir} run ember build -prod")
+  unless system("yarn --cwd #{ember_dir} install")
+    STDERR.puts "Error running yarn install"
+    exit 1
+  end
+
+  unless system("yarn --cwd #{ember_dir} run ember build -prod")
+    STDERR.puts "Error running ember build"
+    exit 1
+  end
 
   # Copy assets and generate manifest data
   Dir["#{ember_cli_assets}**/*"].each do |f|


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
