### PR TITLE
DEV: Replace `equal()` with `strictEqual()`

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/account-created-test.js
@@ -15,7 +15,7 @@ acceptance("Account Created", function () {
     await visit("/u/account-created");
 
     assert.ok(exists(".account-created"));
-    assert.equal(
+    assert.strictEqual(
       queryAll(".account-created .ac-message").text().trim(),
       "Hello World",
       "it displays the message"
@@ -34,7 +34,7 @@ acceptance("Account Created", function () {
     await visit("/u/account-created");
 
     assert.ok(exists(".account-created"));
-    assert.equal(
+    assert.strictEqual(
       queryAll(".account-created .ac-message").text().trim(),
       "Hello World",
       "it displays the message"
@@ -42,9 +42,9 @@ acceptance("Account Created", function () {
 
     await click(".activation-controls .resend");
 
-    assert.equal(currentRouteName(), "account-created.resent");
+    assert.strictEqual(currentRouteName(), "account-created.resent");
     const email = queryAll(".account-created .ac-message b").text();
-    assert.equal(email, "eviltrout@example.com");
+    assert.strictEqual(email, "eviltrout@example.com");
   });
 
   test("account created - update email - cancel", async function (assert) {
@@ -59,12 +59,12 @@ acceptance("Account Created", function () {
 
     await click(".activation-controls .edit-email");
 
-    assert.equal(currentRouteName(), "account-created.edit-email");
+    assert.strictEqual(currentRouteName(), "account-created.edit-email");
     assert.ok(exists(".activation-controls .btn-primary:disabled"));
 
     await click(".activation-controls .edit-cancel");
 
-    assert.equal(currentRouteName(), "account-created.index");
+    assert.strictEqual(currentRouteName(), "account-created.index");
   });
 
   test("account created - update email - submit", async function (assert) {
@@ -87,8 +87,8 @@ acceptance("Account Created", function () {
 
     await click(".activation-controls .btn-primary");
 
-    assert.equal(currentRouteName(), "account-created.resent");
+    assert.strictEqual(currentRouteName(), "account-created.resent");
     const email = queryAll(".account-created .ac-message b").text();
-    assert.equal(email, "newemail@example.com");
+    assert.strictEqual(email, "newemail@example.com");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-badges-award-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-badges-award-test.js
@@ -14,7 +14,7 @@ acceptance("Admin - Badges - Mass Award", function (needs) {
     await click(
       '.admin-badge-list-item span[data-badge-name="Both image and icon"]'
     );
-    assert.equal(
+    assert.strictEqual(
       query("label.grant-existing-holders").textContent.trim(),
       I18n.t("admin.badges.mass_award.grant_existing_holders"),
       "checkbox for granting existing holders is displayed"

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-badges-show-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-badges-show-test.js
@@ -51,7 +51,7 @@ acceptance("Admin - Badges - Show", function (needs) {
     );
     assert.ok(exists(".icon-picker"), "icon picker is visible");
     assert.ok(!exists(".image-uploader"), "image uploader is not visible");
-    assert.equal(query(".icon-picker").textContent.trim(), "fa-rocket");
+    assert.strictEqual(query(".icon-picker").textContent.trim(), "fa-rocket");
   });
 
   test("existing badge that has an image URL", async function (assert) {
@@ -92,6 +92,6 @@ acceptance("Admin - Badges - Show", function (needs) {
     await click("input#badge-icon");
     assert.ok(exists(".icon-picker"), "icon picker is becomes visible");
     assert.ok(!exists(".image-uploader"), "image uploader becomes hidden");
-    assert.equal(query(".icon-picker").textContent.trim(), "fa-rocket");
+    assert.strictEqual(query(".icon-picker").textContent.trim(), "fa-rocket");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-emails-test.js
@@ -32,8 +32,8 @@ acceptance("Admin - Emails", function (needs) {
     await fillIn("textarea.email-body", EMAIL.trim());
     await click(".email-advanced-test button");
 
-    assert.equal(queryAll(".text pre").text(), "Hello, this is a test!");
-    assert.equal(
+    assert.strictEqual(queryAll(".text pre").text(), "Hello, this is a test!");
+    assert.strictEqual(
       queryAll(".elided pre").text(),
       "---\n\nThis part should be elided."
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
@@ -20,8 +20,8 @@ acceptance("Admin - Themes - Install modal", function (needs) {
     await click(".install-theme-content .inputs .advanced-repo");
     await fillIn(branchInput, "tests-passed");
     await click(privateRepoCheckbox);
-    assert.equal(query(urlInput).value, themeUrl, "url input is filled");
-    assert.equal(
+    assert.strictEqual(query(urlInput).value, themeUrl, "url input is filled");
+    assert.strictEqual(
       query(branchInput).value,
       "tests-passed",
       "branch input is filled"
@@ -36,8 +36,8 @@ acceptance("Admin - Themes - Install modal", function (needs) {
 
     await click(".create-actions .btn-primary");
     await click("#remote");
-    assert.equal(query(urlInput).value, "", "url input is reset");
-    assert.equal(query(branchInput).value, "", "branch input is reset");
+    assert.strictEqual(query(urlInput).value, "", "url input is reset");
+    assert.strictEqual(query(branchInput).value, "", "branch input is reset");
     assert.ok(
       !query(privateRepoCheckbox).checked,
       "private repo checkbox unchecked"
@@ -60,7 +60,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
     await fillIn(urlInput, themeUrl);
     await click(".install-theme-content .inputs .advanced-repo");
     await click(privateRepoCheckbox);
-    assert.equal(query(urlInput).value, themeUrl, "url input is filled");
+    assert.strictEqual(query(urlInput).value, themeUrl, "url input is filled");
     assert.ok(
       query(privateRepoCheckbox).checked,
       "private repo checkbox is checked"
@@ -84,7 +84,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
   test("modal can be auto-opened with the right query params", async function (assert) {
     await visit("/admin/customize/themes?repoUrl=testUrl&repoName=testName");
     assert.ok(query(".admin-install-theme-modal"), "modal is visible");
-    assert.equal(
+    assert.strictEqual(
       query(".install-theme code").textContent.trim(),
       "testUrl",
       "repo url is visible"
@@ -101,7 +101,7 @@ acceptance("Admin - Themes - Install modal", function (needs) {
       ),
       "no install button is shown for installed themes"
     );
-    assert.equal(
+    assert.strictEqual(
       query(
         '.popular-theme-item[data-name="Graceful"] .popular-theme-buttons'
       ).textContent.trim(),

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -54,7 +54,7 @@ acceptance("Admin - Site Settings", function (needs) {
   test("links to staff action log", async function (assert) {
     await visit("/admin/site_settings");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".row.setting .setting-label h3 a").attr("href"),
       "/admin/logs/staff_action_logs?filters=%7B%22subject%22%3A%22title%22%2C%22action_name%22%3A%22change_site_setting%22%7D&force_refresh=true",
       "it links to the staff action log"
@@ -64,7 +64,11 @@ acceptance("Admin - Site Settings", function (needs) {
   test("changing value updates dirty state", async function (assert) {
     await visit("/admin/site_settings");
     await fillIn("#setting-filter", " title ");
-    assert.equal(count(".row.setting"), 1, "filter returns 1 site setting");
+    assert.strictEqual(
+      count(".row.setting"),
+      1,
+      "filter returns 1 site setting"
+    );
     assert.ok(!exists(".row.setting.overridden"), "setting isn't overriden");
 
     await fillIn(".input-setting-string", "Test");
@@ -111,31 +115,31 @@ acceptance("Admin - Site Settings", function (needs) {
   test("always shows filtered site settings if a filter is set", async function (assert) {
     await visit("/admin/site_settings");
     await fillIn("#setting-filter", "title");
-    assert.equal(count(".row.setting"), 1);
+    assert.strictEqual(count(".row.setting"), 1);
 
     // navigate away to the "Dashboard" page
     await click(".nav.nav-pills li:nth-child(1) a");
-    assert.equal(count(".row.setting"), 0);
+    assert.strictEqual(count(".row.setting"), 0);
 
     // navigate back to the "Settings" page
     await click(".nav.nav-pills li:nth-child(2) a");
-    assert.equal(count(".row.setting"), 1);
+    assert.strictEqual(count(".row.setting"), 1);
   });
 
   test("filter settings by plugin name", async function (assert) {
     await visit("/admin/site_settings");
 
     await fillIn("#setting-filter", "plugin:discourse-logo");
-    assert.equal(count(".row.setting"), 1);
+    assert.strictEqual(count(".row.setting"), 1);
 
     // inexistent plugin
     await fillIn("#setting-filter", "plugin:discourse-plugin");
-    assert.equal(count(".row.setting"), 0);
+    assert.strictEqual(count(".row.setting"), 0);
   });
 
   test("category name is preserved", async function (assert) {
     await visit("admin/site_settings/category/basic?filter=menu");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "admin/site_settings/category/basic?filter=menu"
     );
@@ -145,16 +149,16 @@ acceptance("Admin - Site Settings", function (needs) {
     await visit("admin/site_settings");
 
     await click(".admin-nav .basic a");
-    assert.equal(currentURL(), "/admin/site_settings/category/basic");
+    assert.strictEqual(currentURL(), "/admin/site_settings/category/basic");
 
     await fillIn("#setting-filter", "menu");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/admin/site_settings/category/basic?filter=menu"
     );
 
     await fillIn("#setting-filter", "contact");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/admin/site_settings/category/all_results?filter=contact"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-text-test.js
@@ -18,14 +18,14 @@ acceptance("Admin - Site Texts", function (needs) {
 
     await fillIn(".site-text-search", "Test");
 
-    assert.equal(currentURL(), "/admin/customize/site_texts?q=Test");
+    assert.strictEqual(currentURL(), "/admin/customize/site_texts?q=Test");
     assert.ok(exists(".site-text"));
     assert.ok(exists(".site-text:not(.overridden)"));
     assert.ok(exists(".site-text.overridden"));
 
     // Only show overridden
     await click(".search-area .filter-options input");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/admin/customize/site_texts?overridden=true&q=Test"
     );
@@ -37,7 +37,7 @@ acceptance("Admin - Site Texts", function (needs) {
   test("edit and revert a site text by key", async function (assert) {
     await visit("/admin/customize/site_texts/site.test?locale=en");
 
-    assert.equal(queryAll(".title h3").text(), "site.test");
+    assert.strictEqual(queryAll(".title h3").text(), "site.test");
     assert.ok(!exists(".saved"));
     assert.ok(!exists(".revert-site-text"));
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
@@ -35,7 +35,7 @@ acceptance("Admin - Suspend User", function (needs) {
     await visit("/admin/users/1234/regular");
     await click(".suspend-user");
 
-    assert.equal(count(".suspend-user-modal:visible"), 1);
+    assert.strictEqual(count(".suspend-user-modal:visible"), 1);
 
     await click(".d-modal-cancel");
 
@@ -46,24 +46,24 @@ acceptance("Admin - Suspend User", function (needs) {
     await visit("/admin/users/1234/regular");
     await click(".suspend-user");
 
-    assert.equal(count(".suspend-user-modal:visible"), 1);
+    assert.strictEqual(count(".suspend-user-modal:visible"), 1);
 
     await fillIn("input.suspend-reason", "for breaking the rules");
     await fillIn(".suspend-message", "this is an email reason why");
 
     await click(".d-modal-cancel");
 
-    assert.equal(count(".bootbox.modal:visible"), 1);
+    assert.strictEqual(count(".bootbox.modal:visible"), 1);
 
     await click(".modal-footer .btn-default");
-    assert.equal(count(".suspend-user-modal:visible"), 1);
-    assert.equal(
+    assert.strictEqual(count(".suspend-user-modal:visible"), 1);
+    assert.strictEqual(
       query(".suspend-message").value,
       "this is an email reason why"
     );
 
     await click(".d-modal-cancel");
-    assert.equal(count(".bootbox.modal:visible"), 1);
+    assert.strictEqual(count(".bootbox.modal:visible"), 1);
     assert.ok(!exists(".suspend-user-modal:visible"));
 
     await click(".modal-footer .btn-primary");
@@ -81,7 +81,11 @@ acceptance("Admin - Suspend User", function (needs) {
 
     await click(".suspend-user");
 
-    assert.equal(count(".perform-suspend[disabled]"), 1, "disabled by default");
+    assert.strictEqual(
+      count(".perform-suspend[disabled]"),
+      1,
+      "disabled by default"
+    );
 
     await suspendUntilCombobox.expand();
     await suspendUntilCombobox.selectRowByValue("tomorrow");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-emails-test.js
@@ -4,13 +4,13 @@ import I18n from "I18n";
 import { test } from "qunit";
 
 function assertNoSecondary(assert) {
-  assert.equal(
+  assert.strictEqual(
     queryAll(".display-row.email .value a").text(),
     "eviltrout@example.com",
     "it should display the primary email"
   );
 
-  assert.equal(
+  assert.strictEqual(
     queryAll(".display-row.secondary-emails .value").text().trim(),
     I18n.t("user.email.no_secondary"),
     "it should not display secondary emails"
@@ -18,13 +18,13 @@ function assertNoSecondary(assert) {
 }
 
 function assertMultipleSecondary(assert, firstEmail, secondEmail) {
-  assert.equal(
+  assert.strictEqual(
     queryAll(".display-row.secondary-emails .value li:first-of-type a").text(),
     firstEmail,
     "it should display the first secondary email"
   );
 
-  assert.equal(
+  assert.strictEqual(
     queryAll(".display-row.secondary-emails .value li:last-of-type a").text(),
     secondEmail,
     "it should display the second secondary email"
@@ -43,7 +43,7 @@ acceptance("Admin - User Emails", function (needs) {
   test("viewing self with multiple secondary emails", async function (assert) {
     await visit("/admin/users/3/markvanlan");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".display-row.email .value a").text(),
       "markvanlan@example.com",
       "it should display the user's primary email"

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -173,7 +173,7 @@ acceptance("Admin - User Index", function (needs) {
     await groupChooser.selectRowByValue(42);
     assert.strictEqual(
       groupChooser.header().value(),
-      42,
+      "42",
       "group should be set"
     );
 

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -101,19 +101,25 @@ acceptance("Admin - User Index", function (needs) {
   test("can edit username", async function (assert) {
     await visit("/admin/users/2/sam");
 
-    assert.equal(queryAll(".display-row.username .value").text().trim(), "sam");
+    assert.strictEqual(
+      queryAll(".display-row.username .value").text().trim(),
+      "sam"
+    );
 
     // Trying cancel.
     await click(".display-row.username button");
     await fillIn(".display-row.username .value input", "new-sam");
     await click(".display-row.username a");
-    assert.equal(queryAll(".display-row.username .value").text().trim(), "sam");
+    assert.strictEqual(
+      queryAll(".display-row.username .value").text().trim(),
+      "sam"
+    );
 
     // Doing edit.
     await click(".display-row.username button");
     await fillIn(".display-row.username .value input", "new-sam");
     await click(".display-row.username button");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".display-row.username .value").text().trim(),
       "new-sam"
     );
@@ -122,7 +128,7 @@ acceptance("Admin - User Index", function (needs) {
   test("shows the number of post edits", async function (assert) {
     await visit("/admin/users/1/eviltrout");
 
-    assert.equal(queryAll(".post-edits-count .value").text().trim(), "6");
+    assert.strictEqual(queryAll(".post-edits-count .value").text().trim(), "6");
 
     assert.ok(
       exists(".post-edits-count .controls .btn.btn-icon"),
@@ -137,7 +143,7 @@ acceptance("Admin - User Index", function (needs) {
 
     await click(".post-edits-count .controls .btn.btn-icon");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/admin/reports/post_edits?filters=${filter}`,
       "it redirects to the right admin report"
@@ -156,7 +162,7 @@ acceptance("Admin - User Index", function (needs) {
   test("will clear unsaved groups when switching user", async function (assert) {
     await visit("/admin/users/2/sam");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".display-row.username .value").text().trim(),
       "sam",
       "the name should be correct"
@@ -165,11 +171,15 @@ acceptance("Admin - User Index", function (needs) {
     const groupChooser = selectKit(".group-chooser");
     await groupChooser.expand();
     await groupChooser.selectRowByValue(42);
-    assert.equal(groupChooser.header().value(), 42, "group should be set");
+    assert.strictEqual(
+      groupChooser.header().value(),
+      42,
+      "group should be set"
+    );
 
     await visit("/admin/users/1/eviltrout");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".display-row.username .value").text().trim(),
       "eviltrout",
       "the name should be correct"
@@ -185,7 +195,7 @@ acceptance("Admin - User Index", function (needs) {
     await visit("/admin/users/3/user1");
     await click(".grant-admin");
     assert.ok(exists(".bootbox"));
-    assert.equal(
+    assert.strictEqual(
       I18n.t("admin.user.grant_admin_confirm"),
       query(".modal-body").textContent.trim()
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -48,7 +48,7 @@ acceptance("Admin - Users List", function (needs) {
 
     await click(".show-emails");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".users-list .user:nth-child(1) .email").text(),
       "<small>eviltrout@example.com</small>",
       "shows the emails"
@@ -56,7 +56,7 @@ acceptance("Admin - Users List", function (needs) {
 
     await click(".hide-emails");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".users-list .user:nth-child(1) .email").text(),
       "",
       "hides the emails"
@@ -71,7 +71,7 @@ acceptance("Admin - Users List", function (needs) {
 
     await visit("/admin/users/list/active");
 
-    assert.equal(queryAll(".admin-title h2").text(), activeTitle);
+    assert.strictEqual(queryAll(".admin-title h2").text(), activeTitle);
     assert.ok(
       queryAll(".users-list .user:nth-child(1) .username")
         .text()
@@ -80,7 +80,7 @@ acceptance("Admin - Users List", function (needs) {
 
     await click('a[href="/admin/users/list/new"]');
 
-    assert.equal(queryAll(".admin-title h2").text(), suspectTitle);
+    assert.strictEqual(queryAll(".admin-title h2").text(), suspectTitle);
     assert.ok(
       queryAll(".users-list .user:nth-child(1) .username")
         .text()
@@ -89,7 +89,7 @@ acceptance("Admin - Users List", function (needs) {
 
     await click(".users-list .sortable:nth-child(4)");
 
-    assert.equal(queryAll(".admin-title h2").text(), suspectTitle);
+    assert.strictEqual(queryAll(".admin-title h2").text(), suspectTitle);
     assert.ok(
       queryAll(".users-list .user:nth-child(1) .username")
         .text()
@@ -98,7 +98,7 @@ acceptance("Admin - Users List", function (needs) {
 
     await click('a[href="/admin/users/list/active"]');
 
-    assert.equal(queryAll(".admin-title h2").text(), activeTitle);
+    assert.strictEqual(queryAll(".admin-title h2").text(), activeTitle);
     assert.ok(
       queryAll(".users-list .user:nth-child(1) .username")
         .text()

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -27,7 +27,7 @@ acceptance("Admin - Watched Words", function (needs) {
 
     await fillIn(".admin-controls .controls input[type=text]", "li");
 
-    assert.equal(
+    assert.strictEqual(
       count(".watched-words-list .watched-word"),
       1,
       "When filtering, show words even if checkbox is unchecked."
@@ -67,7 +67,7 @@ acceptance("Admin - Watched Words", function (needs) {
         found.push(true);
       }
     });
-    assert.equal(found.length, 1);
+    assert.strictEqual(found.length, 1);
   });
 
   test("remove words", async function (assert) {
@@ -84,23 +84,23 @@ acceptance("Admin - Watched Words", function (needs) {
 
     await click(`#${$(word).attr("id")} .delete-word-record`);
 
-    assert.equal(count(".watched-words-list .watched-word"), 2);
+    assert.strictEqual(count(".watched-words-list .watched-word"), 2);
   });
 
   test("test modal - replace", async function (assert) {
     await visit("/admin/customize/watched_words/action/replace");
     await click(".watched-word-test");
     await fillIn(".modal-body textarea", "Hi there!");
-    assert.equal(find(".modal-body li .match").text(), "Hi");
-    assert.equal(find(".modal-body li .replacement").text(), "hello");
+    assert.strictEqual(find(".modal-body li .match").text(), "Hi");
+    assert.strictEqual(find(".modal-body li .replacement").text(), "hello");
   });
 
   test("test modal - tag", async function (assert) {
     await visit("/admin/customize/watched_words/action/tag");
     await click(".watched-word-test");
     await fillIn(".modal-body textarea", "Hello world!");
-    assert.equal(find(".modal-body li .match").text(), "Hello");
-    assert.equal(find(".modal-body li .tag").text(), "greeting");
+    assert.strictEqual(find(".modal-body li .match").text(), "Hello");
+    assert.strictEqual(find(".modal-body li .tag").text(), "greeting");
   });
 });
 
@@ -131,6 +131,6 @@ acceptance("Admin - Watched Words - Bad regular expressions", function (needs) {
 
   test("shows an error message if regex is invalid", async function (assert) {
     await visit("/admin/customize/watched_words/action/block");
-    assert.equal(count(".admin-watched-words .alert-error"), 1);
+    assert.strictEqual(count(".admin-watched-words .alert-error"), 1);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/auth-complete-test.js
@@ -22,7 +22,7 @@ acceptance("Auth Complete", function (needs) {
   test("when login not required", async function (assert) {
     await visit("/");
 
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       "discovery.latest",
       "it stays on the homepage"
@@ -38,7 +38,11 @@ acceptance("Auth Complete", function (needs) {
     this.siteSettings.login_required = true;
     await visit("/");
 
-    assert.equal(currentRouteName(), "login", "it redirects to the login page");
+    assert.strictEqual(
+      currentRouteName(),
+      "login",
+      "it redirects to the login page"
+    );
 
     assert.ok(
       exists("#discourse-modal div.create-account-body"),

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -169,7 +169,7 @@ acceptance("Bookmarking", function (needs) {
     );
     assert.strictEqual(
       selectKit(".bookmark-option-selector").header().value(),
-      1
+      "1"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -167,7 +167,10 @@ acceptance("Bookmarking", function (needs) {
       exists(".bookmark-options-panel"),
       "it should reopen the options panel"
     );
-    assert.equal(selectKit(".bookmark-option-selector").header().value(), 1);
+    assert.strictEqual(
+      selectKit(".bookmark-option-selector").header().value(),
+      1
+    );
   });
 
   test("Saving a bookmark with no reminder or name", async function (assert) {
@@ -236,17 +239,17 @@ acceptance("Bookmarking", function (needs) {
     await click("#tap_tile_tomorrow");
 
     await openEditBookmarkModal();
-    assert.equal(
+    assert.strictEqual(
       queryAll("#bookmark-name").val(),
       "Test name",
       "it should prefill the bookmark name"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll("#custom-date > input").val(),
       tomorrow,
       "it should prefill the bookmark date"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll("#custom-time").val(),
       "08:00",
       "it should prefill the bookmark time"
@@ -265,17 +268,17 @@ acceptance("Bookmarking", function (needs) {
     await click("#tap_tile_post_local_date");
 
     await openEditBookmarkModal();
-    assert.equal(
+    assert.strictEqual(
       queryAll("#bookmark-name").val(),
       "Test name",
       "it should prefill the bookmark name"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll("#custom-date > input").val(),
       postDateFormatted,
       "it should prefill the bookmark date"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll("#custom-time").val(),
       "10:35",
       "it should prefill the bookmark time"
@@ -342,7 +345,7 @@ acceptance("Bookmarking", function (needs) {
     await openBookmarkModal(1);
     await click("#save-bookmark");
 
-    assert.equal(
+    assert.strictEqual(
       query("#topic-footer-button-bookmark").innerText,
       I18n.t("bookmarked.edit_bookmark"),
       "A topic level bookmark button has a label 'Edit Bookmark'"
@@ -360,7 +363,7 @@ acceptance("Bookmarking", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-button-bookmark");
 
-    assert.equal(
+    assert.strictEqual(
       query("#discourse-modal-title").innerText,
       I18n.t("post.bookmarks.create_for_topic"),
       "The create modal says creating a topic bookmark"
@@ -373,7 +376,7 @@ acceptance("Bookmarking", function (needs) {
       "the first post is not marked as being bookmarked"
     );
 
-    assert.equal(
+    assert.strictEqual(
       query("#topic-footer-button-bookmark").innerText,
       I18n.t("bookmarked.edit_bookmark"),
       "A topic level bookmark button has a label 'Edit Bookmark'"
@@ -381,7 +384,7 @@ acceptance("Bookmarking", function (needs) {
 
     await click("#topic-footer-button-bookmark");
 
-    assert.equal(
+    assert.strictEqual(
       query("#discourse-modal-title").innerText,
       I18n.t("post.bookmarks.edit_for_topic"),
       "The edit modal says editing a topic bookmark"
@@ -392,7 +395,7 @@ acceptance("Bookmarking", function (needs) {
 
     await click("#topic-footer-button-bookmark");
 
-    assert.equal(
+    assert.strictEqual(
       query("input#bookmark-name").value,
       "Test name",
       "The topic level bookmark editing preserves the values entered"
@@ -409,7 +412,7 @@ acceptance("Bookmarking", function (needs) {
     );
 
     // deleting all bookmarks in the topic
-    assert.equal(
+    assert.strictEqual(
       query("#topic-footer-button-bookmark").innerText,
       I18n.t("bookmarked.clear_bookmarks"),
       "the footer button says Clear Bookmarks because there is more than one"
@@ -421,7 +424,7 @@ acceptance("Bookmarking", function (needs) {
       !exists(".topic-post:first-child button.bookmark.bookmarked"),
       "the first post bookmark is deleted"
     );
-    assert.equal(
+    assert.strictEqual(
       query("#topic-footer-button-bookmark").innerText,
       I18n.t("bookmarked.title"),
       "the topic level bookmark is deleted"
@@ -433,7 +436,7 @@ acceptance("Bookmarking", function (needs) {
     await click("#topic-footer-button-bookmark");
     await click("#save-bookmark");
 
-    assert.equal(
+    assert.strictEqual(
       query("#topic-footer-button-bookmark").innerText,
       I18n.t("bookmarked.edit_bookmark"),
       "A topic level bookmark button has a label 'Edit Bookmark'"
@@ -456,7 +459,7 @@ acceptance("Bookmarking", function (needs) {
 
     await click(".bootbox.modal .btn-primary");
 
-    assert.equal(
+    assert.strictEqual(
       query("#topic-footer-button-bookmark").innerText,
       I18n.t("bookmarked.title"),
       "A topic level bookmark button no longer says 'Edit Bookmark' after deletion"
@@ -468,7 +471,7 @@ acceptance("Bookmarking", function (needs) {
     await openBookmarkModal(2);
     await click("#save-bookmark");
 
-    assert.equal(
+    assert.strictEqual(
       query("#topic-footer-button-bookmark").innerText,
       I18n.t("bookmarked.edit_bookmark"),
       "A topic level bookmark button has a label 'Edit Bookmark'"

--- a/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-banner-test.js
@@ -60,7 +60,7 @@ acceptance("Category Banners", function (needs) {
     await click(".modal-footer>.btn-primary");
     assert.ok(!visible(".bootbox.modal"), "it closes the modal");
     assert.ok(visible(".category-read-only-banner"), "it shows a banner");
-    assert.equal(
+    assert.strictEqual(
       count(".category-read-only-banner .inner"),
       1,
       "it allows staff to embed html in the message"

--- a/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
@@ -22,6 +22,6 @@ acceptance("CategoryChooser", function (needs) {
   test("prefill category when category_id is set", async function (assert) {
     await visit("/new-topic?category_id=1");
 
-    assert.strictEqual(selectKit(".category-chooser").header().value(), 1);
+    assert.strictEqual(selectKit(".category-chooser").header().value(), "1");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-chooser-test.js
@@ -22,6 +22,6 @@ acceptance("CategoryChooser", function (needs) {
   test("prefill category when category_id is set", async function (assert) {
     await visit("/new-topic?category_id=1");
 
-    assert.equal(selectKit(".category-chooser").header().value(), 1);
+    assert.strictEqual(selectKit(".category-chooser").header().value(), 1);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-security-test.js
@@ -17,10 +17,10 @@ acceptance("Category Edit - security", function (needs) {
 
     const firstRow = queryAll(".row-body").first();
     const badgeName = firstRow.find(".group-name-label").text();
-    assert.equal(badgeName, "everyone");
+    assert.strictEqual(badgeName, "everyone");
 
     const permission = firstRow.find(".d-icon-check-square");
-    assert.equal(permission.length, 3);
+    assert.strictEqual(permission.length, 3);
   });
 
   test("removing a permission", async function (assert) {
@@ -58,8 +58,8 @@ acceptance("Category Edit - security", function (needs) {
 
     const addedRow = queryAll(".row-body").last();
 
-    assert.equal(addedRow.find(".group-name-label").text(), "staff");
-    assert.equal(
+    assert.strictEqual(addedRow.find(".group-name-label").text(), "staff");
+    assert.strictEqual(
       addedRow.find(".d-icon-check-square").length,
       3,
       "new row permissions match default 'everyone' permissions"
@@ -78,12 +78,16 @@ acceptance("Category Edit - security", function (needs) {
     await availableGroups.expand();
     await availableGroups.selectRowByValue("everyone");
 
-    assert.equal(count(".row-body"), 1, "adds back the permission tp the list");
+    assert.strictEqual(
+      count(".row-body"),
+      1,
+      "adds back the permission tp the list"
+    );
 
     const firstRow = queryAll(".row-body").first();
 
-    assert.equal(firstRow.find(".group-name-label").text(), "everyone");
-    assert.equal(
+    assert.strictEqual(firstRow.find(".group-name-label").text(), "everyone");
+    assert.strictEqual(
       firstRow.find(".d-icon-check-square").length,
       1,
       "adds only 'See' permission for a new row"
@@ -97,7 +101,7 @@ acceptance("Category Edit - security", function (needs) {
 
     const everyoneRow = queryAll(".row-body").first();
 
-    assert.equal(
+    assert.strictEqual(
       everyoneRow.find(".reply-granted, .create-granted").length,
       2,
       "everyone has full permissions by default"
@@ -108,7 +112,7 @@ acceptance("Category Edit - security", function (needs) {
 
     const staffRow = queryAll(".row-body").last();
 
-    assert.equal(
+    assert.strictEqual(
       staffRow.find(".reply-granted, .create-granted").length,
       2,
       "staff group also has full permissions"
@@ -116,13 +120,13 @@ acceptance("Category Edit - security", function (needs) {
 
     await click(everyoneRow.find(".reply-toggle")[0]);
 
-    assert.equal(
+    assert.strictEqual(
       everyoneRow.find(".reply-granted, .create-granted").length,
       0,
       "everyone does not have reply or create"
     );
 
-    assert.equal(
+    assert.strictEqual(
       staffRow.find(".reply-granted, .create-granted").length,
       2,
       "staff group still has full permissions"
@@ -130,19 +134,19 @@ acceptance("Category Edit - security", function (needs) {
 
     await click(staffRow.find(".reply-toggle")[0]);
 
-    assert.equal(
+    assert.strictEqual(
       everyoneRow.find(".reply-granted, .create-granted").length,
       0,
       "everyone permission unchanged"
     );
 
-    assert.equal(
+    assert.strictEqual(
       staffRow.find(".reply-granted").length,
       0,
       "staff does not have reply permission"
     );
 
-    assert.equal(
+    assert.strictEqual(
       staffRow.find(".create-granted").length,
       0,
       "staff does not have create permission"
@@ -150,13 +154,13 @@ acceptance("Category Edit - security", function (needs) {
 
     await click(everyoneRow.find(".create-toggle")[0]);
 
-    assert.equal(
+    assert.strictEqual(
       everyoneRow.find(".reply-granted, .create-granted").length,
       2,
       "everyone has full permissions"
     );
 
-    assert.equal(
+    assert.strictEqual(
       staffRow.find(".reply-granted, .create-granted").length,
       2,
       "staff group has full permissions (inherited from everyone)"

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -17,22 +17,22 @@ acceptance("Category Edit", function (needs) {
     await visit("/c/bug");
 
     await click("button.edit-category");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/c/bug/edit/general",
       "it jumps to the correct screen"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".category-breadcrumb .badge-category").text(),
       "bug"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".category-color-editor .badge-category").text(),
       "bug"
     );
     await fillIn("input.category-name", "testing");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".category-color-editor .badge-category").text(),
       "testing"
     );
@@ -43,7 +43,7 @@ acceptance("Category Edit", function (needs) {
     await fillIn(".d-editor-input", "this is the new topic template");
 
     await click("#save-category");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/c/bug/edit/general",
       "it stays on the edit screen"
@@ -55,7 +55,7 @@ acceptance("Category Edit", function (needs) {
     await searchPriorityChooser.selectRowByValue(1);
 
     await click("#save-category");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/c/bug/edit/settings",
       "it stays on the edit screen"
@@ -72,7 +72,7 @@ acceptance("Category Edit", function (needs) {
 
   test("Index Route", async function (assert) {
     await visit("/c/bug/edit");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/c/bug/edit/general",
       "it redirects to the general tab"
@@ -81,12 +81,12 @@ acceptance("Category Edit", function (needs) {
 
   test("Slugless Route", async function (assert) {
     await visit("/c/1-category/edit");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/c/1-category/edit/general",
       "it goes to the general tab"
     );
-    assert.equal(queryAll("input.category-name").val(), "bug");
+    assert.strictEqual(queryAll("input.category-name").val(), "bug");
   });
 
   test("Error Saving", async function (assert) {
@@ -95,7 +95,10 @@ acceptance("Category Edit", function (needs) {
     await click("#save-category");
 
     assert.ok(visible(".bootbox"));
-    assert.equal(queryAll(".bootbox .modal-body").html(), "duplicate email");
+    assert.strictEqual(
+      queryAll(".bootbox .modal-body").html(),
+      "duplicate email"
+    );
 
     await click(".bootbox .btn-primary");
     assert.ok(!visible(".bootbox"));
@@ -156,6 +159,6 @@ acceptance("Category Edit - no permission to edit", function (needs) {
 
   test("returns 404", async function (assert) {
     await visit("/c/bug/edit");
-    assert.equal(currentURL(), "/404");
+    assert.strictEqual(currentURL(), "/404");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -19,17 +19,17 @@ acceptance("Category New", function (needs) {
     assert.notOk(exists(".category-breadcrumb"));
 
     await fillIn("input.category-name", "testing");
-    assert.equal(queryAll(".badge-category").text(), "testing");
+    assert.strictEqual(queryAll(".badge-category").text(), "testing");
 
     await click("#save-category");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/c/testing/edit/general",
       "it transitions to the category edit route"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".edit-category-title h2").text(),
       I18n.t("category.edit_dialog_title", {
         categoryName: "testing",

--- a/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/click-track-test.js
@@ -20,8 +20,11 @@ acceptance("Click Track", function (needs) {
     assert.ok(!exists(".user-card.show"), "card should not appear");
 
     await click('article[data-post-id="3651"] a.mention');
-    assert.equal(count(".user-card.show"), 1, "card appear");
-    assert.equal(currentURL(), "/t/internationalization-localization/280");
+    assert.strictEqual(count(".user-card.show"), 1, "card appear");
+    assert.strictEqual(
+      currentURL(),
+      "/t/internationalization-localization/280"
+    );
     assert.ok(!tracked);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -41,15 +41,21 @@ acceptance("Composer Actions", function (needs) {
     await click("article#post_3 button.reply");
     await composerActions.expand();
 
-    assert.equal(composerActions.rowByIndex(0).value(), "reply_as_new_topic");
-    assert.equal(
+    assert.strictEqual(
+      composerActions.rowByIndex(0).value(),
+      "reply_as_new_topic"
+    );
+    assert.strictEqual(
       composerActions.rowByIndex(1).value(),
       "reply_as_private_message"
     );
-    assert.equal(composerActions.rowByIndex(2).value(), "reply_to_topic");
-    assert.equal(composerActions.rowByIndex(3).value(), "toggle_whisper");
-    assert.equal(composerActions.rowByIndex(4).value(), "toggle_topic_bump");
-    assert.equal(composerActions.rowByIndex(5).value(), undefined);
+    assert.strictEqual(composerActions.rowByIndex(2).value(), "reply_to_topic");
+    assert.strictEqual(composerActions.rowByIndex(3).value(), "toggle_whisper");
+    assert.strictEqual(
+      composerActions.rowByIndex(4).value(),
+      "toggle_topic_bump"
+    );
+    assert.strictEqual(composerActions.rowByIndex(5).value(), undefined);
   });
 
   test("replying to post - reply_as_private_message", async function (assert) {
@@ -62,7 +68,7 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("reply_as_private_message");
 
     const privateMessageUsers = selectKit("#private-message-users");
-    assert.equal(privateMessageUsers.header().value(), "codinghorror");
+    assert.strictEqual(privateMessageUsers.header().value(), "codinghorror");
     assert.ok(
       queryAll(".d-editor-input").val().indexOf("Continuing the discussion") >=
         0
@@ -82,15 +88,15 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_to_topic");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".action-title .topic-link").text().trim(),
       "Internationalization / localization"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".action-title .topic-link").attr("href"),
       "/t/internationalization-localization/280"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "test replying to topic when initially replied to post"
     );
@@ -110,7 +116,7 @@ acceptance("Composer Actions", function (needs) {
       !exists(".composer-actions svg.d-icon-far-eye-slash"),
       "whisper icon is not visible"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-share"),
       1,
       "reply icon is visible"
@@ -119,7 +125,7 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("toggle_whisper");
 
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-far-eye-slash"),
       1,
       "whisper icon is visible"
@@ -152,8 +158,8 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_as_new_topic");
 
-    assert.equal(categoryChooserReplyArea.header().name(), "faq");
-    assert.equal(
+    assert.strictEqual(categoryChooserReplyArea.header().name(), "faq");
+    assert.strictEqual(
       queryAll(".action-title").text().trim(),
       I18n.t("topic.create_long")
     );
@@ -190,11 +196,11 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("reply_as_private_message");
 
     assert.ok(composerActions.el().hasClass("is-hidden"));
-    assert.equal(composerActions.el().children().length, 0);
+    assert.strictEqual(composerActions.el().children().length, 0);
 
     await click("button#create-topic");
     await composerActions.expand();
-    assert.equal(composerActions.rows().length, 2);
+    assert.strictEqual(composerActions.rows().length, 2);
   });
 
   test("interactions", async function (assert) {
@@ -207,64 +213,76 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_to_topic");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".action-title").text().trim(),
       "Internationalization / localization"
     );
-    assert.equal(queryAll(".d-editor-input").val(), quote);
+    assert.strictEqual(queryAll(".d-editor-input").val(), quote);
 
     await composerActions.expand();
 
-    assert.equal(composerActions.rowByIndex(0).value(), "reply_as_new_topic");
-    assert.equal(composerActions.rowByIndex(1).value(), "reply_to_post");
-    assert.equal(
+    assert.strictEqual(
+      composerActions.rowByIndex(0).value(),
+      "reply_as_new_topic"
+    );
+    assert.strictEqual(composerActions.rowByIndex(1).value(), "reply_to_post");
+    assert.strictEqual(
       composerActions.rowByIndex(2).value(),
       "reply_as_private_message"
     );
-    assert.equal(composerActions.rowByIndex(3).value(), "toggle_whisper");
-    assert.equal(composerActions.rowByIndex(4).value(), "toggle_topic_bump");
-    assert.equal(composerActions.rows().length, 5);
+    assert.strictEqual(composerActions.rowByIndex(3).value(), "toggle_whisper");
+    assert.strictEqual(
+      composerActions.rowByIndex(4).value(),
+      "toggle_topic_bump"
+    );
+    assert.strictEqual(composerActions.rows().length, 5);
 
     await composerActions.selectRowByValue("reply_to_post");
     await composerActions.expand();
 
     assert.ok(exists(".action-title img.avatar"));
-    assert.equal(
+    assert.strictEqual(
       queryAll(".action-title .user-link").text().trim(),
       "codinghorror"
     );
-    assert.equal(queryAll(".d-editor-input").val(), quote);
-    assert.equal(composerActions.rowByIndex(0).value(), "reply_as_new_topic");
-    assert.equal(
+    assert.strictEqual(queryAll(".d-editor-input").val(), quote);
+    assert.strictEqual(
+      composerActions.rowByIndex(0).value(),
+      "reply_as_new_topic"
+    );
+    assert.strictEqual(
       composerActions.rowByIndex(1).value(),
       "reply_as_private_message"
     );
-    assert.equal(composerActions.rowByIndex(2).value(), "reply_to_topic");
-    assert.equal(composerActions.rowByIndex(3).value(), "toggle_whisper");
-    assert.equal(composerActions.rowByIndex(4).value(), "toggle_topic_bump");
-    assert.equal(composerActions.rows().length, 5);
+    assert.strictEqual(composerActions.rowByIndex(2).value(), "reply_to_topic");
+    assert.strictEqual(composerActions.rowByIndex(3).value(), "toggle_whisper");
+    assert.strictEqual(
+      composerActions.rowByIndex(4).value(),
+      "toggle_topic_bump"
+    );
+    assert.strictEqual(composerActions.rows().length, 5);
 
     await composerActions.selectRowByValue("reply_as_new_topic");
     await composerActions.expand();
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".action-title").text().trim(),
       I18n.t("topic.create_long")
     );
     assert.ok(queryAll(".d-editor-input").val().includes(quote));
-    assert.equal(composerActions.rowByIndex(0).value(), "reply_to_post");
-    assert.equal(
+    assert.strictEqual(composerActions.rowByIndex(0).value(), "reply_to_post");
+    assert.strictEqual(
       composerActions.rowByIndex(1).value(),
       "reply_as_private_message"
     );
-    assert.equal(composerActions.rowByIndex(2).value(), "reply_to_topic");
-    assert.equal(composerActions.rowByIndex(3).value(), "shared_draft");
-    assert.equal(composerActions.rows().length, 4);
+    assert.strictEqual(composerActions.rowByIndex(2).value(), "reply_to_topic");
+    assert.strictEqual(composerActions.rowByIndex(3).value(), "shared_draft");
+    assert.strictEqual(composerActions.rows().length, 4);
 
     await composerActions.selectRowByValue("reply_as_private_message");
     await composerActions.expand();
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".action-title").text().trim(),
       I18n.t("topic.private_message")
     );
@@ -272,10 +290,13 @@ acceptance("Composer Actions", function (needs) {
       queryAll(".d-editor-input").val().indexOf("Continuing the discussion") ===
         0
     );
-    assert.equal(composerActions.rowByIndex(0).value(), "reply_as_new_topic");
-    assert.equal(composerActions.rowByIndex(1).value(), "reply_to_post");
-    assert.equal(composerActions.rowByIndex(2).value(), "reply_to_topic");
-    assert.equal(composerActions.rows().length, 3);
+    assert.strictEqual(
+      composerActions.rowByIndex(0).value(),
+      "reply_as_new_topic"
+    );
+    assert.strictEqual(composerActions.rowByIndex(1).value(), "reply_to_post");
+    assert.strictEqual(composerActions.rowByIndex(2).value(), "reply_to_topic");
+    assert.strictEqual(composerActions.rows().length, 3);
   });
 
   test("replying to post - toggle_topic_bump", async function (assert) {
@@ -288,7 +309,7 @@ acceptance("Composer Actions", function (needs) {
       !exists(".composer-actions svg.d-icon-anchor"),
       "no-bump icon is not visible"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-share"),
       1,
       "reply icon is visible"
@@ -297,7 +318,7 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("toggle_topic_bump");
 
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-anchor"),
       1,
       "no-bump icon is visible"
@@ -314,7 +335,7 @@ acceptance("Composer Actions", function (needs) {
       !exists(".composer-actions svg.d-icon-anchor"),
       "no-bump icon is not visible"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-share"),
       1,
       "reply icon is visible"
@@ -335,7 +356,7 @@ acceptance("Composer Actions", function (needs) {
       !exists(".composer-fields .whisper .d-icon-anchor"),
       "no-bump icon is not visible"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-share"),
       1,
       "reply icon is visible"
@@ -346,12 +367,12 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("toggle_whisper");
 
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-far-eye-slash"),
       1,
       "whisper icon is visible"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".composer-fields .no-bump .d-icon-anchor"),
       1,
       "no-bump icon is visible"
@@ -370,8 +391,11 @@ acceptance("Composer Actions", function (needs) {
     await click("article#post_3 button.reply");
     await composerActions.expand();
 
-    assert.equal(composerActions.rows().length, 5);
-    assert.equal(composerActions.rowByIndex(4).value(), "toggle_topic_bump");
+    assert.strictEqual(composerActions.rows().length, 5);
+    assert.strictEqual(
+      composerActions.rowByIndex(4).value(),
+      "toggle_topic_bump"
+    );
   });
 
   test("replying to post as TL3 user", async function (assert) {
@@ -382,9 +406,9 @@ acceptance("Composer Actions", function (needs) {
     await click("article#post_3 button.reply");
     await composerActions.expand();
 
-    assert.equal(composerActions.rows().length, 3);
+    assert.strictEqual(composerActions.rows().length, 3);
     Array.from(composerActions.rows()).forEach((row) => {
-      assert.notEqual(
+      assert.notStrictEqual(
         row.value,
         "toggle_topic_bump",
         "toggle button is not visible"
@@ -400,8 +424,11 @@ acceptance("Composer Actions", function (needs) {
     await click("article#post_3 button.reply");
     await composerActions.expand();
 
-    assert.equal(composerActions.rows().length, 4);
-    assert.equal(composerActions.rowByIndex(3).value(), "toggle_topic_bump");
+    assert.strictEqual(composerActions.rows().length, 4);
+    assert.strictEqual(
+      composerActions.rowByIndex(3).value(),
+      "toggle_topic_bump"
+    );
   });
 
   test("replying to first post - reply_as_private_message", async function (assert) {
@@ -414,7 +441,7 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.selectRowByValue("reply_as_private_message");
 
     const privateMessageUsers = selectKit("#private-message-users");
-    assert.equal(privateMessageUsers.header().value(), "uwe_keim");
+    assert.strictEqual(privateMessageUsers.header().value(), "uwe_keim");
     assert.ok(
       queryAll(".d-editor-input").val().indexOf("Continuing the discussion") >=
         0
@@ -429,8 +456,8 @@ acceptance("Composer Actions", function (needs) {
     await click("article#post_1 button.edit");
     await composerActions.expand();
 
-    assert.equal(composerActions.rows().length, 1);
-    assert.equal(composerActions.rowByIndex(0).value(), "reply_to_post");
+    assert.strictEqual(composerActions.rows().length, 1);
+    assert.strictEqual(composerActions.rowByIndex(0).value(), "reply_to_post");
   });
 });
 
@@ -477,24 +504,24 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
       await composerActions.expand();
       await composerActions.selectRowByValue("shared_draft");
 
-      assert.equal(tags.header().value(), "monkey", "tags are not reset");
+      assert.strictEqual(tags.header().value(), "monkey", "tags are not reset");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("#reply-title").val(),
         "This is the new text for the title using 'quotes'"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("#reply-control .btn-primary.create .d-button-label").text(),
         I18n.t("composer.create_shared_draft")
       );
-      assert.equal(
+      assert.strictEqual(
         count(".composer-actions svg.d-icon-far-clipboard"),
         1,
         "shared draft icon is visible"
       );
 
-      assert.equal(count("#reply-control.composing-shared-draft"), 1);
+      assert.strictEqual(count("#reply-control.composing-shared-draft"), 1);
       await click(".modal-footer .btn.btn-default");
     } finally {
       toggleCheckDraftPopup(false);
@@ -509,7 +536,7 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
     await composerActions.expand();
     stubDraftResponse();
     await composerActions.selectRowByValue("reply_as_new_topic");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".bootbox .modal-body").text(),
       I18n.t("composer.composer_actions.reply_as_new_topic.confirm")
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -55,7 +55,7 @@ acceptance("Composer Actions", function (needs) {
       composerActions.rowByIndex(4).value(),
       "toggle_topic_bump"
     );
-    assert.strictEqual(composerActions.rowByIndex(5).value(), undefined);
+    assert.strictEqual(composerActions.rowByIndex(5).value(), null);
   });
 
   test("replying to post - reply_as_private_message", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-attachment-test.js
@@ -27,7 +27,7 @@ async function writeInComposer(assert) {
 
   await fillIn(".d-editor-input", "[test](upload://abcdefg.png)");
 
-  assert.equal(
+  assert.strictEqual(
     queryAll(".d-editor-preview:visible").html().trim(),
     '<p><a href="/404" tabindex="-1">test</a></p>'
   );
@@ -41,7 +41,7 @@ acceptance("Composer Attachment - Cooking", function (needs) {
 
   test("attachments are cooked properly", async function (assert) {
     await writeInComposer(assert);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview:visible").html().trim(),
       '<p><a class="attachment" href="/uploads/short-url/asdsad.png" tabindex="-1">test</a></p>'
     );
@@ -55,7 +55,7 @@ acceptance("Composer Attachment - Secure Media Enabled", function (needs) {
 
   test("attachments are cooked properly when secure media is enabled", async function (assert) {
     await writeInComposer(assert);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview:visible").html().trim(),
       '<p><a class="attachment" href="/secure-media-uploads/default/3X/1/asjdiasjdiasida.png" tabindex="-1">test</a></p>'
     );
@@ -71,13 +71,13 @@ acceptance("Composer Attachment - Upload Placeholder", function (needs) {
     const image = createImage("avatar.png", "/images/avatar.png?1", 200, 300);
 
     await queryAll(".wmd-controls").trigger("fileuploadsend", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Uploading: avatar.png...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "![avatar|200x300](/images/avatar.png?1)\n"
     );
@@ -91,13 +91,13 @@ acceptance("Composer Attachment - Upload Placeholder", function (needs) {
     const image = createImage("avatar.png", "/images/avatar.png?1", 200, 300);
     await queryAll(".wmd-controls").trigger("fileuploadsend", image);
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "The image:\n[Uploading: avatar.png...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "The image:\n![avatar|200x300](/images/avatar.png?1)\n"
     );
@@ -111,13 +111,13 @@ acceptance("Composer Attachment - Upload Placeholder", function (needs) {
     const image = createImage("avatar.png", "/images/avatar.png?1", 200, 300);
     await queryAll(".wmd-controls").trigger("fileuploadsend", image);
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "The image:\n[Uploading: avatar.png...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "The image:\n![avatar|200x300](/images/avatar.png?1)\n"
     );
@@ -134,13 +134,13 @@ acceptance("Composer Attachment - Upload Placeholder", function (needs) {
     const image = createImage("avatar.png", "/images/avatar.png?1", 200, 300);
     await queryAll(".wmd-controls").trigger("fileuploadsend", image);
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "The image \n[Uploading: avatar.png...]()\nText after the image."
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "The image \n![avatar|200x300](/images/avatar.png?1)\nText after the image."
     );
@@ -159,13 +159,13 @@ acceptance("Composer Attachment - Upload Placeholder", function (needs) {
     textArea.selectionEnd = 23;
 
     await queryAll(".wmd-controls").trigger("fileuploadsend", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "The image \n[Uploading: avatar.png...]()\n Text after the image."
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "The image \n![avatar|200x300](/images/avatar.png?1)\n Text after the image."
     );
@@ -181,43 +181,43 @@ acceptance("Composer Attachment - Upload Placeholder", function (needs) {
     const image4 = createImage("image.png", "/images/avatar.png?4", 300, 400);
 
     await queryAll(".wmd-controls").trigger("fileuploadsend", image1);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploadsend", image2);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]()\n[Uploading: test.png(1)...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploadsend", image4);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]()\n[Uploading: test.png(1)...]()\n[Uploading: image.png...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploadsend", image3);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]()\n[Uploading: test.png(1)...]()\n[Uploading: image.png...]()\n[Uploading: image.png(1)...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image2);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]()\n![test|100x200](/images/avatar.png?2)\n[Uploading: image.png...]()\n[Uploading: image.png(1)...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image3);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Uploading: test.png...]()\n![test|100x200](/images/avatar.png?2)\n[Uploading: image.png...]()\n![image|300x400](/images/avatar.png?3)\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image1);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "![test|200x300](/images/avatar.png?1)\n![test|100x200](/images/avatar.png?2)\n[Uploading: image.png...]()\n![image|300x400](/images/avatar.png?3)\n"
     );
@@ -230,13 +230,13 @@ acceptance("Composer Attachment - Upload Placeholder", function (needs) {
     const image = createImage("ima++ge.png", "/images/avatar.png?4", 300, 400);
 
     await queryAll(".wmd-controls").trigger("fileuploadsend", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Uploading: ima++ge.png...]()\n"
     );
 
     await queryAll(".wmd-controls").trigger("fileuploaddone", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "![ima++ge|300x400](/images/avatar.png?4)\n"
     );
@@ -279,7 +279,7 @@ acceptance("Composer Attachment - Upload Handler", function (needs) {
     await fillIn(".d-editor-input", "This is a handler test.");
 
     await queryAll(".wmd-controls").trigger("fileuploadsubmit", image);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".bootbox .modal-body").html(),
       "This is an upload handler test for handlertest.png",
       "it should show the bootbox triggered by the upload handler"
@@ -305,7 +305,7 @@ acceptance("Composer Attachment - File input", function (needs) {
     await click("#create-topic");
 
     assert.ok(exists("input#file-uploader"), "An input is rendered");
-    assert.equal(
+    assert.strictEqual(
       query("input#file-uploader").accept,
       ".jpg,.jpeg,.png",
       "Accepted values are correct"

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-draft-saving-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-draft-saving-test.js
@@ -34,7 +34,7 @@ acceptance("Composer - Draft saving", function (needs) {
     );
 
     await fillIn(".d-editor-input", "This won't be saved because of error");
-    assert.equal(
+    assert.strictEqual(
       query("div#draft-status span").innerText.trim(),
       I18n.t("composer.drafts_offline"),
       "the draft wasn't saved, a warning is rendered"

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-edit-conflict-test.js
@@ -22,7 +22,7 @@ acceptance("Composer - Edit conflict", function (needs) {
       await click(".topic-post:nth-of-type(1) button.edit");
       await fillIn(".d-editor-input", "this will 409");
       await click("#reply-control button.create");
-      assert.equal(
+      assert.strictEqual(
         queryAll("#reply-control button.create").text().trim(),
         I18n.t("composer.overwrite_edit"),
         "it shows the overwrite button"

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-hyperlink-test.js
@@ -27,7 +27,7 @@ acceptance("Composer - Hyperlink", function (needs) {
     await fillIn(".modal-body .link-text", "Google");
     await click(".modal-footer button.btn-primary");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "This is a link to [Google](https://google.com)",
       "adds link with url and text, prepends 'https://'"
@@ -45,7 +45,7 @@ acceptance("Composer - Hyperlink", function (needs) {
     await fillIn(".modal-body .link-text", "Google");
     await click(".modal-footer button.btn-danger");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "Reset textarea contents.",
       "doesn’t insert anything after cancelling"
@@ -64,7 +64,7 @@ acceptance("Composer - Hyperlink", function (needs) {
     await fillIn(".modal-body .link-url", "somelink.com");
     await click(".modal-footer button.btn-primary");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "[Reset](https://somelink.com) textarea contents.",
       "adds link to a selected text"

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-onebox-test.js
@@ -28,7 +28,7 @@ http://www.example.com/has-title.html
         `
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview:visible").html().trim(),
       `
 <p><aside class=\"onebox\"><article class=\"onebox-body\"><h3><a href=\"http://www.example.com/article.html\" tabindex=\"-1\">An interesting article</a></h3></article></aside><br>
@@ -66,15 +66,15 @@ acceptance("Composer - Inline Onebox", function (needs) {
     await click("#topic-footer-buttons .btn.create");
 
     await fillIn(".d-editor-input", `Test www.example.com/page`);
-    assert.equal(requestsCount, 1);
-    assert.equal(
+    assert.strictEqual(requestsCount, 1);
+    assert.strictEqual(
       queryAll(".d-editor-preview").html().trim(),
       '<p>Test <a href="http://www.example.com/page" class="inline-onebox-loading" tabindex="-1">www.example.com/page</a></p>'
     );
 
     await fillIn(".d-editor-input", `Test www.example.com/page Test`);
-    assert.equal(requestsCount, 1);
-    assert.equal(
+    assert.strictEqual(requestsCount, 1);
+    assert.strictEqual(
       queryAll(".d-editor-preview").html().trim(),
       '<p>Test <a href="http://www.example.com/page" tabindex="-1">www.example.com/page</a> Test</p>'
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
@@ -32,7 +32,7 @@ acceptance("Composer - Tags", function (needs) {
     await categoryChooser.selectRowByValue(2);
 
     await click("#reply-control button.create");
-    assert.notEqual(currentURL(), "/");
+    assert.notStrictEqual(currentURL(), "/");
   });
 
   test("users do not bypass tag validation rule", async function (assert) {
@@ -51,8 +51,8 @@ acceptance("Composer - Tags", function (needs) {
     updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
     await click("#reply-control button.create");
-    assert.equal(currentURL(), "/");
-    assert.equal(
+    assert.strictEqual(currentURL(), "/");
+    assert.strictEqual(
       queryAll(".popup-tip.bad").text().trim(),
       I18n.t("composer.error.tags_missing", { count: 1 }),
       "it should display the right alert"
@@ -63,7 +63,7 @@ acceptance("Composer - Tags", function (needs) {
     await tags.selectRowByValue("monkey");
 
     await click("#reply-control button.create");
-    assert.notEqual(currentURL(), "/");
+    assert.notStrictEqual(currentURL(), "/");
   });
 
   test("users do not bypass min required tags in tag group validation rule", async function (assert) {
@@ -85,8 +85,8 @@ acceptance("Composer - Tags", function (needs) {
     updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
 
     await click("#reply-control button.create");
-    assert.equal(currentURL(), "/");
-    assert.equal(
+    assert.strictEqual(currentURL(), "/");
+    assert.strictEqual(
       queryAll(".popup-tip.bad").text().trim(),
       I18n.t("composer.error.tags_missing", { count: 1 }),
       "it should display the right alert"
@@ -97,6 +97,6 @@ acceptance("Composer - Tags", function (needs) {
     await tags.selectRowByValue("monkey");
 
     await click("#reply-control button.create");
-    assert.notEqual(currentURL(), "/");
+    assert.notStrictEqual(currentURL(), "/");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -84,7 +84,7 @@ acceptance("Composer", function (needs) {
     assert.ok(exists(".title-input .popup-tip.good"), "the title is now good");
 
     await fillIn(".d-editor-input", "this is the *content* of a post");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview").html().trim(),
       "<p>this is the <em>content</em> of a post</p>",
       "it previews content"
@@ -109,7 +109,7 @@ acceptance("Composer", function (needs) {
     run(() => textarea.dispatchEvent(event));
 
     const example = I18n.t(`composer.bold_text`);
-    assert.equal(
+    assert.strictEqual(
       queryAll("#reply-control .d-editor-input").val().trim(),
       `this is the *content* of a post**${example}**`,
       "it supports keyboard shortcuts"
@@ -143,7 +143,7 @@ acceptance("Composer", function (needs) {
       "this is the *content* of a new topic post"
     );
     await click("#reply-control button.create");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/t/internationalization-localization/280",
       "it transitions to the newly created topic URL"
@@ -157,7 +157,7 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", "enqueue this content please");
     await click("#reply-control button.create");
     assert.ok(visible(".d-modal"), "it pops up a modal");
-    assert.equal(currentURL(), "/", "it doesn't change routes");
+    assert.strictEqual(currentURL(), "/", "it doesn't change routes");
 
     await click(".modal-footer button");
     assert.ok(invisible(".d-modal"), "the modal can be dismissed");
@@ -169,14 +169,14 @@ acceptance("Composer", function (needs) {
     await fillIn("#reply-title", "This title doesn't matter");
     await fillIn(".d-editor-input", "custom message");
     await click("#reply-control button.create");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".bootbox .modal-body").text(),
       "This is a custom response"
     );
-    assert.equal(currentURL(), "/", "it doesn't change routes");
+    assert.strictEqual(currentURL(), "/", "it doesn't change routes");
 
     await click(".bootbox .btn-primary");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/faq",
       "can navigate to a `route_to` destination"
@@ -200,7 +200,7 @@ acceptance("Composer", function (needs) {
 
     await fillIn(".d-editor-input", "this is the content of my reply");
     await click("#reply-control button.create");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".cooked:last p").text(),
       "If you use gettext format you could leverage Launchpad 13 translations and the community behind it."
     );
@@ -217,7 +217,7 @@ acceptance("Composer", function (needs) {
 
     await click(".modal-footer button.keep-editing");
     assert.ok(invisible(".discard-draft-modal.modal"));
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "this is the content of my reply",
       "composer does not switch when using Keep Editing button"
@@ -227,7 +227,7 @@ acceptance("Composer", function (needs) {
     await click(".modal-footer button.save-draft");
     assert.ok(invisible(".discard-draft-modal.modal"));
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       queryAll(".topic-post:nth-of-type(1) .cooked > p").text(),
       "composer has contents of post to be edited"
@@ -243,12 +243,15 @@ acceptance("Composer", function (needs) {
     );
 
     await visit("/t/1-3-0beta9-no-rate-limit-popups/28830");
-    assert.equal(currentURL(), "/t/1-3-0beta9-no-rate-limit-popups/28830");
+    assert.strictEqual(
+      currentURL(),
+      "/t/1-3-0beta9-no-rate-limit-popups/28830"
+    );
     await click("#reply-control button.create");
     assert.ok(visible(".reply-where-modal"), "it pops up a modal");
 
     await click(".btn-reply-here");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".cooked:last p").text(),
       "If you use gettext format you could leverage Launchpad 13 translations and the community behind it."
     );
@@ -260,7 +263,7 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", "this is the content of the first reply");
 
     await visit("/t/this-is-a-test-topic/9");
-    assert.equal(currentURL(), "/t/this-is-a-test-topic/9");
+    assert.strictEqual(currentURL(), "/t/this-is-a-test-topic/9");
     await click("#topic-footer-buttons .btn.create");
     assert.ok(
       exists(".discard-draft-modal.modal"),
@@ -278,7 +281,7 @@ acceptance("Composer", function (needs) {
 
     await click(".modal-footer button.discard-draft");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "",
       "discards draft and reset composer textarea"
@@ -322,7 +325,7 @@ acceptance("Composer", function (needs) {
 
     await click(".topic-post:nth-of-type(1) button.show-more-actions");
     await click(".topic-post:nth-of-type(1) button.edit");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().indexOf("Any plans to support"),
       0,
       "it populates the input with the post text"
@@ -369,11 +372,11 @@ acceptance("Composer", function (needs) {
     await promise;
 
     // at this point, request is in flight, so post is staged
-    assert.equal(count(".topic-post.staged"), 1);
+    assert.strictEqual(count(".topic-post.staged"), 1);
     assert.ok(
       find(".topic-post:nth-of-type(1)")[0].className.includes("staged")
     );
-    assert.equal(
+    assert.strictEqual(
       find(".topic-post.staged .cooked").text().trim(),
       "will return empty json"
     );
@@ -382,7 +385,7 @@ acceptance("Composer", function (needs) {
     window.resolveLastPromise();
     await visit("/t/internationalization-localization/280");
 
-    assert.equal(count(".topic-post.staged"), 0);
+    assert.strictEqual(count(".topic-post.staged"), 0);
   });
 
   QUnit.skip(
@@ -397,7 +400,7 @@ acceptance("Composer", function (needs) {
       await click("#reply-control button.create");
 
       assert.ok(!exists(".topic-post.staged"));
-      assert.equal(
+      assert.strictEqual(
         find(".topic-post .cooked")[0].innerText,
         "Any plans to support localization of UI elements, so that I (for example) could set up a completely German speaking forum?"
       );
@@ -410,13 +413,13 @@ acceptance("Composer", function (needs) {
     await visit("/t/this-is-a-test-topic/9");
 
     await click(".topic-post:nth-of-type(1) button.edit");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
     );
     await click(".topic-post:nth-of-type(2) button.edit");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
       "it populates the input with the post text"
@@ -435,7 +438,7 @@ acceptance("Composer", function (needs) {
     );
 
     await click(".modal-footer button.discard-draft");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
       "it populates the input with the post text"
@@ -446,15 +449,19 @@ acceptance("Composer", function (needs) {
     await visit("/t/this-is-a-test-topic/9");
 
     await click(".topic-post:nth-of-type(1) button.edit");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
     );
     await click(".topic-post:nth-of-type(1) button.reply");
-    assert.equal(queryAll(".d-editor-input").val(), "", "it clears the input");
+    assert.strictEqual(
+      queryAll(".d-editor-input").val(),
+      "",
+      "it clears the input"
+    );
     await click(".topic-post:nth-of-type(1) button.edit");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
@@ -470,7 +477,7 @@ acceptance("Composer", function (needs) {
     await menu.expand();
     await menu.selectRowByValue("toggleWhisper");
 
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-far-eye-slash"),
       1,
       "it sets the post type to whisper"
@@ -501,7 +508,7 @@ acceptance("Composer", function (needs) {
     await visit("/t/this-is-a-test-topic/9");
     await click(".topic-post:nth-of-type(1) button.reply");
 
-    assert.equal(
+    assert.strictEqual(
       count("#reply-control.open"),
       1,
       "it starts in open state by default"
@@ -509,7 +516,7 @@ acceptance("Composer", function (needs) {
 
     await click(".toggle-fullscreen");
 
-    assert.equal(
+    assert.strictEqual(
       count("#reply-control.fullscreen"),
       1,
       "it expands composer to full screen"
@@ -517,7 +524,7 @@ acceptance("Composer", function (needs) {
 
     await click(".toggle-fullscreen");
 
-    assert.equal(
+    assert.strictEqual(
       count("#reply-control.open"),
       1,
       "it collapses composer to regular size"
@@ -526,7 +533,7 @@ acceptance("Composer", function (needs) {
     await fillIn(".d-editor-input", "This is a dirty reply");
     await click(".toggler");
 
-    assert.equal(
+    assert.strictEqual(
       count("#reply-control.draft"),
       1,
       "it collapses composer to draft bar"
@@ -534,7 +541,7 @@ acceptance("Composer", function (needs) {
 
     await click(".toggle-fullscreen");
 
-    assert.equal(
+    assert.strictEqual(
       count("#reply-control.open"),
       1,
       "from draft, it expands composer back to open state"
@@ -550,7 +557,7 @@ acceptance("Composer", function (needs) {
       "toggleWhisper"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-far-eye-slash"),
       1,
       "it sets the post type to whisper"
@@ -597,7 +604,7 @@ acceptance("Composer", function (needs) {
       "it pops up a confirmation dialog"
     );
     await click(".modal-footer button.discard-draft");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().indexOf("This is the first post."),
       0,
       "it populates the input with the post text"
@@ -615,18 +622,18 @@ acceptance("Composer", function (needs) {
       exists(".discard-draft-modal.modal"),
       "it pops up a confirmation dialog"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-footer button.save-draft").text().trim(),
       I18n.t("post.cancel_composer.save_draft"),
       "has save draft button"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-footer button.keep-editing").text().trim(),
       I18n.t("post.cancel_composer.keep_editing"),
       "has keep editing button"
     );
     await click(".modal-footer button.save-draft");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().indexOf("This is the second post."),
       0,
       "it populates the input with the post text"
@@ -646,18 +653,18 @@ acceptance("Composer", function (needs) {
       exists(".discard-draft-modal.modal"),
       "it pops up a confirmation dialog"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-footer button.save-draft").text().trim(),
       I18n.t("post.cancel_composer.save_draft"),
       "has save draft button"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-footer button.keep-editing").text().trim(),
       I18n.t("post.cancel_composer.keep_editing"),
       "has keep editing button"
     );
     await click(".modal-footer button.save-draft");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "",
       "it clears the composer input"
@@ -673,7 +680,7 @@ acceptance("Composer", function (needs) {
       await click(".topic-post:nth-of-type(1) button.show-more-actions");
       await click(".topic-post:nth-of-type(1) button.edit");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".modal-body").text(),
         I18n.t("drafts.abandon.confirm")
       );
@@ -752,7 +759,7 @@ acceptance("Composer", function (needs) {
       await click(".modal .btn-default");
 
       const privateMessageUsers = selectKit("#private-message-users");
-      assert.equal(privateMessageUsers.header().value(), "codinghorror");
+      assert.strictEqual(privateMessageUsers.header().value(), "codinghorror");
     } finally {
       toggleCheckDraftPopup(false);
     }
@@ -771,14 +778,17 @@ acceptance("Composer", function (needs) {
     );
 
     await visit("/latest");
-    assert.equal(
+    assert.strictEqual(
       queryAll("#create-topic").text().trim(),
       I18n.t("topic.open_draft")
     );
 
     await click("#create-topic");
-    assert.equal(selectKit(".category-chooser").header().value(), "2");
-    assert.equal(selectKit(".mini-tag-chooser").header().value(), "fun,times");
+    assert.strictEqual(selectKit(".category-chooser").header().value(), "2");
+    assert.strictEqual(
+      selectKit(".mini-tag-chooser").header().value(),
+      "fun,times"
+    );
   });
 
   test("Deleting the text content of the first post in a private message", async function (assert) {
@@ -790,7 +800,7 @@ acceptance("Composer", function (needs) {
 
     await fillIn(".d-editor-input", "");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-container textarea").attr("placeholder"),
       I18n.t("composer.reply_placeholder"),
       "it should not block because of missing category"
@@ -798,7 +808,7 @@ acceptance("Composer", function (needs) {
   });
 
   const assertImageResized = (assert, uploads) => {
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       uploads.join("\n"),
       "it resizes uploaded image"
@@ -808,12 +818,12 @@ acceptance("Composer", function (needs) {
   test("reply button has envelope icon when replying to private message", async function (assert) {
     await visit("/t/34");
     await click("article#post_3 button.reply");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".save-or-cancel button.create").text().trim(),
       I18n.t("composer.create_pm"),
       "reply button says Message"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".save-or-cancel button.create svg.d-icon-envelope"),
       1,
       "reply button has envelope icon"
@@ -825,12 +835,12 @@ acceptance("Composer", function (needs) {
     await click("article#post_3 button.show-more-actions");
     await click("article#post_3 button.edit");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".save-or-cancel button.create").text().trim(),
       I18n.t("composer.save_edit"),
       "save button says Save Edit"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".save-or-cancel button.create svg.d-icon-pencil-alt"),
       1,
       "save button has pencil icon"
@@ -871,7 +881,7 @@ acceptance("Composer", function (needs) {
 
     await fillIn(".d-editor-input", uploads.join("\n"));
 
-    assert.equal(
+    assert.strictEqual(
       count(".button-wrapper"),
       10,
       "it adds correct amount of scaling button groups"
@@ -981,7 +991,7 @@ acceptance("Composer", function (needs) {
     assert.ok(!exists(".composer-popup"));
 
     await fillIn(".d-editor-input", "[](https://github.com)");
-    assert.equal(count(".composer-popup"), 1);
+    assert.strictEqual(count(".composer-popup"), 1);
   });
 
   test("Shows the 'group_mentioned' notice", async function (assert) {
@@ -1042,16 +1052,19 @@ acceptance("Composer - Customizations", function (needs) {
   test("Supports text customization", async function (assert) {
     await visit("/");
     await click("#create-topic");
-    assert.equal(query(".action-title").innerText, I18n.t("topic.create_long"));
-    assert.equal(
+    assert.strictEqual(
+      query(".action-title").innerText,
+      I18n.t("topic.create_long")
+    );
+    assert.strictEqual(
       query(".save-or-cancel button").innerText,
       I18n.t("composer.create_topic")
     );
     const tags = selectKit(".mini-tag-chooser");
     await tags.expand();
     await tags.selectRowByValue("monkey");
-    assert.equal(query(".action-title").innerText, "custom text");
-    assert.equal(
+    assert.strictEqual(query(".action-title").innerText, "custom text");
+    assert.strictEqual(
       query(".save-or-cancel button").innerText,
       I18n.t("composer.emoji")
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-topic-links-test.js
@@ -26,7 +26,7 @@ acceptance("Composer topic featured links", function (needs) {
       exists(".d-editor-textarea-wrapper .popup-tip.good"),
       "the body is now good"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".title-input input").val(),
       "An interesting article",
       "title is from the oneboxed article"
@@ -45,7 +45,7 @@ acceptance("Composer topic featured links", function (needs) {
       exists(".d-editor-textarea-wrapper .popup-tip.good"),
       "the body is now good"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".title-input input").val(),
       "http://www.example.com/no-title.html",
       "title is unchanged"
@@ -56,7 +56,7 @@ acceptance("Composer topic featured links", function (needs) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "https://www.youtube.com/watch?v=dQw4w9WgXcQ");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".title-input input").val(),
       "Rick Astley - Never Gonna Give You Up (Video)",
       "title is from the oneboxed article"
@@ -75,7 +75,7 @@ acceptance("Composer topic featured links", function (needs) {
       exists(".d-editor-textarea-wrapper .popup-tip.good"),
       "link is pasted into body"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".title-input input").val(),
       "http://www.example.com/nope-onebox.html",
       "title is unchanged"
@@ -87,17 +87,17 @@ acceptance("Composer topic featured links", function (needs) {
     await click("#create-topic");
     const title = "http://" + window.location.hostname + "/internal-page.html";
     await fillIn("#reply-title", title);
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview").html().trim().indexOf("onebox"),
       -1,
       "onebox preview doesn't show"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().length,
       0,
       "link isn't put into the post"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".title-input input").val(),
       title,
       "title is unchanged"
@@ -119,7 +119,7 @@ acceptance("Composer topic featured links", function (needs) {
       exists(".d-editor-textarea-wrapper .popup-tip.good"),
       "the body is now good"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".title-input input").val(),
       "An interesting article",
       "title is from the oneboxed article"
@@ -130,17 +130,17 @@ acceptance("Composer topic featured links", function (needs) {
     await visit("/");
     await click("#create-topic");
     await fillIn("#reply-title", "http://www.example.com/has-title.html test");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview").html().trim().indexOf("onebox"),
       -1,
       "onebox preview doesn't show"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().length,
       0,
       "link isn't put into the post"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".title-input input").val(),
       "http://www.example.com/has-title.html test",
       "title is unchanged"
@@ -193,7 +193,7 @@ acceptance(
         exists(".d-editor-textarea-wrapper .popup-tip.good"),
         "the body is now good"
       );
-      assert.equal(
+      assert.strictEqual(
         queryAll(".title-input input").val(),
         "An interesting article",
         "title is from the oneboxed article"

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
@@ -71,7 +71,7 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
     const done = assert.async();
 
     appEvents.on("composer:all-uploads-complete", () => {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".d-editor-input").val(),
         "The image:\n![avatar.PNG|690x320](upload://yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg)\n"
       );
@@ -79,7 +79,7 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
     });
 
     appEvents.on("composer:upload-started", () => {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".d-editor-input").val(),
         "The image:\n[Uploading: avatar.png...]()\n"
       );
@@ -98,7 +98,7 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
     const image2 = createFile("avatar2.png");
     const done = assert.async();
     appEvents.on("composer:uploads-aborted", async () => {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".bootbox .modal-body").html(),
         I18n.t("post.errors.too_many_dragged_and_dropped_files", {
           count: 2,
@@ -122,7 +122,7 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
     const done = assert.async();
 
     appEvents.on("composer:uploads-aborted", async () => {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".bootbox .modal-body").html(),
         I18n.t("post.errors.upload_not_authorized", {
           authorized_extensions: authorizedExtensions(
@@ -153,7 +153,7 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
   //   const done = assert.async();
 
   //   appEvents.on("composer:uploads-cancelled", () => {
-  //     assert.equal(
+  //     assert.strictEqual(
   //       queryAll(".d-editor-input").val(),
   //       "The image:\n",
   //       "it should clear the cancelled placeholders"
@@ -166,7 +166,7 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
   //     uploadStarted++;
 
   //     if (uploadStarted === 2) {
-  //       assert.equal(
+  //       assert.strictEqual(
   //         queryAll(".d-editor-input").val(),
   //         "The image:\n[Uploading: avatar.png...]()\n[Uploading: avatar2.png...]()\n",
   //         "it should show the upload placeholders when the upload starts"
@@ -209,7 +209,7 @@ acceptance("Uppy Composer Attachment - Upload Error", function (needs) {
     const done = assert.async();
 
     appEvents.on("composer:upload-error", async () => {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".bootbox .modal-body").html(),
         "There was an error uploading the file, the gif was way too cool.",
         "it should show the error message from the server"
@@ -248,7 +248,7 @@ acceptance("Uppy Composer Attachment - Upload Handler", function (needs) {
     const done = assert.async();
 
     appEvents.on("composer:uploads-aborted", async () => {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".bootbox .modal-body").html(),
         "This is an upload handler test for handlertest.png",
         "it should show the bootbox triggered by the upload handler"

--- a/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-account-user-fields-test.js
@@ -38,7 +38,7 @@ acceptance("Create Account - User Fields", function (needs) {
     assert.ok(exists(".user-field"), "it has at least one user field");
 
     await click(".modal-footer .btn-primary");
-    assert.equal(
+    assert.strictEqual(
       query("#account-email-validation").innerText.trim(),
       "Please enter an email address"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
@@ -52,7 +52,7 @@ acceptance("Invites - Create & Edit Invite Modal", function (needs) {
   test("basic functionality", async function (assert) {
     await visit("/u/eviltrout/invited/pending");
     await click(".user-invite-buttons .btn:first-child");
-    assert.equal(
+    assert.strictEqual(
       find("input.invite-link")[0].value,
       "http://example.com/invites/52641ae8878790bc7b79916247cfe6ba",
       "shows an invite link when modal is opened"
@@ -75,7 +75,11 @@ acceptance("Invites - Create & Edit Invite Modal", function (needs) {
 
     await click(".btn-primary");
 
-    assert.equal(count("tbody tr"), 1, "adds invite to list after saving");
+    assert.strictEqual(
+      count("tbody tr"),
+      1,
+      "adds invite to list after saving"
+    );
 
     await click(".modal-close");
     assert.notOk(deleted, "does not delete invite on close");
@@ -97,7 +101,7 @@ acceptance("Invites - Create & Edit Invite Modal", function (needs) {
 
     await fillIn("#invite-email", "error");
     await click(".invite-link .btn");
-    assert.equal(
+    assert.strictEqual(
       find("#modal-alert").text(),
       "error isn't a valid email address."
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-set-test.js
@@ -18,7 +18,7 @@ acceptance("CustomHTML set", function () {
     setCustomHTML("top", '<span class="custom-html-test">HTML</span>');
 
     await visit("/static/faq");
-    assert.equal(
+    assert.strictEqual(
       queryAll("span.custom-html-test").text(),
       "HTML",
       "it inserted the markup"
@@ -31,7 +31,7 @@ acceptance("CustomHTML set", function () {
     });
 
     await visit("/static/faq");
-    assert.equal(
+    assert.strictEqual(
       queryAll("span.cookie").text(),
       "monster",
       "it inserted the markup"

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -14,7 +14,7 @@ acceptance("CustomHTML template", function (needs) {
 
   test("renders custom template", async function (assert) {
     await visit("/static/faq");
-    assert.equal(
+    assert.strictEqual(
       queryAll("span.top-span").text(),
       "TOP",
       "it inserted the template"

--- a/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
@@ -123,7 +123,7 @@ acceptance("Dashboard", function (needs) {
 
     assert.strictEqual(
       groupFilter.header().value(),
-      88,
+      "88",
       "its set the value of the filter from the query params"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dashboard-test.js
@@ -58,7 +58,7 @@ acceptance("Dashboard", function (needs) {
       "new-contributors report"
     );
 
-    assert.equal(
+    assert.strictEqual(
       $(".section.dashboard-problems .problem-messages ul li:first-child")
         .html()
         .trim(),
@@ -80,7 +80,7 @@ acceptance("Dashboard", function (needs) {
     await visit("/admin");
     await click(".dashboard .navigation-item.reports .navigation-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".dashboard .reports-index.section .reports-list .report")
         .length,
       1
@@ -88,7 +88,7 @@ acceptance("Dashboard", function (needs) {
 
     await fillIn(".dashboard .filter-reports-input", "flags");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".dashboard .reports-index.section .reports-list .report")
         .length,
       0
@@ -97,7 +97,7 @@ acceptance("Dashboard", function (needs) {
     await click(".dashboard .navigation-item.security .navigation-link");
     await click(".dashboard .navigation-item.reports .navigation-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".dashboard .reports-index.section .reports-list .report")
         .length,
       1,
@@ -106,7 +106,7 @@ acceptance("Dashboard", function (needs) {
 
     await fillIn(".dashboard .filter-reports-input", "activities");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".dashboard .reports-index.section .reports-list .report")
         .length,
       1,
@@ -121,7 +121,7 @@ acceptance("Dashboard", function (needs) {
 
     const groupFilter = selectKit(".group-filter .combo-box");
 
-    assert.equal(
+    assert.strictEqual(
       groupFilter.header().value(),
       88,
       "its set the value of the filter from the query params"

--- a/app/assets/javascripts/discourse/tests/acceptance/do-not-disturb-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/do-not-disturb-test.js
@@ -56,7 +56,10 @@ acceptance("Do not disturb", function (needs) {
     await visit("/");
     await click(".header-dropdown-toggle.current-user");
     await click(".menu-links-row .user-preferences-link");
-    assert.equal(query(".do-not-disturb .relative-date").textContent, "1h");
+    assert.strictEqual(
+      query(".do-not-disturb .relative-date").textContent,
+      "1h"
+    );
 
     await click(".do-not-disturb");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/edit-notification-click-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/edit-notification-click-test.js
@@ -43,12 +43,12 @@ acceptance("Edit Notification Click", function (needs) {
     await click(".d-header-icons #current-user");
     await click("#quick-access-notifications .edited");
     const [v1, v2] = queryAll(".history-modal .revision-content");
-    assert.equal(
+    assert.strictEqual(
       v1.textContent.trim(),
       "Hello world this is a test",
       "history modal for the edited post is shown"
     );
-    assert.equal(
+    assert.strictEqual(
       v2.textContent.trim(),
       "Hello world this is a testThis is an edit!",
       "history modal for the edited post is shown"

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
@@ -34,7 +34,7 @@ acceptance("EmojiPicker", function (needs) {
     await click("button.emoji.btn");
     await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       ":grinning:",
       "it adds the emoji code in the editor when selected"
@@ -49,7 +49,7 @@ acceptance("EmojiPicker", function (needs) {
     await fillIn(".d-editor-input", "This is a test input");
     await click("button.emoji.btn");
     await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "This is a test input :grinning:",
       "it adds the emoji code and a leading whitespace when there is text"
@@ -59,7 +59,7 @@ acceptance("EmojiPicker", function (needs) {
     await fillIn(".d-editor-input", "This is a test input ");
     await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       "This is a test input :grinning:",
       "it adds the emoji code and no leading whitespace when user already entered whitespace"
@@ -111,14 +111,14 @@ acceptance("EmojiPicker", function (needs) {
     await click(".emoji-picker-emoji-area img.emoji[title='sunglasses']");
     await click(".emoji-picker-emoji-area img.emoji[title='grinning']");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll('.section[data-section="recent"] .section-group img.emoji')
         .length,
       2,
       "it has multiple recent emojis"
     );
 
-    assert.equal(
+    assert.strictEqual(
       /grinning/.test(
         queryAll(".section.recent .section-group img.emoji").first().attr("src")
       ),

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -11,7 +11,7 @@ acceptance("Emoji", function (needs) {
     await click("#topic-footer-buttons .btn.create");
 
     await fillIn(".d-editor-input", "this is an emoji :blonde_woman:");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview:visible").html().trim(),
       `<p>this is an emoji <img src="/images/emoji/google_classic/blonde_woman.png?v=${v}" title=":blonde_woman:" class="emoji" alt=":blonde_woman:"></p>`
     );
@@ -22,7 +22,7 @@ acceptance("Emoji", function (needs) {
     await click("#topic-footer-buttons .btn.create");
 
     await fillIn(".d-editor-input", "this is an emoji :blonde_woman:t5:");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview:visible").html().trim(),
       `<p>this is an emoji <img src="/images/emoji/google_classic/blonde_woman/5.png?v=${v}" title=":blonde_woman:t5:" class="emoji" alt=":blonde_woman:t5:"></p>`
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/enforce-second-factor-test.js
@@ -34,7 +34,7 @@ acceptance("Enforce Second Factor", function (needs) {
 
     await catchAbortedTransition();
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".control-label").text(),
       "Password",
       "it will not transition from second-factor preferences"
@@ -43,7 +43,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await click("#toggle-hamburger-menu");
     await click("a.admin-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".control-label").text(),
       "Password",
       "it stays at second-factor preferences"
@@ -58,7 +58,7 @@ acceptance("Enforce Second Factor", function (needs) {
 
     await catchAbortedTransition();
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".control-label").text(),
       "Password",
       "it will not transition from second-factor preferences"
@@ -67,7 +67,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await click("#toggle-hamburger-menu");
     await click("a.about-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".control-label").text(),
       "Password",
       "it stays at second-factor preferences"
@@ -83,7 +83,7 @@ acceptance("Enforce Second Factor", function (needs) {
 
     await catchAbortedTransition();
 
-    assert.notEqual(
+    assert.notStrictEqual(
       queryAll(".control-label").text(),
       "Password",
       "it will transition from second-factor preferences"
@@ -92,7 +92,7 @@ acceptance("Enforce Second Factor", function (needs) {
     await click("#toggle-hamburger-menu");
     await click("a.about-link");
 
-    assert.notEqual(
+    assert.notStrictEqual(
       queryAll(".control-label").text(),
       "Password",
       "it is possible to navigate to other pages"

--- a/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
@@ -22,7 +22,7 @@ acceptance("Fast Edit", function (needs) {
     await click(".quote-button .quote-edit-label");
 
     assert.ok(exists("#fast-edit-input"), "fast editor is open");
-    assert.equal(
+    assert.strictEqual(
       queryAll("#fast-edit-input").val(),
       "Any plans",
       "contains selected text"
@@ -43,7 +43,7 @@ acceptance("Fast Edit", function (needs) {
     await triggerKeyEvent(document, "keypress", "e".charCodeAt(0));
 
     assert.ok(exists("#fast-edit-input"), "fast editor is open");
-    assert.equal(
+    assert.strictEqual(
       queryAll("#fast-edit-input").val(),
       "Any plans",
       "contains selected text"

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -141,14 +141,14 @@ acceptance("flagging", function (needs) {
     await silenceUntilCombobox.selectRowByValue("tomorrow");
     await fillIn(".silence-reason", "for breaking the rules");
     await click(".d-modal-cancel");
-    assert.equal(count(".bootbox.modal:visible"), 1);
+    assert.strictEqual(count(".bootbox.modal:visible"), 1);
 
     await click(".modal-footer .btn-default");
     assert.ok(!exists(".bootbox.modal:visible"));
     assert.ok(exists(".silence-user-modal"), "it shows the silence modal");
 
     await click(".d-modal-cancel");
-    assert.equal(count(".bootbox.modal:visible"), 1);
+    assert.strictEqual(count(".bootbox.modal:visible"), 1);
 
     await click(".modal-footer .btn-primary");
     assert.ok(!exists(".bootbox.modal:visible"));

--- a/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/forgot-password-test.js
@@ -23,7 +23,7 @@ acceptance("Forgot password", function (needs) {
     await click("header .login-button");
     await click("#forgot-password-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".forgot-password-reset").attr("disabled"),
       "disabled",
       "it should disable the button until the field is filled"
@@ -32,7 +32,7 @@ acceptance("Forgot password", function (needs) {
     await fillIn("#username-or-email", "someuser");
     await click(".forgot-password-reset");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".alert-error").html().trim(),
       I18n.t("forgot_password.complete_username_not_found", {
         username: "someuser",
@@ -43,7 +43,7 @@ acceptance("Forgot password", function (needs) {
     await fillIn("#username-or-email", "someuser@gmail.com");
     await click(".forgot-password-reset");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".alert-error").html().trim(),
       I18n.t("forgot_password.complete_email_not_found", {
         email: "someuser@gmail.com",
@@ -62,7 +62,7 @@ acceptance("Forgot password", function (needs) {
       "it should remove the flash error when succeeding"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-body").html().trim(),
       I18n.t("forgot_password.complete_username_found", {
         username: "someuser",
@@ -76,7 +76,7 @@ acceptance("Forgot password", function (needs) {
     await fillIn("#username-or-email", "someuser@gmail.com");
     await click(".forgot-password-reset");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-body").html().trim(),
       I18n.t("forgot_password.complete_email_found", {
         email: "someuser@gmail.com",
@@ -100,7 +100,7 @@ acceptance(
       await click("header .login-button");
       await click("#forgot-password-link");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".forgot-password-reset").attr("disabled"),
         "disabled",
         "it should disable the button until the field is filled"
@@ -109,7 +109,7 @@ acceptance(
       await fillIn("#username-or-email", "someuser");
       await click(".forgot-password-reset");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".modal-body").html().trim(),
         I18n.t("forgot_password.complete_username", {
           username: "someuser",

--- a/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
@@ -25,7 +25,7 @@ acceptance("Group Members - Anonymous", function () {
       "it does not allow anon user to manage group members"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".group-username-filter").attr("placeholder"),
       I18n.t("groups.members.filter_placeholder"),
       "it should display the right filter placeholder"
@@ -48,7 +48,7 @@ acceptance("Group Members", function (needs) {
     await visit("/g/discourse");
     await click(".group-members-add");
 
-    assert.equal(
+    assert.strictEqual(
       count(".user-chooser"),
       1,
       "it should display the add members modal"
@@ -63,7 +63,7 @@ acceptance("Group Members", function (needs) {
       "it allows admin user to manage group members"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".group-username-filter").attr("placeholder"),
       I18n.t("groups.members.filter_placeholder_admin"),
       "it should display the right filter placeholder"

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-categories-test.js
@@ -23,7 +23,7 @@ acceptance("Managing Group Category Notification Defaults", function (needs) {
   test("As an admin", async function (assert) {
     await visit("/g/discourse/manage/categories");
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-notifications-form .category-selector"),
       5,
       "it should display category inputs"
@@ -35,7 +35,7 @@ acceptance("Managing Group Category Notification Defaults", function (needs) {
 
     await visit("/g/discourse/manage/categories");
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-notifications-form .category-selector"),
       5,
       "it should display category inputs"

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
@@ -17,7 +17,7 @@ acceptance("Managing Group Email Settings - SMTP Disabled", function (needs) {
       query(".user-secondary-navigation").innerText.includes("Email"),
       "email link is not shown in the sidebar"
     );
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       "group.manage.profile",
       "it redirects to the group profile page"
@@ -37,7 +37,7 @@ acceptance(
         query(".user-secondary-navigation").innerText.includes("Email"),
         "email link is shown in the sidebar"
       );
-      assert.equal(
+      assert.strictEqual(
         currentRouteName(),
         "group.manage.email",
         "it redirects to the group email page"
@@ -84,12 +84,12 @@ acceptance(
       assert.ok(exists(".group-smtp-email-settings"));
 
       await click("#prefill_smtp_gmail");
-      assert.equal(
+      assert.strictEqual(
         query("input[name='smtp_server']").value,
         "smtp.gmail.com",
         "prefills SMTP server settings for gmail"
       );
-      assert.equal(
+      assert.strictEqual(
         query("input[name='smtp_port']").value,
         "587",
         "prefills SMTP port settings for gmail"
@@ -112,7 +112,7 @@ acceptance(
 
       await click(".group-manage-save");
 
-      assert.equal(
+      assert.strictEqual(
         query(".group-manage-save-button > span").innerText,
         "Saved!"
       );
@@ -123,7 +123,7 @@ acceptance(
       );
 
       await click("#enable_smtp");
-      assert.equal(
+      assert.strictEqual(
         query(".modal-body").innerText,
         I18n.t("groups.manage.email.smtp_disable_confirm"),
         "shows a confirm dialogue warning SMTP settings will be wiped"
@@ -155,12 +155,12 @@ acceptance(
       );
 
       await click("#prefill_imap_gmail");
-      assert.equal(
+      assert.strictEqual(
         query("input[name='imap_server']").value,
         "imap.gmail.com",
         "prefills IMAP server settings for gmail"
       );
-      assert.equal(
+      assert.strictEqual(
         query("input[name='imap_port']").value,
         "993",
         "prefills IMAP port settings for gmail"
@@ -175,7 +175,7 @@ acceptance(
 
       await click(".group-manage-save");
 
-      assert.equal(
+      assert.strictEqual(
         query(".group-manage-save-button > span").innerText,
         "Saved!"
       );
@@ -199,7 +199,7 @@ acceptance(
       );
 
       await click("#enable_imap");
-      assert.equal(
+      assert.strictEqual(
         query(".modal-body").innerText,
         I18n.t("groups.manage.email.imap_disable_confirm"),
         "shows a confirm dialogue warning IMAP settings will be wiped"
@@ -277,38 +277,38 @@ acceptance(
       assert.notOk(exists("#enable_smtp:disabled"), "SMTP is not disabled");
       assert.notOk(exists("#enable_imap:disabled"), "IMAP is not disabled");
 
-      assert.equal(
+      assert.strictEqual(
         query("[name='username']").value,
         "test@test.com",
         "email username is prefilled"
       );
-      assert.equal(
+      assert.strictEqual(
         query("[name='password']").value,
         "password",
         "email password is prefilled"
       );
-      assert.equal(
+      assert.strictEqual(
         query("[name='smtp_server']").value,
         "smtp.gmail.com",
         "smtp server is prefilled"
       );
-      assert.equal(
+      assert.strictEqual(
         query("[name='smtp_port']").value,
         "587",
         "smtp port is prefilled"
       );
 
-      assert.equal(
+      assert.strictEqual(
         query("[name='imap_server']").value,
         "imap.gmail.com",
         "imap server is prefilled"
       );
-      assert.equal(
+      assert.strictEqual(
         query("[name='imap_port']").value,
         "993",
         "imap port is prefilled"
       );
-      assert.equal(
+      assert.strictEqual(
         selectKit("#imap_mailbox").header().value(),
         "INBOX",
         "imap mailbox is prefilled"
@@ -359,7 +359,7 @@ acceptance(
       await fillIn('input[name="password"]', "password@gmail.com");
       await click(".test-smtp-settings");
 
-      assert.equal(
+      assert.strictEqual(
         query(".modal-body").innerText,
         "There was an issue with the SMTP credentials provided, check the username and password and try again.",
         "shows a dialogue with the error message from the server"

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-interaction-test.js
@@ -20,31 +20,31 @@ acceptance("Managing Group Interaction Settings", function (needs) {
 
     await visit("/g/alternative-group/manage/interaction");
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-visibility-level"),
       1,
       "it should display visibility level selector"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-mentionable-level"),
       1,
       "it should display mentionable level selector"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-messageable-level"),
       1,
       "it should display messageable level selector"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-incoming-email"),
       1,
       "it should display incoming email input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-default-notification-level"),
       1,
       "it should display default notification level input"
@@ -60,31 +60,31 @@ acceptance("Managing Group Interaction Settings", function (needs) {
 
     await visit("/g/discourse/manage/interaction");
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-visibility-level"),
       0,
       "it should not display visibility level selector"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-mentionable-level"),
       1,
       "it should display mentionable level selector"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-messageable-level"),
       1,
       "it should display messageable level selector"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-incoming-email"),
       0,
       "it should not display incoming email input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-default-notification-level"),
       1,
       "it should display default notification level input"
@@ -101,7 +101,7 @@ acceptance(
       await visit("/g/alternative-group/manage/interaction");
 
       await assert.ok(exists(".groups-form"), "should have the form");
-      await assert.equal(
+      await assert.strictEqual(
         selectKit(".groups-form-default-notification-level").header().value(),
         "0",
         "it should select Muted as the notification level"
@@ -112,7 +112,7 @@ acceptance(
       await visit("/g/discourse/manage/interaction");
 
       await assert.ok(exists(".groups-form"), "should have the form");
-      await assert.equal(
+      await assert.strictEqual(
         selectKit(".groups-form-default-notification-level").header().value(),
         "3",
         "it should select Watching as the notification level"
@@ -123,7 +123,7 @@ acceptance(
       await visit("/g/support/manage/interaction");
 
       await assert.ok(exists(".groups-form"), "should have the form");
-      await assert.equal(
+      await assert.strictEqual(
         selectKit(".groups-form-default-notification-level").header().value(),
         "2",
         "it should select Tracking as the notification level"

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-logs-test.js
@@ -99,14 +99,14 @@ acceptance("Group logs", function (needs) {
 
   test("Browsing group logs", async function (assert) {
     await visit("/g/snorlax/manage/logs");
-    assert.equal(
+    assert.strictEqual(
       count("tr.group-manage-logs-row"),
       2,
       "it should display the right number of logs"
     );
 
     await click(query(".group-manage-logs-row button"));
-    assert.equal(
+    assert.strictEqual(
       count("tr.group-manage-logs-row"),
       1,
       "it should display the right number of logs"

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -16,49 +16,49 @@ acceptance("Managing Group Membership", function (needs) {
 
     await visit("/g/alternative-group/manage/membership");
 
-    assert.equal(
+    assert.strictEqual(
       count('label[for="automatic_membership"]'),
       1,
       "it should display automatic membership label"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-primary-group"),
       1,
       "it should display set as primary group checkbox"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-form-grant-trust-level"),
       1,
       "it should display grant trust level selector"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-public-admission"),
       1,
       "it should display group public admission input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-public-exit"),
       1,
       "it should display group public exit input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-allow-membership-requests"),
       1,
       "it should display group allow_membership_request input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-allow-membership-requests[disabled]"),
       1,
       "it should disable group allow_membership_request input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-flair-inputs"),
       1,
       "it should display avatar flair inputs"
@@ -67,7 +67,7 @@ acceptance("Managing Group Membership", function (needs) {
     await click(".group-form-public-admission");
     await click(".group-form-allow-membership-requests");
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-public-admission[disabled]"),
       1,
       "it should disable group public admission input"
@@ -78,7 +78,7 @@ acceptance("Managing Group Membership", function (needs) {
       "it should not disable group public exit input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-membership-request-template"),
       1,
       "it should display the membership request template field"
@@ -91,7 +91,7 @@ acceptance("Managing Group Membership", function (needs) {
     await emailDomains.fillInFilter("foo.com");
     await emailDomains.selectRowByValue("foo.com");
 
-    assert.equal(emailDomains.header().value(), "foo.com");
+    assert.strictEqual(emailDomains.header().value(), "foo.com");
   });
 
   test("As a group owner", async function (assert) {
@@ -119,25 +119,25 @@ acceptance("Managing Group Membership", function (needs) {
       "it should not display grant trust level selector"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-public-admission"),
       1,
       "it should display group public admission input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-public-exit"),
       1,
       "it should display group public exit input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-allow-membership-requests"),
       1,
       "it should display group allow_membership_request input"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-allow-membership-requests[disabled]"),
       1,
       "it should disable group allow_membership_request input"

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-profile-test.js
@@ -24,17 +24,17 @@ acceptance("Managing Group Profile", function (needs) {
   test("As an admin", async function (assert) {
     await visit("/g/discourse/manage/profile");
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-bio"),
       1,
       "it should display group bio input"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-name"),
       1,
       "it should display group name input"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-full-name"),
       1,
       "it should display group full name input"

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-tags-test.js
@@ -24,7 +24,7 @@ acceptance("Managing Group Tag Notification Defaults", function (needs) {
   test("As an admin", async function (assert) {
     await visit("/g/discourse/manage/tags");
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-notifications-form .tag-chooser"),
       5,
       "it should display tag inputs"
@@ -36,7 +36,7 @@ acceptance("Managing Group Tag Notification Defaults", function (needs) {
 
     await visit("/g/discourse/manage/tags");
 
-    assert.equal(
+    assert.strictEqual(
       count(".groups-notifications-form .tag-chooser"),
       5,
       "it should display tag inputs"

--- a/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-requests-test.js
@@ -89,23 +89,23 @@ acceptance("Group Requests", function (needs) {
   test("Group Requests", async function (assert) {
     await visit("/g/Macdonald/requests");
 
-    assert.equal(count(".group-members tr"), 2);
-    assert.equal(
+    assert.strictEqual(count(".group-members tr"), 2);
+    assert.strictEqual(
       queryAll(".group-members tr:first-child td:nth-child(1)")
         .text()
         .trim()
         .replace(/\s+/g, " "),
       "Robin Ward eviltrout"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".group-members tr:first-child td:nth-child(3)").text().trim(),
       "Please accept my membership request."
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".group-members tr:first-child .btn-primary").text().trim(),
       "Accept"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".group-members tr:first-child .btn-danger").text().trim(),
       "Deny"
     );
@@ -120,7 +120,7 @@ acceptance("Group Requests", function (needs) {
     assert.deepEqual(requests, [["19", "true"]]);
 
     await click(".group-members tr:last-child .btn-danger");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".group-members tr:last-child td:nth-child(4)").text().trim(),
       "denied"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -41,7 +41,7 @@ acceptance("Group - Anonymous", function (needs) {
     await click(".activity-nav li a[href='/g/discourse/activity/topics']");
 
     assert.ok(queryAll(".topic-list"), "it shows the topic list");
-    assert.equal(count(".topic-list-item"), 2, "it lists stream items");
+    assert.strictEqual(count(".topic-list-item"), 2, "it lists stream items");
 
     await click(".activity-nav li a[href='/g/discourse/activity/mentions']");
 
@@ -59,9 +59,9 @@ acceptance("Group - Anonymous", function (needs) {
     const groupDropdown = selectKit(".group-dropdown");
     await groupDropdown.expand();
 
-    assert.equal(groupDropdown.rowByIndex(1).name(), "discourse");
+    assert.strictEqual(groupDropdown.rowByIndex(1).name(), "discourse");
 
-    assert.equal(
+    assert.strictEqual(
       groupDropdown.rowByIndex(0).name(),
       I18n.t("groups.index.all")
     );
@@ -191,19 +191,19 @@ acceptance("Group - Authenticated", function (needs) {
     await visit("/g");
     await click(".group-index-request");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-header .title").text().trim(),
       I18n.t("groups.membership_request.title", { group_name: "Macdonald" })
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".request-group-membership-form textarea").val(),
       "Please add me"
     );
 
     await click(".modal-footer .btn-primary");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".fancy-title").text().trim(),
       "Internationalization / localization"
     );
@@ -212,9 +212,9 @@ acceptance("Group - Authenticated", function (needs) {
 
     await click(".group-message-button");
 
-    assert.equal(count("#reply-control"), 1, "it opens the composer");
+    assert.strictEqual(count("#reply-control"), 1, "it opens the composer");
     const privateMessageUsers = selectKit("#private-message-users");
-    assert.equal(
+    assert.strictEqual(
       privateMessageUsers.header().value(),
       "discourse",
       "it prefills the group name"
@@ -227,7 +227,7 @@ acceptance("Group - Authenticated", function (needs) {
     await visit("/g/alternative-group");
     await click(".nav-pills li a[title='Messages']");
 
-    assert.equal(
+    assert.strictEqual(
       query("span.empty-state-title").innerText.trim(),
       I18n.t("no_group_messages_title"),
       "it should display the right text"
@@ -238,7 +238,7 @@ acceptance("Group - Authenticated", function (needs) {
     await visit("/g/discourse");
     await click(".nav-pills li a[title='Messages']");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".topic-list-item .link-top-line").text().trim(),
       "This is a private message 1",
       "it should display the list of group topics"
@@ -247,7 +247,7 @@ acceptance("Group - Authenticated", function (needs) {
     await click("#search-button");
     await fillIn("#search-term", "smth");
 
-    assert.equal(
+    assert.strictEqual(
       query(
         ".search-menu .results .search-menu-assistant-item:first-child"
       ).innerText.trim(),
@@ -259,18 +259,18 @@ acceptance("Group - Authenticated", function (needs) {
   test("Admin Viewing Group", async function (assert) {
     await visit("/g/discourse");
 
-    assert.equal(
+    assert.strictEqual(
       count(".nav-pills li a[title='Manage']"),
       1,
       "it should show manage group tab if user is admin"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-message-button"),
       1,
       "it displays show group message button"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".group-info-name").text(),
       "Awesome Team",
       "it should display the group name"
@@ -278,7 +278,7 @@ acceptance("Group - Authenticated", function (needs) {
 
     await click(".group-details-button button.btn-danger");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".bootbox .modal-body").html(),
       I18n.t("admin.groups.delete_with_messages_confirm", {
         count: 2,
@@ -292,7 +292,7 @@ acceptance("Group - Authenticated", function (needs) {
   test("Moderator Viewing Group", async function (assert) {
     await visit("/g/alternative-group");
 
-    assert.equal(
+    assert.strictEqual(
       count(".nav-pills li a[title='Manage']"),
       1,
       "it should show manage group tab if user can_admin_group"
@@ -310,11 +310,11 @@ acceptance("Group - Authenticated", function (needs) {
     const memberDropdown = selectKit(".group-member-dropdown:nth-of-type(1)");
     await memberDropdown.expand();
 
-    assert.equal(
+    assert.strictEqual(
       memberDropdown.rowByIndex(0).name(),
       I18n.t("groups.members.remove_member")
     );
-    assert.equal(
+    assert.strictEqual(
       memberDropdown.rowByIndex(1).name(),
       I18n.t("groups.members.make_owner")
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-index-test.js
@@ -12,17 +12,17 @@ acceptance("Groups", function () {
   test("Browsing Groups", async function (assert) {
     await visit("/g?username=eviltrout");
 
-    assert.equal(count(".group-box"), 1, "it displays user's groups");
+    assert.strictEqual(count(".group-box"), 1, "it displays user's groups");
 
     await visit("/g");
 
-    assert.equal(count(".group-box"), 2, "it displays visible groups");
-    assert.equal(
+    assert.strictEqual(count(".group-box"), 2, "it displays visible groups");
+    assert.strictEqual(
       count(".group-index-join"),
       1,
       "it shows button to join group"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".group-index-request"),
       1,
       "it shows button to request for group membership"
@@ -42,7 +42,7 @@ acceptance("Groups", function () {
 
     await click("a[href='/g/discourse/members']");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".group-info-name").text().trim(),
       "Awesome Team",
       "it displays the group page"

--- a/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/groups-new-test.js
@@ -25,7 +25,7 @@ acceptance("New Group - Authenticated", function (needs) {
     await visit("/g");
     await click(".groups-header-new");
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-save[disabled]"),
       1,
       "save button should be disabled"
@@ -33,13 +33,13 @@ acceptance("New Group - Authenticated", function (needs) {
 
     await fillIn("input[name='name']", "1");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".tip.bad").text().trim(),
       I18n.t("admin.groups.new.name.too_short"),
       "it should show the right validation tooltip"
     );
 
-    assert.equal(
+    assert.strictEqual(
       count(".group-form-save:disabled"),
       1,
       "it should disable the save button"
@@ -50,7 +50,7 @@ acceptance("New Group - Authenticated", function (needs) {
       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".tip.bad").text().trim(),
       I18n.t("admin.groups.new.name.too_long"),
       "it should show the right validation tooltip"
@@ -58,7 +58,7 @@ acceptance("New Group - Authenticated", function (needs) {
 
     await fillIn("input[name='name']", "");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".tip.bad").text().trim(),
       I18n.t("admin.groups.new.name.blank"),
       "it should show the right validation tooltip"
@@ -66,7 +66,7 @@ acceptance("New Group - Authenticated", function (needs) {
 
     await fillIn("input[name='name']", "goodusername");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".tip.good").text().trim(),
       I18n.t("admin.groups.new.name.available"),
       "it should show the right validation tooltip"

--- a/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
@@ -19,7 +19,7 @@ acceptance(
       await visit("/");
       await click(".hamburger-dropdown");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".review .badge-notification.reviewables").text(),
         "3"
       );

--- a/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hashtags-test.js
@@ -32,7 +32,7 @@ category vs tag: #bug vs #bug::tag
 uppercase hashtag works too #BUG, #BUG::tag`
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-preview:visible").html().trim(),
       `<p>this is a category hashtag <a href="/c/bugs" class="hashtag" tabindex=\"-1\">#<span>bug</span></a></p>
 <p>this is a tag hashtag <a href="/tag/monkey" class="hashtag" tabindex=\"-1\">#<span>monkey</span></a></p>

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -100,7 +100,7 @@ acceptance("Invite accept", function (needs) {
     await visit("/invites/myvalidinvitetoken");
     assert.ok(exists("#new-account-email"), "shows the email input");
     assert.ok(exists("#new-account-username"), "shows the username input");
-    assert.equal(
+    assert.strictEqual(
       queryAll("#new-account-username").val(),
       "invited",
       "username is prefilled"
@@ -277,18 +277,18 @@ acceptance("Invite link with authentication data", function (needs) {
       "email field is disabled"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("#account-email-validation").text().trim(),
       I18n.t("user.email.authenticated", { provider: "Facebook" })
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("#new-account-username").val(),
       "foobar",
       "username is prefilled"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("#new-account-name").val(),
       "barfoo",
       "name is prefilled"
@@ -312,7 +312,7 @@ acceptance("Email Invite link with authentication data", function (needs) {
 
     await visit("/invites/myvalidinvitetoken");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("#account-email-validation").text().trim(),
       I18n.t("user.email.invite_auth_email_invalid", { provider: "Facebook" })
     );
@@ -350,18 +350,18 @@ acceptance(
       );
       assert.ok(!exists("#new-account-email"), "does not show email field");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("#account-email-validation").text().trim(),
         I18n.t("user.email.authenticated", { provider: "Facebook" })
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("#new-account-username").val(),
         "foobar",
         "username is prefilled"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("#new-account-name").val(),
         "barfoo",
         "name is prefilled"
@@ -388,7 +388,7 @@ acceptance(
 
       await visit("/invites/myvalidinvitetoken");
 
-      assert.equal(
+      assert.strictEqual(
         query(".bad").textContent.trim(),
         "Your invitation email does not match the email authenticated by Facebook"
       );
@@ -416,7 +416,7 @@ acceptance(
 
       assert.ok(!exists("#new-account-email"), "does not show email field");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("#account-email-validation").text().trim(),
         I18n.t("user.email.authenticated_by_invite")
       );
@@ -444,7 +444,7 @@ acceptance(
 
       assert.ok(!exists("#new-account-email"), "does not show email field");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("#account-email-validation").text().trim(),
         I18n.t("user.email.ok")
       );

--- a/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
@@ -30,7 +30,7 @@ acceptance("Jump to", function (needs) {
     await fillIn("input.date-picker", "2014-02-24");
     await click(".jump-to-post-modal .btn-primary");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/t/internationalization-localization/280/3",
       "it jumps to the correct post"
@@ -44,7 +44,7 @@ acceptance("Jump to", function (needs) {
     await fillIn("input.date-picker", "2094-02-24");
     await click(".jump-to-post-modal .btn-primary");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/t/internationalization-localization/280/20",
       "it jumps to the last post if no post found"

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -34,18 +34,18 @@ acceptance("Keyboard Shortcuts - Anonymous Users", function (needs) {
     await visit("/t/this-is-a-test-topic/9");
     await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
-    assert.equal(currentURL(), "/t/this-is-a-test-topic/9");
+    assert.strictEqual(currentURL(), "/t/this-is-a-test-topic/9");
 
     // Suggested topics elements exist.
     await visit("/t/internationalization-localization/280");
     await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
-    assert.equal(currentURL(), "/t/polls-are-still-very-buggy/27331/4");
+    assert.strictEqual(currentURL(), "/t/polls-are-still-very-buggy/27331/4");
 
     await visit("/t/1-3-0beta9-no-rate-limit-popups/28830");
     await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
-    assert.equal(currentURL(), "/t/keyboard-shortcuts-are-awesome/27331");
+    assert.strictEqual(currentURL(), "/t/keyboard-shortcuts-are-awesome/27331");
   });
 });
 
@@ -99,12 +99,12 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
       exists("#dismiss-read-confirm"),
       "confirmation modal to dismiss unread is present"
     );
-    assert.equal(
+    assert.strictEqual(
       query(".modal-body").innerText,
       I18n.t("topics.bulk.also_dismiss_topics")
     );
     await click("#dismiss-read-confirm");
-    assert.equal(
+    assert.strictEqual(
       markReadCalled,
       1,
       "mark read has been called on the backend once"
@@ -129,13 +129,13 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
       exists("#dismiss-read-confirm"),
       "confirmation modal to dismiss unread is present"
     );
-    assert.equal(
+    assert.strictEqual(
       query(".modal-body").innerText,
       "Stop tracking these topics so they never show up as unread for me again"
     );
 
     await click("#dismiss-read-confirm");
-    assert.equal(
+    assert.strictEqual(
       markReadCalled,
       2,
       "mark read has been called on the backend twice"
@@ -154,7 +154,7 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
     assert.ok(exists("#dismiss-new-top"), "dismiss new top button is present");
     await triggerKeyEvent(document, "keypress", "x".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "r".charCodeAt(0));
-    assert.equal(resetNewCalled, 1);
+    assert.strictEqual(resetNewCalled, 1);
 
     // we get rid of all but one topic so the top dismiss button doesn't
     // show up, as it only appears if there are too many topics pushing
@@ -171,7 +171,7 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
     );
     await triggerKeyEvent(document, "keypress", "x".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "r".charCodeAt(0));
-    assert.equal(resetNewCalled, 2);
+    assert.strictEqual(resetNewCalled, 2);
 
     // restore the original topic list
     topicList.topic_list.topics = originalTopics;
@@ -195,6 +195,6 @@ acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {
     await triggerKeyEvent(document, "keypress", "x".charCodeAt(0));
     await triggerKeyEvent(document, "keypress", "r".charCodeAt(0));
 
-    assert.equal(resetNewCalled, 1);
+    assert.strictEqual(resetNewCalled, 1);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/login-redirect-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-redirect-test.js
@@ -5,7 +5,7 @@ import { test } from "qunit";
 acceptance("Login redirect - anonymous", function () {
   test("redirects login to default homepage", async function (assert) {
     await visit("/login");
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       "discovery.latest",
       "it works when latest is the homepage"
@@ -20,7 +20,7 @@ acceptance("Login redirect - categories default", function (needs) {
 
   test("when site setting is categories", async function (assert) {
     await visit("/login");
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       "discovery.categories",
       "it works when categories is the homepage"

--- a/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-required-test.js
@@ -11,10 +11,14 @@ acceptance("Login Required", function (needs) {
 
   test("redirect", async function (assert) {
     await visit("/latest");
-    assert.equal(currentRouteName(), "login", "it redirects them to login");
+    assert.strictEqual(
+      currentRouteName(),
+      "login",
+      "it redirects them to login"
+    );
 
     await click("#site-logo");
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       "login",
       "clicking the logo keeps them on login"

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-and-hide-email-address-taken-test.js
@@ -21,7 +21,7 @@ acceptance("Login with email - hide email address taken", function (needs) {
     await fillIn("#login-account-name", "someuser@example.com");
     await click("#email-login-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".alert-success").html().trim(),
       I18n.t("email_login.complete_email_found", {
         email: "someuser@example.com",

--- a/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/login-with-email-test.js
@@ -37,7 +37,7 @@ acceptance("Login with email", function (needs) {
     await fillIn("#login-account-name", "someuser");
     await click("#email-login-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".alert-error").html(),
       I18n.t("email_login.complete_username_not_found", {
         username: "someuser",
@@ -48,7 +48,7 @@ acceptance("Login with email", function (needs) {
     await fillIn("#login-account-name", "someuser@gmail.com");
     await click("#email-login-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".alert-error").html(),
       I18n.t("email_login.complete_email_not_found", {
         email: "someuser@gmail.com",
@@ -62,7 +62,7 @@ acceptance("Login with email", function (needs) {
 
     await click("#email-login-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".alert-success").html().trim(),
       I18n.t("email_login.complete_username_found", { username: "someuser" }),
       "it should display a success message for a valid username"
@@ -73,7 +73,7 @@ acceptance("Login with email", function (needs) {
     await fillIn("#login-account-name", "someuser@gmail.com");
     await click("#email-login-link");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".alert-success").html().trim(),
       I18n.t("email_login.complete_email_found", {
         email: "someuser@gmail.com",

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-discovery-test.js
@@ -13,7 +13,7 @@ acceptance("Topic Discovery - Mobile", function (needs) {
     assert.ok(exists(".topic-list"), "The list of topics was rendered");
     assert.ok(exists(".topic-list .topic-list-item"), "has topics");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("a[data-user-card=codinghorror] img.avatar").attr("loading"),
       "lazy",
       "it adds loading=`lazy` to topic list avatars"

--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-pan-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-pan-test.js
@@ -108,7 +108,7 @@ acceptance("Mobile - menu swipes", function (needs) {
       await triggerSwipeMove(swipe);
       await triggerSwipeEnd(swipe);
 
-      assert.equal(
+      assert.strictEqual(
         count(".panel-body"),
         1,
         "it should re-open hamburger on a right swipe"

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -36,20 +36,20 @@ acceptance("Modal", function (needs) {
     assert.ok(!exists(".d-modal:visible"), "there is no modal at first");
 
     await click(".login-button");
-    assert.equal(count(".d-modal:visible"), 1, "modal should appear");
+    assert.strictEqual(count(".d-modal:visible"), 1, "modal should appear");
 
     let controller = controllerFor("modal");
-    assert.equal(controller.name, "login");
+    assert.strictEqual(controller.name, "login");
 
     await click(".modal-outer-container");
     assert.ok(
       !exists(".d-modal:visible"),
       "modal should disappear when you click outside"
     );
-    assert.equal(controller.name, null);
+    assert.strictEqual(controller.name, null);
 
     await click(".login-button");
-    assert.equal(count(".d-modal:visible"), 1, "modal should reappear");
+    assert.strictEqual(count(".d-modal:visible"), 1, "modal should reappear");
 
     await triggerKeyEvent("#main-outlet", "keyup", 27);
     assert.ok(!exists(".d-modal:visible"), "ESC should close the modal");
@@ -60,16 +60,16 @@ acceptance("Modal", function (needs) {
 
     run(() => showModal("not-dismissable", {}));
 
-    assert.equal(count(".d-modal:visible"), 1, "modal should appear");
+    assert.strictEqual(count(".d-modal:visible"), 1, "modal should appear");
 
     await click(".modal-outer-container");
-    assert.equal(
+    assert.strictEqual(
       count(".d-modal:visible"),
       1,
       "modal should not disappear when you click outside"
     );
     await triggerKeyEvent("#main-outlet", "keyup", 27);
-    assert.equal(
+    assert.strictEqual(
       count(".d-modal:visible"),
       1,
       "ESC should not close the modal"
@@ -86,7 +86,7 @@ acceptance("Modal", function (needs) {
     await visit("/");
     run(() => showModal("test-raw-title-panels", { panels }));
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-modal .modal-tab:first-child").text().trim(),
       "Test 1",
       "it should display the raw title"
@@ -102,7 +102,7 @@ acceptance("Modal", function (needs) {
     await visit("/");
 
     run(() => showModal("test-title", { title: "test_title" }));
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-modal .title").text().trim(),
       "Test title",
       "it should display the title"
@@ -111,7 +111,7 @@ acceptance("Modal", function (needs) {
     await click(".d-modal .close");
 
     run(() => showModal("test-title-with-body", { title: "test_title" }));
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-modal .title").text().trim(),
       "Test title",
       "it should display the title when used with d-modal-body"
@@ -136,12 +136,12 @@ acceptance("Modal Keyboard Events", function (needs) {
     await click(".admin-topic-timer-update button");
     await triggerKeyEvent(".d-modal", "keydown", 13);
 
-    assert.equal(
+    assert.strictEqual(
       count("#modal-alert:visible"),
       1,
       "hitting Enter triggers modal action"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".d-modal:visible"),
       1,
       "hitting Enter does not dismiss modal due to alert error"

--- a/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-message-test.js
@@ -26,19 +26,19 @@ acceptance("New Message - Authenticated", function (needs) {
     );
 
     assert.ok(exists(".composer-fields"), "it opens composer");
-    assert.equal(
+    assert.strictEqual(
       queryAll("#reply-title").val().trim(),
       "message title",
       "it pre-fills message title"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().trim(),
       "message body",
       "it pre-fills message body"
     );
 
     const privateMessageUsers = selectKit("#private-message-users");
-    assert.equal(
+    assert.strictEqual(
       privateMessageUsers.header().value(),
       "charlie",
       "it selects correct username"

--- a/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
@@ -23,17 +23,17 @@ acceptance("New Topic - Authenticated", function (needs) {
     );
 
     assert.ok(exists(".composer-fields"), "it opens composer");
-    assert.equal(
+    assert.strictEqual(
       queryAll("#reply-title").val().trim(),
       "topic title",
       "it pre-fills topic title"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().trim(),
       "topic body",
       "it pre-fills topic body"
     );
-    assert.equal(
+    assert.strictEqual(
       selectKit(".category-chooser").header().value(),
       1,
       "it selects desired category"

--- a/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/new-topic-test.js
@@ -35,7 +35,7 @@ acceptance("New Topic - Authenticated", function (needs) {
     );
     assert.strictEqual(
       selectKit(".category-chooser").header().value(),
-      1,
+      "1",
       "it selects desired category"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/notifications-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/notifications-test.js
@@ -36,7 +36,7 @@ acceptance("User Notifications", function (needs) {
 
     await visit("/"); // wait for re-render
 
-    assert.equal(count("#quick-access-notifications li"), 6);
+    assert.strictEqual(count("#quick-access-notifications li"), 6);
 
     // high priority, unread notification - should be first
 
@@ -80,8 +80,8 @@ acceptance("User Notifications", function (needs) {
 
     await visit("/"); // wait for re-render
 
-    assert.equal(count("#quick-access-notifications li"), 6);
-    assert.equal(
+    assert.strictEqual(count("#quick-access-notifications li"), 6);
+    assert.strictEqual(
       query("#quick-access-notifications li span[data-topic-id]").innerText,
       "First notification"
     );
@@ -129,8 +129,8 @@ acceptance("User Notifications", function (needs) {
 
     await visit("/"); // wait for re-render
 
-    assert.equal(count("#quick-access-notifications li"), 7);
-    assert.equal(
+    assert.strictEqual(count("#quick-access-notifications li"), 7);
+    assert.strictEqual(
       queryAll("#quick-access-notifications li span[data-topic-id]")[1]
         .innerText,
       "Second notification"
@@ -179,7 +179,7 @@ acceptance("User Notifications", function (needs) {
     });
 
     await visit("/"); // wait for re-render
-    assert.equal(count("#quick-access-notifications li"), 8);
+    assert.strictEqual(count("#quick-access-notifications li"), 8);
     const texts = [];
     queryAll("#quick-access-notifications li").each((_, el) =>
       texts.push(el.innerText.trim())

--- a/app/assets/javascripts/discourse/tests/acceptance/opengraph-tag-updater-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/opengraph-tag-updater-test.js
@@ -14,7 +14,7 @@ acceptance("Opengraph Tag Updater", function (needs) {
     await click("#toggle-hamburger-menu");
     await click("a.about-link");
 
-    assert.equal(
+    assert.strictEqual(
       document
         .querySelector("meta[property='og:title']")
         .getAttribute("content"),

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -22,7 +22,7 @@ acceptance("Personal Message", function (needs) {
   test("suggested messages", async function (assert) {
     await visit("/t/pm-for-testing/12");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("#suggested-topics .suggested-topics-title").text().trim(),
       I18n.t("suggested_topics.pm_title")
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-keyboard-shortcut-test.js
@@ -22,7 +22,7 @@ acceptance("Plugin Keyboard Shortcuts - Logged In", function (needs) {
 
     await visit("/t/this-is-a-test-topic/9");
     await triggerKeyEvent(document, "keypress", "]".charCodeAt(0));
-    assert.equal(
+    assert.strictEqual(
       $("#added-element").length,
       1,
       "the keyboard shortcut callback fires successfully"

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -70,7 +70,7 @@ acceptance("Plugin Outlet - Connector Class", function (needs) {
 
   test("Renders a template into the outlet", async function (assert) {
     await visit("/u/eviltrout");
-    assert.equal(
+    assert.strictEqual(
       count(".user-profile-primary-outlet.hello"),
       1,
       "it has class names"
@@ -81,14 +81,14 @@ acceptance("Plugin Outlet - Connector Class", function (needs) {
     );
 
     await click(".say-hello");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".hello-result").text(),
       "hello!",
       "actions delegate properly"
     );
 
     await click(".say-hi");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".hi-result").text(),
       "hi!",
       "actions delegate properly"

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -52,8 +52,8 @@ acceptance("Plugin Outlet - Decorator", function (needs) {
     )[0];
 
     assert.ok(exists(fooConnector));
-    assert.equal(fooConnector.style.backgroundColor, "yellow");
-    assert.equal(barConnector.style.backgroundColor, "");
+    assert.strictEqual(fooConnector.style.backgroundColor, "yellow");
+    assert.strictEqual(barConnector.style.backgroundColor, "");
 
     await visit("/c/bug");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -27,22 +27,22 @@ acceptance("Plugin Outlet - Multi Template", function (needs) {
 
   test("Renders a template into the outlet", async function (assert) {
     await visit("/u/eviltrout");
-    assert.equal(
+    assert.strictEqual(
       count(".user-profile-primary-outlet.hello"),
       1,
       "it has class names"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".user-profile-primary-outlet.goodbye"),
       1,
       "it has class names"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".hello-span").text(),
       "Hello",
       "it renders into the outlet"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".bye-span").text(),
       "Goodbye",
       "it renders into the outlet"

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -23,12 +23,12 @@ acceptance("Plugin Outlet - Single Template", function (needs) {
 
   test("Renders a template into the outlet", async function (assert) {
     await visit("/u/eviltrout");
-    assert.equal(
+    assert.strictEqual(
       count(".user-profile-primary-outlet.hello"),
       1,
       "it has class names"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".hello-username").text(),
       "eviltrout",
       "it renders into the outlet"

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -82,7 +82,7 @@ acceptance("User Preferences", function (needs) {
     await visit("/u/eviltrout/preferences");
 
     assert.ok($("body.user-preferences-page").length, "has the body class");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/u/eviltrout/preferences/account",
       "defaults to account tab"
@@ -151,7 +151,7 @@ acceptance("User Preferences", function (needs) {
 
     await fillIn("#change-email", "invalidemail");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".tip.bad").text().trim(),
       I18n.t("user.email.invalid"),
       "it should display invalid email tip"
@@ -252,7 +252,7 @@ acceptance("User Preferences", function (needs) {
 
     await click(".avatar-selector-refresh-gravatar");
 
-    assert.equal(
+    assert.strictEqual(
       User.currentProp("gravatar_avatar_upload_id"),
       6543,
       "it should set the gravatar_avatar_upload_id property"
@@ -327,7 +327,7 @@ acceptance("User Preferences when badges are disabled", function (needs) {
   test("visit my preferences", async function (assert) {
     await visit("/u/eviltrout/preferences");
     assert.ok($("body.user-preferences-page").length, "has the body class");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/u/eviltrout/preferences/account",
       "defaults to account tab"
@@ -418,7 +418,7 @@ acceptance("Custom User Fields", function (needs) {
     );
     await field.expand();
     await field.selectRowByValue("Cat");
-    assert.equal(
+    assert.strictEqual(
       field.header().value(),
       "Cat",
       "it sets the value of the field"
@@ -444,7 +444,7 @@ acceptance(
       await click(".save-changes");
       await visit("/");
       assert.ok(exists(".topic-list"), "The list of topics was rendered");
-      assert.equal(
+      assert.strictEqual(
         currentRouteName(),
         "discovery.bookmarks",
         "it navigates to bookmarks"
@@ -487,7 +487,7 @@ acceptance("Security", function (needs) {
   test("recently connected devices", async function (assert) {
     await visit("/u/eviltrout/preferences/security");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".auth-tokens > .auth-token:nth-of-type(1) .auth-token-device")
         .text()
         .trim(),
@@ -495,12 +495,12 @@ acceptance("Security", function (needs) {
       "it should display active token first"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".pref-auth-tokens > a:nth-of-type(1)").text().trim(),
       I18n.t("user.auth_tokens.show_all", { count: 3 }),
       "it should display two tokens"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".pref-auth-tokens .auth-token"),
       2,
       "it should display two tokens"
@@ -508,7 +508,7 @@ acceptance("Security", function (needs) {
 
     await click(".pref-auth-tokens > a:nth-of-type(1)");
 
-    assert.equal(
+    assert.strictEqual(
       count(".pref-auth-tokens .auth-token"),
       3,
       "it should display three tokens"
@@ -518,11 +518,11 @@ acceptance("Security", function (needs) {
     await authTokenDropdown.expand();
     await authTokenDropdown.selectRowByValue("notYou");
 
-    assert.equal(count(".d-modal:visible"), 1, "modal should appear");
+    assert.strictEqual(count(".d-modal:visible"), 1, "modal should appear");
 
     await click(".modal-footer .btn-primary");
 
-    assert.equal(
+    assert.strictEqual(
       count(".pref-password.highlighted"),
       1,
       "it should highlight password preferences"
@@ -543,7 +543,7 @@ acceptance(
       await visit("/u/staged/preferences");
 
       assert.ok($("body.user-preferences-page").length, "has the body class");
-      assert.equal(
+      assert.strictEqual(
         currentURL(),
         "/u/staged/preferences/account",
         "defaults to account tab"

--- a/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
@@ -28,7 +28,7 @@ acceptance("Raw Plugin Outlet", function (needs) {
   test("Renders the raw plugin outlet", async function (assert) {
     await visit("/");
     assert.ok(exists(".topic-lala"), "it renders the outlet");
-    assert.equal(
+    assert.strictEqual(
       query(".topic-lala:nth-of-type(1)").innerText,
       "11557",
       "it has the topic id"

--- a/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
@@ -30,7 +30,11 @@ acceptance("Redirect to Top", function (needs) {
     });
 
     await visit("/categories");
-    assert.equal(currentURL(), "/top?period=weekly", "it works for categories");
+    assert.strictEqual(
+      currentURL(),
+      "/top?period=weekly",
+      "it works for categories"
+    );
   });
 
   test("redirects latest to monthly top", async function (assert) {
@@ -43,7 +47,11 @@ acceptance("Redirect to Top", function (needs) {
     });
 
     await visit("/latest");
-    assert.equal(currentURL(), "/top?period=monthly", "it works for latest");
+    assert.strictEqual(
+      currentURL(),
+      "/top?period=monthly",
+      "it works for latest"
+    );
   });
 
   test("redirects root to All top", async function (assert) {
@@ -56,6 +64,6 @@ acceptance("Redirect to Top", function (needs) {
     });
 
     await visit("/");
-    assert.equal(currentURL(), "/top?period=all", "it works for root");
+    assert.strictEqual(currentURL(), "/top?period=all", "it works for root");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/reports-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/reports-test.js
@@ -8,13 +8,16 @@ acceptance("Reports", function (needs) {
   test("Visit reports page", async function (assert) {
     await visit("/admin/reports");
 
-    assert.equal($(".reports-list .report").length, 1);
+    assert.strictEqual($(".reports-list .report").length, 1);
 
     const $report = $(".reports-list .report:first-child");
 
-    assert.equal($report.find(".report-title").html().trim(), "My report");
+    assert.strictEqual(
+      $report.find(".report-title").html().trim(),
+      "My report"
+    );
 
-    assert.equal(
+    assert.strictEqual(
       $report.find(".report-description").html().trim(),
       "List of my activities"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/review-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/review-test.js
@@ -94,12 +94,12 @@ acceptance("Review", function (needs) {
       "it has a link to the user"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".reviewable-flagged-post .post-body").html().trim(),
       "<b>cooked content</b>"
     );
 
-    assert.equal(count(".reviewable-flagged-post .reviewable-score"), 2);
+    assert.strictEqual(count(".reviewable-flagged-post .reviewable-score"), 2);
   });
 
   test("Flag related", async function (assert) {
@@ -119,16 +119,16 @@ acceptance("Review", function (needs) {
     await visit("/review");
     assert.ok(exists(`${topic} .reviewable-action.approve`));
     assert.ok(!exists(`${topic} .category-name`));
-    assert.equal(
+    assert.strictEqual(
       queryAll(`${topic} .discourse-tag:nth-of-type(1)`).text(),
       "hello"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(`${topic} .discourse-tag:nth-of-type(2)`).text(),
       "world"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(`${topic} .post-body`).text().trim(),
       "existing body"
     );
@@ -148,7 +148,7 @@ acceptance("Review", function (needs) {
 
     await fillIn(".editable-field.payload-raw textarea", "new raw contents");
     await click(`${topic} .reviewable-action.cancel-edit`);
-    assert.equal(
+    assert.strictEqual(
       queryAll(`${topic} .post-body`).text().trim(),
       "existing body",
       "cancelling does not update the value"
@@ -167,24 +167,27 @@ acceptance("Review", function (needs) {
     await fillIn(".editable-field.payload-raw textarea", "new raw contents");
     await click(`${topic} .reviewable-action.save-edit`);
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(`${topic} .discourse-tag:nth-of-type(1)`).text(),
       "hello"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(`${topic} .discourse-tag:nth-of-type(2)`).text(),
       "world"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(`${topic} .discourse-tag:nth-of-type(3)`).text(),
       "monkey"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(`${topic} .post-body`).text().trim(),
       "new raw contents"
     );
-    assert.equal(queryAll(`${topic} .category-name`).text().trim(), "support");
+    assert.strictEqual(
+      queryAll(`${topic} .category-name`).text().trim(),
+      "support"
+    );
   });
 
   test("Reviewables can become stale", async function (assert) {
@@ -192,7 +195,10 @@ acceptance("Review", function (needs) {
 
     const reviewable = query(`[data-reviewable-id="1234"]`);
     assert.notOk(reviewable.className.includes("reviewable-stale"));
-    assert.equal(count(`[data-reviewable-id="1234"] .status .pending`), 1);
+    assert.strictEqual(
+      count(`[data-reviewable-id="1234"] .status .pending`),
+      1
+    );
     assert.ok(!exists(".stale-help"));
 
     publishToMessageBus("/reviewable_counts", {
@@ -205,13 +211,13 @@ acceptance("Review", function (needs) {
     await visit("/review"); // wait for re-render
 
     assert.ok(reviewable.className.includes("reviewable-stale"));
-    assert.equal(count("[data-reviewable-id=1234] .status .approved"), 1);
-    assert.equal(count(".stale-help"), 1);
+    assert.strictEqual(count("[data-reviewable-id=1234] .status .approved"), 1);
+    assert.strictEqual(count(".stale-help"), 1);
     assert.ok(query(".stale-help").innerText.includes("foo"));
 
     await visit("/");
     await visit("/review"); // reload review
 
-    assert.equal(count(".stale-help"), 0);
+    assert.strictEqual(count(".stale-help"), 0);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -111,7 +111,7 @@ acceptance("Search - Full Page", function (needs) {
     await fillIn(".search-query", "discourse");
     await click(".search-cta");
 
-    assert.equal(count(".fps-topic"), 1, "has one post");
+    assert.strictEqual(count(".fps-topic"), 1, "has one post");
   });
 
   test("search for personal messages", async function (assert) {
@@ -120,15 +120,15 @@ acceptance("Search - Full Page", function (needs) {
     await fillIn(".search-query", "discourse in:personal");
     await click(".search-cta");
 
-    assert.equal(count(".fps-topic"), 1, "has one post");
+    assert.strictEqual(count(".fps-topic"), 1, "has one post");
 
-    assert.equal(
+    assert.strictEqual(
       count(".topic-status .personal_message"),
       1,
       "shows the right icon"
     );
 
-    assert.equal(count(".search-highlight"), 1, "search highlights work");
+    assert.strictEqual(count(".search-highlight"), 1, "search highlights work");
   });
 
   test("escape search term", async function (assert) {
@@ -174,7 +174,7 @@ acceptance("Search - Full Page", function (needs) {
         exists('.search-advanced-options span:contains("admin")'),
         'has "admin" pre-populated'
       );
-      assert.equal(
+      assert.strictEqual(
         queryAll(".search-query").val(),
         "none @admin",
         'has updated search term to "none user:admin"'
@@ -199,7 +199,7 @@ acceptance("Search - Full Page", function (needs) {
       exists('.search-advanced-options .badge-category:contains("faq")'),
       'has "faq" populated'
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none #faq",
       'has updated search term to "none #faq"'
@@ -223,7 +223,7 @@ acceptance("Search - Full Page", function (needs) {
       exists('.search-advanced-options .badge-category:contains("快乐的")'),
       'has "快乐的" populated'
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none category:240",
       'has updated search term to "none category:240"'
@@ -239,7 +239,7 @@ acceptance("Search - Full Page", function (needs) {
       exists(".search-advanced-options .in-title:checked"),
       'has "in title" populated'
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none in:title",
       'has updated search term to "none in:title"'
@@ -262,7 +262,7 @@ acceptance("Search - Full Page", function (needs) {
       exists(".search-advanced-options .in-likes:checked"),
       'has "I liked" populated'
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none in:likes",
       'has updated search term to "none in:likes"'
@@ -279,7 +279,7 @@ acceptance("Search - Full Page", function (needs) {
       'has "are in my messages" populated'
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none in:personal",
       'has updated search term to "none in:personal"'
@@ -303,7 +303,7 @@ acceptance("Search - Full Page", function (needs) {
       "it should check the right checkbox"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none in:seen",
       "it should update the search term"
@@ -326,12 +326,12 @@ acceptance("Search - Full Page", function (needs) {
     await inSelector.expand();
     await inSelector.selectRowByValue("bookmarks");
 
-    assert.equal(
+    assert.strictEqual(
       inSelector.header().label(),
       "I bookmarked",
       'has "I bookmarked" populated'
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none in:bookmarks",
       'has updated search term to "none in:bookmarks"'
@@ -349,12 +349,12 @@ acceptance("Search - Full Page", function (needs) {
     await statusSelector.expand();
     await statusSelector.selectRowByValue("closed");
 
-    assert.equal(
+    assert.strictEqual(
       statusSelector.header().label(),
       "are closed",
       'has "are closed" populated'
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none status:closed",
       'has updated search term to "none status:closed"'
@@ -370,7 +370,11 @@ acceptance("Search - Full Page", function (needs) {
 
     await fillIn(".search-query", "status:none");
 
-    assert.equal(statusSelector.header().label(), "any", 'has "any" populated');
+    assert.strictEqual(
+      statusSelector.header().label(),
+      "any",
+      'has "any" populated'
+    );
   });
 
   test("doesn't update in filter header if wrong value entered through searchbox", async function (assert) {
@@ -380,13 +384,17 @@ acceptance("Search - Full Page", function (needs) {
 
     await fillIn(".search-query", "in:none");
 
-    assert.equal(inSelector.header().label(), "any", 'has "any" populated');
+    assert.strictEqual(
+      inSelector.header().label(),
+      "any",
+      'has "any" populated'
+    );
   });
 
   test("update post time through advanced search ui", async function (assert) {
     await visit("/search?expanded=true&q=after:2018-08-22");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "after:2018-08-22",
       "it should update the search term correctly"
@@ -403,13 +411,13 @@ acceptance("Search - Full Page", function (needs) {
     await postTimeSelector.expand();
     await postTimeSelector.selectRowByValue("after");
 
-    assert.equal(
+    assert.strictEqual(
       postTimeSelector.header().label(),
       "after",
       'has "after" populated'
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none after:2016-10-05",
       'has updated search term to "none after:2016-10-05"'
@@ -421,14 +429,14 @@ acceptance("Search - Full Page", function (needs) {
     await fillIn(".search-query", "none");
     await fillIn("#search-min-post-count", "5");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(
         ".search-advanced-additional-options #search-min-post-count"
       ).val(),
       "5",
       'has "5" populated'
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none min_posts:5",
       'has updated search term to "none min_posts:5"'
@@ -440,14 +448,14 @@ acceptance("Search - Full Page", function (needs) {
     await fillIn(".search-query", "none");
     await fillIn("#search-max-post-count", "5");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(
         ".search-advanced-additional-options #search-max-post-count"
       ).val(),
       "5",
       'has "5" populated'
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "none max_posts:5",
       'has updated search term to "none max_posts:5"'
@@ -463,7 +471,7 @@ acceptance("Search - Full Page", function (needs) {
       'has "I liked" populated'
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".search-query").val(),
       "in:likes",
       'has updated search term to "in:likes"'
@@ -506,7 +514,7 @@ acceptance("Search - Full Page", function (needs) {
 
     await click(".search-cta");
 
-    assert.equal(count(".fps-user-item"), 1, "has one user result");
+    assert.strictEqual(count(".fps-user-item"), 1, "has one user result");
 
     await typeSelector.expand();
     await typeSelector.selectRowByValue(SEARCH_TYPE_DEFAULT);
@@ -531,7 +539,7 @@ acceptance("Search - Full Page", function (needs) {
     await click(".search-cta");
 
     assert.ok(!exists(".search-filters"), "has no filters");
-    assert.equal(count(".fps-tag-item"), 2, "has two tag results");
+    assert.strictEqual(count(".fps-tag-item"), 2, "has two tag results");
 
     await typeSelector.expand();
     await typeSelector.selectRowByValue(SEARCH_TYPE_DEFAULT);

--- a/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-mobile-test.js
@@ -33,7 +33,7 @@ acceptance("Search - Mobile", function (needs) {
     await fillIn(".search-query", "discourse");
     await click(".search-cta");
 
-    assert.equal(count(".fps-topic"), 1, "has one post");
+    assert.strictEqual(count(".fps-topic"), 1, "has one post");
 
     assert.ok(
       !visible(".search-advanced-filters"),
@@ -42,7 +42,7 @@ acceptance("Search - Mobile", function (needs) {
 
     await click("#search-button");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("input.full-page-search").val(),
       "discourse",
       "it does not reset input when hitting search icon again"

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -63,7 +63,7 @@ acceptance("Search - Anonymous", function (needs) {
       "quick tip no longer shown"
     );
 
-    assert.equal(
+    assert.strictEqual(
       query(
         ".search-menu .results ul.search-menu-initial-options li:first-child .search-item-slug"
       ).innerText.trim(),
@@ -95,7 +95,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     await click(".show-advanced-search");
 
-    assert.equal(
+    assert.strictEqual(
       query(".full-page-search").value,
       "dev",
       "it goes to full search page and preserves the search term"
@@ -130,7 +130,7 @@ acceptance("Search - Anonymous", function (needs) {
     await visit("/tag/important");
     await click("#search-button");
 
-    assert.equal(
+    assert.strictEqual(
       query(firstResult).textContent.trim(),
       `${I18n.t("search.in")} test`,
       "contenxtual tag search is first available option with no term"
@@ -138,7 +138,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     await fillIn("#search-term", "smth");
 
-    assert.equal(
+    assert.strictEqual(
       query(firstResult).textContent.trim(),
       `smth ${I18n.t("search.in")} test`,
       "tag-scoped search is first available option"
@@ -147,7 +147,7 @@ acceptance("Search - Anonymous", function (needs) {
     await visit("/c/bug");
     await click("#search-button");
 
-    assert.equal(
+    assert.strictEqual(
       query(firstResult).textContent.trim(),
       `smth ${I18n.t("search.in")} bug`,
       "category-scoped search is first available option"
@@ -161,7 +161,7 @@ acceptance("Search - Anonymous", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click("#search-button");
 
-    assert.equal(
+    assert.strictEqual(
       query(firstResult).textContent.trim(),
       `smth ${I18n.t("search.in_this_topic")}`,
       "topic-scoped search is first available option"
@@ -170,7 +170,7 @@ acceptance("Search - Anonymous", function (needs) {
     await visit("/u/eviltrout");
     await click("#search-button");
 
-    assert.equal(
+    assert.strictEqual(
       query(firstResult).textContent.trim(),
       `smth ${I18n.t("search.in_posts_by", {
         username: "eviltrout",
@@ -187,7 +187,7 @@ acceptance("Search - Anonymous", function (needs) {
     const firstResult =
       ".search-menu .results .search-menu-assistant-item:first-child";
 
-    assert.equal(
+    assert.strictEqual(
       query(firstResult).textContent.trim(),
       I18n.t("search.in_this_topic"),
       "contenxtual topic search is first available option"
@@ -203,7 +203,7 @@ acceptance("Search - Anonymous", function (needs) {
       "clicking first option formats results as posts"
     );
 
-    assert.equal(
+    assert.strictEqual(
       query("#post_7 span.highlighted").textContent.trim(),
       "a proper",
       "highlights the post correctly"
@@ -214,7 +214,7 @@ acceptance("Search - Anonymous", function (needs) {
       "search context indicator is visible"
     );
     await click(".clear-search");
-    assert.equal(query("#search-term").value, "", "clear button works");
+    assert.strictEqual(query("#search-term").value, "", "clear button works");
 
     await click(".search-context");
 
@@ -249,9 +249,9 @@ acceptance("Search - Anonymous", function (needs) {
     await click("#search-button");
     await fillIn("#search-term", "@admin");
 
-    assert.equal(count(".search-menu-assistant-item"), 2);
+    assert.strictEqual(count(".search-menu-assistant-item"), 2);
 
-    assert.equal(
+    assert.strictEqual(
       query(
         ".search-menu-assistant-item:first-child .search-item-user .label-suffix"
       ).textContent.trim(),
@@ -259,7 +259,7 @@ acceptance("Search - Anonymous", function (needs) {
       "first result hints in this topic search"
     );
 
-    assert.equal(
+    assert.strictEqual(
       query(
         ".search-menu-assistant-item:nth-child(2) .search-item-user .label-suffix"
       ).textContent.trim(),
@@ -358,13 +358,13 @@ acceptance("Search - Authenticated", function (needs) {
     await triggerKeyEvent(".search-menu", "keydown", 40);
     await click(document.activeElement);
 
-    assert.notEqual(count(".search-menu .results .item"), 0);
+    assert.notStrictEqual(count(".search-menu .results .item"), 0);
 
     await fillIn("#search-term", "plans empty");
     await triggerKeyEvent("#search-term", "keydown", 13);
 
-    assert.equal(count(".search-menu .results .item"), 0);
-    assert.equal(count(".search-menu .results .no-results"), 1);
+    assert.strictEqual(count(".search-menu .results .item"), 0);
+    assert.strictEqual(count(".search-menu .results .no-results"), 1);
   });
 
   test("search dropdown keyboard navigation", async function (assert) {
@@ -389,7 +389,7 @@ acceptance("Search - Authenticated", function (needs) {
 
     await triggerKeyEvent("#search-term", "keydown", keyArrowDown);
 
-    assert.equal(
+    assert.strictEqual(
       document.activeElement.getAttribute("href"),
       query(`${container} li:first-child a`).getAttribute("href"),
       "arrow down selects first element"
@@ -397,7 +397,7 @@ acceptance("Search - Authenticated", function (needs) {
 
     await triggerKeyEvent("#search-term", "keydown", keyArrowDown);
 
-    assert.equal(
+    assert.strictEqual(
       document.activeElement.getAttribute("href"),
       query(`${container} li:nth-child(2) a`).getAttribute("href"),
       "arrow down selects next element"
@@ -408,7 +408,7 @@ acceptance("Search - Authenticated", function (needs) {
     await triggerKeyEvent("#search-term", "keydown", keyArrowDown);
     await triggerKeyEvent("#search-term", "keydown", keyArrowDown);
 
-    assert.equal(
+    assert.strictEqual(
       document.activeElement.getAttribute("href"),
       "/search?q=dev",
       "arrow down sets focus to more results link"
@@ -421,7 +421,7 @@ acceptance("Search - Authenticated", function (needs) {
     await triggerKeyEvent(".search-menu", "keydown", keyArrowDown);
     await triggerKeyEvent(".search-menu", "keydown", keyArrowUp);
 
-    assert.equal(
+    assert.strictEqual(
       document.activeElement.tagName.toLowerCase(),
       "input",
       "arrow up sets focus to search term input"
@@ -437,7 +437,7 @@ acceptance("Search - Authenticated", function (needs) {
     );
     await triggerKeyEvent(".search-menu", "keydown", keyA);
 
-    assert.equal(
+    assert.strictEqual(
       query("#reply-control textarea").value,
       `${window.location.origin}${firstLink}`,
       "hitting A when focused on a search result copies link to composer"
@@ -455,7 +455,7 @@ acceptance("Search - with tagging enabled", function (needs) {
     await fillIn("#search-term", "dev");
     await triggerKeyEvent("#search-term", "keydown", 13);
 
-    assert.equal(
+    assert.strictEqual(
       query(
         ".search-menu .results ul li:nth-of-type(1) .discourse-tags"
       ).textContent.trim(),
@@ -477,7 +477,7 @@ acceptance("Search - with tagging enabled", function (needs) {
     assert.ok(exists(query(firstItem)));
 
     const firstTag = query(`${firstItem} .search-item-tag`).textContent.trim();
-    assert.equal(firstTag, "monkey");
+    assert.strictEqual(firstTag, "monkey");
   });
 });
 
@@ -528,13 +528,13 @@ acceptance("Search - assistant", function (needs) {
     ).textContent.trim();
 
     await click(firstCategory);
-    assert.equal(query("#search-term").value, `#${firstResultSlug}`);
+    assert.strictEqual(query("#search-term").value, `#${firstResultSlug}`);
 
     await fillIn("#search-term", "sam #");
     await triggerKeyEvent("#search-term", "keyup", 51);
 
     assert.ok(exists(query(firstCategory)));
-    assert.equal(
+    assert.strictEqual(
       query(
         ".search-menu .results ul.search-menu-assistant .search-item-prefix"
       ).innerText,
@@ -542,7 +542,7 @@ acceptance("Search - assistant", function (needs) {
     );
 
     await click(firstCategory);
-    assert.equal(query("#search-term").value, `sam #${firstResultSlug}`);
+    assert.strictEqual(query("#search-term").value, `sam #${firstResultSlug}`);
   });
 
   test("shows in: shortcuts", async function (assert) {
@@ -554,15 +554,15 @@ acceptance("Search - assistant", function (needs) {
 
     await fillIn("#search-term", "in:");
     await triggerKeyEvent("#search-term", "keyup", 51);
-    assert.equal(query(firstTarget).innerText, "in:title");
+    assert.strictEqual(query(firstTarget).innerText, "in:title");
 
     await fillIn("#search-term", "sam in:");
     await triggerKeyEvent("#search-term", "keyup", 51);
-    assert.equal(query(firstTarget).innerText, "sam in:title");
+    assert.strictEqual(query(firstTarget).innerText, "sam in:title");
 
     await fillIn("#search-term", "in:pers");
     await triggerKeyEvent("#search-term", "keyup", 51);
-    assert.equal(query(firstTarget).innerText, "in:personal");
+    assert.strictEqual(query(firstTarget).innerText, "in:personal");
   });
 
   test("shows users when typing @", async function (assert) {
@@ -576,9 +576,9 @@ acceptance("Search - assistant", function (needs) {
     const firstUser =
       ".search-menu .results ul.search-menu-assistant .search-item-user";
     const firstUsername = query(firstUser).innerText.trim();
-    assert.equal(firstUsername, "TeaMoe");
+    assert.strictEqual(firstUsername, "TeaMoe");
 
     await click(query(firstUser));
-    assert.equal(query("#search-term").value, `@${firstUsername}`);
+    assert.strictEqual(query("#search-term").value, `@${firstUsername}`);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/shared-drafts-test.js
@@ -10,9 +10,9 @@ import { test } from "qunit";
 acceptance("Shared Drafts", function () {
   test("Viewing and publishing", async function (assert) {
     await visit("/t/some-topic/9");
-    assert.equal(count(".shared-draft-controls"), 1);
+    assert.strictEqual(count(".shared-draft-controls"), 1);
     let categoryChooser = selectKit(".shared-draft-controls .category-chooser");
-    assert.equal(categoryChooser.header().value(), "3");
+    assert.strictEqual(categoryChooser.header().value(), "3");
 
     await click(".publish-shared-draft");
     await click(".bootbox .btn-primary");
@@ -22,7 +22,7 @@ acceptance("Shared Drafts", function () {
 
   test("Updating category", async function (assert) {
     await visit("/t/some-topic/9");
-    assert.equal(count(".shared-draft-controls"), 1);
+    assert.strictEqual(count(".shared-draft-controls"), 1);
 
     await click(".edit-topic");
 
@@ -33,6 +33,6 @@ acceptance("Shared Drafts", function () {
     await click(".edit-controls .btn-primary");
 
     categoryChooser = selectKit(".shared-draft-controls .category-chooser");
-    assert.equal(categoryChooser.header().value(), "7");
+    assert.strictEqual(categoryChooser.header().value(), "7");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sign-in-test.js
@@ -40,14 +40,14 @@ acceptance("Signing In", function () {
     await fillIn("#login-account-name", "eviltrout");
     await fillIn("#login-account-password", "not-activated");
     await click(".modal-footer .btn-primary");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-body b").text(),
       "<small>eviltrout@example.com</small>"
     );
     assert.ok(!exists(".modal-body small"), "it escapes the email address");
 
     await click(".modal-footer button.resend");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".modal-body b").text(),
       "<small>current@example.com</small>"
     );
@@ -63,8 +63,11 @@ acceptance("Signing In", function () {
     await fillIn("#login-account-password", "not-activated-edit");
     await click(".modal-footer .btn-primary");
     await click(".modal-footer button.edit-email");
-    assert.equal(queryAll(".activate-new-email").val(), "current@example.com");
-    assert.equal(
+    assert.strictEqual(
+      queryAll(".activate-new-email").val(),
+      "current@example.com"
+    );
+    assert.strictEqual(
       count(".modal-footer .btn-primary:disabled"),
       1,
       "must change email"
@@ -72,7 +75,10 @@ acceptance("Signing In", function () {
     await fillIn(".activate-new-email", "different@example.com");
     assert.ok(!exists(".modal-footer .btn-primary:disabled"));
     await click(".modal-footer .btn-primary");
-    assert.equal(queryAll(".modal-body b").text(), "different@example.com");
+    assert.strictEqual(
+      queryAll(".modal-body b").text(),
+      "different@example.com"
+    );
   });
 
   skip("second factor", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/static-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/static-test.js
@@ -21,7 +21,7 @@ acceptance("Static", function () {
     assert.ok(exists(".body-page"), "The content is present");
 
     await visit("/login");
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       "discovery.latest",
       "it redirects them to latest unless `login_required`"

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-intersection-test.js
@@ -35,7 +35,7 @@ acceptance("Tags intersection", function (needs) {
     await click("#create-topic");
 
     assert.ok(exists(".mini-tag-chooser"), "The tag selector appears");
-    assert.equal(
+    assert.strictEqual(
       $(".composer-fields .mini-tag-chooser").text().trim(),
       "first, second",
       "populates the tags when clicking 'New topic'"

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -469,6 +469,6 @@ acceptance("Tag info", function (needs) {
     await visit("/tag/planters");
     await click("#create-topic");
     let composer = this.owner.lookup("controller:composer");
-    assert.strictEqual(composer.get("model").tags, null);
+    assert.strictEqual(composer.get("model").tags, undefined);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -191,7 +191,7 @@ acceptance("Tags listed by group", function (needs) {
 
   test("list the tags in groups", async function (assert) {
     await visit("/tags");
-    assert.equal(
+    assert.strictEqual(
       $(".tag-list").length,
       4,
       "shows separate lists for the 3 groups and the ungrouped tags"
@@ -223,7 +223,7 @@ acceptance("Tags listed by group", function (needs) {
       ["/tag/focus", "/tag/escort"],
       "always uses lowercase URLs for mixed case tags"
     );
-    assert.equal(
+    assert.strictEqual(
       $("a[data-tag-name='private']").attr("href"),
       "/u/eviltrout/messages/tags/private",
       "links to private messages"
@@ -237,7 +237,7 @@ acceptance("Tags listed by group", function (needs) {
     assert.ok(!exists("#create-topic:disabled"));
 
     await visit("/tag/staff-only-tag");
-    assert.equal(count("#create-topic:disabled"), 1);
+    assert.strictEqual(count("#create-topic:disabled"), 1);
 
     updateCurrentUser({ moderator: true });
 
@@ -384,7 +384,7 @@ acceptance("Tag info", function (needs) {
     updateCurrentUser({ moderator: false, admin: false });
 
     await visit("/tag/planters");
-    assert.equal(count("#show-tag-info"), 1);
+    assert.strictEqual(count("#show-tag-info"), 1);
 
     await click("#show-tag-info");
     assert.ok(exists(".tag-info .tag-name"), "show tag");
@@ -392,12 +392,16 @@ acceptance("Tag info", function (needs) {
       queryAll(".tag-info .tag-associations").text().indexOf("Gardening") >= 0,
       "show tag group names"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".tag-info .synonyms-list .tag-box"),
       2,
       "shows the synonyms"
     );
-    assert.equal(count(".tag-info .badge-category"), 1, "show the category");
+    assert.strictEqual(
+      count(".tag-info .badge-category"),
+      1,
+      "show the category"
+    );
     assert.ok(!exists("#rename-tag"), "can't rename tag");
     assert.ok(!exists("#edit-synonyms"), "can't edit synonyms");
     assert.ok(!exists("#delete-tag"), "can't delete tag");
@@ -407,7 +411,7 @@ acceptance("Tag info", function (needs) {
     updateCurrentUser({ moderator: false, admin: true });
 
     await visit("/tag/happy-monkey");
-    assert.equal(count("#show-tag-info"), 1);
+    assert.strictEqual(count("#show-tag-info"), 1);
 
     await click("#show-tag-info");
     assert.ok(exists(".tag-info .tag-name"), "show tag");
@@ -431,14 +435,14 @@ acceptance("Tag info", function (needs) {
     await click(".category-breadcrumb .category-drop-header");
     await click('.category-breadcrumb .category-row[data-name="faq"]');
 
-    assert.equal(currentURL(), "/tags/c/faq/4/planters");
+    assert.strictEqual(currentURL(), "/tags/c/faq/4/planters");
   });
 
   test("admin can manage tags", async function (assert) {
     updateCurrentUser({ moderator: false, admin: true });
 
     await visit("/tag/planters");
-    assert.equal(count("#show-tag-info"), 1);
+    assert.strictEqual(count("#show-tag-info"), 1);
 
     await click("#show-tag-info");
     assert.ok(exists("#rename-tag"), "can rename tag");
@@ -447,10 +451,14 @@ acceptance("Tag info", function (needs) {
 
     await click("#edit-synonyms");
     assert.ok(count(".unlink-synonym:visible"), 2, "unlink UI is visible");
-    assert.equal(count(".delete-synonym:visible"), 2, "delete UI is visible");
+    assert.strictEqual(
+      count(".delete-synonym:visible"),
+      2,
+      "delete UI is visible"
+    );
 
     await click(".unlink-synonym:nth-of-type(1)");
-    assert.equal(
+    assert.strictEqual(
       count(".tag-info .synonyms-list .tag-box"),
       1,
       "removed a synonym"
@@ -461,6 +469,6 @@ acceptance("Tag info", function (needs) {
     await visit("/tag/planters");
     await click("#create-topic");
     let composer = this.owner.lookup("controller:composer");
-    assert.equal(composer.get("model").tags, null);
+    assert.strictEqual(composer.get("model").tags, null);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-admin-menu-test.js
@@ -51,7 +51,7 @@ acceptance("Topic - Admin Menu", function (needs) {
     assert.ok(exists("#topic"), "The topic was rendered");
     await click(".toggle-admin-menu");
 
-    assert.equal(
+    assert.strictEqual(
       document.activeElement,
       document.querySelector(".topic-admin-multi-select > button")
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -21,13 +21,13 @@ acceptance("Topic Discovery", function (needs) {
     assert.ok(exists(".topic-list"), "The list of topics was rendered");
     assert.ok(exists(".topic-list .topic-list-item"), "has topics");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("a[data-user-card=eviltrout] img.avatar").attr("title"),
       "Evil Trout - Most Posts",
       "it shows user's full name in avatar title"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("a[data-user-card=eviltrout] img.avatar").attr("loading"),
       "lazy",
       "it adds loading=`lazy` to topic list avatars"

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -133,8 +133,8 @@ acceptance("Topic - Edit timer", function (needs) {
     await timerType.expand();
     await timerType.selectRowByValue("publish_to_category");
 
-    assert.equal(categoryChooser.header().label(), "uncategorized");
-    assert.equal(categoryChooser.header().value(), null);
+    assert.strictEqual(categoryChooser.header().label(), "uncategorized");
+    assert.strictEqual(categoryChooser.header().value(), null);
 
     await categoryChooser.expand();
     await categoryChooser.selectRowByValue("7");
@@ -157,7 +157,7 @@ acceptance("Topic - Edit timer", function (needs) {
       }
     );
 
-    assert.equal(text, el.innerText);
+    assert.strictEqual(text, el.innerText);
   });
 
   test("schedule publish to category - visible for a private category", async function (assert) {
@@ -173,8 +173,8 @@ acceptance("Topic - Edit timer", function (needs) {
     await timerType.expand();
     await timerType.selectRowByValue("publish_to_category");
 
-    assert.equal(categoryChooser.header().label(), "uncategorized");
-    assert.equal(categoryChooser.header().value(), null);
+    assert.strictEqual(categoryChooser.header().label(), "uncategorized");
+    assert.strictEqual(categoryChooser.header().value(), null);
 
     await categoryChooser.expand();
     await categoryChooser.selectRowByValue("7");
@@ -197,7 +197,7 @@ acceptance("Topic - Edit timer", function (needs) {
       }
     );
 
-    assert.equal(text, el.innerText);
+    assert.strictEqual(text, el.innerText);
   });
 
   test("schedule publish to category - visible for an unlisted public topic", async function (assert) {
@@ -217,8 +217,8 @@ acceptance("Topic - Edit timer", function (needs) {
     await timerType.expand();
     await timerType.selectRowByValue("publish_to_category");
 
-    assert.equal(categoryChooser.header().label(), "uncategorized");
-    assert.equal(categoryChooser.header().value(), null);
+    assert.strictEqual(categoryChooser.header().label(), "uncategorized");
+    assert.strictEqual(categoryChooser.header().value(), null);
 
     await categoryChooser.expand();
     await categoryChooser.selectRowByValue("7");
@@ -241,7 +241,7 @@ acceptance("Topic - Edit timer", function (needs) {
       }
     );
 
-    assert.equal(text, el.innerText);
+    assert.strictEqual(text, el.innerText);
   });
 
   test("schedule publish to category - last custom date and time", async function (assert) {
@@ -338,11 +338,11 @@ acceptance("Topic - Edit timer", function (needs) {
     await click(".edit-topic-timer-buttons button.btn-primary");
 
     const removeTimerButton = queryAll(".topic-timer-info .topic-timer-remove");
-    assert.equal(removeTimerButton.attr("title"), "remove timer");
+    assert.strictEqual(removeTimerButton.attr("title"), "remove timer");
 
     await click(".topic-timer-info .topic-timer-remove");
     const topicTimerInfo = queryAll(".topic-timer-info .topic-timer-remove");
-    assert.equal(topicTimerInfo.length, 0);
+    assert.strictEqual(topicTimerInfo.length, 0);
   });
 
   test("Shows correct time frame options", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
@@ -40,12 +40,12 @@ acceptance("Topic footer buttons mobile", function (needs) {
   test("default", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
-    assert.equal(_test, null);
+    assert.strictEqual(_test, null);
 
     const subject = selectKit(".topic-footer-mobile-dropdown");
     await subject.expand();
     await subject.selectRowByValue("my-button");
 
-    assert.equal(_test, 2);
+    assert.strictEqual(_test, 2);
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-footer-buttons-mobile-test.js
@@ -40,7 +40,7 @@ acceptance("Topic footer buttons mobile", function (needs) {
   test("default", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
-    assert.strictEqual(_test, null);
+    assert.strictEqual(_test, undefined);
 
     const subject = selectKit(".topic-footer-mobile-dropdown");
     await subject.expand();

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-list-tracker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-list-tracker-test.js
@@ -11,14 +11,14 @@ acceptance("Topic list tracking", function () {
   test("Navigation", async function (assert) {
     await visit("/");
     let url = await nextTopicUrl();
-    assert.equal(url, "/t/error-after-upgrade-to-0-9-7-9/11557");
+    assert.strictEqual(url, "/t/error-after-upgrade-to-0-9-7-9/11557");
 
     setTopicId(11557);
 
     url = await nextTopicUrl();
-    assert.equal(url, "/t/welcome-to-meta-discourse-org/1");
+    assert.strictEqual(url, "/t/welcome-to-meta-discourse-org/1");
 
     url = await previousTopicUrl();
-    assert.equal(url, "/t/error-after-upgrade-to-0-9-7-9/11557");
+    assert.strictEqual(url, "/t/error-after-upgrade-to-0-9-7-9/11557");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -12,7 +12,7 @@ acceptance("Topic move posts", function (needs) {
     await click(".topic-admin-multi-select .btn");
     await click("#post_11 .select-below");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".selected-posts .move-to-topic").text().trim(),
       I18n.t("topic.move_to.action"),
       "it should show the move to button"
@@ -91,7 +91,7 @@ acceptance("Topic move posts", function (needs) {
     await click(".topic-admin-multi-select .btn");
     await click("#post_1 .select-post");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".selected-posts .move-to-topic").text().trim(),
       I18n.t("topic.move_to.action"),
       "it should show the move to button"
@@ -127,7 +127,7 @@ acceptance("Topic move posts", function (needs) {
     await click(".topic-admin-multi-select .btn");
     await click("#post_2 .select-below");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".selected-posts .move-to-topic").text().trim(),
       I18n.t("topic.move_to.action"),
       "it should show the move to button"

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
@@ -27,7 +27,7 @@ acceptance("Topic Notifications button", function (needs) {
     await notificationOptions.expand();
     await notificationOptions.selectRowByValue("3");
 
-    assert.equal(
+    assert.strictEqual(
       notificationOptions.header().label(),
       "Watching",
       "it should display the right notification level"
@@ -37,7 +37,7 @@ acceptance("Topic Notifications button", function (needs) {
       ".topic-timeline .widget-component-connector .topic-notifications-options"
     );
 
-    assert.equal(
+    assert.strictEqual(
       timelineNotificationOptions.header().value(),
       "3",
       "it should display the right notification level"
@@ -46,13 +46,13 @@ acceptance("Topic Notifications button", function (needs) {
     await timelineNotificationOptions.expand();
     await timelineNotificationOptions.selectRowByValue("0");
 
-    assert.equal(
+    assert.strictEqual(
       timelineNotificationOptions.header().value(),
       "0",
       "it should display the right notification level"
     );
 
-    assert.equal(
+    assert.strictEqual(
       notificationOptions.header().label(),
       "Muted",
       "it should display the right notification level"

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-quote-button-test.js
@@ -54,7 +54,7 @@ acceptance("Topic - Quote button - logged in", function (needs) {
       await selectText("#post_3 aside.onebox p");
       await click(".insert-quote");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".d-editor-input").val().trim(),
         '[quote="group_moderator, post:3, topic:2480"]\nhttps://example.com/57350945\n[/quote]',
         "quote only contains a link"

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-slow-mode-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-slow-mode-test.js
@@ -40,7 +40,7 @@ acceptance("Topic - Slow Mode - enabled", function (needs) {
     await click(".topic-admin-slow-mode button");
 
     const slowModeType = selectKit(".slow-mode-type");
-    assert.equal(
+    assert.strictEqual(
       slowModeType.header().name(),
       I18n.t("topic.slow_mode_update.durations.10_minutes"),
       "slow mode interval is rendered"
@@ -50,7 +50,7 @@ acceptance("Topic - Slow Mode - enabled", function (needs) {
     // but at least we can make sure that components for choosing date and time are rendered
     // (in case of inactive slow mode it would be only a combo box with text "Select a timeframe",
     // and date picker and time picker wouldn't be rendered)
-    assert.equal(
+    assert.strictEqual(
       query("div.enabled-until span.name").innerText,
       I18n.t("topic.auto_update_input.pick_date_and_time"),
       "enabled until combobox is switched to the option Pick Date and Time"
@@ -66,7 +66,7 @@ acceptance("Topic - Slow Mode - enabled", function (needs) {
     await click(".topic-admin-slow-mode button");
     await click(".future-date-input-selector-header");
 
-    assert.equal(
+    assert.strictEqual(
       query("div.modal-footer button.btn-primary span").innerText,
       I18n.t("topic.slow_mode_update.enable"),
       "shows 'Enable' button when slow mode is disabled"
@@ -77,7 +77,7 @@ acceptance("Topic - Slow Mode - enabled", function (needs) {
     await click(".topic-admin-slow-mode button");
     await click(".future-date-input-selector-header");
 
-    assert.equal(
+    assert.strictEqual(
       query("div.modal-footer button.btn-primary span").innerText,
       I18n.t("topic.slow_mode_update.update"),
       "shows 'Update' button when slow mode is enabled"

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -29,12 +29,12 @@ acceptance("Topic", function (needs) {
 
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().trim(),
       `Continuing the discussion from [Internationalization / localization](${window.location.origin}/t/internationalization-localization/280):`,
       "it fills composer with the ring string"
     );
-    assert.equal(
+    assert.strictEqual(
       selectKit(".category-chooser").header().value(),
       "2",
       "it fills category selector with the right category"
@@ -48,14 +48,14 @@ acceptance("Topic", function (needs) {
 
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().trim(),
       `Continuing the discussion from [PM for testing](${window.location.origin}/t/pm-for-testing/12):`,
       "it fills composer with the ring string"
     );
 
     const privateMessageUsers = selectKit("#private-message-users");
-    assert.equal(
+    assert.strictEqual(
       privateMessageUsers.header().value(),
       "someguy,test,Group",
       "it fills up the composer correctly"
@@ -96,12 +96,12 @@ acceptance("Topic", function (needs) {
     await categoryChooser.selectRowByValue(4);
     await click("#topic-title .submit-edit");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("#topic-title .badge-category").text(),
       "faq",
       "it displays the new category"
     );
-    assert.equal(
+    assert.strictEqual(
       queryAll(".fancy-title").text().trim(),
       "this is the new title",
       "it displays the new title"
@@ -117,13 +117,13 @@ acceptance("Topic", function (needs) {
     await click(".topic-post:nth-of-type(1) button.show-post-admin-menu");
     await click(".btn.wiki");
 
-    assert.equal(count("button.wiki"), 1, "it shows the wiki icon");
+    assert.strictEqual(count("button.wiki"), 1, "it shows the wiki icon");
   });
 
   test("Visit topic routes", async function (assert) {
     await visit("/t/12");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".fancy-title").text().trim(),
       "PM for testing",
       "it routes to the right topic"
@@ -131,7 +131,7 @@ acceptance("Topic", function (needs) {
 
     await visit("/t/280/20");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".fancy-title").text().trim(),
       "Internationalization / localization",
       "it routes to the right topic"
@@ -187,7 +187,7 @@ acceptance("Topic", function (needs) {
   test("Suggested topics", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll("#suggested-topics .suggested-topics-title").text().trim(),
       I18n.t("suggested_topics.title")
     );
@@ -242,8 +242,8 @@ acceptance("Topic featured links", function (needs) {
     await visit("/t/-/299/1");
 
     const link = queryAll(".title-wrapper .topic-featured-link");
-    assert.equal(link.text(), " example.com");
-    assert.equal(link.attr("rel"), "ugc");
+    assert.strictEqual(link.text(), " example.com");
+    assert.strictEqual(link.attr("rel"), "ugc");
   });
 
   test("remove featured link", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-timeline-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-timeline-test.js
@@ -334,6 +334,6 @@ acceptance("Topic Timeline", function (needs) {
 
   test("Shows dates of first and last posts", async function (assert) {
     await visit("/t/deleted-topic-with-whisper-post/129");
-    assert.equal(query(".now-date").innerText, "Jul 2020");
+    assert.strictEqual(query(".now-date").innerText, "Jul 2020");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
@@ -16,11 +16,11 @@ acceptance("Category 404", function (needs) {
     await visit("/t/internationalization-localization/280");
 
     await click('[data-for-test="category-404"]');
-    assert.equal(currentURL(), "/404");
+    assert.strictEqual(currentURL(), "/404");
 
     // See that we can navigate away
     await click("#site-logo");
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
   });
 });
 
@@ -55,11 +55,14 @@ acceptance("Unknown", function (needs) {
 
   test("Permalink URL to a Topic", async function (assert) {
     await visit("/viewtopic.php?f=8&t=280");
-    assert.equal(currentURL(), "/t/internationalization-localization/280");
+    assert.strictEqual(
+      currentURL(),
+      "/t/internationalization-localization/280"
+    );
   });
 
   test("Permalink URL to a static page", async function (assert) {
     await visit("/another-url-for-faq");
-    assert.equal(currentURL(), "/faq");
+    assert.strictEqual(currentURL(), "/faq");
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-activity-all-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-activity-all-test.js
@@ -22,7 +22,7 @@ acceptance("User Activity / All - empty state", function (needs) {
   test("When looking at another user activity it renders the 'No activity' message", async function (assert) {
     await visit("/u/charlie/activity");
     assert.ok(exists("div.alert-info"));
-    assert.equal(
+    assert.strictEqual(
       query("div.alert-info").innerText.trim(),
       I18n.t("user_activity.no_activity_others")
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/user-activity-likes-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-activity-likes-test.js
@@ -22,7 +22,7 @@ acceptance("User Activity / Likes - empty state", function (needs) {
   test("When looking at another user activity it renders the 'No activity' message", async function (assert) {
     await visit("/u/charlie/activity/likes-given");
     assert.ok(exists("div.alert-info"));
-    assert.equal(
+    assert.strictEqual(
       query("div.alert-info").innerText.trim(),
       I18n.t("user_activity.no_likes_others")
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/user-activity-replies-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-activity-replies-test.js
@@ -22,7 +22,7 @@ acceptance("User Activity / Replies - empty state", function (needs) {
   test("When looking at another user activity it renders the 'No activity' message", async function (assert) {
     await visit("/u/charlie/activity/replies");
     assert.ok(exists("div.alert-info"));
-    assert.equal(
+    assert.strictEqual(
       query("div.alert-info").innerText.trim(),
       I18n.t("user_activity.no_replies_others")
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-anonymous-test.js
@@ -6,7 +6,11 @@ acceptance("User Anonymous", function () {
   test("Root URL", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok($("body.user-summary-page").length, "has the body class");
-    assert.equal(currentRouteName(), "user.summary", "it defaults to summary");
+    assert.strictEqual(
+      currentRouteName(),
+      "user.summary",
+      "it defaults to summary"
+    );
   });
 
   test("Filters", async function (assert) {
@@ -35,7 +39,7 @@ acceptance("User Anonymous", function () {
   test("Restricted Routes", async function (assert) {
     await visit("/u/eviltrout/preferences");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/u/eviltrout/activity",
       "it redirects from preferences"

--- a/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-drafts-stream-test.js
@@ -14,13 +14,13 @@ acceptance("User Drafts", function (needs) {
 
   test("Stream", async function (assert) {
     await visit("/u/eviltrout/activity/drafts");
-    assert.equal(count(".user-stream-item"), 3, "has drafts");
+    assert.strictEqual(count(".user-stream-item"), 3, "has drafts");
 
     await click(".user-stream-item:last-child .remove-draft");
     assert.ok(visible(".bootbox"));
 
     await click(".bootbox .btn-primary");
-    assert.equal(
+    assert.strictEqual(
       count(".user-stream-item"),
       2,
       "draft removed, list length diminished by one"
@@ -32,7 +32,7 @@ acceptance("User Drafts", function (needs) {
     assert.ok(exists(".user-stream-item"), "has drafts");
 
     await click(".user-stream-item .resume-draft");
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val().trim(),
       "A fun new topic for testing drafts."
     );
@@ -41,11 +41,11 @@ acceptance("User Drafts", function (needs) {
   test("Stream - has excerpt", async function (assert) {
     await visit("/u/eviltrout/activity/drafts");
     assert.ok(exists(".user-stream-item"), "has drafts");
-    assert.equal(
+    assert.strictEqual(
       query(".user-stream-item:nth-child(3) .category").textContent,
       "meta"
     );
-    assert.equal(
+    assert.strictEqual(
       query(".user-stream-item:nth-child(3) .excerpt").innerHTML.trim(),
       'here goes a reply to a PM <img src="/images/emoji/google_classic/slight_smile.png?v=10" title=":slight_smile:" class="emoji" alt=":slight_smile:">'
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -124,7 +124,7 @@ acceptance("User Preferences - Interface", function (needs) {
     await visit("/u/eviltrout/preferences/interface");
 
     assert.ok(exists(".light-color-scheme"), "has regular dropdown");
-    assert.strictEqual(selectKit(".theme .select-kit").header().value(), 2);
+    assert.strictEqual(selectKit(".theme .select-kit").header().value(), "2");
 
     await selectKit(".light-color-scheme .select-kit").expand();
     assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -37,12 +37,12 @@ acceptance("User Preferences - Interface", function (needs) {
     await textSize.selectRowByValue("largest");
     assert.ok(document.documentElement.classList.contains("text-size-largest"));
 
-    assert.equal(cookie("text_size"), null, "cookie is not set");
+    assert.strictEqual(cookie("text_size"), null, "cookie is not set");
 
     // Click save (by default this sets for all browsers, no cookie)
     await savePreferences();
 
-    assert.equal(cookie("text_size"), null, "cookie is not set");
+    assert.strictEqual(cookie("text_size"), null, "cookie is not set");
 
     await textSize.expand();
     await textSize.selectRowByValue("larger");
@@ -50,13 +50,13 @@ acceptance("User Preferences - Interface", function (needs) {
 
     await savePreferences();
 
-    assert.equal(cookie("text_size"), "larger|1", "cookie is set");
+    assert.strictEqual(cookie("text_size"), "larger|1", "cookie is set");
     await click(".text-size input[type=checkbox]");
     await textSize.expand();
     await textSize.selectRowByValue("largest");
 
     await savePreferences();
-    assert.equal(cookie("text_size"), null, "cookie is removed");
+    assert.strictEqual(cookie("text_size"), null, "cookie is removed");
 
     removeCookie("text_size");
   });
@@ -89,11 +89,11 @@ acceptance("User Preferences - Interface", function (needs) {
     await visit("/u/eviltrout/preferences/interface");
     assert.ok(exists(".light-color-scheme"), "has regular dropdown");
 
-    assert.equal(
+    assert.strictEqual(
       selectKit(".light-color-scheme .select-kit").header().value(),
       null
     );
-    assert.equal(
+    assert.strictEqual(
       selectKit(".light-color-scheme .select-kit").header().label(),
       I18n.t("user.color_schemes.default_description")
     );
@@ -124,10 +124,13 @@ acceptance("User Preferences - Interface", function (needs) {
     await visit("/u/eviltrout/preferences/interface");
 
     assert.ok(exists(".light-color-scheme"), "has regular dropdown");
-    assert.equal(selectKit(".theme .select-kit").header().value(), 2);
+    assert.strictEqual(selectKit(".theme .select-kit").header().value(), 2);
 
     await selectKit(".light-color-scheme .select-kit").expand();
-    assert.equal(count(".light-color-scheme .select-kit .select-kit-row"), 2);
+    assert.strictEqual(
+      count(".light-color-scheme .select-kit .select-kit-row"),
+      2
+    );
 
     document.querySelector("meta[name='discourse_theme_id']").remove();
   });
@@ -183,7 +186,7 @@ acceptance(
 
       await visit("/u/eviltrout/preferences/interface");
       assert.ok(exists(".light-color-scheme"), "has light scheme dropdown");
-      assert.equal(
+      assert.strictEqual(
         queryAll(".light-color-scheme .selected-name").data("value"),
         session.userColorSchemeId,
         "user's selected color scheme is selected value in light scheme dropdown"
@@ -207,14 +210,14 @@ acceptance(
 
       assert.ok(exists(".light-color-scheme"), "has regular dropdown");
       const dropdownObject = selectKit(".light-color-scheme .select-kit");
-      assert.equal(dropdownObject.header().value(), null);
-      assert.equal(
+      assert.strictEqual(dropdownObject.header().value(), null);
+      assert.strictEqual(
         dropdownObject.header().label(),
         I18n.t("user.color_schemes.default_description")
       );
 
       await dropdownObject.expand();
-      assert.equal(dropdownObject.rows().length, 1);
+      assert.strictEqual(dropdownObject.rows().length, 1);
 
       document.querySelector("meta[name='discourse_theme_id']").remove();
     });
@@ -240,7 +243,7 @@ acceptance(
       await visit("/u/eviltrout/preferences/interface");
       assert.ok(exists(".light-color-scheme"), "has regular dropdown");
       assert.ok(exists(".dark-color-scheme"), "has dark color scheme dropdown");
-      assert.equal(
+      assert.strictEqual(
         queryAll(".dark-color-scheme .selected-name").data("value"),
         session.userDarkSchemeId,
         "sets site default as selected dark scheme"
@@ -256,19 +259,23 @@ acceptance(
 
       await selectKit(".light-color-scheme .combobox").expand();
       await selectKit(".light-color-scheme .combobox").selectRowByValue(2);
-      assert.equal(cookie("color_scheme_id"), null, "cookie is not set");
+      assert.strictEqual(cookie("color_scheme_id"), null, "cookie is not set");
       assert.ok(
         exists(".color-scheme-checkbox input:checked"),
         "defaults to storing values in user options"
       );
 
       await savePreferences();
-      assert.equal(cookie("color_scheme_id"), null, "cookie is unchanged");
+      assert.strictEqual(
+        cookie("color_scheme_id"),
+        null,
+        "cookie is unchanged"
+      );
 
       // Switch to saving changes in cookies
       await click(".color-scheme-checkbox input[type=checkbox]");
       await savePreferences();
-      assert.equal(cookie("color_scheme_id"), 2, "cookie is set");
+      assert.strictEqual(cookie("color_scheme_id"), 2, "cookie is set");
 
       // dark scheme
       await selectKit(".dark-color-scheme .combobox").expand();
@@ -278,23 +285,23 @@ acceptance(
       );
 
       await selectKit(".dark-color-scheme .combobox").selectRowByValue(-1);
-      assert.equal(
+      assert.strictEqual(
         cookie("dark_scheme_id"),
         null,
         "cookie is not set before saving"
       );
 
       await savePreferences();
-      assert.equal(cookie("dark_scheme_id"), -1, "cookie is set");
+      assert.strictEqual(cookie("dark_scheme_id"), -1, "cookie is set");
 
       await click("button.undo-preview");
-      assert.equal(
+      assert.strictEqual(
         selectKit(".light-color-scheme .combobox").header().value(),
         null,
         "resets light scheme dropdown"
       );
 
-      assert.equal(
+      assert.strictEqual(
         selectKit(".dark-color-scheme .combobox").header().value(),
         session.userDarkSchemeId,
         "resets dark scheme dropdown"

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-interface-test.js
@@ -37,12 +37,12 @@ acceptance("User Preferences - Interface", function (needs) {
     await textSize.selectRowByValue("largest");
     assert.ok(document.documentElement.classList.contains("text-size-largest"));
 
-    assert.strictEqual(cookie("text_size"), null, "cookie is not set");
+    assert.strictEqual(cookie("text_size"), undefined, "cookie is not set");
 
     // Click save (by default this sets for all browsers, no cookie)
     await savePreferences();
 
-    assert.strictEqual(cookie("text_size"), null, "cookie is not set");
+    assert.strictEqual(cookie("text_size"), undefined, "cookie is not set");
 
     await textSize.expand();
     await textSize.selectRowByValue("larger");
@@ -56,7 +56,7 @@ acceptance("User Preferences - Interface", function (needs) {
     await textSize.selectRowByValue("largest");
 
     await savePreferences();
-    assert.strictEqual(cookie("text_size"), null, "cookie is removed");
+    assert.strictEqual(cookie("text_size"), undefined, "cookie is removed");
 
     removeCookie("text_size");
   });
@@ -250,7 +250,6 @@ acceptance(
       );
       assert.ok(
         !exists(".control-group.dark-mode"),
-        0,
         "it does not show disable dark mode checkbox"
       );
 
@@ -259,7 +258,11 @@ acceptance(
 
       await selectKit(".light-color-scheme .combobox").expand();
       await selectKit(".light-color-scheme .combobox").selectRowByValue(2);
-      assert.strictEqual(cookie("color_scheme_id"), null, "cookie is not set");
+      assert.strictEqual(
+        cookie("color_scheme_id"),
+        undefined,
+        "cookie is not set"
+      );
       assert.ok(
         exists(".color-scheme-checkbox input:checked"),
         "defaults to storing values in user options"
@@ -268,14 +271,14 @@ acceptance(
       await savePreferences();
       assert.strictEqual(
         cookie("color_scheme_id"),
-        null,
+        undefined,
         "cookie is unchanged"
       );
 
       // Switch to saving changes in cookies
       await click(".color-scheme-checkbox input[type=checkbox]");
       await savePreferences();
-      assert.strictEqual(cookie("color_scheme_id"), 2, "cookie is set");
+      assert.strictEqual(cookie("color_scheme_id"), "2", "cookie is set");
 
       // dark scheme
       await selectKit(".dark-color-scheme .combobox").expand();
@@ -287,12 +290,12 @@ acceptance(
       await selectKit(".dark-color-scheme .combobox").selectRowByValue(-1);
       assert.strictEqual(
         cookie("dark_scheme_id"),
-        null,
+        undefined,
         "cookie is not set before saving"
       );
 
       await savePreferences();
-      assert.strictEqual(cookie("dark_scheme_id"), -1, "cookie is set");
+      assert.strictEqual(cookie("dark_scheme_id"), "-1", "cookie is set");
 
       await click("button.undo-preview");
       assert.strictEqual(
@@ -303,7 +306,7 @@ acceptance(
 
       assert.strictEqual(
         selectKit(".dark-color-scheme .combobox").header().value(),
-        session.userDarkSchemeId,
+        session.userDarkSchemeId.toString(),
         "resets dark scheme dropdown"
       );
     });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-notifications-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-notifications-test.js
@@ -40,22 +40,22 @@ acceptance("User notification schedule", function (needs) {
       "Saturday",
       "Sunday",
     ].forEach((day) => {
-      assert.equal(
+      assert.strictEqual(
         selectKit(`.day.${day} .starts-at .combobox`).header().label(),
         "8:00 AM",
         "8am is selected"
       );
-      assert.equal(
+      assert.strictEqual(
         selectKit(`.day.${day} .starts-at .combobox`).header().value(),
         "480",
         "8am is 480"
       );
-      assert.equal(
+      assert.strictEqual(
         selectKit(`.day.${day} .ends-at .combobox`).header().label(),
         "5:00 PM",
         "5am is selected"
       );
-      assert.equal(
+      assert.strictEqual(
         selectKit(`.day.${day} .ends-at .combobox`).header().value(),
         "1020",
         "5pm is 1020"
@@ -70,17 +70,17 @@ acceptance("User notification schedule", function (needs) {
     await selectKit(".day.Monday .combobox").expand();
     await selectKit(".day.Monday .combobox").selectRowByValue(-1);
 
-    assert.equal(
+    assert.strictEqual(
       selectKit(".day.Monday .starts-at .combobox").header().value(),
       "-1",
       "set monday input to none"
     );
-    assert.equal(
+    assert.strictEqual(
       selectKit(".day.Monday .starts-at .combobox").header().label(),
       "None",
       "set monday label to none"
     );
-    assert.equal(
+    assert.strictEqual(
       count(".day.Monday .select-kit.single-select"),
       1,
       "The end time input is hidden"
@@ -96,7 +96,7 @@ acceptance("User notification schedule", function (needs) {
       "1350"
     );
 
-    assert.equal(
+    assert.strictEqual(
       selectKit(".day.Tuesday .ends-at .combobox").header().value(),
       "1380",
       "End time is 30 past start time"

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -24,7 +24,11 @@ acceptance(
     test("viewing messages", async function (assert) {
       await visit("/u/eviltrout/messages");
 
-      assert.equal(count(".topic-list-item"), 1, "displays the topic list");
+      assert.strictEqual(
+        count(".topic-list-item"),
+        1,
+        "displays the topic list"
+      );
 
       assert.ok(
         !exists(".group-notifications-button"),
@@ -276,7 +280,7 @@ acceptance(
     test("viewing messages filtered by tags", async function (assert) {
       await visit("/u/charlie/messages/tags");
 
-      assert.equal(
+      assert.strictEqual(
         count(".action-list li"),
         3,
         "it does not expand personal or group inbox"
@@ -342,13 +346,13 @@ acceptance(
 
       await visit("/u/charlie/messages"); // wait for re-render
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.new").innerText.trim(),
         I18n.t("user.messages.new_with_count", { count: 1 }),
         "displays the right count"
       );
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.unread").innerText.trim(),
         I18n.t("user.messages.unread_with_count", { count: 1 }),
         "displays the right count"
@@ -362,7 +366,7 @@ acceptance(
 
       await visit("/u/charlie/messages/new"); // wait for re-render
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.new").innerText.trim(),
         I18n.t("user.messages.new_with_count", { count: 1 }),
         "displays the right count"
@@ -378,7 +382,7 @@ acceptance(
 
       await visit("/u/charlie/messages/unread"); // wait for re-render
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.unread").innerText.trim(),
         I18n.t("user.messages.unread_with_count", { count: 1 }),
         "displays the right count"
@@ -395,13 +399,13 @@ acceptance(
 
       await visit("/u/charlie/messages/group/awesome_group/unread"); // wait for re-render
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.unread").innerText.trim(),
         I18n.t("user.messages.unread_with_count", { count: 1 }),
         "displays the right count"
       );
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.new").innerText.trim(),
         I18n.t("user.messages.new_with_count", { count: 1 }),
         "displays the right count"
@@ -411,13 +415,13 @@ acceptance(
 
       await visit("/u/charlie/messages/unread");
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.unread").innerText.trim(),
         I18n.t("user.messages.unread"),
         "displays the right count"
       );
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.new").innerText.trim(),
         I18n.t("user.messages.new"),
         "displays the right count"
@@ -446,7 +450,7 @@ acceptance(
       publishUnreadToMessageBus({ topicId: 2, userId: 5 });
       publishUnreadToMessageBus({ topicId: 3, userId: 5 });
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         3,
         "displays the right topic list"
@@ -455,13 +459,13 @@ acceptance(
       await click(".btn.dismiss-read");
       await click("#dismiss-read-confirm");
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.unread").innerText.trim(),
         I18n.t("user.messages.unread"),
         "displays the right count"
       );
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         0,
         "displays the right topic list"
@@ -471,7 +475,7 @@ acceptance(
     test("dismissing personal unread messages", async function (assert) {
       await visit("/u/charlie/messages/unread");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         3,
         "displays the right topic list"
@@ -480,7 +484,7 @@ acceptance(
       await click(".btn.dismiss-read");
       await click("#dismiss-read-confirm");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         0,
         "displays the right topic list"
@@ -490,7 +494,7 @@ acceptance(
     test("dismissing group unread messages", async function (assert) {
       await visit("/u/charlie/messages/group/awesome_group/unread");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         3,
         "displays the right topic list"
@@ -499,7 +503,7 @@ acceptance(
       await click(".btn.dismiss-read");
       await click("#dismiss-read-confirm");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         0,
         "displays the right topic list"
@@ -513,7 +517,7 @@ acceptance(
       publishNewToMessageBus({ topicId: 2, userId: 5 });
       publishNewToMessageBus({ topicId: 3, userId: 5 });
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         3,
         "displays the right topic list"
@@ -521,13 +525,13 @@ acceptance(
 
       await click(".btn.dismiss-read");
 
-      assert.equal(
+      assert.strictEqual(
         query(".messages-nav li a.new").innerText.trim(),
         I18n.t("user.messages.new"),
         "displays the right count"
       );
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         0,
         "displays the right topic list"
@@ -537,7 +541,7 @@ acceptance(
     test("dismissing personal new messages", async function (assert) {
       await visit("/u/charlie/messages/new");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         3,
         "displays the right topic list"
@@ -545,7 +549,7 @@ acceptance(
 
       await click(".btn.dismiss-read");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         0,
         "displays the right topic list"
@@ -555,7 +559,7 @@ acceptance(
     test("dismissing new group messages", async function (assert) {
       await visit("/u/charlie/messages/group/awesome_group/new");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         3,
         "displays the right topic list"
@@ -563,7 +567,7 @@ acceptance(
 
       await click(".btn.dismiss-read");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         0,
         "displays the right topic list"
@@ -573,7 +577,7 @@ acceptance(
     test("viewing messages", async function (assert) {
       await visit("/u/charlie/messages");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         3,
         "displays the right topic list"
@@ -581,7 +585,7 @@ acceptance(
 
       await visit("/u/charlie/messages/group/awesome_group");
 
-      assert.equal(
+      assert.strictEqual(
         count(".topic-list-item"),
         2,
         "displays the right topic list"
@@ -596,7 +600,7 @@ acceptance(
     test("suggested messages without new or unread", async function (assert) {
       await visit("/t/12");
 
-      assert.equal(
+      assert.strictEqual(
         query(".suggested-topics-message").innerText.trim(),
         "Want to read more? Browse other messages in personal messages.",
         "displays the right browse more message"
@@ -610,7 +614,7 @@ acceptance(
 
       await visit("/t/12"); // await re-render
 
-      assert.equal(
+      assert.strictEqual(
         query(".suggested-topics-message").innerText.trim(),
         "There is 1 new message remaining, or browse other personal messages",
         "displays the right browse more message"
@@ -620,7 +624,7 @@ acceptance(
 
       await visit("/t/12"); // await re-render
 
-      assert.equal(
+      assert.strictEqual(
         query(".suggested-topics-message").innerText.trim(),
         "There is 1 unread and 1 new message remaining, or browse other personal messages",
         "displays the right browse more message"
@@ -630,7 +634,7 @@ acceptance(
 
       await visit("/t/12"); // await re-render
 
-      assert.equal(
+      assert.strictEqual(
         query(".suggested-topics-message").innerText.trim(),
         "There is 1 new message remaining, or browse other personal messages",
         "displays the right browse more message"
@@ -817,7 +821,7 @@ acceptance(
 
       await click("#reply-control .save-or-cancel button");
 
-      assert.equal(
+      assert.strictEqual(
         currentURL(),
         "/t/testing-private-messages-with-tags/161",
         "it creates the private message"

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -24,13 +24,13 @@ acceptance("User Routes", function (needs) {
       }
     }
 
-    assert.equal(currentRouteName(), "exception-unknown");
+    assert.strictEqual(currentRouteName(), "exception-unknown");
   });
 
   test("Unicode usernames", async function (assert) {
     await visit("/u/%E3%83%A9%E3%82%A4%E3%82%AA%E3%83%B3/summary");
 
-    assert.equal(currentRouteName(), "user.summary");
+    assert.strictEqual(currentRouteName(), "user.summary");
   });
 
   test("Invites", async function (assert) {
@@ -54,7 +54,7 @@ acceptance("User Routes", function (needs) {
   test("Root URL - Viewing Self", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok($("body.user-activity-page").length, "has the body class");
-    assert.equal(
+    assert.strictEqual(
       currentRouteName(),
       "userActivity.index",
       "it defaults to activity"
@@ -101,14 +101,14 @@ acceptance(
 
     test("Periods in current user's username don't act like wildcards", async function (assert) {
       await visit("/u/eviltrout");
-      assert.equal(
+      assert.strictEqual(
         query(".user-profile-names .username").textContent.trim(),
         "eviltrout",
         "eviltrout profile is shown"
       );
 
       await visit("/u/e.il.rout");
-      assert.equal(
+      assert.strictEqual(
         query(".user-profile-names .username").textContent.trim(),
         "e.il.rout",
         "e.il.rout profile is shown"

--- a/app/assets/javascripts/discourse/tests/acceptance/users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/users-test.js
@@ -38,7 +38,10 @@ acceptance("User Directory", function () {
     const columnData = firstRow.querySelectorAll("td");
     const favoriteColorTd = columnData[columnData.length - 1];
 
-    assert.equal(favoriteColorTd.querySelector("span").textContent, "Blue");
+    assert.strictEqual(
+      favoriteColorTd.querySelector("span").textContent,
+      "Blue"
+    );
   });
 });
 
@@ -52,17 +55,17 @@ acceptance("User directory - Editing columns", function (needs) {
     const columns = queryAll(
       ".edit-directory-columns-container .edit-directory-column"
     );
-    assert.equal(columns.length, 8);
+    assert.strictEqual(columns.length, 8);
 
     const checked = queryAll(
       ".edit-directory-columns-container .edit-directory-column input[type='checkbox']:checked"
     );
-    assert.equal(checked.length, 7);
+    assert.strictEqual(checked.length, 7);
 
     const unchecked = queryAll(
       ".edit-directory-columns-container .edit-directory-column input[type='checkbox']:not(:checked)"
     );
-    assert.equal(unchecked.length, 1);
+    assert.strictEqual(unchecked.length, 1);
   });
 
   const fetchColumns = function () {
@@ -75,11 +78,11 @@ acceptance("User directory - Editing columns", function (needs) {
 
     let columns;
     columns = fetchColumns();
-    assert.equal(
+    assert.strictEqual(
       columns[3].querySelector(".column-name").textContent.trim(),
       "Replies Posted"
     );
-    assert.equal(
+    assert.strictEqual(
       columns[4].querySelector(".column-name").textContent.trim(),
       "Topics Viewed"
     );
@@ -88,11 +91,11 @@ acceptance("User directory - Editing columns", function (needs) {
     await click(columns[4].querySelector(".move-column-up"));
 
     columns = fetchColumns();
-    assert.equal(
+    assert.strictEqual(
       columns[3].querySelector(".column-name").textContent.trim(),
       "Topics Viewed"
     );
-    assert.equal(
+    assert.strictEqual(
       columns[4].querySelector(".column-name").textContent.trim(),
       "Replies Posted"
     );
@@ -105,11 +108,11 @@ acceptance("User directory - Editing columns", function (needs) {
     await click(moveUserFieldColumnUpBtn);
 
     columns = fetchColumns();
-    assert.equal(
+    assert.strictEqual(
       columns[4].querySelector(".column-name").textContent.trim(),
       "Favorite Color"
     );
-    assert.equal(
+    assert.strictEqual(
       columns[5].querySelector(".column-name").textContent.trim(),
       "Replies Posted"
     );

--- a/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
@@ -47,12 +47,12 @@ discourseModule("Integration | Component | ace-editor", function (hooks) {
       const $ace = queryAll(".ace_editor");
       assert.expect(3);
       assert.ok($ace.length, "it renders the ace editor");
-      assert.equal(
+      assert.strictEqual(
         $ace.parent().data().editor.getReadOnly(),
         true,
         "it sets ACE to read-only mode"
       );
-      assert.equal(
+      assert.strictEqual(
         $ace.parent().attr("data-disabled"),
         "true",
         "ACE wrapper has `data-disabled` attribute set to true"

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
@@ -22,19 +22,19 @@ discourseModule("Integration | Component | admin-report", function (hooks) {
 
       assert.ok(exists(".admin-report.signups", "it defaults to table mode"));
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".header .item.report").text().trim(),
         "Signups",
         "it has a title"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".header .info").attr("data-tooltip"),
         "New account registrations for this period",
         "it has a description"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".admin-report-table thead tr th:first-child .title")
           .text()
           .trim(),
@@ -42,7 +42,7 @@ discourseModule("Integration | Component | admin-report", function (hooks) {
         "it has col headers"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".admin-report-table thead tr th:nth-child(2) .title")
           .text()
           .trim(),
@@ -50,7 +50,7 @@ discourseModule("Integration | Component | admin-report", function (hooks) {
         "it has col headers"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".admin-report-table tbody tr:nth-child(1) td:nth-child(1)")
           .text()
           .trim(),
@@ -58,7 +58,7 @@ discourseModule("Integration | Component | admin-report", function (hooks) {
         "it has rows"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".admin-report-table tbody tr:nth-child(1) td:nth-child(2)")
           .text()
           .trim(),
@@ -70,7 +70,7 @@ discourseModule("Integration | Component | admin-report", function (hooks) {
 
       await click(".admin-report-table-header.y .sort-btn");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".admin-report-table tbody tr:nth-child(1) td:nth-child(2)")
           .text()
           .trim(),
@@ -94,7 +94,7 @@ discourseModule("Integration | Component | admin-report", function (hooks) {
 
     test(assert) {
       assert.ok(exists(".pagination"), "it paginates the results");
-      assert.equal(
+      assert.strictEqual(
         count(".pagination button"),
         3,
         "it creates the correct number of pages"

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
@@ -40,7 +40,7 @@ discourseModule("Integration | Component | badge-title", function (hooks) {
       await this.subject.expand();
       await this.subject.selectRowByValue(42);
       await click(".btn");
-      assert.equal(this.currentUser.title, "Test");
+      assert.strictEqual(this.currentUser.title, "Test");
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -180,9 +180,12 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(query("#bookmark-name").value, "test");
-      assert.equal(query("#custom-date > .date-picker").value, "2020-05-15");
-      assert.equal(query("#custom-time").value, "09:45");
+      assert.strictEqual(query("#bookmark-name").value, "test");
+      assert.strictEqual(
+        query("#custom-date > .date-picker").value,
+        "2020-05-15"
+      );
+      assert.strictEqual(query("#custom-time").value, "09:45");
     },
   });
 
@@ -191,7 +194,7 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
 
     async test(assert) {
       await click("#tap_tile_custom");
-      assert.equal(query("#custom-time").value, "08:00");
+      assert.strictEqual(query("#custom-time").value, "08:00");
     },
   });
 
@@ -207,7 +210,7 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     },
 
     async test(assert) {
-      assert.equal(
+      assert.strictEqual(
         query("div#tap_tile_next_month div.tap-tile-date").innerText,
         "Feb 1, 8:00 am"
       );

--- a/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
@@ -14,7 +14,7 @@ discourseModule("Integration | Component | cook-text", function (hooks) {
 
     test(assert) {
       const html = query(".post-body").innerHTML.trim();
-      assert.equal(html, "<p><em>foo</em></p>");
+      assert.strictEqual(html, "<p><em>foo</em></p>");
     },
   });
 
@@ -43,7 +43,7 @@ discourseModule("Integration | Component | cook-text", function (hooks) {
 
     test(assert) {
       const html = query(".post-body").innerHTML.trim();
-      assert.equal(
+      assert.strictEqual(
         html,
         '<p><img src="/images/avatar.png" alt="an image"></p>'
       );

--- a/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
@@ -189,7 +189,7 @@ discourseModule("Integration | Component | d-button", function (hooks) {
     template: hbs`{{d-button ariaExpanded=ariaExpanded}}`,
 
     test(assert) {
-      assert.strictEqual(query("button").ariaExpanded, null);
+      assert.strictEqual(query("button").getAttribute("aria-expanded"), null);
 
       this.set("ariaExpanded", true);
       assert.strictEqual(query("button").getAttribute("aria-expanded"), "true");

--- a/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
@@ -22,7 +22,7 @@ discourseModule("Integration | Component | d-button", function (hooks) {
         "it has all the classes"
       );
       assert.ok(exists("button .d-icon.d-icon-plus"), "it has the icon");
-      assert.equal(
+      assert.strictEqual(
         queryAll("button").attr("tabindex"),
         "3",
         "it has the tabindex"
@@ -124,7 +124,7 @@ discourseModule("Integration | Component | d-button", function (hooks) {
     test(assert) {
       this.set("ariaLabel", "test.fooAriaLabel");
 
-      assert.equal(
+      assert.strictEqual(
         query("button").getAttribute("aria-label"),
         I18n.t("test.fooAriaLabel")
       );
@@ -134,7 +134,7 @@ discourseModule("Integration | Component | d-button", function (hooks) {
         translatedAriaLabel: "bar",
       });
 
-      assert.equal(query("button").getAttribute("aria-label"), "bar");
+      assert.strictEqual(query("button").getAttribute("aria-label"), "bar");
     },
   });
 
@@ -147,7 +147,7 @@ discourseModule("Integration | Component | d-button", function (hooks) {
 
     test(assert) {
       this.set("title", "test.fooTitle");
-      assert.equal(
+      assert.strictEqual(
         query("button").getAttribute("title"),
         I18n.t("test.fooTitle")
       );
@@ -157,7 +157,7 @@ discourseModule("Integration | Component | d-button", function (hooks) {
         translatedTitle: "bar",
       });
 
-      assert.equal(query("button").getAttribute("title"), "bar");
+      assert.strictEqual(query("button").getAttribute("title"), "bar");
     },
   });
 
@@ -171,7 +171,7 @@ discourseModule("Integration | Component | d-button", function (hooks) {
     test(assert) {
       this.set("label", "test.fooLabel");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("button .d-button-label").text(),
         I18n.t("test.fooLabel")
       );
@@ -181,7 +181,7 @@ discourseModule("Integration | Component | d-button", function (hooks) {
         translatedLabel: "bar",
       });
 
-      assert.equal(queryAll("button .d-button-label").text(), "bar");
+      assert.strictEqual(queryAll("button .d-button-label").text(), "bar");
     },
   });
 
@@ -189,19 +189,22 @@ discourseModule("Integration | Component | d-button", function (hooks) {
     template: hbs`{{d-button ariaExpanded=ariaExpanded}}`,
 
     test(assert) {
-      assert.equal(query("button").ariaExpanded, null);
+      assert.strictEqual(query("button").ariaExpanded, null);
 
       this.set("ariaExpanded", true);
-      assert.equal(query("button").getAttribute("aria-expanded"), "true");
+      assert.strictEqual(query("button").getAttribute("aria-expanded"), "true");
 
       this.set("ariaExpanded", false);
-      assert.equal(query("button").getAttribute("aria-expanded"), "false");
+      assert.strictEqual(
+        query("button").getAttribute("aria-expanded"),
+        "false"
+      );
 
       this.set("ariaExpanded", "false");
-      assert.equal(query("button").getAttribute("aria-expanded"), null);
+      assert.strictEqual(query("button").getAttribute("aria-expanded"), null);
 
       this.set("ariaExpanded", "true");
-      assert.equal(query("button").getAttribute("aria-expanded"), null);
+      assert.strictEqual(query("button").getAttribute("aria-expanded"), null);
     },
   });
 
@@ -210,7 +213,10 @@ discourseModule("Integration | Component | d-button", function (hooks) {
 
     test(assert) {
       this.set("ariaControls", "foo-bar");
-      assert.equal(query("button").getAttribute("aria-controls"), "foo-bar");
+      assert.strictEqual(
+        query("button").getAttribute("aria-controls"),
+        "foo-bar"
+      );
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -29,8 +29,8 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
       assert.ok(exists(".d-editor-button-bar"));
       await fillIn(".d-editor-input", "hello **world**");
 
-      assert.equal(this.value, "hello **world**");
-      assert.equal(
+      assert.strictEqual(this.value, "hello **world**");
+      assert.strictEqual(
         queryAll(".d-editor-preview").html().trim(),
         "<p>hello <strong>world</strong></p>"
       );
@@ -43,7 +43,7 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
     async test(assert) {
       await fillIn(".d-editor-input", "[discourse](https://www.discourse.org)");
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".d-editor-preview").html().trim(),
         '<p><a href="https://www.discourse.org" tabindex="-1">discourse</a></p>'
       );
@@ -55,7 +55,10 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
 
     async test(assert) {
       await fillIn(".d-editor-input", `"><svg onload="prompt(/xss/)"></svg>`);
-      assert.equal(queryAll(".d-editor-preview").html().trim(), '<p>"&gt;</p>');
+      assert.strictEqual(
+        queryAll(".d-editor-preview").html().trim(),
+        '<p>"&gt;</p>'
+      );
     },
   });
 
@@ -67,7 +70,7 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
     },
 
     async test(assert) {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".d-editor-preview").html().trim(),
         "<p>evil trout</p>"
       );
@@ -75,7 +78,7 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
       this.set("value", "zogstrip");
       await settled();
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".d-editor-preview").html().trim(),
         "<p>zogstrip</p>"
       );
@@ -124,9 +127,9 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
 
       await click(`button.bold`);
 
-      assert.equal(this.value, `hello **w**orld.`);
-      assert.equal(textarea.selectionStart, 8);
-      assert.equal(textarea.selectionEnd, 9);
+      assert.strictEqual(this.value, `hello **w**orld.`);
+      assert.strictEqual(textarea.selectionStart, 8);
+      assert.strictEqual(textarea.selectionEnd, 9);
     }
   );
 
@@ -138,9 +141,9 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
 
       await click(`button.bold`);
 
-      assert.equal(this.value, `**hello** world.`);
-      assert.equal(textarea.selectionStart, 2);
-      assert.equal(textarea.selectionEnd, 7);
+      assert.strictEqual(this.value, `**hello** world.`);
+      assert.strictEqual(textarea.selectionStart, 2);
+      assert.strictEqual(textarea.selectionEnd, 7);
     }
   );
 
@@ -148,9 +151,9 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
     await click(`button.bold`);
 
     const example = I18n.t(`composer.bold_text`);
-    assert.equal(this.value, `hello world.**${example}**`);
-    assert.equal(textarea.selectionStart, 14);
-    assert.equal(textarea.selectionEnd, 14 + example.length);
+    assert.strictEqual(this.value, `hello world.**${example}**`);
+    assert.strictEqual(textarea.selectionStart, 14);
+    assert.strictEqual(textarea.selectionEnd, 14 + example.length);
   });
 
   testCase(`bold button with a selection`, async function (assert, textarea) {
@@ -158,14 +161,14 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
     textarea.selectionEnd = 11;
 
     await click(`button.bold`);
-    assert.equal(this.value, `hello **world**.`);
-    assert.equal(textarea.selectionStart, 8);
-    assert.equal(textarea.selectionEnd, 13);
+    assert.strictEqual(this.value, `hello **world**.`);
+    assert.strictEqual(textarea.selectionStart, 8);
+    assert.strictEqual(textarea.selectionEnd, 13);
 
     await click(`button.bold`);
-    assert.equal(this.value, "hello world.");
-    assert.equal(textarea.selectionStart, 6);
-    assert.equal(textarea.selectionEnd, 11);
+    assert.strictEqual(this.value, "hello world.");
+    assert.strictEqual(textarea.selectionStart, 6);
+    assert.strictEqual(textarea.selectionEnd, 11);
   });
 
   testCase(
@@ -177,14 +180,14 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
       textarea.selectionEnd = 12;
 
       await click(`button.bold`);
-      assert.equal(this.value, `**hello**\n\n**world**\n\ntest.`);
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 20);
+      assert.strictEqual(this.value, `**hello**\n\n**world**\n\ntest.`);
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 20);
 
       await click(`button.bold`);
-      assert.equal(this.value, `hello\n\nworld\n\ntest.`);
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 12);
+      assert.strictEqual(this.value, `hello\n\nworld\n\ntest.`);
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 12);
     }
   );
 
@@ -193,10 +196,10 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
     async function (assert, textarea) {
       await click(`button.italic`);
       const example = I18n.t(`composer.italic_text`);
-      assert.equal(this.value, `hello world.*${example}*`);
+      assert.strictEqual(this.value, `hello world.*${example}*`);
 
-      assert.equal(textarea.selectionStart, 13);
-      assert.equal(textarea.selectionEnd, 13 + example.length);
+      assert.strictEqual(textarea.selectionStart, 13);
+      assert.strictEqual(textarea.selectionEnd, 13 + example.length);
     }
   );
 
@@ -205,14 +208,14 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
     textarea.selectionEnd = 11;
 
     await click(`button.italic`);
-    assert.equal(this.value, `hello *world*.`);
-    assert.equal(textarea.selectionStart, 7);
-    assert.equal(textarea.selectionEnd, 12);
+    assert.strictEqual(this.value, `hello *world*.`);
+    assert.strictEqual(textarea.selectionStart, 7);
+    assert.strictEqual(textarea.selectionEnd, 12);
 
     await click(`button.italic`);
-    assert.equal(this.value, "hello world.");
-    assert.equal(textarea.selectionStart, 6);
-    assert.equal(textarea.selectionEnd, 11);
+    assert.strictEqual(this.value, "hello world.");
+    assert.strictEqual(textarea.selectionStart, 6);
+    assert.strictEqual(textarea.selectionEnd, 11);
   });
 
   testCase(
@@ -224,14 +227,14 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
       textarea.selectionEnd = 12;
 
       await click(`button.italic`);
-      assert.equal(this.value, `*hello*\n\n*world*\n\ntest.`);
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 16);
+      assert.strictEqual(this.value, `*hello*\n\n*world*\n\ntest.`);
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 16);
 
       await click(`button.italic`);
-      assert.equal(this.value, `hello\n\nworld\n\ntest.`);
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 12);
+      assert.strictEqual(this.value, `hello\n\nworld\n\ntest.`);
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 12);
     }
   );
 
@@ -257,7 +260,7 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
       textarea.selectionEnd = textarea.value.length;
 
       await click("button.code");
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `
       function xyz(x, y, z) {
@@ -280,7 +283,7 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
       const textarea = jumpEnd(query("textarea.d-editor-input"));
 
       await click("button.code");
-      assert.equal(this.value, `    ${I18n.t("composer.code_text")}`);
+      assert.strictEqual(this.value, `    ${I18n.t("composer.code_text")}`);
 
       this.set("value", "first line\n\nsecond line\n\nthird line");
 
@@ -288,7 +291,7 @@ discourseModule("Integration | Component | d-editor", function (hooks) {
       textarea.selectionEnd = 11;
 
       await click("button.code");
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `first line
     ${I18n.t("composer.code_text")}
@@ -300,7 +303,7 @@ third line`
       this.set("value", "first line\n\nsecond line\n\nthird line");
 
       await click("button.code");
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `first line
 
@@ -314,7 +317,7 @@ third line\`${I18n.t("composer.code_title")}\``
       textarea.selectionEnd = 5;
 
       await click("button.code");
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `first\`${I18n.t("composer.code_title")}\` line
 
@@ -328,30 +331,33 @@ third line`
       textarea.selectionEnd = 10;
 
       await click("button.code");
-      assert.equal(this.value, "first `line`\n\nsecond line\n\nthird line");
-      assert.equal(textarea.selectionStart, 7);
-      assert.equal(textarea.selectionEnd, 11);
+      assert.strictEqual(
+        this.value,
+        "first `line`\n\nsecond line\n\nthird line"
+      );
+      assert.strictEqual(textarea.selectionStart, 7);
+      assert.strictEqual(textarea.selectionEnd, 11);
 
       await click("button.code");
-      assert.equal(this.value, "first line\n\nsecond line\n\nthird line");
-      assert.equal(textarea.selectionStart, 6);
-      assert.equal(textarea.selectionEnd, 10);
+      assert.strictEqual(this.value, "first line\n\nsecond line\n\nthird line");
+      assert.strictEqual(textarea.selectionStart, 6);
+      assert.strictEqual(textarea.selectionEnd, 10);
 
       textarea.selectionStart = 0;
       textarea.selectionEnd = 23;
 
       await click("button.code");
-      assert.equal(
+      assert.strictEqual(
         this.value,
         "    first line\n\n    second line\n\nthird line"
       );
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 31);
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 31);
 
       await click("button.code");
-      assert.equal(this.value, "first line\n\nsecond line\n\nthird line");
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 23);
+      assert.strictEqual(this.value, "first line\n\nsecond line\n\nthird line");
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 23);
     },
   });
 
@@ -365,15 +371,15 @@ third line`
       const textarea = jumpEnd(query("textarea.d-editor-input"));
 
       await click("button.code");
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `\`\`\`
 ${I18n.t("composer.paste_code_text")}
 \`\`\``
       );
 
-      assert.equal(textarea.selectionStart, 4);
-      assert.equal(textarea.selectionEnd, 27);
+      assert.strictEqual(textarea.selectionStart, 4);
+      assert.strictEqual(textarea.selectionEnd, 27);
 
       this.set("value", "first line\nsecond line\nthird line");
 
@@ -382,7 +388,7 @@ ${I18n.t("composer.paste_code_text")}
 
       await click("button.code");
 
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `\`\`\`
 first line
@@ -392,8 +398,8 @@ third line
 `
       );
 
-      assert.equal(textarea.selectionStart, textarea.value.length);
-      assert.equal(textarea.selectionEnd, textarea.value.length);
+      assert.strictEqual(textarea.selectionStart, textarea.value.length);
+      assert.strictEqual(textarea.selectionEnd, textarea.value.length);
 
       this.set("value", "first line\nsecond line\nthird line");
 
@@ -402,15 +408,15 @@ third line
 
       await click("button.code");
 
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `\`${I18n.t("composer.code_title")}\`first line
 second line
 third line`
       );
 
-      assert.equal(textarea.selectionStart, 1);
-      assert.equal(
+      assert.strictEqual(textarea.selectionStart, 1);
+      assert.strictEqual(
         textarea.selectionEnd,
         I18n.t("composer.code_title").length + 1
       );
@@ -422,15 +428,15 @@ third line`
 
       await click("button.code");
 
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `\`first line\`
 second line
 third line`
       );
 
-      assert.equal(textarea.selectionStart, 1);
-      assert.equal(textarea.selectionEnd, 11);
+      assert.strictEqual(textarea.selectionStart, 1);
+      assert.strictEqual(textarea.selectionEnd, 11);
 
       this.set("value", "first line\nsecond line\nthird line");
 
@@ -439,7 +445,7 @@ third line`
 
       await click("button.code");
 
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `\`\`\`
 first line
@@ -448,8 +454,8 @@ second line
 third line`
       );
 
-      assert.equal(textarea.selectionStart, 30);
-      assert.equal(textarea.selectionEnd, 30);
+      assert.strictEqual(textarea.selectionStart, 30);
+      assert.strictEqual(textarea.selectionEnd, 30);
 
       this.set("value", "first line\nsecond line\nthird line");
 
@@ -458,13 +464,13 @@ third line`
 
       await click("button.code");
 
-      assert.equal(
+      assert.strictEqual(
         this.value,
         `first \n\`\`\`\nline\nsecond\n\`\`\`\n line\nthird line`
       );
 
-      assert.equal(textarea.selectionStart, 27);
-      assert.equal(textarea.selectionEnd, 27);
+      assert.strictEqual(textarea.selectionStart, 27);
+      assert.strictEqual(textarea.selectionEnd, 27);
     },
   });
 
@@ -480,12 +486,12 @@ third line`
 
       await click("button.blockquote");
 
-      assert.equal(this.value, "> one\n> \n> two\n> \n> three");
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 25);
+      assert.strictEqual(this.value, "> one\n> \n> two\n> \n> three");
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 25);
 
       await click("button.blockquote");
-      assert.equal(this.value, "one\n\ntwo\n\nthree");
+      assert.strictEqual(this.value, "one\n\ntwo\n\nthree");
     },
   });
 
@@ -501,7 +507,7 @@ third line`
       textarea.selectionEnd = 10;
 
       await click("button.blockquote");
-      assert.equal(this.value, "one\n\n\n> \n> two");
+      assert.strictEqual(this.value, "one\n\n\n> \n> two");
     },
   });
 
@@ -510,21 +516,21 @@ third line`
     textarea.selectionEnd = 9;
 
     await click("button.blockquote");
-    assert.equal(this.value, "hello\n\n> wor\n\nld.");
-    assert.equal(textarea.selectionStart, 7);
-    assert.equal(textarea.selectionEnd, 12);
+    assert.strictEqual(this.value, "hello\n\n> wor\n\nld.");
+    assert.strictEqual(textarea.selectionStart, 7);
+    assert.strictEqual(textarea.selectionEnd, 12);
 
     await click("button.blockquote");
 
-    assert.equal(this.value, "hello\n\nwor\n\nld.");
-    assert.equal(textarea.selectionStart, 7);
-    assert.equal(textarea.selectionEnd, 10);
+    assert.strictEqual(this.value, "hello\n\nwor\n\nld.");
+    assert.strictEqual(textarea.selectionStart, 7);
+    assert.strictEqual(textarea.selectionEnd, 10);
 
     textarea.selectionStart = 15;
     textarea.selectionEnd = 15;
 
     await click("button.blockquote");
-    assert.equal(this.value, "hello\n\nwor\n\nld.\n\n> Blockquote");
+    assert.strictEqual(this.value, "hello\n\nwor\n\nld.\n\n> Blockquote");
   });
 
   testCase(
@@ -533,12 +539,12 @@ third line`
       const example = I18n.t("composer.list_item");
 
       await click(`button.bullet`);
-      assert.equal(this.value, `hello world.\n\n* ${example}`);
-      assert.equal(textarea.selectionStart, 14);
-      assert.equal(textarea.selectionEnd, 16 + example.length);
+      assert.strictEqual(this.value, `hello world.\n\n* ${example}`);
+      assert.strictEqual(textarea.selectionStart, 14);
+      assert.strictEqual(textarea.selectionEnd, 16 + example.length);
 
       await click(`button.bullet`);
-      assert.equal(this.value, `hello world.\n\n${example}`);
+      assert.strictEqual(this.value, `hello world.\n\n${example}`);
     }
   );
 
@@ -547,14 +553,14 @@ third line`
     textarea.selectionEnd = 11;
 
     await click(`button.bullet`);
-    assert.equal(this.value, `hello\n\n* world\n\n.`);
-    assert.equal(textarea.selectionStart, 7);
-    assert.equal(textarea.selectionEnd, 14);
+    assert.strictEqual(this.value, `hello\n\n* world\n\n.`);
+    assert.strictEqual(textarea.selectionStart, 7);
+    assert.strictEqual(textarea.selectionEnd, 14);
 
     await click(`button.bullet`);
-    assert.equal(this.value, `hello\n\nworld\n\n.`);
-    assert.equal(textarea.selectionStart, 7);
-    assert.equal(textarea.selectionEnd, 12);
+    assert.strictEqual(this.value, `hello\n\nworld\n\n.`);
+    assert.strictEqual(textarea.selectionStart, 7);
+    assert.strictEqual(textarea.selectionEnd, 12);
   });
 
   testCase(
@@ -566,14 +572,14 @@ third line`
       textarea.selectionEnd = 20;
 
       await click(`button.bullet`);
-      assert.equal(this.value, "Hello\n\nWorld\n\nEvil");
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 18);
+      assert.strictEqual(this.value, "Hello\n\nWorld\n\nEvil");
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 18);
 
       await click(`button.bullet`);
-      assert.equal(this.value, "* Hello\n\n* World\n\n* Evil");
-      assert.equal(textarea.selectionStart, 0);
-      assert.equal(textarea.selectionEnd, 24);
+      assert.strictEqual(this.value, "* Hello\n\n* World\n\n* Evil");
+      assert.strictEqual(textarea.selectionStart, 0);
+      assert.strictEqual(textarea.selectionEnd, 24);
     }
   );
 
@@ -581,14 +587,14 @@ third line`
     const example = I18n.t("composer.list_item");
 
     await click(`button.list`);
-    assert.equal(this.value, `hello world.\n\n1. ${example}`);
-    assert.equal(textarea.selectionStart, 14);
-    assert.equal(textarea.selectionEnd, 17 + example.length);
+    assert.strictEqual(this.value, `hello world.\n\n1. ${example}`);
+    assert.strictEqual(textarea.selectionStart, 14);
+    assert.strictEqual(textarea.selectionEnd, 17 + example.length);
 
     await click(`button.list`);
-    assert.equal(this.value, `hello world.\n\n${example}`);
-    assert.equal(textarea.selectionStart, 14);
-    assert.equal(textarea.selectionEnd, 14 + example.length);
+    assert.strictEqual(this.value, `hello world.\n\n${example}`);
+    assert.strictEqual(textarea.selectionStart, 14);
+    assert.strictEqual(textarea.selectionEnd, 14 + example.length);
   });
 
   testCase(`list button with a selection`, async function (assert, textarea) {
@@ -596,14 +602,14 @@ third line`
     textarea.selectionEnd = 11;
 
     await click(`button.list`);
-    assert.equal(this.value, `hello\n\n1. world\n\n.`);
-    assert.equal(textarea.selectionStart, 7);
-    assert.equal(textarea.selectionEnd, 15);
+    assert.strictEqual(this.value, `hello\n\n1. world\n\n.`);
+    assert.strictEqual(textarea.selectionStart, 7);
+    assert.strictEqual(textarea.selectionEnd, 15);
 
     await click(`button.list`);
-    assert.equal(this.value, `hello\n\nworld\n\n.`);
-    assert.equal(textarea.selectionStart, 7);
-    assert.equal(textarea.selectionEnd, 12);
+    assert.strictEqual(this.value, `hello\n\nworld\n\n.`);
+    assert.strictEqual(textarea.selectionStart, 7);
+    assert.strictEqual(textarea.selectionEnd, 12);
   });
 
   testCase(`list button with line sequence`, async function (assert, textarea) {
@@ -613,14 +619,14 @@ third line`
     textarea.selectionEnd = 18;
 
     await click(`button.list`);
-    assert.equal(this.value, "1. Hello\n\n2. World\n\n3. Evil");
-    assert.equal(textarea.selectionStart, 0);
-    assert.equal(textarea.selectionEnd, 27);
+    assert.strictEqual(this.value, "1. Hello\n\n2. World\n\n3. Evil");
+    assert.strictEqual(textarea.selectionStart, 0);
+    assert.strictEqual(textarea.selectionEnd, 27);
 
     await click(`button.list`);
-    assert.equal(this.value, "Hello\n\nWorld\n\nEvil");
-    assert.equal(textarea.selectionStart, 0);
-    assert.equal(textarea.selectionEnd, 18);
+    assert.strictEqual(this.value, "Hello\n\nWorld\n\nEvil");
+    assert.strictEqual(textarea.selectionStart, 0);
+    assert.strictEqual(textarea.selectionEnd, 18);
   });
 
   componentTest("clicking the toggle-direction changes dir from ltr to rtl", {
@@ -633,7 +639,7 @@ third line`
     async test(assert) {
       const textarea = queryAll("textarea.d-editor-input");
       await click("button.toggle-direction");
-      assert.equal(textarea.attr("dir"), "rtl");
+      assert.strictEqual(textarea.attr("dir"), "rtl");
     },
   });
 
@@ -648,7 +654,7 @@ third line`
       const textarea = queryAll("textarea.d-editor-input");
       textarea.attr("dir", "ltr");
       await click("button.toggle-direction");
-      assert.equal(textarea.attr("dir"), "rtl");
+      assert.strictEqual(textarea.attr("dir"), "rtl");
     },
   });
 
@@ -666,7 +672,7 @@ third line`
       textarea.selectionEnd = 3;
 
       await click("button.bold");
-      assert.equal($(textarea).scrollTop(), 0, "it stays scrolled up");
+      assert.strictEqual($(textarea).scrollTop(), 0, "it stays scrolled up");
     }
   );
 
@@ -698,7 +704,7 @@ third line`
       await click(
         '.emoji-picker .section[data-section="smileys_&_emotion"] img.emoji[title="grinning"]'
       );
-      assert.equal(this.value, "hello world. :grinning:");
+      assert.strictEqual(this.value, "hello world. :grinning:");
     },
   });
 
@@ -709,7 +715,7 @@ third line`
       .lookup("service:app-events")
       .trigger("composer:replace-text", "green", "yellow");
 
-    assert.equal(this.value, "red green blue");
+    assert.strictEqual(this.value, "red green blue");
   });
 
   composerTestCase("replace-text event for composer", async function (assert) {
@@ -719,7 +725,7 @@ third line`
       .lookup("service:app-events")
       .trigger("composer:replace-text", "green", "yellow");
 
-    assert.equal(this.value, "red yellow blue");
+    assert.strictEqual(this.value, "red yellow blue");
   });
 
   async function paste(element, text) {
@@ -739,7 +745,7 @@ third line`
     async test(assert) {
       let element = query(".d-editor");
       await paste(element, "\ta\tb\n1\t2\t3");
-      assert.equal(this.value, "||a|b|\n|---|---|---|\n|1|2|3|\n");
+      assert.strictEqual(this.value, "||a|b|\n|---|---|---|\n|1|2|3|\n");
     },
   });
 
@@ -753,7 +759,7 @@ third line`
     async test(assert) {
       let element = query(".d-editor");
       await paste(element, '\ta\tb\n1\t"2\n2.5"\t3');
-      assert.equal(this.value, "||a|b|\n|---|---|---|\n|1|2<br>2.5|3|\n");
+      assert.strictEqual(this.value, "||a|b|\n|---|---|---|\n|1|2<br>2.5|3|\n");
     },
   });
 
@@ -846,7 +852,7 @@ third line`
             this.value,
             getTextareaSelection(textarea)
           );
-          assert.equal(actual, expect);
+          assert.strictEqual(actual, expect);
         });
       });
     }

--- a/app/assets/javascripts/discourse/tests/integration/components/d-icon-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-icon-test.js
@@ -15,7 +15,7 @@ discourseModule("Integration | Component | d-icon", function (hooks) {
 
     test(assert) {
       const html = queryAll(".test").html().trim();
-      assert.equal(
+      assert.strictEqual(
         html,
         '<svg class="fa d-icon d-icon-bars svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#bars"></use></svg>'
       );
@@ -27,7 +27,7 @@ discourseModule("Integration | Component | d-icon", function (hooks) {
 
     test(assert) {
       const html = queryAll(".test").html().trim();
-      assert.equal(
+      assert.strictEqual(
         html,
         '<svg class="fa d-icon d-icon-d-watching svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#discourse-bell-exclamation"></use></svg>'
       );

--- a/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
@@ -27,7 +27,7 @@ discourseModule("Integration | Component | date-input", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(dateInput().value, "2019-01-29");
+      assert.strictEqual(dateInput().value, "2019-01-29");
     },
   });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
@@ -35,10 +35,10 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(fromDateInput().value, "2019-01-29");
-        assert.equal(fromTimeInput().dataset.name, "14:45");
-        assert.equal(toDateInput().value, "");
-        assert.equal(toTimeInput().dataset.name, "--:--");
+        assert.strictEqual(fromDateInput().value, "2019-01-29");
+        assert.strictEqual(fromTimeInput().dataset.name, "14:45");
+        assert.strictEqual(toDateInput().value, "");
+        assert.strictEqual(toTimeInput().dataset.name, "--:--");
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
@@ -33,8 +33,8 @@ discourseModule("Integration | Component | date-time-input", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(dateInput().value, "2019-01-29");
-      assert.equal(timeInput().dataset.name, "14:45");
+      assert.strictEqual(dateInput().value, "2019-01-29");
+      assert.strictEqual(timeInput().dataset.name, "14:45");
     },
   });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
@@ -49,7 +49,7 @@ discourseModule(
       async test(assert) {
         const subject = selectKit(".list-setting");
 
-        assert.equal(
+        assert.strictEqual(
           subject.header().value(),
           "1",
           "it selects the setting's value"
@@ -58,7 +58,7 @@ discourseModule(
         await subject.expand();
         await subject.selectRowByValue("2");
 
-        assert.equal(
+        assert.strictEqual(
           subject.header().value(),
           "1,2",
           "it allows to select a setting from the list of choices"

--- a/app/assets/javascripts/discourse/tests/integration/components/group-membership-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-membership-button-test.js
@@ -55,7 +55,11 @@ discourseModule(
         );
 
         this.set("model.is_group_user", true);
-        assert.equal(count(".group-index-leave"), 1, "allowed to leave group");
+        assert.strictEqual(
+          count(".group-index-leave"),
+          1,
+          "allowed to leave group"
+        );
       },
     });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
@@ -22,7 +22,7 @@ discourseModule("Integration | Component | highlighted-code", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(
+      assert.strictEqual(
         queryAll("code.ruby.hljs .hljs-function .hljs-keyword").text().trim(),
         "def"
       );
@@ -39,7 +39,10 @@ discourseModule("Integration | Component | highlighted-code", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll("code").text().trim(), LONG_CODE_BLOCK.trim());
+      assert.strictEqual(
+        queryAll("code").text().trim(),
+        LONG_CODE_BLOCK.trim()
+      );
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
@@ -15,14 +15,14 @@ discourseModule("Integration | Component | iframed-html", function (hooks) {
 
     async test(assert) {
       const iframe = queryAll("iframe.this-is-an-iframe");
-      assert.equal(iframe.length, 1, "inserts an iframe");
+      assert.strictEqual(iframe.length, 1, "inserts an iframe");
 
       assert.ok(
         iframe[0].classList.contains("this-is-an-iframe"),
         "Adds className to the iframes classList"
       );
 
-      assert.equal(
+      assert.strictEqual(
         iframe[0].contentWindow.document.body.querySelectorAll("#find-me")
           .length,
         1,

--- a/app/assets/javascripts/discourse/tests/integration/components/image-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/image-uploader-test.js
@@ -18,13 +18,13 @@ discourseModule("Integration | Component | image-uploader", function (hooks) {
     `,
 
     async test(assert) {
-      assert.equal(
+      assert.strictEqual(
         count(".d-icon-far-image"),
         1,
         "it displays the upload icon"
       );
 
-      assert.equal(
+      assert.strictEqual(
         count(".d-icon-far-trash-alt"),
         1,
         "it displays the trash icon"
@@ -37,7 +37,7 @@ discourseModule("Integration | Component | image-uploader", function (hooks) {
 
       await click(".image-uploader-lightbox-btn");
 
-      assert.equal(
+      assert.strictEqual(
         document.querySelectorAll(".mfp-container").length,
         1,
         "it displays the image lightbox"
@@ -49,7 +49,7 @@ discourseModule("Integration | Component | image-uploader", function (hooks) {
     template: hbs`{{image-uploader}}`,
 
     test(assert) {
-      assert.equal(
+      assert.strictEqual(
         count(".d-icon-far-image"),
         1,
         "it displays the upload icon"
@@ -71,7 +71,7 @@ discourseModule("Integration | Component | image-uploader", function (hooks) {
     template: hbs`{{image-uploader placeholderUrl='/images/avatar.png'}}`,
 
     test(assert) {
-      assert.equal(
+      assert.strictEqual(
         count(".d-icon-far-image"),
         1,
         "it displays the upload icon"
@@ -87,7 +87,7 @@ discourseModule("Integration | Component | image-uploader", function (hooks) {
         "it does not display the button to open image lightbox"
       );
 
-      assert.equal(
+      assert.strictEqual(
         count(".placeholder-overlay"),
         1,
         "it displays the placeholder image"

--- a/app/assets/javascripts/discourse/tests/integration/components/input-size-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/input-size-test.js
@@ -14,12 +14,12 @@ discourseModule(
       template: hbs`{{d-button icon="plus"}} {{d-button icon="plus" label="topic.create"}} {{d-button label="topic.create"}}`,
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           query(".btn:nth-child(1)").offsetHeight,
           query(".btn:nth-child(2)").offsetHeight,
           "have equal height"
         );
-        assert.equal(
+        assert.strictEqual(
           query(".btn:nth-child(1)").offsetHeight,
           query(".btn:nth-child(3)").offsetHeight,
           "have equal height"
@@ -33,7 +33,7 @@ discourseModule(
       template: hbs`{{text-field}} {{d-button icon="plus" label="topic.create"}}`,
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           query("input").offsetHeight,
           query(".btn").offsetHeight,
           "have equal height"
@@ -47,7 +47,7 @@ discourseModule(
       template: hbs`{{combo-box options=(hash none="category.none")}} {{text-field}}`,
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           query("input").offsetHeight,
           query(".combo-box").offsetHeight,
           "have equal height"

--- a/app/assets/javascripts/discourse/tests/integration/components/invite-panel-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/invite-panel-test.js
@@ -44,7 +44,7 @@ discourseModule("Integration | Component | invite-panel", function (hooks) {
       await input.selectRowByValue("eviltrout@example.com");
       assert.ok(!exists(".send-invite:disabled"));
       await click(".generate-invite-link");
-      assert.equal(
+      assert.strictEqual(
         find(".invite-link-input")[0].value,
         "http://example.com/invites/92c297e886a0ca03089a109ccd6be155"
       );

--- a/app/assets/javascripts/discourse/tests/integration/components/relative-time-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/relative-time-picker-test.js
@@ -20,7 +20,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "mins");
-        assert.strictEqual(prefilledDuration, 5);
+        assert.strictEqual(prefilledDuration, "5");
       },
     });
 
@@ -30,7 +30,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "hours");
-        assert.strictEqual(prefilledDuration, 1.5);
+        assert.strictEqual(prefilledDuration, "1.5");
       },
     });
 
@@ -40,7 +40,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "days");
-        assert.strictEqual(prefilledDuration, 2);
+        assert.strictEqual(prefilledDuration, "2");
       },
     });
 
@@ -52,7 +52,7 @@ discourseModule(
         test(assert) {
           const prefilledDuration = query(".relative-time-duration").value;
           assert.strictEqual(this.subject.header().value(), "months");
-          assert.strictEqual(prefilledDuration, 3);
+          assert.strictEqual(prefilledDuration, "3");
         },
       }
     );
@@ -63,7 +63,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "years");
-        assert.strictEqual(prefilledDuration, 1);
+        assert.strictEqual(prefilledDuration, "1");
       },
     });
 
@@ -73,7 +73,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "hours");
-        assert.strictEqual(prefilledDuration, 5);
+        assert.strictEqual(prefilledDuration, "5");
       },
     });
 
@@ -83,7 +83,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "mins");
-        assert.strictEqual(prefilledDuration, 30);
+        assert.strictEqual(prefilledDuration, "30");
       },
     });
 
@@ -93,7 +93,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "days");
-        assert.strictEqual(prefilledDuration, 2);
+        assert.strictEqual(prefilledDuration, "2");
       },
     });
 
@@ -103,7 +103,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "months");
-        assert.strictEqual(prefilledDuration, 3);
+        assert.strictEqual(prefilledDuration, "3");
       },
     });
 
@@ -113,7 +113,7 @@ discourseModule(
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
         assert.strictEqual(this.subject.header().value(), "years");
-        assert.strictEqual(prefilledDuration, 2);
+        assert.strictEqual(prefilledDuration, "2");
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/relative-time-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/relative-time-picker-test.js
@@ -19,8 +19,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "mins");
-        assert.equal(prefilledDuration, 5);
+        assert.strictEqual(this.subject.header().value(), "mins");
+        assert.strictEqual(prefilledDuration, 5);
       },
     });
 
@@ -29,8 +29,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "hours");
-        assert.equal(prefilledDuration, 1.5);
+        assert.strictEqual(this.subject.header().value(), "hours");
+        assert.strictEqual(prefilledDuration, 1.5);
       },
     });
 
@@ -39,8 +39,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "days");
-        assert.equal(prefilledDuration, 2);
+        assert.strictEqual(this.subject.header().value(), "days");
+        assert.strictEqual(prefilledDuration, 2);
       },
     });
 
@@ -51,8 +51,8 @@ discourseModule(
 
         test(assert) {
           const prefilledDuration = query(".relative-time-duration").value;
-          assert.equal(this.subject.header().value(), "months");
-          assert.equal(prefilledDuration, 3);
+          assert.strictEqual(this.subject.header().value(), "months");
+          assert.strictEqual(prefilledDuration, 3);
         },
       }
     );
@@ -62,8 +62,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "years");
-        assert.equal(prefilledDuration, 1);
+        assert.strictEqual(this.subject.header().value(), "years");
+        assert.strictEqual(prefilledDuration, 1);
       },
     });
 
@@ -72,8 +72,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "hours");
-        assert.equal(prefilledDuration, 5);
+        assert.strictEqual(this.subject.header().value(), "hours");
+        assert.strictEqual(prefilledDuration, 5);
       },
     });
 
@@ -82,8 +82,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "mins");
-        assert.equal(prefilledDuration, 30);
+        assert.strictEqual(this.subject.header().value(), "mins");
+        assert.strictEqual(prefilledDuration, 30);
       },
     });
 
@@ -92,8 +92,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "days");
-        assert.equal(prefilledDuration, 2);
+        assert.strictEqual(this.subject.header().value(), "days");
+        assert.strictEqual(prefilledDuration, 2);
       },
     });
 
@@ -102,8 +102,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "months");
-        assert.equal(prefilledDuration, 3);
+        assert.strictEqual(this.subject.header().value(), "months");
+        assert.strictEqual(prefilledDuration, 3);
       },
     });
 
@@ -112,8 +112,8 @@ discourseModule(
 
       test(assert) {
         const prefilledDuration = query(".relative-time-duration").value;
-        assert.equal(this.subject.header().value(), "years");
-        assert.equal(prefilledDuration, 2);
+        assert.strictEqual(this.subject.header().value(), "years");
+        assert.strictEqual(prefilledDuration, 2);
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
@@ -25,7 +25,7 @@ discourseModule(
         await fillIn(".new-value-input.key", "thirdKey");
         await click(".add-value-btn");
 
-        assert.equal(
+        assert.strictEqual(
           count(".values .value"),
           2,
           "it doesn't add the value to the list if secret is missing"
@@ -35,7 +35,7 @@ discourseModule(
         await fillIn(".new-value-input.secret", "thirdValue");
         await click(".add-value-btn");
 
-        assert.equal(
+        assert.strictEqual(
           count(".values .value"),
           2,
           "it doesn't add the value to the list if key is missing"
@@ -45,7 +45,7 @@ discourseModule(
         await fillIn(".new-value-input.secret", "thirdValue");
         await click(".add-value-btn");
 
-        assert.equal(
+        assert.strictEqual(
           count(".values .value"),
           3,
           "it adds the value to the list of values"
@@ -96,13 +96,13 @@ discourseModule(
 
         await click(".values .value[data-index='0'] .remove-value-btn");
 
-        assert.equal(
+        assert.strictEqual(
           count(".values .value"),
           1,
           "it removes the value from the list of values"
         );
 
-        assert.equal(
+        assert.strictEqual(
           this.values,
           "secondKey|secondValue",
           "it removes the expected value"

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/api-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/api-test.js
@@ -51,11 +51,11 @@ discourseModule("Integration | Component | select-kit:api", function (hooks) {
     async test(assert) {
       await this.comboBox.expand();
 
-      assert.equal(this.comboBox.rows().length, 4);
+      assert.strictEqual(this.comboBox.rows().length, 4);
 
       const appendedRow = this.comboBox.rowByIndex(3);
       assert.ok(appendedRow.exists());
-      assert.equal(appendedRow.value(), "alpaca");
+      assert.strictEqual(appendedRow.value(), "alpaca");
 
       await this.comboBox.collapse();
 
@@ -86,11 +86,11 @@ discourseModule("Integration | Component | select-kit:api", function (hooks) {
     async test(assert) {
       await this.comboBox.expand();
 
-      assert.equal(this.comboBox.rows().length, 4);
+      assert.strictEqual(this.comboBox.rows().length, 4);
 
       const prependedRow = this.comboBox.rowByIndex(0);
       assert.ok(prependedRow.exists());
-      assert.equal(prependedRow.value(), "alpaca");
+      assert.strictEqual(prependedRow.value(), "alpaca");
 
       await this.comboBox.collapse();
 
@@ -118,7 +118,7 @@ discourseModule("Integration | Component | select-kit:api", function (hooks) {
       await this.comboBox.expand();
       await this.comboBox.selectRowByIndex(0);
 
-      assert.equal(queryAll("#test").text(), "foo");
+      assert.strictEqual(queryAll("#test").text(), "foo");
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -64,9 +64,9 @@ discourseModule(
         await this.subject.expand();
 
         assert.strictEqual(this.subject.rowByIndex(0).title(), "feature");
-        assert.strictEqual(this.subject.rowByIndex(0).value(), 2);
+        assert.strictEqual(this.subject.rowByIndex(0).value(), "2");
         assert.strictEqual(this.subject.rowByIndex(1).title(), "spec");
-        assert.strictEqual(this.subject.rowByIndex(1).value(), 26);
+        assert.strictEqual(this.subject.rowByIndex(1).value(), "26");
         assert.strictEqual(
           this.subject.rows().length,
           2,
@@ -97,13 +97,13 @@ discourseModule(
         await this.subject.expand();
 
         // The prioritized category
-        assert.strictEqual(this.subject.rowByIndex(0).value(), 5);
+        assert.strictEqual(this.subject.rowByIndex(0).value(), "5");
         // The prioritized category's child
-        assert.strictEqual(this.subject.rowByIndex(1).value(), 22);
+        assert.strictEqual(this.subject.rowByIndex(1).value(), "22");
         // Other categories in the default order
-        assert.strictEqual(this.subject.rowByIndex(2).value(), 6);
-        assert.strictEqual(this.subject.rowByIndex(3).value(), 21);
-        assert.strictEqual(this.subject.rowByIndex(4).value(), 1);
+        assert.strictEqual(this.subject.rowByIndex(2).value(), "6");
+        assert.strictEqual(this.subject.rowByIndex(3).value(), "21");
+        assert.strictEqual(this.subject.rowByIndex(4).value(), "1");
 
         assert.strictEqual(
           this.subject.rows().length,
@@ -258,13 +258,13 @@ discourseModule(
         await this.subject.expand();
         await this.subject.fillInFilter("bug");
 
-        assert.ok(this.subject.rows().length, 1);
+        assert.strictEqual(this.subject.rows().length, 1);
         assert.strictEqual(this.subject.rowByIndex(0).name(), "bug");
 
         await this.subject.emptyFilter();
         await this.subject.fillInFilter("Bug");
 
-        assert.ok(this.subject.rows().length, 1);
+        assert.strictEqual(this.subject.rows().length, 1);
         assert.strictEqual(this.subject.rowByIndex(0).name(), "bug");
       },
     });
@@ -286,9 +286,9 @@ discourseModule(
 
       async test(assert) {
         await this.subject.expand();
-        await this.subject.fillInFilter("hữ");
+        await this.subject.fillInFilter("gữ");
 
-        assert.ok(this.subject.rows().length, 1);
+        assert.strictEqual(this.subject.rows().length, 1);
         assert.strictEqual(this.subject.rowByIndex(0).name(), "chữ Quốc ngữ");
       },
     });

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -28,8 +28,8 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().value(), 2);
-        assert.equal(this.subject.header().label(), "feature");
+        assert.strictEqual(this.subject.header().value(), 2);
+        assert.strictEqual(this.subject.header().label(), "feature");
       },
     });
 
@@ -63,11 +63,11 @@ discourseModule(
       async test(assert) {
         await this.subject.expand();
 
-        assert.equal(this.subject.rowByIndex(0).title(), "feature");
-        assert.equal(this.subject.rowByIndex(0).value(), 2);
-        assert.equal(this.subject.rowByIndex(1).title(), "spec");
-        assert.equal(this.subject.rowByIndex(1).value(), 26);
-        assert.equal(
+        assert.strictEqual(this.subject.rowByIndex(0).title(), "feature");
+        assert.strictEqual(this.subject.rowByIndex(0).value(), 2);
+        assert.strictEqual(this.subject.rowByIndex(1).title(), "spec");
+        assert.strictEqual(this.subject.rowByIndex(1).value(), 26);
+        assert.strictEqual(
           this.subject.rows().length,
           2,
           "default content is scoped"
@@ -75,7 +75,7 @@ discourseModule(
 
         await this.subject.fillInFilter("bug");
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.rowByIndex(0).name(),
           "bug",
           "search finds outside of scope"
@@ -97,15 +97,15 @@ discourseModule(
         await this.subject.expand();
 
         // The prioritized category
-        assert.equal(this.subject.rowByIndex(0).value(), 5);
+        assert.strictEqual(this.subject.rowByIndex(0).value(), 5);
         // The prioritized category's child
-        assert.equal(this.subject.rowByIndex(1).value(), 22);
+        assert.strictEqual(this.subject.rowByIndex(1).value(), 22);
         // Other categories in the default order
-        assert.equal(this.subject.rowByIndex(2).value(), 6);
-        assert.equal(this.subject.rowByIndex(3).value(), 21);
-        assert.equal(this.subject.rowByIndex(4).value(), 1);
+        assert.strictEqual(this.subject.rowByIndex(2).value(), 6);
+        assert.strictEqual(this.subject.rowByIndex(3).value(), 21);
+        assert.strictEqual(this.subject.rowByIndex(4).value(), 1);
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.rows().length,
           21,
           "all categories are visible"
@@ -113,7 +113,7 @@ discourseModule(
 
         await this.subject.fillInFilter("bug");
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.rowByIndex(0).name(),
           "bug",
           "search still finds categories"
@@ -136,8 +136,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(this.subject.header().value(), null);
-        assert.equal(this.subject.header().label(), "category…");
+        assert.strictEqual(this.subject.header().value(), null);
+        assert.strictEqual(this.subject.header().label(), "category…");
       },
     });
 
@@ -157,8 +157,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(this.subject.header().value(), null);
-        assert.equal(this.subject.header().label(), "(no category)");
+        assert.strictEqual(this.subject.header().value(), null);
+        assert.strictEqual(this.subject.header().label(), "(no category)");
       },
     });
 
@@ -179,8 +179,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(this.subject.header().value(), null);
-        assert.equal(this.subject.header().label(), "root none label");
+        assert.strictEqual(this.subject.header().value(), null);
+        assert.strictEqual(this.subject.header().label(), "root none label");
       },
     });
 
@@ -199,8 +199,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(this.subject.header().value(), null);
-        assert.equal(this.subject.header().label(), "uncategorized");
+        assert.strictEqual(this.subject.header().value(), null);
+        assert.strictEqual(this.subject.header().label(), "uncategorized");
       },
     });
 
@@ -220,8 +220,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(this.subject.header().value(), null);
-        assert.equal(this.subject.header().label(), "(no category)");
+        assert.strictEqual(this.subject.header().value(), null);
+        assert.strictEqual(this.subject.header().label(), "(no category)");
       },
     });
 
@@ -242,8 +242,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(this.subject.header().value(), null);
-        assert.equal(this.subject.header().label(), "root none label");
+        assert.strictEqual(this.subject.header().value(), null);
+        assert.strictEqual(this.subject.header().label(), "root none label");
       },
     });
 
@@ -259,13 +259,13 @@ discourseModule(
         await this.subject.fillInFilter("bug");
 
         assert.ok(this.subject.rows().length, 1);
-        assert.equal(this.subject.rowByIndex(0).name(), "bug");
+        assert.strictEqual(this.subject.rowByIndex(0).name(), "bug");
 
         await this.subject.emptyFilter();
         await this.subject.fillInFilter("Bug");
 
         assert.ok(this.subject.rows().length, 1);
-        assert.equal(this.subject.rowByIndex(0).name(), "bug");
+        assert.strictEqual(this.subject.rowByIndex(0).name(), "bug");
       },
     });
 
@@ -289,7 +289,7 @@ discourseModule(
         await this.subject.fillInFilter("hữ");
 
         assert.ok(this.subject.rows().length, 1);
-        assert.equal(this.subject.rowByIndex(0).name(), "chữ Quốc ngữ");
+        assert.strictEqual(this.subject.rowByIndex(0).name(), "chữ Quốc ngữ");
       },
     });
 
@@ -313,7 +313,7 @@ discourseModule(
       async test(assert) {
         await this.subject.expand();
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.rowByIndex(0).el()[0].querySelector(".category-desc")
             .innerText,
           'baz "bar ‘foo’'

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -28,7 +28,7 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.strictEqual(this.subject.header().value(), 2);
+        assert.strictEqual(this.subject.header().value(), "2");
         assert.strictEqual(this.subject.header().label(), "feature");
       },
     });

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
@@ -178,8 +178,8 @@ discourseModule(
         await this.subject.expand();
 
         const row = this.subject.rowByValue(this.category.id);
-        assert.strictEqual(row.value(), this.category.id);
-        assert.strictEqual(this.category.parent_category_id, null);
+        assert.strictEqual(row.value(), this.category.id.toString());
+        assert.strictEqual(this.category.parent_category_id, undefined);
       },
     });
 
@@ -339,7 +339,7 @@ discourseModule(
 
         assert.strictEqual(
           this.subject.rowByIndex(0).value(),
-          this.categories.firstObject.id,
+          this.categories.firstObject.id.toString(),
           "Shortcuts are not prepended when no category is selected"
         );
       },

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
@@ -72,7 +72,7 @@ discourseModule(
 
       async test(assert) {
         const text = this.subject.header().label();
-        assert.equal(
+        assert.strictEqual(
           text,
           I18n.t("category.all").toLowerCase(),
           "it uses the noneLabel"
@@ -178,8 +178,8 @@ discourseModule(
         await this.subject.expand();
 
         const row = this.subject.rowByValue(this.category.id);
-        assert.equal(row.value(), this.category.id);
-        assert.equal(this.category.parent_category_id, null);
+        assert.strictEqual(row.value(), this.category.id);
+        assert.strictEqual(this.category.parent_category_id, null);
       },
     });
 
@@ -281,7 +281,7 @@ discourseModule(
         const row = this.subject.rowByValue(category.id);
         const topicCount = row.el().find(".topic-count").text().trim();
 
-        assert.equal(
+        assert.strictEqual(
           topicCount,
           "× 481",
           "it doesn't include the topic count of subcategories"
@@ -312,7 +312,7 @@ discourseModule(
         const row = this.subject.rowByValue(category.id);
         const topicCount = row.el().find(".topic-count").text().trim();
 
-        assert.equal(
+        assert.strictEqual(
           topicCount,
           "× 584",
           "it includes the topic count of subcategories"
@@ -337,7 +337,7 @@ discourseModule(
       async test(assert) {
         await this.subject.expand();
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.rowByIndex(0).value(),
           this.categories.firstObject.id,
           "Shortcuts are not prepended when no category is selected"
@@ -361,7 +361,10 @@ discourseModule(
       async test(assert) {
         await this.subject.expand();
 
-        assert.equal(this.subject.rowByIndex(0).value(), ALL_CATEGORIES_ID);
+        assert.strictEqual(
+          this.subject.rowByIndex(0).value(),
+          ALL_CATEGORIES_ID
+        );
       },
     });
 
@@ -384,7 +387,10 @@ discourseModule(
       async test(assert) {
         await this.subject.expand();
 
-        assert.equal(this.subject.rowByIndex(0).value(), NO_CATEGORIES_ID);
+        assert.strictEqual(
+          this.subject.rowByIndex(0).value(),
+          NO_CATEGORIES_ID
+        );
       },
     });
 
@@ -410,8 +416,14 @@ discourseModule(
         async test(assert) {
           await this.subject.expand();
 
-          assert.equal(this.subject.rowByIndex(0).value(), ALL_CATEGORIES_ID);
-          assert.equal(this.subject.rowByIndex(1).value(), NO_CATEGORIES_ID);
+          assert.strictEqual(
+            this.subject.rowByIndex(0).value(),
+            ALL_CATEGORIES_ID
+          );
+          assert.strictEqual(
+            this.subject.rowByIndex(1).value(),
+            NO_CATEGORIES_ID
+          );
         },
       }
     );

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
@@ -60,7 +60,7 @@ discourseModule(
           exists($header.el().find(".btn-clear")),
           "it shows the clear button"
         );
-        assert.equal($header.value(), DEFAULT_VALUE);
+        assert.strictEqual($header.value(), DEFAULT_VALUE);
 
         await click($header.el().find(".btn-clear")[0]);
 
@@ -68,7 +68,7 @@ discourseModule(
           exists($header.el().find(".btn-clear")),
           "it hides the clear button"
         );
-        assert.equal($header.value(), null);
+        assert.strictEqual($header.value(), null);
       },
     });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
@@ -60,7 +60,7 @@ discourseModule(
           exists($header.el().find(".btn-clear")),
           "it shows the clear button"
         );
-        assert.strictEqual($header.value(), DEFAULT_VALUE);
+        assert.strictEqual($header.value(), DEFAULT_VALUE.toString());
 
         await click($header.el().find(".btn-clear")[0]);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/dropdown-select-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/dropdown-select-box-test.js
@@ -87,7 +87,7 @@ discourseModule(
           "it hides the text of the selected item"
         );
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.header().el().attr("title"),
           "[en.test_none]",
           "it adds a title attribute to the button"

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/list-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/list-setting-test.js
@@ -28,13 +28,13 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().name(), "bold,italic");
-        assert.equal(this.subject.header().value(), "bold,italic");
+        assert.strictEqual(this.subject.header().name(), "bold,italic");
+        assert.strictEqual(this.subject.header().value(), "bold,italic");
 
         await this.subject.expand();
 
-        assert.equal(this.subject.rows().length, 1);
-        assert.equal(this.subject.rowByIndex(0).value(), "underline");
+        assert.strictEqual(this.subject.rows().length, 1);
+        assert.strictEqual(this.subject.rowByIndex(0).value(), "underline");
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -26,7 +26,7 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().value(), "foo,bar");
+        assert.strictEqual(this.subject.header().value(), "foo,bar");
       },
     });
 
@@ -38,22 +38,22 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().value(), "foo,bar");
+        assert.strictEqual(this.subject.header().value(), "foo,bar");
 
         await this.subject.expand();
         await this.subject.fillInFilter("mon");
-        assert.equal(
+        assert.strictEqual(
           queryAll(".select-kit-row").text().trim(),
           "monkey x1\ngazelle x2"
         );
         await this.subject.fillInFilter("key");
-        assert.equal(
+        assert.strictEqual(
           queryAll(".select-kit-row").text().trim(),
           "monkey x1\ngazelle x2"
         );
         await this.subject.selectRowByValue("monkey");
 
-        assert.equal(this.subject.header().value(), "foo,bar,monkey");
+        assert.strictEqual(this.subject.header().value(), "foo,bar,monkey");
       },
     });
 
@@ -66,14 +66,14 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().value(), "foo,bar");
+        assert.strictEqual(this.subject.header().value(), "foo,bar");
 
         await this.subject.expand();
         await this.subject.fillInFilter("baz");
         await this.subject.selectRowByValue("monkey");
 
         const error = queryAll(".select-kit-error").text();
-        assert.equal(
+        assert.strictEqual(
           error,
           I18n.t("select_kit.max_content_reached", {
             count: this.siteSettings.max_tags_per_topic,

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
@@ -47,18 +47,18 @@ discourseModule(
         await this.subject.expand();
 
         const content = this.subject.displayedContent();
-        assert.equal(content.length, 3, "it shows rows");
-        assert.equal(
+        assert.strictEqual(content.length, 3, "it shows rows");
+        assert.strictEqual(
           content[0].name,
           this.content.firstObject.name,
           "it has the correct name"
         );
-        assert.equal(
+        assert.strictEqual(
           content[0].id,
           this.content.firstObject.id,
           "it has the correct value"
         );
-        assert.equal(
+        assert.strictEqual(
           this.subject.header().value(),
           null,
           "it doesn't set a value from the content"

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
@@ -55,7 +55,7 @@ discourseModule(
         );
         assert.strictEqual(
           content[0].id,
-          this.content.firstObject.id,
+          this.content.firstObject.id.toString(),
           "it has the correct value"
         );
         assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
@@ -33,12 +33,12 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().name(), "pinned");
+        assert.strictEqual(this.subject.header().name(), "pinned");
 
         await this.subject.expand();
         await this.subject.selectRowByValue("unpinned");
 
-        assert.equal(this.subject.header().name(), "unpinned");
+        assert.strictEqual(this.subject.header().name(), "unpinned");
       },
     });
 
@@ -51,12 +51,12 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().name(), "unpinned");
+        assert.strictEqual(this.subject.header().name(), "unpinned");
 
         await this.subject.expand();
         await this.subject.selectRowByValue("pinned");
 
-        assert.equal(this.subject.header().name(), "pinned");
+        assert.strictEqual(this.subject.header().name(), "pinned");
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
@@ -58,7 +58,7 @@ discourseModule(
         );
         assert.strictEqual(
           content[0].id,
-          this.content.firstObject.id,
+          this.content.firstObject.id.toString(),
           "it has the correct value"
         );
         assert.strictEqual(
@@ -87,7 +87,7 @@ discourseModule(
       test(assert) {
         assert.strictEqual(
           this.subject.header().value(this.content),
-          1,
+          "1",
           "it selects the correct content to display"
         );
       },

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
@@ -50,18 +50,18 @@ discourseModule(
         await this.subject.expand();
 
         const content = this.subject.displayedContent();
-        assert.equal(content.length, 3, "it shows rows");
-        assert.equal(
+        assert.strictEqual(content.length, 3, "it shows rows");
+        assert.strictEqual(
           content[0].name,
           this.content.firstObject.name,
           "it has the correct name"
         );
-        assert.equal(
+        assert.strictEqual(
           content[0].id,
           this.content.firstObject.id,
           "it has the correct value"
         );
-        assert.equal(
+        assert.strictEqual(
           this.subject.header().value(),
           null,
           "it doesn't set a value from the content"
@@ -85,7 +85,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           this.subject.header().value(this.content),
           1,
           "it selects the correct content to display"
@@ -117,7 +117,7 @@ discourseModule(
 
         const filter = this.subject.displayedContent()[1].name;
         await this.subject.fillInFilter(filter);
-        assert.equal(
+        assert.strictEqual(
           this.subject.displayedContent()[0].name,
           filter,
           "it filters the list"
@@ -148,7 +148,7 @@ discourseModule(
         await this.subject.expand();
         await this.subject.fillInFilter("ba");
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.displayedContent().length,
           1,
           "it returns only 1 result"
@@ -181,7 +181,7 @@ discourseModule(
       async test(assert) {
         await this.subject.expand();
 
-        assert.equal(this.subject.selectedRow().value(), this.value);
+        assert.strictEqual(this.subject.selectedRow().value(), this.value);
       },
     });
 
@@ -208,8 +208,8 @@ discourseModule(
         await this.subject.expand();
 
         const noneRow = this.subject.rowByIndex(0);
-        assert.equal(noneRow.value(), null);
-        assert.equal(noneRow.name(), I18n.t("test.none"));
+        assert.strictEqual(noneRow.value(), null);
+        assert.strictEqual(noneRow.name(), I18n.t("test.none"));
       },
     });
 
@@ -235,8 +235,8 @@ discourseModule(
         await this.subject.expand();
 
         const noneRow = this.subject.rowByIndex(0);
-        assert.equal(noneRow.value(), null);
-        assert.equal(noneRow.name(), "(default)");
+        assert.strictEqual(noneRow.value(), null);
+        assert.strictEqual(noneRow.name(), "(default)");
       },
     });
 
@@ -268,13 +268,13 @@ discourseModule(
         await this.subject.expand();
 
         const noneRow = this.subject.rowByIndex(0);
-        assert.equal(noneRow.value(), I18n.t("test.none"));
-        assert.equal(noneRow.name(), I18n.t("test.none"));
-        assert.equal(this.value, "foo");
+        assert.strictEqual(noneRow.value(), I18n.t("test.none"));
+        assert.strictEqual(noneRow.name(), I18n.t("test.none"));
+        assert.strictEqual(this.value, "foo");
 
         await this.subject.selectRowByIndex(0);
 
-        assert.equal(this.value, null);
+        assert.strictEqual(this.value, null);
       },
     });
 
@@ -300,12 +300,12 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().value(), 1);
+        assert.strictEqual(this.subject.header().value(), 1);
 
         await this.subject.expand();
         await this.subject.selectRowByValue(0);
 
-        assert.equal(this.subject.header().value(), 0);
+        assert.strictEqual(this.subject.header().value(), 0);
       },
     });
 
@@ -329,9 +329,9 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.value, DEFAULT_VALUE);
+        assert.strictEqual(this.value, DEFAULT_VALUE);
         await this.subject.expand();
-        assert.equal(this.value, DEFAULT_VALUE);
+        assert.strictEqual(this.value, DEFAULT_VALUE);
       },
     });
 
@@ -352,13 +352,13 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().label(), "JACKSON");
+        assert.strictEqual(this.subject.header().label(), "JACKSON");
 
         await this.subject.expand();
 
         const row = this.subject.rowByValue(1);
 
-        assert.equal(row.label(), "JACKSON");
+        assert.strictEqual(row.label(), "JACKSON");
       },
     });
 
@@ -379,13 +379,13 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().title(), "JACKSON");
+        assert.strictEqual(this.subject.header().title(), "JACKSON");
 
         await this.subject.expand();
 
         const row = this.subject.rowByValue(1);
 
-        assert.equal(row.title(), "JACKSON");
+        assert.strictEqual(row.title(), "JACKSON");
       },
     });
 
@@ -400,7 +400,7 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(
+        assert.strictEqual(
           this.subject.header().el()[0].querySelector(".selected-name").lang,
           ""
         );
@@ -408,11 +408,11 @@ discourseModule(
         await this.subject.expand();
 
         const row = this.subject.rowByValue(1);
-        assert.equal(row.el()[0].lang, "be");
+        assert.strictEqual(row.el()[0].lang, "be");
 
         await this.subject.selectRowByValue(1);
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.header().el()[0].querySelector(".selected-name").lang,
           "be"
         );
@@ -430,7 +430,7 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(
+        assert.strictEqual(
           this.subject.header().el()[0].getAttribute("name"),
           I18n.t("select_kit.select_to_filter")
         );
@@ -438,7 +438,7 @@ discourseModule(
         await this.subject.expand();
         await this.subject.selectRowByValue(1);
 
-        assert.equal(
+        assert.strictEqual(
           this.subject.header().el()[0].getAttribute("name"),
           I18n.t("select_kit.filter_by", {
             name: this.content.firstObject.name,

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
@@ -300,12 +300,12 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.strictEqual(this.subject.header().value(), 1);
+        assert.strictEqual(this.subject.header().value(), "1");
 
         await this.subject.expand();
         await this.subject.selectRowByValue(0);
 
-        assert.strictEqual(this.subject.header().value(), 0);
+        assert.strictEqual(this.subject.header().value(), "0");
       },
     });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
@@ -75,12 +75,12 @@ discourseModule(
 
         const content = this.subject.displayedContent();
 
-        assert.equal(
+        assert.strictEqual(
           content[0].name,
           I18n.t("tagging.selector_no_tags"),
           "it has the translated label for no-tags"
         );
-        assert.equal(
+        assert.strictEqual(
           content[1].name,
           I18n.t("tagging.selector_all_tags"),
           "it has the correct label for all-tags"

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
@@ -50,7 +50,7 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(
+        assert.strictEqual(
           selectKit().header().label(),
           "Normal",
           "it has the correct label"
@@ -58,7 +58,7 @@ discourseModule(
 
         await this.set("topic", buildTopic({ level: 2 }));
 
-        assert.equal(
+        assert.strictEqual(
           selectKit().header().label(),
           "Tracking",
           "it correctly changes the label"
@@ -83,7 +83,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           selectKit().header().label(),
           `${originalTranslation} PM`,
           "it has the correct label for PMs"
@@ -105,7 +105,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-notifications-button .text").text(),
           I18n.t("topic.notifications.reasons.mailing_list_mode"),
           "mailing_list_mode enabled for the user shows unique text"
@@ -128,7 +128,7 @@ discourseModule(
       test(assert) {
         this.set("topic", buildTopic({ level: 3, reason: 999 }));
 
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-notifications-button .text").text(),
           I18n.t("topic.notifications.reasons.3"),
           "fallback to regular level translation if reason does not exist"
@@ -150,7 +150,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-notifications-button .text").text(),
           I18n.t("topic.notifications.reasons.2_8"),
           "use 2_8 notification if user is still tracking category"
@@ -177,7 +177,7 @@ discourseModule(
         },
 
         test(assert) {
-          assert.equal(
+          assert.strictEqual(
             queryAll(".topic-notifications-button .text").text(),
             I18n.t("topic.notifications.reasons.2_8_stale"),
             "use _stale notification if user is no longer tracking category"
@@ -200,7 +200,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-notifications-button .text").text(),
           I18n.t("topic.notifications.reasons.3_6"),
           "use 3_6 notification if user is still watching category"
@@ -227,7 +227,7 @@ discourseModule(
         },
 
         test(assert) {
-          assert.equal(
+          assert.strictEqual(
             queryAll(".topic-notifications-button .text").text(),
             I18n.t("topic.notifications.reasons.3_6_stale"),
             "use _stale notification if user is no longer watching category"
@@ -250,7 +250,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-notifications-button .text").text(),
           I18n.t("topic.notifications.reasons.3_10"),
           "use 3_10 notification if user is still watching tag"
@@ -272,7 +272,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-notifications-button .text").text(),
           I18n.t("topic.notifications.reasons.3_10_stale"),
           "use _stale notification if user is no longer watching tag"

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
@@ -56,13 +56,13 @@ discourseModule(
         const uiTexts = extractDescs(selectKit().rows());
         const descriptions = getTranslations();
 
-        assert.equal(
+        assert.strictEqual(
           uiTexts.length,
           descriptions.length,
           "it has the correct copy"
         );
         uiTexts.forEach((text, index) => {
-          assert.equal(
+          assert.strictEqual(
             text.trim(),
             descriptions[index].trim(),
             "it has the correct copy"
@@ -89,14 +89,14 @@ discourseModule(
         const uiTexts = extractDescs(selectKit().rows());
         const descriptions = getTranslations("_pm");
 
-        assert.equal(
+        assert.strictEqual(
           uiTexts.length,
           descriptions.length,
           "it has the correct copy"
         );
 
         uiTexts.forEach((text, index) => {
-          assert.equal(
+          assert.strictEqual(
             text.trim(),
             descriptions[index].trim(),
             "it has the correct copy"

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/user-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/user-chooser-test.js
@@ -22,7 +22,7 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(this.subject.header().name(), "bob,martin");
+        assert.strictEqual(this.subject.header().name(), "bob,martin");
       },
     });
 
@@ -36,7 +36,7 @@ discourseModule(
       async test(assert) {
         await this.subject.expand();
         await this.subject.deselectItemByValue("bob");
-        assert.equal(this.subject.header().name(), "martin");
+        assert.strictEqual(this.subject.header().name(), "martin");
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
@@ -29,7 +29,7 @@ discourseModule("Integration | Component | simple-list", function (hooks) {
       await fillIn(".add-value-input", "penar");
       await click(".add-value-btn");
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         3,
         "it adds the value to the list of values"
@@ -43,7 +43,7 @@ discourseModule("Integration | Component | simple-list", function (hooks) {
       await fillIn(".add-value-input", "eviltrout");
       await triggerKeyEvent(".add-value-input", "keydown", 13); // enter
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         4,
         "it adds the value when keying Enter"
@@ -61,7 +61,7 @@ discourseModule("Integration | Component | simple-list", function (hooks) {
     async test(assert) {
       await click(".values .value[data-index='0'] .remove-value-btn");
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         1,
         "it removes the value from the list of values"
@@ -85,7 +85,7 @@ discourseModule("Integration | Component | simple-list", function (hooks) {
       await fillIn(".add-value-input", "eviltrout");
       await click(".add-value-btn");
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         3,
         "it adds the value to the list of values"

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -21,7 +21,7 @@ discourseModule("Integration | Component | site-header", function (hooks) {
     },
 
     async test(assert) {
-      assert.equal(
+      assert.strictEqual(
         count(".ring-backdrop"),
         1,
         "there is the first notification mask"

--- a/app/assets/javascripts/discourse/tests/integration/components/slow-mode-info-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/slow-mode-info-test.js
@@ -43,7 +43,7 @@ discourseModule("Integration | Component | slow-mode-info", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(count(".slow-mode-heading"), 1);
+      assert.strictEqual(count(".slow-mode-heading"), 1);
     },
   });
 
@@ -58,7 +58,7 @@ discourseModule("Integration | Component | slow-mode-info", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(count(".slow-mode-remove"), 1);
+      assert.strictEqual(count(".slow-mode-remove"), 1);
     },
   });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
@@ -31,7 +31,7 @@ discourseModule("Integration | Component | text-field", function (hooks) {
 
     test(assert) {
       assert.ok(exists("input[type=text]"));
-      assert.equal(
+      assert.strictEqual(
         queryAll("input").prop("placeholder"),
         "placeholder.i18n.key"
       );
@@ -45,7 +45,7 @@ discourseModule("Integration | Component | text-field", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll("input").attr("dir"), "rtl");
+      assert.strictEqual(queryAll("input").attr("dir"), "rtl");
     },
   });
 
@@ -56,7 +56,7 @@ discourseModule("Integration | Component | text-field", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll("input").attr("dir"), "ltr");
+      assert.strictEqual(queryAll("input").attr("dir"), "ltr");
     },
   });
 
@@ -76,7 +76,7 @@ discourseModule("Integration | Component | text-field", function (hooks) {
       assert.ok(!this.called);
       await fillIn(".tf-test", "new text");
       assert.ok(this.called);
-      assert.equal(this.newValue, "new text");
+      assert.strictEqual(this.newValue, "new text");
     },
   });
 
@@ -96,7 +96,7 @@ discourseModule("Integration | Component | text-field", function (hooks) {
       assert.ok(!this.called);
       await fillIn(".tf-test", "no longer old");
       assert.ok(this.called);
-      assert.equal(this.newValue, "no longer old");
+      assert.strictEqual(this.newValue, "no longer old");
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/themes-list-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/themes-list-item-test.js
@@ -20,7 +20,7 @@ discourseModule("Integration | Component | themes-list-item", function (hooks) {
 
     test(assert) {
       assert.expect(1);
-      assert.equal(count(".d-icon-check"), 1, "shows default theme icon");
+      assert.strictEqual(count(".d-icon-check"), 1, "shows default theme icon");
     },
   });
 
@@ -35,7 +35,7 @@ discourseModule("Integration | Component | themes-list-item", function (hooks) {
 
     test(assert) {
       assert.expect(1);
-      assert.equal(count(".d-icon-sync"), 1, "shows pending update icon");
+      assert.strictEqual(count(".d-icon-sync"), 1, "shows pending update icon");
     },
   });
 
@@ -53,7 +53,7 @@ discourseModule("Integration | Component | themes-list-item", function (hooks) {
 
     test(assert) {
       assert.expect(1);
-      assert.equal(
+      assert.strictEqual(
         count(".d-icon-exclamation-circle"),
         1,
         "shows broken theme icon"

--- a/app/assets/javascripts/discourse/tests/integration/components/themes-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/themes-list-test.js
@@ -45,23 +45,23 @@ discourseModule("Integration | Component | themes-list", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".themes-tab").hasClass("active"),
         true,
         "themes tab is active"
       );
-      assert.equal(
+      assert.strictEqual(
         queryAll(".components-tab").hasClass("active"),
         false,
         "components tab is not active"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".inactive-indicator").index(),
         -1,
         "there is no inactive themes separator when all themes are inactive"
       );
-      assert.equal(count(".themes-list-item"), 5, "displays all themes");
+      assert.strictEqual(count(".themes-list-item"), 5, "displays all themes");
 
       [2, 3].forEach((num) => this.themes[num].set("user_selectable", true));
       this.themes[4].set("default", true);
@@ -74,7 +74,7 @@ discourseModule("Integration | Component | themes-list", function (hooks) {
         names,
         "sorts themes correctly"
       );
-      assert.equal(
+      assert.strictEqual(
         queryAll(".inactive-indicator").index(),
         3,
         "the separator is in the right location"
@@ -82,19 +82,19 @@ discourseModule("Integration | Component | themes-list", function (hooks) {
 
       this.themes.forEach((theme) => theme.set("user_selectable", true));
       this.set("themes", this.themes);
-      assert.equal(
+      assert.strictEqual(
         queryAll(".inactive-indicator").index(),
         -1,
         "there is no inactive themes separator when all themes are user-selectable"
       );
 
       this.set("themes", []);
-      assert.equal(
+      assert.strictEqual(
         count(".themes-list-item"),
         1,
         "shows one entry with a message when there is nothing to display"
       );
-      assert.equal(
+      assert.strictEqual(
         queryAll(".themes-list-item span.empty").text().trim(),
         I18n.t("admin.customize.theme.empty"),
         "displays the right message"
@@ -122,31 +122,35 @@ discourseModule("Integration | Component | themes-list", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".components-tab").hasClass("active"),
         true,
         "components tab is active"
       );
-      assert.equal(
+      assert.strictEqual(
         queryAll(".themes-tab").hasClass("active"),
         false,
         "themes tab is not active"
       );
 
-      assert.equal(
+      assert.strictEqual(
         queryAll(".inactive-indicator").index(),
         -1,
         "there is no separator"
       );
-      assert.equal(count(".themes-list-item"), 5, "displays all components");
+      assert.strictEqual(
+        count(".themes-list-item"),
+        5,
+        "displays all components"
+      );
 
       this.set("components", []);
-      assert.equal(
+      assert.strictEqual(
         count(".themes-list-item"),
         1,
         "shows one entry with a message when there is nothing to display"
       );
-      assert.equal(
+      assert.strictEqual(
         queryAll(".themes-list-item span.empty").text().trim(),
         I18n.t("admin.customize.theme.empty"),
         "displays the right message"
@@ -228,7 +232,7 @@ discourseModule("Integration | Component | themes-list", function (hooks) {
       },
       async test(assert) {
         await fillIn(".themes-list-filter .filter-input", "11");
-        assert.equal(
+        assert.strictEqual(
           query(".themes-list-container").textContent.trim(),
           "Theme 11",
           "only 1 theme is shown"
@@ -273,14 +277,14 @@ discourseModule("Integration | Component | themes-list", function (hooks) {
         );
 
         await fillIn(".themes-list-filter .filter-input", "66");
-        assert.equal(
+        assert.strictEqual(
           query(".themes-list-container").textContent.trim(),
           "Component 66",
           "only 1 component is shown"
         );
 
         await click(".themes-list-header .themes-tab");
-        assert.equal(
+        assert.strictEqual(
           query(".themes-list-container").textContent.trim(),
           "Theme 66",
           "filter term persisted between tabs because both have more than 10 items"

--- a/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
@@ -24,7 +24,7 @@ discourseModule("Integration | Component | time-input", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(this.subject.header().name(), "14:58");
+      assert.strictEqual(this.subject.header().name(), "14:58");
     },
   });
 
@@ -38,7 +38,7 @@ discourseModule("Integration | Component | time-input", function (hooks) {
     async test(assert) {
       await this.subject.expand();
       await this.subject.selectRowByIndex(3);
-      assert.equal(this.subject.header().name(), "14:58");
+      assert.strictEqual(this.subject.header().name(), "14:58");
     },
   });
 
@@ -53,7 +53,7 @@ discourseModule("Integration | Component | time-input", function (hooks) {
     async test(assert) {
       await this.subject.expand();
       await this.subject.selectRowByIndex(3);
-      assert.equal(this.subject.header().name(), "00:45");
+      assert.strictEqual(this.subject.header().name(), "00:45");
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-list-test.js
@@ -40,12 +40,12 @@ discourseModule("Integration | Component | topic-list", function (hooks) {
     },
 
     async test(assert) {
-      assert.equal(this.selected.length, 0, "defaults to 0");
+      assert.strictEqual(this.selected.length, 0, "defaults to 0");
       await click("button.bulk-select");
       assert.ok(this.bulkSelectEnabled, "bulk select is enabled");
 
       await click("button.bulk-select-all");
-      assert.equal(
+      assert.strictEqual(
         this.selected.length,
         2,
         "clicking Select All selects all loaded topics"
@@ -56,7 +56,7 @@ discourseModule("Integration | Component | topic-list", function (hooks) {
       );
 
       await click("button.bulk-clear-all");
-      assert.equal(
+      assert.strictEqual(
         this.selected.length,
         0,
         "clicking Clear All deselects all topics"

--- a/app/assets/javascripts/discourse/tests/integration/components/uppy-image-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/uppy-image-uploader-test.js
@@ -20,13 +20,13 @@ discourseModule(
     `,
 
       async test(assert) {
-        assert.equal(
+        assert.strictEqual(
           count(".d-icon-far-image"),
           1,
           "it displays the upload icon"
         );
 
-        assert.equal(
+        assert.strictEqual(
           count(".d-icon-far-trash-alt"),
           1,
           "it displays the trash icon"
@@ -39,7 +39,7 @@ discourseModule(
 
         await click(".image-uploader-lightbox-btn");
 
-        assert.equal(
+        assert.strictEqual(
           document.querySelectorAll(".mfp-container").length,
           1,
           "it displays the image lightbox"
@@ -51,7 +51,7 @@ discourseModule(
       template: hbs`{{uppy-image-uploader id="test-uppy-image-uploader"}}`,
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           count(".d-icon-far-image"),
           1,
           "it displays the upload icon"
@@ -73,7 +73,7 @@ discourseModule(
       template: hbs`{{uppy-image-uploader id="test-uppy-image-uploader" placeholderUrl='/images/avatar.png'}}`,
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           count(".d-icon-far-image"),
           1,
           "it displays the upload icon"
@@ -89,7 +89,7 @@ discourseModule(
           "it does not display the button to open image lightbox"
         );
 
-        assert.equal(
+        assert.strictEqual(
           count(".placeholder-overlay"),
           1,
           "it displays the placeholder image"

--- a/app/assets/javascripts/discourse/tests/integration/components/user-avatar-flair-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-avatar-flair-test.js
@@ -64,7 +64,7 @@ discourseModule(
       test(assert) {
         assert.ok(exists(".avatar-flair"), "it has the tag");
         assert.ok(exists("svg.d-icon-bars"), "it has the svg icon");
-        assert.equal(
+        assert.strictEqual(
           queryAll(".avatar-flair").attr("style"),
           "background-color: #CC000A; color: #FFFFFA; ",
           "it has styles"
@@ -89,7 +89,7 @@ discourseModule(
       test(assert) {
         assert.ok(exists(".avatar-flair"), "it has the tag");
         assert.ok(exists("svg.d-icon-bars"), "it has the svg icon");
-        assert.equal(
+        assert.strictEqual(
           queryAll(".avatar-flair").attr("style"),
           "background-color: #CC0005; color: #FFFFF5; ",
           "it has styles"
@@ -114,7 +114,7 @@ discourseModule(
       test(assert) {
         assert.ok(exists(".avatar-flair"), "it has the tag");
         assert.ok(exists("svg.d-icon-dice-two"), "it has the svg icon");
-        assert.equal(
+        assert.strictEqual(
           queryAll(".avatar-flair").attr("style"),
           "background-color: #CC0002; color: #FFFFF2; ",
           "it has styles"
@@ -139,7 +139,7 @@ discourseModule(
       test(assert) {
         assert.ok(exists(".avatar-flair"), "it has the tag");
         assert.ok(exists("svg.d-icon-dice-two"), "it has the svg icon");
-        assert.equal(
+        assert.strictEqual(
           queryAll(".avatar-flair").attr("style"),
           "background-color: #CC0002; color: #FFFFF2; ",
           "it has styles"
@@ -189,7 +189,7 @@ discourseModule(
       test(assert) {
         assert.ok(exists(".avatar-flair"), "it has the tag");
         assert.ok(exists("svg.d-icon-times"), "it has the svg icon");
-        assert.equal(
+        assert.strictEqual(
           queryAll(".avatar-flair").attr("style"),
           "background-color: #123456; color: #B0B0B0; ",
           "it has styles"

--- a/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
@@ -23,23 +23,23 @@ discourseModule("Integration | Component | user-selector", function (hooks) {
     test(assert) {
       let element = query(".test-selector");
 
-      assert.equal(this.get("usernames"), "evil,trout");
+      assert.strictEqual(this.get("usernames"), "evil,trout");
       paste(element, "zip,zap,zoom");
-      assert.equal(this.get("usernames"), "evil,trout,zip,zap,zoom");
+      assert.strictEqual(this.get("usernames"), "evil,trout,zip,zap,zoom");
       paste(element, "evil,abc,abc,abc");
-      assert.equal(this.get("usernames"), "evil,trout,zip,zap,zoom,abc");
+      assert.strictEqual(this.get("usernames"), "evil,trout,zip,zap,zoom,abc");
 
       this.set("usernames", "");
       paste(element, "names with spaces");
-      assert.equal(this.get("usernames"), "names,with,spaces");
+      assert.strictEqual(this.get("usernames"), "names,with,spaces");
 
       this.set("usernames", null);
       paste(element, "@eviltrout,@codinghorror sam");
-      assert.equal(this.get("usernames"), "eviltrout,codinghorror,sam");
+      assert.strictEqual(this.get("usernames"), "eviltrout,codinghorror,sam");
 
       this.set("usernames", null);
       paste(element, "eviltrout\nsam\ncodinghorror");
-      assert.equal(this.get("usernames"), "eviltrout,sam,codinghorror");
+      assert.strictEqual(this.get("usernames"), "eviltrout,sam,codinghorror");
     },
   });
 
@@ -54,7 +54,7 @@ discourseModule("Integration | Component | user-selector", function (hooks) {
     test(assert) {
       let element = query(".test-selector");
       paste(element, "roman,penar,jeff,robin");
-      assert.equal(this.get("usernames"), "mark,roman,penar");
+      assert.strictEqual(this.get("usernames"), "mark,roman,penar");
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
@@ -27,7 +27,7 @@ discourseModule("Integration | Component | value-list", function (hooks) {
       await selectKit().fillInFilter("eviltrout");
       await selectKit().keyboard("Enter");
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         3,
         "it adds the value to the list of values"
@@ -51,13 +51,13 @@ discourseModule("Integration | Component | value-list", function (hooks) {
     async test(assert) {
       await click(".values .value[data-index='0'] .remove-value-btn");
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         1,
         "it removes the value from the list of values"
       );
 
-      assert.equal(this.values, "osama", "it removes the expected value");
+      assert.strictEqual(this.values, "osama", "it removes the expected value");
 
       await selectKit().expand();
 
@@ -83,7 +83,7 @@ discourseModule("Integration | Component | value-list", function (hooks) {
       await selectKit().expand();
       await selectKit().selectRowByValue("maja");
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         3,
         "it adds the value to the list of values"
@@ -111,7 +111,7 @@ discourseModule("Integration | Component | value-list", function (hooks) {
       await selectKit().fillInFilter("eviltrout");
       await selectKit().selectRowByValue("eviltrout");
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         3,
         "it adds the value to the list of values"
@@ -139,7 +139,7 @@ discourseModule("Integration | Component | value-list", function (hooks) {
       await selectKit().fillInFilter("eviltrout");
       await selectKit().keyboard("Enter");
 
-      assert.equal(
+      assert.strictEqual(
         count(".values .value"),
         3,
         "it adds the value to the list of values"

--- a/app/assets/javascripts/discourse/tests/integration/widgets/actions-summary-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/actions-summary-test.js
@@ -19,12 +19,12 @@ discourseModule(
         });
       },
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           count(".post-action .d-icon-far-trash-alt"),
           1,
           "it has the deleted icon"
         );
-        assert.equal(
+        assert.strictEqual(
           count(".avatar[title=eviltrout]"),
           1,
           "it has the deleted by avatar"

--- a/app/assets/javascripts/discourse/tests/integration/widgets/avatar-flair-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/avatar-flair-test.js
@@ -25,7 +25,7 @@ discourseModule(
       test(assert) {
         assert.ok(exists(".avatar-flair"), "it has the tag");
         assert.ok(exists("svg.d-icon-bars"), "it has the svg icon");
-        assert.equal(
+        assert.strictEqual(
           queryAll(".avatar-flair").attr("style"),
           "background-color: #CC0000; color: #FFFFFF; ",
           "it has styles"

--- a/app/assets/javascripts/discourse/tests/integration/widgets/button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/button-test.js
@@ -62,7 +62,10 @@ discourseModule("Integration | Component | Widget | button", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(query("button span.d-button-label").innerText, "foo bar");
+      assert.strictEqual(
+        query("button span.d-button-label").innerText,
+        "foo bar"
+      );
     },
   });
 
@@ -74,7 +77,7 @@ discourseModule("Integration | Component | Widget | button", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(query("button").title, "foo bar");
+      assert.strictEqual(query("button").title, "foo bar");
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
@@ -48,7 +48,7 @@ discourseModule(
         pretender.put("/notifications/mark-read", (request) => {
           ++requests;
 
-          assert.equal(
+          assert.strictEqual(
             request.requestBody,
             `id=${this.args.id}`,
             "it sets correct request parameters"
@@ -72,8 +72,8 @@ discourseModule(
         );
         await settled();
 
-        assert.equal(count("li.read"), 1);
-        assert.equal(requests, 1);
+        assert.strictEqual(count("li.read"), 1);
+        assert.strictEqual(requests, 1);
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
@@ -124,8 +124,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count(".category-link"), 8);
-        assert.equal(
+        assert.strictEqual(count(".category-link"), 8);
+        assert.strictEqual(
           queryAll(".category-link .category-name").text(),
           this.site
             .get("categoriesByCount")
@@ -146,8 +146,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count(".category-link"), 8);
-        assert.equal(
+        assert.strictEqual(count(".category-link"), 8);
+        assert.strictEqual(
           queryAll(".category-link .category-name").text(),
           this.site
             .get("categoriesByCount")
@@ -201,7 +201,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           count(".category-link"),
           maxCategoriesToDisplay,
           "categories displayed limited by header_dropdown_category_count"
@@ -218,7 +218,7 @@ discourseModule(
           .uniq()
           .slice(0, maxCategoriesToDisplay);
 
-        assert.equal(
+        assert.strictEqual(
           queryAll(".category-link .category-name").text(),
           ids
             .map(

--- a/app/assets/javascripts/discourse/tests/integration/widgets/home-logo-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/home-logo-test.js
@@ -54,7 +54,7 @@ discourseModule(
         assert.strictEqual(count("img.logo-small"), 1);
         assert.strictEqual(queryAll("img.logo-small").attr("src"), smallLogo);
         assert.strictEqual(queryAll("img.logo-small").attr("alt"), title);
-        assert.strictEqual(queryAll("img.logo-small").attr("width"), 36);
+        assert.strictEqual(queryAll("img.logo-small").attr("width"), "36");
       },
     });
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/home-logo-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/home-logo-test.js
@@ -33,11 +33,11 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count(".title"), 1);
+        assert.strictEqual(count(".title"), 1);
 
-        assert.equal(count("img#site-logo.logo-big"), 1);
-        assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
-        assert.equal(queryAll("#site-logo").attr("alt"), title);
+        assert.strictEqual(count("img#site-logo.logo-big"), 1);
+        assert.strictEqual(queryAll("#site-logo").attr("src"), bigLogo);
+        assert.strictEqual(queryAll("#site-logo").attr("alt"), title);
       },
     });
 
@@ -51,10 +51,10 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count("img.logo-small"), 1);
-        assert.equal(queryAll("img.logo-small").attr("src"), smallLogo);
-        assert.equal(queryAll("img.logo-small").attr("alt"), title);
-        assert.equal(queryAll("img.logo-small").attr("width"), 36);
+        assert.strictEqual(count("img.logo-small"), 1);
+        assert.strictEqual(queryAll("img.logo-small").attr("src"), smallLogo);
+        assert.strictEqual(queryAll("img.logo-small").attr("alt"), title);
+        assert.strictEqual(queryAll("img.logo-small").attr("width"), 36);
       },
     });
 
@@ -68,8 +68,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count("h1#site-text-logo.text-logo"), 1);
-        assert.equal(queryAll("#site-text-logo").text(), title);
+        assert.strictEqual(count("h1#site-text-logo.text-logo"), 1);
+        assert.strictEqual(queryAll("#site-text-logo").text(), title);
       },
     });
 
@@ -83,7 +83,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count(".d-icon-home"), 1);
+        assert.strictEqual(count(".d-icon-home"), 1);
       },
     });
 
@@ -96,8 +96,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count("img#site-logo.logo-mobile"), 1);
-        assert.equal(queryAll("#site-logo").attr("src"), mobileLogo);
+        assert.strictEqual(count("img#site-logo.logo-mobile"), 1);
+        assert.strictEqual(queryAll("#site-logo").attr("src"), mobileLogo);
       },
     });
 
@@ -109,8 +109,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count("img#site-logo.logo-big"), 1);
-        assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
+        assert.strictEqual(count("img#site-logo.logo-big"), 1);
+        assert.strictEqual(queryAll("#site-logo").attr("src"), bigLogo);
       },
     });
 
@@ -126,15 +126,15 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count("img#site-logo.logo-big"), 1);
-        assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
+        assert.strictEqual(count("img#site-logo.logo-big"), 1);
+        assert.strictEqual(queryAll("#site-logo").attr("src"), bigLogo);
 
-        assert.equal(
+        assert.strictEqual(
           queryAll("picture source").attr("media"),
           prefersDark,
           "includes dark mode media attribute"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll("picture source").attr("srcset"),
           darkLogo,
           "includes dark mode alternative logo source"
@@ -157,14 +157,14 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(queryAll("#site-logo").attr("src"), mobileLogo);
+        assert.strictEqual(queryAll("#site-logo").attr("src"), mobileLogo);
 
-        assert.equal(
+        assert.strictEqual(
           queryAll("picture source").attr("media"),
           prefersDark,
           "includes dark mode media attribute"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll("picture source").attr("srcset"),
           darkLogo,
           "includes dark mode alternative logo source"
@@ -184,8 +184,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count("img#site-logo.logo-big"), 1);
-        assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
+        assert.strictEqual(count("img#site-logo.logo-big"), 1);
+        assert.strictEqual(queryAll("#site-logo").attr("src"), bigLogo);
         assert.ok(!exists("picture"), "does not include alternative logo");
       },
     });
@@ -198,8 +198,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count("img#site-logo.logo-big"), 1);
-        assert.equal(queryAll("#site-logo").attr("src"), bigLogo);
+        assert.strictEqual(count("img#site-logo.logo-big"), 1);
+        assert.strictEqual(queryAll("#site-logo").attr("src"), bigLogo);
         assert.ok(!exists("picture"), "does not include alternative logo");
       },
     });
@@ -215,8 +215,8 @@ discourseModule(
         Session.currentProp("defaultColorSchemeIsDark", null);
       },
       test(assert) {
-        assert.equal(count("img#site-logo.logo-big"), 1);
-        assert.equal(
+        assert.strictEqual(count("img#site-logo.logo-big"), 1);
+        assert.strictEqual(
           queryAll("#site-logo").attr("src"),
           darkLogo,
           "uses dark logo"
@@ -236,8 +236,8 @@ discourseModule(
         Session.currentProp("defaultColorSchemeIsDark", null);
       },
       test(assert) {
-        assert.equal(count("img#site-logo.logo-big"), 1);
-        assert.equal(
+        assert.strictEqual(count("img#site-logo.logo-big"), 1);
+        assert.strictEqual(
           queryAll("#site-logo").attr("src"),
           bigLogo,
           "uses regular logo on dark scheme if no dark logo"

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-links-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-links-test.js
@@ -30,7 +30,7 @@ discourseModule(
         });
       },
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           count(".post-links a.track-link"),
           1,
           "it hides the dupe link"
@@ -83,9 +83,9 @@ discourseModule(
         });
       },
       async test(assert) {
-        assert.equal(count(".expand-links"), 1, "collapsed by default");
+        assert.strictEqual(count(".expand-links"), 1, "collapsed by default");
         await click("a.expand-links");
-        assert.equal(count(".post-links a.track-link"), 7);
+        assert.strictEqual(count(".post-links a.track-link"), 7);
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-menu-test.js
@@ -31,7 +31,7 @@ discourseModule(
         });
       },
       async test(assert) {
-        assert.equal(
+        assert.strictEqual(
           count(".actions .extra-buttons .hot-coffee"),
           1,
           "It renders extra button"

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
@@ -73,54 +73,54 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(count(".post-stream"), 1);
-        assert.equal(count(".topic-post"), 6, "renders all posts");
+        assert.strictEqual(count(".post-stream"), 1);
+        assert.strictEqual(count(".topic-post"), 6, "renders all posts");
 
         // look for special class bindings
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-post:nth-of-type(1).topic-owner").length,
           1,
           "it applies the topic owner class"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-post:nth-of-type(1).group-trout").length,
           1,
           "it applies the primary group class"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-post:nth-of-type(1).regular").length,
           1,
           "it applies the regular class"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-post:nth-of-type(2).moderator").length,
           1,
           "it applies the moderator class"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-post:nth-of-type(3).post-hidden").length,
           1,
           "it applies the hidden class"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-post:nth-of-type(4).whisper").length,
           1,
           "it applies the whisper class"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll(".topic-post:nth-of-type(5).wiki").length,
           1,
           "it applies the wiki class"
         );
 
         // it renders an article for the body with appropriate attributes
-        assert.equal(count("article#post_2"), 1);
-        assert.equal(count('article[data-user-id="123"]'), 1);
-        assert.equal(count('article[data-post-id="3"]'), 1);
-        assert.equal(count("article#post_5.via-email"), 1);
-        assert.equal(count("article#post_6.is-auto-generated"), 1);
+        assert.strictEqual(count("article#post_2"), 1);
+        assert.strictEqual(count('article[data-user-id="123"]'), 1);
+        assert.strictEqual(count('article[data-post-id="3"]'), 1);
+        assert.strictEqual(count("article#post_5.via-email"), 1);
+        assert.strictEqual(count("article#post_6.is-auto-generated"), 1);
 
-        assert.equal(
+        assert.strictEqual(
           queryAll("article:nth-of-type(1) .main-avatar").length,
           1,
           "renders the main avatar"
@@ -143,12 +143,12 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(
+        assert.strictEqual(
           count(".topic-post.deleted"),
           1,
           "it applies the deleted class"
         );
-        assert.equal(
+        assert.strictEqual(
           count(".deleted-user-avatar"),
           1,
           "it has the trash avatar"

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -42,8 +42,8 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       });
     },
     async test(assert) {
-      assert.equal(queryAll(".badge.clicks:nth(0)").text(), "1");
-      assert.equal(queryAll(".badge.clicks:nth(1)").text(), "2");
+      assert.strictEqual(queryAll(".badge.clicks:nth(0)").text(), "1");
+      assert.strictEqual(queryAll(".badge.clicks:nth(1)").text(), "2");
     },
   });
 
@@ -70,9 +70,9 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       });
     },
     async test(assert) {
-      assert.equal(queryAll(".badge.clicks").length, 2);
-      assert.equal(queryAll(".badge.clicks:nth(0)").text(), "1");
-      assert.equal(queryAll(".badge.clicks:nth(1)").text(), "2");
+      assert.strictEqual(queryAll(".badge.clicks").length, 2);
+      assert.strictEqual(queryAll(".badge.clicks:nth(0)").text(), "1");
+      assert.strictEqual(queryAll(".badge.clicks:nth(1)").text(), "2");
     },
   });
 
@@ -178,8 +178,8 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       this.set("args", { isWhisper: true });
     },
     test(assert) {
-      assert.equal(count(".topic-post.whisper"), 1);
-      assert.equal(count(".post-info.whisper"), 1);
+      assert.strictEqual(count(".topic-post.whisper"), 1);
+      assert.strictEqual(count(".post-info.whisper"), 1);
     },
   });
 
@@ -198,13 +198,13 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       this.set("args", { likeCount: 1 });
     },
     async test(assert) {
-      assert.equal(count("button.like-count"), 1);
+      assert.strictEqual(count("button.like-count"), 1);
       assert.ok(!exists(".who-liked"));
 
       // toggle it on
       await click("button.like-count");
-      assert.equal(count(".who-liked"), 1);
-      assert.equal(count(".who-liked a.trigger-user-card"), 1);
+      assert.strictEqual(count(".who-liked"), 1);
+      assert.strictEqual(count(".who-liked a.trigger-user-card"), 1);
 
       // toggle it off
       await click("button.like-count");
@@ -255,7 +255,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       await click(".actions button.like");
       assert.ok(!exists(".actions button.like"));
       assert.ok(exists(".actions button.has-like"));
-      assert.equal(count(".actions button.like-count"), 1);
+      assert.strictEqual(count(".actions button.like-count"), 1);
 
       await click(".actions button.has-like");
       assert.ok(exists(".actions button.like"));
@@ -278,7 +278,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       assert.ok(exists(".actions button.like"));
       assert.ok(!exists(".actions button.like-count"));
 
-      assert.equal(
+      assert.strictEqual(
         queryAll("button.like").attr("title"),
         I18n.t("post.controls.like"),
         `shows the right button title for anonymous users`
@@ -366,9 +366,13 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       async test(assert) {
         await click(".show-more-actions");
 
-        assert.equal(count("button.create-flag"), 1, `button is displayed`);
-        assert.equal(count("button.delete"), 1, `button is displayed`);
-        assert.equal(
+        assert.strictEqual(
+          count("button.create-flag"),
+          1,
+          `button is displayed`
+        );
+        assert.strictEqual(count("button.delete"), 1, `button is displayed`);
+        assert.strictEqual(
           queryAll("button.delete").attr("title"),
           I18n.t("post.controls.delete_topic_disallowed"),
           `shows the right button title for users without permissions`
@@ -474,7 +478,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       this.set("showFlags", () => (this.flagsShown = true));
     },
     async test(assert) {
-      assert.equal(count("button.create-flag"), 1);
+      assert.strictEqual(count("button.create-flag"), 1);
 
       await click("button.create-flag");
       assert.ok(this.flagsShown, "it triggered the action");
@@ -547,7 +551,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
     },
     test(assert) {
       assert.ok(exists("a.reply-to-tab"), "shows the tab");
-      assert.equal(count(".avoid-tab"), 1, "has the avoid tab class");
+      assert.strictEqual(count(".avoid-tab"), 1, "has the avoid tab class");
     },
   });
 
@@ -562,10 +566,10 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       this.siteSettings.suppress_reply_directly_above = false;
     },
     async test(assert) {
-      assert.equal(count(".avoid-tab"), 1, "has the avoid tab class");
+      assert.strictEqual(count(".avoid-tab"), 1, "has the avoid tab class");
       await click("a.reply-to-tab");
-      assert.equal(count("section.embedded-posts.top .cooked"), 1);
-      assert.equal(count("section.embedded-posts .d-icon-arrow-up"), 1);
+      assert.strictEqual(count("section.embedded-posts.top .cooked"), 1);
+      assert.strictEqual(count("section.embedded-posts .d-icon-arrow-up"), 1);
     },
   });
 
@@ -617,7 +621,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       this.set("toggleBookmark", () => (args.bookmarked = true));
     },
     async test(assert) {
-      assert.equal(count(".post-menu-area .bookmark"), 1);
+      assert.strictEqual(count(".post-menu-area .bookmark"), 1);
       assert.ok(!exists("button.bookmarked"));
     },
   });
@@ -640,7 +644,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
     async test(assert) {
       assert.ok(!exists(".post-admin-menu"));
       await click(".post-menu-area .show-post-admin-menu");
-      assert.equal(count(".post-admin-menu"), 1, "it shows the popup");
+      assert.strictEqual(count(".post-admin-menu"), 1, "it shows the popup");
       await click(".post-menu-area");
       assert.ok(
         !exists(".post-admin-menu"),
@@ -805,7 +809,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       this.set("args", { replyCount: 2, replyDirectlyBelow: true });
     },
     test(assert) {
-      assert.equal(count("button.show-replies"), 1);
+      assert.strictEqual(count("button.show-replies"), 1);
     },
   });
 
@@ -828,8 +832,8 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
     },
     async test(assert) {
       await click("button.show-replies");
-      assert.equal(count("section.embedded-posts.bottom .cooked"), 1);
-      assert.equal(count("section.embedded-posts .d-icon-arrow-down"), 1);
+      assert.strictEqual(count("section.embedded-posts.bottom .cooked"), 1);
+      assert.strictEqual(count("section.embedded-posts .d-icon-arrow-down"), 1);
     },
   });
 
@@ -859,7 +863,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       );
 
       await click("nav.buttons button");
-      assert.equal(
+      assert.strictEqual(
         count(".topic-map-expanded a.poster"),
         2,
         "shows all when expanded"
@@ -883,7 +887,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       });
     },
     async test(assert) {
-      assert.equal(
+      assert.strictEqual(
         count("li.avatars a.poster"),
         3,
         "limits to three participants"
@@ -891,12 +895,12 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
 
       await click("nav.buttons button");
       assert.ok(!exists("li.avatars a.poster"));
-      assert.equal(
+      assert.strictEqual(
         count(".topic-map-expanded a.poster"),
         4,
         "shows all when expanded"
       );
-      assert.equal(count("a.poster.toggled"), 2, "two are toggled");
+      assert.strictEqual(count("a.poster.toggled"), 2, "two are toggled");
     },
   });
 
@@ -916,22 +920,22 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       });
     },
     async test(assert) {
-      assert.equal(count(".topic-map"), 1);
-      assert.equal(count(".map.map-collapsed"), 1);
+      assert.strictEqual(count(".topic-map"), 1);
+      assert.strictEqual(count(".map.map-collapsed"), 1);
       assert.ok(!exists(".topic-map-expanded"));
 
       await click("nav.buttons button");
       assert.ok(!exists(".map.map-collapsed"));
-      assert.equal(count(".topic-map .d-icon-chevron-up"), 1);
-      assert.equal(count(".topic-map-expanded"), 1);
-      assert.equal(
+      assert.strictEqual(count(".topic-map .d-icon-chevron-up"), 1);
+      assert.strictEqual(count(".topic-map-expanded"), 1);
+      assert.strictEqual(
         count(".topic-map-expanded .topic-link"),
         5,
         "it limits the links displayed"
       );
 
       await click(".link-summary button");
-      assert.equal(
+      assert.strictEqual(
         count(".topic-map-expanded .topic-link"),
         6,
         "all links now shown"
@@ -956,7 +960,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       this.set("showSummary", () => (this.summaryToggled = true));
     },
     async test(assert) {
-      assert.equal(count(".toggle-summary"), 1);
+      assert.strictEqual(count(".toggle-summary"), 1);
 
       await click(".toggle-summary button");
       assert.ok(this.summaryToggled);
@@ -974,8 +978,8 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       });
     },
     test(assert) {
-      assert.equal(count(".private-message-map"), 1);
-      assert.equal(count(".private-message-map .user"), 1);
+      assert.strictEqual(count(".private-message-map"), 1);
+      assert.strictEqual(count(".private-message-map .user"), 1);
     },
   });
 
@@ -998,7 +1002,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       });
     },
     test(assert) {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".post-notice.returning-user:not(.old)").text().trim(),
         I18n.t("post.notice.returning_user", {
           user: "codinghorror",
@@ -1022,7 +1026,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       });
     },
     test(assert) {
-      assert.equal(
+      assert.strictEqual(
         queryAll(".post-notice.old.new-user").text().trim(),
         I18n.t("post.notice.new_user", { user: "Jeff", time: "Jan '10" })
       );
@@ -1039,8 +1043,8 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
     },
     test(assert) {
       const link = queryAll(".group-request a");
-      assert.equal(link.text().trim(), I18n.t("groups.requests.handle"));
-      assert.equal(link.attr("href"), "/g/testGroup/requests?filter=foo");
+      assert.strictEqual(link.text().trim(), I18n.t("groups.requests.handle"));
+      assert.strictEqual(link.attr("href"), "/g/testGroup/requests?filter=foo");
     },
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/widgets/poster-name-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/poster-name-test.js
@@ -27,9 +27,9 @@ discourseModule(
         assert.ok(exists(".names"));
         assert.ok(exists("span.username"));
         assert.ok(exists('a[data-user-card="eviltrout"]'));
-        assert.equal(queryAll(".username a").text(), "eviltrout");
-        assert.equal(queryAll(".full-name a").text(), "Robin Ward");
-        assert.equal(queryAll(".user-title").text(), "Trout Master");
+        assert.strictEqual(queryAll(".username a").text(), "eviltrout");
+        assert.strictEqual(queryAll(".full-name a").text(), "Robin Ward");
+        assert.strictEqual(queryAll(".user-title").text(), "Trout Master");
       },
     });
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/quick-access-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/quick-access-item-test.js
@@ -20,7 +20,7 @@ discourseModule(
 
       test(assert) {
         const contentDiv = query(CONTENT_DIV_SELECTOR);
-        assert.equal(contentDiv.innerText, "<b>bold</b>");
+        assert.strictEqual(contentDiv.innerText, "<b>bold</b>");
       },
     });
 
@@ -33,7 +33,7 @@ discourseModule(
 
       test(assert) {
         const contentDiv = query(CONTENT_DIV_SELECTOR);
-        assert.equal(contentDiv.innerText, '"quote"');
+        assert.strictEqual(contentDiv.innerText, '"quote"');
       },
     });
   }

--- a/app/assets/javascripts/discourse/tests/integration/widgets/small-user-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/small-user-list-test.js
@@ -24,7 +24,7 @@ discourseModule(
         });
       },
       async test(assert) {
-        assert.equal(count('[data-user-card="eviltrout"]'), 1);
+        assert.strictEqual(count('[data-user-card="eviltrout"]'), 1);
         assert.ok(!exists('[data-user-card="someone"]'));
         assert.ok(exists(".unknown"), "includes unknown user");
       },

--- a/app/assets/javascripts/discourse/tests/integration/widgets/software-update-prompt-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/software-update-prompt-test.js
@@ -30,7 +30,7 @@ discourseModule(
 
           const done = assert.async();
           later(() => {
-            assert.equal(
+            assert.strictEqual(
               count("div.software-update-prompt.require-software-refresh"),
               1,
               "it does have the class to show the prompt"

--- a/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
@@ -37,7 +37,7 @@ discourseModule(
       async test(assert) {
         const $links = queryAll(".quick-access-panel li a");
 
-        assert.equal($links.length, 6);
+        assert.strictEqual($links.length, 6);
         assert.ok($links[1].href.includes("/t/a-slug/123"));
 
         assert.ok(
@@ -46,7 +46,7 @@ discourseModule(
           )
         );
 
-        assert.equal(
+        assert.strictEqual(
           $links[2].text,
           `aquaman ${I18n.t("notifications.liked_consolidated_description", {
             count: 5,

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
@@ -128,9 +128,9 @@ discourseModule(
 
       async test(assert) {
         await toggle();
-        assert.strictEqual(rowById(1).dataset.id, 1, "it creates rows");
-        assert.strictEqual(rowById(2).dataset.id, 2, "it creates rows");
-        assert.strictEqual(rowById(3).dataset.id, 3, "it creates rows");
+        assert.strictEqual(rowById(1).dataset.id, "1", "it creates rows");
+        assert.strictEqual(rowById(2).dataset.id, "2", "it creates rows");
+        assert.strictEqual(rowById(3).dataset.id, "3", "it creates rows");
       },
     });
 
@@ -159,7 +159,7 @@ discourseModule(
         await clickRowById(2);
         assert.strictEqual(
           queryAll("#test").text(),
-          2,
+          "2",
           "it calls the onChange actions"
         );
       },
@@ -363,11 +363,7 @@ discourseModule(
 
       async test(assert) {
         await toggle();
-        assert.strictEqual(
-          rowById(1),
-          undefined,
-          "it does not display options"
-        );
+        assert.strictEqual(rowById(1), null, "it does not display options");
       },
     });
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
@@ -95,7 +95,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(headerLabel(), "FooBaz");
+        assert.strictEqual(headerLabel(), "FooBaz");
       },
     });
 
@@ -115,7 +115,7 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(headerLabel(), this.translatedLabel);
+        assert.strictEqual(headerLabel(), this.translatedLabel);
       },
     });
 
@@ -128,9 +128,9 @@ discourseModule(
 
       async test(assert) {
         await toggle();
-        assert.equal(rowById(1).dataset.id, 1, "it creates rows");
-        assert.equal(rowById(2).dataset.id, 2, "it creates rows");
-        assert.equal(rowById(3).dataset.id, 3, "it creates rows");
+        assert.strictEqual(rowById(1).dataset.id, 1, "it creates rows");
+        assert.strictEqual(rowById(2).dataset.id, 2, "it creates rows");
+        assert.strictEqual(rowById(3).dataset.id, 3, "it creates rows");
       },
     });
 
@@ -157,7 +157,7 @@ discourseModule(
       async test(assert) {
         await toggle();
         await clickRowById(2);
-        assert.equal(
+        assert.strictEqual(
           queryAll("#test").text(),
           2,
           "it calls the onChange actions"
@@ -176,7 +176,7 @@ discourseModule(
         assert.ok(exists("#my-dropdown.closed"));
         assert.ok(!exists("#my-dropdown .widget-dropdown-body"));
         await toggle();
-        assert.equal(rowById(2).innerText.trim(), "FooBar");
+        assert.strictEqual(rowById(2).innerText.trim(), "FooBar");
         assert.ok(exists("#my-dropdown.opened"));
         assert.ok(exists("#my-dropdown .widget-dropdown-body"));
         await toggle();
@@ -220,7 +220,7 @@ discourseModule(
 
       async test(assert) {
         await toggle();
-        assert.equal(rowById(2).innerText.trim(), "FooBar");
+        assert.strictEqual(rowById(2).innerText.trim(), "FooBar");
       },
     });
 
@@ -240,7 +240,7 @@ discourseModule(
 
       async test(assert) {
         await toggle();
-        assert.equal(rowById(1).innerText.trim(), "FooBaz");
+        assert.strictEqual(rowById(1).innerText.trim(), "FooBaz");
       },
     });
 
@@ -266,7 +266,10 @@ discourseModule(
 
       async test(assert) {
         await toggle();
-        assert.equal(rowById(4).innerHTML.trim(), "<span><b>baz</b></span>");
+        assert.strictEqual(
+          rowById(4).innerHTML.trim(),
+          "<span><b>baz</b></span>"
+        );
       },
     });
 
@@ -360,7 +363,11 @@ discourseModule(
 
       async test(assert) {
         await toggle();
-        assert.equal(rowById(1), undefined, "it does not display options");
+        assert.strictEqual(
+          rowById(1),
+          undefined,
+          "it does not display options"
+        );
       },
     });
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
@@ -33,7 +33,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll(".test").text(), "Hello Robin");
+      assert.strictEqual(queryAll(".test").text(), "Hello Robin");
     },
   });
 
@@ -51,7 +51,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll(".base-url-test").text(), "/");
+      assert.strictEqual(queryAll(".base-url-test").text(), "/");
     },
   });
 
@@ -67,7 +67,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll("div.test").text(), "Hello Robin");
+      assert.strictEqual(queryAll("div.test").text(), "Hello Robin");
     },
   });
 
@@ -84,7 +84,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll("div.test").text(), "Hello Robin");
+      assert.strictEqual(queryAll("div.test").text(), "Hello Robin");
     },
   });
 
@@ -98,7 +98,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll("div.mydiv").data("my-test"), "hello world");
+      assert.strictEqual(queryAll("div.mydiv").data("my-test"), "hello world");
     },
   });
 
@@ -182,10 +182,10 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
 
     async test(assert) {
       assert.ok(exists("button.test"), "it renders the button");
-      assert.equal(queryAll("button.test").text(), "0 clicks");
+      assert.strictEqual(queryAll("button.test").text(), "0 clicks");
 
       await click(query("button"));
-      assert.equal(queryAll("button.test").text(), "1 clicks");
+      assert.strictEqual(queryAll("button.test").text(), "1 clicks");
     },
   });
 
@@ -216,10 +216,10 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     async test(assert) {
-      assert.equal(queryAll("button.test").text().trim(), "No name");
+      assert.strictEqual(queryAll("button.test").text().trim(), "No name");
 
       await click(query("button"));
-      assert.equal(queryAll("button.test").text().trim(), "Robin");
+      assert.strictEqual(queryAll("button.test").text().trim(), "Robin");
     },
   });
 
@@ -276,7 +276,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
 
     test(assert) {
       assert.ok(exists(".container"), "renders container");
-      assert.equal(queryAll(".container .value").text(), "hello world");
+      assert.strictEqual(queryAll(".container .value").text(), "hello world");
     },
   });
 
@@ -300,7 +300,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
 
     test(assert) {
       assert.ok(queryAll(".container").length, "renders container");
-      assert.equal(queryAll(".container .value").text(), "hello world");
+      assert.strictEqual(queryAll(".container .value").text(), "hello world");
     },
   });
 
@@ -314,7 +314,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(count(".d-icon-arrow-down"), 1);
+      assert.strictEqual(count(".d-icon-arrow-down"), 1);
     },
   });
 
@@ -348,9 +348,9 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
 
     test(assert) {
       // coming up
-      assert.equal(queryAll("span.string").text(), "evil");
-      assert.equal(queryAll("span.var").text(), "trout");
-      assert.equal(queryAll("a").prop("title"), "evil");
+      assert.strictEqual(queryAll("span.string").text(), "evil");
+      assert.strictEqual(queryAll("span.var").text(), "trout");
+      assert.strictEqual(queryAll("a").prop("title"), "evil");
     },
   });
 
@@ -373,8 +373,8 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(count("ul li"), 3);
-      assert.equal(queryAll("ul li:nth-of-type(1)").text(), "one");
+      assert.strictEqual(count("ul li"), 3);
+      assert.strictEqual(queryAll("ul li:nth-of-type(1)").text(), "one");
     },
   });
 
@@ -400,8 +400,8 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
 
     test(assert) {
       assert.ok(exists(".decorate"));
-      assert.equal(queryAll(".decorate b").text(), "before");
-      assert.equal(queryAll(".decorate i").text(), "after");
+      assert.strictEqual(queryAll(".decorate b").text(), "before");
+      assert.strictEqual(queryAll(".decorate i").text(), "after");
     },
   });
 
@@ -417,7 +417,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll(".settings").text(), "age is 36");
+      assert.strictEqual(queryAll(".settings").text(), "age is 36");
     },
   });
 
@@ -437,7 +437,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll(".settings").text(), "age is 37");
+      assert.strictEqual(queryAll(".settings").text(), "age is 37");
     },
   });
 
@@ -457,7 +457,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     },
 
     test(assert) {
-      assert.equal(queryAll("div.test").text(), "Hello eviltrout");
+      assert.strictEqual(queryAll("div.test").text(), "Hello eviltrout");
     },
   });
 

--- a/app/assets/javascripts/discourse/tests/unit/controllers/avatar-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/avatar-selector-test.js
@@ -23,21 +23,21 @@ discourseModule("Unit | Controller | avatar-selector", function (hooks) {
     });
 
     user.set("avatar_template", "system");
-    assert.equal(
+    assert.strictEqual(
       avatarSelectorController.get("selectedUploadId"),
       1,
       "we are using system by default"
     );
 
     user.set("avatar_template", "gravatar");
-    assert.equal(
+    assert.strictEqual(
       avatarSelectorController.get("selectedUploadId"),
       2,
       "we are using gravatar when set"
     );
 
     user.set("avatar_template", "avatar");
-    assert.equal(
+    assert.strictEqual(
       avatarSelectorController.get("selectedUploadId"),
       3,
       "we are using custom when set"

--- a/app/assets/javascripts/discourse/tests/unit/controllers/create-account-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/create-account-test.js
@@ -17,7 +17,7 @@ discourseModule("Unit | Controller | create-account", function () {
       );
     };
 
-    testInvalidUsername("", undefined);
+    testInvalidUsername("", null);
     testInvalidUsername("x", I18n.t("user.username.too_short"));
     testInvalidUsername(
       "123456789012345678901",
@@ -74,7 +74,7 @@ discourseModule("Unit | Controller | create-account", function () {
       );
     };
 
-    testInvalidPassword("", undefined);
+    testInvalidPassword("", null);
     testInvalidPassword("x", I18n.t("user.password.too_short"));
     testInvalidPassword("porkchops", I18n.t("user.password.same_as_username"));
     testInvalidPassword(

--- a/app/assets/javascripts/discourse/tests/unit/controllers/create-account-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/create-account-test.js
@@ -10,7 +10,7 @@ discourseModule("Unit | Controller | create-account", function () {
 
       let validation = controller.basicUsernameValidation(username);
       assert.ok(validation.failed, "username should be invalid: " + username);
-      assert.equal(
+      assert.strictEqual(
         validation.reason,
         expectedReason,
         "username validation reason: " + username + ", " + expectedReason
@@ -32,7 +32,7 @@ discourseModule("Unit | Controller | create-account", function () {
 
     let validation = controller.basicUsernameValidation("porkchops");
     assert.ok(validation.ok, "Prefilled username is valid");
-    assert.equal(
+    assert.strictEqual(
       validation.reason,
       I18n.t("user.username.prefilled"),
       "Prefilled username is valid"
@@ -48,12 +48,12 @@ discourseModule("Unit | Controller | create-account", function () {
     controller.set("prefilledUsername", "porkchops");
     controller.set("accountPassword", "b4fcdae11f9167");
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("passwordValidation.ok"),
       true,
       "Password is ok"
     );
-    assert.equal(
+    assert.strictEqual(
       controller.get("passwordValidation.reason"),
       I18n.t("user.password.ok"),
       "Password is valid"
@@ -62,12 +62,12 @@ discourseModule("Unit | Controller | create-account", function () {
     const testInvalidPassword = (password, expectedReason) => {
       controller.set("accountPassword", password);
 
-      assert.equal(
+      assert.strictEqual(
         controller.get("passwordValidation.failed"),
         true,
         "password should be invalid: " + password
       );
-      assert.equal(
+      assert.strictEqual(
         controller.get("passwordValidation.reason"),
         expectedReason,
         "password validation reason: " + password + ", " + expectedReason
@@ -86,13 +86,13 @@ discourseModule("Unit | Controller | create-account", function () {
   test("authProviderDisplayName", async function (assert) {
     const controller = this.owner.lookup("controller:create-account");
 
-    assert.equal(
+    assert.strictEqual(
       controller.authProviderDisplayName("facebook"),
       I18n.t("login.facebook.name"),
       "provider name is translated correctly"
     );
 
-    assert.equal(
+    assert.strictEqual(
       controller.authProviderDisplayName("idontexist"),
       "idontexist",
       "provider name falls back if not found"

--- a/app/assets/javascripts/discourse/tests/unit/controllers/history-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/history-test.js
@@ -10,7 +10,7 @@ discourseModule("Unit | Controller | history", function () {
       topicController: {},
     });
 
-    assert.equal(
+    assert.strictEqual(
       HistoryController.get("displayEdit"),
       false,
       "it should not display edit button when user cannot edit the post"
@@ -18,14 +18,14 @@ discourseModule("Unit | Controller | history", function () {
 
     HistoryController.set("model.can_edit", true);
 
-    assert.equal(
+    assert.strictEqual(
       HistoryController.get("displayEdit"),
       true,
       "it should display edit button when user can edit the post"
     );
 
     HistoryController.set("topicController", null);
-    assert.equal(
+    assert.strictEqual(
       HistoryController.get("displayEdit"),
       false,
       "it should not display edit button when there is not topic controller"
@@ -33,7 +33,7 @@ discourseModule("Unit | Controller | history", function () {
     HistoryController.set("topicController", {});
 
     HistoryController.set("model.current_revision", 2);
-    assert.equal(
+    assert.strictEqual(
       HistoryController.get("displayEdit"),
       false,
       "it should only display the edit button on the latest revision"
@@ -109,7 +109,7 @@ discourseModule("Unit | Controller | history", function () {
     await HistoryController.bodyDiffChanged();
 
     const output = HistoryController.get("bodyDiff");
-    assert.equal(
+    assert.strictEqual(
       output,
       expectedOutput,
       "it keeps HTML safe and doesn't strip onebox tags"

--- a/app/assets/javascripts/discourse/tests/unit/controllers/preferences-account-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/preferences-account-test.js
@@ -20,15 +20,15 @@ discourseModule("Unit | Controller | preferences/account", function () {
       },
     });
 
-    assert.equal(controller.get("canUpdateAssociatedAccounts"), false);
+    assert.strictEqual(controller.get("canUpdateAssociatedAccounts"), false);
 
     controller.set("model.second_factor_enabled", false);
-    assert.equal(controller.get("canUpdateAssociatedAccounts"), false);
+    assert.strictEqual(controller.get("canUpdateAssociatedAccounts"), false);
 
     controller.set("model.is_anonymous", false);
-    assert.equal(controller.get("canUpdateAssociatedAccounts"), false);
+    assert.strictEqual(controller.get("canUpdateAssociatedAccounts"), false);
 
     controller.set("model.id", 1234);
-    assert.equal(controller.get("canUpdateAssociatedAccounts"), true);
+    assert.strictEqual(controller.get("canUpdateAssociatedAccounts"), true);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/controllers/preferences-profile-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/preferences-profile-test.js
@@ -26,13 +26,17 @@ discourseModule("Unit | Controller | preferences/profile", function () {
       EmberObject.create({ value: [], field: { id: "field_3" } }),
     ]);
     controller.send("_updateUserFields");
-    assert.equal(
+    assert.strictEqual(
       controller.model.user_fields.field_1,
       "2",
       "updates string value"
     );
-    assert.equal(controller.model.user_fields.field_2, null, "updates null");
-    assert.equal(
+    assert.strictEqual(
+      controller.model.user_fields.field_2,
+      null,
+      "updates null"
+    );
+    assert.strictEqual(
       controller.model.user_fields.field_3,
       null,
       "updates empty array as null"

--- a/app/assets/javascripts/discourse/tests/unit/controllers/preferences-second-factor-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/preferences-second-factor-test.js
@@ -8,6 +8,6 @@ discourseModule("Unit | Controller | preferences/second-factor", function () {
         enable_google_oauth2_logins: true,
       },
     });
-    assert.equal(controller.get("displayOAuthWarning"), true);
+    assert.strictEqual(controller.get("displayOAuthWarning"), true);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/controllers/reorder-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/reorder-categories-test.js
@@ -17,7 +17,7 @@ discourseModule("Unit | Controller | reorder-categories", function () {
     controller.reorder();
 
     controller.get("categoriesOrdered").forEach((category, index) => {
-      assert.equal(category.get("position"), index);
+      assert.strictEqual(category.get("position"), index);
     });
   });
 

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -51,8 +51,8 @@ discourseModule("Unit | Controller | topic", function (hooks) {
       controller.get("editingTopic"),
       "calling editTopic enables editing if the user can edit"
     );
-    assert.equal(controller.get("buffered.title"), model.get("title"));
-    assert.equal(
+    assert.strictEqual(controller.get("buffered.title"), model.get("title"));
+    assert.strictEqual(
       controller.get("buffered.category_id"),
       model.get("category_id")
     );
@@ -103,7 +103,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
     );
 
     controller.get("selectedPostIds").pushObject(1);
-    assert.equal(controller.get("selectedPostIds.length"), 1);
+    assert.strictEqual(controller.get("selectedPostIds.length"), 1);
 
     controller.send("toggleMultiSelect");
     await settled();
@@ -112,14 +112,14 @@ discourseModule("Unit | Controller | topic", function (hooks) {
       controller.get("multiSelect"),
       "calling 'toggleMultiSelect' once enables multi selection mode"
     );
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostIds.length"),
       0,
       "toggling 'multiSelect' clears 'selectedPostIds'"
     );
 
     controller.get("selectedPostIds").pushObject(2);
-    assert.equal(controller.get("selectedPostIds.length"), 1);
+    assert.strictEqual(controller.get("selectedPostIds.length"), 1);
 
     controller.send("toggleMultiSelect");
     await settled();
@@ -128,7 +128,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
       controller.get("multiSelect"),
       "calling 'toggleMultiSelect' twice disables multi selection mode"
     );
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostIds.length"),
       0,
       "toggling 'multiSelect' clears 'selectedPostIds'"
@@ -141,7 +141,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
     controller.set("selectedPostIds", [1, 2, 42]);
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPosts.length"),
       2,
       "selectedPosts only contains already loaded posts"
@@ -197,7 +197,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
     const controller = this.getController("topic", { model });
     const selectedPostIds = controller.get("selectedPostIds");
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostsUsername"),
       undefined,
       "no username when no selected posts"
@@ -205,7 +205,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
     selectedPostIds.pushObject(1);
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostsUsername"),
       "gary",
       "username of the selected posts"
@@ -213,7 +213,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
     selectedPostIds.pushObject(2);
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostsUsername"),
       "gary",
       "username of all the selected posts when same user"
@@ -221,7 +221,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
     selectedPostIds.pushObject(3);
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostsUsername"),
       undefined,
       "no username when more than 1 user"
@@ -229,7 +229,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
     selectedPostIds.replace(2, 1, [42]);
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostsUsername"),
       undefined,
       "no username when not already loaded posts are selected"
@@ -455,7 +455,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
     let model = topicWithStream({ stream: [1, 2, 3] });
     const controller = this.getController("topic", { model });
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostsCount"),
       0,
       "no posts selected by default"
@@ -463,7 +463,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
     controller.send("selectAll");
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostsCount"),
       3,
       "calling 'selectAll' selects all posts"
@@ -471,7 +471,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
     controller.send("deselectAll");
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("selectedPostsCount"),
       0,
       "calling 'deselectAll' deselects all posts"
@@ -482,11 +482,15 @@ discourseModule("Unit | Controller | topic", function (hooks) {
     const controller = this.getController("topic");
     const selectedPostIds = controller.get("selectedPostIds");
 
-    assert.equal(selectedPostIds[0], undefined, "no posts selected by default");
+    assert.strictEqual(
+      selectedPostIds[0],
+      undefined,
+      "no posts selected by default"
+    );
 
     controller.send("togglePostSelection", { id: 1 });
 
-    assert.equal(
+    assert.strictEqual(
       selectedPostIds[0],
       1,
       "adds the selected post id if not already selected"
@@ -494,7 +498,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
     controller.send("togglePostSelection", { id: 1 });
 
-    assert.equal(
+    assert.strictEqual(
       selectedPostIds[0],
       undefined,
       "removes the selected post id if already selected"
@@ -516,14 +520,30 @@ discourseModule("Unit | Controller | topic", function (hooks) {
     const controller = this.getController("topic", { site, model });
     let selectedPostIds = controller.get("selectedPostIds");
 
-    assert.equal(selectedPostIds[0], undefined, "no posts selected by default");
+    assert.strictEqual(
+      selectedPostIds[0],
+      undefined,
+      "no posts selected by default"
+    );
 
     controller.send("selectBelow", { id: 3 });
 
-    assert.equal(selectedPostIds[0], 3, "selected post #3");
-    assert.equal(selectedPostIds[1], 4, "also selected 1st post below post #3");
-    assert.equal(selectedPostIds[2], 5, "also selected 2nd post below post #3");
-    assert.equal(selectedPostIds[3], 8, "also selected 3rd post below post #3");
+    assert.strictEqual(selectedPostIds[0], 3, "selected post #3");
+    assert.strictEqual(
+      selectedPostIds[1],
+      4,
+      "also selected 1st post below post #3"
+    );
+    assert.strictEqual(
+      selectedPostIds[2],
+      5,
+      "also selected 2nd post below post #3"
+    );
+    assert.strictEqual(
+      selectedPostIds[3],
+      8,
+      "also selected 3rd post below post #3"
+    );
   });
 
   test("topVisibleChanged", function (assert) {
@@ -533,7 +553,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
     const controller = this.getController("topic", { model });
     const placeholder = new Placeholder("post-placeholder");
 
-    assert.equal(
+    assert.strictEqual(
       controller.send("topVisibleChanged", {
         post: placeholder,
       }),

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -557,7 +557,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
       controller.send("topVisibleChanged", {
         post: placeholder,
       }),
-      null,
+      undefined,
       "it should work with a post-placeholder"
     );
   });

--- a/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
@@ -7,7 +7,7 @@ let resolver;
 function lookupTemplate(assert, name, expectedTemplate, message) {
   let parseName = resolver.parseName(name);
   let result = resolver.resolveTemplate(parseName);
-  assert.equal(result, expectedTemplate, message);
+  assert.strictEqual(result, expectedTemplate, message);
 }
 
 function setTemplates(lookupTemplateStrings) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/bookmark-test.js
@@ -16,7 +16,7 @@ module("Unit | Utility | bookmark", function (hooks) {
     let reminderAtDate = moment
       .tz(reminderAt, "Australia/Brisbane")
       .format("H:mm a");
-    assert.equal(
+    assert.strictEqual(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),
       "tomorrow at " + reminderAtDate
     );
@@ -27,7 +27,7 @@ module("Unit | Utility | bookmark", function (hooks) {
     let reminderAtDate = moment
       .tz(reminderAt, "Australia/Brisbane")
       .format("H:mm a");
-    assert.equal(
+    assert.strictEqual(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),
       "today at " + reminderAtDate
     );
@@ -38,7 +38,7 @@ module("Unit | Utility | bookmark", function (hooks) {
     let reminderAtDate = moment
       .tz(reminderAt, "Australia/Brisbane")
       .format("H:mm a");
-    assert.equal(
+    assert.strictEqual(
       formattedReminderTime(reminderAt, "Australia/Brisbane"),
       "at Apr 15, 2020 " + reminderAtDate
     );

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -21,16 +21,20 @@ discourseModule("Unit | Utility | category-badge", function () {
     });
     const tag = $.parseHTML(categoryBadgeHTML(category))[0];
 
-    assert.equal(tag.tagName, "A", "it creates a `a` wrapper tag");
-    assert.equal(
+    assert.strictEqual(tag.tagName, "A", "it creates a `a` wrapper tag");
+    assert.strictEqual(
       tag.className.trim(),
       "badge-wrapper",
       "it has the correct class"
     );
 
     const label = tag.children[1];
-    assert.equal(label.title, "cool description", "it has the correct title");
-    assert.equal(
+    assert.strictEqual(
+      label.title,
+      "cool description",
+      "it has the correct title"
+    );
+    assert.strictEqual(
       label.children[0].innerText,
       "hello",
       "it has the category name"
@@ -52,7 +56,7 @@ discourseModule("Unit | Utility | category-badge", function () {
     const store = createStore();
     const category = store.createRecord("category", { name: "hello", id: 123 });
 
-    assert.equal(
+    assert.strictEqual(
       categoryBadgeHTML(category).indexOf("topic-count"),
       -1,
       "it does not include topic count by default"
@@ -104,11 +108,11 @@ discourseModule("Unit | Utility | category-badge", function () {
 
     let tag = $.parseHTML(categoryBadgeHTML(rtlCategory))[0];
     let dirSpan = tag.children[1].children[0];
-    assert.equal(dirSpan.dir, "rtl");
+    assert.strictEqual(dirSpan.dir, "rtl");
 
     tag = $.parseHTML(categoryBadgeHTML(ltrCategory))[0];
     dirSpan = tag.children[1].children[0];
-    assert.equal(dirSpan.dir, "ltr");
+    assert.strictEqual(dirSpan.dir, "ltr");
   });
 
   test("recursive", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-edit-history-test.js
@@ -63,7 +63,7 @@ module("Unit | Utility | click-track-edit-history", function (hooks) {
 
     const done = assert.async();
     pretender.post("/clicks/track", (request) => {
-      assert.equal(
+      assert.strictEqual(
         request.requestBody,
         "url=http%3A%2F%2Fdiscuss.domain.com&post_id=42&topic_id=1337"
       );
@@ -78,7 +78,7 @@ module("Unit | Utility | click-track-edit-history", function (hooks) {
 
     const done = assert.async();
     pretender.post("/clicks/track", (request) => {
-      assert.equal(
+      assert.strictEqual(
         request.requestBody,
         "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
       );
@@ -94,7 +94,7 @@ module("Unit | Utility | click-track-edit-history", function (hooks) {
 
     const done = assert.async();
     pretender.post("/clicks/track", (request) => {
-      assert.equal(
+      assert.strictEqual(
         request.requestBody,
         "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
       );

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-profile-page-test.js
@@ -56,7 +56,10 @@ module("Unit | Utility | click-track-profile-page", function (hooks) {
 
     const done = assert.async();
     pretender.post("/clicks/track", (request) => {
-      assert.equal(request.requestBody, "url=http%3A%2F%2Fdiscuss.domain.com");
+      assert.strictEqual(
+        request.requestBody,
+        "url=http%3A%2F%2Fdiscuss.domain.com"
+      );
       done();
     });
 
@@ -68,7 +71,7 @@ module("Unit | Utility | click-track-profile-page", function (hooks) {
 
     const done = assert.async();
     pretender.post("/clicks/track", (request) => {
-      assert.equal(
+      assert.strictEqual(
         request.requestBody,
         "url=http%3A%2F%2Fwww.google.com&post_id=42&topic_id=1337"
       );
@@ -83,7 +86,7 @@ module("Unit | Utility | click-track-profile-page", function (hooks) {
 
     const done = assert.async();
     pretender.post("/clicks/track", (request) => {
-      assert.equal(
+      assert.strictEqual(
         request.requestBody,
         "url=http%3A%2F%2Fwww.google.com&post_id=24&topic_id=7331"
       );

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -189,7 +189,7 @@ module("Unit | Utility | click-track", function (hooks) {
 
     let link = fixture("a");
     assert.ok(link.classList.contains("no-href"));
-    assert.equal(link.dataset.href, "http://www.google.com/");
+    assert.strictEqual(link.dataset.href, "http://www.google.com/");
     assert.blank(link.getAttribute("href"));
     assert.ok(link.dataset.autoRoute);
     assert.ok(window.open.calledWith("http://www.google.com/", "_blank"));
@@ -204,7 +204,10 @@ module("Unit | Utility | click-track", function (hooks) {
 
     const done = assert.async();
     later(() => {
-      assert.equal(fixture("a").getAttribute("href"), "http://www.google.com");
+      assert.strictEqual(
+        fixture("a").getAttribute("href"),
+        "http://www.google.com"
+      );
       done();
     });
   });
@@ -212,7 +215,7 @@ module("Unit | Utility | click-track", function (hooks) {
   function badgeClickCount(assert, id, expected) {
     track(generateClickEventOn(`#${id}`));
     const badge = fixture(`#${id}`).querySelector("span.badge");
-    assert.equal(parseInt(badge.innerHTML, 10), expected);
+    assert.strictEqual(parseInt(badge.innerHTML, 10), expected);
   }
 
   test("does not update badge clicks on my own link", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
@@ -33,7 +33,7 @@ discourseModule("Unit | Utility | computed", function (hooks) {
     }).create();
 
     this.siteSettings.vehicle = "airplane";
-    assert.equal(
+    assert.strictEqual(
       t.get("vehicle"),
       "airplane",
       "it has the value of the site setting"
@@ -79,25 +79,25 @@ discourseModule("Unit | Utility | computed", function (hooks) {
       mood: "happy",
     });
 
-    assert.equal(
+    assert.strictEqual(
       t.get("exclaimyUsername"),
       "!!! eviltrout !!!",
       "it inserts the string"
     );
-    assert.equal(
+    assert.strictEqual(
       t.get("multiple"),
       "eviltrout is happy",
       "it inserts multiple strings"
     );
 
     t.set("username", "codinghorror");
-    assert.equal(
+    assert.strictEqual(
       t.get("multiple"),
       "codinghorror is happy",
       "it supports changing properties"
     );
     t.set("mood", "ecstatic");
-    assert.equal(
+    assert.strictEqual(
       t.get("multiple"),
       "codinghorror is ecstatic",
       "it supports changing another property"
@@ -113,25 +113,25 @@ discourseModule("Unit | Utility | computed", function (hooks) {
       mood: "happy",
     });
 
-    assert.equal(
+    assert.strictEqual(
       t.get("exclaimyUsername"),
       "%@ translated: !!! eviltrout !!!",
       "it inserts the string and then translates"
     );
-    assert.equal(
+    assert.strictEqual(
       t.get("multiple"),
       "%@ translated: eviltrout is happy",
       "it inserts multiple strings and then translates"
     );
 
     t.set("username", "codinghorror");
-    assert.equal(
+    assert.strictEqual(
       t.get("multiple"),
       "%@ translated: codinghorror is happy",
       "it supports changing properties"
     );
     t.set("mood", "ecstatic");
-    assert.equal(
+    assert.strictEqual(
       t.get("multiple"),
       "%@ translated: codinghorror is ecstatic",
       "it supports changing another property"
@@ -146,7 +146,7 @@ discourseModule("Unit | Utility | computed", function (hooks) {
     });
 
     t = testClass.create({ username: "eviltrout" });
-    assert.equal(
+    assert.strictEqual(
       t.get("userUrl"),
       "/u/eviltrout",
       "it supports urls without a prefix"
@@ -154,7 +154,7 @@ discourseModule("Unit | Utility | computed", function (hooks) {
 
     setPrefix("/prefixed");
     t = testClass.create({ username: "eviltrout" });
-    assert.equal(
+    assert.strictEqual(
       t.get("userUrl"),
       "/prefixed/u/eviltrout",
       "it supports urls with a prefix"
@@ -167,6 +167,6 @@ discourseModule("Unit | Utility | computed", function (hooks) {
       desc: htmlSafe("cookies"),
     }).create({ cookies });
 
-    assert.equal(t.get("desc").string, cookies);
+    assert.strictEqual(t.get("desc").string, cookies);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-store-test.js
@@ -13,12 +13,12 @@ discourseModule("Unit | Utility | emoji-emojiStore", function (hooks) {
 
   test("defaults", function (assert) {
     assert.deepEqual(this.emojiStore.favorites, []);
-    assert.equal(this.emojiStore.diversity, 1);
+    assert.strictEqual(this.emojiStore.diversity, 1);
   });
 
   test("diversity", function (assert) {
     this.emojiStore.diversity = 2;
-    assert.equal(this.emojiStore.diversity, 2);
+    assert.strictEqual(this.emojiStore.diversity, 2);
   });
 
   test("favorites", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
@@ -13,7 +13,7 @@ discourseModule("Unit | Utility | emoji", function () {
         this.siteSettings[key] = value;
       }
 
-      assert.equal(emojiUnescape(input), expected, description);
+      assert.strictEqual(emojiUnescape(input), expected, description);
 
       for (const [key, value] of Object.entries(originalSettings)) {
         this.siteSettings[key] = value;
@@ -132,10 +132,10 @@ discourseModule("Unit | Utility | emoji", function () {
 
   test("Emoji search", function (assert) {
     // able to find an alias
-    assert.equal(emojiSearch("+1").length, 1);
+    assert.strictEqual(emojiSearch("+1").length, 1);
 
     // able to find middle of line search
-    assert.equal(emojiSearch("check", { maxResults: 3 }).length, 3);
+    assert.strictEqual(emojiSearch("check", { maxResults: 3 }).length, 3);
 
     // appends diversity
     assert.deepEqual(emojiSearch("woman_artist", { diversity: 5 }), [

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -59,62 +59,74 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
   test("formating medium length dates", function (assert) {
     let shortDateYear = shortDateTester("MMM D, 'YY");
 
-    assert.equal(
+    assert.strictEqual(
       strip(formatMins(1.4, { format: "medium", leaveAgo: true })),
       "1 min ago"
     );
-    assert.equal(
+    assert.strictEqual(
       strip(formatMins(2, { format: "medium", leaveAgo: true })),
       "2 mins ago"
     );
-    assert.equal(
+    assert.strictEqual(
       strip(formatMins(55, { format: "medium", leaveAgo: true })),
       "55 mins ago"
     );
-    assert.equal(
+    assert.strictEqual(
       strip(formatMins(56, { format: "medium", leaveAgo: true })),
       "1 hour ago"
     );
-    assert.equal(
+    assert.strictEqual(
       strip(formatHours(4, { format: "medium", leaveAgo: true })),
       "4 hours ago"
     );
-    assert.equal(
+    assert.strictEqual(
       strip(formatHours(22, { format: "medium", leaveAgo: true })),
       "22 hours ago"
     );
-    assert.equal(
+    assert.strictEqual(
       strip(formatHours(23, { format: "medium", leaveAgo: true })),
       "23 hours ago"
     );
-    assert.equal(
+    assert.strictEqual(
       strip(formatHours(23.5, { format: "medium", leaveAgo: true })),
       "1 day ago"
     );
-    assert.equal(
+    assert.strictEqual(
       strip(formatDays(4.85, { format: "medium", leaveAgo: true })),
       "4 days ago"
     );
 
-    assert.equal(strip(formatMins(0, { format: "medium" })), "just now");
-    assert.equal(strip(formatMins(1.4, { format: "medium" })), "1 min");
-    assert.equal(strip(formatMins(2, { format: "medium" })), "2 mins");
-    assert.equal(strip(formatMins(55, { format: "medium" })), "55 mins");
-    assert.equal(strip(formatMins(56, { format: "medium" })), "1 hour");
-    assert.equal(strip(formatHours(4, { format: "medium" })), "4 hours");
-    assert.equal(strip(formatHours(22, { format: "medium" })), "22 hours");
-    assert.equal(strip(formatHours(23, { format: "medium" })), "23 hours");
-    assert.equal(strip(formatHours(23.5, { format: "medium" })), "1 day");
-    assert.equal(strip(formatDays(4.85, { format: "medium" })), "4 days");
+    assert.strictEqual(strip(formatMins(0, { format: "medium" })), "just now");
+    assert.strictEqual(strip(formatMins(1.4, { format: "medium" })), "1 min");
+    assert.strictEqual(strip(formatMins(2, { format: "medium" })), "2 mins");
+    assert.strictEqual(strip(formatMins(55, { format: "medium" })), "55 mins");
+    assert.strictEqual(strip(formatMins(56, { format: "medium" })), "1 hour");
+    assert.strictEqual(strip(formatHours(4, { format: "medium" })), "4 hours");
+    assert.strictEqual(
+      strip(formatHours(22, { format: "medium" })),
+      "22 hours"
+    );
+    assert.strictEqual(
+      strip(formatHours(23, { format: "medium" })),
+      "23 hours"
+    );
+    assert.strictEqual(strip(formatHours(23.5, { format: "medium" })), "1 day");
+    assert.strictEqual(strip(formatDays(4.85, { format: "medium" })), "4 days");
 
-    assert.equal(strip(formatDays(6, { format: "medium" })), shortDate(6));
-    assert.equal(strip(formatDays(100, { format: "medium" })), shortDate(100)); // eg: Jan 23
-    assert.equal(
+    assert.strictEqual(
+      strip(formatDays(6, { format: "medium" })),
+      shortDate(6)
+    );
+    assert.strictEqual(
+      strip(formatDays(100, { format: "medium" })),
+      shortDate(100)
+    ); // eg: Jan 23
+    assert.strictEqual(
       strip(formatDays(500, { format: "medium" })),
       shortDateYear(500)
     );
 
-    assert.equal(
+    assert.strictEqual(
       stringToDOMNode(formatDays(0, { format: "medium" })).title,
       longDate(new Date())
     );
@@ -128,8 +140,11 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
     this.clock.restore();
     this.clock = sinon.useFakeTimers(new Date(2012, 0, 9, 12, 0).getTime()); // Jan 9, 2012
 
-    assert.equal(strip(formatDays(8, { format: "medium" })), shortDate(8));
-    assert.equal(
+    assert.strictEqual(
+      strip(formatDays(8, { format: "medium" })),
+      shortDate(8)
+    );
+    assert.strictEqual(
       strip(formatDays(10, { format: "medium" })),
       shortDateYear(10)
     );
@@ -138,78 +153,78 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
   test("formating tiny dates", function (assert) {
     let shortDateYear = shortDateTester("MMM 'YY");
 
-    assert.equal(formatMins(0), "1m");
-    assert.equal(formatMins(1), "1m");
-    assert.equal(formatMins(2), "2m");
-    assert.equal(formatMins(60), "1h");
-    assert.equal(formatHours(4), "4h");
-    assert.equal(formatHours(23), "23h");
-    assert.equal(formatHours(23.5), "1d");
-    assert.equal(formatDays(1), "1d");
-    assert.equal(formatDays(14), "14d");
-    assert.equal(formatDays(15), shortDate(15));
-    assert.equal(formatDays(92), shortDate(92));
-    assert.equal(formatDays(364), shortDate(364));
-    assert.equal(formatDays(365), shortDate(365));
-    assert.equal(formatDays(366), shortDateYear(366)); // leap year
-    assert.equal(formatDays(500), shortDateYear(500));
-    assert.equal(formatDays(365 * 2 + 1), shortDateYear(365 * 2 + 1)); // one leap year
+    assert.strictEqual(formatMins(0), "1m");
+    assert.strictEqual(formatMins(1), "1m");
+    assert.strictEqual(formatMins(2), "2m");
+    assert.strictEqual(formatMins(60), "1h");
+    assert.strictEqual(formatHours(4), "4h");
+    assert.strictEqual(formatHours(23), "23h");
+    assert.strictEqual(formatHours(23.5), "1d");
+    assert.strictEqual(formatDays(1), "1d");
+    assert.strictEqual(formatDays(14), "14d");
+    assert.strictEqual(formatDays(15), shortDate(15));
+    assert.strictEqual(formatDays(92), shortDate(92));
+    assert.strictEqual(formatDays(364), shortDate(364));
+    assert.strictEqual(formatDays(365), shortDate(365));
+    assert.strictEqual(formatDays(366), shortDateYear(366)); // leap year
+    assert.strictEqual(formatDays(500), shortDateYear(500));
+    assert.strictEqual(formatDays(365 * 2 + 1), shortDateYear(365 * 2 + 1)); // one leap year
 
-    assert.equal(formatMins(-1), "1m");
-    assert.equal(formatMins(-2), "2m");
-    assert.equal(formatMins(-60), "1h");
-    assert.equal(formatHours(-4), "4h");
-    assert.equal(formatHours(-23), "23h");
-    assert.equal(formatHours(-23.5), "1d");
-    assert.equal(formatDays(-1), "1d");
-    assert.equal(formatDays(-14), "14d");
-    assert.equal(formatDays(-15), shortDateYear(-15));
-    assert.equal(formatDays(-92), shortDateYear(-92));
-    assert.equal(formatDays(-364), shortDateYear(-364));
-    assert.equal(formatDays(-365), shortDateYear(-365));
-    assert.equal(formatDays(-366), shortDateYear(-366)); // leap year
-    assert.equal(formatDays(-500), shortDateYear(-500));
-    assert.equal(formatDays(-365 * 2 - 1), shortDateYear(-365 * 2 - 1)); // one leap year
+    assert.strictEqual(formatMins(-1), "1m");
+    assert.strictEqual(formatMins(-2), "2m");
+    assert.strictEqual(formatMins(-60), "1h");
+    assert.strictEqual(formatHours(-4), "4h");
+    assert.strictEqual(formatHours(-23), "23h");
+    assert.strictEqual(formatHours(-23.5), "1d");
+    assert.strictEqual(formatDays(-1), "1d");
+    assert.strictEqual(formatDays(-14), "14d");
+    assert.strictEqual(formatDays(-15), shortDateYear(-15));
+    assert.strictEqual(formatDays(-92), shortDateYear(-92));
+    assert.strictEqual(formatDays(-364), shortDateYear(-364));
+    assert.strictEqual(formatDays(-365), shortDateYear(-365));
+    assert.strictEqual(formatDays(-366), shortDateYear(-366)); // leap year
+    assert.strictEqual(formatDays(-500), shortDateYear(-500));
+    assert.strictEqual(formatDays(-365 * 2 - 1), shortDateYear(-365 * 2 - 1)); // one leap year
 
     let originalValue = this.siteSettings.relative_date_duration;
     this.siteSettings.relative_date_duration = 7;
-    assert.equal(formatDays(7), "7d");
-    assert.equal(formatDays(8), shortDate(8));
+    assert.strictEqual(formatDays(7), "7d");
+    assert.strictEqual(formatDays(8), shortDate(8));
 
     this.siteSettings.relative_date_duration = 1;
-    assert.equal(formatDays(1), "1d");
-    assert.equal(formatDays(2), shortDate(2));
+    assert.strictEqual(formatDays(1), "1d");
+    assert.strictEqual(formatDays(2), shortDate(2));
 
     this.siteSettings.relative_date_duration = 0;
-    assert.equal(formatMins(0), "1m");
-    assert.equal(formatMins(1), "1m");
-    assert.equal(formatMins(2), "2m");
-    assert.equal(formatMins(60), "1h");
-    assert.equal(formatDays(1), shortDate(1));
-    assert.equal(formatDays(2), shortDate(2));
-    assert.equal(formatDays(366), shortDateYear(366));
+    assert.strictEqual(formatMins(0), "1m");
+    assert.strictEqual(formatMins(1), "1m");
+    assert.strictEqual(formatMins(2), "2m");
+    assert.strictEqual(formatMins(60), "1h");
+    assert.strictEqual(formatDays(1), shortDate(1));
+    assert.strictEqual(formatDays(2), shortDate(2));
+    assert.strictEqual(formatDays(366), shortDateYear(366));
 
     this.siteSettings.relative_date_duration = null;
-    assert.equal(formatDays(1), "1d");
-    assert.equal(formatDays(14), "14d");
-    assert.equal(formatDays(15), shortDate(15));
+    assert.strictEqual(formatDays(1), "1d");
+    assert.strictEqual(formatDays(14), "14d");
+    assert.strictEqual(formatDays(15), shortDate(15));
 
     this.siteSettings.relative_date_duration = 14;
 
     this.clock.restore();
     this.clock = sinon.useFakeTimers(new Date(2012, 0, 12, 12, 0).getTime()); // Jan 12, 2012
 
-    assert.equal(formatDays(11), "11d");
-    assert.equal(formatDays(14), "14d");
-    assert.equal(formatDays(15), shortDateYear(15));
-    assert.equal(formatDays(366), shortDateYear(366));
+    assert.strictEqual(formatDays(11), "11d");
+    assert.strictEqual(formatDays(14), "14d");
+    assert.strictEqual(formatDays(15), shortDateYear(15));
+    assert.strictEqual(formatDays(366), shortDateYear(366));
 
     this.clock.restore();
     this.clock = sinon.useFakeTimers(new Date(2012, 0, 20, 12, 0).getTime()); // Jan 20, 2012
 
-    assert.equal(formatDays(14), "14d");
-    assert.equal(formatDays(15), shortDate(15));
-    assert.equal(formatDays(20), shortDateYear(20));
+    assert.strictEqual(formatDays(14), "14d");
+    assert.strictEqual(formatDays(15), shortDate(15));
+    assert.strictEqual(formatDays(20), shortDateYear(20));
 
     this.siteSettings.relative_date_duration = originalValue;
   });
@@ -218,12 +233,12 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
     let d = moment().subtract(1, "day").toDate();
 
     let elem = stringToDOMNode(autoUpdatingRelativeAge(d));
-    assert.equal(elem.dataset.format, "tiny");
-    assert.equal(elem.dataset.time, d.getTime());
-    assert.equal(elem.title, "");
+    assert.strictEqual(elem.dataset.format, "tiny");
+    assert.strictEqual(elem.dataset.time, d.getTime());
+    assert.strictEqual(elem.title, "");
 
     elem = stringToDOMNode(autoUpdatingRelativeAge(d, { title: true }));
-    assert.equal(elem.title, longDate(d));
+    assert.strictEqual(elem.title, longDate(d));
 
     elem = stringToDOMNode(
       autoUpdatingRelativeAge(d, {
@@ -233,16 +248,16 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
       })
     );
 
-    assert.equal(elem.dataset.format, "medium-with-ago");
-    assert.equal(elem.dataset.time, d.getTime());
-    assert.equal(elem.title, longDate(d));
-    assert.equal(elem.innerHTML, "1 day ago");
+    assert.strictEqual(elem.dataset.format, "medium-with-ago");
+    assert.strictEqual(elem.dataset.time, d.getTime());
+    assert.strictEqual(elem.title, longDate(d));
+    assert.strictEqual(elem.innerHTML, "1 day ago");
 
     elem = stringToDOMNode(autoUpdatingRelativeAge(d, { format: "medium" }));
-    assert.equal(elem.dataset.format, "medium");
-    assert.equal(elem.dataset.time, d.getTime());
-    assert.equal(elem.title, "");
-    assert.equal(elem.innerHTML, "1 day");
+    assert.strictEqual(elem.dataset.format, "medium");
+    assert.strictEqual(elem.dataset.time, d.getTime());
+    assert.strictEqual(elem.title, "");
+    assert.strictEqual(elem.innerHTML, "1 day");
   });
 
   test("updateRelativeAge", function (assert) {
@@ -252,7 +267,7 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
 
     updateRelativeAge(elem);
 
-    assert.equal(elem.innerHTML, "2m");
+    assert.strictEqual(elem.innerHTML, "2m");
 
     d = new Date();
     elem = stringToDOMNode(
@@ -262,42 +277,42 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
 
     updateRelativeAge(elem);
 
-    assert.equal(elem.innerHTML, "2 mins ago");
+    assert.strictEqual(elem.innerHTML, "2 mins ago");
   });
 
   test("number", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       number(123),
       "123",
       "it returns a string version of the number"
     );
-    assert.equal(number("123"), "123", "it works with a string command");
-    assert.equal(number(NaN), "0", "it returns 0 for NaN");
-    assert.equal(number(3333), "3.3k", "it abbreviates thousands");
-    assert.equal(number(2499999), "2.5M", "it abbreviates millions");
-    assert.equal(number("2499999.5"), "2.5M", "it abbreviates millions");
-    assert.equal(number(1000000), "1.0M", "it abbreviates a million");
-    assert.equal(
+    assert.strictEqual(number("123"), "123", "it works with a string command");
+    assert.strictEqual(number(NaN), "0", "it returns 0 for NaN");
+    assert.strictEqual(number(3333), "3.3k", "it abbreviates thousands");
+    assert.strictEqual(number(2499999), "2.5M", "it abbreviates millions");
+    assert.strictEqual(number("2499999.5"), "2.5M", "it abbreviates millions");
+    assert.strictEqual(number(1000000), "1.0M", "it abbreviates a million");
+    assert.strictEqual(
       number(999999),
       "999k",
       "it abbreviates hundreds of thousands"
     );
-    assert.equal(
+    assert.strictEqual(
       number(18.2),
       "18",
       "it returns a float number rounded to an integer as a string"
     );
-    assert.equal(
+    assert.strictEqual(
       number(18.6),
       "19",
       "it returns a float number rounded to an integer as a string"
     );
-    assert.equal(
+    assert.strictEqual(
       number("12.3"),
       "12",
       "it returns a string float rounded to an integer as a string"
     );
-    assert.equal(
+    assert.strictEqual(
       number("12.6"),
       "13",
       "it returns a string float rounded to an integer as a string"
@@ -305,34 +320,50 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
   });
 
   test("durationTiny", function (assert) {
-    assert.equal(durationTiny(), "&mdash;", "undefined is a dash");
-    assert.equal(durationTiny(null), "&mdash;", "null is a dash");
-    assert.equal(durationTiny(0), "< 1m", "0 seconds shows as < 1m");
-    assert.equal(durationTiny(59), "< 1m", "59 seconds shows as < 1m");
-    assert.equal(durationTiny(60), "1m", "60 seconds shows as 1m");
-    assert.equal(durationTiny(90), "2m", "90 seconds shows as 2m");
-    assert.equal(durationTiny(120), "2m", "120 seconds shows as 2m");
-    assert.equal(durationTiny(60 * 45), "1h", "45 minutes shows as 1h");
-    assert.equal(durationTiny(60 * 60), "1h", "60 minutes shows as 1h");
-    assert.equal(durationTiny(60 * 90), "2h", "90 minutes shows as 2h");
-    assert.equal(durationTiny(3600 * 23), "23h", "23 hours shows as 23h");
-    assert.equal(
+    assert.strictEqual(durationTiny(), "&mdash;", "undefined is a dash");
+    assert.strictEqual(durationTiny(null), "&mdash;", "null is a dash");
+    assert.strictEqual(durationTiny(0), "< 1m", "0 seconds shows as < 1m");
+    assert.strictEqual(durationTiny(59), "< 1m", "59 seconds shows as < 1m");
+    assert.strictEqual(durationTiny(60), "1m", "60 seconds shows as 1m");
+    assert.strictEqual(durationTiny(90), "2m", "90 seconds shows as 2m");
+    assert.strictEqual(durationTiny(120), "2m", "120 seconds shows as 2m");
+    assert.strictEqual(durationTiny(60 * 45), "1h", "45 minutes shows as 1h");
+    assert.strictEqual(durationTiny(60 * 60), "1h", "60 minutes shows as 1h");
+    assert.strictEqual(durationTiny(60 * 90), "2h", "90 minutes shows as 2h");
+    assert.strictEqual(durationTiny(3600 * 23), "23h", "23 hours shows as 23h");
+    assert.strictEqual(
       durationTiny(3600 * 24 - 29),
       "1d",
       "23 hours 31 mins shows as 1d"
     );
-    assert.equal(durationTiny(3600 * 24 * 89), "89d", "89 days shows as 89d");
-    assert.equal(
+    assert.strictEqual(
+      durationTiny(3600 * 24 * 89),
+      "89d",
+      "89 days shows as 89d"
+    );
+    assert.strictEqual(
       durationTiny(60 * (525600 - 1)),
       "12mon",
       "364 days shows as 12mon"
     );
-    assert.equal(durationTiny(60 * 525600), "1y", "365 days shows as 1y");
-    assert.equal(durationTiny(86400 * 456), "1y", "456 days shows as 1y");
-    assert.equal(durationTiny(86400 * 457), "> 1y", "457 days shows as > 1y");
-    assert.equal(durationTiny(86400 * 638), "> 1y", "638 days shows as > 1y");
-    assert.equal(durationTiny(86400 * 639), "2y", "639 days shows as 2y");
-    assert.equal(durationTiny(86400 * 821), "2y", "821 days shows as 2y");
-    assert.equal(durationTiny(86400 * 822), "> 2y", "822 days shows as > 2y");
+    assert.strictEqual(durationTiny(60 * 525600), "1y", "365 days shows as 1y");
+    assert.strictEqual(durationTiny(86400 * 456), "1y", "456 days shows as 1y");
+    assert.strictEqual(
+      durationTiny(86400 * 457),
+      "> 1y",
+      "457 days shows as > 1y"
+    );
+    assert.strictEqual(
+      durationTiny(86400 * 638),
+      "> 1y",
+      "638 days shows as > 1y"
+    );
+    assert.strictEqual(durationTiny(86400 * 639), "2y", "639 days shows as 2y");
+    assert.strictEqual(durationTiny(86400 * 821), "2y", "821 days shows as 2y");
+    assert.strictEqual(
+      durationTiny(86400 * 822),
+      "> 2y",
+      "822 days shows as > 2y"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -234,7 +234,7 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
 
     let elem = stringToDOMNode(autoUpdatingRelativeAge(d));
     assert.strictEqual(elem.dataset.format, "tiny");
-    assert.strictEqual(elem.dataset.time, d.getTime());
+    assert.strictEqual(elem.dataset.time, d.getTime().toString());
     assert.strictEqual(elem.title, "");
 
     elem = stringToDOMNode(autoUpdatingRelativeAge(d, { title: true }));
@@ -249,13 +249,13 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
     );
 
     assert.strictEqual(elem.dataset.format, "medium-with-ago");
-    assert.strictEqual(elem.dataset.time, d.getTime());
+    assert.strictEqual(elem.dataset.time, d.getTime().toString());
     assert.strictEqual(elem.title, longDate(d));
     assert.strictEqual(elem.innerHTML, "1 day ago");
 
     elem = stringToDOMNode(autoUpdatingRelativeAge(d, { format: "medium" }));
     assert.strictEqual(elem.dataset.format, "medium");
-    assert.strictEqual(elem.dataset.time, d.getTime());
+    assert.strictEqual(elem.dataset.time, d.getTime().toString());
     assert.strictEqual(elem.title, "");
     assert.strictEqual(elem.innerHTML, "1 day");
   });

--- a/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
@@ -19,63 +19,75 @@ module("Unit | Utility | get-url", function () {
 
   test("getAbsoluteURL", function (assert) {
     setupURL(null, "https://example.com", "/forum");
-    assert.equal(getAbsoluteURL("/cool/path"), "https://example.com/cool/path");
+    assert.strictEqual(
+      getAbsoluteURL("/cool/path"),
+      "https://example.com/cool/path"
+    );
   });
 
   test("withoutPrefix", function (assert) {
     setPrefix("/eviltrout");
-    assert.equal(withoutPrefix("/eviltrout/hello"), "/hello");
-    assert.equal(withoutPrefix("/eviltrout/"), "/");
-    assert.equal(withoutPrefix("/eviltrout"), "");
+    assert.strictEqual(withoutPrefix("/eviltrout/hello"), "/hello");
+    assert.strictEqual(withoutPrefix("/eviltrout/"), "/");
+    assert.strictEqual(withoutPrefix("/eviltrout"), "");
 
     setPrefix("");
-    assert.equal(withoutPrefix("/eviltrout/hello"), "/eviltrout/hello");
-    assert.equal(withoutPrefix("/eviltrout"), "/eviltrout");
-    assert.equal(withoutPrefix("/"), "/");
+    assert.strictEqual(withoutPrefix("/eviltrout/hello"), "/eviltrout/hello");
+    assert.strictEqual(withoutPrefix("/eviltrout"), "/eviltrout");
+    assert.strictEqual(withoutPrefix("/"), "/");
 
     setPrefix(null);
-    assert.equal(withoutPrefix("/eviltrout/hello"), "/eviltrout/hello");
-    assert.equal(withoutPrefix("/eviltrout"), "/eviltrout");
-    assert.equal(withoutPrefix("/"), "/");
+    assert.strictEqual(withoutPrefix("/eviltrout/hello"), "/eviltrout/hello");
+    assert.strictEqual(withoutPrefix("/eviltrout"), "/eviltrout");
+    assert.strictEqual(withoutPrefix("/"), "/");
 
     setPrefix("/f");
-    assert.equal(withoutPrefix("/faq"), "/faq");
-    assert.equal(withoutPrefix("/f/faq"), "/faq");
-    assert.equal(withoutPrefix("/f"), "");
+    assert.strictEqual(withoutPrefix("/faq"), "/faq");
+    assert.strictEqual(withoutPrefix("/f/faq"), "/faq");
+    assert.strictEqual(withoutPrefix("/f"), "");
   });
 
   test("withoutPrefix called multiple times on the same path", function (assert) {
     setPrefix("/eviltrout");
-    assert.equal(withoutPrefix(withoutPrefix("/eviltrout/hello")), "/hello");
-    assert.equal(withoutPrefix(withoutPrefix("/eviltrout/")), "/");
-    assert.equal(withoutPrefix(withoutPrefix("/eviltrout")), "");
+    assert.strictEqual(
+      withoutPrefix(withoutPrefix("/eviltrout/hello")),
+      "/hello"
+    );
+    assert.strictEqual(withoutPrefix(withoutPrefix("/eviltrout/")), "/");
+    assert.strictEqual(withoutPrefix(withoutPrefix("/eviltrout")), "");
 
     setPrefix("");
-    assert.equal(
+    assert.strictEqual(
       withoutPrefix(withoutPrefix("/eviltrout/hello")),
       "/eviltrout/hello"
     );
-    assert.equal(withoutPrefix(withoutPrefix("/eviltrout")), "/eviltrout");
-    assert.equal(withoutPrefix(withoutPrefix("/")), "/");
+    assert.strictEqual(
+      withoutPrefix(withoutPrefix("/eviltrout")),
+      "/eviltrout"
+    );
+    assert.strictEqual(withoutPrefix(withoutPrefix("/")), "/");
 
     setPrefix(null);
-    assert.equal(
+    assert.strictEqual(
       withoutPrefix(withoutPrefix("/eviltrout/hello")),
       "/eviltrout/hello"
     );
-    assert.equal(withoutPrefix(withoutPrefix("/eviltrout")), "/eviltrout");
-    assert.equal(withoutPrefix(withoutPrefix("/")), "/");
+    assert.strictEqual(
+      withoutPrefix(withoutPrefix("/eviltrout")),
+      "/eviltrout"
+    );
+    assert.strictEqual(withoutPrefix(withoutPrefix("/")), "/");
 
     setPrefix("/f");
-    assert.equal(
+    assert.strictEqual(
       withoutPrefix(withoutPrefix("/f/t/falco-says-hello")),
       "/t/falco-says-hello"
     );
-    assert.equal(
+    assert.strictEqual(
       withoutPrefix(withoutPrefix("/f/tag/fast-chain-food")),
       "/tag/fast-chain-food"
     );
-    assert.equal(
+    assert.strictEqual(
       withoutPrefix(withoutPrefix("/f/u/falco/summary")),
       "/u/falco/summary"
     );
@@ -83,56 +95,56 @@ module("Unit | Utility | get-url", function () {
 
   test("getURL with empty paths", function (assert) {
     setupURL(null, "https://example.com", "/");
-    assert.equal(getURL("/"), "/");
-    assert.equal(getURL(""), "");
+    assert.strictEqual(getURL("/"), "/");
+    assert.strictEqual(getURL(""), "");
     setupURL(null, "https://example.com", "");
-    assert.equal(getURL("/"), "/");
-    assert.equal(getURL(""), "");
+    assert.strictEqual(getURL("/"), "/");
+    assert.strictEqual(getURL(""), "");
     setupURL(null, "https://example.com", undefined);
-    assert.equal(getURL("/"), "/");
-    assert.equal(getURL(""), "");
+    assert.strictEqual(getURL("/"), "/");
+    assert.strictEqual(getURL(""), "");
   });
 
   test("getURL on subfolder install", function (assert) {
     setupURL(null, "", "/forum");
-    assert.equal(getURL("/"), "/forum/", "root url has subfolder");
-    assert.equal(
+    assert.strictEqual(getURL("/"), "/forum/", "root url has subfolder");
+    assert.strictEqual(
       getURL("/u/neil"),
       "/forum/u/neil",
       "relative url has subfolder"
     );
 
-    assert.equal(
+    assert.strictEqual(
       getURL("/u/forumadmin"),
       "/forum/u/forumadmin",
       "relative url has subfolder even if username contains subfolder"
     );
 
-    assert.equal(
+    assert.strictEqual(
       getURL(""),
       "/forum",
       "relative url has subfolder without trailing slash"
     );
 
-    assert.equal(
+    assert.strictEqual(
       getURL("/svg-sprite/forum.example.com/svg-sprite.js"),
       "/forum/svg-sprite/forum.example.com/svg-sprite.js",
       "works when the url has the prefix in the middle"
     );
 
-    assert.equal(
+    assert.strictEqual(
       getURL("/forum/t/123"),
       "/forum/t/123",
       "does not prefix if the URL is already prefixed"
     );
 
     setPrefix("/f");
-    assert.equal(
+    assert.strictEqual(
       getURL("/faq"),
       "/f/faq",
       "relative path has subfolder even if it starts with the prefix without trailing slash"
     );
-    assert.equal(
+    assert.strictEqual(
       getURL("/f/faq"),
       "/f/faq",
       "does not prefix if the URL is already prefixed"
@@ -149,6 +161,6 @@ module("Unit | Utility | get-url", function () {
     let url = "//test.s3-us-west-1.amazonaws.com/site/forum/awesome.png";
     let expected = "https://awesome.cdn/site/forum/awesome.png";
 
-    assert.equal(getURLWithCDN(url), expected, "at correct path");
+    assert.strictEqual(getURLWithCDN(url), expected, "at correct path");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/highlight-search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/highlight-search-test.js
@@ -12,7 +12,7 @@ module("Unit | Utility | highlight-search", function () {
 
     const terms = [fixture(`.${CLASS_NAME}`).textContent];
 
-    assert.equal(
+    assert.strictEqual(
       terms.join(" "),
       "some text",
       "it should highlight the terms correctly"
@@ -28,7 +28,7 @@ module("Unit | Utility | highlight-search", function () {
 
     const terms = [fixture(`.${CLASS_NAME}`).textContent];
 
-    assert.equal(
+    assert.strictEqual(
       terms.join(" "),
       "தமிழ் & русский",
       "it should highlight the terms correctly"

--- a/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/i18n-test.js
@@ -100,27 +100,31 @@ module("Unit | Utility | i18n", function (hooks) {
   });
 
   test("defaults", function (assert) {
-    assert.equal(I18n.defaultLocale, "en", "it has English as default locale");
+    assert.strictEqual(
+      I18n.defaultLocale,
+      "en",
+      "it has English as default locale"
+    );
     assert.ok(I18n.pluralizationRules["en"], "it has English pluralizer");
   });
 
   test("translations", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       I18n.t("topic.reply.title"),
       "Répondre",
       "uses locale translations when they exist"
     );
-    assert.equal(
+    assert.strictEqual(
       I18n.t("topic.reply.help"),
       "begin composing a reply to this topic",
       "fallbacks to English translations"
     );
-    assert.equal(
+    assert.strictEqual(
       I18n.t("hello.world"),
       "Hello World!",
       "doesn't break if a key is overriden in a locale"
     );
-    assert.equal(I18n.t("hello.universe"), "", "allows empty strings");
+    assert.strictEqual(I18n.t("hello.universe"), "", "allows empty strings");
   });
 
   test("extra translations", function (assert) {
@@ -176,19 +180,19 @@ module("Unit | Utility | i18n", function (hooks) {
       return "other";
     };
 
-    assert.equal(
+    assert.strictEqual(
       I18n.t("admin.dashboard.title"),
       "Raporty",
       "it uses extra translations when they exists"
     );
 
-    assert.equal(
+    assert.strictEqual(
       I18n.t("admin.web_hooks.events.incoming", { count: 2 }),
       "Istnieją 2 nowe wydarzenia.",
       "it uses pluralized extra translation when it exists"
     );
 
-    assert.equal(
+    assert.strictEqual(
       I18n.t("admin.dashboard.backup_count", { count: 2 }),
       "2 backups",
       "it falls back to English and uses extra translations when they exists"
@@ -196,28 +200,28 @@ module("Unit | Utility | i18n", function (hooks) {
   });
 
   test("pluralizations", function (assert) {
-    assert.equal(I18n.t("character_count", { count: 0 }), "0 ZERO");
-    assert.equal(I18n.t("character_count", { count: 1 }), "1 ONE");
-    assert.equal(I18n.t("character_count", { count: 2 }), "2 TWO");
-    assert.equal(I18n.t("character_count", { count: 3 }), "3 FEW");
-    assert.equal(I18n.t("character_count", { count: 10 }), "10 MANY");
-    assert.equal(I18n.t("character_count", { count: 100 }), "100 OTHER");
+    assert.strictEqual(I18n.t("character_count", { count: 0 }), "0 ZERO");
+    assert.strictEqual(I18n.t("character_count", { count: 1 }), "1 ONE");
+    assert.strictEqual(I18n.t("character_count", { count: 2 }), "2 TWO");
+    assert.strictEqual(I18n.t("character_count", { count: 3 }), "3 FEW");
+    assert.strictEqual(I18n.t("character_count", { count: 10 }), "10 MANY");
+    assert.strictEqual(I18n.t("character_count", { count: 100 }), "100 OTHER");
 
-    assert.equal(I18n.t("word_count", { count: 0 }), "0 words");
-    assert.equal(I18n.t("word_count", { count: 1 }), "1 word");
-    assert.equal(I18n.t("word_count", { count: 2 }), "2 words");
-    assert.equal(I18n.t("word_count", { count: 3 }), "3 words");
-    assert.equal(I18n.t("word_count", { count: 10 }), "10 words");
-    assert.equal(I18n.t("word_count", { count: 100 }), "100 words");
+    assert.strictEqual(I18n.t("word_count", { count: 0 }), "0 words");
+    assert.strictEqual(I18n.t("word_count", { count: 1 }), "1 word");
+    assert.strictEqual(I18n.t("word_count", { count: 2 }), "2 words");
+    assert.strictEqual(I18n.t("word_count", { count: 3 }), "3 words");
+    assert.strictEqual(I18n.t("word_count", { count: 10 }), "10 words");
+    assert.strictEqual(I18n.t("word_count", { count: 100 }), "100 words");
   });
 
   test("fallback", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       I18n.t("days", { count: 1 }),
       "1 day",
       "uses fallback locale for missing plural key"
     );
-    assert.equal(
+    assert.strictEqual(
       I18n.t("days", { count: 200 }),
       "200 jours",
       "uses existing French plural key"
@@ -226,17 +230,17 @@ module("Unit | Utility | i18n", function (hooks) {
     I18n.locale = "fr_FOO";
     I18n.fallbackLocale = "fr";
 
-    assert.equal(
+    assert.strictEqual(
       I18n.t("topic.reply.title"),
       "Foo",
       "uses locale translations when they exist"
     );
-    assert.equal(
+    assert.strictEqual(
       I18n.t("topic.share.title"),
       "Partager",
       "falls back to fallbackLocale translations when they exist"
     );
-    assert.equal(
+    assert.strictEqual(
       I18n.t("topic.reply.help"),
       "begin composing a reply to this topic",
       "falls back to English translations"
@@ -244,7 +248,7 @@ module("Unit | Utility | i18n", function (hooks) {
   });
 
   test("Dollar signs are properly escaped", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       I18n.t("dollar_sign", {
         description: "$& $&",
       }),

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -10,8 +10,8 @@ module("Unit | Utility | icon-library", function () {
     assert.ok(iconHTML("bars").indexOf('use xlink:href="#bars"') > -1);
 
     const nodeIcon = iconNode("bars");
-    assert.equal(nodeIcon.tagName, "svg");
-    assert.equal(
+    assert.strictEqual(nodeIcon.tagName, "svg");
+    assert.strictEqual(
       nodeIcon.properties.attributes.class,
       "fa d-icon d-icon-bars svg-icon svg-node"
     );

--- a/app/assets/javascripts/discourse/tests/unit/lib/key-value-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/key-value-store-test.js
@@ -5,7 +5,7 @@ module("Unit | Utility | key-value-store", function () {
   test("it's able to get the result back from the store", function (assert) {
     const store = new KeyValueStore("_test");
     store.set({ key: "bob", value: "uncle" });
-    assert.equal(store.get("bob"), "uncle");
+    assert.strictEqual(store.get("bob"), "uncle");
   });
 
   test("is able to nuke the store", function (assert) {
@@ -13,7 +13,7 @@ module("Unit | Utility | key-value-store", function () {
     store.set({ key: "bob1", value: "uncle" });
     store.abandonLocal();
     localStorage.a = 1;
-    assert.equal(store.get("bob1"), void 0);
-    assert.equal(localStorage.a, "1");
+    assert.strictEqual(store.get("bob1"), void 0);
+    assert.strictEqual(localStorage.a, "1");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/link-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/link-mentions-test.js
@@ -59,12 +59,15 @@ module("Unit | Utility | link-mentions", function () {
       }, 500);
     });
 
-    assert.equal(root.querySelector("a").innerText, "@valid_user");
-    assert.equal(root.querySelectorAll("a")[1].innerText, "@valid_group");
-    assert.equal(
+    assert.strictEqual(root.querySelector("a").innerText, "@valid_user");
+    assert.strictEqual(root.querySelectorAll("a")[1].innerText, "@valid_group");
+    assert.strictEqual(
       root.querySelector("a.notify").innerText,
       "@mentionable_group"
     );
-    assert.equal(root.querySelector("span.mention").innerHTML, "@invalid");
+    assert.strictEqual(
+      root.querySelector("span.mention").innerHTML,
+      "@invalid"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/load-script-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/load-script-test.js
@@ -19,22 +19,22 @@ module("Unit | Utility | load-script", function () {
   });
 
   test("works when a value is not present", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       cacheBuster("/javascripts/my-script.js"),
       "/javascripts/my-script.js"
     );
-    assert.equal(
+    assert.strictEqual(
       cacheBuster("/javascripts/my-project/script.js"),
       "/javascripts/my-project/script.js"
     );
   });
 
   test("generates URLs with version number in the query params", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       cacheBuster("/javascripts/pikaday.js"),
       `/javascripts/${jsVersions["pikaday.js"]}`
     );
-    assert.equal(
+    assert.strictEqual(
       cacheBuster("/javascripts/ace/ace.js"),
       `/javascripts/${jsVersions["ace/ace.js"]}`
     );

--- a/app/assets/javascripts/discourse/tests/unit/lib/oneboxer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/oneboxer-test.js
@@ -21,12 +21,12 @@ module("Unit | Utility | oneboxer", function () {
 
     await loadOnebox(element);
 
-    assert.equal(
+    assert.strictEqual(
       failedCache["http://somebadurl.com"],
       true,
       "stores the url as failed in a cache"
     );
-    assert.equal(
+    assert.strictEqual(
       loadOnebox(element),
       undefined,
       "it returns early for a failed cache"

--- a/app/assets/javascripts/discourse/tests/unit/lib/parse-bbcode-tag-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/parse-bbcode-tag-test.js
@@ -5,8 +5,8 @@ module("Unit | Utility | parseBBCodeTag", function () {
   test("block with multiple quoted attributes", function (assert) {
     const parsed = parseBBCodeTag('[test one="foo" two="bar bar"]', 0, 30);
 
-    assert.equal(parsed.tag, "test");
-    assert.equal(parsed.attrs.one, "foo");
-    assert.equal(parsed.attrs.two, "bar bar");
+    assert.strictEqual(parsed.tag, "test");
+    assert.strictEqual(parsed.attrs.one, "foo");
+    assert.strictEqual(parsed.attrs.two, "bar bar");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/preload-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/preload-store-test.js
@@ -9,7 +9,7 @@ module("Unit | Utility | preload-store", function (hooks) {
 
   test("get", function (assert) {
     assert.blank(PreloadStore.get("joker"), "returns blank for a missing key");
-    assert.equal(
+    assert.strictEqual(
       PreloadStore.get("bane"),
       "evil",
       "returns the value for that key"
@@ -32,26 +32,26 @@ module("Unit | Utility | preload-store", function (hooks) {
     const finder = () => "batdance";
     const result = await PreloadStore.getAndRemove("joker", finder);
 
-    assert.equal(result, "batdance");
+    assert.strictEqual(result, "batdance");
   });
 
   test("getAndRemove returns a promise that resolves to the result of the finder's promise", async function (assert) {
     const finder = () => Promise.resolve("hahahah");
     const result = await PreloadStore.getAndRemove("joker", finder);
 
-    assert.equal(result, "hahahah");
+    assert.strictEqual(result, "hahahah");
   });
 
   test("returns a promise that rejects with the result of the finder's rejected promise", async function (assert) {
     const finder = () => Promise.reject("error");
 
     await PreloadStore.getAndRemove("joker", finder).catch((result) => {
-      assert.equal(result, "error");
+      assert.strictEqual(result, "error");
     });
   });
 
   test("returns a promise that resolves to 'evil'", async function (assert) {
     const result = await PreloadStore.getAndRemove("bane");
-    assert.equal(result, "evil");
+    assert.strictEqual(result, "evil");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1268,7 +1268,7 @@ eviltrout</p>
     });
 
     function formatQuote(val, expected, text, opts) {
-      assert.equal(buildQuote(post, val, opts), expected, text);
+      assert.strictEqual(buildQuote(post, val, opts), expected, text);
     }
 
     formatQuote(undefined, "", "empty string for undefined content");
@@ -1334,7 +1334,7 @@ eviltrout</p>
       '[quote="sam, post:1, topic:1, full:true"]\nhello\n[/quote]'
     );
 
-    assert.equal(
+    assert.strictEqual(
       quote,
       '[quote="eviltrout, post:1, topic:2"]\n[quote="sam, post:1, topic:1, full:true"]\nhello\n[/quote]\n[/quote]\n\n',
       "allows quoting a quote"
@@ -1447,7 +1447,7 @@ var bar = 'bar';
     const result = new PrettyText(defaultOpts).cook(
       '[quote="EvilTrout, post:123, topic:456, full:true"]\nhello\n[/quote]\n*Test*'
     );
-    assert.equal(
+    assert.strictEqual(
       result,
       `<aside class=\"quote no-group\" data-username=\"EvilTrout\" data-post=\"123\" data-topic=\"456\" data-full=\"true\">
 <div class=\"title\">

--- a/app/assets/javascripts/discourse/tests/unit/lib/sanitizer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/sanitizer-test.js
@@ -13,22 +13,22 @@ module("Unit | Utility | sanitizer", function () {
       })
     );
     const cooked = (input, expected, text) =>
-      assert.equal(pt.cook(input), expected.replace(/\/>/g, ">"), text);
+      assert.strictEqual(pt.cook(input), expected.replace(/\/>/g, ">"), text);
 
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize('<i class="fa-bug fa-spin">bug</i>'),
       "<i>bug</i>"
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize("<div><script>alert('hi');</script></div>"),
       "<div></div>"
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize("<div><p class=\"funky\" wrong='1'>hello</p></div>"),
       "<div><p>hello</p></div>"
     );
-    assert.equal(pt.sanitize("<3 <3"), "&lt;3 &lt;3");
-    assert.equal(pt.sanitize("<_<"), "&lt;_&lt;");
+    assert.strictEqual(pt.sanitize("<3 <3"), "&lt;3 &lt;3");
+    assert.strictEqual(pt.sanitize("<_<"), "&lt;_&lt;");
 
     cooked(
       "hello<script>alert(42)</script>",
@@ -67,10 +67,10 @@ module("Unit | Utility | sanitizer", function () {
       "it allows iframe to OpenStreetMap"
     );
 
-    assert.equal(pt.sanitize("<textarea>hullo</textarea>"), "hullo");
-    assert.equal(pt.sanitize("<button>press me!</button>"), "press me!");
-    assert.equal(pt.sanitize("<canvas>draw me!</canvas>"), "draw me!");
-    assert.equal(pt.sanitize("<progress>hello"), "hello");
+    assert.strictEqual(pt.sanitize("<textarea>hullo</textarea>"), "hullo");
+    assert.strictEqual(pt.sanitize("<button>press me!</button>"), "press me!");
+    assert.strictEqual(pt.sanitize("<canvas>draw me!</canvas>"), "draw me!");
+    assert.strictEqual(pt.sanitize("<progress>hello"), "hello");
 
     cooked(
       "[the answer](javascript:alert(42))",
@@ -145,28 +145,31 @@ module("Unit | Utility | sanitizer", function () {
 
   test("ids on headings", function (assert) {
     const pt = new PrettyText(buildOptions({ siteSettings: {} }));
-    assert.equal(pt.sanitize("<h3>Test Heading</h3>"), "<h3>Test Heading</h3>");
-    assert.equal(
+    assert.strictEqual(
+      pt.sanitize("<h3>Test Heading</h3>"),
+      "<h3>Test Heading</h3>"
+    );
+    assert.strictEqual(
       pt.sanitize(`<h1 id="heading--test">Test Heading</h1>`),
       `<h1 id="heading--test">Test Heading</h1>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h2 id="heading--cool">Test Heading</h2>`),
       `<h2 id="heading--cool">Test Heading</h2>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h3 id="heading--dashed-name">Test Heading</h3>`),
       `<h3 id="heading--dashed-name">Test Heading</h3>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h4 id="heading--underscored_name">Test Heading</h4>`),
       `<h4 id="heading--underscored_name">Test Heading</h4>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h5 id="heading--trout">Test Heading</h5>`),
       `<h5 id="heading--trout">Test Heading</h5>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h6 id="heading--discourse">Test Heading</h6>`),
       `<h6 id="heading--discourse">Test Heading</h6>`
     );
@@ -206,41 +209,42 @@ module("Unit | Utility | sanitizer", function () {
 
   test("poorly formed ids on headings", function (assert) {
     let pt = new PrettyText(buildOptions({ siteSettings: {} }));
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h1 id="evil-trout">Test Heading</h1>`),
       `<h1>Test Heading</h1>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h1 id="heading--">Test Heading</h1>`),
       `<h1>Test Heading</h1>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h1 id="heading--with space">Test Heading</h1>`),
       `<h1>Test Heading</h1>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h1 id="heading--with*char">Test Heading</h1>`),
       `<h1>Test Heading</h1>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h1 id="heading--">Test Heading</h1>`),
       `<h1>Test Heading</h1>`
     );
-    assert.equal(
+    assert.strictEqual(
       pt.sanitize(`<h1 id="test-heading--cool">Test Heading</h1>`),
       `<h1>Test Heading</h1>`
     );
   });
 
   test("urlAllowed", function (assert) {
-    const allowed = (url, msg) => assert.equal(hrefAllowed(url), url, msg);
+    const allowed = (url, msg) =>
+      assert.strictEqual(hrefAllowed(url), url, msg);
 
     allowed("/foo/bar.html", "allows relative urls");
     allowed("http://eviltrout.com/evil/trout", "allows full urls");
     allowed("https://eviltrout.com/evil/trout", "allows https urls");
     allowed("//eviltrout.com/evil/trout", "allows protocol relative urls");
 
-    assert.equal(
+    assert.strictEqual(
       hrefAllowed("http://google.com/test'onmouseover=alert('XSS!');//.swf"),
       "http://google.com/test%27onmouseover=alert(%27XSS!%27);//.swf",
       "escape single quotes"

--- a/app/assets/javascripts/discourse/tests/unit/lib/search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/search-test.js
@@ -37,26 +37,26 @@ module("Unit | Utility | search", function () {
   });
 
   test("searchContextDescription", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       searchContextDescription("topic"),
       I18n.t("search.context.topic")
     );
-    assert.equal(
+    assert.strictEqual(
       searchContextDescription("user", "silvio.dante"),
       I18n.t("search.context.user", { username: "silvio.dante" })
     );
-    assert.equal(
+    assert.strictEqual(
       searchContextDescription("category", "staff"),
       I18n.t("search.context.category", { category: "staff" })
     );
-    assert.equal(
+    assert.strictEqual(
       searchContextDescription("tag", "important"),
       I18n.t("search.context.tag", { tag: "important" })
     );
-    assert.equal(
+    assert.strictEqual(
       searchContextDescription("private_messages"),
       I18n.t("search.context.private_messages")
     );
-    assert.equal(searchContextDescription("bad_type"), null);
+    assert.strictEqual(searchContextDescription("bad_type"), null);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/search-test.js
@@ -57,6 +57,6 @@ module("Unit | Utility | search", function () {
       searchContextDescription("private_messages"),
       I18n.t("search.context.private_messages")
     );
-    assert.strictEqual(searchContextDescription("bad_type"), null);
+    assert.strictEqual(searchContextDescription("bad_type"), undefined);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/sharing-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/sharing-test.js
@@ -19,7 +19,7 @@ module("Unit | Utility | sharing", function (hooks) {
       id: "facebook",
     });
 
-    assert.equal(Sharing.activeSources(sharingSettings).length, 1);
+    assert.strictEqual(Sharing.activeSources(sharingSettings).length, 1);
   });
 
   test("addSharingId", function (assert) {
@@ -38,7 +38,7 @@ module("Unit | Utility | sharing", function (hooks) {
 
     Sharing.addSharingId("new-source");
 
-    assert.equal(
+    assert.strictEqual(
       Sharing.activeSources(sharingSettings).length,
       1,
       "it adds sharing id to existing sharing settings"
@@ -51,7 +51,7 @@ module("Unit | Utility | sharing", function (hooks) {
     });
     Sharing.addSharingId("another-source");
 
-    assert.equal(
+    assert.strictEqual(
       Sharing.activeSources(sharingSettings, privateContext).length,
       0,
       "it does not add a regular source to sources in a private context"
@@ -63,7 +63,7 @@ module("Unit | Utility | sharing", function (hooks) {
     });
     Sharing.addSharingId("a-private-friendly-source");
 
-    assert.equal(
+    assert.strictEqual(
       Sharing.activeSources(sharingSettings, privateContext).length,
       1,
       "it does not add a regular source to sources in a private context"

--- a/app/assets/javascripts/discourse/tests/unit/lib/text-direction-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/text-direction-test.js
@@ -4,20 +4,20 @@ import { module, test } from "qunit";
 module("Unit | Utility | text-direction", function () {
   test("isRTL", function (assert) {
     // Hebrew
-    assert.equal(isRTL("זה מבחן"), true);
+    assert.strictEqual(isRTL("זה מבחן"), true);
 
     // Arabic
-    assert.equal(isRTL("هذا اختبار"), true);
+    assert.strictEqual(isRTL("هذا اختبار"), true);
 
     // Persian
-    assert.equal(isRTL("این یک امتحان است"), true);
+    assert.strictEqual(isRTL("این یک امتحان است"), true);
 
-    assert.equal(isRTL("This is a test"), false);
-    assert.equal(isRTL(""), false);
+    assert.strictEqual(isRTL("This is a test"), false);
+    assert.strictEqual(isRTL(""), false);
   });
 
   test("isLTR", function (assert) {
-    assert.equal(isLTR("This is a test"), true);
-    assert.equal(isLTR("זה מבחן"), false);
+    assert.strictEqual(isLTR("This is a test"), true);
+    assert.strictEqual(isLTR("זה מבחן"), false);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/time-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/time-utils-test.js
@@ -17,26 +17,32 @@ const timezone = "Australia/Brisbane";
 discourseModule("Unit | lib | timeUtils", function () {
   test("nextMonth gets next month correctly", function (assert) {
     withFrozenTime("2019-12-11T08:00:00", timezone, () => {
-      assert.equal(nextMonth(timezone).format("YYYY-MM-DD"), "2020-01-01");
+      assert.strictEqual(
+        nextMonth(timezone).format("YYYY-MM-DD"),
+        "2020-01-01"
+      );
     });
   });
 
   test("laterThisWeek gets 2 days from now", function (assert) {
     withFrozenTime("2019-12-10T08:00:00", timezone, () => {
-      assert.equal(laterThisWeek(timezone).format("YYYY-MM-DD"), "2019-12-12");
+      assert.strictEqual(
+        laterThisWeek(timezone).format("YYYY-MM-DD"),
+        "2019-12-12"
+      );
     });
   });
 
   test("tomorrow gets tomorrow correctly", function (assert) {
     withFrozenTime("2019-12-11T08:00:00", timezone, () => {
-      assert.equal(tomorrow(timezone).format("YYYY-MM-DD"), "2019-12-12");
+      assert.strictEqual(tomorrow(timezone).format("YYYY-MM-DD"), "2019-12-12");
     });
   });
 
   test("startOfDay changes the time of the provided date to 8:00am correctly", function (assert) {
     let dt = moment.tz("2019-12-11T11:37:16", timezone);
 
-    assert.equal(
+    assert.strictEqual(
       startOfDay(dt).format("YYYY-MM-DD HH:mm:ss"),
       "2019-12-11 08:00:00"
     );
@@ -44,7 +50,7 @@ discourseModule("Unit | lib | timeUtils", function () {
 
   test("laterToday gets 3 hours from now and if before half-past, it rounds down", function (assert) {
     withFrozenTime("2019-12-11T08:13:00", timezone, () => {
-      assert.equal(
+      assert.strictEqual(
         laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
         "2019-12-11 11:00:00"
       );
@@ -53,7 +59,7 @@ discourseModule("Unit | lib | timeUtils", function () {
 
   test("laterToday gets 3 hours from now and if after half-past, it rounds up to the next hour", function (assert) {
     withFrozenTime("2019-12-11T08:43:00", timezone, () => {
-      assert.equal(
+      assert.strictEqual(
         laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
         "2019-12-11 12:00:00"
       );
@@ -62,7 +68,7 @@ discourseModule("Unit | lib | timeUtils", function () {
 
   test("laterToday is capped to 6pm. later today at 3pm = 6pm, 3:30pm = 6pm, 4pm = 6pm, 4:59pm = 6pm", function (assert) {
     withFrozenTime("2019-12-11T15:00:00", timezone, () => {
-      assert.equal(
+      assert.strictEqual(
         laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
         "2019-12-11 18:00:00",
         "3pm should max to 6pm"
@@ -70,7 +76,7 @@ discourseModule("Unit | lib | timeUtils", function () {
     });
 
     withFrozenTime("2019-12-11T15:31:00", timezone, () => {
-      assert.equal(
+      assert.strictEqual(
         laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
         "2019-12-11 18:00:00",
         "3:30pm should max to 6pm"
@@ -78,7 +84,7 @@ discourseModule("Unit | lib | timeUtils", function () {
     });
 
     withFrozenTime("2019-12-11T16:00:00", timezone, () => {
-      assert.equal(
+      assert.strictEqual(
         laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
         "2019-12-11 18:00:00",
         "4pm should max to 6pm"
@@ -86,7 +92,7 @@ discourseModule("Unit | lib | timeUtils", function () {
     });
 
     withFrozenTime("2019-12-11T16:59:00", timezone, () => {
-      assert.equal(
+      assert.strictEqual(
         laterToday(timezone).format("YYYY-MM-DD HH:mm:ss"),
         "2019-12-11 18:00:00",
         "4:59pm should max to 6pm"

--- a/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
@@ -5,57 +5,57 @@ module("Unit | Utility | to-markdown", function () {
   test("converts styles between normal words", function (assert) {
     const html = `Line with <s>styles</s> <b><i>between</i></b> words.`;
     const markdown = `Line with ~~styles~~ ***between*** words.`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
-    assert.equal(toMarkdown("A <b>bold </b>word"), "A **bold** word");
-    assert.equal(toMarkdown("A <b>bold</b>, word"), "A **bold**, word");
+    assert.strictEqual(toMarkdown("A <b>bold </b>word"), "A **bold** word");
+    assert.strictEqual(toMarkdown("A <b>bold</b>, word"), "A **bold**, word");
   });
 
   test("converts inline nested styles", function (assert) {
     let html = `<em>Italicised line with <strong>some random</strong> <b>bold</b> words.</em>`;
     let markdown = `*Italicised line with **some random** **bold** words.*`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     html = `<i class="fa">Italicised line
      with <b title="strong">some<br>
      random</b> <s>bold</s> words.</i>`;
     markdown = `<i>Italicised line with <b>some\nrandom</b> ~~bold~~ words.</i>`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     // eslint-disable-next-line no-irregular-whitespace
     html = `<span>this is<span> </span></span><strong>bold</strong><span><span> </span>statement</span>`;
     markdown = `this is **bold** statement`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("converts a link", function (assert) {
     let html = `<a href="https://discourse.org">Discourse</a>`;
     let markdown = `[Discourse](https://discourse.org)`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     html = `<a href="https://discourse.org">Disc\n\n\nour\n\nse</a>`;
     markdown = `[Disc our se](https://discourse.org)`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("converts a link which is an attachment", function (assert) {
     let html = `<a class="attachment" href="https://discourse.org/pdfs/stuff.pdf">stuff.pdf</a>`;
     let markdown = `[stuff.pdf|attachment](https://discourse.org/pdfs/stuff.pdf)`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("put raw URL instead of converting the link", function (assert) {
     let url = "https://discourse.org";
     const html = () => `<a href="${url}">${url}</a>`;
 
-    assert.equal(toMarkdown(html()), url);
+    assert.strictEqual(toMarkdown(html()), url);
 
     url = "discourse.org/t/topic-slug/1";
-    assert.equal(toMarkdown(html()), url);
+    assert.strictEqual(toMarkdown(html()), url);
   });
 
   test("skip empty link", function (assert) {
-    assert.equal(toMarkdown(`<a href="https://example.com"></a>`), "");
+    assert.strictEqual(toMarkdown(`<a href="https://example.com"></a>`), "");
   });
 
   test("converts heading tags", function (assert) {
@@ -78,7 +78,7 @@ module("Unit | Utility | to-markdown", function () {
   <h6>Heading 6</h6>
     `;
     const markdown = `# Heading 1\n\n## Heading 2\n\n### Heading 3\n\n#### Heading 4\n\n##### Heading 5\n\n###### Heading 6`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("converts ul list tag", function (assert) {
@@ -97,7 +97,7 @@ module("Unit | Utility | to-markdown", function () {
     </ul>
     `;
     let markdown = `* Item 1\n* Item 2\n  * Sub Item 1\n  * Sub Item 2\n  * Sub Item 3\n    * Sub *Sub* Item 1\n    * Sub **Sub** Item 2\n* Item 3`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     html = `
   <ul>
@@ -110,7 +110,7 @@ module("Unit | Utility | to-markdown", function () {
     * Bullets at level 3
   * Bullets at level 2
 * Bullets at level 1`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("stripes unwanted inline tags", function (assert) {
@@ -119,7 +119,7 @@ module("Unit | Utility | to-markdown", function () {
     <p>Ut minim veniam, <label>quis nostrud</label> laboris <nisi> ut aliquip ex ea</nisi> commodo.</p>
     `;
     const markdown = `Lorem ipsum dolor sit amet, consectetur ~~elit.~~\n\nUt minim veniam, quis nostrud laboris ut aliquip ex ea commodo.`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("converts table tags", function (assert) {
@@ -134,14 +134,14 @@ module("Unit | Utility | to-markdown", function () {
   </table>
     `;
     let markdown = `Discourse Avenue\n\n**laboris**\n\n|Heading 1|Head 2|\n| --- | --- |\n|Lorem|ipsum|\n|**dolor**|*sit amet*|`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     html = `<table>
               <tr><th>Heading 1</th><th>Head 2</th></tr>
               <tr><td><a href="http://example.com"><img src="http://example.com/image.png" alt="Lorem" width="45" height="45"></a></td><td>ipsum</td></tr>
             </table>`;
     markdown = `|Heading 1|Head 2|\n| --- | --- |\n|[![Lorem\\|45x45](http://example.com/image.png)](http://example.com)|ipsum|`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("replace pipes with spaces if table format not supported", function (assert) {
@@ -153,7 +153,7 @@ module("Unit | Utility | to-markdown", function () {
   </table>
     `;
     let markdown = `Headi\n\nng 1 Head 2\nLorem ipsum\n[![](http://dolor.com/image.png)](http://example.com) *sit amet*`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     html = `<table>
       <thead> <tr><th>Heading 1</th></tr> </thead>
@@ -163,75 +163,75 @@ module("Unit | Utility | to-markdown", function () {
   </table>
     `;
     markdown = `Heading 1\nLorem\n*sit amet*`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     html = `<table><tr><td>Lorem</td><td><strong>sit amet</strong></td></tr></table>`;
     markdown = `Lorem **sit amet**`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("converts img tag", function (assert) {
     const url = "https://example.com/image.png";
     const base62SHA1 = "q16M6GR110R47Z9p9Dk3PMXOJoE";
     let html = `<img src="${url}" width="100" height="50">`;
-    assert.equal(toMarkdown(html), `![|100x50](${url})`);
+    assert.strictEqual(toMarkdown(html), `![|100x50](${url})`);
 
     html = `<img src="${url}" width="100" height="50" title="some title">`;
-    assert.equal(toMarkdown(html), `![|100x50](${url} "some title")`);
+    assert.strictEqual(toMarkdown(html), `![|100x50](${url} "some title")`);
 
     html = `<img src="${url}" width="100" height="50" title="some title" data-base62-sha1="${base62SHA1}">`;
-    assert.equal(
+    assert.strictEqual(
       toMarkdown(html),
       `![|100x50](upload://${base62SHA1} "some title")`
     );
 
     html = `<div><span><img src="${url}" alt="description" width="50" height="100" /></span></div>`;
-    assert.equal(toMarkdown(html), `![description|50x100](${url})`);
+    assert.strictEqual(toMarkdown(html), `![description|50x100](${url})`);
 
     html = `<a href="http://example.com"><img src="${url}" alt="description" /></a>`;
-    assert.equal(
+    assert.strictEqual(
       toMarkdown(html),
       `[![description](${url})](http://example.com)`
     );
 
     html = `<a href="http://example.com">description <img src="${url}" /></a>`;
-    assert.equal(
+    assert.strictEqual(
       toMarkdown(html),
       `[description ![](${url})](http://example.com)`
     );
 
     html = `<img alt="description" />`;
-    assert.equal(toMarkdown(html), "");
+    assert.strictEqual(toMarkdown(html), "");
 
     html = `<a><img src="${url}" alt="description" /></a>`;
-    assert.equal(toMarkdown(html), `![description](${url})`);
+    assert.strictEqual(toMarkdown(html), `![description](${url})`);
   });
 
   test("supporting html tags by keeping them", function (assert) {
     let html =
       "Lorem <del>ipsum dolor</del> sit <big>amet, <ins>consectetur</ins></big>";
     let output = html;
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
 
     html = `Lorem <del style="font-weight: bold">ipsum dolor</del> sit <big>amet, <ins onclick="alert('hello')">consectetur</ins></big>`;
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
 
     html = `<a href="http://example.com" onload="">Lorem <del style="font-weight: bold">ipsum dolor</del> sit</a>.`;
     output = `[Lorem <del>ipsum dolor</del> sit](http://example.com).`;
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
 
     html = `Lorem <del>ipsum dolor</del> sit.`;
-    assert.equal(toMarkdown(html), html);
+    assert.strictEqual(toMarkdown(html), html);
 
     html = `Have you tried clicking the <kbd>Help Me!</kbd> button?`;
-    assert.equal(toMarkdown(html), html);
+    assert.strictEqual(toMarkdown(html), html);
 
     html = `<mark>This is highlighted!</mark>`;
-    assert.equal(toMarkdown(html), html);
+    assert.strictEqual(toMarkdown(html), html);
 
     html = `Lorem <a href="http://example.com"><del>ipsum \n\n\n dolor</del> sit.</a>`;
     output = `Lorem [<del>ipsum dolor</del> sit.](http://example.com)`;
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
   });
 
   test("converts code tags", function (assert) {
@@ -244,7 +244,7 @@ helloWorld();</code></pre>
   consectetur.`;
     let output = `Lorem ipsum dolor sit amet,\n\n\`\`\`\nvar helloWorld = () => {\n  alert('    hello \t\t world    ');\n    return;\n}\nhelloWorld();\n\`\`\`\n\nconsectetur.`;
 
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
 
     html = `Lorem ipsum dolor sit amet, <code>var helloWorld = () => {
   alert('    hello \t\t world    ');
@@ -253,23 +253,23 @@ helloWorld();</code></pre>
 helloWorld();</code>consectetur.`;
     output = `Lorem ipsum dolor sit amet, \`var helloWorld = () => {\n  alert('    hello \t\t world    ');\n    return;\n}\nhelloWorld();\`consectetur.`;
 
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
   });
 
   test("converts blockquote tag", function (assert) {
     let html = "<blockquote>Lorem ipsum</blockquote>";
     let output = "> Lorem ipsum";
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
 
     html =
       "<blockquote>Lorem ipsum</blockquote><blockquote><p>dolor sit amet</p></blockquote>";
     output = "> Lorem ipsum\n\n> dolor sit amet";
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
 
     html =
       "<blockquote>\nLorem ipsum\n<blockquote><p>dolor <blockquote>sit</blockquote> amet</p></blockquote></blockquote>";
     output = "> Lorem ipsum\n> > dolor\n> > > sit\n> > amet";
-    assert.equal(toMarkdown(html), output);
+    assert.strictEqual(toMarkdown(html), output);
   });
 
   test("converts ol list tag", function (assert) {
@@ -287,7 +287,7 @@ helloWorld();</code>consectetur.`;
     </ol>
     `;
     const markdown = `Testing\n\n1. Item 1\n2. Item 2\n  100. Sub Item 1\n  101. Sub Item 2\n3. Item 3`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("converts list tag from word", function (assert) {
@@ -334,7 +334,7 @@ helloWorld();</code>consectetur.`;
       <![endif]>Item 4</p>
     <!--EndFragment-->List`;
     const markdown = `Sample\n\n* **Item 1**\n  * *Item 2*\n    * Item 3\n* Item 4\n\nList`;
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("keeps mention/hash class", function (assert) {
@@ -347,7 +347,7 @@ helloWorld();</code>consectetur.`;
 
     const markdown = `User mention: @discourse\n\nGroup mention: @discourse-group\n\nCategory link: #foo\n\nSub-category link: #foo:bar`;
 
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("keeps emoji and removes click count", function (assert) {
@@ -360,7 +360,7 @@ helloWorld();</code>consectetur.`;
 
     const markdown = `A [link](http://example.com) with click count and :boom: emoji.`;
 
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("keeps emoji syntax for custom emoji", function (assert) {
@@ -372,7 +372,7 @@ helloWorld();</code>consectetur.`;
 
     const markdown = `:custom_emoji:`;
 
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("converts image lightboxes to markdown", function (assert) {
@@ -383,11 +383,11 @@ helloWorld();</code>consectetur.`;
     `;
     let markdown = `![sherlock3_sig.jpg](https://d11a6trkgmumsb.cloudfront.net/uploads/default/original/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba.jpeg)`;
 
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     html = `<a class="lightbox" href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/original/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba.jpeg" data-download-href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba" title="sherlock3_sig.jpg" rel="nofollow noopener"><img src="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg" alt="sherlock3_sig" width="689" height="459" class="d-lazyload" srcset="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1033x688.jpeg 1.5x, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1378x918.jpeg 2x"></a>`;
 
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
 
     html = `
     <a class="lightbox" href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/original/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba.jpeg" data-download-href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba" title="sherlock3_sig.jpg" rel="nofollow noopener"><img src="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg" data-base62-sha1="1frsimI7TOtFJyD2LLyKSHM8JWe" alt="sherlock3_sig" width="689" height="459" class="d-lazyload" srcset="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1033x688.jpeg 1.5x, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1378x918.jpeg 2x"><div class="meta">
@@ -396,7 +396,7 @@ helloWorld();</code>consectetur.`;
     `;
     markdown = `![sherlock3_sig.jpg](upload://1frsimI7TOtFJyD2LLyKSHM8JWe)`;
 
-    assert.equal(toMarkdown(html), markdown);
+    assert.strictEqual(toMarkdown(html), markdown);
   });
 
   test("converts quotes to markdown", function (assert) {
@@ -423,12 +423,12 @@ this is a quote
 there is a quote above
 `;
 
-    assert.equal(toMarkdown(html), markdown.trim());
+    assert.strictEqual(toMarkdown(html), markdown.trim());
   });
 
   test("strips base64 image URLs", function (assert) {
     const html =
       '<img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD/7AARRHVja3kAAQAEAAAAPAAA/+4AJkFkb2JlAGTAAAAAAQMAFQQDBgoNAAABywAAAgsAAAJpAAACyf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoKDBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8IAEQgAEAAQAwERAAIRAQMRAf/EAJQAAQEBAAAAAAAAAAAAAAAAAAMFBwEAAwEAAAAAAAAAAAAAAAAAAAEDAhAAAQUBAQAAAAAAAAAAAAAAAgABAwQFESARAAIBAwIHAAAAAAAAAAAAAAERAgAhMRIDQWGRocEiIxIBAAAAAAAAAAAAAAAAAAAAIBMBAAMAAQQDAQAAAAAAAAAAAQARITHwQVGBYXGR4f/aAAwDAQACEQMRAAAB0UlMciEJn//aAAgBAQABBQK5bGtFn6pWi2K12wWTRkjb/9oACAECAAEFAvH/2gAIAQMAAQUCIuIJOqRndRiv/9oACAECAgY/Ah//2gAIAQMCBj8CH//aAAgBAQEGPwLWQzwHepfNbcUNfM4tUIbA9QL4AvnxTlAxacpWJReOlf/aAAgBAQMBPyHZDveuCyu4B4lz2lDKto2ca5uclPK0aoq32x8xgTSLeSgbyzT65n//2gAIAQIDAT8hlQjP/9oACAEDAwE/IaE9GcZFJ//aAAwDAQACEQMRAAAQ5F//2gAIAQEDAT8Q1oowKccI3KTdAWkPLw2ssIrwKYUzuJoUJsIHOCoG23ISlja+rU9QvCx//9oACAECAwE/EAuNIiKf/9oACAEDAwE/ECujJzHf7iwHOv5NhK+8efH50z//2Q==" />';
-    assert.equal(toMarkdown(html), "[image]");
+    assert.strictEqual(toMarkdown(html), "[image]");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/upload-short-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/upload-short-url-test.js
@@ -152,14 +152,14 @@ module("Unit | Utility | pretty-text/upload-short-url", function (hooks) {
     let video = fixture().querySelector("video");
     let link = fixture().querySelector("a");
 
-    assert.equal(image1.getAttribute("src"), "/images/avatar.png?a");
-    assert.equal(image2.getAttribute("src"), "/images/avatar.png?b");
-    assert.equal(link.getAttribute("href"), "/uploads/short-url/c.pdf");
-    assert.equal(
+    assert.strictEqual(image1.getAttribute("src"), "/images/avatar.png?a");
+    assert.strictEqual(image2.getAttribute("src"), "/images/avatar.png?b");
+    assert.strictEqual(link.getAttribute("href"), "/uploads/short-url/c.pdf");
+    assert.strictEqual(
       video.querySelector("source").getAttribute("src"),
       "/uploads/default/original/3X/c/b/4.mp4"
     );
-    assert.equal(
+    assert.strictEqual(
       audio.querySelector("source").getAttribute("src"),
       "/uploads/default/original/3X/c/b/5.mp3"
     );
@@ -171,7 +171,7 @@ module("Unit | Utility | pretty-text/upload-short-url", function (hooks) {
     await settled();
     let video = fixture().querySelectorAll("video")[1];
 
-    assert.equal(
+    assert.strictEqual(
       video.querySelector("source").getAttribute("src"),
       "http://localhost:3000/uploads/default/original/3X/c/b/6.mp4"
     );
@@ -193,7 +193,7 @@ module("Unit | Utility | pretty-text/upload-short-url", function (hooks) {
     await settled();
 
     let link = fixture().querySelector("a");
-    assert.equal(
+    assert.strictEqual(
       link.getAttribute("href"),
       "/secure-media-uploads/default/original/3X/c/b/3.pdf"
     );

--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -275,40 +275,40 @@ discourseModule("Unit | Utility | uploads", function () {
   }
 
   test("getUploadMarkdown", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       testUploadMarkdown("lolcat.gif"),
       "![lolcat|100x200](/uploads/123/abcdef.ext)"
     );
-    assert.equal(
+    assert.strictEqual(
       testUploadMarkdown("[foo|bar].png"),
       "![foobar|100x200](/uploads/123/abcdef.ext)"
     );
-    assert.equal(
+    assert.strictEqual(
       testUploadMarkdown("file name with space.png"),
       "![file name with space|100x200](/uploads/123/abcdef.ext)"
     );
 
-    assert.equal(
+    assert.strictEqual(
       testUploadMarkdown("image.file.name.with.dots.png"),
       "![image.file.name.with.dots|100x200](/uploads/123/abcdef.ext)"
     );
 
     const short_url = "uploads://asdaasd.ext";
 
-    assert.equal(
+    assert.strictEqual(
       testUploadMarkdown("important.txt", { short_url }),
       `[important.txt|attachment](${short_url}) (42 Bytes)`
     );
   });
 
   test("getUploadMarkdown - replaces GUID in image alt text on iOS", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
       "![8F2B469B-6B2C-4213-BC68-57B4876365A0|100x200](/uploads/123/abcdef.ext)"
     );
 
     sinon.stub(Utilities, "isAppleDevice").returns(true);
-    assert.equal(
+    assert.strictEqual(
       testUploadMarkdown("8F2B469B-6B2C-4213-BC68-57B4876365A0.jpeg"),
       "![image|100x200](/uploads/123/abcdef.ext)"
     );

--- a/app/assets/javascripts/discourse/tests/unit/lib/uppy-checksum-plugin-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uppy-checksum-plugin-test.js
@@ -134,7 +134,10 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
     plugin.uppy.preprocessors[0]([fileId]).then(() => {
       assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
       assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-complete");
-      assert.strictEqual(plugin.uppy.getFile(fileId).meta.sha1_checksum, null);
+      assert.strictEqual(
+        plugin.uppy.getFile(fileId).meta.sha1_checksum,
+        undefined
+      );
       done();
     });
   });

--- a/app/assets/javascripts/discourse/tests/unit/lib/uppy-checksum-plugin-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uppy-checksum-plugin-test.js
@@ -49,8 +49,8 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
     const plugin = new UppyChecksum(fakeUppy, {
       capabilities,
     });
-    assert.equal(plugin.id, "uppy-checksum");
-    assert.equal(plugin.capabilities, capabilities);
+    assert.strictEqual(plugin.id, "uppy-checksum");
+    assert.strictEqual(plugin.capabilities, capabilities);
   });
 
   test("it does nothing if not running in a secure context", function (assert) {
@@ -67,7 +67,7 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
     const fileId =
       "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
     plugin.uppy.preprocessors[0]([fileId]).then(() => {
-      assert.equal(
+      assert.strictEqual(
         plugin.uppy.emitted.length,
         1,
         "only the complete event was fired by the checksum plugin because it skipped the file"
@@ -90,7 +90,7 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
     const fileId =
       "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
     plugin.uppy.preprocessors[0]([fileId]).then(() => {
-      assert.equal(
+      assert.strictEqual(
         plugin.uppy.emitted.length,
         1,
         "only the complete event was fired by the checksum plugin because it skipped the file"
@@ -111,7 +111,7 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
     const fileId =
       "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
     plugin.uppy.preprocessors[0]([fileId]).then(() => {
-      assert.equal(
+      assert.strictEqual(
         plugin.uppy.emitted.length,
         1,
         "only the complete event was fired by the checksum plugin because it skipped the file"
@@ -132,9 +132,9 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
     const fileId =
       "uppy-test/file/mnb3/jfhrg43x/blah3/png-1d-1d-2v-1d-1e-image/jpeg-111111-1837921727764";
     plugin.uppy.preprocessors[0]([fileId]).then(() => {
-      assert.equal(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[1].event, "preprocess-complete");
-      assert.equal(plugin.uppy.getFile(fileId).meta.sha1_checksum, null);
+      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.getFile(fileId).meta.sha1_checksum, null);
       done();
     });
   });
@@ -153,17 +153,17 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
       "uppy-test/file/blah1/ads37x2/blah1/png-1d-1d-2v-1d-1e-image/jpeg-99999-1837921727764",
     ];
     plugin.uppy.preprocessors[0](fileIds).then(() => {
-      assert.equal(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[1].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[2].event, "preprocess-complete");
-      assert.equal(plugin.uppy.emitted[3].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[2].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.emitted[3].event, "preprocess-complete");
 
       // these checksums are the actual SHA1 hashes of the test file names
-      assert.equal(
+      assert.strictEqual(
         plugin.uppy.getFile(fileIds[0]).meta.sha1_checksum,
         "d9bafe64b034b655db018ad0226c6865300ada31"
       );
-      assert.equal(
+      assert.strictEqual(
         plugin.uppy.getFile(fileIds[1]).meta.sha1_checksum,
         "cb10341e3efeab45f0bc309a1c497edca4c5a744"
       );
@@ -191,10 +191,10 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
       .rejects({ message: "Algorithm: Unrecognized name" });
 
     plugin.uppy.preprocessors[0](fileIds).then(() => {
-      assert.equal(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[1].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[2].event, "preprocess-complete");
-      assert.equal(plugin.uppy.emitted[3].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[2].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.emitted[3].event, "preprocess-complete");
 
       assert.deepEqual(plugin.uppy.getFile(fileIds[0]).meta, {});
       assert.deepEqual(plugin.uppy.getFile(fileIds[1]).meta, {});

--- a/app/assets/javascripts/discourse/tests/unit/lib/uppy-media-optimization-plugin-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uppy-media-optimization-plugin-test.js
@@ -42,9 +42,9 @@ module("Unit | Utility | UppyMediaOptimization Plugin", function () {
         return "wow such optimized";
       },
     });
-    assert.equal(plugin.id, "uppy-media-optimization");
-    assert.equal(plugin.runParallel, true);
-    assert.equal(plugin.optimizeFn(), "wow such optimized");
+    assert.strictEqual(plugin.id, "uppy-media-optimization");
+    assert.strictEqual(plugin.runParallel, true);
+    assert.strictEqual(plugin.optimizeFn(), "wow such optimized");
   });
 
   test("installation uses the correct function", function (assert) {
@@ -59,11 +59,11 @@ module("Unit | Utility | UppyMediaOptimization Plugin", function () {
       return "using serial";
     };
     plugin.install();
-    assert.equal(plugin.uppy.preprocessors[0](), "using parallel");
+    assert.strictEqual(plugin.uppy.preprocessors[0](), "using parallel");
     plugin.runParallel = false;
     plugin.uppy.preprocessors = [];
     plugin.install();
-    assert.equal(plugin.uppy.preprocessors[0](), "using serial");
+    assert.strictEqual(plugin.uppy.preprocessors[0](), "using serial");
   });
 
   test("sets the file state when successfully optimizing the file and emits events", function (assert) {
@@ -80,9 +80,9 @@ module("Unit | Utility | UppyMediaOptimization Plugin", function () {
       "uppy-test/file/vv2/xvejg5w/blah/jpg-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
 
     plugin.uppy.preprocessors[0]([fileId]).then(() => {
-      assert.equal(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[1].event, "preprocess-complete");
-      assert.equal(plugin.uppy.getFile(fileId).data, "new file state");
+      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.getFile(fileId).data, "new file state");
       done();
     });
   });
@@ -103,9 +103,9 @@ module("Unit | Utility | UppyMediaOptimization Plugin", function () {
       "uppy-test/file/vv2/xvejg5w/blah/jpg-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
 
     plugin.uppy.preprocessors[0]([fileId]).then(() => {
-      assert.equal(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[1].event, "preprocess-complete");
-      assert.equal(plugin.uppy.getFile(fileId).data, "old file state");
+      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.getFile(fileId).data, "old file state");
       done();
     });
   });
@@ -126,12 +126,18 @@ module("Unit | Utility | UppyMediaOptimization Plugin", function () {
     ];
 
     plugin.uppy.preprocessors[0](fileIds).then(() => {
-      assert.equal(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[1].event, "preprocess-complete");
-      assert.equal(plugin.uppy.emitted[2].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[3].event, "preprocess-complete");
-      assert.equal(plugin.uppy.getFile(fileIds[0]).data, "new file state");
-      assert.equal(plugin.uppy.getFile(fileIds[1]).data, "new file state");
+      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.emitted[2].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[3].event, "preprocess-complete");
+      assert.strictEqual(
+        plugin.uppy.getFile(fileIds[0]).data,
+        "new file state"
+      );
+      assert.strictEqual(
+        plugin.uppy.getFile(fileIds[1]).data,
+        "new file state"
+      );
       done();
     });
   });
@@ -152,12 +158,18 @@ module("Unit | Utility | UppyMediaOptimization Plugin", function () {
     ];
 
     plugin.uppy.preprocessors[0](fileIds).then(() => {
-      assert.equal(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[1].event, "preprocess-progress");
-      assert.equal(plugin.uppy.emitted[2].event, "preprocess-complete");
-      assert.equal(plugin.uppy.emitted[3].event, "preprocess-complete");
-      assert.equal(plugin.uppy.getFile(fileIds[0]).data, "new file state");
-      assert.equal(plugin.uppy.getFile(fileIds[1]).data, "new file state");
+      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-progress");
+      assert.strictEqual(plugin.uppy.emitted[2].event, "preprocess-complete");
+      assert.strictEqual(plugin.uppy.emitted[3].event, "preprocess-complete");
+      assert.strictEqual(
+        plugin.uppy.getFile(fileIds[0]).data,
+        "new file state"
+      );
+      assert.strictEqual(
+        plugin.uppy.getFile(fileIds[1]).data,
+        "new file state"
+      );
       done();
     });
   });

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -58,14 +58,14 @@ module("Unit | Utility | url", function () {
   });
 
   test("userPath", function (assert) {
-    assert.equal(userPath(), "/u");
-    assert.equal(userPath("eviltrout"), "/u/eviltrout");
+    assert.strictEqual(userPath(), "/u");
+    assert.strictEqual(userPath("eviltrout"), "/u/eviltrout");
   });
 
   test("userPath with prefix", function (assert) {
     setPrefix("/forum");
-    assert.equal(userPath(), "/forum/u");
-    assert.equal(userPath("eviltrout"), "/forum/u/eviltrout");
+    assert.strictEqual(userPath(), "/forum/u");
+    assert.strictEqual(userPath("eviltrout"), "/forum/u/eviltrout");
   });
 
   test("routeTo with prefix", async function (assert) {
@@ -82,16 +82,19 @@ module("Unit | Utility | url", function () {
   });
 
   test("prefixProtocol", async function (assert) {
-    assert.equal(
+    assert.strictEqual(
       prefixProtocol("mailto:mr-beaver@aol.com"),
       "mailto:mr-beaver@aol.com"
     );
-    assert.equal(prefixProtocol("discourse.org"), "https://discourse.org");
-    assert.equal(
+    assert.strictEqual(
+      prefixProtocol("discourse.org"),
+      "https://discourse.org"
+    );
+    assert.strictEqual(
       prefixProtocol("www.discourse.org"),
       "https://www.discourse.org"
     );
-    assert.equal(
+    assert.strictEqual(
       prefixProtocol("www.discourse.org/mailto:foo"),
       "https://www.discourse.org/mailto:foo"
     );

--- a/app/assets/javascripts/discourse/tests/unit/lib/user-search-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/user-search-test.js
@@ -83,17 +83,17 @@ module("Unit | Utility | user-search", function (hooks) {
 
   test("it flushes cache when switching categories", async function (assert) {
     let results = await userSearch({ term: "hello", categoryId: 1 });
-    assert.equal(results[0].username, "category_1");
-    assert.equal(results.length, 1);
+    assert.strictEqual(results[0].username, "category_1");
+    assert.strictEqual(results.length, 1);
 
     // this is cached ... so let's check the cache is good
     results = await userSearch({ term: "hello", categoryId: 1 });
-    assert.equal(results[0].username, "category_1");
-    assert.equal(results.length, 1);
+    assert.strictEqual(results[0].username, "category_1");
+    assert.strictEqual(results.length, 1);
 
     results = await userSearch({ term: "hello", categoryId: 2 });
-    assert.equal(results[0].username, "category_2");
-    assert.equal(results.length, 1);
+    assert.strictEqual(results[0].username, "category_2");
+    assert.strictEqual(results.length, 1);
   });
 
   test("it returns cancel when eager completing with no results", async function (assert) {
@@ -102,31 +102,31 @@ module("Unit | Utility | user-search", function (hooks) {
     for (let i = 0; i < 2; i++) {
       // No topic or category, will always cancel
       let result = await userSearch({ term: "" });
-      assert.equal(result, CANCELLED_STATUS);
+      assert.strictEqual(result, CANCELLED_STATUS);
     }
 
     for (let i = 0; i < 2; i++) {
       // Unsecured category, so has no recommendations
       let result = await userSearch({ term: "", categoryId: 3 });
-      assert.equal(result, CANCELLED_STATUS);
+      assert.strictEqual(result, CANCELLED_STATUS);
     }
 
     for (let i = 0; i < 2; i++) {
       // Secured category, will have 1 recommendation
       let results = await userSearch({ term: "", categoryId: 1 });
-      assert.equal(results[0].username, "category_1");
-      assert.equal(results.length, 1);
+      assert.strictEqual(results[0].username, "category_1");
+      assert.strictEqual(results.length, 1);
     }
   });
 
   test("it places groups unconditionally for exact match", async function (assert) {
     let results = await userSearch({ term: "Team" });
-    assert.equal(results[results.length - 1]["name"], "team");
+    assert.strictEqual(results[results.length - 1]["name"], "team");
   });
 
   test("it strips @ from the beginning", async function (assert) {
     let results = await userSearch({ term: "@Team" });
-    assert.equal(results[results.length - 1]["name"], "team");
+    assert.strictEqual(results[results.length - 1]["name"], "team");
   });
 
   test("it skips a search depending on punctuation", async function (assert) {
@@ -140,7 +140,7 @@ module("Unit | Utility | user-search", function (hooks) {
 
     for (let term of skippedTerms) {
       results = await userSearch({ term });
-      assert.equal(results.length, 0);
+      assert.strictEqual(results.length, 0);
     }
 
     let allowedTerms = [
@@ -155,23 +155,23 @@ module("Unit | Utility | user-search", function (hooks) {
 
     for (let term of allowedTerms) {
       results = await userSearch({ term, topicId });
-      assert.equal(results.length, 6);
+      assert.strictEqual(results.length, 6);
     }
 
     results = await userSearch({ term: "sam@sam.com", allowEmails: true });
     // 6 + email
-    assert.equal(results.length, 7);
+    assert.strictEqual(results.length, 7);
 
     results = await userSearch({ term: "sam+test@sam.com", allowEmails: true });
-    assert.equal(results.length, 7);
+    assert.strictEqual(results.length, 7);
 
     results = await userSearch({ term: "sam@sam.com" });
-    assert.equal(results.length, 0);
+    assert.strictEqual(results.length, 0);
 
     results = await userSearch({
       term: "no-results@example.com",
       allowEmails: true,
     });
-    assert.equal(results.length, 1);
+    assert.strictEqual(results.length, 1);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -21,15 +21,19 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("Unit | Utilities", function () {
   test("escapeExpression", function (assert) {
-    assert.equal(escapeExpression(">"), "&gt;", "escapes unsafe characters");
+    assert.strictEqual(
+      escapeExpression(">"),
+      "&gt;",
+      "escapes unsafe characters"
+    );
 
-    assert.equal(
+    assert.strictEqual(
       escapeExpression(new Handlebars.SafeString("&gt;")),
       "&gt;",
       "does not double-escape safe strings"
     );
 
-    assert.equal(
+    assert.strictEqual(
       escapeExpression(undefined),
       "",
       "returns a falsy string when given a falsy value"
@@ -48,22 +52,22 @@ discourseModule("Unit | Utilities", function () {
   });
 
   test("extractDomainFromUrl", function (assert) {
-    assert.equal(
+    assert.strictEqual(
       extractDomainFromUrl("http://meta.discourse.org:443/random"),
       "meta.discourse.org",
       "extract domain name from url"
     );
-    assert.equal(
+    assert.strictEqual(
       extractDomainFromUrl("meta.discourse.org:443/random"),
       "meta.discourse.org",
       "extract domain regardless of scheme presence"
     );
-    assert.equal(
+    assert.strictEqual(
       extractDomainFromUrl("http://192.168.0.1:443/random"),
       "192.168.0.1",
       "works for IP address"
     );
-    assert.equal(
+    assert.strictEqual(
       extractDomainFromUrl("http://localhost:443/random"),
       "localhost",
       "works for localhost"
@@ -73,12 +77,12 @@ discourseModule("Unit | Utilities", function () {
   test("avatarUrl", function (assert) {
     let rawSize = getRawSize;
     assert.blank(avatarUrl("", "tiny"), "no template returns blank");
-    assert.equal(
+    assert.strictEqual(
       avatarUrl("/fake/template/{size}.png", "tiny"),
       "/fake/template/" + rawSize(20) + ".png",
       "simple avatar url"
     );
-    assert.equal(
+    assert.strictEqual(
       avatarUrl("/fake/template/{size}.png", "large"),
       "/fake/template/" + rawSize(45) + ".png",
       "different size"
@@ -98,13 +102,13 @@ discourseModule("Unit | Utilities", function () {
     setDevicePixelRatio(2);
 
     let avatarTemplate = "/path/to/avatar/{size}.png";
-    assert.equal(
+    assert.strictEqual(
       avatarImg({ avatarTemplate: avatarTemplate, size: "tiny" }),
       "<img loading='lazy' alt='' width='20' height='20' src='/path/to/avatar/40.png' class='avatar'>",
       "it returns the avatar html"
     );
 
-    assert.equal(
+    assert.strictEqual(
       avatarImg({
         avatarTemplate: avatarTemplate,
         size: "tiny",
@@ -114,7 +118,7 @@ discourseModule("Unit | Utilities", function () {
       "it adds a title if supplied"
     );
 
-    assert.equal(
+    assert.strictEqual(
       avatarImg({
         avatarTemplate: avatarTemplate,
         size: "tiny",
@@ -138,7 +142,7 @@ discourseModule("Unit | Utilities", function () {
     meta.content = "hot";
     document.body.appendChild(meta);
     initializeDefaultHomepage(this.siteSettings);
-    assert.equal(
+    assert.strictEqual(
       defaultHomepage(),
       "hot",
       "default homepage is pulled from <meta name=discourse_current_homepage>"
@@ -149,7 +153,7 @@ discourseModule("Unit | Utilities", function () {
   test("defaultHomepage via site settings", function (assert) {
     this.siteSettings.top_menu = "top|latest|hot";
     initializeDefaultHomepage(this.siteSettings);
-    assert.equal(
+    assert.strictEqual(
       defaultHomepage(),
       "top",
       "default homepage is the first item in the top_menu site setting"
@@ -158,9 +162,9 @@ discourseModule("Unit | Utilities", function () {
 
   test("setDefaultHomepage", function (assert) {
     initializeDefaultHomepage(this.siteSettings);
-    assert.equal(defaultHomepage(), "latest");
+    assert.strictEqual(defaultHomepage(), "latest");
     setDefaultHomepage("top");
-    assert.equal(defaultHomepage(), "top");
+    assert.strictEqual(defaultHomepage(), "top");
   });
 
   test("caretRowCol", function (assert) {
@@ -173,12 +177,12 @@ discourseModule("Unit | Utilities", function () {
       setCaretPosition(textarea, setCaretPos);
 
       const result = caretRowCol(textarea);
-      assert.equal(
+      assert.strictEqual(
         result.rowNum,
         expectedRowNum,
         "returns the right row of the caret"
       );
-      assert.equal(
+      assert.strictEqual(
         result.colNum,
         expectedColNum,
         "returns the right col of the caret"
@@ -198,13 +202,13 @@ discourseModule("Unit | Utilities", function () {
     const accentedString = "Créme_Brûlée!";
     const unicodeString = "談話";
 
-    assert.equal(
+    assert.strictEqual(
       toAsciiPrintable(accentedString, "discourse"),
       "Creme_Brulee!",
       "it replaces accented characters with the appropriate ASCII equivalent"
     );
 
-    assert.equal(
+    assert.strictEqual(
       toAsciiPrintable(unicodeString, "discourse"),
       "discourse",
       "it uses the fallback string when unable to convert"
@@ -222,19 +226,23 @@ discourseModule("Unit | Utilities", function () {
     const accentedString = "Créme_Brûlée!";
     const unicodeString = "談話";
 
-    assert.equal(
+    assert.strictEqual(
       slugify(asciiString),
       "0-some-cool-discourse-site-0",
       "it properly slugifies an ASCII string"
     );
 
-    assert.equal(
+    assert.strictEqual(
       slugify(accentedString),
       "crme-brle",
       "it removes accented characters"
     );
 
-    assert.equal(slugify(unicodeString), "", "it removes unicode characters");
+    assert.strictEqual(
+      slugify(unicodeString),
+      "",
+      "it removes unicode characters"
+    );
   });
 
   test("fillMissingDates", function (assert) {
@@ -243,7 +251,7 @@ discourseModule("Unit | Utilities", function () {
     const data =
       '[{"x":"2017-11-12","y":3},{"x":"2017-11-27","y":2},{"x":"2017-12-06","y":9},{"x":"2017-12-11","y":2}]';
 
-    assert.equal(
+    assert.strictEqual(
       fillMissingDates(JSON.parse(data), startDate, endDate).length,
       31,
       "it returns a JSON array with 31 dates"
@@ -269,7 +277,7 @@ discourseModule("Unit | Utilities", function () {
     texts.forEach((text) => {
       for (let i = 0; i < text.length; ++i) {
         if (text[i] === "0" || text[i] === "1") {
-          assert.equal(inCodeBlock(text, i), text[i] === "1");
+          assert.strictEqual(inCodeBlock(text, i), text[i] === "1");
         }
       }
     });

--- a/app/assets/javascripts/discourse/tests/unit/localization-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/localization-test.js
@@ -45,12 +45,12 @@ test("translation overrides", function (assert) {
   };
   LocalizationInitializer.initialize(getApplication());
 
-  assert.equal(
+  assert.strictEqual(
     I18n.t("composer.reply"),
     "WAT",
     "overrides existing translation in current locale"
   );
-  assert.equal(
+  assert.strictEqual(
     I18n.t("topic.reply.help"),
     "foobar",
     "overrides translation in default locale"
@@ -64,5 +64,5 @@ test("skip translation override if parent node is not an object", function (asse
   };
   LocalizationInitializer.initialize(getApplication());
 
-  assert.equal(I18n.t("composer.reply.help"), "[fr.composer.reply.help]");
+  assert.strictEqual(I18n.t("composer.reply.help"), "[fr.composer.reply.help]");
 });

--- a/app/assets/javascripts/discourse/tests/unit/mixins/setting-object-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/mixins/setting-object-test.js
@@ -10,8 +10,8 @@ module("Unit | Mixin | setting-object", function () {
       valid_values: ["foo", "bar"],
     });
 
-    assert.equal(fooSettingInstance.computedValueProperty, null);
-    assert.equal(fooSettingInstance.computedNameProperty, null);
+    assert.strictEqual(fooSettingInstance.computedValueProperty, null);
+    assert.strictEqual(fooSettingInstance.computedNameProperty, null);
   });
 
   test("object", function (assert) {
@@ -21,8 +21,8 @@ module("Unit | Mixin | setting-object", function () {
       valid_values: [{ value: "foo", name: "bar" }],
     });
 
-    assert.equal(fooSettingInstance.computedValueProperty, "value");
-    assert.equal(fooSettingInstance.computedNameProperty, "name");
+    assert.strictEqual(fooSettingInstance.computedValueProperty, "value");
+    assert.strictEqual(fooSettingInstance.computedNameProperty, "name");
   });
 
   test("no values", function (assert) {
@@ -32,8 +32,8 @@ module("Unit | Mixin | setting-object", function () {
       valid_values: [],
     });
 
-    assert.equal(fooSettingInstance.computedValueProperty, null);
-    assert.equal(fooSettingInstance.computedNameProperty, null);
+    assert.strictEqual(fooSettingInstance.computedValueProperty, null);
+    assert.strictEqual(fooSettingInstance.computedNameProperty, null);
   });
 
   test("value/name properties defined", function (assert) {
@@ -45,7 +45,7 @@ module("Unit | Mixin | setting-object", function () {
       valid_values: [],
     });
 
-    assert.equal(fooSettingInstance.computedValueProperty, "foo");
-    assert.equal(fooSettingInstance.computedNameProperty, "bar");
+    assert.strictEqual(fooSettingInstance.computedValueProperty, "foo");
+    assert.strictEqual(fooSettingInstance.computedNameProperty, "bar");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/mixins/singleton-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/mixins/singleton-test.js
@@ -9,12 +9,12 @@ module("Unit | Mixin | singleton", function () {
 
     let current = DummyModel.current();
     assert.present(current, "current returns the current instance");
-    assert.equal(
+    assert.strictEqual(
       current,
       DummyModel.current(),
       "calling it again returns the same instance"
     );
-    assert.notEqual(
+    assert.notStrictEqual(
       current,
       DummyModel.create({}),
       "we can create other instances that are not the same as current"
@@ -31,7 +31,7 @@ module("Unit | Mixin | singleton", function () {
       "by default attributes are blank"
     );
     current.set("evil", "trout");
-    assert.equal(
+    assert.strictEqual(
       DummyModel.currentProp("evil"),
       "trout",
       "after changing the instance, the value is set"
@@ -47,22 +47,22 @@ module("Unit | Mixin | singleton", function () {
       "by default attributes are blank"
     );
     let result = DummyModel.currentProp("adventure", "time");
-    assert.equal(result, "time", "it returns the new value");
-    assert.equal(
+    assert.strictEqual(result, "time", "it returns the new value");
+    assert.strictEqual(
       DummyModel.currentProp("adventure"),
       "time",
       "after calling currentProp the value is set"
     );
 
     DummyModel.currentProp("count", 0);
-    assert.equal(
+    assert.strictEqual(
       DummyModel.currentProp("count"),
       0,
       "we can set the value to 0"
     );
 
     DummyModel.currentProp("adventure", null);
-    assert.equal(
+    assert.strictEqual(
       DummyModel.currentProp("adventure"),
       null,
       "we can set the value to null"
@@ -77,7 +77,7 @@ module("Unit | Mixin | singleton", function () {
       },
     });
 
-    assert.equal(
+    assert.strictEqual(
       Shoe.currentProp("toes"),
       5,
       "it created the class using `createCurrent`"

--- a/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/badge-test.js
@@ -20,8 +20,12 @@ module("Unit | Model | badge", function () {
     const badges = Badge.createFromJson(badgesJson);
 
     assert.ok(Array.isArray(badges), "returns an array");
-    assert.equal(badges[0].get("name"), "Badge 1", "badge details are set");
-    assert.equal(
+    assert.strictEqual(
+      badges[0].get("name"),
+      "Badge 1",
+      "badge details are set"
+    );
+    assert.strictEqual(
       badges[0].get("badge_type.name"),
       "Silver 1",
       "badge_type reference is set"
@@ -46,8 +50,8 @@ module("Unit | Model | badge", function () {
     };
     const badge = Badge.create({ name: "Badge 1" });
     badge.updateFromJson(badgeJson);
-    assert.equal(badge.get("id"), 1126, "id is set");
-    assert.equal(
+    assert.strictEqual(badge.get("id"), 1126, "id is set");
+    assert.strictEqual(
       badge.get("badge_type.name"),
       "Silver 1",
       "badge_type reference is set"

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -8,7 +8,7 @@ module("Unit | Model | category", function () {
     const store = createStore();
 
     const slugFor = function (cat, val, text) {
-      assert.equal(Category.slugFor(cat), val, text);
+      assert.strictEqual(Category.slugFor(cat), val, text);
     };
 
     slugFor(

--- a/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/composer-test.js
@@ -31,7 +31,7 @@ discourseModule("Unit | Model | composer", function () {
   test("replyLength", function (assert) {
     const replyLength = function (val, expectedLength) {
       const composer = createComposer({ reply: val });
-      assert.equal(composer.get("replyLength"), expectedLength);
+      assert.strictEqual(composer.get("replyLength"), expectedLength);
     };
 
     replyLength("basic reply", 11, "basic reply length");
@@ -79,7 +79,11 @@ discourseModule("Unit | Model | composer", function () {
         action = CREATE_TOPIC;
       }
       const composer = createComposer({ reply: val, action });
-      assert.equal(composer.get("missingReplyCharacters"), expected, message);
+      assert.strictEqual(
+        composer.get("missingReplyCharacters"),
+        expected,
+        message
+      );
     };
 
     missingReplyCharacters(
@@ -115,7 +119,7 @@ discourseModule("Unit | Model | composer", function () {
       reply: link,
     });
 
-    assert.equal(
+    assert.strictEqual(
       composer.get("missingReplyCharacters"),
       0,
       "don't require any post content"
@@ -128,7 +132,11 @@ discourseModule("Unit | Model | composer", function () {
         title: val,
         action: isPM ? PRIVATE_MESSAGE : REPLY,
       });
-      assert.equal(composer.get("missingTitleCharacters"), expected, message);
+      assert.strictEqual(
+        composer.get("missingTitleCharacters"),
+        expected,
+        message
+      );
     };
 
     missingTitleCharacters(
@@ -168,9 +176,13 @@ discourseModule("Unit | Model | composer", function () {
     assert.blank(composer.get("reply"), "the reply is blank by default");
 
     composer.appendText("hello");
-    assert.equal(composer.get("reply"), "hello", "it appends text to nothing");
+    assert.strictEqual(
+      composer.get("reply"),
+      "hello",
+      "it appends text to nothing"
+    );
     composer.appendText(" world");
-    assert.equal(
+    assert.strictEqual(
       composer.get("reply"),
       "hello world",
       "it appends text to existing text"
@@ -180,19 +192,19 @@ discourseModule("Unit | Model | composer", function () {
     composer.appendText("a\n\n\n\nb");
     composer.appendText("c", 3, { block: true });
 
-    assert.equal(composer.get("reply"), "a\n\nc\n\nb");
+    assert.strictEqual(composer.get("reply"), "a\n\nc\n\nb");
 
     composer.clearState();
     composer.appendText("ab");
     composer.appendText("c", 1, { block: true });
 
-    assert.equal(composer.get("reply"), "a\n\nc\n\nb");
+    assert.strictEqual(composer.get("reply"), "a\n\nc\n\nb");
 
     composer.clearState();
     composer.appendText("\nab");
     composer.appendText("c", 0, { block: true });
 
-    assert.equal(composer.get("reply"), "c\n\nab");
+    assert.strictEqual(composer.get("reply"), "c\n\nab");
   });
 
   test("prependText", function (assert) {
@@ -201,17 +213,21 @@ discourseModule("Unit | Model | composer", function () {
     assert.blank(composer.get("reply"), "the reply is blank by default");
 
     composer.prependText("hello");
-    assert.equal(composer.get("reply"), "hello", "it prepends text to nothing");
+    assert.strictEqual(
+      composer.get("reply"),
+      "hello",
+      "it prepends text to nothing"
+    );
 
     composer.prependText("world ");
-    assert.equal(
+    assert.strictEqual(
       composer.get("reply"),
       "world hello",
       "it prepends text to existing text"
     );
 
     composer.prependText("before new line", { new_line: true });
-    assert.equal(
+    assert.strictEqual(
       composer.get("reply"),
       "before new line\n\nworld hello",
       "it prepends text with new line to existing text"
@@ -253,7 +269,7 @@ discourseModule("Unit | Model | composer", function () {
       topic: EmberObject.create({ pm_with_non_human_user: true }),
     });
 
-    assert.equal(composer.get("minimumPostLength"), 1);
+    assert.strictEqual(composer.get("minimumPostLength"), 1);
   });
 
   test("editingFirstPost", function (assert) {
@@ -325,12 +341,12 @@ discourseModule("Unit | Model | composer", function () {
       });
     };
 
-    assert.equal(
+    assert.strictEqual(
       newComposer().get("originalText"),
       quote,
       "originalText is the quote"
     );
-    assert.equal(
+    assert.strictEqual(
       newComposer().get("replyDirty"),
       false,
       "replyDirty is initially false with a quote"
@@ -367,14 +383,14 @@ discourseModule("Unit | Model | composer", function () {
 
   test("title placeholder depends on what you're doing", function (assert) {
     let composer = createComposer({ action: CREATE_TOPIC });
-    assert.equal(
+    assert.strictEqual(
       composer.get("titlePlaceholder"),
       "composer.title_placeholder",
       "placeholder for normal topic"
     );
 
     composer = createComposer({ action: PRIVATE_MESSAGE });
-    assert.equal(
+    assert.strictEqual(
       composer.get("titlePlaceholder"),
       "composer.title_placeholder",
       "placeholder for private message"
@@ -383,14 +399,14 @@ discourseModule("Unit | Model | composer", function () {
     this.siteSettings.topic_featured_link_enabled = true;
 
     composer = createComposer({ action: CREATE_TOPIC });
-    assert.equal(
+    assert.strictEqual(
       composer.get("titlePlaceholder"),
       "composer.title_or_link_placeholder",
       "placeholder invites you to paste a link"
     );
 
     composer = createComposer({ action: PRIVATE_MESSAGE });
-    assert.equal(
+    assert.strictEqual(
       composer.get("titlePlaceholder"),
       "composer.title_placeholder",
       "placeholder for private message with topic links enabled"
@@ -401,7 +417,7 @@ discourseModule("Unit | Model | composer", function () {
     this.siteSettings.topic_featured_link_enabled = true;
     this.siteSettings.allow_uncategorized_topics = false;
     let composer = createComposer({ action: CREATE_TOPIC });
-    assert.equal(
+    assert.strictEqual(
       composer.get("titlePlaceholder"),
       "composer.title_or_link_placeholder",
       "placeholder invites you to paste a link"

--- a/app/assets/javascripts/discourse/tests/unit/models/email-log-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/email-log-test.js
@@ -26,7 +26,7 @@ module("Unit | Model | email-log", function () {
       },
     };
     const emailLog = EmailLog.create(attrs);
-    assert.equal(
+    assert.strictEqual(
       emailLog.get("post_url"),
       "/forum/t/some-pro-tips-for-you/41/5",
       "includes the subfolder in the post url"

--- a/app/assets/javascripts/discourse/tests/unit/models/group-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/group-test.js
@@ -5,7 +5,7 @@ module("Unit | Model | group", function () {
   test("displayName", function (assert) {
     const group = Group.create({ name: "test", display_name: "donkey" });
 
-    assert.equal(
+    assert.strictEqual(
       group.get("displayName"),
       "donkey",
       "it should return the display name"
@@ -13,7 +13,7 @@ module("Unit | Model | group", function () {
 
     group.set("display_name", null);
 
-    assert.equal(
+    assert.strictEqual(
       group.get("displayName"),
       "test",
       "it should return the group's name"

--- a/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
@@ -20,7 +20,11 @@ module("Unit | Model | nav-item", function (hooks) {
     assert.expect(4);
 
     function href(text, opts, expected, label) {
-      assert.equal(NavItem.fromText(text, opts).get("href"), expected, label);
+      assert.strictEqual(
+        NavItem.fromText(text, opts).get("href"),
+        expected,
+        label
+      );
     }
 
     href("latest", {}, "/latest", "latest");
@@ -37,7 +41,7 @@ module("Unit | Model | nav-item", function (hooks) {
   test("count", function (assert) {
     const navItem = createStore().createRecord("nav-item", { name: "new" });
 
-    assert.equal(navItem.get("count"), 0, "it has no count by default");
+    assert.strictEqual(navItem.get("count"), 0, "it has no count by default");
 
     const tracker = navItem.get("topicTrackingState");
     tracker.modifyState("t1", {
@@ -47,7 +51,7 @@ module("Unit | Model | nav-item", function (hooks) {
     });
     tracker.incrementMessageCount();
 
-    assert.equal(
+    assert.strictEqual(
       navItem.get("count"),
       1,
       "it updates when a new message arrives"

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -189,7 +189,7 @@ module("Unit | Model | post-stream", function () {
     const postStream = buildStream(1231);
     postStream.set("timelineLookup", []);
 
-    assert.strictEqual(postStream.closestDaysAgoFor(1), null);
+    assert.strictEqual(postStream.closestDaysAgoFor(1), undefined);
   });
 
   test("updateFromJson", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -44,7 +44,11 @@ module("Unit | Model | post-stream", function () {
     const postStream = buildStream(4567, [1, 3, 4]);
     const store = postStream.store;
 
-    assert.equal(postStream.get("lastPostId"), 4, "the last post id is 4");
+    assert.strictEqual(
+      postStream.get("lastPostId"),
+      4,
+      "the last post id is 4"
+    );
 
     assert.ok(!postStream.get("hasPosts"), "there are no posts by default");
     assert.ok(
@@ -52,7 +56,7 @@ module("Unit | Model | post-stream", function () {
       "the first post is not loaded"
     );
     assert.ok(!postStream.get("loadedAllPosts"), "the last post is not loaded");
-    assert.equal(
+    assert.strictEqual(
       postStream.get("posts.length"),
       0,
       "it has no posts initially"
@@ -65,7 +69,7 @@ module("Unit | Model | post-stream", function () {
       !postStream.get("firstPostPresent"),
       "the first post is still not loaded"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.get("posts.length"),
       1,
       "it has one post in the stream"
@@ -79,7 +83,7 @@ module("Unit | Model | post-stream", function () {
       "the first post is still loaded"
     );
     assert.ok(postStream.get("loadedAllPosts"), "the last post is now loaded");
-    assert.equal(
+    assert.strictEqual(
       postStream.get("posts.length"),
       2,
       "it has two posts in the stream"
@@ -88,7 +92,7 @@ module("Unit | Model | post-stream", function () {
     postStream.appendPost(
       store.createRecord("post", { id: 4, post_number: 4 })
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.get("posts.length"),
       2,
       "it will not add the same post with id twice"
@@ -96,13 +100,13 @@ module("Unit | Model | post-stream", function () {
 
     const stagedPost = store.createRecord("post", { raw: "incomplete post" });
     postStream.appendPost(stagedPost);
-    assert.equal(
+    assert.strictEqual(
       postStream.get("posts.length"),
       3,
       "it can handle posts without ids"
     );
     postStream.appendPost(stagedPost);
-    assert.equal(
+    assert.strictEqual(
       postStream.get("posts.length"),
       3,
       "it won't add the same post without an id twice"
@@ -136,22 +140,22 @@ module("Unit | Model | post-stream", function () {
       store.createRecord("post", { id: 2, post_number: 3 })
     );
 
-    assert.equal(
+    assert.strictEqual(
       postStream.closestPostNumberFor(2),
       2,
       "If a post is in the stream it returns its post number"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.closestPostNumberFor(3),
       3,
       "If a post is in the stream it returns its post number"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.closestPostNumberFor(10),
       3,
       "it clips to the upper bound of the stream"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.closestPostNumberFor(0),
       2,
       "it clips to the lower bound of the stream"
@@ -166,26 +170,26 @@ module("Unit | Model | post-stream", function () {
       [5, 1],
     ]);
 
-    assert.equal(postStream.closestDaysAgoFor(1), 10);
-    assert.equal(postStream.closestDaysAgoFor(2), 10);
-    assert.equal(postStream.closestDaysAgoFor(3), 8);
-    assert.equal(postStream.closestDaysAgoFor(4), 8);
-    assert.equal(postStream.closestDaysAgoFor(5), 1);
+    assert.strictEqual(postStream.closestDaysAgoFor(1), 10);
+    assert.strictEqual(postStream.closestDaysAgoFor(2), 10);
+    assert.strictEqual(postStream.closestDaysAgoFor(3), 8);
+    assert.strictEqual(postStream.closestDaysAgoFor(4), 8);
+    assert.strictEqual(postStream.closestDaysAgoFor(5), 1);
 
     // Out of bounds
-    assert.equal(postStream.closestDaysAgoFor(-1), 10);
-    assert.equal(postStream.closestDaysAgoFor(0), 10);
-    assert.equal(postStream.closestDaysAgoFor(10), 1);
+    assert.strictEqual(postStream.closestDaysAgoFor(-1), 10);
+    assert.strictEqual(postStream.closestDaysAgoFor(0), 10);
+    assert.strictEqual(postStream.closestDaysAgoFor(10), 1);
 
     postStream.set("timelineLookup", []);
-    assert.equal(postStream.closestDaysAgoFor(1), undefined);
+    assert.strictEqual(postStream.closestDaysAgoFor(1), undefined);
   });
 
   test("closestDaysAgoFor - empty", function (assert) {
     const postStream = buildStream(1231);
     postStream.set("timelineLookup", []);
 
-    assert.equal(postStream.closestDaysAgoFor(1), null);
+    assert.strictEqual(postStream.closestDaysAgoFor(1), null);
   });
 
   test("updateFromJson", function (assert) {
@@ -197,10 +201,14 @@ module("Unit | Model | post-stream", function () {
       extra_property: 12,
     });
 
-    assert.equal(postStream.get("posts.length"), 1, "it loaded the posts");
+    assert.strictEqual(
+      postStream.get("posts.length"),
+      1,
+      "it loaded the posts"
+    );
     assert.containsInstance(postStream.get("posts"), Post);
 
-    assert.equal(postStream.get("extra_property"), 12);
+    assert.strictEqual(postStream.get("extra_property"), 12);
   });
 
   test("removePosts", function (assert) {
@@ -217,10 +225,10 @@ module("Unit | Model | post-stream", function () {
 
     // Removing nothing does nothing
     postStream.removePosts();
-    assert.equal(postStream.get("posts.length"), 3);
+    assert.strictEqual(postStream.get("posts.length"), 3);
 
     postStream.removePosts([p1, p3]);
-    assert.equal(postStream.get("posts.length"), 1);
+    assert.strictEqual(postStream.get("posts.length"), 1);
     assert.deepEqual(postStream.get("stream"), [2]);
   });
 
@@ -245,22 +253,26 @@ module("Unit | Model | post-stream", function () {
     const postStream = buildStream(1234, [10, 20, 30, 40, 50, 60, 70]);
     postStream.set("gaps", { before: { 60: [55, 58] } });
 
-    assert.equal(
+    assert.strictEqual(
       postStream.findPostIdForPostNumber(500),
       null,
       "it returns null when the post cannot be found"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.findPostIdForPostNumber(1),
       10,
       "it finds the postId at the beginning"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.findPostIdForPostNumber(5),
       50,
       "it finds the postId in the middle"
     );
-    assert.equal(postStream.findPostIdForPostNumber(8), 60, "it respects gaps");
+    assert.strictEqual(
+      postStream.findPostIdForPostNumber(8),
+      60,
+      "it respects gaps"
+    );
   });
 
   test("fillGapBefore", function (assert) {
@@ -287,7 +299,7 @@ module("Unit | Model | post-stream", function () {
     const postStream = buildStream(1236);
     sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
-    assert.equal(
+    assert.strictEqual(
       postStream.get("userFilters.length"),
       0,
       "by default no participants are toggled"
@@ -313,21 +325,21 @@ module("Unit | Model | post-stream", function () {
 
     sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
-    assert.equal(
+    assert.strictEqual(
       postStream.get("filterRepliesToPostNumber"),
       false,
       "by default no replies are filtered"
     );
 
     postStream.filterReplies(3, 2);
-    assert.equal(
+    assert.strictEqual(
       postStream.get("filterRepliesToPostNumber"),
       3,
       "postNumber is in the filters"
     );
 
     postStream.cancelFilter();
-    assert.equal(
+    assert.strictEqual(
       postStream.get("filterRepliesToPostNumber"),
       false,
       "cancelFilter clears"
@@ -344,17 +356,21 @@ module("Unit | Model | post-stream", function () {
 
     sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
-    assert.equal(
+    assert.strictEqual(
       postStream.get("filterUpwardsPostID"),
       false,
       "by default filter is false"
     );
 
     postStream.filterUpwards(2);
-    assert.equal(postStream.get("filterUpwardsPostID"), 2, "filter is set");
+    assert.strictEqual(
+      postStream.get("filterUpwardsPostID"),
+      2,
+      "filter is set"
+    );
 
     postStream.cancelFilter();
-    assert.equal(
+    assert.strictEqual(
       postStream.get("filterUpwardsPostID"),
       false,
       "filter cleared"
@@ -525,13 +541,13 @@ module("Unit | Model | post-stream", function () {
       "it has no highest post number yet"
     );
     let stored = postStream.storePost(post);
-    assert.equal(post, stored, "it returns the post it stored");
-    assert.equal(
+    assert.strictEqual(post, stored, "it returns the post it stored");
+    assert.strictEqual(
       post.get("topic"),
       postStream.get("topic"),
       "it creates the topic reference properly"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.get("topic.highest_post_number"),
       100,
       "it set the highest post number"
@@ -543,12 +559,12 @@ module("Unit | Model | post-stream", function () {
       raw: "updated value",
     });
     const storedDupe = postStream.storePost(dupePost);
-    assert.equal(
+    assert.strictEqual(
       storedDupe,
       post,
       "it returns the previously stored post instead to avoid dupes"
     );
-    assert.equal(
+    assert.strictEqual(
       storedDupe.get("raw"),
       "updated value",
       "it updates the previously stored post"
@@ -556,7 +572,7 @@ module("Unit | Model | post-stream", function () {
 
     const postWithoutId = store.createRecord("post", { raw: "hello world" });
     stored = postStream.storePost(postWithoutId);
-    assert.equal(stored, postWithoutId, "it returns the same post back");
+    assert.strictEqual(stored, postWithoutId, "it returns the same post back");
   });
 
   test("identity map", async function (assert) {
@@ -570,7 +586,7 @@ module("Unit | Model | post-stream", function () {
       store.createRecord("post", { id: 3, post_number: 4 })
     );
 
-    assert.equal(
+    assert.strictEqual(
       postStream.findLoadedPost(1),
       p1,
       "it can return cached posts by id"
@@ -579,15 +595,19 @@ module("Unit | Model | post-stream", function () {
 
     // Find posts by ids uses the identity map
     const result = await postStream.findPostsByIds([1, 2, 3]);
-    assert.equal(result.length, 3);
-    assert.equal(result.objectAt(0), p1);
-    assert.equal(result.objectAt(1).get("post_number"), 2);
-    assert.equal(result.objectAt(2), p3);
+    assert.strictEqual(result.length, 3);
+    assert.strictEqual(result.objectAt(0), p1);
+    assert.strictEqual(result.objectAt(1).get("post_number"), 2);
+    assert.strictEqual(result.objectAt(2), p3);
   });
 
   test("loadIntoIdentityMap with no data", async function (assert) {
     const result = await buildStream(1234).loadIntoIdentityMap([]);
-    assert.equal(result.length, 0, "requesting no posts produces no posts");
+    assert.strictEqual(
+      result.length,
+      0,
+      "requesting no posts produces no posts"
+    );
   });
 
   test("loadIntoIdentityMap with post ids", async function (assert) {
@@ -616,7 +636,7 @@ module("Unit | Model | post-stream", function () {
       "it adds the returned post to the store"
     );
 
-    assert.equal(
+    assert.strictEqual(
       postStream.get("posts").length,
       6,
       "it adds the right posts into the stream"
@@ -639,7 +659,7 @@ module("Unit | Model | post-stream", function () {
       "it adds the returned post to the store"
     );
 
-    assert.equal(
+    assert.strictEqual(
       postStream.get("posts").length,
       6,
       "it adds the right posts into the stream"
@@ -680,8 +700,8 @@ module("Unit | Model | post-stream", function () {
 
     // Stage the new post in the stream
     const result = postStream.stagePost(stagedPost, user);
-    assert.equal(result, "staged", "it returns staged");
-    assert.equal(
+    assert.strictEqual(result, "staged", "it returns staged");
+    assert.strictEqual(
       topic.get("highest_post_number"),
       2,
       "it updates the highest_post_number"
@@ -696,20 +716,24 @@ module("Unit | Model | post-stream", function () {
       "it doesn't consider staged posts as the lastAppended"
     );
 
-    assert.equal(topic.get("posts_count"), 2, "it increases the post count");
+    assert.strictEqual(
+      topic.get("posts_count"),
+      2,
+      "it increases the post count"
+    );
     assert.present(topic.get("last_posted_at"), "it updates last_posted_at");
-    assert.equal(
+    assert.strictEqual(
       topic.get("details.last_poster"),
       user,
       "it changes the last poster"
     );
 
-    assert.equal(
+    assert.strictEqual(
       stagedPost.get("topic"),
       topic,
       "it assigns the topic reference"
     );
-    assert.equal(
+    assert.strictEqual(
       stagedPost.get("post_number"),
       2,
       "it is assigned the probable post_number"
@@ -722,19 +746,27 @@ module("Unit | Model | post-stream", function () {
       postStream.get("posts").includes(stagedPost),
       "the post is added to the stream"
     );
-    assert.equal(stagedPost.get("id"), -1, "the post has a magical -1 id");
+    assert.strictEqual(
+      stagedPost.get("id"),
+      -1,
+      "the post has a magical -1 id"
+    );
 
     // Undoing a created post (there was an error)
     postStream.undoPost(stagedPost);
 
     assert.ok(!postStream.get("loading"), "it is no longer loading");
-    assert.equal(
+    assert.strictEqual(
       topic.get("highest_post_number"),
       1,
       "it reverts the highest_post_number"
     );
-    assert.equal(topic.get("posts_count"), 1, "it reverts the post count");
-    assert.equal(
+    assert.strictEqual(
+      topic.get("posts_count"),
+      1,
+      "it reverts the post count"
+    );
+    assert.strictEqual(
       postStream.get("filteredPostsCount"),
       1,
       "it retains the filteredPostsCount"
@@ -781,7 +813,7 @@ module("Unit | Model | post-stream", function () {
 
     // Stage the new post in the stream
     let result = postStream.stagePost(stagedPost, user);
-    assert.equal(result, "staged", "it returns staged");
+    assert.strictEqual(result, "staged", "it returns staged");
 
     assert.ok(
       postStream.get("loading"),
@@ -790,7 +822,7 @@ module("Unit | Model | post-stream", function () {
     stagedPost.setProperties({ id: 1234, raw: "different raw value" });
 
     result = postStream.stagePost(stagedPost, user);
-    assert.equal(
+    assert.strictEqual(
       result,
       "alreadyStaging",
       "you can't stage a post while it is currently staging"
@@ -808,7 +840,7 @@ module("Unit | Model | post-stream", function () {
     );
     assert.ok(!postStream.get("loading"), "it is no longer loading");
 
-    assert.equal(
+    assert.strictEqual(
       postStream.get("filteredPostsCount"),
       2,
       "it increases the filteredPostsCount"
@@ -817,7 +849,7 @@ module("Unit | Model | post-stream", function () {
     const found = postStream.findLoadedPost(stagedPost.get("id"));
     assert.present(found, "the post is in the identity map");
     assert.ok(postStream.indexOf(stagedPost) > -1, "the post is in the stream");
-    assert.equal(
+    assert.strictEqual(
       found.get("raw"),
       "different raw value",
       "it also updated the value in the stream"
@@ -869,7 +901,7 @@ module("Unit | Model | post-stream", function () {
       return response({ id: 4, post_number: 4 });
     });
 
-    assert.equal(
+    assert.strictEqual(
       postStream.get("postsWithPlaceholders.length"),
       4,
       "it should return the right length"
@@ -877,7 +909,7 @@ module("Unit | Model | post-stream", function () {
 
     await postStream.triggerRecoveredPost(4);
 
-    assert.equal(
+    assert.strictEqual(
       postStream.get("postsWithPlaceholders.length"),
       5,
       "it should return the right length"
@@ -901,7 +933,7 @@ module("Unit | Model | post-stream", function () {
     });
 
     postStream.stagePost(stagedPost, user);
-    assert.equal(
+    assert.strictEqual(
       postStream.get("filteredPostsCount"),
       0,
       "it has no filteredPostsCount yet"
@@ -910,10 +942,14 @@ module("Unit | Model | post-stream", function () {
 
     sinon.stub(postStream, "appendMore");
     postStream.triggerNewPostsInStream([123]);
-    assert.equal(postStream.get("filteredPostsCount"), 1, "it added the post");
+    assert.strictEqual(
+      postStream.get("filteredPostsCount"),
+      1,
+      "it added the post"
+    );
 
     postStream.commitPost(stagedPost);
-    assert.equal(
+    assert.strictEqual(
       postStream.get("filteredPostsCount"),
       1,
       "it does not add the same post twice"
@@ -953,12 +989,12 @@ module("Unit | Model | post-stream", function () {
       .returns(Promise.resolve([post2]));
 
     await postStream.triggerNewPostsInStream([101]);
-    assert.equal(
+    assert.strictEqual(
       postStream.posts.length,
       2,
       "it added the regular post to the posts"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.get("stream.length"),
       2,
       "it added the regular post to the stream"
@@ -968,12 +1004,12 @@ module("Unit | Model | post-stream", function () {
     sinon.stub(postStream, "findPostsByIds").returns(Promise.resolve([post3]));
 
     await postStream.triggerNewPostsInStream([102]);
-    assert.equal(
+    assert.strictEqual(
       postStream.posts.length,
       2,
       "it does not add the ignored post to the posts"
     );
-    assert.equal(
+    assert.strictEqual(
       postStream.stream.length,
       2,
       "it does not add the ignored post to the stream"
@@ -997,61 +1033,61 @@ module("Unit | Model | post-stream", function () {
     postStream.appendPost(p3);
 
     // Test enumerable and array access
-    assert.equal(postsWithPlaceholders.get("length"), 3);
-    assert.equal(testProxy.get("length"), 3);
-    assert.equal(postsWithPlaceholders.nextObject(0), p1);
-    assert.equal(postsWithPlaceholders.objectAt(0), p1);
-    assert.equal(postsWithPlaceholders.nextObject(1, p1), p2);
-    assert.equal(postsWithPlaceholders.objectAt(1), p2);
-    assert.equal(postsWithPlaceholders.nextObject(2, p2), p3);
-    assert.equal(postsWithPlaceholders.objectAt(2), p3);
+    assert.strictEqual(postsWithPlaceholders.get("length"), 3);
+    assert.strictEqual(testProxy.get("length"), 3);
+    assert.strictEqual(postsWithPlaceholders.nextObject(0), p1);
+    assert.strictEqual(postsWithPlaceholders.objectAt(0), p1);
+    assert.strictEqual(postsWithPlaceholders.nextObject(1, p1), p2);
+    assert.strictEqual(postsWithPlaceholders.objectAt(1), p2);
+    assert.strictEqual(postsWithPlaceholders.nextObject(2, p2), p3);
+    assert.strictEqual(postsWithPlaceholders.objectAt(2), p3);
 
     const promise = postStream.appendMore();
-    assert.equal(
+    assert.strictEqual(
       postsWithPlaceholders.get("length"),
       8,
       "we immediately have a larger placeholder window"
     );
-    assert.equal(testProxy.get("length"), 8);
+    assert.strictEqual(testProxy.get("length"), 8);
     assert.ok(!!postsWithPlaceholders.nextObject(3, p3));
     assert.ok(!!postsWithPlaceholders.objectAt(4));
     assert.ok(postsWithPlaceholders.objectAt(3) !== p4);
     assert.ok(testProxy.objectAt(3) !== p4);
 
     await promise;
-    assert.equal(postsWithPlaceholders.objectAt(3), p4);
-    assert.equal(
+    assert.strictEqual(postsWithPlaceholders.objectAt(3), p4);
+    assert.strictEqual(
       postsWithPlaceholders.get("length"),
       8,
       "have a larger placeholder window when loaded"
     );
-    assert.equal(testProxy.get("length"), 8);
-    assert.equal(testProxy.objectAt(3), p4);
+    assert.strictEqual(testProxy.get("length"), 8);
+    assert.strictEqual(testProxy.objectAt(3), p4);
   });
 
   test("filteredPostsCount", function (assert) {
     const postStream = buildStream(4567, [1, 3, 4]);
 
-    assert.equal(postStream.get("filteredPostsCount"), 3);
+    assert.strictEqual(postStream.get("filteredPostsCount"), 3);
 
     // Megatopic
     postStream.set("isMegaTopic", true);
     postStream.set("topic.highest_post_number", 4);
 
-    assert.equal(postStream.get("filteredPostsCount"), 4);
+    assert.strictEqual(postStream.get("filteredPostsCount"), 4);
   });
 
   test("lastPostId", function (assert) {
     const postStream = buildStream(4567, [1, 3, 4]);
 
-    assert.equal(postStream.get("lastPostId"), 4);
+    assert.strictEqual(postStream.get("lastPostId"), 4);
 
     postStream.setProperties({
       isMegaTopic: true,
       lastId: 2,
     });
 
-    assert.equal(postStream.get("lastPostId"), 2);
+    assert.strictEqual(postStream.get("lastPostId"), 2);
   });
 
   test("progressIndexOfPostId", function (assert) {
@@ -1059,10 +1095,10 @@ module("Unit | Model | post-stream", function () {
     const store = createStore();
     const post = store.createRecord("post", { id: 1, post_number: 5 });
 
-    assert.equal(postStream.progressIndexOfPostId(post), 1);
+    assert.strictEqual(postStream.progressIndexOfPostId(post), 1);
 
     postStream.set("isMegaTopic", true);
 
-    assert.equal(postStream.progressIndexOfPostId(post), 5);
+    assert.strictEqual(postStream.progressIndexOfPostId(post), 5);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -255,8 +255,8 @@ module("Unit | Model | post-stream", function () {
 
     assert.strictEqual(
       postStream.findPostIdForPostNumber(500),
-      null,
-      "it returns null when the post cannot be found"
+      undefined,
+      "it returns undefined when the post cannot be found"
     );
     assert.strictEqual(
       postStream.findPostIdForPostNumber(1),

--- a/app/assets/javascripts/discourse/tests/unit/models/post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-test.js
@@ -54,7 +54,7 @@ module("Unit | Model | post", function () {
       })
     );
 
-    assert.equal(post.get("raw"), "different raw", "raw field updated");
+    assert.strictEqual(post.get("raw"), "different raw", "raw field updated");
   });
 
   test("destroy by staff", async function (assert) {
@@ -64,7 +64,7 @@ module("Unit | Model | post", function () {
     await post.destroy(user);
 
     assert.present(post.get("deleted_at"), "it has a `deleted_at` field.");
-    assert.equal(
+    assert.strictEqual(
       post.get("deleted_by"),
       user,
       "it has the user in the `deleted_by` field"
@@ -97,6 +97,6 @@ module("Unit | Model | post", function () {
       post.get("cooked") !== originalCooked,
       "the cooked content changed"
     );
-    assert.equal(post.get("version"), 2, "the version number increased");
+    assert.strictEqual(post.get("version"), 2, "the version number increased");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/report-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/report-test.js
@@ -489,7 +489,7 @@ module("Unit | Model | report", function () {
     computedFlagCountLabel = flagCountLabel.compute(row, {
       formatNumbers: false,
     });
-    assert.strictEqual(computedFlagCountLabel.formatedValue, 1876);
+    assert.strictEqual(computedFlagCountLabel.formatedValue, "1876");
 
     const timeReadLabel = computedLabels[2];
     assert.strictEqual(timeReadLabel.mainProperty, "time_read");

--- a/app/assets/javascripts/discourse/tests/unit/models/report-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/report-test.js
@@ -18,21 +18,21 @@ module("Unit | Model | report", function () {
   test("counts", function (assert) {
     const report = reportWithData([5, 4, 3, 2, 1, 100, 99, 98, 1000]);
 
-    assert.equal(report.get("todayCount"), 5);
-    assert.equal(report.get("yesterdayCount"), 4);
-    assert.equal(
+    assert.strictEqual(report.get("todayCount"), 5);
+    assert.strictEqual(report.get("yesterdayCount"), 4);
+    assert.strictEqual(
       report.valueFor(2, 4),
       6,
       "adds the values for the given range of days, inclusive"
     );
-    assert.equal(
+    assert.strictEqual(
       report.get("lastSevenDaysCount"),
       307,
       "sums 7 days excluding today"
     );
 
     report.set("type", "time_to_first_response");
-    assert.equal(
+    assert.strictEqual(
       report.valueFor(2, 4),
       2,
       "averages the values for the given range of days"
@@ -42,14 +42,30 @@ module("Unit | Model | report", function () {
   test("percentChangeString", function (assert) {
     const report = reportWithData([]);
 
-    assert.equal(report.percentChangeString(5, 8), "+60%", "value increased");
-    assert.equal(report.percentChangeString(8, 2), "-75%", "value decreased");
-    assert.equal(report.percentChangeString(8, 8), "0%", "value unchanged");
+    assert.strictEqual(
+      report.percentChangeString(5, 8),
+      "+60%",
+      "value increased"
+    );
+    assert.strictEqual(
+      report.percentChangeString(8, 2),
+      "-75%",
+      "value decreased"
+    );
+    assert.strictEqual(
+      report.percentChangeString(8, 8),
+      "0%",
+      "value unchanged"
+    );
     assert.blank(
       report.percentChangeString(0, 8),
       "returns blank when previous value was 0"
     );
-    assert.equal(report.percentChangeString(8, 0), "-100%", "yesterday was 0");
+    assert.strictEqual(
+      report.percentChangeString(8, 0),
+      "-100%",
+      "yesterday was 0"
+    );
     assert.blank(
       report.percentChangeString(0, 0),
       "returns blank when both were 0"
@@ -64,7 +80,7 @@ module("Unit | Model | report", function () {
 
   test("yesterdayCountTitle when two days ago was 0", function (assert) {
     const title = reportWithData([6, 8, 0, 2, 1]).get("yesterdayCountTitle");
-    assert.equal(title.indexOf("%"), -1);
+    assert.strictEqual(title.indexOf("%"), -1);
     assert.ok(title.match(/Was 0/));
   });
 
@@ -451,98 +467,101 @@ module("Unit | Model | report", function () {
     const computedLabels = report.get("computedLabels");
 
     const usernameLabel = computedLabels[0];
-    assert.equal(usernameLabel.mainProperty, "username");
-    assert.equal(usernameLabel.sortProperty, "username");
-    assert.equal(usernameLabel.title, "Moderator");
-    assert.equal(usernameLabel.type, "user");
+    assert.strictEqual(usernameLabel.mainProperty, "username");
+    assert.strictEqual(usernameLabel.sortProperty, "username");
+    assert.strictEqual(usernameLabel.title, "Moderator");
+    assert.strictEqual(usernameLabel.type, "user");
     const computedUsernameLabel = usernameLabel.compute(row);
-    assert.equal(
+    assert.strictEqual(
       computedUsernameLabel.formatedValue,
       "<a href='/admin/users/1/joffrey'><img loading='lazy' alt='' width='20' height='20' src='/' class='avatar' title='joffrey' aria-label='joffrey'><span class='username'>joffrey</span></a>"
     );
-    assert.equal(computedUsernameLabel.value, "joffrey");
+    assert.strictEqual(computedUsernameLabel.value, "joffrey");
 
     const flagCountLabel = computedLabels[1];
-    assert.equal(flagCountLabel.mainProperty, "flag_count");
-    assert.equal(flagCountLabel.sortProperty, "flag_count");
-    assert.equal(flagCountLabel.title, "Flag count");
-    assert.equal(flagCountLabel.type, "number");
+    assert.strictEqual(flagCountLabel.mainProperty, "flag_count");
+    assert.strictEqual(flagCountLabel.sortProperty, "flag_count");
+    assert.strictEqual(flagCountLabel.title, "Flag count");
+    assert.strictEqual(flagCountLabel.type, "number");
     let computedFlagCountLabel = flagCountLabel.compute(row);
-    assert.equal(computedFlagCountLabel.formatedValue, "1.9k");
+    assert.strictEqual(computedFlagCountLabel.formatedValue, "1.9k");
     assert.strictEqual(computedFlagCountLabel.value, 1876);
     computedFlagCountLabel = flagCountLabel.compute(row, {
       formatNumbers: false,
     });
-    assert.equal(computedFlagCountLabel.formatedValue, 1876);
+    assert.strictEqual(computedFlagCountLabel.formatedValue, 1876);
 
     const timeReadLabel = computedLabels[2];
-    assert.equal(timeReadLabel.mainProperty, "time_read");
-    assert.equal(timeReadLabel.sortProperty, "time_read");
-    assert.equal(timeReadLabel.title, "Time read");
-    assert.equal(timeReadLabel.type, "seconds");
+    assert.strictEqual(timeReadLabel.mainProperty, "time_read");
+    assert.strictEqual(timeReadLabel.sortProperty, "time_read");
+    assert.strictEqual(timeReadLabel.title, "Time read");
+    assert.strictEqual(timeReadLabel.type, "seconds");
     const computedTimeReadLabel = timeReadLabel.compute(row);
-    assert.equal(computedTimeReadLabel.formatedValue, "3d");
-    assert.equal(computedTimeReadLabel.value, 287362);
+    assert.strictEqual(computedTimeReadLabel.formatedValue, "3d");
+    assert.strictEqual(computedTimeReadLabel.value, 287362);
 
     const noteLabel = computedLabels[3];
-    assert.equal(noteLabel.mainProperty, "note");
-    assert.equal(noteLabel.sortProperty, "note");
-    assert.equal(noteLabel.title, "Note");
-    assert.equal(noteLabel.type, "text");
+    assert.strictEqual(noteLabel.mainProperty, "note");
+    assert.strictEqual(noteLabel.sortProperty, "note");
+    assert.strictEqual(noteLabel.title, "Note");
+    assert.strictEqual(noteLabel.type, "text");
     const computedNoteLabel = noteLabel.compute(row);
-    assert.equal(computedNoteLabel.formatedValue, "This is a long note");
-    assert.equal(computedNoteLabel.value, "This is a long note");
+    assert.strictEqual(computedNoteLabel.formatedValue, "This is a long note");
+    assert.strictEqual(computedNoteLabel.value, "This is a long note");
 
     const topicLabel = computedLabels[4];
-    assert.equal(topicLabel.mainProperty, "topic_title");
-    assert.equal(topicLabel.sortProperty, "topic_title");
-    assert.equal(topicLabel.title, "Topic");
-    assert.equal(topicLabel.type, "topic");
+    assert.strictEqual(topicLabel.mainProperty, "topic_title");
+    assert.strictEqual(topicLabel.sortProperty, "topic_title");
+    assert.strictEqual(topicLabel.title, "Topic");
+    assert.strictEqual(topicLabel.type, "topic");
     const computedTopicLabel = topicLabel.compute(row);
-    assert.equal(
+    assert.strictEqual(
       computedTopicLabel.formatedValue,
       "<a href='/t/-/2'>Test topic &lt;html&gt;</a>"
     );
-    assert.equal(computedTopicLabel.value, "Test topic <html>");
+    assert.strictEqual(computedTopicLabel.value, "Test topic <html>");
 
     const postLabel = computedLabels[5];
-    assert.equal(postLabel.mainProperty, "post_raw");
-    assert.equal(postLabel.sortProperty, "post_raw");
-    assert.equal(postLabel.title, "Post");
-    assert.equal(postLabel.type, "post");
+    assert.strictEqual(postLabel.mainProperty, "post_raw");
+    assert.strictEqual(postLabel.sortProperty, "post_raw");
+    assert.strictEqual(postLabel.title, "Post");
+    assert.strictEqual(postLabel.type, "post");
     const computedPostLabel = postLabel.compute(row);
-    assert.equal(
+    assert.strictEqual(
       computedPostLabel.formatedValue,
       "<a href='/t/-/2/3'>This is the beginning of &lt;html&gt;</a>"
     );
-    assert.equal(computedPostLabel.value, "This is the beginning of <html>");
+    assert.strictEqual(
+      computedPostLabel.value,
+      "This is the beginning of <html>"
+    );
 
     const filesizeLabel = computedLabels[6];
-    assert.equal(filesizeLabel.mainProperty, "filesize");
-    assert.equal(filesizeLabel.sortProperty, "filesize");
-    assert.equal(filesizeLabel.title, "Filesize");
-    assert.equal(filesizeLabel.type, "bytes");
+    assert.strictEqual(filesizeLabel.mainProperty, "filesize");
+    assert.strictEqual(filesizeLabel.sortProperty, "filesize");
+    assert.strictEqual(filesizeLabel.title, "Filesize");
+    assert.strictEqual(filesizeLabel.type, "bytes");
     const computedFilesizeLabel = filesizeLabel.compute(row);
-    assert.equal(computedFilesizeLabel.formatedValue, "569.0 KB");
-    assert.equal(computedFilesizeLabel.value, 582641);
+    assert.strictEqual(computedFilesizeLabel.formatedValue, "569.0 KB");
+    assert.strictEqual(computedFilesizeLabel.value, 582641);
 
     // subfolder support
     setPrefix("/forum");
 
     const postLink = computedLabels[5].compute(row).formatedValue;
-    assert.equal(
+    assert.strictEqual(
       postLink,
       "<a href='/forum/t/-/2/3'>This is the beginning of &lt;html&gt;</a>"
     );
 
     const topicLink = computedLabels[4].compute(row).formatedValue;
-    assert.equal(
+    assert.strictEqual(
       topicLink,
       "<a href='/forum/t/-/2'>Test topic &lt;html&gt;</a>"
     );
 
     const userLink = computedLabels[0].compute(row).formatedValue;
-    assert.equal(
+    assert.strictEqual(
       userLink,
       "<a href='/forum/admin/users/1/joffrey'><img loading='lazy' alt='' width='20' height='20' src='/forum/' class='avatar' title='joffrey' aria-label='joffrey'><span class='username'>joffrey</span></a>"
     );

--- a/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/rest-model-test.js
@@ -16,13 +16,13 @@ module("Unit | Model | rest-model", function () {
     });
 
     let g = Grape.create({ store, percent: 0.4 });
-    assert.equal(g.get("inverse"), 0.6, "it runs `munge` on `create`");
+    assert.strictEqual(g.get("inverse"), 0.6, "it runs `munge` on `create`");
   });
 
   test("update", async function (assert) {
     const store = createStore();
     const widget = await store.find("widget", 123);
-    assert.equal(widget.get("name"), "Trout Lure");
+    assert.strictEqual(widget.get("name"), "Trout Lure");
     assert.ok(!widget.get("isSaving"), "it is not saving");
 
     const spyBeforeUpdate = sinon.spy(widget, "beforeUpdate");
@@ -34,10 +34,10 @@ module("Unit | Model | rest-model", function () {
     const result = await promise;
     assert.ok(spyAfterUpdate.calledOn(widget));
     assert.ok(!widget.get("isSaving"), "it is no longer saving");
-    assert.equal(widget.get("name"), "new name");
+    assert.strictEqual(widget.get("name"), "new name");
 
     assert.ok(result.target, "it has a reference to the record");
-    assert.equal(result.target.name, widget.get("name"));
+    assert.strictEqual(result.target.name, widget.get("name"));
   });
 
   test("updating simultaneously", async function (assert) {
@@ -81,7 +81,7 @@ module("Unit | Model | rest-model", function () {
     assert.ok(!widget.get("isNew"), "it is no longer new");
 
     assert.ok(result.target, "it has a reference to the record");
-    assert.equal(result.target.name, widget.get("name"));
+    assert.strictEqual(result.target.name, widget.get("name"));
   });
 
   test("creating simultaneously", function (assert) {
@@ -127,18 +127,18 @@ module("Unit | Model | rest-model", function () {
     //Create
     const widget = store.createRecord("my-widget");
     await widget.save({ name: "Evil Widget" });
-    assert.equal(widget.id, 100, "it saved a new record successfully");
-    assert.equal(widget.get("name"), "Evil Widget");
+    assert.strictEqual(widget.id, 100, "it saved a new record successfully");
+    assert.strictEqual(widget.get("name"), "Evil Widget");
 
     // Update
     await widget.update({ name: "new name" });
-    assert.equal(widget.get("name"), "new name");
+    assert.strictEqual(widget.get("name"), "new name");
 
     // Destroy
     await widget.destroyRecord();
 
     // Lookup
     const foundWidget = await store.find("my-widget", 123);
-    assert.equal(foundWidget.name, "Trout Lure");
+    assert.strictEqual(foundWidget.name, "Trout Lure");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
@@ -5,8 +5,8 @@ import createStore from "discourse/tests/helpers/create-store";
 module("Unit | Model | result-set", function () {
   test("defaults", function (assert) {
     const resultSet = ResultSet.create({ content: [] });
-    assert.equal(resultSet.get("length"), 0);
-    assert.equal(resultSet.get("totalRows"), 0);
+    assert.strictEqual(resultSet.get("length"), 0);
+    assert.strictEqual(resultSet.get("totalRows"), 0);
     assert.ok(!resultSet.get("loadMoreUrl"));
     assert.ok(!resultSet.get("loading"));
     assert.ok(!resultSet.get("loadingMore"));
@@ -16,8 +16,8 @@ module("Unit | Model | result-set", function () {
   test("pagination support", async function (assert) {
     const store = createStore();
     const resultSet = await store.findAll("widget");
-    assert.equal(resultSet.get("length"), 2);
-    assert.equal(resultSet.get("totalRows"), 4);
+    assert.strictEqual(resultSet.get("length"), 2);
+    assert.strictEqual(resultSet.get("totalRows"), 4);
     assert.ok(resultSet.get("loadMoreUrl"), "has a url to load more");
     assert.ok(!resultSet.get("loadingMore"), "it is not loading more");
     assert.ok(resultSet.get("canLoadMore"));
@@ -27,7 +27,7 @@ module("Unit | Model | result-set", function () {
 
     await promise;
     assert.ok(!resultSet.get("loadingMore"), "it finished loading more");
-    assert.equal(resultSet.get("length"), 4);
+    assert.strictEqual(resultSet.get("length"), 4);
     assert.ok(!resultSet.get("loadMoreUrl"));
     assert.ok(!resultSet.get("canLoadMore"));
   });
@@ -35,7 +35,7 @@ module("Unit | Model | result-set", function () {
   test("refresh support", async function (assert) {
     const store = createStore();
     const resultSet = await store.findAll("widget");
-    assert.equal(
+    assert.strictEqual(
       resultSet.get("refreshUrl"),
       "/widgets?refresh=true",
       "it has the refresh url"

--- a/app/assets/javascripts/discourse/tests/unit/models/site-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/site-test.js
@@ -39,17 +39,17 @@ module("Unit | Model | site", function () {
     site.get("sortedCategories");
 
     assert.present(categories, "The categories are present");
-    assert.equal(categories.length, 3, "it loaded all three categories");
+    assert.strictEqual(categories.length, 3, "it loaded all three categories");
 
     const parent = categories.findBy("id", 1234);
     assert.present(parent, "it loaded the parent category");
     assert.blank(parent.get("parentCategory"), "it has no parent category");
 
-    assert.equal(parent.get("subcategories").length, 1);
+    assert.strictEqual(parent.get("subcategories").length, 1);
 
     const subcategory = categories.findBy("id", 3456);
     assert.present(subcategory, "it loaded the subcategory");
-    assert.equal(
+    assert.strictEqual(
       subcategory.get("parentCategory"),
       parent,
       "it has associated the child with the parent"
@@ -59,12 +59,12 @@ module("Unit | Model | site", function () {
     categories.removeObject(categories[2]);
     categories.removeObject(categories[1]);
 
-    assert.equal(
+    assert.strictEqual(
       categories.length,
       site.get("categoriesByCount").length,
       "categories by count should change on removal"
     );
-    assert.equal(
+    assert.strictEqual(
       categories.length,
       site.get("sortedCategories").length,
       "sorted categories should change on removal"

--- a/app/assets/javascripts/discourse/tests/unit/models/theme-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/theme-test.js
@@ -6,7 +6,7 @@ module("Unit | Model | theme");
 test("can add an upload correctly", function (assert) {
   let theme = Theme.create();
 
-  assert.equal(
+  assert.strictEqual(
     theme.get("uploads.length"),
     0,
     "uploads should be an empty array"
@@ -14,9 +14,9 @@ test("can add an upload correctly", function (assert) {
 
   theme.setField("common", "bob", "", 999, 2);
   let fields = theme.get("theme_fields");
-  assert.equal(fields.length, 1, "expecting 1 theme field");
-  assert.equal(fields[0].upload_id, 999, "expecting upload id to be set");
-  assert.equal(fields[0].type_id, 2, "expecting type id to be set");
+  assert.strictEqual(fields.length, 1, "expecting 1 theme field");
+  assert.strictEqual(fields[0].upload_id, 999, "expecting upload id to be set");
+  assert.strictEqual(fields[0].type_id, 2, "expecting type id to be set");
 
-  assert.equal(theme.get("uploads.length"), 1, "expecting an upload");
+  assert.strictEqual(theme.get("uploads.length"), 1, "expecting an upload");
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-details-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-details-test.js
@@ -21,7 +21,7 @@ module("Unit | Model | topic-details", function () {
       allowed_users: [{ username: "eviltrout" }],
     });
 
-    assert.equal(
+    assert.strictEqual(
       details.get("allowed_users.length"),
       1,
       "it loaded the allowed users"

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -49,7 +49,7 @@ discourseModule("Unit | Model | topic", function () {
 
     topic.set("category", category);
 
-    assert.equal(topic.get("lastUnreadUrl"), "/t/hello/101/1");
+    assert.strictEqual(topic.get("lastUnreadUrl"), "/t/hello/101/1");
   });
 
   test("has details", function (assert) {
@@ -57,7 +57,7 @@ discourseModule("Unit | Model | topic", function () {
     const topicDetails = topic.get("details");
 
     assert.present(topicDetails, "a topic has topicDetails after we create it");
-    assert.equal(
+    assert.strictEqual(
       topicDetails.get("topic"),
       topic,
       "the topicDetails has a reference back to the topic"
@@ -69,7 +69,7 @@ discourseModule("Unit | Model | topic", function () {
     const postStream = topic.get("postStream");
 
     assert.present(postStream, "a topic has a postStream after we create it");
-    assert.equal(
+    assert.strictEqual(
       postStream.get("topic"),
       topic,
       "the postStream has a reference back to the topic"
@@ -80,7 +80,11 @@ discourseModule("Unit | Model | topic", function () {
     const topic = Topic.create({ suggested_topics: [{ id: 1 }, { id: 2 }] });
     const suggestedTopics = topic.get("suggestedTopics");
 
-    assert.equal(suggestedTopics.length, 2, "it loaded the suggested_topics");
+    assert.strictEqual(
+      suggestedTopics.length,
+      2,
+      "it loaded the suggested_topics"
+    );
     assert.containsInstance(suggestedTopics, Topic);
   });
 
@@ -89,7 +93,7 @@ discourseModule("Unit | Model | topic", function () {
     const category = Category.list()[0];
     const topic = Topic.create({ id: 1111, category_id: category.get("id") });
 
-    assert.equal(topic.get("category"), category);
+    assert.strictEqual(topic.get("category"), category);
   });
 
   test("updateFromJson", function (assert) {
@@ -104,9 +108,17 @@ discourseModule("Unit | Model | topic", function () {
     });
 
     assert.blank(topic.get("post_stream"), "it does not update post_stream");
-    assert.equal(topic.get("details.hello"), "world", "it updates the details");
-    assert.equal(topic.get("cool"), "property", "it updates other properties");
-    assert.equal(topic.get("category"), category);
+    assert.strictEqual(
+      topic.get("details.hello"),
+      "world",
+      "it updates the details"
+    );
+    assert.strictEqual(
+      topic.get("cool"),
+      "property",
+      "it updates other properties"
+    );
+    assert.strictEqual(topic.get("category"), category);
   });
 
   test("recover", async function (assert) {
@@ -128,7 +140,7 @@ discourseModule("Unit | Model | topic", function () {
       fancy_title: ":smile: with all :) the emojis :pear::peach:",
     });
 
-    assert.equal(
+    assert.strictEqual(
       topic.get("fancyTitle"),
       `<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'> with all <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'> the emojis <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/pear.png?v=${v}' title='pear' alt='pear' class='emoji'><img width=\"20\" height=\"20\" src='/images/emoji/google_classic/peach.png?v=${v}' title='peach' alt='peach' class='emoji'>`,
       "supports emojis"
@@ -140,12 +152,12 @@ discourseModule("Unit | Model | topic", function () {
     const ltrTopic = Topic.create({ fancy_title: "This is a test" });
 
     this.siteSettings.support_mixed_text_direction = true;
-    assert.equal(
+    assert.strictEqual(
       rtlTopic.get("fancyTitle"),
       `<span dir="rtl">هذا اختبار</span>`,
       "sets the dir-span to rtl"
     );
-    assert.equal(
+    assert.strictEqual(
       ltrTopic.get("fancyTitle"),
       `<span dir="ltr">This is a test</span>`,
       "sets the dir-span to ltr"
@@ -158,7 +170,7 @@ discourseModule("Unit | Model | topic", function () {
       pinned: true,
     });
 
-    assert.equal(
+    assert.strictEqual(
       topic.get("escapedExcerpt"),
       `This is a test topic <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "supports emojis"
@@ -167,15 +179,15 @@ discourseModule("Unit | Model | topic", function () {
 
   test("visible & invisible", function (assert) {
     const topic = Topic.create();
-    assert.equal(topic.visible, undefined);
-    assert.equal(topic.invisible, undefined);
+    assert.strictEqual(topic.visible, undefined);
+    assert.strictEqual(topic.invisible, undefined);
 
     const visibleTopic = Topic.create({ visible: true });
-    assert.equal(visibleTopic.visible, true);
-    assert.equal(visibleTopic.invisible, false);
+    assert.strictEqual(visibleTopic.visible, true);
+    assert.strictEqual(visibleTopic.invisible, false);
 
     const invisibleTopic = Topic.create({ visible: false });
-    assert.equal(invisibleTopic.visible, false);
-    assert.equal(invisibleTopic.invisible, true);
+    assert.strictEqual(invisibleTopic.visible, false);
+    assert.strictEqual(invisibleTopic.invisible, true);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -634,7 +634,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         publishToMessageBus("/new", newTopicPayload);
         assert.strictEqual(
           trackingState.findState(222),
-          null,
+          undefined,
           "the new topic is not in the state"
         );
       });
@@ -644,7 +644,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         publishToMessageBus("/new", newTopicPayload);
         assert.strictEqual(
           trackingState.findState(222),
-          null,
+          undefined,
           "the new topic is not in the state"
         );
       });

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -71,14 +71,22 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
     const tagCounts = trackingState.countTags(["baz", "pending"]);
 
-    assert.equal(tagCounts["baz"].newCount, 2, "baz tag new counts");
-    assert.equal(tagCounts["baz"].unreadCount, 0, "baz tag unread counts");
-    assert.equal(
+    assert.strictEqual(tagCounts["baz"].newCount, 2, "baz tag new counts");
+    assert.strictEqual(
+      tagCounts["baz"].unreadCount,
+      0,
+      "baz tag unread counts"
+    );
+    assert.strictEqual(
       tagCounts["pending"].unreadCount,
       2,
       "pending tag unread counts"
     );
-    assert.equal(tagCounts["pending"].newCount, 0, "pending tag new counts");
+    assert.strictEqual(
+      tagCounts["pending"].newCount,
+      0,
+      "pending tag new counts"
+    );
   });
 
   test("tag counts - with total", function (assert) {
@@ -151,12 +159,20 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       includeTotal: true,
     });
 
-    assert.equal(states["baz"].newCount, 2, "baz tag new counts");
-    assert.equal(states["baz"].unreadCount, 0, "baz tag unread counts");
-    assert.equal(states["baz"].totalCount, 3, "baz tag total counts");
-    assert.equal(states["pending"].unreadCount, 2, "pending tag unread counts");
-    assert.equal(states["pending"].newCount, 0, "pending tag new counts");
-    assert.equal(states["pending"].totalCount, 4, "pending tag total counts");
+    assert.strictEqual(states["baz"].newCount, 2, "baz tag new counts");
+    assert.strictEqual(states["baz"].unreadCount, 0, "baz tag unread counts");
+    assert.strictEqual(states["baz"].totalCount, 3, "baz tag total counts");
+    assert.strictEqual(
+      states["pending"].unreadCount,
+      2,
+      "pending tag unread counts"
+    );
+    assert.strictEqual(states["pending"].newCount, 0, "pending tag new counts");
+    assert.strictEqual(
+      states["pending"].totalCount,
+      4,
+      "pending tag total counts"
+    );
   });
 
   test("forEachTracked", function (assert) {
@@ -231,10 +247,10 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       }
     });
 
-    assert.equal(randomNew, 1, "random tag new");
-    assert.equal(randomUnread, 0, "random tag unread");
-    assert.equal(sevenNew, 0, "category seven new");
-    assert.equal(sevenUnread, 2, "category seven unread");
+    assert.strictEqual(randomNew, 1, "random tag new");
+    assert.strictEqual(randomUnread, 0, "random tag unread");
+    assert.strictEqual(sevenNew, 0, "category seven new");
+    assert.strictEqual(sevenUnread, 2, "category seven unread");
   });
 
   test("sync - delayed new topics for backend list are removed", function (assert) {
@@ -253,7 +269,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     };
 
     trackingState.sync(list, "new");
-    assert.equal(
+    assert.strictEqual(
       list.topics.length,
       0,
       "expect new topic to be removed as it was seen"
@@ -278,12 +294,12 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     };
 
     trackingState.sync(list, "unread");
-    assert.equal(
+    assert.strictEqual(
       list.topics[0].unseen,
       false,
       "expect unread topic to be marked as seen"
     );
-    assert.equal(
+    assert.strictEqual(
       list.topics[0].prevent_sync,
       true,
       "expect unread topic to be marked as prevent_sync"
@@ -354,7 +370,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
     let state111 = trackingState.findState(111);
     let state222 = trackingState.findState(222);
-    assert.equal(
+    assert.strictEqual(
       state111.last_read_post_number,
       null,
       "unseen topics get last_read_post_number reset to null"
@@ -364,7 +380,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       { highest_post_number: 20, tags: ["pending"], category_id: 1 },
       "highest_post_number, category, and tags are set for a topic"
     );
-    assert.equal(
+    assert.strictEqual(
       state222.last_read_post_number,
       17,
       "last_read_post_number is highest_post_number - (unread + new)"
@@ -395,14 +411,14 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     };
 
     trackingState.sync(list, "unread");
-    assert.equal(
+    assert.strictEqual(
       trackingState.findState(111).last_read_post_number,
       5,
       "last_read_post_number set to highest post number to pretend read"
     );
 
     trackingState.sync(list, "new");
-    assert.equal(
+    assert.strictEqual(
       trackingState.findState(222).last_read_post_number,
       1,
       "last_read_post_number set to 1 to pretend not new"
@@ -454,7 +470,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       test("message count is incremented", function (assert) {
         publishToMessageBus(`/unread/${currentUser.id}`, unreadTopicPayload);
 
-        assert.equal(
+        assert.strictEqual(
           trackingState.messageCount,
           1,
           "message count incremented"
@@ -481,7 +497,11 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
           },
           "topic state updated"
         );
-        assert.equal(stateCallbackCalled, true, "state change callback called");
+        assert.strictEqual(
+          stateCallbackCalled,
+          true,
+          "state change callback called"
+        );
       });
 
       test("adds incoming so it is counted in topic lists", function (assert) {
@@ -492,7 +512,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
           [111],
           "unread topic is incoming"
         );
-        assert.equal(
+        assert.strictEqual(
           trackingState.incomingCount,
           1,
           "incoming count is increased"
@@ -512,7 +532,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
           [111],
           "unread topic is incoming"
         );
-        assert.equal(
+        assert.strictEqual(
           trackingState.incomingCount,
           1,
           "incoming count is increased"
@@ -535,7 +555,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
           message_type: "dismiss_new",
           payload: { topic_ids: [112] },
         });
-        assert.equal(trackingState.findState(112).is_seen, true);
+        assert.strictEqual(trackingState.findState(112).is_seen, true);
       });
 
       test("marks a topic as read", function (assert) {
@@ -612,7 +632,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       test("topics in muted categories do not get added to the state", function (assert) {
         trackingState.currentUser.set("muted_category_ids", [123]);
         publishToMessageBus("/new", newTopicPayload);
-        assert.equal(
+        assert.strictEqual(
           trackingState.findState(222),
           null,
           "the new topic is not in the state"
@@ -622,7 +642,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       test("topics in muted tags do not get added to the state", function (assert) {
         trackingState.currentUser.set("muted_tag_ids", [44]);
         publishToMessageBus("/new", newTopicPayload);
-        assert.equal(
+        assert.strictEqual(
           trackingState.findState(222),
           null,
           "the new topic is not in the state"
@@ -632,7 +652,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       test("message count is incremented", function (assert) {
         publishToMessageBus("/new", newTopicPayload);
 
-        assert.equal(
+        assert.strictEqual(
           trackingState.messageCount,
           1,
           "message count incremented"
@@ -658,7 +678,11 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
           },
           "new topic loaded into state"
         );
-        assert.equal(stateCallbackCalled, true, "state change callback called");
+        assert.strictEqual(
+          stateCallbackCalled,
+          true,
+          "state change callback called"
+        );
       });
 
       test("adds incoming so it is counted in topic lists", function (assert) {
@@ -669,7 +693,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
           [222],
           "new topic is incoming"
         );
-        assert.equal(
+        assert.strictEqual(
           trackingState.incomingCount,
           1,
           "incoming count is increased"
@@ -691,12 +715,16 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
     publishToMessageBus("/delete", { topic_id: 111 });
 
-    assert.equal(
+    assert.strictEqual(
       trackingState.findState(111).deleted,
       true,
       "marks the topic as deleted"
     );
-    assert.equal(trackingState.messageCount, 1, "increments message count");
+    assert.strictEqual(
+      trackingState.messageCount,
+      1,
+      "increments message count"
+    );
   });
 
   test("establishChannels - /recover MessageBus channel payloads processed", function (assert) {
@@ -712,12 +740,16 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
     publishToMessageBus("/recover", { topic_id: 111 });
 
-    assert.equal(
+    assert.strictEqual(
       trackingState.findState(111).deleted,
       false,
       "marks the topic as not deleted"
     );
-    assert.equal(trackingState.messageCount, 1, "increments message count");
+    assert.strictEqual(
+      trackingState.messageCount,
+      1,
+      "increments message count"
+    );
   });
 
   test("establishChannels - /destroy MessageBus channel payloads processed", function (assert) {
@@ -737,7 +769,11 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
     publishToMessageBus("/destroy", { topic_id: 111 });
 
-    assert.equal(trackingState.messageCount, 1, "increments message count");
+    assert.strictEqual(
+      trackingState.messageCount,
+      1,
+      "increments message count"
+    );
     assert.ok(
       DiscourseURL.redirectTo.calledWith("/"),
       "redirect to / because topic is destroyed"
@@ -765,7 +801,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       payload: { category_id: 26 },
     });
 
-    assert.equal(
+    assert.strictEqual(
       trackingState.get("incomingCount"),
       2,
       "expect to properly track incoming for category"
@@ -785,7 +821,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       payload: { category_id: 3 },
     });
 
-    assert.equal(
+    assert.strictEqual(
       trackingState.get("incomingCount"),
       0,
       "parent or other category doesn't affect subcategory"
@@ -797,7 +833,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       payload: { category_id: 26 },
     });
 
-    assert.equal(
+    assert.strictEqual(
       trackingState.get("incomingCount"),
       1,
       "expect to properly track incoming for subcategory"
@@ -812,7 +848,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       payload: { category_id: 26 },
     });
 
-    assert.equal(
+    assert.strictEqual(
       trackingState.get("incomingCount"),
       1,
       "expect to properly track incoming for subcategory using none tags route"
@@ -869,9 +905,9 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
 
     const trackingState = TopicTrackingState.create({ currentUser });
 
-    assert.equal(trackingState.countNew(1), 0);
-    assert.equal(trackingState.countNew(2), 0);
-    assert.equal(trackingState.countNew(3), 0);
+    assert.strictEqual(trackingState.countNew(1), 0);
+    assert.strictEqual(trackingState.countNew(2), 0);
+    assert.strictEqual(trackingState.countNew(3), 0);
 
     trackingState.states.set("t112", {
       last_read_post_number: null,
@@ -881,11 +917,11 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       created_in_new_period: true,
     });
 
-    assert.equal(trackingState.countNew(1), 1);
-    assert.equal(trackingState.countNew(1, undefined, true), 0);
-    assert.equal(trackingState.countNew(1, "missing-tag"), 0);
-    assert.equal(trackingState.countNew(2), 1);
-    assert.equal(trackingState.countNew(3), 0);
+    assert.strictEqual(trackingState.countNew(1), 1);
+    assert.strictEqual(trackingState.countNew(1, undefined, true), 0);
+    assert.strictEqual(trackingState.countNew(1, "missing-tag"), 0);
+    assert.strictEqual(trackingState.countNew(2), 1);
+    assert.strictEqual(trackingState.countNew(3), 0);
 
     trackingState.states.set("t113", {
       last_read_post_number: null,
@@ -896,11 +932,11 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       created_in_new_period: true,
     });
 
-    assert.equal(trackingState.countNew(1), 2);
-    assert.equal(trackingState.countNew(2), 2);
-    assert.equal(trackingState.countNew(3), 1);
-    assert.equal(trackingState.countNew(3, "amazing"), 1);
-    assert.equal(trackingState.countNew(3, "missing"), 0);
+    assert.strictEqual(trackingState.countNew(1), 2);
+    assert.strictEqual(trackingState.countNew(2), 2);
+    assert.strictEqual(trackingState.countNew(3), 1);
+    assert.strictEqual(trackingState.countNew(3, "amazing"), 1);
+    assert.strictEqual(trackingState.countNew(3, "missing"), 0);
 
     trackingState.states.set("t111", {
       last_read_post_number: null,
@@ -910,16 +946,16 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       created_in_new_period: true,
     });
 
-    assert.equal(trackingState.countNew(1), 3);
-    assert.equal(trackingState.countNew(2), 2);
-    assert.equal(trackingState.countNew(3), 1);
+    assert.strictEqual(trackingState.countNew(1), 3);
+    assert.strictEqual(trackingState.countNew(2), 2);
+    assert.strictEqual(trackingState.countNew(3), 1);
 
     trackingState.states.set("t115", {
       last_read_post_number: null,
       id: 115,
       category_id: 4,
     });
-    assert.equal(trackingState.countNew(4), 0);
+    assert.strictEqual(trackingState.countNew(4), 0);
   });
 
   test("mute and unmute topic", function (assert) {
@@ -934,21 +970,21 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       topic_id: 1,
       message_type: "muted",
     });
-    assert.equal(currentUser.muted_topics[0].topicId, 1);
+    assert.strictEqual(currentUser.muted_topics[0].topicId, 1);
 
     trackingState.trackMutedOrUnmutedTopic({
       topic_id: 2,
       message_type: "unmuted",
     });
-    assert.equal(currentUser.unmuted_topics[0].topicId, 2);
+    assert.strictEqual(currentUser.unmuted_topics[0].topicId, 2);
 
     trackingState.pruneOldMutedAndUnmutedTopics();
-    assert.equal(trackingState.isMutedTopic(1), true);
-    assert.equal(trackingState.isUnmutedTopic(2), true);
+    assert.strictEqual(trackingState.isMutedTopic(1), true);
+    assert.strictEqual(trackingState.isUnmutedTopic(2), true);
 
     this.clock.tick(60000);
     trackingState.pruneOldMutedAndUnmutedTopics();
-    assert.equal(trackingState.isMutedTopic(1), false);
-    assert.equal(trackingState.isUnmutedTopic(2), false);
+    assert.strictEqual(trackingState.isMutedTopic(1), false);
+    assert.strictEqual(trackingState.isUnmutedTopic(2), false);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/user-action-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-action-test.js
@@ -24,8 +24,8 @@ module("Unit | Model | user-action", function () {
       }),
     ]);
 
-    assert.equal(actions.length, 2);
-    assert.equal(actions[0].get("children.length"), 1);
-    assert.equal(actions[0].get("children")[0].items.length, 2);
+    assert.strictEqual(actions.length, 2);
+    assert.strictEqual(actions[0].get("children.length"), 1);
+    assert.strictEqual(actions[0].get("children")[0].items.length, 2);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
@@ -8,17 +8,17 @@ module("Unit | Model | user-badge", function () {
       JSON.parse(JSON.stringify(badgeFixtures["/user_badges"]))
     );
     assert.ok(!Array.isArray(userBadge), "does not return an array");
-    assert.equal(
+    assert.strictEqual(
       userBadge.get("badge.name"),
       "Badge 2",
       "badge reference is set"
     );
-    assert.equal(
+    assert.strictEqual(
       userBadge.get("badge.badge_type.name"),
       "Silver 2",
       "badge.badge_type reference is set"
     );
-    assert.equal(
+    assert.strictEqual(
       userBadge.get("granted_by.username"),
       "anne3",
       "granted_by reference is set"
@@ -30,7 +30,7 @@ module("Unit | Model | user-badge", function () {
       JSON.parse(JSON.stringify(badgeFixtures["/user-badges/:username"]))
     );
     assert.ok(Array.isArray(userBadges), "returns an array");
-    assert.equal(
+    assert.strictEqual(
       userBadges[0].get("granted_by"),
       null,
       "granted_by reference is not set when null"

--- a/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-badge-test.js
@@ -32,7 +32,7 @@ module("Unit | Model | user-badge", function () {
     assert.ok(Array.isArray(userBadges), "returns an array");
     assert.strictEqual(
       userBadges[0].get("granted_by"),
-      null,
+      undefined,
       "granted_by reference is not set when null"
     );
   });

--- a/app/assets/javascripts/discourse/tests/unit/models/user-drafts-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-drafts-test.js
@@ -9,7 +9,11 @@ module("Unit | Model | user-draft", function () {
     const user = User.create({ id: 1, username: "eviltrout" });
     const stream = user.userDraftsStream;
     assert.present(stream, "a user has a drafts stream by default");
-    assert.equal(stream.content.length, 0, "no items are loaded by default");
+    assert.strictEqual(
+      stream.content.length,
+      0,
+      "no items are loaded by default"
+    );
     assert.blank(stream.content, "no content by default");
   });
 
@@ -24,8 +28,8 @@ module("Unit | Model | user-draft", function () {
       }),
     ];
 
-    assert.equal(drafts.length, 2, "drafts count is right");
-    assert.equal(
+    assert.strictEqual(drafts.length, 2, "drafts count is right");
+    assert.strictEqual(
       drafts[1].draftType,
       I18n.t("drafts.new_topic"),
       "loads correct draftType label"

--- a/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
@@ -32,7 +32,7 @@ module("Unit | Model | user-stream", function () {
     assert.strictEqual(stream.get("filterParam"), "4,5");
 
     stream.set("filter", UserAction.TYPES.topics);
-    assert.strictEqual(stream.get("filterParam"), "4");
+    assert.strictEqual(stream.get("filterParam"), 4);
 
     stream.set("filter", UserAction.TYPES.likes_given);
     assert.strictEqual(stream.get("filterParam"), UserAction.TYPES.likes_given);

--- a/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-stream-test.js
@@ -7,13 +7,13 @@ module("Unit | Model | user-stream", function () {
     let user = User.create({ id: 1, username: "eviltrout" });
     let stream = user.get("stream");
     assert.present(stream, "a user has a stream by default");
-    assert.equal(
+    assert.strictEqual(
       stream.get("user"),
       user,
       "the stream points back to the user"
     );
 
-    assert.equal(
+    assert.strictEqual(
       stream.get("itemsLoaded"),
       0,
       "no items are loaded by default"
@@ -29,15 +29,15 @@ module("Unit | Model | user-stream", function () {
     let stream = user.get("stream");
 
     // defaults to posts/topics
-    assert.equal(stream.get("filterParam"), "4,5");
+    assert.strictEqual(stream.get("filterParam"), "4,5");
 
     stream.set("filter", UserAction.TYPES.topics);
-    assert.equal(stream.get("filterParam"), "4");
+    assert.strictEqual(stream.get("filterParam"), "4");
 
     stream.set("filter", UserAction.TYPES.likes_given);
-    assert.equal(stream.get("filterParam"), UserAction.TYPES.likes_given);
+    assert.strictEqual(stream.get("filterParam"), UserAction.TYPES.likes_given);
 
     stream.set("filter", UserAction.TYPES.replies);
-    assert.equal(stream.get("filterParam"), "6,9");
+    assert.strictEqual(stream.get("filterParam"), "6,9");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -105,7 +105,7 @@ module("Unit | Model | user", function () {
     let otherUser = User.create({ username: "howardhamlin", id: 999 });
     assert.strictEqual(
       otherUser.resolvedTimezone(user),
-      null,
+      undefined,
       "if the user has no timezone and the user is not the current user, do NOT guess with moment"
     );
     assert.not(

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -45,7 +45,7 @@ module("Unit | Model | user", function () {
     let user = User.create({ admin: true });
     let group = Group.create({ automatic: true });
 
-    assert.equal(
+    assert.strictEqual(
       user.canManageGroup(group),
       false,
       "automatic groups cannot be managed."
@@ -54,7 +54,7 @@ module("Unit | Model | user", function () {
     group.set("automatic", false);
     group.setProperties({ can_admin_group: true });
 
-    assert.equal(
+    assert.strictEqual(
       user.canManageGroup(group),
       true,
       "an admin should be able to manage the group"
@@ -63,7 +63,7 @@ module("Unit | Model | user", function () {
     user.set("admin", false);
     group.setProperties({ is_group_owner: true });
 
-    assert.equal(
+    assert.strictEqual(
       user.canManageGroup(group),
       true,
       "a group owner should be able to manage the group"
@@ -78,7 +78,7 @@ module("Unit | Model | user", function () {
     sinon.stub(ajaxlib.ajax);
     let spy = sinon.spy(ajaxlib, "ajax");
 
-    assert.equal(
+    assert.strictEqual(
       user.resolvedTimezone(user),
       tz,
       "if the user already has a timezone return it"
@@ -88,7 +88,7 @@ module("Unit | Model | user", function () {
       "if the user already has a timezone do not call AJAX update"
     );
     user = User.create({ username: "chuck", id: 111 });
-    assert.equal(
+    assert.strictEqual(
       user.resolvedTimezone(user),
       "America/Chicago",
       "if the user has no timezone guess it with moment"
@@ -103,7 +103,7 @@ module("Unit | Model | user", function () {
     );
 
     let otherUser = User.create({ username: "howardhamlin", id: 999 });
-    assert.equal(
+    assert.strictEqual(
       otherUser.resolvedTimezone(user),
       null,
       "if the user has no timezone and the user is not the current user, do NOT guess with moment"

--- a/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
@@ -25,16 +25,16 @@ discourseModule("Unit | Service | document-title", function (hooks) {
 
   test("it updates the document title", function (assert) {
     this.documentTitle.setTitle("Test Title");
-    assert.equal(document.title, "Test Title", "title is correct");
+    assert.strictEqual(document.title, "Test Title", "title is correct");
   });
 
   test("it doesn't display notification counts for anonymous users", function (assert) {
     this.documentTitle.setTitle("test notifications");
     this.documentTitle.updateNotificationCount(5);
-    assert.equal(document.title, "test notifications");
+    assert.strictEqual(document.title, "test notifications");
     this.documentTitle.setFocus(false);
     this.documentTitle.updateNotificationCount(6);
-    assert.equal(document.title, "test notifications");
+    assert.strictEqual(document.title, "test notifications");
   });
 
   test("it displays notification counts for logged in users", function (assert) {
@@ -42,12 +42,12 @@ discourseModule("Unit | Service | document-title", function (hooks) {
     this.documentTitle.currentUser.dynamic_favicon = false;
     this.documentTitle.setTitle("test notifications");
     this.documentTitle.updateNotificationCount(5);
-    assert.equal(document.title, "test notifications");
+    assert.strictEqual(document.title, "test notifications");
     this.documentTitle.setFocus(false);
     this.documentTitle.updateNotificationCount(6);
-    assert.equal(document.title, "(6) test notifications");
+    assert.strictEqual(document.title, "(6) test notifications");
     this.documentTitle.setFocus(true);
-    assert.equal(document.title, "test notifications");
+    assert.strictEqual(document.title, "test notifications");
   });
 
   test("it doesn't display notification counts for users in do not disturb", function (assert) {
@@ -60,25 +60,25 @@ discourseModule("Unit | Service | document-title", function (hooks) {
     this.documentTitle.currentUser.dynamic_favicon = false;
     this.documentTitle.setTitle("test notifications");
     this.documentTitle.updateNotificationCount(5);
-    assert.equal(document.title, "test notifications");
+    assert.strictEqual(document.title, "test notifications");
     this.documentTitle.setFocus(false);
     this.documentTitle.updateNotificationCount(6);
-    assert.equal(document.title, "test notifications");
+    assert.strictEqual(document.title, "test notifications");
   });
 
   test("it doesn't increment background context counts when focused", function (assert) {
     this.documentTitle.setTitle("background context");
     this.documentTitle.setFocus(true);
     this.documentTitle.incrementBackgroundContextCount();
-    assert.equal(document.title, "background context");
+    assert.strictEqual(document.title, "background context");
   });
 
   test("it increments background context counts when not focused", function (assert) {
     this.documentTitle.setTitle("background context");
     this.documentTitle.setFocus(false);
     this.documentTitle.incrementBackgroundContextCount();
-    assert.equal(document.title, "(1) background context");
+    assert.strictEqual(document.title, "(1) background context");
     this.documentTitle.setFocus(true);
-    assert.equal(document.title, "background context");
+    assert.strictEqual(document.title, "background context");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/services/presence-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/presence-test.js
@@ -196,8 +196,8 @@ acceptance("Presence - Subscribing", function (needs) {
       false,
       "channelDup is not subscribed"
     );
-    assert.strictEqual(channelDup.count, null, "channelDup has no count");
-    assert.strictEqual(channelDup.users, null, "channelDup has users");
+    assert.strictEqual(channelDup.count, undefined, "channelDup has no count");
+    assert.strictEqual(channelDup.users, undefined, "channelDup has users");
 
     await channelDup.subscribe();
     assert.strictEqual(channelDup.subscribed, true, "channelDup can subscribe");

--- a/app/assets/javascripts/discourse/tests/unit/services/presence-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/presence-test.js
@@ -58,14 +58,14 @@ acceptance("Presence - Subscribing", function (needs) {
   test("subscribing and receiving updates", async function (assert) {
     let presenceService = this.container.lookup("service:presence");
     let channel = presenceService.getChannel("/test/ch1");
-    assert.equal(channel.name, "/test/ch1");
+    assert.strictEqual(channel.name, "/test/ch1");
 
     await channel.subscribe({
       users: usersFixture(),
       last_message_id: 1,
     });
 
-    assert.equal(channel.users.length, 3, "it starts with three users");
+    assert.strictEqual(channel.users.length, 3, "it starts with three users");
 
     publishToMessageBus(
       "/presence/test/ch1",
@@ -76,7 +76,7 @@ acceptance("Presence - Subscribing", function (needs) {
       2
     );
 
-    assert.equal(channel.users.length, 2, "one user is removed");
+    assert.strictEqual(channel.users.length, 2, "one user is removed");
 
     publishToMessageBus(
       "/presence/test/ch1",
@@ -87,7 +87,7 @@ acceptance("Presence - Subscribing", function (needs) {
       3
     );
 
-    assert.equal(channel.users.length, 3, "one user is added");
+    assert.strictEqual(channel.users.length, 3, "one user is added");
   });
 
   test("fetches data when no initial state", async function (assert) {
@@ -96,7 +96,7 @@ acceptance("Presence - Subscribing", function (needs) {
 
     await channel.subscribe();
 
-    assert.equal(channel.users.length, 3, "loads initial state");
+    assert.strictEqual(channel.users.length, 3, "loads initial state");
 
     publishToMessageBus(
       "/presence/test/ch1",
@@ -107,7 +107,7 @@ acceptance("Presence - Subscribing", function (needs) {
       2
     );
 
-    assert.equal(
+    assert.strictEqual(
       channel.users.length,
       2,
       "updates following messagebus message"
@@ -124,7 +124,7 @@ acceptance("Presence - Subscribing", function (needs) {
 
     await channel._presenceState._resubscribePromise;
 
-    assert.equal(
+    assert.strictEqual(
       channel.users.length,
       3,
       "detects missed messagebus message, fetches data from server"
@@ -148,9 +148,9 @@ acceptance("Presence - Subscribing", function (needs) {
 
     await channel.subscribe();
 
-    assert.equal(channel.count, 3, "has the correct count");
-    assert.equal(channel.countOnly, true, "identifies as countOnly");
-    assert.equal(channel.users, null, "has null users list");
+    assert.strictEqual(channel.count, 3, "has the correct count");
+    assert.strictEqual(channel.countOnly, true, "identifies as countOnly");
+    assert.strictEqual(channel.users, null, "has null users list");
 
     publishToMessageBus(
       "/presence/countonly/ch1",
@@ -161,7 +161,7 @@ acceptance("Presence - Subscribing", function (needs) {
       2
     );
 
-    assert.equal(channel.count, 4, "updates the count via messagebus");
+    assert.strictEqual(channel.count, 4, "updates the count via messagebus");
 
     publishToMessageBus(
       "/presence/countonly/ch1",
@@ -174,7 +174,7 @@ acceptance("Presence - Subscribing", function (needs) {
 
     await channel._presenceState._resubscribePromise;
 
-    assert.equal(
+    assert.strictEqual(
       channel.count,
       3,
       "resubscribes when receiving a non-count-only message"
@@ -187,37 +187,45 @@ acceptance("Presence - Subscribing", function (needs) {
     let channelDup = presenceService.getChannel("/test/ch1");
 
     await channel.subscribe();
-    assert.equal(channel.subscribed, true, "channel is subscribed");
-    assert.equal(channel.count, 3, "channel has the correct count");
-    assert.equal(channel.users.length, 3, "channel has users");
+    assert.strictEqual(channel.subscribed, true, "channel is subscribed");
+    assert.strictEqual(channel.count, 3, "channel has the correct count");
+    assert.strictEqual(channel.users.length, 3, "channel has users");
 
-    assert.equal(channelDup.subscribed, false, "channelDup is not subscribed");
-    assert.equal(channelDup.count, null, "channelDup has no count");
-    assert.equal(channelDup.users, null, "channelDup has users");
+    assert.strictEqual(
+      channelDup.subscribed,
+      false,
+      "channelDup is not subscribed"
+    );
+    assert.strictEqual(channelDup.count, null, "channelDup has no count");
+    assert.strictEqual(channelDup.users, null, "channelDup has users");
 
     await channelDup.subscribe();
-    assert.equal(channelDup.subscribed, true, "channelDup can subscribe");
+    assert.strictEqual(channelDup.subscribed, true, "channelDup can subscribe");
     assert.ok(
       channelDup._presenceState,
       "channelDup has a valid internal state"
     );
-    assert.equal(
+    assert.strictEqual(
       channelDup._presenceState,
       channel._presenceState,
       "internal state is shared"
     );
 
     await channel.unsubscribe();
-    assert.equal(channel.subscribed, false, "channel can unsubscribe");
-    assert.equal(
+    assert.strictEqual(channel.subscribed, false, "channel can unsubscribe");
+    assert.strictEqual(
       channelDup._presenceState,
       channel._presenceState,
       "state is maintained"
     );
 
     await channelDup.unsubscribe();
-    assert.equal(channel.subscribed, false, "channelDup can unsubscribe");
-    assert.equal(channelDup._presenceState, undefined, "state is cleared");
+    assert.strictEqual(channel.subscribed, false, "channelDup can unsubscribe");
+    assert.strictEqual(
+      channelDup._presenceState,
+      undefined,
+      "state is cleared"
+    );
   });
 });
 
@@ -250,7 +258,7 @@ acceptance("Presence - Entering and Leaving", function (needs) {
     const channel = presenceService.getChannel("/test/ch1");
 
     await channel.enter();
-    assert.equal(requests.length, 1, "updated the server for enter");
+    assert.strictEqual(requests.length, 1, "updated the server for enter");
     let presentChannels = requests.pop().getAll("present_channels[]");
     assert.deepEqual(
       presentChannels,
@@ -259,7 +267,7 @@ acceptance("Presence - Entering and Leaving", function (needs) {
     );
 
     await channel.leave();
-    assert.equal(requests.length, 1, "updated the server for leave");
+    assert.strictEqual(requests.length, 1, "updated the server for leave");
     const request = requests.pop();
     presentChannels = request.getAll("present_channels[]");
     const leaveChannels = request.getAll("leave_channels[]");
@@ -287,32 +295,32 @@ acceptance("Presence - Entering and Leaving", function (needs) {
     const channelDup = presenceService.getChannel("/test/ch1");
 
     await channel.enter();
-    assert.equal(channel.present, true, "channel is present");
-    assert.equal(channelDup.present, false, "channelDup is absent");
+    assert.strictEqual(channel.present, true, "channel is present");
+    assert.strictEqual(channelDup.present, false, "channelDup is absent");
     assert.ok(
       presenceService._presentChannels.has("/test/ch1"),
       "service shows present"
     );
 
     await channelDup.enter();
-    assert.equal(channel.present, true, "channel is present");
-    assert.equal(channelDup.present, true, "channelDup is present");
+    assert.strictEqual(channel.present, true, "channel is present");
+    assert.strictEqual(channelDup.present, true, "channelDup is present");
     assert.ok(
       presenceService._presentChannels.has("/test/ch1"),
       "service shows present"
     );
 
     await channel.leave();
-    assert.equal(channel.present, false, "channel is absent");
-    assert.equal(channelDup.present, true, "channelDup is present");
+    assert.strictEqual(channel.present, false, "channel is absent");
+    assert.strictEqual(channelDup.present, true, "channelDup is present");
     assert.ok(
       presenceService._presentChannels.has("/test/ch1"),
       "service shows present"
     );
 
     await channelDup.leave();
-    assert.equal(channel.present, false, "channel is absent");
-    assert.equal(channel.present, false, "channelDup is absent");
+    assert.strictEqual(channel.present, false, "channel is absent");
+    assert.strictEqual(channel.present, false, "channelDup is absent");
     assert.notOk(
       presenceService._presentChannels.has("/test/ch1"),
       "service shows absent"

--- a/app/assets/javascripts/discourse/tests/unit/services/store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/store-test.js
@@ -7,8 +7,8 @@ module("Unit | Service | store", function () {
     const widget = store.createRecord("widget", { id: 111, name: "hello" });
 
     assert.ok(!widget.get("isNew"), "it is not a new record");
-    assert.equal(widget.get("name"), "hello");
-    assert.equal(widget.get("id"), 111);
+    assert.strictEqual(widget.get("name"), "hello");
+    assert.strictEqual(widget.get("id"), 111);
   });
 
   test("createRecord without an `id`", function (assert) {
@@ -26,9 +26,9 @@ module("Unit | Service | store", function () {
     const obj = { id: 1, name: "something" };
 
     const other = store.createRecord("widget", obj);
-    assert.equal(widget, other, "returns the same record");
-    assert.equal(widget.name, "something", "it updates the properties");
-    assert.equal(obj.id, 1, "it does not remove the id from the input");
+    assert.strictEqual(widget, other, "returns the same record");
+    assert.strictEqual(widget.name, "something", "it updates the properties");
+    assert.strictEqual(obj.id, 1, "it does not remove the id from the input");
   });
 
   test("createRecord without attributes", function (assert) {
@@ -44,17 +44,17 @@ module("Unit | Service | store", function () {
     const widget = store.createRecord("widget", { id: 33 });
     const secondWidget = store.createRecord("widget", { id: 33 });
 
-    assert.equal(widget, secondWidget, "they should be the same");
+    assert.strictEqual(widget, secondWidget, "they should be the same");
   });
 
   test("find", async function (assert) {
     const store = createStore();
 
     const widget = await store.find("widget", 123);
-    assert.equal(widget.get("name"), "Trout Lure");
-    assert.equal(widget.get("id"), 123);
+    assert.strictEqual(widget.get("name"), "Trout Lure");
+    assert.strictEqual(widget.get("id"), 123);
     assert.ok(!widget.get("isNew"), "found records are not new");
-    assert.equal(
+    assert.strictEqual(
       widget.get("extras.hello"),
       "world",
       "extra attributes are set"
@@ -62,8 +62,8 @@ module("Unit | Service | store", function () {
 
     // A second find by id returns the same object
     const widget2 = await store.find("widget", 123);
-    assert.equal(widget, widget2);
-    assert.equal(
+    assert.strictEqual(widget, widget2);
+    assert.strictEqual(
       widget.get("extras.hello"),
       "world",
       "extra attributes are set"
@@ -73,13 +73,13 @@ module("Unit | Service | store", function () {
   test("find with object id", async function (assert) {
     const store = createStore();
     const widget = await store.find("widget", { id: 123 });
-    assert.equal(widget.get("firstObject.name"), "Trout Lure");
+    assert.strictEqual(widget.get("firstObject.name"), "Trout Lure");
   });
 
   test("find with query param", async function (assert) {
     const store = createStore();
     const widget = await store.find("widget", { name: "Trout Lure" });
-    assert.equal(widget.get("firstObject.id"), 123);
+    assert.strictEqual(widget.get("firstObject.id"), 123);
   });
 
   test("findStale with no stale results", async function (assert) {
@@ -89,7 +89,7 @@ module("Unit | Service | store", function () {
     assert.ok(!stale.hasResults, "there are no stale results");
     assert.ok(!stale.results, "results are present");
     const widget = await stale.refresh();
-    assert.equal(
+    assert.strictEqual(
       widget.get("firstObject.id"),
       123,
       "a `refresh()` method provides results for stale"
@@ -106,17 +106,17 @@ module("Unit | Service | store", function () {
     const store = createStore();
     const result = await store.update("cool-thing", 123, { name: "hello" });
     assert.ok(result);
-    assert.equal(result.payload.name, "hello");
+    assert.strictEqual(result.payload.name, "hello");
   });
 
   test("findAll", async function (assert) {
     const store = createStore();
     const result = await store.findAll("widget");
-    assert.equal(result.get("length"), 2);
+    assert.strictEqual(result.get("length"), 2);
 
     const widget = result.findBy("id", 124);
     assert.ok(!widget.get("isNew"), "found records are not new");
-    assert.equal(widget.get("name"), "Evil Repellant");
+    assert.strictEqual(widget.get("name"), "Evil Repellant");
   });
 
   test("destroyRecord", async function (assert) {
@@ -139,9 +139,9 @@ module("Unit | Service | store", function () {
     assert.ok(fruit.get("farmer"), "it has the embedded object");
 
     const fruitCols = fruit.get("colors");
-    assert.equal(fruitCols.length, 2);
-    assert.equal(fruitCols[0].get("id"), 1);
-    assert.equal(fruitCols[1].get("id"), 2);
+    assert.strictEqual(fruitCols.length, 2);
+    assert.strictEqual(fruitCols[0].get("id"), 1);
+    assert.strictEqual(fruitCols[1].get("id"), 2);
   });
 
   test("embedded records can be cleared", async function (assert) {
@@ -156,7 +156,7 @@ module("Unit | Service | store", function () {
   test("meta types", async function (assert) {
     const store = createStore();
     const barn = await store.find("barn", 1);
-    assert.equal(
+    assert.strictEqual(
       barn.get("owner.name"),
       "Old MacDonald",
       "it has the embedded farmer"
@@ -166,29 +166,29 @@ module("Unit | Service | store", function () {
   test("findAll embedded", async function (assert) {
     const store = createStore();
     const fruits = await store.findAll("fruit");
-    assert.equal(fruits.objectAt(0).get("farmer.name"), "Old MacDonald");
-    assert.equal(
+    assert.strictEqual(fruits.objectAt(0).get("farmer.name"), "Old MacDonald");
+    assert.strictEqual(
       fruits.objectAt(0).get("farmer"),
       fruits.objectAt(1).get("farmer"),
       "points at the same object"
     );
-    assert.equal(
+    assert.strictEqual(
       fruits.get("extras.hello"),
       "world",
       "it can supply extra information"
     );
 
     const fruitCols = fruits.objectAt(0).get("colors");
-    assert.equal(fruitCols.length, 2);
-    assert.equal(fruitCols[0].get("id"), 1);
-    assert.equal(fruitCols[1].get("id"), 2);
+    assert.strictEqual(fruitCols.length, 2);
+    assert.strictEqual(fruitCols[0].get("id"), 1);
+    assert.strictEqual(fruitCols[1].get("id"), 2);
 
-    assert.equal(fruits.objectAt(2).get("farmer.name"), "Luke Skywalker");
+    assert.strictEqual(fruits.objectAt(2).get("farmer.name"), "Luke Skywalker");
   });
 
   test("custom primaryKey", async function (assert) {
     const store = createStore();
     const cats = await store.findAll("cat");
-    assert.equal(cats.objectAt(0).name, "souna");
+    assert.strictEqual(cats.objectAt(0).name, "souna");
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
@@ -42,12 +42,12 @@ discourseModule("utils:decorators", function (hooks) {
 
     async test(assert) {
       assert.ok(exists(document.querySelector(".foo-component")));
-      assert.equal(this.baz, 1);
+      assert.strictEqual(this.baz, 1);
 
       await this.clearRender();
 
       assert.ok(!exists(document.querySelector(".foo-component")));
-      assert.equal(this.baz, 1);
+      assert.strictEqual(this.baz, 1);
     },
   });
 });

--- a/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
+++ b/app/assets/javascripts/wizard/test/acceptance/wizard-test.js
@@ -21,7 +21,7 @@ function exists(selector) {
 test("Wizard starts", async function (assert) {
   await visit("/");
   assert.ok(exists(".wizard-column-contents"));
-  assert.equal(currentRouteName(), "step");
+  assert.strictEqual(currentRouteName(), "step");
 });
 
 test("Going back and forth in steps", async function (assert) {

--- a/app/assets/javascripts/wizard/test/components/invite-list-test.js
+++ b/app/assets/javascripts/wizard/test/components/invite-list-test.js
@@ -21,7 +21,7 @@ componentTest("can add users", {
     );
 
     const firstVal = JSON.parse(this.get("field.value"));
-    assert.equal(firstVal.length, 0, "empty JSON at first");
+    assert.strictEqual(firstVal.length, 0, "empty JSON at first");
 
     assert.ok(
       this.get("field.warning"),
@@ -45,8 +45,8 @@ componentTest("can add users", {
     assert.ok(document.querySelectorAll(".new-user .invalid").length === 0);
 
     const val = JSON.parse(this.get("field.value"));
-    assert.equal(val.length, 1);
-    assert.equal(
+    assert.strictEqual(val.length, 1);
+    assert.strictEqual(
       val[0].email,
       "eviltrout@example.com",
       "adds the email to the JSON"

--- a/plugins/discourse-details/test/javascripts/acceptance/details-button-test.js.es6
+++ b/plugins/discourse-details/test/javascripts/acceptance/details-button-test.js.es6
@@ -21,7 +21,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.expand();
     await popupMenu.selectRowByValue("insertDetails");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       `\n[details="${I18n.t("composer.details_title")}"]\n${I18n.t(
         "composer.details_text"
@@ -38,7 +38,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.expand();
     await popupMenu.selectRowByValue("insertDetails");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       `\n[details="${I18n.t(
         "composer.details_title"
@@ -46,12 +46,12 @@ acceptance("Details Button", function (needs) {
       "it should contain the right selected output"
     );
 
-    assert.equal(
+    assert.strictEqual(
       textarea.selectionStart,
       21,
       "it should start highlighting at the right position"
     );
-    assert.equal(
+    assert.strictEqual(
       textarea.selectionEnd,
       37,
       "it should end highlighting at the right position"
@@ -65,7 +65,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.expand();
     await popupMenu.selectRowByValue("insertDetails");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       `Before \n[details="${I18n.t(
         "composer.details_title"
@@ -73,12 +73,12 @@ acceptance("Details Button", function (needs) {
       "it should contain the right output"
     );
 
-    assert.equal(
+    assert.strictEqual(
       textarea.selectionStart,
       28,
       "it should start highlighting at the right position"
     );
-    assert.equal(
+    assert.strictEqual(
       textarea.selectionEnd,
       48,
       "it should end highlighting at the right position"
@@ -92,7 +92,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.expand();
     await popupMenu.selectRowByValue("insertDetails");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       `Before \n\n[details="${I18n.t(
         "composer.details_title"
@@ -100,12 +100,12 @@ acceptance("Details Button", function (needs) {
       "it should contain the right output"
     );
 
-    assert.equal(
+    assert.strictEqual(
       textarea.selectionStart,
       29,
       "it should start highlighting at the right position"
     );
-    assert.equal(
+    assert.strictEqual(
       textarea.selectionEnd,
       49,
       "it should end highlighting at the right position"
@@ -127,7 +127,7 @@ acceptance("Details Button", function (needs) {
     await popupMenu.expand();
     await popupMenu.selectRowByValue("insertDetails");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       `\n[details="${I18n.t(
         "composer.details_title"

--- a/plugins/discourse-details/test/javascripts/lib/details-cooked-test.js.es6
+++ b/plugins/discourse-details/test/javascripts/lib/details-cooked-test.js.es6
@@ -16,7 +16,7 @@ const defaultOpts = buildOptions({
 
 test("details", function (assert) {
   const cooked = (input, expected, text) => {
-    assert.equal(
+    assert.strictEqual(
       new PrettyText(defaultOpts).cook(input),
       expected.replace(/\/>/g, ">"),
       text

--- a/plugins/discourse-local-dates/test/javascripts/acceptance/download-calendar-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/download-calendar-test.js.es6
@@ -30,7 +30,7 @@ acceptance(
 
       await click(".discourse-local-date");
       await click(document.querySelector(".download-calendar"));
-      assert.equal(
+      assert.strictEqual(
         query("#discourse-modal-title").textContent.trim(),
         I18n.t("download_calendar.title"),
         "it should display modal to select calendar"

--- a/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js.es6
@@ -20,25 +20,29 @@ acceptance("Local Dates - composer", function (needs) {
       '[date=2017-10-23 time=01:30:00 displayedTimezone="America/Chicago" format="LLLL" calendar="off" recurring="1.weeks" timezone=" Asia/Calcutta" timezones="Europe/Paris|America/Los_Angeles"]'
     );
 
-    assert.equal(getAttr("date"), "2017-10-23", "it has the correct date");
-    assert.equal(getAttr("time"), "01:30:00", "it has the correct time");
-    assert.equal(
+    assert.strictEqual(
+      getAttr("date"),
+      "2017-10-23",
+      "it has the correct date"
+    );
+    assert.strictEqual(getAttr("time"), "01:30:00", "it has the correct time");
+    assert.strictEqual(
       getAttr("displayed-timezone"),
       "America/Chicago",
       "it has the correct displayed timezone"
     );
-    assert.equal(getAttr("format"), "LLLL", "it has the correct format");
-    assert.equal(
+    assert.strictEqual(getAttr("format"), "LLLL", "it has the correct format");
+    assert.strictEqual(
       getAttr("timezones"),
       "Europe/Paris|America/Los_Angeles",
       "it has the correct timezones"
     );
-    assert.equal(
+    assert.strictEqual(
       getAttr("recurring"),
       "1.weeks",
       "it has the correct recurring"
     );
-    assert.equal(
+    assert.strictEqual(
       getAttr("timezone"),
       "Asia/Calcutta",
       "it has the correct timezone"
@@ -49,7 +53,11 @@ acceptance("Local Dates - composer", function (needs) {
       '[date=2017-10-24 format="LL" timezone="Asia/Calcutta" timezones="Europe/Paris|America/Los_Angeles"]'
     );
 
-    assert.equal(getAttr("date"), "2017-10-24", "it has the correct date");
+    assert.strictEqual(
+      getAttr("date"),
+      "2017-10-24",
+      "it has the correct date"
+    );
     assert.notOk(getAttr("time"), "it doesn’t have time");
   });
 });

--- a/plugins/discourse-local-dates/test/javascripts/lib/date-with-zone-helper-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/date-with-zone-helper-test.js.es6
@@ -26,7 +26,7 @@ test("#format", function (assert) {
     minute: 36,
     timezone: PARIS,
   });
-  assert.equal(date.format(), "2020-03-15T15:36:00.000+01:00");
+  assert.strictEqual(date.format(), "2020-03-15T15:36:00.000+01:00");
 });
 
 test("#unitRepetitionsBetweenDates", function (assert) {
@@ -39,7 +39,7 @@ test("#unitRepetitionsBetweenDates", function (assert) {
     minute: 36,
     timezone: PARIS,
   });
-  assert.equal(
+  assert.strictEqual(
     date.unitRepetitionsBetweenDates(
       "1.hour",
       moment.tz("2020-02-15 15:36", SYDNEY)
@@ -55,7 +55,7 @@ test("#unitRepetitionsBetweenDates", function (assert) {
     minute: 36,
     timezone: PARIS,
   });
-  assert.equal(
+  assert.strictEqual(
     date.unitRepetitionsBetweenDates(
       "1.minute",
       moment.tz("2020-02-15 15:36", PARIS)
@@ -71,7 +71,7 @@ test("#unitRepetitionsBetweenDates", function (assert) {
     minute: 36,
     timezone: PARIS,
   });
-  assert.equal(
+  assert.strictEqual(
     date.unitRepetitionsBetweenDates(
       "1.minute",
       moment.tz("2020-02-15 15:37", PARIS)
@@ -87,7 +87,7 @@ test("#unitRepetitionsBetweenDates", function (assert) {
     minute: 36,
     timezone: PARIS,
   });
-  assert.equal(
+  assert.strictEqual(
     date.unitRepetitionsBetweenDates(
       "2.minutes",
       moment.tz("2020-02-15 15:41", PARIS)
@@ -112,7 +112,7 @@ test("#add", function (assert) {
   assert.notOk(date.isDST());
   futureLocalDate = date.add(8, "months");
   assert.notOk(futureLocalDate.isDST());
-  assert.equal(
+  assert.strictEqual(
     futureLocalDate.format(),
     "2020-11-19T15:36:00.000+01:00",
     "it correctly adds from a !isDST date to a !isDST date"
@@ -128,7 +128,7 @@ test("#add", function (assert) {
   assert.ok(date.isDST());
   futureLocalDate = date.add(1, "year");
   assert.ok(futureLocalDate.isDST());
-  assert.equal(
+  assert.strictEqual(
     futureLocalDate.format(),
     "2021-04-25T15:36:00.000+02:00",
     "it correctly adds from a isDST date to a isDST date"
@@ -144,7 +144,7 @@ test("#add", function (assert) {
   assert.notOk(date.isDST());
   futureLocalDate = date.add(1, "week");
   assert.ok(futureLocalDate.isDST());
-  assert.equal(
+  assert.strictEqual(
     futureLocalDate.format(),
     "2020-04-01T15:36:00.000+02:00",
     "it correctly adds from a !isDST date to a isDST date"
@@ -161,7 +161,7 @@ test("#add", function (assert) {
   assert.ok(date.isDST());
   futureLocalDate = date.add(8, "months");
   assert.notOk(futureLocalDate.isDST());
-  assert.equal(
+  assert.strictEqual(
     futureLocalDate.format(),
     "2020-12-01T15:36:00.000+01:00",
     "it correctly adds from a isDST date to a !isDST date"

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js.es6
@@ -47,7 +47,7 @@ QUnit.assert.buildsCorrectDate = function (options, expected, message) {
   );
 
   if (expected.formated) {
-    this.test.assert.equal(
+    this.test.assert.strictEqual(
       localDateBuilder.build().formated,
       expected.formated,
       message || "it formates the date correctly"

--- a/plugins/discourse-presence/test/javascripts/acceptance/discourse-presence-test.js
+++ b/plugins/discourse-presence/test/javascripts/acceptance/discourse-presence-test.js
@@ -27,7 +27,7 @@ acceptance("Discourse Presence Plugin", function (needs) {
     );
     await click("#reply-control button.create");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/t/internationalization-localization/280",
       "it transitions to the newly created topic URL"
@@ -81,7 +81,7 @@ acceptance("Discourse Presence Plugin", function (needs) {
     await menu.expand();
     await menu.selectRowByValue("toggleWhisper");
 
-    assert.equal(
+    assert.strictEqual(
       count(".composer-actions svg.d-icon-far-eye-slash"),
       1,
       "it sets the post type to whisper"
@@ -114,7 +114,7 @@ acceptance("Discourse Presence Plugin", function (needs) {
     await click(".topic-post:nth-of-type(1) button.show-more-actions");
     await click(".topic-post:nth-of-type(1) button.edit");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".d-editor-input").val(),
       queryAll(".topic-post:nth-of-type(1) .cooked > p").text(),
       "composer has contents of post to be edited"
@@ -156,7 +156,7 @@ acceptance("Discourse Presence Plugin", function (needs) {
       exists(".topic-above-footer-buttons-outlet.presence"),
       "includes the presence component"
     );
-    assert.equal(count(avatarSelector), 0, "no avatars displayed");
+    assert.strictEqual(count(avatarSelector), 0, "no avatars displayed");
 
     await joinChannel("/discourse-presence/reply/280", {
       id: 123,
@@ -164,7 +164,7 @@ acceptance("Discourse Presence Plugin", function (needs) {
       username: "myusername",
     });
 
-    assert.equal(count(avatarSelector), 1, "avatar displayed");
+    assert.strictEqual(count(avatarSelector), 1, "avatar displayed");
 
     await joinChannel("/discourse-presence/whisper/280", {
       id: 124,
@@ -172,19 +172,19 @@ acceptance("Discourse Presence Plugin", function (needs) {
       username: "myusername2",
     });
 
-    assert.equal(count(avatarSelector), 2, "whisper avatar displayed");
+    assert.strictEqual(count(avatarSelector), 2, "whisper avatar displayed");
 
     await leaveChannel("/discourse-presence/reply/280", {
       id: 123,
     });
 
-    assert.equal(count(avatarSelector), 1, "reply avatar removed");
+    assert.strictEqual(count(avatarSelector), 1, "reply avatar removed");
 
     await leaveChannel("/discourse-presence/whisper/280", {
       id: 124,
     });
 
-    assert.equal(count(avatarSelector), 0, "whisper avatar removed");
+    assert.strictEqual(count(avatarSelector), 0, "whisper avatar removed");
   });
 
   test("Displays replying and whispering presence in composer", async function (assert) {
@@ -198,7 +198,7 @@ acceptance("Discourse Presence Plugin", function (needs) {
       exists(".composer-fields-outlet.presence"),
       "includes the presence component"
     );
-    assert.equal(count(avatarSelector), 0, "no avatars displayed");
+    assert.strictEqual(count(avatarSelector), 0, "no avatars displayed");
 
     await joinChannel("/discourse-presence/reply/280", {
       id: 123,
@@ -206,7 +206,7 @@ acceptance("Discourse Presence Plugin", function (needs) {
       username: "myusername",
     });
 
-    assert.equal(count(avatarSelector), 1, "avatar displayed");
+    assert.strictEqual(count(avatarSelector), 1, "avatar displayed");
 
     await joinChannel("/discourse-presence/whisper/280", {
       id: 124,
@@ -214,18 +214,18 @@ acceptance("Discourse Presence Plugin", function (needs) {
       username: "myusername2",
     });
 
-    assert.equal(count(avatarSelector), 2, "whisper avatar displayed");
+    assert.strictEqual(count(avatarSelector), 2, "whisper avatar displayed");
 
     await leaveChannel("/discourse-presence/reply/280", {
       id: 123,
     });
 
-    assert.equal(count(avatarSelector), 1, "reply avatar removed");
+    assert.strictEqual(count(avatarSelector), 1, "reply avatar removed");
 
     await leaveChannel("/discourse-presence/whisper/280", {
       id: 124,
     });
 
-    assert.equal(count(avatarSelector), 0, "whisper avatar removed");
+    assert.strictEqual(count(avatarSelector), 0, "whisper avatar removed");
   });
 });

--- a/plugins/poll/test/javascripts/acceptance/poll-breakdown-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-breakdown-test.js.es6
@@ -76,7 +76,7 @@ acceptance("Poll breakdown", function (needs) {
 
     assert.ok(exists(".poll-breakdown-total-votes"), "displays the vote count");
 
-    assert.equal(
+    assert.strictEqual(
       count(".poll-breakdown-chart-container"),
       2,
       "renders a chart for each of the groups in group_results response"
@@ -92,7 +92,7 @@ acceptance("Poll breakdown", function (needs) {
     await visit("/t/-/topic_with_pie_chart_poll");
     await click(".poll-show-breakdown");
 
-    assert.equal(
+    assert.strictEqual(
       query(".poll-breakdown-option-count").textContent.trim(),
       "40.0%",
       "displays the correct vote percentage"
@@ -100,7 +100,7 @@ acceptance("Poll breakdown", function (needs) {
 
     await click(".modal-tabs .count");
 
-    assert.equal(
+    assert.strictEqual(
       query(".poll-breakdown-option-count").textContent.trim(),
       "2",
       "displays the correct vote count"
@@ -108,7 +108,7 @@ acceptance("Poll breakdown", function (needs) {
 
     await click(".modal-tabs .percentage");
 
-    assert.equal(
+    assert.strictEqual(
       query(".poll-breakdown-option-count").textContent.trim(),
       "40.0%",
       "displays the percentage again"

--- a/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-pie-chart-test.js.es6
@@ -18,25 +18,25 @@ acceptance("Rendering polls with pie charts", function (needs) {
 
     const poll = query(".poll");
 
-    assert.equal(
+    assert.strictEqual(
       query(".info-number", poll).innerHTML,
       "2",
       "it should display the right number of voters"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".info-number", poll)[1].innerHTML,
       "5",
       "it should display the right number of votes"
     );
 
-    assert.equal(
+    assert.strictEqual(
       poll.classList.contains("pie"),
       true,
       "pie class is present on poll div"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".poll-results-chart", poll).length,
       1,
       "Renders the chart div instead of bar container"

--- a/plugins/poll/test/javascripts/acceptance/poll-quote-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-quote-test.js.es6
@@ -432,7 +432,7 @@ acceptance("Poll quote", function (needs) {
   test("renders and extends", async function (assert) {
     await visit("/t/-/topic_with_two_quoted_polls");
     await click(".quote-controls");
-    assert.equal(count(".poll"), 2, "polls are rendered");
-    assert.equal(count(".poll-buttons"), 2, "polls are extended");
+    assert.strictEqual(count(".poll"), 2, "polls are rendered");
+    assert.strictEqual(count(".poll-buttons"), 2, "polls are extended");
   });
 });

--- a/plugins/poll/test/javascripts/acceptance/poll-results-test.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/poll-results-test.js.es6
@@ -567,11 +567,11 @@ acceptance("Poll results", function (needs) {
   test("can load more voters", async function (assert) {
     await visit("/t/-/load-more-poll-voters");
 
-    assert.equal(
+    assert.strictEqual(
       find(".poll-container .results li:nth-child(1) .poll-voters li").length,
       1
     );
-    assert.equal(
+    assert.strictEqual(
       find(".poll-container .results li:nth-child(2) .poll-voters li").length,
       0
     );
@@ -626,11 +626,11 @@ acceptance("Poll results", function (needs) {
     });
     await visit("/t/-/load-more-poll-voters");
 
-    assert.equal(
+    assert.strictEqual(
       find(".poll-container .results li:nth-child(1) .poll-voters li").length,
       1
     );
-    assert.equal(
+    assert.strictEqual(
       find(".poll-container .results li:nth-child(2) .poll-voters li").length,
       1
     );
@@ -638,11 +638,11 @@ acceptance("Poll results", function (needs) {
     await click(".poll-voters-toggle-expand a");
     await visit("/t/-/load-more-poll-voters");
 
-    assert.equal(
+    assert.strictEqual(
       find(".poll-container .results li:nth-child(1) .poll-voters li").length,
       2
     );
-    assert.equal(
+    assert.strictEqual(
       find(".poll-container .results li:nth-child(2) .poll-voters li").length,
       0
     );
@@ -652,13 +652,13 @@ acceptance("Poll results", function (needs) {
     await visit("/t/-/load-more-poll-voters");
     await click(".toggle-results");
 
-    assert.equal(count(".poll-container .d-icon-circle"), 1);
-    assert.equal(count(".poll-container .d-icon-far-circle"), 1);
+    assert.strictEqual(count(".poll-container .d-icon-circle"), 1);
+    assert.strictEqual(count(".poll-container .d-icon-far-circle"), 1);
 
     await click(".remove-vote");
 
-    assert.equal(count(".poll-container .d-icon-circle"), 0);
-    assert.equal(count(".poll-container .d-icon-far-circle"), 2);
+    assert.strictEqual(count(".poll-container .d-icon-circle"), 0);
+    assert.strictEqual(count(".poll-container .d-icon-far-circle"), 2);
   });
 });
 

--- a/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-desktop.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-desktop.js.es6
@@ -46,15 +46,15 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
 
     const polls = queryAll(".poll");
 
-    assert.equal(polls.length, 2, "it should render the polls correctly");
+    assert.strictEqual(polls.length, 2, "it should render the polls correctly");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".info-number", polls[0]).text(),
       "2",
       "it should display the right number of votes"
     );
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".info-number", polls[1]).text(),
       "3",
       "it should display the right number of votes"
@@ -65,11 +65,11 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
     await visit("/t/-/14");
 
     const polls = queryAll(".poll");
-    assert.equal(polls.length, 1, "it should render the poll correctly");
+    assert.strictEqual(polls.length, 1, "it should render the poll correctly");
 
     await click("button.toggle-results");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".poll-voters:nth-of-type(1) li").length,
       25,
       "it should display the right number of voters"
@@ -77,7 +77,7 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
 
     await click(".poll-voters-toggle-expand:nth-of-type(1) a");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".poll-voters:nth-of-type(1) li").length,
       26,
       "it should display the right number of voters"
@@ -88,11 +88,11 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
     await visit("/t/-/13");
 
     const polls = queryAll(".poll");
-    assert.equal(polls.length, 1, "it should render the poll correctly");
+    assert.strictEqual(polls.length, 1, "it should render the poll correctly");
 
     await click("button.toggle-results");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".poll-voters:nth-of-type(1) li").length,
       25,
       "it should display the right number of voters"
@@ -105,7 +105,7 @@ acceptance("Rendering polls with bar charts - desktop", function (needs) {
 
     await click(".poll-voters-toggle-expand:nth-of-type(1) a");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".poll-voters:nth-of-type(1) li").length,
       30,
       "it should display the right number of voters"

--- a/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-mobile.js.es6
+++ b/plugins/poll/test/javascripts/acceptance/polls-bar-chart-test-mobile.js.es6
@@ -27,11 +27,11 @@ acceptance("Rendering polls with bar charts - mobile", function (needs) {
     await visit("/t/-/13");
 
     const polls = queryAll(".poll");
-    assert.equal(polls.length, 1, "it should render the poll correctly");
+    assert.strictEqual(polls.length, 1, "it should render the poll correctly");
 
     await click("button.toggle-results");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".poll-voters:nth-of-type(1) li").length,
       25,
       "it should display the right number of voters"
@@ -44,7 +44,7 @@ acceptance("Rendering polls with bar charts - mobile", function (needs) {
 
     await click(".poll-voters-toggle-expand:nth-of-type(1) a");
 
-    assert.equal(
+    assert.strictEqual(
       queryAll(".poll-voters:nth-of-type(1) li").length,
       35,
       "it should display the right number of voters"

--- a/plugins/poll/test/javascripts/controllers/poll-ui-builder-test.js.es6
+++ b/plugins/poll/test/javascripts/controllers/poll-ui-builder-test.js.es6
@@ -23,14 +23,14 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
       pollOptions: [{ value: "a" }],
     });
 
-    assert.equal(controller.isMultiple, true, "it should be true");
+    assert.strictEqual(controller.isMultiple, true, "it should be true");
 
     controller.setProperties({
       pollType: "random",
       pollOptions: [{ value: "b" }],
     });
 
-    assert.equal(controller.isMultiple, false, "it should be false");
+    assert.strictEqual(controller.isMultiple, false, "it should be false");
   });
 
   test("isNumber", function (assert) {
@@ -38,11 +38,11 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
 
     controller.set("pollType", REGULAR_POLL_TYPE);
 
-    assert.equal(controller.isNumber, false, "it should be false");
+    assert.strictEqual(controller.isNumber, false, "it should be false");
 
     controller.set("pollType", NUMBER_POLL_TYPE);
 
-    assert.equal(controller.isNumber, true, "it should be true");
+    assert.strictEqual(controller.isNumber, true, "it should be true");
   });
 
   test("pollOptionsCount", function (assert) {
@@ -50,47 +50,47 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
 
     controller.set("pollOptions", [{ value: "1" }, { value: "2" }]);
 
-    assert.equal(controller.pollOptionsCount, 2, "it should equal 2");
+    assert.strictEqual(controller.pollOptionsCount, 2, "it should equal 2");
 
     controller.set("pollOptions", []);
 
-    assert.equal(controller.pollOptionsCount, 0, "it should equal 0");
+    assert.strictEqual(controller.pollOptionsCount, 0, "it should equal 0");
   });
 
   test("disableInsert", function (assert) {
     const controller = setupController(this);
     controller.siteSettings.poll_maximum_options = 20;
 
-    assert.equal(controller.disableInsert, true, "it should be true");
+    assert.strictEqual(controller.disableInsert, true, "it should be true");
 
     controller.set("pollOptions", [{ value: "a" }, { value: "b" }]);
 
-    assert.equal(controller.disableInsert, false, "it should be false");
+    assert.strictEqual(controller.disableInsert, false, "it should be false");
 
     controller.set("pollType", NUMBER_POLL_TYPE);
 
-    assert.equal(controller.disableInsert, false, "it should be false");
+    assert.strictEqual(controller.disableInsert, false, "it should be false");
 
     controller.setProperties({
       pollType: REGULAR_POLL_TYPE,
       pollOptions: [{ value: "a" }, { value: "b" }, { value: "c" }],
     });
 
-    assert.equal(controller.disableInsert, false, "it should be false");
+    assert.strictEqual(controller.disableInsert, false, "it should be false");
 
     controller.setProperties({
       pollType: REGULAR_POLL_TYPE,
       pollOptions: [],
     });
 
-    assert.equal(controller.disableInsert, true, "it should be true");
+    assert.strictEqual(controller.disableInsert, true, "it should be true");
 
     controller.setProperties({
       pollType: REGULAR_POLL_TYPE,
       pollOptions: [{ value: "w" }],
     });
 
-    assert.equal(controller.disableInsert, false, "it should be false");
+    assert.strictEqual(controller.disableInsert, false, "it should be false");
   });
 
   test("number pollOutput", async function (assert) {
@@ -103,7 +103,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
     });
     await settled();
 
-    assert.equal(
+    assert.strictEqual(
       controller.pollOutput,
       "[poll type=number results=always min=1 max=20 step=1]\n[/poll]\n",
       "it should return the right output"
@@ -111,7 +111,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
     controller.set("pollStep", 2);
     await settled();
 
-    assert.equal(
+    assert.strictEqual(
       controller.pollOutput,
       "[poll type=number results=always min=1 max=20 step=2]\n[/poll]\n",
       "it should return the right output"
@@ -119,7 +119,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
 
     controller.set("publicPoll", true);
 
-    assert.equal(
+    assert.strictEqual(
       controller.pollOutput,
       "[poll type=number results=always min=1 max=20 step=2 public=true]\n[/poll]\n",
       "it should return the right output"
@@ -127,7 +127,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
 
     controller.set("pollStep", 0);
 
-    assert.equal(
+    assert.strictEqual(
       controller.pollOutput,
       "[poll type=number results=always min=1 max=20 step=1 public=true]\n[/poll]\n",
       "it should return the right output"
@@ -143,7 +143,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
       pollType: REGULAR_POLL_TYPE,
     });
 
-    assert.equal(
+    assert.strictEqual(
       controller.pollOutput,
       "[poll type=regular results=always chartType=bar]\n* 1\n* 2\n[/poll]\n",
       "it should return the right output"
@@ -151,7 +151,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
 
     controller.set("publicPoll", "true");
 
-    assert.equal(
+    assert.strictEqual(
       controller.pollOutput,
       "[poll type=regular results=always public=true chartType=bar]\n* 1\n* 2\n[/poll]\n",
       "it should return the right output"
@@ -159,7 +159,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
 
     controller.set("pollGroups", "test");
 
-    assert.equal(
+    assert.strictEqual(
       controller.get("pollOutput"),
       "[poll type=regular results=always public=true chartType=bar groups=test]\n* 1\n* 2\n[/poll]\n",
       "it should return the right output"
@@ -176,7 +176,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
       pollOptions: [{ value: "1" }, { value: "2" }],
     });
 
-    assert.equal(
+    assert.strictEqual(
       controller.pollOutput,
       "[poll type=multiple results=always min=1 max=2 chartType=bar]\n* 1\n* 2\n[/poll]\n",
       "it should return the right output"
@@ -184,7 +184,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
 
     controller.set("publicPoll", "true");
 
-    assert.equal(
+    assert.strictEqual(
       controller.pollOutput,
       "[poll type=multiple results=always min=1 max=2 public=true chartType=bar]\n* 1\n* 2\n[/poll]\n",
       "it should return the right output"
@@ -204,7 +204,7 @@ discourseModule("Unit | Controller | poll-ui-builder", function () {
 
   test("poll result is always by default", function (assert) {
     const controller = setupController(this);
-    assert.equal(controller.pollResult, "always");
+    assert.strictEqual(controller.pollResult, "always");
   });
 
   test("staff_only option is present for staff", async function (assert) {

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-standard-results-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-standard-results-test.js.es6
@@ -31,8 +31,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(queryAll(".option .percentage")[0].innerText, "56%");
-        assert.equal(queryAll(".option .percentage")[1].innerText, "44%");
+        assert.strictEqual(queryAll(".option .percentage")[0].innerText, "56%");
+        assert.strictEqual(queryAll(".option .percentage")[1].innerText, "44%");
       },
     });
 
@@ -50,8 +50,8 @@ discourseModule(
       },
 
       test(assert) {
-        assert.equal(queryAll(".option .percentage")[0].innerText, "56%");
-        assert.equal(queryAll(".option .percentage")[1].innerText, "44%");
+        assert.strictEqual(queryAll(".option .percentage")[0].innerText, "56%");
+        assert.strictEqual(queryAll(".option .percentage")[1].innerText, "44%");
       },
     });
 
@@ -78,17 +78,17 @@ discourseModule(
 
       test(assert) {
         let percentages = queryAll(".option .percentage");
-        assert.equal(percentages[0].innerText, "41%");
-        assert.equal(percentages[1].innerText, "33%");
-        assert.equal(percentages[2].innerText, "16%");
-        assert.equal(percentages[3].innerText, "8%");
+        assert.strictEqual(percentages[0].innerText, "41%");
+        assert.strictEqual(percentages[1].innerText, "33%");
+        assert.strictEqual(percentages[2].innerText, "16%");
+        assert.strictEqual(percentages[3].innerText, "8%");
 
-        assert.equal(
+        assert.strictEqual(
           queryAll(".option")[3].querySelectorAll("span")[1].innerText,
           "a"
         );
-        assert.equal(percentages[4].innerText, "8%");
-        assert.equal(
+        assert.strictEqual(percentages[4].innerText, "8%");
+        assert.strictEqual(
           queryAll(".option")[4].querySelectorAll("span")[1].innerText,
           "b"
         );

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-test.js.es6
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-test.js.es6
@@ -123,12 +123,12 @@ discourseModule(
         await click(
           "li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29']"
         );
-        assert.equal(requests, 1);
-        assert.equal(count(".chosen"), 1);
-        assert.equal(queryAll(".chosen").text(), "100%yes");
+        assert.strictEqual(requests, 1);
+        assert.strictEqual(count(".chosen"), 1);
+        assert.strictEqual(queryAll(".chosen").text(), "100%yes");
 
         await click(".toggle-results");
-        assert.equal(
+        assert.strictEqual(
           queryAll("li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29']")
             .length,
           1
@@ -171,11 +171,11 @@ discourseModule(
         await click(
           "li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29']"
         );
-        assert.equal(
+        assert.strictEqual(
           queryAll(".poll-container .alert").text(),
           I18n.t("poll.results.groups.title", { groups: "foo" })
         );
-        assert.equal(requests, 0);
+        assert.strictEqual(requests, 0);
         assert.ok(!exists(".chosen"));
       },
     });


### PR DESCRIPTION
We already use strict comparisons in the app code. Makes sense to do the same in test assertions. Also, no-assert-equal is now a recommended rule in eslint-plugin-qunit (which I'd like us to start using at some point)