### PR TITLE
UX: timestamp should not hide handle of topic timeline in mobile.

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -241,6 +241,9 @@
 
     .timeline-ago {
       color: var(--primary-med-or-secondary-med);
+      max-width: 70px;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .timeline-scroller {


### PR DESCRIPTION
Previously, since the space of the timestamp is big in some locales, it blocked the visibility of the topic timeline handle in mobile view.