### PR TITLE
FIX: Allow S3Helper.ensure_cors! to apply more than one rule and cache rules

### DIFF
--- a/app/services/external_upload_manager.rb
+++ b/app/services/external_upload_manager.rb
@@ -20,6 +20,50 @@ class ExternalUploadManager
     Discourse.redis.get("#{BAN_USER_REDIS_PREFIX}#{user.id}") == "1"
   end
 
+  def self.create_direct_upload(current_user:, file_name:, file_size:, upload_type:, metadata: {})
+    Discourse.store.s3_helper.ensure_cors!([S3CorsRulesets::DIRECT_UPLOAD])
+    url = Discourse.store.signed_url_for_temporary_upload(
+      file_name, metadata: metadata
+    )
+    key = Discourse.store.path_from_url(url)
+
+    upload_stub = ExternalUploadStub.create!(
+      key: key,
+      created_by: current_user,
+      original_filename: file_name,
+      upload_type: upload_type,
+      filesize: file_size
+    )
+
+    { url: url, key: key, unique_identifier: upload_stub.unique_identifier }
+  end
+
+  def self.create_direct_multipart_upload(
+    current_user:, file_name:, file_size:, upload_type:, metadata: {}
+  )
+    Discourse.store.s3_helper.ensure_cors!([S3CorsRulesets::DIRECT_UPLOAD])
+    content_type = MiniMime.lookup_by_filename(file_name)&.content_type
+    multipart_upload = Discourse.store.create_multipart(
+      file_name, content_type, metadata: metadata
+    )
+
+    upload_stub = ExternalUploadStub.create!(
+      key: multipart_upload[:key],
+      created_by: current_user,
+      original_filename: file_name,
+      upload_type: upload_type,
+      external_upload_identifier: multipart_upload[:upload_id],
+      multipart: true,
+      filesize: file_size
+    )
+
+    {
+      external_upload_identifier: upload_stub.external_upload_identifier,
+      key: upload_stub.key,
+      unique_identifier: upload_stub.unique_identifier
+    }
+  end
+
   def initialize(external_upload_stub, upload_create_opts = {})
     @external_upload_stub = external_upload_stub
     @upload_create_opts = upload_create_opts

--- a/lib/backup_restore/s3_backup_store.rb
+++ b/lib/backup_restore/s3_backup_store.rb
@@ -44,7 +44,7 @@ module BackupRestore
       obj = @s3_helper.object(filename)
       raise BackupFileExists.new if obj.exists?
 
-      ensure_cors!
+      @s3_helper.ensure_cors!([S3CorsRulesets::BACKUP_DIRECT_UPLOAD])
       presigned_url(obj, :put, UPLOAD_URL_EXPIRES_AFTER_SECONDS)
     rescue Aws::Errors::ServiceError => e
       Rails.logger.warn("Failed to generate upload URL for S3: #{e.message.presence || e.class.name}")
@@ -80,10 +80,6 @@ module BackupRestore
 
     def presigned_url(obj, method, expires_in_seconds)
       obj.presigned_url(method, expires_in: expires_in_seconds)
-    end
-
-    def ensure_cors!
-      @s3_helper.ensure_cors!([S3CorsRulesets::BACKUP_DIRECT_UPLOAD])
     end
 
     def cleanup_allowed?

--- a/lib/s3_cors_rulesets.rb
+++ b/lib/s3_cors_rulesets.rb
@@ -14,4 +14,12 @@ class S3CorsRulesets
     allowed_origins: [Discourse.base_url_no_prefix],
     max_age_seconds: 3000
   }.freeze
+
+  DIRECT_UPLOAD = {
+    allowed_headers: ["Authorization", "Content-Disposition", "Content-Type"],
+    expose_headers: ["ETag"],
+    allowed_methods: ["GET", "HEAD", "PUT"],
+    allowed_origins: ["*"],
+    max_age_seconds: 3000
+  }
 end

--- a/spec/lib/backup_restore/shared_examples_for_backup_store.rb
+++ b/spec/lib/backup_restore/shared_examples_for_backup_store.rb
@@ -267,6 +267,12 @@ shared_examples "remote backup store" do
         expect(url).to match(upload_url_regex("default", filename, multisite: false))
       end
 
+      it "ensures the CORS rules for backup uploads exist" do
+        store.instance_variable_get(:@s3_helper).expects(:ensure_cors!).with([S3CorsRulesets::BACKUP_DIRECT_UPLOAD])
+        filename = "foo.tar.gz"
+        url = store.generate_upload_url(filename)
+      end
+
       it "raises an exception when a file with same filename exists" do
         expect { store.generate_upload_url(backup1.filename) }
           .to raise_exception(BackupRestore::BackupStore::BackupFileExists)

--- a/spec/multisite/s3_store_spec.rb
+++ b/spec/multisite/s3_store_spec.rb
@@ -183,14 +183,15 @@ RSpec.describe 'Multisite s3 uploads', type: :multisite do
       it "returns signed URL with correct path" do
         test_multisite_connection('default') do
           upload = Fabricate(:upload, original_filename: "small.pdf", extension: "pdf", secure: true)
+          path = Discourse.store.get_path_for_upload(upload)
 
           s3_helper.expects(:s3_bucket).returns(s3_bucket).at_least_once
-          s3_bucket.expects(:object).with("#{upload_path}/original/1X/#{upload.sha1}.pdf").returns(s3_object).at_least_once
+          s3_bucket.expects(:object).with("#{upload_path}/#{path}").returns(s3_object).at_least_once
           s3_object.expects(:presigned_url).with(:get, expires_in: S3Helper::DOWNLOAD_URL_EXPIRES_AFTER_SECONDS)
 
           upload.url = store.store_upload(uploaded_file, upload)
           expect(upload.url).to eq(
-            "//some-really-cool-bucket.s3.dualstack.us-west-1.amazonaws.com/#{upload_path}/original/1X/#{upload.sha1}.pdf"
+            "//some-really-cool-bucket.s3.dualstack.us-west-1.amazonaws.com/#{upload_path}/#{path}"
           )
 
           expect(store.url_for(upload)).not_to eq(upload.url)

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -711,6 +711,7 @@ describe UploadsController do
         sign_in(user)
         SiteSetting.enable_direct_s3_uploads = true
         setup_s3
+        stub_bucket_cors_requests
       end
 
       it "errors if the correct params are not provided" do
@@ -792,6 +793,7 @@ describe UploadsController do
         sign_in(user)
         SiteSetting.enable_direct_s3_uploads = true
         setup_s3
+        stub_bucket_cors_requests
         FileStore::S3Store.any_instance.stubs(:temporary_upload_path).returns(
           "uploads/default/test_0/temp/28fccf8259bbe75b873a2bd2564b778c/test.png"
         )
@@ -1074,6 +1076,22 @@ describe UploadsController do
         expect(response.status).to eq(404)
       end
     end
+  end
+
+  def stub_bucket_cors_requests
+    cors_response = <<~BODY
+          <?xml version="1.0" encoding="UTF-8"?>
+          <CORSConfiguration>
+          </CORSConfiguration>
+    BODY
+    stub_request(
+      :get,
+      "https://s3-upload-bucket.s3.us-west-1.amazonaws.com/?cors"
+    ).to_return({ status: 200, body: "" })
+    stub_request(
+      :put,
+      "https://s3-upload-bucket.s3.us-west-1.amazonaws.com/?cors"
+    ).to_return({ status: 200 })
   end
 
   describe "#complete_multipart" do


### PR DESCRIPTION
The ensure_cors! function needs to be able to add CORS
rules for the S3 bucket for 3 things now:

* assets
* direct S3 backups
* direct S3 uploads

As it is, only one rule can be applied, which is generally
the assets rule as it is called first. This commit changes
the ensure_cors! method to be able to apply new rules as
well as the existing ones.

Also in this commit we are calling ensure_cors! when creating
presigned PUT and multipart uploads when uploading direct to
S3, so the rules definitely exist to avoid errors in the process.

I've also added caching to S3 ensure_cors! rules fetching.
When fetching CORS rules from S3, it takes ~1s to get the rules,
which will add up a lot over lots of upload requests. This commit
introduces a 1 day cache of the bucket CORS rules. This cache is
broken whenever there are new rules not already in the existing rule
set from the cache, and is initially set when we fetch the rules
from S3 for the bucket.

Getting the cached rules from redis takes ~0.000265s, so it's a
huge improvement over going to S3 every time.