### PR TITLE
FEATURE: User preference to disable push notifications

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
@@ -1,4 +1,5 @@
 import Controller from "@ember/controller";
+import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -11,7 +12,6 @@ export default Controller.extend({
       "muted_usernames",
       "new_topic_duration_minutes",
       "auto_track_topics_after_msecs",
-      "notification_level_when_replying",
       "like_notification_frequency",
       "allow_private_messages",
       "enable_allowed_pm_users",
@@ -87,6 +87,11 @@ export default Controller.extend({
       },
       { name: I18n.t("user.new_topic_duration.last_here"), value: -2 },
     ];
+  },
+
+  @discourseComputed("saveAttrNames")
+  showPushNotificationsDisabled(saveAttrNames) {
+    return saveAttrNames.includes("push_notifications_disabled");
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -98,6 +98,7 @@ let userOptionFields = [
   "timezone",
   "skip_new_user_tips",
   "default_calendar",
+  "push_notifications_disabled",
 ];
 
 export function addSaveableUserOptionField(fieldName) {

--- a/app/assets/javascripts/discourse/app/routes/preferences-notifications.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-notifications.js
@@ -2,4 +2,15 @@ import RestrictedUserRoute from "discourse/routes/restricted-user";
 
 export default RestrictedUserRoute.extend({
   showFooter: true,
+
+  setupController(controller, model) {
+    this._super(...arguments);
+
+    if (
+      model.user_option &&
+      "push_notifications_disabled" in model.user_option
+    ) {
+      controller.saveAttrNames.push("push_notifications_disabled");
+    }
+  },
 });

--- a/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
@@ -52,6 +52,18 @@
   </div>
 {{/unless}}
 
+{{#if showPushNotificationsDisabled}}
+  <div class="control-group push-notifications-disabled">
+    <label class="control-label">{{i18n "user.push_notifications_disabled.title"}}</label>
+
+    <div class="controls">
+      {{preference-checkbox
+          labelKey="user.push_notifications_disabled.label"
+          checked=model.user_option.push_notifications_disabled}}
+    </div>
+  </div>
+{{/if}}
+
 {{user-notification-schedule model=model}}
 
 {{#if siteSettings.enable_personal_messages}}

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -98,6 +98,10 @@ class SiteSetting < ActiveRecord::Base
     SiteSetting.manual_polling_enabled? || SiteSetting.pop3_polling_enabled?
   end
 
+  def self.push_notifications_to_hub_supported?
+    allow_user_api_key_scopes.split("|").include?("push") && allowed_user_api_push_urls.present?
+  end
+
   WATCHED_SETTINGS ||= [
     :default_locale,
     :blocked_attachment_content_types,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1438,6 +1438,17 @@ class User < ActiveRecord::Base
     ShelvedNotification.joins(:notification).where("notifications.user_id = ?", self.id)
   end
 
+  def active_hub_client_ids
+    user_api_keys
+      .joins(:scopes)
+      .where("user_api_key_scopes.name IN ('push', 'notifications')")
+      .where("push_url IS NOT NULL AND push_url <> ''")
+      .where("position(push_url IN ?) > 0", SiteSetting.allowed_user_api_push_urls)
+      .where("revoked_at IS NULL")
+      .order(client_id: :asc)
+      .pluck(:client_id, :push_url)
+  end
+
   protected
 
   def badge_grant

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -85,6 +85,8 @@ class UserOption < ActiveRecord::Base
 
     self.title_count_mode = SiteSetting.default_title_count_mode
 
+    self.push_notifications_disabled = false
+
     true
   end
 

--- a/app/serializers/user_option_serializer.rb
+++ b/app/serializers/user_option_serializer.rb
@@ -34,6 +34,7 @@ class UserOptionSerializer < ApplicationSerializer
              :timezone,
              :skip_new_user_tips,
              :default_calendar,
+             :push_notifications_disabled
 
   def auto_track_topics_after_msecs
     object.auto_track_topics_after_msecs || SiteSetting.default_other_auto_track_topics_after_msecs
@@ -51,4 +52,8 @@ class UserOptionSerializer < ApplicationSerializer
     object.theme_ids.presence || [SiteSetting.default_theme_id]
   end
 
+  def include_push_notifications_disabled?
+    user = object.user
+    user.push_subscriptions.any? || user.active_hub_client_ids.any?
+  end
 end

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -47,7 +47,8 @@ class UserUpdater
     :title_count_mode,
     :timezone,
     :skip_new_user_tips,
-    :default_calendar
+    :default_calendar,
+    :push_notifications_disabled
   ]
 
   NOTIFICATION_SCHEDULE_ATTRS = -> {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1002,6 +1002,10 @@ en:
       new_private_message: "New Message"
       private_message: "Message"
       private_messages: "Messages"
+      push_notifications_disabled:
+        title: "Push notifications"
+        label: "Disable mobile push notifications"
+
       user_notifications:
         filters:
           filter_by: "Filter By"

--- a/db/migrate/20211027192614_add_disable_push_notifications_to_user_options.rb
+++ b/db/migrate/20211027192614_add_disable_push_notifications_to_user_options.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDisablePushNotificationsToUserOptions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_options, :push_notifications_disabled, :boolean, null: true
+    add_index :user_options, [:push_notifications_disabled]
+  end
+end


### PR DESCRIPTION
User preference that is shown if the user has at least one `push_subscription` record (PWA), or a user_api_key active for Hub push notifications. Disables push notifications

![image](https://user-images.githubusercontent.com/16214023/139143949-7001b77d-e7bc-4af1-84fc-8cb7c355d921.png)