### PR TITLE
UX: Fix extra indent on lists when supporting mixed text direction

### DIFF
--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -56,22 +56,13 @@
 }
 
 // For the support_mixed_text_direction setting
-html:not(.rtl) {
-  .cooked ul[dir="rtl"],
-  .d-editor-preview ul[dir="rtl"] {
-    padding-left: 0;
-    padding-right: 1.25em;
-    margin-right: 1.25em;
-  }
-}
-
-.rtl {
-  .cooked ul[dir="ltr"],
-  .d-editor-preview ul[dir="ltr"] {
-    padding-left: 0;
-    padding-right: 1.25em;
-    margin-right: 1.25em;
-  }
+html:not(.rtl) .cooked ul[dir="rtl"],
+html:not(.rtl) .d-editor-preview ul[dir="rtl"],
+.rtl .cooked ul[dir="ltr"],
+.rtl .d-editor-preview ul[dir="ltr"] {
+  padding-left: 0;
+  padding-right: 1.25em;
+  margin-right: 1.25em;
 }
 
 // Fixes github oneboxes for RTL sites

--- a/app/assets/stylesheets/common/base/rtl.scss
+++ b/app/assets/stylesheets/common/base/rtl.scss
@@ -55,21 +55,23 @@
   float: left !important;
 }
 
-// This is for the support_mixed_text_direction setting
-.cooked ul[dir="ltr"],
-.d-editor-preview ul[dir="ltr"],
-.rtl .cooked ul[dir="rtl"],
-.rtl .d-editor-preview ul[dir="rtl"] {
-  padding-left: 40px;
-  padding-right: 0;
+// For the support_mixed_text_direction setting
+html:not(.rtl) {
+  .cooked ul[dir="rtl"],
+  .d-editor-preview ul[dir="rtl"] {
+    padding-left: 0;
+    padding-right: 1.25em;
+    margin-right: 1.25em;
+  }
 }
 
-.cooked ul[dir="rtl"],
-.d-editor-preview ul[dir="rtl"],
-.rtl .cooked ul[dir="ltr"],
-.rtl .d-editor-preview ul[dir="ltr"] {
-  padding-left: 0;
-  padding-right: 40px;
+.rtl {
+  .cooked ul[dir="ltr"],
+  .d-editor-preview ul[dir="ltr"] {
+    padding-left: 0;
+    padding-right: 1.25em;
+    margin-right: 1.25em;
+  }
 }
 
 // Fixes github oneboxes for RTL sites


### PR DESCRIPTION
The RTL stylesheet is quite tricky, all values but those marked with `!important` are flipped. And we have four possible scenarios when `support_mixed_text_direction` is enabled:

1. both page and ul set to `ltr`
2. page set to `ltr`, ul set to`rtl`
3. both page and ul set to `rtl`
4. page set to `rtl`, ul set to `rtl`

This change ensures overrides only apply to 2. and 4 and values match `ul` styles outside the overrides (`1.25em` vs `40px`).