### PR TITLE
DEV: trash category definition topic instead of destroying.

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -25,7 +25,7 @@ class Category < ActiveRecord::Base
   register_custom_field_type(REQUIRE_REPLY_APPROVAL, :boolean)
   register_custom_field_type(NUM_AUTO_BUMP_DAILY, :integer)
 
-  belongs_to :topic, dependent: :destroy
+  belongs_to :topic
   belongs_to :topic_only_relative_url,
               -> { select "id, title, slug" },
               class_name: "Topic",
@@ -67,6 +67,7 @@ class Category < ActiveRecord::Base
   validates :slug, exclusion: { in: RESERVED_SLUGS }
 
   after_create :create_category_definition
+  after_destroy :trash_category_definition
 
   before_save :apply_permissions
   before_save :downcase_email
@@ -294,6 +295,10 @@ class Category < ActiveRecord::Base
 
       t
     end
+  end
+
+  def trash_category_definition
+    self.topic.trash!
   end
 
   def topic_url

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -298,7 +298,7 @@ class Category < ActiveRecord::Base
   end
 
   def trash_category_definition
-    self.topic.trash!
+    self.topic&.trash!
   end
 
   def topic_url

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -539,6 +539,7 @@ describe Category do
       @category.destroy
       expect(Category.exists?(id: @category_id)).to be false
       expect(Topic.exists?(id: @topic_id)).to be false
+      expect(Topic.with_deleted.exists?(id: @topic_id)).to be true
       expect(SiteSetting.shared_drafts_category).to be_blank
     end
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -538,8 +538,7 @@ describe Category do
     it 'is deleted correctly' do
       @category.destroy
       expect(Category.exists?(id: @category_id)).to be false
-      expect(Topic.exists?(id: @topic_id)).to be false
-      expect(Topic.with_deleted.exists?(id: @topic_id)).to be true
+      expect(Topic.with_deleted.where.not(deleted_at: nil).exists?(id: @topic_id)).to be true
       expect(SiteSetting.shared_drafts_category).to be_blank
     end
 


### PR DESCRIPTION
After deleting a category, we should soft-delete the category definition topic instead of hard deleting it. Else it causes issues while doing the user merge action if the source user has an orphan post that belongs to the deleted topic.
