### PR TITLE
DEV: allow composer option to skip jumping to a post on save

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -633,7 +633,7 @@ export default Controller.extend({
 
     save(ignore, event) {
       this.save(false, {
-        jump: !(event && event.shiftKey) && !this.skipJumpOnSave,
+        jump: !event?.shiftKey && !this.skipJumpOnSave,
       });
     },
 


### PR DESCRIPTION
Add an option for composer.open() skipJumpOnSave.

When true, the composer session unconditionally skips jumping to a post on save.