### PR TITLE
FIX: check if BasicBadge is enabled for TL1 welcome message

### DIFF
--- a/lib/promotion.rb
+++ b/lib/promotion.rb
@@ -26,7 +26,9 @@ class Promotion
 
   def review_tl0
     if Promotion.tl1_met?(@user) && change_trust_level!(TrustLevel[1])
-      @user.enqueue_member_welcome_message unless @user.badges.where(id: Badge::BasicUser).count > 0
+      if Badge.exists?(id: Badge::BasicUser, enabled: true) && !@user.badges.exists?(id: Badge::BasicUser)
+        @user.enqueue_member_welcome_message
+      end
       return true
     end
     false

--- a/spec/components/promotion_spec.rb
+++ b/spec/components/promotion_spec.rb
@@ -95,6 +95,17 @@ describe Promotion do
         expect(Jobs::SendSystemMessage.jobs.length).to eq(0)
       end
 
+      it "does not not send when the tl1 badge is disabled" do
+        SiteSetting.send_tl1_welcome_message = true
+        Badge.find(1).update!(enabled: false)
+        stat = user.user_stat
+        stat.topics_entered = SiteSetting.tl1_requires_topics_entered
+        stat.posts_read_count = SiteSetting.tl1_requires_read_posts
+        stat.time_read = SiteSetting.tl1_requires_time_spent_mins * 60
+        Promotion.recalculate(user)
+        expect(Jobs::SendSystemMessage.jobs.length).to eq(0)
+      end
+
       it "can be turned off" do
         SiteSetting.send_tl1_welcome_message = false
         @result = promotion.review


### PR DESCRIPTION
In 2018 check was added that TL1 welcome message is sent unless user already has BasicBadge granted.

I think we should also check if BasicBadge is even enabled. Otherwise, each time group is assigned to a user and trust level is recalculated, they will receive a welcome message.

