### PR TITLE
Update max_new_accounts_per_registration_ip description

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1950,7 +1950,7 @@ en:
     user_profile_view_duration_hours: "Count a new user profile view once per IP/User every N hours"
 
     levenshtein_distance_spammer_emails: "When matching spammer emails, number of characters difference that will still allow a fuzzy match."
-    max_new_accounts_per_registration_ip: "If there are already (n) trust level 0 accounts from this IP (and none is a staff member or at TL2 or higher), stop accepting new signups from that IP."
+    max_new_accounts_per_registration_ip: "If there are already (n) trust level 0 accounts from this IP (and none is a staff member or at TL2 or higher), stop accepting new signups from that IP. Set to 0 to disable the limit."
     min_ban_entries_for_roll_up: "When clicking the Roll up button, will create a new subnet ban entry if there are at least (N) entries."
 
     max_age_unmatched_emails: "Delete unmatched screened email entries after (N) days."


### PR DESCRIPTION
The `max_new_accounts_per_registration_ip` functionality can be disabled by setting its value to `<= 0`. That happens in the code here: https://github.com/discourse/discourse/blob/main/lib/spam_handler.rb#L6.

This PR updates the the setting's description to indicate how to disable the IP registration limit.