### PR TITLE
DEV: Destroy application instance after each test

### DIFF
--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -31,6 +31,7 @@ import { flushMap } from "discourse/models/store";
 import { registerObjects } from "discourse/pre-initializers/inject-discourse-objects";
 import { setupApplicationTest } from "ember-qunit";
 import sinon from "sinon";
+import { run } from "@ember/runloop";
 
 const Plugin = $.fn.modal;
 const Modal = Plugin.Constructor;
@@ -63,6 +64,10 @@ let app;
 let started = false;
 
 function createApplication(config, settings) {
+  if (app) {
+    run(app, "destroy");
+  }
+
   app = Application.create(config);
   setApplication(app);
   setResolver(buildResolver("discourse").create({ namespace: app }));


### PR DESCRIPTION
Under Ember CLI, we create a new application instance for each test. We were not correctly destroying it after the test, causing many references to be maintaned (e.g. at the end of a test run, `Ember.Namespace.NAMESPACES` would have an entry for each application instance).

Calling `destroy` on the application instance tidies up these references, and is one step towards fixing our test memory leak problem. Unfortunately there still seem to be other references being held to the application, so this commit is not a total fix.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
