### PR TITLE
UX: Fix date input icon display issues

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -245,11 +245,6 @@ input {
   padding-bottom: 0;
 }
 
-// Fixes Chrome height inconsistency
-::-webkit-calendar-picker-indicator {
-  height: 100%;
-}
-
 ::placeholder {
   text-overflow: ellipsis;
 }

--- a/app/assets/stylesheets/common/components/date-input.scss
+++ b/app/assets/stylesheets/common/components/date-input.scss
@@ -1,3 +1,5 @@
+$calendar-icon: '<svg xmlns="http://www.w3.org/2000/svg" width="14px" height="16px" viewBox="0 0 448 512"><path d="M400 64h-48V12c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v52H160V12c0-6.6-5.4-12-12-12h-40c-6.6 0-12 5.4-12 12v52H48C21.5 64 0 85.5 0 112v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V112c0-26.5-21.5-48-48-48zm-6 400H54c-3.3 0-6-2.7-6-6V160h352v298c0 3.3-2.7 6-6 6z"></path></svg>';
+
 .d-date-input {
   display: inline-flex;
   cursor: pointer;
@@ -10,20 +12,13 @@
     margin: 0;
     text-align: left;
     width: 100%;
-    box-shadow: none !important;
+    box-shadow: none;
+    position: relative;
 
-    &::-webkit-input-placeholder {
-      font-size: $font-0;
-      color: var(--primary-medium);
-    }
-
-    &::-ms-input-placeholder {
-      font-size: $font-0;
-      color: var(--primary-medium);
-    }
-
+    &::-webkit-input-placeholder,
+    &::-ms-input-placeholder,
     &::placeholder {
-      font-size: $font-0;
+      font-size: var(--font-0);
       color: var(--primary-medium);
     }
 
@@ -32,12 +27,42 @@
     }
 
     // iOS doesn't display the placeholder attribute for date inputs
-    .ios-device &:after {
+    html.ios-device &:after {
       font-size: var(--font-0);
       color: var(--primary-medium);
       content: attr(placeholder);
     }
+
+    // use custom icon and fix issues across browsers
+    // - Safari does not use an icon
+    // - default Chrome/IE icon too tall, makes input height inconsistent
+    // - default Chrome/IE icon are black on dark themes
+    // - allows themes to style as needed
+    // Note that this does nothing in Firefox
+    html:not(.ios-device) & {
+      &::after {
+        content: "";
+        -webkit-mask: svg-uri($calendar-icon) no-repeat 50% 50%;
+        mask: svg-uri($calendar-icon) no-repeat 50% 50%;
+        position: absolute;
+        right: 4px;
+        top: 0px;
+        box-sizing: border-box;
+        background-color: var(--primary);
+        height: 100%;
+        width: 20px;
+        z-index: 1;
+      }
+      &::-webkit-calendar-picker-indicator {
+        background: transparent;
+        position: absolute;
+        cursor: pointer;
+        right: 0px;
+        z-index: 2;
+      }
+    }
   }
+
   .pika-single {
     margin-left: -1px;
     margin-top: 1px;


### PR DESCRIPTION
Fixes a regression where icon was missing in Chrome but also refactors icon display to: 

- show it in Safari
- display the same icon across browsers
- use the theme's color scheme (fixes icon display in dark mode themes especially)

Sadly this doesn't apply to Firefox at all (no change for Firefox). 

Before (Chrome on macOS)

<img width="194" alt="image" src="https://user-images.githubusercontent.com/368961/133793960-4b50e52e-8098-4057-a705-b6c2f413fecf.png"> <img width="227" alt="image" src="https://user-images.githubusercontent.com/368961/133793943-83fe57bc-9f2f-463f-b8bb-7ca005d19604.png">

After (also Chrome on macOS)

<img width="194" alt="image" src="https://user-images.githubusercontent.com/368961/133794026-f60d0843-62e6-4e4d-b85e-5c141285782a.png"> <img width="184" alt="image" src="https://user-images.githubusercontent.com/368961/133794038-5b0b33bf-d3c7-4ab0-ab68-13e0560b96bb.png">

Before (Safari desktop)

<img width="174" alt="image" src="https://user-images.githubusercontent.com/368961/133794386-e747c6b8-71f9-42a0-806b-be0ff55b65a3.png">

After (Safari desktop)

<img width="182" alt="image" src="https://user-images.githubusercontent.com/368961/133794423-461d6e0b-4687-4f4b-bb7d-35667c248f24.png">

Before (IE 93 Windows 10)

<img width="212" alt="image" src="https://user-images.githubusercontent.com/368961/133794621-ef66d6e3-a7d8-4470-b503-e9943ecea769.png">

After (IE 93 Windows 10)

<img width="197" alt="image" src="https://user-images.githubusercontent.com/368961/133794688-c72a09cf-d5df-446d-8200-cc12a44aea3a.png">
