### PR TITLE
FIX: Redirect to homepage if no posts exist

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -189,7 +189,8 @@ export default createWidget("post-stream", {
     const posts = attrs.posts || [];
     const postArray = posts.toArray();
     const postArrayLength = postArray.length;
-    const maxPostNumber = postArray[postArrayLength - 1].post_number;
+    const maxPostNumber =
+      postArrayLength > 0 ? postArray[postArrayLength - 1].post_number : 0;
     const result = [];
     const before = attrs.gaps && attrs.gaps.before ? attrs.gaps.before : {};
     const after = attrs.gaps && attrs.gaps.after ? attrs.gaps.after : {};


### PR DESCRIPTION
After permanently deleting the first post of a topic the user was
sometimes stuck on the page because of an infinite loop. This problem
happened more often in Firefox.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
