### PR TITLE
FIX: Broken quick search on iPadOS

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -7,7 +7,6 @@ import { createWidget } from "discourse/widgets/widget";
 import getURL from "discourse-common/lib/get-url";
 import { h } from "virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
-import putCursorAtEnd from "discourse/lib/put-cursor-at-end";
 import { schedule } from "@ember/runloop";
 import { scrollTop } from "discourse/mixins/scroll-top";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
@@ -626,7 +625,9 @@ export default createWidget("header", {
   focusSearchInput() {
     if (this.state.searchVisible) {
       schedule("afterRender", () => {
-        putCursorAtEnd(document.querySelector("#search-term"));
+        const searchInput = document.querySelector("#search-term");
+        searchInput.focus();
+        searchInput.select();
       });
     }
   },


### PR DESCRIPTION
This also reverts back to selecting the search input text when reopening
the search panel.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
