### PR TITLE
DEV: Support translated title in desktop/notifications

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -153,11 +153,13 @@ function onNotification(data, siteSettings, user) {
     return;
   }
 
-  const notificationTitle = I18n.t(i18nKey(data.notification_type), {
-    site_title: siteSettings.title,
-    topic: data.topic_title,
-    username: formatUsername(data.username),
-  });
+  const notificationTitle =
+    data.translated_title ||
+    I18n.t(i18nKey(data.notification_type), {
+      site_title: siteSettings.title,
+      topic: data.topic_title,
+      username: formatUsername(data.username),
+    });
 
   const notificationBody = data.excerpt;
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -76,8 +76,7 @@ class Notification < ActiveRecord::Base
       DELETE
         FROM notifications n
        WHERE high_priority
-         AND notification_type <> #{types[:chat_mention].to_i}
-         AND notification_type <> #{types[:chat_message].to_i}
+         AND notification_type NOT IN (#{types[:chat_mention].to_i}, #{types[:chat_message].to_i})
          AND NOT EXISTS (
             SELECT 1
               FROM posts p

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -75,7 +75,9 @@ class Notification < ActiveRecord::Base
     DB.exec(<<~SQL)
       DELETE
         FROM notifications n
-       WHERE high_priority AND notification_type <> #{types[:chat_mention].to_i}
+       WHERE high_priority
+         AND notification_type <> #{types[:chat_mention].to_i}
+         AND notification_type <> #{types[:chat_message].to_i}
          AND NOT EXISTS (
             SELECT 1
               FROM posts p
@@ -117,7 +119,8 @@ class Notification < ActiveRecord::Base
                         votes_released: 26,
                         event_reminder: 27,
                         event_invitation: 28,
-                        chat_mention: 29
+                        chat_mention: 29,
+                        chat_message: 30,
                        )
   end
 

--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -7,7 +7,7 @@ class PushNotificationPusher
   def self.push(user, payload)
     I18n.with_locale(user.effective_locale) do
       message = {
-        title: I18n.t(
+        title: payload[:translated_title] || I18n.t(
           "discourse_push_notifications.popup.#{Notification.types[payload[:notification_type]]}",
           site_title: SiteSetting.title,
           topic: payload[:topic_title],

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -48,6 +48,8 @@ describe Notification do
         expect(@types[:votes_released]).to eq(26)
         expect(@types[:event_reminder]).to eq(27)
         expect(@types[:event_invitation]).to eq(28)
+        expect(@types[:chat_mention]).to eq(29)
+        expect(@types[:chat_message]).to eq(30)
       end
     end
   end

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -94,6 +94,9 @@
         },
         "chat_mention": {
           "type": "integer"
+        },
+        "chat_message": {
+          "type": "integer"
         }
       },
       "required": [


### PR DESCRIPTION
Allow translated title to be passed to desktop and push notifications, to be used instead of generating the translation on the client.

 This is useful because only a small number of variables are passed into the client translation. If you have something like I do (I need a chat channel name as a variable in the translation), you're currently out of luck. https://github.com/discourse/discourse/blob/c16358ecc09c9df70eed45c71fadda852848f005/app/assets/javascripts/discourse/app/lib/desktop-notifications.js#L156-L160
 
 Also on the ensure_consistency job, exclude `chat_message` notifications from being cleaned up (they aren't associated with a topic or post). There may be a slicker way to do this rather than another `AND` condition