### PR TITLE
DEV: prevents Firefox ESR tests to crash on `||=`

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/presence-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/presence-pretender.js
@@ -35,8 +35,10 @@ export default function (helper) {
 }
 
 export function getChannelInfo(name) {
-  channels[name] ||= { count: 0, users: [], last_message_id: 0 };
-  return channels[name];
+  return (
+    channels[name] ||
+    (channels[name] = { count: 0, users: [], last_message_id: 0 })
+  );
 }
 
 export function joinChannel(name, user) {


### PR DESCRIPTION
A follow up PR should investigate why `proposal-logical-assignment-operators` is not getting used here (test file?) but this should be enough to get things running.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
