### PR TITLE
DEV: use native lazy load on avatars in topic lists and posts

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -95,7 +95,7 @@ export function avatarImg(options, customGetURL) {
     title = ` title='${escaped}' aria-label='${escaped}'`;
   }
 
-  return `<img alt='' width='${size}' height='${size}' src='${path}' class='${classes}'${title}>`;
+  return `<img loading='lazy' alt='' width='${size}' height='${size}' src='${path}' class='${classes}'${title}>`;
 }
 
 export function tinyAvatar(avatarTemplate, options) {

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -58,6 +58,7 @@ export function avatarImg(wanted, attrs) {
       src: getURLWithCDN(url),
       title,
       "aria-label": title,
+      loading: "lazy",
     },
     className,
   };

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
@@ -1,4 +1,8 @@
-import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  exists,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 
@@ -8,6 +12,12 @@ acceptance("Topic Discovery - Mobile", function (needs) {
     await visit("/");
     assert.ok(exists(".topic-list"), "The list of topics was rendered");
     assert.ok(exists(".topic-list .topic-list-item"), "has topics");
+
+    assert.equal(
+      queryAll("a[data-user-card=codinghorror] img.avatar").attr("loading"),
+      "lazy",
+      "it adds loading=`lazy` to topic list avatars"
+    );
 
     await visit("/categories");
     assert.ok(exists(".category"), "has a list of categories");

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
@@ -20,6 +20,7 @@ acceptance("Topic Discovery - Mobile", function (needs) {
     );
 
     await visit("/categories");
+
     assert.ok(exists(".category"), "has a list of categories");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
@@ -20,7 +20,6 @@ acceptance("Topic Discovery - Mobile", function (needs) {
     );
 
     await visit("/categories");
-
     assert.ok(exists(".category"), "has a list of categories");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -27,6 +27,12 @@ acceptance("Topic Discovery", function (needs) {
       "it shows user's full name in avatar title"
     );
 
+    assert.equal(
+      queryAll("a[data-user-card=eviltrout] img.avatar").attr("loading"),
+      "lazy",
+      "it adds loading=`lazy` to topic list avatars"
+    );
+
     await visit("/c/bug");
     assert.ok(exists(".topic-list"), "The list of topics was rendered");
     assert.ok(exists(".topic-list .topic-list-item"), "has topics");

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -100,7 +100,7 @@ discourseModule("Unit | Utilities", function () {
     let avatarTemplate = "/path/to/avatar/{size}.png";
     assert.equal(
       avatarImg({ avatarTemplate: avatarTemplate, size: "tiny" }),
-      "<img alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar'>",
+      "<img loading='lazy' alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar'>",
       "it returns the avatar html"
     );
 
@@ -110,7 +110,7 @@ discourseModule("Unit | Utilities", function () {
         size: "tiny",
         title: "evilest trout",
       }),
-      "<img alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar' title='evilest trout' aria-label='evilest trout'>",
+      "<img loading='lazy' alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar' title='evilest trout' aria-label='evilest trout'>",
       "it adds a title if supplied"
     );
 
@@ -120,7 +120,7 @@ discourseModule("Unit | Utilities", function () {
         size: "tiny",
         extraClasses: "evil fish",
       }),
-      "<img alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar evil fish'>",
+      "<img loading='lazy' alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar evil fish'>",
       "it adds extra classes if supplied"
     );
 


### PR DESCRIPTION
This PR adds the `loading="lazy"` attribute to avatars in topic lists and in posts (poster avatar).

Avatars in the topic list are small, so bandwidth is not really the concern. It's more about prioritizing the requests for the ones that are already in the viewport.

This should be handled by the browser natively. Browser support is currently at [75%](https://caniuse.com/loading-lazy-attr).

Safari has this behind a flag. If disabled, it will simply ignore the attribute.