### PR TITLE
FIX: Cleanup PresenceChannel instances when composer closed

### DIFF
--- a/app/assets/javascripts/discourse/app/services/presence.js
+++ b/app/assets/javascripts/discourse/app/services/presence.js
@@ -331,6 +331,9 @@ export default class PresenceService extends Service {
   _removeSubscribed(channelProxy) {
     let subscribed = this._subscribedProxies[channelProxy.name];
     subscribed?.delete(channelProxy);
+    if (subscribed?.size === 0) {
+      delete this._subscribedProxies[channelProxy.name];
+    }
     return subscribed?.size || 0;
   }
 

--- a/plugins/discourse-presence/assets/javascripts/discourse/components/composer-presence-display.js.es6
+++ b/plugins/discourse-presence/assets/javascripts/discourse/components/composer-presence-display.js.es6
@@ -14,11 +14,10 @@ export default Component.extend({
     "model.replyingToTopic",
     "model.editingPost",
     "model.whisper",
-    "model.composerOpened",
-    "isDestroying"
+    "model.composerOpened"
   )
-  state(replyingToTopic, editingPost, whisper, composerOpen, isDestroying) {
-    if (!composerOpen || isDestroying) {
+  state(replyingToTopic, editingPost, whisper, composerOpen) {
+    if (!composerOpen) {
       return;
     } else if (editingPost) {
       return "edit";
@@ -73,6 +72,12 @@ export default Component.extend({
     this._setupChannel("editChannel", this.editChannelName);
   },
 
+  _cleanupChannels() {
+    this._setupChannel("replyChannel", null);
+    this._setupChannel("whisperChannel", null);
+    this._setupChannel("editChannel", null);
+  },
+
   replyingUsers: union("replyChannel.users", "whisperChannel.users"),
   editingUsers: readOnly("editChannel.users"),
 
@@ -102,7 +107,7 @@ export default Component.extend({
 
   @on("willDestroyElement")
   closeComposer() {
-    this._setupChannels();
+    this._cleanupChannels();
     this.composerPresenceManager.leave();
   },
 });


### PR DESCRIPTION
I was previously relying on `this.isDestroying` returning `true` during `willDestroyElement`. This was an incorrect assumption.

This commit refactors the logic into an explicit `cleanup` function, and also adds some cleanup for empty keys in the `subscribedProxy` array

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
