### PR TITLE
UX: remove `aria-label` for buttons when `title` attribute exists.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/button.js
+++ b/app/assets/javascripts/discourse/app/widgets/button.js
@@ -38,7 +38,6 @@ export const ButtonClass = {
     }
 
     if (title) {
-      attributes["aria-label"] = title;
       attributes.title = title;
     }
 


### PR DESCRIPTION
Both `aria-label` and `title` have the same value and NVDA reading both the texts while navigating between buttons. NVDA already has an open issue https://github.com/nvaccess/nvda/issues/7841. We're removing `aria-label` until they fix it.