### PR TITLE
FEATURE: adds uploads scope for API keys

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -35,6 +35,9 @@ class ApiKeyScope < ActiveRecord::Base
         posts: {
           edit: { actions: %w[posts#update], params: %i[id] }
         },
+        uploads: {
+          create: { actions: %w[uploads#create] }
+        },
         users: {
           bookmarks: { actions: %w[users#bookmarks], params: %i[username] },
           sync_sso: { actions: %w[admin/users#sync_sso], params: %i[sso sig] },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4183,6 +4183,8 @@ en:
               wordpress: Necessary for the WordPress wp-discourse plugin to work.
             posts:
               edit: Edit any post or a specific one.
+            uploads:
+              create: Upload a new image.
             users:
               bookmarks: List user bookmarks. It returns bookmark reminders when using the ICS format.
               sync_sso: Synchronize a user using DiscourseConnect.

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4184,7 +4184,7 @@ en:
             posts:
               edit: Edit any post or a specific one.
             uploads:
-              create: Upload a new image.
+              create: Upload a new file.
             users:
               bookmarks: List user bookmarks. It returns bookmark reminders when using the ICS format.
               sync_sso: Synchronize a user using DiscourseConnect.

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -237,7 +237,7 @@ describe Admin::ApiController do
 
         scopes = response.parsed_body['scopes']
 
-        expect(scopes.keys).to contain_exactly('topics', 'users', 'email', 'posts', 'global')
+        expect(scopes.keys).to contain_exactly('topics', 'users', 'email', 'posts', 'uploads', 'global')
       end
     end
   end


### PR DESCRIPTION
Context: https://meta.discourse.org/t/api-a-scope-with-access-to-uploads/208895

Testing this is not within my present familiarity with the discourse codebase.