### PR TITLE
FEATURE: Mention @here to notify users in topic 

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -561,10 +561,11 @@ export default Component.extend(ComposerUpload, {
   _renderUnseenMentions(preview, unseen) {
     // 'Create a New Topic' scenario is not supported (per conversation with codinghorror)
     // https://meta.discourse.org/t/taking-another-1-7-release-task/51986/7
-    fetchUnseenMentions(unseen, this.get("composer.topic.id")).then(() => {
+    fetchUnseenMentions(unseen, this.get("composer.topic.id")).then((r) => {
       linkSeenMentions(preview, this.siteSettings);
       this._warnMentionedGroups(preview);
       this._warnCannotSeeMention(preview);
+      this._warnHereMention(r.here_count);
     });
   },
 
@@ -636,6 +637,22 @@ export default Component.extend(ComposerUpload, {
       });
 
       this.set("warnedCannotSeeMentions", found);
+    });
+  },
+
+  _warnHereMention(hereCount) {
+    if (!hereCount || hereCount === 0) {
+      return;
+    }
+
+    schedule("afterRender", () => {
+      later(
+        this,
+        () => {
+          this.hereMention(hereCount);
+        },
+        2000
+      );
     });
   },
 

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -645,15 +645,13 @@ export default Component.extend(ComposerUpload, {
       return;
     }
 
-    schedule("afterRender", () => {
-      later(
-        this,
-        () => {
-          this.hereMention(hereCount);
-        },
-        2000
-      );
-    });
+    later(
+      this,
+      () => {
+        this.hereMention(hereCount);
+      },
+      2000
+    );
   },
 
   @bind

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -723,7 +723,10 @@ export default Controller.extend({
       this.appEvents.trigger("composer-messages:create", {
         extraClass: "custom-body",
         templateName: "custom-body",
-        body: I18n.t("composer.here_mention", { count }),
+        body: I18n.t("composer.here_mention", {
+          here: this.siteSettings.here_mention,
+          count,
+        }),
       });
     },
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -719,6 +719,14 @@ export default Controller.extend({
       });
     },
 
+    hereMention(count) {
+      this.appEvents.trigger("composer-messages:create", {
+        extraClass: "custom-body",
+        templateName: "custom-body",
+        body: I18n.t("composer.here_mention", { count }),
+      });
+    },
+
     applyUnorderedList() {
       this.toolbarEvent.applyList("* ", "list_item");
     },

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -129,6 +129,7 @@
           uploadProgress=uploadProgress
           groupsMentioned=(action "groupsMentioned")
           cannotSeeMention=(action "cannotSeeMention")
+          hereMention=(action "hereMention")
           importQuote=(action "importQuote")
           togglePreview=(action "togglePreview")
           processPreview=showPreview

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -497,7 +497,7 @@ class UsersController < ApplicationController
     here_count = nil
 
     topic_id = params[:topic_id]
-    if topic = Topic.find_by(id: topic_id)
+    if topic_id.present? && topic = Topic.find_by(id: topic_id)
       usernames.each do |username|
         if !Guardian.new(User.find_by_username(username)).can_see?(topic)
           cannot_see.push(username)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -493,21 +493,20 @@ class UsersController < ApplicationController
     usernames -= groups
     usernames.each(&:downcase!)
 
-    topic_id = params[:topic_id]
-    topic = Topic.find_by(id: topic_id) if !topic_id.blank?
-
     cannot_see = []
-    if topic
+    here_count = nil
+
+    topic_id = params[:topic_id]
+    if topic = Topic.find_by(id: topic_id)
       usernames.each do |username|
         if !Guardian.new(User.find_by_username(username)).can_see?(topic)
           cannot_see.push(username)
         end
       end
-    end
 
-    here_count = nil
-    if usernames.include?(SiteSetting.here_mention) && guardian.can_mention_here?
-      here_count = PostAlerter.new.expand_here_mention(topic.first_post, exclude_ids: [current_user.id]).size
+      if usernames.include?(SiteSetting.here_mention) && guardian.can_mention_here?
+        here_count = PostAlerter.new.expand_here_mention(topic.first_post, exclude_ids: [current_user.id]).size
+      end
     end
 
     result = User.where(staged: false)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -506,7 +506,7 @@ class UsersController < ApplicationController
     end
 
     here_count = nil
-    if usernames.include?(SiteSetting.here_mention) && !User.where(username_lower: SiteSetting.here_mention).exists?
+    if usernames.include?(SiteSetting.here_mention) && guardian.can_mention_here?
       PostAlerter.new.expand_here_mention(topic.first_post, exclude_ids: [current_user.id]) do |users|
         here_count = users.size
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -506,8 +506,8 @@ class UsersController < ApplicationController
     end
 
     here_count = nil
-    if usernames.include?(PostAlerter::HERE_MENTION) && !User.where(username_lower: PostAlerter::HERE_MENTION).exists?
-      PostAlerter.new.expand_here_mention(topic.first_post) do |users|
+    if usernames.include?(SiteSetting.here_mention) && !User.where(username_lower: SiteSetting.here_mention).exists?
+      PostAlerter.new.expand_here_mention(topic.first_post, exclude_ids: [current_user.id]) do |users|
         here_count = users.size
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -507,9 +507,7 @@ class UsersController < ApplicationController
 
     here_count = nil
     if usernames.include?(SiteSetting.here_mention) && guardian.can_mention_here?
-      PostAlerter.new.expand_here_mention(topic.first_post, exclude_ids: [current_user.id]) do |users|
-        here_count = users.size
-      end
+      here_count = PostAlerter.new.expand_here_mention(topic.first_post, exclude_ids: [current_user.id]).size
     end
 
     result = User.where(staged: false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -285,6 +285,8 @@ class User < ActiveRecord::Base
   def self.reserved_username?(username)
     username = normalize_username(username)
 
+    return true if SiteSetting.here_mention == username
+
     SiteSetting.reserved_usernames.unicode_normalize.split("|").any? do |reserved|
       username.match?(/^#{Regexp.escape(reserved).gsub('\*', '.*')}$/)
     end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -2,6 +2,8 @@
 
 class PostAlerter
   USER_BATCH_SIZE = 100
+  HERE_MENTION = "here"
+  HERE_MENTIONED = 10
 
   def self.post_created(post, opts = {})
     PostAlerter.new(opts).after_save_post(post, true)
@@ -111,9 +113,9 @@ class PostAlerter
     notified = [post.user, post.last_editor].uniq
 
     # mentions (users/groups)
-    mentioned_groups, mentioned_users = extract_mentions(post)
+    mentioned_groups, mentioned_users, mentioned_here = extract_mentions(post)
 
-    if mentioned_groups || mentioned_users
+    if mentioned_groups || mentioned_users || mentioned_here
       mentioned_opts = {}
       editor = post.last_editor
 
@@ -130,6 +132,13 @@ class PostAlerter
       expand_group_mentions(mentioned_groups, post) do |group, users|
         users = only_allowed_users(users, post)
         notified += notify_users(users - notified, :group_mentioned, post, mentioned_opts.merge(group: group))
+      end
+
+      if mentioned_here
+        expand_here_mention(post) do |users|
+          users = only_allowed_users(users, post)
+          notified += notify_users(users - notified, :mentioned, post, mentioned_opts)
+        end
       end
     end
 
@@ -543,6 +552,50 @@ class PostAlerter
 
   end
 
+  def expand_here_mention(post)
+    user_ids = []
+
+    # users that were allowed to topic
+    if user_ids.size < HERE_MENTIONED
+      user_ids += TopicAllowedUser
+        .where(topic_id: post.topic_id)
+        .pluck(:user_id)
+
+      user_ids.uniq!
+    end
+
+    # users that are members of groups allowed to topic
+    if user_ids.size < HERE_MENTIONED
+      user_ids += GroupUser
+        .where(group_id: TopicAllowedGroup.select(:group_id).where(topic_id: post.topic_id))
+        .pluck(:user_id)
+
+      user_ids.uniq!
+    end
+
+    # users that liked posts in topic
+    if user_ids.size < HERE_MENTIONED
+      user_ids += PostAction
+        .where(post_id: Post.select(:id).where(topic_id: post.topic_id))
+        .where(post_action_type_id: PostActionType.types[:like])
+        .pluck(:user_id)
+
+      user_ids.uniq!
+    end
+
+    # users that read the topic
+    if user_ids.size < HERE_MENTIONED
+      user_ids += TopicUser
+        .where(topic_id: post.topic_id)
+        .order(total_msecs_viewed: :desc)
+        .pluck(:user_id)
+
+      user_ids.uniq!
+    end
+
+    yield User.where(id: user_ids[0..HERE_MENTIONED])
+  end
+
   # TODO: Move to post-analyzer?
   def extract_mentions(post)
     mentions = post.raw_mentions
@@ -557,7 +610,10 @@ class PostAlerter
       users = nil if users.empty?
     end
 
-    [groups, users]
+    # @here can be a user mention and then this feature is disabled
+    here = mentions.include?(HERE_MENTION) && !User.where(username_lower: HERE_MENTION).exists?
+
+    [groups, users, here]
   end
 
   # TODO: Move to post-analyzer?

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -608,7 +608,7 @@ class PostAlerter
     end
 
     # @here can be a user mention and then this feature is disabled
-    here = mentions.include?(SiteSetting.here_mention) && !User.where(username_lower: SiteSetting.here_mention).exists?
+    here = mentions.include?(SiteSetting.here_mention) && Guardian.new(post.user).can_mention_here?
 
     [groups, users, here]
   end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -560,7 +560,7 @@ class PostAlerter
     end
 
     User.real
-      .where(id: posts.distinct.select(:user_id))
+      .where(id: posts.select(:user_id))
       .limit(SiteSetting.max_here_mentioned)
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2105,6 +2105,9 @@ en:
       cannot_see_mention:
         category: "You mentioned %{username} but they won't be notified because they do not have access to this category. You will need to add them to a group that has access to this category."
         private: "You mentioned %{username} but they won't be notified because they are unable to see this personal message. You will need to invite them to this PM."
+      here_mention:
+        one: "By mentioning <b>@here</b>, you are about to notify %{count} user – are you sure?"
+        other: "By mentioning <b>@here</b>, you are about to notify %{count} users – are you sure?"
       duplicate_link: "It looks like your link to <b>%{domain}</b> was already posted in the topic by <b>@%{username}</b> in <a href='%{post_url}'>a reply on %{ago}</a> – are you sure you want to post it again?"
       reference_topic_title: "RE: %{title}"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2106,8 +2106,8 @@ en:
         category: "You mentioned %{username} but they won't be notified because they do not have access to this category. You will need to add them to a group that has access to this category."
         private: "You mentioned %{username} but they won't be notified because they are unable to see this personal message. You will need to invite them to this PM."
       here_mention:
-        one: "By mentioning <b>@here</b>, you are about to notify %{count} user – are you sure?"
-        other: "By mentioning <b>@here</b>, you are about to notify %{count} users – are you sure?"
+        one: "By mentioning <b>@%{here}</b>, you are about to notify %{count} user – are you sure?"
+        other: "By mentioning <b>@%{here}</b>, you are about to notify %{count} users – are you sure?"
       duplicate_link: "It looks like your link to <b>%{domain}</b> was already posted in the topic by <b>@%{username}</b> in <a href='%{post_url}'>a reply on %{ago}</a> – are you sure you want to post it again?"
       reference_topic_title: "RE: %{title}"
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1885,6 +1885,7 @@ en:
     enable_mentions: "Allow users to mention other users."
     here_mention: "Name used for @here mention. Must not be an existent username."
     max_here_mentioned: "Maximum number of mentioned people by @here."
+    min_trust_level_for_here_mention: "The minimum trust level allowed to mention @here."
 
     create_thumbnails: "Create thumbnails and lightbox images that are too large to fit in a post."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1883,6 +1883,8 @@ en:
     max_mentions_per_post: "Maximum number of @name notifications anyone can use in a post."
     max_users_notified_per_group_mention: "Maximum number of users that may receive a notification if a group is mentioned (if threshold is met no notifications will be raised)"
     enable_mentions: "Allow users to mention other users."
+    here_mention: "Name used for @here mention. Must not be an existent username."
+    max_here_mentioned: "Maximum number of mentioned people by @here."
 
     create_thumbnails: "Create thumbnails and lightbox images that are too large to fit in a post."
 
@@ -2325,6 +2327,7 @@ en:
       invalid_css_color: "Invalid color. Enter a color name or hex value."
       invalid_email: "Invalid email address."
       invalid_username: "There's no user with that username."
+      valid_username: "There's a user with that username."
       invalid_group: "There's no group with that name."
       invalid_integer_min_max: "Value must be between %{min} and %{max}."
       invalid_integer_min: "Value must be %{min} or greater."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -876,6 +876,7 @@ posting:
   here_mention:
     default: "here"
     validator: "NotUsernameValidator"
+    client: true
   max_here_mentioned: 10
   min_trust_level_for_here_mention:
     default: "2"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -877,6 +877,9 @@ posting:
     default: "here"
     validator: "NotUsernameValidator"
   max_here_mentioned: 10
+  min_trust_level_for_here_mention:
+    default: "2"
+    enum: "TrustLevelAndStaffSetting"
   title_max_word_length:
     default: 30
     locale_default:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -873,6 +873,10 @@ posting:
   max_users_notified_per_group_mention: 100
   newuser_max_replies_per_topic: 3
   newuser_max_mentions_per_post: 2
+  here_mention:
+    default: "here"
+    validator: "NotUsernameValidator"
+  max_here_mentioned: 10
   title_max_word_length:
     default: 30
     locale_default:

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -547,9 +547,7 @@ class Guardian
     return false if !authenticated?
     return false if User.where(username_lower: SiteSetting.here_mention).exists?
 
-    return is_admin? if SiteSetting.min_trust_level_for_here_mention.to_s == 'admin'
-    return is_staff? if SiteSetting.min_trust_level_for_here_mention.to_s == 'staff'
-    @user.has_trust_level?(SiteSetting.min_trust_level_for_here_mention.to_i)
+    @user.has_trust_level_or_staff?(SiteSetting.min_trust_level_for_here_mention)
   end
 
   private

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -541,6 +541,17 @@ class Guardian
     UserAuthToken.hash_token(token) if token
   end
 
+  def can_mention_here?
+    return false if SiteSetting.here_mention.blank?
+    return false if SiteSetting.max_here_mentioned < 0
+    return false if !authenticated?
+    return false if User.where(username_lower: SiteSetting.here_mention).exists?
+
+    return is_admin? if SiteSetting.min_trust_level_for_here_mention.to_s == 'admin'
+    return is_staff? if SiteSetting.min_trust_level_for_here_mention.to_s == 'staff'
+    @user.has_trust_level?(SiteSetting.min_trust_level_for_here_mention.to_i)
+  end
+
   private
 
   def is_my_own?(obj)

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -543,7 +543,7 @@ class Guardian
 
   def can_mention_here?
     return false if SiteSetting.here_mention.blank?
-    return false if SiteSetting.max_here_mentioned < 0
+    return false if SiteSetting.max_here_mentioned < 1
     return false if !authenticated?
     return false if User.where(username_lower: SiteSetting.here_mention).exists?
 

--- a/lib/validators/not_username_validator.rb
+++ b/lib/validators/not_username_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class NotUsernameValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    val.blank? || !User.where(username: val).exists?
+  end
+
+  def error_message
+    I18n.t('site_settings.errors.valid_username')
+  end
+end

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -3943,4 +3943,44 @@ describe Guardian do
       end
     end
   end
+
+  describe "can_mention_here?" do
+    it 'returns false if disabled' do
+      SiteSetting.max_here_mentioned = 0
+      expect(admin.guardian.can_mention_here?).to eq(false)
+    end
+
+    it 'returns false if disabled' do
+      SiteSetting.here_mention = ''
+      expect(admin.guardian.can_mention_here?).to eq(false)
+    end
+
+    it 'works with trust levels' do
+      SiteSetting.min_trust_level_for_here_mention = 2
+
+      expect(trust_level_0.guardian.can_mention_here?).to eq(false)
+      expect(trust_level_1.guardian.can_mention_here?).to eq(false)
+      expect(trust_level_2.guardian.can_mention_here?).to eq(true)
+      expect(trust_level_3.guardian.can_mention_here?).to eq(true)
+      expect(trust_level_4.guardian.can_mention_here?).to eq(true)
+      expect(moderator.guardian.can_mention_here?).to eq(true)
+      expect(admin.guardian.can_mention_here?).to eq(true)
+    end
+
+    it 'works with staff' do
+      SiteSetting.min_trust_level_for_here_mention = 'staff'
+
+      expect(trust_level_4.guardian.can_mention_here?).to eq(false)
+      expect(moderator.guardian.can_mention_here?).to eq(true)
+      expect(admin.guardian.can_mention_here?).to eq(true)
+    end
+
+    it 'works with admin' do
+      SiteSetting.min_trust_level_for_here_mention = 'admin'
+
+      expect(trust_level_4.guardian.can_mention_here?).to eq(false)
+      expect(moderator.guardian.can_mention_here?).to eq(false)
+      expect(admin.guardian.can_mention_here?).to eq(true)
+    end
+  end
 end

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -3944,7 +3944,7 @@ describe Guardian do
     end
   end
 
-  describe "can_mention_here?" do
+  describe "#can_mention_here?" do
     it 'returns false if disabled' do
       SiteSetting.max_here_mentioned = 0
       expect(admin.guardian.can_mention_here?).to eq(false)

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -29,6 +29,7 @@ describe PostAlerter do
 
   fab!(:evil_trout) { Fabricate(:evil_trout) }
   fab!(:user) { Fabricate(:user) }
+  fab!(:tl2_user) { Fabricate(:user, trust_level: TrustLevel[2]) }
 
   def create_post_with_alerts(args = {})
     post = Fabricate(:post, args)
@@ -345,7 +346,7 @@ describe PostAlerter do
 
   context '@here' do
     let(:topic) { Fabricate(:topic) }
-    let(:post) { create_post_with_alerts(raw: "Hello @here how are you?", topic: topic) }
+    let(:post) { create_post_with_alerts(raw: "Hello @here how are you?", user: tl2_user, topic: topic) }
 
     before do
       Jobs.run_immediately!
@@ -356,7 +357,7 @@ describe PostAlerter do
     end
 
     it 'does not work if user here exists' do
-      Fabricate(:user, username: PostAlerter::HERE_MENTION)
+      Fabricate(:user, username: SiteSetting.here_mention)
       Fabricate(:topic_allowed_user, topic: topic, user: evil_trout)
       expect { post }.to change(evil_trout.notifications, :count).by(0)
     end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -363,8 +363,20 @@ describe PostAlerter do
     end
 
     it 'notifies users who replied' do
-      post2 = Fabricate(:post, topic: topic)
+      post2 = Fabricate(:post, topic: topic, post_type: Post.types[:whisper])
       post3 = Fabricate(:post, topic: topic)
+
+      expect { post }
+        .to change(other_post.user.notifications, :count).by(1)
+        .and change(post2.user.notifications, :count).by(0)
+        .and change(post3.user.notifications, :count).by(1)
+    end
+
+    it 'notifies users who whispered' do
+      post2 = Fabricate(:post, topic: topic, post_type: Post.types[:whisper])
+      post3 = Fabricate(:post, topic: topic)
+
+      tl2_user.grant_admin!
 
       expect { post }
         .to change(other_post.user.notifications, :count).by(1)


### PR DESCRIPTION
Use @here to mention all users that were allowed to topic directly or
through group, who liked topics or read the topic. Only first 10 users
will be notified.