### PR TITLE
DEV: Allow Ember CLI for `rake qunit:test` and `rake plugin:qunit`

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -1,4 +1,4 @@
-name: (experimental) Ember CLI tests
+name: (experimental) Ember CLI tests (core)
 
 on:
   pull_request:

--- a/.github/workflows/ember_with_plugins.yml
+++ b/.github/workflows/ember_with_plugins.yml
@@ -1,4 +1,4 @@
-name: (experimental) Ember CLI tests with official plugins
+name: (experimental) Ember CLI tests (plugins)
 
 on:
   schedule:
@@ -43,7 +43,7 @@ jobs:
           bundle clean
           bundle exec rake plugin:install_all_official
 
-      - name: Core QUnit
+      - name: QUnit
         working-directory: ./app/assets/javascripts/discourse
-        run: sudo -E -u discourse -H rake qunit:test LOAD_PLUGINS=1
+        run: QUNIT_EMBER_CLI=1 sudo -E -u discourse -H rake plugin:qunit
         timeout-minutes: 60

--- a/bin/unicorn
+++ b/bin/unicorn
@@ -42,7 +42,7 @@ end
 # in development do some fussing around, to automate config
 if !ARGV.include?("-E") &&
     !ARGV.include?("--env") &&
-    (ENV["RAILS_ENV"] == "development" || !ENV["RAILS_ENV"])
+    (["development", "test"].include?(ENV["RAILS_ENV"]) || !ENV["RAILS_ENV"])
 
   dev_mode = true
 


### PR DESCRIPTION
To use Ember CLI, set QUNIT_EMBER_CLI=1

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
