### PR TITLE
FIX: also track textContent mutations

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -913,6 +913,7 @@ export default Component.extend(TextareaTextManipulation, {
       childList: true,
       subtree: true,
       attributes: false,
+      characterData: true,
     });
 
     return observer;


### PR DESCRIPTION
Tracking innerHTML was not enough to catch every mutations.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
