### PR TITLE
DEV: Rename discourse-presence endpoints and messagebus channels

### DIFF
--- a/plugins/discourse-presence/assets/javascripts/discourse/lib/presence.js.es6
+++ b/plugins/discourse-presence/assets/javascripts/discourse/lib/presence.js.es6
@@ -98,7 +98,7 @@ const Presence = EmberObject.extend({
 
   @discourseComputed("topicId")
   channel(topicId) {
-    return `/presence/${topicId}`;
+    return `/presence-plugin/${topicId}`;
   },
 
   publish(state, whisper, postId, staffOnly) {
@@ -134,7 +134,7 @@ const Presence = EmberObject.extend({
       data.staff_only = true;
     }
 
-    return ajax("/presence/publish", {
+    return ajax("/presence-plugin/publish", {
       type: "POST",
       data,
     });

--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -15,7 +15,7 @@ PLUGIN_NAME ||= -"discourse-presence"
 
 after_initialize do
 
-  MessageBus.register_client_message_filter('/presence/') do |message|
+  MessageBus.register_client_message_filter('/presence-plugin/') do |message|
     published_at = message.data["published_at"]
 
     if published_at
@@ -146,7 +146,7 @@ after_initialize do
         payload[:post_id] = post_id
       end
 
-      MessageBus.publish("/presence/#{topic_id}", payload, opts)
+      MessageBus.publish("/presence-plugin/#{topic_id}", payload, opts)
 
       render json: success_json
     end
@@ -172,7 +172,7 @@ after_initialize do
   end
 
   Discourse::Application.routes.append do
-    mount ::Presence::Engine, at: '/presence'
+    mount ::Presence::Engine, at: '/presence-plugin'
   end
 
 end


### PR DESCRIPTION
We are working to introduce a general core API for presence, which will clash with this plugin's `/presence` namespace

This commit introduces no functional change. There may be a slight interruption in discourse-presence functionality during a deploy of this commit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
