### PR TITLE
DEV: skip S3 CDN urls with different path in prefix.

### DIFF
--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -158,8 +158,11 @@ module FileStore
       end
 
       return false if SiteSetting.Upload.s3_cdn_url.blank?
-      cdn_hostname = URI.parse(SiteSetting.Upload.s3_cdn_url || "").hostname
-      return true if cdn_hostname.presence && url[cdn_hostname]
+
+      s3_cdn_url = URI.parse(SiteSetting.Upload.s3_cdn_url || "")
+      cdn_hostname = s3_cdn_url.hostname
+
+      return true if cdn_hostname.presence && url[cdn_hostname] && (s3_cdn_url.path.blank? || parsed_url.path.starts_with?(s3_cdn_url.path))
       false
     end
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1715,6 +1715,17 @@ describe Post do
       post.each_upload_url { |src, _, _| urls << src }
       expect(urls).to be_empty
     end
+
+    it "skip S3 cdn urls with different path" do
+      setup_s3
+      SiteSetting.Upload.stubs(:s3_cdn_url).returns("https://cdn.example.com/site1")
+
+      urls = []
+      raw = "<img src='https://cdn.example.com/site1/original/1X/bc68acbc8c022726e69f980e00d6811212r.jpg' /><img src='https://cdn.example.com/site2/original/1X/bc68acbc8c022726e69f980e00d68112128.jpg' />"
+      post = Fabricate(:post, raw: raw)
+      post.each_upload_url { |src, _, _| urls << src }
+      expect(urls).to contain_exactly("https://cdn.example.com/site1/original/1X/bc68acbc8c022726e69f980e00d6811212r.jpg")
+    end
   end
 
   describe "#publish_changes_to_client!" do


### PR DESCRIPTION
Previously, while retrieving each upload URL in a post S3 CDN URLs with a different path in prefix (external URLs technically) are considered as uploaded URLs. It created an issue while checking missing uploads.