### PR TITLE
UX: do not show selected composer education messages on whisper post

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -130,7 +130,12 @@ export default Component.extend({
       }
     }
 
-    this.queuedForTyping.forEach((msg) => this.send("popup", msg));
+    this.queuedForTyping.forEach((msg) => {
+      if (composer.whisper && msg.hide_if_whisper) {
+        return;
+      }
+      this.send("popup", msg);
+    });
   },
 
   _create(info) {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -501,7 +501,7 @@ export default Controller.extend({
 
           const [linkWarn, linkInfo] = linkLookup.check(post, href);
 
-          if (linkWarn) {
+          if (linkWarn && !this.get("isWhispering")) {
             const body = I18n.t("composer.duplicate_link", {
               domain: linkInfo.domain,
               username: linkInfo.username,

--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -117,6 +117,7 @@ class ComposerMessagesFinder
       templateName: 'education',
       wait_for_typing: true,
       extraClass: 'education-message',
+      hide_if_whisper: true,
       body: PrettyText.cook(I18n.t('education.sequential_replies'))
     }
   end


### PR DESCRIPTION
This commit disables the "sequential_replies" and "duplicate_link" education message on composer when creating a whipser post.


Meta ref: https://meta.discourse.org/t/dont-warn-whisperers/199028/