### PR TITLE
FIX: log proper error message when SSO nonce verification fails

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -156,7 +156,7 @@ class SessionController < ApplicationController
 
     if !sso.nonce_valid?
       if SiteSetting.verbose_discourse_connect_logging
-        Rails.logger.warn("Verbose SSO log: Nonce has already expired\n\n#{sso.diagnostics}")
+        Rails.logger.warn("Verbose SSO log: #{sso.nonce_error}\n\n#{sso.diagnostics}")
       end
       return render_sso_error(text: I18n.t("discourse_connect.timeout_expired"), status: 419)
     end

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -50,6 +50,10 @@ class SingleSignOn
     @nonce_expiry_time = v
   end
 
+  def self.used_nonce_expiry_time
+    24.hours
+  end
+
   attr_accessor(*ACCESSORS)
   attr_writer :sso_secret, :sso_url
 


### PR DESCRIPTION
This commit ensures that we provide proper error message in Rails logs when the nonce verification fails.