### PR TITLE
DEV: ensures container is not destroyed before showing tooltip

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -130,8 +130,12 @@ export default {
   name: "discourse-local-dates",
 
   showDatePopover(event) {
-    const siteSettings = getOwner(this).lookup("site-settings:main");
+    const owner = getOwner(this);
+    if (owner.isDestroyed || owner.isDestroying) {
+      return;
+    }
 
+    const siteSettings = owner.lookup("site-settings:main");
     if (event?.target?.classList?.contains("discourse-local-date")) {
       showPopover(event, {
         htmlContent: buildHtmlPreview(event.target, siteSettings),


### PR DESCRIPTION
In fast tests it could results in an error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
