### PR TITLE
DEV: Lint SCSS with prettier in pre-commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,10 @@ pre-commit:
       glob: "*.js"
       include: "app/assets/javascripts|test/javascripts"
       run: yarn pprettier --list-different {staged_files}
+    prettier-scss:
+      glob: "*.scss"
+      include: "app/assets/stylesheets"
+      run: yarn pprettier --list-different {staged_files}
     eslint:
       glob: "*.js"
       include: "app/assets/javascripts|test/javascripts"
@@ -50,6 +54,10 @@ lints:
     prettier:
       glob: "*.js"
       include: "app/assets/javascripts|test/javascripts"
+      run: yarn pprettier --list-different {all_files}
+    prettier-scss:
+      glob: "*.scss"
+      include: "app/assets/stylesheets"
       run: yarn pprettier --list-different {all_files}
     eslint-assets-js:
       run: yarn eslint app/assets/javascripts


### PR DESCRIPTION
We are linting SCSS on the GitHub actions CI but not
on pre-commit, which can lead to lint failures in CI.
Better to warn developers about this locally like
our other lints.