### PR TITLE
UX: fix share/notify modal styles

### DIFF
--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -1,18 +1,16 @@
 // styles that apply to the "share" modal & popup when sharing a link to a post or topic
 
-.link-share-container {
+.link-share-container,
+.notify-user-input {
   display: flex;
-  button {
+  button.no-text {
     margin-left: 0.5em;
     transition-property: background-color, color; // don't transition outline
   }
-  input {
+  input,
+  .select-kit {
     width: 100%;
-    font-size: var(--font-up-1);
     margin-bottom: 0;
-    &:focus + button {
-      outline: 1px solid var(--tertiary);
-    }
   }
 }
 
@@ -111,23 +109,6 @@
       margin-top: 0;
       margin-right: 0;
     }
-  }
-}
-
-.notify-user-input {
-  display: flex;
-  align-items: stretch;
-
-  .select-kit {
-    width: 100%;
-  }
-
-  .multi-select-header {
-    width: 100%;
-  }
-
-  .select-kit.multi-select .choices {
-    padding: 0;
   }
 }
 

--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -3,9 +3,8 @@
 .link-share-container,
 .notify-user-input {
   display: flex;
-  button.no-text {
+  .btn {
     margin-left: 0.5em;
-    transition-property: background-color, color; // don't transition outline
   }
   input,
   .select-kit {


### PR DESCRIPTION
fixing some broken styles, simplifying 

Before (note the checkmark button):
![Screen Shot 2021-11-09 at 11 24 04 AM](https://user-images.githubusercontent.com/1681963/140963659-f18330cc-4058-4ae0-adc6-eea454eef9a6.png)

After:
![Screen Shot 2021-11-09 at 11 23 45 AM](https://user-images.githubusercontent.com/1681963/140963696-09eba191-38ec-4936-9445-509bf3aa33d4.png)

