### PR TITLE
DEV: Add chat to notifications to test notification-types

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/concerns/notification-types.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/concerns/notification-types.js
@@ -31,4 +31,6 @@ export const NOTIFICATION_TYPES = {
   votes_released: 26,
   event_reminder: 27,
   event_invitation: 28,
+  chat_mention: 29,
+  chat_message: 30,
 };


### PR DESCRIPTION
These are needed for testing these notification types in the chat plugin.