### PR TITLE
UX: mobile topic list fixes follow-up to 0e371d4

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/mobile/list/topic-list-item.hbr
@@ -1,4 +1,4 @@
-<td>
+<td class="topic-list-data">
   {{~raw-plugin-outlet name="topic-list-before-columns"}}
   {{~#if showMobileAvatar}}
   <div class='pull-left'>

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -122,6 +122,7 @@ ol.category-breadcrumb {
     line-height: $line-height-medium;
     position: relative;
     z-index: z("base") + 1; // Intentionally overlapping category to create bigger tap target
+    font-size: var(--font-up-1);
     a.title {
       color: var(--primary);
       padding: 0.5em 0 1.2em 0;
@@ -162,7 +163,7 @@ ol.category-breadcrumb {
 
   .topic-item-stats {
     position: relative;
-    margin-top: 0.25em;
+    margin-top: 0.5em;
     z-index: z("base");
     .category,
     .num,
@@ -229,7 +230,6 @@ ol.category-breadcrumb {
   }
 
   .posts {
-    width: 10%;
     vertical-align: top;
   }
 
@@ -434,9 +434,12 @@ td .main-link {
   }
 }
 .topic-list {
-  .num.posts-map button {
+  .num.posts-map {
     font-size: $font-up-2;
     padding: 0;
+    button {
+      padding: 0;
+    }
   }
   .num.activity a {
     padding: 0;


### PR DESCRIPTION
 follow-up to 0e371d4

Before:
![Screen Shot 2021-11-15 at 8 43 59 PM](https://user-images.githubusercontent.com/1681963/141880536-9a38c8aa-0b01-4a5c-9989-045d89190276.png)

After:
![Screen Shot 2021-11-15 at 8 41 59 PM](https://user-images.githubusercontent.com/1681963/141880560-4ce71db4-b8d2-4f71-8b0c-e1c5627018d7.png)