### PR TITLE
FIX: Remove dismiss read topics from PM topic tracking state.

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/bulk-topic-selection.js
+++ b/app/assets/javascripts/discourse/app/mixins/bulk-topic-selection.js
@@ -51,7 +51,11 @@ export default Mixin.create({
 
       promise.then((result) => {
         if (result && result.topic_ids) {
-          this.topicTrackingState.removeTopics(result.topic_ids);
+          if (options.private_message_inbox) {
+            this.pmTopicTrackingState.removeTopics(result.topic_ids);
+          } else {
+            this.topicTrackingState.removeTopics(result.topic_ids);
+          }
         }
 
         this.send("closeModal");

--- a/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
@@ -81,6 +81,15 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
     }
   },
 
+  removeTopics(topicIds) {
+    if (!this.isTracking) {
+      return;
+    }
+
+    topicIds.forEach((topicId) => this.states.delete(topicId));
+    this.incrementProperty("statesModificationCounter");
+  },
+
   _userChannel() {
     return `${this.CHANNEL_PREFIX}/user/${this.currentUser.id}`;
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -166,7 +166,9 @@ acceptance(
           fetchUserNew = true;
         }
 
-        return helper.response({});
+        return helper.response({
+          topic_ids: [1, 2, 3],
+        });
       });
     });
 
@@ -459,6 +461,10 @@ acceptance(
     test("dismissing all unread messages", async function (assert) {
       await visit("/u/charlie/messages/unread");
 
+      publishUnreadToMessageBus({ topicId: 1, userId: 5 });
+      publishUnreadToMessageBus({ topicId: 2, userId: 5 });
+      publishUnreadToMessageBus({ topicId: 3, userId: 5 });
+
       assert.equal(
         count(".topic-list-item"),
         3,
@@ -467,6 +473,12 @@ acceptance(
 
       await click(".btn.dismiss-read");
       await click("#dismiss-read-confirm");
+
+      assert.equal(
+        query(".messages-nav li a.unread").innerText.trim(),
+        I18n.t("user.messages.unread"),
+        "displays the right count"
+      );
 
       assert.equal(
         count(".topic-list-item"),


### PR DESCRIPTION
Follow-up to fc1fd1b41689694b3916dc4e10605eb9b8bb89b7