### PR TITLE
DEV: Print usedJSHeapSize to the console after QUnit run

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -1,3 +1,27 @@
+const TapReporter = require("testem/lib/reporters/tap_reporter");
+
+class Reporter {
+  constructor() {
+    this._tapReporter = new TapReporter(...arguments);
+  }
+
+  reportMetadata(tag, metadata) {
+    if (tag === "summary-line") {
+      process.stdout.write(`\n${metadata.message}\n`);
+    } else {
+      this._tapReporter.reportMetadata(...arguments);
+    }
+  }
+
+  report(prefix, data) {
+    this._tapReporter.report(prefix, data);
+  }
+
+  finish() {
+    this._tapReporter.finish();
+  }
+}
+
 module.exports = {
   test_page: "tests/index.html?hidepassed",
   disable_watching: true,
@@ -15,6 +39,7 @@ module.exports = {
       "--mute-audio",
       "--remote-debugging-port=4201",
       "--window-size=1440,900",
+      "--enable-precise-memory-info",
     ].filter(Boolean),
     Firefox: ["-headless", "--width=1440", "--height=900"],
     "Headless Firefox": ["--width=1440", "--height=900"],
@@ -22,4 +47,5 @@ module.exports = {
   browser_paths: {
     "Headless Firefox": "/opt/firefox-evergreen/firefox",
   },
+  reporter: Reporter,
 };

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -127,6 +127,32 @@ function setupToolbar() {
   });
 }
 
+function reportMemoryUsageAfterTests() {
+  QUnit.done(() => {
+    const usageBytes = performance.memory?.usedJSHeapSize;
+    let result;
+    if (usageBytes) {
+      result = `${(usageBytes / Math.pow(2, 30)).toFixed(3)}GB`;
+    } else {
+      result = "(performance.memory api unavailable)";
+    }
+
+    writeSummaryLine(`Used JS Heap Size: ${result}`);
+  });
+}
+
+function writeSummaryLine(message) {
+  // eslint-disable-next-line no-console
+  console.log(`\n${message}\n`);
+  if (window.Testem) {
+    window.Testem.useCustomAdapter(function (socket) {
+      socket.emit("test-metadata", "summary-line", {
+        message: message,
+      });
+    });
+  }
+}
+
 function setupTestsCommon(application, container, config) {
   QUnit.config.hidepassed = true;
 
@@ -353,6 +379,7 @@ function setupTestsCommon(application, container, config) {
   jQuery.fx.off = true;
 
   setupToolbar();
+  reportMemoryUsageAfterTests();
   setApplication(application);
   setDefaultOwner(application.__container__);
   resetSite();

--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -42,6 +42,7 @@ async function runAllTests() {
         "--disable-dev-shm-usage",
         "--mute-audio",
         "--window-size=1440,900",
+        "--enable-precise-memory-info",
       ],
     };
 


### PR DESCRIPTION
This is `console.log`'d to the browser console. run-qunit will print this to stdout. testem will not, so a custom reporter is implemented to print this message.

The `--enable-precise-memory-info` is added so that chrome provides high-resolution memory information. This API is not supported by firefox. The logic will degrade gracefully.


TestEm output:

```
...
Built project successfully. Stored in "/var/folders/c7/3jzsz23s16l3_jtzrttkxwfw0000gn/T/tests-dist-2021828-53762-zyrvye.43hq".

Used JS Heap Size: 0.080GB

1..5
# tests 5
# pass  5
# skip  0
# todo  0
# fail  0

# ok
✨  Done in 21.07s.
```

Run-qunit output:
```
...
↪ Integration | Component | Widget | discourse-poll-option::multi, selected [✔]

Used JS Heap Size: 0.232GB

Slowest tests
----------------------------------------------
...
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
