### PR TITLE
FIX: phpbb import - attachments not embedded in posts

### DIFF
--- a/script/import_scripts/phpbb3/support/text_processor.rb
+++ b/script/import_scripts/phpbb3/support/text_processor.rb
@@ -159,7 +159,7 @@ module ImportScripts::PhpBB3
       attachment_regexp = /\[attachment=([\d])+\]<!-- [\w]+ -->([^<]+)<!-- [\w]+ -->\[\/attachment\]?/i
       unreferenced_attachments = attachments.dup
 
-      text = text.gsub(attachment_regexp) do
+      text.gsub!(attachment_regexp) do
         index = $1.to_i
         real_filename = $2
         unreferenced_attachments[index] = nil


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
## Problem

The phpBB import script successfully recognizes and imports the attachments to Discourse but fails to embed them correctly in the posts' Markdown. See [relevant discussion](https://meta.discourse.org/t/importing-migrating-from-phpbb3/30810/628) in DIscourse meta.

The issue is in `TextProcessor::process_attachments` which is responsible for embedding the attachment Markdown code to the post text.

```ruby
# This replaces existing [attachment] BBCodes with the corresponding HTML tags for Discourse.
# All attachments that haven't been referenced in the text are appended to the end of the text.
def process_attachments(text, attachments)
  attachment_regexp = /\[attachment=([\d])+\]<!-- [\w]+ -->([^<]+)<!-- [\w]+ -->\[\/attachment\]?/i
  unreferenced_attachments = attachments.dup

  text = text.gsub(attachment_regexp) do
    index = $1.to_i
    real_filename = $2
    unreferenced_attachments[index] = nil
    attachments.fetch(index, real_filename)
  end

  add_unreferenced_attachments(text, unreferenced_attachments)
end
```

The faulty line is `text = text.gsub(attachment_regexp) do` since it causes the `text` reference to change only inside `process_attachments` (see [How arguments are passed?](https://www.ruby-lang.org/en/documentation/faq/4/) in Ruby docs) and the return value even though it is correct, is not used by the caller.

## Fix
`text = text.gsub(...)` is changed to `text.gsub!(...)`

## Notes
I wasn't sure where to add tests. Any suggestions would be welcome. :)