### PR TITLE
DEV: Do not abort direct S3 uploads if upload_debug_mode enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -239,6 +239,8 @@ export default Mixin.create({
     this._inProgressUploads--;
     this._resetUpload(file, { removePlaceholder: true });
 
+    file.meta.error = error;
+
     if (!this.userCancelled) {
       displayErrorForUpload(response || error, this.siteSettings, file.name);
       this.appEvents.trigger("composer:upload-error", file);
@@ -430,6 +432,13 @@ export default Mixin.create({
         // will not be set, and we don't have to abort the upload because
         // it will not exist yet
         if (!key || !uploadId) {
+          return;
+        }
+
+        // this gives us a chance to inspect the upload stub before
+        // it is deleted from external storage by aborting the multipart
+        // upload; see also ExternalUploadManager
+        if (file.meta.error && self.siteSettings.enable_upload_debug_mode) {
           return;
         }
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -283,6 +283,7 @@ basic:
   enable_upload_debug_mode:
     default: false
     hidden: true
+    client: true
   default_theme_id:
     default: -1
     hidden: true


### PR DESCRIPTION
See the previous commit d66b258b0e9a635a67007b1d95d3d50475f662cf as
well.

If enable_upload_debug_mode is true, we do not want to abort the
direct S3 upload, because that will delete the file on S3 and prevent
further inspection of any errors that have come up.

