### PR TITLE
SECURITY: User's read state for topic is leaked to unauthorized clients.

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -124,6 +124,15 @@ class TopicTrackingState
     return unless post.topic.regular?
     # TODO at high scale we are going to have to defer this,
     #   perhaps cut down to users that are around in the last 7 days as well
+    tags = nil
+    tag_ids = nil
+    if include_tags_in_report?
+      tag_ids, tags = post.topic.tags.pluck(:id, :name).transpose
+    end
+
+    scope = TopicUser
+      .tracking(post.topic_id)
+      .includes(user: :user_stat)
 
     group_ids =
       if post.post_type == Post.types[:whisper]
@@ -132,13 +141,13 @@ class TopicTrackingState
         post.topic.category && post.topic.category.secure_group_ids
       end
 
-    tags = nil
-    if include_tags_in_report?
-      tags = post.topic.tags.pluck(:name)
+    if group_ids.present?
+      scope = scope
+        .joins("INNER JOIN group_users gu ON gu.user_id = topic_users.user_id")
+        .where("gu.group_id IN (?)", group_ids)
     end
 
-    TopicUser
-      .tracking(post.topic_id)
+    scope
       .select([:user_id, :last_read_post_number, :notification_level])
       .each do |tu|
 
@@ -159,7 +168,9 @@ class TopicTrackingState
         payload: payload
       }
 
-      MessageBus.publish(self.unread_channel_key(tu.user_id), message.as_json, group_ids: group_ids)
+      MessageBus.publish(self.unread_channel_key(tu.user_id), message.as_json,
+        user_ids: [tu.user_id]
+      )
     end
 
   end

--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -137,7 +137,8 @@ describe PostCreator do
         Jobs.run_immediately!
         UserActionManager.enable
 
-        admin = Fabricate(:admin)
+        admin = Fabricate(:user)
+        admin.grant_admin!
 
         cat = Fabricate(:category)
         cat.set_permissions(admins: :full)


### PR DESCRIPTION
A user's read state for a topic such as the last read post number and the notification level is exposed.

