### PR TITLE
UX: Sometimes the footer would show up while refreshing a list route

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -74,6 +74,7 @@ const controllerOpts = {
       // router and ember throws an error due to missing `handlerInfos`.
       // Lesson learned: Don't call `loading` yourself.
       this.set("discovery.loading", true);
+      this.set("model.canLoadMore", true);
 
       this.topicTrackingState.resetTracking();
 


### PR DESCRIPTION
This happens because the state of `canLoadMore` is not cleared as the
refresh occurs, which is enough to make the page think a footer should
be displayed.

No tests here because it's tricky to test refreshing and none of our
existing acceptance tests seem to.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
