### PR TITLE
DEV: Improve multisite testing

### DIFF
--- a/spec/integration/multisite_spec.rb
+++ b/spec/integration/multisite_spec.rb
@@ -2,62 +2,33 @@
 
 require 'rails_helper'
 
-describe 'multisite', type: :multisite do
-  class DBNameMiddleware
-    def initialize(app, config = {})
-      @app = app
-    end
-
-    def call(env)
-      # note current_db is already being ruined on boot cause its not multisite
-      [200, {}, [RailsMultisite::ConnectionManagement.current_hostname]]
-    end
-  end
-
-  let :session do
-    stack = ActionDispatch::MiddlewareStack.new
-    stack.use RailsMultisite::Middleware, RailsMultisite::DiscoursePatches.config
-    stack.use DBNameMiddleware
-
-    routes = ActionDispatch::Routing::RouteSet.new
-    stack.build(routes)
-  end
-
+describe 'multisite', type: [:multisite, :request] do
   it "should always allow /srv/status through" do
-    headers = {
-      "HTTP_HOST" => "unknown.com",
-      "REQUEST_METHOD" => "GET",
-      "PATH_INFO" => "/srv/status",
-      "rack.input" => StringIO.new
-    }
-
-    code, _, body = session.call(headers)
-    expect(code).to eq(200)
-    expect(body.join).to eq("test.localhost")
+    get "http://unknown.com/srv/status"
+    expect(response.status).to eq(200)
+    expect(request.env["HTTP_HOST"]).to eq("test.localhost") # Rewritten by EnforceHostname middleware
   end
 
-  it "should 404 on unknown routes" do
-    headers = {
-      "HTTP_HOST" => "unknown.com",
-      "REQUEST_METHOD" => "GET",
-      "PATH_INFO" => "/topics",
-      "rack.input" => StringIO.new
-    }
-
-    code, _ = session.call(headers)
-    expect(code).to eq(404)
+  it "should 404 for unknown domains" do
+    get "http://unknown.com/about.json"
+    expect(response.status).to eq(404)
   end
 
-  it "should hit correct site elsewise" do
-    headers = {
-      "HTTP_HOST" => "test2.localhost",
-      "REQUEST_METHOD" => "GET",
-      "PATH_INFO" => "/topics",
-      "rack.input" => StringIO.new
-    }
+  it "should hit correct site otherwise" do
+    site_1_url = Fabricate(:topic, title: "Site 1 Topic Title", user: Discourse.system_user).relative_url
 
-    code, _, body = session.call(headers)
-    expect(code).to eq(200)
-    expect(body.join).to eq("test2.localhost")
+    test_multisite_connection('second') do
+      site_2_url = Fabricate(:topic, title: "Site 2 Topic Title", user: Discourse.system_user).relative_url
+
+      get "http://test.localhost/#{site_1_url}.json"
+      expect(request.env["RAILS_MULTISITE_HOST"]).to eq("test.localhost")
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["title"]).to eq("Site 1 Topic Title")
+
+      get "http://test2.localhost/#{site_2_url}.json"
+      expect(response.status).to eq(200)
+      expect(request.env["RAILS_MULTISITE_HOST"]).to eq("test2.localhost")
+      expect(response.parsed_body["title"]).to eq("Site 2 Topic Title")
+    end
   end
 end

--- a/spec/lib/backup_restore/uploads_restorer_spec.rb
+++ b/spec/lib/backup_restore/uploads_restorer_spec.rb
@@ -99,7 +99,7 @@ describe BackupRestore::UploadsRestorer do
     let!(:multisite) { { name: "multisite", value: true } }
     let!(:no_multisite) { { name: "multisite", value: false } }
     let!(:source_db_name) { { name: "db_name", value: "foo" } }
-    let!(:base_url) { { name: "base_url", value: "https://www.example.com/forum" } }
+    let!(:base_url) { { name: "base_url", value: "https://test.localhost/forum" } }
     let!(:no_cdn_url)  { { name: "cdn_url", value: nil } }
     let!(:cdn_url)  { { name: "cdn_url", value: "https://some-cdn.example.com" } }
     let(:target_site_name) { target_site_type == multisite ? "second" : "default" }
@@ -187,7 +187,7 @@ describe BackupRestore::UploadsRestorer do
         expect_remap(
           target_site_name: target_site_name,
           metadata: [source_site_type, base_url],
-          from: "https://www.example.com/forum",
+          from: "https://test.localhost/forum",
           to: "http://localhost"
         )
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -291,6 +291,10 @@ RSpec.configure do |config|
     DB.test_transaction = ActiveRecord::Base.connection.current_transaction
   end
 
+  # Match the request hostname to the value in `database.yml`
+  config.before(:all, type: [:request, :multisite]) { host! "test.localhost" }
+  config.before(:each, type: [:request, :multisite]) { host! "test.localhost" }
+
   config.before(:each, type: :multisite) do
     Rails.configuration.multisite = true # rubocop:disable Discourse/NoDirectMultisiteManipulation
 


### PR DESCRIPTION
This commit adds the RailsMultisite middleware in test mode when Rails.configuration.multisite is true. This allows for much more realistic integration testing. The `multisite_spec.rb` file is rewritten to avoid needing to simulate a middleware stack.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
