### PR TITLE
DEV: Only set `tap_failed_tests_only` to true for CI.

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -27,7 +27,7 @@ module.exports = {
   disable_watching: true,
   launch_in_ci: ["Chrome", "Firefox", "Headless Firefox"], // Firefox is old ESR version, Headless Firefox is up-to-date evergreen version
   launch_in_dev: ["Chrome"],
-  tap_failed_tests_only: true,
+  tap_failed_tests_only: process.env.CI,
   parallel: 1, // disable parallel tests for stability
   browser_start_timeout: 120,
   browser_args: {


### PR DESCRIPTION
It may seem like the command crashed when running tests locally since we get no feedback until it finishes running all the tests.

