### PR TITLE
DEV: adds server:after-body-open

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,6 +66,10 @@
   </head>
 
   <body class="<%= body_classes %>">
+    <%- if allow_plugins? %>
+      <%= build_plugin_html 'server:after-body-open' %>
+    <%- end -%>
+
     <%= render_google_tag_manager_body_code %>
     <noscript data-path="<%= request.env['PATH_INFO'] %>">
       <%= render partial: 'header' %>

--- a/app/views/layouts/no_ember.html.erb
+++ b/app/views/layouts/no_ember.html.erb
@@ -19,6 +19,10 @@
   <%- end -%>
 </head>
 <body class="no-ember <%= @custom_body_class %>">
+  <%- if allow_plugins? %>
+    <%= build_plugin_html 'server:after-body-open' %>
+  <%- end -%>
+
   <%- unless customization_disabled? %>
     <%= theme_lookup("header") %>
   <%- end %>


### PR DESCRIPTION
This change is to allow to add a node at the top of body. This is currently done through DOM in a plugin which is causing a full Recalculate Style.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
