### PR TITLE
FIX: exclude suppressed category topics in digest even if unmuted.

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -511,7 +511,7 @@ class Topic < ActiveRecord::Base
     # Remove muted and shared draft categories
     remove_category_ids = CategoryUser.where(user_id: user.id, notification_level: CategoryUser.notification_levels[:muted]).pluck(:category_id)
     if SiteSetting.digest_suppress_categories.present?
-      remove_category_ids += SiteSetting.digest_suppress_categories.split("|").map(&:to_i)
+      topics = topics.where("topics.category_id NOT IN (?)", SiteSetting.digest_suppress_categories.split("|").map(&:to_i))
     end
     if SiteSetting.shared_drafts_enabled?
       remove_category_ids << SiteSetting.shared_drafts_category

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2071,9 +2071,13 @@ describe Topic do
       it "doesn't return topics from suppressed categories" do
         user = Fabricate(:user)
         category = Fabricate(:category_with_definition, created_at: 2.minutes.ago)
-        Fabricate(:topic, category: category, created_at: 1.minute.ago)
+        topic = Fabricate(:topic, category: category, created_at: 1.minute.ago)
 
         SiteSetting.digest_suppress_categories = "#{category.id}"
+
+        expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to be_blank
+
+        Fabricate(:topic_user, user: user, topic: topic, notification_level: TopicUser.notification_levels[:regular])
 
         expect(Topic.for_digest(user, 1.year.ago, top_order: true)).to be_blank
       end


### PR DESCRIPTION
Previously, suppressed category topics are included in the digest emails if the user visited that topic before, and the `TopicUser` record is created with any notification level except 'muted'.
