### PR TITLE
FIX: Match on any segments after search term is processed by cppjieba.

### DIFF
--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -1133,11 +1133,21 @@ describe Search do
 
       SiteSetting.default_locale = 'zh_TW'
       SiteSetting.min_search_term_length = 1
-      topic = Fabricate(:topic, title: 'My Title Discourse社區指南')
+
+      topic = Fabricate(:topic, title: 'My Title Discourse 社區指南')
       post = Fabricate(:post, topic: topic)
 
       expect(Search.execute('社區指南').posts.first.id).to eq(post.id)
       expect(Search.execute('指南').posts.first.id).to eq(post.id)
+
+      # The `白名单` term becomes `名单 白名单` after it is processed by
+      # cppjieba. However, `白名单` is not tokenized as such by cppjieba when it
+      # appears in a string of text. The workaround we took here is to match on
+      # either `名单` or `白名单` when terms are processed by cppjieba
+      topic = Fabricate(:topic, title: "Some topic title 白名单")
+      post = Fabricate(:post, topic: topic)
+
+      expect(Search.execute('白名单').posts.first.id).to eq(post.id)
     end
 
     it 'finds chinese topic based on title if tokenization is forced' do


### PR DESCRIPTION
This commit only affects Chinese and Japanese where the search terms are
processed by cppjieba prior to searching.

The `白名单` term becomes `名单 白名单` after it is processed by
cppjieba. However, `白名单` is not tokenized as such by cppjieba when it
appears in a string of text. The workaround we took here is to match on
either `名单` or `白名单` when terms are processed by cppjieba.

The change here will result in partial matches of terms making search
slightly less accurate. For example, `社區指南` becomes `社區 指南`
when processed by cppjieba and the change here means that we will match
on either `社區` or `指南` instead of matching on both terms. This is a
concious trade-off which we're making where we think having a poor
result is better than having no result for the Chinese and Japanese
language. To properly support search for Chinese and Japanese languages,
we may look into integrating the PGroonga extension into Discourse in
the future.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
