### PR TITLE
FEATURE: Add after query param topic filter

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -42,6 +42,7 @@ class TopicQuery
   def self.public_valid_options
     @public_valid_options ||=
       %i(page
+         after
          before
          bumped_before
          topic_ids
@@ -742,6 +743,12 @@ class TopicQuery
     if before = options[:before]
       if (before = before.to_i) > 0
         result = result.where('topics.created_at < ?', before.to_i.days.ago)
+      end
+    end
+
+    if after = options[:after]
+      if (after = after.to_i) > 0
+        result = result.where('topics.created_at > ?', after.to_i.days.ago)
       end
     end
 

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -233,6 +233,34 @@ describe TopicQuery do
     end
   end
 
+  context 'before and after filter' do
+    before do
+      Fabricate(:topic, title: '10 day old topic', created_at: 10.days.ago)
+      Fabricate(:topic, title: '15 day old topic', created_at: 15.days.ago)
+      Fabricate(:topic, title: '30 day old topic', created_at: 30.days.ago)
+    end
+
+    it "filters before date topics correctly" do
+      expect(TopicQuery.new(user).list_latest.topics.size).to eq(3)
+      expect(TopicQuery.new(user, before: '20').list_latest.topics.size).to eq(1)
+      expect(TopicQuery.new(user, before: '20').list_latest.topics.first.title).to eq('30 day old topic')
+      expect(TopicQuery.new(user, before: '60').list_latest.topics.size).to eq(0)
+      expect(TopicQuery.new(user, before: '12').list_latest.topics.size).to eq(2)
+      expect(TopicQuery.new(user, before: '9').list_latest.topics.size).to eq(3)
+    end
+
+    it "filters after date topics correctly" do
+      expect(TopicQuery.new(user, after: '20').list_latest.topics.size).to eq(2)
+      expect(TopicQuery.new(user, after: '12').list_latest.topics.size).to eq(1)
+      expect(TopicQuery.new(user, after: '12').list_latest.topics.first.title).to eq('10 day old topic')
+    end
+
+    it "filters before and after date topics correctly" do
+      expect(TopicQuery.new(user, after: '16', before: '14').list_latest.topics.size).to eq(1)
+      expect(TopicQuery.new(user, after: '16', before: '14').list_latest.topics.first.title).to eq('15 day old topic')
+    end
+  end
+
   describe 'include_pms option' do
     it "includes users own pms in regular topic lists" do
       topic = Fabricate(:topic)


### PR DESCRIPTION
This will allow you to pass in the `after` option to filter topics by
certain days. The `before` option flag already exists.

Examples:

`/latest?after=10`

or along with `before`

`/latest?before=3&after=10`

Here is a list of topics without a filter, but if we add the the `/latest?before=3&after=10` filter it will include what is in the blue box:

![image](https://user-images.githubusercontent.com/1490496/135153911-6291e16c-6aaf-4ce1-92db-6b1fec4cba39.png)

with the filter applied:

![image](https://user-images.githubusercontent.com/1490496/135154191-cadf998c-80e6-4c40-88d7-51546a8ac879.png)


