### PR TITLE
DEV: adds plugin-outlet before category in /latest on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/mobile/list/topic-list-item.hbr
@@ -36,6 +36,7 @@
         </div>
         <div class="topic-item-stats clearfix">
           {{#unless hideCategory}}
+            {{~raw-plugin-outlet name="topic-list-before-category"}}
             <div class='category'>
               {{category-link topic.category}}
             </div>


### PR DESCRIPTION
Adding this so themes can avoid template overrides.