### PR TITLE
FIX: Prevent duplicate search requests to backend

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -11,6 +11,7 @@ import { Promise } from "rsvp";
 import { search as searchCategoryTag } from "discourse/lib/category-tag-search";
 import userSearch from "discourse/lib/user-search";
 import { CANCELLED_STATUS } from "discourse/lib/autocomplete";
+import { cancel } from "@ember/runloop";
 
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
 const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
@@ -190,6 +191,7 @@ export default createWidget("search-menu", {
   defaultState(attrs) {
     return {
       inTopicContext: attrs.inTopicContext,
+      _debouncer: null,
     };
   },
 
@@ -434,11 +436,17 @@ export default createWidget("search-menu", {
       }
 
       searchData.loading = true;
+      cancel(this.state._debouncer);
       SearchHelper.perform(this);
     } else {
       searchData.loading = false;
       if (!this.state.inTopicContext) {
-        discourseDebounce(SearchHelper, SearchHelper.perform, this, 400);
+        this.state._debouncer = discourseDebounce(
+          SearchHelper,
+          SearchHelper.perform,
+          this,
+          400
+        );
       }
     }
   },


### PR DESCRIPTION
When sending a full search request to backend (i.e. when hitting Enter),
the debouncer needs to be cancelled, otherwise it will get invoked and
trigger a second search request to the backend.