### PR TITLE
FIX: Notification menu broken on older browsers

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
@@ -33,7 +33,7 @@ export const DefaultNotificationItem = createWidget(
       const lookup = this.site.get("notificationLookup");
       const notificationName = lookup[notificationType];
       if (notificationName) {
-        classNames.push(notificationName.replaceAll("_", "-"));
+        classNames.push(notificationName.replace(/_/g, "-"));
       }
       return classNames;
     },


### PR DESCRIPTION
replaceAll is not available in all versions of Chrome/Firefox/Edge
that we support, so we need to use replace instead.

This bug was introduced in https://github.com/discourse/discourse/commit/e67670c1e4b0a9de886a532a25ba7b87feb2b2d7
