### PR TITLE
FIX: Do not query backend when searching "in this topic"

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -428,7 +428,6 @@ export default createWidget("search-menu", {
 
   triggerSearch() {
     searchData.noResults = false;
-
     if (SearchHelper.includesTopics()) {
       if (this.state.inTopicContext) {
         this.searchService().set("highlightTerm", searchData.term);
@@ -438,7 +437,9 @@ export default createWidget("search-menu", {
       SearchHelper.perform(this);
     } else {
       searchData.loading = false;
-      discourseDebounce(SearchHelper, SearchHelper.perform, this, 400);
+      if (!this.state.inTopicContext) {
+        discourseDebounce(SearchHelper, SearchHelper.perform, this, 400);
+      }
     }
   },
 

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -36,8 +36,9 @@ $search-pad-horizontal: 0.5em;
       }
     }
 
-    .btn {
+    .btn.search-context {
       margin: 2px;
+      margin-right: 0;
     }
     &:focus-within {
       @include default-focus;


### PR DESCRIPTION
When a user enables searching within the topic, we no longer show any suggestions (because the suggestions don't filter much on the topic search). But we were still querying the backend, that's wasteful, we don't show those results anyway. 

This also adjusts the spacing of the input while searching "in this topic".