### PR TITLE
FEATURE: allow adding small action codes dedicated to groups

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -53,7 +53,10 @@ import { addPluginOutletDecorator } from "discourse/components/plugin-connector"
 import { addPluginReviewableParam } from "discourse/components/reviewable-item";
 import { addPopupMenuOptionsCallback } from "discourse/controllers/composer";
 import { addPostClassesCallback } from "discourse/widgets/post";
-import { addPostSmallActionIcon } from "discourse/widgets/post-small-action";
+import {
+  addGroupPostSmallActionCode,
+  addPostSmallActionIcon,
+} from "discourse/widgets/post-small-action";
 import { addQuickAccessProfileItem } from "discourse/widgets/quick-access-profile";
 import { addTagsHtmlCallback } from "discourse/lib/render-tags";
 import { addToolbarCallback } from "discourse/components/d-editor";
@@ -81,7 +84,7 @@ import { addSearchResultsCallback } from "discourse/lib/search";
 import { addSearchSuggestion } from "discourse/widgets/search-menu-results";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.12.1";
+const PLUGIN_API_VERSION = "0.12.2";
 
 class PluginApi {
   constructor(version, container) {
@@ -713,6 +716,17 @@ class PluginApi {
    **/
   addPostSmallActionIcon(key, icon) {
     addPostSmallActionIcon(key, icon);
+  }
+
+  /**
+   * Register a small action code to be used for small post actions containing a link to a group
+   *
+   * ```javascript
+   * api.addGroupPostSmallActionCode('group_assigned');
+   * ```
+   **/
+  addGroupPostSmallActionCode(actionCode) {
+    addGroupPostSmallActionCode(actionCode);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -16,7 +16,7 @@ export function actionDescriptionHtml(actionCode, createdAt, username) {
 
   let who = "";
   if (username) {
-    if (actionCode === "invited_group" || actionCode === "removed_group") {
+    if (groupActionCodes.includes(actionCode)) {
       who = `<a class="mention-group" href="/g/${username}">@${username}</a>`;
     } else {
       who = `<a class="mention" href="${userPath(username)}">@${username}</a>`;
@@ -33,6 +33,8 @@ export function actionDescription(actionCode, createdAt, username) {
     }
   });
 }
+
+const groupActionCodes = ["invited_group", "removed_group"];
 
 const icons = {
   "closed.enabled": "lock",
@@ -62,6 +64,10 @@ const icons = {
 
 export function addPostSmallActionIcon(key, icon) {
   icons[key] = icon;
+}
+
+export function addGroupPostSmallActionCode(actionCode) {
+  groupActionCodes.push(actionCode);
 }
 
 export default createWidget("post-small-action", {


### PR DESCRIPTION
Plugin API is allowing to add small action codes dedicated to groups.
This will be used by assign-plugin when topic is assigned or unassigned from group.
