### PR TITLE
FIX: escape values of HTML attributes

### DIFF
--- a/lib/discourse_diff.rb
+++ b/lib/discourse_diff.rb
@@ -256,7 +256,7 @@ class DiscourseDiff
     USELESS_TAGS = %w{html body}
     def start_element(name, attributes = [])
       return if USELESS_TAGS.include?(name)
-      attrs = attributes.map { |a| " #{a[0]}=\"#{a[1]}\"" }.join
+      attrs = attributes.map { |a| " #{a[0]}=\"#{CGI::escapeHTML(a[1])}\"" }.join
       @tokens << "<#{name}#{attrs}>"
     end
 

--- a/spec/components/discourse_diff_spec.rb
+++ b/spec/components/discourse_diff_spec.rb
@@ -107,6 +107,11 @@ describe DiscourseDiff do
       expect(DiscourseDiff.new(before, after).side_by_side_html).to eq("<div class=\"revision-content\"><p><del>&#39;</del></p></div><div class=\"revision-content\"><p></p></div>")
     end
 
+    it "escapes attribute values" do
+      before = "<p data-attr='Some \"quoted\" string'></p>"
+      after = "<p data-attr='Some \"quoted\" string'></p>"
+      expect(DiscourseDiff.new(before, after).side_by_side_html).to eq("<div class=\"revision-content\"><p data-attr=\"Some &quot;quoted&quot; string\"></p></div><div class=\"revision-content\"><p data-attr=\"Some &quot;quoted&quot; string\"></p></div>")
+    end
   end
 
   describe "side_by_side_markdown" do


### PR DESCRIPTION
If parsed HTML has quotes in attribute values (e.g. some JSON data) then `DiscourseDiff` generates invalid HTML quotes. This can be easily fixed by escaping attribute values.