### PR TITLE
FIX: Pass fileName to error handler for media optimization

### DIFF
--- a/public/javascripts/media-optimization-worker.js
+++ b/public/javascripts/media-optimization-worker.js
@@ -139,7 +139,8 @@ onmessage = async function (e) {
         console.error(error);
         postMessage({
           type: "error",
-          file: e.data.file
+          file: e.data.file,
+          fileName: e.data.fileName
         });
       }
       break;


### PR DESCRIPTION
The file name is used to look up the promise to resolve; it
was being passed for the successful path but not for the
error path.

Here is where the fileName needed to be passed through:

https://github.com/discourse/discourse/blob/ac96ffc5995739e4fbc1749ea550f7ad86b712ab/app/assets/javascripts/discourse/app/services/media-optimization-worker.js#L131-L140