### PR TITLE
FIX: Composer Processing/Uploading status not clearing on cancel and trash

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -60,6 +60,8 @@ export default Mixin.create({
 
     this.appEvents.off("composer:add-files", this._addFiles.bind(this));
 
+    this._reset();
+
     if (this._uppyInstance) {
       this._uppyInstance.close();
       this._uppyInstance = null;

--- a/app/assets/javascripts/discourse/app/mixins/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload.js
@@ -129,6 +129,13 @@ export default Mixin.create({
 
     const $element = $(this.element);
 
+    this.setProperties({
+      uploadProgress: 0,
+      isUploading: false,
+      isProcessingUpload: false,
+      isCancellable: false,
+    });
+
     $.blueimp.fileupload.prototype.processActions = this.uploadProcessorActions;
 
     $element.fileupload({


### PR DESCRIPTION
When the composer reply is cancelled and the draft is trashed,
the isUploading and isProcessing statuses were not being reset,
so when the composer was opened again the Uploading... or
Processing... message still showed even when the uploads had
been cancelled correctly.

The regular composer-upload mixin suffered the same problem
as the uppy one, where the Processing/Uploading message was not
reset when a reply was cancelled and the draft destroyed.

![image](https://user-images.githubusercontent.com/920448/129496448-b977bddb-3572-436d-8153-27a1c577dd33.png)
