### PR TITLE
DEV: Deprecate unused route instead of removing it.

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -554,6 +554,13 @@ class PostsController < ApplicationController
     render body: nil
   end
 
+  def flagged_posts
+    deprecate('posts#flagged_posts is deprecated. Please use /review instead.', since: '2.8.0.beta4', drop_from: '2.9')
+    review_queue_url = path("/review?status=all&type=ReviewableFlaggedPost&username=#{params[:username]}")
+
+    redirect_to review_queue_url, status: 301
+  end
+
   def deleted_posts
     params.permit(:offset, :limit)
     guardian.ensure_can_see_deleted_posts!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -564,6 +564,7 @@ Discourse::Application.routes.draw do
     get "posts/:id/reply-ids"     => "posts#reply_ids"
     get "posts/:id/reply-ids/all" => "posts#all_reply_ids"
     get "posts/:username/deleted" => "posts#deleted_posts", constraints: { username: RouteFormat.username }
+    get "posts/:username/flagged" => "posts#flagged_posts", constraints: { username: RouteFormat.username }
 
     %w{groups g}.each do |root_path|
       resources :groups, id: RouteFormat.username, path: root_path do


### PR DESCRIPTION
This route was removed in #14011.

We'll no longer use this route, so we'll return a 301 with the new URL just in case someone is still using it.