### PR TITLE
FIX: Address ArgumentError to support Ruby 3 keyword arguments

### DIFF
--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -13,7 +13,7 @@ module SeedData
     def create(site_setting_names: nil, include_welcome_topics: true)
       I18n.with_locale(@locale) do
         topics(site_setting_names, include_welcome_topics).each do |params|
-          create_topic(params)
+          create_topic(**params)
         end
       end
     end


### PR DESCRIPTION
This pull request allows to run `bundle exec rake db:create` with Ruby 3. 

- Steps to reproduce
```ruby
% ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-darwin21]
% bundle exec rake db:create
% bundle exec rake db:migrate
```

- Actual result without this commit:
```ruby
% bundle exec rake db:create
... snip ...
> Seeding theme and color schemes
rake aborted!
ArgumentError: wrong number of arguments (given 1, expected 0; required keywords: site_setting_name, title, raw)
/Users/yahonda/src/github.com/discourse/discourse/lib/seed_data/topics.rb:126:in `create_topic'
/Users/yahonda/src/github.com/discourse/discourse/lib/seed_data/topics.rb:16:in `block (2 levels) in create'
/Users/yahonda/src/github.com/discourse/discourse/lib/seed_data/topics.rb:15:in `each'
/Users/yahonda/src/github.com/discourse/discourse/lib/seed_data/topics.rb:15:in `block in create'
/Users/yahonda/src/github.com/discourse/discourse/lib/seed_data/topics.rb:14:in `create'
(eval):14:in `block (2 levels) in run_file'
/Users/yahonda/src/github.com/discourse/discourse/lib/tasks/db.rake:225:in `block (2 levels) in <main>'
/Users/yahonda/src/github.com/discourse/discourse/lib/distributed_mutex.rb:33:in `block in synchronize'
/Users/yahonda/src/github.com/discourse/discourse/lib/distributed_mutex.rb:29:in `synchronize'
/Users/yahonda/src/github.com/discourse/discourse/lib/distributed_mutex.rb:29:in `synchronize'
/Users/yahonda/src/github.com/discourse/discourse/lib/distributed_mutex.rb:14:in `synchronize'
/Users/yahonda/src/github.com/discourse/discourse/lib/tasks/db.rake:210:in `block in <main>'
/Users/yahonda/.rbenv/versions/3.0.2/bin/bundle:23:in `load'
/Users/yahonda/.rbenv/versions/3.0.2/bin/bundle:23:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
%
```

* With this fix

```ruby
% bundle exec rake db:create
... snip ...
> Seeding theme and color schemes
%
```

I understand Discourse itself does not support Ruby 3 yet but there are some issues reported like this. Allowing Ruby 3 would be helpful to address these issues/questions. https://meta.discourse.org/t/discourse-installation-fails-on-database-migration/194867