### PR TITLE
DEV: Fix thor deprecation warning

### DIFF
--- a/script/discourse
+++ b/script/discourse
@@ -4,6 +4,10 @@
 require "thor"
 
 class DiscourseCLI < Thor
+  def self.exit_on_failure?
+    true
+  end
+
   desc "remap [--global,--regex] FROM TO", "Remap a string sequence across all tables"
   long_desc <<-LONGDESC
     Replace a string sequence FROM with TO across all tables.


### PR DESCRIPTION
```
Deprecation warning: Thor exit with status 0 on errors. To keep this behavior, you must define `exit_on_failure?` in `DiscourseCLI`
```
