### PR TITLE
UX: reduce composer jumpiness on android

### DIFF
--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -23,11 +23,14 @@
   }
 
   .keyboard-visible &.open {
-    height: calc(var(--composer-vh, 1vh) * 100);
+    height: 100%; // Android: Reduces composer jumpiness when the keyboard toggles
   }
 
-  .keyboard-visible body.ios-safari-composer-hacks &.open .reply-area {
-    padding-bottom: 0px;
+  .keyboard-visible body.ios-safari-composer-hacks &.open {
+    height: calc(var(--composer-vh, 1vh) * 100);
+    .reply-area {
+      padding-bottom: 0px;
+    }
   }
 
   .reply-to {


### PR DESCRIPTION
Discussion here: https://meta.discourse.org/t/composer-on-android/200499

This fixes the issue reported above and moves the existing height calculation to be more specific to iOS 