### PR TITLE
FIX: resolve responses of 103 should be retried using small_get

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -239,7 +239,7 @@ class FinalDestination
       @content_type = response.headers['Content-Type'] if response.headers.has_key?('Content-Type')
       @status = :resolved
       return @uri
-    when 400, 405, 406, 409, 500, 501
+    when 103, 400, 405, 406, 409, 500, 501
       response_status, small_headers = small_get(request_headers)
 
       if response_status == 200


### PR DESCRIPTION
If the initial `get`/`head` response within `resolve` returns a status code of `103`, attempt to fetch the same URL with the alternative `small_get` method.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
