### PR TITLE
FIX: reset sso email and payload when user navigates away

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-user-index.js
@@ -20,6 +20,8 @@ export default DiscourseRoute.extend({
       originalPrimaryGroupId: model.primary_group_id,
       availableGroups: this._availableGroups,
       customGroupIdsBuffer: model.customGroups.mapBy("id"),
+      ssoExternalEmail: null,
+      ssoLastPayload: null,
       model,
     });
   },


### PR DESCRIPTION
Meta ref: https://meta.discourse.org/t/discourseconnect-single-sign-on-email-last-payload-cached-across-users/206077/