### PR TITLE
FIX: Remove spacing from GitHub oneboxes

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -212,7 +212,8 @@ module Email
       style('span.post-count', 'margin: 0 5px; color: #777;')
       style('pre', 'word-wrap: break-word; max-width: 694px;')
       style('code', 'background-color: #f9f9f9; padding: 2px 5px;')
-      style('pre code', 'display: block; background-color: #f9f9f9; overflow: auto; padding: 5px;')
+      style('pre code', 'display: block; background-color: #f9f9f9; overflow: auto; padding: 5px; white-space: normal;')
+      style('pre code li', 'white-space: pre;')
       style('.featured-topic a', "text-decoration: none; font-weight: bold; color: #{SiteSetting.email_link_color}; line-height:1.5em;")
       style('.summary-email', "-moz-box-sizing:border-box;-ms-text-size-adjust:100%;-webkit-box-sizing:border-box;-webkit-text-size-adjust:100%;box-sizing:border-box;color:#0a0a0a;font-family:Arial,sans-serif;font-size:14px;font-weight:400;line-height:1.3;margin:0;min-width:100%;padding:0;width:100%")
 


### PR DESCRIPTION
Each code line was surrounded by a lot of white space. The new styles
are similar to what the web interface is using.

Before:

![image](https://user-images.githubusercontent.com/23153890/130770820-6bbc151b-d336-4892-9a9e-cf2b1b20a1dc.png)

After:

![image](https://user-images.githubusercontent.com/23153890/130770855-33633a10-20ad-4431-8f79-e69a028e1f34.png)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
