### PR TITLE
UX: update member visibility help text to include flair information

### DIFF
--- a/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.js
+++ b/app/assets/javascripts/discourse/app/components/groups-form-interaction-fields.js
@@ -97,4 +97,15 @@ export default Component.extend({
   canAdminGroup(isCreated, canAdmin, canCreate) {
     return (!isCreated && canCreate) || (isCreated && canAdmin);
   },
+
+  @discourseComputed("membersVisibilityLevel")
+  membersVisibilityLevelsDescription(membersVisibilityLevel) {
+    if (
+      membersVisibilityLevel === this.visibilityLevelOptions.firstObject.value
+    ) {
+      return "admin.groups.manage.interaction.members_visibility_levels.description";
+    } else {
+      return "admin.groups.manage.interaction.members_visibility_levels.description_flair_visible";
+    }
+  },
 });

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
@@ -30,7 +30,7 @@
     }}
 
     <div class="control-instructions">
-      {{i18n "admin.groups.manage.interaction.members_visibility_levels.description"}}
+      {{i18n membersVisibilityLevelsDescription}}
     </div>
   </div>
 {{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3919,6 +3919,7 @@ en:
             members_visibility_levels:
               title: "Who can see this group's members?"
               description: "Admins can see members of all groups."
+              description_flair_visible: "Admins can see members of all groups. Flair is visible to all users."
             publish_read_state: "On group messages publish group read state"
 
           membership:


### PR DESCRIPTION
This commit updates group member visibility help text to include the flair visibility information.

<img width="404" alt="Screen Shot 2021-08-10 at 18 42 08" src="https://user-images.githubusercontent.com/5732281/128872940-87c7313f-7940-4c24-a0be-1728da96942d.png">
