### PR TITLE
A11Y: Add labels to some search fields, category notification selector

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/date-input.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/date-input.hbs
@@ -4,6 +4,7 @@
   placeholder=placeholder
   value=(readonly value)
   input=(action "onChangeDate")
+  id=inputId
 }}
 
 {{#unless useGlobalPickerContainer}}

--- a/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
@@ -168,7 +168,7 @@
         {{date-input
           date=searchedTerms.time.days
           onChange=(action "onChangeWhenDate")
-          id="search-post-date"
+          inputId="search-post-date"
         }}
       </div>
     </div>
@@ -191,6 +191,7 @@
           id="search-min-post-count"
           input=(action "onChangeSearchTermMinPostCount" value="target.value")
           placeholder=(i18n "search.advanced.post.min.placeholder")
+          aria-label=(i18n "search.advanced.post.min.aria_label")
         }}
         {{d-icon "arrows-alt-h"}}
         {{input
@@ -200,6 +201,7 @@
           id="search-max-post-count"
           input=(action "onChangeSearchTermMaxPostCount" value="target.value")
           placeholder=(i18n "search.advanced.post.max.placeholder")
+          aria-label=(i18n "search.advanced.post.max.aria_label")
         }}
       </div>
     </div>
@@ -215,6 +217,7 @@
           id="search-min-views"
           input=(action "onChangeSearchTermMinViews" value="target.value")
           placeholder=(i18n "search.advanced.min_views.placeholder")
+          aria-label=(i18n "search.advanced.post.min_views.aria_label")
         }}
         {{d-icon "arrows-alt-h"}}
         {{input
@@ -224,6 +227,7 @@
           id="search-max-views"
           input=(action "onChangeSearchTermMaxViews" value="target.value")
           placeholder=(i18n "search.advanced.max_views.placeholder")
+          aria-label=(i18n "search.advanced.post.max_views.aria_label")
         }}
       </div>
     </div>

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -93,7 +93,6 @@
               castInteger=true
               onChange=(action (mut sortOrder))
               id="search-sort-by"
-              ariaLabel="Some label"
             }}
           </div>
         </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -395,7 +395,7 @@ acceptance("Search - Full Page", function (needs) {
     await visit("/search");
 
     await fillIn(".search-query", "none");
-    await selectDate("#search-post-date .date-picker", "2016-10-05");
+    await selectDate(".date-picker#search-post-date", "2016-10-05");
 
     const postTimeSelector = selectKit(
       ".search-advanced-options .select-kit#postTime"

--- a/app/assets/javascripts/select-kit/addon/components/category-notifications-button.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-notifications-button.js
@@ -1,5 +1,6 @@
 import NotificationOptionsComponent from "select-kit/components/notifications-button";
 import { or } from "@ember/object/computed";
+import I18n from "I18n";
 
 export default NotificationOptionsComponent.extend({
   pluginApiIdentifiers: ["category-notifications-button"],
@@ -9,5 +10,6 @@ export default NotificationOptionsComponent.extend({
   selectKitOptions: {
     i18nPrefix: "category.notifications",
     showFullTitle: false,
+    headerAriaLabel: I18n.t("category.notifications.title"),
   },
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2416,8 +2416,10 @@ en:
             label: Posts
           min:
             placeholder: minimum
+            aria_label: filter by minimum number of posts
           max:
             placeholder: maximum
+            aria_label: filter by maximum number of posts
           time:
             label: Posted
             aria_label: Filter by posted date
@@ -2427,8 +2429,10 @@ en:
           label: Views
         min_views:
           placeholder: minimum
+          aria_label: filter by minimum views
         max_views:
           placeholder: maximum
+          aria_label: filter by maximum views
         additional_options:
           label: "Filter by post count and topic views"
 
@@ -3324,6 +3328,7 @@ en:
       num_auto_bump_daily: "Number of open topics to automatically bump daily:"
       navigate_to_first_post_after_read: "Navigate to first post after topics are read"
       notifications:
+        title: "change notification level for this category"
         watching:
           title: "Watching"
           description: "You will automatically watch all topics in this category. You will be notified of every new post in every topic, and a count of new replies will be shown."


### PR DESCRIPTION
- Adds labels to search post min/max, views min/max fields
- Adjusts label for date search so it applies to the input (not its parent element)
- Adds label for category notifications dropdown