### PR TITLE
UX: Comma separate public custom field lists

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -238,7 +238,7 @@
                   <span class="user-field-value">
                     {{#each uf.value as |v|}} <!-- some values are arrays -->
                       <span class="user-field-value-list-item">{{v}}</span>
-                    {{else }}
+                    {{else}}
                       {{uf.value}}
                     {{/each}}
                   </span>

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -235,7 +235,13 @@
               {{#if uf.value}}
                 <div class="public-user-field {{uf.field.dasherized_name}}">
                   <span class="user-field-name">{{uf.field.name}}:</span>
-                  <span class="user-field-value">{{uf.value}}</span>
+                  <span class="user-field-value">
+                    {{#each uf.value as |v|}} <!-- some values are arrays -->
+                      <span class="user-field-value-list-item">{{v}}</span>
+                    {{else }}
+                      {{uf.value}}
+                    {{/each}}
+                  </span>
                 </div>
               {{/if}}
             {{/each}}

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -236,7 +236,7 @@
                 <div class="public-user-field {{uf.field.dasherized_name}}">
                   <span class="user-field-name">{{uf.field.name}}:</span>
                   <span class="user-field-value">
-                    {{#each uf.value as |v|}} <!-- some values are arrays -->
+                    {{#each uf.value as |v|}} {{! some values are arrays }}
                       <span class="user-field-value-list-item">{{v}}</span>
                     {{else}}
                       {{uf.value}}

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -159,7 +159,13 @@
                   {{#if uf.value}}
                     <div class="public-user-field {{uf.field.dasherized_name}}">
                       <span class="user-field-name">{{uf.field.name}}</span>:
-                      <span class="user-field-value">{{uf.value}}</span>
+                      <span class="user-field-value">
+                        {{#each uf.value as |v|}} <!-- some values are arrays -->
+                          <span class="user-field-value-list-item">{{v}}</span>
+                        {{else }}
+                          {{uf.value}}
+                        {{/each}}
+                      </span>
                     </div>
                   {{/if}}
                 {{/each}}

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -160,7 +160,7 @@
                     <div class="public-user-field {{uf.field.dasherized_name}}">
                       <span class="user-field-name">{{uf.field.name}}</span>:
                       <span class="user-field-value">
-                        {{#each uf.value as |v|}} <!-- some values are arrays -->
+                        {{#each uf.value as |v|}} {{! some values are arrays }}
                           <span class="user-field-value-list-item">{{v}}</span>
                         {{else }}
                           {{uf.value}}

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -362,6 +362,13 @@
   .collapsed-info & {
     display: none;
   }
+
+  .user-field-value-list-item:not(:last-of-type) {
+    &:after {
+      // create comma separated list
+      content: ",";
+    }
+  }
 }
 
 .avatar-selector {

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -221,6 +221,12 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
   // custom user fields
   .public-user-fields {
     margin: 0;
+    .user-field-value-list-item:not(:last-of-type) {
+      &:after {
+        // create comma separated list
+        content: ",";
+      }
+    }
   }
 
   // badges


### PR DESCRIPTION
Issue described here: https://meta.discourse.org/t/multiselect-user-field-overflowing-in-user-card/202082

tl;dlr – arrays from multiselect fields were displaying as `one,two,three` (unspaced)

this update better separates arrays on profiles and usercards

![Screen Shot 2021-08-31 at 11 50 57 AM](https://user-images.githubusercontent.com/1681963/131535051-bee559ad-eb79-4a48-8458-9d20d08e3e08.png)

![Screen Shot 2021-08-31 at 11 51 22 AM](https://user-images.githubusercontent.com/1681963/131535106-969b97ca-bc30-4b8e-9aed-e570af4e827b.png)

