### PR TITLE
update INSTALL-cloud for discourse-setup

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -72,7 +72,9 @@ Answer the following questions when prompted:
     SMTP port? [587]: 
     SMTP user name? [user@example.com]: 
     SMTP password? [pa$$word]: 
-    Let's Encrypt account email? (ENTER to skip) [me@example.com]: 
+    notification email address? [noreply@x.y.com]: 
+    Optional email address for Let's Encrypt warnings? (ENTER to skip) [me@example.com]: 
+    Optional Maxmind License key (ENTER to continue without MAXMIND GeoLite2 geolocation database) [1234567890123456]: 
 
 This will generate an `app.yml` configuration file on your behalf, and then kicks off bootstrap. Bootstrapping takes between **2-8 minutes** to set up your Discourse. If you need to change these settings after bootstrapping, you can run `./discourse-setup` again (it will re-use your previous values from the file) or edit `/containers/app.yml` manually with `nano` and then `./launcher rebuild app`, otherwise your changes will not take effect.
 


### PR DESCRIPTION
`discourse-setup`'s prompts changed, but they weren't changed in INSTALL-cloud as described in https://meta.discourse.org/t/discourse-installation-on-azure-not-reachable/36880/10?u=pfaffman

This brings INSTALL-cloud in line with the earlier changes to `discourse-setup`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
