### PR TITLE
FIX: Don't throw errors on duplicate keys in Yaml

### DIFF
--- a/app/assets/javascripts/discourse/lib/translation-plugin.js
+++ b/app/assets/javascripts/discourse/lib/translation-plugin.js
@@ -47,7 +47,7 @@ class TranslationPlugin extends Plugin {
     this.inputPaths.forEach((path) => {
       let file = path + "/" + this.inputFile;
       let yaml = fs.readFileSync(file, { encoding: "UTF-8" });
-      let loaded = Yaml.load(yaml);
+      let loaded = Yaml.load(yaml, { json: true });
       parsed = deepmerge(parsed, loaded);
     });
 


### PR DESCRIPTION
We shouldn't have them, but they shouldn't break a build either.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
