### PR TITLE
FIX: Do not error mobile upload button if !allowUpload

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -237,8 +237,10 @@ export default Component.extend(ComposerUpload, {
       putCursorAtEnd(this.element.querySelector(".d-editor-input"));
     }
 
-    this._bindUploadTarget();
-    this._bindMobileUploadButton();
+    if (this.allowUpload) {
+      this._bindUploadTarget();
+      this._bindMobileUploadButton();
+    }
 
     this.appEvents.trigger("composer:will-open");
   },


### PR DESCRIPTION
allowUpload can be false for the composer if there are no
allowed file extensions. This causes the _bindMobileUploadButton
code to fail because the button does not get rendered in the
template if !allowUpload. This commit changes composer-editor
to only bind upload functionality if allowUpload.

See also: https://meta.discourse.org/t/restrict-uploads/112688/12?u=martin