### PR TITLE
FIX: Do not reload card if already loaded

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -38,7 +38,7 @@ export default Mixin.create({
   isFixed: false,
   isDocked: false,
 
-  _show(username, target) {
+  _show(username, target, event) {
     // No user card for anon
     if (this.siteSettings.hide_user_profiles_from_public && !this.currentUser) {
       return false;
@@ -53,8 +53,11 @@ export default Mixin.create({
       return false;
     }
 
+    this.set("lastEvent", event);
+
     const currentUsername = this.username;
-    if (username === currentUsername && this.loading === username) {
+    if (username === currentUsername || this.loading === username) {
+      this._positionCard($(target));
       return;
     }
 
@@ -170,11 +173,10 @@ export default Mixin.create({
 
       event.preventDefault();
       event.stopPropagation();
-      return this._show(transformText(matchingEl), matchingEl);
+      return this._show(transformText(matchingEl), matchingEl, event);
     }
-    {
-      return false;
-    }
+
+    return false;
   },
 
   _topicHeaderTrigger(username, $target) {
@@ -320,6 +322,7 @@ export default Mixin.create({
       visible: false,
       username: null,
       loading: null,
+      lastEvent: null,
       cardTarget: null,
       post: null,
       isFixed: false,


### PR DESCRIPTION
This change does not try to reload the user card if one was already
loaded for the same user or is being loaded at this moment. This is
a problem when user clicks on same user avatar twice and the card is
loaded twice.

The lastEvent change is needed for future customizations.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
