### PR TITLE
UX: Remove animation in admin theme list

### DIFF
--- a/app/assets/javascripts/admin/addon/components/themes-list-item.js
+++ b/app/assets/javascripts/admin/addon/components/themes-list-item.js
@@ -1,10 +1,8 @@
 import { and, gt } from "@ember/object/computed";
-import discourseComputed, { observes } from "discourse-common/utils/decorators";
+import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import { escape } from "pretty-text/sanitizer";
 import { iconHTML } from "discourse-common/lib/icon-library";
-import { isTesting } from "discourse-common/config/environment";
-import { schedule } from "@ember/runloop";
 
 const MAX_COMPONENTS = 4;
 
@@ -19,36 +17,6 @@ export default Component.extend({
   click(e) {
     if (!$(e.target).hasClass("others-count")) {
       this.navigateToTheme();
-    }
-  },
-
-  init() {
-    this._super(...arguments);
-    this.scheduleAnimation();
-  },
-
-  @observes("theme.selected")
-  triggerAnimation() {
-    this.animate();
-  },
-
-  scheduleAnimation() {
-    schedule("afterRender", () => {
-      this.animate(true);
-    });
-  },
-
-  animate(isInitial) {
-    const $container = $(this.element);
-    const $list = $(this.element.querySelector(".components-list"));
-    if ($list.length === 0 || isTesting()) {
-      return;
-    }
-    const duration = 300;
-    if (this.get("theme.selected")) {
-      this.collapseComponentsList($container, $list, duration);
-    } else if (!isInitial) {
-      this.expandComponentsList($container, $list, duration);
     }
   },
 
@@ -89,54 +57,6 @@ export default Component.extend({
       return 0;
     }
     return childrenCount - MAX_COMPONENTS;
-  },
-
-  expandComponentsList($container, $list, duration) {
-    $container.css("height", `${$container.height()}px`);
-    $list.css("display", "");
-    $container.animate(
-      {
-        height: `${$container.height() + $list.outerHeight(true)}px`,
-      },
-      {
-        duration,
-        done: () => {
-          $list.css("display", "");
-          $container.css("height", "");
-        },
-      }
-    );
-    $list.animate(
-      {
-        opacity: 1,
-      },
-      {
-        duration,
-      }
-    );
-  },
-
-  collapseComponentsList($container, $list, duration) {
-    $container.animate(
-      {
-        height: `${$container.height() - $list.outerHeight(true)}px`,
-      },
-      {
-        duration,
-        done: () => {
-          $list.css("display", "none");
-          $container.css("height", "");
-        },
-      }
-    );
-    $list.animate(
-      {
-        opacity: 0,
-      },
-      {
-        duration,
-      }
-    );
   },
 
   actions: {

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -244,9 +244,6 @@
         .components-list {
           color: var(--secondary);
         }
-        .fa {
-          color: inherit;
-        }
       }
       &:not(.selected) {
         .broken-indicator {
@@ -284,8 +281,12 @@
 
         .others-count,
         .others-count:hover {
-          color: var(--primary-high);
+          color: inherit;
           text-decoration: underline;
+        }
+
+        .d-icon {
+          color: inherit;
         }
       }
 


### PR DESCRIPTION
Previously we were hiding the active theme's list of components using an animation. IMO the animation isn't useful, it's better to see the list of components for the active theme. 

Before
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/139084048-05b881ba-33c5-4206-a96b-a50101324b90.png">

After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/139083921-2efb810c-c591-42af-967f-71fec9b27ac1.png">
