### PR TITLE
FIX: Error when SMTP enabled in PostAlerter with no incoming email

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -639,12 +639,17 @@ class PostAlerter
   end
 
   def group_notifying_via_smtp(post)
-    return nil if !SiteSetting.enable_smtp || post.post_type != Post.types[:regular]
+    return if !SiteSetting.enable_smtp || post.post_type != Post.types[:regular]
+    return if post.topic.allowed_groups.none?
+
     if post.topic.allowed_groups.count == 1
       return post.topic.first_smtp_enabled_group
     end
 
-    group = Group.find_by_email(post.topic.incoming_email.first.to_addresses)
+    topic_incoming_email = post.topic.incoming_email.first
+    return if topic_incoming_email.blank?
+
+    group = Group.find_by_email(topic_incoming_email.to_addresses)
     if !group&.smtp_enabled
       return post.topic.first_smtp_enabled_group
     end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1362,6 +1362,30 @@ describe PostAlerter do
       Email::Receiver.new(raw_mail, {}).process!
     end
 
+    it "does not error if SMTP is enabled and the topic has no incoming email or allowed groups" do
+      topic = Fabricate(:private_message_topic)
+      Fabricate(:post, topic: topic)
+      post = Fabricate(:post, topic: topic)
+      expect { PostAlerter.new.after_save_post(post, true) }.not_to raise_error
+    end
+
+    it "does not error if SMTP is enabled and the topic has no incoming email but does have an allowed group" do
+      topic = Fabricate(:private_message_topic)
+      Fabricate(:post, topic: topic)
+      post = Fabricate(:post, topic: topic)
+      TopicAllowedGroup.create(topic: topic, group: Fabricate(:group))
+      expect { PostAlerter.new.after_save_post(post, true) }.not_to raise_error
+    end
+
+    it "does not error if SMTP is enabled and the topic has no incoming email but has multiple allowed groups" do
+      topic = Fabricate(:private_message_topic)
+      Fabricate(:post, topic: topic)
+      post = Fabricate(:post, topic: topic)
+      TopicAllowedGroup.create(topic: topic, group: Fabricate(:group))
+      TopicAllowedGroup.create(topic: topic, group: Fabricate(:group))
+      expect { PostAlerter.new.after_save_post(post, true) }.not_to raise_error
+    end
+
     it "sends a group smtp email because SMTP is enabled for the site and the group" do
       incoming_email_post = create_post_with_incoming
       topic = incoming_email_post.topic


### PR DESCRIPTION
When https://github.com/discourse/discourse/commit/31035010afc4770d81fca577a055b9abacb48d95
was done it failed to take into account the case where the smtp_enabled
site setting was true, but the topic had no allowed groups / no
incoming email record, which caused errors for topics even with
nothing to do with group SMTP.
