### PR TITLE
UX: Better visibility for context search

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -480,7 +480,8 @@ createWidget("search-menu-initial-options", {
     const ctx = service.get("searchContext");
 
     const content = [];
-    if (attrs.term) {
+
+    if (attrs.term || ctx) {
       if (ctx) {
         const term = attrs.term ? `${attrs.term} ` : "";
 
@@ -549,8 +550,9 @@ createWidget("search-menu-initial-options", {
         }
       }
 
-      const rowOptions = { withLabel: true };
-      content.push(this.defaultRow(attrs.term, rowOptions));
+      if (attrs.term) {
+        content.push(this.defaultRow(attrs.term, { withLabel: true }));
+      }
       return content;
     }
 
@@ -601,6 +603,7 @@ createWidget("search-menu-assistant-item", {
           category: attrs.category,
           allowUncategorized: true,
           recursive: true,
+          link: false,
         })
       );
     } else if (attrs.tag) {

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -117,6 +117,13 @@ acceptance("Search - Anonymous", function (needs) {
 
     await visit("/tag/important");
     await click("#search-button");
+
+    assert.equal(
+      query(firstResult).textContent.trim(),
+      `${I18n.t("search.in")} test`,
+      "contenxtual tag search is first available option with no term"
+    );
+
     await fillIn("#search-term", "smth");
 
     assert.equal(
@@ -132,6 +139,11 @@ acceptance("Search - Anonymous", function (needs) {
       query(firstResult).textContent.trim(),
       `smth ${I18n.t("search.in")} bug`,
       "category-scoped search is first available option"
+    );
+
+    assert.ok(
+      exists(`${firstResult} span.badge-wrapper`),
+      "category badge is a span (i.e. not a link)"
     );
 
     await visit("/t/internationalization-localization/280");
@@ -159,6 +171,16 @@ acceptance("Search - Anonymous", function (needs) {
     await visit("/t/internationalization-localization/280/1");
 
     await click("#search-button");
+
+    const firstResult =
+      ".search-menu .results .search-menu-assistant-item:first-child";
+
+    assert.equal(
+      query(firstResult).textContent.trim(),
+      I18n.t("search.in_this_topic"),
+      "contenxtual topic search is first available option"
+    );
+
     await fillIn("#search-term", "a proper");
     await focus("input#search-term");
     await triggerKeyEvent(".search-menu", "keydown", 40);


### PR DESCRIPTION
When in a topic/category/user/group page, this shows the contextual search option even when there is no search term (i.e. instead of the random tips shown previously). This should be more helpful to users, given that it exposes to them the ability to search within the given context. 

This also fixes a bug where clicking on the category badge in the search suggestions routed the user to the category page. 
