### PR TITLE
DEV: Ensure redirects are passed through to the client by ember-cli

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -240,6 +240,7 @@ async function handleRequest(proxy, baseURL, req, res) {
     method: req.method,
     body: /GET|HEAD/.test(req.method) ? null : req.body,
     headers: req.headers,
+    redirect: "manual",
   });
 
   response.headers.forEach((value, header) => {


### PR DESCRIPTION
By default, `fetch` will transparently follow redirects, even across domain boundaries

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
