### PR TITLE
FEATURE: Hide suspended users from site-wide search to regular users

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1801,7 +1801,7 @@ en:
     external_emoji_url: "URL of the external service for emoji images. Leave blank to disable."
     use_site_small_logo_as_system_avatar: "Use the site's small logo instead of the system user's avatar. Requires the logo to be present."
     restrict_letter_avatar_colors: "A list of 6-digit hexadecimal color values to be used for letter avatar background."
-
+    enable_listing_suspended_users_on_search: "Enable regular users to find suspended users."
     selectable_avatars_enabled: "Force users to choose an avatar from the list."
     selectable_avatars: "List of avatars users can choose from."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2197,6 +2197,9 @@ uncategorized:
   use_site_small_logo_as_system_avatar:
     default: true
 
+  enable_listing_suspended_users_on_search:
+    default: false
+
   disable_system_edit_notifications: true
 
   notification_consolidation_threshold:


### PR DESCRIPTION
Regular users were able to see suspended users when searching their username.

This is fine for admins, but not for regular users, unless specified by the new site setting `enable_listing_suspended_users_on_search `.