### PR TITLE
FIX: empty state message on the group messages pages

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-private-messages-group-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-private-messages-group-route.js
@@ -1,5 +1,5 @@
-import I18n from "I18n";
 import createPMRoute from "discourse/routes/build-private-messages-route";
+import I18n from "I18n";
 import { findOrResetCachedTopicList } from "discourse/lib/cached-topic-list";
 
 export default (inboxType, filter) => {
@@ -35,7 +35,16 @@ export default (inboxType, filter) => {
 
       return lastTopicList
         ? lastTopicList
-        : this.store.findFiltered("topicList", { filter: topicListFilter });
+        : this.store
+            .findFiltered("topicList", { filter: topicListFilter })
+            .then((topicList) => {
+              // andrei: we agreed that this is an anti pattern,
+              // it's better to avoid mutating a rest model like this
+              // this place we'll be refactored later
+              // see https://github.com/discourse/discourse/pull/14313#discussion_r708784704
+              topicList.set("emptyState", this.emptyState());
+              return topicList;
+            });
     },
 
     afterModel(model) {
@@ -67,6 +76,13 @@ export default (inboxType, filter) => {
       );
 
       this.controllerFor("user-private-messages").set("group", this.group);
+    },
+
+    emptyState() {
+      return {
+        title: I18n.t("user.no_messages_title"),
+        body: "",
+      };
     },
 
     dismissReadOptions() {


### PR DESCRIPTION
After my recent changes, we start showing blank pages when there are no group messages, for example:

<img width="550" alt="Screenshot 2021-09-17 at 17 07 43" src="https://user-images.githubusercontent.com/1274517/133822762-344480e4-3118-4174-af27-1eeacdd7ec4c.png">

This PR fixes this. Note that before we were showing this when there are no messages:

<img width="550" alt="Screenshot 2021-09-17 at 17 07 47" src="https://user-images.githubusercontent.com/1274517/133822481-413cff4b-dc55-4fe7-aba5-c7a5cc183c65.png">

Now we'll be showing this, the copy will be expanded and improved later:

<img width="550" alt="Screenshot 2021-09-17 at 18 29 26" src="https://user-images.githubusercontent.com/1274517/133822543-3b066d95-c7d5-49ba-aa83-0cf6ea4ea51f.png">


