### PR TITLE
PERF: Reduce work when external sources are allowed in `InlineUploads`

### DIFF
--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -149,7 +149,7 @@ class InlineUploads
 
   def self.match_md_inline_img(markdown, external_src: false)
     markdown.scan(/(!?\[([^\[\]]*)\]\(([^\s\)]+)([ ]*['"]{1}[^\)]*['"]{1}[ ]*)?\))/) do |match|
-      if (matched_uploads(match[2]).present? || external_src) && block_given?
+      if (external_src || matched_uploads(match[2]).present?) && block_given?
         yield(
           match[0],
           match[2],
@@ -162,7 +162,7 @@ class InlineUploads
 
   def self.match_bbcode_img(markdown, external_src: false)
     markdown.scan(/(\[img\]\s*([^\[\]\s]+)\s*\[\/img\])/i) do |match|
-      if (matched_uploads(match[1]).present? && block_given?) || external_src
+      if (external_src || (matched_uploads(match[1]).present?)) && block_given?
         yield(match[0], match[1], +"![](#{PLACEHOLDER})", $~.offset(0)[0])
       end
     end
@@ -186,7 +186,7 @@ class InlineUploads
       node = Nokogiri::HTML5::fragment(match[0]).children[0]
       href =  node.attributes["href"]&.value
 
-      if href && (matched_uploads(href).present? || external_href)
+      if href && (external_href || matched_uploads(href).present?)
         has_attachment = node.attributes["class"]&.value
         index = $~.offset(0)[0]
         text = match[2].strip.gsub("\n", "").gsub(/ +/, " ")
@@ -202,7 +202,7 @@ class InlineUploads
       node = Nokogiri::HTML5::fragment(match[2].strip).children[0]
       src = node&.attributes&.[]("src")&.value
 
-      if src && (matched_uploads(src).present? || external_src)
+      if src && (external_src || matched_uploads(src).present?)
         upload = uploads&.[](src)
 
         text = upload&.original_filename || node.attributes["alt"]&.value


### PR DESCRIPTION
It also fixes a bug in `match_bbcode_img()` which didn't check `block_given?` for all conditions.