### PR TITLE
FIX: Don't overwrite computed property for loading spinner fix

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery.js
@@ -2,7 +2,6 @@ import Controller, { inject as controller } from "@ember/controller";
 import { alias, equal, not } from "@ember/object/computed";
 import Category from "discourse/models/category";
 import DiscourseURL from "discourse/lib/url";
-import { observes } from "discourse-common/utils/decorators";
 import { inject as service } from "@ember/service";
 
 export default Controller.extend({
@@ -14,7 +13,6 @@ export default Controller.extend({
     "router.currentRouteName",
     "discovery.categories"
   ),
-
   loading: false,
 
   category: alias("navigationCategory.category"),
@@ -22,8 +20,13 @@ export default Controller.extend({
 
   loadedAllItems: not("discoveryTopics.model.canLoadMore"),
 
-  @observes("loadedAllItems")
-  _showFooter() {
+  loadingBegan() {
+    this.set("loading", true);
+    this.set("application.showFooter", false);
+  },
+
+  loadingComplete() {
+    this.set("loading", false);
     this.set("application.showFooter", this.loadedAllItems);
   },
 

--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -66,15 +66,14 @@ const controllerOpts = {
       this.send("resetParams", options.skipResettingParams);
 
       // Don't refresh if we're still loading
-      if (this.get("discovery.loading")) {
+      if (this.discovery.loading) {
         return;
       }
 
       // If we `send('loading')` here, due to returning true it bubbles up to the
       // router and ember throws an error due to missing `handlerInfos`.
       // Lesson learned: Don't call `loading` yourself.
-      this.set("discovery.loading", true);
-      this.set("model.canLoadMore", true);
+      this.discovery.loadingBegan();
 
       this.topicTrackingState.resetTracking();
 

--- a/app/assets/javascripts/discourse/app/routes/discovery.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery.js
@@ -46,25 +46,24 @@ export default DiscourseRoute.extend(OpenComposer, {
 
   actions: {
     loading() {
-      this.controllerFor("discovery").set("loading", true);
+      this.controllerFor("discovery").loadingBegan();
+
+      // We don't want loading to bubble
       return true;
     },
 
     loadingComplete() {
-      this.controllerFor("discovery").set("loading", false);
+      this.controllerFor("discovery").loadingComplete();
       if (!this.session.get("topicListScrollPosition")) {
         scrollTop();
       }
-      return false;
     },
 
     didTransition() {
-      this.controllerFor("discovery")._showFooter();
       this.send("loadingComplete");
 
       const model = this.controllerFor("discovery/topics").get("model");
       setTopicList(model);
-      return false;
     },
 
     // clear a pinned topic


### PR DESCRIPTION
This fixes an issue CvX found on PR #14666 where a previous fix
overwrote a computed property.

The better fix (as is often the case with Ember) is to remove an
observer and call methods when things change ourselves.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
