### PR TITLE
DEV: Remove `TopicView#first_post_id`.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -100,23 +100,18 @@ export default RestModel.extend({
   canAppendMore: and("notLoading", "hasPosts", "lastPostNotLoaded"),
   canPrependMore: and("notLoading", "hasPosts", "firstPostNotLoaded"),
 
-  @discourseComputed("hasLoadedData", "firstPostId", "posts.[]")
-  firstPostPresent(hasLoadedData, firstPostId) {
+  @discourseComputed("hasLoadedData", "posts.[]")
+  firstPostPresent(hasLoadedData) {
     if (!hasLoadedData) {
       return false;
     }
-    return !!this.posts.findBy("id", firstPostId);
+
+    return !!this.posts.findBy("post_number", 1);
   },
 
   firstPostNotLoaded: not("firstPostPresent"),
 
-  firstId: null,
   lastId: null,
-
-  @discourseComputed("isMegaTopic", "stream.firstObject", "firstId")
-  firstPostId(isMegaTopic, streamFirstId, firstId) {
-    return isMegaTopic ? firstId : streamFirstId;
-  },
 
   @discourseComputed("isMegaTopic", "stream.lastObject", "lastId")
   lastPostId(isMegaTopic, streamLastId, lastId) {

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -44,7 +44,6 @@ module("Unit | Model | post-stream", function () {
     const postStream = buildStream(4567, [1, 3, 4]);
     const store = postStream.store;
 
-    assert.equal(postStream.get("firstPostId"), 1);
     assert.equal(postStream.get("lastPostId"), 4, "the last post id is 4");
 
     assert.ok(!postStream.get("hasPosts"), "there are no posts by default");
@@ -1040,19 +1039,6 @@ module("Unit | Model | post-stream", function () {
     postStream.set("topic.highest_post_number", 4);
 
     assert.equal(postStream.get("filteredPostsCount"), 4);
-  });
-
-  test("firstPostId", function (assert) {
-    const postStream = buildStream(4567, [1, 3, 4]);
-
-    assert.equal(postStream.get("firstPostId"), 1);
-
-    postStream.setProperties({
-      isMegaTopic: true,
-      firstId: 2,
-    });
-
-    assert.equal(postStream.get("firstPostId"), 2);
   });
 
   test("lastPostId", function (assert) {

--- a/app/serializers/post_stream_serializer_mixin.rb
+++ b/app/serializers/post_stream_serializer_mixin.rb
@@ -22,7 +22,6 @@ module PostStreamSerializerMixin
         result[:stream] = object.filtered_post_ids
       else
         result[:isMegaTopic] = true
-        result[:firstId] = object.first_post_id
         result[:lastId] = object.last_post_id
       end
     end

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -631,10 +631,6 @@ class TopicView
     @is_mega_topic ||= (@topic.posts_count >= MEGA_TOPIC_POSTS_COUNT)
   end
 
-  def first_post_id
-    @filtered_posts.order(sort_order: :asc).pluck_first(:id)
-  end
-
   def last_post_id
     @filtered_posts.order(sort_order: :desc).pluck_first(:id)
   end

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -839,7 +839,7 @@ describe TopicView do
     end
   end
 
-  describe '#first_post_id and #last_post_id' do
+  describe '#last_post_id' do
     let!(:p3) { Fabricate(:post, topic: topic) }
     let!(:p2) { Fabricate(:post, topic: topic) }
     let!(:p1) { Fabricate(:post, topic: topic) }
@@ -851,7 +851,6 @@ describe TopicView do
     end
 
     it 'should return the right id' do
-      expect(topic_view.first_post_id).to eq(p1.id)
       expect(topic_view.last_post_id).to eq(p3.id)
     end
   end


### PR DESCRIPTION
The method was only used for mega topics but it was redundant as the
first post can be determined from using the condition where
`Post#post_number` equal to one.