### PR TITLE
DEV: Add plugin outlet to the bottom of flag modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
@@ -12,6 +12,8 @@
       }}
     {{/flag-selection}}
   </form>
+
+  {{plugin-outlet name="flag-modal-bottom" tagName="" args=(hash post=model)}}
 {{/d-modal-body}}
 
 <div class="modal-footer">


### PR DESCRIPTION
This will be used by discourse-akismet to show the current status of the
Akismet scan (post marked as spam, not spam, etc).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
