### PR TITLE
DEV: Remove site_setting_saved event

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -7,11 +7,6 @@ class SiteSetting < ActiveRecord::Base
   validates_presence_of :name
   validates_presence_of :data_type
 
-  after_save do |site_setting|
-    DiscourseEvent.trigger(:site_setting_saved, site_setting)
-    true
-  end
-
   def self.load_settings(file, plugin: nil)
     SiteSettings::YamlLoader.new(file).load do |category, name, default, opts|
       setting(name, default, opts.merge(category: category, plugin: plugin))

--- a/lib/discourse_event.rb
+++ b/lib/discourse_event.rb
@@ -17,7 +17,7 @@ class DiscourseEvent
 
   def self.on(event_name, &block)
     if event_name == :site_setting_saved
-      Discourse.deprecate("The :site_setting_saved event is deprecated. Please use :site_setting_changed instead", since: "2.3.0beta8", drop_from: "2.4")
+      Discourse.deprecate("The :site_setting_saved event is no longer supported. Please use :site_setting_changed instead")
     end
     events[event_name] << block
   end

--- a/lib/discourse_event.rb
+++ b/lib/discourse_event.rb
@@ -17,7 +17,7 @@ class DiscourseEvent
 
   def self.on(event_name, &block)
     if event_name == :site_setting_saved
-      Discourse.deprecate("The :site_setting_saved event is no longer supported. Please use :site_setting_changed instead")
+      Discourse.deprecate("The :site_setting_saved event is deprecated. Please use :site_setting_changed instead", since: "2.3.0beta8", drop_from: "2.4", raise_error: true)
     end
     events[event_name] << block
   end

--- a/lib/site_settings/local_process_provider.rb
+++ b/lib/site_settings/local_process_provider.rb
@@ -45,7 +45,6 @@ class SiteSettings::LocalProcessProvider
       settings[name] = setting
     end
     setting.value = value.to_s
-    DiscourseEvent.trigger(:site_setting_saved, setting)
     setting
   end
 


### PR DESCRIPTION
We said we would drop it from 2.4, so this is long overdue

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
