### PR TITLE
FIX: Allow poll feature to be disabled in discourse-markdown

### DIFF
--- a/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
+++ b/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
@@ -262,7 +262,9 @@ const rule = {
 
 function newApiInit(helper) {
   helper.registerOptions((opts, siteSettings) => {
-    opts.features.poll = !!siteSettings.poll_enabled;
+    if (!siteSettings.poll_enabled) {
+      opts.features.poll = false;
+    }
     opts.pollMaximumOptions = siteSettings.poll_maximum_options;
   });
 


### PR DESCRIPTION
Currently you cannot disable `poll` markdown processing outside of site settings. This change makes it so that if you pass 
```
{ 
  features: {
    poll: false
  }
}
```
to PrettyText, poll's won't be parsed, because the site setting is no longer overriding the `features` value if it's false.