### PR TITLE
FIX: the empty state message was appearing on the user bookmarks page when a user have bookmarks

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -25,14 +25,11 @@ export default Controller.extend({
       content: [],
       loading: true,
       permissionDenied: false,
+      searchTerm: this.q,
     });
 
-    if (this.q && !this.searchTerm) {
-      this.set("searchTerm", this.q);
-    }
-
     return this.model
-      .loadItems({ q: this.searchTerm })
+      .loadItems({ q: this.q })
       .then((response) => this._processLoadResponse(response))
       .catch(() => this._bookmarksListDenied())
       .finally(() => {
@@ -85,7 +82,7 @@ export default Controller.extend({
     this.set("loadingMore", true);
 
     return this.model
-      .loadMore({ q: this.searchTerm })
+      .loadMore({ q: this.q })
       .then((response) => this._processLoadResponse(response))
       .catch(() => this._bookmarksListDenied())
       .finally(() => this.set("loadingMore", false));


### PR DESCRIPTION
Steps to reproduce:
1. Go to `activity/bookmarks`
2. Search for something that isn’t in your bookmarks, so you get no results
3. Navigate away and then click "Bookmarked" on the sidebar  or open the user menu and click the View All Bookmarks button on the bottom of the bookmarks tab, and you get this:

<kbd>![a0be517e9e92bcd16ccb813d4dc4a6e3bdb5e68f_2_1380x370](https://user-images.githubusercontent.com/1274517/130608104-b699dda4-bd79-4613-8903-18d944fb1d7a.png)</kbd>

This PR fixes the problem. We have a controller with a query parameter `q` that contains a search query. And we also have a property `searchTerm` that is bound to the search box on the page and mirrors the value in `q`. We were using a value from `searchTerm` when querying the server, but ember controllers are singletons so the `searchTerm` value persisted between page visits and leaded to this bug.

To make things work properly, we should be using the value from `q` everywhere except two places when we copy a value from `q` to `searchTerm` and vice versa. 


