### PR TITLE
PERF: Updating first unread PM for user not respecting limits.

### DIFF
--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -53,6 +53,14 @@ class UserStat < ActiveRecord::Base
         )
         GROUP BY tau.user_id
       ) AS X ON X.user_id = u1.id
+      WHERE u1.id IN (
+        SELECT id
+        FROM users
+        WHERE last_seen_at IS NOT NULL
+        AND last_seen_at > :last_seen
+        ORDER BY last_seen_at DESC
+        LIMIT :limit
+      )
     ) AS Z
     WHERE us.user_id = Z.user_id
     SQL

--- a/db/migrate/20211123033311_reset_first_unread_pm_at_on_user_stat.rb
+++ b/db/migrate/20211123033311_reset_first_unread_pm_at_on_user_stat.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ResetFirstUnreadPmAtOnUserStat < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+    UPDATE user_stats us
+    SET first_unread_pm_at = u.created_at
+    FROM users u
+    WHERE u.id = us.user_id
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
In b8c8909a9d38039782283c5f0305671b72774ad9, we introduced a regression
where users may have had their `UserStat.first_unread_pm_at` set
incorrectly. This commit introduces a migration to reset `UserStat.first_unread_pm_at` back to
`User#created_at`.

Follow-up to b8c8909a9d38039782283c5f0305671b72774ad9.