### PR TITLE
FIX: bug with navigation to the activity/topics and the activity/read pages

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-activity-read.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-read.js
@@ -1,5 +1,6 @@
 import UserAction from "discourse/models/user-action";
 import UserTopicListRoute from "discourse/routes/user-topic-list";
+import { action } from "@ember/object";
 
 export default UserTopicListRoute.extend({
   userActionType: UserAction.TYPES.topics,
@@ -8,5 +9,10 @@ export default UserTopicListRoute.extend({
     return this.store.findFiltered("topicList", {
       filter: "read",
     });
+  },
+
+  @action
+  refresh() {
+    this.refresh();
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
@@ -1,5 +1,6 @@
 import UserAction from "discourse/models/user-action";
 import UserTopicListRoute from "discourse/routes/user-topic-list";
+import { action } from "@ember/object";
 
 export default UserTopicListRoute.extend({
   userActionType: UserAction.TYPES.topics,
@@ -9,5 +10,10 @@ export default UserTopicListRoute.extend({
       filter:
         "topics/created-by/" + this.modelFor("user").get("username_lower"),
     });
+  },
+
+  @action
+  refresh() {
+    this.refresh();
   },
 });


### PR DESCRIPTION
Under specific circumstances, navigation to these pages doesn't work when developing locally (because of assertion), in production navigation works, but chances are that this problem causes some issues with updating content of topic lists on these pages.

## Steps to reproduce
When running Discourse locally
1. Firstly, go to the `u/:username/messages` page
2. Then click the Activity tab
3. Then click "Topics" on the left.
This will open `u/:username/activity/topics`, but the topic list will be empty and there'll be an error in the console:

<img width="600" alt="Screenshot 2021-08-27 at 23 18 57" src="https://user-images.githubusercontent.com/1274517/131189797-52ecb579-bc68-42e0-9fc6-adf6b12b7e6d.png">

The same can be reproduced for the `activity/read` page.

The problem is that we use the `user-topic-list` component on these pages, and this component calls the `refresh` action from the route:
https://github.com/discourse/discourse/blob/b47f288b13dbdf940055b04b826486cd99552c61/app/assets/javascripts/discourse/app/templates/user-topics-list.hbs#L11

The `/messages` route [contains](https://github.com/discourse/discourse/blob/b47f288b13dbdf940055b04b826486cd99552c61/app/assets/javascripts/discourse/app/routes/user-private-messages.js#L66) this action, but the `activity/topics` and the `activity/read` routes don't. This PR adds this action to these routes.

