### PR TITLE
DEV: Use double quotes for js-flags

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -41,7 +41,7 @@ module.exports = {
       "--remote-debugging-port=4201",
       "--window-size=1440,900",
       "--enable-precise-memory-info",
-      "--js-flags='--max_old_space_size=512 --max_semi_space_size=512'",
+      '--js-flags="--max_old_space_size=512 --max_semi_space_size=512"',
     ].filter(Boolean),
     Firefox: ["-headless", "--width=1440", "--height=900"],
     "Headless Firefox": ["--width=1440", "--height=900"],


### PR DESCRIPTION
Single quotes seem to be raising parse errors in some CI situations. Switching to double quotes seems to fix the problem.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
