### PR TITLE
FIX: Drop malformed CC addresses in GroupSmtpEmail job

### DIFF
--- a/spec/jobs/regular/group_smtp_email_spec.rb
+++ b/spec/jobs/regular/group_smtp_email_spec.rb
@@ -160,6 +160,16 @@ RSpec.describe Jobs::GroupSmtpEmail do
     expect(email_log.smtp_group_id).to eq(group.id)
   end
 
+  it "drops malformed cc addresses when sending the email" do
+    args2 = args.clone
+    args2[:cc_emails] << "somebadccemail@test.com<mailto:somebadccemail@test.com"
+    subject.execute(args2)
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+    last_email = ActionMailer::Base.deliveries.last
+    expect(last_email.subject).to eq("Re: Help I need support")
+    expect(last_email.cc).to match_array(["otherguy@test.com", "cormac@lit.com"])
+  end
+
   context "when there are cc_addresses" do
     it "has the cc_addresses and cc_user_ids filled in correctly" do
       subject.execute(args)


### PR DESCRIPTION
Sometimes, a user may have a malformed email such as
`test@test.com<mailto:test@test.com` their email address,
and as a topic participant will be included as a CC email
when sending a GroupSmtpEmail. This causes the CC parsing to
fail and further down the line in Email::Sender the code
to check the CC addresses expects an array but gets a string
instead because of the parse failure.

Instead, we can just check if the CC addresses are valid
and drop them if they are not in the GroupSmtpEmail job.

