### PR TITLE
UX: Add title attribute to reports cells

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report-table-cell.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-table-cell.js
@@ -6,6 +6,7 @@ export default Component.extend({
   tagName: "td",
   classNames: ["admin-report-table-cell"],
   classNameBindings: ["type", "property"],
+  attributeBindings: ["value:title"],
   options: null,
 
   @discourseComputed("label", "data", "options")


### PR DESCRIPTION
Some reports, like the Web Crawler User Agents report, have very long strings that need to be truncated when displayed. However, there is no way to see the full value without exporting the report or inspecting the elements using dev tools. This PR set a `title` attribute with the full value to the reports `<td>` elements so that the full value is shown on hover.

Screenshot:

![image](https://user-images.githubusercontent.com/17474474/144025704-79e4d3ec-0945-4178-8021-a15b23f2a3bb.png)