### PR TITLE
UX: Fallback to regular auth title if screen-reader title is unavailable

### DIFF
--- a/app/assets/javascripts/discourse/app/models/login-method.js
+++ b/app/assets/javascripts/discourse/app/models/login-method.js
@@ -15,7 +15,10 @@ const LoginMethod = EmberObject.extend({
 
   @discourseComputed
   screenReaderTitle() {
-    return this.title_override || I18n.t(`login.${this.name}.sr_title`);
+    return (
+      this.title_override ||
+      I18n.t(`login.${this.name}.sr_title`, { defaultValue: this.title })
+    );
   },
 
   @discourseComputed


### PR DESCRIPTION
c401d641 introduced a new translation key for auth providers, and provided new strings for core providers. However, not all plugins have added this string. This commit makes the screenreader title fallback to the regular title in those cases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
