### PR TITLE
FIX: Use Map instead of Object for caching

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1689,6 +1689,7 @@ var bar = 'bar';
     };
 
     assert.cookedOptions("test fun funny", opts, "<p>test times funny</p>");
+    assert.cookedOptions("constructor", opts, "<p>constructor</p>");
   });
 
   test("watched words link", function (assert) {

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
@@ -73,7 +73,7 @@ export function setup(helper) {
       return;
     }
 
-    const cache = {};
+    const cache = new Map();
 
     md.core.ruler.push("watched-words", (state) => {
       for (let j = 0, l = state.tokens.length; j < l; j++) {
@@ -153,8 +153,14 @@ export function setup(helper) {
 
           if (currentToken.type === "text") {
             const text = currentToken.content;
-            const matches = (cache[text] =
-              cache[text] || findAllMatches(text, matchers));
+
+            let matches;
+            if (cache.has(text)) {
+              matches = cache.get(text);
+            } else {
+              matches = findAllMatches(text, matchers);
+              cache.set(text, matches);
+            }
 
             // Now split string to nodes
             const nodes = [];


### PR DESCRIPTION
Objects have default properties, such as "constructor" that can cause
issues when using similar texts as keys.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
