### PR TITLE
FIX: Do not show recipient user in email participants list

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -560,6 +560,8 @@ class UserNotifications < ActionMailer::Base
       end
 
       post.topic.allowed_users.each do |u|
+        next if u.id == user.id
+
         if SiteSetting.prioritize_username_in_ux?
           participant_list.push "[#{u.username}](#{Discourse.base_url}/u/#{u.username_lower})"
         else

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -591,14 +591,14 @@ describe UserNotifications do
       expect(mail.subject).to include("[PM] ")
     end
 
-    it "includes a list of participants, groups first with member lists" do
+    it "includes a list of participants (except for the destination user), groups first with member lists" do
       group1 = Fabricate(:group, name: "group1")
       group2 = Fabricate(:group, name: "group2")
 
       user1 = Fabricate(:user, username: "one", groups: [group1, group2])
       user2 = Fabricate(:user, username: "two", groups: [group1])
 
-      topic.allowed_users = [user1, user2]
+      topic.allowed_users = [user, user1, user2]
       topic.allowed_groups = [group1, group2]
 
       mail = UserNotifications.user_private_message(


### PR DESCRIPTION
This commit removes the recipient's username from the
respond to / participants list that is shown at the bottom
of user notification emails. For example if the recipient's
username was jsmith, and there were participants ljones and
bmiller, we currently show this:

> "reply to this email to respond to jsmith, ljones, bmiller"

or

> "Participants: jsmith, ljones, bmiller"

However this is a bit redundant, as you are not replying to
yourself here if you are the recipient user. So we omit the
recipient user's username from this list, which is only used
in the text of the email and not elsewhere.
