### PR TITLE
FIX: Don't publish notifications to MessageBus for inactive users

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -28,7 +28,11 @@ class PostAlerter
       }
 
       DiscourseEvent.trigger(:pre_notification_alert, user, payload)
-      MessageBus.publish("/notification-alert/#{user.id}", payload, user_ids: [user.id])
+
+      if user.allow_live_notifications?
+        MessageBus.publish("/notification-alert/#{user.id}", payload, user_ids: [user.id])
+      end
+
       push_notification(user, payload)
       DiscourseEvent.trigger(:post_notification_alert, user, payload)
     end


### PR DESCRIPTION
We are pushing /notification-alert/#{user_id} and /notification/#{user_id}
messages to MessageBus from both PostAlerter and User#publish_notification_state.
This can cause memory issues on large sites with many users. This commit
stems the bleeding by only sending these alert messages if the user
in question has been seen in the last 30 days, which eliminates a large
chunk of users on some sites.
