### PR TITLE
DEV: Avoid cancelling in-progress tests for `main`

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ember-${{ format('{0}-{1}', github.head_ref, github.job) || format('{0}-{1}', github.ref, github.run_number) }}
+  group: ember-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: linting-${{ format('{0}-{1}', github.head_ref, github.job) || format('{0}-{1}', github.ref, github.run_number) }}
+  group: linting-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: tests-${{ format('{0}-{1}', github.head_ref, github.job) || format('{0}-{1}', github.ref, github.run_number) }}
+  group: tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Followup to https://github.com/discourse/discourse/commit/78830d14b2bd4694abcfc7ac872358fdabe02c32, we only want to cancel PR runs, not main branch runs. 