### PR TITLE
DEV: Allow onStateChange callbacks for PM topic tracking state.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
@@ -25,6 +25,11 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
     this.statesModificationCounter = 0;
     this.isTracking = false;
     this.newIncoming = [];
+    this.stateChangeCallbacks = {};
+  },
+
+  onStateChange(name, callback) {
+    this.stateChangeCallbacks[name] = callback;
   },
 
   startTracking() {
@@ -34,7 +39,7 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
 
     this._establishChannels();
 
-    this._loadInitialState().finally(() => {
+    return this._loadInitialState().finally(() => {
       this.set("isTracking", true);
     });
   },
@@ -87,7 +92,7 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
     }
 
     topicIds.forEach((topicId) => this.states.delete(topicId));
-    this.incrementProperty("statesModificationCounter");
+    this._afterStateChange();
   },
 
   _userChannel() {
@@ -225,8 +230,13 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
     this.states.set(topicId, newState);
 
     if (!opts.skipIncrement) {
-      this.incrementProperty("statesModificationCounter");
+      this._afterStateChange();
     }
+  },
+
+  _afterStateChange() {
+    this.incrementProperty("statesModificationCounter");
+    Object.values(this.stateChangeCallbacks).forEach((callback) => callback());
   },
 });
 

--- a/app/assets/javascripts/discourse/tests/unit/models/private-message-topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/private-message-topic-tracking-state-test.js
@@ -1,0 +1,32 @@
+import { test } from "qunit";
+import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
+import MessageBus from "message-bus-client";
+import PrivateMessageTopicTrackingState from "discourse/models/private-message-topic-tracking-state";
+import User from "discourse/models/user";
+
+discourseModule(
+  "Unit | Model | private-message-topic-tracking-state",
+  function (hooks) {
+    let pmTopicTrackingState;
+
+    hooks.beforeEach(function () {
+      pmTopicTrackingState = PrivateMessageTopicTrackingState.create({
+        messageBus: MessageBus,
+        currentUser: User.create({ id: 1, username: "test" }),
+      });
+    });
+
+    test("modifying state calls onStateChange callbacks", function (assert) {
+      let callbackCalled = false;
+
+      pmTopicTrackingState.onStateChange("testing", () => {
+        callbackCalled = true;
+      });
+
+      pmTopicTrackingState.set("isTracking", true);
+      pmTopicTrackingState.removeTopics([]);
+
+      assert.ok(callbackCalled);
+    });
+  }
+);


### PR DESCRIPTION
The changes here are in anticipation of a private plugin that will soon
be merged into Discourse core.