### PR TITLE
DEV: Remove unnecessary condition in `TopicTrackingState` on client.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -13,7 +13,6 @@ function isNew(topic) {
     topic.last_read_post_number === null &&
     ((topic.notification_level !== 0 && !topic.notification_level) ||
       topic.notification_level >= NotificationLevels.TRACKING) &&
-    topic.created_in_new_period &&
     isUnseen(topic)
   );
 }
@@ -22,8 +21,7 @@ function isUnread(topic) {
   return (
     topic.last_read_post_number !== null &&
     topic.last_read_post_number < topic.highest_post_number &&
-    topic.notification_level >= NotificationLevels.TRACKING &&
-    topic.unread_not_too_old
+    topic.notification_level >= NotificationLevels.TRACKING
   );
 }
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
@@ -178,7 +178,6 @@ discourseModule(
                   last_read_post_number: 1,
                   highest_post_number: 2,
                   notification_level: NotificationLevels.TRACKING,
-                  unread_not_too_old: true,
                 });
               }
             } else {
@@ -187,7 +186,6 @@ discourseModule(
                 c.topicTrackingState.modifyState(321 + i, {
                   category_id: c.id,
                   last_read_post_number: null,
-                  created_in_new_period: true,
                 });
               }
               return false;

--- a/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
@@ -43,7 +43,6 @@ module("Unit | Model | nav-item", function (hooks) {
     tracker.modifyState("t1", {
       topic_id: 1,
       last_read_post_number: null,
-      created_in_new_period: true,
     });
     tracker.incrementMessageCount();
 

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -31,13 +31,11 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         topic_id: 1,
         last_read_post_number: null,
         tags: ["foo", "baz"],
-        created_in_new_period: true,
       },
       {
         topic_id: 2,
         last_read_post_number: null,
         tags: ["baz"],
-        created_in_new_period: true,
       },
       {
         topic_id: 3,
@@ -50,7 +48,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         highest_post_number: 7,
         tags: ["pending"],
         notification_level: NotificationLevels.TRACKING,
-        unread_not_too_old: true,
       },
       {
         topic_id: 5,
@@ -58,7 +55,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         highest_post_number: 7,
         tags: ["bar", "pending"],
         notification_level: NotificationLevels.TRACKING,
-        unread_not_too_old: true,
       },
       {
         topic_id: 6,
@@ -89,13 +85,11 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         topic_id: 1,
         last_read_post_number: null,
         tags: ["foo", "baz"],
-        created_in_new_period: true,
       },
       {
         topic_id: 2,
         last_read_post_number: null,
         tags: ["baz"],
-        created_in_new_period: true,
       },
       {
         topic_id: 3,
@@ -108,7 +102,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         highest_post_number: 7,
         tags: ["pending"],
         notification_level: NotificationLevels.TRACKING,
-        unread_not_too_old: true,
       },
       {
         topic_id: 5,
@@ -116,7 +109,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         highest_post_number: 7,
         tags: ["bar", "pending"],
         notification_level: NotificationLevels.TRACKING,
-        unread_not_too_old: true,
       },
       {
         topic_id: 6,
@@ -177,7 +169,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         topic_id: 3,
         last_read_post_number: null,
         tags: ["random"],
-        created_in_new_period: true,
       },
       {
         topic_id: 4,
@@ -186,7 +177,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         category_id: 7,
         tags: ["bug"],
         notification_level: NotificationLevels.TRACKING,
-        unread_not_too_old: true,
       },
       {
         topic_id: 5,
@@ -195,7 +185,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         tags: ["bar", "bug"],
         category_id: 7,
         notification_level: NotificationLevels.TRACKING,
-        unread_not_too_old: true,
       },
       {
         topic_id: 6,
@@ -379,14 +368,12 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         last_read_post_number: 4,
         highest_post_number: 5,
         notification_level: NotificationLevels.TRACKING,
-        unread_not_too_old: true,
       },
       {
         topic_id: 222,
         last_read_post_number: null,
         seen: false,
         notification_level: NotificationLevels.TRACKING,
-        created_in_new_period: true,
       },
     ]);
 
@@ -847,7 +834,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       id: 112,
       notification_level: NotificationLevels.TRACKING,
       category_id: 2,
-      created_in_new_period: true,
     });
 
     assert.equal(trackingState.countNew(1), 1);
@@ -862,7 +848,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       notification_level: NotificationLevels.TRACKING,
       category_id: 3,
       tags: ["amazing"],
-      created_in_new_period: true,
     });
 
     assert.equal(trackingState.countNew(1), 2);
@@ -876,7 +861,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       id: 111,
       notification_level: NotificationLevels.TRACKING,
       category_id: 1,
-      created_in_new_period: true,
     });
 
     assert.equal(trackingState.countNew(1), 3);

--- a/app/serializers/topic_tracking_state_serializer.rb
+++ b/app/serializers/topic_tracking_state_serializer.rb
@@ -6,18 +6,5 @@ class TopicTrackingStateSerializer < ApplicationSerializer
              :last_read_post_number,
              :created_at,
              :category_id,
-             :notification_level,
-             :created_in_new_period,
-             :unread_not_too_old,
-             :treat_as_new_topic_start_date
-
-  def created_in_new_period
-    return true if !scope
-    object.created_at >= treat_as_new_topic_start_date
-  end
-
-  def unread_not_too_old
-    return true if object.first_unread_at.blank?
-    object.updated_at >= object.first_unread_at
-  end
+             :notification_level
 end


### PR DESCRIPTION
The columns do not serve any purpose in Discourse core context.
