### PR TITLE
FIX: Reenable global setting HTML support.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/global-notice.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/global-notice.hbs
@@ -4,7 +4,7 @@
       {{#if notice.options.html}}
         {{html-safe notice.options.html}}
       {{/if}}
-      <span class="text">{{notice.text}}</span>
+      <span class="text">{{html-safe notice.text}}</span>
 
       {{#if notice.options.dismissable}}
         {{d-button

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2122,7 +2122,7 @@ en:
 
     permalink_normalizations: "Apply the following regex before matching permalinks, for example: /(topic.*)\\?.*/\\1 will strip query strings from topic routes. Format is regex+string use \\1 etc. to access captures"
 
-    global_notice: "Display an URGENT, EMERGENCY, non-dismissible global banner notice to all visitors, change to blank to hide it."
+    global_notice: "Display an URGENT, EMERGENCY, non-dismissible global banner notice to all visitors, change to blank to hide it (HTML allowed)."
 
     disable_system_edit_notifications: "Disables edit notifications by the system user when 'download_remote_images_to_local' is active."
 


### PR DESCRIPTION
We still want to drop support for HTML, but we'll temporarily reenable and  figure out a transition plan.