### PR TITLE
UX: move fast edit before sharing

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
@@ -7,6 +7,17 @@
       label="post.quote_reply"}}
   {{/if}}
 
+  {{#if siteSettings.enable_fast_edit}}
+    {{#if _canEditPost}}
+      {{d-button
+        icon="pencil-alt"
+        action=(action "_toggleFastEditForm")
+        label="post.quote_edit"
+        class="btn-flat quote-edit-label"
+      }}
+    {{/if}}
+  {{/if}}
+
   {{#if quoteSharingEnabled}}
     <span class="quote-sharing">
       {{#if quoteSharingShowLabel}}
@@ -26,19 +37,7 @@
         {{/each}}
         {{plugin-outlet name="quote-share-buttons-after" tagName=""}}
       </span>
-
     </span>
-  {{/if}}
-
-  {{#if siteSettings.enable_fast_edit}}
-    {{#if _canEditPost}}
-      {{d-button
-        icon="pencil-alt"
-        action=(action "_toggleFastEditForm")
-        label="post.quote_edit"
-        class="btn-flat quote-edit-label"
-      }}
-    {{/if}}
   {{/if}}
 </div>
 


### PR DESCRIPTION
As sharing has some hover behavior, it was looking slightly clunky with fast edit changing position. Putting sharing at the last position will reduce this effect.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
