### PR TITLE
FIX: Show perma-delete in menu without refresh

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -52,7 +52,7 @@ export function transformBasicPost(post) {
     created_at: post.created_at,
     updated_at: post.updated_at,
     canDelete: post.can_delete,
-    canPermanentlyDelete: post.can_permanently_delete,
+    canPermanentlyDelete: false,
     showFlagDelete: false,
     canRecover: post.can_recover,
     canEdit: post.can_edit,
@@ -262,7 +262,8 @@ export default function transformPost(
     postAtts.canRecoverTopic = postAtts.isDeleted && details.can_recover;
     postAtts.canDeleteTopic = !postAtts.isDeleted && details.can_delete;
     postAtts.expandablePost = topic.expandable_first_post;
-    postAtts.canPermanentlyDeleteTopic = details.can_permanently_delete;
+    postAtts.canPermanentlyDelete =
+      postAtts.isDeleted && details.can_permanently_delete;
 
     // Show a "Flag to delete" message if not staff and you can't
     // otherwise delete it.
@@ -279,6 +280,8 @@ export default function transformPost(
       !post.deleted_at &&
       currentUser &&
       (currentUser.staff || !post.user_deleted);
+    postAtts.canPermanentlyDelete =
+      postAtts.isDeleted && post.can_permanently_delete;
   }
 
   _additionalAttributes.forEach((a) => (postAtts[a] = post[a]));

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -208,6 +208,8 @@ const Post = RestModel.extend({
         deleted_at: new Date(),
         deleted_by: deletedBy,
         can_delete: false,
+        can_permanently_delete:
+          this.siteSettings.can_permanently_delete && deletedBy.admin,
         can_recover: true,
       });
     } else {
@@ -219,6 +221,7 @@ const Post = RestModel.extend({
         this.setProperties({
           cooked: cooked,
           can_delete: false,
+          can_permanently_delete: false,
           version: this.version + 1,
           can_recover: true,
           can_edit: false,

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -450,6 +450,8 @@ const Topic = RestModel.extend({
           deleted_by: deleted_by,
           "details.can_delete": false,
           "details.can_recover": true,
+          "details.can_permanently_delete":
+            this.siteSettings.can_permanently_delete && deleted_by.admin,
         });
         if (!deleted_by.staff) {
           DiscourseURL.redirectTo("/");

--- a/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js
@@ -37,7 +37,7 @@ export function buildManageButtons(attrs, currentUser, siteSettings) {
     });
   }
 
-  if (attrs.canPermanentlyDelete || attrs.canPermanentlyDeleteTopic) {
+  if (attrs.canPermanentlyDelete) {
     contents.push({
       icon: "trash-alt",
       className: "popup-menu-button permanently-delete",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -652,7 +652,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
   componentTest("permanently delete topic", {
     template: hbs`{{mount-widget widget="post" args=args permanentlyDeletePost=permanentlyDeletePost}}`,
     beforeEach() {
-      this.set("args", { canManage: true, canPermanentlyDeleteTopic: true });
+      this.set("args", { canManage: true, canPermanentlyDelete: true });
       this.set("permanentlyDeletePost", () => (this.deleted = true));
     },
     async test(assert) {

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1676,6 +1676,7 @@ security:
     hidden: true
   can_permanently_delete:
     default: false
+    client: true
     hidden: true
 
 onebox:


### PR DESCRIPTION
It needed a page refresh because the post was not updated on the client
side.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
