### PR TITLE
FEATURE: local dates range on click

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -40,7 +40,7 @@ function buildOptionsFromElement(element, siteSettings) {
   const opts = {};
   const dataset = element.dataset;
 
-  if (element.parentElement.children.length > 1) {
+  if (_rangeElements(element).length === 2) {
     opts.duration = _calculateDuration(element);
   }
 
@@ -60,6 +60,12 @@ function buildOptionsFromElement(element, siteSettings) {
   opts.format = dataset.format || (opts.time ? "LLL" : "LL");
   opts.countdown = dataset.countdown;
   return opts;
+}
+
+function _rangeElements(element) {
+  return Array.from(element.parentElement.children).filter(
+    (span) => span.dataset.date
+  );
 }
 
 function initializeDiscourseLocalDates(api) {
@@ -133,10 +139,13 @@ function buildHtmlPreview(element, siteSettings) {
 }
 
 function _calculateDuration(element) {
-  const startDataset = element.parentElement.children[0].dataset;
-  const endDataset = element.parentElement.children[1].dataset;
-  const startDateTime = moment(`${startDataset.date} ${startDataset.time}`);
-  const endDateTime = moment(`${endDataset.date} ${endDataset.time}`);
+  const [startDataset, endDataset] = _rangeElements(element).map(
+    (dateElement) => dateElement.dataset
+  );
+  const startDateTime = moment(
+    `${startDataset.date} ${startDataset.time || ""}`
+  );
+  const endDateTime = moment(`${endDataset.date} ${endDataset.time || ""}`);
   const duration = endDateTime.diff(startDateTime, "minutes");
 
   // negative duration is used when we calculate difference for end date from range

--- a/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js.es6
@@ -1,9 +1,15 @@
 import DateWithZoneHelper from "./date-with-zone-helper";
 import I18n from "I18n";
+import { renderIcon } from "discourse-common/lib/icon-library";
 
-const TIME_FORMAT = "LLL";
+const DATETIME_FORMAT = "LLL";
 const DATE_FORMAT = "LL";
+const FULL_DATETIME_FORMAT = "LLLL";
+const TIME_FORMAT = "h:mm A";
+const DAY_OF_THE_WEEK_FORMAT = "dddd";
 const RANGE_SEPARATOR = "→";
+const TIME_ICON = "clock";
+const SHORT_FORMAT_DAYS_PERIOD = 1;
 
 export default class LocalDateBuilder {
   constructor(params = {}, localTimezone) {
@@ -17,8 +23,9 @@ export default class LocalDateBuilder {
     this.calendar =
       typeof params.calendar === "undefined" ? true : params.calendar;
     this.displayedTimezone = params.displayedTimezone;
-    this.format = params.format || (this.time ? TIME_FORMAT : DATE_FORMAT);
+    this.format = params.format || (this.time ? DATETIME_FORMAT : DATE_FORMAT);
     this.countdown = params.countdown;
+    this.duration = params.duration;
     this.localTimezone = localTimezone;
   }
 
@@ -95,7 +102,8 @@ export default class LocalDateBuilder {
           localDate.timezone,
           this.localTimezone
         ),
-        this.time
+        this.time,
+        this.duration
       ),
     });
 
@@ -126,7 +134,8 @@ export default class LocalDateBuilder {
             localDate.timezone,
             timezone
           ),
-          this.time
+          this.time,
+          this.duration
         ),
       });
     });
@@ -148,19 +157,56 @@ export default class LocalDateBuilder {
     );
   }
 
-  _createDateTimeRange(startRange, time) {
+  _createDateTimeRange(startRange, time, duration) {
+    const [startDate, endDate] = this._calculateDatesForRange(
+      startRange,
+      time,
+      duration
+    );
+    let formatElements = [
+      startDate.format(`${DAY_OF_THE_WEEK_FORMAT}, ${DATE_FORMAT}`),
+      this._optionalTimeIcon(startDate, endDate),
+      startDate.format(TIME_FORMAT),
+    ];
+    if (endDate) {
+      formatElements = formatElements.concat([
+        RANGE_SEPARATOR,
+        endDate.format(this._endDateFormat(startDate, endDate)),
+      ]);
+    }
+    return formatElements.filter(Boolean).join(" ");
+  }
+
+  _shortFormat(startDate, endDate) {
+    return (
+      endDate.datetime.diff(startDate.datetime, "days") <
+      SHORT_FORMAT_DAYS_PERIOD
+    );
+  }
+
+  _optionalTimeIcon(startDate, endDate) {
+    if (!endDate || this._shortFormat(startDate, endDate)) {
+      return `<br />${renderIcon("string", TIME_ICON)}`;
+    }
+  }
+
+  _endDateFormat(startDate, endDate) {
+    return this._shortFormat(startDate, endDate)
+      ? TIME_FORMAT
+      : FULL_DATETIME_FORMAT;
+  }
+
+  _calculateDatesForRange(date, time, duration) {
     // if a time has been given we do not attempt to automatically create a range
     // instead we show only one date with a format showing the time
-    if (time) {
-      return startRange.format(TIME_FORMAT);
-    } else {
-      const endRange = startRange.add(24, "hours");
-      return [
-        startRange.format("LLLL"),
-        RANGE_SEPARATOR,
-        endRange.format("LLLL"),
-      ].join(" ");
+    if (time && !duration) {
+      return [date];
     }
+    const dates = [
+      date,
+      duration ? date.add(duration, "minutes") : date.add(24, "hours"),
+    ];
+    return duration < 0 ? dates.reverse() : dates;
   }
 
   _applyFormatting(localDate, displayedTimezone) {

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
@@ -448,12 +448,45 @@ test("previews", function (assert) {
 
   freezeTime({ date: "2020-03-22", timezone: PARIS }, () => {
     assert.buildsCorrectDate(
+      { duration: 90, timezone: PARIS, timezones: [PARIS] },
+      {
+        previews: [
+          {
+            current: true,
+            formated:
+              'Sunday, March 22, 2020 <br /><svg class=\'fa d-icon d-icon-clock svg-icon svg-string\' xmlns="http://www.w3.org/2000/svg"><use xlink:href="#clock" /></svg> 12:00 AM → 1:30 AM',
+            timezone: "Paris",
+          },
+        ],
+      }
+    );
+  });
+
+  freezeTime({ date: "2020-03-22", timezone: PARIS }, () => {
+    assert.buildsCorrectDate(
+      { duration: 1440, timezone: PARIS, timezones: [PARIS] },
+      {
+        previews: [
+          {
+            current: true,
+            formated:
+              "Sunday, March 22, 2020 12:00 AM → Monday, March 23, 2020 12:00 AM",
+            timezone: "Paris",
+          },
+        ],
+      }
+    );
+  });
+
+  freezeTime({ date: "2020-03-22", timezone: PARIS }, () => {
+    assert.buildsCorrectDate(
       { time: "11:34", timezone: PARIS, timezones: [PARIS] },
       {
         previews: [
           {
             current: true,
-            formated: "March 22, 2020 11:34 AM",
+            formated:
+              'Sunday, March 22, 2020 <br /><svg class=\'fa d-icon d-icon-clock svg-icon svg-string\' xmlns="http://www.w3.org/2000/svg"><use xlink:href="#clock" /></svg> 11:34 AM',
             timezone: "Paris",
           },
         ],
@@ -508,19 +541,23 @@ test("previews", function (assert) {
         previews: [
           {
             current: true,
-            formated: "April 7, 2020 2:54 PM",
+            formated:
+              'Tuesday, April 7, 2020 <br /><svg class=\'fa d-icon d-icon-clock svg-icon svg-string\' xmlns="http://www.w3.org/2000/svg"><use xlink:href="#clock" /></svg> 2:54 PM',
             timezone: "Paris",
           },
           {
-            formated: "April 7, 2020 1:54 PM",
+            formated:
+              'Tuesday, April 7, 2020 <br /><svg class=\'fa d-icon d-icon-clock svg-icon svg-string\' xmlns="http://www.w3.org/2000/svg"><use xlink:href="#clock" /></svg> 1:54 PM',
             timezone: "London",
           },
           {
-            formated: "April 7, 2020 1:54 PM",
+            formated:
+              'Tuesday, April 7, 2020 <br /><svg class=\'fa d-icon d-icon-clock svg-icon svg-string\' xmlns="http://www.w3.org/2000/svg"><use xlink:href="#clock" /></svg> 1:54 PM',
             timezone: "Lagos",
           },
           {
-            formated: "April 7, 2020 10:54 PM",
+            formated:
+              'Tuesday, April 7, 2020 <br /><svg class=\'fa d-icon d-icon-clock svg-icon svg-string\' xmlns="http://www.w3.org/2000/svg"><use xlink:href="#clock" /></svg> 10:54 PM',
             timezone: "Sydney",
           },
         ],
@@ -539,11 +576,13 @@ test("previews", function (assert) {
         previews: [
           {
             current: true,
-            formated: "May 13, 2020 11:00 AM",
+            formated:
+              'Wednesday, May 13, 2020 <br /><svg class=\'fa d-icon d-icon-clock svg-icon svg-string\' xmlns="http://www.w3.org/2000/svg"><use xlink:href="#clock" /></svg> 11:00 AM',
             timezone: "Los Angeles",
           },
           {
-            formated: "May 13, 2020 6:00 PM",
+            formated:
+              'Wednesday, May 13, 2020 <br /><svg class=\'fa d-icon d-icon-clock svg-icon svg-string\' xmlns="http://www.w3.org/2000/svg"><use xlink:href="#clock" /></svg> 6:00 PM',
             timezone: "UTC",
           },
         ],


### PR DESCRIPTION
This PR is introducing 2 changes.
1. Date popup is displayed on click instead on hover
2. If the range is given then the whole range is always displayed for both startDate and endDate
3. For range, short time is displayed for end if the range is < 24 hours

<img width="604" alt="Screen Shot 2021-09-16 at 4 26 33 pm" src="https://user-images.githubusercontent.com/72780/133561597-2872c151-78c3-453e-a09a-316fbd303c61.png">
<img width="503" alt="Screen Shot 2021-09-16 at 4 26 26 pm" src="https://user-images.githubusercontent.com/72780/133561609-c1fa3166-996c-4e60-ae9e-a79cd393618c.png">
<img width="275" alt="Screen Shot 2021-09-16 at 4 26 20 pm" src="https://user-images.githubusercontent.com/72780/133561614-42ffdf6a-87be-4b7e-be54-42df5d9327dd.png">
<img width="344" alt="Screen Shot 2021-09-16 at 4 26 15 pm" src="https://user-images.githubusercontent.com/72780/133561617-3bbfa285-3347-4348-af65-fd30e36cbb77.png">

