### PR TITLE
FIX: Address ArgumentError: wrong number of arguments (given 4, expected 3)

### DIFF
--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -37,7 +37,7 @@ class DiscourseRedis
   end
 
   # prefix the key with the namespace
-  def method_missing(meth, *args, &block)
+  def method_missing(meth, *args, **kwargs, &block)
     if @redis.respond_to?(meth)
       DiscourseRedis.ignore_readonly { @redis.public_send(meth, *args, &block) }
     else
@@ -54,9 +54,9 @@ class DiscourseRedis
    :sdiff, :set, :setbit, :setex, :setnx, :setrange, :sinter, :sismember, :smembers, :sort, :spop, :srandmember, :srem, :strlen,
    :sunion, :ttl, :type, :watch, :zadd, :zcard, :zcount, :zincrby, :zrange, :zrangebyscore, :zrank, :zrem, :zremrangebyrank,
    :zremrangebyscore, :zrevrange, :zrevrangebyscore, :zrevrank, :zrangebyscore ].each do |m|
-    define_method m do |*args|
+    define_method m do |*args, **kwargs|
       args[0] = "#{namespace}:#{args[0]}" if @namespace
-      DiscourseRedis.ignore_readonly { @redis.public_send(m, *args) }
+      DiscourseRedis.ignore_readonly { @redis.public_send(m, *args, **kwargs) }
     end
   end
 


### PR DESCRIPTION
This pull request addresses ArgumentError: wrong number of arguments (given 4, expected 3) to support Ruby 3 keyword arguments.

### Steps to reproduce

```
% ruby -v                                                                                                                                                                                                                                  ruby3
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-darwin21]
% bundle exec rails server
```

### Expected result
It should run without errors.

### Actual result
It gets `ArgumentError: wrong number of arguments (given 4, expected 3)` when calling `zrange` method.

```
2021-09-27T03:12:23.255Z pid=42543 tid=17hb WARN: {"current_db":"default","current_hostname":"localhost","message":"While ticking scheduling manager"}
2021-09-27T03:12:23.255Z pid=42543 tid=17hb WARN: ArgumentError: wrong number of arguments (given 4, expected 3)
2021-09-27T03:12:23.255Z pid=42543 tid=17hb WARN: /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/redis-4.4.0/lib/redis.rb:1784:in `zrange'
/Users/yahonda/src/github.com/discourse/discourse/lib/discourse_redis.rb:68:in `public_send'
/Users/yahonda/src/github.com/discourse/discourse/lib/discourse_redis.rb:68:in `block (3 levels) in <class:DiscourseRedis>'
/Users/yahonda/src/github.com/discourse/discourse/lib/discourse_redis.rb:29:in `ignore_readonly'
/Users/yahonda/src/github.com/discourse/discourse/lib/discourse_redis.rb:68:in `block (2 levels) in <class:DiscourseRedis>'
/Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/mini_scheduler-0.13.0/lib/mini_scheduler/manager.rb:279:in `schedule_next_job'
/Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/mini_scheduler-0.13.0/lib/mini_scheduler/manager.rb:273:in `block in tick'
/Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/mini_scheduler-0.13.0/lib/mini_scheduler/manager.rb:323:in `block in lock'
/Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/mini_scheduler-0.13.0/lib/mini_scheduler/distributed_mutex.rb:46:in `synchronize'
/Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/mini_scheduler-0.13.0/lib/mini_scheduler/distributed_mutex.rb:14:in `synchronize'
/Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/mini_scheduler-0.13.0/lib/mini_scheduler/manager.rb:322:in `lock'
/Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/mini_scheduler-0.13.0/lib/mini_scheduler/manager.rb:272:in `tick'
/Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/mini_scheduler-0.13.0/lib/mini_scheduler.rb:71:in `block (2 levels) in start'
Job exception: wrong number of arguments (given 4, expected 3)
```

#### Additional information.
When `args` is like this, it gets the ArgumentError.

* `args`
```
["default:_scheduler_queue_default_", 0, 0, {:withscores=>true}]
```

The `zrange` method signature is:

```ruby
def zrange(key, start, stop, withscores: false, with_scores: withscores)
...
end
```