### PR TITLE
FIX: Exclude PMs that user sent to themselves.

### DIFF
--- a/lib/topic_query/private_message_lists.rb
+++ b/lib/topic_query/private_message_lists.rb
@@ -5,6 +5,15 @@ class TopicQuery
     def list_private_messages(user)
       list = private_messages_for(user, :user)
       list = not_archived(list, user)
+
+      list = list.where(<<~SQL)
+        NOT (
+          topics.participant_count = 1
+          AND topics.user_id = #{user.id.to_i}
+          AND topics.moderator_posts_count = 0
+        )
+      SQL
+
       create_list(:private_messages, {}, list)
     end
 

--- a/spec/lib/topic_query/private_message_lists_spec.rb
+++ b/spec/lib/topic_query/private_message_lists_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 describe TopicQuery::PrivateMessageLists do
+  fab!(:admin) { Fabricate(:admin) }
   fab!(:user) { Fabricate(:user) }
   fab!(:user_2) { Fabricate(:user) }
   fab!(:user_3) { Fabricate(:user) }
@@ -49,6 +50,17 @@ describe TopicQuery::PrivateMessageLists do
       topics = TopicQuery.new(nil).list_private_messages(user_2).topics
 
       expect(topics).to contain_exactly(private_message)
+    end
+
+    it "includes topics with moderator posts" do
+      pm = Fabricate(:private_message_post, user: user_4).topic
+
+      expect(TopicQuery.new(user_4).list_private_messages(user_4).topics).to be_empty
+
+      pm.add_moderator_post(admin, "Thank you for your flag")
+
+      expect(TopicQuery.new(user_4).list_private_messages(user_4).topics)
+        .to contain_exactly(pm)
     end
   end
 


### PR DESCRIPTION
Regression from 016efeadf6f242e04daf5ef8e18c2ca708a1392d

Follow-up to 016efeadf6f242e04daf5ef8e18c2ca708a1392d