### PR TITLE
FIX: Make the `verbose_auth_token_logging` setting off by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -465,7 +465,7 @@ login:
     default: false
   verbose_auth_token_logging:
     hidden: true
-    default: true
+    default: false
   max_suspicious_distance_km:
     hidden: true
     default: 500


### PR DESCRIPTION
The `generate`, `rotate` and `suspicious`  auth token logs are now always logged regardless of the `verbose_auth_token_logging` setting because we rely no these to detect suspicious logins.