### PR TITLE
PERF: Remove redundant post_timings_summary index

### DIFF
--- a/app/models/post_timing.rb
+++ b/app/models/post_timing.rb
@@ -225,6 +225,5 @@ end
 # Indexes
 #
 #  index_post_timings_on_user_id  (user_id)
-#  post_timings_summary           (topic_id,post_number)
 #  post_timings_unique            (topic_id,post_number,user_id) UNIQUE
 #

--- a/db/migrate/20210824203421_remove_post_timings_summary_index.rb
+++ b/db/migrate/20210824203421_remove_post_timings_summary_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemovePostTimingsSummaryIndex < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :post_timings, column: [:topic_id, :post_number], name: :post_timings_summary, if_exists: true
+  end
+end


### PR DESCRIPTION
It's redundant since post_timings_unique exists which has a superset of
the columns with the same prefix.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
