### PR TITLE
FIX: Always show the creation date of posts in crawler view

### DIFF
--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -66,16 +66,13 @@
           <% end %>
 
           <span class="crawler-post-infos">
-            <% if post.updated_at > post.created_at %>
-              <meta itemprop='datePublished' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
-              <time itemprop='dateModified' datetime='<%= post.updated_at.to_formatted_s(:iso8601) %>' class='post-time'>
-                <%= l post.updated_at, format: :long %>
-              </time>
-            <% else %>
               <time itemprop='datePublished' datetime='<%= post.created_at.to_formatted_s(:iso8601) %>' class='post-time'>
                 <%= l post.created_at, format: :long %>
               </time>
-              <meta itemprop='dateModified' content='<%= post.updated_at.to_formatted_s(:iso8601) %>'>
+            <% if post.version > 1 %>
+              <meta itemprop='dateModified' content='<%= post.last_version_at.to_formatted_s(:iso8601) %>'>
+            <% else %>
+              <meta itemprop='dateModified' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
             <% end %>
           <span itemprop='position'>#<%= post.post_number %></span>
           </span>


### PR DESCRIPTION
The modification date should always be a meta tag to make this less confusing. Especially for imported posts.
That's more in line with how the rest of Discourse presents post dates.