### PR TITLE
UX: minor fast edit tweaks

### DIFF
--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -58,7 +58,9 @@
   }
   &[disabled],
   &.disabled {
-    opacity: 0.4;
+    &:not(.is-loading) {
+      opacity: 0.4;
+    }
     &:hover {
       color: $text-color;
       background: $bg-color;


### PR DESCRIPTION
- do not reduce opacity of disabled buttons if they are loading
- replace ‘|’ by single quotes not double quotes
- always start from index 0
- reduces amount of work by checking row's length
- apply quotefix to fallback
- do not add 1 to caretposition if index is 0

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
