### PR TITLE
UX: display correct replies count in embedded comments view.

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -96,17 +96,13 @@ class EmbedController < ApplicationController
                                   exclude_first: true,
                                   exclude_deleted_users: true,
                                   exclude_hidden: true)
+      raise Discourse::NotFound if @topic_view.blank?
 
-      @second_post_url = "#{@topic_view.topic.url}/2" if @topic_view
       @posts_left = 0
-      if @topic_view && @topic_view.posts.size == SiteSetting.embed_post_limit
-        @posts_left = @topic_view.topic.posts_count - SiteSetting.embed_post_limit - 1
-      end
-
-      if @topic_view
-        @reply_count = @topic_view.topic.posts_count - 1
-        @reply_count = 0 if @reply_count < 0
-      end
+      @second_post_url = "#{@topic_view.topic.url}/2"
+      @reply_count = @topic_view.filtered_posts.count - 1
+      @reply_count = 0 if @reply_count < 0
+      @posts_left = @reply_count - SiteSetting.embed_post_limit if @reply_count > SiteSetting.embed_post_limit
     elsif embed_url.present?
       Jobs.enqueue(:retrieve_topic,
                       user_id: current_user.try(:id),

--- a/app/views/embed/comments.html.erb
+++ b/app/views/embed/comments.html.erb
@@ -1,7 +1,7 @@
 <header class='discourse' data-embed-state='loaded'>
-  <% if @topic_view.topic.posts_count < 2 %>
+  <% if @reply_count < 1 %>
     <%= link_to(I18n.t('embed.start_discussion'), @topic_view.topic.url, class: 'button', target: '_blank') %>
-  <% elsif @topic_view.topic.posts_count > 10 %>
+  <% elsif @reply_count >= 10 %>
     <%= link_to(I18n.t('embed.continue'), @second_post_url, class: 'button', target: '_blank') %>
   <% end %>
   <span class='replies'><%= I18n.t('embed.replies', count: @reply_count) %></span>

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -166,3 +166,7 @@ end
 Fabricator(:whisper, from: :post) do
   post_type Post.types[:whisper]
 end
+
+Fabricator(:small_action, from: :post) do
+  post_type Post.types[:small_action]
+end

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -229,6 +229,14 @@ describe EmbedController do
 
         expect(response.body).to match(I18n.t('embed.continue'))
         expect(response.body).to match(post.cooked)
+        expect(response.body).to match("<span class='replies'>1 reply</span>")
+
+        small_action = Fabricate(:small_action, topic: topic_embed.topic)
+
+        get '/embed/comments', params: { embed_url: embed_url }, headers: headers
+
+        expect(response.body).not_to match("post-#{small_action.id}")
+        expect(response.body).to match("<span class='replies'>1 reply</span>")
       end
 
       it "provides the topic retriever with the discourse username when provided" do


### PR DESCRIPTION
Previously, the reply count included the "small_action" posts too. It also caused the broken embed HTML issue.