### PR TITLE
DEV: Let's always give a drop_from param to deprecate

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -247,7 +247,7 @@ class GroupsController < ApplicationController
 
     dir = (params[:asc] && params[:asc].present?) ? 'ASC' : 'DESC'
     if params[:desc]
-      Discourse.deprecate(":desc is deprecated please use :asc instead", output_in_test: true)
+      Discourse.deprecate(":desc is deprecated please use :asc instead", output_in_test: true, drop_from: '2.9.0')
       dir = (params[:desc] && params[:desc].present?) ? 'DESC' : 'ASC'
     end
     order = ""

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -776,7 +776,7 @@ class PostsController < ApplicationController
     result[:referrer] = request.env["HTTP_REFERER"]
 
     if recipients = result[:target_usernames]
-      Discourse.deprecate("`target_usernames` is deprecated, use `target_recipients` instead.", output_in_test: true)
+      Discourse.deprecate("`target_usernames` is deprecated, use `target_recipients` instead.", output_in_test: true, drop_from: '2.9.0')
     else
       recipients = result[:target_recipients]
     end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -747,7 +747,7 @@ class Category < ActiveRecord::Base
   end
 
   def url_with_id
-    Discourse.deprecate("Category#url_with_id is deprecated. Use `Category#url` instead.", output_in_test: true)
+    Discourse.deprecate("Category#url_with_id is deprecated. Use `Category#url` instead.", output_in_test: true, drop_from: '2.9.0')
 
     url
   end

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -103,7 +103,11 @@ class PostAction < ActiveRecord::Base
   end
 
   def self.act(created_by, post, post_action_type_id, opts = {})
-    Discourse.deprecate("PostAction.act is deprecated. Use `PostActionCreator` instead.", output_in_test: true)
+    Discourse.deprecate(
+      "PostAction.act is deprecated. Use `PostActionCreator` instead.",
+      output_in_test: true,
+      drop_from: '2.9.0',
+    )
 
     result = PostActionCreator.new(
       created_by,
@@ -131,7 +135,8 @@ class PostAction < ActiveRecord::Base
   def self.remove_act(user, post, post_action_type_id)
     Discourse.deprecate(
       "PostAction.remove_act is deprecated. Use `PostActionDestroyer` instead.",
-      output_in_test: true
+      output_in_test: true,
+      drop_from: '2.9.0',
     )
 
     PostActionDestroyer.new(user, post, post_action_type_id).perform

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -107,7 +107,7 @@ class Report
   def add_filter(name, options = {})
     if options[:type].blank?
       options[:type] = name
-      Discourse.deprecate("#{name} filter should define a `:type` option. Temporarily setting type to #{name}.")
+      Discourse.deprecate("#{name} filter should define a `:type` option. Temporarily setting type to #{name}.", drop_from: '2.9.0')
     end
 
     available_filters[name] = options

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -402,7 +402,8 @@ class Reviewable < ActiveRecord::Base
   def post_options
     Discourse.deprecate(
       "Reviewable#post_options is deprecated. Please use #payload instead.",
-      output_in_test: true
+      output_in_test: true,
+      drop_from: '2.9.0',
     )
   end
 

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -90,7 +90,7 @@ class SiteSetting < ActiveRecord::Base
   end
 
   def self.queue_jobs=(val)
-    Discourse.deprecate("queue_jobs is deprecated. Please use Jobs.run_immediately! instead")
+    Discourse.deprecate("queue_jobs is deprecated. Please use Jobs.run_immediately! instead", drop_from: '2.9.0')
     val ? Jobs.run_later! : Jobs.run_immediately!
   end
 

--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -37,7 +37,7 @@ class AdminUserIndexQuery
   end
 
   def custom_direction
-    Discourse.deprecate(":ascending is deprecated please use :asc instead", output_in_test: true) if params[:ascending]
+    Discourse.deprecate(":ascending is deprecated please use :asc instead", output_in_test: true, drop_from: '2.9.0') if params[:ascending]
     asc = params[:asc] || params[:ascending]
     asc.present? && asc ? "ASC" : "DESC"
   end

--- a/lib/auth/auth_provider.rb
+++ b/lib/auth/auth_provider.rb
@@ -16,24 +16,24 @@ class Auth::AuthProvider
   attr_accessor(*auth_attributes)
 
   def enabled_setting=(val)
-    Discourse.deprecate("(#{authenticator.name}) enabled_setting is deprecated. Please define authenticator.enabled? instead")
+    Discourse.deprecate("(#{authenticator.name}) enabled_setting is deprecated. Please define authenticator.enabled? instead", drop_from: '2.9.0')
     @enabled_setting = val
   end
 
   def background_color=(val)
-    Discourse.deprecate("(#{authenticator.name}) background_color is no longer functional. Please use CSS instead")
+    Discourse.deprecate("(#{authenticator.name}) background_color is no longer functional. Please use CSS instead", drop_from: '2.9.0')
   end
 
   def full_screen_login=(val)
-    Discourse.deprecate("(#{authenticator.name}) full_screen_login is now forced. The full_screen_login parameter can be removed from the auth_provider.")
+    Discourse.deprecate("(#{authenticator.name}) full_screen_login is now forced. The full_screen_login parameter can be removed from the auth_provider.", drop_from: '2.9.0')
   end
 
   def full_screen_login_setting=(val)
-    Discourse.deprecate("(#{authenticator.name}) full_screen_login is now forced. The full_screen_login_setting parameter can be removed from the auth_provider.")
+    Discourse.deprecate("(#{authenticator.name}) full_screen_login is now forced. The full_screen_login_setting parameter can be removed from the auth_provider.", drop_from: '2.9.0')
   end
 
   def message=(val)
-    Discourse.deprecate("(#{authenticator.name}) message is no longer used because all logins are full screen. It should be removed from the auth_provider")
+    Discourse.deprecate("(#{authenticator.name}) message is no longer used because all logins are full screen. It should be removed from the auth_provider", drop_from: '2.9.0')
   end
 
   def name

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -383,7 +383,7 @@ class Auth::DefaultCurrentUserProvider
 
     limit = GlobalSetting.max_admin_api_reqs_per_minute.to_i
     if GlobalSetting.respond_to?(:max_admin_api_reqs_per_key_per_minute)
-      Discourse.deprecate("DISCOURSE_MAX_ADMIN_API_REQS_PER_KEY_PER_MINUTE is deprecated. Please use DISCOURSE_MAX_ADMIN_API_REQS_PER_MINUTE")
+      Discourse.deprecate("DISCOURSE_MAX_ADMIN_API_REQS_PER_KEY_PER_MINUTE is deprecated. Please use DISCOURSE_MAX_ADMIN_API_REQS_PER_MINUTE", drop_from: '2.9.0')
       limit = [ GlobalSetting.max_admin_api_reqs_per_key_per_minute.to_i, limit].max
     end
 

--- a/lib/freedom_patches/active_record_base.rb
+++ b/lib/freedom_patches/active_record_base.rb
@@ -26,7 +26,7 @@ class ActiveRecord::Base
   # Execute SQL manually
   def self.exec_sql(*args)
 
-    Discourse.deprecate("exec_sql should not be used anymore, please use DB.exec or DB.query instead!")
+    Discourse.deprecate("exec_sql should not be used anymore, please use DB.exec or DB.query instead!", drop_from: '2.9.0')
 
     conn = ActiveRecord::Base.connection
     sql = ActiveRecord::Base.public_send(:sanitize_sql_array, args)

--- a/lib/new_post_result.rb
+++ b/lib/new_post_result.rb
@@ -36,7 +36,8 @@ class NewPostResult
   def queued_post
     Discourse.deprecate(
       "NewPostManager#queued_post is deprecated. Please use #reviewable instead.",
-      output_in_test: true
+      output_in_test: true,
+      drop_from: '2.9.0',
     )
 
     reviewable

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -744,9 +744,9 @@ class Plugin::Instance
         provider.authenticator.enabled?
       rescue NotImplementedError
         provider.authenticator.define_singleton_method(:enabled?) do
-          Discourse.deprecate("#{provider.authenticator.class.name} should define an `enabled?` function. Patching for now.")
+          Discourse.deprecate("#{provider.authenticator.class.name} should define an `enabled?` function. Patching for now.", drop_from: '2.9.0')
           return SiteSetting.get(provider.enabled_setting) if provider.enabled_setting
-          Discourse.deprecate("#{provider.authenticator.class.name} has not defined an enabled_setting. Defaulting to true.")
+          Discourse.deprecate("#{provider.authenticator.class.name} has not defined an enabled_setting. Defaulting to true.", drop_from: '2.9.0')
           true
         end
       end

--- a/lib/sql_builder.rb
+++ b/lib/sql_builder.rb
@@ -4,7 +4,7 @@ class SqlBuilder
 
   def initialize(template, klass = nil)
 
-    Discourse.deprecate("SqlBuilder is deprecated and will be removed, please use DB.build instead!")
+    Discourse.deprecate("SqlBuilder is deprecated and will be removed, please use DB.build instead!", drop_from: '2.9.0')
 
     @args = {}
     @sql = template

--- a/lib/stylesheet/functions.rb
+++ b/lib/stylesheet/functions.rb
@@ -3,11 +3,11 @@
 module Stylesheet
   module ScssFunctions
     def asset_url(path)
-      Discourse.deprecate("The `asset-url` SCSS function is deprecated. Use `absolute-image-url` instead.")
+      Discourse.deprecate("The `asset-url` SCSS function is deprecated. Use `absolute-image-url` instead.", drop_from: '2.9.0')
       SassC::Script::Value::String.new("url('#{ActionController::Base.helpers.asset_url(path.value)}')")
     end
     def image_url(path)
-      Discourse.deprecate("The `image-url` SCSS function is deprecated. Use `absolute-image-url` instead.")
+      Discourse.deprecate("The `image-url` SCSS function is deprecated. Use `absolute-image-url` instead.", drop_from: '2.9.0')
       SassC::Script::Value::String.new("url('#{ActionController::Base.helpers.image_url(path.value)}')")
     end
   end


### PR DESCRIPTION
So that we know when deprecations can be removed in the future.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
