### PR TITLE
UX: Make PresenceChannel changes more responsive

### DIFF
--- a/app/assets/javascripts/discourse/app/services/presence.js
+++ b/app/assets/javascripts/discourse/app/services/presence.js
@@ -18,7 +18,7 @@ import User from "discourse/models/user";
 
 const PRESENCE_INTERVAL_S = 30;
 const PRESENCE_DEBOUNCE_MS = isTesting() ? 0 : 500;
-const PRESENCE_THROTTLE_MS = isTesting() ? 0 : 5000;
+const PRESENCE_THROTTLE_MS = isTesting() ? 0 : 1000;
 
 const PRESENCE_GET_RETRY_MS = 5000;
 

--- a/app/controllers/presence_controller.rb
+++ b/app/controllers/presence_controller.rb
@@ -39,8 +39,9 @@ class PresenceController < ApplicationController
     client_id = params[:client_id]
     raise Discourse::InvalidParameters.new(:client_id) if !client_id.is_a?(String) || client_id.blank?
 
-    # JS client is designed to throttle to one request every 5 seconds
-    RateLimiter.new(nil, "update-presence-#{current_user.id}-#{client_id}}", 3, 10.seconds).performed!
+    # JS client is designed to throttle to one request per second
+    # When no changes are being made, it makes one request every 30 seconds
+    RateLimiter.new(nil, "update-presence-#{current_user.id}", 20, 10.seconds).performed!
 
     present_channels = params[:present_channels]
     if present_channels && !(present_channels.is_a?(Array) && present_channels.all? { |c| c.is_a? String })


### PR DESCRIPTION
For very fast-paced things (e.g. replying... indicators), 5s resolution is not great. This commit improves the resolution to 1 update per second.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
