### PR TITLE
DEV: Reuse can_invite_to_forum? in can_invite_to?

### DIFF
--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -566,6 +566,7 @@ describe Guardian do
       end
 
       it 'returns true for a group owner' do
+        group_owner.update!(trust_level: SiteSetting.min_trust_level_to_allow_invite)
         expect(Guardian.new(group_owner).can_invite_to?(group_private_topic)).to be_truthy
       end
 
@@ -595,6 +596,7 @@ describe Guardian do
         end
 
         it 'should return true for a group owner' do
+          group_owner.update!(trust_level: SiteSetting.min_trust_level_to_allow_invite)
           expect(Guardian.new(group_owner).can_invite_to?(topic)).to eq(true)
         end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -7,7 +7,7 @@ describe Topic do
   let(:now) { Time.zone.local(2013, 11, 20, 8, 0) }
   fab!(:user) { Fabricate(:user) }
   fab!(:another_user) { Fabricate(:user) }
-  fab!(:trust_level_2) { Fabricate(:user, trust_level: TrustLevel[2]) }
+  fab!(:trust_level_2) { Fabricate(:user, trust_level: SiteSetting.min_trust_level_to_allow_invite) }
 
   context 'validations' do
     let(:topic) { Fabricate.build(:topic) }
@@ -899,7 +899,7 @@ describe Topic do
         end
 
         describe 'when user can invite via email' do
-          before { user.update!(trust_level: TrustLevel[2]) }
+          before { user.update!(trust_level: SiteSetting.min_trust_level_to_allow_invite) }
 
           it 'should create an invite' do
             Jobs.run_immediately!

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3868,7 +3868,7 @@ RSpec.describe TopicsController do
         fab!(:topic) { Fabricate(:topic, user: user) }
 
         it 'should return the right response' do
-          user.update!(trust_level: TrustLevel[2])
+          user.update!(trust_level: SiteSetting.min_trust_level_to_allow_invite)
 
           expect do
             post "/t/#{topic.id}/invite.json", params: {
@@ -3890,6 +3890,10 @@ RSpec.describe TopicsController do
         end
 
         let!(:recipient) { 'jake@adventuretime.ooo' }
+
+        before do
+          user.update!(trust_level: SiteSetting.min_trust_level_to_allow_invite)
+        end
 
         it "should attach group to the invite" do
           post "/t/#{group_private_topic.id}/invite.json", params: {


### PR DESCRIPTION
This commit resolves refactors can_invite_to? to use
can_invite_to_forum? for checking the site-wide permissions and then
perform topic specific checkups.

can_invite_to_forum? was never used with a parameter, so it was removed.

Similarly, can_invite_to? is always used with a topic object and this is
now enforced.

There was another problem before when `must_approve_users` site setting
was not checked when inviting users to forum, but was checked when
inviting to a topic.

Another minor security issue was that group owners could invite to
group topics even if they did not have the minimum trust level to do
it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
