### PR TITLE
FIX: Native File object was not passed to uploadHandler

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -159,7 +159,9 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
             } else {
               handlerBuckets[matchingHandler.method] = {
                 fn: matchingHandler.method,
-                files: [file],
+                // file.data is the native File object, which is all the plugins
+                // should need, not the uppy wrapper
+                files: [file.data],
               };
             }
           } else {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
@@ -1,5 +1,6 @@
 import {
   acceptance,
+  createFile,
   loggedInUser,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -44,15 +45,6 @@ function pretender(server, helper) {
     },
     500 // this delay is important to slow down the uploads a bit so we can click elements in the UI like the cancel button
   );
-}
-
-function createFile(name, type = "image/png") {
-  // the blob content doesn't matter at all, just want it to be random-ish
-  const file = new Blob([(Math.random() + 1).toString(36).substring(2)], {
-    type,
-  });
-  file.name = name;
-  return file;
 }
 
 acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
@@ -233,7 +225,10 @@ acceptance("Uppy Composer Attachment - Upload Handler", function (needs) {
     withPluginApi("0.8.14", (api) => {
       api.addComposerUploadHandler(["png"], (files) => {
         const file = files[0];
-        bootbox.alert(`This is an upload handler test for ${file.name}`);
+        const isNativeFile = file instanceof File ? "WAS" : "WAS NOT";
+        bootbox.alert(
+          `This is an upload handler test for ${file.name}. The file ${isNativeFile} a native file object.`
+        );
       });
     });
   });
@@ -248,7 +243,7 @@ acceptance("Uppy Composer Attachment - Upload Handler", function (needs) {
     appEvents.on("composer:uploads-aborted", async () => {
       assert.strictEqual(
         queryAll(".bootbox .modal-body").html(),
-        "This is an upload handler test for handlertest.png",
+        "This is an upload handler test for handlertest.png. The file WAS a native file object.",
         "it should show the bootbox triggered by the upload handler"
       );
       await click(".modal-footer .btn");

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -547,3 +547,14 @@ export function chromeTest(name, testCase) {
 export function firefoxTest(name, testCase) {
   conditionalTest(name, navigator.userAgent.includes("Firefox"), testCase);
 }
+
+export function createFile(name, type = "image/png", blobData = null) {
+  // the blob content doesn't matter at all, just want it to be random-ish
+  blobData = blobData || (Math.random() + 1).toString(36).substring(2);
+  const blob = new Blob([blobData]);
+  const file = new File([blob], name, {
+    type,
+    lastModified: new Date().getTime(),
+  });
+  return file;
+}

--- a/app/assets/javascripts/discourse/tests/unit/lib/uppy-checksum-plugin-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uppy-checksum-plugin-test.js
@@ -1,5 +1,6 @@
 import UppyChecksum from "discourse/lib/uppy-checksum-plugin";
 import { module, test } from "qunit";
+import { createFile } from "discourse/tests/helpers/qunit-helpers";
 import sinon from "sinon";
 
 class FakeUppy {
@@ -9,17 +10,17 @@ class FakeUppy {
     this.files = {
       "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764": {
         meta: {},
-        data: createFile("test1.png"),
+        data: createFile("test1.png", "image/png", "testblobdata1"),
         size: 1024,
       },
       "uppy-test/file/blah1/ads37x2/blah1/png-1d-1d-2v-1d-1e-image/jpeg-99999-1837921727764": {
         meta: {},
-        data: createFile("test2.png"),
+        data: createFile("test2.png", "image/png", "testblobdata2"),
         size: 2048,
       },
       "uppy-test/file/mnb3/jfhrg43x/blah3/png-1d-1d-2v-1d-1e-image/jpeg-111111-1837921727764": {
         meta: {},
-        data: createFile("test2.png"),
+        data: createFile("test2.png", "image/png", "testblobdata2"),
         size: 209715200,
       },
     };
@@ -164,11 +165,11 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
       // these checksums are the actual SHA1 hashes of the test file names
       assert.strictEqual(
         plugin.uppy.getFile(fileIds[0]).meta.sha1_checksum,
-        "d9bafe64b034b655db018ad0226c6865300ada31"
+        "2aa31a700d084c78cecbf030b041ad63eb4f6e8a"
       );
       assert.strictEqual(
         plugin.uppy.getFile(fileIds[1]).meta.sha1_checksum,
-        "cb10341e3efeab45f0bc309a1c497edca4c5a744"
+        "dfa8c725a5a6710ce4467f29655ec9d26a8de3d0"
       );
 
       done();
@@ -206,11 +207,3 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
     });
   });
 });
-
-function createFile(name, type = "image/png") {
-  const file = new Blob([name], {
-    type,
-  });
-  file.name = name;
-  return file;
-}


### PR DESCRIPTION
The commit 20b2a42f491c2633323a4db0c5b43c5b2f31324b broke
upload handlers, because previously we passed through the
native File object to the handler, not the uppy-wrapped
File object.