### PR TITLE
DEV: Fix a call-after-destroy issue

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -155,6 +155,10 @@ export default Component.extend({
 
   @bind
   _intersectionHandler(entries) {
+    if (!this.element || this.isDestroying || this.isDestroyed) {
+      return;
+    }
+
     if (entries[0].isIntersecting === true) {
       this.set("docked", true);
     } else {


### PR DESCRIPTION
Intersection observer callback can be called after the component gets destroyed:

```
Assertion Failed: calling set on destroyed object: <@ember/component:ember6019>.docked = false
    at assert (ember:37774:17)
    at _set2 (ember:17304:46)
    at Class.set (ember:29529:29)
    at Class._intersectionHandler (discourse/app/components/topic-progress:135:16)
    at Backburner._run (ember:56389:25)
    at Backburner._join (ember:56365:21)
    at Backburner.join (ember:56082:19)
    at join (ember:42874:28)
    at IntersectionObserver.eval (ember:42978:19)
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
