### PR TITLE
FIX: uses keyUp as widgets dont handle bubbling

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-controls.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-controls.js
@@ -23,7 +23,7 @@ createWidget("search-term", {
     };
   },
 
-  keyDown(e) {
+  keyUp(e) {
     if (e.key === "Enter" && !this.state.afterAutocomplete) {
       return this.sendWidgetAction("fullSearch");
     }


### PR DESCRIPTION
discourse/app/widgets/search-menu.js is using keyDown to handle all kind of behaviors, using keyUp here prevents override.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
