### PR TITLE
FIX: do not show spoiler content in RSS

### DIFF
--- a/app/views/list/list.rss.erb
+++ b/app/views/list/list.rss.erb
@@ -18,7 +18,7 @@
           <category><%= topic.category.name %></category>
           <description><![CDATA[
             <%- if first_post = topic.ordered_posts.first %>
-            <%= first_post.cooked.html_safe %>
+            <%= PrettyText.format_for_email(first_post.cooked, first_post).html_safe %>
             <%- end %>
             <p><small><%= t 'rss_num_posts', count: topic.posts_count %> - <%= t 'rss_num_participants', count: topic.participant_count %></small></p>
             <p><%= link_to t('read_full_topic'), topic_url %></p>

--- a/app/views/posts/latest.rss.erb
+++ b/app/views/posts/latest.rss.erb
@@ -11,7 +11,7 @@
       <item>
         <title><%= post.topic.title %></title>
         <dc:creator><![CDATA[<%= "@#{post.user.username}#{" #{post.user.name}" if (post.user.name.present? && SiteSetting.enable_names?)}" -%>]]></dc:creator>
-        <description><![CDATA[ <%= post.cooked.html_safe %> ]]></description>
+        <description><![CDATA[ <%= PrettyText.format_for_email(post.cooked, post).html_safe %> ]]></description>
         <link><%= Discourse.base_url + post.url %></link>
         <pubDate><%= post.created_at.rfc2822 %></pubDate>
         <guid isPermaLink="false"><%= Discourse.current_hostname %>-post-<%= post.id %></guid>

--- a/app/views/topics/show.rss.erb
+++ b/app/views/topics/show.rss.erb
@@ -21,7 +21,7 @@
           <% if post.hidden %>
             <%= t('flagging.user_must_edit').html_safe %>
           <% else %>
-            <%= post.cooked.html_safe %>
+            <%= PrettyText.format_for_email(post.cooked, post).html_safe %>
           <% end %>
           <p><%= link_to t('read_full_topic'), post_url %></p>
         ]]></description>


### PR DESCRIPTION
This commit updates the RSS post content to use email formatting. Many
plugins are using the `reduce_cooked` method to format content that is
not displayed outside of Discourse application. Using email formatting
also strips the secure media and various other things that is only meant
for Discourse client side application.

Meta ref: https://meta.discourse.org/t/rss-feed-reveals-spoilers/165689/
