### PR TITLE
FIX: add locales for group mention PM variants

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3638,6 +3638,30 @@ en:
 
         %{respond_instructions}
 
+    user_group_mentioned_pm:
+      title: "User Group Mentioned PM"
+      subject_template: "[%{email_prefix}] [PM] %{topic_title}"
+      text_body_template: |
+        %{header_instructions}
+
+        %{message}
+
+        %{context}
+
+        %{respond_instructions}
+
+    user_group_mentioned_pm_group:
+      title: "User Group Mentioned PM"
+      subject_template: "[%{email_prefix}] [PM] %{topic_title}"
+      text_body_template: |
+        %{header_instructions}
+
+        %{message}
+
+        %{context}
+
+        %{respond_instructions}
+
     user_posted:
       title: "User Posted"
       subject_template: "[%{email_prefix}] %{topic_title}"

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -908,6 +908,20 @@ describe UserNotifications do
     end
   end
 
+  describe "group mentioned email" do
+    include_examples "notification email building" do
+      let(:notification_type) { :group_mentioned }
+      let(:post) { Fabricate(:private_message_post) }
+      let(:user) { post.user }
+      let(:mail_type) { "group_mentioned" }
+      let(:mail_template) { "user_notifications.user_#{notification_type}_pm" }
+
+      include_examples "respect for private_email"
+      include_examples "supports reply by email"
+      include_examples "sets user locale"
+    end
+  end
+
   describe "user replied" do
     include_examples "notification email building" do
       let(:notification_type) { :replied }


### PR DESCRIPTION
The text/plain part of "group mentioned" email were missing. This commit adds locales to fix the issue.