### PR TITLE
DEV: avoid sending events to a destroying object and enable few skipped tests

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -290,7 +290,9 @@ export default Controller.extend(ModalFunctionality, {
           });
         })
         .catch((error) => {
-          this.send("closeModal");
+          if (!this.isDestroying && !this.isDestroyed) {
+            this.send("closeModal");
+          }
           popupAjaxError(error);
         });
     },

--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -275,10 +275,12 @@ export default Controller.extend(ModalFunctionality, {
       postAction
         .act(this.model, params)
         .then(() => {
+          if (this.isDestroying || this.isDestroyed) {
+            return;
+          }
+
           if (!params.skipClose) {
-            if (!this.isDestroying) {
-              this.send("closeModal");
-            }
+            this.send("closeModal");
           }
           if (params.message) {
             this.set("message", "");

--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -276,7 +276,9 @@ export default Controller.extend(ModalFunctionality, {
         .act(this.model, params)
         .then(() => {
           if (!params.skipClose) {
-            this.send("closeModal");
+            if (!this.isDestroying) {
+              this.send("closeModal");
+            }
           }
           if (params.message) {
             this.set("message", "");

--- a/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/flag-post-test.js
@@ -6,7 +6,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { skip, test } from "qunit";
+import { test } from "qunit";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
 import { run } from "@ember/runloop";
 
@@ -154,7 +154,7 @@ acceptance("flagging", function (needs) {
     assert.ok(!exists(".bootbox.modal:visible"));
   });
 
-  skip("CTRL + ENTER accepts the modal", async function (assert) {
+  test("CTRL + ENTER accepts the modal", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();
 
@@ -170,7 +170,7 @@ acceptance("flagging", function (needs) {
     assert.ok(!exists("#discourse-modal:visible"), "The modal was closed");
   });
 
-  skip("CMD or WINDOWS-KEY + ENTER accepts the modal", async function (assert) {
+  test("CMD or WINDOWS-KEY + ENTER accepts the modal", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();
 


### PR DESCRIPTION
This PR enables two tests that [originally](https://github.com/discourse/discourse/pull/13497) were skipped because they weren't passing in Ember-CLI. That was happening because of an assertion that prevents calling `send()` and `sendAction()` on destroying objects.

The problem is solved by wrapping a `send` call:
```javascript
if (!this.isDestroying) {
  this.send("closeModal");
}
```

See https://github.com/emberjs/ember.js/issues/16778.



