### PR TITLE
DEV: Revert "prevent auto-scroll when focus is set inside header panels"

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -484,9 +484,7 @@ export default createWidget("header", {
 
     // auto focus on first button in dropdown
     schedule("afterRender", () =>
-      document.querySelector(".user-menu button")?.focus({
-        preventScroll: true,
-      })
+      document.querySelector(".user-menu button")?.focus()
     );
   },
 
@@ -496,9 +494,7 @@ export default createWidget("header", {
 
     // auto focus on first link in dropdown
     schedule("afterRender", () => {
-      document.querySelector(".hamburger-panel .menu-links a")?.focus({
-        preventScroll: true,
-      });
+      document.querySelector(".hamburger-panel .menu-links a")?.focus();
     });
   },
 
@@ -628,9 +624,7 @@ export default createWidget("header", {
     if (this.state.searchVisible) {
       schedule("afterRender", () => {
         const searchInput = document.querySelector("#search-term");
-        searchInput.focus({
-          preventScroll: true,
-        });
+        searchInput.focus();
         searchInput.select();
       });
     }


### PR DESCRIPTION
This reverts commit f444e3e3f704ef71c29d57461018b3a292ef905f.

After a little bit of reading, I managed to track down the root cause of the issue that the commit above was attempting to fix. 
The bug only occurs if the user has enabled `Experimental Web Platform features` in Chrome flags. 

chrome://flags/#enable-experimental-web-platform-features

Once this is disabled, the bug no longer reproduces. 

This PR removes the unnecessary code that was added to circumvent the bug. 


