### PR TITLE
FIX: Parse address lists in embedded emails

### DIFF
--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -2015,4 +2015,12 @@ describe Email::Receiver do
       expect { receive(email_3) }.to change { Topic.count }.by(0).and change { Post.where(post_type: Post.types[:regular]).count }.by(1)
     end
   end
+
+  it 'fixes valid addresses in embedded emails' do
+    Fabricate(:group, incoming_email: "group-fwd@example.com")
+    process(:long_embedded_email_headers)
+    incoming_email = IncomingEmail.find_by(message_id: "example1@mail.gmail.com")
+    expect(incoming_email.cc_addresses).to include("a@example.com")
+    expect(incoming_email.cc_addresses).to include("c@example.com")
+  end
 end

--- a/spec/fixtures/emails/long_embedded_email_headers.eml
+++ b/spec/fixtures/emails/long_embedded_email_headers.eml
@@ -1,0 +1,21 @@
+MIME-Version: 1.0
+Date: Sat, 2 Oct 2021 21:52:36 -0400
+Message-ID: <example1@mail.gmail.com>
+Subject: Fwd: Your receipt from Civilized Discourse Construction Kit, Inc. #2348-2277
+From: Example Group <group@example.com>
+To: group-fwd@example.com
+Cc: C <c@example.com>, D <d@
+example.com>
+
+
+---------- Forwarded message ---------
+Date: Sat, 2 Oct 2021 21:52:36 -0400
+Message-ID: <example2@mail.gmail.com>
+Subject: Fwd: Your receipt from Civilized Discourse Construction Kit, Inc. #2348-2277
+From: User <user@example.com>
+To: Example Group <group@example.com>
+Cc: A <a@example.com>, B <
+b@example.com>
+
+
+Hello world!


### PR DESCRIPTION
Same fix is applied to emails immediately after being parsed because
long headers are sometimes in an invalid format.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
