### PR TITLE
DEV: Add if a user is using an Apple device in widget capabilities

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -478,9 +478,9 @@ export function inCodeBlock(text, pos) {
 }
 
 export function translateModKey(string) {
-  const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
-  // Mac users are used to glyphs for shortcut keys
-  if (mac) {
+  const { isApple } = helperContext().capabilities;
+  // Apple device users are used to glyphs for shortcut keys
+  if (isApple) {
     string = string
       .replace("Shift", "\u21E7")
       .replace("Meta", "\u2318")

--- a/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
@@ -1,17 +1,8 @@
 // Initializes an object that lets us know about browser's capabilities
 
-const APPLE_NAVIGATOR_PLATFORMS = [
-  "iPhone",
-  "iPod",
-  "iPad",
-  "iPhone Simulator",
-  "iPod Simulator",
-  "iPad Simulator",
-  "Macintosh",
-  "MacIntel",
-];
+const APPLE_NAVIGATOR_PLATFORMS = /iPhone|iPod|iPad|Macintosh|MacIntel/;
 
-const APPLE_USERAGENTDATA_PLATFORM = ["macOS"];
+const APPLE_USERAGENTDATA_PLATFORM = /macOS/;
 
 export default {
   name: "sniff-capabilities",
@@ -43,11 +34,9 @@ export default {
       !window.MSStream;
 
     caps.isApple =
-      APPLE_NAVIGATOR_PLATFORMS.includes(navigator.platform) ||
+      APPLE_NAVIGATOR_PLATFORMS.test(navigator.platform) ||
       (navigator.userAgentData &&
-        APPLE_USERAGENTDATA_PLATFORM.includes(
-          navigator.userAgentData.platform
-        ));
+        APPLE_USERAGENTDATA_PLATFORM.test(navigator.userAgentData.platform));
 
     caps.hasContactPicker =
       "contacts" in navigator && "ContactsManager" in window;

--- a/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
@@ -1,4 +1,18 @@
 // Initializes an object that lets us know about browser's capabilities
+
+const APPLE_NAVIGATOR_PLATFORMS = [
+  "iPhone",
+  "iPod",
+  "iPad",
+  "iPhone Simulator",
+  "iPod Simulator",
+  "iPad Simulator",
+  "Macintosh",
+  "MacIntel",
+];
+
+const APPLE_USERAGENTDATA_PLATFORM = ["macOS"];
+
 export default {
   name: "sniff-capabilities",
 
@@ -27,6 +41,13 @@ export default {
     caps.isIOS =
       (/iPhone|iPod/.test(navigator.userAgent) || caps.isIpadOS) &&
       !window.MSStream;
+
+    caps.isApple =
+      APPLE_NAVIGATOR_PLATFORMS.includes(navigator.platform) ||
+      (navigator.userAgentData &&
+        APPLE_USERAGENTDATA_PLATFORM.includes(
+          navigator.userAgentData.platform
+        ));
 
     caps.hasContactPicker =
       "contacts" in navigator && "ContactsManager" in window;


### PR DESCRIPTION
From `sniff-capabilities`, we can find out if a user

- isAndroid
- isWinphone
- isOpera
- isFirefox
- isChrome
- isSafari
- isIpadOS
- isIOS

and the user may be using iOS and Chrome. 

We will need this new property to determine OS specific features like if search was using cmd+f or ctrl+f. 

There are two `navigator` properties used in this implementation, as `navigator.platform` is deprecated and the recommended new property to use is `navigator.userAgentData.platform`. However, `navigator.userAgentData` is absent on Safari for the Macbook and iPhone, so we have to use the deprecated version. 😞 


Relevant MDN links:
- https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
- https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform