### PR TITLE
DEV: Use named parameters for dir-span helper

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/dir-span.js
+++ b/app/assets/javascripts/discourse/app/helpers/dir-span.js
@@ -13,7 +13,13 @@ function setDir(text) {
   return content;
 }
 
-export default registerUnbound("dir-span", function (str, escapeText = true) {
-  let text = escapeText ? escapeExpression(str) : str;
+export default registerUnbound("dir-span", function (str, params) {
+  let isHtmlSafe = false;
+  if (params) {
+    if (params.htmlSafe) {
+      isHtmlSafe = params.htmlSafe;
+    }
+  }
+  let text = isHtmlSafe ? str : escapeExpression(str);
   return htmlSafe(setDir(text));
 });

--- a/app/assets/javascripts/discourse/app/helpers/dir-span.js
+++ b/app/assets/javascripts/discourse/app/helpers/dir-span.js
@@ -13,12 +13,10 @@ function setDir(text) {
   return content;
 }
 
-export default registerUnbound("dir-span", function (str, params) {
+export default registerUnbound("dir-span", function (str, params = {}) {
   let isHtmlSafe = false;
-  if (params) {
-    if (params.htmlSafe) {
-      isHtmlSafe = params.htmlSafe;
-    }
+  if (params.htmlSafe) {
+    isHtmlSafe = params.htmlSafe;
   }
   let text = isHtmlSafe ? str : escapeExpression(str);
   return htmlSafe(setDir(text));

--- a/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
@@ -5,7 +5,7 @@
       {{category-title-link category=category}}
       {{#if category.description_excerpt}}
         <div class="category-description">
-          {{dir-span category.description_excerpt false}}
+          {{dir-span category.description_excerpt htmlSafe=true}}
         </div>
       {{/if}}
       {{#if category.isGrandParent}}

--- a/app/assets/javascripts/discourse/app/templates/components/sub-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sub-category-row.hbs
@@ -4,7 +4,7 @@
       {{category-title-link tagName="h4" category=category}}
       {{#if category.description_excerpt}}
         <div class="category-description subcategory-description">
-          {{dir-span category.description_excerpt false}}
+          {{dir-span category.description_excerpt htmlSafe=true}}
         </div>
       {{/if}}
       {{#if category.subcategories}}

--- a/app/assets/javascripts/discourse/app/templates/list/topic-excerpt.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-excerpt.hbr
@@ -1,6 +1,6 @@
 {{#if topic.hasExcerpt}}
   <a href="{{topic.url}}" class="topic-excerpt">
-    {{dir-span topic.escapedExcerpt false}}
+    {{dir-span topic.escapedExcerpt htmlSafe=true}}
     {{#if topic.excerptTruncated}}
       <span class="topic-excerpt-more">{{i18n 'read_more'}}</span>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -11,7 +11,7 @@
     }}
 
     {{#if category.description}}
-      <p>{{dir-span category.description false}}</p>
+      <p>{{dir-span category.description htmlSafe=true}}</p>
     {{/if}}
   {{/if}}
 

--- a/app/assets/javascripts/select-kit/addon/templates/components/category-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/category-row.hbs
@@ -9,7 +9,7 @@
   </div>
 
   {{#if shouldDisplayDescription}}
-    <div class="category-desc" aria-hidden="true">{{dir-span description false}}</div>
+    <div class="category-desc" aria-hidden="true">{{dir-span description htmlSafe=true}}</div>
   {{/if}}
 {{else}}
   {{html-safe label}}


### PR DESCRIPTION
Follow up to: e50a5c0c73d8f983286b50ac45e10ce52924269e

In order to improve code clarity this change introduces named parameters
for the dir-span helper. This is specifically for the new `htmlSafe`
parameter which you can use instead of just passing in a boolean if the
strings you are passing in have already been escaped.

Before: `{{dir-span category.description false}}`
After: `{{dir-span category.description htmlSafe=true}}`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
