### PR TITLE
DEV: only use the records that are auto populated by the task.

### DIFF
--- a/lib/discourse_dev/record.rb
+++ b/lib/discourse_dev/record.rb
@@ -73,8 +73,8 @@ module DiscourseDev
       self.new.populate!
     end
 
-    def self.random(model)
-      model.joins(:_custom_fields).where("#{:type}_custom_fields.name = '#{AUTO_POPULATED}'") if model.new.respond_to?(:custom_fields)
+    def self.random(model, use_existing_records: true)
+      model.joins(:_custom_fields).where("#{:type}_custom_fields.name = '#{AUTO_POPULATED}'") if !use_existing_records && model.new.respond_to?(:custom_fields)
       count = model.count
       raise "#{:type} records are not yet populated" if count == 0
 

--- a/lib/discourse_dev/user.rb
+++ b/lib/discourse_dev/user.rb
@@ -44,7 +44,7 @@ module DiscourseDev
     end
 
     def self.random
-      super(::User)
+      super(::User, use_existing_records: false)
     end
 
     def set_random_avatar(user)


### PR DESCRIPTION
Previously, it was using existing user and topic records to generate random posts.