### PR TITLE
FEATURE: Use uppy for watched word uploader

### DIFF
--- a/app/assets/javascripts/admin/addon/components/watched-word-uploader.js
+++ b/app/assets/javascripts/admin/addon/components/watched-word-uploader.js
@@ -1,15 +1,16 @@
 import Component from "@ember/component";
 import I18n from "I18n";
-import UploadMixin from "discourse/mixins/upload";
+import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import { alias } from "@ember/object/computed";
 import bootbox from "bootbox";
 import discourseComputed from "discourse-common/utils/decorators";
 
-export default Component.extend(UploadMixin, {
+export default Component.extend(UppyUploadMixin, {
   type: "txt",
   classNames: "watched-words-uploader",
   uploadUrl: "/admin/customize/watched_words/upload",
   addDisabled: alias("uploading"),
+  preventDirectS3Uploads: true,
 
   validateUploadedFilesOptions() {
     return { skipValidation: true };

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -287,5 +287,6 @@ export default Mixin.create({
       processing: false,
       uploadProgress: 0,
     });
+    this.fileInputEl.value = "";
   },
 });


### PR DESCRIPTION
This commit, while changing the watched word uploader to use
uppy, also fixes a minor bug with the UppyUploadMixin where
the file input's value was not cleared after reset, which
prevented subsequent file uploads. The composer mixin already
has this fix.
