### PR TITLE
REFACTOR: move composer min-height to CSS

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -15,7 +15,6 @@ const START_EVENTS = "touchstart mousedown";
 const DRAG_EVENTS = "touchmove mousemove";
 const END_EVENTS = "touchend mouseup";
 
-const MIN_COMPOSER_SIZE = 255;
 const THROTTLE_RATE = 20;
 
 function mouseYPos(e) {
@@ -121,7 +120,6 @@ export default Component.extend(KeyEnterEscape, {
 
       const winHeight = $(window).height();
       size = Math.min(size, winHeight - headerHeight());
-      size = Math.max(size, MIN_COMPOSER_SIZE);
       this.movePanels(size);
       $composer.height(size);
     };

--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -15,7 +15,7 @@ const START_EVENTS = "touchstart mousedown";
 const DRAG_EVENTS = "touchmove mousemove";
 const END_EVENTS = "touchend mouseup";
 
-const MIN_COMPOSER_SIZE = 240;
+const MIN_COMPOSER_SIZE = 255;
 const THROTTLE_RATE = 20;
 
 function mouseYPos(e) {

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -515,6 +515,12 @@ body.ios-safari-composer-hacks {
 
 body:not(.ios-safari-composer-hacks) {
   #reply-control.open {
+    --min-height: 255px;
+    min-height: var(--min-height);
+    &.composer-action-reply {
+      // we can let the reply composer get a little shorter
+      min-height: calc(var(--min-height) - 4em);
+    }
     padding-bottom: var(--composer-ipad-padding);
   }
 }


### PR DESCRIPTION
The composer content is a little taller than it used to be, so it overflows sometimes:

![Screen Shot 2021-09-17 at 8 54 39 PM](https://user-images.githubusercontent.com/1681963/133866711-3a65cc75-3fdd-4a88-83b5-4d226584dbf1.png)

This lead me to wonder why we set the min-height in JS at all... some themes might have different sized composers, so it would be nice if this could be in CSS instead (I also added some height to the min to avoid the overflow).