### PR TITLE
DEV: Don't try to load admin locales in tests

### DIFF
--- a/app/views/qunit/index.html.erb
+++ b/app/views/qunit/index.html.erb
@@ -9,7 +9,6 @@
     <%= preload_script "discourse/tests/core_plugins_tests" %>
     <%= preload_script "discourse/tests/test_starter" %>
     <%= csrf_meta_tags %>
-    <script src="<%= ExtraLocalesController.url('admin') %>"></script>
     <meta property="og:title" content="">
     <meta property="og:url" content="">
   </head>

--- a/app/views/qunit/theme.html.erb
+++ b/app/views/qunit/theme.html.erb
@@ -21,7 +21,6 @@
       <%= theme_js_lookup %>
       <%= theme_lookup("head_tag") %>
       <%= theme_tests %>
-      <%= preload_script_url ExtraLocalesController.url('admin') %>
       <%= tag.meta id: 'data-discourse-setup', data: client_side_setup_data %>
       <meta property="og:title" content="">
       <meta property="og:url" content="">

--- a/spec/requests/qunit_controller_spec.rb
+++ b/spec/requests/qunit_controller_spec.rb
@@ -108,7 +108,6 @@ describe QunitController do
         expect(response.body).to match(/\/theme-javascripts\/\h{40}\.js/)
         expect(response.body).to include("/theme-javascripts/tests/#{theme.id}-")
         expect(response.body).to include("/assets/discourse/tests/test_starter.js")
-        expect(response.body).to include("/extra-locales/admin")
       end
     end
   end


### PR DESCRIPTION
It always fails with:

```
Failed to load resource: the server responded with a status of 403 (Forbidden), url: http://localhost:60099/extra-locales/admin?v=[…]
```
