### PR TITLE
Revert "Build(deps-dev): Bump parallel_tests from 3.7.1 to 3.7.2 (#14136)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
       openssl (~> 2.0)
     optimist (3.0.1)
     parallel (1.20.1)
-    parallel_tests (3.7.2)
+    parallel_tests (3.7.1)
       parallel
     parser (3.0.2.0)
       ast (~> 2.4.1)


### PR DESCRIPTION
Gem got yanked or something. Doesn't exists anymore.

This reverts commit 21beeb4e15b8122a51e52b591c2214e44cc86f2d.