### PR TITLE
FIX: Keep existent tags when editing tag topics

### DIFF
--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -77,6 +77,9 @@ module DiscourseTagging
           only_tag_names: tag_names
         )
 
+        # keep existent tags that current user cannot use
+        tags += Tag.where(name: old_tag_names & tag_names)
+
         tags = Tag.where(id: tags.map(&:id)).all.to_a if tags.size > 0
 
         if tags.size < tag_names.size && (category.nil? || category.allow_global_tags || (category.tags.count == 0 && category.tag_groups.count == 0))

--- a/spec/components/discourse_tagging_spec.rb
+++ b/spec/components/discourse_tagging_spec.rb
@@ -383,6 +383,18 @@ describe DiscourseTagging do
       expect(topic.tags.pluck(:name)).to be_blank
     end
 
+    it 'can remove tags and keep existent ones' do
+      tag1 = Fabricate(:tag)
+      tag2 = Fabricate(:tag)
+      topic = Fabricate(:topic, tags: [tag1, tag2])
+      Fabricate(:category, allowed_tags: [tag1.name])
+
+      result = DiscourseTagging.tag_topic_by_names(topic, Guardian.new(admin), [tag1.name])
+
+      expect(result).to eq(true)
+      expect(topic.reload.tags.pluck(:name)).to eq([tag1.name])
+    end
+
     context 'respects category minimum_required_tags setting' do
       fab!(:category) { Fabricate(:category, minimum_required_tags: 2) }
       fab!(:topic) { Fabricate(:topic, category: category) }


### PR DESCRIPTION
Allow current user to keep existent tags when adding or removing a tag.
For example, a user could not remove a tag from a topic if the topic
had another tag that was restricted to a different category.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
