### PR TITLE
FIX: Resolve quoting issues by reverting new shortcuts

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -232,8 +232,6 @@ export default Component.extend(KeyEnterEscape, {
       }
 
       $quoteButton.offset({ top, left });
-
-      this.element.querySelector("button")?.focus();
     });
   },
 
@@ -279,24 +277,6 @@ export default Component.extend(KeyEnterEscape, {
           onSelectionChanged();
         }
       });
-  },
-
-  keyDown(event) {
-    this._super(...arguments);
-
-    if (!this.visible) {
-      return;
-    }
-
-    if (!this._displayFastEditInput && event.key === "e") {
-      this._toggleFastEditForm();
-      return false;
-    }
-
-    if (event.key === "q") {
-      this.insertQuote();
-      return false;
-    }
   },
 
   willDestroyElement() {

--- a/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/quote-button.hbs
@@ -4,9 +4,7 @@
       class="btn-flat insert-quote"
       action=(action "insertQuote")
       icon="quote-left"
-      label="post.quote_reply"
-      title="post.quote_reply_shortcut"
-    }}
+      label="post.quote_reply"}}
   {{/if}}
 
   {{#if siteSettings.enable_fast_edit}}
@@ -16,7 +14,6 @@
         action=(action "_toggleFastEditForm")
         label="post.quote_edit"
         class="btn-flat quote-edit-label"
-        title="post.quote_edit_shortcut"
       }}
     {{/if}}
   {{/if}}

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -423,12 +423,6 @@ aside.quote {
     color: var(--secondary-or-primary);
   }
 
-  .btn:focus:not(:hover),
-  .btn:focus:not(:hover) .d-icon {
-    color: var(--secondary);
-    background-color: var(--secondary-high);
-  }
-
   .insert-quote + .quote-sharing {
     border-left: 1px solid rgba(255, 255, 255, 0.3);
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3016,9 +3016,7 @@ en:
 
     post:
       quote_reply: "Quote"
-      quote_reply_shortcut: "Or press q"
       quote_edit: "Edit"
-      quote_edit_shortcut: "Or press e"
       quote_share: "Share"
       edit_reason: "Reason: "
       post_number: "post %{number}"


### PR DESCRIPTION
This reverts the new `e` and `q` shortcuts for quick-edit, and quote. The current implementation of these is causing issues with quoting on mobile devices.

We intend restore these new shortcuts soon.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
