### PR TITLE
DEV: Update email responses in api docs

### DIFF
--- a/spec/requests/api/schemas/json/admin_user_response.json
+++ b/spec/requests/api/schemas/json/admin_user_response.json
@@ -13,13 +13,6 @@
     "avatar_template": {
       "type": "string"
     },
-    "email": {
-      "type": "string"
-    },
-    "secondary_emails": {
-      "type": "array",
-      "items": []
-    },
     "active": {
       "type": "boolean"
     },

--- a/spec/requests/api/schemas/json/user_emails_response.json
+++ b/spec/requests/api/schemas/json/user_emails_response.json
@@ -1,0 +1,26 @@
+{
+  "additionalProperties": false,
+  "properties": {
+    "email": {
+      "type": "string"
+    },
+    "secondary_emails": {
+      "type": "array",
+      "items": []
+    },
+    "unconfirmed_emails": {
+      "type": "array",
+      "items": []
+    },
+    "associated_accounts": {
+      "type": "array",
+      "items": []
+    }
+  },
+  "required": [
+    "email",
+    "secondary_emails",
+    "unconfirmed_emails",
+    "associated_accounts"
+  ]
+}

--- a/spec/requests/api/schemas/json/user_get_response.json
+++ b/spec/requests/api/schemas/json/user_get_response.json
@@ -74,18 +74,6 @@
         "badge_count": {
           "type": "integer"
         },
-        "email": {
-          "type": "string"
-        },
-        "secondary_emails": {
-          "type": "array"
-        },
-        "unconfirmed_emails": {
-          "type": "array"
-        },
-        "associated_accounts": {
-          "type": "array"
-        },
         "second_factor_backup_enabled": {
           "type": "boolean"
         },

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -63,7 +63,8 @@ describe 'users' do
         expected_response_schema = load_spec_schema('user_get_response')
         schema expected_response_schema
 
-        let(:username) { 'system' }
+        let(:username) { Fabricate(:user).username }
+
         it_behaves_like "a JSON endpoint", 200 do
           let(:expected_response_schema) { expected_response_schema }
           let(:expected_request_schema) { expected_request_schema }
@@ -574,6 +575,29 @@ describe 'users' do
             'password' => 'NH8QYbxYS5Zv5qEFzA4jULvM'
           }
         end
+
+        it_behaves_like "a JSON endpoint", 200 do
+          let(:expected_response_schema) { expected_response_schema }
+          let(:expected_request_schema) { expected_request_schema }
+        end
+      end
+    end
+  end
+
+  path '/u/{username}/emails.json' do
+    get 'Get email addresses belonging to a user' do
+      tags 'Users'
+      operationId 'getUserEmails'
+      consumes 'application/json'
+      expected_request_schema = nil
+      parameter name: :username, in: :path, type: :string, required: true
+
+      produces 'application/json'
+      response '200', 'success response' do
+        expected_response_schema = load_spec_schema('user_emails_response')
+        schema expected_response_schema
+
+        let(:username) { Fabricate(:user).username }
 
         it_behaves_like "a JSON endpoint", 200 do
           let(:expected_response_schema) { expected_response_schema }


### PR DESCRIPTION
Documenting the `/u/:username:/emails.json` endpoint.

Also removing some email fields from user api responses because they
aren't actually included in the response unless you are querying
yourself.
