### PR TITLE
FIX: Use CDN URL for internal onebox avatars

### DIFF
--- a/app/services/username_changer.rb
+++ b/app/services/username_changer.rb
@@ -24,7 +24,7 @@ class UsernameChanger
       UsernameChanger.update_username(user_id: @user.id,
                                       old_username: @old_username,
                                       new_username: @new_username,
-                                      avatar_template: @user.avatar_template,
+                                      avatar_template: @user.avatar_template_url,
                                       asynchronous: asynchronous) if run_update_job
       return true
     end

--- a/db/post_migrate/20211124161346_queue_internal_onebox_rebake.rb
+++ b/db/post_migrate/20211124161346_queue_internal_onebox_rebake.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class QueueInternalOneboxRebake < ActiveRecord::Migration[6.1]
+  def up
+    # Prior to this fix, internal oneboxes were bypassing the CDN for avatar URLs.
+    # If a site has a CDN, queue up a rebake in the background
+    if GlobalSetting.cdn_url
+      execute <<~SQL
+        UPDATE posts SET baked_version = 0
+        WHERE cooked LIKE '%src="/user_avatar/%'
+      SQL
+    end
+  end
+
+  def down
+    # Do nothing
+  end
+end

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -321,7 +321,7 @@ module Oneboxer
       args = {
         topic_id: topic.id,
         post_number: post.post_number,
-        avatar: PrettyText.avatar_img(post.user.avatar_template, "tiny"),
+        avatar: PrettyText.avatar_img(post.user.avatar_template_url, "tiny"),
         original_url: url,
         title: PrettyText.unescape_emoji(CGI::escapeHTML(topic.title)),
         category_html: CategoryBadge.html_for(topic.category),

--- a/spec/components/oneboxer_spec.rb
+++ b/spec/components/oneboxer_spec.rb
@@ -72,7 +72,7 @@ describe Oneboxer do
       onebox = preview(public_reply.url, user, public_category)
       expect(onebox).to include(public_reply.excerpt)
       expect(onebox).to include(%{data-post="2"})
-      expect(onebox).to include(PrettyText.avatar_img(replier.avatar_template, "tiny"))
+      expect(onebox).to include(PrettyText.avatar_img(replier.avatar_template_url, "tiny"))
 
       short_url = "#{Discourse.base_path}/t/#{public_topic.id}"
       expect(preview(short_url, user, public_category)).to include(public_topic.title)
@@ -80,11 +80,11 @@ describe Oneboxer do
       onebox = preview(public_moderator_action.url, user, public_category)
       expect(onebox).to include(public_moderator_action.excerpt)
       expect(onebox).to include(%{data-post="4"})
-      expect(onebox).to include(PrettyText.avatar_img(staff.avatar_template, "tiny"))
+      expect(onebox).to include(PrettyText.avatar_img(staff.avatar_template_url, "tiny"))
 
       onebox = preview(public_reply.url, user, public_category, public_topic)
       expect(onebox).not_to include(public_topic.title)
-      expect(onebox).to include(replier.avatar_template.sub("{size}", "40"))
+      expect(onebox).to include(replier.avatar_template_url.sub("{size}", "40"))
 
       expect(preview(public_hidden.url, user, public_category)).to match_html(link(public_hidden.url))
       expect(preview(secured_topic.relative_url, user, public_category)).to match_html(link(secured_topic.relative_url))

--- a/spec/services/username_changer_spec.rb
+++ b/spec/services/username_changer_spec.rb
@@ -323,7 +323,7 @@ describe UsernameChanger do
 
       context 'quotes' do
         let(:quoted_post) { create_post(user: user, topic: topic, post_number: 1, raw: "quoted post") }
-        let(:avatar_url) { user.avatar_template.gsub("{size}", "40") }
+        let(:avatar_url) { user.avatar_template_url.gsub("{size}", "40") }
 
         it 'replaces the username in quote tags and updates avatar' do
           post = create_post_and_change_username(raw: <<~RAW)
@@ -448,7 +448,7 @@ describe UsernameChanger do
         end
 
         def user_avatar_url(u)
-          u.avatar_template.gsub("{size}", "40")
+          u.avatar_template_url.gsub("{size}", "40")
         end
 
         it 'updates avatar for linked topics and posts' do


### PR DESCRIPTION
This commit will also trigger a background rebake for all existing posts with internal oneboxes

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
