### PR TITLE
DEV: Fix moment warnings

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -170,9 +170,11 @@ function _calculateDuration(element) {
     (dateElement) => dateElement.dataset
   );
   const startDateTime = moment(
-    `${startDataset.date} ${startDataset.time || ""}`
+    `${startDataset.date} ${startDataset.time || ""}`.trim()
   );
-  const endDateTime = moment(`${endDataset.date} ${endDataset.time || ""}`);
+  const endDateTime = moment(
+    `${endDataset.date} ${endDataset.time || ""}`.trim()
+  );
   const duration = endDateTime.diff(startDateTime, "minutes");
 
   // negative duration is used when we calculate difference for end date from range


### PR DESCRIPTION
When start/end was missing the time component the string passed to `moment()` would have a space at the end. This was causing these warnings:

```
Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
```