### PR TITLE
DEV: Require uppy.js in theme_qunit_vendor.js

### DIFF
--- a/app/assets/javascripts/discourse/tests/theme_qunit_vendor.js
+++ b/app/assets/javascripts/discourse/tests/theme_qunit_vendor.js
@@ -29,6 +29,7 @@
 //= require mousetrap-global-bind.js
 //= require rsvp.js
 //= require show-html.js
+//= require uppy.js
 //= require buffered-proxy
 //= require jquery.autoellipsis-1.0.10
 //= require virtual-dom


### PR DESCRIPTION
The smoke test has been failing with the error:

```
TypeError: Cannot read properties of undefined (reading 'Core')
```

Since https://github.com/discourse/discourse-encrypt/commit/de20c460770ac37a530518ab3e6d2a5fa2a8627d
 and 9873a942e3d2df367717f119c591492c690d291d this error has been occurring,
possibly now because Uppy is required by a plugin. Adding uppy.js into
the require list for theme_qunit_vendor.js fixes the issue.