### PR TITLE
FEATURE: Send a 'noindex' header in non-canonical responses

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1590,6 +1590,9 @@ security:
     regex: "^(Lax|Strict|Disabled|None)$"
   enable_escaped_fragments: true
   allow_index_in_robots_txt: true
+  allow_indexing_non_canonical_urls:
+    default: true
+    hidden: true
   moderators_manage_categories_and_groups: false
   moderators_change_post_ownership:
     client: true

--- a/lib/canonical_url.rb
+++ b/lib/canonical_url.rb
@@ -2,6 +2,8 @@
 
 module CanonicalURL
   module ControllerExtensions
+    ALLOWED_CANONICAL_PARAMS = %w(page)
+
     def canonical_url(url_for_options = {})
       case url_for_options
       when Hash
@@ -10,21 +12,26 @@ module CanonicalURL
         @canonical_url = url_for_options
       end
     end
+
+    def default_canonical
+      @default_canonical ||= begin
+        canonical = +"#{Discourse.base_url_no_prefix}#{request.path}"
+        allowed_params = params.select { |key| ALLOWED_CANONICAL_PARAMS.include?(key) }
+        if allowed_params.present?
+          canonical << "?#{allowed_params.keys.zip(allowed_params.values).map { |key, value| "#{key}=#{value}" }.join("&")}"
+        end
+        canonical
+      end
+    end
+
+    def self.included(base)
+      base.helper_method :default_canonical
+    end
   end
 
   module Helpers
-    ALLOWED_CANONICAL_PARAMS = %w(page)
     def canonical_link_tag(url = nil)
       tag('link', rel: 'canonical', href: url || @canonical_url || default_canonical)
-    end
-
-    def default_canonical
-      canonical = +"#{Discourse.base_url_no_prefix}#{request.path}"
-      allowed_params = params.select { |key| ALLOWED_CANONICAL_PARAMS.include?(key) }
-      if allowed_params.present?
-        canonical << "?#{allowed_params.keys.zip(allowed_params.values).map { |key, value| "#{key}=#{value}" }.join("&")}"
-      end
-      canonical
     end
   end
 end

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -176,12 +176,6 @@ describe GroupsController do
       )
     end
 
-    it 'should return correct X-Robots-Tag header when allow_index_in_robots_txt is set to false' do
-      SiteSetting.allow_index_in_robots_txt = false
-      get "/groups"
-      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow')
-    end
-
     context 'viewing groups of another user' do
       describe 'when an invalid username is given' do
         it 'should return the right response' do


### PR DESCRIPTION
While the Discourse SPA has URLs for every single post in a topic,
we don't want crawlers to waste time indexing those. In order to
generalize the header application, we are replying with it every time a
canonical is generated an is different from the requested URL.
