### PR TITLE
FIX: treats ipad as mobileView for popper positioning

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -862,7 +862,7 @@ export default Component.extend(
         );
 
         const placementStrategy =
-          this.capabilities.isIpadOS || this.site?.mobileView
+          this.capabilities?.isIpadOS || this.site?.mobileView
             ? "absolute"
             : "fixed";
         const verticalOffset = 3;

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -861,7 +861,10 @@ export default Component.extend(
           `#${this.selectKit.uniqueID}-body`
         );
 
-        const placementStrategy = this?.site?.mobileView ? "absolute" : "fixed";
+        const placementStrategy =
+          this.capabilities.isIpadOS || this.site?.mobileView
+            ? "absolute"
+            : "fixed";
         const verticalOffset = 3;
 
         this.popper = createPopper(anchor, popper, {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
