### PR TITLE
FIX: register customOptions as select kit filter

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/user-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/user-chooser.js
@@ -27,6 +27,7 @@ export default MultiSelectComponent.extend({
     allowEmails: false,
     groupMembersOf: undefined,
     excludeCurrentUser: false,
+    customOptions: {},
   },
 
   content: computed("value.[]", function () {
@@ -70,7 +71,7 @@ export default MultiSelectComponent.extend({
       (obj, option) => {
         return {
           ...obj,
-          [option]: options[option],
+          [option]: options.customOptions[option],
         };
       },
       {}

--- a/app/assets/javascripts/select-kit/addon/components/user-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/user-chooser.js
@@ -4,6 +4,7 @@ import userSearch, {
 } from "discourse/lib/user-search";
 import MultiSelectComponent from "select-kit/components/multi-select";
 import { computed } from "@ember/object";
+import { isPresent } from "@ember/utils";
 import { makeArray } from "discourse-common/lib/helpers";
 
 export const CUSTOM_USER_SEARCH_OPTIONS = [];
@@ -27,7 +28,7 @@ export default MultiSelectComponent.extend({
     allowEmails: false,
     groupMembersOf: undefined,
     excludeCurrentUser: false,
-    customOptions: {},
+    customSearchOptions: undefined,
   },
 
   content: computed("value.[]", function () {
@@ -67,15 +68,18 @@ export default MultiSelectComponent.extend({
       return;
     }
 
-    let customUserSearchOptions = CUSTOM_USER_SEARCH_OPTIONS.reduce(
-      (obj, option) => {
-        return {
-          ...obj,
-          [option]: options.customOptions[option],
-        };
-      },
-      {}
-    );
+    let customUserSearchOptions = {};
+    if (options.customSearchOptions && isPresent(CUSTOM_USER_SEARCH_OPTIONS)) {
+      customUserSearchOptions = CUSTOM_USER_SEARCH_OPTIONS.reduce(
+        (obj, option) => {
+          return {
+            ...obj,
+            [option]: options.customSearchOptions[option],
+          };
+        },
+        {}
+      );
+    }
 
     return userSearch({
       term: filter,


### PR DESCRIPTION
We are allowing plugins to define custom filters which are added to CUSTOM_USER_SEARCH_OPTIONS const. However, we need to have static placeholder for custom filters, so those props will be passed, and we can use it later.

Related PR: https://github.com/discourse/discourse-assign/pull/240