### PR TITLE
FIX: prevents s shortcut to generate an error

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -536,13 +536,13 @@ export default {
   _bindToClick(selector, binding) {
     binding = binding.split(",");
     this.keyTrapper.bind(binding, function (e) {
-      const $sel = $(selector);
+      const selection = document.querySelector(selector);
 
       // Special case: We're binding to enter.
       if (e && e.keyCode === 13) {
         // Binding to enter should only be effective when there is something
         // to select.
-        if ($sel.length === 0) {
+        if (!selection) {
           return;
         }
 
@@ -550,10 +550,7 @@ export default {
         e.preventDefault();
       }
 
-      // If there is more than one match for the selector, just click
-      // the first one, we don't want to click multiple things from one
-      // shortcut.
-      $sel[0].click();
+      selection?.click();
     });
   },
 


### PR DESCRIPTION
When no element is selected, on the homepage for example, pressing `s` would generate the following error:

```
Uncaught TypeError: Cannot read property 'click' of undefined
```

Note that this commit also removes jquery usage.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
