### PR TITLE
FIX: Stop tracking incoming message after navigating away take 2.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/private-message-topic-tracking-state.js
@@ -78,21 +78,20 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
 
   trackIncoming(inbox, filter, group) {
     this.setProperties({ inbox, filter, activeGroup: group });
+    this.set("isTrackingIncoming", true);
   },
 
   resetIncomingTracking() {
-    if (this.inbox) {
+    if (this.isTrackingIncoming) {
       this.set("newIncoming", []);
     }
   },
 
   stopIncomingTracking() {
-    if (this.inbox) {
+    if (this.isTrackingIncoming) {
       this.setProperties({
+        isTrackingIncoming: false,
         newIncoming: [],
-        inbox: null,
-        filter: null,
-        activeGroup: null,
       });
     }
   },
@@ -213,7 +212,7 @@ const PrivateMessageTopicTrackingState = EmberObject.extend({
   },
 
   _notifyIncoming(topicId) {
-    if (this.newIncoming.indexOf(topicId) === -1) {
+    if (this.isTrackingIncoming && this.newIncoming.indexOf(topicId) === -1) {
       this.newIncoming.pushObject(topicId);
     }
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -423,6 +423,21 @@ acceptance(
       );
     });
 
+    test("incoming messages is not tracked on non user messages route", async function (assert) {
+      await visit("/u/charlie/messages");
+      await visit("/t/13");
+
+      publishNewToMessageBus({ topicId: 1, userId: 5 });
+
+      await visit("/t/13"); // await re-render
+      await visit("/u/charlie/messages");
+
+      assert.ok(
+        !exists(".show-mores"),
+        `does not display the topic incoming info`
+      );
+    });
+
     test("dismissing all unread messages", async function (assert) {
       await visit("/u/charlie/messages/unread");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -434,7 +434,7 @@ acceptance(
 
       assert.ok(
         !exists(".show-mores"),
-        `does not display the topic incoming info`
+        "does not display the topic incoming info"
       );
     });
 


### PR DESCRIPTION
Previous fix in d82e5cd37c1c3b2377507ed0354bbdce6a96ae99 resulted in
counts being flappy as we cleared the active inbox between routes.

Follow-up to d82e5cd37c1c3b2377507ed0354bbdce6a96ae99