### PR TITLE
FEATURE: add update banner to the categories and latest topics view

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
@@ -42,5 +42,13 @@ export default DiscoveryController.extend({
     refresh() {
       this.send("triggerRefresh");
     },
+    showInserted() {
+      const tracker = this.topicTrackingState;
+
+      // Move inserted into topics
+      this.model.loadBefore(tracker.get("newIncoming"), true);
+      tracker.resetTracking();
+      return false;
+    },
   },
 });

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -236,7 +236,10 @@ const TopicTrackingState = EmberObject.extend({
 
     // always add incoming if looking at the latest list and a latest channel
     // message comes through
-    if (filter === "latest" && data.message_type === "latest") {
+    if (
+      (filter === "latest" || filter === "categories") &&
+      data.message_type === "latest"
+    ) {
       this._addIncoming(data.topic_id);
     }
 

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
@@ -1,6 +1,14 @@
 {{plugin-outlet name="above-discovery-categories" tagName="" args=(hash categories=model.categories categoryPageStyle=categoryPageStyle topics=model.topics)}}
 
 {{#discovery-categories refresh=(action "refresh")}}
+  {{#if topicTrackingState.hasIncoming}}
+    <div class="show-more {{if hasTopics "has-topics"}}">
+      <div role="button" class="alert alert-info clickable" {{action "showInserted"}}>
+        {{count-i18n key="topic_count_" suffix=topicTrackingState.filter count=topicTrackingState.incomingCount}}
+      </div>
+    </div>
+  {{/if}}
+
   {{component categoryPageStyle
               categories=model.categories
               topics=model.topics}}

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -499,6 +499,26 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         );
       });
 
+      test("adds incoming in the categories latest topics list", function (assert) {
+        trackingState.trackIncoming("categories");
+        const unreadCategoriesLatestTopicsPayload = {
+          ...unreadTopicPayload,
+          message_type: "latest",
+        };
+
+        publishToMessageBus(`/latest`, unreadCategoriesLatestTopicsPayload);
+        assert.deepEqual(
+          trackingState.newIncoming,
+          [111],
+          "unread topic is incoming"
+        );
+        assert.equal(
+          trackingState.incomingCount,
+          1,
+          "incoming count is increased"
+        );
+      });
+
       test("dismisses new topic", function (assert) {
         trackingState.loadStates([
           {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -349,6 +349,10 @@ en:
         yes_value: "Discard"
         no_value: "Resume editing"
 
+    topic_count_categories:
+      one: "See %{count} new or updated topic"
+      other: "See %{count} new or updated topics"
+
     topic_count_latest:
       one: "See %{count} new or updated topic"
       other: "See %{count} new or updated topics"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3180866/134200728-8d65c340-887c-4d90-b8c8-e7fc58725c2f.png)

Note: the image says `post` and not `topic` because of an AGC translation override. This shouldn't affect core.