### PR TITLE
FIX: Global log notice regressed in #15000

### DIFF
--- a/app/assets/javascripts/discourse/app/components/global-notice.js
+++ b/app/assets/javascripts/discourse/app/components/global-notice.js
@@ -16,6 +16,8 @@ export function addGlobalNotice(text, id, options = {}) {
 const GLOBAL_NOTICE_DISMISSED_PROMPT_KEY = "dismissed-global-notice-v2";
 
 const Notice = EmberObject.extend({
+  logsNoticeService: service("logsNotice"),
+
   text: null,
   id: null,
   options: null,


### PR DESCRIPTION
Notice models didn't have the same injections as GlobalNotice components.
