### PR TITLE
DEV: Don't clear cache/trigger events if site setting hasn't changed

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -355,6 +355,9 @@ module SiteSettingExtension
     old_val = current[name]
     provider.destroy(name)
     current[name] = defaults.get(name, default_locale)
+
+    return if current[name] == old_val
+
     clear_uploads_cache(name)
     clear_cache!
     DiscourseEvent.trigger(:site_setting_changed, name, old_val, current[name]) if old_val != current[name]
@@ -369,6 +372,9 @@ module SiteSettingExtension
     sanitized_val = sanitize_override ? sanitize_field(val) : val
     provider.save(name, sanitized_val, type)
     current[name] = type_supervisor.to_rb_value(name, sanitized_val)
+
+    return if current[name] == old_val
+
     clear_uploads_cache(name)
     notify_clients!(name) if client_settings.include? name
     clear_cache!


### PR DESCRIPTION
Doing this:

```rb
SiteSetting.tagging_enabled = true
SiteSetting.tagging_enabled = true
SiteSetting.tagging_enabled = true
```

…should result in (at most) one cache clear and one message bus publish call.