### PR TITLE
FIX: pick-files-button component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/pick-files-button.js
+++ b/app/assets/javascripts/discourse/app/components/pick-files-button.js
@@ -79,7 +79,7 @@ export default Component.extend({
   _haveAcceptedTypes(files) {
     for (const file of files) {
       if (
-        !(this._hasAcceptedExtension(file) && this._hasAcceptedMimeType(file))
+        !(this._hasAcceptedExtension(file) || this._hasAcceptedMimeType(file))
       ) {
         return false;
       }

--- a/app/assets/javascripts/discourse/tests/integration/components/pick-files-button-tests.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/pick-files-button-tests.js
@@ -19,8 +19,58 @@ discourseModule(
   function (hooks) {
     setupRenderingTest(hooks);
 
+    componentTest("it doesn't show alert if a file has a supported MIME type", {
+      skip: true,
+      template: hbs`
+        {{pick-files-button
+          acceptedFileTypes=this.acceptedFileTypes
+          onFilesChosen=this.onFilesChosen}}`,
+
+      beforeEach() {
+        const expectedExtension = ".json";
+        this.set("acceptedFileTypes", [expectedExtension]);
+        this.set("onFilesChosen", () => {});
+      },
+
+      async test(assert) {
+        sinon.stub(bootbox, "alert");
+
+        const wrongExtension = ".txt";
+        const file = createBlob("text/json", wrongExtension);
+
+        await triggerEvent("input#file-input", "change", { files: [file] });
+
+        assert.ok(bootbox.alert.notCalled);
+      },
+    });
+
+    componentTest("it doesn't show alert if a file has a supported extension", {
+      skip: true,
+      template: hbs`
+        {{pick-files-button
+          acceptedFileTypes=this.acceptedFileTypes
+          onFilesChosen=this.onFilesChosen}}`,
+
+      beforeEach() {
+        const expectedMimeType = "text/json";
+        this.set("acceptedFileTypes", [expectedMimeType]);
+        this.set("onFilesChosen", () => {});
+      },
+
+      async test(assert) {
+        sinon.stub(bootbox, "alert");
+
+        const wrongMimeType = "text/plain";
+        const file = createBlob(wrongMimeType, ".json");
+
+        await triggerEvent("input#file-input", "change", { files: [file] });
+
+        assert.ok(bootbox.alert.notCalled);
+      },
+    });
+
     componentTest(
-      "it shows alert if a file with an unsupported extension was chosen",
+      "it shows alert if a file has an unsupported extension and unsupported MIME type",
       {
         skip: true,
         template: hbs`
@@ -30,7 +80,8 @@ discourseModule(
 
         beforeEach() {
           const expectedExtension = ".json";
-          this.set("acceptedFileTypes", [expectedExtension]);
+          const expectedMimeType = "text/json";
+          this.set("acceptedFileTypes", [expectedExtension, expectedMimeType]);
           this.set("onFilesChosen", () => {});
         },
 
@@ -38,35 +89,8 @@ discourseModule(
           sinon.stub(bootbox, "alert");
 
           const wrongExtension = ".txt";
-          const file = createBlob("text/json", wrongExtension);
-
-          await triggerEvent("input#file-input", "change", { files: [file] });
-
-          assert.ok(bootbox.alert.calledOnce);
-        },
-      }
-    );
-
-    componentTest(
-      "it shows alert if a file with an unsupported MIME type was chosen",
-      {
-        skip: true,
-        template: hbs`
-        {{pick-files-button
-          acceptedFileTypes=this.acceptedFileTypes
-          onFilesChosen=this.onFilesChosen}}`,
-
-        beforeEach() {
-          const expectedMimeType = "text/json";
-          this.set("acceptedFileTypes", [expectedMimeType]);
-          this.set("onFilesChosen", () => {});
-        },
-
-        async test(assert) {
-          sinon.stub(bootbox, "alert");
-
           const wrongMimeType = "text/plain";
-          const file = createBlob(wrongMimeType, ".json");
+          const file = createBlob(wrongMimeType, wrongExtension);
 
           await triggerEvent("input#file-input", "change", { files: [file] });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/pick-files-button-tests.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/pick-files-button-tests.js
@@ -17,28 +17,30 @@ function createBlob(mimeType, extension) {
 discourseModule(
   "Integration | Component | pick-files-button",
   function (hooks) {
+    const expectedExtension = ".json";
+    const expectedMimeType = "text/json";
+
     setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.set("acceptedFileTypes", [expectedExtension, expectedMimeType]);
+      this.set("onFilesPicked", () => {});
+    });
 
     componentTest("it doesn't show alert if a file has a supported MIME type", {
       skip: true,
       template: hbs`
         {{pick-files-button
           acceptedFileTypes=this.acceptedFileTypes
-          onFilesChosen=this.onFilesChosen}}`,
-
-      beforeEach() {
-        const expectedExtension = ".json";
-        this.set("acceptedFileTypes", [expectedExtension]);
-        this.set("onFilesChosen", () => {});
-      },
+          onFilesPicked=this.onFilesPicked}}`,
 
       async test(assert) {
         sinon.stub(bootbox, "alert");
 
         const wrongExtension = ".txt";
-        const file = createBlob("text/json", wrongExtension);
+        const file = createBlob(expectedMimeType, wrongExtension);
 
-        await triggerEvent("input#file-input", "change", { files: [file] });
+        await triggerEvent("input[type='file']", "change", { files: [file] });
 
         assert.ok(bootbox.alert.notCalled);
       },
@@ -49,21 +51,15 @@ discourseModule(
       template: hbs`
         {{pick-files-button
           acceptedFileTypes=this.acceptedFileTypes
-          onFilesChosen=this.onFilesChosen}}`,
-
-      beforeEach() {
-        const expectedMimeType = "text/json";
-        this.set("acceptedFileTypes", [expectedMimeType]);
-        this.set("onFilesChosen", () => {});
-      },
+          onFilesPicked=this.onFilesPicked}}`,
 
       async test(assert) {
         sinon.stub(bootbox, "alert");
 
         const wrongMimeType = "text/plain";
-        const file = createBlob(wrongMimeType, ".json");
+        const file = createBlob(wrongMimeType, expectedExtension);
 
-        await triggerEvent("input#file-input", "change", { files: [file] });
+        await triggerEvent("input[type='file']", "change", { files: [file] });
 
         assert.ok(bootbox.alert.notCalled);
       },
@@ -76,14 +72,7 @@ discourseModule(
         template: hbs`
         {{pick-files-button
           acceptedFileTypes=this.acceptedFileTypes
-          onFilesChosen=this.onFilesChosen}}`,
-
-        beforeEach() {
-          const expectedExtension = ".json";
-          const expectedMimeType = "text/json";
-          this.set("acceptedFileTypes", [expectedExtension, expectedMimeType]);
-          this.set("onFilesChosen", () => {});
-        },
+          onFilesPicked=this.onFilesPicked}}`,
 
         async test(assert) {
           sinon.stub(bootbox, "alert");
@@ -92,7 +81,7 @@ discourseModule(
           const wrongMimeType = "text/plain";
           const file = createBlob(wrongMimeType, wrongExtension);
 
-          await triggerEvent("input#file-input", "change", { files: [file] });
+          await triggerEvent("input[type='file']", "change", { files: [file] });
 
           assert.ok(bootbox.alert.calledOnce);
         },


### PR DESCRIPTION
A file should be accepted if it has supported extension **_OR_** supported MIME type.
