### PR TITLE
FIX: Bookmark delete button alignment in modal-footer

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
@@ -51,9 +51,7 @@
     {{d-button id="save-bookmark" label="bookmarks.save" class="btn-primary" action=(action "saveAndClose")}}
     {{d-modal-cancel close=(action "closeWithoutSavingBookmark")}}
     {{#if showDelete}}
-      <div class="pull-right">
-        {{d-button id="delete-bookmark" icon="trash-alt" class="btn-danger" action=(action "delete")}}
-      </div>
+      {{d-button id="delete-bookmark" icon="trash-alt" class="delete-bookmark btn-danger" action=(action "delete")}}
     {{/if}}
   </div>
 {{/conditional-loading-spinner}}

--- a/app/assets/stylesheets/common/components/bookmark-modal.scss
+++ b/app/assets/stylesheets/common/components/bookmark-modal.scss
@@ -7,6 +7,10 @@
     margin: 0;
     border-top: 0;
     padding: 10px 0;
+
+    .delete-bookmark {
+      margin-left: auto;
+    }
   }
   .modal-body {
     width: 375px;


### PR DESCRIPTION
The commit cd38ec2a4d6761128fa4f213ba6358f77eec0530 broke
the bookmark delete button alignment in the modal.

Broken:

![image](https://user-images.githubusercontent.com/920448/129986461-3fd08432-bca8-4fec-bcc8-33f39e1789f7.png)

Fixed:

![image](https://user-images.githubusercontent.com/920448/129986475-77a05a05-2e18-4712-a688-3a5f206f6e00.png)
