### PR TITLE
SECURITY: User's read state for topic is leaked to unauthorized clients.

### DIFF
--- a/spec/components/post_creator_spec.rb
+++ b/spec/components/post_creator_spec.rb
@@ -137,7 +137,8 @@ describe PostCreator do
         Jobs.run_immediately!
         UserActionManager.enable
 
-        admin = Fabricate(:admin)
+        admin = Fabricate(:user)
+        admin.grant_admin!
 
         cat = Fabricate(:category)
         cat.set_permissions(admins: :full)


### PR DESCRIPTION
A user's read state for a topic such as the last read post number and the notification level is exposed.
