### PR TITLE
DEV: Bump uppy-s3 to 2.0.2 to fix XHR bug

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -21,7 +21,7 @@
     "@ember/test-helpers": "^2.2.0",
     "@glimmer/component": "^1.0.0",
     "@popperjs/core": "2.9.3",
-    "@uppy/aws-s3": "^2.0.1",
+    "@uppy/aws-s3": "^2.0.2",
     "@uppy/aws-s3-multipart": "^2.0.2",
     "@uppy/core": "^2.0.1",
     "@uppy/drop-target": "^1.0.1",

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -1395,14 +1395,14 @@
     "@uppy/companion-client" "^2.0.0"
     "@uppy/utils" "^4.0.0"
 
-"@uppy/aws-s3@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@uppy/aws-s3/-/aws-s3-2.0.1.tgz#d59058f606044f258a9df763dfe1b6a2f7363feb"
-  integrity sha512-mgdRiXYeX7+yOyXXb28M+j/AzCCmkOyaiXsyFfoKtkCP+ALw2HHCWO4dycl0xaghSFIALBIoLN8ZGQ8zR6P9Pg==
+"@uppy/aws-s3@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@uppy/aws-s3/-/aws-s3-2.0.2.tgz#6bd4e17bf3984bf7f8633264c3669a454d9853d5"
+  integrity sha512-Nxp0nFGTVYgNIVN4bHdWHx+1nEkdCdFeYGw3KltIGPhzN4RRMAvrsCB3Mk4AAWL4KSVKs4BgkNfYNVt3nRJVqg==
   dependencies:
     "@uppy/companion-client" "^2.0.0"
     "@uppy/utils" "^4.0.0"
-    "@uppy/xhr-upload" "^2.0.1"
+    "@uppy/xhr-upload" "^2.0.2"
     nanoid "^3.1.25"
 
 "@uppy/companion-client@^2.0.0":
@@ -1450,6 +1450,15 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@uppy/xhr-upload/-/xhr-upload-2.0.1.tgz#751f00c30bd00004aa38d0e0eda653dee0e42206"
   integrity sha512-7LMZL1+MdpUT1v3+JTs23Zhw+vZ1XL0a3r6cH0+1/JeN4Kx0AnSUouXF2tamdA5OOZpSqseY4lfFO3pJqCXOOA==
+  dependencies:
+    "@uppy/companion-client" "^2.0.0"
+    "@uppy/utils" "^4.0.0"
+    nanoid "^3.1.25"
+
+"@uppy/xhr-upload@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@uppy/xhr-upload/-/xhr-upload-2.0.2.tgz#dc61332fc6bf53fcc79892ec41330ac475bdfba6"
+  integrity sha512-yb/yCUquX0m96jABMEpUQGnxBqjtB5b3u9l8pY+wi3N7SEuDk1u2PPakkbzI6xcguW1e9Peb+Q2LYK6wWaPIxQ==
   dependencies:
     "@uppy/companion-client" "^2.0.0"
     "@uppy/utils" "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@highlightjs/cdn-assets": "^10.6.0",
     "@json-editor/json-editor": "^2.5.2",
     "@popperjs/core": "v2.9.3",
-    "@uppy/aws-s3": "^2.0.1",
+    "@uppy/aws-s3": "^2.0.2",
     "@uppy/aws-s3-multipart": "^2.0.2",
     "@uppy/core": "^2.0.1",
     "@uppy/drop-target": "^1.0.1",

--- a/vendor/assets/javascripts/uppy.js
+++ b/vendor/assets/javascripts/uppy.js
@@ -1266,18 +1266,9 @@ function _uploadLocalFile2(file, current, total) {
     const data = opts.formData ? createFormDataUpload(file, opts) : createBareUpload(file, opts);
     const xhr = new XMLHttpRequest();
     this.uploaderEvents[file.id] = new EventTracker(this.uppy);
-    const queuedRequest = this.requests.run(() => {
-      xhr.send(data);
-      return () => {
-        // eslint-disable-next-line no-use-before-define
-        timer.done();
-        xhr.abort();
-      };
-    }, {
-      priority: 1
-    });
     const timer = new ProgressTimeout(opts.timeout, () => {
-      xhr.abort();
+      xhr.abort(); // eslint-disable-next-line no-use-before-define
+
       queuedRequest.done();
       const error = new Error(this.i18n('timedOut', {
         seconds: Math.ceil(opts.timeout / 1000)
@@ -1305,7 +1296,8 @@ function _uploadLocalFile2(file, current, total) {
     });
     xhr.addEventListener('load', ev => {
       this.uppy.log(`[AwsS3/XHRUpload] ${id} finished`);
-      timer.done();
+      timer.done(); // eslint-disable-next-line no-use-before-define
+
       queuedRequest.done();
 
       if (this.uploaderEvents[file.id]) {
@@ -1341,7 +1333,8 @@ function _uploadLocalFile2(file, current, total) {
     });
     xhr.addEventListener('error', () => {
       this.uppy.log(`[AwsS3/XHRUpload] ${id} errored`);
-      timer.done();
+      timer.done(); // eslint-disable-next-line no-use-before-define
+
       queuedRequest.done();
 
       if (this.uploaderEvents[file.id]) {
@@ -1364,6 +1357,16 @@ function _uploadLocalFile2(file, current, total) {
 
     Object.keys(opts.headers).forEach(header => {
       xhr.setRequestHeader(header, opts.headers[header]);
+    });
+    const queuedRequest = this.requests.run(() => {
+      xhr.send(data);
+      return () => {
+        // eslint-disable-next-line no-use-before-define
+        timer.done();
+        xhr.abort();
+      };
+    }, {
+      priority: 1
     });
 
     _classPrivateFieldLooseBase(this, _addEventHandlerForFile)[_addEventHandlerForFile]('file-removed', file.id, () => {
@@ -1697,7 +1700,9 @@ module.exports = (_temp = (_client = /*#__PURE__*/_classPrivateFieldLooseKey("cl
     };
     this.opts = { ...defaultOptions,
       ...opts
-    };
+    }; // TODO: remove i18n once we can depend on XHRUpload instead of MiniXHRUpload
+
+    this.i18nInit();
     _classPrivateFieldLooseBase(this, _client)[_client] = new RequestClient(uppy, opts);
     _classPrivateFieldLooseBase(this, _requests)[_requests] = new RateLimitedQueue(this.opts.limit);
   }
@@ -1779,7 +1784,7 @@ module.exports = (_temp = (_client = /*#__PURE__*/_classPrivateFieldLooseKey("cl
       responseType: 'text',
       getResponseData: this.opts.getResponseData || defaultGetResponseData,
       getResponseError: defaultGetResponseError
-    }; // Only for MiniXHRUpload, remove once we can depend on XHRUpload directly again
+    }; // TODO: remove i18n once we can depend on XHRUpload instead of MiniXHRUpload
 
     xhrOptions.i18n = this.i18n; // Revert to `uppy.use(XHRUpload)` once the big comment block at the top of
     // this file is solved
@@ -1791,7 +1796,7 @@ module.exports = (_temp = (_client = /*#__PURE__*/_classPrivateFieldLooseKey("cl
     this.uppy.removeUploader(_classPrivateFieldLooseBase(this, _handleUpload)[_handleUpload]);
   }
 
-}), _class.VERSION = "2.0.1", _temp);
+}), _class.VERSION = "2.0.2", _temp);
 },{"./MiniXHRUpload":4,"./isXml":6,"@uppy/companion-client":12,"@uppy/core":17,"@uppy/utils/lib/RateLimitedQueue":26,"@uppy/utils/lib/settle":46}],6:[function(require,module,exports){
 "use strict";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,14 +267,14 @@
     "@uppy/companion-client" "^2.0.0"
     "@uppy/utils" "^4.0.0"
 
-"@uppy/aws-s3@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@uppy/aws-s3/-/aws-s3-2.0.1.tgz#d59058f606044f258a9df763dfe1b6a2f7363feb"
-  integrity sha512-mgdRiXYeX7+yOyXXb28M+j/AzCCmkOyaiXsyFfoKtkCP+ALw2HHCWO4dycl0xaghSFIALBIoLN8ZGQ8zR6P9Pg==
+"@uppy/aws-s3@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@uppy/aws-s3/-/aws-s3-2.0.2.tgz#6bd4e17bf3984bf7f8633264c3669a454d9853d5"
+  integrity sha512-Nxp0nFGTVYgNIVN4bHdWHx+1nEkdCdFeYGw3KltIGPhzN4RRMAvrsCB3Mk4AAWL4KSVKs4BgkNfYNVt3nRJVqg==
   dependencies:
     "@uppy/companion-client" "^2.0.0"
     "@uppy/utils" "^4.0.0"
-    "@uppy/xhr-upload" "^2.0.1"
+    "@uppy/xhr-upload" "^2.0.2"
     nanoid "^3.1.25"
 
 "@uppy/companion-client@^2.0.0":
@@ -322,6 +322,15 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@uppy/xhr-upload/-/xhr-upload-2.0.1.tgz#751f00c30bd00004aa38d0e0eda653dee0e42206"
   integrity sha512-7LMZL1+MdpUT1v3+JTs23Zhw+vZ1XL0a3r6cH0+1/JeN4Kx0AnSUouXF2tamdA5OOZpSqseY4lfFO3pJqCXOOA==
+  dependencies:
+    "@uppy/companion-client" "^2.0.0"
+    "@uppy/utils" "^4.0.0"
+    nanoid "^3.1.25"
+
+"@uppy/xhr-upload@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@uppy/xhr-upload/-/xhr-upload-2.0.2.tgz#dc61332fc6bf53fcc79892ec41330ac475bdfba6"
+  integrity sha512-yb/yCUquX0m96jABMEpUQGnxBqjtB5b3u9l8pY+wi3N7SEuDk1u2PPakkbzI6xcguW1e9Peb+Q2LYK6wWaPIxQ==
   dependencies:
     "@uppy/companion-client" "^2.0.0"
     "@uppy/utils" "^4.0.0"


### PR DESCRIPTION
This fixes an error when trying to upload a profile
background image for the user card when the
enable_direct_s3_uploads setting was true:

> Failed to execute 'send' on 'XMLHttpRequest': The object's state must be OPENED.

This was fixed in the upstream commit by the uppy devs:

https://github.com/transloadit/uppy/commit/5937bf21271597ed507eb8852ba7e46ff87a7079
