### PR TITLE
FIX: Strip `discourse-logged-in` header during `force_anonymous!`

### DIFF
--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -171,6 +171,7 @@ module Middleware
       def force_anonymous!
         @env[Auth::DefaultCurrentUserProvider::USER_API_KEY] = nil
         @env['HTTP_COOKIE'] = nil
+        @env['HTTP_DISCOURSE_LOGGED_IN'] = nil
         @env['rack.request.cookie.hash'] = {}
         @env['rack.request.cookie.string'] = ''
         @env['_bypass_cache'] = nil

--- a/spec/components/middleware/anonymous_cache_spec.rb
+++ b/spec/components/middleware/anonymous_cache_spec.rb
@@ -186,7 +186,7 @@ describe Middleware::AnonymousCache do
 
       app = Middleware::AnonymousCache.new(
         lambda do |env|
-          is_anon = env["HTTP_COOKIE"].nil?
+          is_anon = env["HTTP_COOKIE"].nil? && env["HTTP_DISCOURSE_LOGGED_IN"].nil?
           [200, {}, ["ok"]]
         end
       )
@@ -196,6 +196,7 @@ describe Middleware::AnonymousCache do
 
       env = {
         "HTTP_COOKIE" => "_t=#{SecureRandom.hex}",
+        "HTTP_DISCOURSE_LOGGED_IN" => "true",
         "HOST" => "site.com",
         "REQUEST_METHOD" => "GET",
         "REQUEST_URI" => "/somewhere/rainbow",


### PR DESCRIPTION
When the anonymous cache forces users into anonymous mode, it strips the cookies from their request. However, the discourse-logged-in header from the JS client remained.

When the discourse-logged-in header is present without any valid auth_token, the current_user_provider [marks the request as ['logged out'](https://github.com/discourse/discourse/blob/dbbfad7ed07c47674f9dee4ac7021ca51cc04e2e/lib/auth/default_current_user_provider.rb#L125-L125), and a [discourse-logged-out header is returned to the client](https://github.com/discourse/discourse/blob/dbbfad7ed07c47674f9dee4ac7021ca51cc04e2e/lib/middleware/request_tracker.rb#L209-L211). This causes the JS app to [popup a "you were logged out" modal](https://github.com/discourse/discourse/blob/dbbfad7ed07c47674f9dee4ac7021ca51cc04e2e/app/assets/javascripts/discourse/app/components/d-document.js#L29-L29), which is very disruptive.

This commit strips the discourse-logged-in header from the request at the same time as the auth cookie.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
