### PR TITLE
DEV: Add default on encoding to dir-span

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/dir-span.js
+++ b/app/assets/javascripts/discourse/app/helpers/dir-span.js
@@ -1,6 +1,7 @@
 import { helperContext, registerUnbound } from "discourse-common/lib/helpers";
 import { htmlSafe } from "@ember/template";
 import { isRTL } from "discourse/lib/text-direction";
+import { escapeExpression } from "discourse/lib/utilities";
 
 function setDir(text) {
   let content = text ? text : "";
@@ -12,6 +13,7 @@ function setDir(text) {
   return content;
 }
 
-export default registerUnbound("dir-span", function (str) {
-  return htmlSafe(setDir(str));
+export default registerUnbound("dir-span", function (str, escapeText = true) {
+  let text = escapeText ? escapeExpression(str) : str;
+  return htmlSafe(setDir(text));
 });

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -8,7 +8,6 @@ import { ajax } from "discourse/lib/ajax";
 import { get } from "@ember/object";
 import { getOwner } from "discourse-common/lib/get-owner";
 import getURL from "discourse-common/lib/get-url";
-import { escapeExpression } from "discourse/lib/utilities";
 
 const STAFF_GROUP_NAME = "staff";
 
@@ -55,11 +54,6 @@ const Category = RestModel.extend({
   @discourseComputed("id")
   searchContext(id) {
     return { type: "category", id, category: this };
-  },
-
-  @discourseComputed("name")
-  escapeName(name) {
-    return escapeExpression(name);
   },
 
   @discourseComputed("parentCategory.ancestors")

--- a/app/assets/javascripts/discourse/app/templates/components/category-title-link.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/category-title-link.hbs
@@ -4,7 +4,7 @@
     {{#if category.read_restricted}}
       {{d-icon lockIcon}}
     {{/if}}
-    <span class="category-name">{{dir-span category.escapeName}}</span>
+    <span class="category-name">{{dir-span category.name}}</span>
   </div>
   {{#if category.uploaded_logo.url}}
     {{cdn-img

--- a/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
@@ -5,7 +5,7 @@
       {{category-title-link category=category}}
       {{#if category.description_excerpt}}
         <div class="category-description">
-          {{dir-span category.description_excerpt}}
+          {{dir-span category.description_excerpt false}}
         </div>
       {{/if}}
       {{#if category.isGrandParent}}

--- a/app/assets/javascripts/discourse/app/templates/components/sub-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sub-category-row.hbs
@@ -4,7 +4,7 @@
       {{category-title-link tagName="h4" category=category}}
       {{#if category.description_excerpt}}
         <div class="category-description subcategory-description">
-          {{dir-span category.description_excerpt}}
+          {{dir-span category.description_excerpt false}}
         </div>
       {{/if}}
       {{#if category.subcategories}}

--- a/app/assets/javascripts/discourse/app/templates/list/topic-excerpt.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-excerpt.hbr
@@ -1,6 +1,6 @@
 {{#if topic.hasExcerpt}}
   <a href="{{topic.url}}" class="topic-excerpt">
-    {{dir-span topic.escapedExcerpt}}
+    {{dir-span topic.escapedExcerpt false}}
     {{#if topic.excerptTruncated}}
       <span class="topic-excerpt-more">{{i18n 'read_more'}}</span>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -11,7 +11,7 @@
     }}
 
     {{#if category.description}}
-      <p>{{dir-span category.description}}</p>
+      <p>{{dir-span category.description false}}</p>
     {{/if}}
   {{/if}}
 

--- a/app/assets/javascripts/select-kit/addon/templates/components/category-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/category-row.hbs
@@ -9,7 +9,7 @@
   </div>
 
   {{#if shouldDisplayDescription}}
-    <div class="category-desc" aria-hidden="true">{{dir-span description}}</div>
+    <div class="category-desc" aria-hidden="true">{{dir-span description false}}</div>
   {{/if}}
 {{else}}
   {{html-safe label}}


### PR DESCRIPTION
This is a follow up commit to:

75b0d6df93e1fd99a87195487b0de12533ec909f

Adds encoding of the input text passed into the dir-span helper so that
it is on by default. This way any new implementations of dir-span will
be encoded. Most of the uses of dir-span already have encoding so this
includes a new optional parameter to disable the encoding if the input
being passed in is already encoded.
