### PR TITLE
FIX: Hide form after password reset

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/forgot-password.js
+++ b/app/assets/javascripts/discourse/app/controllers/forgot-password.js
@@ -54,14 +54,23 @@ export default Controller.extend(ModalFunctionality, {
           const accountEmailOrUsername = escapeExpression(
             this.accountEmailOrUsername
           );
-          const isEmail = accountEmailOrUsername.match(/@/);
-          let key = `forgot_password.complete_${
-            isEmail ? "email" : "username"
-          }`;
-          let extraClass;
 
-          if (data.user_found === true) {
-            key += "_found";
+          let key = "forgot_password.complete";
+          key += accountEmailOrUsername.match(/@/) ? "_email" : "_username";
+
+          if (data.user_found === false) {
+            key += "_not_found";
+
+            this.flash(
+              I18n.t(key, {
+                email: accountEmailOrUsername,
+                username: accountEmailOrUsername,
+              }),
+              "error"
+            );
+          } else {
+            key += data.user_found ? "_found" : "";
+
             this.set("accountEmailOrUsername", "");
             this.set(
               "offerHelp",
@@ -70,19 +79,7 @@ export default Controller.extend(ModalFunctionality, {
                 username: accountEmailOrUsername,
               })
             );
-          } else {
-            if (data.user_found === false) {
-              key += "_not_found";
-              extraClass = "error";
-            }
-
-            this.flash(
-              I18n.t(key, {
-                email: accountEmailOrUsername,
-                username: accountEmailOrUsername,
-              }),
-              extraClass
-            );
+            this.set("helpSeen", !data.user_found);
           }
         })
         .catch((e) => {


### PR DESCRIPTION
When hide_email_address_taken was disabled, the forgot password modal
showed a flash message and continued to display the form causing
confusion. This change shows the flash message only when an error occurs
and in all other cases it shows a success message and hides the form.

This message used to be a flash message:

![image](https://user-images.githubusercontent.com/23153890/136173328-57f71933-50f4-43cf-8cc3-9bf0717079fe.png)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
