### PR TITLE
Revert "FIX: Composer height issue in Safari on iOS 15 (#14282)"

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/safari-hacks.js
+++ b/app/assets/javascripts/discourse/app/lib/safari-hacks.js
@@ -98,7 +98,7 @@ function positioningWorkaround($fixedElement) {
 
   positioningWorkaround.blur = function (evt) {
     if (workaroundActive) {
-      $("body").removeClass("ios-safari-composer-hacks");
+      document.body.classList.remove("ios-safari-composer-hacks");
       window.scrollTo(0, originalScrollTop);
 
       if (evt && evt.target) {
@@ -188,7 +188,7 @@ function positioningWorkaround($fixedElement) {
         return;
       }
 
-      $("body").addClass("ios-safari-composer-hacks");
+      document.body.classList.add("ios-safari-composer-hacks");
       window.scrollTo(0, 0);
 
       if (!iOSWithVisualViewport()) {

--- a/app/assets/javascripts/discourse/app/lib/safari-hacks.js
+++ b/app/assets/javascripts/discourse/app/lib/safari-hacks.js
@@ -98,10 +98,7 @@ function positioningWorkaround($fixedElement) {
 
   positioningWorkaround.blur = function (evt) {
     if (workaroundActive) {
-      document.body.classList.remove("ios-safari-composer-hacks");
-      if (caps.isIOS15Safari) {
-        document.body.classList.remove("ios-safari-15-hack");
-      }
+      $("body").removeClass("ios-safari-composer-hacks");
       window.scrollTo(0, originalScrollTop);
 
       if (evt && evt.target) {
@@ -191,10 +188,7 @@ function positioningWorkaround($fixedElement) {
         return;
       }
 
-      document.body.classList.add("ios-safari-composer-hacks");
-      if (caps.isIOS15Safari) {
-        document.body.classList.add("ios-safari-15-hack");
-      }
+      $("body").addClass("ios-safari-composer-hacks");
       window.scrollTo(0, 0);
 
       if (!iOSWithVisualViewport()) {

--- a/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
@@ -43,11 +43,6 @@ export default {
         (/iPhone|iPod/.test(navigator.userAgent) || caps.isIpadOS) &&
         !window.MSStream;
 
-      caps.isIOS15Safari =
-        caps.isIOS &&
-        /Version\/15/.test(navigator.userAgent) &&
-        !/DiscourseHub/.test(navigator.userAgent);
-
       caps.hasContactPicker =
         "contacts" in navigator && "ContactsManager" in window;
 

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -32,13 +32,6 @@
     padding-bottom: 0px;
   }
 
-  // iOS 15 Safari has a floating address bar that displays above the composer submit bar
-  // we cannot detect its preseence, so we need to add extra padding
-  // Apple says it's a known issue, see https://bugs.webkit.org/show_bug.cgi?id=229876
-  .keyboard-visible body.ios-safari-15-hack &.open .reply-area {
-    padding-bottom: 45px;
-  }
-
   .reply-to {
     margin: 5px 0;
     .reply-details {


### PR DESCRIPTION
This reverts commit 0dab1634b060077f18a741b0cf433571f3f523e9.

Fixed in iOS 15.1, we don't need to carry this workaround anymore. 

See also https://bugs.webkit.org/show_bug.cgi?id=229876