### PR TITLE
DEV: Use a single message bus subscription for topic tracking state. 

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -65,36 +65,28 @@ const TopicTrackingState = EmberObject.extend({
    * @method establishChannels
    */
   establishChannels() {
-    this.messageBus.subscribe("/new", this._processChannelPayload.bind(this));
-    this.messageBus.subscribe(
-      "/latest",
-      this._processChannelPayload.bind(this)
-    );
-    if (this.currentUser) {
-      this.messageBus.subscribe(
-        "/unread/" + this.currentUser.get("id"),
-        this._processChannelPayload.bind(this)
-      );
-    }
-
-    this.messageBus.subscribe("/delete", (msg) => {
-      this.modifyStateProp(msg, "deleted", true);
-      this.incrementMessageCount();
-    });
-
-    this.messageBus.subscribe("/recover", (msg) => {
-      this.modifyStateProp(msg, "deleted", false);
-      this.incrementMessageCount();
-    });
-
-    this.messageBus.subscribe("/destroy", (msg) => {
-      this.incrementMessageCount();
-      const currentRoute = DiscourseURL.router.currentRoute.parent;
-      if (
-        currentRoute.name === "topic" &&
-        parseInt(currentRoute.params.id, 10) === msg.topic_id
-      ) {
-        DiscourseURL.redirectTo("/");
+    this.messageBus.subscribe("/topic-tracking-state", (data) => {
+      switch (data.message_type) {
+        case "delete":
+          this.modifyStateProp(data, "deleted", true);
+          this.incrementMessageCount();
+          break;
+        case "recover":
+          this.modifyStateProp(data, "deleted", false);
+          this.incrementMessageCount();
+          break;
+        case "destroy":
+          this.incrementMessageCount();
+          const currentRoute = DiscourseURL.router.currentRoute.parent;
+          if (
+            currentRoute.name === "topic" &&
+            parseInt(currentRoute.params.id, 10) === data.topic_id
+          ) {
+            DiscourseURL.redirectTo("/");
+          }
+          break;
+        default:
+          this._processChannelPayload(data);
       }
     });
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -94,7 +94,7 @@ acceptance("Topic Discovery", function (needs) {
       "shows the topic unread"
     );
 
-    publishToMessageBus("/latest", {
+    publishToMessageBus("/topic-tracking-state", {
       message_type: "read",
       topic_id: 11995,
       payload: {

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -410,7 +410,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
   });
 
   discourseModule(
-    "establishChannels - /unread/:userId MessageBus channel payloads processed",
+    "establishChannels - unread message payload processed",
     function (unreadHooks) {
       let trackingState;
       let unreadTopicPayload = {
@@ -457,7 +457,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         trackingState.onMessageIncrement(() => {
           messageIncrementCalled = true;
         });
-        publishToMessageBus(`/unread/${currentUser.id}`, unreadTopicPayload);
+        publishToMessageBus("/topic-tracking-state", unreadTopicPayload);
         assert.equal(
           trackingState.messageCount,
           1,
@@ -475,7 +475,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         trackingState.onStateChange(() => {
           stateCallbackCalled = true;
         });
-        publishToMessageBus(`/unread/${currentUser.id}`, unreadTopicPayload);
+        publishToMessageBus("/topic-tracking-state", unreadTopicPayload);
         assert.deepEqual(
           trackingState.findState(111),
           {
@@ -496,7 +496,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
       test("adds incoming so it is counted in topic lists", function (assert) {
         trackingState.trackIncoming("all");
-        publishToMessageBus(`/unread/${currentUser.id}`, unreadTopicPayload);
+        publishToMessageBus("/topic-tracking-state", unreadTopicPayload);
         assert.deepEqual(
           trackingState.newIncoming,
           [111],
@@ -521,7 +521,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
           },
         ]);
 
-        publishToMessageBus(`/unread/${currentUser.id}`, {
+        publishToMessageBus("/topic-tracking-state", {
           message_type: "dismiss_new",
           payload: { topic_ids: [112] },
         });
@@ -539,7 +539,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
             tags: ["foo"],
           },
         ]);
-        publishToMessageBus(`/unread/${currentUser.id}`, {
+        publishToMessageBus("/topic-tracking-state", {
           message_type: "read",
           topic_id: 112,
           payload: {
@@ -568,7 +568,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
   );
 
   discourseModule(
-    "establishChannels - /new MessageBus channel payloads processed",
+    "establishChannels - new message payload processed",
     function (establishChannelsHooks) {
       let trackingState;
       let newTopicPayload = {
@@ -603,7 +603,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
       test("topics in muted categories do not get added to the state", function (assert) {
         trackingState.currentUser.set("muted_category_ids", [123]);
-        publishToMessageBus("/new", newTopicPayload);
+        publishToMessageBus("/topic-tracking-state", newTopicPayload);
         assert.equal(
           trackingState.findState(222),
           null,
@@ -613,7 +613,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
       test("topics in muted tags do not get added to the state", function (assert) {
         trackingState.currentUser.set("muted_tag_ids", [44]);
-        publishToMessageBus("/new", newTopicPayload);
+        publishToMessageBus("/topic-tracking-state", newTopicPayload);
         assert.equal(
           trackingState.findState(222),
           null,
@@ -626,7 +626,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         trackingState.onMessageIncrement(() => {
           messageIncrementCalled = true;
         });
-        publishToMessageBus("/new", newTopicPayload);
+        publishToMessageBus("/topic-tracking-state", newTopicPayload);
         assert.equal(
           trackingState.messageCount,
           1,
@@ -644,7 +644,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         trackingState.onStateChange(() => {
           stateCallbackCalled = true;
         });
-        publishToMessageBus("/new", newTopicPayload);
+        publishToMessageBus("/topic-tracking-state", newTopicPayload);
         assert.deepEqual(
           trackingState.findState(222),
           {
@@ -664,7 +664,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
       test("adds incoming so it is counted in topic lists", function (assert) {
         trackingState.trackIncoming("all");
-        publishToMessageBus("/new", newTopicPayload);
+        publishToMessageBus("/topic-tracking-state", newTopicPayload);
         assert.deepEqual(
           trackingState.newIncoming,
           [222],
@@ -679,7 +679,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     }
   );
 
-  test("establishChannels - /delete MessageBus channel payloads processed", function (assert) {
+  test("establishChannels - delete message payload processed", function (assert) {
     const trackingState = TopicTrackingState.create({ messageBus: MessageBus });
     trackingState.establishChannels();
 
@@ -690,7 +690,10 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       },
     ]);
 
-    publishToMessageBus("/delete", { topic_id: 111 });
+    publishToMessageBus("/topic-tracking-state", {
+      message_type: "delete",
+      topic_id: 111,
+    });
 
     assert.equal(
       trackingState.findState(111).deleted,
@@ -700,7 +703,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     assert.equal(trackingState.messageCount, 1, "increments message count");
   });
 
-  test("establishChannels - /recover MessageBus channel payloads processed", function (assert) {
+  test("establishChannels - recover message payload processed", function (assert) {
     const trackingState = TopicTrackingState.create({ messageBus: MessageBus });
     trackingState.establishChannels();
 
@@ -711,7 +714,10 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       },
     ]);
 
-    publishToMessageBus("/recover", { topic_id: 111 });
+    publishToMessageBus("/topic-tracking-state", {
+      message_type: "recover",
+      topic_id: 111,
+    });
 
     assert.equal(
       trackingState.findState(111).deleted,
@@ -721,7 +727,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     assert.equal(trackingState.messageCount, 1, "increments message count");
   });
 
-  test("establishChannels - /destroy MessageBus channel payloads processed", function (assert) {
+  test("establishChannels - destroy message payload processed", function (assert) {
     sinon.stub(DiscourseURL, "router").value({
       currentRoute: { parent: { name: "topic", params: { id: 111 } } },
     });
@@ -736,7 +742,10 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       },
     ]);
 
-    publishToMessageBus("/destroy", { topic_id: 111 });
+    publishToMessageBus("/topic-tracking-state", {
+      message_type: "destroy",
+      topic_id: 111,
+    });
 
     assert.equal(trackingState.messageCount, 1, "increments message count");
     assert.ok(

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -30,6 +30,7 @@ class TopicTrackingState
   READ_MESSAGE_TYPE = "read"
   DISMISS_NEW_MESSAGE_TYPE = "dismiss_new"
   MAX_TOPICS = 5000
+  TOPIC_CHANNEL = "/topic-tracking-state"
 
   attr_accessor :user_id,
                 :topic_id,
@@ -71,7 +72,7 @@ class TopicTrackingState
 
     group_ids = topic.category && topic.category.secure_group_ids
 
-    MessageBus.publish("/new", message.as_json, group_ids: group_ids)
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, group_ids: group_ids)
     publish_read(topic.id, 1, topic.user_id)
   end
 
@@ -104,11 +105,7 @@ class TopicTrackingState
       else
         topic.category && topic.category.secure_group_ids
       end
-    MessageBus.publish("/latest", message.as_json, group_ids: group_ids)
-  end
-
-  def self.unread_channel_key(user_id)
-    "/unread/#{user_id}"
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.publish_muted(topic)
@@ -124,7 +121,7 @@ class TopicTrackingState
       topic_id: topic.id,
       message_type: MUTED_MESSAGE_TYPE,
     }
-    MessageBus.publish("/latest", message.as_json, user_ids: user_ids)
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, user_ids: user_ids)
   end
 
   def self.publish_unmuted(topic)
@@ -139,7 +136,7 @@ class TopicTrackingState
       topic_id: topic.id,
       message_type: UNMUTED_MESSAGE_TYPE,
     }
-    MessageBus.publish("/latest", message.as_json, user_ids: user_ids)
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, user_ids: user_ids)
   end
 
   def self.publish_unread(post)
@@ -189,7 +186,10 @@ class TopicTrackingState
         payload: payload
       }
 
-      MessageBus.publish(self.unread_channel_key(tu.user_id), message.as_json, group_ids: group_ids)
+      MessageBus.publish(TOPIC_CHANNEL, message.as_json,
+        group_ids: group_ids,
+        user_ids: [tu.user_id]
+      )
     end
 
   end
@@ -202,7 +202,7 @@ class TopicTrackingState
       message_type: RECOVER_MESSAGE_TYPE
     }
 
-    MessageBus.publish("/recover", message.as_json, group_ids: group_ids)
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, group_ids: group_ids)
 
   end
 
@@ -214,7 +214,7 @@ class TopicTrackingState
       message_type: DELETE_MESSAGE_TYPE
     }
 
-    MessageBus.publish("/delete", message.as_json, group_ids: group_ids)
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.publish_destroy(topic)
@@ -225,7 +225,7 @@ class TopicTrackingState
       message_type: DESTROY_MESSAGE_TYPE
     }
 
-    MessageBus.publish("/destroy", message.as_json, group_ids: group_ids)
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.publish_read(topic_id, last_read_post_number, user_id, notification_level = nil)
@@ -242,7 +242,7 @@ class TopicTrackingState
       }
     }
 
-    MessageBus.publish(self.unread_channel_key(user_id), message.as_json, user_ids: [user_id])
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, user_ids: [user_id])
   end
 
   def self.publish_dismiss_new(user_id, topic_ids: [])
@@ -252,7 +252,7 @@ class TopicTrackingState
         topic_ids: topic_ids
       }
     }
-    MessageBus.publish(self.unread_channel_key(user_id), message.as_json, user_ids: [user_id])
+    MessageBus.publish(TOPIC_CHANNEL, message.as_json, user_ids: [user_id])
   end
 
   def self.new_filter_sql

--- a/spec/components/post_revisor_spec.rb
+++ b/spec/components/post_revisor_spec.rb
@@ -293,12 +293,12 @@ describe PostRevisor do
 
       it "should send muted and latest message" do
         TopicUser.create!(topic: post.topic, user: post.user, notification_level: 0)
-        messages = MessageBus.track_publish("/latest") do
+        messages = MessageBus.track_publish(TopicTrackingState::TOPIC_CHANNEL) do
           subject.revise!(post.user, { raw: 'updated body' }, revised_at: post.updated_at + SiteSetting.editing_grace_period + 1.seconds)
         end
 
-        muted_message = messages.find { |message| message.data["message_type"] == "muted" }
-        latest_message = messages.find { |message| message.data["message_type"] == "latest" }
+        muted_message = messages.find { |message| message.data["message_type"] == TopicTrackingState::MUTED_MESSAGE_TYPE }
+        latest_message = messages.find { |message| message.data["message_type"] == TopicTrackingState::LATEST_MESSAGE_TYPE }
 
         expect(muted_message.data["topic_id"]).to eq(topic.id)
         expect(latest_message.data["topic_id"]).to eq(topic.id)


### PR DESCRIPTION
No point having multiple subscriptions when data can be differentiate
via message_type. Helps to keep the code much simpler since we just have
to deal with a single channel for regular topics instead of having
multiple channel. Also, this refactor faciliates the addition of a new private message topic tracking state
message bus channel that will be added soon.