### PR TITLE
FIX: only replaces double quotes and uses unicode

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -37,6 +37,8 @@ function getQuoteTitle(element) {
 }
 
 function fixQuotes(str) {
+  // u+201c “
+  // u+201d ”
   return str.replace(/[\u201C\u201D]/g, '"');
 }
 


### PR DESCRIPTION
`’` is actually not converted and doesn’t need to be normalised to `'`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
