### PR TITLE
UX: only apply link formats on paste to selections that do not contain links

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -285,7 +285,8 @@ export default Mixin.create({
       this._cachedLinkify &&
       plainText &&
       !handled &&
-      selected.end > selected.start
+      selected.end > selected.start &&
+      !this._cachedLinkify.test(selectedValue)
     ) {
       if (this._cachedLinkify.test(plainText)) {
         const match = this._cachedLinkify.match(plainText)[0];

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -833,6 +833,19 @@ third line`
     }
   );
 
+  testCase(
+    `pasting a url onto a selection that contains urls and other content will use default paste behavior`,
+    async function (assert, textarea) {
+      this.set("value", "Try https://www.discourse.org");
+      setTextareaSelection(textarea, 0, 29);
+      const element = query(".d-editor");
+      const event = await paste(element, "https://www.discourse.com/");
+      // Synthetic paste events do not manipulate document content.
+      assert.strictEqual(this.value, "Try https://www.discourse.org");
+      assert.strictEqual(event.defaultPrevented, false);
+    }
+  );
+
   (() => {
     // Tests to check cursor/selection after replace-text event.
     const BEFORE = "red green blue";


### PR DESCRIPTION
This is a follow up to https://github.com/discourse/discourse/pull/15010, where WordPress-style link pasting was added. This PR updates behavior to testing if the current text selection has a link. If it does, we should default to normal paste behavior even if the paste value contains a link.

This was discussed in https://meta.discourse.org/t/new-behavior-when-copy-pasting-links/210721