### PR TITLE
DEV: Remove `yarn install` during `assets:precompile`

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -240,13 +240,6 @@ def copy_ember_cli_assets
   assets = {}
   files = {}
 
-  log_task_duration('yarn install') {
-    unless system("yarn --cwd #{ember_dir} install")
-      STDERR.puts "Error running yarn install"
-      exit 1
-    end
-  }
-
   log_task_duration('ember build -prod') {
     unless system("yarn --cwd #{ember_dir} run ember build -prod")
       STDERR.puts "Error running ember build"


### PR DESCRIPTION
Instead, we'll do it alongside `bundle install` in `web.template.yml`: https://github.com/discourse/discourse_docker/pull/565

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
