### PR TITLE
FIX: select all button on group assigned page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -165,6 +165,10 @@ export default Component.extend(LoadMore, {
     );
   },
 
+  updateAutoAddTopicsToBulkSelect(newVal) {
+    this.set("autoAddTopicsToBulkSelect", newVal);
+  },
+
   click(e) {
     let self = this;
     let onClick = function (sel, callback) {


### PR DESCRIPTION
Button is not working properly because `updateAutoAddTopicsToBulkSelect` function is not available.

Meta: https://meta.discourse.org/t/select-all-in-group-assigned-doesnt-work/205270

<img width="510" alt="Screen Shot 2021-10-06 at 2 59 15 pm" src="https://user-images.githubusercontent.com/72780/136138806-9fbfe3dd-72f8-47be-a54d-909706904c9d.png">

