### PR TITLE
PERF: Use more efficient text-direction check in select-kit init

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -27,9 +27,7 @@ const SELECT_KIT_OPTIONS = Mixin.create({
 });
 
 function isDocumentRTL() {
-  return (
-    window.getComputedStyle(document.querySelector("html")).direction === "rtl"
-  );
+  return document.documentElement.classList.contains("rtl");
 }
 
 export default Component.extend(


### PR DESCRIPTION
Calling `window.getComputedStyle` during initialization causes the browser to pause and 'Recalculate Style'. On my machine, this adds about 7ms to boot time. Instead, we can check for the `rtl` class on the html element, which is added by the server, and doesn't require computing styles.

We have a `discourse/lib/text-direction` helper which is implemented using this classList check. However, we can't easily reference it from this file since select-kit is used in non-discourse contexts (e.g. the Wizard). I didn't think this use-case was worth the effort/deprecation-cycle of moving the `text-direction` library to `discourse-common`.

<img width="784" alt="Screenshot 2021-11-19 at 00 50 31" src="https://user-images.githubusercontent.com/6270921/142520182-3b7efbc7-d2ee-4df2-9359-6f4999082dba.png">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
