### PR TITLE
FIX: do not persist tags query param

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
@@ -9,7 +9,6 @@ export const queryParams = {
   search: { replace: true, refreshModel: true },
   max_posts: { replace: true, refreshModel: true },
   q: { replace: true, refreshModel: true },
-  tags: { replace: true },
   before: { replace: true, refreshModel: true },
   bumped_before: { replace: true, refreshModel: true },
   f: { replace: true, refreshModel: true },


### PR DESCRIPTION
This commit fixes the inconsistent behaviour where a user lands on blank
page from the `/new-topic` route if the tag beign used does not have any
topic attached.

https://meta.discourse.org/t/tag-route-when-creating-a-topic-via-url/204973
