### PR TITLE
FIX: Use absolute URLs in search shortcut

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -299,7 +299,7 @@ export default createWidget("search-menu", {
 
           this.appEvents.trigger(
             "composer:insert-text",
-            document.activeElement.getAttribute("href"),
+            document.activeElement.href,
             {
               ensureSpace: true,
             }

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -350,7 +350,7 @@ acceptance("Search - Authenticated", function (needs) {
 
     assert.equal(
       query("#reply-control textarea").value,
-      firstLink,
+      `${window.location.origin}${firstLink}`,
       "hitting A when focused on a search result copies link to composer"
     );
   });


### PR DESCRIPTION
This regressed in https://github.com/discourse/discourse/commit/e9b1d29d8bac50abc5997b552457086f3a66462e