### PR TITLE
FIX: prevents a circular json error in tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/presence-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/presence-pretender.js
@@ -48,7 +48,7 @@ export function joinChannel(name, user) {
     publishToMessageBus(
       `/presence${name}`,
       {
-        entering_users: [user],
+        entering_users: [Object.assign({}, user)],
       },
       0,
       channel.last_message_id


### PR DESCRIPTION
The flow goes from:

- getting current user object
- creating a POJO using some of the current user keys
- passing this POJO around, which ends up being used in message bus
- the processing fn associated ends up doing `User.create()` on this object which will both create a `User` object, but also inject `store` in it, store is holding a reference to `currentUser` Object and...

BOOM, we have an object holding a reference to the same object, which `JSON.stringify` used in `prepareBody` of pretender doesn't like.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
