### PR TITLE
FIX: Remove incoming messages for read events.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
@@ -152,12 +152,7 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
       case "read":
         this._modifyState(message.topic_id, message.payload);
 
-        if (
-          this.filter === UNREAD_FILTER &&
-          this._shouldDisplayMessageForInbox(message)
-        ) {
-          this._notifyIncoming(message.topic_id);
-        }
+        break;
       case "unread":
         this._modifyState(message.topic_id, message.payload);
 
@@ -178,6 +173,8 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
         ) {
           this._notifyIncoming(message.topic_id);
         }
+
+        break;
     }
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -280,16 +280,6 @@ acceptance(
       );
     };
 
-    test("incoming read message on unread filter", async function (assert) {
-      await visit("/u/charlie/messages/unread");
-
-      publishReadToMessageBus({ topicId: 1 });
-
-      await visit("/u/charlie/messages/unread"); // wait for re-render
-
-      assert.ok(exists(".show-mores"), `displays the topic incoming info`);
-    });
-
     test("incoming group archive message acted by current user", async function (assert) {
       await visit("/u/charlie/messages");
 


### PR DESCRIPTION
This prevents the incoming message banner from showing unnecessarily
when reading a post and then navigating back to the unread list.