### PR TITLE
DEV: Ensure scrolling-post-stream event listeners are removed correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -365,8 +365,8 @@ export default MountWidget.extend({
 
   willDestroyElement() {
     this._super(...arguments);
-    document.removeEventListener("touchmove", this._debouncedScrollCallback);
-    window.removeEventListener("scroll", this._debouncedScrollCallback);
+    document.removeEventListener("touchmove", this._debouncedScroll);
+    window.removeEventListener("scroll", this._debouncedScroll);
     this.appEvents.off("post-stream:refresh", this, "_debouncedScroll");
     $(this.element).off("mouseenter.post-stream");
     $(this.element).off("mouseleave.post-stream");


### PR DESCRIPTION
The method was switched from _debouncedScrollCallback to _debouncedScroll in ff72522f, but the cleanup was not updated to match.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
