### PR TITLE
FIX: Handle forwarded email quotes around Reply-To display name

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -637,11 +637,7 @@ module Email
 
         comparison_failed = false
         comparison_headers.each do |comparison_header|
-          comparison_address = address_field.address
-          comparison_display_name = address_field.display_name&.to_s
-
-          if comparison_address != from_address ||
-              comparison_display_name != from_display_name
+          if mail_object[comparison_header].to_s != "#{from_display_name} <#{from_address}>"
             comparison_failed = true
           end
         end

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -639,6 +639,7 @@ module Email
         comparison_headers.each do |comparison_header|
           if mail_object[comparison_header].to_s != "#{from_display_name} <#{from_address}>"
             comparison_failed = true
+            break
           end
         end
 

--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -637,7 +637,13 @@ module Email
 
         comparison_failed = false
         comparison_headers.each do |comparison_header|
-          comparison_failed = true if address_field.to_s != mail_object[comparison_header].to_s
+          comparison_address = address_field.address
+          comparison_display_name = address_field.display_name&.to_s
+
+          if comparison_address != from_address ||
+              comparison_display_name != from_display_name
+            comparison_failed = true
+          end
         end
 
         next if comparison_failed

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -872,7 +872,7 @@ describe Email::Receiver do
     describe "reply-to header" do
       it "handles emails where there is a Reply-To address, using that instead of the from address, if X-Original-From is present" do
         SiteSetting.block_auto_generated_emails = false
-        expect { process(:reply_to_different_to_from) }.to change(Topic, :count)
+        expect { process(:reply_to_different_to_from) }.to change(Topic, :count).by(1)
         user = User.last
         incoming = IncomingEmail.find_by(message_id: "3848c3m98r439c348mc349@test.mailinglist.com")
         topic = incoming.topic
@@ -882,7 +882,7 @@ describe Email::Receiver do
 
       it "allows for quotes around the display name of the Reply-To address" do
         SiteSetting.block_auto_generated_emails = false
-        expect { process(:reply_to_different_to_from_quoted_display_name) }.to change(Topic, :count)
+        expect { process(:reply_to_different_to_from_quoted_display_name) }.to change(Topic, :count).by(1)
         user = User.last
         incoming = IncomingEmail.find_by(message_id: "3848c3m98r439c348mc349@test.mailinglist.com")
         topic = incoming.topic
@@ -892,7 +892,7 @@ describe Email::Receiver do
 
       it "does not use the reply-to address if an X-Original-From header is not present" do
         SiteSetting.block_auto_generated_emails = false
-        expect { process(:reply_to_different_to_from_no_x_original) }.to change(Topic, :count)
+        expect { process(:reply_to_different_to_from_no_x_original) }.to change(Topic, :count).by(1)
         user = User.last
         incoming = IncomingEmail.find_by(message_id: "3848c3m98r439c348mc349@test.mailinglist.com")
         topic = incoming.topic
@@ -902,7 +902,7 @@ describe Email::Receiver do
 
       it "does not use the reply-to address if the X-Original-From header is different from the reply-to address" do
         SiteSetting.block_auto_generated_emails = false
-        expect { process(:reply_to_different_to_from_x_original_different) }.to change(Topic, :count)
+        expect { process(:reply_to_different_to_from_x_original_different) }.to change(Topic, :count).by(1)
         user = User.last
         incoming = IncomingEmail.find_by(message_id: "3848c3m98r439c348mc349@test.mailinglist.com")
         topic = incoming.topic

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -870,7 +870,7 @@ describe Email::Receiver do
     end
 
     describe "reply-to header" do
-      it "handles emails where there is a reply-to address, using that instead of the from address" do
+      it "handles emails where there is a Reply-To address, using that instead of the from address, if X-Original-From is present" do
         SiteSetting.block_auto_generated_emails = false
         expect { process(:reply_to_different_to_from) }.to change(Topic, :count)
         user = User.last
@@ -878,6 +878,16 @@ describe Email::Receiver do
         topic = incoming.topic
         expect(incoming.from_address).to eq("arthurmorgan@reddeadtest.com")
         expect(user.email).to eq("arthurmorgan@reddeadtest.com")
+      end
+
+      it "allows for quotes around the display name of the Reply-To address" do
+        SiteSetting.block_auto_generated_emails = false
+        expect { process(:reply_to_different_to_from_quoted_display_name) }.to change(Topic, :count)
+        user = User.last
+        incoming = IncomingEmail.find_by(message_id: "3848c3m98r439c348mc349@test.mailinglist.com")
+        topic = incoming.topic
+        expect(incoming.from_address).to eq("johnmarston@reddeadtest.com")
+        expect(user.email).to eq("johnmarston@reddeadtest.com")
       end
 
       it "does not use the reply-to address if an X-Original-From header is not present" do

--- a/spec/fixtures/emails/reply_to_different_to_from_quoted_display_name.eml
+++ b/spec/fixtures/emails/reply_to_different_to_from_quoted_display_name.eml
@@ -1,5 +1,5 @@
-From: 'John Marston' via Western Support <westernsupport@test.mailinglist.com>
-Reply-To: =?iso-8859-1?Q?Marsden=2C_John?= <johnmarston@reddeadtest.com>
+From: 'Marston, John' via Western Support <westernsupport@test.mailinglist.com>
+Reply-To: =?iso-8859-1?Q?Marston=2C_John?= <johnmarston@reddeadtest.com>
 To: team@bar.com
 Subject: I need some support
 Date: Fri, 15 Jan 2016 00:12:43 +0100
@@ -7,7 +7,7 @@ Message-ID: <3848c3m98r439c348mc349@test.mailinglist.com>
 Mime-Version: 1.0
 Content-Type: text/plain
 Content-Transfer-Encoding: 7bit
-X-Original-From: John Marston <johnmarston@reddeadtest.com>
+X-Original-From: Marston, John <johnmarston@reddeadtest.com>
 Precedence: list
 Mailing-list: list westernsupport@test.mailinglist.com; contact
  westernsupport+owners@test.mailinglist.com

--- a/spec/fixtures/emails/reply_to_different_to_from_quoted_display_name.eml
+++ b/spec/fixtures/emails/reply_to_different_to_from_quoted_display_name.eml
@@ -1,0 +1,16 @@
+From: 'John Marston' via Western Support <westernsupport@test.mailinglist.com>
+Reply-To: =?iso-8859-1?Q?Marsden=2C_John?= <johnmarston@reddeadtest.com>
+To: team@bar.com
+Subject: I need some support
+Date: Fri, 15 Jan 2016 00:12:43 +0100
+Message-ID: <3848c3m98r439c348mc349@test.mailinglist.com>
+Mime-Version: 1.0
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+X-Original-From: John Marston <johnmarston@reddeadtest.com>
+Precedence: list
+Mailing-list: list westernsupport@test.mailinglist.com; contact
+ westernsupport+owners@test.mailinglist.com
+List-ID: <westernsupport@test.mailinglist.com>
+
+Ain't no trouble.


### PR DESCRIPTION
The display name can have quotes around it, which does not work
with our current comparison of a from field (in this case Reply-To)
and another header (X-Original-From), because we are not comparing
the two values in the same way. This causes an issue where the
commit here: b88d8c889432a6eb4900f92ee00a66190624e5bd will not
work properly; the forwarded email gets the From address instead
of the Reply-To address as intended.
