### PR TITLE
DEV: reapply height hack for iOS

### DIFF
--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -83,6 +83,7 @@
       display: flex;
       flex: 1 0 auto;
       align-items: center;
+      height: 100%;
     }
 
     .d-icon-spinner {


### PR DESCRIPTION
Without this the container is not full height on iOS

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
