### PR TITLE
FIX: Use mouse down event when cancelling search

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -316,7 +316,7 @@ export default createWidget("search-menu", {
     });
   },
 
-  clickOutside() {
+  mouseDownOutside() {
     this.sendWidgetAction("toggleSearchMenu");
   },
 


### PR DESCRIPTION
This fixes an issue where selecting text in the search input and ending that selection with the cursor outside of the search panel would close the search panel. The `mouseDown` event is better for this use case because it doesn't get invoked when selecting text. 