### PR TITLE
UX: Ensure sticky elements don't overflow header

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -183,16 +183,21 @@ const SiteHeaderComponent = MountWidget.extend(
       }
 
       const offset = info.offset();
+      const headerRect = header.getBoundingClientRect(),
+        headerOffset = headerRect.top + headerRect.height,
+        doc = document.documentElement;
       if (offset >= this.docAt) {
         if (!this.dockedHeader) {
           document.body.classList.add("docked");
           this.dockedHeader = true;
+          doc.style.setProperty("--header-offset", `${headerOffset}px`);
         }
       } else {
         if (this.dockedHeader) {
           document.body.classList.remove("docked");
           this.dockedHeader = false;
         }
+        doc.style.setProperty("--header-offset", `${headerOffset}px`);
       }
     },
 

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -171,8 +171,7 @@
 
 .sticky-header thead {
   @include sticky;
-  // TODO: Use calculated header height
-  top: 60px;
+  top: var(--header-offset, 60px);
   background: var(--secondary);
   z-index: 2;
 }

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -517,6 +517,7 @@ body:not(.ios-safari-composer-hacks) {
   #reply-control.open {
     --min-height: 255px;
     min-height: var(--min-height);
+    max-height: calc(100vh - var(--header-offset, 4em));
     &.composer-action-reply {
       // we can let the reply composer get a little shorter
       min-height: calc(var(--min-height) - 4em);

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -46,7 +46,7 @@
       grid-area: timeline;
       align-self: start;
       @include sticky;
-      top: 6em;
+      top: calc(var(--header-offset, 60px) + 2em);
       margin-left: 1em;
       z-index: z("timeline");
     }


### PR DESCRIPTION
The header height is the same on the vast majority of Discourse sites, but there are some exceptions. This PR adds a way to have the header's offset always available so we can correctly calculate the placement of specific elements. This is done by adding/updating the `--header-offset` CSS custom property. 

It simplifies and makes consistent several things: 

- the position of sticky table headers
- the position of the topic timeline
- the max height of the composer (which previously could exceed the viewport height too)

And more importantly, the position of all these elements should work correctly on all scenarios, including the iPad DiscourseHub app and custom themes with taller headers (whether docked or not). 

@awesomerobot @jordanvidrine We will likely need to do some cleanup in customer themes, 