### PR TITLE
SECURITY: Disallow caching of MIME/Content-Type errors (stable)

### DIFF
--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -314,7 +314,7 @@ module Middleware
       if PAYLOAD_INVALID_REQUEST_METHODS.include?(env[Rack::REQUEST_METHOD]) &&
         env[Rack::RACK_INPUT].size > 0
 
-        return [413, {}, []]
+        return [413, { "Cache-Control" => "private, max-age=0, must-revalidate" }, []]
       end
 
       helper = Helper.new(env)

--- a/lib/middleware/discourse_public_exceptions.rb
+++ b/lib/middleware/discourse_public_exceptions.rb
@@ -35,7 +35,7 @@ module Middleware
           begin
             request.format
           rescue Mime::Type::InvalidMimeType
-            return [400, {}, ["Invalid MIME type"]]
+            return [400, { "Cache-Control" => "private, max-age=0, must-revalidate" }, ["Invalid MIME type"]]
           end
 
           if ApplicationController.rescue_with_handler(exception, object: fake_controller)

--- a/spec/components/middleware/anonymous_cache_spec.rb
+++ b/spec/components/middleware/anonymous_cache_spec.rb
@@ -243,11 +243,12 @@ describe Middleware::AnonymousCache do
 
   context 'invalid request payload' do
     it 'returns 413 for GET request with payload' do
-      status, _, _ = middleware.call(env.tap do |environment|
+      status, headers, _ = middleware.call(env.tap do |environment|
         environment[Rack::RACK_INPUT].write("test")
       end)
 
       expect(status).to eq(413)
+      expect(headers["Cache-Control"]).to eq("private, max-age=0, must-revalidate")
     end
   end
 


### PR DESCRIPTION
This will sign intermediary proxies and/or misconfigured CDNs to not
cache those error responses.

(stable backport of #14907)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
