### PR TITLE
DEV: Promote all `javascripts/discourse` devDependencies to dependencies

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -15,7 +15,7 @@
     "start": "ember serve",
     "test": "ember test"
   },
-  "devDependencies": {
+  "dependencies": {
     "@babel/core": "^7.14.3",
     "@ember/optional-features": "^1.1.0",
     "@ember/test-helpers": "^2.2.0",


### PR DESCRIPTION
This is required so that we get all these dependencies installed when using `yarn install` with the `--production` flag
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

(tested successfully on a self-hosted install)