### PR TITLE
UX: limit select-kit tag chooser width

### DIFF
--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -275,9 +275,7 @@ header .discourse-tag {
     display: flex;
     justify-content: space-between;
   }
-  .group-tags-list .tag-chooser {
-    width: calc(100% - 1em);
-  }
+
   .saving {
     margin-left: 20px;
   }

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -84,6 +84,7 @@
       flex: 1 0 auto;
       align-items: center;
       height: 100%;
+      max-width: 100%;
     }
 
     .d-icon-spinner {


### PR DESCRIPTION
Before:
![Screen Shot 2021-09-03 at 3 53 24 PM](https://user-images.githubusercontent.com/1681963/132059178-edabe321-1a78-4e44-9aab-d7a055b332f4.png)
![Screen Shot 2021-09-03 at 3 54 29 PM](https://user-images.githubusercontent.com/1681963/132059250-11414830-395f-475e-b615-967decb2f00a.png)

After:
![Screen Shot 2021-09-03 at 3 53 07 PM](https://user-images.githubusercontent.com/1681963/132059185-72c91b8c-79fb-4cf7-bb43-2854ddce9398.png)
![Screen Shot 2021-09-03 at 3 54 34 PM](https://user-images.githubusercontent.com/1681963/132059256-5ebb7954-3b53-46d2-a2a6-a43ff87868be.png)



