### PR TITLE
FIX: Do not replace watched words in mentions and hashtags

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
@@ -119,6 +119,14 @@ export function setup(helper) {
                 continue;
               }
 
+              if (
+                matches[ln].index > 0 &&
+                (text[matches[ln].index - 1] === "@" ||
+                  text[matches[ln].index - 1] === "#")
+              ) {
+                continue;
+              }
+
               if (matches[ln].index > lastPos) {
                 token = new state.Token("text", "", 0);
                 token.content = text.slice(lastPos, matches[ln].index);

--- a/spec/components/pretty_text_spec.rb
+++ b/spec/components/pretty_text_spec.rb
@@ -1465,6 +1465,20 @@ HTML
       expect(PrettyText.cook("f.o")).to match_html("<p>test</p>")
     end
 
+    it "does not replace hashtags and mentions" do
+      Fabricate(:user, username: "test")
+      category = Fabricate(:category, slug: "test")
+      Fabricate(:watched_word, action: WatchedWord.actions[:replace], word: "test", replacement: "discourse")
+
+      expect(PrettyText.cook("@test #test test")).to match_html(<<~HTML)
+        <p>
+          <a class="mention" href="/u/test">@test</a>
+          <a class="hashtag" href="/c/test/#{category.id}">#<span>test</span></a>
+          discourse
+        </p>
+      HTML
+    end
+
     it "supports overlapping words" do
       Fabricate(:watched_word, action: WatchedWord.actions[:link], word: "meta", replacement: "https://meta.discourse.org")
       Fabricate(:watched_word, action: WatchedWord.actions[:replace], word: "iz", replacement: "is")


### PR DESCRIPTION
Watched words of type 'replace' or 'link' replaced the text inside
mentions or hashtags too, which broke these. These types of watched
words must skip any match that has an @ or # before it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
