### PR TITLE
DEV: Don't polute all ActiveRecord classes

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -80,7 +80,7 @@ class Reviewable < ActiveRecord::Base
   # Generate `pending?`, `rejected?`, etc helper methods
   statuses.each do |name, id|
     define_method("#{name}?") { status == id }
-    self.class.define_method(name) { where(status: id) }
+    singleton_class.define_method(name) { where(status: id) }
   end
 
   def self.default_visible


### PR DESCRIPTION
`pending`, `approved`, `rejected`, `ignored`, and `deleted` scope method were accessible on all model classes… 😂

Fixes `Creating scope :pending. Overwriting existing method DiscoursePostEvent::EventDate.pending.` warnings.