### PR TITLE
FIX: Remove markers from all translated languages

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -549,11 +549,19 @@ module Email
     end
 
     def previous_replies_regex
-      @previous_replies_regex ||= /^--[- ]\n\*#{I18n.t("user_notifications.previous_discussion")}\*\n/im
+      strings = I18n.available_locales.map do |locale|
+        I18n.with_locale(locale) { I18n.t("user_notifications.previous_discussion") }
+      end.uniq
+
+      @previous_replies_regex ||= /^--[- ]\n\*(?:#{strings.map { |x| Regexp.escape(x) }.join("|")})\*\n/im
     end
 
     def reply_above_line_regex
-      @reply_above_line_regex ||= /\n#{I18n.t("user_notifications.reply_above_line")}\n/im
+      strings = I18n.available_locales.map do |locale|
+        I18n.with_locale(locale) { I18n.t("user_notifications.reply_above_line") }
+      end.uniq
+
+      @reply_above_line_regex ||= /\n(?:#{strings.map { |x| Regexp.escape(x) }.join("|")})\n/im
     end
 
     def trim_discourse_markers(reply)

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -412,8 +412,18 @@ describe Email::Receiver do
       expect(topic.posts.last.raw).to eq("This will not include the previous discussion that is present in this email.")
     end
 
+    it "removes the trnaslated 'Previous Replies' marker" do
+      expect { process(:previous_replies_de) }.to change { topic.posts.count }
+      expect(topic.posts.last.raw).to eq("This will not include the previous discussion that is present in this email.")
+    end
+
     it "removes the 'type reply above' marker" do
       expect { process(:reply_above) }.to change { topic.posts.count }
+      expect(topic.posts.last.raw).to eq("This will not include the previous discussion that is present in this email.")
+    end
+
+    it "removes the translated 'Previous Replies' marker" do
+      expect { process(:reply_above_de) }.to change { topic.posts.count }
       expect(topic.posts.last.raw).to eq("This will not include the previous discussion that is present in this email.")
     end
 

--- a/spec/fixtures/emails/previous_replies_de.eml
+++ b/spec/fixtures/emails/previous_replies_de.eml
@@ -1,0 +1,23 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Fri, 15 Jan 2016 00:12:43 +0100
+Message-ID: <21@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+
+This will not include the previous discussion that is present in this email.
+
+---
+*Vorherige Antworten*
+
+This is previous reply #1.
+
+Posted by foo bar on 01/15/2016
+
+---
+[Visit the Topic](https://bar.com/t/wat/1/1) to respond
+
+To stop receiving notifications for this particular topic, [click here](h=
+ttps://bar.com/t/wat/1/unsubscribe). To unsubscribe from these emails, ch=
+ange your [user preferences](https://bar.com/my/preferences).

--- a/spec/fixtures/emails/reply_above_de.eml
+++ b/spec/fixtures/emails/reply_above_de.eml
@@ -1,0 +1,15 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Fri, 15 Jan 2016 00:12:43 +0100
+Message-ID: <21@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+
+<p>This will not include the previous discussion that is present in this email.</p>
+
+<div>
+## Bitte gib deine Antwort oberhalb dieser Zeile ein. ##
+</div>
+
+<div>previous discussion</div>


### PR DESCRIPTION
Emails can include the marker in a different language, depending on
site and user settings. The email receiver always looked for the marker
in default language.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
