### PR TITLE
FIX: Remove xlink:href to favour href due to deprecation

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/image-controls.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/image-controls.js
@@ -73,7 +73,7 @@ function buildImageAltTextButton(altText) {
   <span class="alt-text" aria-label="${I18n.t(
     "composer.image_alt_text.aria_label"
   )}">${altText}</span>
-  <span class="alt-text-edit-btn"><svg aria-hidden="true" class="fa d-icon d-icon-pencil svg-icon svg-string"><use xlink:href="#pencil-alt"></use></svg></span>
+  <span class="alt-text-edit-btn"><svg aria-hidden="true" class="fa d-icon d-icon-pencil svg-icon svg-string"><use href="#pencil-alt"></use></svg></span>
   <input class="alt-text-input" hidden="true" type="text" value="${altText}" />
 </span>
 `;
@@ -132,7 +132,7 @@ export function setup(helper) {
       "span.alt-text-readonly-container.alt-text",
       "span.alt-text-readonly-container.alt-text-edit-btn",
       "svg[class=fa d-icon d-icon-pencil svg-icon svg-string]",
-      "use[xlink:href=#pencil-alt]",
+      "use[href=#pencil-alt]",
       "input[type=text]",
       "input[hidden=true]",
       "input[class=alt-text-input]",


### PR DESCRIPTION
Based on docs here https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#attributes,
the xlink:href attribute is deprecated and we should probably move away from it soon. Can also confirm that the removal of `xlink` made the feature work on the deployed site, and not just locally.

(No test updates, since our method of testing uses attributes, and testing for the attribute doesn't necessitate the visibility of the svg. Whereas snapshot testing may cover absence of the rendered icon)