### PR TITLE
FIX: tag transition only if tag name changed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/tag-info.js
+++ b/app/assets/javascripts/discourse/app/components/tag-info.js
@@ -99,8 +99,11 @@ export default Component.extend({
         .then((result) => {
           this.set("editing", false);
           this.tagInfo.set("description", this.newTagDescription);
-          if (result.payload && oldTagName !== result.payload.id) {
-            this.router.transitionTo("tag.show", result.payload.id);
+          if (
+            result.responseJson.tag &&
+            oldTagName !== result.responseJson.tag.id
+          ) {
+            this.router.transitionTo("tag.show", result.responseJson.tag.id);
           }
         })
         .catch(popupAjaxError);

--- a/app/assets/javascripts/discourse/app/components/tag-info.js
+++ b/app/assets/javascripts/discourse/app/components/tag-info.js
@@ -93,12 +93,13 @@ export default Component.extend({
     },
 
     finishedEditing() {
+      const oldTagName = this.tag.id;
       this.tag
         .update({ id: this.newTagName, description: this.newTagDescription })
         .then((result) => {
           this.set("editing", false);
           this.tagInfo.set("description", this.newTagDescription);
-          if (result.payload) {
+          if (result.payload && oldTagName !== result.payload.id) {
             this.router.transitionTo("tag.show", result.payload.id);
           }
         })

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -8,7 +8,7 @@ import {
   queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
-import { click, currentURL, visit } from "@ember/test-helpers";
+import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
 acceptance("Tags", function (needs) {
@@ -350,6 +350,10 @@ acceptance("Tag info", function (needs) {
         ],
       });
     });
+    server.put("/tag/happy-monkey", (request) => {
+      const data = helper.parsePostData(request.requestBody);
+      return helper.response({ tag: { id: data.tag.id } });
+    });
 
     server.get("/tag/happy-monkey/info", () => {
       return helper.response({
@@ -451,6 +455,23 @@ acceptance("Tag info", function (needs) {
       query("#edit-description").value,
       "happy monkey description",
       "it displays original tag description"
+    );
+
+    await fillIn("#edit-description", "new description");
+    await click(".submit-edit");
+    assert.strictEqual(
+      currentURL(),
+      "/tag/happy-monkey",
+      "it doesn't change URL"
+    );
+
+    await click("#edit-tag");
+    await fillIn("#edit-name", "happy-monkey2");
+    await click(".submit-edit");
+    assert.strictEqual(
+      currentURL(),
+      "/tag/happy-monkey2",
+      "it changes URL to new tag path"
     );
   });
 


### PR DESCRIPTION
We need to change path only if tag name is changed. If description is added, we don't need to reload.
