### PR TITLE
DEV: Fix a flaky bookmarks test

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -410,7 +410,7 @@ class TopicView
   def bookmarks
     @bookmarks ||= @topic.bookmarks.where(user: @user).joins(:topic).select(
       :id, :post_id, "topics.id AS topic_id", :for_topic, :reminder_at, :name, :auto_delete_preference
-    ).order(:id)
+    )
   end
 
   MAX_PARTICIPANTS = 24

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -410,7 +410,7 @@ class TopicView
   def bookmarks
     @bookmarks ||= @topic.bookmarks.where(user: @user).joins(:topic).select(
       :id, :post_id, "topics.id AS topic_id", :for_topic, :reminder_at, :name, :auto_delete_preference
-    )
+    ).order(:id)
   end
 
   MAX_PARTICIPANTS = 24

--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -416,7 +416,7 @@ describe TopicView do
       it "gets the first post bookmark reminder at for the user" do
         topic_view = TopicView.new(topic.id, user)
 
-        first, second = topic_view.bookmarks
+        first, second = topic_view.bookmarks.sort_by(&:id)
         expect(first[:post_id]).to eq(bookmark1.post_id)
         expect(first[:reminder_at]).to eq_time(bookmark1.reminder_at)
         expect(second[:post_id]).to eq(bookmark2.post_id)


### PR DESCRIPTION
Fixes a flaky test:

```
 1) TopicView with a few sample posts #bookmarks gets the first post bookmark reminder at for the user
     Failure/Error: expect(first[:post_id]).to eq(bookmark1.post_id)

       expected: 1901
            got: 1902

       (compared using ==)
     # ./spec/components/topic_view_spec.rb:420:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:284:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.7.0/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```