### PR TITLE
DEV: simplify username suggester

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -317,7 +317,7 @@ class DiscourseSingleSignOn < SingleSignOn
       if user.username.downcase == username.downcase
         user.username = username # there may be a change of case
       elsif user.username != username
-        user.username = UserNameSuggester.suggest(username || name || email, user.username)
+        user.username = UserNameSuggester.suggest(username, user.username)
       end
     end
 

--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -317,7 +317,7 @@ class DiscourseSingleSignOn < SingleSignOn
       if user.username.downcase == username.downcase
         user.username = username # there may be a change of case
       elsif user.username != username
-        user.username = UserNameSuggester.suggest(username, user.username)
+        user.username = UserNameSuggester.suggest(username)
       end
     end
 

--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -78,7 +78,7 @@ class Auth::Result
   def apply_user_attributes!
     change_made = false
     if SiteSetting.auth_overrides_username? && username.present? && username != user.username
-      user.username = UserNameSuggester.suggest(username_suggester_attributes, user.username)
+      user.username = UserNameSuggester.suggest(username, user.username)
       change_made = true
     end
 

--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -78,7 +78,7 @@ class Auth::Result
   def apply_user_attributes!
     change_made = false
     if SiteSetting.auth_overrides_username? && username.present? && username != user.username
-      user.username = UserNameSuggester.suggest(username, user.username)
+      user.username = UserNameSuggester.suggest(username)
       change_made = true
     end
 

--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -4,11 +4,11 @@ module UserNameSuggester
   GENERIC_NAMES = ['i', 'me', 'info', 'support', 'admin', 'webmaster', 'hello', 'mail', 'office', 'contact', 'team']
   LAST_RESORT_USERNAME = "user"
 
-  def self.suggest(name_or_email, allowed_username = nil)
+  def self.suggest(name_or_email)
     return unless name_or_email.present?
 
     name = parse_name_from_email(name_or_email)
-    find_available_username_based_on(name, allowed_username)
+    find_available_username_based_on(name)
   end
 
   def self.parse_name_from_email(name_or_email)
@@ -22,22 +22,13 @@ module UserNameSuggester
     name
   end
 
-  def self.find_available_username_based_on(name, allowed_username = nil)
+  def self.find_available_username_based_on(name)
     name = fix_username(name)
     offset = nil
     i = 1
 
     attempt = name
-    normalized_attempt = User.normalize_username(attempt)
-
-    original_allowed_username = allowed_username
-    allowed_username = User.normalize_username(allowed_username) if allowed_username
-
-    until (
-      normalized_attempt == allowed_username ||
-      User.username_available?(attempt) ||
-      i > 100
-    )
+    until User.username_available?(attempt) || i > 100
 
       if offset.nil?
         normalized = User.normalize_username(name)
@@ -53,8 +44,7 @@ module UserNameSuggester
 
           params = {
             count: count + 10,
-            name: normalized,
-            allowed_normalized: allowed_username || ''
+            name: normalized
           }
 
           # increasing the search space a bit to allow for some extra noise
@@ -62,11 +52,7 @@ module UserNameSuggester
             WITH numbers AS (SELECT generate_series(1, :count) AS n)
 
             SELECT n FROM numbers
-            LEFT JOIN users ON (
-              username_lower = :name || n::varchar
-            ) AND (
-              username_lower <> :allowed_normalized
-            )
+            LEFT JOIN users ON (username_lower = :name || n::varchar)
             WHERE users.id IS NULL
             ORDER by n ASC
             LIMIT 1
@@ -84,22 +70,15 @@ module UserNameSuggester
 
       max_length = User.username_length.end - suffix.length
       attempt = "#{truncate(name, max_length)}#{suffix}"
-      normalized_attempt = User.normalize_username(attempt)
       i += 1
     end
 
-    until normalized_attempt == allowed_username || User.username_available?(attempt) || i > 200
+    until User.username_available?(attempt) || i > 200
       attempt = SecureRandom.hex[1..SiteSetting.max_username_length]
-      normalized_attempt = User.normalize_username(attempt)
       i += 1
     end
 
-    if allowed_username == normalized_attempt
-      original_allowed_username
-    else
-      attempt
-    end
-
+    attempt
   end
 
   def self.fix_username(name)

--- a/spec/components/user_name_suggester_spec.rb
+++ b/spec/components/user_name_suggester_spec.rb
@@ -160,14 +160,6 @@ describe UserNameSuggester do
         expect(UserNameSuggester.suggest('য়া')).to eq('য়া11')
       end
 
-      it "does not skip ove allowed names" do
-        Fabricate(:user, username: 'sam')
-        Fabricate(:user, username: 'saM1')
-        Fabricate(:user, username: 'sam2')
-
-        expect(UserNameSuggester.suggest('SaM', 'Sam1')).to eq('Sam1')
-      end
-
       it "normalizes usernames" do
         actual = 'Löwe'    # NFD, "Lo\u0308we"
         expected = 'Löwe'  # NFC, "L\u00F6we"


### PR DESCRIPTION
This PR doesn't change any behavior, but just removes code that wasn't in use. This is a pretty dangerous place to change, since it gets called during user's registration. At the same time the refactoring is very straightforward, it's clear that this code wasn't doing any work (it still needs to be double-checked during review though). Also, the test coverage of `UserNameSuggester` is good.

Here is the explanation of what I've done (or you can just look at the commit history in this PR). We have this code:
https://github.com/discourse/discourse/blob/20e70d0ac5febfeee6c6cc0a83881a79422bba57/lib/auth/result.rb#L80-L83

If we inline `username_suggester_attributes`, we'll get this:
```ruby
    if SiteSetting.auth_overrides_username? && username.present? && username != user.username
      user.username = UserNameSuggester.suggest(username || name || email, user.username)
      ...
    end
```

But we check if `username.present?` in the if condition, so it's always present inside the if block, so it's clear that ` || name || email` never gets called, we can remove it:
```ruby
    if SiteSetting.auth_overrides_username? && username.present? && username != user.username
      user.username = UserNameSuggester.suggest(username, user.username)
      ...
    end
```

Now, we pass `user.username` as a second parameter to `UserNameSuggester`, the name of that parameter is `allowed_username`. If the suggester has found a suggestion that's equal to `allowed_username` it stops looking for another available usernames and just returns this suggestion. We need it to avoid the situation when the suggester tries to suggest a username of the current user (without this parameter, the suggester would think that this name isn't free, when in fact it's fine to use this username).

But, we check if `username != user.username` in the condition of if block, so there is no point in passing `user.username` to the username suggester, we already know that this isn't the username of the current user.
```ruby
    if SiteSetting.auth_overrides_username? && username.present? && username != user.username
      user.username = UserNameSuggester.suggest(username)
      ...
    end
```

There is only one more place when we pass the second parameter to `UserNameSuggester` and that place can be simplified using the same steps. 

After that, we can just remove the second parameter from `UserNameSuggester.suggest` which simplifies the code significantly and also makes the signature logical. The signature was confusing before:
https://github.com/discourse/discourse/blob/20e70d0ac5febfeee6c6cc0a83881a79422bba57/lib/user_name_suggester.rb#L7

Why pass `allowed_username` to `UserNameSuggester`? I mean, if we already know the allowed username, why call  `UserNameSuggester` at all? We can just use that name. After this refactoring, we'll have just:
```ruby
def self.suggest(name_or_email)
  ..
end
```