### PR TITLE
FIX: rss gem is bundled gem since Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -208,8 +208,9 @@ gem 'rbtrace', require: false, platform: :mri
 gem 'gc_tracer', require: false, platform: :mri
 
 # required for feed importing and embedding
-# rss gem is bundled gem since Ruby 3
 gem 'ruby-readability', require: false
+
+# rss gem is a bundled gem from Ruby 3 onwards
 gem 'rss', require: false
 
 gem 'stackprof', require: false, platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -208,7 +208,9 @@ gem 'rbtrace', require: false, platform: :mri
 gem 'gc_tracer', require: false, platform: :mri
 
 # required for feed importing and embedding
+# rss gem is bundled gem since Ruby 3
 gem 'ruby-readability', require: false
+gem 'rss', require: false
 
 gem 'stackprof', require: false, platform: :mri
 gem 'memory_profiler', require: false, platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,6 +380,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
+    rss (0.2.9)
+      rexml
     rswag-specs (2.4.0)
       activesupport (>= 3.1, < 7.0)
       json-schema (~> 2.2)
@@ -581,6 +583,7 @@ DEPENDENCIES
   rspec
   rspec-html-matchers
   rspec-rails
+  rss
   rswag-specs
   rtlit
   rubocop-discourse


### PR DESCRIPTION
This pull request address `cannot load such file -- rss` with Ruby 3 since `rss` is a bundled gem since Ruby 3 https://github.com/ruby/ruby/pull/2832

- Steps to reproduce
```ruby
% ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-darwin21]
% bundle exec rake db:create
% bundle exec rake db:migrate
% RAILS_ENV=test bundle exec rake db:create db:migrate
% bundle exec rspec ./spec/components/feed_element_installer_spec.rb ./spec/components/feed_item_accessor_spec.rb
```

- Actual result without this commit:
```ruby
% bundle exec rspec ./spec/components/feed_element_installer_spec.rb ./spec/components/feed_item_accessor_spec.rb                                                                                                         main

An error occurred while loading ./spec/components/feed_element_installer_spec.rb. - Did you mean?
                    rspec ./spec/components/feed_item_accessor_spec.rb

Failure/Error: require 'rss'

LoadError:
  cannot load such file -- rss
# ./lib/feed_element_installer.rb:4:in `require'
# ./lib/feed_element_installer.rb:4:in `<top (required)>'
# ./spec/components/feed_element_installer_spec.rb:3:in `require'
# ./spec/components/feed_element_installer_spec.rb:3:in `<top (required)>'

An error occurred while loading ./spec/components/feed_item_accessor_spec.rb. - Did you mean?
                    rspec ./spec/components/email/processor_spec.rb
                    rspec ./spec/components/cooked_post_processor_spec.rb

Failure/Error: require 'rss'

LoadError:
  cannot load such file -- rss
# ./spec/components/feed_item_accessor_spec.rb:3:in `require'
# ./spec/components/feed_item_accessor_spec.rb:3:in `<top (required)>'
No examples found.


Finished in 0.00005 seconds (files took 0.88278 seconds to load)
0 examples, 0 failures, 2 errors occurred outside of examples

%
```

* With this fix

```ruby
% bundle exec rspec ./spec/components/feed_element_installer_spec.rb ./spec/components/feed_item_accessor_spec.rb                                                                                  rss_is_bundled_gem_in_ruby3

Randomized with seed 40133
........

Finished in 0.41425 seconds (files took 6.31 seconds to load)
8 examples, 0 failures

Randomized with seed 40133

%
```

I understand Discourse itself does not support Ruby 3 yet, still, it would contribute to preparing it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
