### PR TITLE
DEV: prevents hooks to create leaks on widgets

### DIFF
--- a/app/assets/javascripts/discourse/app/components/mount-widget.js
+++ b/app/assets/javascripts/discourse/app/components/mount-widget.js
@@ -63,6 +63,9 @@ export default Component.extend({
 
     this._connected.forEach((v) => v.destroy());
     this._connected.length = 0;
+
+    this._rootNode = patch(this._rootNode, diff(this._tree, null));
+    this._tree = null;
   },
 
   willDestroyElement() {

--- a/app/assets/javascripts/discourse/app/widgets/glue.js
+++ b/app/assets/javascripts/discourse/app/widgets/glue.js
@@ -60,5 +60,8 @@ export default class WidgetGlue {
     traverseCustomWidgets(this._tree, (w) => w.destroy());
 
     cancel(this._timeout);
+
+    this._rootNode = patch(this._rootNode, diff(this._tree, null));
+    this._tree = null;
   }
 }


### PR DESCRIPTION
Before this, mounted widgets were not correctly unhooked and would keep a reference to a custom widget object.

Here is a before/after heap trace after executing a single module test: "Acceptance: Poll results: can load more voters"

Before:
<img width="421" alt="Capture d’écran 2021-09-01 à 14 02 57" src="https://user-images.githubusercontent.com/339945/131668344-e1115ca6-4684-4778-9caf-3cf4e02fbe37.png">

After:
<img width="498" alt="Capture d’écran 2021-09-01 à 14 02 26" src="https://user-images.githubusercontent.com/339945/131668335-435eabc3-c338-4777-9193-8b76a8f6e4a0.png">


Note we still have leaks but this won't be fixed in this PR.