### PR TITLE
DEV: Revert eslint-config-discourse bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chart.js": "3.5.1",
     "chartjs-plugin-datalabels": "^2.0.0",
     "diffhtml": "^1.0.0-beta.20",
-    "eslint-config-discourse": "^1.1.9",
+    "eslint-config-discourse": "^1.1.8",
     "handlebars": "^4.7.7",
     "jquery": "3.5.1",
     "jquery-color": "3.0.0-alpha.1",


### PR DESCRIPTION
Just the package.json part of 23b7b42acd1efda21cf8c80a45057be5a705ac57,
because all the plugins/themes need to be updated to follow this
new rule as well.
