### PR TITLE
DEV: Move rate limiter disable to after :each for tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -106,7 +106,6 @@ module TestSetup
     #
     # Discourse.redis = DiscourseMockRedis.new
 
-    RateLimiter.disable
     PostActionNotifier.disable
     SearchIndexer.disable
     UserActionManager.disable
@@ -260,6 +259,8 @@ RSpec.configure do |config|
 
     unfreeze_time
     ActionMailer::Base.deliveries.clear
+    RateLimiter.disable
+    RateLimiter.clear_all!
 
     if ActiveRecord::Base.connection_pool.stat[:busy] > 1
       raise ActiveRecord::Base.connection_pool.stat.inspect


### PR DESCRIPTION
We weren't calling clear_all! for the rate limiter which
was the first problem, and the second problem was that it
is very odd to do state cleanup before tests instead of after,
so moved the disabling and clear_all! to after.
