### PR TITLE
UX: Share button margin consistency

### DIFF
--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -3,6 +3,7 @@
 .link-share-container {
   display: flex;
   button {
+    margin-left: 0.5em;
     transition-property: background-color, color; // don't transition outline
   }
   input {

--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -70,7 +70,6 @@
 
   input[type="text"] {
     width: 100%;
-    margin-right: 0.5em;
   }
 
   .title {


### PR DESCRIPTION
Making the space consistent with this one:

![Screen Shot 2021-09-17 at 5 15 00 PM](https://user-images.githubusercontent.com/1681963/133854421-a6d1158f-a5a6-469b-878d-9d6f1d55f62e.png)


Before: 

![Screen Shot 2021-09-17 at 5 16 03 PM](https://user-images.githubusercontent.com/1681963/133854483-f94f9ac2-a2f9-4999-a00c-2d1856762678.png)

After:

![Screen Shot 2021-09-17 at 5 13 51 PM](https://user-images.githubusercontent.com/1681963/133854439-ea7347fe-4aff-4c75-8d70-8646780207d1.png)
