### PR TITLE
DEV: Change uploads.filesize column to bigint

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -513,7 +513,7 @@ end
 #  id                           :integer          not null, primary key
 #  user_id                      :integer          not null
 #  original_filename            :string           not null
-#  filesize                     :integer          not null
+#  filesize                     :bigint           not null
 #  width                        :integer
 #  height                       :integer
 #  url                          :string           not null

--- a/db/migrate/20210914011037_change_uploads_filesize_to_bigint.rb
+++ b/db/migrate/20210914011037_change_uploads_filesize_to_bigint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeUploadsFilesizeToBigint < ActiveRecord::Migration[6.1]
+  def change
+    change_column :uploads, :filesize, :bigint
+  end
+end


### PR DESCRIPTION
This is necessary to allow for large file uploads via
the direct S3 upload mechanism, as we convert the external
file to an Upload record via ExternalUploadManager once
it is complete.

This will allow for files larger than 2,147,483,647 bytes (2.14GB)
to be referenced in the uploads table.

This is a table locking migration, but since it is not as highly
trafficked as posts, topics, or users, the disruption should be minimal.