### PR TITLE
DEV: Make legacy ember tests less likely to fail

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -54,7 +54,8 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
     "DISCOURSE_SKIP_CSS_WATCHER" => "1",
     "UNICORN_LISTENER" => "127.0.0.1:#{unicorn_port}",
     "LOGSTASH_UNICORN_URI" => nil,
-    "UNICORN_WORKERS" => "3"
+    "UNICORN_WORKERS" => "1",
+    "UNICORN_TIMEOUT" => "90",
   }
 
   cmd = if ember_cli

--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -148,7 +148,7 @@ async function runAllTests() {
     });
   }
 
-  console.log("navigate to ", url);
+  console.log("navigate to", url);
   Page.navigate({ url });
 
   Page.loadEventFired(async () => {


### PR DESCRIPTION
Hopefully fixes issues with plugin frontend tests failing to start:

```
I, [2021-11-30T19:22:56.085844 #3231]  INFO -- : master process ready
I, [2021-11-30T19:23:06.934524 #3272]  INFO -- : worker=0 ready
I, [2021-11-30T19:23:08.230472 #3287]  INFO -- : worker=1 ready
node /__w/discourse/discourse/test/run-qunit.js http://localhost:60099/qunit?hidepassed=1\&qunit_skip_core=1\&seed=76633572646997843322295252999102721291 1200000
Warming up Rails server
Rails server is warmed up
I, [2021-11-30T19:23:08.705138 #3298]  INFO -- : worker=2 ready
navigate to  http://localhost:60099/qunit?hidepassed=1&qunit_skip_core=1&seed=76633572646997843322295252999102721291&qunit_disable_auto_start=1
E, [2021-11-30T19:24:10.157022 #3231] ERROR -- : worker=2 PID:3298 timeout (61s > 60s), killing
E, [2021-11-30T19:24:10.194673 #3231] ERROR -- : reaped #<Process::Status: pid 3298 SIGKILL (signal 9)> worker=2
2021-11-30T19:24:10.195Z - (type: network/error) message: Failed to load resource: net::ERR_EMPTY_RESPONSE, url: http://localhost:60099/assets/discourse/tests/test_helper.js
```