### PR TITLE
Revert "FIX: Close emoji autocomplete when the opening colon `:` is removed (#14102)"

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -580,7 +580,7 @@ export default function (options) {
       }
 
       // If we've backspaced past the beginning, cancel unless no key
-      if (cp - 1 <= completeStart && options.key) {
+      if (cp <= completeStart && options.key) {
         closeAutocomplete();
         return true;
       }


### PR DESCRIPTION
This reverts commit c74f116a48b3bac29b91712ad6d38a87fc7eb2af.

Unfortunately it appears to be making mention autocomplete fail
