### PR TITLE
FIX: `Topic.similar_to` results in invalid query for certain locales.

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -581,11 +581,11 @@ class Topic < ActiveRecord::Base
   def self.similar_to(title, raw, user = nil)
     return [] if title.blank?
     raw = raw.presence || ""
+    search_data = Search.prepare_data(title.strip)
 
-    tsquery = Search.set_tsquery_weight_filter(
-      Search.prepare_data(title.strip),
-      'A'
-    )
+    return [] if search_data.blank?
+
+    tsquery = Search.set_tsquery_weight_filter(search_data, 'A')
 
     if raw.present?
       cooked = SearchIndexer::HtmlScrubber.scrub(

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -540,6 +540,12 @@ describe Topic do
       expect(Topic.similar_to('some title', 'https://discourse.org/#INCORRECT#URI')).to be_empty
     end
 
+    it 'does not result in invalid statement when title is all stopwords for zh_CN' do
+      SiteSetting.default_locale = "zh_CN"
+
+      expect(Topic.similar_to("怎么上自己的", '')).to eq([])
+    end
+
     context 'with a similar topic' do
       fab!(:post) {
         SearchIndexer.enable


### PR DESCRIPTION
For `zh_CN`, we use the `cppjieba_rb` gem to remove stop words so
calling `Search.prepare_data` may result in an empty string.