### PR TITLE
FIX: topic_tracking_state not erroring when missing user_stat

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -171,7 +171,7 @@ class TopicTrackingState
         category_id: post.topic.category_id,
         notification_level: tu.notification_level,
         archetype: post.topic.archetype,
-        first_unread_at: tu.user.user_stat.first_unread_at,
+        first_unread_at: tu.user.user_stat&.first_unread_at,
         unread_not_too_old: true
       }
 

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -92,6 +92,17 @@ describe TopicTrackingState do
       expect(data["payload"]["archetype"]).to eq(Archetype.default)
     end
 
+    it "is not erroring when user_stat is missing" do
+      post.user.user_stat.destroy!
+      message = MessageBus.track_publish(described_class.unread_channel_key(post.user.id)) do
+        TopicTrackingState.publish_unread(post)
+      end.first
+
+      data = message.data
+
+      expect(message.user_ids).to contain_exactly(post.user.id)
+    end
+
     it "does not publish whisper post to non-staff users" do
       post.update!(post_type: Post.types[:whisper])
 


### PR DESCRIPTION
publish_unread should not error when UserStat is missing

