### PR TITLE
Small copy fixes

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5449,7 +5449,7 @@ en:
       embedding:
         get_started: "If you'd like to embed Discourse on another website, begin by adding its host."
         confirm_delete: "Are you sure you want to delete that host?"
-        sample: "Use the following HTML code into your site to create and embed discourse topics. Replace <b>REPLACE_ME</b> with the canonical URL of the page you are embedding it on."
+        sample: "Paste the following HTML code into your site to create and embed discourse topics. Replace <b>REPLACE_ME</b> with the canonical URL of the page you are embedding it on."
         title: "Embedding"
         host: "Allowed Hosts"
         class_name: "Class Name"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4811,10 +4811,10 @@ en:
             label: "Your community’s name"
             placeholder: "Jane’s Hangout"
           site_description:
-            label: "Describe your community in one short sentence"
+            label: "Describe your community in one short sentence (used in search results and social media)"
             placeholder: "A place for Jane and her friends to discuss cool stuff"
           short_site_description:
-            label: "Describe your community in few words"
+            label: "Describe your community in few words (used for the homepage title)"
             placeholder: "Best community ever"
 
       introduction:


### PR DESCRIPTION
Small copy fixes for the setup wizard to fix some ambiguity between two similar prompts for site description.