### PR TITLE
DEV: Fix api docs for default calendar

### DIFF
--- a/spec/requests/api/schemas/json/user_get_response.json
+++ b/spec/requests/api/schemas/json/user_get_response.json
@@ -777,7 +777,7 @@
               "type": "boolean"
             },
             "default_calendar": {
-              "type": "none_selected"
+              "type": "string"
             }
           },
           "required": [


### PR DESCRIPTION
Change the type for default_calendar to a string.

The type specified for the default calendar in the api docs wasn't a
valid type. The linting in the api docs repo reports:

```
`type` can be one of the following only: "object", "array", "string", "number", "integer", "boolean", "null".
```

This linting currently is only in the `discourse_api_docs` repo.

Follow up to: cb5b0cb9d833345798dc93e9eaed6ac68c95e038

cc: @lis2 