### PR TITLE
FIX: Check env for multisite config path even if config file exists

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -99,7 +99,8 @@ module Discourse
     config.skip_multisite_middleware = true
     config.skip_rails_failover_active_record_middleware = true
 
-    config.multisite_config_path = File.absolute_path(GlobalSetting.multisite_config_path, Rails.root)
+    multisite_config_path = ENV['DISCOURSE_MULTISITE_CONFIG_PATH'] || GlobalSetting.multisite_config_path
+    config.multisite_config_path = File.absolute_path(multisite_config_path, Rails.root)
 
     # Disable so this is only run manually
     # we may want to change this later on


### PR DESCRIPTION
... so that it can be overridden for rake tasks without changing the
config file.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
