### PR TITLE
A11Y: Add "skip to main content" link

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -1,4 +1,5 @@
 {{#discourse-root}}
+  <a href="#main-container" id="skip-link">{{i18n "skip_to_main_content"}}</a>
   {{d-document}}
   {{plugin-outlet name="above-site-header" tagName=""}}
   {{site-header canSignUp=canSignUp
@@ -14,7 +15,7 @@
 
   <div id="main-outlet" class="wrap" role="main">
     {{plugin-outlet name="above-main-container" tagName=""}}
-    <div class="container">
+    <div class="container" id="main-container">
       {{#if showTop}}
         {{custom-html name="top"}}
       {{/if}}

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -880,3 +880,18 @@ table {
     }
   }
 }
+
+a#skip-link {
+  padding: 0.25em 0.5em;
+  position: absolute;
+  top: -40px;
+  left: 1em;
+  color: var(--secondary);
+  background: var(--tertiary);
+  transition: top 0.3s ease-out;
+  z-index: z("header") + 1;
+  &:focus {
+    top: 0px;
+    transition: top 0.15s ease-in;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -175,6 +175,7 @@ en:
       forwarded: "forwarded the above email"
 
     topic_admin_menu: "topic actions"
+    skip_to_main_content: "Skip to main content"
 
     wizard_required: "Welcome to your new Discourse! Let’s get started with <a href='%{url}' data-auto-route='true'>the setup wizard</a> ✨"
     emails_are_disabled: "All outgoing email has been globally disabled by an administrator. No email notifications of any kind will be sent."


### PR DESCRIPTION
Adds a new element that is only shown by pressing <kbd>Tab</kbd>. Clicking the element skips the header and sets focus to the main content area. 

https://user-images.githubusercontent.com/368961/131394848-da381a13-ab88-4758-9d98-6eed8b693976.mp4

