### PR TITLE
FEATURE: Add the ability to go back and forth between PM and New Topic

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -2,6 +2,7 @@ import {
   acceptance,
   count,
   exists,
+  query,
   queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -187,7 +188,7 @@ acceptance("Composer Actions", function (needs) {
     assert.deepEqual(privateMessageUsers.header().value(), "foo,foo_group");
   });
 
-  test("hide component if no content", async function (assert) {
+  test("allow switching back to New Topic", async function (assert) {
     await visit("/");
     await click("button#create-topic");
 
@@ -195,12 +196,18 @@ acceptance("Composer Actions", function (needs) {
     await composerActions.expand();
     await composerActions.selectRowByValue("reply_as_private_message");
 
-    assert.ok(composerActions.el().hasClass("is-hidden"));
-    assert.strictEqual(composerActions.el().children().length, 0);
+    assert.strictEqual(
+      query(".action-title").innerText,
+      I18n.t("topic.private_message")
+    );
 
-    await click("button#create-topic");
     await composerActions.expand();
-    assert.strictEqual(composerActions.rows().length, 2);
+    await composerActions.selectRowByValue("create_topic");
+
+    assert.strictEqual(
+      query(".action-title").innerText,
+      I18n.t("topic.create_long")
+    );
   });
 
   test("interactions", async function (assert) {

--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -208,11 +208,6 @@ export default DropdownSelectBoxComponent.extend({
       });
     }
 
-    let showCreateTopic = false;
-    if (this.action === CREATE_SHARED_DRAFT) {
-      showCreateTopic = true;
-    }
-
     if (this.action === CREATE_TOPIC) {
       if (this.site.shared_drafts_category_id) {
         // Shared Drafts Choice
@@ -223,24 +218,6 @@ export default DropdownSelectBoxComponent.extend({
           id: "shared_draft",
         });
       }
-
-      // Edge case: If personal messages are disabled, it is possible to have
-      // no items which still renders a button that pops up nothing. In this
-      // case, add an option for what you're currently doing.
-      if (items.length === 0) {
-        showCreateTopic = true;
-      }
-    }
-
-    if (showCreateTopic) {
-      items.push({
-        name: I18n.t("composer.composer_actions.create_topic.label"),
-        description: I18n.t(
-          "composer.composer_actions.reply_as_new_topic.desc"
-        ),
-        icon: "share",
-        id: "create_topic",
-      });
     }
 
     const showToggleTopicBump =
@@ -253,6 +230,17 @@ export default DropdownSelectBoxComponent.extend({
         description: I18n.t("composer.composer_actions.toggle_topic_bump.desc"),
         icon: "anchor",
         id: "toggle_topic_bump",
+      });
+    }
+
+    if (items.length === 0) {
+      items.push({
+        name: I18n.t("composer.composer_actions.create_topic.label"),
+        description: I18n.t(
+          "composer.composer_actions.reply_as_new_topic.desc"
+        ),
+        icon: "share",
+        id: "create_topic",
       });
     }
 


### PR DESCRIPTION
Before this, if you were composing a new topic and then switched the mode to "New Message", the dropdown would disappear.

So if you changed your mind, you'd have to copy the text you typed, cancel, click "New Topic" again, and then paste the text. (and if you already had a title entered too, things would be more complicated…)