### PR TITLE
DEV: Invite page changes

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
@@ -45,6 +45,13 @@ export default Controller.extend({
   inviteExpired: equal("filter", "expired"),
   invitePending: equal("filter", "pending"),
 
+  @discourseComputed("model")
+  hasEmailInvites(model) {
+    return model.invites.some((invite) => {
+      return invite.email;
+    });
+  },
+
   @discourseComputed("filter")
   showBulkActionButtons(filter) {
     return (
@@ -57,9 +64,9 @@ export default Controller.extend({
   canInviteToForum: reads("currentUser.can_invite_to_forum"),
   canBulkInvite: reads("currentUser.admin"),
 
-  @discourseComputed("invitesCount.total")
-  showSearch(invitesCountTotal) {
-    return invitesCountTotal > 0;
+  @discourseComputed("invitesCount", "filter")
+  showSearch(invitesCount, filter) {
+    return invitesCount[filter] > 5;
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
@@ -17,9 +17,9 @@
           {{#if showBulkActionButtons}}
             {{#if inviteExpired}}
               {{#if removedAll}}
-                <li>
+                <span class="removed-all">
                   {{i18n "user.invited.removed_all"}}
-                </li>
+                </span>
               {{else}}
                 {{d-button icon="times" action=(action "destroyAllExpired") label="user.invited.remove_all"}}
               {{/if}}
@@ -27,10 +27,10 @@
 
             {{#if invitePending}}
               {{#if reinvitedAll}}
-                <li>
-                  {{i18n "user.invited.reinvited_all"}}
-                </li>
-              {{else}}
+                <span class="reinvited-all">
+                  {{d-button icon="check" disabled=true label="user.invited.reinvited_all" class="ok"}}
+                </span>
+              {{else if hasEmailInvites}}
                 {{d-button class="btn-default" icon="sync" action=(action "reinviteAll") label="user.invited.reinvite_all"}}
               {{/if}}
             {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
@@ -28,7 +28,7 @@
             {{#if invitePending}}
               {{#if reinvitedAll}}
                 <span class="reinvited-all">
-                  {{d-button icon="check" disabled=true label="user.invited.reinvited_all" class="ok"}}
+                  {{d-button icon="check" disabled=true label="user.invited.reinvited_all"}}
                 </span>
               {{else if hasEmailInvites}}
                 {{d-button class="btn-default" icon="sync" action=(action "reinviteAll") label="user.invited.reinvite_all"}}

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -7,7 +7,7 @@
   display: grid;
   grid-template-columns: 1fr 5fr;
   grid-template-rows: auto auto 1fr auto;
-  grid-row-gap: 20px;
+  grid-gap: 20px;
   .user-primary-navigation {
     grid-column-start: 1;
     grid-column-end: 3;

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -29,7 +29,10 @@
 
     li {
       border-bottom: none;
-
+      &:hover,
+      &.active {
+        background: var(--primary-very-low);
+      }
       &.archive {
         padding-left: 1.4em;
       }


### PR DESCRIPTION
This PR makes a couple more changes to the user & user-invites pages.

- Secondary navigation elements now have an added `hover` & `.active` style
- `Resend Invites` is now only shown if the invite list has at least *one* invitee who has an email listed
- After re-sending invites, the button is `disabled` and shows the user the re-send was successful
- The search bar is only shown if the currently viewed invite filter IE. `pending`, `expired`, or `redeemed` has more than 5 invites.
