### PR TITLE
FIX: set `null` to group if `groupAttrs` param is not available.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/users.js
@@ -83,7 +83,7 @@ export default Controller.extend({
   @action
   groupChanged(_, groupAttrs) {
     // First param is the group name, which include none or 'all groups'. Ignore this and look at second param.
-    this.set("group", groupAttrs ? groupAttrs.id : null);
+    this.set("group", groupAttrs?.id);
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/controllers/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/users.js
@@ -83,7 +83,7 @@ export default Controller.extend({
   @action
   groupChanged(_, groupAttrs) {
     // First param is the group name, which include none or 'all groups'. Ignore this and look at second param.
-    this.set("group", groupAttrs.id);
+    this.set("group", groupAttrs ? groupAttrs.id : null);
   },
 
   @action


### PR DESCRIPTION
Because of this bug "all groups" option in the group selector dropdown was not selectable on the user directory page.