### PR TITLE
UX: Fix mobile styling for admin color schemes

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
@@ -17,7 +17,7 @@
         label="admin.customize.copy"
       }}
       {{d-button
-        class="btn-default"
+        class="btn-default copy-to-clipboard"
         action=(action "copyToClipboard" model)
         icon="far-clipboard"
         label="admin.customize.copy_to_clipboard"
@@ -37,8 +37,6 @@
         }}
       {{/if}}
     </div>
-
-    <br>
 
     <div class="admin-controls">
       {{#unless model.theme_id}}

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -46,6 +46,9 @@
     input {
       margin-bottom: 0;
       font-size: $font-down-2;
+      .ios-device & {
+        font-size: var(--font-down-2);
+      }
     }
   }
 
@@ -84,7 +87,7 @@
       font-weight: bold;
       margin-bottom: 0.25em;
       display: flex;
-      align-items: stretch;
+      align-items: center;
 
       input {
         margin: 0;
@@ -513,7 +516,8 @@
     .controls {
       display: flex;
       align-items: center;
-      button,
+      margin-bottom: 1em;
+      button:not(:last-child),
       a {
         margin-right: 10px;
       }
@@ -533,6 +537,9 @@
     }
     td.hex {
       width: 160px;
+      .color-picker {
+        display: inline-flex;
+      }
     }
     td.actions {
       width: 200px;

--- a/app/assets/stylesheets/mobile/admin_customize.scss
+++ b/app/assets/stylesheets/mobile/admin_customize.scss
@@ -1,13 +1,15 @@
-.admin-customize {
+body .admin-customize {
   .show-current-style {
     padding: 0;
     width: 100%;
   }
 
-  .themes-list {
+  .themes-list,
+  .color-schemes {
     width: 100%;
     margin-bottom: 1em;
   }
+
   .form-horizontal.theme.settings .setting-label,
   .admin-container .select-kit {
     width: 100%;
@@ -16,5 +18,40 @@
   .admin-container {
     display: flex;
     flex-wrap: wrap;
+    padding: 0;
+  }
+
+  .content-list.color-schemes ul {
+    max-height: 250px;
+    overflow-x: auto;
+  }
+
+  .color-scheme {
+    h1,
+    h1 input {
+      width: 100%;
+    }
+    .copy-to-clipboard {
+      display: none;
+    }
+
+    .controls {
+      width: 100%;
+    }
+
+    .admin-controls {
+      width: 100%;
+    }
+
+    .sp-replacer {
+      flex-shrink: 0;
+    }
+
+    td {
+      vertical-align: top;
+    }
+    td.actions {
+      width: 40px;
+    }
   }
 }

--- a/app/assets/stylesheets/mobile/admin_customize.scss
+++ b/app/assets/stylesheets/mobile/admin_customize.scss
@@ -35,10 +35,7 @@ body .admin-customize {
       display: none;
     }
 
-    .controls {
-      width: 100%;
-    }
-
+    .controls,
     .admin-controls {
       width: 100%;
     }


### PR DESCRIPTION
Before

<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/132917029-e2530fdf-f7f6-4230-b06d-30014003e27f.png">

After

<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/132916760-ed9f9c95-2103-4ca9-a732-34870d2366d1.png">
