### PR TITLE
FIX: correct api version after minor bump

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -95,7 +95,7 @@ import { disableDefaultBadging } from "discourse/initializers/badging";
 import { downloadCalendar } from "discourse/lib/download-calendar";
 
 // If you add any methods to the API ensure you bump up this number
-const PLUGIN_API_VERSION = "0.13.6";
+const PLUGIN_API_VERSION = "0.13.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {


### PR DESCRIPTION
After minor version update, patch should be 0
