### PR TITLE
FIX: `BackupRestore::DatabaseRestorer` failures with Ruby 3

### DIFF
--- a/spec/lib/backup_restore/shared_context_for_backup_restore.rb
+++ b/spec/lib/backup_restore/shared_context_for_backup_restore.rb
@@ -33,7 +33,7 @@ shared_context "shared stuff" do
   end
 
   def expect_db_migrate
-    Discourse::Utils.expects(:execute_command).with do |env, *command, **options|
+    Discourse::Utils.expects(:execute_command).with do |env, *command, options|
       env["SKIP_POST_DEPLOYMENT_MIGRATIONS"] == "0" &&
         env["SKIP_OPTIMIZE_ICONS"] == "1" &&
         env["DISABLE_TRANSLATION_OVERRIDES"] == "1" &&


### PR DESCRIPTION
This pull request addresses `BackupRestore::DatabaseRestorer` failures with Ruby 3. by implementing a workaround suggested at https://github.com/freerange/mocha/issues/445#issuecomment-644944003

### Actual result without this commit

```ruby
$ bundle exec rspec ./spec/lib/backup_restore/database_restorer_multisite_spec.rb:15
Run options: include {:locations=>{"./spec/lib/backup_restore/database_restorer_multisite_spec.rb"=>[15]}}

Randomized with seed 12264
F

Failures:

  1) BackupRestore::DatabaseRestorer#restore database connection reconnects to the correct database
     Failure/Error:
       log Discourse::Utils.execute_command(
         {
           "SKIP_POST_DEPLOYMENT_MIGRATIONS" => "0",
           "SKIP_OPTIMIZE_ICONS" => "1",
           "DISABLE_TRANSLATION_OVERRIDES" => "1"
         },
         "rake", "db:migrate",
         failure_message: "Failed to migrate database.",
         chdir: Rails.root
       )

     Mocha::ExpectationError:
       unexpected invocation: Discourse::Utils.execute_command({"SKIP_POST_DEPLOYMENT_MIGRATIONS" => "0", "SKIP_OPTIMIZE_ICONS" => "1", "DISABLE_TRANSLATION_OVERRIDES" => "1"}, "rake", "db:migrate", {:failure_message => "Failed to migrate database.", :chdir => #<Pathname:0xd598>})
       unsatisfied expectations:
       - expected exactly once, invoked never: Discourse::Utils.execute_command()
       satisfied expectations:
       - expected exactly once, invoked once: BackupRestore.move_tables_between_schemas("public", "backup")
       - expected at least once, invoked 77 times: Migration::BaseDropper.create_readonly_function(any_parameters)
       - expected exactly once, invoked once: #<Mock:psql status>.exitstatus(any_parameters)
       - expected exactly once, invoked once: Process.last_status(any_parameters)
       - expected exactly twice, invoked twice: #<Mock:psql>.readline(any_parameters)
       - expected exactly once, invoked once: IO.popen(any_parameters)
     # ./lib/backup_restore/database_restorer.rb:138:in `migrate_database'
     # ./lib/backup_restore/database_restorer.rb:27:in `restore'
     # ./spec/lib/backup_restore/shared_context_for_backup_restore.rb:59:in `execute_stubbed_restore'
     # ./spec/lib/backup_restore/database_restorer_multisite_spec.rb:17:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:279:in `block (2 levels) in <top (required)>'

Finished in 0.30193 seconds (files took 2.7 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/backup_restore/database_restorer_multisite_spec.rb:15 # BackupRestore::DatabaseRestorer#restore database connection reconnects to the correct database

Randomized with seed 12264

$
```

### Failing specs addressed by this commit

```ruby
bundle exec rspec ./spec/lib/backup_restore/database_restorer_multisite_spec.rb:15 # BackupRestore::DatabaseRestorer#restore database connection reconnects to the correct database
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:170 # BackupRestore::DatabaseRestorer readonly functions creates and drops only missing functions during restore
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:160 # BackupRestore::DatabaseRestorer readonly functions creates and drops all functions when none exist
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:136 # BackupRestore::DatabaseRestorer#rollback moves tables back when tables were moved
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:14 # BackupRestore::DatabaseRestorer#restore executes everything in the correct order
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:25 # BackupRestore::DatabaseRestorer#restore stores the date of the last restore
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:129 # BackupRestore::DatabaseRestorer#restore database connection it is not erroring for non-multisite
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:69 # BackupRestore::DatabaseRestorer#restore with real psql restores from PostgreSQL 11
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:64 # BackupRestore::DatabaseRestorer#restore with real psql restores from PostgreSQL 10
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:49 # BackupRestore::DatabaseRestorer#restore with real psql restores from PostgreSQL 9.3
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:73 # BackupRestore::DatabaseRestorer#restore with real psql restores from PostgreSQL 12
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:59 # BackupRestore::DatabaseRestorer#restore with real psql restores from PostgreSQL 9.5
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:54 # BackupRestore::DatabaseRestorer#restore with real psql restores from PostgreSQL 9.5.5
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:105 # BackupRestore::DatabaseRestorer#restore rewrites database dump replaces `EXECUTE FUNCTION` when restoring on PostgreSQL < 11
bundle exec rspec ./spec/lib/backup_restore/database_restorer_spec.rb:116 # BackupRestore::DatabaseRestorer#restore rewrites database dump does not replace `EXECUTE FUNCTION` when restoring on PostgreSQL >= 11
```