### PR TITLE
DEV: Reuse code for TrustLevelAndStaffSetting

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1021,6 +1021,12 @@ class User < ActiveRecord::Base
     admin? || moderator? || staged? || TrustLevel.compare(trust_level, level)
   end
 
+  def has_trust_level_or_staff?(level)
+    return admin? if level.to_s == 'admin'
+    return staff? if level.to_s == 'staff'
+    has_trust_level?(level.to_i)
+  end
+
   # a touch faster than automatic
   def admin?
     admin

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -56,6 +56,9 @@ class Guardian
     def has_trust_level?(level)
       false
     end
+    def has_trust_level_or_staff?(level)
+      false
+    end
     def email
       nil
     end
@@ -444,9 +447,7 @@ class Guardian
     # User is authenticated
     return false if !authenticated?
     # User is trusted enough
-    return is_admin? if SiteSetting.min_trust_to_send_email_messages.to_s == 'admin'
-    return is_staff? if SiteSetting.min_trust_to_send_email_messages.to_s == 'staff'
-    SiteSetting.enable_personal_messages && @user.has_trust_level?(SiteSetting.min_trust_to_send_email_messages.to_i)
+    SiteSetting.enable_personal_messages && @user.has_trust_level_or_staff?(SiteSetting.min_trust_to_send_email_messages)
   end
 
   def can_export_entity?(entity)

--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -3,11 +3,11 @@
 #mixin for all guardian methods dealing with tagging permissions
 module TagGuardian
   def can_create_tag?
-    SiteSetting.tagging_enabled && user&.has_trust_level_or_staff?(SiteSetting.min_trust_to_create_tag)
+    SiteSetting.tagging_enabled && @user.has_trust_level_or_staff?(SiteSetting.min_trust_to_create_tag)
   end
 
   def can_tag_topics?
-    SiteSetting.tagging_enabled && user&.has_trust_level_or_staff?(SiteSetting.min_trust_level_to_tag_topics)
+    SiteSetting.tagging_enabled && @user.has_trust_level_or_staff?(SiteSetting.min_trust_level_to_tag_topics)
   end
 
   def can_tag_pms?

--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -3,15 +3,11 @@
 #mixin for all guardian methods dealing with tagging permissions
 module TagGuardian
   def can_create_tag?
-    return is_admin? if SiteSetting.min_trust_to_create_tag.to_s == 'admin'
-    return is_staff? if SiteSetting.min_trust_to_create_tag.to_s == 'staff'
-    user && SiteSetting.tagging_enabled && user.has_trust_level?(SiteSetting.min_trust_to_create_tag.to_i)
+    SiteSetting.tagging_enabled && user&.has_trust_level_or_staff?(SiteSetting.min_trust_to_create_tag)
   end
 
   def can_tag_topics?
-    return is_admin? if SiteSetting.min_trust_level_to_tag_topics.to_s == 'admin'
-    return is_staff? if SiteSetting.min_trust_level_to_tag_topics.to_s == 'staff'
-    user && SiteSetting.tagging_enabled && user.has_trust_level?(SiteSetting.min_trust_level_to_tag_topics.to_i)
+    SiteSetting.tagging_enabled && user&.has_trust_level_or_staff?(SiteSetting.min_trust_level_to_tag_topics)
   end
 
   def can_tag_pms?

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -32,10 +32,7 @@ module TopicGuardian
   end
 
   def can_see_shared_draft?
-    return is_admin? if SiteSetting.shared_drafts_min_trust_level.to_s == 'admin'
-    return is_staff? if SiteSetting.shared_drafts_min_trust_level.to_s == 'staff'
-
-    @user.has_trust_level?(SiteSetting.shared_drafts_min_trust_level.to_i)
+    @user.has_trust_level_or_staff?(SiteSetting.shared_drafts_min_trust_level)
   end
 
   def can_create_whisper?


### PR DESCRIPTION
The code that checked this permission was duplicated everytime a new
settings of this type was added. This commit changes the behavior of
some functionality because some feature checks were bypassed for staff
members.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
