### PR TITLE
UX: Show fewer toolbar icons in mobile composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -64,7 +64,7 @@ let _createCallbacks = [];
 
 class Toolbar {
   constructor(opts) {
-    const { site } = opts;
+    const { site, siteSettings } = opts;
     this.shortcuts = {};
     this.context = null;
 
@@ -152,6 +152,18 @@ class Toolbar {
             (i) => (!i ? "1. " : `${parseInt(i, 10) + 1}. `),
             "list_item"
           ),
+      });
+    }
+
+    if (siteSettings.support_mixed_text_direction) {
+      this.addButton({
+        id: "toggle-direction",
+        group: "extras",
+        icon: "exchange-alt",
+        shortcut: "Shift+6",
+        title: "composer.toggle_direction",
+        preventFocus: true,
+        perform: (e) => e.toggleDirection(),
       });
     }
 
@@ -333,7 +345,9 @@ export default Component.extend(TextareaTextManipulation, {
 
   @discourseComputed()
   toolbar() {
-    const toolbar = new Toolbar(this.getProperties("site", "showLink"));
+    const toolbar = new Toolbar(
+      this.getProperties("site", "siteSettings", "showLink")
+    );
     toolbar.context = this;
 
     _createCallbacks.forEach((cb) => cb(toolbar));

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -340,18 +340,6 @@ export default Controller.extend({
         );
       }
 
-      if (this.siteSettings.support_mixed_text_direction) {
-        options.push(
-          this._setupPopupMenuOption(() => {
-            return {
-              action: "toggleDirection",
-              icon: "exchange-alt",
-              label: "composer.toggle_direction",
-            };
-          })
-        );
-      }
-
       options.push(
         this._setupPopupMenuOption(() => {
           return {
@@ -723,10 +711,6 @@ export default Controller.extend({
         (i) => (!i ? "1. " : `${parseInt(i, 10) + 1}. `),
         "list_item"
       );
-    },
-
-    toggleDirection() {
-      this.toolbarEvent.toggleDirection();
     },
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1057,23 +1057,3 @@ acceptance("Composer - Customizations", function (needs) {
     );
   });
 });
-
-acceptance("Composer - Text Direction", function (needs) {
-  needs.user();
-  needs.settings({
-    support_mixed_text_direction: true,
-    default_locale: "en",
-  });
-
-  test("Composer can toggle direction from ltr to rtl", async function (assert) {
-    const menu = selectKit(".toolbar-popup-menu-options");
-
-    await visit("/t/this-is-a-test-topic/9");
-    await click(".topic-post:nth-of-type(1) button.reply");
-
-    await menu.expand();
-    await menu.selectRowByValue("toggleDirection");
-
-    assert.ok(query("textarea.d-editor-input").getAttribute("dir"), "rtl");
-  });
-});

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -623,6 +623,35 @@ third line`
     assert.equal(textarea.selectionEnd, 18);
   });
 
+  componentTest("clicking the toggle-direction changes dir from ltr to rtl", {
+    template: hbs`{{d-editor value=value}}`,
+    beforeEach() {
+      this.siteSettings.support_mixed_text_direction = true;
+      this.siteSettings.default_locale = "en";
+    },
+
+    async test(assert) {
+      const textarea = queryAll("textarea.d-editor-input");
+      await click("button.toggle-direction");
+      assert.equal(textarea.attr("dir"), "rtl");
+    },
+  });
+
+  componentTest("clicking the toggle-direction changes dir from ltr to rtl", {
+    template: hbs`{{d-editor value=value}}`,
+    beforeEach() {
+      this.siteSettings.support_mixed_text_direction = true;
+      this.siteSettings.default_locale = "en";
+    },
+
+    async test(assert) {
+      const textarea = queryAll("textarea.d-editor-input");
+      textarea.attr("dir", "ltr");
+      await click("button.toggle-direction");
+      assert.equal(textarea.attr("dir"), "rtl");
+    },
+  });
+
   testCase(
     `doesn't jump to bottom with long text`,
     async function (assert, textarea) {


### PR DESCRIPTION
- Moves ordered list, unordered list icons under the extra items dropdown on mobile
- Removes dividers on mobile

**Before**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/137500735-076b757a-5198-4669-9a26-f04e50a54e19.png">


**After**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/137500619-98205005-bbfb-44d1-a9fd-e7eb15198fdd.png">
