### PR TITLE
DEV: Set composer upload btn selectors in component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -90,6 +90,8 @@ export function cleanUpComposerUploadMarkdownResolver() {
 export default Component.extend(ComposerUpload, {
   classNameBindings: ["showToolbar:toolbar-visible", ":wmd-controls"],
 
+  fileUploadElementId: "file-uploader",
+  mobileFileUploaderId: "mobile-file-upload",
   shouldBuildScrollMap: true,
   scrollMap: null,
   processPreview: true,

--- a/app/assets/javascripts/discourse/app/mixins/composer-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload.js
@@ -331,9 +331,11 @@ export default Mixin.create({
 
   _bindMobileUploadButton() {
     if (this.site.mobileView) {
-      this.mobileUploadButton = document.getElementById("mobile-file-upload");
-      this.mobileUploadButtonEventListener = function mobileButtonEventListener() {
-        document.getElementById("file-uploader").click();
+      this.mobileUploadButton = document.getElementById(
+        this.mobileFileUploaderId
+      );
+      this.mobileUploadButtonEventListener = () => {
+        document.getElementById(this.fileUploadElementId).click();
       };
       this.mobileUploadButton.addEventListener(
         "click",


### PR DESCRIPTION
Working on the chat plugin, I have the chat composer that can be rendered inside the widget, or inside the full page. This allows for setting different IDs in the chat composer based on it's position to avoid the Emberjs error of trying to render an element with the same ID in 2 places.