### PR TITLE
FIX: Include topic details when PMing

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -206,9 +206,9 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
       this._close();
     },
 
-    composePM(user, post) {
+    composePM(user) {
       this._close();
-      this.composePrivateMessage(user, post);
+      this.composePrivateMessage(user, this.topic);
     },
 
     cancelFilter() {

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -70,14 +70,14 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       });
     },
 
-    composePrivateMessage(user, post) {
+    composePrivateMessage(user, topic) {
       const recipients = user ? user.get("username") : "";
-      const reply = post
-        ? `${window.location.protocol}//${window.location.host}${post.url}`
+      const reply = topic
+        ? `${window.location.protocol}//${window.location.host}${topic.url}`
         : null;
-      const title = post
+      const title = topic
         ? I18n.t("composer.reference_topic_title", {
-            title: post.topic.title,
+            title: topic.title,
           })
         : null;
 

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -68,7 +68,7 @@
             <li class="compose-pm">
               {{d-button
               class="btn-primary"
-              action=(action "composePM" this.user this.post)
+              action=(action "composePM" this.user)
               icon="envelope"
               label="user.private_message"}}
             </li>


### PR DESCRIPTION
We used to do this and at some point regressed when we lost a reference
to the `post` object. This restores the old behaviour.

I think we removed a lot of user card tests for being flakey so there isn't an easy way to prove this works. I tested in browser, though.
