### PR TITLE
DEV: prevents broken tests due to focus bubbling

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
@@ -158,6 +158,10 @@ export default Component.extend(UtilsMixin, {
     }
   },
 
+  focusIn(event) {
+    event.stopImmediatePropagation();
+  },
+
   keyDown(event) {
     if (this.selectKit.isExpanded) {
       if (event.key === "Backspace") {


### PR DESCRIPTION
After a lot of debugging, I discovered that focusing the row would sometimes bubble up to the document and trigger a focus through `magnific-popup` js code which is adding a listener on focus on the document. This would generate a blur of select-kit which might cause a close.

<img width="594" alt="Capture d’écran 2021-09-02 à 17 56 11" src="https://user-images.githubusercontent.com/339945/131879146-0c8d0ac9-3799-44b5-8f4d-2d12dd612609.png">

