### PR TITLE
FIX: `TopicTrackingState.report` not including unread for staff posts.

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -385,7 +385,7 @@ class TopicTrackingState
       if skip_unread
         "1=0"
       else
-        unread_filter_sql
+        unread_filter_sql(staff: staff)
       end
 
     filter_old_unread_sql =

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -688,4 +688,27 @@ describe TopicTrackingState do
     expect(TopicTrackingState.report(post.user)).to be_empty
     expect(TopicTrackingState.report(user)).to be_empty
   end
+
+  describe ".report" do
+    it "correctly reports topics with staff posts" do
+      create_post(
+        raw: "this is a test post",
+        topic: topic,
+        user: post.user
+      )
+
+      create_post(
+        raw: "this is a test post",
+        topic: topic,
+        post_type: Post.types[:whisper],
+        user: user
+      )
+
+      post.user.grant_admin!
+
+      state = TopicTrackingState.report(post.user)
+
+      expect(state.map(&:topic_id)).to contain_exactly(topic.id)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to e15c86e8c5ff9fcb8aec32d3bab641c2ab4193a9