### PR TITLE
DEV: Catch Mocha::ExpectationError in request specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,9 +46,9 @@ class RspecErrorTracker
       @app.call(env)
 
     # This is a little repetitive, but since WebMock::NetConnectNotAllowedError
-    # inherits from Exception instead of StandardError it does not get captured
-    # by the rescue => e shorthand :(
-    rescue WebMock::NetConnectNotAllowedError, StandardError => e
+    # and also Mocha::ExpectationError inherit from Exception instead of StandardError
+    # they do not get captured by the rescue => e shorthand :(
+    rescue WebMock::NetConnectNotAllowedError, Mocha::ExpectationError, StandardError => e
       RspecErrorTracker.last_exception = e
       raise e
     end


### PR DESCRIPTION
Same issue as 28b00dc6fc4f9903c7bd0d4a84aabee1b4391e74, the
Mocha::ExpectationError inherits from Exception instead
of StandardError so RspecErrorTracker does not show the
actual failed expectation in request specs, the status of
the response is just 500 with no further detail.
