### PR TITLE
FEATURE: Mark omniauth failures as HTML safe.

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -98,8 +98,14 @@ class Users::OmniauthCallbacksController < ApplicationController
   end
 
   def failure
-    error_key = params[:message].to_s.gsub(/[^\w-]/, "") || "generic"
-    flash[:error] = I18n.t("login.omniauth_error.#{error_key}", default: I18n.t("login.omniauth_error.generic"))
+    error_key = params[:message].to_s.gsub(/[^\w-]/, "")
+    error_key = "generic" if error_key.blank?
+
+    flash[:error] = I18n.t(
+      "login.omniauth_error.#{error_key}",
+      default: I18n.t("login.omniauth_error.generic")
+    ).html_safe
+
     render 'failure'
   end
 


### PR DESCRIPTION
Plugins can add HTML elements to auth error messages.
