### PR TITLE
UX: capitalize unsubscribed email locale

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1031,7 +1031,7 @@ en:
 
   unsubscribed:
     title: "Email preferences updated!"
-    description: "email preferences for <b>%{email}</b> were updated. To change your email settings <a href='%{url}'>visit your user preferences</a>."
+    description: "Email preferences for <b>%{email}</b> were updated. To change your email settings <a href='%{url}'>visit your user preferences</a>."
     topic_description: "To re-subscribe to %{link}, use the notification control at the bottom or right of the topic."
     private_topic_description: "To re-subscribe, use the notification control at the bottom or right of the topic."
 


### PR DESCRIPTION
https://meta.discourse.org/t/unsubscribed-description-text-needs-a-capital-letter/205239