### PR TITLE
DEV: Match viewport metadata on mobile in Ember CLI

### DIFF
--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Discourse - Ember CLI</title>
     <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes, viewport-fit=cover">
 
     <bootstrap-content key="before-script-load">
     {{content-for "before-script-load"}}


### PR DESCRIPTION
This matches the viewport metatag used in the Rails app, and fixes some rendering discrepancies on mobile when running Ember CLI locally. 