### PR TITLE
FEATURE: Enable auto dark mode on new instances

### DIFF
--- a/db/fixtures/600_themes.rb
+++ b/db/fixtures/600_themes.rb
@@ -18,4 +18,11 @@ if !Theme.exists?
   name = I18n.t('color_schemes.default_theme_name')
   default_theme = Theme.create!(name: name, user_id: -1)
   default_theme.set_default!
+
+  if SiteSetting.default_dark_mode_color_scheme_id == SiteSetting.defaults[:default_dark_mode_color_scheme_id]
+    dark_scheme = ColorScheme.find_by(base_scheme_id: "Dark")
+    if dark_scheme.present?
+      SiteSetting.default_dark_mode_color_scheme_id = dark_scheme.id
+    end
+  end
 end

--- a/db/fixtures/600_themes.rb
+++ b/db/fixtures/600_themes.rb
@@ -20,9 +20,10 @@ if !Theme.exists?
   default_theme.set_default!
 
   if SiteSetting.default_dark_mode_color_scheme_id == SiteSetting.defaults[:default_dark_mode_color_scheme_id]
-    dark_scheme = ColorScheme.find_by(base_scheme_id: "Dark")
-    if dark_scheme.present?
-      SiteSetting.default_dark_mode_color_scheme_id = dark_scheme.id
+    dark_scheme_id = ColorScheme.where(base_scheme_id: "Dark").pluck_first(:id)
+    
+    if dark_scheme_id.present?
+      SiteSetting.default_dark_mode_color_scheme_id = dark_scheme_id
     end
   end
 end

--- a/db/fixtures/600_themes.rb
+++ b/db/fixtures/600_themes.rb
@@ -21,7 +21,7 @@ if !Theme.exists?
 
   if SiteSetting.default_dark_mode_color_scheme_id == SiteSetting.defaults[:default_dark_mode_color_scheme_id]
     dark_scheme_id = ColorScheme.where(base_scheme_id: "Dark").pluck_first(:id)
-    
+
     if dark_scheme_id.present?
       SiteSetting.default_dark_mode_color_scheme_id = dark_scheme_id
     end

--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -203,6 +203,14 @@ class Wizard
           updater.update_setting(:base_font, updater.fields[:body_font])
           updater.update_setting(:heading_font, updater.fields[:heading_font])
 
+          if updater.fields[:homepage_style] == 'latest'
+            top_menu = "latest|new|unread|top|categories"
+          else
+            top_menu = "categories|latest|new|unread|top"
+            updater.update_setting(:desktop_category_page_style, updater.fields[:homepage_style])
+          end
+          updater.update_setting(:top_menu, top_menu)
+
           scheme_name = (
             (updater.fields[:color_scheme] || "") ||
             ColorScheme::LIGHT_THEME_ID
@@ -228,13 +236,9 @@ class Wizard
             theme.set_default!
           end
 
-          if updater.fields[:homepage_style] == 'latest'
-            top_menu = "latest|new|unread|top|categories"
-          else
-            top_menu = "categories|latest|new|unread|top"
-            updater.update_setting(:desktop_category_page_style, updater.fields[:homepage_style])
+          if scheme.is_dark?
+            updater.update_setting(:default_dark_mode_color_scheme_id, -1)
           end
-          updater.update_setting(:top_menu, top_menu)
         end
       end
 

--- a/spec/components/wizard/step_updater_spec.rb
+++ b/spec/components/wizard/step_updater_spec.rb
@@ -169,7 +169,11 @@ describe Wizard::StepUpdater do
 
   context "styling step" do
     it "updates fonts" do
-      updater = wizard.create_updater('styling', body_font: 'open_sans', heading_font: 'oswald')
+      updater = wizard.create_updater('styling',
+        body_font: 'open_sans',
+        heading_font: 'oswald',
+        homepage_style: 'latest'
+      )
       updater.update
       expect(updater.success?).to eq(true)
       expect(wizard.completed_steps?('styling')).to eq(true)
@@ -182,7 +186,12 @@ describe Wizard::StepUpdater do
         fab!(:color_scheme) { Fabricate(:color_scheme, name: 'existing', via_wizard: true) }
 
         it "updates the scheme" do
-          updater = wizard.create_updater('styling', color_scheme: 'Dark', body_font: 'arial', heading_font: 'arial', homepage_style: 'latest')
+          updater = wizard.create_updater('styling',
+            color_scheme: 'Dark',
+            body_font: 'arial',
+            heading_font: 'arial',
+            homepage_style: 'latest'
+          )
           updater.update
           expect(updater.success?).to eq(true)
           expect(wizard.completed_steps?('styling')).to eq(true)
@@ -277,12 +286,43 @@ describe Wizard::StepUpdater do
           expect(theme.color_scheme_id).to eq(color_scheme.id)
         end
       end
+
+      context "auto dark mode" do
+        let(:dark_scheme) { ColorScheme.where(name: "Dark").first }
+
+        it "does nothing when selected scheme is light" do
+          SiteSetting.default_dark_mode_color_scheme_id = dark_scheme.id
+
+          updater = wizard.create_updater('styling',
+            color_scheme: 'Neutral',
+            body_font: 'arial',
+            heading_font: 'arial',
+            homepage_style: 'latest'
+          )
+
+          expect { updater.update }.not_to change { SiteSetting.default_dark_mode_color_scheme_id }
+        end
+
+        it "unsets auto dark mode site setting when default selected scheme is also dark" do
+          SiteSetting.default_dark_mode_color_scheme_id = dark_scheme.id
+
+          updater = wizard.create_updater('styling',
+            color_scheme: 'Latte',
+            body_font: 'arial',
+            heading_font: 'arial',
+            homepage_style: 'latest'
+          )
+
+          expect { updater.update }.to change { SiteSetting.default_dark_mode_color_scheme_id }
+          expect(SiteSetting.default_dark_mode_color_scheme_id).to eq(-1)
+        end
+      end
+
     end
 
     context "homepage style" do
       it "updates the fields correctly" do
         updater = wizard.create_updater('styling',
-          color_scheme: 'Dark',
           body_font: 'arial',
           heading_font: 'arial',
           homepage_style: "categories_and_top_topics"
@@ -295,7 +335,6 @@ describe Wizard::StepUpdater do
         expect(SiteSetting.desktop_category_page_style).to eq('categories_and_top_topics')
 
         updater = wizard.create_updater('styling',
-          color_scheme: 'Dark',
           body_font: 'arial',
           heading_font: 'arial',
           homepage_style: "latest"

--- a/spec/components/wizard/step_updater_spec.rb
+++ b/spec/components/wizard/step_updater_spec.rb
@@ -288,11 +288,12 @@ describe Wizard::StepUpdater do
       end
 
       context "auto dark mode" do
-        let(:dark_scheme) { ColorScheme.where(name: "Dark").first }
+        before do
+          dark_scheme = ColorScheme.where(name: "Dark").first
+          SiteSetting.default_dark_mode_color_scheme_id = dark_scheme.id
+        end
 
         it "does nothing when selected scheme is light" do
-          SiteSetting.default_dark_mode_color_scheme_id = dark_scheme.id
-
           updater = wizard.create_updater('styling',
             color_scheme: 'Neutral',
             body_font: 'arial',
@@ -304,8 +305,6 @@ describe Wizard::StepUpdater do
         end
 
         it "unsets auto dark mode site setting when default selected scheme is also dark" do
-          SiteSetting.default_dark_mode_color_scheme_id = dark_scheme.id
-
           updater = wizard.create_updater('styling',
             color_scheme: 'Latte',
             body_font: 'arial',

--- a/spec/components/wizard/step_updater_spec.rb
+++ b/spec/components/wizard/step_updater_spec.rb
@@ -313,8 +313,7 @@ describe Wizard::StepUpdater do
             homepage_style: 'latest'
           )
 
-          expect { updater.update }.to change { SiteSetting.default_dark_mode_color_scheme_id }
-          expect(SiteSetting.default_dark_mode_color_scheme_id).to eq(-1)
+          expect { updater.update }.to change { SiteSetting.default_dark_mode_color_scheme_id }.to(-1)
         end
       end
 


### PR DESCRIPTION
Sets the "Dark" scheme as the default dark mode color scheme while seeding data (which only runs on new instances). 

This also adds some logic to the wizard to unset the relevant site setting if the selected default color scheme for the site is dark.