### PR TITLE
FEATURE: Log only topic/post search queries in search log

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -252,7 +252,7 @@ class Search
 
   # Query a term
   def execute(readonly_mode: Discourse.readonly_mode?)
-    if SiteSetting.log_search_queries? && @opts[:search_type].present? && !readonly_mode
+    if log_query?(readonly_mode)
       status, search_log_id = SearchLog.log(
         term: @term,
         search_type: @opts[:search_type],
@@ -1294,4 +1294,10 @@ class Search
     end
   end
 
+  def log_query?(readonly_mode)
+    SiteSetting.log_search_queries? &&
+    @opts[:search_type].present? &&
+    !readonly_mode &&
+    @opts[:type_filter] != "exclude_topics"
+  end
 end

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -231,6 +231,13 @@ describe SearchController do
       expect(SearchLog.where(term: 'wookie')).to be_blank
     end
 
+    it "doesn't log when filtering by exclude_topics" do
+      SiteSetting.log_search_queries = true
+      get "/search/query.json", params: { term: 'boop', type_filter: 'exclude_topics' }
+      expect(response.status).to eq(200)
+      expect(SearchLog.where(term: 'boop')).to be_blank
+    end
+
     it "does not raise 500 with an empty term" do
       get "/search/query.json", params: { term: "in:first", type_filter: "topic", search_for_id: true }
       expect(response.status).to eq(200)


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/14499, we introduced a new search type that groups all non-topic non-post results (i.e. users, groups, tags, categories). This is used to populate the quick search panel as the user types. In this PR, we remove logging for these queries. 