### PR TITLE
FIX: Errno::EXDEV when across filesystem boundaries

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -99,7 +99,7 @@ module Discourse
         fd.fsync()
       end
 
-      File.rename(temp_destination, destination)
+      FileUtils.mv(temp_destination, destination)
 
       nil
     end
@@ -113,7 +113,7 @@ module Discourse
       FileUtils.mkdir_p(File.join(Rails.root, 'tmp'))
       temp_destination = File.join(Rails.root, 'tmp', SecureRandom.hex)
       execute_command('ln', '-s', source, temp_destination)
-      File.rename(temp_destination, destination)
+      FileUtils.mv(temp_destination, destination)
 
       nil
     end


### PR DESCRIPTION
ref https://bugs.ruby-lang.org/issues/12615

```
        W: rake aborted!
        W: Errno::EXDEV: Invalid cross-device link @ rb_file_s_rename - (/app/tmp/adeeee62504de67238341871bda1aaf0, /app/app/assets/javascripts/plugins/discourse-cakeday.js.e
rb)
        W: lib/discourse.rb:65:in `rename'
        W: lib/discourse.rb:65:in `atomic_write_file'
        W: /app/lib/plugin/instance.rb:683:in `activate!'
        W: lib/discourse.rb:246:in `block in activate_plugins!'
        W: lib/discourse.rb:243:in `each'
        W: lib/discourse.rb:243:in `activate_plugins!'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
