### PR TITLE
FIX: ensure required_tag_group_name is null if no value present

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -210,8 +210,8 @@ const Category = RestModel.extend({
         custom_fields: this.custom_fields,
         topic_template: this.topic_template,
         all_topics_wiki: this.all_topics_wiki,
-        allow_unlimited_owner_edits_on_first_post: this
-          .allow_unlimited_owner_edits_on_first_post,
+        allow_unlimited_owner_edits_on_first_post:
+          this.allow_unlimited_owner_edits_on_first_post,
         allowed_tags:
           this.allowed_tags && this.allowed_tags.length > 0
             ? this.allowed_tags
@@ -221,7 +221,7 @@ const Category = RestModel.extend({
             ? this.allowed_tag_groups
             : null,
         allow_global_tags: this.allow_global_tags,
-        required_tag_group_name: 
+        required_tag_group_name:
           this.required_tag_groups && this.required_tag_groups.length > 0
             ? this.required_tag_groups[0]
             : null,

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -221,9 +221,10 @@ const Category = RestModel.extend({
             ? this.allowed_tag_groups
             : null,
         allow_global_tags: this.allow_global_tags,
-        required_tag_group_name: this.required_tag_groups
-          ? this.required_tag_groups[0]
-          : null,
+        required_tag_group_name: 
+          this.required_tag_groups && this.required_tag_groups.length > 0
+            ? this.required_tag_groups[0]
+            : null,
         min_tags_from_required_group: this.min_tags_from_required_group,
         sort_order: this.sort_order,
         sort_ascending: this.sort_ascending,

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -210,8 +210,8 @@ const Category = RestModel.extend({
         custom_fields: this.custom_fields,
         topic_template: this.topic_template,
         all_topics_wiki: this.all_topics_wiki,
-        allow_unlimited_owner_edits_on_first_post:
-          this.allow_unlimited_owner_edits_on_first_post,
+        allow_unlimited_owner_edits_on_first_post: this
+          .allow_unlimited_owner_edits_on_first_post,
         allowed_tags:
           this.allowed_tags && this.allowed_tags.length > 0
             ? this.allowed_tags


### PR DESCRIPTION
If the array was present but empty `required_tag_group_name` would be set to undefined, which would then be removed from the payload of the remote request.

Adding the length check ensures the value is set to null, which is sent as an empty value (which the backend sees, and can remove it and persist the change on the Category object).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
