### PR TITLE
PERF: Update like count in visible posts without an extra GET per like

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1598,6 +1598,12 @@ export default Controller.extend(bufferedProperty("model"), {
               .then(() => refresh({ id: data.id, refreshLikes: true }));
             break;
           }
+          case "liked": {
+            postStream
+              .triggerLikedPost(data.id, data.likes_count)
+              .then(() => refresh({ id: data.id, refreshLikes: false }));
+            break;
+          }
           case "revised":
           case "rebaked": {
             postStream

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1601,7 +1601,7 @@ export default Controller.extend(bufferedProperty("model"), {
           case "liked": {
             postStream
               .triggerLikedPost(data.id, data.likes_count)
-              .then(() => refresh({ id: data.id, refreshLikes: false }));
+              .then(() => refresh({ id: data.id, refreshLikes: true }));
             break;
           }
           case "revised":

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -847,6 +847,18 @@ export default RestModel.extend({
     return resolved;
   },
 
+  triggerLikedPost(postId, likesCount) {
+    const resolved = Promise.resolve();
+
+    const post = this.findLoadedPost(postId);
+    if (post) {
+      post.updateLikeCount(likesCount);
+      this.storePost(post);
+    }
+
+    return resolved;
+  },
+
   triggerReadPost(postId, readersCount) {
     const resolved = Promise.resolve();
     resolved.then(() => {

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -367,7 +367,7 @@ const Post = RestModel.extend({
         actions_summary: [
           {
             id: likeActionID,
-            count: count,
+            count,
           },
         ],
       });

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -357,13 +357,16 @@ const Post = RestModel.extend({
 
   updateLikeCount(count) {
     let current_actions_summary = this.get("actions_summary");
+    let likeActionID = Site.current().post_action_types.find(
+      (a) => a.name_key === "like"
+    ).id;
 
-    if (!this.actions_summary.find((entry) => entry.id === 2)) {
+    if (!this.actions_summary.find((entry) => entry.id === likeActionID)) {
       let json = Post.munge({
         id: this.id,
         actions_summary: [
           {
-            id: 2,
+            id: likeActionID,
             count: count,
           },
         ],
@@ -375,7 +378,9 @@ const Post = RestModel.extend({
       this.set("actionByName", json.actionByName);
       this.set("likeAction", json.likeAction);
     } else {
-      this.actions_summary.find((entry) => entry.id === 2).count = count;
+      this.actions_summary.find(
+        (entry) => entry.id === likeActionID
+      ).count = count;
       this.actionByName["like"] = count;
       this.likeAction.count = count;
     }

--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -355,6 +355,32 @@ const Post = RestModel.extend({
     }
   },
 
+  updateLikeCount(count) {
+    let current_actions_summary = this.get("actions_summary");
+
+    if (!this.actions_summary.find((entry) => entry.id === 2)) {
+      let json = Post.munge({
+        id: this.id,
+        actions_summary: [
+          {
+            id: 2,
+            count: count,
+          },
+        ],
+      });
+      this.set(
+        "actions_summary",
+        Object.assign(current_actions_summary, json.actions_summary)
+      );
+      this.set("actionByName", json.actionByName);
+      this.set("likeAction", json.likeAction);
+    } else {
+      this.actions_summary.find((entry) => entry.id === 2).count = count;
+      this.actionByName["like"] = count;
+      this.likeAction.count = count;
+    }
+  },
+
   revertToRevision(version) {
     return ajax(`/posts/${this.id}/revisions/${version}/revert`, {
       type: "PUT",

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -156,13 +156,15 @@ private
   end
 
   def notify_subscribers
-    if self.class.notify_types.include?(@post_action_name)
+    if @post_action_name == :like
+      @post.publish_change_to_clients! :liked, { likes_count: @post.like_count + 1 }
+    elsif self.class.notify_types.include?(@post_action_name)
       @post.publish_change_to_clients! :acted
     end
   end
 
   def self.notify_types
-    @notify_types ||= ([:like] + PostActionType.notify_flag_types.keys)
+    @notify_types ||= PostActionType.notify_flag_types.keys
   end
 
   def enforce_rules


### PR DESCRIPTION
Currently when a user is reading a topic and some post in it receive a
like from another user, the Ember app will be notified via MessageBus
and issue a GET to `/posts/{id}` to get the new like count. This worked
fine for us until today, but it can easily create a self-inflicted DDoS
when a topic with a large number of visitors gets a large number of
likes, since we will issue `visitors * likes` GET requests requests.

This patch optimizes this flow, by sending the new like count down in
the MessageBus notification, removing any need for the extra request.

It shouldn't cause any drift on the count because we send down the full
count instead of the difference too.

Possible follow-ups could include handling like removal.
