### PR TITLE
Support parsing array in #param_to_integer_list

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -928,8 +928,11 @@ class ApplicationController < ActionController::Base
   # returns an array of integers given a param key
   # returns nil if key is not found
   def param_to_integer_list(key, delimiter = ',')
-    if params[key]
+    case params[key]
+    when String
       params[key].split(delimiter).map(&:to_i)
+    when Array
+      params[key].map(&:to_i)
     end
   end
 

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe ListController do
 
       get "/latest?search="
       expect(response.status).to eq(200)
+
+      get "/latest.json?topic_ids%5B%5D=14583&topic_ids%5B%5D=14584"
+      expect(response.status).to eq(200)
+
+      get "/latest.json?topic_ids=14583%2C14584"
+      expect(response.status).to eq(200)
     end
 
     (Discourse.anonymous_filters - [:categories]).each do |filter|


### PR DESCRIPTION
This PR adds support for `topic_ids` to be passed as an array in the query parameter.

Context/Usecase:
We pass `topic_ids` as an array to the `/latest.json` route to get select topics. 

Expected Behaviour:
```json
{"topic_list":{"can_create_topic":false,"per_page":30,"top_tags":[],"topics":[]}}
```

Current Behaviour:
discourse errors out with `internal server error`.

example:
```
http://localhost:3000/latest.json?topic_ids%5B%5D=14583&topic_ids%5B%5D=14584

#=> {"status":500,"error":"Internal Server Error"}
```