### PR TITLE
DEV: Add for_topic column to bookmarks

### DIFF
--- a/db/migrate/20210913032326_add_for_topic_to_bookmarks.rb
+++ b/db/migrate/20210913032326_add_for_topic_to_bookmarks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddForTopicToBookmarks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :bookmarks, :for_topic, :boolean, default: false, null: false
+    add_index :bookmarks, [:user_id, :post_id, :for_topic], unique: true
+    remove_index :bookmarks, [:user_id, :post_id]
+  end
+end


### PR DESCRIPTION
This new column will be used to indicate that a bookmark
is at the topic level. The first post of a topic can be
bookmarked twice after this change -- with for_topic set
to true and with for_topic set to false.

A later PR will use this column for logic to bookmark the
topic, and then topic-level bookmark links will take you
to the last unread post in the topic.

See also 22208836c5f2adcf8c85a62d27b67968743b20f0
