### PR TITLE
FEATURE: Notify responders of post removal

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1497,6 +1497,7 @@ en:
     tl2_post_edit_time_limit: "A tl2+ author can edit their post for (n) minutes after posting. Set to 0 for forever."
     edit_history_visible_to_public: "Allow everyone to see previous versions of an edited post. When disabled, only staff members can view."
     delete_removed_posts_after: "Posts removed by the author will be automatically deleted after (n) hours. If set to 0, posts will be deleted immediately."
+    notify_users_after_responses_deleted_on_flagged_post: "When a post is flagged and then removed, all users that responded to the post and had their responses removed will be notified."
     max_image_width: "Maximum thumbnail width of images in a post"
     max_image_height: "Maximum thumbnail height of images in a post"
     responsive_post_image_sizes: "Resize lightbox preview images to allow for high DPI screens of the following pixel ratios. Remove all values to disable responsive images."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2811,6 +2811,11 @@ en:
     inappropriate: "Your post was flagged as **inappropriate**: the community feels it is offensive, abusive, or a violation of [our community guidelines](%{base_path}/guidelines)."
     spam: "Your post was flagged as **spam**: the community feels it is an advertisement, something that is overly promotional in nature instead of being useful or relevant to the topic as expected."
     notify_moderators: "Your post was flagged **for moderator attention**: the community feels something about the post requires manual intervention by a staff member."
+    responder:
+      off_topic: "The post was flagged as **off-topic**: the community feels it is not a good fit for the topic, as currently defined by the title and the first post."
+      inappropriate: "The post was flagged as **inappropriate**: the community feels it is offensive, abusive, or a violation of [our community guidelines](%{base_path}/guidelines)."
+      spam: "The post was flagged as **spam**: the community feels it is an advertisement, something that is overly promotional in nature instead of being useful or relevant to the topic as expected."
+      notify_moderators: "The post was flagged **for moderator attention**: the community feels something about the post requires manual intervention by a staff member."
 
   flags_dispositions:
     agreed: "Thanks for letting us know. We agree there is an issue and we're looking into it."
@@ -2908,6 +2913,24 @@ en:
         ```
 
         Please review our [community guidelines](%{base_url}/guidelines) for details.
+
+    flags_agreed_and_post_deleted_for_responders:
+      title: "Reply removed from flagged post by staff"
+      subject_template: "Reply removed from flagged post by staff"
+      text_body_template: |
+        Hello,
+
+        This is an automated message from %{site_name} to let you know that a [post](%{base_url}%{url}) you replied to was removed.
+
+        %{flag_reason}
+
+        This post was flagged by the community and a staff member opted to remove it.
+
+        ``` markdown
+        %{flagged_post_raw_content}
+        ```
+
+        For more details on the reason for removal, please review our [community guidelines](%{base_url}/guidelines).
 
     usage_tips:
       text_body_template: |

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -826,6 +826,8 @@ posting:
   delete_removed_posts_after:
     client: true
     default: 24
+  notify_users_after_responses_deleted_on_flagged_post:
+    default: false
   traditional_markdown_linebreaks:
     client: true
     default: false

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -45,11 +45,7 @@ class PostDestroyer
     PostDestroyer.new(performed_by, post, reviewable: reviewable).destroy
 
     options = { defer_flags: defer_reply_flags }
-    if SiteSetting.notify_users_after_responses_deleted_on_flagged_post
-      options[:reviewable] = reviewable
-      options[:notify_responders] = true
-      options[:parent_post] = post
-    end
+    options.merge!({ reviewable: reviewable, notify_responders: true, parent_post: post }) if SiteSetting.notify_users_after_responses_deleted_on_flagged_post
     replies.each { |reply| PostDestroyer.new(performed_by, reply, options).destroy }
   end
 

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -185,7 +185,6 @@ class PostDestroyer
       TopicUser.update_post_action_cache(post_id: @post.id)
 
       DB.after_commit do
-        # WE MAKE IT HERE
         if @opts[:reviewable]
           notify_deletion(@opts[:reviewable], { notify_responders: @opts[:notify_responders], parent_post: @opts[:parent_post] })
         elsif reviewable = @post.reviewable_flag

--- a/spec/fabricators/reviewable_fabricator.rb
+++ b/spec/fabricators/reviewable_fabricator.rb
@@ -57,6 +57,9 @@ Fabricator(:reviewable_flagged_post) do
   topic
   target_type 'Post'
   target { Fabricate(:post) }
+  reviewable_scores { |p| [
+    Fabricate.build(:reviewable_score, reviewable_id: p[:id]),
+  ]}
 end
 
 Fabricator(:reviewable_user) do

--- a/spec/fabricators/reviewable_score_fabricator.rb
+++ b/spec/fabricators/reviewable_score_fabricator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Fabricator(:reviewable_score) do
+  reviewable_id
+  user { Fabricate(:user) }
+  reviewable_score_type { 4 }
+  status { 1 }
+  score { 11.0 }
+  reviewed_by { Fabricate(:user) }
+end

--- a/spec/fabricators/reviewable_score_fabricator.rb
+++ b/spec/fabricators/reviewable_score_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:reviewable_score) do
-  reviewable_id
+  reviewable { Fabricate(:reviewable) }
   user { Fabricate(:user) }
   reviewable_score_type { 4 }
   status { 1 }

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -283,15 +283,26 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
   end
 
   describe "#perform_delete_and_agree_replies" do
-    it 'ignore flagged replies' do
-      flagged_post = Fabricate(:reviewable_flagged_post)
-      reply = create_reply(flagged_post.target)
-      flagged_post.target.update(reply_count: 1)
-      flagged_reply = Fabricate(:reviewable_flagged_post, target: reply)
+    let(:flagged_post) { Fabricate(:reviewable_flagged_post) }
+    let!(:reply) { create_reply(flagged_post.target) }
 
+    before do
+      flagged_post.target.update(reply_count: 1)
+    end
+
+    it 'ignore flagged replies' do
+      flagged_reply = Fabricate(:reviewable_flagged_post, target: reply)
       flagged_post.perform(moderator, :delete_and_agree_replies)
 
       expect(flagged_reply.reload.status).to eq(Reviewable.statuses[:ignored])
+    end
+
+    it 'notifies users that responded to flagged post' do
+      SiteSetting.notify_users_after_responses_deleted_on_flagged_post = true
+      flagged_post.perform(moderator, :delete_and_agree_replies)
+
+      expect(Jobs::SendSystemMessage.jobs.size).to eq(2)
+      expect(Jobs::SendSystemMessage.jobs.last["args"].first["message_type"]).to eq("flags_agreed_and_post_deleted_for_responders")
     end
   end
 

--- a/spec/serializers/topic_view_posts_serializer_spec.rb
+++ b/spec/serializers/topic_view_posts_serializer_spec.rb
@@ -4,28 +4,20 @@ require 'rails_helper'
 
 describe TopicViewPostsSerializer do
 
+  let(:user) { Fabricate(:user) }
+  let(:post) { Fabricate(:post) }
+  let(:topic) { post.topic }
+  let!(:reviewable) { Fabricate(:reviewable_flagged_post,
+    created_by: user,
+    target: post,
+    topic: topic,
+    reviewable_scores: [
+      Fabricate(:reviewable_score, reviewable_score_type: 0, status: ReviewableScore.statuses[:pending]),
+      Fabricate(:reviewable_score, reviewable_score_type: 0, status: ReviewableScore.statuses[:ignored])
+    ]
+  )}
+
   it 'should return the right attributes' do
-
-    user = Fabricate(:user)
-    post = Fabricate(:post)
-    topic = post.topic
-
-    reviewable = Fabricate(:reviewable_flagged_post, created_by: user, target: post, topic: topic)
-
-    ReviewableScore.create!(
-      reviewable_id: reviewable.id,
-      user_id: user.id,
-      reviewable_score_type: 0,
-      status: ReviewableScore.statuses[:pending]
-    )
-
-    ReviewableScore.create!(
-      reviewable_id: reviewable.id,
-      user_id: user.id,
-      reviewable_score_type: 0,
-      status: ReviewableScore.statuses[:ignored]
-    )
-
     topic_view = TopicView.new(topic, user, post_ids: [post.id])
 
     serializer = TopicViewPostsSerializer.new(


### PR DESCRIPTION
- Added SiteSetting of `notify_users_after_responses_deleted_on_flagged_post`
- Add response of `flags_agreed_and_post_deleted_for_responders` for recursively deleted posts
- Add `ReviewableScore` Fabricator, and update new / old specs to utilize it

## Response
<img width="368" alt="Screen Shot 2021-11-22 at 3 14 16 PM" src="https://user-images.githubusercontent.com/50783505/142936178-fb66a118-d337-4cef-85a5-5706909db985.png">
<img width="821" alt="Screen Shot 2021-11-22 at 3 14 45 PM" src="https://user-images.githubusercontent.com/50783505/142936235-ce7a1493-e5e6-4f5d-ba47-893d17df3609.png"> 

## Site Setting
<img width="681" alt="Screen Shot 2021-11-22 at 3 13 25 PM" src="https://user-images.githubusercontent.com/50783505/142936100-80585d32-cfe5-466d-a73c-eaa68f2b73df.png">

# Challenges
I am not sure on how to handle (without crazy queries) not sending multiple emails if a user has responded to a deleted post multiple times. Maybe that is something we are okay with... but my thoughts were that we should send a single email even if you have 10 responses to the flagged post deleted.