### PR TITLE
DEV: Fix silence user context message

### DIFF
--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -35,7 +35,7 @@ class UserSilencer
           @opts[:message_body]
         ).format
 
-        context = "#{message_type}: '#{post.topic&.title rescue ''}' #{@opts[:reason]}"
+        context = "#{message_type}: #{@opts[:reason]}"
 
         if @by_user
           log_params = { context: context, details: details }


### PR DESCRIPTION
No wonder `rescue ''` was needed. There's no `post` variable.