### PR TITLE
FIX: Display embeddable host's post to category.

### DIFF
--- a/app/assets/javascripts/admin/addon/components/embeddable-host.js
+++ b/app/assets/javascripts/admin/addon/components/embeddable-host.js
@@ -12,8 +12,19 @@ export default Component.extend(bufferedProperty("host"), {
   editToggled: false,
   tagName: "tr",
   categoryId: null,
+  category: null,
 
   editing: or("host.isNew", "editToggled"),
+
+  init() {
+    this._super(...arguments);
+
+    const host = this.host;
+    const categoryId = host.category_id || this.site.uncategorized_category_id;
+    const category = Category.findById(categoryId);
+
+    host.set("category", category);
+  },
 
   @discourseComputed("buffered.host", "host.isSaving")
   cantSave(host, isSaving) {

--- a/app/assets/javascripts/admin/addon/templates/components/embeddable-host.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/embeddable-host.hbs
@@ -27,7 +27,7 @@
   <td><div class="label">{{i18n "admin.embedding.host"}}</div>{{host.host}}</td>
   <td><div class="label">{{i18n "admin.embedding.class_name"}}</div>{{host.class_name}}</td>
   <td><div class="label">{{i18n "admin.embedding.allowed_paths"}}</div>{{host.allowed_paths}}</td>
-  <td><div class="label">{{i18n "admin.embedding.category"}}</div>{{category-badge host.category}}</td>
+  <td><div class="label">{{i18n "admin.embedding.category"}}</div>{{category-badge host.category allowUncategorized=true}}</td>
   <td class="controls">
     {{d-button icon="pencil-alt" action=(action "edit")}}
     {{d-button icon="far-trash-alt" action=(action "delete") class="btn-danger"}}


### PR DESCRIPTION
The host's category was successfully updated on the database, but the category property was not properly set when rendering the component for the first time.


