### PR TITLE
UX: Show scrollbar only when needed in dropdowns

### DIFF
--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -169,7 +169,7 @@
 
     .selected-content {
       max-height: 300px;
-      overflow-y: scroll;
+      overflow-y: auto;
     }
   }
 


### PR DESCRIPTION
Avoids showing a disabled scrollbar when not necessary.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
