### PR TITLE
DEV: Fix wasm_bindgen double loading errors in Firefox

### DIFF
--- a/public/javascripts/media-optimization-worker.js
+++ b/public/javascripts/media-optimization-worker.js
@@ -155,8 +155,15 @@ async function loadLibs(settings){
 
   if (self.codecs) return;
 
-  importScripts(settings.mozjpeg_script);
-  importScripts(settings.resize_script);
+  if (!self.loadedMozJpeg) {
+    importScripts(settings.mozjpeg_script);
+    self.loadedMozJpeg = true;
+  }
+
+  if (!self.loadedResizeScript) {
+    importScripts(settings.resize_script);
+    self.loadedResizeScript = true;
+  }
 
   let encoderModuleOverrides = {
     locateFile: function(path, prefix) {


### PR DESCRIPTION
When we are calling the loadLibs function, which in turn calls:

importScripts(settings.mozjpeg_script);
importScripts(settings.resize_script);

For the media-optimization-worker service worker, we are getting
an error in Firefox, which balks at wasm_bindgen, a global
variable defined with let, being redefined when the module loads.
This causes image processing to fail in Firefox when more than one
image is uploaded at a time.

The solution to this is to just check whether the scripts are
already imported, and if so do not import them again.

Chrome doesn't seem to care about this variable redefinition
and does not error, and it seems to be expected behaviour that
the script can be loaded multiple times (see https://github.com/w3c/ServiceWorker/issues/1041)

