### PR TITLE
DEV: Remove warnings on console

### DIFF
--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -127,7 +127,8 @@ class FileHelper
         jpegrecompress: false,
         # Skip looking for gifsicle, svgo binaries
         gifsicle: false,
-        svgo: false
+        svgo: false,
+        oxipng: false
       )
     end
   end

--- a/lib/file_store/base_store.rb
+++ b/lib/file_store/base_store.rb
@@ -3,8 +3,8 @@
 module FileStore
 
   class BaseStore
-    UPLOAD_PATH_REGEX = %r|/(original/\d+X/.*)|
-    OPTIMIZED_IMAGE_PATH_REGEX = %r|/(optimized/\d+X/.*)|
+    UPLOAD_PATH_REGEX ||= %r|/(original/\d+X/.*)|
+    OPTIMIZED_IMAGE_PATH_REGEX ||= %r|/(optimized/\d+X/.*)|
     TEMPORARY_UPLOAD_PREFIX ||= "temp/"
 
     def store_upload(file, upload, content_type = nil)


### PR DESCRIPTION
We don't use oxipng from the image_optim gem and rake tasks complained that constants have already been initialized.