### PR TITLE
UX: Remove `:empty` on topic-statuses, clean up

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -287,9 +287,6 @@
     line-height: $line-height-large;
     padding-right: 20px;
   }
-  .topic-statuses:empty {
-    display: none;
-  }
 
   .num {
     text-align: center;

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -829,19 +829,16 @@ table {
 }
 
 .topic-statuses {
-  display: inline;
+  // avoid adding margin/padding on this parent; sometimes it appears as an empty container
   float: left;
-  margin-right: 0.15em;
   .topic-status {
     margin: 0;
     display: inline-flex;
     color: var(--primary-medium);
+    margin-right: 0.2em;
     .d-icon {
       height: 0.74em;
       width: 0.75em;
-    }
-    &:not(:last-child) {
-      margin-right: 0.15em;
     }
   }
 

--- a/app/assets/stylesheets/common/base/reviewables.scss
+++ b/app/assets/stylesheets/common/base/reviewables.scss
@@ -465,11 +465,6 @@
       font-size: $font-up-2;
       margin-right: 0.75em;
     }
-    .topic-statuses {
-      &:empty {
-        display: none;
-      }
-    }
   }
 }
 

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -158,10 +158,6 @@
   }
   .topic-statuses {
     line-height: 1.2;
-    margin-right: 0.15em;
-    &:empty {
-      margin-right: 0;
-    }
     .d-icon {
       color: var(--primary-medium);
     }

--- a/app/assets/stylesheets/common/components/bookmark-list.scss
+++ b/app/assets/stylesheets/common/components/bookmark-list.scss
@@ -70,10 +70,6 @@ $mobile-breakpoint: 700px;
     }
     .topic-statuses {
       float: none;
-      &:empty {
-        // avoids extra margin
-        display: none;
-      }
     }
   }
 

--- a/app/assets/stylesheets/desktop/category-list.scss
+++ b/app/assets/stylesheets/desktop/category-list.scss
@@ -84,9 +84,6 @@
       @include ellipsis;
       flex: 0 1 auto;
     }
-    .topic-statuses {
-      margin-right: 0.15em;
-    }
     .topic-post-badges .badge.unread-posts,
     .title {
       margin-right: 5px;

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -195,9 +195,6 @@
       flex: 0 1 auto;
       margin-right: 0.5em;
     }
-    .topic-statuses:empty {
-      display: none;
-    }
     span.badge-wrapper {
       margin-left: 0;
     }


### PR DESCRIPTION
Using `:empty` can be fragile, because there are lots of cases where whitespace or empty containers may appear... and then it's not empty despite the appearance. 

I also standardized the margins and removed some duplicate and unused styles.  