### PR TITLE
FIX: prevents exception on malformatted messages

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -558,7 +558,10 @@ module Email
 
     def trim_discourse_markers(reply)
       reply = reply.split(previous_replies_regex)[0]
-      reply.split(reply_above_line_regex)[0]
+      if reply
+        reply = reply.split(reply_above_line_regex)[0]
+      end
+      reply
     end
 
     def parse_from_field(mail = nil)


### PR DESCRIPTION
The following example message would generate an exception:

```
Return-Path: <discourse@bar.com>
From: Foo Bar <discourse@bar.com>
To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
Date: Fri, 15 Jan 2016 00:12:43 +0100
Message-ID: <21@foo.bar.mail>
Mime-Version: 1.0
Content-Type: text/html; charset=UTF-8

</div>

```

Exception:

```
NoMethodError:
       undefined method `split' for nil:NilClass
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
