### PR TITLE
FIX: prevents extreme cases to overflow in selected content

### DIFF
--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -166,6 +166,11 @@
     display: none;
     background: var(--secondary);
     box-sizing: border-box;
+
+    .selected-content {
+      max-height: 300px;
+      overflow-y: scroll;
+    }
   }
 
   .select-kit-row {


### PR DESCRIPTION
It would for example cause an issue for a lot of selected items with long names.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
