### PR TITLE
SECURITY: Remove ember-cli specific response from application routes (stable)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -596,7 +596,7 @@ module ApplicationHelper
   end
 
   def hijack_if_ember_cli!
-    if request.headers["HTTP_X_DISCOURSE_EMBER_CLI"] == "true"
+    if !Rails.env.production? && request.headers["HTTP_X_DISCOURSE_EMBER_CLI"] == "true"
       raise ApplicationController::EmberCLIHijacked.new
     end
   end


### PR DESCRIPTION
Under some conditions, these varied responses could lead to cache poisoning, hence the 'security' label.

For the stable branch, we are disabling the use of Ember CLI against production sites. A new implementation has been added to the tests-passed/beta branches

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
