### PR TITLE
DEV: Automatically handle macOS readlink issues

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -72,13 +72,20 @@ echo "Using data in:   ${DATA_DIR}"
 
 mkdir -p "${DATA_DIR}"
 
+# `readlink -f` doesn't work on macOS
+READLINK="readlink -f"
+{
+    $READLINK ${DATA_DIR}
+} || {
+    READLINK=/tmp/readlink.py
+    echo -e "#!/usr/bin/env python\nimport os,sys;print(os.path.realpath(sys.argv[1]))" > $READLINK
+    chmod +x $READLINK
+    $READLINK ${DATA_DIR}
+}
+
 mount_plugin_symlinks=""
 for symlink in $(find $PLUGINS_DIR -maxdepth 1 -type l); do
-    # `readlink -f` doesn't work on macOS, to fix it you need to override the `readlink` with `greadlink`
-    # > brew install coreutils
-    # > ln -s "$(which greadlink)" "$(dirname "$(which greadlink)")/readlink"
-    # reference: https://meta.discourse.org/t/beginners-guide-to-install-discourse-for-development-using-docker/102009/124?u=aleber
-    symlink_value=$(readlink -f $symlink)
+    symlink_value=$($READLINK $symlink)
     plugin_name=$(basename $symlink)
     mount_plugin_symlinks+=" -v ${symlink_value}:/src/plugins/${plugin_name}:delegated"
 done


### PR DESCRIPTION
The Docker `boot_dev` script has a bug on macOS when using plugins: it attempts to invoke `readlink -f`, which works fine with GNU `readlink` but doesn't work with macOS `readlink`. (I reproduce the issue on macOS Big Sur 11.6, which is latest as of today.)

The script on `master` includes a comment documenting how to work around the issue manually, using Homebrew to install `coreutils`, which installs a GNU version of `readlink` as `greadlink`. The comment then recommends symlinking `readlink` to `greadlink` so bare calls to `readlink` will use the GNU version instead of the macOS default version.

That's a pretty weird thing to do to a machine just to satisfy this one script, and, anyway, it's a bummer that the script fails and that the end user has to manually follow directions in a comment to fix it.

In this PR, I attempt to `readlink -f` the directory that we just created; if that fails, we create a one-liner Python script that does the same thing as `readlink -f`, and we use that, instead.

I got the one-liner from https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac … there are other implementations there, including a few pure-bash implementations, but they're kinda verbose; various replies warn that there are a lot of weird corner cases. The Python one-liner seems like the easiest way to handle it.

(This infrastructure script has no tests, and I didn't add any.)