### PR TITLE
FIX: Category group moderators can read flagged post meta_topics

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -445,7 +445,7 @@ class Guardian
     # Can't send PMs to suspended users
     (is_staff? || is_group || !target.suspended?) &&
     # Check group messageable level
-    (is_staff? || is_user || Group.messageable(@user).where(id: target.id).exists?) &&
+    (is_staff? || is_user || Group.messageable(@user).where(id: target.id).exists? || notify_moderators) &&
     # Silenced users can only send PM to staff
     (!is_silenced? || target.staff?)
   end

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -306,7 +306,11 @@ private
 
     if [:notify_moderators, :spam].include?(@post_action_name)
       create_args[:subtype] = TopicSubtype.notify_moderators
-      create_args[:target_group_names] = Group[:moderators].name
+      create_args[:target_group_names] = [Group[:moderators].name]
+
+      if SiteSetting.enable_category_group_moderation? && @post.topic&.category&.reviewable_by_group_id?
+        create_args[:target_group_names] << @post.topic.category.reviewable_by_group.name
+      end
     else
       create_args[:subtype] = TopicSubtype.notify_user
 


### PR DESCRIPTION
When a post is flagged with the reason of 'Something Else' a brief message can be added by the user which subsequently creates a `meta_topic` private message. The group `moderators` is automatically added to this topic.

If category group moderation is enabled, and the post belongs to a category with a reviewable group, that group should also be added to the meta_topic.

Note: This extends the `notify_moderators` logic, and will add the reviewable group to the meta_topic, regardless of the settings of that group.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
