### PR TITLE
FIX: Git should not prompt for credentials

### DIFF
--- a/lib/theme_store/git_importer.rb
+++ b/lib/theme_store/git_importer.rb
@@ -87,9 +87,9 @@ class ThemeStore::GitImporter
   def import_public!
     begin
       if @branch.present?
-        Discourse::Utils.execute_command("git", "clone", "--single-branch", "-b", @branch, @url, @temp_folder)
+        Discourse::Utils.execute_command({ "GIT_TERMINAL_PROMPT" => "0" }, "git", "clone", "--single-branch", "-b", @branch, @url, @temp_folder)
       else
-        Discourse::Utils.execute_command("git", "clone", @url, @temp_folder)
+        Discourse::Utils.execute_command({ "GIT_TERMINAL_PROMPT" => "0" }, "git", "clone", @url, @temp_folder)
       end
     rescue RuntimeError
       raise RemoteTheme::ImportError.new(I18n.t("themes.import_error.git"))

--- a/spec/components/theme_store/git_importer_spec.rb
+++ b/spec/components/theme_store/git_importer_spec.rb
@@ -22,14 +22,14 @@ describe ThemeStore::GitImporter do
     end
 
     it "should import from http url" do
-      Discourse::Utils.expects(:execute_command).with("git", "clone", url, @temp_folder)
+      Discourse::Utils.expects(:execute_command).with({ "GIT_TERMINAL_PROMPT" => "0" }, "git", "clone", url, @temp_folder)
 
       importer = ThemeStore::GitImporter.new(url)
       importer.import!
     end
 
     it "should work with trailing slash url" do
-      Discourse::Utils.expects(:execute_command).with("git", "clone", url, @temp_folder)
+      Discourse::Utils.expects(:execute_command).with({ "GIT_TERMINAL_PROMPT" => "0" }, "git", "clone", url, @temp_folder)
 
       importer = ThemeStore::GitImporter.new(trailing_slash_url)
       importer.import!
@@ -45,7 +45,7 @@ describe ThemeStore::GitImporter do
     end
 
     it "should import branch from http url" do
-      Discourse::Utils.expects(:execute_command).with("git", "clone", "--single-branch", "-b", branch, url, @temp_folder)
+      Discourse::Utils.expects(:execute_command).with({ "GIT_TERMINAL_PROMPT" => "0" }, "git", "clone", "--single-branch", "-b", branch, url, @temp_folder)
 
       importer = ThemeStore::GitImporter.new(url, branch: branch)
       importer.import!


### PR DESCRIPTION
When cloning a public remote repository (no key), git should not prompt
for credentials.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
