### PR TITLE
DEV: Add license field to api docs info section

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -95,7 +95,11 @@ RSpec.configure do |config|
           url: 'https://discourse-meta.s3-us-west-1.amazonaws.com/optimized/3X/9/d/9d543e92b15b06924249654667a81441a55867eb_1_690x184.png',
         },
         version: 'latest',
-        description: api_docs_description
+        description: api_docs_description,
+        license: {
+          name: 'MIT',
+          url: 'https://docs.discourse.org/LICENSE.txt'
+        }
       },
       paths: {},
       servers: [


### PR DESCRIPTION
One of the fields that should be present for openapi docs is the "license"
field.

https://spec.openapis.org/oas/latest.html#infoObject

Our API docs already had a license, so this commit just specifies that
and provides a link to it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
