### PR TITLE
FIX: Allow PresenceChannel to work on Redis 6.0

### DIFF
--- a/lib/presence_channel.rb
+++ b/lib/presence_channel.rb
@@ -584,7 +584,7 @@ class PresenceChannel
     local time = ARGV[2]
     local mutex_value = ARGV[3]
 
-    local expire = redis.call('ZRANGE', zlist_key, '-inf', time, 'BYSCORE')
+    local expire = redis.call('ZRANGEBYSCORE', zlist_key, '-inf', time)
 
     local has_mutex = false
 


### PR DESCRIPTION
The `ZRANGE ... BYSCORE` syntax was only added in 6.2. We can use the older `ZRANGEBYSCORE` instead

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
