### PR TITLE
Add `embed_url` to the api docs

### DIFF
--- a/spec/requests/api/schemas/json/topic_create_request.json
+++ b/spec/requests/api/schemas/json/topic_create_request.json
@@ -33,10 +33,13 @@
     },
     "created_at": {
       "type": "string"
+    },
+    "embed_url": {
+      "type": "string",
+      "description": "Provide a URL from a remote system to associate a forum topic with that URL, typically for using Discourse as a comments system for an external blog."
     }
   },
   "required": [
     "raw"
   ]
 }
-


### PR DESCRIPTION
When creating a topic via the api you can pass in the `embed_url` param,
so adding this to the api docs.

See: https://github.com/discourse/discourse_api_docs/pull/26

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
