### PR TITLE
DEV: Add basic theme support to the mini_profiler badge

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -985,3 +985,4 @@ a.inline-editable-field {
 @import "common/admin/admin_report_inline_table";
 @import "common/admin/admin_intro";
 @import "common/admin/admin_emojis";
+@import "common/admin/mini_profiler";

--- a/app/assets/stylesheets/common/admin/mini_profiler.scss
+++ b/app/assets/stylesheets/common/admin/mini_profiler.scss
@@ -1,0 +1,22 @@
+// Some basic overrides to https://github.com/MiniProfiler/rack-mini-profiler/blob/master/lib/html/includes.scss
+// which make the badge conform to the current site theme.
+
+div.profiler-results {
+  .profiler-button {
+    background-color: var(--header_background);
+    color: var(--header_primary);
+    border-bottom: 1px solid var(--header_primary-low);
+
+    .profiler-number {
+      color: var(--header_primary);
+    }
+
+    .profiler-unit {
+      color: var(--header_primary-medium);
+    }
+  }
+
+  &.profiler-left.profiler-top .profiler-button {
+    border-right: 1px solid var(--header_primary-low);
+  }
+}


### PR DESCRIPTION
In dark mode, the white mini-profiler badge can be quite distracting. This commit adds some basic overrides so that the badge conforms to the current site theme.

Before:
<img width="357" alt="Screenshot 2021-11-15 at 18 31 17" src="https://user-images.githubusercontent.com/6270921/141836063-a22603d2-ae6d-40b3-b21a-aeb70e46bc8b.png">

After:

<img width="314" alt="Screenshot 2021-11-15 at 18 30 57" src="https://user-images.githubusercontent.com/6270921/141835855-7cb935a6-367c-4cf3-bca0-18c54940ff32.png">


