### PR TITLE
FIX: Close emoji autocomplete when the opening colon `:` is removed

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -580,7 +580,7 @@ export default function (options) {
       }
 
       // If we've backspaced past the beginning, cancel unless no key
-      if (cp <= completeStart && options.key) {
+      if (cp - 1 <= completeStart && options.key) {
         closeAutocomplete();
         return true;
       }


### PR DESCRIPTION
As you can see in the video, I type `A :a` in the composer and the emoji autocomplete menu shows up with 5 suggestions as expected. However, when I backspace and delete `:a`, the emoji autocomplete menu remains shown even though the colon that triggers emoji autocomplete has been removed.

https://user-images.githubusercontent.com/17474474/130228484-29aad09b-4108-45d9-9a39-f280684bfd7c.mp4
