### PR TITLE
Always show input when editing text by removing hover

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -688,6 +688,7 @@ export default Component.extend(ComposerUpload, {
 
     imageResize.removeAttribute("hidden");
     readonlyContainer.removeAttribute("hidden");
+    buttonWrapper.removeAttribute("editing");
     editContainer.setAttribute("hidden", "true");
   },
 
@@ -743,6 +744,7 @@ export default Component.extend(ComposerUpload, {
     );
     const editContainerInput = editContainer.querySelector(".alt-text-input");
 
+    buttonWrapper.setAttribute("editing", "true");
     imageResize.setAttribute("hidden", "true");
     readonlyContainer.setAttribute("hidden", "true");
     editContainerInput.value = altText.textContent;

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -195,6 +195,10 @@
     z-index: 1; // needs to be higher than image
     background: var(--secondary); // for when images are wider than controls
 
+    &[editing] {
+      opacity: 1;
+    }
+
     .scale-btn-container,
     .alt-text-readonly-container,
     .alt-text-edit-container {


### PR DESCRIPTION
This prevents the user from having the input disappear when wanting to edit the alt text on the image preview.