### PR TITLE
UX: Use consistent category badge font size in dropdowns

### DIFF
--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -126,6 +126,10 @@
         border-bottom-width: 5px;
         border-bottom-style: solid;
       }
+
+      .badge-wrapper {
+        font-size: inherit;
+      }
     }
 
     .btn-clear {


### PR DESCRIPTION
Category badges are set globally to have a font size set to `font-down-1`, but in dropdowns it's more consistent to have them inherit the size from the parent. This way the form elements line up properly regardless of the site's or user's font size setting. 