### PR TITLE
FIX: Remove dismissed new topics from PM topic tracking state.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-topics-list.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-topics-list.js
@@ -67,8 +67,11 @@ export default Controller.extend(BulkTopicSelection, {
       opts.groupName = this.group.name;
     }
 
-    Topic.pmResetNew(opts).then(() => {
-      this.send("refresh");
+    Topic.pmResetNew(opts).then((result) => {
+      if (result && result.topic_ids.length > 0) {
+        this.pmTopicTrackingState.removeTopics(result.topic_ids);
+        this.send("refresh");
+      }
     });
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -144,7 +144,7 @@ acceptance(
           fetchedNew = true;
         }
 
-        return helper.response({});
+        return helper.response({ topic_ids: [1, 2, 3] });
       });
 
       server.put("/topics/bulk", (request) => {
@@ -528,6 +528,10 @@ acceptance(
     test("dismissing all new messages", async function (assert) {
       await visit("/u/charlie/messages/new");
 
+      publishNewToMessageBus({ topicId: 1, userId: 5 });
+      publishNewToMessageBus({ topicId: 2, userId: 5 });
+      publishNewToMessageBus({ topicId: 3, userId: 5 });
+
       assert.equal(
         count(".topic-list-item"),
         3,
@@ -535,6 +539,12 @@ acceptance(
       );
 
       await click(".btn.dismiss-read");
+
+      assert.equal(
+        query(".messages-nav li a.new").innerText.trim(),
+        I18n.t("user.messages.new"),
+        "displays the right count"
+      );
 
       assert.equal(
         count(".topic-list-item"),

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -962,13 +962,13 @@ class TopicsController < ApplicationController
       topic_scope = topic_query.filter_private_message_new(current_user, filter)
     end
 
-    TopicsBulkAction.new(
+    topic_ids = TopicsBulkAction.new(
       current_user,
       topic_scope.pluck(:id),
       type: "dismiss_topics"
     ).perform!
 
-    render json: success_json
+    render json: success_json.merge(topic_ids: topic_ids)
   end
 
   def reset_new

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -4383,6 +4383,7 @@ RSpec.describe TopicsController do
       }
 
       expect(response.status).to eq(200)
+      expect(response.parsed_body["topic_ids"]).to contain_exactly(group_message.id)
 
       expect(DismissedTopicUser.count).to eq(1)
 
@@ -4396,6 +4397,10 @@ RSpec.describe TopicsController do
       }
 
       expect(response.status).to eq(200)
+      expect(response.parsed_body["topic_ids"]).to contain_exactly(
+        private_message.id,
+        private_message_2.id
+      )
 
       expect(DismissedTopicUser.count).to eq(2)
 


### PR DESCRIPTION
Follow-up to fc1fd1b41689694b3916dc4e10605eb9b8bb89b7