### PR TITLE
FIX: Better positioning for "Skip to main content" button

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -880,8 +880,8 @@ table {
 
 a#skip-link {
   padding: 0.25em 0.5em;
-  position: absolute;
-  top: -200px;
+  position: fixed;
+  top: -50px;
   left: 1em;
   color: var(--secondary);
   background: var(--tertiary);


### PR DESCRIPTION
Fixed positioning is better suited for this (it is relative to the window), some sites can have very tall headers injected before the ember app scaffolding. 