### PR TITLE
FIX: update flair group of all members if primary group setting changed.

### DIFF
--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -198,11 +198,18 @@ describe Group do
   end
 
   describe '#primary_group=' do
-    it "updates all members' #primary_group" do
+    before do
       group.add(user)
+    end
 
+    it "updates all members' #primary_group" do
       expect { group.update(primary_group: true) }.to change { user.reload.primary_group }.from(nil).to(group)
       expect { group.update(primary_group: false) }.to change { user.reload.primary_group }.from(group).to(nil)
+    end
+
+    it "updates all members' #flair_group" do
+      expect { group.update(primary_group: true) }.to change { user.reload.flair_group }.from(nil).to(group)
+      expect { group.update(primary_group: false) }.to change { user.reload.flair_group }.from(group).to(nil)
     end
   end
 


### PR DESCRIPTION
Previously, if we enable the `primary_group` setting on a group then the `flair_group_id` of its' members are not affected.