### PR TITLE
Replace `-depth` -> `-maxdepth` in boot_dev

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -73,7 +73,7 @@ echo "Using data in:   ${DATA_DIR}"
 mkdir -p "${DATA_DIR}"
 
 mount_plugin_symlinks=""
-for symlink in $(find $PLUGINS_DIR -depth 1 -type l); do
+for symlink in $(find $PLUGINS_DIR -maxdepth 1 -type l); do
     # `readlink -f` doesn't work on macOS, to fix it you need to override the `readlink` with `greadlink`
     # > brew install coreutils
     # > ln -s "$(which greadlink)" "$(dirname "$(which greadlink)")/readlink"


### PR DESCRIPTION
The `-depth` flag is incorrect on Linux, it does not take an argument
and causes an error and results in no plugins ever being found.

Copied from `man find`:

```
The global options occur after the list of start points, and so are not the same kind of option as -L, for example.

       -d     A synonym for -depth, for compatibility with FreeBSD, NetBSD, MacOS X and OpenBSD.

       -depth Process each directory's contents before the directory itself.  The -delete action also implies -depth.

       ...

       -maxdepth levels
              Descend at most levels (a non-negative integer) levels of directories below the starting-points.  Using -maxdepth 0  means
              only apply the tests and actions to the starting-points themselves.
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
