### PR TITLE
FIX: Use `127.0.0.1` instead of `localhost` for ember CLI

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -5,7 +5,7 @@ require 'pathname'
 
 RAILS_ROOT = File.expand_path("../../", Pathname.new(__FILE__).realpath)
 PORT = ENV["UNICORN_PORT"] ||= "3000"
-HOSTNAME = ENV["DISCOURSE_HOSTNAME"] ||= "localhost"
+HOSTNAME = ENV["DISCOURSE_HOSTNAME"] ||= "127.0.0.1"
 yarn_dir = File.join(RAILS_ROOT, "app/assets/javascripts/discourse")
 
 PROXY =


### PR DESCRIPTION
On new macs, `localhost` resolves to IPV6 of `::1` and unfortunately
unicorn doesn't bind to IPv6 by default.

This seems to be the path of least resistance. By using 127.0.0.1 we
force IPv4 which works great.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
