### PR TITLE
FEATURE: Allow linking an existing account from invite acceptance

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -212,6 +212,17 @@ export default Controller.extend(
     @discourseComputed
     ssoPath: () => getUrl("/session/sso"),
 
+    @discourseComputed("authOptions.associate_url", "authOptions.auth_provider")
+    associateHtml(url, provider) {
+      if (!url) {
+        return;
+      }
+      return I18n.t("create_account.associate", {
+        associate_link: url,
+        provider: I18n.t(`login.${provider}.name`),
+      });
+    },
+
     actions: {
       submit() {
         const userFields = this.userFields;

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -20,6 +20,12 @@
         <p>{{i18n "invites.invited_by"}}</p>
         <p>{{user-info user=invitedBy}}</p>
 
+        {{#if associateHtml}}
+          <p class="create-account-associate-link">
+            {{html-safe associateHtml}}
+          </p>
+        {{/if}}
+
         {{#unless isInviteLink}}
           <p class="email-message">
             {{html-safe yourEmailMessage}}

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -451,3 +451,30 @@ acceptance(
     });
   }
 );
+
+acceptance(
+  "Invite link with authentication data, and associate link",
+  function (needs) {
+    needs.settings({ enable_local_logins: false });
+
+    setAuthenticationData(needs.hooks, {
+      auth_provider: "facebook",
+      email: "blah@example.com",
+      email_valid: true,
+      username: "foobar",
+      name: "barfoo",
+      associate_url: "/associate/abcde",
+    });
+
+    test("shows the associate link", async function (assert) {
+      preloadInvite({ link: true });
+
+      await visit("/invites/myvalidinvitetoken");
+
+      assert.ok(
+        exists(".create-account-associate-link"),
+        "shows the associate account link"
+      );
+    });
+  }
+);


### PR DESCRIPTION
The invite acceptance page is an alternative signup flow, so it makes sense to include the new 'link' functionality there as well.

Followup to 7dc8f8b794cbb36b14737710ccfe417d1c074d12

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
