### PR TITLE
UX: More consistent shortcut labels for macOS

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-save-button.js
+++ b/app/assets/javascripts/discourse/app/components/composer-save-button.js
@@ -1,6 +1,10 @@
 import Button from "discourse/components/d-button";
+import I18n from "I18n";
+import { macFriendlyShortcutLabel } from "discourse/lib/utilities";
 
 export default Button.extend({
   classNameBindings: [":btn-primary", ":create", "disableSubmit:disabled"],
-  title: "composer.title",
+  translatedTitle: macFriendlyShortcutLabel(I18n.t("composer.title"), {
+    replaceCtrl: true,
+  }),
 });

--- a/app/assets/javascripts/discourse/app/components/composer-save-button.js
+++ b/app/assets/javascripts/discourse/app/components/composer-save-button.js
@@ -1,10 +1,10 @@
 import Button from "discourse/components/d-button";
 import I18n from "I18n";
-import { macFriendlyShortcutLabel } from "discourse/lib/utilities";
+import { translateModKey } from "discourse/lib/utilities";
 
 export default Button.extend({
   classNameBindings: [":btn-primary", ":create", "disableSubmit:disabled"],
-  translatedTitle: macFriendlyShortcutLabel(I18n.t("composer.title"), {
-    replaceCtrl: true,
+  translatedTitle: I18n.t("composer.title", {
+    modifier: translateModKey("Meta+"),
   }),
 });

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -1,5 +1,9 @@
 import { ajax } from "discourse/lib/ajax";
-import { caretPosition, inCodeBlock } from "discourse/lib/utilities";
+import {
+  caretPosition,
+  inCodeBlock,
+  macFriendlyShortcutLabel,
+} from "discourse/lib/utilities";
 import discourseComputed, {
   observes,
   on,
@@ -192,23 +196,9 @@ class Toolbar {
       const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
       const mod = mac ? "Meta" : "Ctrl";
       let shortcutTitle = `${mod}+${button.shortcut}`;
-
-      // Mac users are used to glyphs for shortcut keys
-      if (mac) {
-        shortcutTitle = shortcutTitle
-          .replace("Shift", "\u21E7")
-          .replace("Meta", "\u2318")
-          .replace("Alt", "\u2325")
-          .replace(/\+/g, "");
-      } else {
-        shortcutTitle = shortcutTitle
-          .replace("Shift", I18n.t("shortcut_modifier_key.shift"))
-          .replace("Ctrl", I18n.t("shortcut_modifier_key.ctrl"))
-          .replace("Alt", I18n.t("shortcut_modifier_key.alt"));
-      }
+      shortcutTitle = macFriendlyShortcutLabel(shortcutTitle);
 
       createdButton.title = `${title} (${shortcutTitle})`;
-
       this.shortcuts[`${mod}+${button.shortcut}`.toLowerCase()] = createdButton;
     } else {
       createdButton.title = title;

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -2,7 +2,7 @@ import { ajax } from "discourse/lib/ajax";
 import {
   caretPosition,
   inCodeBlock,
-  macFriendlyShortcutLabel,
+  translateModKey,
 } from "discourse/lib/utilities";
 import discourseComputed, {
   observes,
@@ -195,8 +195,10 @@ class Toolbar {
     if (button.shortcut) {
       const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
       const mod = mac ? "Meta" : "Ctrl";
-      let shortcutTitle = `${mod}+${button.shortcut}`;
-      shortcutTitle = macFriendlyShortcutLabel(shortcutTitle);
+
+      const shortcutTitle = `${translateModKey(mod + "+")}${translateModKey(
+        button.shortcut
+      )}`;
 
       createdButton.title = `${title} (${shortcutTitle})`;
       this.shortcuts[`${mod}+${button.shortcut}`.toLowerCase()] = createdButton;

--- a/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
+++ b/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
@@ -1,11 +1,12 @@
 import Controller from "@ember/controller";
 import I18n from "I18n";
+import { macFriendlyShortcutLabel } from "discourse/lib/utilities";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 
 const KEY = "keyboard_shortcuts_help";
 
 const SHIFT = I18n.t("shortcut_modifier_key.shift");
-const ALT = I18n.t("shortcut_modifier_key.alt");
+const ALT = macFriendlyShortcutLabel(I18n.t("shortcut_modifier_key.alt"));
 const CTRL = I18n.t("shortcut_modifier_key.ctrl");
 const ENTER = I18n.t("shortcut_modifier_key.enter");
 
@@ -210,7 +211,7 @@ export default Controller.extend(ModalFunctionality, {
           keys1: ["m", "w"],
         }),
         print: buildShortcut("actions.print", {
-          keys1: [CTRL, "p"],
+          keys1: [macFriendlyShortcutLabel(CTRL, { replaceCtrl: true }), "p"],
           keysDelimiter: PLUS,
         }),
         defer: buildShortcut("actions.defer", {

--- a/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
+++ b/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
@@ -1,12 +1,12 @@
 import Controller from "@ember/controller";
 import I18n from "I18n";
-import { macFriendlyShortcutLabel } from "discourse/lib/utilities";
+import { translateModKey } from "discourse/lib/utilities";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 
 const KEY = "keyboard_shortcuts_help";
 
 const SHIFT = I18n.t("shortcut_modifier_key.shift");
-const ALT = macFriendlyShortcutLabel(I18n.t("shortcut_modifier_key.alt"));
+const ALT = translateModKey("Alt");
 const CTRL = I18n.t("shortcut_modifier_key.ctrl");
 const ENTER = I18n.t("shortcut_modifier_key.enter");
 
@@ -211,7 +211,7 @@ export default Controller.extend(ModalFunctionality, {
           keys1: ["m", "w"],
         }),
         print: buildShortcut("actions.print", {
-          keys1: [macFriendlyShortcutLabel(CTRL, { replaceCtrl: true }), "p"],
+          keys1: [translateModKey("Meta"), "p"],
           keysDelimiter: PLUS,
         }),
         defer: buildShortcut("actions.defer", {

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -496,28 +496,24 @@ export function inCodeBlock(text, pos) {
   return lastOpenBlock !== -1 && pos >= end + lastOpenBlock;
 }
 
-export function macFriendlyShortcutLabel(string, opts = {}) {
-  let shortcutLabel = string;
+export function translateModKey(string) {
   const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
-
   // Mac users are used to glyphs for shortcut keys
   if (mac) {
-    shortcutLabel = shortcutLabel
+    string = string
       .replace("Shift", "\u21E7")
       .replace("Meta", "\u2318")
       .replace("Alt", "\u2325")
       .replace(/\+/g, "");
-    if (opts.replaceCtrl) {
-      shortcutLabel = shortcutLabel.replace("Ctrl", "\u2318");
-    }
   } else {
-    shortcutLabel = shortcutLabel
+    string = string
       .replace("Shift", I18n.t("shortcut_modifier_key.shift"))
       .replace("Ctrl", I18n.t("shortcut_modifier_key.ctrl"))
+      .replace("Meta", I18n.t("shortcut_modifier_key.ctrl"))
       .replace("Alt", I18n.t("shortcut_modifier_key.alt"));
   }
 
-  return shortcutLabel;
+  return string;
 }
 // This prevents a mini racer crash
 export default {};

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -1,5 +1,6 @@
 import getURL, { getURLWithCDN } from "discourse-common/lib/get-url";
 import Handlebars from "handlebars";
+import I18n from "I18n";
 import { deepMerge } from "discourse-common/lib/object";
 import { escape } from "pretty-text/sanitizer";
 import { helperContext } from "discourse-common/lib/helpers";
@@ -495,5 +496,28 @@ export function inCodeBlock(text, pos) {
   return lastOpenBlock !== -1 && pos >= end + lastOpenBlock;
 }
 
+export function macFriendlyShortcutLabel(string, opts = {}) {
+  let shortcutLabel = string;
+  const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+  // Mac users are used to glyphs for shortcut keys
+  if (mac) {
+    shortcutLabel = shortcutLabel
+      .replace("Shift", "\u21E7")
+      .replace("Meta", "\u2318")
+      .replace("Alt", "\u2325")
+      .replace(/\+/g, "");
+    if (opts.replaceCtrl) {
+      shortcutLabel = shortcutLabel.replace("Ctrl", "\u2318");
+    }
+  } else {
+    shortcutLabel = shortcutLabel
+      .replace("Shift", I18n.t("shortcut_modifier_key.shift"))
+      .replace("Ctrl", I18n.t("shortcut_modifier_key.ctrl"))
+      .replace("Alt", I18n.t("shortcut_modifier_key.alt"));
+  }
+
+  return shortcutLabel;
+}
 // This prevents a mini racer crash
 export default {};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2137,7 +2137,7 @@ en:
       create_whisper: "Whisper"
       create_shared_draft: "Create Shared Draft"
       edit_shared_draft: "Edit Shared Draft"
-      title: "Or press Ctrl+Enter"
+      title: "Or press %{modifier}Enter"
 
       users_placeholder: "Add a user"
       title_placeholder: "What is this discussion about in one brief sentence?"


### PR DESCRIPTION
We previously showed macOS/iOS glyphs for the composer toolbar buttons only. This uses them for the composer Submit button tooltip and on the keyboard shortcuts modal. 

I left Shift and Ctrl untouched on the keyboard shortcuts modal. This is a little inconsistent, but Shift and Ctrl are easier to read and macOS keyboards very often don't have icons for the Shift key, i.e.: https://www.apple.com/shop/product/MK293LL/A/magic-keyboard-with-touch-id-for-mac-models-with-apple-silicon-us-english