### PR TITLE
FIX: rename action_code_href to action_code_path

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -1,7 +1,7 @@
 import I18n from "I18n";
 import { isEmpty } from "@ember/utils";
 import { userPath } from "discourse/lib/url";
-import { getAbsoluteURL } from "discourse-common/lib/get-url";
+import getURL from "discourse-common/lib/get-url";
 
 const _additionalAttributes = [];
 
@@ -148,9 +148,7 @@ export default function transformPost(
   postAtts.linkCounts = post.link_counts;
   postAtts.actionCode = post.action_code;
   postAtts.actionCodeWho = post.action_code_who;
-  postAtts.actionCodeHref = getAbsoluteURL(
-    post.action_code_href || `/t/${topic.id}`
-  );
+  postAtts.actionCodePath = getURL(post.action_code_path || `/t/${topic.id}`);
   postAtts.topicUrl = topic.get("url");
   postAtts.isSaving = post.isSaving;
   postAtts.staged = post.staged;

--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -8,7 +8,7 @@ import { h } from "virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { userPath } from "discourse/lib/url";
 
-export function actionDescriptionHtml(actionCode, createdAt, username, href) {
+export function actionDescriptionHtml(actionCode, createdAt, username, path) {
   const dt = new Date(createdAt);
   const when = autoUpdatingRelativeAge(dt, {
     format: "medium-with-ago-and-on",
@@ -22,7 +22,7 @@ export function actionDescriptionHtml(actionCode, createdAt, username, href) {
       who = `<a class="mention" href="${userPath(username)}">@${username}</a>`;
     }
   }
-  return I18n.t(`action_codes.${actionCode}`, { who, when, href }).htmlSafe();
+  return I18n.t(`action_codes.${actionCode}`, { who, when, path }).htmlSafe();
 }
 
 export function actionDescription(actionCode, createdAt, username) {
@@ -132,7 +132,7 @@ export default createWidget("post-small-action", {
       attrs.actionCode,
       new Date(attrs.created_at),
       attrs.actionCodeWho,
-      attrs.actionCodeHref
+      attrs.actionCodePath
     );
     contents.push(new RawHtml({ html: `<p>${description}</p>` }));
 

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -170,7 +170,7 @@ class UserAction < ActiveRecord::Base
     action_type
     action_code
     action_code_who
-    action_code_href
+    action_code_path
     topic_closed
     topic_id
     topic_archived
@@ -219,7 +219,7 @@ class UserAction < ActiveRecord::Base
         p.post_type,
         p.action_code,
         pc.value AS action_code_who,
-        pc2.value AS action_code_href,
+        pc2.value AS action_code_path,
         p.edit_reason,
         t.category_id
       FROM user_actions as a
@@ -231,7 +231,7 @@ class UserAction < ActiveRecord::Base
       JOIN users au on au.id = a.user_id
       LEFT JOIN categories c on c.id = t.category_id
       LEFT JOIN post_custom_fields pc ON pc.post_id = a.target_post_id AND pc.name = 'action_code_who'
-      LEFT JOIN post_custom_fields pc2 ON pc2.post_id = a.target_post_id AND pc.name = 'action_code_href'
+      LEFT JOIN post_custom_fields pc2 ON pc2.post_id = a.target_post_id AND pc.name = 'action_code_path'
       /*where*/
       /*order_by*/
       /*offset*/

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -79,7 +79,7 @@ class PostSerializer < BasicPostSerializer
              :is_auto_generated,
              :action_code,
              :action_code_who,
-             :action_code_href,
+             :action_code_path,
              :notice,
              :last_wiki_edit,
              :locked,
@@ -444,12 +444,12 @@ class PostSerializer < BasicPostSerializer
     include_action_code? && action_code_who.present?
   end
 
-  def action_code_href
-    post_custom_fields["action_code_href"]
+  def action_code_path
+    post_custom_fields["action_code_path"]
   end
 
-  def include_action_code_href?
-    include_action_code? && action_code_href.present?
+  def include_action_code_path?
+    include_action_code? && action_code_path.present?
   end
 
   def notice

--- a/app/serializers/user_action_serializer.rb
+++ b/app/serializers/user_action_serializer.rb
@@ -29,7 +29,7 @@ class UserActionSerializer < ApplicationSerializer
              :post_type,
              :action_code,
              :action_code_who,
-             :action_code_href,
+             :action_code_path,
              :edit_reason,
              :category_id,
              :closed,
@@ -91,12 +91,12 @@ class UserActionSerializer < ApplicationSerializer
     object.action_code_who
   end
 
-  def include_action_code_href?
-    action_code_href.present?
+  def include_action_code_path?
+    action_code_path.present?
   end
 
-  def action_code_href
-    object.action_code_href
+  def action_code_path
+    object.action_code_path
   end
 
 end

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -53,7 +53,7 @@
             <%
               post_custom_fields = @topic_view.post_custom_fields[post.id] || {}
               who_username = post_custom_fields["action_code_who"] || ""
-              small_action_href = post_custom_fields["action_code_href"] || ""
+              small_action_href = post_custom_fields["action_code_path"] || ""
               if post.action_code
             %>
               <%= t("js.action_codes.#{post.action_code}", when: "", who: who_username, href: small_action_href).html_safe %>

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -54,7 +54,7 @@ class TopicView
   end
 
   def self.default_post_custom_fields
-    @default_post_custom_fields ||= [Post::NOTICE, "action_code_who", "action_code_href"]
+    @default_post_custom_fields ||= [Post::NOTICE, "action_code_who", "action_code_path"]
   end
 
   def self.post_custom_fields_allowlisters


### PR DESCRIPTION
Small actions should use path instead of absolute url. getURL function is necessary to insert a potential subfolder prefix.

Related PR: https://github.com/discourse/discourse-assign/pull/234
