### PR TITLE
FIX: include new tags in validation if user can create one.

### DIFF
--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -26,11 +26,13 @@ class TopicCreator
 
     category = find_category
     if category.present? && guardian.can_tag?(topic)
-      tags = @opts[:tags].present? ? Tag.where(name: @opts[:tags]) : (@opts[:tags] || [])
+      tags = @opts[:tags].presence || []
+      existing_tags = tags.present? ? Tag.where(name: tags) : []
+      valid_tags = guardian.can_create_tag? ? tags : existing_tags
 
       # both add to topic.errors
-      DiscourseTagging.validate_min_required_tags_for_category(guardian, topic, category, tags)
-      DiscourseTagging.validate_required_tags_from_group(guardian, topic, category, tags)
+      DiscourseTagging.validate_min_required_tags_for_category(guardian, topic, category, valid_tags)
+      DiscourseTagging.validate_required_tags_from_group(guardian, topic, category, existing_tags)
     end
 
     DiscourseEvent.trigger(:after_validate_topic, topic, self)

--- a/spec/components/topic_creator_spec.rb
+++ b/spec/components/topic_creator_spec.rb
@@ -140,6 +140,12 @@ describe TopicCreator do
           expect(topic.tags.length).to eq(2)
         end
 
+        it "minimum_required_tags is satisfying for new tags if user can create" do
+          topic = TopicCreator.create(user, Guardian.new(user), valid_attrs.merge(tags: ["new tag", "another tag"], category: category.id))
+          expect(topic).to be_valid
+          expect(topic.tags.length).to eq(2)
+        end
+
         it "lets new user create a topic if they don't have sufficient trust level to tag topics" do
           SiteSetting.min_trust_level_to_tag_topics = 1
           new_user = Fabricate(:newuser)


### PR DESCRIPTION
Previously, users who have enough trust level are unable to create topics with new tags if the selected category required a minimum number of tags.
