### PR TITLE
FEATURE: user/category/tag results in full page search

### DIFF
--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.js
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.js
@@ -81,14 +81,13 @@ export function addAdvancedSearchOptions(options) {
 
 export default Component.extend({
   tagName: "details",
-  attributeBindings: ["expanded:open"],
+  attributeBindings: ["expandFilters:open"],
   category: null,
 
   init() {
     this._super(...arguments);
 
     this.setProperties({
-      expanded: false,
       searchedTerms: {
         username: null,
         category: null,
@@ -118,6 +117,7 @@ export default Component.extend({
         : inOptionsForAll(),
       statusOptions: statusOptions(),
       postTimeOptions: postTimeOptions(),
+      showAllTagsCheckbox: false,
     });
   },
 
@@ -191,10 +191,6 @@ export default Component.extend({
       "searchedTerms.max_views",
       REGEXP_MAX_VIEWS_PREFIX
     );
-
-    if (this.site.mobileView) {
-      this.set("expanded", false);
-    }
   },
 
   findSearchTerms() {
@@ -319,10 +315,10 @@ export default Component.extend({
       const userInput = match[0].replace(REGEXP_TAGS_REPLACE, "");
 
       if (existingInput !== userInput) {
-        this.set(
-          "searchedTerms.tags",
-          userInput.length !== 0 ? userInput.split(joinChar) : null
-        );
+        const updatedTags = userInput?.split(joinChar);
+
+        this.set("searchedTerms.tags", updatedTags);
+        this.set("showAllTagsCheckbox", !!(updatedTags.length > 1));
       }
     } else if (!tags) {
       this.set("searchedTerms.tags", null);
@@ -502,6 +498,9 @@ export default Component.extend({
         searchTerm += ` tags:${tags}`;
       }
 
+      if (tagFilter.length > 1) {
+        this.set("showAllTagsCheckbox", true);
+      }
       this._updateSearchTerm(searchTerm);
     } else if (match.length !== 0) {
       searchTerm = searchTerm.replace(match[0], "");

--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.js
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.js
@@ -82,6 +82,7 @@ export function addAdvancedSearchOptions(options) {
 export default Component.extend({
   tagName: "details",
   attributeBindings: ["expandFilters:open"],
+  classNames: ["advanced-filters"],
   category: null,
 
   init() {

--- a/app/assets/javascripts/discourse/app/components/search-advanced-options.js
+++ b/app/assets/javascripts/discourse/app/components/search-advanced-options.js
@@ -80,13 +80,15 @@ export function addAdvancedSearchOptions(options) {
 }
 
 export default Component.extend({
-  classNames: ["search-advanced-options"],
+  tagName: "details",
+  attributeBindings: ["expanded:open"],
   category: null,
 
   init() {
     this._super(...arguments);
 
     this.setProperties({
+      expanded: false,
       searchedTerms: {
         username: null,
         category: null,
@@ -189,6 +191,10 @@ export default Component.extend({
       "searchedTerms.max_views",
       REGEXP_MAX_VIEWS_PREFIX
     );
+
+    if (this.site.mobileView) {
+      this.set("expanded", false);
+    }
   },
 
   findSearchTerms() {

--- a/app/assets/javascripts/discourse/app/components/search-result-entry.js
+++ b/app/assets/javascripts/discourse/app/components/search-result-entry.js
@@ -1,5 +1,7 @@
 import Component from "@ember/component";
 
 export default Component.extend({
-  tagName: "",
+  tagName: "div",
+  classNames: ["fps-result"],
+  classNameBindings: ["bulkSelectEnabled"],
 });

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -383,7 +383,12 @@ export default Controller.extend({
       this.selected.clear();
     },
 
-    search() {
+    search(collapseFilters = false) {
+      if (collapseFilters) {
+        document
+          .querySelector("details.advanced-filters")
+          .removeAttribute("open");
+      }
       this.set("page", 1);
       this._search();
     },

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -387,7 +387,7 @@ export default Controller.extend({
       if (collapseFilters) {
         document
           .querySelector("details.advanced-filters")
-          .removeAttribute("open");
+          ?.removeAttribute("open");
       }
       this.set("page", 1);
       this._search();

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -63,6 +63,11 @@ export default Controller.extend({
     return (resultCount || 0) > 0;
   },
 
+  @discourseComputed("expanded")
+  expandFilters(expanded) {
+    return expanded === "true";
+  },
+
   @discourseComputed("q")
   hasAutofocus(q) {
     return isEmpty(q);

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -32,9 +32,8 @@ const SearchTypes = [
   {
     name: I18n.t("search.type.categories_and_tags"),
     id: 1,
-    term: "in:categories",
   },
-  { name: I18n.t("search.type.users"), id: 2, term: "in:users" },
+  { name: I18n.t("search.type.users"), id: 2 },
 ];
 const PAGE_LIMIT = 10;
 
@@ -221,12 +220,14 @@ export default Controller.extend({
     if (!this.model.posts) {
       return 0;
     }
-    const totalCount =
+
+    this.set(
+      "resultCount",
       this.model.posts.length +
-      this.model.categories.length +
-      this.model.tags.length +
-      this.model.users.length;
-    this.set("resultCount", totalCount);
+        this.model.categories.length +
+        this.model.tags.length +
+        this.model.users.length
+    );
   },
 
   @discourseComputed("hasResults")
@@ -317,7 +318,6 @@ export default Controller.extend({
               loading: false,
             });
           });
-
         break;
       case 2:
         userSearch({ term: searchTerm, limit: 20 })
@@ -331,7 +331,6 @@ export default Controller.extend({
               loading: false,
             });
           });
-
         break;
       default:
         ajax("/search", { data: args })

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -27,13 +27,17 @@ const SortOrders = [
   { name: I18n.t("search.latest_topic"), id: 4, term: "order:latest_topic" },
 ];
 
+export const SEARCH_TYPE_DEFAULT = "topics_posts";
+export const SEARCH_TYPE_CATS_TAGS = "categories_tags";
+export const SEARCH_TYPE_USERS = "users";
+
 const SearchTypes = [
-  { name: I18n.t("search.type.default"), id: 0 },
+  { name: I18n.t("search.type.default"), id: SEARCH_TYPE_DEFAULT },
   {
     name: I18n.t("search.type.categories_and_tags"),
-    id: 1,
+    id: SEARCH_TYPE_CATS_TAGS,
   },
-  { name: I18n.t("search.type.users"), id: 2 },
+  { name: I18n.t("search.type.users"), id: SEARCH_TYPE_USERS },
 ];
 const PAGE_LIMIT = 10;
 
@@ -52,9 +56,8 @@ export default Controller.extend({
     "search_type",
   ],
   q: undefined,
-  selected: [],
   context_id: null,
-  search_type: 0,
+  search_type: SEARCH_TYPE_DEFAULT,
   context: null,
   searching: false,
   sortOrder: 0,
@@ -63,6 +66,12 @@ export default Controller.extend({
   page: 1,
   resultCount: null,
   searchTypes: SearchTypes,
+
+  init() {
+    this._super(...arguments);
+
+    this.selected = [];
+  },
 
   @discourseComputed("resultCount")
   hasResults(resultCount) {
@@ -247,7 +256,7 @@ export default Controller.extend({
 
   @discourseComputed("search_type")
   usingDefaultSearchType(searchType) {
-    return searchType === 0;
+    return searchType === SEARCH_TYPE_DEFAULT;
   },
 
   @discourseComputed("bulkSelectEnabled")
@@ -299,8 +308,8 @@ export default Controller.extend({
 
     const searchKey = getSearchKey(args);
 
-    switch (parseInt(this.search_type, 10)) {
-      case 1:
+    switch (this.search_type) {
+      case SEARCH_TYPE_CATS_TAGS:
         const categoryTagSearch = searchCategoryTag(
           searchTerm,
           this.siteSettings
@@ -319,7 +328,7 @@ export default Controller.extend({
             });
           });
         break;
-      case 2:
+      case SEARCH_TYPE_USERS:
         userSearch({ term: searchTerm, limit: 20 })
           .then(async (results) => {
             const model = (await translateResults({ users: results })) || {};

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -164,6 +164,14 @@ export default Controller.extend({
     }
   },
 
+  @observes("search_type")
+  triggerSearchOnTypeChange() {
+    if (this.searchActive) {
+      this.set("page", 1);
+      this._search();
+    }
+  },
+
   @observes("model")
   modelChanged() {
     if (this.searchTerm !== this.q) {
@@ -296,23 +304,33 @@ export default Controller.extend({
           searchTerm,
           this.siteSettings
         );
-        Promise.resolve(categoryTagSearch).then(async (results) => {
-          const categories = results.filter((c) => Boolean(c.model));
-          const tags = results.filter((c) => !Boolean(c.model));
-          const model = (await translateResults({ categories, tags })) || {};
-          this.set("model", model);
-          this.set("searching", false);
-          this.set("loading", false);
-        });
+        Promise.resolve(categoryTagSearch)
+          .then(async (results) => {
+            const categories = results.filter((c) => Boolean(c.model));
+            const tags = results.filter((c) => !Boolean(c.model));
+            const model = (await translateResults({ categories, tags })) || {};
+            this.set("model", model);
+          })
+          .finally(() => {
+            this.setProperties({
+              searching: false,
+              loading: false,
+            });
+          });
 
         break;
       case 2:
-        userSearch({ term: searchTerm, limit: 20 }).then(async (results) => {
-          const model = (await translateResults({ users: results })) || {};
-          this.set("model", model);
-          this.set("searching", false);
-          this.set("loading", false);
-        });
+        userSearch({ term: searchTerm, limit: 20 })
+          .then(async (results) => {
+            const model = (await translateResults({ users: results })) || {};
+            this.set("model", model);
+          })
+          .finally(() => {
+            this.setProperties({
+              searching: false,
+              loading: false,
+            });
+          });
 
         break;
       default:
@@ -340,8 +358,10 @@ export default Controller.extend({
             }
           })
           .finally(() => {
-            this.set("searching", false);
-            this.set("loading", false);
+            this.setProperties({
+              searching: false,
+              loading: false,
+            });
           });
         break;
     }

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -52,7 +52,7 @@ export default Controller.extend({
     "skip_context",
     "search_type",
   ],
-  q: null,
+  q: undefined,
   selected: [],
   context_id: null,
   search_type: 0,

--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -55,7 +55,7 @@ export function translateResults(results, opts) {
 
   results.categories = results.categories
     .map(function (category) {
-      return Category.list().findBy("id", category.id);
+      return Category.list().findBy("id", category.id || category.model.id);
     })
     .compact();
 

--- a/app/assets/javascripts/discourse/app/templates/components/google-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/google-search.hbs
@@ -1,7 +1,5 @@
-<div>
-  <form action="//google.com/search" id="google-search">
-    <input type="text" name="q" aria-label={{i18n "search.search_google"}} value={{searchTerm}}>
-    <input name="as_sitesearch" value={{siteUrl}} type="hidden">
-    <button class="btn btn-primary" type="submit">{{i18n "search.search_google_button"}}</button>
-  </form>
-</div>
+<form action="//google.com/search" id="google-search" class="inline-form">
+  <input type="text" name="q" aria-label={{i18n "search.search_google"}} value={{searchTerm}}>
+  <input name="as_sitesearch" value={{siteUrl}} type="hidden">
+  <button class="btn btn-primary" type="submit">{{i18n "search.search_google_button"}}</button>
+</form>

--- a/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
@@ -1,224 +1,231 @@
-{{plugin-outlet name="advanced-search-options-above" args=(hash searchedTerms=searchedTerms onChangeSearchedTermField=onChangeSearchedTermField) tagName=""}}
+<summary>
+  {{i18n "search.advanced.title"}}
+</summary>
+<div class="search-advanced-filters">
+  <div class="search-advanced-options">
+    {{plugin-outlet name="advanced-search-options-above" args=(hash searchedTerms=searchedTerms onChangeSearchedTermField=onChangeSearchedTermField) tagName=""}}
 
-<div class="container advanced-search-posted-by-group">
-  <div class="control-group pull-left">
-    <label class="control-label" for="search-posted-by">
-      {{i18n "search.advanced.posted_by.label"}}
-    </label>
-    <div class="controls">
-      {{user-chooser
-        id="search-posted-by"
-        value=searchedTerms.username
-        onChange=(action "onChangeSearchTermForUsername")
-        options=(hash
-          maximum=1
-          excludeCurrentUser=false
-        )
-      }}
+    <div class="container advanced-search-posted-by-group">
+      <div class="control-group pull-left">
+        <label class="control-label" for="search-posted-by">
+          {{i18n "search.advanced.posted_by.label"}}
+        </label>
+        <div class="controls">
+          {{user-chooser
+            id="search-posted-by"
+            value=searchedTerms.username
+            onChange=(action "onChangeSearchTermForUsername")
+            options=(hash
+              maximum=1
+              excludeCurrentUser=false
+            )
+          }}
+        </div>
+      </div>
+      <div class="control-group pull-left">
+        <label class="control-label" for="search-in-category">{{i18n "search.advanced.in_category.label"}}</label>
+        <div class="controls">
+          {{search-advanced-category-chooser
+            id="search-in-category"
+            value=searchedTerms.category.id
+            onChange=(action "onChangeSearchTermForCategory")
+          }}
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="control-group pull-left">
-    <label class="control-label" for="search-in-category">{{i18n "search.advanced.in_category.label"}}</label>
-    <div class="controls">
-      {{search-advanced-category-chooser
-        id="search-in-category"
-        value=searchedTerms.category.id
-        onChange=(action "onChangeSearchTermForCategory")
-      }}
+
+    {{#if siteSettings.tagging_enabled}}
+      <div class="container advanced-search-tag-group">
+        <div class="control-group">
+          <label class="control-label" for="search-with-tags">{{i18n "search.advanced.with_tags.label"}}</label>
+          <div class="controls">
+            {{tag-chooser
+              id="search-with-tags"
+              tags=searchedTerms.tags
+              allowCreate=false
+              everyTag=true
+              unlimitedTagCount=true
+              onChange=(action "onChangeSearchTermForTags")
+            }}
+            <section class="field">
+              <label>
+                {{input
+                  type="checkbox"
+                  class="all-tags"
+                  checked=searchedTerms.special.all_tags
+                  click=(action "onChangeSearchTermForAllTags" value="target.checked")
+                }}
+                {{i18n "search.advanced.filters.all_tags"}}
+              </label>
+            </section>
+          </div>
+        </div>
+      </div>
+    {{/if}}
+
+    <div class="container advanced-search-topics-posts-group">
+      <div class="control-group pull-left">
+        <div class="controls">
+          <fieldset class="grouped-control">
+            <legend class="grouped-control-label" for="search-in-options">{{i18n "search.advanced.filters.label"}}</legend>
+
+            {{#if currentUser}}
+              <div class="grouped-control-field">
+                {{input
+                  id="matching-title-only"
+                  type="checkbox"
+                  class="in-title"
+                  checked=searchedTerms.special.in.title
+                  click=(action "onChangeSearchTermForSpecialInTitle" value="target.checked")
+                }}
+                <label for="matching-title-only">
+                  {{i18n "search.advanced.filters.title"}}
+                </label>
+              </div>
+
+              <div class="grouped-control-field">
+                {{input
+                  id="matching-liked"
+                  type="checkbox"
+                  class="in-likes"
+                  checked=searchedTerms.special.in.likes
+                  click=(action "onChangeSearchTermForSpecialInLikes" value="target.checked")
+                }}
+                <label for="matching-liked">{{i18n "search.advanced.filters.likes"}}</label>
+              </div>
+
+              <div class="grouped-control-field">
+                {{input
+                  id="matching-in-messages"
+                  type="checkbox"
+                  class="in-private"
+                  checked=searchedTerms.special.in.personal
+                  click=(action "onChangeSearchTermForSpecialInPersonal" value="target.checked")
+                }}
+                <label for="matching-in-messages">{{i18n "search.advanced.filters.private"}}</label>
+              </div>
+
+              <div class="grouped-control-field">
+                {{input
+                  id="matching-seen"
+                  type="checkbox"
+                  class="in-seen"
+                  checked=searchedTerms.special.in.seen
+                  click=(action "onChangeSearchTermForSpecialInSeen" value="target.checked")
+                }}
+                <label for="matching-seen">{{i18n "search.advanced.filters.seen"}}</label>
+              </div>
+            {{/if}}
+            {{combo-box
+              id="in"
+              valueProperty="value"
+              content=inOptions
+              value=searchedTerms.in
+              onChange=(action "onChangeSearchTermForIn")
+              options=(hash
+                none="user.locale.any"
+                clearable=true
+              )
+            }}
+          </fieldset>
+        </div>
+      </div>
+      <div class="control-group pull-left">
+        <label class="control-label" for="search-status-options">{{i18n "search.advanced.statuses.label"}}</label>
+        <div class="controls">
+          {{combo-box
+            id="search-status-options"
+            valueProperty="value"
+            content=statusOptions
+            value=searchedTerms.status
+            onChange=(action "onChangeSearchTermForStatus")
+            options=(hash
+              none="user.locale.any"
+              clearable=true
+            )
+          }}
+        </div>
+      </div>
     </div>
+
+    <div class="container advanced-search-date-count-group">
+      <div class="control-group">
+        <label class="control-label" for="search-post-date">{{i18n "search.advanced.post.time.label"}}</label>
+        <div class="controls full-search-dates">
+          {{combo-box
+            id="postTime"
+            valueProperty="value"
+            content=postTimeOptions
+            value=searchedTerms.time.when
+            onChange=(action "onChangeWhenTime")
+          }}
+          {{date-input
+            date=searchedTerms.time.days
+            onChange=(action "onChangeWhenDate")
+            id="search-post-date"
+          }}
+        </div>
+      </div>
+
+      <div class="count-group control-group clearfix">
+        <label class="control-label" for="search-min-post-count">{{i18n "search.advanced.post.count.label"}}</label>
+        <div class="count pull-left">
+          <div class="controls">
+            {{input
+              type="number"
+              value=(readonly searchedTerms.min_posts)
+              class="input-small"
+              id="search-min-post-count"
+              input=(action "onChangeSearchTermMinPostCount" value="target.value")
+              placeholder=(i18n "search.advanced.post.min.placeholder")
+            }}
+          </div>
+        </div>
+        <span class="count-dash">&mdash;</span>
+        <div class="count pull-right">
+          <div class="controls">
+            {{input
+              type="number"
+              value=(readonly searchedTerms.max_posts)
+              class="input-small"
+              id="search-max-post-count"
+              input=(action "onChangeSearchTermMaxPostCount" value="target.value")
+              placeholder=(i18n "search.advanced.post.max.placeholder")
+            }}
+          </div>
+        </div>
+      </div>
+
+      <div class="count-group control-group clearfix">
+        <label class="control-label" for="search-min-views">{{i18n "search.advanced.views.label"}}</label>
+        <div class="count pull-left">
+          <div class="controls">
+            {{input
+              type="number"
+              value=(readonly searchedTerms.min_views)
+              class="input-small"
+              id="search-min-views"
+              input=(action "onChangeSearchTermMinViews" value="target.value")
+              placeholder=(i18n "search.advanced.min_views.placeholder")
+            }}
+          </div>
+        </div>
+        <span class="count-dash">&mdash;</span>
+        <div class="count pull-right">
+          <div class="controls">
+            {{input
+              type="number"
+              value=(readonly searchedTerms.max_views)
+              class="input-small"
+              id="search-max-views"
+              input=(action "onChangeSearchTermMaxViews" value="target.value")
+              placeholder=(i18n "search.advanced.max_views.placeholder")
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {{plugin-outlet name="advanced-search-options-below" args=(hash searchedTerms=searchedTerms onChangeSearchedTermField=onChangeSearchedTermField) tagName=""}}
   </div>
 </div>
-
-{{#if siteSettings.tagging_enabled}}
-  <div class="container advanced-search-tag-group">
-    <div class="control-group">
-      <label class="control-label" for="search-with-tags">{{i18n "search.advanced.with_tags.label"}}</label>
-      <div class="controls">
-        {{tag-chooser
-          id="search-with-tags"
-          tags=searchedTerms.tags
-          allowCreate=false
-          everyTag=true
-          unlimitedTagCount=true
-          onChange=(action "onChangeSearchTermForTags")
-        }}
-        <section class="field">
-          <label>
-            {{input
-              type="checkbox"
-              class="all-tags"
-              checked=searchedTerms.special.all_tags
-              click=(action "onChangeSearchTermForAllTags" value="target.checked")
-            }}
-            {{i18n "search.advanced.filters.all_tags"}}
-          </label>
-        </section>
-      </div>
-    </div>
-  </div>
-{{/if}}
-
-<div class="container advanced-search-topics-posts-group">
-  <div class="control-group pull-left">
-    <div class="controls">
-      <fieldset class="grouped-control">
-        <legend class="grouped-control-label" for="search-in-options">{{i18n "search.advanced.filters.label"}}</legend>
-
-        {{#if currentUser}}
-          <div class="grouped-control-field">
-            {{input
-              id="matching-title-only"
-              type="checkbox"
-              class="in-title"
-              checked=searchedTerms.special.in.title
-              click=(action "onChangeSearchTermForSpecialInTitle" value="target.checked")
-            }}
-            <label for="matching-title-only">
-              {{i18n "search.advanced.filters.title"}}
-            </label>
-          </div>
-
-          <div class="grouped-control-field">
-            {{input
-              id="matching-liked"
-              type="checkbox"
-              class="in-likes"
-              checked=searchedTerms.special.in.likes
-              click=(action "onChangeSearchTermForSpecialInLikes" value="target.checked")
-            }}
-            <label for="matching-liked">{{i18n "search.advanced.filters.likes"}}</label>
-          </div>
-
-          <div class="grouped-control-field">
-            {{input
-              id="matching-in-messages"
-              type="checkbox"
-              class="in-private"
-              checked=searchedTerms.special.in.personal
-              click=(action "onChangeSearchTermForSpecialInPersonal" value="target.checked")
-            }}
-            <label for="matching-in-messages">{{i18n "search.advanced.filters.private"}}</label>
-          </div>
-
-          <div class="grouped-control-field">
-            {{input
-              id="matching-seen"
-              type="checkbox"
-              class="in-seen"
-              checked=searchedTerms.special.in.seen
-              click=(action "onChangeSearchTermForSpecialInSeen" value="target.checked")
-            }}
-            <label for="matching-seen">{{i18n "search.advanced.filters.seen"}}</label>
-          </div>
-        {{/if}}
-        {{combo-box
-          id="in"
-          valueProperty="value"
-          content=inOptions
-          value=searchedTerms.in
-          onChange=(action "onChangeSearchTermForIn")
-          options=(hash
-            none="user.locale.any"
-            clearable=true
-          )
-        }}
-      </fieldset>
-    </div>
-  </div>
-  <div class="control-group pull-left">
-    <label class="control-label" for="search-status-options">{{i18n "search.advanced.statuses.label"}}</label>
-    <div class="controls">
-      {{combo-box
-        id="search-status-options"
-        valueProperty="value"
-        content=statusOptions
-        value=searchedTerms.status
-        onChange=(action "onChangeSearchTermForStatus")
-        options=(hash
-          none="user.locale.any"
-          clearable=true
-        )
-      }}
-    </div>
-  </div>
-</div>
-
-<div class="container advanced-search-date-count-group">
-  <div class="control-group pull-left">
-    <label class="control-label" for="search-post-date">{{i18n "search.advanced.post.time.label"}}</label>
-    <div class="controls full-search-dates">
-      {{combo-box
-        id="postTime"
-        valueProperty="value"
-        content=postTimeOptions
-        value=searchedTerms.time.when
-        onChange=(action "onChangeWhenTime")
-      }}
-      {{date-input
-        date=searchedTerms.time.days
-        onChange=(action "onChangeWhenDate")
-        id="search-post-date"
-      }}
-    </div>
-  </div>
-
-  <div class="count-group control-group pull-left">
-    <label class="control-label" for="search-min-post-count">{{i18n "search.advanced.post.count.label"}}</label>
-    <div class="count pull-left">
-      <div class="controls">
-        {{input
-          type="number"
-          value=(readonly searchedTerms.min_posts)
-          class="input-small"
-          id="search-min-post-count"
-          input=(action "onChangeSearchTermMinPostCount" value="target.value")
-          placeholder=(i18n "search.advanced.post.min.placeholder")
-        }}
-      </div>
-    </div>
-    <span class="count-dash">&mdash;</span>
-    <div class="count pull-right">
-      <div class="controls">
-        {{input
-          type="number"
-          value=(readonly searchedTerms.max_posts)
-          class="input-small"
-          id="search-max-post-count"
-          input=(action "onChangeSearchTermMaxPostCount" value="target.value")
-          placeholder=(i18n "search.advanced.post.max.placeholder")
-        }}
-      </div>
-    </div>
-  </div>
-
-  <div class="count-group control-group pull-left">
-    <label class="control-label" for="search-min-views">{{i18n "search.advanced.views.label"}}</label>
-    <div class="count pull-left">
-      <div class="controls">
-        {{input
-          type="number"
-          value=(readonly searchedTerms.min_views)
-          class="input-small"
-          id="search-min-views"
-          input=(action "onChangeSearchTermMinViews" value="target.value")
-          placeholder=(i18n "search.advanced.min_views.placeholder")
-        }}
-      </div>
-    </div>
-    <span class="count-dash">&mdash;</span>
-    <div class="count pull-right">
-      <div class="controls">
-        {{input
-          type="number"
-          value=(readonly searchedTerms.max_views)
-          class="input-small"
-          id="search-max-views"
-          input=(action "onChangeSearchTermMaxViews" value="target.value")
-          placeholder=(i18n "search.advanced.max_views.placeholder")
-        }}
-      </div>
-    </div>
-  </div>
-</div>
-
-{{plugin-outlet name="advanced-search-options-below" args=(hash searchedTerms=searchedTerms onChangeSearchedTermField=onChangeSearchedTermField) tagName=""}}

--- a/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
@@ -6,7 +6,7 @@
     {{plugin-outlet name="advanced-search-options-above" args=(hash searchedTerms=searchedTerms onChangeSearchedTermField=onChangeSearchedTermField) tagName=""}}
 
     <div class="container advanced-search-posted-by-group">
-      <div class="control-group pull-left">
+      <div class="control-group">
         <label class="control-label" for="search-posted-by">
           {{i18n "search.advanced.posted_by.label"}}
         </label>
@@ -22,7 +22,7 @@
           }}
         </div>
       </div>
-      <div class="control-group pull-left">
+      <div class="control-group">
         <label class="control-label" for="search-in-category">{{i18n "search.advanced.in_category.label"}}</label>
         <div class="controls">
           {{search-advanced-category-chooser
@@ -47,24 +47,26 @@
               unlimitedTagCount=true
               onChange=(action "onChangeSearchTermForTags")
             }}
-            <section class="field">
-              <label>
-                {{input
-                  type="checkbox"
-                  class="all-tags"
-                  checked=searchedTerms.special.all_tags
-                  click=(action "onChangeSearchTermForAllTags" value="target.checked")
-                }}
-                {{i18n "search.advanced.filters.all_tags"}}
-              </label>
-            </section>
+            {{#if showAllTagsCheckbox}}
+              <section class="field">
+                <label>
+                  {{input
+                    type="checkbox"
+                    class="all-tags"
+                    checked=searchedTerms.special.all_tags
+                    click=(action "onChangeSearchTermForAllTags" value="target.checked")
+                  }}
+                  {{i18n "search.advanced.filters.all_tags"}}
+                </label>
+              </section>
+            {{/if}}
           </div>
         </div>
       </div>
     {{/if}}
 
     <div class="container advanced-search-topics-posts-group">
-      <div class="control-group pull-left">
+      <div class="control-group">
         <div class="controls">
           <fieldset class="grouped-control">
             <legend class="grouped-control-label" for="search-in-options">{{i18n "search.advanced.filters.label"}}</legend>
@@ -116,6 +118,7 @@
                 <label for="matching-seen">{{i18n "search.advanced.filters.seen"}}</label>
               </div>
             {{/if}}
+
             {{combo-box
               id="in"
               valueProperty="value"
@@ -130,7 +133,7 @@
           </fieldset>
         </div>
       </div>
-      <div class="control-group pull-left">
+      <div class="control-group">
         <label class="control-label" for="search-status-options">{{i18n "search.advanced.statuses.label"}}</label>
         <div class="controls">
           {{combo-box
@@ -167,9 +170,9 @@
         </div>
       </div>
 
-      <div class="count-group control-group clearfix">
+      <div class="count-group control-group">
         <label class="control-label" for="search-min-post-count">{{i18n "search.advanced.post.count.label"}}</label>
-        <div class="count pull-left">
+        <div class="count">
           <div class="controls">
             {{input
               type="number"
@@ -196,9 +199,9 @@
         </div>
       </div>
 
-      <div class="count-group control-group clearfix">
+      <div class="count-group control-group">
         <label class="control-label" for="search-min-views">{{i18n "search.advanced.views.label"}}</label>
-        <div class="count pull-left">
+        <div class="count">
           <div class="controls">
             {{input
               type="number"

--- a/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
@@ -5,230 +5,219 @@
   <div class="search-advanced-options">
     {{plugin-outlet name="advanced-search-options-above" args=(hash searchedTerms=searchedTerms onChangeSearchedTermField=onChangeSearchedTermField) tagName=""}}
 
-    <div class="container advanced-search-posted-by-group">
-      <div class="control-group">
-        <label class="control-label" for="search-posted-by">
-          {{i18n "search.advanced.posted_by.label"}}
-        </label>
-        <div class="controls">
-          {{user-chooser
-            id="search-posted-by"
-            value=searchedTerms.username
-            onChange=(action "onChangeSearchTermForUsername")
-            options=(hash
-              maximum=1
-              excludeCurrentUser=false
-            )
-          }}
-        </div>
-      </div>
-      <div class="control-group">
-        <label class="control-label" for="search-in-category">{{i18n "search.advanced.in_category.label"}}</label>
-        <div class="controls">
-          {{search-advanced-category-chooser
-            id="search-in-category"
-            value=searchedTerms.category.id
-            onChange=(action "onChangeSearchTermForCategory")
-          }}
-        </div>
+    <div class="control-group advanced-search-category">
+      <label class="control-label" for="search-in-category">{{i18n "search.advanced.in_category.label"}}</label>
+      <div class="controls">
+        {{search-advanced-category-chooser
+          id="search-in-category"
+          value=searchedTerms.category.id
+          onChange=(action "onChangeSearchTermForCategory")
+        }}
       </div>
     </div>
 
     {{#if siteSettings.tagging_enabled}}
-      <div class="container advanced-search-tag-group">
-        <div class="control-group">
-          <label class="control-label" for="search-with-tags">{{i18n "search.advanced.with_tags.label"}}</label>
-          <div class="controls">
-            {{tag-chooser
-              id="search-with-tags"
-              tags=searchedTerms.tags
-              allowCreate=false
-              everyTag=true
-              unlimitedTagCount=true
-              onChange=(action "onChangeSearchTermForTags")
-            }}
-            {{#if showAllTagsCheckbox}}
-              <section class="field">
-                <label>
-                  {{input
-                    type="checkbox"
-                    class="all-tags"
-                    checked=searchedTerms.special.all_tags
-                    click=(action "onChangeSearchTermForAllTags" value="target.checked")
-                  }}
-                  {{i18n "search.advanced.filters.all_tags"}}
-                </label>
-              </section>
-            {{/if}}
-          </div>
+      <div class="control-group advanced-search-tags">
+        <label class="control-label" for="search-with-tags">{{i18n "search.advanced.with_tags.label"}}</label>
+        <div class="controls">
+          {{tag-chooser
+            id="search-with-tags"
+            tags=searchedTerms.tags
+            allowCreate=false
+            everyTag=true
+            unlimitedTagCount=true
+            onChange=(action "onChangeSearchTermForTags")
+          }}
+          {{#if showAllTagsCheckbox}}
+            <section class="field">
+              <label>
+                {{input
+                  type="checkbox"
+                  class="all-tags"
+                  checked=searchedTerms.special.all_tags
+                  click=(action "onChangeSearchTermForAllTags" value="target.checked")
+                }}
+                {{i18n "search.advanced.filters.all_tags"}}
+              </label>
+            </section>
+          {{/if}}
         </div>
       </div>
     {{/if}}
 
-    <div class="container advanced-search-topics-posts-group">
-      <div class="control-group">
-        <div class="controls">
-          <fieldset class="grouped-control">
-            <legend class="grouped-control-label" for="search-in-options">{{i18n "search.advanced.filters.label"}}</legend>
+    <div class="control-group advanced-search-topics-posts">
+      <div class="controls">
+        <fieldset class="grouped-control">
+          <legend class="grouped-control-label" for="search-in-options">{{i18n "search.advanced.filters.label"}}</legend>
 
-            {{#if currentUser}}
-              <div class="grouped-control-field">
-                {{input
-                  id="matching-title-only"
-                  type="checkbox"
-                  class="in-title"
-                  checked=searchedTerms.special.in.title
-                  click=(action "onChangeSearchTermForSpecialInTitle" value="target.checked")
-                }}
-                <label for="matching-title-only">
-                  {{i18n "search.advanced.filters.title"}}
-                </label>
-              </div>
+          {{#if currentUser}}
+            <div class="grouped-control-field">
+              {{input
+                id="matching-title-only"
+                type="checkbox"
+                class="in-title"
+                checked=searchedTerms.special.in.title
+                click=(action "onChangeSearchTermForSpecialInTitle" value="target.checked")
+              }}
+              <label for="matching-title-only">
+                {{i18n "search.advanced.filters.title"}}
+              </label>
+            </div>
 
-              <div class="grouped-control-field">
-                {{input
-                  id="matching-liked"
-                  type="checkbox"
-                  class="in-likes"
-                  checked=searchedTerms.special.in.likes
-                  click=(action "onChangeSearchTermForSpecialInLikes" value="target.checked")
-                }}
-                <label for="matching-liked">{{i18n "search.advanced.filters.likes"}}</label>
-              </div>
+            <div class="grouped-control-field">
+              {{input
+                id="matching-liked"
+                type="checkbox"
+                class="in-likes"
+                checked=searchedTerms.special.in.likes
+                click=(action "onChangeSearchTermForSpecialInLikes" value="target.checked")
+              }}
+              <label for="matching-liked">{{i18n "search.advanced.filters.likes"}}</label>
+            </div>
 
-              <div class="grouped-control-field">
-                {{input
-                  id="matching-in-messages"
-                  type="checkbox"
-                  class="in-private"
-                  checked=searchedTerms.special.in.personal
-                  click=(action "onChangeSearchTermForSpecialInPersonal" value="target.checked")
-                }}
-                <label for="matching-in-messages">{{i18n "search.advanced.filters.private"}}</label>
-              </div>
+            <div class="grouped-control-field">
+              {{input
+                id="matching-in-messages"
+                type="checkbox"
+                class="in-private"
+                checked=searchedTerms.special.in.personal
+                click=(action "onChangeSearchTermForSpecialInPersonal" value="target.checked")
+              }}
+              <label for="matching-in-messages">{{i18n "search.advanced.filters.private"}}</label>
+            </div>
 
-              <div class="grouped-control-field">
-                {{input
-                  id="matching-seen"
-                  type="checkbox"
-                  class="in-seen"
-                  checked=searchedTerms.special.in.seen
-                  click=(action "onChangeSearchTermForSpecialInSeen" value="target.checked")
-                }}
-                <label for="matching-seen">{{i18n "search.advanced.filters.seen"}}</label>
-              </div>
-            {{/if}}
+            <div class="grouped-control-field">
+              {{input
+                id="matching-seen"
+                type="checkbox"
+                class="in-seen"
+                checked=searchedTerms.special.in.seen
+                click=(action "onChangeSearchTermForSpecialInSeen" value="target.checked")
+              }}
+              <label for="matching-seen">{{i18n "search.advanced.filters.seen"}}</label>
+            </div>
+          {{/if}}
 
-            {{combo-box
-              id="in"
-              valueProperty="value"
-              content=inOptions
-              value=searchedTerms.in
-              onChange=(action "onChangeSearchTermForIn")
-              options=(hash
-                none="user.locale.any"
-                clearable=true
-              )
-            }}
-          </fieldset>
-        </div>
-      </div>
-      <div class="control-group">
-        <label class="control-label" for="search-status-options">{{i18n "search.advanced.statuses.label"}}</label>
-        <div class="controls">
           {{combo-box
-            id="search-status-options"
+            id="in"
             valueProperty="value"
-            content=statusOptions
-            value=searchedTerms.status
-            onChange=(action "onChangeSearchTermForStatus")
+            content=inOptions
+            value=searchedTerms.in
+            onChange=(action "onChangeSearchTermForIn")
             options=(hash
               none="user.locale.any"
               clearable=true
             )
           }}
-        </div>
+        </fieldset>
       </div>
     </div>
 
-    <div class="container advanced-search-date-count-group">
-      <div class="control-group">
-        <label class="control-label" for="search-post-date">{{i18n "search.advanced.post.time.label"}}</label>
-        <div class="controls full-search-dates">
-          {{combo-box
-            id="postTime"
-            valueProperty="value"
-            content=postTimeOptions
-            value=searchedTerms.time.when
-            onChange=(action "onChangeWhenTime")
-          }}
-          {{date-input
-            date=searchedTerms.time.days
-            onChange=(action "onChangeWhenDate")
-            id="search-post-date"
-          }}
-        </div>
+    <div class="control-group advanced-search-topic-status">
+      <label class="control-label" for="search-status-options">{{i18n "search.advanced.statuses.label"}}</label>
+      <div class="controls">
+        {{combo-box
+          id="search-status-options"
+          valueProperty="value"
+          content=statusOptions
+          value=searchedTerms.status
+          onChange=(action "onChangeSearchTermForStatus")
+          options=(hash
+            none="user.locale.any"
+            clearable=true
+          )
+        }}
       </div>
+    </div>
 
-      <div class="count-group control-group">
-        <label class="control-label" for="search-min-post-count">{{i18n "search.advanced.post.count.label"}}</label>
-        <div class="count">
-          <div class="controls">
-            {{input
-              type="number"
-              value=(readonly searchedTerms.min_posts)
-              class="input-small"
-              id="search-min-post-count"
-              input=(action "onChangeSearchTermMinPostCount" value="target.value")
-              placeholder=(i18n "search.advanced.post.min.placeholder")
-            }}
-          </div>
-        </div>
-        <span class="count-dash">&mdash;</span>
-        <div class="count pull-right">
-          <div class="controls">
-            {{input
-              type="number"
-              value=(readonly searchedTerms.max_posts)
-              class="input-small"
-              id="search-max-post-count"
-              input=(action "onChangeSearchTermMaxPostCount" value="target.value")
-              placeholder=(i18n "search.advanced.post.max.placeholder")
-            }}
-          </div>
-        </div>
+    <div class="control-group advanced-search-posted-by">
+      <label class="control-label" for="search-posted-by">
+        {{i18n "search.advanced.posted_by.label"}}
+      </label>
+      <div class="controls">
+        {{user-chooser
+        id="search-posted-by"
+        value=searchedTerms.username
+        onChange=(action "onChangeSearchTermForUsername")
+        options=(hash
+        maximum=1
+        excludeCurrentUser=false
+        )
+        }}
       </div>
+    </div>
 
-      <div class="count-group control-group">
-        <label class="control-label" for="search-min-views">{{i18n "search.advanced.views.label"}}</label>
-        <div class="count">
-          <div class="controls">
-            {{input
-              type="number"
-              value=(readonly searchedTerms.min_views)
-              class="input-small"
-              id="search-min-views"
-              input=(action "onChangeSearchTermMinViews" value="target.value")
-              placeholder=(i18n "search.advanced.min_views.placeholder")
-            }}
-          </div>
-        </div>
-        <span class="count-dash">&mdash;</span>
-        <div class="count pull-right">
-          <div class="controls">
-            {{input
-              type="number"
-              value=(readonly searchedTerms.max_views)
-              class="input-small"
-              id="search-max-views"
-              input=(action "onChangeSearchTermMaxViews" value="target.value")
-              placeholder=(i18n "search.advanced.max_views.placeholder")
-            }}
-          </div>
-        </div>
+    <div class="control-group advanced-search-posted-date">
+      <label class="control-label" for="search-post-date">{{i18n "search.advanced.post.time.label"}}</label>
+      <div class="controls inline-form full-width">
+        {{combo-box
+          id="postTime"
+          valueProperty="value"
+          content=postTimeOptions
+          value=searchedTerms.time.when
+          onChange=(action "onChangeWhenTime")
+        }}
+        {{date-input
+          date=searchedTerms.time.days
+          onChange=(action "onChangeWhenDate")
+          id="search-post-date"
+        }}
       </div>
     </div>
 
     {{plugin-outlet name="advanced-search-options-below" args=(hash searchedTerms=searchedTerms onChangeSearchedTermField=onChangeSearchedTermField) tagName=""}}
   </div>
+
+  <details class="search-advanced-additional-options">
+    <summary>
+      {{i18n "search.advanced.additional_options.label"}}
+    </summary>
+    <div class="count-group control-group">
+      {{!-- TODO: Using a label here fails no-nested-interactive lint rule --}}
+      <span class="control-label" for="search-min-post-count">{{i18n "search.advanced.post.count.label"}}</span>
+      <div class="controls">
+        {{input
+          type="number"
+          value=(readonly searchedTerms.min_posts)
+          class="input-small"
+          id="search-min-post-count"
+          input=(action "onChangeSearchTermMinPostCount" value="target.value")
+          placeholder=(i18n "search.advanced.post.min.placeholder")
+        }}
+        {{d-icon "arrows-alt-h"}}
+        {{input
+          type="number"
+          value=(readonly searchedTerms.max_posts)
+          class="input-small"
+          id="search-max-post-count"
+          input=(action "onChangeSearchTermMaxPostCount" value="target.value")
+          placeholder=(i18n "search.advanced.post.max.placeholder")
+        }}
+      </div>
+    </div>
+
+    <div class="count-group control-group">
+      {{!-- TODO: Using a label here fails no-nested-interactive lint rule --}}
+      <span class="control-label" for="search-min-views">{{i18n "search.advanced.views.label"}}</span>
+      <div class="controls">
+        {{input
+          type="number"
+          value=(readonly searchedTerms.min_views)
+          class="input-small"
+          id="search-min-views"
+          input=(action "onChangeSearchTermMinViews" value="target.value")
+          placeholder=(i18n "search.advanced.min_views.placeholder")
+        }}
+        {{d-icon "arrows-alt-h"}}
+        {{input
+          type="number"
+          value=(readonly searchedTerms.max_views)
+          class="input-small"
+          id="search-max-views"
+          input=(action "onChangeSearchTermMaxViews" value="target.value")
+          placeholder=(i18n "search.advanced.max_views.placeholder")
+        }}
+      </div>
+    </div>
+  </details>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/search-result-entries.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-result-entries.hbs
@@ -1,5 +1,5 @@
 <div class="fps-result-entries">
   {{#each posts as |post|}}
-    {{search-result-entry post=post bulkSelectEnabled=bulkSelectEnabled selected=selected}}
+    {{search-result-entry post=post bulkSelectEnabled=bulkSelectEnabled selected=selected highlightQuery=highlightQuery}}
   {{/each}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/search-result-entry.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-result-entry.hbs
@@ -1,66 +1,64 @@
-<div class="fps-result">
-  <div class="author">
-    <a href={{post.userPath}} data-user-card={{post.username}}>
-      {{avatar post imageSize="large"}}
-    </a>
-  </div>
+<div class="author">
+  <a href={{post.userPath}} data-user-card={{post.username}}>
+    {{avatar post imageSize="large"}}
+  </a>
+</div>
 
-  <div class="fps-topic">
-    <div class="topic">
-      {{#if bulkSelectEnabled}}
-        {{track-selected selectedList=selected selectedId=post.topic class="bulk-select"}}
-      {{/if}}
+<div class="fps-topic">
+  <div class="topic">
+    {{#if bulkSelectEnabled}}
+      {{track-selected selectedList=selected selectedId=post.topic class="bulk-select"}}
+    {{/if}}
 
-      <a href={{post.url}} {{action "logClick" post.topic_id}} class="search-link">
-        {{raw "topic-status" topic=post.topic showPrivateMessageIcon=true}}
-        <span class="topic-title">
-          {{#if post.useTopicTitleHeadline}}
-            {{html-safe post.topicTitleHeadline}}
-          {{else}}
-            {{#highlight-search highlight=q}}
-              {{html-safe post.topic.fancyTitle}}
-            {{/highlight-search}}
-          {{/if}}
-        </span>
-      </a>
-
-      <div class="search-category">
-        {{#if post.topic.category.parentCategory}}
-          {{category-link post.topic.category.parentCategory}}
-        {{/if}}
-        {{category-link post.topic.category hideParent=true}}
-        {{#if post.topic}}
-          {{discourse-tags post.topic}}
-        {{/if}}
-        {{plugin-outlet name="full-page-search-category" args=(hash post=post)}}
-      </div>
-    </div>
-
-    <div class="blurb container">
-      <span class="date">
-        {{format-date post.created_at format="tiny"}}
-        {{#if post.blurb}}
-          <span class="separator">-</span>
-        {{/if}}
-      </span>
-
-      {{#if post.blurb}}
-        {{#if siteSettings.use_pg_headlines_for_excerpt}}
-          {{html-safe post.blurb}}
+    <a href={{post.url}} {{action "logClick" post.topic_id}} class="search-link">
+      {{raw "topic-status" topic=post.topic showPrivateMessageIcon=true}}
+      <span class="topic-title">
+        {{#if post.useTopicTitleHeadline}}
+          {{html-safe post.topicTitleHeadline}}
         {{else}}
-          {{#highlight-search highlight=highlightQuery}}
-            {{html-safe post.blurb}}
+          {{#highlight-search highlight=q}}
+            {{html-safe post.topic.fancyTitle}}
           {{/highlight-search}}
         {{/if}}
-      {{/if}}
-    </div>
+      </span>
+    </a>
 
-    {{#if showLikeCount}}
-      {{#if post.like_count}}
-        <span class="like-count">
-          <span class="value">{{post.like_count}}</span> {{d-icon "heart"}}
-        </span>
+    <div class="search-category">
+      {{#if post.topic.category.parentCategory}}
+        {{category-link post.topic.category.parentCategory}}
+      {{/if}}
+      {{category-link post.topic.category hideParent=true}}
+      {{#if post.topic}}
+        {{discourse-tags post.topic}}
+      {{/if}}
+      {{plugin-outlet name="full-page-search-category" args=(hash post=post)}}
+    </div>
+  </div>
+
+  <div class="blurb container">
+    <span class="date">
+      {{format-date post.created_at format="tiny"}}
+      {{#if post.blurb}}
+        <span class="separator">-</span>
+      {{/if}}
+    </span>
+
+    {{#if post.blurb}}
+      {{#if siteSettings.use_pg_headlines_for_excerpt}}
+        {{html-safe post.blurb}}
+      {{else}}
+        {{#highlight-search highlight=highlightQuery}}
+          {{html-safe post.blurb}}
+        {{/highlight-search}}
       {{/if}}
     {{/if}}
   </div>
+
+  {{#if showLikeCount}}
+    {{#if post.like_count}}
+      <span class="like-count">
+        <span class="value">{{post.like_count}}</span> {{d-icon "heart"}}
+      </span>
+    {{/if}}
+  {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/search-result-entry.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-result-entry.hbs
@@ -16,7 +16,7 @@
         {{#if post.useTopicTitleHeadline}}
           {{html-safe post.topicTitleHeadline}}
         {{else}}
-          {{#highlight-search highlight=q}}
+          {{#highlight-search highlight=highlightQuery}}
             {{html-safe post.topic.fancyTitle}}
           {{/highlight-search}}
         {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -153,7 +153,7 @@
               {{#if hasResults}}
                 {{#if model.categories.length}}
                   <h4 class="category-heading">
-                    Categories
+                    {{i18n "search.categories"}}
                   </h4>
                   <div class="category-items">
                     {{#each model.categories as |category|}}
@@ -164,7 +164,7 @@
 
                 {{#if model.tags.length}}
                   <h4 class="tag-heading">
-                    Tags
+                    {{i18n "search.tags"}}
                   </h4>
                   <div class="tag-items">
                     {{#each model.tags as |tag|}}

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -1,48 +1,58 @@
 {{#d-section pageClass="search" class="search-container"}}
   {{scroll-tracker name="full-page-search" tag=searchTerm class="hidden"}}
-  <h1 class="search-page-heading">
-    {{#if hasResults}}
-      <div class="result-count" id="search-result-count" aria-live="polite">
-        {{html-safe resultCountLabel}}
-      </div>
-    {{else}}
-      Search
-    {{/if}}
-  </h1>
-  <div class="search-bar">
-    {{search-text-field
-      value=searchTerm
-      class="full-page-search search no-blur search-query"
-      aria-label=(i18n "search.full_page_title")
-      enter=(action "search")
-      hasAutofocus=hasAutofocus
-      aria-controls="search-result-count"
-    }}
-    {{combo-box
-      value=searchType
-      content=searchTypes
-      castInteger=true
-      onChange=(action (mut searchType))
-    }}
-    {{d-button
-      action=(action "search")
-      icon="search"
-      label="search.search_button"
-      class="btn-primary search-cta"
-      ariaLabel="search.search_button"
-      disabled=searchButtonDisabled
-    }}
-  </div>
-  {{#if usingDefaultSearchType}}
-    <div class="search-filters">
-      {{search-advanced-options
-        searchTerm=(readonly searchTerm)
-        onChangeSearchTerm=(action (mut searchTerm))
-        expandFilters=expandFilters
+  <div class="search-header">
+    <h1 class="search-page-heading">
+      {{#if hasResults}}
+        <div class="result-count" id="search-result-count" aria-live="polite">
+          {{html-safe resultCountLabel}}
+        </div>
+      {{else}}
+        {{i18n "search.full_page_title"}}
+      {{/if}}
+    </h1>
+    <div class="search-bar">
+      {{search-text-field
+        value=searchTerm
+        class="full-page-search search no-blur search-query"
+        aria-label=(i18n "search.search_term_label")
+        enter=(action "search")
+        hasAutofocus=hasAutofocus
+        aria-controls="search-result-count"
+      }}
+      {{combo-box
+        value=search_type
+        content=searchTypes
+        castInteger=true
+        onChange=(action (mut search_type))
+      }}
+      {{d-button
+        action=(action "search")
+        icon="search"
+        label="search.search_button"
+        class="btn-primary search-cta"
+        ariaLabel="search.search_button"
+        disabled=searchButtonDisabled
       }}
     </div>
-  {{/if}}
-  <div class="search-advanced">
+    {{#if usingDefaultSearchType}}
+      {{!-- context is only provided when searching from mobile view --}}
+      {{#if context}}
+        <div class="search-context">
+          <label>
+            {{input type="checkbox" name="searchContext" checked=searchContextEnabled}} {{searchContextDescription}}
+          </label>
+        </div>
+      {{/if}}
+
+      <div class="search-filters">
+        {{search-advanced-options
+          searchTerm=(readonly searchTerm)
+          onChangeSearchTerm=(action (mut searchTerm))
+          expandFilters=expandFilters
+        }}
+      </div>
+    {{/if}}
+
     <div class="search-notice">
       {{#if invalidSearch}}
         <div class="fps-invalid">
@@ -51,40 +61,32 @@
       {{/if}}
     </div>
 
-    {{!-- context is only provided when searching from mobile view --}}
-    <div class="search-context">
-      {{#if context}}
-        <div class="fps-search-context">
-          <label>
-            {{input type="checkbox" name="searchContext" checked=searchContextEnabled}} {{searchContextDescription}}
-          </label>
-        </div>
-      {{/if}}
-    </div>
+  </div>
 
+  <div class="search-advanced">
     {{#if hasResults}}
       {{#if usingDefaultSearchType}}
-        <div class="search-info">
+        <div class={{searchInfoClassNames}}>
           {{#if canBulkSelect}}
             {{d-button icon="list" class="btn-default bulk-select" title="topics.bulk.toggle" action=(action "toggleBulkSelect")}}
             {{bulk-select-button selected=selected category=category action=(action "search")}}
           {{/if}}
 
           {{#if bulkSelectEnabled}}
-            <div class="fps-select">
-              {{d-button icon="check-square" class="btn-default" action=(action "selectAll") label="search.select_all"~}}
-              {{d-button icon="far-square" class="btn-default" action=(action "clearAll") label="search.clear_all"}}
-            </div>
+            {{d-button icon="check-square" class="btn-default" action=(action "selectAll") label="search.select_all"~}}
+            {{d-button icon="far-square" class="btn-default" action=(action "clearAll") label="search.clear_all"}}
           {{/if}}
-          <div class="sort-by">
-            <span class="desc">
+
+          <div class="sort-by inline-form">
+            <label for="search-sort-by">
               {{i18n "search.sort_by"}}
-            </span>
+            </label>
             {{combo-box
               value=sortOrder
               content=sortOrders
               castInteger=true
               onChange=(action (mut sortOrder))
+              id="search-sort-by"
             }}
           </div>
         </div>
@@ -145,24 +147,55 @@
               {{/if}}
             {{/conditional-loading-spinner}}
           {{else}}
-            {{#if model.categories}}
-              {{#each model.categories as |category|}}
-                <div class="category-item">
-                  {{category-link category}}
-                </div>
-              {{/each}}
-            {{/if}}
+            {{#conditional-loading-spinner condition=loading }}
+              {{#unless hasResults}}
+                <h3>{{i18n "search.no_results"}}</h3>
+              {{/unless}}
 
-            {{#if model.users}}
-              {{#each model.users as |user|}}
-                {{#user-link user=user}}
-                  <div class="user-item">
-                    {{avatar user imageSize="large"}}
-                    {{user.username}}
+              {{#if hasResults}}
+                {{#if model.categories.length}}
+                  <h4 class="category-heading">
+                    Categories
+                  </h4>
+                  <div class="category-items">
+                    {{#each model.categories as |category|}}
+                      {{category-link category}}
+                    {{/each}}
                   </div>
-                {{/user-link}}
-              {{/each}}
-            {{/if}}
+                {{/if}}
+
+                {{#if model.tags.length}}
+                  <h4 class="tag-heading">
+                    Tags
+                  </h4>
+                  <div class="tag-items">
+                    {{#each model.tags as |tag|}}
+                      <a href={{tag.url}}>
+                        {{tag.id}}
+                      </a>
+                    {{/each}}
+                  </div>
+                {{/if}}
+
+                {{#if model.users}}
+                  {{#each model.users as |user|}}
+                    {{#user-link user=user class="user-item"}}
+                      {{avatar user imageSize="large"}}
+                      <div class="user-titles">
+                        {{#if user.name}}
+                          <span class="name">
+                            {{user.name}}
+                          </span>
+                        {{/if}}
+                        <span class="username">
+                          {{user.username}}
+                        </span>
+                      </div>
+                    {{/user-link}}
+                  {{/each}}
+                {{/if}}
+              {{/if}}
+            {{/conditional-loading-spinner}}
           {{/if}}
         {{/load-more}}
       </div>

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -148,10 +148,6 @@
             {{/conditional-loading-spinner}}
           {{else}}
             {{#conditional-loading-spinner condition=loading }}
-              {{#unless hasResults}}
-                <h3>{{i18n "search.no_results"}}</h3>
-              {{/unless}}
-
               {{#if hasResults}}
                 {{#if model.categories.length}}
                   <h4 class="category-heading">
@@ -194,7 +190,12 @@
                     {{/user-link}}
                   {{/each}}
                 {{/if}}
+              {{else}}
+                {{#if searchActive}}
+                  <h3>{{i18n "search.no_results"}}</h3>
+                {{/if}}
               {{/if}}
+
             {{/conditional-loading-spinner}}
           {{/if}}
         {{/load-more}}

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -1,21 +1,47 @@
 {{#d-section pageClass="search" class="search-container"}}
   {{scroll-tracker name="full-page-search" tag=searchTerm class="hidden"}}
-
-  <div class="search-advanced">
-    {{#unless site.mobileView}}
-      <div class="search-bar">
-        {{search-text-field
-          value=searchTerm
-          class="full-page-search search no-blur search-query"
-          aria-label=(i18n "search.full_page_title")
-          enter=(action "search")
-          hasAutofocus=hasAutofocus
-          aria-controls="search-result-count"
-        }}
-        {{d-button action=(action "search") icon="search" class="btn-primary search-cta" ariaLabel="search.search_button" disabled=searchButtonDisabled}}
+  <h1 class="search-page-heading">
+    {{#if hasResults}}
+      <div class="result-count" id="search-result-count" aria-live="polite">
+        {{html-safe resultCountLabel}}
       </div>
-    {{/unless}}
-
+    {{else}}
+      Search
+    {{/if}}
+  </h1>
+  <div class="search-bar">
+    {{search-text-field
+      value=searchTerm
+      class="full-page-search search no-blur search-query"
+      aria-label=(i18n "search.full_page_title")
+      enter=(action "search")
+      hasAutofocus=hasAutofocus
+      aria-controls="search-result-count"
+    }}
+    {{combo-box
+      value=searchType
+      content=searchTypes
+      castInteger=true
+      onChange=(action (mut searchType))
+    }}
+    {{d-button
+      action=(action "search")
+      icon="search"
+      label="search.search_button"
+      class="btn-primary search-cta"
+      ariaLabel="search.search_button"
+      disabled=searchButtonDisabled
+    }}
+  </div>
+  {{#if usingDefaultSearchType}}
+    <div class="search-filters">
+      {{search-advanced-options
+        searchTerm=(readonly searchTerm)
+        onChangeSearchTerm=(action (mut searchTerm))
+      }}
+    </div>
+  {{/if}}
+  <div class="search-advanced">
     <div class="search-notice">
       {{#if invalidSearch}}
         <div class="fps-invalid">
@@ -36,40 +62,32 @@
     </div>
 
     {{#if hasResults}}
-      <div class="search-title">
-        {{#if hasResults}}
-          {{create-topic-button canCreateTopic=canCreateTopic action=(action "createTopic" searchTerm)}}
-        {{/if}}
+      {{#if usingDefaultSearchType}}
+        <div class="search-info">
+          {{#if canBulkSelect}}
+            {{d-button icon="list" class="btn-default bulk-select" title="topics.bulk.toggle" action=(action "toggleBulkSelect")}}
+            {{bulk-select-button selected=selected category=category action=(action "search")}}
+          {{/if}}
 
-        {{#if canBulkSelect}}
-          {{d-button icon="list" class="btn-default bulk-select" title="topics.bulk.toggle" action=(action "toggleBulkSelect")}}
-          {{bulk-select-button selected=selected category=category action=(action "search")}}
-        {{/if}}
-
-        {{#if bulkSelectEnabled}}
-          <div class="fps-select">
-            {{d-button icon="check-square" class="btn-default" action=(action "selectAll") label="search.select_all"~}}
-            {{d-button icon="far-square" class="btn-default" action=(action "clearAll") label="search.clear_all"}}
+          {{#if bulkSelectEnabled}}
+            <div class="fps-select">
+              {{d-button icon="check-square" class="btn-default" action=(action "selectAll") label="search.select_all"~}}
+              {{d-button icon="far-square" class="btn-default" action=(action "clearAll") label="search.clear_all"}}
+            </div>
+          {{/if}}
+          <div class="sort-by">
+            <span class="desc">
+              {{i18n "search.sort_by"}}
+            </span>
+            {{combo-box
+              value=sortOrder
+              content=sortOrders
+              castInteger=true
+              onChange=(action (mut sortOrder))
+            }}
           </div>
-        {{/if}}
-      </div>
-
-      <div class="search-info">
-        <div class="result-count" id="search-result-count" aria-live="polite">
-          {{html-safe resultCountLabel}}
         </div>
-        <div class="sort-by">
-          <span class="desc">
-            {{i18n "search.sort_by"}}
-          </span>
-          {{combo-box
-            value=sortOrder
-            content=sortOrders
-            castInteger=true
-            onChange=(action (mut sortOrder))
-          }}
-        </div>
-      </div>
+      {{/if}}
     {{/if}}
 
     {{plugin-outlet name="full-page-search-below-search-info" args=(hash search=searchTerm)}}
@@ -79,98 +97,73 @@
     {{else}}
       <div class="search-results">
         {{#load-more selector=".fps-result" action=(action "loadMore")}}
-          {{search-result-entries posts=model.posts bulkSelectEnabled=bulkSelectEnabled selected=selected}}
+          {{#if usingDefaultSearchType}}
+            {{search-result-entries posts=model.posts bulkSelectEnabled=bulkSelectEnabled selected=selected}}
 
-          {{#conditional-loading-spinner condition=loading }}
-            {{#unless hasResults}}
-              {{#if searchActive}}
-                <h3>{{i18n "search.no_results"}}</h3>
+            {{#conditional-loading-spinner condition=loading }}
+              {{#unless hasResults}}
+                {{#if searchActive}}
+                  <h3>{{i18n "search.no_results"}}</h3>
 
-                {{#if model.grouped_search_result.error}}
-                  <div class="warning">
-                    {{model.grouped_search_result.error}}
-                  </div>
-                {{/if}}
-
-                {{#if showSuggestion}}
-                  <div class="no-results-suggestion">
-                    {{i18n "search.cant_find"}}
-                    {{#if canCreateTopic}}
-                      <a href {{action "createTopic" searchTerm}}>{{i18n "search.start_new_topic"}}</a>
-                      {{#unless siteSettings.login_required}}
-                        {{i18n "search.or_search_google"}}
-                      {{/unless}}
-                    {{else}}
-                      {{i18n "search.search_google"}}
-                    {{/if}}
-                  </div>
-
-                  {{google-search searchTerm=searchTerm}}
-                {{/if}}
-              {{/if}}
-            {{/unless}}
-
-            {{#if hasResults}}
-              {{#unless loading}}
-                <h3 class="search-footer">
-                  {{#if model.grouped_search_result.more_full_page_results}}
-                    {{#if isLastPage }}
-                      {{i18n "search.more_results"}}
-                    {{/if}}
-                  {{else}}
-                    {{i18n "search.no_more_results"}}
+                  {{#if model.grouped_search_result.error}}
+                    <div class="warning">
+                      {{model.grouped_search_result.error}}
+                    </div>
                   {{/if}}
-                </h3>
+
+                  {{#if showSuggestion}}
+                    <div class="no-results-suggestion">
+                      {{i18n "search.cant_find"}}
+                      {{#if canCreateTopic}}
+                        <a href {{action "createTopic" searchTerm}}>{{i18n "search.start_new_topic"}}</a>
+                        {{#unless siteSettings.login_required}}
+                          {{i18n "search.or_search_google"}}
+                        {{/unless}}
+                      {{else}}
+                        {{i18n "search.search_google"}}
+                      {{/if}}
+                    </div>
+
+                    {{google-search searchTerm=searchTerm}}
+                  {{/if}}
+                {{/if}}
               {{/unless}}
+
+              {{#if hasResults}}
+                {{#unless loading}}
+                  <h3 class="search-footer">
+                    {{#if model.grouped_search_result.more_full_page_results}}
+                      {{#if isLastPage }}
+                        {{i18n "search.more_results"}}
+                      {{/if}}
+                    {{else}}
+                      {{i18n "search.no_more_results"}}
+                    {{/if}}
+                  </h3>
+                {{/unless}}
+              {{/if}}
+            {{/conditional-loading-spinner}}
+          {{else}}
+            {{#if model.categories}}
+              {{#each model.categories as |category|}}
+                <div class="category-item">
+                  {{category-link category}}
+                </div>
+              {{/each}}
             {{/if}}
-          {{/conditional-loading-spinner}}
+
+            {{#if model.users}}
+              {{#each model.users as |user|}}
+                {{#user-link user=user}}
+                  <div class="user-item">
+                    {{avatar user imageSize="large"}}
+                    {{user.username}}
+                  </div>
+                {{/user-link}}
+              {{/each}}
+            {{/if}}
+          {{/if}}
         {{/load-more}}
-      </div>
-    {{/if}}
-  </div>
-
-  <div class="search-advanced-sidebar">
-    {{#if site.mobileView}}
-      <div class="search-bar">
-        {{search-text-field value=searchTerm class="full-page-search search no-blur search-query" enter=(action "search") hasAutofocus=hasAutofocus}}
-        {{d-button action=(action "search") icon="search" class="btn-primary search-cta" ariaLabel="search.search_button" disabled=searchButtonDisabled}}
-      </div>
-    {{/if}}
-
-    {{#if site.mobileView}}
-      <div role="button" class="search-advanced-title" {{on "click" (action "toggleAdvancedSearch")}}>
-        {{d-icon (if expanded "caret-down" "caret-right")}}
-        <span>{{i18n "search.advanced.title"}}</span>
-      </div>
-    {{else}}
-      <h1 class="search-advanced-title">
-        {{i18n "search.advanced.title"}}
-      </h1>
-    {{/if}}
-
-    {{#if site.mobileView}}
-      {{#if expanded}}
-        <div class="search-advanced-filters">
-          {{search-advanced-options
-            searchTerm=(readonly searchTerm)
-            onChangeSearchTerm=(action (mut searchTerm))
-          }}
-        </div>
-      {{/if}}
-    {{else}}
-      <div class="search-advanced-filters">
-        {{search-advanced-options
-          searchTerm=(readonly searchTerm)
-          onChangeSearchTerm=(action (mut searchTerm))
-          onChangeCategory=(action (mut category))
-        }}
-
-        {{d-button
-          label="submit"
-          action=(action "search")
-          icon="search"
-          class="btn-primary search-cta"
-          disabled=searchButtonDisabled}}
       </div>
     {{/if}}
   </div>

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -21,6 +21,7 @@
         aria-controls="search-result-count"
       }}
       {{combo-box
+        id="search-type"
         value=search_type
         content=searchTypes
         castInteger=true
@@ -156,7 +157,7 @@
                   </h4>
                   <div class="category-items">
                     {{#each model.categories as |category|}}
-                      {{category-link category}}
+                      {{category-link category extraClasses="fps-category-item"}}
                     {{/each}}
                   </div>
                 {{/if}}
@@ -167,16 +168,18 @@
                   </h4>
                   <div class="tag-items">
                     {{#each model.tags as |tag|}}
-                      <a href={{tag.url}}>
-                        {{tag.id}}
-                      </a>
+                      <div class="fps-tag-item">
+                        <a href={{tag.url}}>
+                          {{tag.id}}
+                        </a>
+                      </div>
                     {{/each}}
                   </div>
                 {{/if}}
 
                 {{#if model.users}}
                   {{#each model.users as |user|}}
-                    {{#user-link user=user class="user-item"}}
+                    {{#user-link user=user class="fps-user-item"}}
                       {{avatar user imageSize="large"}}
                       <div class="user-titles">
                         {{#if user.name}}

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -1,5 +1,6 @@
 {{#d-section pageClass="search" class="search-container"}}
   {{scroll-tracker name="full-page-search" tag=searchTerm class="hidden"}}
+
   <div class="search-header">
     <h1 class="search-page-heading">
       {{#if hasResults}}
@@ -15,7 +16,7 @@
         value=searchTerm
         class="full-page-search search no-blur search-query"
         aria-label=(i18n "search.search_term_label")
-        enter=(action "search")
+        enter=(action "search" true)
         hasAutofocus=hasAutofocus
         aria-controls="search-result-count"
       }}
@@ -26,7 +27,7 @@
         onChange=(action (mut search_type))
       }}
       {{d-button
-        action=(action "search")
+        action=(action "search" true)
         icon="search"
         label="search.search_button"
         class="btn-primary search-cta"

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -38,6 +38,7 @@
       {{search-advanced-options
         searchTerm=(readonly searchTerm)
         onChangeSearchTerm=(action (mut searchTerm))
+        expandFilters=expandFilters
       }}
     </div>
   {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -103,7 +103,12 @@
       <div class="search-results">
         {{#load-more selector=".fps-result" action=(action "loadMore")}}
           {{#if usingDefaultSearchType}}
-            {{search-result-entries posts=model.posts bulkSelectEnabled=bulkSelectEnabled selected=selected}}
+            {{search-result-entries
+              posts=model.posts
+              bulkSelectEnabled=bulkSelectEnabled
+              selected=selected
+              highlightQuery=highlightQuery
+            }}
 
             {{#conditional-loading-spinner condition=loading }}
               {{#unless hasResults}}

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -473,4 +473,86 @@ acceptance("Search - Full Page", function (needs) {
       "does not populate the likes checkbox"
     );
   });
+
+  test("search for users", async function (assert) {
+    await visit("/search");
+
+    const typeSelector = selectKit(".search-bar .select-kit#search-type");
+
+    await fillIn(".search-query", "admin");
+    assert.ok(!exists(".fps-user-item"), "has no user results");
+
+    await typeSelector.expand();
+    await typeSelector.selectRowByValue("2");
+
+    assert.ok(!exists(".search-filters"), "has no filters");
+
+    await click(".search-cta");
+
+    assert.equal(count(".fps-user-item"), 1, "has one user result");
+
+    await typeSelector.expand();
+    await typeSelector.selectRowByValue("0");
+
+    assert.ok(
+      exists(".search-filters"),
+      "returning to topic/posts shows filters"
+    );
+    assert.ok(!exists(".fps-user-item"), "has no user results");
+  });
+
+  test("search for categories/tags", async function (assert) {
+    await visit("/search");
+
+    await fillIn(".search-query", "monk");
+    const typeSelector = selectKit(".search-bar .select-kit#search-type");
+
+    assert.ok(!exists(".fps-tag-item"), "has no category/tag results");
+
+    await typeSelector.expand();
+    await typeSelector.selectRowByIndex(1);
+    await click(".search-cta");
+
+    assert.ok(!exists(".search-filters"), "has no filters");
+    assert.equal(count(".fps-tag-item"), 1, "has one tag result");
+
+    await typeSelector.expand();
+    await typeSelector.selectRowByValue("0");
+
+    assert.ok(
+      exists(".search-filters"),
+      "returning to topic/posts shows filters"
+    );
+    assert.ok(!exists(".user-item"), "has no user results");
+  });
+
+  test("filters expand/collapse as expected", async function (assert) {
+    await visit("/search?expanded=true");
+
+    assert.ok(
+      visible(".search-advanced-options"),
+      "advanced filters are expanded when url query param is included"
+    );
+
+    await fillIn(".search-query", "none");
+    await click(".search-cta");
+
+    assert.ok(
+      !visible(".search-advanced-options"),
+      "launching a search collapses advanced filters"
+    );
+
+    await visit("/search");
+
+    assert.ok(
+      !visible(".search-advanced-options"),
+      "filters are collapsed when query param is not present"
+    );
+
+    await click(".advanced-filters > summary");
+    assert.ok(
+      visible(".search-advanced-options"),
+      "clicking on element expands filters"
+    );
+  });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -16,7 +16,12 @@ acceptance("Search - Full Page", function (needs) {
   needs.settings({ tagging_enabled: true });
   needs.pretender((server, helper) => {
     server.get("/tags/filter/search", () => {
-      return helper.response({ results: [{ text: "monkey", count: 1 }] });
+      return helper.response({
+        results: [
+          { text: "monkey", count: 1 },
+          { text: "gazelle", count: 2 },
+        ],
+      });
     });
 
     server.get("/u/search/users", () => {
@@ -474,6 +479,20 @@ acceptance("Search - Full Page", function (needs) {
     );
   });
 
+  test("all tags checkbox only visible for two or more tags", async function (assert) {
+    await visit("/search?expanded=true");
+
+    const tagSelector = selectKit("#search-with-tags");
+
+    await tagSelector.expand();
+    await tagSelector.selectRowByValue("monkey");
+
+    assert.ok(!visible("input.all-tags"), "all tags checkbox not visible");
+
+    await tagSelector.selectRowByValue("gazelle");
+    assert.ok(visible("input.all-tags"), "all tags checkbox is visible");
+  });
+
   test("search for users", async function (assert) {
     await visit("/search");
 
@@ -514,7 +533,7 @@ acceptance("Search - Full Page", function (needs) {
     await click(".search-cta");
 
     assert.ok(!exists(".search-filters"), "has no filters");
-    assert.equal(count(".fps-tag-item"), 1, "has one tag result");
+    assert.equal(count(".fps-tag-item"), 2, "has two tag results");
 
     await typeSelector.expand();
     await typeSelector.selectRowByValue("0");

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -131,6 +131,8 @@ acceptance("Search - Full Page", function (needs) {
       1,
       "shows the right icon"
     );
+
+    assert.equal(count(".search-highlight"), 1, "search highlights work");
   });
 
   test("escape search term", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -9,6 +9,11 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { skip, test } from "qunit";
+import {
+  SEARCH_TYPE_CATS_TAGS,
+  SEARCH_TYPE_DEFAULT,
+  SEARCH_TYPE_USERS,
+} from "discourse/controllers/full-page-search";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Search - Full Page", function (needs) {
@@ -504,7 +509,7 @@ acceptance("Search - Full Page", function (needs) {
     assert.ok(!exists(".fps-user-item"), "has no user results");
 
     await typeSelector.expand();
-    await typeSelector.selectRowByValue("2");
+    await typeSelector.selectRowByValue(SEARCH_TYPE_USERS);
 
     assert.ok(!exists(".search-filters"), "has no filters");
 
@@ -513,7 +518,7 @@ acceptance("Search - Full Page", function (needs) {
     assert.equal(count(".fps-user-item"), 1, "has one user result");
 
     await typeSelector.expand();
-    await typeSelector.selectRowByValue("0");
+    await typeSelector.selectRowByValue(SEARCH_TYPE_DEFAULT);
 
     assert.ok(
       exists(".search-filters"),
@@ -531,14 +536,14 @@ acceptance("Search - Full Page", function (needs) {
     assert.ok(!exists(".fps-tag-item"), "has no category/tag results");
 
     await typeSelector.expand();
-    await typeSelector.selectRowByIndex(1);
+    await typeSelector.selectRowByValue(SEARCH_TYPE_CATS_TAGS);
     await click(".search-cta");
 
     assert.ok(!exists(".search-filters"), "has no filters");
     assert.equal(count(".fps-tag-item"), 2, "has two tag results");
 
     await typeSelector.expand();
-    await typeSelector.selectRowByValue("0");
+    await typeSelector.selectRowByValue(SEARCH_TYPE_DEFAULT);
 
     assert.ok(
       exists(".search-filters"),

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -419,7 +419,9 @@ acceptance("Search - Full Page", function (needs) {
     await fillIn("#search-min-post-count", "5");
 
     assert.equal(
-      queryAll(".search-advanced-options #search-min-post-count").val(),
+      queryAll(
+        ".search-advanced-additional-options #search-min-post-count"
+      ).val(),
       "5",
       'has "5" populated'
     );
@@ -436,7 +438,9 @@ acceptance("Search - Full Page", function (needs) {
     await fillIn("#search-max-post-count", "5");
 
     assert.equal(
-      queryAll(".search-advanced-options #search-max-post-count").val(),
+      queryAll(
+        ".search-advanced-additional-options #search-max-post-count"
+      ).val(),
       "5",
       'has "5" populated'
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -3,6 +3,7 @@ import {
   count,
   exists,
   queryAll,
+  visible,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
@@ -22,11 +23,10 @@ acceptance("Search - Mobile", function (needs) {
 
     assert.ok(!exists(".search-results .fps-topic"), "no results by default");
 
-    await click(".search-advanced-title");
+    await click(".advanced-filters summary");
 
-    assert.equal(
-      count(".search-advanced-filters"),
-      1,
+    assert.ok(
+      visible(".search-advanced-filters"),
       "it should expand advanced search filters"
     );
 
@@ -36,7 +36,7 @@ acceptance("Search - Mobile", function (needs) {
     assert.equal(count(".fps-topic"), 1, "has one post");
 
     assert.ok(
-      !exists(".search-advanced-filters"),
+      !visible(".search-advanced-filters"),
       "it should collapse advanced search filters"
     );
 

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -148,12 +148,12 @@
 
     .search-advanced-filters {
       background: var(--primary-very-low);
-      padding: 0 2em 2em 2em;
+      padding: 0em 10% 2em 10%;
 
       @include breakpoint(medium, min-width) {
         .search-advanced-options {
-          column-count: 3;
-          column-gap: 2.5em;
+          column-count: 2;
+          column-gap: 6em;
           .container {
             break-inside: avoid;
           }

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -3,65 +3,77 @@
 }
 
 .search-container {
-  display: flex;
-  justify-content: space-between;
-
   .warning {
     background-color: var(--danger-medium);
     padding: 5px 8px;
     color: var(--secondary);
   }
 
+  .search-page-heading {
+    font-size: var(--font-up-3);
+    padding: 1em 10% 0 10%;
+    margin-bottom: 0;
+    background: var(--primary-very-low);
+
+    // spans can be in different orders depending of locale
+    span + span {
+      margin-left: 0.25em;
+    }
+
+    span.term {
+      background: var(--tertiary-low);
+    }
+  }
+
   .search-bar {
     display: flex;
     justify-content: space-between;
     align-items: stretch;
-    margin-bottom: 1em;
+    padding: 2em 10%;
+    background: var(--primary-very-low);
 
     .search-query {
       flex: 1 0 0px;
-      margin: 0 0.5em 0 0;
+      margin: 0 1em 0 0;
+      font-size: var(--font-up-1);
     }
 
-    .search-cta {
-      padding-bottom: 6.5px;
-      padding-top: 6.5px;
+    .select-kit {
+      margin-right: 1em;
+      .select-kit-header {
+        font-size: var(--font-up-1);
+        padding-top: 0.25em;
+        padding-bottom: 0.25em;
+      }
     }
   }
 
   .search-advanced {
-    width: 70%;
-    @include breakpoint(medium) {
-      width: 65%;
-    }
-
     .search-actions,
-    .search-notice,
-    .search-results,
     .search-title,
     .search-bar {
       margin-bottom: 1em;
     }
 
+    .search-results {
+      padding: 1em 10%;
+    }
+
     .search-info {
       display: flex;
+      padding: 1em 10%;
       flex-wrap: wrap;
       border-bottom: 1px solid var(--primary-low);
-      padding-bottom: 1em;
-      margin-bottom: 1.5em;
+      margin-bottom: 2em;
       flex-direction: row;
-      align-items: center;
+      align-items: flex-start;
+      justify-content: flex-start;
 
       .result-count {
         display: flex;
 
         .term {
           font-weight: bold;
-        }
-
-        // spans can be in different orders depending of locale
-        span + span {
-          margin-left: 0.25em;
         }
       }
 
@@ -78,31 +90,19 @@
           min-width: 150px;
         }
       }
-    }
 
-    .search-title {
-      display: flex;
-      justify-content: flex-start;
-      align-items: stretch;
-      flex-wrap: wrap;
-      padding-right: 2.6em; // placeholder for fixed position bulk search button
       button {
         margin: 0 0.5em 0.5em 0;
       }
 
-      .bulk-select-container {
-        order: 2; // last button
-        margin-left: auto;
-        z-index: z("dropdown"); // below composer
-      }
-
       #bulk-select {
-        position: fixed;
+        position: relative;
         right: unset;
         margin: 0;
+        padding: 0;
         button {
-          margin: 0;
-          box-shadow: 0 0 0.4em 0.45em var(--secondary); // slight fade behind the button, because it can overlay content
+          margin: 0px;
+          margin-right: 0.5em;
         }
       }
     }
@@ -117,14 +117,17 @@
     }
   }
 
-  .search-advanced-sidebar {
-    width: 30%;
-    @include breakpoint(medium) {
-      width: 35%;
-    }
-    margin-left: 1em;
+  .search-filters {
+    background: var(--primary-very-low);
     display: flex;
     flex-direction: column;
+
+    > details {
+      > summary {
+        padding: 0em 10% 2em 10%;
+        cursor: pointer;
+      }
+    }
 
     .input-small,
     .combo-box,
@@ -143,33 +146,21 @@
       }
     }
 
-    .d-date-input {
-      margin-top: 0.5em;
-      width: 100%;
-    }
-
-    .search-advanced-title {
-      font-size: $font-up-1;
-      background: var(--primary-low);
-      padding: 0.358em 1em;
-      margin-bottom: 0;
-      @include breakpoint(medium) {
-        padding: 0.358em 0.5em;
-      }
-      font-weight: 700;
-      text-align: left;
-      cursor: pointer;
-
-      .d-icon {
-        margin: 0;
-      }
-    }
-
     .search-advanced-filters {
       background: var(--primary-very-low);
-      padding: 1em;
+      padding: 0 2em 2em 2em;
+
+      @include breakpoint(medium, min-width) {
+        .search-advanced-options {
+          column-count: 3;
+          column-gap: 2.5em;
+          .container {
+            break-inside: avoid;
+          }
+        }
+      }
       .control-group {
-        margin-bottom: 15px;
+        margin-bottom: 1em;
       }
       section.field {
         margin-top: 5px;
@@ -196,6 +187,19 @@
           vertical-align: middle;
         }
       }
+
+      .full-search-dates {
+        display: flex;
+        > .select-kit,
+        > .d-date-input {
+          width: auto;
+          min-width: auto;
+          flex: auto;
+        }
+        > .select-kit {
+          margin-right: 1em;
+        }
+      }
     }
   }
 }
@@ -207,9 +211,14 @@
 .fps-result {
   display: flex;
   padding: 0 0.5em;
-  margin-bottom: 28px;
-  max-width: 780px;
+  margin-bottom: 2em;
+  max-width: 100%;
   word-break: break-word;
+  position: relative;
+
+  &.bulk-select-enabled {
+    padding-left: 3em;
+  }
 
   .author {
     display: inline-block;
@@ -229,7 +238,15 @@
     grid-template-columns: auto 1fr;
     align-items: baseline;
     .bulk-select {
-      grid-area: bulk-select;
+      position: absolute;
+      left: 0px;
+      top: 0px;
+      padding: 0.5em;
+      background: var(--tertiary-very-low);
+      input[type="checkbox"] {
+        margin: 0;
+        background: yellow;
+      }
     }
     .search-link {
       grid-area: title;
@@ -260,19 +277,9 @@
     }
   }
 
-  input[type="checkbox"] {
-    margin-top: 0;
-    margin-left: 0;
-    // cross-browser alignment below
-    position: relative;
-    vertical-align: bottom;
-    margin-bottom: 0.39em;
-  }
-
   .blurb {
     font-size: $font-0;
     line-height: $line-height-large;
-    max-width: 640px;
     color: var(--primary-medium);
     .date {
       color: var(--primary-high);
@@ -333,4 +340,16 @@
 
 .google-search-form {
   margin-top: 2em;
+}
+
+// temporary
+
+.search-results {
+  .user-item {
+    margin-bottom: 1em;
+  }
+
+  .category-item {
+    font-size: var(--font-up-3);
+  }
 }

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -332,8 +332,8 @@
 // temporary
 
 .search-results {
-  .user-item {
-    margin-bottom: 2em;
+  .fps-user-item {
+    margin-bottom: 1.5em;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -361,6 +361,11 @@
 
   .category-items,
   .tag-items {
-    margin-bottom: 1em;
+    margin-bottom: 1.5em;
+    .fps-category-item,
+    .fps-tag-item {
+      margin-bottom: 1.5em;
+      display: block;
+    }
   }
 }

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -1,8 +1,18 @@
+@mixin search-page-spacing {
+  padding: 1rem 10%;
+  @include breakpoint(medium) {
+    padding: 1rem;
+  }
+}
 .search-highlight {
   font-weight: bold;
 }
 
 .search-container {
+  .search-header {
+    @include search-page-spacing();
+    background: var(--primary-very-low);
+  }
   .warning {
     background-color: var(--danger-medium);
     padding: 5px 8px;
@@ -11,9 +21,6 @@
 
   .search-page-heading {
     font-size: var(--font-up-3);
-    padding: 1em 10% 0 10%;
-    margin-bottom: 0;
-    background: var(--primary-very-low);
 
     // spans can be in different orders depending of locale
     span + span {
@@ -29,26 +36,30 @@
     display: flex;
     justify-content: space-between;
     align-items: stretch;
-    padding: 2em 10%;
     background: var(--primary-very-low);
 
-    .search-query {
+    input.search-query {
       flex: 1 0 0px;
       margin: 0 1em 0 0;
-      font-size: var(--font-up-1);
     }
 
     .select-kit {
       margin-right: 1em;
-      .select-kit-header {
-        font-size: var(--font-up-1);
-        padding-top: 0.25em;
-        padding-bottom: 0.25em;
+    }
+
+    @include breakpoint(medium) {
+      flex-direction: column;
+
+      input.search-query,
+      .select-kit {
+        margin-right: 0;
+        margin-bottom: 0.5em;
       }
     }
   }
 
   .search-advanced {
+    position: relative;
     .search-actions,
     .search-title,
     .search-bar {
@@ -56,39 +67,30 @@
     }
 
     .search-results {
-      padding: 1em 10%;
+      @include search-page-spacing();
+      padding-bottom: 3em;
     }
 
     .search-info {
       display: flex;
-      padding: 1em 10%;
+      @include search-page-spacing();
       flex-wrap: wrap;
       border-bottom: 1px solid var(--primary-low);
+      padding-top: 2em;
       margin-bottom: 2em;
       flex-direction: row;
       align-items: flex-start;
       justify-content: flex-start;
 
-      .result-count {
-        display: flex;
-
-        .term {
-          font-weight: bold;
-        }
+      &.bulk-select-visible {
+        @include sticky;
+        top: 60px;
+        background-color: var(--secondary);
+        z-index: 10;
       }
 
       .sort-by {
-        display: flex;
         margin-left: auto;
-        align-items: center;
-
-        .desc {
-          margin-right: 0.5em;
-        }
-
-        .combo-box {
-          min-width: 150px;
-        }
       }
 
       button {
@@ -100,21 +102,23 @@
         right: unset;
         margin: 0;
         padding: 0;
+        display: inline;
         button {
-          margin: 0px;
           margin-right: 0.5em;
         }
       }
     }
+  }
 
-    .search-notice {
-      .fps-invalid {
-        padding: 0.5em;
-        background-color: var(--danger-low);
-        border: 1px solid var(--danger-medium);
-        color: var(--danger);
-      }
-    }
+  .search-notice .fps-invalid {
+    padding: 0.5em;
+    background-color: var(--danger-low);
+    border: 1px solid var(--danger-medium);
+    color: var(--danger);
+  }
+
+  .search-context {
+    margin-top: 1em;
   }
 
   .search-filters {
@@ -122,52 +126,47 @@
     display: flex;
     flex-direction: column;
 
-    > details {
+    details.advanced-filters,
+    details.search-advanced-additional-options {
+      margin-top: 1em;
+
       > summary {
-        padding: 0em 10% 2em 10%;
+        color: var(--tertiary);
         cursor: pointer;
+      }
+      &[open] > summary {
+        color: var(--primary);
+        margin-bottom: 1em;
       }
     }
 
-    .input-small,
-    .combo-box,
-    .ac-wrap,
+    details.search-advanced-additional-options {
+      > summary {
+        font-size: var(--font-down-1);
+      }
+    }
+
+    .combo-box:not(#postTime),
     .control-group,
-    .multi-select,
-    .search-advanced-category-chooser {
-      box-sizing: border-box;
+    .multi-select {
       width: 100%;
       min-width: 100%;
-      margin: 0;
-
-      input,
-      .item {
-        padding-left: 4px; // temporarily normalizing input padding for this section
-      }
     }
 
     .search-advanced-filters {
       background: var(--primary-very-low);
-      padding: 0em 10% 2em 10%;
 
       @include breakpoint(medium, min-width) {
         .search-advanced-options {
           column-count: 2;
           column-gap: 6em;
-          .container {
+          .control-group {
             break-inside: avoid;
           }
         }
       }
-      .control-group {
-        margin-bottom: 1em;
-      }
-      section.field {
-        margin-top: 5px;
-      }
+
       @include breakpoint(medium) {
-        padding: 0.75em 0.5em;
-        .ac-wrap,
         .choices,
         .select-kit.multi-select {
           // overriding inline width from JS
@@ -178,26 +177,18 @@
         }
       }
 
-      .count-group {
-        .count {
-          width: 45%;
-        }
-        .count-dash {
-          padding-left: 6px;
-          vertical-align: middle;
-        }
+      .control-group {
+        margin-bottom: 1em;
       }
 
-      .full-search-dates {
-        display: flex;
-        > .select-kit,
-        > .d-date-input {
-          width: auto;
-          min-width: auto;
-          flex: auto;
+      .count-group {
+        input[type="number"] {
+          width: 8em;
         }
-        > .select-kit {
-          margin-right: 1em;
+
+        .d-icon {
+          margin-left: 0.25em;
+          margin-right: 0.25em;
         }
       }
     }
@@ -205,6 +196,7 @@
 }
 
 .fps-invalid {
+  margin-top: 1em;
   margin-bottom: 1em;
 }
 
@@ -245,7 +237,6 @@
       background: var(--tertiary-very-low);
       input[type="checkbox"] {
         margin: 0;
-        background: yellow;
       }
     }
     .search-link {
@@ -326,30 +317,43 @@
   }
 }
 
-.no-results-suggestion {
-  margin-top: 30px;
-}
-
-.search-footer {
-  margin-bottom: 30px;
-}
-
-.panel-body-contents .search-context label {
-  float: left;
-}
-
+.no-results-suggestion,
 .google-search-form {
-  margin-top: 2em;
+  margin-top: 1em;
 }
 
 // temporary
 
 .search-results {
   .user-item {
-    margin-bottom: 1em;
+    margin-bottom: 2em;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    .avatar {
+      margin-right: 0.5em;
+      min-width: 25px;
+    }
+    .user-titles {
+      display: flex;
+      flex-direction: column;
+      max-width: 300px;
+      .name {
+        color: var(--primary-high-or-secondary-low);
+        font-size: var(--font-0);
+        font-weight: 700;
+        @include ellipsis;
+      }
+      .username {
+        color: var(--primary-high-or-secondary-low);
+        font-size: var(--font-down-1);
+        @include ellipsis;
+      }
+    }
   }
 
-  .category-item {
-    font-size: var(--font-up-3);
+  .category-items,
+  .tag-items {
+    margin-bottom: 1em;
   }
 }

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -39,15 +39,16 @@
     background: var(--primary-very-low);
 
     input.search-query {
-      flex: 1 0 0px;
+      flex: 1 0 60%;
       margin: 0 1em 0 0;
     }
 
     .select-kit {
       margin-right: 1em;
+      flex: 1 0 20%;
     }
 
-    @include breakpoint(medium) {
+    @include breakpoint(mobile-extra-large) {
       flex-direction: column;
 
       input.search-query,
@@ -156,13 +157,19 @@
     .search-advanced-filters {
       background: var(--primary-very-low);
 
-      @include breakpoint(medium, min-width) {
+      @include breakpoint(mobile-extra-large, min-width) {
         .search-advanced-options {
           column-count: 2;
-          column-gap: 6em;
+          column-gap: 2em;
           .control-group {
             break-inside: avoid;
           }
+        }
+      }
+
+      @include breakpoint(medium, min-width) {
+        .search-advanced-options {
+          column-gap: 5em;
         }
       }
 

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -174,7 +174,8 @@ input[type="submit"] {
   > .select-kit,
   > input[type="text"],
   > label,
-  > .btn {
+  > .btn,
+  > .d-date-input {
     margin-bottom: 0.5em; // for when items wrap (mobile, narrow windows)
     margin-right: 0.5em;
     &:last-child {

--- a/app/assets/stylesheets/mobile/search.scss
+++ b/app/assets/stylesheets/mobile/search.scss
@@ -1,48 +1,6 @@
 .search-container {
-  flex-direction: column;
-  margin: 0;
-
-  .search-advanced {
-    order: 1;
-    width: 100%;
-
-    .search-info {
-      flex-direction: column;
-      align-items: left;
-      justify-content: center;
-
-      .sort-by {
-        display: flex;
-        align-items: center;
-        margin-top: 0.5em;
-        margin-left: 0;
-        width: 100%;
-
-        .select-kit {
-          flex: 1 1 auto;
-        }
-      }
-    }
-  }
-
-  .search-notice {
-    margin-top: 1em;
-  }
-
-  .search-advanced-sidebar {
-    order: 0;
-    width: 100%;
-    margin: 0;
-
-    .tag-chooser,
-    .user-chooser {
-      width: 100%;
-    }
-  }
-}
-
-.fps-result {
-  input[type="checkbox"] {
-    vertical-align: baseline;
+  .search-advanced .search-info {
+    padding-left: 0;
+    padding-right: 0;
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2348,6 +2348,11 @@ en:
       search_google_button: "Google"
       search_button: "Search"
 
+      type:
+        default: "Topics/posts"
+        users: "Users"
+        categories_and_tags: "Categories/tags"
+
       context:
         user: "Search posts by @%{username}"
         category: "Search the #%{category} category"
@@ -2356,7 +2361,7 @@ en:
         private_messages: "Search messages"
 
       advanced:
-        title: Advanced Search
+        title: Advanced filters
         posted_by:
           label: Posted by
         in_category:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2348,6 +2348,8 @@ en:
       search_google_button: "Google"
       search_button: "Search"
       search_term_label: "enter search keyword"
+      categories: "Categories"
+      tags: "Tags"
 
       type:
         default: "Topics/posts"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2335,7 +2335,7 @@ en:
         one: "<span>%{count} result for</span><span class='term'>%{term}</span>"
         other: "<span>%{count}%{plus} results for</span><span class='term'>%{term}</span>"
       title: "search topics, posts, users, or categories"
-      full_page_title: "search topics or posts"
+      full_page_title: "Search"
       no_results: "No results found."
       no_more_results: "No more results found."
       post_format: "#%{post_number} by %{username}"
@@ -2347,6 +2347,7 @@ en:
       search_google: "Try searching with Google instead:"
       search_google_button: "Google"
       search_button: "Search"
+      search_term_label: "enter search keyword"
 
       type:
         default: "Topics/posts"
@@ -2414,6 +2415,8 @@ en:
           placeholder: minimum
         max_views:
           placeholder: maximum
+        additional_options:
+          label: "Filter by post count and topic views"
 
     hamburger_menu: "go to another topic list or category"
     new_item: "new"


### PR DESCRIPTION
In order to allow searching for users, categories, tags in `/search`, we needed to make some more drastic changes to the UI of that screen, and that's what this does. Best described by screenshots: 

Collapsed filters by default
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/133451719-62402523-67fd-4a2c-a141-8ae45523a22e.png">

Expanded filters, i.e. `/search?expanded=true` (options link in search dropdown leads to this)
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/133451671-13195af1-6c9f-4155-8a6f-1a9e75bd6056.png">

On search, filters auto-collapse
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/133451962-c46df46c-6804-446d-ba46-64f4eff2d49b.png">

Mobile
<img width="319" alt="image" src="https://user-images.githubusercontent.com/368961/133452048-030fe64b-3339-44f0-ae9e-edd7a025a1e5.png">

Updated UI for bulk select
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/133452234-4edcb0bd-cf13-4f2b-98c9-0a6a5862f4fa.png">

Category/tag results
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/133452365-fe7a31c5-b470-40b8-85ab-94d02a34dbdc.png">

User results
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/133452437-fa496a05-8899-4472-9d0c-7b558897fff3.png">
