### PR TITLE
DEV: add plugin outlet before topic list views

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -73,6 +73,9 @@
   </td>
 {{/if}}
 
-<td class="num views {{topic.viewsHeat}} topic-list-data">{{number topic.views numberKey="views_long"}}</td>
+<td class="num views {{topic.viewsHeat}} topic-list-data">
+  {{raw-plugin-outlet name="topic-list-before-view-count"}}
+  {{number topic.views numberKey="views_long"}}
+</td>
 
 {{raw "list/activity-column" topic=topic class="num topic-list-data" tagName="td"}}


### PR DESCRIPTION
The other columns already have an outlet, and I need this one for a customer theme. 