### PR TITLE
DEV: Don't create unnecessary scope methods

### DIFF
--- a/app/models/directory_column.rb
+++ b/app/models/directory_column.rb
@@ -6,7 +6,7 @@ class DirectoryColumn < ActiveRecord::Base
   self.ignored_columns = ["automatic"]
   self.inheritance_column = nil
 
-  enum type: { automatic: 0, user_field: 1, plugin: 2 }
+  enum type: { automatic: 0, user_field: 1, plugin: 2 }, _scopes: false
 
   def self.automatic_column_names
     @automatic_column_names ||= [:likes_received,

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -11,7 +11,7 @@ class UserOption < ActiveRecord::Base
 
   after_save :update_tracked_topics
 
-  enum default_calendar: { none_selected: 0, ics: 1, google: 2 }
+  enum default_calendar: { none_selected: 0, ics: 1, google: 2 }, _scopes: false
 
   def self.ensure_consistency!
     sql = <<~SQL

--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -13,29 +13,29 @@ class Poll < ActiveRecord::Base
     regular: 0,
     multiple: 1,
     number: 2,
-  }
+  }, _scopes: false
 
   enum status: {
     open: 0,
     closed: 1,
-  }
+  }, _scopes: false
 
   enum results: {
     always: 0,
     on_vote: 1,
     on_close: 2,
     staff_only: 3,
-  }
+  }, _scopes: false
 
   enum visibility: {
     secret: 0,
     everyone: 1,
-  }
+  }, _scopes: false
 
   enum chart_type: {
     bar: 0,
     pie: 1
-  }
+  }, _scopes: false
 
   validates :min, numericality: { allow_nil: true, only_integer: true, greater_than_or_equal_to: 0 }
   validates :max, numericality: { allow_nil: true, only_integer: true, greater_than: 0 }


### PR DESCRIPTION
Skipping methods we don't use gives us mem/perf gains (minuscule but still), but more importantly fixes warnings about `Poll#open` (created by `enum :status`) conflicting with some internal AR method. 😃 