### PR TITLE
FIX: Show search context only in topic routes

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -351,9 +351,7 @@ export default createWidget("header", {
     let inTopicRoute = false;
 
     if (this.state.inTopicContext) {
-      inTopicRoute = this.router
-        .get("_router.currentPath")
-        .startsWith("topic.");
+      inTopicRoute = this.router.currentRouteName.startsWith("topic.");
     }
 
     let contents = () => {
@@ -458,9 +456,7 @@ export default createWidget("header", {
         params = `?context=${context.type}&context_id=${context.id}&skip_context=${this.state.skipSearchContext}`;
       }
 
-      const currentPath = this.router.get("_router.currentPath");
-
-      if (currentPath === "full-page-search") {
+      if (this.router.currentRouteName === "full-page-search") {
         scrollTop();
         $(".full-page-search").focus();
         return false;
@@ -533,16 +529,10 @@ export default createWidget("header", {
     const { state } = this;
     state.inTopicContext = false;
 
-    const currentPath = this.router.get("_router.currentPath");
-    const blocklist = [/^discovery\.categories/];
-    const allowlist = [/^topic\./];
-    const check = function (regex) {
-      return !!currentPath.match(regex);
-    };
-    let showSearch = allowlist.any(check) && !blocklist.any(check);
+    let showSearch = this.router.currentRouteName.startsWith("topic.");
 
     // If we're viewing a topic, only intercept search if there are cloaked posts
-    if (showSearch && currentPath.match(/^topic\./)) {
+    if (showSearch) {
       const controller = this.register.lookup("controller:topic");
       const total = controller.get("model.postStream.stream.length") || 0;
       const chunkSize = controller.get("model.chunk_size") || 0;


### PR DESCRIPTION
Fixes an issue where the "in this topic" indicator in the quick search
widget would remain visible even after having navigated away from the
topic route.
