### PR TITLE
FEATURE: improve "blank page syndrome" on the user bookmarks page

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
@@ -1,22 +1,34 @@
-<div class="form-horizontal bookmark-search-form">
-  {{input type="text"
-          value=searchTerm
-          placeholder=(i18n "bookmarks.search_placeholder")
-          enter=(action "search")
-          id="bookmark-search" autocomplete="discourse"}}
-  {{d-button
-      class="btn-primary"
-      action=(action "search")
-      type="button"
-      icon="search"}}
-</div>
-{{#if noContent}}
-  <div class="alert alert-info">{{noResultsHelpMessage}}</div>
-{{else}}
-  {{bookmark-list
-    loadMore=(action "loadMore")
-    reload=(action "reload")
-    loading=loading
-    loadingMore=loadingMore
-    content=content}}
-{{/if}}
+{{#conditional-loading-spinner condition=loading}}
+  {{#if permissionDenied}}
+    <div class="alert alert-info">{{i18n "bookmarks.list_permission_denied"}}</div>
+  {{else if userDoesNotHaveBookmarks}}
+    <div class="empty-state">
+      <span class="empty-state-title">{{i18n "user.no_bookmarks_title"}}</span>
+      <div class="empty-state-body">
+        <p>{{emptyStateBody}}</p>
+      </div>
+    </div>
+  {{else}}
+    <div class="form-horizontal bookmark-search-form">
+      {{input type="text"
+        value=searchTerm
+        placeholder=(i18n "bookmarks.search_placeholder")
+        enter=(action "search")
+        id="bookmark-search" autocomplete="discourse"}}
+      {{d-button
+        class="btn-primary"
+        action=(action "search")
+        type="button"
+        icon="search"}}
+    </div>
+    {{#if nothingFound}}
+      <div class="alert alert-info">{{i18n "user.no_bookmarks_search"}}</div>
+    {{else}}
+      {{bookmark-list
+        loadMore=(action "loadMore")
+        reload=(action "reload")
+        loadingMore=loadingMore
+        content=content}}
+    {{/if}}
+  {{/if}}
+{{/conditional-loading-spinner}}

--- a/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-bookmarks-test.js
@@ -1,8 +1,4 @@
-import {
-  acceptance,
-  exists,
-  queryAll,
-} from "discourse/tests/helpers/qunit-helpers";
+import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 import { click, visit } from "@ember/test-helpers";
 import { cloneJSON } from "discourse-common/lib/object";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -21,6 +17,11 @@ acceptance("User's bookmarks", function (needs) {
     await dropdown.selectRowByValue("remove");
 
     assert.not(exists(".bootbox.modal"), "it should not show the modal");
+  });
+
+  test("it renders search controls if there are bookmarks", async function (assert) {
+    await visit("/u/eviltrout/activity/bookmarks");
+    assert.ok(exists("div.bookmark-search-form"));
   });
 });
 
@@ -55,13 +56,16 @@ acceptance("User's bookmarks - no bookmarks", function (needs) {
     server.get("/u/eviltrout/bookmarks.json", () =>
       helper.response({
         bookmarks: [],
-        no_results_help: "no bookmarks",
       })
     );
   });
 
   test("listing users bookmarks - no bookmarks", async function (assert) {
     await visit("/u/eviltrout/activity/bookmarks");
-    assert.equal(queryAll(".alert.alert-info").text(), "no bookmarks");
+    assert.notOk(
+      exists("div.bookmark-search-form"),
+      "does not render search controls"
+    );
+    assert.ok(exists("div.empty-state", "renders the empty-state message"));
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1067,6 +1067,7 @@ en:
       no_bookmarks_title: "You haven’t bookmarked anything yet"
       no_bookmarks_body: >
         Start bookmarking posts with the %{icon} button and they will be listed here for easy reference. You can schedule a reminder too!
+      no_bookmarks_search: "No bookmarks found with the provided search query."
       no_notifications_title: "You don’t have any notifications yet"
       no_notifications_body: >
         You will be notified in this panel about activity directly relevant to you, including replies to your topics and posts, when someone <b>@mentions</b> you or quotes you, and replies to topics you are watching. Notifications will also be sent to your email when you haven’t logged in for a while.


### PR DESCRIPTION
Some time ago, we made the bookmarks panel on the user menu look like this when a user doesn't have bookmarks yet:
<img width="200" alt="Screenshot 2021-08-19 at 20 40 57" src="https://user-images.githubusercontent.com/1274517/130126318-3e06a781-a700-43dc-996b-be8f7ad87014.png">

Now we want to use the same design on the user bookmarks page:

<img width="450" alt="Screenshot 2021-08-19 at 20 45 10" src="https://user-images.githubusercontent.com/1274517/130126570-81d290a4-3ea0-454f-aa3e-39a06d847f9e.png">

There'll be further discussion about design of this page, we'll probably adjust styles a bit.

From technical point of view, the change is not very straight forward because there exist several reasons why the bookmarks page can contain an empty list of bookmarks:
1. A user may have no bookmarks yet (the case we're handling in this PR)
2. A user may try to look at bookmarks of another user and don't have permissions for doing that
2. A user may enter a search query that doesn't return results

This PR:
1. Rework the template and the controller to make handling of these different cases explicit and straight forward
2. Suppress the search box on the bookmarks page when a user doesn't have bookmarks
3. Make the page show a new design when user doesn't have bookmarks

Also, this PR fixes a little bug. When a user had bookmarks, the message "You have no bookmarked posts" appeared for a while when loading the page:
https://user-images.githubusercontent.com/1274517/130128266-4201dc9f-12e4-4604-9660-265dc8dfcb6c.mov

It's fixed now:
https://user-images.githubusercontent.com/1274517/130128619-b89e879f-66b4-462c-a337-aa0d713be69d.mov


