### PR TITLE
PERF: Use a subquery when excluding a tag from topic query.

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -691,8 +691,15 @@ class TopicQuery
         result = result.where.not(id: TopicTag.distinct.pluck(:topic_id))
       end
 
-      if @options[:exclude_tag] && tag = Tag.find_by(name: @options[:exclude_tag])
-        result = result.where.not(id: TopicTag.distinct.where(tag_id: tag.id).pluck(:topic_id))
+      if @options[:exclude_tag].present?
+        result = result.where(<<~SQL, name: @options[:exclude_tag])
+        topics.id NOT IN (
+          SELECT topic_tags.topic_id
+          FROM topic_tags
+          INNER JOIN tags ON tags.id = topic_tags.tag_id
+          WHERE tags.name = :name
+        )
+        SQL
       end
     end
 


### PR DESCRIPTION
When a tag with alot of topics is used, we end up allocating a Ruby
array of all the topic ids. Instead, we can just use a subquery here and
handle all of the exclusion logic in PG.

Follow-up to ae13839f98b1b2530a4727a09feee89d7a6ebd88