### PR TITLE
FIX: none and all categories filter

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -38,6 +38,7 @@ export default ComboBoxComponent.extend({
     autoInsertNoneItem: false,
     displayCategoryDescription: "displayCategoryDescription",
     headerComponent: "category-drop/category-drop-header",
+    parentCategory: false,
   },
 
   modifyComponentForRow() {


### PR DESCRIPTION
parentCategory is passed to drop-category component: https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs#L11

However, it is not available if it is not explicitly allow listed in selectKitOptions


https://user-images.githubusercontent.com/72780/142297603-0c27a706-3a0d-40cf-b50d-812c38567b1b.mov


