### PR TITLE
FIX: when using external auth disallowed characters weren't removed from username

### DIFF
--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -157,12 +157,9 @@ class Auth::Result
   private
 
   def staged_user
-    @staged_user ||= begin
-      if email.present? && email_valid
-        User.where(staged: true).find_by_email(email)
-      else
-        nil
-      end
+    return @staged_user if defined?(@staged_user)
+    if email.present? && email_valid
+      @staged_user = User.where(staged: true).find_by_email(email)
     end
   end
 

--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -135,18 +135,9 @@ class Auth::Result
       return result
     end
 
-    suggested_username = UserNameSuggester.suggest(username_suggester_attributes)
-    if email_valid && email.present?
-      if username.present? && User.username_available?(username, email)
-        suggested_username = username
-      elsif staged_user = User.where(staged: true).find_by_email(email)
-        suggested_username = staged_user.username
-      end
-    end
-
     result = {
       email: email,
-      username: suggested_username,
+      username: resolve_username,
       auth_provider: authenticator_name,
       email_valid: !!email_valid,
       can_edit_username: can_edit_username,
@@ -167,5 +158,18 @@ class Auth::Result
 
   def username_suggester_attributes
     username || name || email
+  end
+
+  def resolve_username
+    suggested_username = UserNameSuggester.suggest(username_suggester_attributes)
+    if email.present? && email_valid
+      if username.present? && User.username_available?(username, email)
+        suggested_username = username
+      elsif staged_user = User.where(staged: true).find_by_email(email)
+        suggested_username = staged_user.username
+      end
+    end
+
+    suggested_username
   end
 end


### PR DESCRIPTION
We've discovered this regression when testing Discourse OpenID Connect plugin. If username in the external auth payload contained disallowed characters, those characters weren't removed and user saw this:

<img width="450" alt="Screenshot 2021-12-03 at 22 01 19" src="https://user-images.githubusercontent.com/1274517/144672457-e7efb433-1723-42c9-827e-b39c54e40fa6.png">

In fact, that field should contain a fixed username, the right part of email should be removed, a `+` should be replaced with underscore (the username should be `test_1` in this case).

This problem was introduced by [FIX: Suggest current username for staged users](https://github.com/discourse/discourse/pull/13706). That PR addressed an issue with staged users, but accidentally introduced this regression.

Note that the bug is reproducible for any user, not only for the staged one. Also, it is reproducible with any external auth provider (GitHub, Google etc.), not only with Discourse OpenID Connect plugin.

This PR fixes the bug. I also added more tests for staged users, to make sure I didn't break previous fixes.

