### PR TITLE
DEV: Upgrade Rails to 6.1.4.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,13 +18,14 @@ else
   # this allows us to include the bits of rails we use without pieces we do not.
   #
   # To issue a rails update bump the version number here
-  gem 'actionmailer', '6.1.3.2'
-  gem 'actionpack', '6.1.3.2'
-  gem 'actionview', '6.1.3.2'
-  gem 'activemodel', '6.1.3.2'
-  gem 'activerecord', '6.1.3.2'
-  gem 'activesupport', '6.1.3.2'
-  gem 'railties', '6.1.3.2'
+  rails_version = '6.1.4.1'
+  gem 'actionmailer', rails_version
+  gem 'actionpack', rails_version
+  gem 'actionview', rails_version
+  gem 'activemodel', rails_version
+  gem 'activerecord', rails_version
+  gem 'activesupport', rails_version
+  gem 'railties', rails_version
   gem 'sprockets-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,22 +8,22 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (6.1.3.2)
-      actionpack (= 6.1.3.2)
-      actionview (= 6.1.3.2)
-      activejob (= 6.1.3.2)
-      activesupport (= 6.1.3.2)
+    actionmailer (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      actionview (= 6.1.4.1)
+      activejob (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.1.3.2)
-      actionview (= 6.1.3.2)
-      activesupport (= 6.1.3.2)
+    actionpack (6.1.4.1)
+      actionview (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       rack (~> 2.0, >= 2.0.9)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.1.3.2)
-      activesupport (= 6.1.3.2)
+    actionview (6.1.4.1)
+      activesupport (= 6.1.4.1)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
@@ -32,15 +32,15 @@ GEM
       actionview (>= 6.0.a)
     active_model_serializers (0.8.4)
       activemodel (>= 3.0)
-    activejob (6.1.3.2)
-      activesupport (= 6.1.3.2)
+    activejob (6.1.4.1)
+      activesupport (= 6.1.4.1)
       globalid (>= 0.3.6)
-    activemodel (6.1.3.2)
-      activesupport (= 6.1.3.2)
-    activerecord (6.1.3.2)
-      activemodel (= 6.1.3.2)
-      activesupport (= 6.1.3.2)
-    activesupport (6.1.3.2)
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activerecord (6.1.4.1)
+      activemodel (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -326,11 +326,11 @@ GEM
     rails_multisite (3.0.0)
       activerecord (> 5.0, < 7)
       railties (> 5.0, < 7)
-    railties (6.1.3.2)
-      actionpack (= 6.1.3.2)
-      activesupport (= 6.1.3.2)
+    railties (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       method_source
-      rake (>= 0.8.7)
+      rake (>= 0.13)
       thor (~> 1.0)
     rainbow (3.0.0)
     raindrops (0.19.2)
@@ -481,14 +481,14 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionmailer (= 6.1.3.2)
-  actionpack (= 6.1.3.2)
-  actionview (= 6.1.3.2)
+  actionmailer (= 6.1.4.1)
+  actionpack (= 6.1.4.1)
+  actionview (= 6.1.4.1)
   actionview_precompiler
   active_model_serializers (~> 0.8.3)
-  activemodel (= 6.1.3.2)
-  activerecord (= 6.1.3.2)
-  activesupport (= 6.1.3.2)
+  activemodel (= 6.1.4.1)
+  activerecord (= 6.1.4.1)
+  activesupport (= 6.1.4.1)
   addressable
   annotate
   aws-sdk-s3
@@ -568,7 +568,7 @@ DEPENDENCIES
   rack-protection
   rails_failover
   rails_multisite
-  railties (= 6.1.3.2)
+  railties (= 6.1.4.1)
   rake
   rb-fsevent
   rbtrace


### PR DESCRIPTION
This pulls in a fix for CVE-2021-22942 but we're not tagging it as a
security fix because Discourse is not affected by it in production.