### PR TITLE
FIX: Avoid another N+1 query in `Site.json_for`

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -32,7 +32,7 @@ class Site
   end
 
   def user_fields
-    UserField.order(:position).all
+    UserField.includes(:user_field_options).order(:position).all
   end
 
   def self.categories_cache_key
@@ -142,7 +142,7 @@ class Site
       return {
         periods: TopTopic.periods.map(&:to_s),
         filters: Discourse.filters.map(&:to_s),
-        user_fields: UserField.includes(:user_field_options).all.map do |userfield|
+        user_fields: UserField.includes(:user_field_options).order(:position).all.map do |userfield|
           UserFieldSerializer.new(userfield, root: false, scope: guardian)
         end,
         auth_providers: Discourse.enabled_auth_providers.map do |provider|
@@ -161,7 +161,6 @@ class Site
       if cached_json && seq == cached_seq.to_i && Discourse.git_version == cached_version
         return cached_json
       end
-
     end
 
     site = Site.new(guardian)


### PR DESCRIPTION
A follow-up to #14729, this time for logged-in users and/or non-login-required sites.