### PR TITLE
PERF: Use different column for better query plan

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -86,8 +86,8 @@ class Post < ActiveRecord::Base
 
   scope :private_posts_for_user, ->(user) do
     where(
-      "posts.topic_id IN (#{Topic::PRIVATE_MESSAGES_SQL_USER})
-      OR posts.topic_id IN (#{Topic::PRIVATE_MESSAGES_SQL_GROUP})",
+      "topics.id IN (#{Topic::PRIVATE_MESSAGES_SQL_USER})
+      OR topics.id IN (#{Topic::PRIVATE_MESSAGES_SQL_GROUP})",
       user_id: user.id
     )
   end


### PR DESCRIPTION
Using topics.id provides a better query plan than posts.topic_id which
speeds up search by almost 50%.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
