### PR TITLE
FIX: if the category slug is not present then search via ID

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.js
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.js
@@ -528,8 +528,10 @@ export default Component.extend({
             idCategoryMatches[0],
             `category:${id}`
           );
-        } else {
+        } else if (slug) {
           searchTerm += ` #${parentSlug}:${slug}`;
+        } else {
+          searchTerm += ` category:${id}`;
         }
 
         this._updateSearchTerm(searchTerm);
@@ -541,8 +543,10 @@ export default Component.extend({
             idCategoryMatches[0],
             `category:${id}`
           );
-        } else {
+        } else if (slug) {
           searchTerm += ` #${slug}`;
+        } else {
+          searchTerm += ` category:${id}`;
         }
 
         this._updateSearchTerm(searchTerm);

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -203,6 +203,30 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
+  test("update category without slug through advanced search ui", async function (assert) {
+    const categoryChooser = selectKit(
+      ".search-advanced-options .category-chooser"
+    );
+
+    await visit("/search");
+
+    await fillIn(".search-query", "none");
+
+    await categoryChooser.expand();
+    await categoryChooser.fillInFilter("快乐的");
+    await categoryChooser.selectRowByValue(240);
+
+    assert.ok(
+      exists('.search-advanced-options .badge-category:contains("快乐的")'),
+      'has "快乐的" populated'
+    );
+    assert.equal(
+      queryAll(".search-query").val(),
+      "none category:240",
+      'has updated search term to "none category:240"'
+    );
+  });
+
   test("update in:title filter through advanced search ui", async function (assert) {
     await visit("/search");
     await fillIn(".search-query", "none");

--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -421,6 +421,23 @@ export default {
           default_view: "latest",
           subcategory_list_style: "boxes",
         },
+        {
+          id: 240,
+          name: "快乐的",
+          color: "0E78BD",
+          text_color: "FFFFFF",
+          slug: "",
+          topic_count: 137,
+          post_count: 1142,
+          description: "关于幸福的讨论",
+          topic_url: "/t/category-definition-for-快乐的/11",
+          read_restricted: false,
+          permission: 1,
+          notification_level: null,
+          show_subcategory_list: true,
+          default_view: "latest",
+          subcategory_list_style: "boxes",
+        },
       ],
       post_action_types: [
         {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -113,7 +113,7 @@ discourseModule(
 
         assert.equal(
           this.subject.rows().length,
-          20,
+          21,
           "all categories are visible"
         );
 


### PR DESCRIPTION
Meta ref: https://meta.discourse.org/t/when-click-traditional-chinese-category-in-search-it-only-puts/200435/