### PR TITLE
FIX: Allow invites if must_approve_users is true

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -362,7 +362,6 @@ class Guardian
 
   def can_invite_to_forum?(groups = nil)
     authenticated? &&
-    (is_staff? || !SiteSetting.must_approve_users?) &&
     (is_staff? || SiteSetting.max_invites_per_day.to_i.positive?) &&
     (is_staff? || @user.has_trust_level?(SiteSetting.min_trust_level_to_allow_invite.to_i)) &&
     (is_admin? || groups.blank? || groups.all? { |g| can_edit_group?(g) })

--- a/spec/components/guardian_spec.rb
+++ b/spec/components/guardian_spec.rb
@@ -492,9 +492,9 @@ describe Guardian do
       expect(Guardian.new.can_invite_to_forum?).to be_falsey
     end
 
-    it 'returns true when the site requires approving users and is mod' do
+    it 'returns true when the site requires approving users' do
       SiteSetting.must_approve_users = true
-      expect(Guardian.new(moderator).can_invite_to_forum?).to be_truthy
+      expect(Guardian.new(trust_level_2).can_invite_to_forum?).to be_truthy
     end
 
     it 'returns false when max_invites_per_day is 0' do


### PR DESCRIPTION
This was implemented in 36e0e6a, but then regressed when the guardian
for invites was refactored in 76a7b75.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
