### PR TITLE
FIX: allows more precise placement strategy on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/composer-action-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-action-title.hbs
@@ -10,6 +10,9 @@
   post=model.post
   whisper=model.whisper
   noBump=model.noBump
+  options=(hash
+    desktopPlacementStrategy="fixed"
+  )
 }}
 
 <span class="action-title">

--- a/app/assets/javascripts/discourse/app/templates/components/composer-action-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-action-title.hbs
@@ -11,7 +11,7 @@
   whisper=model.whisper
   noBump=model.noBump
   options=(hash
-    desktopPlacementStrategy="fixed"
+    mobilePlacementStrategy="fixed"
   )
 }}
 

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -289,6 +289,9 @@ export default Component.extend(
       focusAfterOnChange: true,
       triggerOnChangeOnTab: true,
       autofocus: false,
+      placementStrategy: null,
+      mobilePlacementStrategy: null,
+      desktopPlacementStrategy: null,
     },
 
     autoFilterable: computed("content.[]", "selectKit.filter", function () {
@@ -849,36 +852,28 @@ export default Component.extend(
       }
 
       this.selectKit.mainElement().open = true;
-
       this.clearErrors();
-
-      const inModal = this.element.closest("#discourse-modal");
-
       this.selectKit.onOpen(event);
 
       if (!this.popper) {
+        const inModal = this.element.closest("#discourse-modal");
         const anchor = document.querySelector(
           `#${this.selectKit.uniqueID}-header`
         );
         const popper = document.querySelector(
           `#${this.selectKit.uniqueID}-body`
         );
-
-        const placementStrategy =
-          this.capabilities?.isIpadOS || this.site?.mobileView
-            ? "absolute"
-            : "fixed";
-        const verticalOffset = 3;
+        const strategy = this._computePlacementStrategy();
 
         this.popper = createPopper(anchor, popper, {
           eventsEnabled: false,
-          strategy: placementStrategy,
+          strategy,
           placement: this.selectKit.options.placement,
           modifiers: [
             {
               name: "offset",
               options: {
-                offset: [0, verticalOffset],
+                offset: [0, 3],
               },
             },
             {
@@ -888,7 +883,11 @@ export default Component.extend(
               fn({ state }) {
                 if (!inModal) {
                   let { x } = state.elements.reference.getBoundingClientRect();
-                  state.modifiersData.popperOffsets.x = -x + 10;
+                  if (strategy === "fixed") {
+                    state.modifiersData.popperOffsets.x = 0 + 10;
+                  } else {
+                    state.modifiersData.popperOffsets.x = -x + 10;
+                  }
                 }
               },
             },
@@ -1034,6 +1033,24 @@ export default Component.extend(
       this._deprecateValueAttribute();
       this._deprecateMutations();
       this._deprecateOptions();
+    },
+
+    _computePlacementStrategy() {
+      let placementStrategy = this.selectKit.options.placementStrategy;
+
+      if (placementStrategy) {
+        return placementStrategy;
+      }
+
+      if (this.capabilities?.isIpadOS || this.site?.mobileView) {
+        placementStrategy =
+          this.selectKit.options.mobilePlacementStrategy || "absolute";
+      } else {
+        placementStrategy =
+          this.selectKit.options.desktopPlacementStrategy || "fixed";
+      }
+
+      return placementStrategy;
     },
 
     _deprecated(text) {

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
@@ -56,6 +56,10 @@ export default Component.extend(UtilsMixin, {
     }
   },
 
+  mouseDown() {
+    return false;
+  },
+
   click(event) {
     event.preventDefault();
     event.stopPropagation();


### PR DESCRIPTION
- default to absolute on mobile, fixed on desktop
- allows to set a global `placementStrategy` or a specific to each view `mobilePlacementStrategy` `desktopPlacementStrategy`

This is mainly used to allow a proper composer-actions positioning in mobile.

<img width="428" alt="Screenshot 2021-12-02 at 16 19 10" src="https://user-images.githubusercontent.com/339945/144450375-fb8089cd-f42c-4235-9228-bd01ac107dc2.png">

Note this commit also fixes a mouseDown event which could propagate quote-button event and cause the composer to close full screen on mobile