### PR TITLE
FIX: Stop incoming message tracking after navigating away.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-topics-list.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-topics-list.js
@@ -49,7 +49,7 @@ export default Controller.extend(BulkTopicSelection, {
   },
 
   unsubscribe() {
-    this.pmTopicTrackingState.resetIncomingTracking();
+    this.pmTopicTrackingState.stopIncomingTracking();
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
@@ -81,6 +81,17 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
     }
   },
 
+  stopIncomingTracking() {
+    if (this.inbox) {
+      this.setProperties({
+        newIncoming: [],
+        inbox: null,
+        filter: null,
+        activeGroup: null,
+      });
+    }
+  },
+
   removeTopics(topicIds) {
     if (!this.isTracking) {
       return;


### PR DESCRIPTION
Income messages should only be tracking when we're watching the inbox. Once you navigate away, we need to clear the inbox property to make sure we stop tracking.

No tests cause the test is complicated to set up for little gain.