### PR TITLE
FIX: Don't publish polls on message bus when there are no polls

### DIFF
--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -160,10 +160,11 @@ after_initialize do
     guardian = Guardian.new(user)
     DiscoursePoll::Poll.schedule_jobs(post)
 
-    unless post.is_first_post?
-      polls = ActiveModel::ArraySerializer.new(post.polls, each_serializer: PollSerializer, root: false, scope: guardian).as_json
-      post.publish_message!("/polls/#{post.topic_id}", post_id: post.id, polls: polls)
-    end
+    next if post.is_first_post?
+    next if post.custom_fields[DiscoursePoll::HAS_POLLS].blank?
+
+    polls = ActiveModel::ArraySerializer.new(post.polls, each_serializer: PollSerializer, root: false, scope: guardian).as_json
+    post.publish_message!("/polls/#{post.topic_id}", post_id: post.id, polls: polls)
   end
 
   on(:merging_users) do |source_user, target_user|


### PR DESCRIPTION
`poll` plugin was publishing on `/polls/[topic_id]` every time a non-first post was created. I can't imagine this being needed. It regressed 3 years ago in https://github.com/discourse/discourse/pull/6359