### PR TITLE
FIX: JS error when showing topic search results

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -61,7 +61,9 @@ export function addSearchSuggestion(value) {
 class Highlighted extends RawHtml {
   constructor(html, term) {
     super({ html: `<span>${html}</span>` });
-    this.term = term.replace(TOPIC_REPLACE_REGEXP, "");
+    if (term) {
+      this.term = term.replace(TOPIC_REPLACE_REGEXP, "");
+    }
   }
 
   decorate($html) {


### PR DESCRIPTION
The `search-result-topic` widget is used in quick search results, mainly. But it is also used in the composer, when displaying similar topics. But in that context, we don't have a search term, and that was causing the similar topics box to be empty and output a console error. 

See also: https://meta.discourse.org/t/your-topic-is-similar-to-popup-is-empty/205452

Bug was initially introduced in https://github.com/discourse/discourse/commit/e9b1d29d8bac50abc5997b552457086f3a66462e 