### PR TITLE
DEV: Deprecate message bus site settings

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -339,3 +339,9 @@ cluster_name =
 
 # The YAML file used to configure multisite clusters
 multisite_config_path = config/multisite.yml
+
+# If false, only short (regular) polling will be attempted
+enable_long_polling =
+
+# Length of time to hold open a long polling connection in milliseconds
+long_polling_interval =

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -120,7 +120,7 @@ end
 MessageBus.reliable_pub_sub.max_backlog_size = GlobalSetting.message_bus_max_backlog_size
 
 if SiteSetting.table_exists? && SiteSetting.where(name: ['enable_long_polling', 'long_polling_interval']).exists?
-  Discourse.deprecate("enable_long_polling/long_polling_interval have switched from site settings to global settings. Remove the override from the Site Settings UI, and use environment variables to set the global settings.", drop_from: '2.9.0')
+  Discourse.deprecate("enable_long_polling/long_polling_interval have switched from site settings to global settings. Remove the override from the Site Settings UI, and use a config file or environment variables to set the global settings.", drop_from: '2.9.0')
 
   MessageBus.long_polling_enabled = SiteSetting.enable_long_polling
   MessageBus.long_polling_interval = SiteSetting.long_polling_interval

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -119,8 +119,16 @@ else
 end
 MessageBus.reliable_pub_sub.max_backlog_size = GlobalSetting.message_bus_max_backlog_size
 
-MessageBus.long_polling_enabled = SiteSetting.enable_long_polling
-MessageBus.long_polling_interval = SiteSetting.long_polling_interval
+if SiteSetting.table_exists? && SiteSetting.where(name: ['enable_long_polling', 'long_polling_interval']).exists?
+  Discourse.deprecate("enable_long_polling/long_polling_interval have switched from site settings to global settings", drop_from: '2.9.0')
+
+  MessageBus.long_polling_enabled = SiteSetting.enable_long_polling
+  MessageBus.long_polling_interval = SiteSetting.long_polling_interval
+else
+  MessageBus.long_polling_enabled = GlobalSetting.enable_long_polling || true
+  MessageBus.long_polling_interval = GlobalSetting.long_polling_interval || 25000
+end
+
 MessageBus.cache_assets = !Rails.env.development?
 MessageBus.enable_diagnostics
 

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -125,7 +125,7 @@ if SiteSetting.table_exists? && SiteSetting.where(name: ['enable_long_polling', 
   MessageBus.long_polling_enabled = SiteSetting.enable_long_polling
   MessageBus.long_polling_interval = SiteSetting.long_polling_interval
 else
-  MessageBus.long_polling_enabled = GlobalSetting.enable_long_polling || true
+  MessageBus.long_polling_enabled = GlobalSetting.enable_long_polling.nil? ? true : GlobalSetting.enable_long_polling
   MessageBus.long_polling_interval = GlobalSetting.long_polling_interval || 25000
 end
 

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -120,7 +120,7 @@ end
 MessageBus.reliable_pub_sub.max_backlog_size = GlobalSetting.message_bus_max_backlog_size
 
 if SiteSetting.table_exists? && SiteSetting.where(name: ['enable_long_polling', 'long_polling_interval']).exists?
-  Discourse.deprecate("enable_long_polling/long_polling_interval have switched from site settings to global settings", drop_from: '2.9.0')
+  Discourse.deprecate("enable_long_polling/long_polling_interval have switched from site settings to global settings. Remove the override from the Site Settings UI, and use environment variables to set the global settings.", drop_from: '2.9.0')
 
   MessageBus.long_polling_enabled = SiteSetting.enable_long_polling
   MessageBus.long_polling_interval = SiteSetting.long_polling_interval


### PR DESCRIPTION
It makes much more sense for these to be GlobalSettings, since, in
multisite clusters, only the default site's settings would be respected.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
