### PR TITLE
PERF: Move `preload` hints to the `<head>`

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,8 @@
 
     <%= build_plugin_html 'server:before-script-load' %>
 
+    <link rel="preload" href="<%= script_asset_path "start-discourse" %>" as="script">
+    <link rel="preload" href="<%= script_asset_path "browser-update" %>" as="script">
     <%= preload_script 'browser-detect' %>
 
     <%= preload_script "locales/#{I18n.locale}" %>
@@ -113,11 +115,12 @@
     <% end %>
 
     <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
-    <%= preload_script "start-discourse" %>
+
+    <script src="<%= script_asset_path "start-discourse" %>"></script>
 
     <%= yield :data %>
 
-    <%= preload_script 'browser-update' %>
+    <script src="<%= script_asset_path "browser-update" %>"></script>
 
     <%- unless customization_disabled? %>
       <%= theme_lookup("body_tag") %>


### PR DESCRIPTION
We have two JS assets which are included in the `<body>` of responses. We were including the `<link rel='preload'` hint alongside the script tag in the body. Instead, we can move the preload hint to the `<head>` so that the browser discovers it earlier, and can start preloading the assets while the body is loading. This does not change the order of JS execution.

Visual commit description:

<img width="1053" alt="Screenshot 2021-11-18 at 17 04 46" src="https://user-images.githubusercontent.com/6270921/142463160-117856bf-32d3-4d73-bfaf-4e7542ab5cd3.png">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
