### PR TITLE
FIX: Persist notifications in OS X

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -177,18 +177,10 @@ function onNotification(data, siteSettings, user) {
       tag: notificationTag,
     });
 
-    function clickEventHandler() {
+    notification.onclick = () => {
       DiscourseURL.routeTo(data.post_url);
-      // Cannot delay this until the page renders
-      // due to trigger-based permissions
-      window.focus();
-    }
-
-    notification.addEventListener("click", clickEventHandler);
-    later(() => {
       notification.close();
-      notification.removeEventListener("click", clickEventHandler);
-    }, 10 * 1000);
+    };
   });
 }
 


### PR DESCRIPTION
We were previously triggering the close event 10 seconds after showing the notification, which in OSX meant that notifications would be removed from the Notification Center.