### PR TITLE
FIX: The `LogsNotice` service was never unsubscribing from the mbus

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/logs-notice.js
+++ b/app/assets/javascripts/discourse/app/initializers/logs-notice.js
@@ -5,7 +5,7 @@ export default {
   name: "logs-notice",
   after: "message-bus",
 
-  initialize: function (container) {
+  initialize(container) {
     const siteSettings = container.lookup("site-settings:main");
     const messageBus = container.lookup("message-bus:main");
     const keyValueStore = container.lookup("key-value-store:main");
@@ -20,5 +20,9 @@ export default {
         });
       },
     });
+  },
+
+  teardown() {
+    LogsNotice.current().destroy();
   },
 };

--- a/app/assets/javascripts/discourse/app/services/logs-notice.js
+++ b/app/assets/javascripts/discourse/app/services/logs-notice.js
@@ -1,7 +1,4 @@
-import discourseComputed, {
-  observes,
-  on,
-} from "discourse-common/utils/decorators";
+import discourseComputed, { observes } from "discourse-common/utils/decorators";
 import EmberObject from "@ember/object";
 import I18n from "I18n";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
@@ -11,11 +8,14 @@ import { isEmpty } from "@ember/utils";
 
 const LOGS_NOTICE_KEY = "logs-notice-text";
 
-const LogsNotice = EmberObject.extend({
+const CHANNEL = "/logs_error_rate_exceeded";
+
+export default EmberObject.extend({
   text: "",
 
-  @on("init")
-  _setup() {
+  init() {
+    this._super();
+
     if (!this.isActivated) {
       return;
     }
@@ -25,7 +25,7 @@ const LogsNotice = EmberObject.extend({
       this.set("text", text);
     }
 
-    this.messageBus.subscribe("/logs_error_rate_exceeded", (data) => {
+    this.messageBus.subscribe(CHANNEL, (data) => {
       const duration = data.duration;
       const rate = data.rate;
       let siteSettingLimit = 0;
@@ -51,6 +51,11 @@ const LogsNotice = EmberObject.extend({
         })
       );
     });
+  },
+
+  willDestroy() {
+    this._super();
+    this.messageBus.unsubscribe(CHANNEL);
   },
 
   @discourseComputed("text")
@@ -86,5 +91,3 @@ const LogsNotice = EmberObject.extend({
     return errorsPerHour > 0 || errorsPerMinute > 0;
   },
 });
-
-export default LogsNotice;


### PR DESCRIPTION
Whenever we `subscribe` to something there should be an equivalent
`unsubscribe` and this implements it for `LogsNotice`.

In the future we should make this closer to what Ember expects a Service
to be, but at least it's properly cleaning up after itself now.

Thanks to @markvanlan who spotted this one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
