### PR TITLE
FIX: Don't attempt to migrate multisite test db while holding the mutex

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -231,10 +231,10 @@ task 'db:migrate' => ['load_config', 'environment', 'set_locale'] do |_, args|
     if !Discourse.skip_post_deployment_migrations? && ENV['SKIP_OPTIMIZE_ICONS'] != '1'
       SiteIconManager.ensure_optimized!
     end
+  end
 
-    if !Discourse.is_parallel_test? && MultisiteTestHelpers.load_multisite?
-      system("RAILS_DB=discourse_test_multisite rake db:migrate")
-    end
+  if !Discourse.is_parallel_test? && MultisiteTestHelpers.load_multisite?
+    system("RAILS_DB=discourse_test_multisite rake db:migrate")
   end
 end
 


### PR DESCRIPTION
Since you'll have to wait for the mutex to timeout before it can
continue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
