### PR TITLE
FIX: use correct attribute method to get post id from dataset. 

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -206,9 +206,9 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
       this._close();
     },
 
-    composePM(user) {
+    composePM(user, post) {
       this._close();
-      this.composePrivateMessage(user, this.topic);
+      this.composePrivateMessage(user, post);
     },
 
     cancelFilter() {

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -63,7 +63,7 @@ export default Mixin.create({
     }
 
     const closestArticle = target.closest("article");
-    const postId = closestArticle ? closestArticle.dataset["post-id"] : null;
+    const postId = closestArticle ? closestArticle.dataset.postId : null;
     const wasVisible = this.visible;
     const previousTarget = this.cardTarget;
 

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -70,14 +70,14 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
       });
     },
 
-    composePrivateMessage(user, topic) {
+    composePrivateMessage(user, post) {
       const recipients = user ? user.get("username") : "";
-      const reply = topic
-        ? `${window.location.protocol}//${window.location.host}${topic.url}`
+      const reply = post
+        ? `${window.location.protocol}//${window.location.host}${post.url}`
         : null;
-      const title = topic
+      const title = post
         ? I18n.t("composer.reference_topic_title", {
-            title: topic.title,
+            title: post.topic.title,
           })
         : null;
 

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -68,7 +68,7 @@
             <li class="compose-pm">
               {{d-button
               class="btn-primary"
-              action=(action "composePM" this.user)
+              action=(action "composePM" this.user this.post)
               icon="envelope"
               label="user.private_message"}}
             </li>


### PR DESCRIPTION
Because of this bug, the post details were not included in the PMs which are initiated from the user card in posts. And this PR reverts the commit https://github.com/discourse/discourse/commit/e3e0d025eaf1b5e9ec081b9c6668474234277a25.