### PR TITLE
DEV: adds a plugin-outlet before topic category in latest

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -35,6 +35,7 @@
   <div class="link-bottom-line">
     {{#unless hideCategory}}
       {{#unless topic.isPinnedUncategorized}}
+        {{~raw-plugin-outlet name="topic-list-before-category"}}
         {{category-link topic.category}}
       {{/unless}}
     {{/unless}}


### PR DESCRIPTION
Adding this so themes can avoid template overrides.