### PR TITLE
FIX: fix regressions introduced in ae16b0a

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -558,6 +558,8 @@ export default function (options) {
     if (e.which === keys.esc) {
       if (div !== null) {
         closeAutocomplete();
+        e.preventDefault();
+        e.stopImmediatePropagation();
         return false;
       }
       return true;
@@ -605,6 +607,7 @@ export default function (options) {
             selectedOption = 0;
           }
           markSelected();
+          e.preventDefault();
           return false;
         case keys.downArrow:
           total = autocompleteOptions.length;
@@ -616,6 +619,7 @@ export default function (options) {
             selectedOption = 0;
           }
           markSelected();
+          e.preventDefault();
           return false;
         case keys.backSpace:
           autocompleteOptions = null;


### PR DESCRIPTION
- ensures arrow up/down doesn’t also apply to textarea while autocomplete is opened
- ensures esc is closing autocomplete and also not closing composer while autocomplete is opened

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
