### PR TITLE
FIX: Do not perform link lookup for replaced links

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -505,6 +505,11 @@ export default Controller.extend({
       $links.each((idx, l) => {
         const href = l.href;
         if (href && href.length) {
+          // skip links added by watched words
+          if (l.dataset.word !== undefined) {
+            return true;
+          }
+
           // skip links in quotes and oneboxes
           for (let element = l; element; element = element.parentElement) {
             if (

--- a/app/assets/javascripts/pretty-text/addon/allow-lister.js
+++ b/app/assets/javascripts/pretty-text/addon/allow-lister.js
@@ -139,6 +139,7 @@ export const DEFAULT_LIST = [
   `a.inline-onebox`,
   `a.inline-onebox-loading`,
   "a[data-bbcode]",
+  "a[data-word]",
   "a[name]",
   "a[rel=nofollow]",
   "a[rel=ugc]",

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
@@ -32,6 +32,8 @@ function findAllMatches(text, matchers) {
 }
 
 export function setup(helper) {
+  const opts = helper.getOptions();
+
   helper.registerPlugin((md) => {
     const matchers = [];
 
@@ -139,6 +141,9 @@ export function setup(helper) {
                 if (htmlLinkLevel === 0 && state.md.validateLink(url)) {
                   token = new state.Token("link_open", "a", 1);
                   token.attrs = [["href", url]];
+                  if (opts.discourse.previewing) {
+                    token.attrs.push(["data-word", ""]);
+                  }
                   token.level = level++;
                   token.markup = "linkify";
                   token.info = "auto";


### PR DESCRIPTION
A link that was added because a watched word was replaced could create
a notice if the same link was present before.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
