### PR TITLE
FIX: Emoji uploader not using data.name on uppy upload

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -1,4 +1,5 @@
 import Mixin from "@ember/object/mixin";
+import { isEmpty } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
 import {
   bindFileInputChangeListener,
@@ -118,6 +119,13 @@ export default Mixin.create(UppyS3Multipart, {
           );
           this._reset();
           return false;
+        }
+
+        // for a single file, we want to override file meta with the
+        // data property (which may be computed), to override any keys
+        // specified by this.data (such as name)
+        if (this.data && !isEmpty(this.data) && fileCount === 1) {
+          deepMerge(Object.values(files)[0].meta, this.data);
         }
       },
     });

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -1,5 +1,4 @@
 import Mixin from "@ember/object/mixin";
-import { isEmpty } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
 import {
   bindFileInputChangeListener,
@@ -124,7 +123,7 @@ export default Mixin.create(UppyS3Multipart, {
         // for a single file, we want to override file meta with the
         // data property (which may be computed), to override any keys
         // specified by this.data (such as name)
-        if (this.data && !isEmpty(this.data) && fileCount === 1) {
+        if (this.data && Object.keys(this.data).length && fileCount === 1) {
           deepMerge(Object.values(files)[0].meta, this.data);
         }
       },

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -123,7 +123,7 @@ export default Mixin.create(UppyS3Multipart, {
         // for a single file, we want to override file meta with the
         // data property (which may be computed), to override any keys
         // specified by this.data (such as name)
-        if (this.data && Object.keys(this.data).length && fileCount === 1) {
+        if (fileCount === 1) {
           deepMerge(Object.values(files)[0].meta, this.data);
         }
       },


### PR DESCRIPTION
When uploading emoji with the new uppy upload mixin, we were
not sending the name of the emoji in the payload, or more
accurately uppy was already using the file name as the name
value and we were not overriding it from data. This commit
changes the behaviour for single files uploaded via the uppy
upload mixin, by merging the file's meta object with this.data
from the parent component.
