### PR TITLE
DEV: Allow Chrome Ember CLI tests to fail in GitHub Actions

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: discourse/discourse_test:release
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.browser == 'Chrome' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
We are actively working on improving these, but for now the failures are quite noisy. This commit allows the Chrome Ember-CLI runs to fail quietly, without interrupting our PR workflows.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
