### PR TITLE
DEV: Stop if theme:update fails for default site

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -76,7 +76,7 @@ task "themes:update" => :environment do
   if ENV['RAILS_DB'].present?
     update_themes
   else
-    RailsMultisite::ConnectionManagement.each_connection do |db|
+    RailsMultisite::ConnectionManagement.each_connection do
       update_themes
     end
   end


### PR DESCRIPTION
The error handling of the theme:update Rake task has been improved. If
an error occurs while updating the default site, then the exception will
be propagated and the process will exit with non-zero status.

This is a follow-up to commit 3f97f884fef9d3e4b33ae6361d7891c3c414802b.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
