### PR TITLE
FIX: Skip post validations for system revisions when author deletes topic

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -205,7 +205,8 @@ class PostDestroyer
       @post.revise(@user,
         { raw: I18n.t(key) },
         force_new_version: true,
-        deleting_post: true
+        deleting_post: true,
+        skip_validations: true
       )
 
       Post.transaction do


### PR DESCRIPTION
Bug report: https://meta.discourse.org/t/topic-closed-without-system-record/196813?u=osama.

Discourse allows regular users to delete their own topics, but to prevent abuse the deletion doesn't take effect immediately and the topic is marked for deletion by closing the topic and editing it to say `(topic deleted by author)` (it can be changed via text customizations but this is the default copy).

If the `min_first_post_length` site setting is increased and becomes larger than the length of the default copy, the topic edit won't succeed but it will get closed resulting in a confusing situation where the topic appears to be closed for no reasons.

This PR skips all validations for the edit that Discourse makes when a topic is marked for deletion by the author.