### PR TITLE
FIX: exclude topics from muted tag in category featured list.

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -70,6 +70,7 @@ class CategoryList
         .where('COALESCE(tu.notification_level,1) > :muted', muted: TopicUser.notification_levels[:muted])
     end
 
+    @all_topics = TopicQuery.remove_muted_tags(@all_topics, @guardian.user)
     @all_topics = @all_topics.includes(:last_poster) if @options[:include_topics]
     @all_topics.each do |t|
       # hint for the serializer

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -822,7 +822,7 @@ class TopicQuery
   def remove_muted(list, user, options)
     list = remove_muted_topics(list, user) unless options && options[:state] == "muted"
     list = remove_muted_categories(list, user, exclude: options[:category])
-    remove_muted_tags(list, user, options)
+    TopicQuery.remove_muted_tags(list, user, options)
   end
 
   def remove_muted_topics(list, user)
@@ -867,7 +867,7 @@ class TopicQuery
     list
   end
 
-  def remove_muted_tags(list, user, opts = {})
+  def self.remove_muted_tags(list, user, opts = {})
     if !SiteSetting.tagging_enabled || SiteSetting.remove_muted_tags_from_latest == 'never'
       return list
     end

--- a/lib/topic_query/private_message_lists.rb
+++ b/lib/topic_query/private_message_lists.rb
@@ -39,7 +39,7 @@ class TopicQuery
 
     def list_private_messages_new(user, type = :user)
       list = filter_private_message_new(user, type)
-      list = remove_muted_tags(list, user)
+      list = TopicQuery.remove_muted_tags(list, user)
       list = remove_dismissed(list, user)
 
       create_list(:private_messages, {}, list)

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -41,12 +41,16 @@ describe CategoryList do
       secret_subcat.set_permissions(admins: :full)
       secret_subcat.save
 
+      muted_tag = Fabricate(:tag) # muted tag
+      SiteSetting.default_tags_muted = muted_tag.name
+      Fabricate(:topic, category: public_cat, tags: [muted_tag])
+
       CategoryFeaturedTopic.feature_topics
 
-      expect(CategoryList.new(Guardian.new(admin), include_topics: true).categories.find { |x| x.name == public_cat.name }.displayable_topics.count).to eq(2)
+      expect(CategoryList.new(Guardian.new(admin), include_topics: true).categories.find { |x| x.name == public_cat.name }.displayable_topics.count).to eq(3)
       expect(CategoryList.new(Guardian.new(admin), include_topics: true).categories.find { |x| x.name == private_cat.name }.displayable_topics.count).to eq(1)
 
-      expect(CategoryList.new(Guardian.new(user), include_topics: true).categories.find { |x| x.name == public_cat.name }.displayable_topics.count).to eq(1)
+      expect(CategoryList.new(Guardian.new(user), include_topics: true).categories.find { |x| x.name == public_cat.name }.displayable_topics.count).to eq(2)
       expect(CategoryList.new(Guardian.new(user), include_topics: true).categories.find { |x| x.name == private_cat.name }).to eq(nil)
 
       expect(CategoryList.new(Guardian.new(nil), include_topics: true).categories.find { |x| x.name == public_cat.name }.displayable_topics.count).to eq(1)


### PR DESCRIPTION
Topics from muted tags were visible in the categories page's featured topics section since we didn't filter it before.