### PR TITLE
FIX: Visible "skip navigation" link on some themes

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -884,7 +884,7 @@ table {
 a#skip-link {
   padding: 0.25em 0.5em;
   position: absolute;
-  top: -40px;
+  top: -200px;
   left: 1em;
   color: var(--secondary);
   background: var(--tertiary);


### PR DESCRIPTION
Move this further out of the window for the default state. Some themes add `position: relative` to the `#main` element, which case cause this to show when `#main` has a margin relative to the body.
