### PR TITLE
FIX: Disable scroll events while on full screen

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -81,7 +81,7 @@ export default MountWidget.extend({
     if (
       isWorkaroundActive() ||
       document.webkitFullscreenElement ||
-      document.mozFullScreenElement
+      document.fullscreenElement
     ) {
       return;
     }

--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -77,7 +77,12 @@ export default MountWidget.extend({
     if (this.isDestroyed || this.isDestroying) {
       return;
     }
-    if (isWorkaroundActive()) {
+
+    if (
+      isWorkaroundActive() ||
+      document.webkitFullscreenElement ||
+      document.mozFullScreenElement
+    ) {
       return;
     }
 


### PR DESCRIPTION
On Safari/Firefox (macOS), toggling full screen on a video triggers several scroll events, and confuses the post stream. On Safari, this results in scrolling ~20 posts upwards after exiting a fullscreen video.

This PR disables scroll calculations while there is a full screen element which at least partially addresses the issue.
