### PR TITLE
DEV: Fix flaky search-full-page test

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -20,15 +20,6 @@ acceptance("Search - Full Page", function (needs) {
   needs.user();
   needs.settings({ tagging_enabled: true });
   needs.pretender((server, helper) => {
-    server.get("/tags/filter/search", () => {
-      return helper.response({
-        results: [
-          { text: "monkey", count: 1 },
-          { text: "gazelle", count: 2 },
-        ],
-      });
-    });
-
     server.get("/u/search/users", () => {
       return helper.response({
         users: [
@@ -530,7 +521,7 @@ acceptance("Search - Full Page", function (needs) {
   test("search for categories/tags", async function (assert) {
     await visit("/search");
 
-    await fillIn(".search-query", "monk");
+    await fillIn(".search-query", "none");
     const typeSelector = selectKit(".search-bar .select-kit#search-type");
 
     assert.ok(!exists(".fps-tag-item"), "has no category/tag results");
@@ -549,7 +540,7 @@ acceptance("Search - Full Page", function (needs) {
       exists(".search-filters"),
       "returning to topic/posts shows filters"
     );
-    assert.ok(!exists(".user-item"), "has no user results");
+    assert.ok(!exists(".fps-tag-item"), "has no tag results");
   });
 
   test("filters expand/collapse as expected", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -134,7 +134,12 @@ export function applyDefaultHandlers(pretender) {
   pretender.delete("/bookmarks/:id", () => response({}));
 
   pretender.get("/tags/filter/search", () => {
-    return response({ results: [{ text: "monkey", count: 1 }] });
+    return response({
+      results: [
+        { text: "monkey", count: 1 },
+        { text: "gazelle", count: 2 },
+      ],
+    });
   });
 
   pretender.get(`/u/:username/emails.json`, (request) => {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -42,9 +42,15 @@ discourseModule(
 
         await this.subject.expand();
         await this.subject.fillInFilter("mon");
-        assert.equal(queryAll(".select-kit-row").text().trim(), "monkey x1");
+        assert.equal(
+          queryAll(".select-kit-row").text().trim(),
+          "monkey x1\ngazelle x2"
+        );
         await this.subject.fillInFilter("key");
-        assert.equal(queryAll(".select-kit-row").text().trim(), "monkey x1");
+        assert.equal(
+          queryAll(".select-kit-row").text().trim(),
+          "monkey x1\ngazelle x2"
+        );
         await this.subject.selectRowByValue("monkey");
 
         assert.equal(this.subject.header().value(), "foo,bar,monkey");


### PR DESCRIPTION
The `search for categories/tags` test was failing sporadically, i suspect it's because in some runs the local pretender for `/tags/filter/search` was being replaced by the global pretender. I opted to remove the local pretender and update the global one with two results, hopefully this fixes the issue. 