### PR TITLE
FIX: `include_` serializer methods must end with ?

### DIFF
--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -75,7 +75,7 @@ class CategorySerializer < SiteCategorySerializer
     scope && scope.cannot_delete_category_reason(object)
   end
 
-  def include_cannot_delete_reason
+  def include_cannot_delete_reason?
     !include_can_delete? && scope && scope.can_edit?(object)
   end
 

--- a/app/serializers/group_user_serializer.rb
+++ b/app/serializers/group_user_serializer.rb
@@ -10,7 +10,7 @@ class GroupUserSerializer < BasicUserSerializer
              :added_at,
              :timezone
 
-  def include_added_at
+  def include_added_at?
     object.respond_to? :added_at
   end
 

--- a/app/serializers/invited_user_record_serializer.rb
+++ b/app/serializers/invited_user_record_serializer.rb
@@ -47,7 +47,7 @@ class InvitedUserRecordSerializer < BasicUserSerializer
     ((Time.now - object.created_at) / 60 / 60 / 24).ceil
   end
 
-  def include_days_since_created
+  def include_days_since_created?
     can_see_invite_details?
   end
 

--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -107,10 +107,6 @@ class UserCardSerializer < BasicUserSerializer
     uri.host.sub(/^www\./, '') + uri.path
   end
 
-  def include_website_name
-    website.present?
-  end
-
   def ignored
     scope_ignored_user_ids = scope.user&.ignored_user_ids || []
     scope_ignored_user_ids.include?(object.id)

--- a/spec/requests/api/schemas/json/category_create_response.json
+++ b/spec/requests/api/schemas/json/category_create_response.json
@@ -215,12 +215,6 @@
         "can_delete": {
           "type": "boolean"
         },
-        "cannot_delete_reason": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "allow_badges": {
           "type": "boolean"
         },
@@ -287,7 +281,6 @@
         "mailinglist_mirror",
         "all_topics_wiki",
         "can_delete",
-        "cannot_delete_reason",
         "allow_badges",
         "topic_featured_link_allowed",
         "search_priority",

--- a/spec/requests/api/schemas/json/category_update_response.json
+++ b/spec/requests/api/schemas/json/category_update_response.json
@@ -218,12 +218,6 @@
         "can_delete": {
           "type": "boolean"
         },
-        "cannot_delete_reason": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "allow_badges": {
           "type": "boolean"
         },
@@ -290,7 +284,6 @@
         "mailinglist_mirror",
         "all_topics_wiki",
         "can_delete",
-        "cannot_delete_reason",
         "allow_badges",
         "topic_featured_link_allowed",
         "search_priority",


### PR DESCRIPTION
Otherwise, they are simply dead code and the attribute is visible by
default. These bugs did not expose any sensitive information.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
