### PR TITLE
FIX: Use file.id instead of file.name for media-optimization resolvers

### DIFF
--- a/public/javascripts/media-optimization-worker.js
+++ b/public/javascripts/media-optimization-worker.js
@@ -131,7 +131,8 @@ onmessage = async function (e) {
           {
             type: "file",
             file: optimized,
-            fileName: e.data.fileName
+            fileName: e.data.fileName,
+            fileId: e.data.fileId
           },
           [optimized]
         );
@@ -140,7 +141,8 @@ onmessage = async function (e) {
         postMessage({
           type: "error",
           file: e.data.file,
-          fileName: e.data.fileName
+          fileName: e.data.fileName,
+          fileId: e.data.fileId
         });
       }
       break;


### PR DESCRIPTION
This change only applies when uppy is calling the media-optimization-worker.

Since the old way of calling the worker via jQuery file uploader will
be removed soon, there is no point coming up with some random string
to use in place of the file name for the promise resolvers there, we
can live with this for now.
