### PR TITLE
UX: fix profile button spacing

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -216,10 +216,6 @@
         list-style-type: none;
         margin-top: 0;
       }
-
-      .btn {
-        margin-bottom: 10px;
-      }
     }
 
     &.collapsed-info {

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -217,6 +217,10 @@ table.user-invite-list {
       float: right;
       max-width: 13.5em;
 
+      li {
+        margin-bottom: 0.5em;
+      }
+
       li > .select-kit-header, // select-kit
       .btn {
         min-width: 9.5em;


### PR DESCRIPTION
This regressed due to select-kit changes I think


Before:
![Screen Shot 2021-09-17 at 5 09 40 PM](https://user-images.githubusercontent.com/1681963/133853972-2b50693e-0e2f-43a4-80df-62c842376cfe.png)

After:
![Screen Shot 2021-09-17 at 5 09 27 PM](https://user-images.githubusercontent.com/1681963/133853981-ae5e1c63-3c91-436e-9652-88086960cbba.png)

