### PR TITLE
FIX: Handle separately invite to topic and forum

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -365,7 +365,7 @@ class Guardian
   end
 
   def can_invite_to?(object, groups = nil)
-    return false if !can_invite_to_forum?(groups)
+    return false if !authenticated?
     return false if !object.is_a?(Topic) || !can_see?(object)
     return false if groups.present?
 
@@ -385,6 +385,7 @@ class Guardian
   end
 
   def can_invite_via_email?(object)
+    return false if !can_invite_to_forum?
     return false if !can_invite_to?(object)
 
     (SiteSetting.enable_local_logins || SiteSetting.enable_discourse_connect) &&

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -548,11 +548,11 @@ describe Guardian do
         expect(Guardian.new(nil).can_invite_to?(topic)).to be_falsey
         expect(Guardian.new(moderator).can_invite_to?(nil)).to be_falsey
         expect(Guardian.new(moderator).can_invite_to?(topic)).to be_truthy
-        expect(Guardian.new(trust_level_1).can_invite_to?(topic)).to be_falsey
+        expect(Guardian.new(trust_level_1).can_invite_to?(topic)).to be_truthy
 
         SiteSetting.max_invites_per_day = 0
 
-        expect(Guardian.new(user).can_invite_to?(topic)).to be_falsey
+        expect(Guardian.new(user).can_invite_to?(topic)).to be_truthy
         # staff should be immune to max_invites_per_day setting
         expect(Guardian.new(moderator).can_invite_to?(topic)).to be_truthy
       end
@@ -575,9 +575,9 @@ describe Guardian do
         expect(Guardian.new(trust_level_2).can_invite_to?(topic)).to be_truthy
       end
 
-      it 'fails for normal users if must_approve_users' do
+      it 'return true for normal users even if must_approve_users' do
         SiteSetting.must_approve_users = true
-        expect(Guardian.new(user).can_invite_to?(topic)).to be_falsey
+        expect(Guardian.new(user).can_invite_to?(topic)).to be_truthy
         expect(Guardian.new(admin).can_invite_to?(topic)).to be_truthy
       end
 
@@ -640,23 +640,6 @@ describe Guardian do
 
         it "doesn't allow a regular user to invite" do
           expect(Guardian.new(admin).can_invite_to?(pm)).to be_truthy
-          expect(Guardian.new(user).can_invite_to?(pm)).to be_falsey
-        end
-      end
-
-      context "when private messages are enabled" do
-        before do
-          SiteSetting.enable_personal_messages = true
-          SiteSetting.min_trust_level_to_allow_invite = 2
-        end
-
-        it "returns true if user has sufficient trust level" do
-          user.trust_level = 2
-          expect(Guardian.new(user).can_invite_to?(pm)).to be_truthy
-        end
-
-        it "returns false if user has sufficient trust level" do
-          user.trust_level = 1
           expect(Guardian.new(user).can_invite_to?(pm)).to be_falsey
         end
       end


### PR DESCRIPTION
Invite is used in two contexts, when inviting a new user to the forum
and when inviting an existent user to a topic. The first case is more
complex and it involves permission checks to ensure that new users can
be created. In the second case, it is enough to ensure that the topic
is visible for both users and that all preconditions are met.

One edge case is the invite to topic via email functionality which
checks for both conditions because first the user must be invited to
create an account first and then to the topic.

A side effect of these changes is that all site settings related to
invites refer to inviting new users only now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
