### PR TITLE
DEV: Send multiple files in batches to composer upload handlers when using uppy

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
@@ -234,7 +234,8 @@ acceptance("Uppy Composer Attachment - Upload Handler", function (needs) {
   });
   needs.hooks.beforeEach(() => {
     withPluginApi("0.8.14", (api) => {
-      api.addComposerUploadHandler(["png"], (file) => {
+      api.addComposerUploadHandler(["png"], (files) => {
+        const file = files[0];
         bootbox.alert(`This is an upload handler test for ${file.name}`);
       });
     });


### PR DESCRIPTION
In jQuery file upload land, we were sending a single file through
at a time to matching upload handlers. This in turn required plugin
authors to marshal the files as they came through one by one if they
wanted to group them together to do something with them. Now that
we are using uppy, files come through in the groups they are added
in (for example dropping multiple, selecting multiple from the system
file dialogue).

This commit changes the matching upload handlers to send through
all matching files at once instead of piecemeal.
