### PR TITLE
DEV: Segment Ember CLI tests

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -45,7 +45,23 @@ jobs:
         working-directory: ./app/assets/javascripts/discourse
         run: yarn install
 
-      - name: Core QUnit
+      - name: Ember Build
         working-directory: ./app/assets/javascripts/discourse
-        run: sudo -E -u discourse -H yarn ember test --launch "${{ matrix.browser }}"
+        run: |
+          sudo -E -u discourse mkdir /tmp/emberbuild
+          sudo -E -u discourse -H yarn ember build --environment=test  -o /tmp/emberbuild
+
+      - name: Core QUnit 1
+        working-directory: ./app/assets/javascripts/discourse
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=1 --launch "${{ matrix.browser }}"
+        timeout-minutes: 60
+
+      - name: Core QUnit 2
+        working-directory: ./app/assets/javascripts/discourse
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=2 --launch "${{ matrix.browser }}"
+        timeout-minutes: 60
+
+      - name: Core QUnit 3
+        working-directory: ./app/assets/javascripts/discourse
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=3 --launch "${{ matrix.browser }}"
         timeout-minutes: 60

--- a/app/assets/javascripts/discourse/tests/acceptance/user-activity-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-activity-topic-test.js
@@ -11,7 +11,7 @@ acceptance("User Activity / Topics - bulk actions", function (needs) {
       return helper.response(userFixtures["/topics/created-by/eviltrout.json"]);
     });
 
-    server.put("topics/bulk", () => {
+    server.put("/topics/bulk", () => {
       return helper.response({ topic_ids: [7764, 9318] });
     });
   });


### PR DESCRIPTION
This enables 3 segments of Ember CLI tests which helps with memory use. It also contains a fix for a bug that only shows up when segmenting tests (an incorrect bulk path.)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
