### PR TITLE
FIX: Ember CLI was being hijacked before potential errors

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,3 @@
-<%- hijack_if_ember_cli! -%>
 <!DOCTYPE html>
 <html lang="<%= html_lang %>" class="<%= html_classes %>">
   <head>
@@ -129,3 +128,4 @@
     <%- end %>
   </body>
 </html>
+<%- hijack_if_ember_cli! -%>


### PR DESCRIPTION
This was problematic if something like SCSS file throws an error as the
app would tell Ember CLI to bootstrap as if everything is fine and not
display the error.

The fix is to only hijack the rendering at the end of the template
instead of the beginning.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
