### PR TITLE
DEV: Fix flaky site.json api test

### DIFF
--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -382,7 +382,7 @@
             },
             "color_scheme_id": {
               "type": [
-                "string",
+                "integer",
                 "null"
               ]
             }


### PR DESCRIPTION
The color_scheme_id needs to be an integer not a string.

This is one of the failing tests that showed this error:

 https://github.com/discourse/discourse/runs/3598414971

It showed this error

`POSSIBLE ISSUE W/: /user_themes/0/color_scheme_id`

And this is part of the site.json response:

```
...
"user_themes"=>[{"theme_id"=>149, "name"=>"Cool theme 111", "default"=>false, "color_scheme_id"=>37}]
...
```