### PR TITLE
DEV: Allow using incorrect headers with ember-cli

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -286,7 +286,7 @@ to serve API requests. For example:
 
     baseURL = rootURL === "" ? "/" : cleanBaseURL(rootURL || baseURL);
 
-    const rawMiddleware = express.raw({ type: "*/*", limit: "100mb" });
+    const rawMiddleware = express.raw({ type: () => true, limit: "100mb" });
 
     app.use(rawMiddleware, async (req, res, next) => {
       try {


### PR DESCRIPTION
Makes it possible to pass-through invalid headers, e.g. `Content-Type: multipart/form-data;;`

That ability regressed with the latest changes.
