### PR TITLE
FIX: Query the items in the queue to calculate a user's flagged post count.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1220,12 +1220,7 @@ class User < ActiveRecord::Base
   end
 
   def number_of_flagged_posts
-    Post.with_deleted
-      .where(user_id: self.id)
-      .where(id: PostAction.where(post_action_type_id: PostActionType.notify_flag_type_ids)
-                             .where(disagreed_at: nil)
-                             .select(:post_id))
-      .count
+    ReviewableFlaggedPost.where(target_created_by: self.id).count
   end
 
   def number_of_rejected_posts

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1649,6 +1649,20 @@ describe User do
         expect(user.number_of_rejected_posts).to eq(0)
       end
     end
+
+    describe '#number_of_flagged_posts' do
+      it 'counts flagged posts from the user' do
+        Fabricate(:reviewable_flagged_post, target_created_by: user)
+
+        expect(user.number_of_flagged_posts).to eq(1)
+      end
+
+      it 'ignores flagged posts from another user' do
+        Fabricate(:reviewable_flagged_post, target_created_by: Fabricate(:user))
+
+        expect(user.number_of_flagged_posts).to eq(0)
+      end
+    end
   end
 
   describe "new_user?" do


### PR DESCRIPTION
When a staff member clicks on a user's number of flagged posts, we redirect them to the review queue, so it makes sense to count the number of items there to calculate the count.

We used to look at post action items to calculate this number, which doesn't match the number of items in the queue if old flags exist.
