### PR TITLE
FIX: extract filter pm and categories from UserAction

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -417,6 +417,11 @@ class UserAction < ActiveRecord::Base
       builder.where("a.action_type not in (#{BOOKMARK})")
     end
 
+    filter_private_messages(builder, user_id, guardian, ignore_private_messages)
+    filter_categories(builder, guardian)
+  end
+
+  def self.filter_private_messages(builder, user_id, guardian, ignore_private_messages = false)
     if !guardian.can_see_private_messages?(user_id) || ignore_private_messages || !guardian.user
       builder.where("t.archetype <> :private_message", private_message: Archetype::private_message)
     else
@@ -436,7 +441,10 @@ class UserAction < ActiveRecord::Base
         builder.where(sql, private_message: Archetype::private_message, current_user_id: guardian.user.id)
       end
     end
+    builder
+  end
 
+  def self.filter_categories(builder, guardian)
     unless guardian.is_admin?
       allowed = guardian.secure_category_ids
       if allowed.present?
@@ -447,6 +455,7 @@ class UserAction < ActiveRecord::Base
         builder.where("(c.read_restricted IS NULL OR NOT c.read_restricted)")
       end
     end
+    builder
   end
 
   def self.require_parameters(data, *params)


### PR DESCRIPTION
Those two methods are useful for different places like discourse-reactions:

https://github.com/discourse/discourse-reactions/commit/213d90b82fd15c4186ebc290fee18817d9727d0d#diff-00e1224615af30993a63193531b5073c11d5c20e91c46e2a59c1cd25e8952da6R203

