### PR TITLE
DEV: Allow TopicEmbed.import to optionally receive a list of tags

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -59,7 +59,7 @@ class TopicEmbed < ActiveRecord::Base
           skip_validations: true,
           cook_method: cook_method,
           category: category_id || eh.try(:category_id),
-          tags: tags,
+          tags: SiteSetting.tagging_enabled ? tags : nil,
         }
         if SiteSetting.embed_unlisted?
           create_args[:visible] = false

--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -27,7 +27,7 @@ class TopicEmbed < ActiveRecord::Base
   end
 
   # Import an article from a source (RSS/Atom/Other)
-  def self.import(user, url, title, contents, category_id: nil, cook_method: nil)
+  def self.import(user, url, title, contents, category_id: nil, cook_method: nil, tags: nil)
     return unless url =~ /^https?\:\/\//
 
     if SiteSetting.embed_truncate && cook_method.nil?
@@ -58,7 +58,8 @@ class TopicEmbed < ActiveRecord::Base
           raw: absolutize_urls(url, contents),
           skip_validations: true,
           cook_method: cook_method,
-          category: category_id || eh.try(:category_id)
+          category: category_id || eh.try(:category_id),
+          tags: tags,
         }
         if SiteSetting.embed_unlisted?
           create_args[:visible] = false

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -17,6 +17,7 @@ describe TopicEmbed do
     let(:contents) { "<p>hello world new post <a href='/hello'>hello</a> <img src='/images/wat.jpg'></p>" }
     fab!(:embeddable_host) { Fabricate(:embeddable_host) }
     fab!(:category) { Fabricate(:category) }
+    fab!(:tag) { Fabricate(:tag) }
 
     it "returns nil when the URL is malformed" do
       expect(TopicEmbed.import(user, "invalid url", title, contents)).to eq(nil)
@@ -102,6 +103,13 @@ describe TopicEmbed do
         imported_post = TopicEmbed.import(user, "http://eviltrout.com/abcd", title, "some random content", category_id: category.id)
         expect(imported_post.topic.category).not_to eq(embeddable_host.category)
         expect(imported_post.topic.category).to eq(category)
+      end
+
+      it "creates the topic with the tag passed as a parameter" do
+        Jobs.run_immediately!
+        SiteSetting.tagging_enabled = true
+        imported_post = TopicEmbed.import(user, "http://eviltrout.com/abcd", title, "some random content", tags: [tag.name])
+        expect(imported_post.topic.tags).to include(tag)
       end
 
       it "respects overriding the cook_method when asked" do


### PR DESCRIPTION
This will be used by the rss-polling plugin
