### PR TITLE
DEV: refactor JS files to not use `self = this` in code.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -170,13 +170,13 @@ export default Component.extend(LoadMore, {
   },
 
   click(e) {
-    let onClick = function (sel, callback) {
+    const onClick = (sel, callback) => {
       let target = $(e.target).closest(sel);
 
       if (target.length === 1) {
         callback.apply(this, [target]);
       }
-    }.bind(this);
+    }
 
     onClick("button.bulk-select", function () {
       this.toggleBulkSelect();

--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -176,7 +176,7 @@ export default Component.extend(LoadMore, {
       if (target.length === 1) {
         callback.apply(this, [target]);
       }
-    }
+    };
 
     onClick("button.bulk-select", function () {
       this.toggleBulkSelect();

--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -170,14 +170,13 @@ export default Component.extend(LoadMore, {
   },
 
   click(e) {
-    let self = this;
     let onClick = function (sel, callback) {
       let target = $(e.target).closest(sel);
 
       if (target.length === 1) {
-        callback.apply(self, [target]);
+        callback.apply(this, [target]);
       }
-    };
+    }.bind(this);
 
     onClick("button.bulk-select", function () {
       this.toggleBulkSelect();

--- a/app/assets/javascripts/discourse/app/lib/debounce.js
+++ b/app/assets/javascripts/discourse/app/lib/debounce.js
@@ -5,15 +5,14 @@ import { debounce } from "@ember/runloop";
   Original function will be called with the context and arguments from the last call made.
 **/
 export default function (func, wait) {
-  let self, args;
+  let args;
   const later = function () {
-    func.apply(self, args);
+    func.apply(this, args);
   };
 
   return function () {
-    self = this;
     args = arguments;
 
-    debounce(null, later, wait);
+    debounce(null, later.bind(this), wait);
   };
 }

--- a/app/assets/javascripts/discourse/app/lib/debounce.js
+++ b/app/assets/javascripts/discourse/app/lib/debounce.js
@@ -6,13 +6,13 @@ import { debounce } from "@ember/runloop";
 **/
 export default function (func, wait) {
   let args;
-  const later = function () {
+  const later = () => {
     func.apply(this, args);
   };
 
   return function () {
     args = arguments;
 
-    debounce(null, later.bind(this), wait);
+    debounce(null, later, wait);
   };
 }


### PR DESCRIPTION
We no longer use this pattern. Instead, we can use `bind(this)` to the functions.
