### PR TITLE
Revert "DEV: add routes_lazy_route to boost boot-up time (#14545)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,7 +151,6 @@ group :test do
 end
 
 group :test, :development do
-  gem 'routes_lazy_routes'
   gem 'rspec'
   gem 'mock_redis'
   gem 'listen', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,9 +352,6 @@ GEM
     rexml (3.2.5)
     rinku (2.0.6)
     rotp (6.2.0)
-    routes_lazy_routes (0.4.2)
-      actionpack
-      railties
     rqrcode (2.1.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
@@ -581,7 +578,6 @@ DEPENDENCIES
   redis-namespace
   rinku
   rotp
-  routes_lazy_routes
   rqrcode
   rspec
   rspec-html-matchers

--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'sidekiq/api'
-
 module Jobs
 
   def self.queued


### PR DESCRIPTION
This reverts commit f5cf647e579d6a2c844a38d695877e5aad951184.

The gem breaks usage of Rails URL helpers when used outside views and
controllers, for example in
https://github.com/discourse/discourse/blob/88ecb83382e4dc5cec1d9599619a6c40a07825ae/app/models/upload.rb#L239-L242
the `upload_short_path` method call fails with an undefined method
exception when this gem is enabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
