### PR TITLE
UX: Use default font size for buttons at the end of /top page

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -364,9 +364,10 @@
 }
 
 .top-title-buttons {
-  display: inline-flex;
-  margin: 0.25em 0;
+  display: flex;
+  margin: 0.5em 0;
   flex-wrap: wrap;
+  font-size: var(--font-0-rem);
 
   button {
     margin-right: 0.5em;


### PR DESCRIPTION
These buttons are inside an `h3` element, which uses the browser's default font size. Buttons in it inherit that font size, so we need to use the site's base `rem` size to make them consistent with the rest of the buttons. 