### PR TITLE
remove some hardcoded 'localhost's from dev environment

### DIFF
--- a/app/views/layouts/ember_cli.html.erb
+++ b/app/views/layouts/ember_cli.html.erb
@@ -17,7 +17,7 @@
 
     <p>Then visit the following URL to use Discourse:</p>
 
-   <h3><a href="http://localhost:4200/">http://localhost:4200</a></h3>
+   <h3><a href="http://<%= Discourse.current_hostname %>:4200/">http://<%= Discourse.current_hostname %>:4200</a></h3>
   </div>
 </body>
 </html>

--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -5,14 +5,14 @@ require 'pathname'
 
 RAILS_ROOT = File.expand_path("../../", Pathname.new(__FILE__).realpath)
 PORT = ENV["UNICORN_PORT"] ||= "3000"
-
+HOSTNAME = ENV["DISCOURSE_HOSTNAME"] ||= "localhost"
 yarn_dir = File.join(RAILS_ROOT, "app/assets/javascripts/discourse")
 
 PROXY =
   if ARGV.include?("--try")
     "https://try.discourse.org"
   else
-    "http://localhost:#{PORT}"
+    "http://#{HOSTNAME}:#{PORT}"
   end
 
 command =

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@ development:
     ### If you change this setting you will need to
     ###   - restart sidekiq if you change this setting
     ###   - rebake all to posts using: `RAILS_ENV=production bundle exec rake posts:rebake`
-    - "localhost"
+    - "<%= ENV['DISCOURSE_HOSTNAME'] || 'localhost' %>"
   variables: <%= ENV.filter { |k,v| k.start_with? 'DISCOURSE_DB_VARIABLES_' }
                     .transform_keys { |k| k.slice(('DISCOURSE_DB_VARIABLES_'.length)..).downcase }
                     .to_json %>


### PR DESCRIPTION
Trying to use a local test hostname other than localhost
(e.g. discourse.test )for discourse development was difficult due
the fact that localhost was hardcoded in a few places. This patch
uses existing environment variables to allow a developer to use a
different domain when developing.

