### PR TITLE
DEV: Ensure ember-cli does not attempt to bootstrap non-ember pages

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -270,9 +270,11 @@ async function handleRequest(proxy, baseURL, req, res) {
   }
 
   const contentType = response.headers.get("content-type");
+  const isHTML = contentType && contentType.startsWith("text/html");
   const responseText = await response.text();
+  const preloadJson = isHTML ? extractPreloadJson(responseText) : null;
 
-  if (contentType && contentType.startsWith("text/html")) {
+  if (preloadJson) {
     const html = await buildFromBootstrap(
       proxy,
       baseURL,


### PR DESCRIPTION
1b3d124a introduced a logic change which meant that we attempted to bootstrap, even on pages without any `preloadJson` (i.e. non-ember HTML pages from Discourse). This commit restores the original logic, making sure to avoid `?.`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
