### PR TITLE
FIX: correctly defines data-attributes used by local-dates

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/discourse-markdown/discourse-local-dates.js.es6
@@ -140,7 +140,20 @@ function closeBuffer(buffer, state, text) {
 }
 
 export function setup(helper) {
-  helper.allowList(["span.discourse-local-date", "span[aria-label]"]);
+  helper.allowList([
+    "span.discourse-local-date",
+    "span[aria-label]",
+    "span[data-date]",
+    "span[data-time]",
+    "span[data-format]",
+    "span[data-countdown]",
+    "span[data-calendar]",
+    "span[data-displayed-timezone]",
+    "span[data-timezone]",
+    "span[data-timezones]",
+    "span[data-recurring]",
+    "span[data-email-preview]",
+  ]);
 
   helper.registerOptions((opts, siteSettings) => {
     opts.datesEmailFormat = siteSettings.discourse_local_dates_email_format;


### PR DESCRIPTION
This was previously relying on data-* being allowed by other initialisers which could cause bugs if local dates ends up being used in other contexts.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
