### PR TITLE
DEV: Add include_subcategories param to api docs

### DIFF
--- a/spec/requests/api/categories_spec.rb
+++ b/spec/requests/api/categories_spec.rb
@@ -51,6 +51,8 @@ describe 'categories' do
         expected_response_schema = load_spec_schema('category_list_response')
         schema expected_response_schema
 
+        let(:include_subcategories) { true }
+
         it_behaves_like "a JSON endpoint", 200 do
           let(:expected_response_schema) { expected_response_schema }
           let(:expected_request_schema) { expected_request_schema }


### PR DESCRIPTION
Adding the `include_subcategories=true` query param to the
`/categories.json` api docs.

Follow up to: fe676f334aa07489092b4d6af61d643ecb95aa27

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
