### PR TITLE
UX: Prevent overflow on mobile fullscreen timeline dates

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -72,7 +72,6 @@
       touch-action: none;
 
       .timeline-date-wrapper {
-        float: right;
         text-align: right;
       }
       .post-excerpt {
@@ -142,7 +141,6 @@
         border-right-style: solid;
         border-right-width: 1px;
         max-width: 120px;
-        margin-top: 2em;
 
         .timeline-scroller {
           position: relative;

--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -115,8 +115,10 @@ sub sub {
 .topic-timeline {
   .start-date,
   .now-date {
-    font-size: $font-up-1;
-    padding: 5px;
+    padding: 0.5em 0;
+  }
+  .timeline-scrollarea-wrapper .timeline-date-wrapper {
+    @include ellipsis;
   }
   .topic-category {
     margin-bottom: 0.5rem;


### PR DESCRIPTION
Some locales have very long text, and this change makes this text smaller to accommodate more... and in extreme cases truncates long text. This also fixes a related issue where the text wasn't bound by the width of its parent container. 

![Screen Shot 2021-12-03 at 1 21 29 PM](https://user-images.githubusercontent.com/1681963/144653310-7783b7f8-a5d0-43cc-84fb-1ce22917dcf9.png)
