### PR TITLE
UX: Fix date input display in iOS

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/date-time-input-range.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/date-time-input-range.hbs
@@ -3,6 +3,7 @@
   onChange=(action "onChangeRanges" (hash prop="from"))
   showTime=showFromTime
   class="from"
+  placeholder=(i18n "dates.from_placeholder")
 }}
 
 {{date-time-input
@@ -13,4 +14,5 @@
   showTime=showToTime
   clearable=clearable
   class="to"
+  placeholder=(i18n "dates.to_placeholder")
 }}

--- a/app/assets/javascripts/discourse/app/templates/components/date-time-input.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/date-time-input.hbs
@@ -1,6 +1,7 @@
 {{#unless timeFirst}}
   {{date-input
     date=date
+    placeholder=placeholder
     relativeDate=relativeDate
     onChange=(action "onChangeDate")
     useGlobalPickerContainer=useGlobalPickerContainer
@@ -18,6 +19,7 @@
 {{#if timeFirst}}
   {{date-input
     date=date
+    placeholder=placeholder
     relativeDate=relativeDate
     onChange=(action "onChangeDate")
     useGlobalPickerContainer=useGlobalPickerContainer

--- a/app/assets/javascripts/discourse/app/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.hbs
@@ -93,6 +93,7 @@
       {{/if}}
 
       <div class="reviewable-filter date-range">
+        {{i18n "review.date_filter"}}
         {{date-time-input-range
           from=filterFromDate
           to=filterToDate

--- a/app/assets/stylesheets/common/components/date-input.scss
+++ b/app/assets/stylesheets/common/components/date-input.scss
@@ -30,8 +30,14 @@
     &:focus {
       @include default-focus;
     }
-  }
 
+    // iOS doesn't display the placeholder attribute for date inputs
+    .ios-device &:after {
+      font-size: var(--font-0);
+      color: var(--primary-medium);
+      content: attr(placeholder);
+    }
+  }
   .pika-single {
     margin-left: -1px;
     margin-top: 1px;

--- a/app/assets/stylesheets/mobile/reviewables.scss
+++ b/app/assets/stylesheets/mobile/reviewables.scss
@@ -36,8 +36,6 @@
   }
 
   .reviewable-filter {
-    margin: 0 0 0.5em 0;
-
     .filter-label {
       margin: 0;
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -132,6 +132,8 @@ en:
       previous_month: "Previous Month"
       next_month: "Next Month"
       placeholder: date
+      from_placeholder: "from date"
+      to_placeholder: "to date"
     share:
       topic_html: 'Topic: <span class="topic-title">%{topicTitle}</span>'
       post: "post #%{postNumber}"
@@ -411,6 +413,7 @@ en:
 
     review:
       order_by: "Order by"
+      date_filter: "Posted between"
       in_reply_to: "in reply to"
       explain:
         why: "explain why this item ended up in the queue"


### PR DESCRIPTION
iOS does not show date input placeholders, this adds a CSS trick to fake display the placeholder text in an `:after` pseudoelement.

Before

<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/132900017-485ab733-bf3e-4c5d-9089-d3edc9d6b6ff.png">

After

<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/132899956-003e2f40-140c-4757-b33d-5b6eb92a71b4.png">

Also adds a label in all devices just above the date fields in the Review Queue filters. 