### PR TITLE
FIX: allow staff to upload when they should and authorized_extensions is blank

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -202,7 +202,11 @@ export function authorizesOneOrMoreExtensions(staff, siteSettings) {
 
   return (
     siteSettings.authorized_extensions.split("|").filter((ext) => ext).length >
-    0
+      0 ||
+    (siteSettings.authorized_extensions_for_staff
+      .split("|")
+      .filter((ext) => ext).length > 0 &&
+      staff)
   );
 }
 


### PR DESCRIPTION
Allow staff to upload when authorized_extensions is blank, but authorized_extensions_for_staff is not.

This case was missed when authorized_extensions_for_staff was added initially.