### PR TITLE
Revert "DEV: Define --footer-nav-height css var (#14008)"

### DIFF
--- a/app/assets/stylesheets/common/components/footer-nav.scss
+++ b/app/assets/stylesheets/common/components/footer-nav.scss
@@ -2,10 +2,7 @@
 // Footer nav bar (displayed in DiscourseHub app and PWAs)
 // --------------------------------------------------
 
-:root {
-  --footer-nav-height: 49px;
-}
-$footer-nav-height: var(--footer-nav-height);
+$footer-nav-height: 49px;
 
 body.footer-nav-visible {
   #main-outlet {


### PR DESCRIPTION
This reverts commit 3119b881aa6c297e3fdb281188a1d1b9a5fcd349.

This caused the nav bar to sometimes show up in the middle of the viewport. I believe this is because we use `-$footer-nav-height` in this file. That translates to `-var(--footer-nav-height)` in the outputted CSS and it seems to cause issues. 

I checked with @markvanlan as well, we no longer use this property in a plugin, so it's safe to revert. 