### PR TITLE
FIX: Adding debugging and fixing media-optimization-worker issues

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/register-media-optimization-upload-processor.js
+++ b/app/assets/javascripts/discourse/app/initializers/register-media-optimization-upload-processor.js
@@ -9,10 +9,10 @@ export default {
       addComposerUploadProcessor(
         { action: "optimizeJPEG" },
         {
-          optimizeJPEG: (data) =>
+          optimizeJPEG: (data, opts) =>
             container
               .lookup("service:media-optimization-worker")
-              .optimizeImage(data),
+              .optimizeImage(data, opts),
         }
       );
     }

--- a/app/assets/javascripts/discourse/app/lib/uppy-media-optimization-plugin.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy-media-optimization-plugin.js
@@ -23,7 +23,7 @@ export default class UppyMediaOptimization extends Plugin {
 
     this.uppy.emit("preprocess-progress", this.pluginClass, file);
 
-    return this.optimizeFn(file, { stopWorkerOnError: false })
+    return this.optimizeFn(file, { stopWorkerOnError: !this.runParallel })
       .then((optimizedFile) => {
         if (!optimizedFile) {
           warn("Nothing happened, possible error or other restriction.", {

--- a/app/assets/javascripts/discourse/app/lib/uppy-media-optimization-plugin.js
+++ b/app/assets/javascripts/discourse/app/lib/uppy-media-optimization-plugin.js
@@ -23,7 +23,7 @@ export default class UppyMediaOptimization extends Plugin {
 
     this.uppy.emit("preprocess-progress", this.pluginClass, file);
 
-    return this.optimizeFn(file)
+    return this.optimizeFn(file, { stopWorkerOnError: false })
       .then((optimizedFile) => {
         if (!optimizedFile) {
           warn("Nothing happened, possible error or other restriction.", {


### PR DESCRIPTION
When we encountered an error with the media-optimization-worker,
we stopped the worker, which made it so further messages were not
received when optimizing images in parallel. Removed this based
on an option.

Also added more debugging lines to help track down issues.
