### PR TITLE
DEV: Fix a computed property overwrite

### DIFF
--- a/app/assets/javascripts/discourse/app/models/reviewable.js
+++ b/app/assets/javascripts/discourse/app/models/reviewable.js
@@ -46,11 +46,6 @@ const Reviewable = RestModel.extend({
         updated.payload || {}
       );
 
-      if (updated.category_id) {
-        updated.category = Category.findById(updated.category_id);
-        delete updated.category_id;
-      }
-
       this.setProperties(updated);
     });
   },


### PR DESCRIPTION
There's a `category` computed property that already does what this piece of code did.