### PR TITLE
DEV: Output webmock errors in request specs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,8 +126,9 @@ class ApplicationController < ActionController::Base
     send_ember_cli_bootstrap
   end
 
-  rescue_from WebMock::NetConnectNotAllowedError do |err|
-    if Rails.env.test?
+  if Rails.env.test?
+    require 'webmock/rspec'
+    rescue_from WebMock::NetConnectNotAllowedError do |err|
       Rails.logger.error("#{e.class} #{e.message}: #{e.backtrace.join("\n")}")
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,13 +126,6 @@ class ApplicationController < ActionController::Base
     send_ember_cli_bootstrap
   end
 
-  if Rails.env.test?
-    require 'webmock/rspec'
-    rescue_from WebMock::NetConnectNotAllowedError do |err|
-      Rails.logger.error("#{e.class} #{e.message}: #{e.backtrace.join("\n")}")
-    end
-  end
-
   rescue_from RenderEmpty do
     catch_ember_cli_hijack do
       with_resolved_locale { render 'default/empty' }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,6 +126,12 @@ class ApplicationController < ActionController::Base
     send_ember_cli_bootstrap
   end
 
+  rescue_from WebMock::NetConnectNotAllowedError do |err|
+    if Rails.env.test?
+      Rails.logger.error("#{e.class} #{e.message}: #{e.backtrace.join("\n")}")
+    end
+  end
+
   rescue_from RenderEmpty do
     catch_ember_cli_hijack do
       with_resolved_locale { render 'default/empty' }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,7 +44,11 @@ class RspecErrorTracker
   def call(env)
     begin
       @app.call(env)
-    rescue => e
+
+    # This is a little repetitive, but since WebMock::NetConnectNotAllowedError
+    # inherits from Exception instead of StandardError it does not get captured
+    # by the rescue => e shorthand :(
+    rescue WebMock::NetConnectNotAllowedError, StandardError => e
       RspecErrorTracker.last_exception = e
       raise e
     end


### PR DESCRIPTION
In request specs, if you had not properly mocked an external
HTTP call, you would end up with a 500 error with no further
information instead of your expected response code, with an
rspec output like this:

```
Failures:

  1) UploadsController#generate_presigned_put when the store is external generates a presigned URL and creates an external upload stub
     Failure/Error: expect(response.status).to eq(200)

       expected: 200
            got: 500

       (compared using ==)
     # ./spec/requests/uploads_controller_spec.rb:727:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:280:in `block (2 levels) in <top (required)>'
```

This is not helpful at all when you want to find what you actually
failed to mock, which is shown straight away in non-request specs.

We have `RspecErrorTracker` middleware that is supposed to
capture this, but `WebMock::NetConnectNotAllowedError` does
not inherit from `StandardError` so it does not get captured by
`rescue => e`. So this commit captures that webmock error explicitly,
with this result:

```
Failures:

  1) UploadsController#generate_presigned_put when the store is external generates a presigned URL and creates an external upload stub
     Failure/Error: expect(response.status).to eq(200)

       expected: 200
            got: 500

       (compared using ==)
     # ./spec/requests/uploads_controller_spec.rb:727:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:280:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # WebMock::NetConnectNotAllowedError:
     #   Real HTTP connections are disabled. Unregistered request: GET https://s3-upload-bucket.s3.us-west-1.amazonaws.com/?cors with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'', 'Authorization'=>'AWS4-HMAC-SHA256 Credential=some key/20211101/us-west-1/s3/aws4_request, SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=test', 'Host'=>'s3-upload-bucket.s3.us-west-1.amazonaws.com', 'User-Agent'=>'aws-sdk-ruby3/3.121.2 ruby/2.7.1 x86_64-linux aws-sdk-s3/1.96.1', 'X-Amz-Content-Sha256'=>'test', 'X-Amz-Date'=>'20211101T035113Z'}
     #
     #   You can stub this request with the following snippet:
     #
     #   stub_request(:get, "https://s3-upload-bucket.s3.us-west-1.amazonaws.com/?cors").
     #     with(
     #       headers: {
     #   	  'Accept'=>'*/*',
     #   	  'Accept-Encoding'=>'',
     #   	  'Authorization'=>'AWS4-HMAC-SHA256 Credential=some key/20211101/us-west-1/s3/aws4_request, SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date, Signature=test',
     #   	  'Host'=>'s3-upload-bucket.s3.us-west-1.amazonaws.com',
     #   	  'User-Agent'=>'aws-sdk-ruby3/3.121.2 ruby/2.7.1 x86_64-linux aws-sdk-s3/1.96.1',
     #   	  'X-Amz-Content-Sha256'=>'test',
     #   	  'X-Amz-Date'=>'20211101T035113Z'
     #       }).
     #     to_return(status: 200, body: "", headers: {})
     #
     #   registered request stubs:
     #
     #   stub_request(:head, "https://s3-upload-bucket.s3.us-west-1.amazonaws.com/")
     #
     #   ============================================================
```
