### PR TITLE
SECURITY: Prevent users from getting watching-first-post notifications on tag (groups) they don't have membership in

### DIFF
--- a/app/models/tag_user.rb
+++ b/app/models/tag_user.rb
@@ -4,6 +4,18 @@ class TagUser < ActiveRecord::Base
   belongs_to :tag
   belongs_to :user
 
+  scope :notification_level_visible, -> (notification_levels) {
+    joins("LEFT OUTER JOIN tag_group_memberships ON tag_users.tag_id = tag_group_memberships.tag_id")
+      .joins("LEFT OUTER JOIN tag_group_permissions ON tag_group_memberships.tag_group_id = tag_group_permissions.tag_group_id")
+      .joins("LEFT OUTER JOIN group_users on group_users.user_id = tag_users.user_id")
+      .where("(tag_group_permissions.group_id IS NULL
+               OR tag_group_permissions.group_id = group_users.group_id
+               OR group_users.group_id = ?)
+              AND tag_users.notification_level IN (?)",
+             Group::AUTO_GROUPS[:staff],
+             notification_levels)
+  }
+
   def self.notification_levels
     NotificationLevels.all
   end

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -774,9 +774,14 @@ class PostAlerter
           FROM tag_users
      LEFT JOIN topic_users tu ON tu.user_id = tag_users.user_id
                              AND tu.topic_id = :topic_id
-         WHERE tag_users.notification_level = :watching
-           AND tag_users.tag_id IN (:tag_ids)
-           AND (tu.user_id IS NULL OR tu.notification_level = :watching)
+     LEFT JOIN tag_group_memberships tgm ON tag_users.tag_id = tgm.tag_id
+     LEFT JOIN tag_group_permissions tgp ON tgm.tag_group_id = tgp.tag_group_id
+     LEFT JOIN group_users gu ON gu.user_id = tag_users.user_id
+
+         WHERE (tgp.group_id IS NULL OR tgp.group_id = gu.group_id OR gu.group_id = 3)
+               AND (tag_users.notification_level = :watching
+                    AND tag_users.tag_id IN (:tag_ids)
+                    AND (tu.user_id IS NULL OR tu.notification_level = :watching))
       SQL
     end
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -179,15 +179,9 @@ class PostAlerter
   end
 
   def tag_watchers(topic)
-    topic.tag_users
-      .joins("LEFT OUTER JOIN tag_group_memberships ON tag_users.tag_id = tag_group_memberships.tag_id")
-      .joins("LEFT OUTER JOIN tag_group_permissions ON tag_group_memberships.tag_group_id = tag_group_permissions.tag_group_id")
-      .joins("LEFT OUTER JOIN group_users on group_users.user_id = tag_users.user_id")
-      .where("(tag_group_permissions.group_id IS NULL
-               OR tag_group_permissions.group_id = group_users.group_id)
-              AND tag_users.notification_level = ?",
-              TagUser.notification_levels[:watching_first_post],
-              )
+    topic
+      .tag_users
+      .notification_level_visible([TagUser.notification_levels[:watching_first_post]])
       .distinct(:user_id).pluck(:user_id)
   end
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -180,7 +180,6 @@ class PostAlerter
 
   def tag_watchers(topic)
     topic.tag_users
-      .select("tag_users.user_id")
       .joins("LEFT OUTER JOIN tag_group_memberships ON tag_users.tag_id = tag_group_memberships.tag_id")
       .joins("LEFT OUTER JOIN tag_group_permissions ON tag_group_memberships.tag_group_id = tag_group_permissions.tag_group_id")
       .joins("LEFT OUTER JOIN group_users on group_users.user_id = tag_users.user_id")

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -184,10 +184,8 @@ class PostAlerter
       .joins("LEFT OUTER JOIN tag_group_permissions ON tag_group_memberships.tag_group_id = tag_group_permissions.tag_group_id")
       .joins("LEFT OUTER JOIN group_users on group_users.user_id = tag_users.user_id")
       .where("(tag_group_permissions.group_id IS NULL
-               OR tag_group_permissions.group_id = group_users.group_id
-               OR group_users.group_id = ?)
+               OR tag_group_permissions.group_id = group_users.group_id)
               AND tag_users.notification_level = ?",
-              Group::AUTO_GROUPS[:staff],
               TagUser.notification_levels[:watching_first_post],
               )
       .distinct(:user_id).pluck(:user_id)
@@ -778,7 +776,7 @@ class PostAlerter
      LEFT JOIN tag_group_permissions tgp ON tgm.tag_group_id = tgp.tag_group_id
      LEFT JOIN group_users gu ON gu.user_id = tag_users.user_id
 
-         WHERE (tgp.group_id IS NULL OR tgp.group_id = gu.group_id OR gu.group_id = 3)
+         WHERE (tgp.group_id IS NULL OR tgp.group_id = gu.group_id)
                AND (tag_users.notification_level = :watching
                     AND tag_users.tag_id IN (:tag_ids)
                     AND (tu.user_id IS NULL OR tu.notification_level = :watching))

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -180,8 +180,18 @@ class PostAlerter
 
   def tag_watchers(topic)
     topic.tag_users
-      .where(notification_level: TagUser.notification_levels[:watching_first_post])
-      .pluck(:user_id)
+      .select("tag_users.user_id")
+      .joins("LEFT OUTER JOIN tag_group_memberships ON tag_users.tag_id = tag_group_memberships.tag_id")
+      .joins("LEFT OUTER JOIN tag_group_permissions ON tag_group_memberships.tag_group_id = tag_group_permissions.tag_group_id")
+      .joins("LEFT OUTER JOIN group_users on group_users.user_id = tag_users.user_id")
+      .where("(tag_group_permissions.group_id IS NULL
+               OR tag_group_permissions.group_id = group_users.group_id
+               OR group_users.group_id = ?)
+              AND tag_users.notification_level = ?",
+              Group::AUTO_GROUPS[:staff],
+              TagUser.notification_levels[:watching_first_post],
+              )
+      .distinct(:user_id).pluck(:user_id)
   end
 
   def category_watchers(topic)

--- a/spec/fabricators/tag_group_permission_fabricator.rb
+++ b/spec/fabricators/tag_group_permission_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:tag_group_permission) do
+  tag_group
+  group
+end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1225,7 +1225,7 @@ describe PostAlerter do
         expect(Notification.count).to eq(0)
       end
 
-      it "adds notification if user does not belong to tag group with permissions" do
+      it "adds notification if user belongs to tag group with permissions" do
         tag = Fabricate(:tag)
         topic = Fabricate(:topic, tags: [tag])
         post = Fabricate(:post, topic: topic)

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1340,6 +1340,17 @@ describe PostAlerter do
 
           expect(user.notifications.where(notification_type: Notification.types[notification_type]).count).to eq(1)
         end
+
+        it "notifies a staff watching a tag with tag group permissions that he does not belong to" do
+          staff_group = Group.find(Group::AUTO_GROUPS[:staff])
+          Fabricate(:group_user, group: staff_group, user: user)
+
+          TagUser.change(user.id, tag.id, TagUser.notification_levels[notification_level])
+
+          PostAlerter.post_created(post)
+
+          expect(user.notifications.where(notification_type: Notification.types[notification_type]).count).to eq(1)
+        end
       end
 
       context "with :watching notification level" do

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1449,17 +1449,17 @@ describe PostAlerter do
 
     def create_post_with_incoming
       raw_mail = <<~MAIL
-        From: Foo <foo@discourse.org>
-        To: discourse@example.com
-        Cc: bar@discourse.org, jim@othersite.com
-        Subject: Full email group username flow
-        Date: Fri, 15 Jan 2021 00:12:43 +0100
-        Message-ID: <u4w8c9r4y984yh98r3h69873@example.com.mail>
-        Mime-Version: 1.0
-        Content-Type: text/plain
-        Content-Transfer-Encoding: 7bit
+      From: Foo <foo@discourse.org>
+      To: discourse@example.com
+      Cc: bar@discourse.org, jim@othersite.com
+      Subject: Full email group username flow
+      Date: Fri, 15 Jan 2021 00:12:43 +0100
+      Message-ID: <u4w8c9r4y984yh98r3h69873@example.com.mail>
+      Mime-Version: 1.0
+      Content-Type: text/plain
+      Content-Transfer-Encoding: 7bit
 
-        This is the first email.
+      This is the first email.
       MAIL
 
       Email::Receiver.new(raw_mail, {}).process!
@@ -1608,18 +1608,18 @@ describe PostAlerter do
 
       # the reply post from someone who was emailed
       reply_raw_mail = <<~MAIL
-        From: Bar <bar@discourse.org>
-        To: discourse@example.com
-        Cc: someothernewcc@baz.com, finalnewcc@doom.com
-        Subject: #{email.subject}
-        Date: Fri, 16 Jan 2021 00:12:43 +0100
-        Message-ID: <sdugj3o4iyu4832x3487@discourse.org.mail>
-        In-Reply-To: #{email.message_id}
-        Mime-Version: 1.0
-        Content-Type: text/plain
-        Content-Transfer-Encoding: 7bit
+      From: Bar <bar@discourse.org>
+      To: discourse@example.com
+      Cc: someothernewcc@baz.com, finalnewcc@doom.com
+      Subject: #{email.subject}
+      Date: Fri, 16 Jan 2021 00:12:43 +0100
+      Message-ID: <sdugj3o4iyu4832x3487@discourse.org.mail>
+      In-Reply-To: #{email.message_id}
+      Mime-Version: 1.0
+      Content-Type: text/plain
+      Content-Transfer-Encoding: 7bit
 
-        Hey here is my reply!
+      Hey here is my reply!
       MAIL
 
       reply_post_from_email = nil
@@ -1659,18 +1659,18 @@ describe PostAlerter do
 
       # the reply post from someone who was emailed
       reply_raw_mail = <<~MAIL
-        From: Foo <foo@discourse.org>
-        To: discourse@example.com
-        Cc: someothernewcc@baz.com, finalnewcc@doom.com
-        Subject: #{email.subject}
-        Date: Fri, 16 Jan 2021 00:12:43 +0100
-        Message-ID: <sgk094238uc0348c334483@discourse.org.mail>
-        In-Reply-To: #{email.message_id}
-        Mime-Version: 1.0
-        Content-Type: text/plain
-        Content-Transfer-Encoding: 7bit
+      From: Foo <foo@discourse.org>
+      To: discourse@example.com
+      Cc: someothernewcc@baz.com, finalnewcc@doom.com
+      Subject: #{email.subject}
+      Date: Fri, 16 Jan 2021 00:12:43 +0100
+      Message-ID: <sgk094238uc0348c334483@discourse.org.mail>
+      In-Reply-To: #{email.message_id}
+      Mime-Version: 1.0
+      Content-Type: text/plain
+      Content-Transfer-Encoding: 7bit
 
-        I am ~~Commander Shepherd~~ the OP and I approve of this message.
+      I am ~~Commander Shepherd~~ the OP and I approve of this message.
       MAIL
 
       reply_post_from_email = nil
@@ -1703,16 +1703,16 @@ describe PostAlerter do
       # this is a special case where we are not CC'ing on the original email,
       # only on the follow up email
       raw_mail = <<~MAIL
-        From: Foo <foo@discourse.org>
-        To: discourse@example.com
-        Subject: Full email group username flow
-        Date: Fri, 14 Jan 2021 00:12:43 +0100
-        Message-ID: <f4832ujfc3498u398i3@example.com.mail>
-        Mime-Version: 1.0
-        Content-Type: text/plain
-        Content-Transfer-Encoding: 7bit
+      From: Foo <foo@discourse.org>
+      To: discourse@example.com
+      Subject: Full email group username flow
+      Date: Fri, 14 Jan 2021 00:12:43 +0100
+      Message-ID: <f4832ujfc3498u398i3@example.com.mail>
+      Mime-Version: 1.0
+      Content-Type: text/plain
+      Content-Transfer-Encoding: 7bit
 
-        This is the first email.
+      This is the first email.
       MAIL
 
       incoming_email_post = Email::Receiver.new(raw_mail, {}).process!
@@ -1725,18 +1725,18 @@ describe PostAlerter do
 
       # the reply post from the OP, cc'ing new people in
       reply_raw_mail = <<~MAIL
-        From: Foo <foo@discourse.org>
-        To: discourse@example.com
-        Cc: someothernewcc@baz.com, finalnewcc@doom.com
-        Subject: #{email.subject}
-        Date: Fri, 16 Jan 2021 00:12:43 +0100
-        Message-ID: <3849cu9843yncr9834yr9348x934@discourse.org.mail>
-        In-Reply-To: #{email.message_id}
-        Mime-Version: 1.0
-        Content-Type: text/plain
-        Content-Transfer-Encoding: 7bit
+      From: Foo <foo@discourse.org>
+      To: discourse@example.com
+      Cc: someothernewcc@baz.com, finalnewcc@doom.com
+      Subject: #{email.subject}
+      Date: Fri, 16 Jan 2021 00:12:43 +0100
+      Message-ID: <3849cu9843yncr9834yr9348x934@discourse.org.mail>
+      In-Reply-To: #{email.message_id}
+      Mime-Version: 1.0
+      Content-Type: text/plain
+      Content-Transfer-Encoding: 7bit
 
-        I am inviting my mates to this email party.
+      I am inviting my mates to this email party.
       MAIL
 
       reply_post_from_email = nil


### PR DESCRIPTION
Related:
https://meta.discourse.org/t/non-forum-staff-getting-notifications-for-staff-only-tags/184895

This solves the first half of the problem where the user was getting watch-first-post notifications despite the tag belonging to a tag group with permissions only to certain groups. (The next half would be preventing the user from seeing the tag in /u/<id>/preferences/tags)

Tests cover topic tags with groups and without tag groups.

<img width="360" alt="Screenshot 2021-11-29 at 10 53 43 AM" src="https://user-images.githubusercontent.com/1555215/143801403-1db52a88-215d-4f7b-9b20-6f251f31aaff.png">

<img width="587" alt="Screenshot 2021-11-29 at 10 55 12 AM" src="https://user-images.githubusercontent.com/1555215/143801554-f7192132-8b5e-45c9-9f40-5ccbeee3a978.png">
 