### PR TITLE
FIX: Set `auto_update` to false for non-git themes/components

### DIFF
--- a/app/controllers/admin/themes_controller.rb
+++ b/app/controllers/admin/themes_controller.rb
@@ -59,7 +59,7 @@ class Admin::ThemesController < Admin::AdminController
       json = JSON::parse(params[:theme].read)
       theme = json['theme']
 
-      @theme = Theme.new(name: theme["name"], user_id: theme_user.id)
+      @theme = Theme.new(name: theme["name"], user_id: theme_user.id, auto_update: false)
       theme["theme_fields"]&.each do |field|
 
         if field["raw_upload"]
@@ -116,7 +116,14 @@ class Admin::ThemesController < Admin::AdminController
       update_components = params[:components]
       match_theme_by_name = !!params[:bundle] && !params.key?(:theme_id) # Old theme CLI behavior, match by name. Remove Jan 2020
       begin
-        @theme = RemoteTheme.update_zipped_theme(bundle.path, bundle.original_filename, match_theme: match_theme_by_name, user: theme_user, theme_id: theme_id, update_components: update_components)
+        @theme = RemoteTheme.update_zipped_theme(
+          bundle.path,
+          bundle.original_filename,
+          match_theme: match_theme_by_name,
+          user: theme_user,
+          theme_id: theme_id,
+          update_components: update_components
+        )
         log_theme_change(nil, @theme)
         render json: @theme, status: :created
       rescue RemoteTheme::ImportError => e

--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -40,7 +40,7 @@ class RemoteTheme < ActiveRecord::Base
 
     existing = true
     if theme.blank?
-      theme = Theme.new(user_id: user&.id || -1, name: theme_info["name"])
+      theme = Theme.new(user_id: user&.id || -1, name: theme_info["name"], auto_update: false)
       existing = false
     end
 

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -149,6 +149,7 @@ describe Admin::ThemesController do
 
       expect(json["theme"]["name"]).to eq("Sam's Simple Theme")
       expect(json["theme"]["theme_fields"].length).to eq(2)
+      expect(json["theme"]["auto_update"]).to eq(false)
       expect(UserHistory.where(action: UserHistory.actions[:change_theme]).count).to eq(1)
     end
 
@@ -163,6 +164,7 @@ describe Admin::ThemesController do
 
       expect(json["theme"]["name"]).to eq("Header Icons")
       expect(json["theme"]["theme_fields"].length).to eq(5)
+      expect(json["theme"]["auto_update"]).to eq(false)
       expect(UserHistory.where(action: UserHistory.actions[:change_theme]).count).to eq(1)
     end
 
@@ -219,6 +221,7 @@ describe Admin::ThemesController do
       expect(json["theme"]["name"]).to eq("Header Icons")
       expect(json["theme"]["id"]).not_to eq(existing_theme.id)
       expect(json["theme"]["theme_fields"].length).to eq(5)
+      expect(json["theme"]["auto_update"]).to eq(false)
       expect(UserHistory.where(action: UserHistory.actions[:change_theme]).count).to eq(1)
     end
   end


### PR DESCRIPTION
Related to https://github.com/discourse/discourse/pull/15156.

`auto_update` is true by default at the database level, but it doesn't make sense for `auto_update` to be true on themes that are not imported from a Git repository.