### PR TITLE
FEATURE: Add email blocking using regex

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1645,6 +1645,7 @@ en:
 
     allow_index_in_robots_txt: "Specify in robots.txt that this site is allowed to be indexed by web search engines. In exceptional cases you can permanently <a href='%{base_path}/admin/customize/robots'>override robots.txt</a>."
     blocked_email_domains: "A pipe-delimited list of email domains that users are not allowed to register accounts with. Example: mailinator.com|trashmail.net"
+    blocked_email_pattern: "A regular expression that matches email addresses that users are not allowed to register accounts with. Example: .*@mailinator\\.com"
     allowed_email_domains: "A pipe-delimited list of email domains that users MUST register accounts with. WARNING: Users with email domains other than those listed will not be allowed!"
     auto_approve_email_domains: "Users with email addresses from this list of domains will be automatically approved."
     hide_email_address_taken: "Don't inform users that an account exists with a given email address during signup and from the forgot password form."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -507,6 +507,8 @@ login:
     default: "mailinator.com"
     type: list
     list_type: simple
+  blocked_email_pattern:
+    default: ""
   allowed_email_domains:
     default: ""
     type: list

--- a/spec/components/validators/email_validator_spec.rb
+++ b/spec/components/validators/email_validator_spec.rb
@@ -30,6 +30,14 @@ describe EmailValidator do
       expect(blocks?('sam@googlemail.com')).to eq(false)
     end
 
+    it "blocks based on blocked_email_pattern" do
+      SiteSetting.blocked_email_pattern = ".*\\+.*@gmail\\.com"
+      expect(blocks?('sam@email.com')).to eq(false)
+      expect(blocks?('sam+test@email.com')).to eq(false)
+      expect(blocks?('sam@gmail.com')).to eq(false)
+      expect(blocks?('sam+test@gmail.com')).to eq(true)
+    end
+
     it "blocks based on allowed_email_domains" do
       SiteSetting.allowed_email_domains = "googlemail.com|email.com"
       expect(blocks?('sam@email.com')).to eq(false)


### PR DESCRIPTION
blocked_email_pattern site setting can block email matching a regular
expression.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
