### PR TITLE
DEV: Remove enable_experimental_image_uploader site setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -267,10 +267,6 @@ basic:
     client: true
     default: true
     hidden: true
-  enable_experimental_image_uploader:
-    client: true
-    default: false
-    hidden: true
   enable_experimental_composer_uploader:
     client: true
     default: false


### PR DESCRIPTION
This setting was already removed in the UI and the DB in
2364626dedc82b0ff3086407f68705cff22c2849,
but I forgot to remove the actual setting from yml.
