### PR TITLE
FIX: Reset preProcessorStatus state correctly for composer-upload-uppy

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -352,7 +352,12 @@ export default Mixin.create({
       isCancellable: false,
     });
     this._eachPreProcessor((pluginClass) => {
-      this._preProcessorStatus[pluginClass] = {};
+      this._preProcessorStatus[pluginClass] = {
+        needProcessing: 0,
+        activeProcessing: 0,
+        completeProcessing: 0,
+        allComplete: false,
+      };
     });
     this.fileInputEl.value = "";
   },


### PR DESCRIPTION
When resetting the preprocessor status states, we weren't using
the same default state as when the preprocessor status state is
first initialized with an associated plugin. This commit brings
the two into alignment, fixing a bug where if you cancelled an
upload then tried a new one the "Processing Upload" message would
never change to "Uploading... X", so any subsequent uploads were
uncancellable.

Since the state was not being reset correctly, the properties that
were supposed to be numbers ended up as `undefined`, so when calling
prop-- or prop++, they turned into NaN.

See:

https://github.com/discourse/discourse/blob/5b39eb1549614d6a440c1271914b2175db19a732/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js#L425-L435
