### PR TITLE
FIX: Display unread/new PM links only when viewing own user.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -31,16 +31,20 @@
           {{i18n "user.messages.sent"}}
         {{/link-to}}
       </li>
-      <li>
-        {{#link-to "userPrivateMessages.new" model class="new"}}
-          {{newLinkText}}
-        {{/link-to}}
-      </li>
-      <li>
-        {{#link-to "userPrivateMessages.unread" model class="unread"}}
-          {{unreadLinkText}}
-        {{/link-to}}
-      </li>
+
+      {{#if viewingSelf}}
+        <li>
+          {{#link-to "userPrivateMessages.new" model class="new"}}
+            {{newLinkText}}
+          {{/link-to}}
+        </li>
+        <li>
+          {{#link-to "userPrivateMessages.unread" model class="unread"}}
+            {{unreadLinkText}}
+          {{/link-to}}
+        </li>
+      {{/if}}
+
       <li>
         {{#link-to "userPrivateMessages.archive" model}}
           {{i18n "user.messages.archive"}}
@@ -54,16 +58,20 @@
           {{i18n "user.messages.latest"}}
         {{/link-to}}
       </li>
-      <li>
-        {{#link-to "userPrivateMessages.groupNew" group.name class="new"}}
-          {{newLinkText}}
-        {{/link-to}}
-      </li>
-      <li>
-        {{#link-to "userPrivateMessages.groupUnread" group.name class="unread"}}
-          {{unreadLinkText}}
-        {{/link-to}}
-      </li>
+
+      {{#if viewingSelf}}
+        <li>
+          {{#link-to "userPrivateMessages.groupNew" group.name class="new"}}
+            {{newLinkText}}
+          {{/link-to}}
+        </li>
+        <li>
+          {{#link-to "userPrivateMessages.groupUnread" group.name class="unread"}}
+            {{unreadLinkText}}
+          {{/link-to}}
+        </li>
+      {{/if}}
+
       <li>
         {{#link-to "userPrivateMessages.groupArchive" group.name}}
           {{i18n "user.messages.archive"}}
@@ -82,16 +90,20 @@
           {{i18n "user.messages.sent"}}
         {{/link-to}}
       </li>
-      <li>
-        {{#link-to "userPrivateMessages.personalNew" model class="new"}}
-          {{newLinkText}}
-        {{/link-to}}
-      </li>
-      <li>
-        {{#link-to "userPrivateMessages.personalUnread" model class="unread"}}
-          {{unreadLinkText}}
-        {{/link-to}}
-      </li>
+
+      {{#if viewingSelf}}
+        <li>
+          {{#link-to "userPrivateMessages.personalNew" model class="new"}}
+            {{newLinkText}}
+          {{/link-to}}
+        </li>
+        <li>
+          {{#link-to "userPrivateMessages.personalUnread" model class="unread"}}
+            {{unreadLinkText}}
+          {{/link-to}}
+        </li>
+      {{/if}}
+
       <li>
         {{#link-to "userPrivateMessages.personalArchive" model}}
           {{i18n "user.messages.archive"}}

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -7,6 +7,7 @@ import {
   exists,
   publishToMessageBus,
   query,
+  updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { PERSONAL_INBOX } from "discourse/controllers/user-private-messages";
@@ -36,6 +37,22 @@ acceptance(
       assert.ok(
         !exists(".group-notifications-button"),
         "displays the group notifications button"
+      );
+    });
+
+    test("viewing messages of another user", async function (assert) {
+      updateCurrentUser({ id: 5, username: "charlie" });
+
+      await visit("/u/eviltrout/messages");
+
+      assert.ok(
+        !exists(".messages-nav li a.new"),
+        "it does not display new filter"
+      );
+
+      assert.ok(
+        !exists(".messages-nav li a.unread"),
+        "it does not display unread filter"
       );
     });
   }

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -155,6 +155,14 @@ class ListController < ApplicationController
     target_user = fetch_user_from_params({ include_inactive: current_user.try(:staff?) }, [:user_stat, :user_option])
 
     case action
+    when :private_messages_unread,
+         :private_messages_new,
+         :private_messages_group_new,
+         :private_messages_group_unread,
+         :private_messages_all_new,
+         :private_messages_all_unread
+
+      raise Discourse::NotFound if target_user.id != current_user.id
     when :private_messages_tag
       raise Discourse::NotFound if !guardian.can_tag_pms?
     when :private_messages_warnings

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -703,10 +703,10 @@ RSpec.describe ListController do
       end
     end
 
-    it "returns 403 error when the user can't see private message" do
+    it "returns 404 when the user can't see private message" do
       sign_in(Fabricate(:user))
       get "/topics/private-messages-unread/#{pm_user.username}.json"
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(404)
     end
 
     it "succeeds when the user can see private messages" do


### PR DESCRIPTION
At this point in time, we do not think supporting unread and new when an
admin is looking at another user's messages is worth supporting.

Follow-up to fc1fd1b41689694b3916dc4e10605eb9b8bb89b7