### PR TITLE
FIX: Topic timeline not updating in megatopics.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -555,7 +555,7 @@ export default createWidget("topic-timeline", {
     if (!attrs.mobileView) {
       const streamLength = attrs.topic.get("postStream.stream.length");
 
-      if (streamLength < 2) {
+      if (streamLength === 1) {
         const postsWrapper = document.querySelector(".posts-wrapper");
         if (postsWrapper && postsWrapper.offsetHeight < 1000) {
           displayTimeLineScrollArea = false;


### PR DESCRIPTION
Before this fix, jumping to posts using the topic timeline scrollbar
will not update the counts since the topic scrollarea is not rerendered.

Follow-up to db337b10ee2af66f464082ca24bb33536da5fbde