### PR TITLE
FIX: Add plugin event to topic list user lookup

### DIFF
--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -113,6 +113,8 @@ class TopicList
       user_ids << ft.user_id << ft.last_post_user_id << ft.featured_user_ids << ft.allowed_user_ids
     end
 
+    DiscourseEvent.trigger(:before_topic_list_user_lookup, @topics, user_ids)
+
     user_lookup = UserLookup.new(user_ids)
 
     @topics.each do |ft|

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -25,6 +25,19 @@ class TopicList
     end
   end
 
+  def self.on_preload_user_ids(&blk)
+    (@preload_user_ids ||= Set.new) << blk
+  end
+
+  def self.preload_user_ids(topics, user_ids, object)
+    if @preload_user_ids
+      @preload_user_ids.each do |preload_user_ids|
+        user_ids = preload_user_ids.call(topics, user_ids, object)
+      end
+    end
+    user_ids
+  end
+
   attr_accessor(
     :more_topics_url,
     :prev_topics_url,
@@ -113,8 +126,7 @@ class TopicList
       user_ids << ft.user_id << ft.last_post_user_id << ft.featured_user_ids << ft.allowed_user_ids
     end
 
-    DiscourseEvent.trigger(:before_topic_list_user_lookup, @topics, user_ids)
-
+    user_ids = TopicList.preload_user_ids(@topics, user_ids, self)
     user_lookup = UserLookup.new(user_ids)
 
     @topics.each do |ft|

--- a/app/models/topic_posters_summary.rb
+++ b/app/models/topic_posters_summary.rb
@@ -41,10 +41,10 @@ class TopicPostersSummary
     topic_poster
   end
 
-  def descriptions_by_id
+  def descriptions_by_id(ids: nil)
     @descriptions_by_id ||= begin
       result = {}
-      ids = user_ids
+      ids = ids || user_ids
 
       if id = ids.shift
         result[id] ||= []

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -210,6 +210,16 @@ class Plugin::Instance
     TopicView.add_custom_filter(trigger, &block)
   end
 
+  # Allows to add more user IDs to the list of preloaded users. This can be
+  # useful to efficiently change the list of posters or participants.
+  # Example usage:
+  #   register_topic_list_preload_user_ids do |topics, user_ids, topic_list|
+  #     user_ids << Discourse::SYSTEM_USER_ID
+  #   end
+  def register_topic_list_preload_user_ids(&block)
+    TopicList.on_preload_user_ids(&block)
+  end
+
   # Allow to eager load additional tables in Search. Useful to avoid N+1 performance problems.
   # Example usage:
   #   register_search_topic_eager_load do |opts|


### PR DESCRIPTION
This can be used to change the list of topic posters. For example,
discourse-solved can use this to move the user who posted the solution
after the original poster.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
