### PR TITLE
DEV: Don't clear sidekiq default error handlers in development.

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -111,5 +111,8 @@ class SidekiqLogsterReporter < Sidekiq::ExceptionHandler::Logger
   end
 end
 
-Sidekiq.error_handlers.clear
+unless Rails.env.development?
+  Sidekiq.error_handlers.clear
+end
+
 Sidekiq.error_handlers << SidekiqLogsterReporter.new


### PR DESCRIPTION
Restores error logs in the development environment.