### PR TITLE
FEATURE: enable users to choose Unseen as a default view

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -26,6 +26,7 @@ const USER_HOMES = {
   4: "new",
   5: "top",
   6: "bookmarks",
+  7: "unseen",
 };
 
 const TEXT_SIZES = ["smallest", "smaller", "normal", "larger", "largest"];

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -168,6 +168,7 @@ class UserOption < ActiveRecord::Base
     when 4 then "new"
     when 5 then "top"
     when 6 then "bookmarks"
+    when 7 then "unseen"
     else SiteSetting.homepage
     end
   end


### PR DESCRIPTION
Users can choose a default view on the `/preferences/interface` page, now the "Unseen" options is available in that list:

<img width="400" alt="Screenshot 2021-09-03 at 16 28 22" src="https://user-images.githubusercontent.com/1274517/132022042-4c6fc134-d9a0-470c-82e9-92a9274c0548.png">


