### PR TITLE
DEV: Add single file progress and cancel for uppy in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/uppy-s3-multipart.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-s3-multipart.js
@@ -122,6 +122,10 @@ export default Mixin.create({
 
   @bind
   _completeMultipartUpload(file, data) {
+    if (file.meta.cancelled) {
+      return;
+    }
+
     this._uppyInstance.emit("complete-multipart", file.id);
     const parts = data.parts.map((part) => {
       return { part_number: part.PartNumber, etag: part.ETag };
@@ -158,6 +162,8 @@ export default Mixin.create({
     if (file.meta.error && this.siteSettings.enable_upload_debug_mode) {
       return;
     }
+
+    file.meta.cancelled = true;
 
     return ajax(getUrl(`${this.uploadRootPath}/abort-multipart.json`), {
       type: "POST",


### PR DESCRIPTION
This commit adds handlers for the composer uppy mixin to allow
for cancelling individual file uploads, not just all of them
at once. This is also combined with better tracking of in progress
uploads along with their progress percentage, for UI that needs
to be able to display the progress for individual files and
also cancel individual files.

To use this, a cancel button in the UI should call a function like this:

```javascript
cancelSingleUpload(fileId) {
  this.appEvents.trigger(`${this.eventPrefix}:cancel-upload`, {
    fileId,
  });
},
```

Additionally, the `inProgressUploads` can be shown in the UI. It is an array of objects with the file name, ID, and the progress percentage. We can add more data to this if needed down the line.
