### PR TITLE
FEATURE: remove duplicated messages about new advices

### DIFF
--- a/app/jobs/scheduled/dashboard_stats.rb
+++ b/app/jobs/scheduled/dashboard_stats.rb
@@ -5,12 +5,20 @@ module Jobs
     every 30.minutes
 
     def execute(args)
-      problems_started_at = AdminDashboardData.problems_started_at
-      if problems_started_at && problems_started_at < 2.days.ago
+      if persistent_problems?
         # If there have been problems reported on the dashboard for a while,
         # send a message to admins no more often than once per week.
-        GroupMessage.create(Group[:admins].name, :dashboard_problems, limit_once_per: 7.days.to_i)
+        group_message = GroupMessage.new(Group[:admins].name, :dashboard_problems, limit_once_per: 7.days.to_i)
+        group_message.delete_previous!
+        group_message.create
       end
+    end
+
+    private
+
+    def persistent_problems?
+      problems_started_at = AdminDashboardData.problems_started_at
+      problems_started_at && problems_started_at < 2.days.ago
     end
   end
 end

--- a/app/jobs/scheduled/dashboard_stats.rb
+++ b/app/jobs/scheduled/dashboard_stats.rb
@@ -9,8 +9,10 @@ module Jobs
         # If there have been problems reported on the dashboard for a while,
         # send a message to admins no more often than once per week.
         group_message = GroupMessage.new(Group[:admins].name, :dashboard_problems, limit_once_per: 7.days.to_i)
-        group_message.delete_previous!
-        group_message.create
+        Topic.transaction do
+          group_message.delete_previous!
+          group_message.create
+        end
       end
     end
 

--- a/app/services/group_message.rb
+++ b/app/services/group_message.rb
@@ -14,6 +14,8 @@ class GroupMessage
 
   include Rails.application.routes.url_helpers
 
+  RECENT_MESSAGE_PERIOD = 3.months
+
   def self.create(group_name, message_type, opts = {})
     GroupMessage.new(group_name, message_type, opts).create
   end
@@ -50,11 +52,11 @@ class GroupMessage
         archetype: Archetype.private_message,
         subtype: TopicSubtype.system_message,
         title: I18n.t("system_messages.#{@message_type}.subject_template", message_params),
-        topic_allowed_groups: { 
-          groups: { name: @group_name } 
+        topic_allowed_groups: {
+          groups: { name: @group_name }
         }
       })
-      .where("posts.created_at > ?", 3.months.ago)
+      .where("posts.created_at > ?", RECENT_MESSAGE_PERIOD.ago)
       .where(raw: I18n.t("system_messages.#{@message_type}.text_body_template", message_params).rstrip)
 
     posts.find_each do |post|

--- a/app/services/group_message.rb
+++ b/app/services/group_message.rb
@@ -45,8 +45,10 @@ class GroupMessage
     posts = Post
       .joins(topic: { topic_allowed_groups: :group })
       .where(topic: { posts_count: 1 })
+      .where(topic: { user_id: Discourse.system_user })
       .where(topic: { archetype: Archetype.private_message })
       .where(topic: { subtype: TopicSubtype.system_message })
+      .where("posts.created_at > ?", 3.months.ago)
       .where(topic: { title: I18n.t("system_messages.#{@message_type}.subject_template", message_params) })
       .where(topic: { topic_allowed_groups: { groups: { name: @group_name } } })
       .where(raw: I18n.t("system_messages.#{@message_type}.text_body_template", message_params).rstrip)

--- a/app/services/group_message.rb
+++ b/app/services/group_message.rb
@@ -44,13 +44,17 @@ class GroupMessage
   def delete_previous!
     posts = Post
       .joins(topic: { topic_allowed_groups: :group })
-      .where(topic: { posts_count: 1 })
-      .where(topic: { user_id: Discourse.system_user })
-      .where(topic: { archetype: Archetype.private_message })
-      .where(topic: { subtype: TopicSubtype.system_message })
+      .where(topic: {
+        posts_count: 1,
+        user_id: Discourse.system_user,
+        archetype: Archetype.private_message,
+        subtype: TopicSubtype.system_message,
+        title: I18n.t("system_messages.#{@message_type}.subject_template", message_params),
+        topic_allowed_groups: { 
+          groups: { name: @group_name } 
+        }
+      })
       .where("posts.created_at > ?", 3.months.ago)
-      .where(topic: { title: I18n.t("system_messages.#{@message_type}.subject_template", message_params) })
-      .where(topic: { topic_allowed_groups: { groups: { name: @group_name } } })
       .where(raw: I18n.t("system_messages.#{@message_type}.text_body_template", message_params).rstrip)
 
     posts.find_each do |post|

--- a/spec/jobs/dashboard_stats_spec.rb
+++ b/spec/jobs/dashboard_stats_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ::Jobs::DashboardStats do
+  let(:group_message) { GroupMessage.new(Group[:admins].name, :dashboard_problems, limit_once_per: 7.days.to_i) }
+
+  def clear_recently_sent!
+    Discourse.redis.del(group_message.sent_recently_key)
+  end
+
+  before do
+    clear_recently_sent!
+  end
+
+  it 'creates group message when problems are persistent for 2 days' do
+    Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, Time.zone.now.to_s)
+    expect { described_class.new.execute({}) }.not_to change { Topic.count }
+
+    Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
+    expect { described_class.new.execute({}) }.to change { Topic.count }
+  end
+
+  it 'does not duplicate messages' do
+    Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
+    expect { described_class.new.execute({}) }.to change { Topic.count }
+    topic = Topic.last
+    clear_recently_sent!
+
+    expect { described_class.new.execute({}) }.not_to change { Topic.count }
+    expect(topic.reload.deleted_at).not_to be_nil
+  end
+
+  it 'duplicates message if previous one has replies' do
+    Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
+    expect { described_class.new.execute({}) }.to change { Topic.count }
+    clear_recently_sent!
+
+    _reply_1 = Fabricate(:post, topic: Topic.last)
+    expect { described_class.new.execute({}) }.to change { Topic.count }
+  end
+end

--- a/spec/jobs/dashboard_stats_spec.rb
+++ b/spec/jobs/dashboard_stats_spec.rb
@@ -39,4 +39,14 @@ describe ::Jobs::DashboardStats do
     _reply_1 = Fabricate(:post, topic: Topic.last)
     expect { described_class.new.execute({}) }.to change { Topic.count }
   end
+
+  it 'duplicates message if previous was 3 months ago' do
+    freeze_time 4.months.ago do
+      Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
+      expect { described_class.new.execute({}) }.to change { Topic.count }
+      clear_recently_sent!
+    end
+
+    expect { described_class.new.execute({}) }.to change { Topic.count }
+  end
 end

--- a/spec/jobs/dashboard_stats_spec.rb
+++ b/spec/jobs/dashboard_stats_spec.rb
@@ -28,7 +28,7 @@ describe ::Jobs::DashboardStats do
     clear_recently_sent!
 
     expect { described_class.new.execute({}) }.not_to change { Topic.count }
-    expect(topic.reload.deleted_at).not_to be_nil
+    expect(topic.reload.deleted_at.present?).to eq(true)
   end
 
   it 'duplicates message if previous one has replies' do


### PR DESCRIPTION
Discourse is sending regularly message to admins when potential problems are persisted. 

Most of the time they have exactly the same content.

In that case, when there are no replies, the old one should be trashed before a new one is created.
