### PR TITLE
FEATURE: improve "blank page syndrome" on the user notifications page

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-notifications.js
@@ -1,6 +1,9 @@
 import Controller, { inject as controller } from "@ember/controller";
 import discourseComputed, { observes } from "discourse-common/utils/decorators";
 import { ajax } from "discourse/lib/ajax";
+import { iconHTML } from "discourse-common/lib/icon-library";
+import getURL from "discourse-common/lib/get-url";
+import I18n from "I18n";
 
 export default Controller.extend({
   application: controller(),
@@ -12,8 +15,13 @@ export default Controller.extend({
     this.set("application.showFooter", !this.get("model.canLoadMore"));
   },
 
+  @discourseComputed("filter")
+  filtered() {
+    return this.filter && this.filter !== "all";
+  },
+
   @discourseComputed("model.content.length")
-  hasFilteredNotifications(length) {
+  hasNotifications(length) {
     return length > 0;
   },
 
@@ -22,6 +30,24 @@ export default Controller.extend({
     return !this.get("model.content").some(
       (notification) => !notification.get("read")
     );
+  },
+
+  @discourseComputed("filtered", "hasNotifications")
+  userDoesNotHaveNotifications(filtered, hasNotifications) {
+    return !filtered && !hasNotifications;
+  },
+
+  @discourseComputed("filtered", "hasNotifications")
+  nothingFound(filtered, hasNotifications) {
+    return filtered && !hasNotifications;
+  },
+
+  @discourseComputed()
+  emptyStateBody() {
+    return I18n.t("user.no_notifications_page_body", {
+      preferencesUrl: getURL("/my/preferences/notifications"),
+      icon: iconHTML("bell"),
+    }).htmlSafe();
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/controllers/user-notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-notifications.js
@@ -18,7 +18,7 @@ export default Controller.extend({
   },
 
   @discourseComputed("filter")
-  filtered() {
+  isFiltered() {
     return this.filter && this.filter !== "all";
   },
 
@@ -29,14 +29,14 @@ export default Controller.extend({
     );
   },
 
-  @discourseComputed("filtered", "hasNotifications")
-  userDoesNotHaveNotifications(filtered, hasNotifications) {
-    return !filtered && !hasNotifications;
+  @discourseComputed("isFiltered", "hasNotifications")
+  userDoesNotHaveNotifications(isFiltered, hasNotifications) {
+    return !isFiltered && !hasNotifications;
   },
 
-  @discourseComputed("filtered", "hasNotifications")
-  nothingFound(filtered, hasNotifications) {
-    return filtered && !hasNotifications;
+  @discourseComputed("isFiltered", "hasNotifications")
+  nothingFound(isFiltered, hasNotifications) {
+    return isFiltered && !hasNotifications;
   },
 
   @discourseComputed()

--- a/app/assets/javascripts/discourse/app/controllers/user-notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-notifications.js
@@ -4,13 +4,11 @@ import { ajax } from "discourse/lib/ajax";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import getURL from "discourse-common/lib/get-url";
 import I18n from "I18n";
-import { gt } from "@ember/object/computed";
 
 export default Controller.extend({
   application: controller(),
   queryParams: ["filter"],
   filter: "all",
-  hasNotifications: gt("model.content.length", 0),
 
   @observes("model.canLoadMore")
   _showFooter() {
@@ -29,14 +27,14 @@ export default Controller.extend({
     );
   },
 
-  @discourseComputed("isFiltered", "hasNotifications")
-  userDoesNotHaveNotifications(isFiltered, hasNotifications) {
-    return !isFiltered && !hasNotifications;
+  @discourseComputed("isFiltered", "model.content.length")
+  doesNotHaveNotifications(isFiltered, contentLength) {
+    return !isFiltered && contentLength === 0;
   },
 
-  @discourseComputed("isFiltered", "hasNotifications")
-  nothingFound(isFiltered, hasNotifications) {
-    return isFiltered && !hasNotifications;
+  @discourseComputed("isFiltered", "model.content.length")
+  nothingFound(isFiltered, contentLength) {
+    return isFiltered && contentLength === 0;
   },
 
   @discourseComputed()

--- a/app/assets/javascripts/discourse/app/controllers/user-notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-notifications.js
@@ -4,11 +4,13 @@ import { ajax } from "discourse/lib/ajax";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import getURL from "discourse-common/lib/get-url";
 import I18n from "I18n";
+import { gt } from "@ember/object/computed";
 
 export default Controller.extend({
   application: controller(),
   queryParams: ["filter"],
   filter: "all",
+  hasNotifications: gt("model.content.length", 0),
 
   @observes("model.canLoadMore")
   _showFooter() {
@@ -18,11 +20,6 @@ export default Controller.extend({
   @discourseComputed("filter")
   filtered() {
     return this.filter && this.filter !== "all";
-  },
-
-  @discourseComputed("model.content.length")
-  hasNotifications(length) {
-    return length > 0;
   },
 
   @discourseComputed("model.content.@each.read")

--- a/app/assets/javascripts/discourse/app/templates/user/notifications-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications-index.hbs
@@ -6,7 +6,7 @@
       {{i18n "errors.desc.unknown"}}
     {{/if}}
   </div>
-{{else if userDoesNotHaveNotifications}}
+{{else if doesNotHaveNotifications}}
   <div class="empty-state">
     <span class="empty-state-title">{{i18n "user.no_notifications_page_title"}}</span>
     <div class="empty-state-body">

--- a/app/assets/javascripts/discourse/app/templates/user/notifications-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications-index.hbs
@@ -6,15 +6,22 @@
       {{i18n "errors.desc.unknown"}}
     {{/if}}
   </div>
-{{/if}}
-
-<div class="user-notifications-filter-select-kit">
-  {{notifications-filter value=filter onChange=(action (mut filter))}}
-</div>
-
-{{#if hasFilteredNotifications}}
-  {{user-notifications-large notifications=model filter=filter}}
-  {{conditional-loading-spinner condition=loading}}
+{{else if userDoesNotHaveNotifications}}
+  <div class="empty-state">
+    <span class="empty-state-title">{{i18n "user.no_notifications_page_title"}}</span>
+    <div class="empty-state-body">
+      <p>{{emptyStateBody}}</p>
+    </div>
+  </div>
 {{else}}
-  <div class="alert alert-info">{{i18n "notifications.empty"}}</div>
+  <div class="user-notifications-filter-select-kit">
+    {{notifications-filter value=filter onChange=(action (mut filter))}}
+  </div>
+
+  {{#if nothingFound}}
+    <div class="alert alert-info">{{i18n "notifications.empty"}}</div>
+  {{else}}
+    {{user-notifications-large notifications=model filter=filter}}
+    {{conditional-loading-spinner condition=loading}}
+  {{/if}}
 {{/if}}

--- a/app/assets/javascripts/discourse/tests/acceptance/notifications-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/notifications-test.js
@@ -2,6 +2,7 @@ import { visit } from "@ember/test-helpers";
 import {
   acceptance,
   count,
+  exists,
   publishToMessageBus,
   query,
   queryAll,
@@ -198,3 +199,29 @@ acceptance("User Notifications", function (needs) {
     ]);
   });
 });
+
+acceptance(
+  "User Notifications - there is no notifications yet",
+  function (needs) {
+    needs.user();
+
+    needs.pretender((server, helper) => {
+      server.get("/notifications", () => {
+        return helper.response({
+          notifications: [],
+        });
+      });
+    });
+
+    test("It renders the empty state panel", async function (assert) {
+      await visit("/u/eviltrout/notifications");
+      assert.ok(exists("div.empty-state"));
+    });
+
+    test("It does not render filter", async function (assert) {
+      await visit("/u/eviltrout/notifications");
+
+      assert.notOk(exists("div.user-notifications-filter-select-kit"));
+    });
+  }
+);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1073,6 +1073,11 @@ en:
         You will be notified in this panel about activity directly relevant to you, including replies to your topics and posts, when someone <b>@mentions</b> you or quotes you, and replies to topics you are watching. Notifications will also be sent to your email when you haven’t logged in for a while.
         <br><br>
         Look for the %{icon} to decide which specific topics, categories and tags you want to be notified about. For more, see your <a href='%{preferencesUrl}'>notification preferences</a>.
+      no_notifications_page_title: "You don’t have any notifications yet"
+      no_notifications_page_body: >
+        You will be notified about activity directly relevant to you, including replies to your topics and posts, when someone <b>@mentions</b> you or quotes you, and replies to topics you are watching. Notifications will also be sent to your email when you haven’t logged in for a while.
+        <br><br>
+        Look for the %{icon} to decide which specific topics, categories and tags you want to be notified about. For more, see your <a href='%{preferencesUrl}'>notification preferences</a>.
       first_notification: "Your first notification! Select it to begin."
       dynamic_favicon: "Show counts on browser icon"
       skip_new_user_tips:


### PR DESCRIPTION
We'll be showing this when a user doesn't have notifications yet. The text will probably be adjusted in subsequent PRs:

<img width="500" alt="Screenshot 2021-08-20 at 16 33 48" src="https://user-images.githubusercontent.com/1274517/130249776-a26bda32-44d8-40b4-b5bc-692b1324efe4.png">

