### PR TITLE
FIX: empty state message on the user bookmarks page

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -66,24 +66,22 @@ export default Controller.extend({
 
     this.set("loadingMore", true);
 
-    return this._loadMoreBookmarks({ q: this.q })
+    return this._loadMoreBookmarks(this.q)
       .then((response) => this._processLoadResponse(response))
       .catch(() => this._bookmarksListDenied())
       .finally(() => this.set("loadingMore", false));
   },
 
-  _loadMoreBookmarks(additionalParams) {
+  _loadMoreBookmarks(searchQuery) {
     if (!this.model.loadMoreUrl) {
       return Promise.resolve();
     }
 
     let moreUrl = this.model.loadMoreUrl;
-    if (additionalParams) {
-      if (moreUrl.includes("?")) {
-        moreUrl += "&" + $.param(additionalParams);
-      } else {
-        moreUrl += "?" + $.param(additionalParams);
-      }
+    if (searchQuery) {
+      const delimiter = moreUrl.includes("?") ? "&" : "?";
+      const q = encodeURIComponent(searchQuery);
+      moreUrl += `${delimiter}q=${q}`;
     }
 
     return ajax({ url: moreUrl });

--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -78,18 +78,11 @@ export default Controller.extend({
     }
 
     let moreUrl = this.model.loadMoreUrl;
-    if (moreUrl) {
-      let [url, params] = moreUrl.split("?");
-      moreUrl = url;
-      if (params) {
-        moreUrl += "?" + params;
-      }
-      if (additionalParams) {
-        if (moreUrl.includes("?")) {
-          moreUrl += "&" + $.param(additionalParams);
-        } else {
-          moreUrl += "?" + $.param(additionalParams);
-        }
+    if (additionalParams) {
+      if (moreUrl.includes("?")) {
+        moreUrl += "&" + $.param(additionalParams);
+      } else {
+        moreUrl += "?" + $.param(additionalParams);
       }
     }
 

--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -101,19 +101,21 @@ export default Controller.extend({
     this.model.more_bookmarks_url = response.more_bookmarks_url;
 
     if (response.bookmarks) {
-      const bookmarkModels = response.bookmarks.map((bookmark) => {
-        const bookmarkModel = Bookmark.create(bookmark);
-        bookmarkModel.topicStatus = EmberObject.create({
-          closed: bookmark.closed,
-          archived: bookmark.archived,
-          is_warning: bookmark.is_warning,
-          pinned: false,
-          unpinned: false,
-          invisible: bookmark.invisible,
-        });
-        return bookmarkModel;
-      });
+      const bookmarkModels = response.bookmarks.map(this.transform);
       this.content.pushObjects(bookmarkModels);
     }
+  },
+
+  transform(bookmark) {
+    const bookmarkModel = Bookmark.create(bookmark);
+    bookmarkModel.topicStatus = EmberObject.create({
+      closed: bookmark.closed,
+      archived: bookmark.archived,
+      is_warning: bookmark.is_warning,
+      pinned: false,
+      unpinned: false,
+      invisible: bookmark.invisible,
+    });
+    return bookmarkModel;
   },
 });

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -141,30 +141,6 @@ const Bookmark = RestModel.extend({
     });
   },
 
-  loadMore(additionalParams) {
-    if (!this.more_bookmarks_url) {
-      return Promise.resolve();
-    }
-
-    let moreUrl = this.more_bookmarks_url;
-    if (moreUrl) {
-      let [url, params] = moreUrl.split("?");
-      moreUrl = url;
-      if (params) {
-        moreUrl += "?" + params;
-      }
-      if (additionalParams) {
-        if (moreUrl.includes("?")) {
-          moreUrl += "&" + $.param(additionalParams);
-        } else {
-          moreUrl += "?" + $.param(additionalParams);
-        }
-      }
-    }
-
-    return ajax({ url: moreUrl });
-  },
-
   @discourseComputed(
     "post_user_username",
     "post_user_avatar_template",

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -141,16 +141,6 @@ const Bookmark = RestModel.extend({
     });
   },
 
-  loadItems(params) {
-    let url = `/u/${this.user.username}/bookmarks.json`;
-
-    if (params) {
-      url += "?" + $.param(params);
-    }
-
-    return ajax(url);
-  },
-
   loadMore(additionalParams) {
     if (!this.more_bookmarks_url) {
       return Promise.resolve();

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -1,4 +1,6 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import { ajax } from "discourse/lib/ajax";
+import { action } from "@ember/object";
 
 export default DiscourseRoute.extend({
   queryParams: {
@@ -6,23 +8,52 @@ export default DiscourseRoute.extend({
     q: { refreshModel: true },
   },
 
-  model() {
-    return this.modelFor("user").get("bookmarks");
+  model(params) {
+    const controller = this.controllerFor("user-activity-bookmarks");
+
+    return this._loadBookmarks(params)
+      .then((response) => {
+        const bookmarks = response.user_bookmark_list.bookmarks.map(
+          controller.transform
+        );
+        const loadMoreUrl = response.user_bookmark_list.more_bookmarks_url;
+
+        return { bookmarks, loadMoreUrl };
+      })
+      .catch(() => controller.set("permissionDenied", true));
   },
 
   renderTemplate() {
     this.render("user_bookmarks");
   },
 
-  setupController(controller, model) {
-    controller.set("model", model);
-    controller.loadItems();
+  @action
+  didTransition() {
+    this.controllerFor("user-activity")._showFooter();
+    return true;
   },
 
-  actions: {
-    didTransition() {
-      this.controllerFor("user-activity")._showFooter();
-      return true;
-    },
+  @action
+  loading(transition) {
+    let controller = this.controllerFor("user-activity-bookmarks");
+    controller.set("loading", true);
+    transition.promise.finally(function () {
+      controller.set("loading", false);
+    });
+  },
+
+  @action
+  triggerRefresh() {
+    this.refresh();
+  },
+
+  _loadBookmarks(params) {
+    let url = `/u/${this.modelFor("user").username}/bookmarks.json`;
+
+    if (params) {
+      url += "?" + $.param(params);
+    }
+
+    return ajax(url);
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -13,6 +13,10 @@ export default DiscourseRoute.extend({
 
     return this._loadBookmarks(params)
       .then((response) => {
+        if (!response.user_bookmark_list) {
+          return { bookmarks: [] };
+        }
+
         const bookmarks = response.user_bookmark_list.bookmarks.map(
           controller.transform
         );

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -3,6 +3,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 export default DiscourseRoute.extend({
   queryParams: {
     acting_username: { refreshModel: true },
+    q: { refreshModel: true },
   },
 
   model() {

--- a/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
@@ -1,3 +1,4 @@
+{{log loading}}
 {{#conditional-loading-spinner condition=loading}}
   {{#if permissionDenied}}
     <div class="alert alert-info">{{i18n "bookmarks.list_permission_denied"}}</div>
@@ -29,7 +30,7 @@
         loadMore=(action "loadMore")
         reload=(action "reload")
         loadingMore=loadingMore
-        content=content
+        content=model.bookmarks
       }}
     {{/if}}
   {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
@@ -1,4 +1,3 @@
-{{log loading}}
 {{#conditional-loading-spinner condition=loading}}
   {{#if permissionDenied}}
     <div class="alert alert-info">{{i18n "bookmarks.list_permission_denied"}}</div>


### PR DESCRIPTION
After adding an empty state banner to the user bookmarks page, we have found the bug. Steps to reproduce:
1. Go to the user bookmarks page
2. Search for something that doesn’t exist in bookmarks
3. Click again <kbd>Bookmarked</kbd> on the sidebar or <kbd>View All Bookmarks</kbd> on the user menu again

You'll see the empty state banner:

![412fa97284508d597ea3dbf7ef58a2a0cce135bd_2_1034x272](https://user-images.githubusercontent.com/1274517/132215244-3a772e12-72a7-41da-8880-e852cf6a38f1.jpeg)

This is the problem with routing, and it's hard to fix because of how this page is implemented. We're not loading the model in the model hook in the route, so when transition is happening ember calls the model hook, but the loading isn't happening.

This PR removes code that load bookmarks from the _ember model._ I moved initial loading to the model hook in the route, and loading of additional bookmarks that is triggered when a user scroll down the page - to the controller. This fixes the bug, and it also will save us from problems in the future when touching this code or migrating to new Ember versions.