### PR TITLE
FIX: Skip themes that have blank URL in the `themes:update` rake task

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -56,7 +56,7 @@ def update_themes
   Theme.includes(:remote_theme).where(enabled: true, auto_update: true).find_each do |theme|
     begin
       remote_theme = theme.remote_theme
-      next if remote_theme.blank?
+      next if remote_theme.blank? || remote_theme.remote_url.blank?
 
       puts "Updating '#{theme.name}' for '#{RailsMultisite::ConnectionManagement.current_db}'..."
       remote_theme.update_from_remote


### PR DESCRIPTION
Themes that are imported via a ZIP file do have a `remote_theme` record in the database but the record has a blank value for the `remote_url` field which means attempting to do an update git via will result in an error.