### PR TITLE
FIX: do not focus after search if dropdown is collapsed

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -683,8 +683,10 @@ export default Component.extend(
           });
 
           this._safeAfterRender(() => {
-            this.popper && this.popper.update();
-            this._focusFilter();
+            if (this.selectKit.isExpanded) {
+              this.popper && this.popper.update();
+              this._focusFilter();
+            }
           });
         })
         .finally(() => {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
