### PR TITLE
FIX: Use correct group out of multiple for SMTP sender

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1777,6 +1777,10 @@ class Topic < ActiveRecord::Base
     end
   end
 
+  def first_smtp_enabled_group
+    self.allowed_groups.where(smtp_enabled: true).first
+  end
+
   private
 
   def invite_to_private_message(invited_by, target_user, guardian)

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -643,8 +643,9 @@ class PostAlerter
     if post.topic.allowed_groups.count == 1
       return post.topic.first_smtp_enabled_group
     end
+
     group = Group.find_by_email(post.topic.incoming_email.first.to_addresses)
-    if group.blank? || !group.smtp_enabled
+    if !group&.smtp_enabled
       return post.topic.first_smtp_enabled_group
     end
     group

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -640,7 +640,14 @@ class PostAlerter
 
   def group_notifying_via_smtp(post)
     return nil if !SiteSetting.enable_smtp || post.post_type != Post.types[:regular]
-    post.topic.allowed_groups.where(smtp_enabled: true).first
+    if post.topic.allowed_groups.count == 1
+      return post.topic.first_smtp_enabled_group
+    end
+    group = Group.find_by_email(post.topic.incoming_email.first.to_addresses)
+    if group.blank? || !group.smtp_enabled
+      return post.topic.first_smtp_enabled_group
+    end
+    group
   end
 
   def email_using_group_smtp_if_configured(post)

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1381,7 +1381,9 @@ describe PostAlerter do
       TopicAllowedGroup.create(group: other_allowed_group, topic: topic)
       post = Fabricate(:post, topic: topic)
       group.update!(smtp_enabled: false)
+
       expect { PostAlerter.new.after_save_post(post, true) }.to change { ActionMailer::Base.deliveries.size }.by(1)
+
       email = ActionMailer::Base.deliveries.last
       expect(email.from).to include(other_allowed_group.email_username)
       expect(email.to).to contain_exactly(topic.reload.topic_allowed_users.order(:created_at).first.user.email)


### PR DESCRIPTION
When there are multiple groups on a topic, we were selecting
the first from the topic allowed groups to act as the sender
email address when sending group SMTP replies via PostAlerter.
However, this was not ordered, and since there is no created_at
column on TopicAllowedGroup we cannot order this nicely, which
caused just a random group to be used (based on whatever postgres
decided it felt like that morning).

This commit changes the group used for SMTP sending to be the
group using the email_username of the to address of the first
incoming email for the topic, if there are more than one allowed
groups on the topic. Otherwise it just uses the only SMTP enabled
group.

