### PR TITLE
FIX: Include admins in presence reply channel permissions

### DIFF
--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -23,7 +23,7 @@ after_initialize do
         config.allowed_user_ids = topic.allowed_users.pluck(:id)
         config.allowed_group_ids = topic.allowed_groups.pluck(:group_id) + [::Group::AUTO_GROUPS[:staff]]
       elsif secure_group_ids = topic.secure_group_ids
-        config.allowed_group_ids = secure_group_ids
+        config.allowed_group_ids = secure_group_ids + [::Group::AUTO_GROUPS[:admins]]
       else
         # config.public=true would make data available to anon, so use the tl0 group instead
         config.allowed_group_ids = [ ::Group::AUTO_GROUPS[:trust_level_0] ]

--- a/plugins/discourse-presence/spec/integration/presence_spec.rb
+++ b/plugins/discourse-presence/spec/integration/presence_spec.rb
@@ -94,7 +94,7 @@ describe "discourse-presence" do
     it 'handles permissions for secure category topics' do
       c = PresenceChannel.new("/discourse-presence/reply/#{private_topic.id}")
       expect(c.config.public).to eq(false)
-      expect(c.config.allowed_group_ids).to contain_exactly(group.id)
+      expect(c.config.allowed_group_ids).to contain_exactly(group.id, Group::AUTO_GROUPS[:admins])
       expect(c.config.allowed_user_ids).to eq(nil)
     end
 


### PR DESCRIPTION
Admins can see all regular topics, regardless of category permissions

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
