### PR TITLE
UX: Add second Search button on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -411,8 +411,8 @@ export default Controller.extend({
       this.selected.clear();
     },
 
-    search(collapseFilters = false) {
-      if (collapseFilters) {
+    search(options = {}) {
+      if (options.collapseFilters) {
         document
           .querySelector("details.advanced-filters")
           ?.removeAttribute("open");

--- a/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
@@ -220,4 +220,17 @@
       </div>
     </div>
   </details>
+
+  {{#if site.mobileView}}
+    <div class="second-search-button">
+      {{d-button
+        action=search
+        icon="search"
+        label="search.search_button"
+        class="btn-primary search-cta"
+        ariaLabel="search.search_button"
+        disabled=searchButtonDisabled
+      }}
+    </div>
+  {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -50,6 +50,8 @@
         {{search-advanced-options
           searchTerm=(readonly searchTerm)
           onChangeSearchTerm=(action (mut searchTerm))
+          search=(action "search" true)
+          searchButtonDisabled=searchButtonDisabled
           expandFilters=expandFilters
         }}
       </div>

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -16,7 +16,7 @@
         value=searchTerm
         class="full-page-search search no-blur search-query"
         aria-label=(i18n "search.search_term_label")
-        enter=(action "search" true)
+        enter=(action "search" (hash collapseFilters=true))
         hasAutofocus=hasAutofocus
         aria-controls="search-result-count"
       }}
@@ -28,7 +28,7 @@
         onChange=(action (mut search_type))
       }}
       {{d-button
-        action=(action "search" true)
+        action=(action "search" (hash collapseFilters=true))
         icon="search"
         label="search.search_button"
         class="btn-primary search-cta"
@@ -50,7 +50,7 @@
         {{search-advanced-options
           searchTerm=(readonly searchTerm)
           onChangeSearchTerm=(action (mut searchTerm))
-          search=(action "search" true)
+          search=(action "search" (hash collapseFilters=true))
           searchButtonDisabled=searchButtonDisabled
           expandFilters=expandFilters
         }}

--- a/app/assets/stylesheets/mobile/search.scss
+++ b/app/assets/stylesheets/mobile/search.scss
@@ -3,4 +3,12 @@
     padding-left: 0;
     padding-right: 0;
   }
+
+  .second-search-button {
+    margin-top: 1em;
+    display: flex;
+    .btn {
+      width: 100%;
+    }
+  }
 }


### PR DESCRIPTION
On mobile, when the advanced options are expanded in the full page search UI, it's useful to have a second button so users don't have to scroll back up. 

<img width="300" alt="image" src="https://user-images.githubusercontent.com/368961/134198908-56984faf-50ec-4ba1-a681-c9e982c9879a.png">
