### PR TITLE
FIX: Clean up emoji name which is file name

### DIFF
--- a/app/controllers/admin/emojis_controller.rb
+++ b/app/controllers/admin/emojis_controller.rb
@@ -16,6 +16,7 @@ class Admin::EmojisController < Admin::AdminController
 
     hijack do
       # fix the name
+      name = File.basename(name, ".*")
       name = name.gsub(/[^a-z0-9]+/i, '_')
         .gsub(/_{2,}/, '_')
         .downcase

--- a/spec/requests/admin/emojis_controller_spec.rb
+++ b/spec/requests/admin/emojis_controller_spec.rb
@@ -92,6 +92,40 @@ RSpec.describe Admin::EmojisController do
       expect(response.status).to eq(200)
       expect(custom_emoji.group).to eq("foo")
     end
+
+    it 'should fix up the emoji name' do
+      Emoji.expects(:clear_cache).times(3)
+
+      post "/admin/customize/emojis.json", params: {
+        name: 'test.png',
+        file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png")
+      }
+
+      custom_emoji = CustomEmoji.last
+      upload = custom_emoji.upload
+
+      expect(upload.original_filename).to eq('logo.png')
+      expect(custom_emoji.name).to eq("test")
+      expect(response.status).to eq(200)
+
+      post "/admin/customize/emojis.json", params: {
+        name: 'st&#* onk$',
+        file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png")
+      }
+
+      custom_emoji = CustomEmoji.last
+      expect(custom_emoji.name).to eq("st_onk_")
+      expect(response.status).to eq(200)
+
+      post "/admin/customize/emojis.json", params: {
+        name: 'PaRTYpaRrot',
+        file: fixture_file_upload("#{Rails.root}/spec/fixtures/images/logo.png")
+      }
+
+      custom_emoji = CustomEmoji.last
+      expect(custom_emoji.name).to eq("partyparrot")
+      expect(response.status).to eq(200)
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
Uppy adds the file name as the "name" parameter in the
payload by default, which means that for things like the
emoji uploader which have a name param used by the controller,
that param will be passed as the file name. We already use
the existing file name if the name param is null, so this
commit just does further cleanup of the name param, removing
the extension if it is a filename so we don't end up with
emoji names like blah_png.