### PR TITLE
DEV: prevents flakky spec when deleting plugin

### DIFF
--- a/spec/components/discourse_spec.rb
+++ b/spec/components/discourse_spec.rb
@@ -104,6 +104,7 @@ describe Discourse do
     after do
       Discourse.plugins.delete plugin1
       Discourse.plugins.delete plugin2
+      DiscoursePluginRegistry.reset!
     end
 
     before do

--- a/spec/components/svg_sprite/svg_sprite_spec.rb
+++ b/spec/components/svg_sprite/svg_sprite_spec.rb
@@ -243,6 +243,7 @@ describe SvgSprite do
 
       after do
         Discourse.plugins.delete plugin1
+        DiscoursePluginRegistry.reset!
       end
 
       it "includes custom icons from plugins" do

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -234,6 +234,7 @@ describe ContentSecurityPolicy do
       expect(parse(policy)['manifest-src']).to_not include('https://manifest-src.com')
 
       Discourse.plugins.delete plugin
+      DiscoursePluginRegistry.reset!
     end
 
     it 'can extend frame_ancestors' do
@@ -251,6 +252,7 @@ describe ContentSecurityPolicy do
       expect(parse(policy)['frame-ancestors']).to_not include('https://frame-ancestors-plugin.ext')
 
       Discourse.plugins.delete plugin
+      DiscoursePluginRegistry.reset!
     end
   end
 


### PR DESCRIPTION
Not reseting the registry could lead to assets still being registered for example.

This flakky spec was reprdocible with this call: `bundle exec rspec --seed 9472 spec/components/discourse_plugin_registry_spec.rb spec/components/svg_sprite/svg_sprite_spec.rb`

Which would trigger the following error:

```
Failures:

  1) DiscoursePluginRegistry#register_asset registers vendored_core_pretty_text properly
     Failure/Error: expect(registry.javascripts.count).to eq(0)

       expected: 0
            got: 1

       (compared using ==)
     # ./spec/components/discourse_plugin_registry_spec.rb:248:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:280:in `block (2 levels) in <top (required)>'
     # /Users/joffreyjaffeux/.gem/ruby/2.7.3/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
