### PR TITLE
FIX: Hide full screen toggle button when textarea is disabled

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -124,11 +124,6 @@ export default Component.extend(ComposerUpload, {
     );
   },
 
-  @discourseComputed("composer.requiredCategoryMissing", "composer.replyLength")
-  disableTextarea(requiredCategoryMissing, replyLength) {
-    return requiredCategoryMissing && replyLength === 0;
-  },
-
   @observes("focusTarget")
   setFocus() {
     if (this.focusTarget === "editor") {

--- a/app/assets/javascripts/discourse/app/components/composer-toggles.js
+++ b/app/assets/javascripts/discourse/app/components/composer-toggles.js
@@ -40,4 +40,12 @@ export default Component.extend({
       ? "discourse-compress"
       : "discourse-expand";
   },
+
+  @discourseComputed("disableTextarea")
+  showFullScreenButton(disableTextarea) {
+    if (this.site.mobileView) {
+      return false;
+    }
+    return !disableTextarea;
+  },
 });

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -302,6 +302,11 @@ export default Controller.extend({
     return defaultComposer;
   },
 
+  @discourseComputed("model.requiredCategoryMissing", "model.replyLength")
+  disableTextarea(requiredCategoryMissing, replyLength) {
+    return requiredCategoryMissing && replyLength === 0;
+  },
+
   @discourseComputed("model.composeState", "model.creatingTopic", "model.post")
   popupMenuOptions(composeState) {
     if (composeState === "open" || composeState === "fullscreen") {

--- a/app/assets/javascripts/discourse/app/templates/components/composer-toggles.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-toggles.hbs
@@ -20,7 +20,7 @@
     tabindex=-1
   }}
 
-  {{#unless site.mobileView}}
+  {{#if showFullScreenButton}}
     {{d-button
       class="btn-flat toggle-fullscreen btn-mini-toggle"
       icon=fullscreenIcon
@@ -28,5 +28,5 @@
       title=fullscreenTitle
       tabindex=-1
     }}
-  {{/unless}}
+  {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -45,10 +45,12 @@
               </div>
             {{/unless}}
             {{composer-toggles
-              composeState=model.composeState showToolbar=showToolbar
+              composeState=model.composeState
+              showToolbar=showToolbar
               toggleComposer=(action "toggle")
               toggleToolbar=(action "toggleToolbar")
               toggleFullscreen=(action "fullscreenComposer")
+              disableTextarea=disableTextarea
             }}
           </div>
           {{#unless model.viewFullscreen}}
@@ -111,29 +113,31 @@
         </div>
 
         {{component composerComponent
-                          topic=topic
-                          composer=model
-                          lastValidatedAt=lastValidatedAt
-                          canWhisper=canWhisper
-                          storeToolbarState=(action "storeToolbarState")
-                          onPopupMenuAction=(action "onPopupMenuAction")
-                          showUploadModal=(route-action "showUploadSelector")
-                          popupMenuOptions=popupMenuOptions
-                          draftStatus=model.draftStatus
-                          isUploading=isUploading
-                          isProcessingUpload=isProcessingUpload
-                          allowUpload=allowUpload
-                          uploadIcon=uploadIcon
-                          isCancellable=isCancellable
-                          uploadProgress=uploadProgress
-                          groupsMentioned=(action "groupsMentioned")
-                          cannotSeeMention=(action "cannotSeeMention")
-                          importQuote=(action "importQuote")
-                          togglePreview=(action "togglePreview")
-                          processPreview=showPreview
-                          showToolbar=showToolbar
-                          afterRefresh=(action "afterRefresh")
-                          focusTarget=focusTarget}}
+          topic=topic
+          composer=model
+          lastValidatedAt=lastValidatedAt
+          canWhisper=canWhisper
+          storeToolbarState=(action "storeToolbarState")
+          onPopupMenuAction=(action "onPopupMenuAction")
+          showUploadModal=(route-action "showUploadSelector")
+          popupMenuOptions=popupMenuOptions
+          draftStatus=model.draftStatus
+          isUploading=isUploading
+          isProcessingUpload=isProcessingUpload
+          allowUpload=allowUpload
+          uploadIcon=uploadIcon
+          isCancellable=isCancellable
+          uploadProgress=uploadProgress
+          groupsMentioned=(action "groupsMentioned")
+          cannotSeeMention=(action "cannotSeeMention")
+          importQuote=(action "importQuote")
+          togglePreview=(action "togglePreview")
+          processPreview=showPreview
+          showToolbar=showToolbar
+          afterRefresh=(action "afterRefresh")
+          focusTarget=focusTarget
+          disableTextarea=disableTextarea
+        }}
 
         {{plugin-outlet name="composer-after-composer-editor" connectorTagName="" args=(hash model=model)}}
         <div class="submit-panel">
@@ -247,7 +251,8 @@
         {{/if}}
       </div>
 
-      {{composer-toggles composeState=model.composeState
+      {{composer-toggles
+        composeState=model.composeState
         toggleFullscreen=(action "openIfDraft")
         toggleComposer=(action "toggle")
         toggleToolbar=(action "toggleToolbar")

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uncategorized-test.js
@@ -29,6 +29,11 @@ acceptance(
         "textarea is disabled"
       );
 
+      assert.ok(
+        !exists("button.toggle-fullscreen"),
+        "fullscreen button is not present"
+      );
+
       const categoryChooser = selectKit(".category-chooser");
 
       await categoryChooser.expand();
@@ -46,6 +51,11 @@ acceptance(
       assert.ok(
         !exists(".d-editor-textarea-wrapper.disabled"),
         "textarea is still enabled"
+      );
+
+      assert.ok(
+        exists("button.toggle-fullscreen"),
+        "fullscreen button is present"
       );
     });
   }
@@ -89,6 +99,11 @@ acceptance(
       assert.ok(
         !exists(".d-editor-textarea-wrapper.disabled"),
         "textarea is enabled"
+      );
+
+      assert.ok(
+        exists("button.toggle-fullscreen"),
+        "fullscreen button is present"
       );
 
       await click("#reply-control button.create");

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -37,7 +37,8 @@
   &.disabled {
     cursor: not-allowed;
     .d-editor-button-bar {
-      visibility: hidden;
+      opacity: 0.5;
+      pointer-events: none;
     }
   }
 }


### PR DESCRIPTION
When the composer is disabled (happens on sites where a category is required and at least one category has a topic template), the full screen toggle is not useful because it will show only a disabled textarea. It's better to hide the full screen toggle button in this case.

A second, cosmetic change: the toolbar is shown at half opacity when the textarea is disabled. 

Before: 

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/368961/137778237-365fb9bf-b819-4905-850a-f00b9a256998.png">

After: 

<img width="1267" alt="image" src="https://user-images.githubusercontent.com/368961/137778202-062e4f85-5dc6-4b23-ad93-eba3b7878049.png">
