### PR TITLE
DEV: uses standard browser_disconnect_timeout

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -29,7 +29,7 @@ module.exports = {
   launch_in_dev: ["Chrome"],
   tap_failed_tests_only: true,
   parallel: 1, // disable parallel tests for stability
-  browser_disconnect_timeout: 120,
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: [
       // --no-sandbox is needed when running Chrome inside a container

--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -29,6 +29,7 @@ module.exports = {
   launch_in_dev: ["Chrome"],
   tap_failed_tests_only: true,
   parallel: 1, // disable parallel tests for stability
+  browser_disconnect_timeout: 120,
   browser_args: {
     Chrome: [
       // --no-sandbox is needed when running Chrome inside a container


### PR DESCRIPTION
This is what the ember cli blueprint uses now: https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/testem.js