### PR TITLE
DEV: `Discourse.User` has been deprecated since 2.6

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -22,7 +22,6 @@ import UserDraftsStream from "discourse/models/user-drafts-stream";
 import UserPostsStream from "discourse/models/user-posts-stream";
 import UserStream from "discourse/models/user-stream";
 import { ajax } from "discourse/lib/ajax";
-import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
 import { emojiUnescape } from "discourse/lib/text";
 import { getOwner } from "discourse-common/lib/get-owner";
@@ -1119,21 +1118,5 @@ User.reopenClass(Singleton, {
     });
   },
 });
-
-if (typeof Discourse !== "undefined") {
-  let warned = false;
-  Object.defineProperty(Discourse, "User", {
-    get() {
-      if (!warned) {
-        deprecated("Import the User class instead of using User", {
-          since: "2.4.0",
-          dropFrom: "2.6.0",
-        });
-        warned = true;
-      }
-      return User;
-    },
-  });
-}
 
 export default User;


### PR DESCRIPTION
It's time to remove it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
