### PR TITLE
FIX: Cache all watched words

### DIFF
--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -8,7 +8,10 @@ class WordWatcher
   end
 
   def self.words_for_action(action)
-    words = WatchedWord.where(action: WatchedWord.actions[action.to_sym]).limit(1000)
+    words = WatchedWord
+      .where(action: WatchedWord.actions[action.to_sym])
+      .limit(WatchedWord::MAX_WORDS_PER_ACTION)
+
     if WatchedWord.has_replacement?(action.to_sym)
       words.pluck(:word, :replacement).to_h
     else


### PR DESCRIPTION
It used to cache up to 1000 words, but the maximum number of watched
word is 2000.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
