### PR TITLE
DEV: increase lock timeout for multisite migration

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -114,7 +114,7 @@ task 'multisite:migrate' => ['db:load_config', 'environment', 'set_locale'] do |
     raise "Multisite migrate is only supported in production"
   end
 
-  DistributedMutex.synchronize('db_migration', redis: Discourse.redis.without_namespace, validity: 300) do
+  DistributedMutex.synchronize('db_migration', redis: Discourse.redis.without_namespace, validity: 1200) do
     # TODO: Switch to processes for concurrent migrations because Rails migration
     # is not thread safe by default.
     concurrency = 1
@@ -548,12 +548,14 @@ end
 
 desc 'Check that the DB can be accessed'
 task 'db:status:json' do
-  begin
-    Rake::Task['environment'].invoke
-    DB.query('SELECT 1')
-  rescue
-    puts({ status: 'error' }.to_json)
-  else
-    puts({ status: 'ok' }.to_json)
+  DistributedMutex.synchronize('db_migration', redis: Discourse.redis.without_namespace, validity: 1200) do
+    begin
+      Rake::Task['environment'].invoke
+      DB.query('SELECT 1')
+    rescue
+      puts({ status: 'error' }.to_json)
+    else
+      puts({ status: 'ok' }.to_json)
+    end
   end
 end


### PR DESCRIPTION
- Increase lock timeout - given multisites may take a while to migrate
- Ensure we do not check for status while db is migrating
