### PR TITLE
Add cta app event

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/signup-cta.js
+++ b/app/assets/javascripts/discourse/app/initializers/signup-cta.js
@@ -14,6 +14,7 @@ export default {
     const siteSettings = container.lookup("site-settings:main");
     const keyValueStore = container.lookup("key-value-store:main");
     const user = container.lookup("current-user:main");
+    const appEvents = container.lookup("service:app-events");
 
     screenTrack.keyValueStore = keyValueStore;
 

--- a/app/assets/javascripts/discourse/app/initializers/signup-cta.js
+++ b/app/assets/javascripts/discourse/app/initializers/signup-cta.js
@@ -72,6 +72,7 @@ export default {
 
       // Requirements met.
       session.set("showSignupCta", true);
+      appEvents.trigger("cta:shown");
     }
 
     screenTrack.registerAnonCallback(checkSignupCtaRequirements);


### PR DESCRIPTION
This PR adds an app event for when the anon CTA is triggered in Discourse. This will allow components or other areas of Discourse to access when this happens.
