### PR TITLE
FEATURE: Adds an API to exclude a tag from a TopicQuery

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -60,7 +60,8 @@ class TopicQuery
          tags
          match_all_tags
          no_subcategories
-         no_tags)
+         no_tags
+         exclude_tag)
   end
 
   def self.valid_options
@@ -688,6 +689,10 @@ class TopicQuery
       elsif @options[:no_tags]
         # the following will do: ("topics"."id" NOT IN (SELECT DISTINCT "topic_tags"."topic_id" FROM "topic_tags"))
         result = result.where.not(id: TopicTag.distinct.pluck(:topic_id))
+      end
+
+      if @options[:exclude_tag] && tag = Tag.find_by(name: @options[:exclude_tag])
+        result = result.where.not(id: TopicTag.distinct.where(tag_id: tag.id).pluck(:topic_id))
       end
     end
 

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -383,6 +383,11 @@ describe TopicQuery do
       fab!(:no_tags_topic) { Fabricate(:topic) }
       let(:synonym) { Fabricate(:tag, target_tag: tag, name: 'synonym') }
 
+      it "excludes a tag if desired" do
+        topics = TopicQuery.new(moderator, exclude_tag: tag.name).list_latest.topics
+        expect(topics.any? { |t| t.tags.include?(tag) }).to eq(false)
+      end
+
       it "returns topics with the tag when filtered to it" do
         expect(TopicQuery.new(moderator, tags: tag.name).list_latest.topics)
           .to contain_exactly(tagged_topic1, tagged_topic3)


### PR DESCRIPTION
To exclude a tag from a topic list, add the `exclude_tag` query
parameter. For example: `latest?exclude_tag=music`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
