### PR TITLE
DEV: Remove an unnecessary join in `TopicTrackingState.report` take 2.

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -475,8 +475,8 @@ class TopicTrackingState
       JOIN user_options AS uo ON uo.user_id = u.id
       JOIN categories c ON c.id = topics.category_id
       LEFT JOIN topic_users tu ON tu.topic_id = topics.id AND tu.user_id = u.id
-      LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{user.id}
-      LEFT JOIN dismissed_topic_users ON dismissed_topic_users.topic_id = topics.id AND dismissed_topic_users.user_id = #{user.id}
+      LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = :user_id
+      #{skip_new ? "" : "LEFT JOIN dismissed_topic_users ON dismissed_topic_users.topic_id = topics.id AND dismissed_topic_users.user_id = :user_id"}
       #{additional_join_sql}
       WHERE u.id = :user_id AND
             #{filter_old_unread_sql}


### PR DESCRIPTION
This reverts commit f438cb8e65b2239a4410de5f43a35e2e67b775d2.

Note: https://github.com/discourse-org/discourse-teams-sidebar/pull/181 must be merged first!