### PR TITLE
DEV: Add caret_position.js to ember-cli build

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -42,6 +42,7 @@ module.exports = function (defaults) {
   app.import(vendorJs + "jquery.fileupload.js");
   app.import(vendorJs + "jquery.fileupload-process.js");
   app.import(vendorJs + "jquery.autoellipsis-1.0.10.js");
+  app.import(vendorJs + "caret_position.js");
   app.import(vendorJs + "show-html.js");
   app.import("node_modules/ember-source/dist/ember-template-compiler.js", {
     type: "test",


### PR DESCRIPTION
This is used when positioning autocompletes in the composer, and elsewhere

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
