### PR TITLE
FIX: Show right message when permanently deleting topic

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1755,6 +1755,15 @@ class Topic < ActiveRecord::Base
     ).performed!
   end
 
+  def cannot_permanently_delete_reason(user)
+    if self.posts_count > 0
+      I18n.t('post.cannot_permanently_delete.many_posts')
+    elsif self.deleted_by_id == user&.id && self.deleted_at >= Post::PERMANENT_DELETE_TIMER.ago
+      time_left = RateLimiter.time_left(Post::PERMANENT_DELETE_TIMER.to_i - Time.zone.now.to_i + self.deleted_at.to_i)
+      I18n.t('post.cannot_permanently_delete.wait_or_different_admin', time_left: time_left)
+    end
+  end
+
   private
 
   def invite_to_private_message(invited_by, target_user, guardian)
@@ -1814,15 +1823,6 @@ class Topic < ActiveRecord::Base
 
   def apply_per_day_rate_limit_for(key, method_name)
     RateLimiter.new(user, "#{key}-per-day", SiteSetting.get(method_name), 1.day.to_i)
-  end
-
-  def cannot_permanently_delete_reason(user)
-    if self.posts_count > 1
-      I18n.t('post.cannot_permanently_delete.many_posts')
-    elsif self.deleted_by_id == user&.id && self.deleted_at >= Post::PERMANENT_DELETE_TIMER.ago
-      time_left = RateLimiter.time_left(Post::PERMANENT_DELETE_TIMER.to_i - Time.zone.now.to_i + self.deleted_at.to_i)
-      I18n.t('post.cannot_permanently_delete.wait_or_different_admin', time_left: time_left)
-    end
   end
 end
 

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -156,7 +156,7 @@ module TopicGuardian
   def can_permanently_delete_topic?(topic)
     return false if !SiteSetting.can_permanently_delete
     return false if !topic
-    return false if topic.posts_count > 1
+    return false if topic.posts_count > 0
     return false if !is_admin? || !can_see_topic?(topic)
     return false if !topic.deleted_at
     return false if topic.deleted_by_id == @user.id && topic.deleted_at >= Post::PERMANENT_DELETE_TIMER.ago

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1755,4 +1755,22 @@ describe Post do
       post.publish_change_to_clients!(:created)
     end
   end
+
+  describe "#cannot_permanently_delete_reason" do
+    fab!(:post) { Fabricate(:post) }
+    fab!(:admin) { Fabricate(:admin) }
+
+    before do
+      freeze_time
+      PostDestroyer.new(admin, post).destroy
+    end
+
+    it 'returns error message if same admin and time did not pass' do
+      expect(post.cannot_permanently_delete_reason(admin)).to eq(I18n.t('post.cannot_permanently_delete.wait_or_different_admin', time_left: RateLimiter.time_left(Post::PERMANENT_DELETE_TIMER.to_i)))
+    end
+
+    it 'returns nothing if different admin' do
+      expect(post.cannot_permanently_delete_reason(Fabricate(:admin))).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
There must be no other posts in the topic when permanently deleting it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
