### PR TITLE
FIX: Use named params correctly with dir-span

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/dir-span.js
+++ b/app/assets/javascripts/discourse/app/helpers/dir-span.js
@@ -16,7 +16,7 @@ function setDir(text) {
 export default registerUnbound("dir-span", function (str, params = {}) {
   let isHtmlSafe = false;
   if (params.htmlSafe) {
-    isHtmlSafe = params.htmlSafe;
+    isHtmlSafe = params.htmlSafe === "true";
   }
   let text = isHtmlSafe ? str : escapeExpression(str);
   return htmlSafe(setDir(text));

--- a/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
@@ -5,7 +5,7 @@
       {{category-title-link category=category}}
       {{#if category.description_excerpt}}
         <div class="category-description">
-          {{dir-span category.description_excerpt htmlSafe=true}}
+          {{dir-span category.description_excerpt htmlSafe="true"}}
         </div>
       {{/if}}
       {{#if category.isGrandParent}}

--- a/app/assets/javascripts/discourse/app/templates/components/sub-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sub-category-row.hbs
@@ -4,7 +4,7 @@
       {{category-title-link tagName="h4" category=category}}
       {{#if category.description_excerpt}}
         <div class="category-description subcategory-description">
-          {{dir-span category.description_excerpt htmlSafe=true}}
+          {{dir-span category.description_excerpt htmlSafe="true"}}
         </div>
       {{/if}}
       {{#if category.subcategories}}

--- a/app/assets/javascripts/discourse/app/templates/list/topic-excerpt.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-excerpt.hbr
@@ -1,6 +1,6 @@
 {{#if topic.hasExcerpt}}
   <a href="{{topic.url}}" class="topic-excerpt">
-    {{dir-span topic.escapedExcerpt htmlSafe=true}}
+    {{dir-span topic.escapedExcerpt htmlSafe="true"}}
     {{#if topic.excerptTruncated}}
       <span class="topic-excerpt-more">{{i18n 'read_more'}}</span>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -11,7 +11,7 @@
     }}
 
     {{#if category.description}}
-      <p>{{dir-span category.description htmlSafe=true}}</p>
+      <p>{{dir-span category.description htmlSafe="true"}}</p>
     {{/if}}
   {{/if}}
 

--- a/app/assets/javascripts/select-kit/addon/templates/components/category-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/category-row.hbs
@@ -9,7 +9,7 @@
   </div>
 
   {{#if shouldDisplayDescription}}
-    <div class="category-desc" aria-hidden="true">{{dir-span description htmlSafe=true}}</div>
+    <div class="category-desc" aria-hidden="true">{{dir-span description htmlSafe="true"}}</div>
   {{/if}}
 {{else}}
   {{html-safe label}}


### PR DESCRIPTION
Follow up to: a2ccf0a9ff22f3e8467ac0d61f93be136bb66b31

These named params need to be passed in as strings.

With `htmlSafe=true` the params show up as `{}`, but with `htmlSafe="true"`,
the params show up as `{"htmlSafe":"true"}`

Bug reported here: https://meta.discourse.org/t/202246

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
