### PR TITLE
DEV: Disable Ember CLI tests on Github.

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     name: run
+    if: false # something is broken with this job so skip for now
     runs-on: ubuntu-latest
     container: discourse/discourse_test:release
     timeout-minutes: 40


### PR DESCRIPTION
Tests are consistently failing on Github so we're disabling it for now.