### PR TITLE
DEV: Plugin API to add to document title count

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-document.js
+++ b/app/assets/javascripts/discourse/app/components/d-document.js
@@ -6,6 +6,11 @@ import logout from "discourse/lib/logout";
 import { inject as service } from "@ember/service";
 import { setLogoffCallback } from "discourse/lib/ajax";
 
+let pluginCounterFunctions = [];
+export function addPluginDocumentTitleCounter(counterFunction) {
+  pluginCounterFunctions.push(counterFunction);
+}
+
 export default Component.extend({
   tagName: "",
   documentTitle: service(),
@@ -44,10 +49,11 @@ export default Component.extend({
       return;
     }
 
-    this.documentTitle.updateNotificationCount(
+    const count =
+      pluginCounterFunctions.reduce((sum, fn) => sum + fn(), 0) +
       this.currentUser.unread_notifications +
-        this.currentUser.unread_high_priority_notifications
-    );
+      this.currentUser.unread_high_priority_notifications;
+    this.documentTitle.updateNotificationCount(count);
   },
 
   @bind

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -50,6 +50,7 @@ import { addFeaturedLinkMetaDecorator } from "discourse/lib/render-topic-feature
 import { addGTMPageChangedCallback } from "discourse/lib/page-tracker";
 import { addGlobalNotice } from "discourse/components/global-notice";
 import { addNavItem } from "discourse/models/nav-item";
+import { addPluginDocumentTitleCounter } from "discourse/components/d-document";
 import { addPluginOutletDecorator } from "discourse/components/plugin-connector";
 import { addPluginReviewableParam } from "discourse/components/reviewable-item";
 import { addPopupMenuOptionsCallback } from "discourse/controllers/composer";
@@ -1241,6 +1242,18 @@ class PluginApi {
     addGlobalNotice(id, text, options);
   }
 
+  /**
+   * Used for modifying the document title count. The core count is unread notifications, and
+   * the returned value from calling the passed in function will be added to this number.
+   *
+   * For example, to add a count
+   * api.addDocumentTitleCounter(() => {
+   *   return currentUser.somePluginValue;
+   * })
+   **/
+  addDocumentTitleCounter(counterFunction) {
+    addPluginDocumentTitleCounter(counterFunction);
+  }
   /**
    * Used for decorating the rendered HTML content of a plugin-outlet after it's been rendered
    *


### PR DESCRIPTION
This adds the ability to add additional numbers to the document title. Used in the unreleased chat plugin to add unread direct message counts to document title.

This is hard to test, because the numbers in the title only get updated if the browser doesn't have focus.. and I tried to find how to do that in qunit and came up empty.