### PR TITLE
FIX: Ensure mobile topic-list links are treated as Ember transitions

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -228,7 +228,7 @@
     font-size: $font-0;
   }
 
-  .topic-list-data.main-link {
+  .main-link {
     @extend .topic-list-main-link;
 
     .raw-topic-link > * {


### PR DESCRIPTION
In the topic lists, it's important that we apply `pointer-events: none;` to the links. 0e371d4 updated the selector used for this css.

In `templates/list/topic-list-item.hbs`, `.main-link` is applied to the same element as `.topic-list-data`, so the new selector applied correctly.

In `templates/mobile/list/topic-list-item.hbr`, `.main-link` is nested within `.topic-list-data`, so the new selector did not apply correctly.

This commit switches the selector back to simply `.main-link`, so that it works for both mobile and desktop.

---

@jordanvidrine do you remember the reason for making this `.main-link` selector more specific in 0e371d4?

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
