### PR TITLE
Refine dismiss notification confirmation

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/dismiss-notification-confirmation.js
+++ b/app/assets/javascripts/discourse/app/controllers/dismiss-notification-confirmation.js
@@ -3,7 +3,7 @@ import ModalFunctionality from "discourse/mixins/modal-functionality";
 
 export default Controller.extend(ModalFunctionality, {
   actions: {
-    confirm() {
+    dismiss() {
       this.send("closeModal");
       this.dismissNotifications();
     },

--- a/app/assets/javascripts/discourse/app/controllers/dismiss-notification-confirmation.js
+++ b/app/assets/javascripts/discourse/app/controllers/dismiss-notification-confirmation.js
@@ -1,0 +1,11 @@
+import Controller from "@ember/controller";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+
+export default Controller.extend(ModalFunctionality, {
+  actions: {
+    confirm() {
+      this.send("closeModal");
+      this.dismissNotifications();
+    },
+  },
+});

--- a/app/assets/javascripts/discourse/app/templates/modal/dismiss-notification-confirmation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/dismiss-notification-confirmation.hbs
@@ -1,0 +1,8 @@
+{{#d-modal-body headerClass="hidden" class="dismiss-notification-confirmation"}}
+    {{i18n "notifications.dismiss_confirmation.body" count=count}}
+{{/d-modal-body}}
+
+<div class="modal-footer">
+  {{d-button icon="check" class="btn-primary" action=(action "confirm") label="notifications.dismiss_confirmation.confirm"}}
+  {{d-button action=(route-action "closeModal") label="notifications.dismiss_confirmation.cancel" class="cancel"}}
+</div>

--- a/app/assets/javascripts/discourse/app/templates/modal/dismiss-notification-confirmation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/dismiss-notification-confirmation.hbs
@@ -1,8 +1,15 @@
 {{#d-modal-body headerClass="hidden" class="dismiss-notification-confirmation"}}
-    {{i18n "notifications.dismiss_confirmation.body" count=count}}
+  {{i18n "notifications.dismiss_confirmation.body" count=count}}
 {{/d-modal-body}}
 
 <div class="modal-footer">
-  {{d-button icon="check" class="btn-primary" action=(action "confirm") label="notifications.dismiss_confirmation.confirm"}}
-  {{d-button action=(route-action "closeModal") label="notifications.dismiss_confirmation.cancel" class="cancel"}}
+  {{d-button
+    icon="check"
+    class="btn-primary"
+    action=(action "dismiss")
+    label="notifications.dismiss_confirmation.dismiss"}}
+  {{d-button
+    action=(route-action "closeModal")
+    label="notifications.dismiss_confirmation.cancel"
+    class="btn-default"}}
 </div>

--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -1,8 +1,7 @@
 import { later } from "@ember/runloop";
-import bootbox from "bootbox";
 import { createWidget } from "discourse/widgets/widget";
-import I18n from "I18n";
 import { h } from "virtual-dom";
+import showModal from "discourse/lib/show-modal";
 
 const UserMenuAction = {
   QUICK_ACCESS: "quickAccess",
@@ -256,18 +255,10 @@ export default createWidget("user-menu", {
     );
 
     if (unreadHighPriorityNotifications > 0) {
-      return bootbox.confirm(
-        I18n.t("notifications.dismiss_confirmation.body", {
-          count: unreadHighPriorityNotifications,
-        }),
-        I18n.t("notifications.dismiss_confirmation.cancel"),
-        I18n.t("notifications.dismiss_confirmation.confirm"),
-        (result) => {
-          if (result) {
-            this.state.markRead();
-          }
-        }
-      );
+      return showModal("dismiss-notification-confirmation").setProperties({
+        count: unreadHighPriorityNotifications,
+        dismissNotifications: () => this.state.markRead(),
+      });
     } else {
       return this.state.markRead();
     }

--- a/app/assets/javascripts/discourse/tests/acceptance/dismiss-notification-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dismiss-notification-modal-test.js
@@ -33,7 +33,7 @@ acceptance("Dismiss notification confirmation", function (needs) {
 
     assert.strictEqual(
       query(".dismiss-notification-confirmation-modal .modal-body").innerText,
-      "You have 2 important notifications, are you sure you would like to dismiss?"
+      "Are you sure? You have 2 important notifications."
     );
   });
 
@@ -47,7 +47,7 @@ acceptance("Dismiss notification confirmation", function (needs) {
 
     assert.strictEqual(
       query(".dismiss-notification-confirmation-modal .btn-primary").innerText,
-      "Confirm"
+      "Dismiss"
     );
     pretender.put("/notifications/mark-read", () => {
       return [200, { "Content-Type": "application/json" }, { success: true }];
@@ -67,11 +67,11 @@ acceptance("Dismiss notification confirmation", function (needs) {
     await click(".notifications-dismiss");
 
     assert.strictEqual(
-      query(".dismiss-notification-confirmation-modal .cancel").innerText,
+      query(".dismiss-notification-confirmation-modal .btn-default").innerText,
       "Cancel"
     );
 
-    await click(".dismiss-notification-confirmation-modal .cancel");
+    await click(".dismiss-notification-confirmation-modal .btn-default");
 
     assert.notOk(exists(".dismiss-notification-confirmation"));
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/dismiss-notification-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dismiss-notification-modal-test.js
@@ -19,7 +19,7 @@ acceptance("Dismiss notification confirmation", function (needs) {
     await visit("/");
     await click(".current-user");
     await click(".notifications-dismiss");
-    assert.notOk(exists(".bootbox.modal"));
+    assert.notOk(exists(".dismiss-notification-confirmation"));
   });
 
   test("shows confirmation modal", async function (assert) {
@@ -29,13 +29,12 @@ acceptance("Dismiss notification confirmation", function (needs) {
     await visit("/");
     await click(".current-user");
     await click(".notifications-dismiss");
-    assert.ok(exists(".bootbox.modal"));
+    assert.ok(exists(".dismiss-notification-confirmation"));
 
     assert.strictEqual(
-      query(".bootbox.modal .modal-body").innerText,
+      query(".dismiss-notification-confirmation-modal .modal-body").innerText,
       "You have 2 important notifications, are you sure you would like to dismiss?"
     );
-    await click(".bootbox.modal .btn-default");
   });
 
   test("marks unread when confirm and closes modal", async function (assert) {
@@ -47,19 +46,19 @@ acceptance("Dismiss notification confirmation", function (needs) {
     await click(".notifications-dismiss");
 
     assert.strictEqual(
-      query(".bootbox.modal .btn-primary span").innerText,
+      query(".dismiss-notification-confirmation-modal .btn-primary").innerText,
       "Confirm"
     );
     pretender.put("/notifications/mark-read", () => {
       return [200, { "Content-Type": "application/json" }, { success: true }];
     });
 
-    await click(".bootbox.modal .btn-primary");
+    await click(".dismiss-notification-confirmation-modal .btn-primary");
 
-    assert.notOk(exists(".bootbox.modal"));
+    assert.notOk(exists(".dismiss-notification-confirmation"));
   });
 
-  test("marks unread when cancel and closes modal", async function (assert) {
+  test("does marks unread when cancel and closes modal", async function (assert) {
     updateCurrentUser({
       unread_high_priority_notifications: 2,
     });
@@ -68,12 +67,12 @@ acceptance("Dismiss notification confirmation", function (needs) {
     await click(".notifications-dismiss");
 
     assert.strictEqual(
-      query(".bootbox.modal .btn-default span").innerText,
+      query(".dismiss-notification-confirmation-modal .cancel").innerText,
       "Cancel"
     );
 
-    await click(".bootbox.modal .btn-default");
+    await click(".dismiss-notification-confirmation-modal .cancel");
 
-    assert.notOk(exists(".bootbox.modal"));
+    assert.notOk(exists(".dismiss-notification-confirmation"));
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/dismiss-notification-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dismiss-notification-modal-test.js
@@ -5,6 +5,7 @@ import {
   query,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
+import I18n from "I18n";
 import { test } from "qunit";
 import pretender from "../helpers/create-pretender";
 
@@ -33,7 +34,7 @@ acceptance("Dismiss notification confirmation", function (needs) {
 
     assert.strictEqual(
       query(".dismiss-notification-confirmation-modal .modal-body").innerText,
-      "Are you sure? You have 2 important notifications."
+      I18n.t("notifications.dismiss_confirmation.body", { count: 2 })
     );
   });
 
@@ -47,7 +48,7 @@ acceptance("Dismiss notification confirmation", function (needs) {
 
     assert.strictEqual(
       query(".dismiss-notification-confirmation-modal .btn-primary").innerText,
-      "Dismiss"
+      I18n.t("notifications.dismiss_confirmation.dismiss")
     );
     pretender.put("/notifications/mark-read", () => {
       return [200, { "Content-Type": "application/json" }, { success: true }];
@@ -68,7 +69,7 @@ acceptance("Dismiss notification confirmation", function (needs) {
 
     assert.strictEqual(
       query(".dismiss-notification-confirmation-modal .btn-default").innerText,
-      "Cancel"
+      I18n.t("notifications.dismiss_confirmation.cancel")
     );
 
     await click(".dismiss-notification-confirmation-modal .btn-default");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2287,9 +2287,9 @@ en:
       votes_released: "%{description} - completed"
       dismiss_confirmation:
         body:
-          one: "You have %{count} important notification, are you sure you would like to dismiss?"
-          other: "You have %{count} important notifications, are you sure you would like to dismiss?"
-        confirm: "Confirm"
+          one: "Are you sure? You have %{count} important notification."
+          other: "Are you sure? You have %{count} important notifications."
+        dismiss: "Dismiss"
         cancel: "Cancel"
 
       group_message_summary:


### PR DESCRIPTION
Based on /t/44871 I've made some modifications to the dialog mostly for copy and consistency.

<img width="358" alt="Screenshot 2021-11-19 at 11 03 15 AM" src="https://user-images.githubusercontent.com/1555215/142558014-1262c3c9-44e1-4c54-84fe-151dab877092.png">

Note that I had the choice to [use bootbox's ability to add an icon to a button](http://bootboxjs.com/examples.html#bb-confirm), but I see that there are zero occurrences of this usage in the codebase, so I made a decision not to introduce something new, and re-introduce the template instead.