### PR TITLE
Revert "DEV: Remove an unnecessary join in `TopicTrackingState.report`."

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -476,7 +476,7 @@ class TopicTrackingState
       JOIN categories c ON c.id = topics.category_id
       LEFT JOIN topic_users tu ON tu.topic_id = topics.id AND tu.user_id = u.id
       LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{user.id}
-      #{skip_new ? "" : "LEFT JOIN dismissed_topic_users ON dismissed_topic_users.topic_id = topics.id AND dismissed_topic_users.user_id = #{user.id}"}
+      LEFT JOIN dismissed_topic_users ON dismissed_topic_users.topic_id = topics.id AND dismissed_topic_users.user_id = #{user.id}
       #{additional_join_sql}
       WHERE u.id = :user_id AND
             #{filter_old_unread_sql}


### PR DESCRIPTION
This reverts commit 06ee0e5a51e90d98efffd446c8f088cf74663188.

This clause is still used by new_filter_sql