### PR TITLE
FIX: selection going missing in Safari

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -206,13 +206,6 @@ export default Component.extend(KeyEnterEscape, {
     // merge back all text nodes so they don't get messed up
     parent.normalize();
 
-    // work around Safari that would sometimes lose the selection
-    if (isSafari) {
-      this._reselected = true;
-      selection.removeAllRanges();
-      selection.addRange(clone);
-    }
-
     // change the position of the button
     schedule("afterRender", () => {
       if (!this.element || this.isDestroying || this.isDestroyed) {
@@ -234,6 +227,13 @@ export default Component.extend(KeyEnterEscape, {
       $quoteButton.offset({ top, left });
 
       this.element.querySelector("button")?.focus();
+
+      // work around Safari that would sometimes lose the selection
+      if (isSafari) {
+        this._reselected = true;
+        selection.removeAllRanges();
+        selection.addRange(clone);
+      }
     });
   },
 


### PR DESCRIPTION
We need to do this after setting `focus()` to an element, otherwise Safari loses the visual effect of the selection. 