### PR TITLE
DEV: Remove Firefox browsers from Embeer tests in CI. 

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -1,7 +1,7 @@
 module.exports = {
   test_page: "tests/index.html?hidepassed",
   disable_watching: true,
-  launch_in_ci: ["Chrome", "Firefox", "Headless Firefox"], // Firefox is old ESR version, Headless Firefox is up-to-date evergreen version
+  launch_in_ci: ["Chrome"], // Firefox is old ESR version, Headless Firefox is up-to-date evergreen version
   launch_in_dev: ["Chrome"],
   parallel: 1, // disable parallel tests for stability
   browser_args: {


### PR DESCRIPTION
This is making our CI take upwards of 45 mins.

Partial revert of 789613fe51733f108f97a926e22f409421e18fbc and 9b30fbdbbdf6c0af4811c606f5b1634e17fe833a