### PR TITLE
FIX: Call `_clearFlash()` when displaying a modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-modal-body.js
+++ b/app/assets/javascripts/discourse/app/components/d-modal-body.js
@@ -10,7 +10,7 @@ export default Component.extend({
     this._super(...arguments);
     this._modalAlertElement = document.getElementById("modal-alert");
     if (this._modalAlertElement) {
-      this._modalAlertElement.innerHTML = "";
+      this._clearFlash();
     }
 
     let fixedParent = $(this.element).closest(".d-modal.fixed-modal");

--- a/app/assets/javascripts/discourse/app/controllers/change-owner.js
+++ b/app/assets/javascripts/discourse/app/controllers/change-owner.js
@@ -50,7 +50,7 @@ export default Controller.extend(ModalFunctionality, {
           );
         },
         () => {
-          this.flash(I18n.t("topic.change_owner.error"), "alert-error");
+          this.flash(I18n.t("topic.change_owner.error"), "error");
           this.set("saving", false);
         }
       );

--- a/app/assets/javascripts/discourse/app/controllers/change-timestamp.js
+++ b/app/assets/javascripts/discourse/app/controllers/change-timestamp.js
@@ -54,7 +54,7 @@ export default Controller.extend(ModalFunctionality, {
           next(() => DiscourseURL.routeTo(topic.url));
         })
         .catch(() =>
-          this.flash(I18n.t("topic.change_timestamp.error"), "alert-error")
+          this.flash(I18n.t("topic.change_timestamp.error"), "error")
         )
         .finally(() => this.set("saving", false));
 

--- a/app/assets/javascripts/discourse/app/controllers/delete-topic-confirm.js
+++ b/app/assets/javascripts/discourse/app/controllers/delete-topic-confirm.js
@@ -29,7 +29,7 @@ export default Controller.extend(ModalFunctionality, {
       .destroy(this.currentUser)
       .then(() => this.send("closeModal"))
       .catch(() => {
-        this.flash(I18n.t("post.controls.delete_topic_error"), "alert-error");
+        this.flash(I18n.t("post.controls.delete_topic_error"), "error");
         this.set("deletingTopic", false);
       });
 

--- a/app/assets/javascripts/discourse/app/controllers/edit-topic-timer.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-topic-timer.js
@@ -185,7 +185,7 @@ export default Controller.extend(ModalFunctionality, {
       ) {
         this.flash(
           I18n.t("topic.topic_status_update.time_frame_required"),
-          "alert-error"
+          "error"
         );
         return;
       }
@@ -195,19 +195,13 @@ export default Controller.extend(ModalFunctionality, {
         !this.get("topicTimer.updateTime")
       ) {
         if (this.get("topicTimer.duration_minutes") <= 0) {
-          this.flash(
-            I18n.t("topic.topic_status_update.min_duration"),
-            "alert-error"
-          );
+          this.flash(I18n.t("topic.topic_status_update.min_duration"), "error");
           return;
         }
 
         // cannot be more than 20 years
         if (this.get("topicTimer.duration_minutes") > 20 * 365 * 1440) {
-          this.flash(
-            I18n.t("topic.topic_status_update.max_duration"),
-            "alert-error"
-          );
+          this.flash(I18n.t("topic.topic_status_update.max_duration"), "error");
           return;
         }
       }

--- a/app/assets/javascripts/discourse/app/controllers/ignore-duration-with-username.js
+++ b/app/assets/javascripts/discourse/app/controllers/ignore-duration-with-username.js
@@ -13,7 +13,7 @@ export default Controller.extend(ModalFunctionality, {
       if (!this.ignoredUntil || !this.ignoredUsername) {
         this.flash(
           I18n.t("user.user_notifications.ignore_duration_time_frame_required"),
-          "alert-error"
+          "error"
         );
         return;
       }

--- a/app/assets/javascripts/discourse/app/controllers/ignore-duration.js
+++ b/app/assets/javascripts/discourse/app/controllers/ignore-duration.js
@@ -11,7 +11,7 @@ export default Controller.extend(ModalFunctionality, {
       if (!this.ignoredUntil) {
         this.flash(
           I18n.t("user.user_notifications.ignore_duration_time_frame_required"),
-          "alert-error"
+          "error"
         );
         return;
       }


### PR DESCRIPTION
`d-modal-body.js` was setting the text of a `modal-alert` element to `""`, but not removing any classes on that element. Changing this to call `_clearFlash()` ensures that a variety of styling classes are also removed from the element, which prevents empty alert elements being included on any subsequent modals that are displayed.

Several other controllers have also been modified to change the class of the error from `alert-error` to `error`. The `alert-` is unnecessary, as it is added by `_flash(msg)` within `d-modal-body.js`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
