### PR TITLE
FIX: Topic queryParams are removed from history state when scrolling.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -103,7 +103,17 @@ export default Controller.extend(bufferedProperty("model"), {
   ),
 
   updateQueryParams() {
-    this.setProperties(this.get("model.postStream.streamFilters"));
+    const filters = this.get("model.postStream.streamFilters");
+
+    if (Object.keys(filters).length > 0) {
+      this.setProperties(filters);
+    } else {
+      this.setProperties({
+        username_filters: null,
+        filter: null,
+        replies_to_post_number: null,
+      });
+    }
   },
 
   @observes("model.title", "category")

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -183,10 +183,32 @@ const TopicRoute = DiscourseRoute.extend({
       }
 
       const topic = this.modelFor("topic");
+
       if (topic && currentPost) {
-        let postUrl = topic.get("url");
+        let postUrl;
+
         if (currentPost > 1) {
-          postUrl += "/" + currentPost;
+          postUrl = topic.urlForPostNumber(currentPost);
+        } else {
+          postUrl = topic.url;
+        }
+
+        if (this._router.currentRoute.queryParams) {
+          let searchParams;
+
+          Object.entries(this._router.currentRoute.queryParams).map(
+            ([key, value]) => {
+              if (!searchParams) {
+                searchParams = new URLSearchParams();
+              }
+
+              searchParams.append(key, value);
+            }
+          );
+
+          if (searchParams) {
+            postUrl += `?${searchParams.toString()}`;
+          }
         }
 
         cancel(this.scheduledReplace);


### PR DESCRIPTION
* Also fixed a bug where the queryParams are not removed when toggling
  between filters.