### PR TITLE
UX: Improve composer button bar on mobile

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -49,60 +49,6 @@
   flex-direction: column;
 }
 
-.d-editor-button-bar {
-  display: flex;
-  align-items: center;
-  border-bottom: 1px solid var(--primary-low);
-  padding: 2px;
-
-  .btn:focus {
-    border-radius: 0;
-    @include default-focus;
-  }
-
-  .btn,
-  .btn-default {
-    background-color: transparent;
-    display: inline-block;
-    color: var(--primary-medium);
-    height: 34px;
-    box-sizing: border-box;
-
-    .d-icon {
-      color: currentColor;
-    }
-    &:hover {
-      color: var(--primary-low);
-    }
-
-    svg {
-      -webkit-transform: translate3d(
-        0,
-        0,
-        0
-      ); // Hack: Reduces composer icon jitter while scrolling in Safari on iOS12
-    }
-  }
-
-  .d-editor-spacer {
-    height: 1em;
-    display: inline-block;
-    border-left: 1px solid var(--primary-low-mid);
-  }
-
-  .btn:not(.no-text) {
-    font-size: $font-up-1;
-  }
-
-  .btn.bold {
-    font-weight: bolder;
-  }
-
-  .btn.italic {
-    font-style: italic;
-  }
-}
-
 .d-editor-preview-wrapper {
   overflow: auto;
   cursor: default;
@@ -269,90 +215,55 @@
   opacity: 1;
 }
 
-// d-editor bar button sizing for all editors - this is kept separate to keep
-// everything in one place
+// d-editor bar button sizing
 .d-editor-button-bar {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--primary-low);
+  width: 100%;
   box-sizing: border-box;
-
-  // shared styles for all font sizes
-  .btn,
-  .btn-default {
-    padding: 0.5em;
-    margin: 0;
-  }
+  padding-left: 2px;
+  padding-right: 2px;
 
   .d-editor-spacer {
+    height: 1em;
+    display: inline-block;
+    border-left: 1px solid var(--primary-low-mid);
     margin: 0 0.25em;
   }
 
-  // small text size
-  .text-size-smaller & {
-    @include breakpoint(mobile-large) {
-      .btn,
-      .btn-default {
-        padding: 0 0.4em;
-      }
+  .btn:focus {
+    @include default-focus;
+  }
+
+  .btn {
+    margin: 0;
+    background-color: transparent;
+    color: var(--primary-medium);
+
+    .d-icon {
+      color: currentColor;
     }
-    @include breakpoint(mobile-medium) {
-      .btn,
-      .btn-default {
-        padding: 0 0.3em;
-      }
-      .d-editor-spacer {
-        margin: 0 0.25em;
-      }
+    &:hover {
+      color: var(--primary-low);
     }
   }
 
-  // normal text size
-  .text-size-normal & {
-    @include breakpoint(mobile-large) {
-      .btn,
-      .btn-default {
-        padding: 0 0.35em;
-      }
-    }
-    @include breakpoint(mobile-medium) {
-      .btn,
-      .btn-default {
-        padding: 0 0.25em;
-      }
-    }
-  }
-
-  // larger text size
-  .text-size-larger & {
-    @include breakpoint(mobile-large) {
-      .btn,
-      .btn-default {
-        padding: 0 0.3em;
-      }
-    }
-    @include breakpoint(mobile-medium) {
-      .btn,
-      .btn-default {
-        padding: 0 0.2em;
-      }
-    }
-  }
-
-  // largest text size
-  .text-size-largest & {
-    .btn,
-    .btn-default {
-      font-size: $font-down-1;
+  // ensures items grow/shrink on mobile to fit available space
+  @include breakpoint(mobile-large) {
+    .btn {
+      flex-grow: 1;
+      flex-shrink: 1;
+      flex-basis: auto;
+      padding-left: 0.25em;
+      padding-right: 0.25em;
     }
 
-    @include breakpoint(mobile-large) {
-      .btn,
-      .btn-default {
-        padding: 0 0.3em;
-      }
-    }
-    @include breakpoint(mobile-medium) {
-      .btn,
-      .btn-default {
-        padding: 0 0.2em;
+    .select-kit.toolbar-popup-menu-options {
+      flex-grow: 1;
+      flex-basis: auto;
+      .select-kit-header .select-kit-header-wrapper {
+        justify-content: center;
       }
     }
   }

--- a/app/assets/stylesheets/common/select-kit/toolbar-popup-menu-options.scss
+++ b/app/assets/stylesheets/common/select-kit/toolbar-popup-menu-options.scss
@@ -7,27 +7,6 @@
         border-radius: 0;
       }
 
-      .select-kit-header {
-        width: 30px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-
-        &:focus {
-          border-color: var(--tertiary);
-        }
-
-        .d-icon {
-          color: var(--primary-medium);
-        }
-
-        &:hover {
-          .d-icon {
-            color: var(--primary-low);
-          }
-        }
-      }
-
       .select-kit-row {
         padding: 0.75em 0.5em;
         border-bottom: 1px solid rgba(var(--primary-low-rgb), 0.5);


### PR DESCRIPTION
This aims to fix issues on mobile where the buttons in the composer overflow the allotted space. 

Example of the problem: 

<img width="271" alt="image" src="https://user-images.githubusercontent.com/368961/133832703-9952327a-84fb-4c59-b848-3ba78651adc2.png">

This is a tricky issue. Buttons on mobile shouldn't be below a certain size (they're already too small per most guidelines). We also can't easily make this section scrollable horizontally, because the last item (cog icon) is a dropdown so we can't use `overflow: hidden`. In any case, scrolling such a small element horizontally would be awkward. 

The proposed solution is to let flexbox do its magic. Each button's horizontal padding has been reduced and each button is allowed to expand via `flex-grow: 1`. In all scenarios, the buttons will fill the full width of the button bar. 

Screenshots

Default
<img width="464" alt="image" src="https://user-images.githubusercontent.com/368961/133833528-8f98afa6-c334-434a-8ce8-13c05abf9bda.png">

With two extra icons (text direction support and a video component)
<img width="465" alt="image" src="https://user-images.githubusercontent.com/368961/133833440-73e5179e-079f-4847-9a52-8e641185b0c5.png">

iPhone 8 with the extra icons (crowded, but usable)
<img width="422" alt="image" src="https://user-images.githubusercontent.com/368961/133833813-1f42f775-f873-4241-9f87-020f42c807e3.png">
