### PR TITLE
FIX: do not show default locale option on site text customization

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-text-index.hbs
@@ -24,10 +24,7 @@
         value=locale
         onChange=(action "updateLocale")
         class="locale-search"
-        options=(hash
-          filterable=true
-          none="user.locale.default"
-        )
+        options=(hash filterable=true)
       }}
     </div>
 


### PR DESCRIPTION
Meta ref: https://meta.discourse.org/t/error-when-selecting-a-text-customization-with-default-set-as-language/193828