### PR TITLE
DEV: Allow actions to change the manifest endpoint

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -613,6 +613,10 @@ module ApplicationHelper
     absolute_url
   end
 
+  def manifest_url
+    @manifest_url || "#{Discourse.base_path}/manifest.webmanifest"
+  end
+
   def can_sign_up?
     SiteSetting.allow_new_registrations &&
     !SiteSetting.invite_only &&

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
 
     <%= render_google_tag_manager_head_code %>
     <%= render_google_universal_analytics_code %>
-    <link rel="manifest" href="<%= Discourse.base_path %>/manifest.webmanifest" crossorigin="use-credentials">
+    <link id="manifest-link" rel="manifest" href=<%= manifest_url %> crossorigin="use-credentials">
 
     <%- if include_ios_native_app_banner? %>
         <meta name="apple-itunes-app" content="app-id=<%= SiteSetting.ios_app_id %><%= ios_app_argument %>">


### PR DESCRIPTION
This allows plugins to set `@manifest_url` in an action, so that the manifest endpoint can be changed.