### PR TITLE
FIX: Allow every tag for watched words

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/watched-word-form.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/watched-word-form.hbs
@@ -18,6 +18,7 @@
       class="watched-word-input-field"
       tags=selectedTags
       onChange=(action "changeSelectedTags")
+      everyTag=true
       options=(hash
         allowAny=true
         disabled=formSubmitted


### PR DESCRIPTION
If a watched word was restricted to a category, new rules for that
watched word could not be created.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
