### PR TITLE
FEATURE: Show browser search tip when discourse search shows up in a topic

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -13,7 +13,6 @@ import userSearch from "discourse/lib/user-search";
 import { CANCELLED_STATUS } from "discourse/lib/autocomplete";
 import { cancel } from "@ember/runloop";
 import I18n from "I18n";
-import RawHtml from "discourse/widgets/raw-html";
 
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
 const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
@@ -513,10 +512,14 @@ createWidget("browser-search-tip", {
   tagName: "div.browser-search-tip",
 
   html() {
-    return new RawHtml({
-      html: `<span>${I18n.t("search.browser_tip", {
-        modifier: translateModKey("Meta"),
-      }).htmlSafe()}</span>`,
-    });
+    return [
+      h(
+        "span.tip-label",
+        I18n.t("search.browser_tip", {
+          modifier: translateModKey("Meta"),
+        })
+      ),
+      h("span.tip-description", I18n.t("search.browser_tip_description")),
+    ];
   },
 });

--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -5,13 +5,15 @@ import discourseDebounce from "discourse-common/lib/debounce";
 import getURL from "discourse-common/lib/get-url";
 import { h } from "virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
-import { isiPad } from "discourse/lib/utilities";
+import { isiPad, translateModKey } from "discourse/lib/utilities";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { Promise } from "rsvp";
 import { search as searchCategoryTag } from "discourse/lib/category-tag-search";
 import userSearch from "discourse/lib/user-search";
 import { CANCELLED_STATUS } from "discourse/lib/autocomplete";
 import { cancel } from "@ember/runloop";
+import I18n from "I18n";
+import RawHtml from "discourse/widgets/raw-html";
 
 const CATEGORY_SLUG_REGEXP = /(\#[a-zA-Z0-9\-:]*)$/gi;
 const USERNAME_REGEXP = /(\@[a-zA-Z0-9\-\_]*)$/gi;
@@ -279,6 +281,11 @@ export default createWidget("search-menu", {
       this.state.inTopicContext &&
       (!SearchHelper.includesTopics() || !searchData.term)
     ) {
+      const isMobileDevice = this.site.isMobileDevice;
+
+      if (!isMobileDevice) {
+        results.push(this.attach("browser-search-tip"));
+      }
       return results;
     }
 
@@ -498,5 +505,18 @@ export default createWidget("search-menu", {
     }
 
     return false;
+  },
+});
+
+createWidget("browser-search-tip", {
+  buildKey: () => "browser-search-tip",
+  tagName: "div.browser-search-tip",
+
+  html() {
+    return new RawHtml({
+      html: `<span>${I18n.t("search.browser_tip", {
+        modifier: translateModKey("Meta"),
+      }).htmlSafe()}</span>`,
+    });
   },
 });

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -242,22 +242,27 @@ $search-pad-horizontal: 0.5em;
         }
       }
     }
+  }
 
-    .search-random-quick-tip {
-      padding: $search-pad-vertical $search-pad-horizontal;
-      padding-bottom: 0;
-      font-size: var(--font-down-2);
-      color: var(--primary-medium);
-      .tip-label {
-        background-color: rgba(var(--tertiary-rgb), 0.1);
-        margin-right: 4px;
-        padding: 2px 4px;
-        display: inline-block;
-        &.tip-clickable {
-          cursor: pointer;
-        }
+  .browser-search-tip,
+  .search-random-quick-tip {
+    padding: $search-pad-vertical $search-pad-horizontal;
+    padding-bottom: 0;
+    font-size: var(--font-down-2);
+    color: var(--primary-medium);
+    .tip-label {
+      background-color: rgba(var(--tertiary-rgb), 0.1);
+      margin-right: 4px;
+      padding: 2px 4px;
+      display: inline-block;
+      &.tip-clickable {
+        cursor: pointer;
       }
     }
+  }
+
+  .browser-search-tip {
+    padding-top: 0.5em;
   }
 
   .searching {
@@ -325,19 +330,6 @@ $search-pad-horizontal: 0.5em;
   .search-result-post {
     .search-link {
       padding: 0.5em;
-    }
-  }
-
-  .browser-search-tip {
-    display: flex;
-    padding-top: 0.5em;
-    padding-left: 0.5em;
-    font-size: var(--font-down-2);
-    color: var(--primary-medium);
-
-    > * {
-      display: flex;
-      align-items: center;
     }
   }
 }

--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -327,4 +327,17 @@ $search-pad-horizontal: 0.5em;
       padding: 0.5em;
     }
   }
+
+  .browser-search-tip {
+    display: flex;
+    padding-top: 0.5em;
+    padding-left: 0.5em;
+    font-size: var(--font-down-2);
+    color: var(--primary-medium);
+
+    > * {
+      display: flex;
+      align-items: center;
+    }
+  }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2379,6 +2379,7 @@ en:
       in_topics_posts: "in all topics and posts"
       enter_hint: "or press Enter"
       in_posts_by: "in posts by %{username}"
+      browser_tip: "Press <kbd>%{modifier}</kbd>+<kbd>f</kbd> again to use native browser search."
 
       type:
         default: "Topics/posts"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2379,7 +2379,8 @@ en:
       in_topics_posts: "in all topics and posts"
       enter_hint: "or press Enter"
       in_posts_by: "in posts by %{username}"
-      browser_tip: "Press <kbd>%{modifier}</kbd>+<kbd>f</kbd> again to use native browser search."
+      browser_tip: "%{modifier} + f"
+      browser_tip_description: "again to use native browser search"
 
       type:
         default: "Topics/posts"


### PR DESCRIPTION
<img width="634" alt="Screenshot 2021-11-23 at 11 15 58 AM" src="https://user-images.githubusercontent.com/1555215/142967556-ff37a375-8951-442c-bde8-a51e7878fc56.png">

The search tip only shows up when a user invokes browser search in topics and sees our topic search. This tip would disappear if the user hits backspace and removes the "in this topic" label. This tip would also not show up if the user manually clicks on the search icon in the header.

Note that there are no acceptance tests as it is not possible to make topic search show up due to pre-requisites not being satisfied as we don't cloak in test mode:
- https://github.com/discourse/discourse/blob/8a3ab1cc438468ab5a7e6dbe277bd5dd7ca6ba50/app/assets/javascripts/discourse/app/widgets/header.js#L537-L539
- https://github.com/discourse/discourse/blob/88523a6d6a65255a3bfd5157b33d848acbd0cd86/app/assets/javascripts/discourse/app/widgets/post-stream.js#L28
