### PR TITLE
FIX: Move bookmark modal buttons into modal-footer

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
@@ -47,7 +47,7 @@
     {{/if}}
   </div>
 
-  <div class="control-group">
+  <div class="modal-footer control-group">
     {{d-button id="save-bookmark" label="bookmarks.save" class="btn-primary" action=(action "saveAndClose")}}
     {{d-modal-cancel close=(action "closeWithoutSavingBookmark")}}
     {{#if showDelete}}

--- a/app/assets/stylesheets/common/components/bookmark-modal.scss
+++ b/app/assets/stylesheets/common/components/bookmark-modal.scss
@@ -3,6 +3,11 @@
     box-sizing: border-box;
     min-width: 310px;
   }
+  .modal-footer {
+    margin: 0;
+    border-top: 0;
+    padding: 10px 0;
+  }
   .modal-body {
     width: 375px;
     box-sizing: border-box;


### PR DESCRIPTION
I don't often like to leave descriptions blank, but this one is pretty self-explanatory!