### PR TITLE
UX: Add data-topic-id to featured topic items

### DIFF
--- a/app/assets/javascripts/discourse/app/components/categories-boxes-topic.js
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes-topic.js
@@ -3,6 +3,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
   tagName: "li",
+  attributeBindings: ["topic.id:data-topic-id"],
 
   @discourseComputed("topic.pinned", "topic.closed", "topic.archived")
   topicStatusIcon(pinned, closed, archived) {

--- a/app/assets/javascripts/discourse/app/components/featured-topic.js
+++ b/app/assets/javascripts/discourse/app/components/featured-topic.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 export default Component.extend({
   classNameBindings: [":featured-topic"],
+  attributeBindings: ["topic.id:data-topic-id"],
 
   click(e) {
     const $target = $(e.target);


### PR DESCRIPTION
This pr adds `data-topic-id` as an attribute to featured topics on both the **category boxes** layout, as well as  the **categories with featured topics** layout.
