### PR TITLE
FIX: Composer height issue in iOS 15 Safari

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/safari-hacks.js
+++ b/app/assets/javascripts/discourse/app/lib/safari-hacks.js
@@ -98,7 +98,10 @@ function positioningWorkaround($fixedElement) {
 
   positioningWorkaround.blur = function (evt) {
     if (workaroundActive) {
-      $("body").removeClass("ios-safari-composer-hacks");
+      document.body.classList.remove("ios-safari-composer-hacks");
+      if (caps.isIOS15Safari) {
+        document.body.classList.remove("ios-safari-15-hack");
+      }
       window.scrollTo(0, originalScrollTop);
 
       if (evt && evt.target) {
@@ -188,7 +191,10 @@ function positioningWorkaround($fixedElement) {
         return;
       }
 
-      $("body").addClass("ios-safari-composer-hacks");
+      document.body.classList.add("ios-safari-composer-hacks");
+      if (caps.isIOS15Safari) {
+        document.body.classList.add("ios-safari-15-hack");
+      }
       window.scrollTo(0, 0);
 
       if (!iOSWithVisualViewport()) {

--- a/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
@@ -43,6 +43,11 @@ export default {
         (/iPhone|iPod/.test(navigator.userAgent) || caps.isIpadOS) &&
         !window.MSStream;
 
+      caps.isIOS15Safari =
+        caps.isIOS &&
+        /Version\/15/.test(navigator.userAgent) &&
+        !/DiscourseHub/.test(navigator.userAgent);
+
       caps.hasContactPicker =
         "contacts" in navigator && "ContactsManager" in window;
 

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -32,6 +32,13 @@
     padding-bottom: 0px;
   }
 
+  // iOS 15 Safari has a floating address bar that displays above the composer submit bar
+  // we cannot detect its preseence, so we need to add extra padding
+  // Apple says it's a known issue, see https://bugs.webkit.org/show_bug.cgi?id=229876
+  .keyboard-visible body.ios-safari-15-hack &.open .reply-area {
+    padding-bottom: 45px;
+  }
+
   .reply-to {
     margin: 5px 0;
     .reply-details {


### PR DESCRIPTION
Safari on iOS 15 has an address bar pinned to the bottom of the viewport. When the software keyboard is invoked, this bar floats above the content, hiding the buttons in the composer. 

<img width="319" alt="image" src="https://user-images.githubusercontent.com/368961/132542444-c4dac20b-fca4-41b1-9873-f5b924563207.png">

This PR adds bottom padding for Safari iOS15 only, the issue is not present on other browsers in iOS (like Chrome) or in DiscourseHub. 

At this time, there is no way to detect Safari's floating address bar. Apple has recognized this is a known issue in this Webkit bug report: https://bugs.webkit.org/show_bug.cgi?id=229876 

See also: https://stackoverflow.com/questions/68974702/ios-15-safari-detect-floating-address-bar-when-keyboard-is-visible 