### PR TITLE
A11Y: Use listbox role for dropdowns

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
@@ -18,7 +18,7 @@ export default Component.extend(UtilsMixin, {
 
   selectKit: null,
 
-  role: "application",
+  role: "listbox",
 
   ariaLevel: 1,
 

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/single-select-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/single-select-header.js
@@ -8,7 +8,7 @@ export default SelectKitHeaderComponent.extend(UtilsMixin, {
   tagName: "summary",
   layout,
   classNames: ["single-select-header"],
-  attributeBindings: ["name"],
+  attributeBindings: ["name", "name:aria-label"],
 
   focusIn(event) {
     event.stopImmediatePropagation();


### PR DESCRIPTION
@jjaffeux I believe the `listbox` role is more appropriate for SK dropdowns, but maybe there is a different reason why we use role `application` here? 

This change was inspired by some testing with VoiceOver on macOS. When using the rotor (VO modifier + U), I see this (focus on the first two items in the list, please): 

<img width="699" alt="image" src="https://user-images.githubusercontent.com/368961/134048542-e7427da4-2d23-4b0a-8aef-ec944769a9cc.png">

With the changes in this PR, I would see this: 

<img width="605" alt="image" src="https://user-images.githubusercontent.com/368961/134048619-512e8629-a014-4dc5-8007-74b634db704b.png">
