### PR TITLE
DEV: Fix api docs tagging format

### DIFF
--- a/spec/requests/api/user_badges_spec.rb
+++ b/spec/requests/api/user_badges_spec.rb
@@ -13,7 +13,7 @@ describe 'user_badges' do
   path '/user-badges/{username}.json' do
 
     get 'List badges for a user' do
-      tags 'Badges, Users'
+      tags 'Badges', 'Users'
       consumes 'application/json'
       expected_request_schema = nil
       parameter name: :username, in: :path, schema: { type: :string }


### PR DESCRIPTION
When specifying multiple tags they should be separate strings, not a
single string.