### PR TITLE
FIX: Setting bookmarks in some cases was broken

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -493,7 +493,10 @@ const Topic = RestModel.extend({
     keys.forEach((key) => this.set(key, json[key]));
 
     if (this.bookmarks.length) {
-      this.bookmarks = this.bookmarks.map((bm) => Bookmark.create(bm));
+      this.set(
+        "bookmarks",
+        this.bookmarks.map((bm) => Bookmark.create(bm))
+      );
     }
 
     return this;


### PR DESCRIPTION
Error introduced in #14781

```
Error: Assertion Failed: You attempted to update <(unknown):ember3217>.bookmarks to "<(unknown):ember3846>", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this.
```