### PR TITLE
FIX: return empty array when no parent for range

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -63,6 +63,9 @@ function buildOptionsFromElement(element, siteSettings) {
 }
 
 function _rangeElements(element) {
+  if (!element.parentElement) {
+    return [];
+  }
   return Array.from(element.parentElement.children).filter(
     (span) => span.dataset.date
   );


### PR DESCRIPTION
If parent element for range does not exists, range calculator should
return empty array. In that case duration calculations will stop because
of:

```
if (_rangeElements(element).length === 2) {
  opts.duration = _calculateDuration(element);
}
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
