### PR TITLE
UX: Don't show anchor icon on touch devices

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -108,10 +108,10 @@ $quote-share-maxwidth: 150px;
       }
     }
 
-    .discourse-no-touch a.anchor:hover,
+    // show when hovering where icon should be
+    // show when hovering header
+    .discourse-no-touch & a.anchor:hover,
     .discourse-no-touch &:hover a.anchor {
-      // show when hovering where icon should be
-      // show when hovering header
       opacity: 1;
     }
   }


### PR DESCRIPTION
Hover state gets invoked while scrolling sometimes, and the icon shown on mobile is not useful (and half of it is outside the viewport). 

![image](https://user-images.githubusercontent.com/368961/138916280-9addc043-3876-4ad4-8ce4-66d53bce1745.png)
