### PR TITLE
FIX: Use <textarea> for theme translations

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -146,7 +146,9 @@ export default Controller.extend({
 
   @discourseComputed("model.translations")
   translations(translations) {
-    return translations.map((setting) => ThemeSettings.create(setting));
+    return translations.map((setting) =>
+      ThemeSettings.create({ ...setting, textarea: true })
+    );
   },
 
   hasTranslations: notEmpty("translations"),

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -336,6 +336,10 @@
       padding-bottom: 0;
       margin-top: 18px;
       min-height: 35px;
+
+      .input-setting-textarea {
+        height: unset;
+      }
     }
     .setting-label {
       width: 25%;


### PR DESCRIPTION
Translations are often multi-line. Using a regular `<input>` doesn't allow newlines, so if you try to edit a multiline theme translation, all the line breaks will be removed.

This commit updates the theme translations UI to use `<textarea>`, just like the core translation editing UI.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
