### PR TITLE
FIX: Give the topic timeline unique keys for state

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -144,7 +144,7 @@ createWidget("timeline-padding", {
 
 createWidget("timeline-scrollarea", {
   tagName: "div.timeline-scrollarea",
-  buildKey: () => `timeline-scrollarea`,
+  buildKey: (attrs) => `timeline-scrollarea-${attrs.topic.id}`,
 
   buildAttributes() {
     return { style: `height: ${scrollareaHeight()}px` };
@@ -411,7 +411,7 @@ createWidget("timeline-footer-controls", {
 export default createWidget("topic-timeline", {
   tagName: "div.topic-timeline",
 
-  buildKey: () => "topic-timeline-area",
+  buildKey: (attrs) => `topic-timeline-area-${attrs.topic.id}`,
 
   defaultState() {
     return { position: null, excerpt: null };


### PR DESCRIPTION
We've observed an error where the back button is displayed improperly in
the topic timeline. It's unfortunately been hard to reproduce but we
suspect it's related to leftover state when re-rendering.

This fix optimistically tries to fix the error by introducing the
topic's id to the unique key the widgets use for state. We can deploy
this and keep an eye out for the bug in the future.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
