### PR TITLE
UX: pasting links on a selection will apply a link format

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/text.js
+++ b/app/assets/javascripts/discourse/app/lib/text.js
@@ -50,6 +50,13 @@ export function generateCookFunction(options) {
   });
 }
 
+export function generateLinkifyFunction(options) {
+  return loadMarkdownIt().then(() => {
+    const prettyText = createPrettyText(options);
+    return prettyText.opts.engine.linkify;
+  });
+}
+
 export function sanitize(text, options) {
   return textSanitize(text, new AllowLister(options));
 }

--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -295,6 +295,8 @@ export default Mixin.create({
           match.index === 0 &&
           match.lastIndex === match.raw.length
         ) {
+          // When specified, linkify supports fuzzy links and emails. Prefer providing the protocol.
+          // eg: pasting "example@discourse.org" may apply a link format of "mailto:example@discourse.org"
           this._addText(selected, `[${selectedValue}](${match.url})`);
           handled = true;
         }

--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -242,7 +242,8 @@ export default Mixin.create({
     let html = clipboard.getData("text/html");
     let handled = false;
 
-    const { pre, lineVal } = this._getSelected(null, { lineVal: true });
+    const selected = this._getSelected(null, { lineVal: true });
+    const { pre, value: selectedValue, lineVal } = selected;
     const isInlinePasting = pre.match(/[^\n]$/);
     const isCodeBlock = isInside(pre, /(^|\n)```/g);
 
@@ -269,6 +270,19 @@ export default Mixin.create({
         );
       } else {
         canPasteHtml = !isCodeBlock;
+      }
+    }
+
+    if (plainText && !handled && selected.end > selected.start) {
+      let isURL;
+      try {
+        isURL = !!new URL(plainText);
+      } catch {
+        isURL = false;
+      }
+      if (isURL) {
+        this._addText(selected, `[${selectedValue}](${plainText})`);
+        handled = true;
       }
     }
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -805,6 +805,34 @@ third line`
     }
   );
 
+  testCase(
+    `pasting text that contains urls and other content will use default paste behavior`,
+    async function (assert, textarea) {
+      this.set("value", "a link example:");
+      setTextareaSelection(textarea, 0, 1);
+      const element = query(".d-editor");
+      const event = await paste(
+        element,
+        "Try out Discourse at: https://www.discourse.org/"
+      );
+      // Synthetic paste events do not manipulate document content.
+      assert.strictEqual(this.value, "a link example:");
+      assert.strictEqual(event.defaultPrevented, false);
+    }
+  );
+
+  testCase(
+    `pasting an email into a selection applies a link format`,
+    async function (assert, textarea) {
+      this.set("value", "team email");
+      setTextareaSelection(textarea, 5, 10);
+      const element = query(".d-editor");
+      const event = await paste(element, "mailto:team@discourse.org");
+      assert.strictEqual(this.value, "team [email](mailto:team@discourse.org)");
+      assert.strictEqual(event.defaultPrevented, true);
+    }
+  );
+
   (() => {
     // Tests to check cursor/selection after replace-text event.
     const BEFORE = "red green blue";


### PR DESCRIPTION
One handy way of adding a link is by copying a link url and pasting it into a text selection. This has been in use as a way of adding links in [WordPress](https://wordpress.org/) for quite some time.

If there isn't a text selection, or the copied item is not a link we should see default paste behavior. 

Changes in this PR implement the idea in Discourse as discussed in https://meta.discourse.org/t/idea-paste-links-in-the-editor

https://user-images.githubusercontent.com/1270189/143144443-01316a2b-5bd0-4742-8844-1b5f180012c6.mp4


### Testing Instructions

- No regressions for paste behavior in d-editor
- Verify that the new qunit tests make sense. In order to fully test paste events, we may need to switch these to integration tests, but let me know if folks have preferences.

