### PR TITLE
UX: Indicate capped history revisions only when they're actually capped

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/history.js
+++ b/app/assets/javascripts/discourse/app/controllers/history.js
@@ -46,6 +46,15 @@ export default Controller.extend(ModalFunctionality, {
   previousTagChanges: customTagArray("model.tags_changes.previous"),
   currentTagChanges: customTagArray("model.tags_changes.current"),
 
+  @discourseComputed("post.version")
+  modalTitleKey(version) {
+    if (version > 100) {
+      return "history_capped_revisions";
+    } else {
+      return "history";
+    }
+  },
+
   @discourseComputed(
     "previousVersion",
     "model.current_version",

--- a/app/assets/javascripts/discourse/app/templates/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/history.hbs
@@ -1,4 +1,4 @@
-{{#d-modal-body title="history" maxHeight="70%"}}
+{{#d-modal-body title=modalTitleKey maxHeight="70%"}}
   <div id="revision">
     <div id="revision-details">
       {{d-icon "pencil-alt"}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3402,7 +3402,8 @@ en:
       one: "user"
       other: "users"
     category_title: "Category"
-    history: "History, last 100 revisions"
+    history_capped_revisions: "History, last 100 revisions"
+    history: "History"
     changed_by: "by %{author}"
 
     raw_email:


### PR DESCRIPTION
We've recently added a limit to the posts history modal so it displays the last 100 revisions only for performance reasons. However, the title of the modal now always says `History, last 100 revisions` even when the post has fewer than 100 revisions which can be a bit noisy.

This PR amends the history modal so the title of the modal says `History` when the post's revisions count is ≤100, and `History, last 100 revisions` when it has more >100 revisions.