### PR TITLE
UX: add a title to the admin user filter input

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -16,7 +16,7 @@
 </div>
 
 <div class="username controls">
-  {{text-field value=listFilter placeholder=searchHint}}
+  {{text-field value=listFilter placeholder=searchHint title=searchHint}}
 </div>
 
 {{#load-more class="users-list-container" selector=".users-list tr" action=(action "loadMore")}}


### PR DESCRIPTION
Adding a title here, the input placeholder can end up truncated, especially in other languages 

![Screen Shot 2021-08-13 at 8 15 25 PM](https://user-images.githubusercontent.com/1681963/129428609-4fd21381-7608-43e6-b454-cae5880c0844.png)
