### PR TITLE
UX: launch full page search on second `Enter` hit

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
+++ b/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
@@ -232,6 +232,10 @@ export default Controller.extend(ModalFunctionality, {
         insert_url: buildShortcut("search_menu.insert_url", {
           keys1: ["a"],
         }),
+        full_page_search: buildShortcut("search_menu.full_page_search", {
+          keys1: [translateModKey("Meta"), "Enter"],
+          keysDelimiter: PLUS,
+        }),
       },
     });
   },

--- a/app/assets/javascripts/discourse/app/templates/modal/keyboard-shortcuts-help.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/keyboard-shortcuts-help.hbs
@@ -100,6 +100,7 @@
       <ul>
         <li>{{html-safe shortcuts.search_menu.prev_next}}</li>
         <li>{{html-safe shortcuts.search_menu.insert_url}}</li>
+        <li>{{html-safe shortcuts.search_menu.full_page_search}}</li>
       </ul>
     </section>
   </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -480,6 +480,31 @@ acceptance("Search - Authenticated", function (needs) {
       `${window.location.origin}${firstLink}`,
       "hitting A when focused on a search result copies link to composer"
     );
+
+    await click("#search-button");
+    await triggerKeyEvent("#search-term", "keydown", keyEnter);
+
+    assert.ok(
+      exists(query(`${container} .search-result-topic`)),
+      "has topic results"
+    );
+
+    await triggerKeyEvent("#search-term", "keydown", keyEnter);
+
+    assert.ok(
+      exists(query(`.search-container`)),
+      "second Enter hit goes to full page search"
+    );
+    assert.ok(
+      !exists(query(`.search-menu`)),
+      "search dropdown is collapsed after second Enter hit"
+    );
+
+    // new search launched, Enter key should be reset
+    await click("#search-button");
+    assert.ok(exists(query(`${container} ul li`)), "has a list of items");
+    await triggerKeyEvent("#search-term", "keydown", keyEnter);
+    assert.ok(exists(query(`.search-menu`)), "search dropdown is visible");
   });
 });
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3714,6 +3714,7 @@ en:
         title: "Search Menu"
         prev_next: "%{shortcut} Move selection up and down"
         insert_url: "%{shortcut} Insert selection into open composer"
+        full_page_search: "%{shortcut} Launches full page search"
 
     badges:
       earned_n_times:


### PR DESCRIPTION
When using the quick search, a second hit of the `Enter` key should launch the full page search. This is useful now that topic/post results require hitting Enter. To ensure this doesn't cause any unwanted redirects, this only applies as long as the first press of the `Enter` key happened no more than 15 seconds ago. 

This PR also adds a keyboard shortcut entry in the help modal for `Ctrl` + `Enter`, which also launches full page search. 