### PR TITLE
DEV: Bump eslint-config-discourse again

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chart.js": "3.5.1",
     "chartjs-plugin-datalabels": "^2.0.0",
     "diffhtml": "^1.0.0-beta.20",
-    "eslint-config-discourse": "^1.1.8",
+    "eslint-config-discourse": "^1.1.9",
     "handlebars": "^4.7.7",
     "jquery": "3.5.1",
     "jquery-color": "3.0.0-alpha.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1492,7 +1492,7 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-discourse@^1.1.8:
+eslint-config-discourse@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/eslint-config-discourse/-/eslint-config-discourse-1.1.9.tgz#9a5ee6b3a4b986e5243f517e7945d1709c4e22df"
   integrity sha512-a4KG+/9/7ZhYVV0URGK70K7QtxlydYKjie0ZssHEGxl2auOUTDcdRMBfZQBtIxQr9X8TF0+eeUUsScBXNU6xZw==


### PR DESCRIPTION
Now all the plugins are updated it is safe to bump
to 1.1.9
