### PR TITLE
DEV: Order outputted theme stylesheets

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -365,9 +365,6 @@ basic:
     default: "arial"
     enum: "BaseFontSetting"
     refresh: true
-  order_stylesheets:
-    default: false
-    hidden: true
 
 login:
   invite_only:

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -231,7 +231,7 @@ class Stylesheet::Manager
           stylesheets << data
         end
 
-        if SiteSetting.order_stylesheets && stylesheets.size > 1
+        if stylesheets.size > 1
           stylesheets = stylesheets.sort_by do |s|
             [
               s[:remote] ? 0 : 1,

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -152,10 +152,6 @@ describe Stylesheet::Manager do
         end
       end
 
-      before do
-        SiteSetting.order_stylesheets = true
-      end
-
       it 'output remote child, then sort children alphabetically, then local parent' do
         theme.add_relative_theme!(:child, z_child_theme)
         theme.add_relative_theme!(:child, child_remote)


### PR DESCRIPTION
Followup to #13735, this sets a load order for theme (and theme component) stylesheets. As per the original PR, the load order is the following

- remote theme components (ordered alphabetically)
- remote main theme (if applicable)
- local theme components (ordered alphabetically)
- local main theme (if applicable)

Theoretically, this can cause unexpected style changes on sites with many themes and components but we have tested this internally with 100+ instances and did not run into any issues. 