### PR TITLE
FIX: Feature detect globalThis

### DIFF
--- a/app/assets/javascripts/browser-detect.js
+++ b/app/assets/javascripts/browser-detect.js
@@ -1,4 +1,4 @@
-if (!window.WeakMap || !window.Promise || typeof globalThis === 'undefined') {
+if (!window.WeakMap || !window.Promise || typeof globalThis === "undefined") {
   window.unsupportedBrowser = true;
 } else {
   // Some implementations of `WeakMap.prototype.has` do not accept false

--- a/app/assets/javascripts/browser-detect.js
+++ b/app/assets/javascripts/browser-detect.js
@@ -1,4 +1,4 @@
-if (!window.WeakMap || !window.Promise) {
+if (!window.WeakMap || !window.Promise || typeof globalThis === 'undefined') {
   window.unsupportedBrowser = true;
 } else {
   // Some implementations of `WeakMap.prototype.has` do not accept false


### PR DESCRIPTION
So browsers without support will receive a warning and browse our JS-less view.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
