### PR TITLE
DEV: Remove unused server-side route.

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -554,22 +554,6 @@ class PostsController < ApplicationController
     render body: nil
   end
 
-  def flagged_posts
-    params.permit(:offset, :limit)
-    guardian.ensure_can_see_flagged_posts!
-
-    user = fetch_user_from_params
-    offset = [params[:offset].to_i, 0].max
-    limit = [(params[:limit] || 60).to_i, 100].min
-
-    posts = user_posts(guardian, user.id, offset: offset, limit: limit)
-      .where(id: PostAction.where(post_action_type_id: PostActionType.notify_flag_type_ids)
-                                   .where(disagreed_at: nil)
-                                   .select(:post_id))
-
-    render_serialized(posts, AdminUserActionSerializer)
-  end
-
   def deleted_posts
     params.permit(:offset, :limit)
     guardian.ensure_can_see_deleted_posts!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -564,7 +564,6 @@ Discourse::Application.routes.draw do
     get "posts/:id/reply-ids"     => "posts#reply_ids"
     get "posts/:id/reply-ids/all" => "posts#all_reply_ids"
     get "posts/:username/deleted" => "posts#deleted_posts", constraints: { username: RouteFormat.username }
-    get "posts/:username/flagged" => "posts#flagged_posts", constraints: { username: RouteFormat.username }
 
     %w{groups g}.each do |root_path|
       resources :groups, id: RouteFormat.username, path: root_path do

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1705,44 +1705,6 @@ describe PostsController do
     end
   end
 
-  describe '#flagged_posts' do
-    include_examples "action requires login", :get, "/posts/system/flagged.json"
-
-    describe "when logged in" do
-      it "raises an error if the user doesn't have permission to see the flagged posts" do
-        sign_in(user)
-        get "/posts/system/flagged.json"
-        expect(response).to be_forbidden
-      end
-
-      it "can see the flagged posts when authorized" do
-        sign_in(moderator)
-        get "/posts/system/flagged.json"
-        expect(response.status).to eq(200)
-      end
-
-      it "only shows agreed and deferred flags" do
-        post_agreed = create_post(user: user)
-        post_deferred = create_post(user: user)
-        post_disagreed = create_post(user: user)
-
-        r0 = PostActionCreator.spam(moderator, post_agreed).reviewable
-        r1 = PostActionCreator.off_topic(moderator, post_deferred).reviewable
-        r2 = PostActionCreator.inappropriate(moderator, post_disagreed).reviewable
-
-        r0.perform(admin, :agree_and_keep)
-        r1.perform(admin, :ignore)
-        r2.perform(admin, :disagree)
-
-        sign_in(Fabricate(:moderator))
-        get "/posts/#{user.username}/flagged.json"
-        expect(response.status).to eq(200)
-
-        expect(response.parsed_body.length).to eq(2)
-      end
-    end
-  end
-
   describe '#deleted_posts' do
     include_examples "action requires login", :get, "/posts/system/deleted.json"
 


### PR DESCRIPTION
We no longer use this route. When a staff member wants to see a user flagged posts, we redirect them to the review queue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
