### PR TITLE
PERF: Fix N+1 queries in SiteSerialier.

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -124,7 +124,9 @@ class Site
   end
 
   def groups
-    Group.visible_groups(@guardian.user, "name ASC", include_everyone: true)
+    Group
+      .visible_groups(@guardian.user, "name ASC", include_everyone: true)
+      .includes(:flair_upload)
   end
 
   def archetypes


### PR DESCRIPTION
`SiteSerializer#groups` loads `Group#flair_upload` for each group so
we need to eagerload this.

Follow-up to e8a9917db1731636f8659db63e925e743ae4ed11