### PR TITLE
UX: Fix fast edit save button color in dark schemes

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -432,6 +432,13 @@ aside.quote {
     color: var(--secondary-or-primary);
   }
 
+  .btn-primary,
+  .btn-primary:hover,
+  .btn-primary .d-icon,
+  .btn-primary:hover .d-icon {
+    color: var(--secondary);
+  }
+
   .insert-quote + .quote-sharing {
     border-left: 1px solid rgba(255, 255, 255, 0.3);
   }


### PR DESCRIPTION
Dark schemes were previously using `--primary` text on `--tertiary` background, which doesn't work well (was white on yellow for the Grey Amber theme, for example). 