### PR TITLE
Version bump to v2.8.0.beta6

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -10,7 +10,7 @@ module Discourse
       MAJOR = 2
       MINOR = 8
       TINY  = 0
-      PRE   = 'beta5'
+      PRE   = 'beta6'
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
     end


### PR DESCRIPTION
v2.8.0.beta5 can cause segfaults due to the oj gem v3.13.3.
