### PR TITLE
FIX: allow single string values on multiple select fields

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1607,6 +1607,7 @@ class UsersController < ApplicationController
     if field.field_type == "dropdown"
       field.user_field_options.find_by_value(field_values)&.value
     elsif field.field_type == "multiselect"
+      field_values = Array.wrap(field_values)
       bad_values = field_values - field.user_field_options.map(&:value)
       field_values - bad_values
     else

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1279,6 +1279,16 @@ describe UsersController do
             end
           end
 
+          it "should allow single values and not just arrays" do
+            expect do
+              put update_user_url, params: { user_fields: { field_id => 'Axe' } }
+            end.to change { user.reload.user_fields[field_id] }.from(nil).to('Axe')
+
+            expect do
+              put update_user_url, params: { user_fields: { field_id => %w[Axe Juice Sword] } }
+            end.to change { user.reload.user_fields[field_id] }.from('Axe').to(%w[Axe Sword])
+          end
+
           it "shouldn't allow unregistered field values" do
             expect do
               put update_user_url, params: { user_fields: { field_id => %w[Juice] } }


### PR DESCRIPTION
This error was logged in our dev logs

```
NoMethodError (undefined method `-' for "he/him":String
Did you mean?  -@)
```

This PR solved the issue by allowing single string values on custom multiple select fields.