### PR TITLE
FIX: Ensure subcategory list is hidden when not required

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -192,6 +192,8 @@ export default (filterArg, params) => {
           outlet: "header-list-container",
           model: this._categoryList,
         });
+      } else {
+        this.disconnectOutlet({ outlet: "header-list-container" });
       }
       this.render("discovery/topics", {
         controller: "discovery/topics",


### PR DESCRIPTION
When the loading spinner is removed (e.g. via the loading-slider component), the subcategory list view will persist, even when no longer required. This is because we were conditionally rendering the list into the `header-list-container` outlet. When the condition was false, we were doing nothing. Instead, we should use `disconectOutlet` to make sure the content is removed from the DOM.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
