### PR TITLE
DEV: prevents route nodes to leak on each test run

### DIFF
--- a/app/assets/javascripts/discourse/app/mapping-router.js
+++ b/app/assets/javascripts/discourse/app/mapping-router.js
@@ -134,12 +134,21 @@ export function mapRoutes() {
     }
   });
 
-  return BareRouter.extend({
+  const extendedRouter = BareRouter.extend({
     rootURL: getURL("/"),
   }).map(function () {
     tree.mapRoutes(this);
     this.route("unknown", { path: "*path" });
   });
+
+  _extendedRouter = extendedRouter;
+  return extendedRouter;
+}
+
+let _extendedRouter;
+export function unRegisterRouter() {
+  _extendedRouter.dslCallbacks[0] = null;
+  _extendedRouter = null;
 }
 
 export function registerRouter(registry) {

--- a/app/assets/javascripts/discourse/app/pre-initializers/map-routes.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/map-routes.js
@@ -1,6 +1,6 @@
 import Application from "@ember/application";
 import { isLegacyEmber } from "discourse-common/config/environment";
-import { registerRouter } from "discourse/mapping-router";
+import { registerRouter, unRegisterRouter } from "discourse/mapping-router";
 
 let originalBuildInstance;
 
@@ -22,5 +22,9 @@ export default {
         return originalBuildInstance.apply(this);
       };
     }
+  },
+
+  teardown(container) {
+    unRegisterRouter(container);
   },
 };

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -296,6 +296,11 @@ export function acceptance(name, optionsOrCallback) {
           initializer.teardown(this.container);
         }
       });
+      app._runInitializer("initializers", (initName, initializer) => {
+        if (initializer && initializer.teardown) {
+          initializer.teardown(this.container);
+        }
+      });
 
       if (LEGACY_ENV) {
         app.__registeredObjects__ = false;


### PR DESCRIPTION
Note this commit is also adding support for teardown in pre-initializers just like we have for initializers.

Before/After memory snapshot on a run of about 40 tests:

Before:
<img width="472" alt="Capture d’écran 2021-09-28 à 14 17 17" src="https://user-images.githubusercontent.com/339945/135085700-c1212819-f994-45d0-ad32-dd8d9376fe47.png">

After:
<img width="433" alt="Capture d’écran 2021-09-28 à 14 18 50" src="https://user-images.githubusercontent.com/339945/135085721-03afb90d-ae00-4978-8b02-77e74a3835f6.png">
