### PR TITLE
DEV: Specify the latest openapi spec version

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -88,7 +88,7 @@ RSpec.configure do |config|
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.swagger_docs = {
     'openapi.yaml' => {
-      openapi: '3.0.3',
+      openapi: '3.1.0',
       info: {
         title: 'Discourse API Documentation',
         'x-logo': {


### PR DESCRIPTION
The latest openapi spec version is v3.1.0

 https://spec.openapis.org/oas/v3.1.0

Specifying the latest version will allow our openapi spec linter to use
this version and allow use to use the new type format that allows for
specifying a type as "null", which we need because sometimes our api
responses include null values instead of a "string", "integer", or
"object" type.

See: https://stackoverflow.com/a/48114322/588458
