### PR TITLE
FIX: Use unread post excerpt for topic-level bookmark excerpt

### DIFF
--- a/app/serializers/user_bookmark_serializer.rb
+++ b/app/serializers/user_bookmark_serializer.rb
@@ -109,7 +109,13 @@ class UserBookmarkSerializer < ApplicationSerializer
   end
 
   def cooked
-    post.cooked
+    @cooked ||= \
+      if object.for_topic && last_read_post_number.present?
+        post_number = [last_read_post_number + 1, highest_post_number].min
+        Post.where(post_number: post_number, topic: topic).pluck_first(:cooked)
+      else
+        post.cooked
+      end
   end
 
   def slug

--- a/app/serializers/user_bookmark_serializer.rb
+++ b/app/serializers/user_bookmark_serializer.rb
@@ -111,11 +111,22 @@ class UserBookmarkSerializer < ApplicationSerializer
   def cooked
     @cooked ||= \
       if object.for_topic && last_read_post_number.present?
-        post_number = [last_read_post_number + 1, highest_post_number].min
-        Post.where(post_number: post_number, topic: topic).pluck_first(:cooked)
+        for_topic_cooked_post
       else
         post.cooked
       end
+  end
+
+  def for_topic_cooked_post
+    post_number = [last_read_post_number + 1, highest_post_number].min
+    posts = Post.where(topic: topic, post_type: Post.types[:regular]).order(:post_number)
+    first_unread_cooked = posts.where("post_number >= ?", post_number).pluck_first(:cooked)
+
+    # if first_unread_cooked is blank this likely means that the last
+    # read post was either deleted or is a small action post.
+    # in this case we should just get the last regular post and
+    # use that for the cooked value so we have something to show
+    first_unread_cooked || posts.last.cooked
   end
 
   def slug


### PR DESCRIPTION
In the user bookmark list, when we show the excerpt of the bookmark
(which is usually just the bookmarked post excerpt), we want to show
the first unread post's excerpt instead for for_topic bookmarks. This
is because when the user clicks on that bookmark link, they are taken
to the first unread post in the topic, not the OP, as per:

27699648ef8a73d20f0729e97b8ca684513edfd5