### PR TITLE
PERF: Set --header-offset property only when changed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -186,7 +186,13 @@ const SiteHeaderComponent = MountWidget.extend(
       const headerRect = header.getBoundingClientRect(),
         headerOffset = headerRect.top + headerRect.height,
         doc = document.documentElement;
-      doc.style.setProperty("--header-offset", `${headerOffset}px`);
+
+      const newValue = `${headerOffset}px`;
+      if (newValue !== this.currentHeaderOffsetValue) {
+        this.currentHeaderOffsetValue = newValue;
+        doc.style.setProperty("--header-offset", newValue);
+      }
+
       if (offset >= this.docAt) {
         if (!this.dockedHeader) {
           document.body.classList.add("docked");


### PR DESCRIPTION
Calling `setProperty("--header-offset", newValue)` seems to always cause a 'Recalculate Style' event, even if the value is unchanged. On my browser, these 'Recalculate Style' events take about 6-7ms each time the `dockCheck` function is run.

This commit stores the 'previous' value in an instance variable, and only calls setProperty if the value has changed. This brings the total runtime of `dockCheck` down to about 70µs on my machine.


### Flamegraph during scrolling:
Before:



<img width="1680" alt="Screenshot 2021-11-26 at 14 12 52" src="https://user-images.githubusercontent.com/6270921/143597562-d019b284-a714-4451-bd15-ad4ecaa6e578.png">

After:

<img width="1680" alt="Screenshot 2021-11-26 at 14 13 35" src="https://user-images.githubusercontent.com/6270921/143597575-e75c7301-9e1b-41be-a11e-b8aca521d9b6.png">



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
