### PR TITLE
FIX: nil the baked version after moving the posts.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -732,12 +732,11 @@ class Post < ActiveRecord::Base
   before_save do
     self.last_editor_id ||= user_id
 
-    if !new_record? && will_save_change_to_raw?
-      self.cooked = cook(raw, topic_id: topic_id)
+    if will_save_change_to_raw?
+      self.cooked = cook(raw, topic_id: topic_id) if !new_record?
+      self.baked_at = Time.zone.now
+      self.baked_version = BAKED_VERSION
     end
-
-    self.baked_at = Time.zone.now
-    self.baked_version = BAKED_VERSION
   end
 
   def advance_draft_sequence

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -191,7 +191,8 @@ class PostMover
       post_number: @move_map[post.post_number],
       reply_to_post_number: @move_map[post.reply_to_post_number],
       topic_id: destination_topic.id,
-      sort_order: @move_map[post.post_number]
+      sort_order: @move_map[post.post_number],
+      baked_version: nil
     }
 
     unless @move_map[post.reply_to_post_number]

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -120,7 +120,7 @@ describe PostMover do
             .to  change { p2.reload.topic_id }
             .and change { p2.post_number }
             .and change { p3.reload.raw }
-            .and change { p3.baked_version }.to nil
+            .and change { p2.baked_version || p3.baked_version }.to nil
 
           expect(p3.raw).to include("post:#{p2.post_number}, topic:#{p2.topic_id}")
         end


### PR DESCRIPTION
Previously, quotes from original topics are rendered incorrectly since the moved posts are not rebaked.