### PR TITLE
UX: Missing translation for title attribute for PM tag route.

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-private-messages-tags-show.js
+++ b/app/assets/javascripts/discourse/app/routes/user-private-messages-tags-show.js
@@ -1,9 +1,20 @@
 import createPMRoute from "discourse/routes/build-private-messages-route";
+import I18n from "I18n";
 
 export default createPMRoute("tags", "private-messages-tags").extend({
+  titleToken() {
+    return [
+      this.get("tagId"),
+      I18n.t("tagging.tags"),
+      I18n.t("user.private_messages"),
+    ];
+  },
+
   model(params) {
     this.controllerFor("user-private-messages").set("tagId", params.id);
     const username = this.modelFor("user").get("username_lower");
+    this.set("tagId", params.id);
+
     return this.store.findFiltered("topicList", {
       filter: `topics/private-messages-tags/${username}/${params.id}`,
     });


### PR DESCRIPTION
Skipping a test here because the impact of this change is so small that I don't think it is worth it carrying a test.