### PR TITLE
FIX: Do not show 'new or updated topics' for mobile categories page

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -6,6 +6,7 @@ import DiscourseURL from "discourse/lib/url";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import PreloadStore from "discourse/lib/preload-store";
 import User from "discourse/models/user";
+import Site from "discourse/models/site";
 import { isEmpty } from "@ember/utils";
 
 function isNew(topic) {
@@ -244,6 +245,7 @@ const TopicTrackingState = EmberObject.extend({
     if (
       filter === "categories" &&
       data.message_type === "latest" &&
+      !Site.current().mobileView &&
       this.siteSettings.desktop_category_page_style ===
         "categories_and_latest_topics"
     ) {


### PR DESCRIPTION
This banner should only show on the 'categories + latest topics' view, which is desktop-only

https://meta.discourse.org/t/204979

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
