### PR TITLE
DEV: Swap out optipng with oxipng

### DIFF
--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -116,7 +116,8 @@ class FileHelper
         timeout: 15,
         skip_missing_workers: true,
         # PNG
-        optipng: { level: 2, strip: strip_image_metadata },
+        oxipng: { level: 3, strip: strip_image_metadata },
+        optipng: false,
         advpng: false,
         pngcrush: false,
         pngout: false,
@@ -128,7 +129,6 @@ class FileHelper
         # Skip looking for gifsicle, svgo binaries
         gifsicle: false,
         svgo: false,
-        oxipng: false
       )
     end
   end


### PR DESCRIPTION
The oxipng binary has been added to our base docker image here:

https://github.com/discourse/discourse_docker/commit/244c9cb110df44eb9d846a24b5572471a2687071

oxipng is a rust replacement for optipng that provides increased
performance and multi-threading. Checkout
https://github.com/shssoichiro/oxipng for more info.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
