### PR TITLE
DEV: Allow passing cook_method to TopicEmbed.import to override default

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -27,10 +27,10 @@ class TopicEmbed < ActiveRecord::Base
   end
 
   # Import an article from a source (RSS/Atom/Other)
-  def self.import(user, url, title, contents, category_id: nil)
+  def self.import(user, url, title, contents, category_id: nil, cook_method: nil)
     return unless url =~ /^https?\:\/\//
 
-    if SiteSetting.embed_truncate
+    if SiteSetting.embed_truncate && cook_method.nil?
       contents = first_paragraph_from(contents)
     end
     contents ||= ''
@@ -47,7 +47,7 @@ class TopicEmbed < ActiveRecord::Base
       Topic.transaction do
         eh = EmbeddableHost.record_for_url(url)
 
-        cook_method = if SiteSetting.embed_support_markdown
+        cook_method ||= if SiteSetting.embed_support_markdown
           Post.cook_methods[:regular]
         else
           Post.cook_methods[:raw_html]

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -108,21 +108,9 @@ describe TopicEmbed do
         Jobs.run_immediately!
         SiteSetting.embed_support_markdown = false
         stub_request(:get, "https://www.youtube.com/watch?v=K56soYl0U1w")
-          .with(
-            headers: {
-              'Accept' => '*/*',
-              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'User-Agent' => 'Discourse Forum Onebox v2.8.0.beta4'
-            }
-          ).to_return(status: 200, body: "", headers: {})
+          .to_return(status: 200, body: "", headers: {})
         stub_request(:get, "https://www.youtube.com/embed/K56soYl0U1w")
-          .with(
-            headers: {
-              'Accept' => '*/*',
-              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'User-Agent' => 'Discourse Forum Onebox v2.8.0.beta4'
-            }
-          ).to_return(status: 200, body: "", headers: {})
+          .to_return(status: 200, body: "", headers: {})
 
         imported_post = TopicEmbed.import(user, "http://eviltrout.com/abcd", title, "https://www.youtube.com/watch?v=K56soYl0U1w", cook_method: Post.cook_methods[:regular])
         expect(imported_post.cooked).to match(/onebox|iframe/)

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -99,10 +99,33 @@ describe TopicEmbed do
 
       it "creates the topic in the category passed as a parameter" do
         Jobs.run_immediately!
-        SiteSetting.embed_unlisted = false
         imported_post = TopicEmbed.import(user, "http://eviltrout.com/abcd", title, "some random content", category_id: category.id)
         expect(imported_post.topic.category).not_to eq(embeddable_host.category)
         expect(imported_post.topic.category).to eq(category)
+      end
+
+      it "respects overriding the cook_method when asked" do
+        Jobs.run_immediately!
+        SiteSetting.embed_support_markdown = false
+        stub_request(:get, "https://www.youtube.com/watch?v=K56soYl0U1w")
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'User-Agent' => 'Discourse Forum Onebox v2.8.0.beta4'
+            }
+          ).to_return(status: 200, body: "", headers: {})
+        stub_request(:get, "https://www.youtube.com/embed/K56soYl0U1w")
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'User-Agent' => 'Discourse Forum Onebox v2.8.0.beta4'
+            }
+          ).to_return(status: 200, body: "", headers: {})
+
+        imported_post = TopicEmbed.import(user, "http://eviltrout.com/abcd", title, "https://www.youtube.com/watch?v=K56soYl0U1w", cook_method: Post.cook_methods[:regular])
+        expect(imported_post.cooked).to match(/iframe/)
       end
     end
 

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -125,7 +125,7 @@ describe TopicEmbed do
           ).to_return(status: 200, body: "", headers: {})
 
         imported_post = TopicEmbed.import(user, "http://eviltrout.com/abcd", title, "https://www.youtube.com/watch?v=K56soYl0U1w", cook_method: Post.cook_methods[:regular])
-        expect(imported_post.cooked).to match(/iframe/)
+        expect(imported_post.cooked).to match(/onebox|iframe/)
       end
     end
 


### PR DESCRIPTION
This will be used in the rss-polling plugin when we want to have
oneboxes on feed content, like youtube for example.
