### PR TITLE
PERF: Disable ember touchstart listener

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/ember-events.js
+++ b/app/assets/javascripts/discourse/app/initializers/ember-events.js
@@ -5,14 +5,13 @@ export default {
 
   initialize() {
     // By default Ember listens to too many events. This tells it the only events
-    // we're interested in. (it removes mousemove and touchmove)
+    // we're interested in. (it removes mousemove, touchstart and touchmove)
     if (initializedOnce) {
       return;
     }
 
     Ember.EventDispatcher.reopen({
       events: {
-        touchstart: "touchStart",
         touchend: "touchEnd",
         touchcancel: "touchCancel",
         keydown: "keyDown",


### PR DESCRIPTION
Registering non-passive listeners for the touchstart event can affect scroll performance on mobile devices, and now shows a warning in Chrome. Our current version of Ember unconditionally registers all event listeners, even if they're unused. It also doesn't support passive event listeners. Once we get to Ember 4.0, it lazily registers event listeners, and supports passive listeners via the `{{on` helper.

We already disable the ember `mousemove` and `touchmove` events for performance, so it makes sense to do the same for `touchstart`. We are not using `touchstart` anywhere in core, and I cannot find any official/unofficial plugins which use it. If a `touchstart` event is required, plugins/themes can always register their own listeners (preferably on a specific element, rather than the whole `document`)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
