### PR TITLE
FIX: local date trim when no time available

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js.es6
@@ -182,7 +182,7 @@ function _downloadCalendarNode(element) {
     "data-starts-at",
     moment
       .tz(
-        `${startDataset.date} ${startDataset.time || ""}`,
+        `${startDataset.date} ${startDataset.time || ""}`.trim(),
         startDataset.timezone
       )
       .toISOString()
@@ -191,7 +191,10 @@ function _downloadCalendarNode(element) {
     node.setAttribute(
       "data-ends-at",
       moment
-        .tz(`${endDataset.date} ${endDataset.time || ""}`, endDataset.timezone)
+        .tz(
+          `${endDataset.date} ${endDataset.time || ""}`.trim(),
+          endDataset.timezone
+        )
         .toISOString()
     );
   }


### PR DESCRIPTION
When there is a blank space in the end of date, moment is returning a different value:

```javascript
  console.log(moment.tz("2021-09-09 ", "Australia/Sydney").toISOString());
  // 2021-09-09T00:00:00.000Z
  console.log(moment.tz("2021-09-09", "Australia/Sydney").toISOString());
  // 2021-09-08T14:00:00.000Z
```
