### PR TITLE
DEV: prevents _lastKeyTimeout to leak after component lifecycle

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -213,6 +213,8 @@ export default Component.extend(KeyEnterEscape, {
     if (this._visualViewportResizing()) {
       window.visualViewport.removeEventListener("resize", this.viewportResize);
     }
+
+    cancel(this._lastKeyTimeout);
   },
 
   click() {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
