### PR TITLE
DEV: Clear pretender request log between test runs

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -1111,3 +1111,10 @@ export function applyDefaultHandlers(pretender) {
     });
   });
 }
+
+export function resetPretender() {
+  instance.handlers = [];
+  instance.handledRequests = [];
+  instance.unhandledRequests = [];
+  instance.passthroughRequests = [];
+}

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -3,9 +3,10 @@ import {
   exists,
   resetSite,
 } from "discourse/tests/helpers/qunit-helpers";
-import createPretender, {
+import pretender, {
   applyDefaultHandlers,
   pretenderHelpers,
+  resetPretender,
 } from "discourse/tests/helpers/create-pretender";
 import {
   currentSettings,
@@ -244,8 +245,7 @@ function setupTestsCommon(application, container, config) {
       setupS3CDN(null, null);
     }
 
-    server = createPretender;
-    server.handlers = [];
+    server = pretender;
     applyDefaultHandlers(server);
 
     server.prepareBody = function (body) {
@@ -307,6 +307,7 @@ function setupTestsCommon(application, container, config) {
 
   QUnit.testDone(function () {
     sinon.restore();
+    resetPretender();
 
     // Destroy any modals
     $(".modal-backdrop").remove();


### PR DESCRIPTION
Previously we would store every FakeRequest object for all tests, resulting in many hundreds/thousands of objects in the `handledRequests` array.

This commit ensures all pretender state is reset between tests.

The leaking objects showed as `FakeRequest` instances in the chrome memory inspector, and could be viewed in the console by running

```javascript
> require("discourse/tests/helpers/create-pretender").default.handledRequests
// (10) [FakeRequest, FakeRequest, FakeRequest, FakeRequest, FakeRequest, FakeRequest, FakeRequest, FakeRequest, FakeRequest, FakeRequest]
```