### PR TITLE
FIX: Support Ruby 3 keyword arguments

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -679,10 +679,10 @@ class Theme < ActiveRecord::Base
     keys = schema["items"]["properties"].keys
     return if !keys
 
-    current_values = CSV.parse(setting_row.value, { col_sep: '|' }).flatten
+    current_values = CSV.parse(setting_row.value, **{ col_sep: '|' }).flatten
     new_values = []
     current_values.each do |item|
-      parts = CSV.parse(item, { col_sep: ',' }).flatten
+      parts = CSV.parse(item, **{ col_sep: ',' }).flatten
       props = parts.map.with_index { |p, idx| [keys[idx], p] }.to_h
       new_values << props
     end

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -2,7 +2,7 @@
 
 <section itemscope itemtype="https://schema.org/AboutPage">
   <h1 itemprop="name">
-    <%=t "js.about.title", {title: @about.title} %>
+    <%=t "js.about.title", **{title: @about.title} %>
   </h1>
 
   <div itemprop="text">

--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -94,12 +94,12 @@ class DiscourseRedis
         end
 
       if block
-        @redis.scan_each(options) do |key|
+        @redis.scan_each(**options) do |key|
           key = remove_namespace(key) if @namespace
           block.call(key)
         end
       else
-        @redis.scan_each(options).map do |key|
+        @redis.scan_each(**options).map do |key|
           key = remove_namespace(key) if @namespace
           key
         end

--- a/lib/seed_data/categories.rb
+++ b/lib/seed_data/categories.rb
@@ -21,7 +21,7 @@ module SeedData
         categories(site_setting_names).each do |params|
           params.slice!(:site_setting_name, :name, :description)
           params[:skip_changed] = skip_changed
-          update_category(params)
+          update_category(**params)
         end
       end
     end

--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -23,7 +23,7 @@ module SeedData
         topics(site_setting_names).each do |params|
           params.except!(:category, :after_create)
           params[:skip_changed] = skip_changed
-          update_topic(params)
+          update_topic(**params)
         end
       end
     end

--- a/lib/tasks/posts.rake
+++ b/lib/tasks/posts.rake
@@ -137,7 +137,7 @@ def rebake_post(post, opts = {})
   if !opts[:priority]
     opts[:priority] = :ultra_low
   end
-  post.rebake!(opts)
+  post.rebake!(**opts)
 rescue => e
   puts "", "Failed to rebake (topic_id: #{post.topic_id}, post_id: #{post.id})", e, e.backtrace.join("\n")
 end

--- a/lib/upload_recovery.rb
+++ b/lib/upload_recovery.rb
@@ -60,9 +60,9 @@ class UploadRecovery
     }
 
     if Discourse.store.external?
-      recover_post_upload_from_s3(attributes)
+      recover_post_upload_from_s3(**attributes)
     else
-      recover_post_upload_from_local(attributes)
+      recover_post_upload_from_local(**attributes)
     end
   end
 

--- a/lib/validators/post_validator.rb
+++ b/lib/validators/post_validator.rb
@@ -20,11 +20,11 @@ class PostValidator < ActiveModel::Validator
 
   def presence(post)
     unless options[:skip_topic]
-      post.errors.add(:topic_id, :blank, options) if post.topic_id.blank?
+      post.errors.add(:topic_id, :blank, **options) if post.topic_id.blank?
     end
 
     if post.new_record? && post.user_id.nil?
-      post.errors.add(:user_id, :blank, options)
+      post.errors.add(:user_id, :blank, **options)
     end
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -72,7 +72,7 @@ end
 
 shared_examples 'action requires login' do |method, url, params = {}|
   it 'raises an exception when not logged in' do
-    self.public_send(method, url, params)
+    self.public_send(method, url, **params)
     expect(response.status).to eq(403)
   end
 end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3369,7 +3369,7 @@ RSpec.describe TopicsController do
 
         TopicTrackingState.expects(:publish_dismiss_new).with(user.id, topic_ids: [topic2.id, topic3.id]).at_least_once
 
-        put "/topics/reset-new.json", { params: { topic_ids: [topic2.id, topic3.id] } }
+        put "/topics/reset-new.json", **{ params: { topic_ids: [topic2.id, topic3.id] } }
         expect(response.status).to eq(200)
         user.reload
         expect(user.user_stat.new_since.to_date).not_to eq(old_date.to_date)
@@ -3391,7 +3391,7 @@ RSpec.describe TopicsController do
           old_date = 2.years.ago
           user.user_stat.update_column(:new_since, old_date)
 
-          put "/topics/reset-new.json?tracked=true", { params: { topic_ids: [topic2.id, topic3.id] } }
+          put "/topics/reset-new.json?tracked=true", **{ params: { topic_ids: [topic2.id, topic3.id] } }
           expect(response.status).to eq(200)
           user.reload
           expect(user.user_stat.new_since.to_date).to eq(old_date.to_date)
@@ -3412,7 +3412,7 @@ RSpec.describe TopicsController do
 
           create_post # This is a new post, but is not tracked so a record will not be created for it
           expect do
-            put "/topics/reset-new.json?tracked=true", { params: { topic_ids: [tracked_topic.id, topic2.id, topic3.id] } }
+            put "/topics/reset-new.json?tracked=true", **{ params: { topic_ids: [tracked_topic.id, topic2.id, topic3.id] } }
           end.to change { DismissedTopicUser.where(user_id: user.id).count }.by(2)
           expect(DismissedTopicUser.where(user_id: user.id).pluck(:topic_id)).to match_array([tracked_topic.id, topic2.id])
         end

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -742,7 +742,7 @@ describe UploadsController do
       end
 
       it "includes accepted metadata in the presigned url when provided" do
-        post "/uploads/generate-presigned-put.json", {
+        post "/uploads/generate-presigned-put.json", **{
           params: {
             file_name: "test.png",
             file_size: 1024,
@@ -806,7 +806,7 @@ describe UploadsController do
 
       it "returns 422 when the create request errors" do
         FileStore::S3Store.any_instance.stubs(:create_multipart).raises(Aws::S3::Errors::ServiceError.new({}, "test"))
-        post "/uploads/create-multipart.json", {
+        post "/uploads/create-multipart.json", **{
           params: {
             file_name: "test.png",
             file_size: 1024,
@@ -818,7 +818,7 @@ describe UploadsController do
 
       it "returns 422 when the file is an attachment and it's too big" do
         SiteSetting.max_attachment_size_kb = 1024
-        post "/uploads/create-multipart.json", {
+        post "/uploads/create-multipart.json", **{
           params: {
             file_name: "test.zip",
             file_size: 9999999,
@@ -846,7 +846,7 @@ describe UploadsController do
 
       it "creates a multipart upload and creates an external upload stub that is marked as multipart" do
         stub_create_multipart_request
-        post "/uploads/create-multipart.json", {
+        post "/uploads/create-multipart.json", **{
           params: {
             file_name: "test.png",
             file_size: 1024,
@@ -879,7 +879,7 @@ describe UploadsController do
           "test.png", "image/png", metadata: { "sha1-checksum" => "testing" }
         ).returns({ key: "test" })
 
-        post "/uploads/create-multipart.json", {
+        post "/uploads/create-multipart.json", **{
           params: {
             file_name: "test.png",
             file_size: 1024,

--- a/spec/services/user_authenticator_spec.rb
+++ b/spec/services/user_authenticator_spec.rb
@@ -50,7 +50,7 @@ describe UserAuthenticator do
 
       authentication = github_auth(true)
 
-      UserAuthenticator.new(user, authentication: authentication).finish
+      UserAuthenticator.new(user, { authentication: authentication }).finish
       expect(user.email_confirmed?).to be_truthy
       expect(group.usernames).to include(user.username)
     end
@@ -60,7 +60,7 @@ describe UserAuthenticator do
 
       authentication = github_auth(false)
 
-      UserAuthenticator.new(user, authentication: authentication).finish
+      UserAuthenticator.new(user, { authentication: authentication }).finish
       expect(user.email_confirmed?).to be_falsey
       expect(group.usernames).not_to include(user.username)
     end
@@ -70,7 +70,7 @@ describe UserAuthenticator do
 
       authentication = github_auth(true)
 
-      UserAuthenticator.new(user, authentication: authentication).finish
+      UserAuthenticator.new(user, { authentication: authentication }).finish
       expect(user.email_confirmed?).to be_falsey
       expect(group.usernames).not_to include(user.username)
     end


### PR DESCRIPTION
This pull request supports Ruby 3 keyword argument.

### Example without this change

```ruby
$ ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux]
$ bundle exec rspec ./spec/lib/site_settings/validations_spec.rb:107
Run options: include {:locations=>{"./spec/lib/site_settings/validations_spec.rb"=>[107]}}

Randomized with seed 27763
F

Failures:

  1) SiteSettings::Validations s3 buckets reusage #validate_s3_upload_bucket cannot be made blank unless the setting is false
     Failure/Error:
       @redis.scan_each(options).map do |key|
         key = remove_namespace(key) if @namespace
         key
       end

     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # ./lib/discourse_redis.rb:102:in `block in scan_each'
     # ./lib/discourse_redis.rb:29:in `ignore_readonly'
     # ./lib/discourse_redis.rb:86:in `scan_each'
     # ./lib/cache.rb:46:in `keys'
     # ./app/models/report.rb:135:in `clear_cache'
     # ./config/initializers/014-track-setting-changes.rb:32:in `block in <main>'
     # ./lib/discourse_event.rb:14:in `block in trigger'
     # ./lib/discourse_event.rb:13:in `trigger'
     # ./spec/support/discourse_event_helper.rb:5:in `trigger'
     # ./lib/site_setting_extension.rb:370:in `add_override!'
     # ./lib/site_setting_extension.rb:537:in `block in setup_methods'
     # ./spec/lib/site_settings/validations_spec.rb:108:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:279:in `block (2 levels) in <top (required)>'

Finished in 0.16988 seconds (files took 2.55 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/site_settings/validations_spec.rb:107 # SiteSettings::Validations s3 buckets reusage #validate_s3_upload_bucket cannot be made blank unless the setting is false

Randomized with seed 27763

$
```

### Example with this change

```ruby
$ ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux]
$ bundle exec rspec ./spec/lib/site_settings/validations_spec.rb:107
Run options: include {:locations=>{"./spec/lib/site_settings/validations_spec.rb"=>[107]}}

Randomized with seed 22075
.

Finished in 0.16971 seconds (files took 2.41 seconds to load)
1 example, 0 failures

Randomized with seed 22075

$
```

### Fixed spec failures with Ruby 3

Compared rspec result between main branch and this branch, this commit addresses these 259 failures.

```ruby

rspec ./spec/lib/site_settings/validations_spec.rb:107 # SiteSettings::Validations s3 buckets reusage #validate_s3_upload_bucket cannot be made blank unless the setting is false
rspec ./spec/lib/site_settings/validations_spec.rb:99 # SiteSettings::Validations s3 buckets reusage #validate_s3_upload_bucket should raise an error when the 's3_upload_bucket' is a subdirectory of 's3_backup_bucket'
rspec ./spec/lib/site_settings/validations_spec.rb[1:2:2:1:4] # SiteSettings::Validations s3 buckets reusage #validate_s3_upload_bucket behaves like s3 bucket validation should raise an error when both buckets are equal
rspec ./spec/lib/site_settings/validations_spec.rb[1:2:2:1:5] # SiteSettings::Validations s3 buckets reusage #validate_s3_upload_bucket behaves like s3 bucket validation should raise an error when both buckets are equal except for a trailing slash
rspec ./spec/lib/site_settings/validations_spec.rb[1:2:2:1:3] # SiteSettings::Validations s3 buckets reusage #validate_s3_upload_bucket behaves like s3 bucket validation shouldn't raise an error when both buckets are equal, but use a different path
rspec ./spec/components/post_creator_spec.rb:1271 # PostCreator doesn't strip starting whitespaces
rspec ./spec/components/post_creator_spec.rb:23 # PostCreator new topic can create a topic with null byte central
rspec ./spec/components/post_creator_spec.rb:29 # PostCreator new topic can be created with auto tracking disabled
rspec ./spec/components/post_creator_spec.rb:35 # PostCreator new topic can be created with first post as wiki
rspec ./spec/components/post_creator_spec.rb:43 # PostCreator new topic can be created with a hidden reason
rspec ./spec/components/post_creator_spec.rb:52 # PostCreator new topic ensures the user can create the topic
rspec ./spec/components/post_creator_spec.rb:57 # PostCreator new topic can be created with custom fields
rspec ./spec/components/post_creator_spec.rb:63 # PostCreator new topic reply to post number omits reply to post number if received on a new topic
rspec ./spec/components/post_creator_spec.rb:72 # PostCreator new topic invalid title has errors
rspec ./spec/components/post_creator_spec.rb:81 # PostCreator new topic invalid raw has errors
rspec ./spec/components/post_creator_spec.rb:90 # PostCreator new topic success is not hidden
rspec ./spec/components/post_creator_spec.rb:98 # PostCreator new topic success doesn't return true for spam
rspec ./spec/components/post_creator_spec.rb:103 # PostCreator new topic success triggers extensibility events
rspec ./spec/components/post_creator_spec.rb:119 # PostCreator new topic success does not notify on system messages
rspec ./spec/components/post_creator_spec.rb:131 # PostCreator new topic success enqueues job to generate messages
rspec ./spec/components/post_creator_spec.rb:136 # PostCreator new topic success generates the correct messages for a secure topic
rspec ./spec/components/post_creator_spec.rb:180 # PostCreator new topic success generates the correct messages for a normal topic
rspec ./spec/components/post_creator_spec.rb:207 # PostCreator new topic success extracts links from the post
rspec ./spec/components/post_creator_spec.rb:213 # PostCreator new topic success queues up post processing job when saved
rspec ./spec/components/post_creator_spec.rb:235 # PostCreator new topic success passes the invalidate_oneboxes along to the job if present
rspec ./spec/components/post_creator_spec.rb:242 # PostCreator new topic success passes the image_sizes along to the job if present
rspec ./spec/components/post_creator_spec.rb:250 # PostCreator new topic success assigns a category when supplied
rspec ./spec/components/post_creator_spec.rb:254 # PostCreator new topic success adds  meta data from the post
rspec ./spec/components/post_creator_spec.rb:258 # PostCreator new topic success passes the image sizes through
rspec ./spec/components/post_creator_spec.rb:263 # PostCreator new topic success sets topic excerpt if first post, but not second post
rspec ./spec/components/post_creator_spec.rb:273 # PostCreator new topic success supports custom excerpts
rspec ./spec/components/post_creator_spec.rb:288 # PostCreator new topic success creates post stats
rspec ./spec/components/post_creator_spec.rb:304 # PostCreator new topic success updates topic stats
rspec ./spec/components/post_creator_spec.rb:313 # PostCreator new topic success creates a post with featured link
rspec ./spec/components/post_creator_spec.rb:322 # PostCreator new topic success allows notification email to be skipped
rspec ./spec/components/post_creator_spec.rb:339 # PostCreator new topic success topic's auto close doesn't update topic's auto close when it's not based on last post
rspec ./spec/components/post_creator_spec.rb:367 # PostCreator new topic success topic's auto close topic's auto close based on last post updates topic's auto close date
rspec ./spec/components/post_creator_spec.rb:388 # PostCreator new topic success topic's auto close topic's auto close based on last post when auto_close_topics_post_count has been reached closes the topic and deletes the topic timer
rspec ./spec/components/post_creator_spec.rb:409 # PostCreator new topic success topic's auto close topic's auto close based on last post when auto_close_topics_post_count has been reached uses the system locale for the message
rspec ./spec/components/post_creator_spec.rb:434 # PostCreator new topic success topic's auto close topic's auto close based on last post when auto_close_topics_post_count has been reached auto_close_topics_create_linked_topic is enabled enqueues a job to create a new lin
ked topic
rspec ./spec/components/post_creator_spec.rb:464 # PostCreator new topic success tags tagging disabled doesn't create tags
rspec ./spec/components/post_creator_spec.rb:481 # PostCreator new topic success tags tagging enabled can create tags can create all tags if none exist
rspec ./spec/components/post_creator_spec.rb:486 # PostCreator new topic success tags tagging enabled can create tags creates missing tags if some exist
rspec ./spec/components/post_creator_spec.rb:500 # PostCreator new topic success tags tagging enabled cannot create tags only uses existing tags
rspec ./spec/components/post_creator_spec.rb:514 # PostCreator new topic success tags tagging enabled automatically tags first posts without regular expressions works with many tags
rspec ./spec/components/post_creator_spec.rb:521 # PostCreator new topic success tags tagging enabled automatically tags first posts without regular expressions works with overlapping words
rspec ./spec/components/post_creator_spec.rb:529 # PostCreator new topic success tags tagging enabled automatically tags first posts without regular expressions does not treat as regular expressions
rspec ./spec/components/post_creator_spec.rb:538 # PostCreator new topic success tags tagging enabled automatically tags first posts with regular expressions works
rspec ./spec/components/post_creator_spec.rb:552 # PostCreator new topic when auto-close param is given ensures the user can auto-close the topic, but ignores auto-close param silently
rspec ./spec/components/post_creator_spec.rb:564 # PostCreator whisper whispers do not mess up the public view
rspec ./spec/components/post_creator_spec.rb:642 # PostCreator silent silent do not mess up the public view
rspec ./spec/components/post_creator_spec.rb:681 # PostCreator uniqueness disabled returns true for another post with the same content
rspec ./spec/components/post_creator_spec.rb:694 # PostCreator uniqueness enabled fails for dupe post across topic
rspec ./spec/components/post_creator_spec.rb:707 # PostCreator uniqueness enabled returns blank for another post with the same content
rspec ./spec/components/post_creator_spec.rb:714 # PostCreator uniqueness enabled returns a post for admins
rspec ./spec/components/post_creator_spec.rb:721 # PostCreator uniqueness enabled returns a post for moderators
rspec ./spec/components/post_creator_spec.rb:741 # PostCreator host spam does not create the post
rspec ./spec/components/post_creator_spec.rb:749 # PostCreator host spam sends a message to moderators
rspec ./spec/components/post_creator_spec.rb:756 # PostCreator host spam does not create a reviewable post if the review_every_post setting is enabled
rspec ./spec/components/post_creator_spec.rb:770 # PostCreator existing topic ensures the user can create the post
rspec ./spec/components/post_creator_spec.rb:779 # PostCreator existing topic success create correctly
rspec ./spec/components/post_creator_spec.rb:794 # PostCreator existing topic when the user has bookmarks with auto_delete_preference on_owner_reply deletes the bookmarks, but not the ones without an auto_delete_preference
rspec ./spec/components/post_creator_spec.rb:803 # PostCreator existing topic when the user has bookmarks with auto_delete_preference on_owner_reply when there are no bookmarks left in the topic sets TopicUser.bookmarked to false
rspec ./spec/components/post_creator_spec.rb:820 # PostCreator existing topic topic stats updates topic stats
rspec ./spec/components/post_creator_spec.rb:829 # PostCreator existing topic topic stats updates topic stats even when topic fails validation
rspec ./spec/components/post_creator_spec.rb:847 # PostCreator existing topic when the topic is in slow mode fails if the user recently posted in this topic
rspec ./spec/components/post_creator_spec.rb:857 # PostCreator existing topic when the topic is in slow mode creates the topic if the user last post is older than the slow mode interval
rspec ./spec/components/post_creator_spec.rb:866 # PostCreator existing topic when the topic is in slow mode creates the topic if the user is a staff member
rspec ./spec/components/post_creator_spec.rb:883 # PostCreator closed topic responds with an error message
rspec ./spec/components/post_creator_spec.rb:895 # PostCreator missing topic responds with an error message
rspec ./spec/components/post_creator_spec.rb:906 # PostCreator cooking options passes the cooking options through correctly
rspec ./spec/components/post_creator_spec.rb:932 # PostCreator private message acts correctly
rspec ./spec/components/post_creator_spec.rb:984 # PostCreator private message does not add whisperers to allowed users of the topic
rspec ./spec/components/post_creator_spec.rb:1000 # PostCreator private message does not increase posts count for small actions
rspec ./spec/components/post_creator_spec.rb:1034 # PostCreator warnings works as expected
rspec ./spec/components/post_creator_spec.rb:1062 # PostCreator auto closing closes private messages that have more than N posts
rspec ./spec/components/post_creator_spec.rb:1084 # PostCreator auto closing closes topics that have more than N posts
rspec ./spec/components/post_creator_spec.rb:1124 # PostCreator private message to group can post to a group correctly
rspec ./spec/components/post_creator_spec.rb:1161 # PostCreator setting created_at supports Time instances
rspec ./spec/components/post_creator_spec.rb:1182 # PostCreator setting created_at supports strings
rspec ./spec/components/post_creator_spec.rb:1207 # PostCreator disable validations can save a post
rspec ./spec/components/post_creator_spec.rb:1215 # PostCreator word_count has a word count
rspec ./spec/components/post_creator_spec.rb:1229 # PostCreator embed_url creates the topic_embed record
rspec ./spec/components/post_creator_spec.rb:1250 # PostCreator read credit for creator should give credit to creator
rspec ./spec/components/post_creator_spec.rb:1262 # PostCreator suspended users does not allow suspended users to create topics
rspec ./spec/components/post_creator_spec.rb:1293 # PostCreator events fires both event when creating a topic
rspec ./spec/components/post_creator_spec.rb:1300 # PostCreator events fires only the post event when creating a post
rspec ./spec/components/post_creator_spec.rb:1311 # PostCreator staged users automatically watches all messages it participates in
rspec ./spec/components/post_creator_spec.rb:1323 # PostCreator topic tracking automatically watches topic based on preference
rspec ./spec/components/post_creator_spec.rb:1340 # PostCreator topic tracking topic notification level remains tracking based on preference
rspec ./spec/components/post_creator_spec.rb:1357 # PostCreator topic tracking topic notification level is normal based on preference
rspec ./spec/components/post_creator_spec.rb:1374 # PostCreator topic tracking user preferences for notification level when replying doesn't affect PMs
rspec ./spec/components/post_creator_spec.rb:1390 # PostCreator topic tracking sets the last_posted_at timestamp to track the last time the user posted
rspec ./spec/components/post_creator_spec.rb:1405 # PostCreator#create! should return the post if it was successfully created
rspec ./spec/components/post_creator_spec.rb:1417 # PostCreator#create! should raise an error when post fails to be created
rspec ./spec/components/post_creator_spec.rb:1422 # PostCreator#create! does not generate an alert for empty posts
rspec ./spec/components/post_creator_spec.rb:1455 # PostCreator private message to a user that has disabled private messages should not be valid
rspec ./spec/components/post_creator_spec.rb:1471 # PostCreator private message to a user that has disabled private messages should not be valid if the name is downcased
rspec ./spec/components/post_creator_spec.rb:1488 # PostCreator private message to a muted user should fail
rspec ./spec/components/post_creator_spec.rb:1509 # PostCreator private message to a muted user succeeds if the user is staff
rspec ./spec/components/post_creator_spec.rb:1532 # PostCreator private message to an ignored user when post author is ignored should fail
rspec ./spec/components/post_creator_spec.rb:1552 # PostCreator private message to an ignored user when post author is admin who is ignored succeeds if the user is staff
rspec ./spec/components/post_creator_spec.rb:1574 # PostCreator private message to user in allow list when post author is allowed should succeed
rspec ./spec/components/post_creator_spec.rb:1593 # PostCreator private message to user in allow list when personal messages are disabled should fail
rspec ./spec/components/post_creator_spec.rb:1621 # PostCreator private message to user not in allow list when post author is not allowed should fail
rspec ./spec/components/post_creator_spec.rb:1638 # PostCreator private message to user not in allow list when post author is not allowed should succeed when not enabled
rspec ./spec/components/post_creator_spec.rb:1661 # PostCreator private message when post author is admin who is not in allow list succeeds if the user is staff
rspec ./spec/components/post_creator_spec.rb:1682 # PostCreator private message to multiple users and one is not allowed when post author is not allowed should fail
rspec ./spec/components/post_creator_spec.rb:1712 # PostCreator private message recipients limit (max_allowed_message_recipients) reached for normal user fails when sending message to multiple recipients
rspec ./spec/components/post_creator_spec.rb:1724 # PostCreator private message recipients limit (max_allowed_message_recipients) reached for normal user succeeds when sending message to multiple recipients if skip_validations is true
rspec ./spec/components/post_creator_spec.rb:1741 # PostCreator private message recipients limit (max_allowed_message_recipients) reached always succeeds if the user is staff when sending message to multiple recipients
rspec ./spec/components/post_creator_spec.rb:1760 # PostCreator#create_post_notice generates post notices for new users
rspec ./spec/components/post_creator_spec.rb:1768 # PostCreator#create_post_notice generates post notices for returning users
rspec ./spec/components/post_creator_spec.rb:1779 # PostCreator#create_post_notice does not generate for non-human, staged or anonymous users
rspec ./spec/components/post_creator_spec.rb:1802 # PostCreator secure media uploads links post uploads
rspec ./spec/components/post_creator_spec.rb:1814 # PostCreator queue for review created a reviewable post after creating the post
rspec ./spec/components/post_creator_spec.rb:1823 # PostCreator queue for review does not create a reviewable post if the post is not valid2342a7903,7918
rspec ./spec/lib/backup_restore/system_interface_multisite_spec.rb:12 # BackupRestore::SystemInterface#flush_redis removes only keys from the current site in a multisite
rspec ./spec/requests/about_controller_spec.rb:33 # AboutController.index crawler view should include correct title
rspec ./spec/requests/about_controller_spec.rb:39 # AboutController.index crawler view should include correct user URLs
rspec ./spec/components/discourse_redis_spec.rb:25 # DiscourseRedis redis commands when namespace is enabled should append namespace to the keys
rspec ./spec/lib/upload_recovery_spec.rb:100 # UploadRecovery#recover recovers uploads and attachments
rspec ./spec/lib/upload_recovery_spec.rb:197 # UploadRecovery#recover image tag recovers the upload
rspec ./spec/lib/upload_recovery_spec.rb:122 # UploadRecovery#recover S3 store recovers the upload
rspec ./spec/lib/upload_recovery_spec.rb:165 # UploadRecovery#recover S3 store when the upload exists but its file is missing does not create a duplicate upload when secure uploads are enabled
rspec ./spec/lib/upload_recovery_spec.rb:146 # UploadRecovery#recover S3 store when the upload exists but its file is missing recovers the file
rspec ./spec/lib/upload_recovery_spec.rb:224 # UploadRecovery#recover image markdown recovers the upload
rspec ./spec/lib/upload_recovery_spec.rb:251 # UploadRecovery#recover bbcode recovers the upload
rspec ./spec/lib/upload_recovery_spec.rb:86 # UploadRecovery#recover for a missing attachment recovers the attachment
rspec ./spec/components/cache_spec.rb:95 # Cache can fetch keys with pattern
rspec ./spec/components/cache_spec.rb:34 # Cache can be cleared
rspec ./spec/requests/admin/site_texts_controller_spec.rb:542 # Admin::SiteTextsController when logged in as admin reseeding #reseed reseeds categories and topics
rspec ./spec/models/report_spec.rb:97 # Report counting topics counts the correct records
rspec ./spec/models/theme_spec.rb:584 # Theme convert_settings can migrate a list field to a string field with json schema
rspec ./spec/models/theme_spec.rb:605 # Theme convert_settings does not update setting if data does not validate against json schema
rspec ./spec/lib/seed_data/categories_spec.rb:148 # SeedData::Categories#update works when the category name is already used by another category
rspec ./spec/lib/seed_data/categories_spec.rb:136 # SeedData::Categories#update skips category when `skip_changed` is true and description was changed
rspec ./spec/lib/seed_data/categories_spec.rb:124 # SeedData::Categories#update updates an existing category
rspec ./spec/lib/backup_restore/backup_file_handler_spec.rb:48 # BackupRestore::BackupFileHandler allows overriding the backup store
rspec ./spec/lib/backup_restore/backup_file_handler_spec.rb:26 # BackupRestore::BackupFileHandler works with backup file which uses wrong upload path
rspec ./spec/lib/backup_restore/system_interface_spec.rb:177 # BackupRestore::SystemInterface#flush_redis Sidekiq doesn't unpause Sidekiq
rspec ./spec/requests/static_controller_spec.rb:25 # StaticController#favicon local store returns the default favicon if favicon has not been configured
rspec ./spec/requests/static_controller_spec.rb:33 # StaticController#favicon local store returns the configured favicon
rspec ./spec/requests/static_controller_spec.rb:58 # StaticController#favicon external store can proxy a favicon correctly
rspec ./spec/components/topic_view_spec.rb:956 # TopicView#reviewable_counts include posts queued for other reasons
rspec ./spec/components/topic_view_spec.rb:937 # TopicView#reviewable_counts exclude posts queued because the category needs approval
rspec ./spec/services/user_authenticator_spec.rb:47 # UserAuthenticator#finish confirms email and adds the user to appropriate groups based on email
rspec ./spec/services/user_authenticator_spec.rb:58 # UserAuthenticator#finish doesn't confirm email if email is invalid
rspec ./spec/services/user_authenticator_spec.rb:68 # UserAuthenticator#finish doesn't confirm email if it was changed
rspec ./spec/components/wizard/step_updater_spec.rb:22 # Wizard::StepUpdater locale updates the locale and requires refresh when it does change
rspec ./spec/models/post_spec.rb:65 # Post is expected to validate that :raw cannot be empty/falsy
rspec ./spec/models/post_spec.rb:69 # Post is expected not to allow :raw to be ‹"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...›
rspec ./spec/models/post_spec.rb:70 # Post is expected not to allow :raw to be ‹"     x"›
rspec ./spec/models/post_spec.rb:68 # Post is expected not to allow :raw to be ‹"x"›
rspec ./spec/models/post_spec.rb:644 # Post validation create blank posts as invalid
rspec ./spec/lib/backup_restore/local_backup_store_spec.rb[1:1:3:7:3] # BackupRestore::LocalBackupStore behaves like backup store with backup files #download_file works with multisite
rspec ./spec/lib/backup_restore/local_backup_store_spec.rb[1:1:3:4:3] # BackupRestore::LocalBackupStore behaves like backup store with backup files #delete_old works with multisite
rspec ./spec/lib/backup_restore/local_backup_store_spec.rb[1:1:3:4:2] # BackupRestore::LocalBackupStore behaves like backup store with backup files #delete_old deletes files starting by the oldest
rspec ./spec/lib/backup_restore/local_backup_store_spec.rb[1:1:3:6:1] # BackupRestore::LocalBackupStore behaves like backup store with backup files #delete_file deletes file when the file exists
rspec ./spec/lib/backup_restore/local_backup_store_spec.rb[1:1:3:6:3] # BackupRestore::LocalBackupStore behaves like backup store with backup files #delete_file works with multisite
rspec ./spec/lib/backup_restore/local_backup_store_spec.rb[1:1:3:3:1] # BackupRestore::LocalBackupStore behaves like backup store with backup files #reset_cache resets the storage stats report
rspec ./spec/lib/backup_restore/local_backup_store_spec.rb[1:1:3:2:2] # BackupRestore::LocalBackupStore behaves like backup store with backup files #latest_file returns nil when there are no files
rspec ./spec/jobs/vacate_legacy_prefix_backups_spec.rb:24 # Jobs::VacateLegacyPrefixBackups copies the backups from legacy path to new path
rspec ./spec/components/topic_retriever_spec.rb:11 # TopicRetriever can initialize without optional parameters
rspec ./spec/requests/uploads_controller_spec.rb:819 # UploadsController#create_multipart when the store is external returns 422 when the file is an attachment and it's too big
rspec ./spec/requests/uploads_controller_spec.rb:807 # UploadsController#create_multipart when the store is external returns 422 when the create request errors
rspec ./spec/requests/uploads_controller_spec.rb:876 # UploadsController#create_multipart when the store is external includes accepted metadata when calling the store to create_multipart, but only allowed keys
rspec ./spec/requests/uploads_controller_spec.rb:847 # UploadsController#create_multipart when the store is external creates a multipart upload and creates an external upload stub that is marked as multipart
rspec ./spec/requests/uploads_controller_spec.rb:744 # UploadsController#generate_presigned_put when the store is external includes accepted metadata in the presigned url when provided
rspec ./spec/components/email/receiver_spec.rb:1353 # Email::Receiver new topic in a category creates hidden topic for X-Spam-Flag
rspec ./spec/components/email/receiver_spec.rb:1395 # Email::Receiver new topic in a category works when approving is enabled
rspec ./spec/components/email/receiver_spec.rb:1377 # Email::Receiver new topic in a category creates hidden topic for failed Authentication-Results header
rspec ./spec/components/email/receiver_spec.rb:1361 # Email::Receiver new topic in a category creates hidden topic for X-Spam-Status
rspec ./spec/components/email/receiver_spec.rb:1369 # Email::Receiver new topic in a category creates hidden topic for X-SES-Spam-Verdict
rspec ./spec/integration/watched_words_spec.rb:101 # WatchedWord require_approval looks at title too
rspec ./spec/integration/watched_words_spec.rb:94 # WatchedWord require_approval should queue the post for approval
rspec ./spec/lib/seed_data/topics_spec.rb:84 # SeedData::Topics#update updates an existing first reply when `static_first_reply` is true
rspec ./spec/lib/seed_data/topics_spec.rb:96 # SeedData::Topics#update does not update a change topic and `skip_changed` is true
rspec ./spec/lib/seed_data/topics_spec.rb:70 # SeedData::Topics#update updates the changed topic
rspec ./spec/requests/admin/backups_controller_spec.rb:132 # Admin::BackupsController#destroy removes the backup if found
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:2:1] # BackupRestore::S3BackupStore behaves like remote backup store is a remote store
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:2:2:2:2] # BackupRestore::S3BackupStore behaves like remote backup store with backups #generate_upload_url raises an exception when a file with same filename exists
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:2:2:2:3] # BackupRestore::S3BackupStore behaves like remote backup store with backups #generate_upload_url works with multisite
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:2:2:2:1] # BackupRestore::S3BackupStore behaves like remote backup store with backups #generate_upload_url generates upload URL
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:2:2:1:3] # BackupRestore::S3BackupStore behaves like remote backup store with backups #upload_file raises an exception when a file with same filename exists
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:2:2:1:2] # BackupRestore::S3BackupStore behaves like remote backup store with backups #upload_file works with multisite
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:2:2:1:1] # BackupRestore::S3BackupStore behaves like remote backup store with backups #upload_file uploads file into store
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:1] # BackupRestore::S3BackupStore behaves like backup store creates the correct backup store
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:8:1] # BackupRestore::S3BackupStore behaves like backup store with backup files #stats returns the correct stats
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:1:3] # BackupRestore::S3BackupStore behaves like backup store with backup files #files works with multisite
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:1:1] # BackupRestore::S3BackupStore behaves like backup store with backup files #files sorts files by last modified date in descending order
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:1:2] # BackupRestore::S3BackupStore behaves like backup store with backup files #files returns only *.gz and *.tgz files
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:7:3] # BackupRestore::S3BackupStore behaves like backup store with backup files #download_file works with multisite
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:7:2] # BackupRestore::S3BackupStore behaves like backup store with backup files #download_file raises an exception when the download fails
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:7:1] # BackupRestore::S3BackupStore behaves like backup store with backup files #download_file downloads file to the destination
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:5:4] # BackupRestore::S3BackupStore behaves like backup store with backup files #file works with multisite
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:5:2] # BackupRestore::S3BackupStore behaves like backup store with backup files #file returns nil when the file doesn't exist
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:5:3] # BackupRestore::S3BackupStore behaves like backup store with backup files #file includes the file's source location if it is requested
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:5:1] # BackupRestore::S3BackupStore behaves like backup store with backup files #file returns information about the file when the file exists
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:4:2] # BackupRestore::S3BackupStore behaves like backup store with backup files #delete_old deletes files starting by the oldest
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:4:1] # BackupRestore::S3BackupStore behaves like backup store with backup files #delete_old does nothing if the number of files is <= maximum_backups
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:4:3] # BackupRestore::S3BackupStore behaves like backup store with backup files #delete_old works with multisite
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:6:1] # BackupRestore::S3BackupStore behaves like backup store with backup files #delete_file deletes file when the file exists
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:6:2] # BackupRestore::S3BackupStore behaves like backup store with backup files #delete_file does nothing when the file doesn't exist
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:6:3] # BackupRestore::S3BackupStore behaves like backup store with backup files #delete_file works with multisite
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:3:1] # BackupRestore::S3BackupStore behaves like backup store with backup files #reset_cache resets the storage stats report
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:2:3] # BackupRestore::S3BackupStore behaves like backup store with backup files #latest_file works with multisite
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:2:1] # BackupRestore::S3BackupStore behaves like backup store with backup files #latest_file returns the most recent backup file
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:3:2:2] # BackupRestore::S3BackupStore behaves like backup store with backup files #latest_file returns nil when there are no files
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:2:2:1] # BackupRestore::S3BackupStore behaves like backup store without backup files #latest_file returns nil when there are no files
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:2:1:1] # BackupRestore::S3BackupStore behaves like backup store without backup files #files returns an empty array when there are no files
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb[1:1:2:3:1] # BackupRestore::S3BackupStore behaves like backup store without backup files #stats works when there are no files
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb:86 # BackupRestore::S3BackupStore S3 specific behavior #delete_old doesn't delete files when cleanup is disabled
rspec ./spec/lib/backup_restore/s3_backup_store_spec.rb:95 # BackupRestore::S3BackupStore S3 specific behavior #stats returns nil for 'free_bytes'
rspec ./spec/tasks/posts_spec.rb:49 # Post rake tasks rebake_match rebakes matched posts
rspec ./spec/requests/posts_controller_spec.rb[1:12:1] # PostsController#post_type raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:11:1] # PostsController#wiki raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:7:1] # PostsController#destroy_many raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:8:1] # PostsController#recover raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:16:1] # PostsController#revert raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:13:1] # PostsController#rebake raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:18:1] # PostsController#flagged_posts raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:26:1] # PostsController#raw_email raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:14:1] # PostsController#create raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb:913 # PostsController#create when logged in silences correctly based on silence watched words
rspec ./spec/requests/posts_controller_spec.rb:893 # PostsController#create when logged in silences correctly based on auto_silence_first_post_regex
rspec ./spec/requests/posts_controller_spec.rb:807 # PostsController#create when logged in fast typing queues the post if min_first_post_typing_time is not met
rspec ./spec/requests/posts_controller_spec.rb[1:19:1] # PostsController#deleted_posts raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:6:1] # PostsController#destroy raises an exception when not logged in
rspec ./spec/requests/posts_controller_spec.rb[1:9:1] # PostsController#update raises an exception when not logged in
rspec ./spec/components/new_post_manager_spec.rb:581 # NewPostManager when posting in the category requires approval when new posts require approval enqueues new posts
rspec ./spec/components/new_post_manager_spec.rb:464 # NewPostManager when posting in the category requires approval when new topics require approval enqueues new topics
rspec ./spec/components/new_post_manager_spec.rb:536 # NewPostManager when posting in the category requires approval when new topics require approval when the category has tagging rules when there is a minimum number of tags required from a certain tag group for the categ
ory errors when there are no tags from the group provided
rspec ./spec/components/new_post_manager_spec.rb:556 # NewPostManager when posting in the category requires approval when new topics require approval when the category has tagging rules when there is a minimum number of tags required from a certain tag group for the categ
ory enqueues the topic if there are tags provided
rspec ./spec/components/new_post_manager_spec.rb:499 # NewPostManager when posting in the category requires approval when new topics require approval when the category has tagging rules when there is a minimum number of tags required for the category errors when there are
 no tags provided
rspec ./spec/components/new_post_manager_spec.rb:512 # NewPostManager when posting in the category requires approval when new topics require approval when the category has tagging rules when there is a minimum number of tags required for the category enqueues the topic if
 there are tags provided
rspec ./spec/components/new_post_manager_spec.rb:105 # NewPostManager default handler with a high approval post count and TL0 will return an enqueue result
rspec ./spec/components/new_post_manager_spec.rb:173 # NewPostManager default handler with uncategorized disabled, and approval will return an enqueue result
rspec ./spec/components/new_post_manager_spec.rb:138 # NewPostManager default handler with a high approval post count and secure category does not create topic
rspec ./spec/components/new_post_manager_spec.rb:79 # NewPostManager default handler basic post/topic count restrictions works with a correct `user_stat.post_count`
rspec ./spec/components/new_post_manager_spec.rb:89 # NewPostManager default handler basic post/topic count restrictions works with a correct `user_stat.topic_count`
rspec ./spec/components/new_post_manager_spec.rb:193 # NewPostManager default handler with staged moderation setting enabled will return an enqueue result
rspec ./spec/components/new_post_manager_spec.rb:259 # NewPostManager default handler with media queues the post for review because if it contains embedded media.
rspec ./spec/components/new_post_manager_spec.rb:159 # NewPostManager default handler with a high trust level setting will return an enqueue result
rspec ./spec/components/new_post_manager_spec.rb:118 # NewPostManager default handler with a high approval post count and TL1 will return an enqueue result
rspec ./spec/components/new_post_manager_spec.rb:227 # NewPostManager default handler with a fast typer runs the watched words check before checking if the user is a fast typer
rspec ./spec/components/new_post_manager_spec.rb:218 # NewPostManager default handler with a fast typer adds the silence reason in the system locale
rspec ./spec/components/new_post_manager_spec.rb:286 # NewPostManager new topic handler with a high trust level setting for new topics will return an enqueue result
rspec ./spec/components/new_post_manager_spec.rb:685 # NewPostManager via email with an authentication results failure doesn't silence users
rspec ./spec/components/new_post_manager_spec.rb:700 # NewPostManager via email with an authentication results failure still enqueues exempt users
rspec ./spec/components/new_post_manager_spec.rb:650 # NewPostManager via email with a spam failure silences users if its their first post
rspec ./spec/components/new_post_manager_spec.rb:633 # NewPostManager via email will store via_email and raw_email in the enqueued post
rspec ./spec/components/validators/post_validator_spec.rb[1:10:1] # PostValidator staged user skips most validations
rspec ./spec/components/validators/post_validator_spec.rb[1:9:1] # PostValidator admin editing a static page skips most validations
rspec ./spec/components/validators/post_validator_spec.rb:229 # PostValidator invalid post should be invalid
rspec ./spec/components/redis_store_spec.rb:46 # Redis Store can be cleared without clearing our cache
rspec ./spec/requests/topics_controller_spec.rb:3363 # TopicsController#reset_new specific topics updates the `new_since` date
rspec ./spec/requests/topics_controller_spec.rb:3388 # TopicsController#reset_new specific topics when tracked param is true does not update user_stat.new_since and does not dismiss untracked topics
rspec ./spec/requests/topics_controller_spec.rb:3401 # TopicsController#reset_new specific topics when tracked param is true creates topic user records for each unread topic
```