### PR TITLE
FIX: Make user-card-metadata plugin outlet tagless

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -222,7 +222,7 @@
                 {{/if}}
               </h3>
             {{/if}}
-            {{plugin-outlet name="user-card-metadata" args=(hash user=this.user)}}
+            {{plugin-outlet name="user-card-metadata" args=(hash user=this.user) tagName=""}}
           </div>
         {{/unless}}
         {{plugin-outlet name="user-card-after-metadata" args=(hash user=this.user) tagName=""}}


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
