### PR TITLE
FIX: Stop saving bookmark on modal press ESC

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -239,12 +239,14 @@ export default Component.extend({
     }
   },
 
-  _onModalClose(initiatedByCloseButton) {
+  _onModalClose(closeOpts) {
     // we want to close without saving if the user already saved
     // manually or deleted the bookmark, as well as when the modal
     // is just closed with the X button
     this._closeWithoutSaving =
-      this._closeWithoutSaving || initiatedByCloseButton;
+      this._closeWithoutSaving ||
+      closeOpts.initiatedByCloseButton ||
+      closeOpts.initiatedByESC;
 
     if (!this._closeWithoutSaving && !this._savingBookmarkManually) {
       this._saveBookmark().catch((e) => this._handleSaveError(e));

--- a/app/assets/javascripts/discourse/app/controllers/bookmark.js
+++ b/app/assets/javascripts/discourse/app/controllers/bookmark.js
@@ -77,7 +77,7 @@ export default Controller.extend(ModalFunctionality, {
    */
   onClose(opts = {}) {
     if (this.onCloseHandler) {
-      this.onCloseHandler(opts.initiatedByCloseButton);
+      this.onCloseHandler(opts);
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -174,13 +174,14 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
         if (controller) {
           this.appEvents.trigger("modal:closed", {
             name: controllerName,
-            controller: controller,
+            controller,
           });
 
           if (controller.onClose) {
             controller.onClose({
               initiatedByCloseButton: initiatedBy === "initiatedByCloseButton",
               initiatedByClickOut: initiatedBy === "initiatedByClickOut",
+              initiatedByESC: initiatedBy === "initiatedByESC",
             });
           }
         }
@@ -283,7 +284,7 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
 
     if (!this.siteSettings.enable_local_logins && methods.length === 1) {
       this.controllerFor("login").send("externalLogin", methods[0], {
-        signup: signup,
+        signup,
       });
     } else {
       showModal(modal, { titleAriaElementId });


### PR DESCRIPTION
Since db7be947df29bb2ab27dd3abd80e3b470dcb74e5 the functionality
to not save a bookmark when pressing ESC on the modal has been
broken, because a new initiatedByESC event was introduced there
in d-modal instead of clicking on the modal close button. This
commit fixes the issue by adding an initiatedByESC property
to onClose inside application.js, and checking for that OR
initiatedByCloseButton in the bookmark modal.

See: https://meta.discourse.org/t/hitting-the-bookmark-shortcut-and-then-hitting-esc-still-creates-a-bookmark/206306/2