### PR TITLE
DEV: Don't error when emoji-picker is used outside composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -88,9 +88,9 @@ export default Component.extend({
         return;
       }
 
-      if (!this.site.isMobileDevice) {
+      const textareaWrapper = document.querySelector(".d-editor-textarea-wrapper");
+      if (!this.site.isMobileDevice && textareaWrapper) {
         this._popper = createPopper(
-          document.querySelector(".d-editor-textarea-wrapper"),
           emojiPicker,
           {
             placement: "auto",

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -88,25 +88,24 @@ export default Component.extend({
         return;
       }
 
-      const textareaWrapper = document.querySelector(".d-editor-textarea-wrapper");
+      const textareaWrapper = document.querySelector(
+        ".d-editor-textarea-wrapper"
+      );
       if (!this.site.isMobileDevice && textareaWrapper) {
-        this._popper = createPopper(
-          emojiPicker,
-          {
-            placement: "auto",
-            modifiers: [
-              {
-                name: "preventOverflow",
+        this._popper = createPopper(textareaWrapper, emojiPicker, {
+          placement: "auto",
+          modifiers: [
+            {
+              name: "preventOverflow",
+            },
+            {
+              name: "offset",
+              options: {
+                offset: [5, 5],
               },
-              {
-                name: "offset",
-                options: {
-                  offset: [5, 5],
-                },
-              },
-            ],
-          }
-        );
+            },
+          ],
+        });
       }
 
       // this is a low-tech trick to prevent appending hundreds of emojis


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
