### PR TITLE
FIX: Paste event not propagating from composer using Uppy

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -382,13 +382,12 @@ export default Mixin.create({
           return;
         }
 
-        const { canUpload, canPasteHtml, types } = clipboardHelpers(event, {
+        const { canUpload } = clipboardHelpers(event, {
           siteSettings: this.siteSettings,
           canUpload: true,
         });
 
-        if (!canUpload || canPasteHtml || types.includes("text/plain")) {
-          event.preventDefault();
+        if (!canUpload) {
           return;
         }
 


### PR DESCRIPTION
When I added the paste event for files in the composer to
send to Uppy, I inadvertently called event.preventDefault()
if the pasted data was text. I removed that now, and I only
return early if the user cannot upload, and if there are no
files on the clipboard nothing happens.
