### PR TITLE
FIX: update translation key to match flag reason.

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -6,7 +6,7 @@ class ReviewableScoreSerializer < ApplicationSerializer
     trust_level: 'approve_unless_trust_level',
     new_topics_unless_trust_level: 'approve_new_topics_unless_trust_level',
     fast_typer: 'min_first_post_typing_time',
-    auto_silence_regexp: 'auto_silence_first_post_regex',
+    auto_silence_regex: 'auto_silence_first_post_regex',
     staged: 'approve_unless_staged',
     must_approve_users: 'must_approve_users',
     invite_only: 'invite_only',
@@ -40,11 +40,12 @@ class ReviewableScoreSerializer < ApplicationSerializer
       text = I18n.t("reviewables.reasons.#{object.reason}", link: link, default: nil)
     else
       text = I18n.t("reviewables.reasons.#{object.reason}", default: nil)
+
       # TODO(roman): Remove after the 2.8 release.
       # The discourse-antivirus and akismet plugins still use the backtick format for settings.
       # It'll be hard to migrate them to the new format without breaking backwards compatibility, so I'm keeping the old behavior for now.
       # Will remove after the 2.8 release.
-      linkify_backticks(object.reason, text)
+      linkify_backticks(object.reason, text) if text
     end
 
     text

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5001,7 +5001,7 @@ en:
       trust_level: "Users at low trust levels must have replies approved by staff. See %{link}."
       new_topics_unless_trust_level: "Users at low trust levels must have topics approved by staff. See %{link}."
       fast_typer: "New user typed their first post suspiciously fast, suspected bot or spammer behavior. See %{link}."
-      auto_silence_regexp: "New user whose first post matches the %{link} setting."
+      auto_silence_regex: "New user whose first post matches the %{link} setting."
       watched_word: "This post included a Watched Word. See your %{link}."
       staged: "New topics and posts for staged users must be approved by staff. See %{link}."
       category: "Posts in this category require manual approval by staff. See the %{link}."

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -29,7 +29,7 @@ describe ReviewableScoreSerializer do
 
     context 'site setting links' do
       reasons = %w[
-        post_count trust_level new_topics_unless_trust_level fast_typer auto_silence_regexp
+        post_count trust_level new_topics_unless_trust_level fast_typer auto_silence_regex
         staged must_approve_users invite_only email_spam suspect_user contains_media
       ]
 


### PR DESCRIPTION
The refactor introduced in https://github.com/discourse/discourse/pull/14475 made this visible. Adds a safeguard to make sure translation is present before trying to linkify backticks.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
