### PR TITLE
FIX: Use addresses to compare email header

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -637,7 +637,8 @@ module Email
 
         comparison_failed = false
         comparison_headers.each do |comparison_header|
-          if mail_object[comparison_header].to_s != "#{from_display_name} <#{from_address}>"
+          comparison_header_address = mail_object[comparison_header].to_s[/<([^>]+)>/, 1]
+          if comparison_header_address != from_address
             comparison_failed = true
             break
           end

--- a/spec/fixtures/emails/reply_to_whitespaces.eml
+++ b/spec/fixtures/emails/reply_to_whitespaces.eml
@@ -1,0 +1,12 @@
+From: "'John Doe' via Forwarder" <team@bar.com>
+To: "team@bar.com" <team@bar.com>
+Subject: Greetings
+Date: Wed, 01 Jan 2021 12:00:00 +0000
+Message-ID: <TXULO4v6YU0TzeL2buFAJNU2MK21c7t4@example.com>
+X-Original-Sender: johndoe@example.com
+X-Original-From: "John Doe"
+    <johndoe@example.com>
+Reply-To: "John Doe"
+    <johndoe@example.com>
+
+Hello world!


### PR DESCRIPTION
Usually, when an email is received a user lookup is performed using the
email address found in the `From` header. When an email has an
`X-Original-From` header, if it is equal to `Reply-To` then it uses that
one instead. The comparison was sensitive to whitespaces and other
insignificant characters such as quotes because it reconstructed the
`From` header.

For the fixture added in this commit, it compared the reconstructed
`From` header `John Doe <johndoe@example.com>` with the `Reply-To`
header `"John Doe"    <johndoe@example.com>`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
