### PR TITLE
DEV: Add 201 to bootstrap-json accepted status codes

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -230,7 +230,18 @@ async function handleRequest(proxy, baseURL, req, res) {
     req.headers["X-Discourse-Asset-Path"] = req.path;
   }
 
-  const acceptedStatusCodes = [200, 301, 302, 303, 307, 308, 404, 403, 500];
+  const acceptedStatusCodes = [
+    200,
+    201,
+    301,
+    302,
+    303,
+    307,
+    308,
+    404,
+    403,
+    500,
+  ];
   const proxyRequest = bent(req.method, acceptedStatusCodes);
   const requestBody = req.method === "GET" ? null : req.body;
   const response = await proxyRequest(url, requestBody, req.headers);


### PR DESCRIPTION
The theme creator endpoints return JSON with a 201 CREATED
status code. With the recent changes to bootstrap-json/index.js
for the Ember CLI proxy, these endpoints were broken because
201 was not an accepted status code. This commit simply
adds 201 to the array, but prettier forced a reformat as well!
