### PR TITLE
FIX: Move check if user is suspended later

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -14,6 +14,8 @@ class PostAlerter
   end
 
   def self.create_notification_alert(user:, post:, notification_type:, excerpt: nil, username: nil)
+    return if user.suspended?
+
     if post_url = post.url
       payload = {
        notification_type: notification_type,
@@ -502,7 +504,7 @@ class PostAlerter
       skip_send_email: skip_send_email
     )
 
-    if created.id && existing_notifications.empty? && NOTIFIABLE_TYPES.include?(type) && !user.suspended?
+    if created.id && existing_notifications.empty? && NOTIFIABLE_TYPES.include?(type)
       create_notification_alert(user: user, post: original_post, notification_type: type, username: original_username)
     end
 


### PR DESCRIPTION
Calling create_notification_alert could still send a notification to a
suspended user. This just moves the check if user is suspended right
before sending the notification.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
