### PR TITLE
FIX: Display top posts from private categories if the user has access.

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -279,7 +279,9 @@ class CategoriesController < ApplicationController
     if topics_filter == :latest
       result.topic_list = TopicQuery.new(current_user, topic_options).list_latest
     elsif topics_filter == :top
-      result.topic_list = TopicQuery.new(nil, topic_options).list_top_for(SiteSetting.top_page_default_timeframe.to_sym)
+      result.topic_list = TopicQuery.new(current_user, topic_options).list_top_for(
+        SiteSetting.top_page_default_timeframe.to_sym
+      )
     end
 
     render_serialized(result, CategoryAndTopicListsSerializer, root: false)


### PR DESCRIPTION
Users viewing the top topics from the categories page should see those belonging to a private category if they have access to it.