### PR TITLE
DEV: Do not destroy external upload stub on error in debug mode

### DIFF
--- a/app/models/external_upload_stub.rb
+++ b/app/models/external_upload_stub.rb
@@ -38,6 +38,7 @@ class ExternalUploadStub < ActiveRecord::Base
     @statuses ||= Enum.new(
       created: 1,
       uploaded: 2,
+      failed: 3,
     )
   end
 

--- a/app/services/external_upload_manager.rb
+++ b/app/services/external_upload_manager.rb
@@ -88,7 +88,12 @@ class ExternalUploadManager
     # because at this point (calling promote_to_upload!), the multipart
     # upload would already be complete.
     Discourse.store.delete_file(external_upload_stub.key)
-    external_upload_stub.destroy!
+
+    if !SiteSetting.enable_upload_debug_mode
+      external_upload_stub.destroy!
+    else
+      external_upload_stub.update(status: ExternalUploadStub.statuses[:failed])
+    end
 
     raise
   ensure

--- a/spec/services/external_upload_manager_spec.rb
+++ b/spec/services/external_upload_manager_spec.rb
@@ -127,6 +127,13 @@ RSpec.describe ExternalUploadManager do
             expect { subject.promote_to_upload! }.to raise_error(ExternalUploadManager::ChecksumMismatchError)
             expect(ExternalUploadStub.exists?(id: external_upload_stub.id)).to eq(false)
           end
+
+          it "does not delete the stub if enable_upload_debug_mode" do
+            SiteSetting.enable_upload_debug_mode = true
+            expect { subject.promote_to_upload! }.to raise_error(ExternalUploadManager::ChecksumMismatchError)
+            external_stub = ExternalUploadStub.find(external_upload_stub.id)
+            expect(external_stub.status).to eq(ExternalUploadStub.statuses[:failed])
+          end
         end
       end
 
@@ -145,6 +152,13 @@ RSpec.describe ExternalUploadManager do
             :delete,
             "#{upload_base_url}/#{external_upload_stub.key}"
           )
+        end
+
+        it "does not delete the stub if enable_upload_debug_mode" do
+          SiteSetting.enable_upload_debug_mode = true
+          expect { subject.promote_to_upload! }.to raise_error(ExternalUploadManager::SizeMismatchError)
+          external_stub = ExternalUploadStub.find(external_upload_stub.id)
+          expect(external_stub.status).to eq(ExternalUploadStub.statuses[:failed])
         end
       end
     end


### PR DESCRIPTION
We do not want to destroy the external upload stub records
in debug mode because they allow for investigation of problems
occuring.