### PR TITLE
DEV: Delete an old `appEvents.off` call

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -207,7 +207,6 @@ export default Component.extend(KeyEnterEscape, {
 
   willDestroyElement() {
     this._super(...arguments);
-    this.appEvents.off("composer:resize", this, this.resize);
     if (this._visualViewportResizing()) {
       window.visualViewport.removeEventListener("resize", this.viewportResize);
     }


### PR DESCRIPTION
There's no `composer:resize` anymore.