### PR TITLE
FIX: prevent auto-scroll when setting focus inside header panels

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -484,7 +484,9 @@ export default createWidget("header", {
 
     // auto focus on first button in dropdown
     schedule("afterRender", () =>
-      document.querySelector(".user-menu button")?.focus()
+      document.querySelector(".user-menu button")?.focus({
+        preventScroll: true,
+      })
     );
   },
 
@@ -494,7 +496,9 @@ export default createWidget("header", {
 
     // auto focus on first link in dropdown
     schedule("afterRender", () => {
-      document.querySelector(".hamburger-panel .menu-links a")?.focus();
+      document.querySelector(".hamburger-panel .menu-links a")?.focus({
+        preventScroll: true,
+      });
     });
   },
 
@@ -624,7 +628,9 @@ export default createWidget("header", {
     if (this.state.searchVisible) {
       schedule("afterRender", () => {
         const searchInput = document.querySelector("#search-term");
-        searchInput.focus();
+        searchInput.focus({
+          preventScroll: true,
+        });
         searchInput.select();
       });
     }


### PR DESCRIPTION
Context:

https://meta.discourse.org/t/width-of-page-causes-an-autoscroll-to-the-top-of-the-page-when-accessing-serach-user-hamburger-comboboxes-chrome-only/207459

When one of the header panels is opened, there's some logic to set the focus either on the first link - in the case of the hamburger and user menus - or the search bar in the case of the search panel.

Hamburger

https://github.com/discourse/discourse/blob/1f8939c0f130892397fb7ee8b0f348f2a7f8b636/app/assets/javascripts/discourse/app/widgets/header.js#L497

User menu 

https://github.com/discourse/discourse/blob/1f8939c0f130892397fb7ee8b0f348f2a7f8b636/app/assets/javascripts/discourse/app/widgets/header.js#L487

Search panel

https://github.com/discourse/discourse/blob/1f8939c0f130892397fb7ee8b0f348f2a7f8b636/app/assets/javascripts/discourse/app/widgets/header.js#L627

When `focus()` is called, the browser automatically scrolls to that element. This wouldn't normally be an issue; however, since the header is set to sticky, it causes problems on Chrome specifically. Here's what it looks like

https://d11a6trkgmumsb.cloudfront.net/original/3X/1/e/1e5cafe12de556ba09f13c42cd74f1f38c873868.mp4

and it's even more prominent on topic pages since it tries to find the top of the page, causing more posts to load, which causes the height to change, which causes jitter.

This PR adds the [preventScroll](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focus_with_focusoption) option to `focus()` to prevent this automatic scrolling

Here's what it looks like after

https://d11a6trkgmumsb.cloudfront.net/original/3X/8/e/8e475f7b3a4cd7151fa034343e88c4ab4d09cb11.mp4

