### PR TITLE
FIX: Allow bulk invites to be used with DiscourseConnect

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -397,7 +397,7 @@ class Guardian
   end
 
   def can_bulk_invite_to_forum?(user)
-    user.admin? && !SiteSetting.enable_discourse_connect
+    user.admin?
   end
 
   def can_resend_all_invites?(user)

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -904,6 +904,16 @@ describe InvitesController do
         expect(Jobs::BulkInvite.jobs.size).to eq(1)
       end
 
+      it 'allows admin to bulk invite when DiscourseConnect enabled' do
+        SiteSetting.discourse_connect_url = "https://example.com"
+        SiteSetting.enable_discourse_connect = true
+
+        sign_in(admin)
+        post '/invites/upload_csv.json', params: { file: file, name: 'discourse.csv' }
+        expect(response.status).to eq(200)
+        expect(Jobs::BulkInvite.jobs.size).to eq(1)
+      end
+
       it 'sends limited invites at a time' do
         SiteSetting.max_bulk_invites = 3
         sign_in(admin)


### PR DESCRIPTION
Support for invites alongside DiscourseConnect was added in 355d51af. This commit fixes the guardian method so that the bulk invite button functionality also works.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
