### PR TITLE
DEV: Fix uploadHandler impl. in composer-upload-uppy mixin

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -161,8 +161,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
         // jQuery file uploader passed through a single file at a time to
         // the upload handlers.
         uploadHandlerFiles.forEach((fileWithHandler) => {
-          const file = fileWithHandler[0];
-          const matchingHandler = fileWithHandler[1];
+          const [file, matchingHandler] = fileWithHandler;
           if (matchingHandler && !matchingHandler.method(file.data, this)) {
             return this._abortAndReset();
           }


### PR DESCRIPTION
In f6528afa019ded81012947efdf2835324488183b I added parity support
for composer upload handlers to the uppy-ized composer. However the
way I assumed that it was only possible to handle a single file
upload at a time was false; it only appeared this way in the old
jQuery file upload composer because jQuery file upload sent through
files one at a time even if multiple were added at once. This caused
issues in certain plugins and themes by third parties.

This commit fixes the issue by making the uppy upload handler work
the same as the old one, by capturing all of the added files that
have matching handlers then going through them one by one and passing
them to the handler function.


