### PR TITLE
FIX: Always reload post's raw when editing a post

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -831,22 +831,13 @@ const Composer = RestModel.extend({
       this.setProperties(topicProps);
 
       promise = promise.then(() => {
-        let rawPromise = Promise.resolve();
-
-        if (!this.post.raw) {
-          rawPromise = this.store.find("post", opts.post.id).then((post) => {
-            this.setProperties({
-              post,
-              reply: post.raw,
-              originalText: post.raw,
-            });
-          });
-        } else {
+        let rawPromise = this.store.find("post", opts.post.id).then((post) => {
           this.setProperties({
-            reply: this.post.raw,
-            originalText: this.post.raw,
+            post,
+            reply: post.raw,
+            originalText: post.raw,
           });
-        }
+        });
 
         // edge case ... make a post then edit right away
         // store does not have topic for the post


### PR DESCRIPTION
Sometimes the message bus update can be delayed and editing a post when
that happens will automatically result in a draft conflict.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
