### PR TITLE
FEATURE: Change all core to use uppy-image-uploader

### DIFF
--- a/app/assets/javascripts/admin/addon/components/site-settings-image-uploader.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings-image-uploader.js
@@ -1,6 +1,0 @@
-import ImageUploader from "discourse/components/image-uploader";
-
-export default ImageUploader.extend({
-  layoutName: "components/image-uploader",
-  uploadUrlParams: "&for_site_setting=true",
-});

--- a/app/assets/javascripts/admin/addon/templates/badges-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/badges-show.hbs
@@ -40,12 +40,14 @@
         </label>
       </div>
       {{#if imageUploaderSelected}}
-        {{image-uploader
+        {{uppy-image-uploader
+          id="badge-image-uploader"
           imageUrl=buffered.image_url
+          type="badge_image"
           onUploadDone=(action "setImage")
           onUploadDeleted=(action "removeImage")
-          type="badge_image"
-          class="no-repeat contain-image"}}
+          class="no-repeat contain-image"
+        }}
         <div class="control-instructions">
           <p class="help">{{i18n "admin.badges.image_help"}}</p>
         </div>

--- a/app/assets/javascripts/admin/addon/templates/components/site-settings/upload.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/site-settings/upload.hbs
@@ -1,2 +1,8 @@
-{{site-settings-image-uploader imageUrl=value placeholderUrl=setting.placeholder type="site_setting"}}
+{{uppy-image-uploader
+  imageUrl=value
+  placeholderUrl=setting.placeholder
+  queryParams=(hash for_site_setting=true)
+  type="site_setting"
+  id=(concat "site-setting-image-uploader-" setting.setting)
+}}
 <div class="desc">{{html-safe setting.description}}</div>

--- a/app/assets/javascripts/discourse/app/components/image-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/image-uploader.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import deprecated from "discourse-common/lib/deprecated";
 import UploadMixin from "discourse/mixins/upload";
 import { ajax } from "discourse/lib/ajax";
 import discourseComputed from "discourse-common/utils/decorators";
@@ -14,6 +15,10 @@ export default Component.extend(UploadMixin, {
 
   init() {
     this._super(...arguments);
+    // TODO (martin) (2022-01-22) Remove this component.
+    deprecated(
+      "image-uploader will be removed in a future version, use uppy-image-uploader instead (the API is the same)"
+    );
     this._applyLightbox();
   },
 

--- a/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
@@ -69,8 +69,6 @@ export default Component.extend(UppyUploadMixin, {
 
   uploadDone(upload) {
     this.setProperties({
-      imageUrl: upload.url,
-      imageId: upload.id,
       imageFilesize: upload.human_filesize,
       imageFilename: upload.original_filename,
       imageWidth: upload.width,
@@ -79,8 +77,13 @@ export default Component.extend(UppyUploadMixin, {
 
     this._applyLightbox();
 
+    // the value of the property used for imageUrl should be set
+    // in this callback. this should be done in cases where imageUrl
+    // is bound to a computed property of the parent component.
     if (this.onUploadDone) {
       this.onUploadDone(upload);
+    } else {
+      this.set("imageUrl", upload.url);
     }
   },
 
@@ -123,13 +126,16 @@ export default Component.extend(UppyUploadMixin, {
     },
 
     trash() {
-      this.setProperties({ imageUrl: null, imageId: null });
-
       // uppy needs to be reset to allow for more uploads
       this._reset();
 
+      // the value of the property used for imageUrl should be cleared
+      // in this callback. this should be done in cases where imageUrl
+      // is bound to a computed property of the parent component.
       if (this.onUploadDeleted) {
         this.onUploadDeleted();
+      } else {
+        this.setProperties({ imageUrl: null });
       }
     },
   },

--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -57,10 +57,6 @@ export default Controller.extend({
     "model.can_upload_user_card_background"
   ),
 
-  experimentalUserCardImageUpload: readOnly(
-    "siteSettings.enable_experimental_image_uploader"
-  ),
-
   actions: {
     showFeaturedTopicModal() {
       showModal("feature-topic-on-profile", {

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -530,4 +530,14 @@ export function getEditCategoryUrl(category, subcategories, tab) {
   return getURL(url);
 }
 
+export function queryParams(source) {
+  const array = [];
+
+  for (const [key, value] of Object.entries(source)) {
+    array.push(encodeURIComponent(key) + "=" + encodeURIComponent(value));
+  }
+
+  return array.join("&");
+}
+
 export default _urlInstance;

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -1,5 +1,6 @@
 import Mixin from "@ember/object/mixin";
 import { ajax } from "discourse/lib/ajax";
+import { queryParams } from "discourse/lib/url";
 import {
   bindFileInputChangeListener,
   displayErrorForUpload,
@@ -224,8 +225,8 @@ export default Mixin.create({
     return (
       getUrl(this.getWithDefault("uploadUrl", "/uploads")) +
       ".json?client_id=" +
-      (this.messageBus && this.messageBus.clientId) +
-      this.uploadUrlParams
+      this.messageBus?.clientId +
+      this._additionalQueryParams()
     );
   },
 
@@ -247,6 +248,14 @@ export default Mixin.create({
         }
       }
     );
+  },
+
+  _additionalQueryParams() {
+    if (!this.queryParams) {
+      return "";
+    }
+
+    return queryParams(this.queryParams);
   },
 
   _completeExternalUpload(file) {

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-images.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-images.hbs
@@ -1,18 +1,22 @@
 <section class="field category-logo">
   <label>{{i18n "category.logo"}}</label>
-  {{image-uploader
+  {{uppy-image-uploader
     imageUrl=logoImageUrl
     onUploadDone=(action "logoUploadDone")
     onUploadDeleted=(action "logoUploadDeleted")
     type="category_logo"
-    class="no-repeat contain-image"}}
+    class="no-repeat contain-image"
+    id="category-logo-upload"
+  }}
 </section>
 
 <section class="field category-background-image">
   <label>{{i18n "category.background_image"}}</label>
-  {{image-uploader
+  {{uppy-image-uploader
     imageUrl=backgroundImageUrl
     onUploadDone=(action "backgroundUploadDone")
     onUploadDeleted=(action "backgroundUploadDeleted")
-    type="category_background"}}
+    type="category_background"
+    id="category-background-upload"
+  }}
 </section>

--- a/app/assets/javascripts/discourse/app/templates/components/group-flair-inputs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-flair-inputs.hbs
@@ -21,11 +21,12 @@
       onChange=(action (mut model.flair_icon))
     }}
   {{else if flairPreviewImage}}
-    {{image-uploader
+    {{uppy-image-uploader
       imageUrl=flairImageUrl
       onUploadDone=(action "setFlairImage")
       onUploadDeleted=(action "removeFlairImage")
       type="group_flair"
+      id="group-flair-uploader"
       class="no-repeat contain-image"}}
     <div class="control-instructions">
       {{i18n "groups.flair_upload_description"}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
@@ -47,8 +47,11 @@
     <div class="control-group pref-profile-bg">
       <label class="control-label">{{i18n "user.change_profile_background.title"}}</label>
       <div class="controls">
-        {{image-uploader imageUrl=model.profile_background_upload_url
-          type="profile_background"}}
+        {{uppy-image-uploader
+          imageUrl=model.profile_background_upload_url
+          type="profile_background"
+          id="profile-background"
+        }}
       </div>
       <div class="instructions">
         {{i18n "user.change_profile_background.instructions"}}
@@ -59,15 +62,11 @@
     <div class="control-group pref-profile-bg">
       <label class="control-label">{{i18n "user.change_card_background.title"}}</label>
       <div class="controls">
-        {{#if experimentalUserCardImageUpload}}
-          {{uppy-image-uploader
-            imageUrl=model.card_background_upload_url
-            type="card_background"
-            id="profile-card-background"
-          }}
-        {{else}}
-          {{image-uploader imageUrl=model.card_background_upload_url type="card_background"}}
-        {{/if}}
+        {{uppy-image-uploader
+          imageUrl=model.card_background_upload_url
+          type="card_background"
+          id="profile-card-background"
+        }}
       </div>
       <div class="instructions">
         {{i18n "user.change_card_background.instructions"}}


### PR DESCRIPTION
Instead of using image-uploader, which relies on the old
UploadMixin, we can now use the uppy-image-uploader which
uses the new UppyUploadMixin which is stable enough and
supports both regular XHR uploads and direct S3 uploads,
controlled by a site setting (default to XHR).

At some point it may make sense to rename uppy-image-uploader
back to image-uploader, once we have gone through plugins
etc. and given a bit of deprecation time period.

This commit also introduces `queryParams` to lib/url.js,
which is a drop-in replacement for $.param to generate a
queryString from a JS object literal. A later PR will make
changes to more places in core and plugins to use this.
