### PR TITLE
FIX: Jump to reply arrow in post stream was not working

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -499,7 +499,16 @@ createWidget("post-contents", {
       .then((posts) => {
         this.state.repliesBelow = posts.map((p) => {
           let result = transformWithCallbacks(p);
-          result.shareUrl = `${topicUrl}/${p.post_number}`;
+
+          // these would conflict with computed properties with identical names
+          // in the post model if we kept them.
+          delete result.new_user;
+          delete result.deleted;
+          delete result.shareUrl;
+          delete result.firstPost;
+          delete result.usernameUrl;
+
+          result.customShare = `${topicUrl}/${p.post_number}`;
           result.asPost = this.store.createRecord("post", result);
           return result;
         });


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/jump-to-reply-arrow-seems-broken-after-updating-to-latest-beta-of-discourse/201006?u=osama.

The arrow is an `<a>` tag and it was missing the `href` attribute because the `customShare` property was not set.