### PR TITLE
FIX: exclude moderator_action post for reply count in user summary.

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -392,7 +392,7 @@ class Topic < ActiveRecord::Base
     end
   end
 
-  def self.visible_post_types(viewed_by = nil, include_moderator_actions = true)
+  def self.visible_post_types(viewed_by = nil, include_moderator_actions: true)
     types = Post.types
     result = [types[:regular]]
     result += [types[:moderator_action], types[:small_action]] if include_moderator_actions

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -392,9 +392,10 @@ class Topic < ActiveRecord::Base
     end
   end
 
-  def self.visible_post_types(viewed_by = nil)
+  def self.visible_post_types(viewed_by = nil, include_moderator_actions = true)
     types = Post.types
-    result = [types[:regular], types[:moderator_action], types[:small_action]]
+    result = [types[:regular]]
+    result += [types[:moderator_action], types[:small_action]] if include_moderator_actions
     result << types[:whisper] if viewed_by&.staff?
     result
   end

--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -199,7 +199,7 @@ protected
     Post
       .joins(:topic)
       .includes(:topic)
-      .where('posts.post_type IN (?)', Topic.visible_post_types(@guardian&.user, false))
+      .where('posts.post_type IN (?)', Topic.visible_post_types(@guardian&.user, include_moderator_actions: false))
       .merge(Topic.listable_topics.visible.secured(@guardian))
       .where(user: @user)
   end

--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -197,11 +197,11 @@ protected
 
   def post_query
     Post
-    .joins(:topic)
-    .includes(:topic)
-    .where('posts.post_type IN (?)', Topic.visible_post_types(@guardian&.user, false))
-    .merge(Topic.listable_topics.visible.secured(@guardian))
-    .where(user: @user)
+      .joins(:topic)
+      .includes(:topic)
+      .where('posts.post_type IN (?)', Topic.visible_post_types(@guardian&.user, false))
+      .merge(Topic.listable_topics.visible.secured(@guardian))
+      .where(user: @user)
   end
 
 end

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -78,4 +78,19 @@ describe UserSummary do
     expect(summary.top_categories.length).to eq(UserSummary::MAX_SUMMARY_RESULTS)
     expect(summary.top_categories.first[:id]).to eq(top_category.id)
   end
+
+  it "excludes moderator action posts" do
+    topic = create_post.topic
+    user = topic.user
+    create_post(user: user, topic: topic)
+    Fabricate(:small_action, topic: topic, user: user)
+
+    summary = UserSummary.new(user, Guardian.new)
+
+    expect(summary.topics.length).to eq(1)
+    expect(summary.replies.length).to eq(1)
+    expect(summary.top_categories.length).to eq(1)
+    expect(summary.top_categories.first[:topic_count]).to eq(1)
+    expect(summary.top_categories.first[:post_count]).to eq(1)
+  end
 end


### PR DESCRIPTION
Previously, incorrect reply counts are displayed in the "top categories" section of the user summary page since we included the `moderator_action` and `small_action` post types.