### PR TITLE
DEV: Disable 'passive' handlers for pan-events mixin

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/pan-events.js
+++ b/app/assets/javascripts/discourse/app/mixins/pan-events.js
@@ -34,7 +34,7 @@ export default Mixin.create({
       this.touchCancel = (e) => this._panMove({ type: "pointercancel" }, e);
 
       const opts = {
-        passive: true,
+        passive: false,
       };
       element.addEventListener("touchstart", this.touchStart, opts);
       element.addEventListener("touchmove", this.touchMove, opts);


### PR DESCRIPTION
These were set to `passive: true` in ff72522f.

However, two consumers of this mixin (topic-navigation and site-header) do need to call `e.preventDefault()`, so we can't use passive listeners here.

That's ok, because this mixin only applies to a specific component's element, not the entire page. So having these non-passive listeners doesn't affect the vast majority of scrolling

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
