### PR TITLE
FEATURE: Allow theme settings to request refresh

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -573,7 +573,9 @@ class Theme < ActiveRecord::Base
 
     target_setting.value = new_value
 
-    Discourse.request_refresh! if target_setting.requests_refresh?
+    if target_setting.requests_refresh?
+      DB.after_commit { Discourse.request_refresh! }
+    end
   end
 
   def update_translation(translation_key, new_value)

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -572,6 +572,8 @@ class Theme < ActiveRecord::Base
     raise Discourse::NotFound unless target_setting
 
     target_setting.value = new_value
+
+    Discourse.request_refresh! if target_setting.requests_refresh?
   end
 
   def update_translation(translation_key, new_value)

--- a/lib/theme_settings_manager.rb
+++ b/lib/theme_settings_manager.rb
@@ -37,6 +37,10 @@ class ThemeSettingsManager
     @opts[:description] # Old method of specifying description. Is now overridden by locale file
   end
 
+  def requests_refresh?
+    @opts[:refresh]
+  end
+
   def value=(new_value)
     ensure_is_valid_value!(new_value)
 

--- a/lib/theme_settings_parser.rb
+++ b/lib/theme_settings_parser.rb
@@ -43,6 +43,8 @@ class ThemeSettingsParser
     opts[:textarea] = !!raw_opts[:textarea]
     opts[:json_schema] = raw_opts[:json_schema]
 
+    opts[:refresh] = !!raw_opts[:refresh]
+
     opts
   end
 

--- a/spec/fixtures/theme_settings/valid_settings.yaml
+++ b/spec/fixtures/theme_settings/valid_settings.yaml
@@ -80,3 +80,7 @@ invalid_json_schema_setting:
 valid_json_schema_setting:
   default: ""
   json_schema: '{ "type": "array", "uniqueItems": true, "items": { "type": "object", "properties": { "color": { "type": "string" }, "icon": { "type": "string" } }, "additionalProperties": false } }'
+
+causes_refresh:
+  default: ""
+  refresh: true


### PR DESCRIPTION
Similar to site settings, adds support for `refresh` option to theme settings.

```yaml
super_feature_enabled:
  type: bool
  default: false
  refresh: true
```