### PR TITLE
FIX: ignore canonical link for medium.com oneboxes

### DIFF
--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -7,7 +7,7 @@ module Onebox
 
     class DownloadTooLarge < StandardError; end
 
-    IGNORE_CANONICAL_DOMAINS ||= ['www.instagram.com', 'youtube.com']
+    IGNORE_CANONICAL_DOMAINS ||= ['www.instagram.com', 'medium.com', 'youtube.com']
 
     def self.symbolize_keys(hash)
       return {} if hash.nil?


### PR DESCRIPTION
https://meta.discourse.org/t/bug-in-onebox-link-being-rendered-as-a-gist-when-it-isnt/202463
