### PR TITLE
UX: Re-order auth-related site settings for clarity

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -449,12 +449,17 @@ login:
     client: true
   auth_immediately:
     default: true
+  auth_overrides_email:
+    default: false
+    validator: "SsoOverridesEmailValidator"
+    client: true
+  auth_overrides_username: false
+  auth_overrides_name: false
   enable_discourse_connect:
     client: true
     default: false
     validator: "EnableSsoValidator"
   discourse_connect_allows_all_return_paths: false
-  enable_discourse_connect_provider: false
   verbose_discourse_connect_logging: false
   verbose_upload_logging:
     hidden: true
@@ -471,22 +476,8 @@ login:
   discourse_connect_secret:
     default: ""
     secret: true
-  discourse_connect_provider_secrets:
-    default: ""
-    type: list
-    list_type: secret
-    secret: true
-    placeholder:
-      key: "sso_provider.key_placeholder"
-      value: "sso_provider.value_placeholder"
   discourse_connect_overrides_groups: false
   discourse_connect_overrides_bio: false
-  auth_overrides_email:
-    default: false
-    validator: "SsoOverridesEmailValidator"
-    client: true
-  auth_overrides_username: false
-  auth_overrides_name: false
   discourse_connect_overrides_avatar:
     default: false
     client: true
@@ -498,6 +489,15 @@ login:
   discourse_connect_csrf_protection:
     default: true
     hidden: true
+  enable_discourse_connect_provider: false
+  discourse_connect_provider_secrets:
+    default: ""
+    type: list
+    list_type: secret
+    secret: true
+    placeholder:
+      key: "sso_provider.key_placeholder"
+      value: "sso_provider.value_placeholder"
   blocked_email_domains:
     default: "mailinator.com"
     type: list


### PR DESCRIPTION
This commit groups `auth_overrides_*`, `discourse_connect_*` and `discourse_connect_provider_*` settings separately, rather than interspersing them.

There will be no functional change. This only affects the order in which they're shown in the admin panel

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
