### PR TITLE
DEV: Include `login_required` attribute in basic info endpoint

### DIFF
--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -34,7 +34,8 @@ class SiteController < ApplicationController
       title: SiteSetting.title,
       description: SiteSetting.site_description,
       header_primary_color: ColorScheme.hex_for_name('header_primary') || '333333',
-      header_background_color: ColorScheme.hex_for_name('header_background') || 'ffffff'
+      header_background_color: ColorScheme.hex_for_name('header_background') || 'ffffff',
+      login_required: SiteSetting.login_required
     }
 
     if mobile_logo_url = SiteSetting.site_mobile_logo_url.presence

--- a/spec/requests/site_controller_spec.rb
+++ b/spec/requests/site_controller_spec.rb
@@ -29,6 +29,7 @@ describe SiteController do
       expect(json["mobile_logo_url"]).to eq(expected_url)
       expect(json["header_primary_color"]).to eq("333333")
       expect(json["header_background_color"]).to eq("ffffff")
+      expect(json["login_required"]).to eq(true)
     end
   end
 


### PR DESCRIPTION
This is useful in the DiscourseHub mobile app, currently the app queries the `about.json` endpoint for this info, which can raise a CORS network error, for example when the site only accepts logins from an external provider.