### PR TITLE
FEATURE: experimental fast edit

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -31,6 +31,10 @@ function getQuoteTitle(element) {
   return titleEl.textContent.trim().replace(/:$/, "");
 }
 
+function regexSafeStr(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export default Component.extend({
   classNames: ["quote-button"],
   classNameBindings: ["visible"],
@@ -133,19 +137,20 @@ export default Component.extend({
       // by fast edit, so ignore it
       // if the selection is present multiple times, we also consider it too complex
       // and ignore it, note this specific case could probably be handled in the future
-      const regexp = new RegExp(quoteState.buffer, "gi");
+      const regexp = new RegExp(regexSafeStr(quoteState.buffer), "gi");
+      const matches = postBody.match(regexp);
       if (
         quoteState.buffer.length < 1 ||
         quoteState.buffer.match(/\n/g) ||
-        postBody.match(regexp).length > 1
+        matches?.length > 1
       ) {
         this.set("_isFastEditable", false);
         this.set("_fastEditInitalSelection", null);
         this.set("_fastEditNewSelection", null);
-      } else {
+      } else if (matches?.length === 1) {
         this.set("_isFastEditable", true);
-        this.set("_fastEditInitalSelection", quoteState.buffer.toString());
-        this.set("_fastEditNewSelection", quoteState.buffer.toString());
+        this.set("_fastEditInitalSelection", quoteState.buffer);
+        this.set("_fastEditNewSelection", quoteState.buffer);
       }
     }
 

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -37,7 +37,7 @@ export default Component.extend({
   visible: false,
   privateCategory: alias("topic.category.read_restricted"),
 
-  _displayFastEditButton: false,
+  _isFastEditable: false,
   _displayFastEditInput: false,
   _fastEditInitalSelection: null,
   _fastEditNewSelection: null,
@@ -50,7 +50,7 @@ export default Component.extend({
     this.quoteState.clear();
     this.set("visible", false);
 
-    this.set("_displayFastEditButton", false);
+    this.set("_isFastEditable", false);
     this.set("_displayFastEditInput", false);
     this.set("_fastEditInitalSelection", null);
     this.set("_fastEditNewSelection", null);
@@ -134,11 +134,11 @@ export default Component.extend({
         quoteState.buffer.match(/\n/g) ||
         postBody.match(regexp).length > 1
       ) {
-        this.set("_displayFastEditButton", false);
+        this.set("_isFastEditable", false);
         this.set("_fastEditInitalSelection", null);
         this.set("_fastEditNewSelection", null);
       } else {
-        this.set("_displayFastEditButton", true);
+        this.set("_isFastEditable", true);
         this.set("_fastEditInitalSelection", quoteState.buffer.toString());
         this.set("_fastEditNewSelection", quoteState.buffer.toString());
       }
@@ -327,11 +327,17 @@ export default Component.extend({
 
   @action
   _toggleFastEditForm() {
-    this.toggleProperty("_displayFastEditInput");
+    if (this._isFastEditable) {
+      this.toggleProperty("_displayFastEditInput");
 
-    schedule("afterRender", () => {
-      document.querySelector("#fast-edit-input")?.focus();
-    });
+      schedule("afterRender", () => {
+        document.querySelector("#fast-edit-input")?.focus();
+      });
+    } else {
+      const postId = this.quoteState?.postId;
+      const postModel = this.topic.postStream.findLoadedPost(postId);
+      this.editPost(postModel);
+    }
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -348,7 +348,7 @@ export default Component.extend({
         document.querySelector("#fast-edit-input")?.focus();
       });
     } else {
-      const postId = this.quoteState?.postId;
+      const postId = this.quoteState.postId;
       const postModel = this.topic.postStream.findLoadedPost(postId);
       this.editPost(postModel);
     }

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -42,6 +42,7 @@ export default Component.extend({
   _fastEditInitalSelection: null,
   _fastEditNewSelection: null,
   _isSavingFastEdit: false,
+  _canEditPost: false,
 
   _isMouseDown: false,
   _reselected: false,
@@ -123,12 +124,16 @@ export default Component.extend({
     this.set("visible", quoteState.buffer.length > 0);
 
     if (this.siteSettings.enable_fast_edit) {
-      const regexp = new RegExp(quoteState.buffer, "gi");
+      this.set(
+        "_canEditPost",
+        this.topic.postStream.findLoadedPost(postId)?.can_edit
+      );
 
       // if we have a linebreak, the selection is probably too complex to be handled
       // by fast edit, so ignore it
       // if the selection is present multiple times, we also consider it too complex
       // and ignore it, note this specific case could probably be handled in the future
+      const regexp = new RegExp(quoteState.buffer, "gi");
       if (
         quoteState.buffer.length < 1 ||
         quoteState.buffer.match(/\n/g) ||

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -44,6 +44,7 @@ export default Component.extend({
   classNameBindings: ["visible"],
   visible: false,
   privateCategory: alias("topic.category.read_restricted"),
+  editPost: null,
 
   _isFastEditable: false,
   _displayFastEditInput: false,
@@ -350,7 +351,7 @@ export default Component.extend({
     } else {
       const postId = this.quoteState.postId;
       const postModel = this.topic.postStream.findLoadedPost(postId);
-      this.editPost(postModel);
+      this?.editPost(postModel);
     }
   },
 

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -31,6 +31,10 @@ function getQuoteTitle(element) {
   return titleEl.textContent.trim().replace(/:$/, "");
 }
 
+function fixQuotes(str) {
+  return str.replace(/‘|’|„|“|«|»|”/g, '"');
+}
+
 function regexSafeStr(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -360,8 +364,8 @@ export default Component.extend({
     return ajax(`/posts/${postModel.id}`, { type: "GET", cache: false })
       .then((result) => {
         const newRaw = result.raw.replace(
-          this._fastEditInitalSelection,
-          this._fastEditNewSelection
+          fixQuotes(this._fastEditInitalSelection),
+          fixQuotes(this._fastEditNewSelection)
         );
 
         postModel

--- a/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
@@ -31,12 +31,14 @@
   {{/if}}
 
   {{#if siteSettings.enable_fast_edit}}
-    {{d-button
-      icon="pencil-alt"
-      action=(action "_toggleFastEditForm")
-      label="post.quote_edit"
-      class="btn-flat quote-edit-label"
-    }}
+    {{#if _canEditPost}}
+      {{d-button
+        icon="pencil-alt"
+        action=(action "_toggleFastEditForm")
+        label="post.quote_edit"
+        class="btn-flat quote-edit-label"
+      }}
+    {{/if}}
   {{/if}}
 </div>
 

--- a/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
@@ -31,14 +31,12 @@
   {{/if}}
 
   {{#if siteSettings.enable_fast_edit}}
-    {{#if _displayFastEditButton}}
-      {{d-button
-        icon="pencil-alt"
-        action=(action "_toggleFastEditForm")
-        label="post.quote_edit"
-        class="btn-flat quote-edit-label"
-      }}
-    {{/if}}
+    {{d-button
+      icon="pencil-alt"
+      action=(action "_toggleFastEditForm")
+      label="post.quote_edit"
+      class="btn-flat quote-edit-label"
+    }}
   {{/if}}
 </div>
 

--- a/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
@@ -1,31 +1,64 @@
-{{#if embedQuoteButton}}
-  {{d-button
-    class="btn-flat insert-quote"
-    action=(action "insertQuote")
-    icon="quote-left"
-    label="post.quote_reply"}}
-{{/if}}
+<div class="buttons">
+  {{#if embedQuoteButton}}
+    {{d-button
+      class="btn-flat insert-quote"
+      action=(action "insertQuote")
+      icon="quote-left"
+      label="post.quote_reply"}}
+  {{/if}}
 
-{{#if quoteSharingEnabled}}
-  <span class="quote-sharing">
-    {{#if quoteSharingShowLabel}}
-      {{d-button
-        icon="share"
-        label="post.quote_share"
-        class="btn-flat quote-share-label"}}
-    {{/if}}
-
-    <span class="quote-share-buttons">
-      {{#each quoteSharingSources as |source|}}
+  {{#if quoteSharingEnabled}}
+    <span class="quote-sharing">
+      {{#if quoteSharingShowLabel}}
         {{d-button
-          class="btn-flat"
-          action=(action "share" source)
-          translatedTitle=source.title
-          icon=source.icon}}
-      {{/each}}
-      {{plugin-outlet name="quote-share-buttons-after" tagName=""}}
-    </span>
-  </span>
-{{/if}}
+          icon="share"
+          label="post.quote_share"
+          class="btn-flat quote-share-label"}}
+      {{/if}}
 
-{{plugin-outlet name="quote-button-after" tagName=""}}
+      <span class="quote-share-buttons">
+        {{#each quoteSharingSources as |source|}}
+          {{d-button
+            class="btn-flat"
+            action=(action "share" source)
+            translatedTitle=source.title
+            icon=source.icon}}
+        {{/each}}
+        {{plugin-outlet name="quote-share-buttons-after" tagName=""}}
+      </span>
+
+    </span>
+  {{/if}}
+
+  {{#if siteSettings.enable_fast_edit}}
+    {{#if _displayFastEditButton}}
+      {{d-button
+        icon="pencil-alt"
+        action=(action "_toggleFastEditForm")
+        label="post.quote_edit"
+        class="btn-flat quote-edit-label"
+      }}
+    {{/if}}
+  {{/if}}
+</div>
+
+<div class="extra">
+  {{#if siteSettings.enable_fast_edit}}
+    {{#if _displayFastEditInput}}
+      <div class="fast-edit-container">
+        {{textarea
+          id="fast-edit-input"
+          value=_fastEditNewSelection
+        }}
+        {{d-button
+          action=(action "_saveFastEdit")
+          class="btn-default btn-primary save-fast-edit"
+          label="save"
+          disabled=_saveFastEditDisabled
+          isLoading=_isSavingFastEdit
+        }}
+      </div>
+    {{/if}}
+  {{/if}}
+  {{plugin-outlet name="quote-button-after" tagName=""}}
+</div>

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -404,5 +404,12 @@
 
   {{share-popup topic=model replyAsNewTopic=(action "replyAsNewTopic")}}
 
-  {{quote-button quoteState=quoteState selectText=(action "selectText") topic=model composerVisible=composer.visible}}
+  {{quote-button
+    quoteState=quoteState
+    selectText=(action "selectText")
+    editPost=(action "editPost")
+    topic=model
+    composerVisible=composer.visible
+
+  }}
 {{/discourse-topic}}

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -378,9 +378,37 @@ aside.quote {
   z-index: z("dropdown");
   opacity: 0.9;
   background-color: var(--secondary-high);
+  flex-direction: column;
 
   &.visible {
-    display: inline-flex;
+    display: flex;
+  }
+
+  .buttons {
+    display: flex;
+  }
+
+  .extra {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .fast-edit-container {
+    display: flex;
+    padding: 0.25em;
+    flex-direction: column;
+    align-items: flex-start;
+
+    #fast-edit-input {
+      margin: 0;
+      width: 300px;
+      height: 90px;
+    }
+
+    .save-fast-edit {
+      margin-top: 0.25em;
+    }
   }
 
   .btn,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2973,6 +2973,7 @@ en:
 
     post:
       quote_reply: "Quote"
+      quote_edit: "Edit"
       quote_share: "Share"
       edit_reason: "Reason: "
       post_number: "post %{number}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2210,6 +2210,7 @@ en:
     watched_words_regular_expressions: "Watched words are regular expressions."
 
     enable_diffhtml_preview: "Experimental feature which uses diffHTML to sync preview instead of full re-render"
+    enable_fast_edit: "Experimental feature which enables small selection of a post text to be edited inline."
 
     old_post_notice_days: "Days before post notice becomes old"
     new_user_notice_tl: "Minimum trust level required to see new user post notices."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1010,6 +1010,9 @@ posting:
   enable_diffhtml_preview:
     default: false
     client: true
+  enable_fast_edit:
+    default: false
+    client: true
   old_post_notice_days:
     default: 14
     max: 36500


### PR DESCRIPTION
Fast edit allows you to quickly edit a typo in a post, this is experimental ATM and behind a site setting: `enable_fast_edit`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

https://user-images.githubusercontent.com/339945/133297071-72f5850b-0afe-4fab-bb5a-d3dab457617e.mp4




