### PR TITLE
FIX: Make bindMobileUploadButton explicit for upload mixins

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -219,6 +219,8 @@ export default Component.extend(ComposerUpload, {
     }
 
     this._bindUploadTarget();
+    this._bindMobileUploadButton();
+
     this.appEvents.trigger("composer:will-open");
   },
 

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -609,6 +609,7 @@ export default Component.extend(ComposerUpload, {
 
   @on("willDestroyElement")
   _composerClosed() {
+    this._unbindMobileUploadButton();
     this.appEvents.trigger("composer:will-close");
     next(() => {
       // need to wait a bit for the "slide down" transition of the composer

--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -46,11 +46,6 @@ export default Mixin.create({
 
   @on("willDestroyElement")
   _unbindUploadTarget() {
-    this.mobileUploadButton?.removeEventListener(
-      "click",
-      this.mobileUploadButtonEventListener
-    );
-
     this.fileInputEl?.removeEventListener(
       "change",
       this.fileInputEventListener

--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -86,7 +86,6 @@ export default Mixin.create({
     this._unbindUploadTarget();
     this._bindFileInputChangeListener();
     this._bindPasteListener();
-    this._bindMobileUploadButton();
 
     this._uppyInstance = new Uppy({
       id: this.uppyId,

--- a/app/assets/javascripts/discourse/app/mixins/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload.js
@@ -327,8 +327,6 @@ export default Mixin.create({
         }
       });
     });
-
-    this._bindMobileUploadButton();
   },
 
   _bindMobileUploadButton() {

--- a/app/assets/javascripts/discourse/app/mixins/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload.js
@@ -343,13 +343,15 @@ export default Mixin.create({
     }
   },
 
-  @on("willDestroyElement")
-  _unbindUploadTarget() {
+  _unbindMobileUploadButton() {
     this.mobileUploadButton?.removeEventListener(
       "click",
       this.mobileUploadButtonEventListener
     );
+  },
 
+  @on("willDestroyElement")
+  _unbindUploadTarget() {
     this._validUploads = 0;
     const $uploadTarget = $(this.element);
     try {


### PR DESCRIPTION
When using ComposerUpload and/or ComposerUploadUppy, we were
always calling bindMobileUploadButton. However with more composer-like
interfaces being developed, we need this to be optional, as not
everywhere will have a separate mobile upload button to bind to.

Also makes it so the composer extending the ComposerUpload mixins is
responsible for explicitly unbinding the mobile upload button if
it needs to.
