### PR TITLE
FIX: adds 422 status code to bootstrap json

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -240,6 +240,7 @@ async function handleRequest(proxy, baseURL, req, res) {
     308,
     404,
     403,
+    422,
     500,
   ];
   const proxyRequest = bent(req.method, acceptedStatusCodes);


### PR DESCRIPTION
A post error validation would return a 422 status code. This status code was not accepted with the recent changes to bootstrap-json/index.js and would return a "Discourse Build Error" string, preventing any kind of bootbox popup error in the composer.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
