### PR TITLE
FIX: Match for indeterminate depth in URL during upload tests

### DIFF
--- a/spec/support/uploads_helpers.rb
+++ b/spec/support/uploads_helpers.rb
@@ -19,7 +19,7 @@ module UploadsHelpers
   end
 
   def stub_upload(upload)
-    url = "https://#{SiteSetting.s3_upload_bucket}.s3.#{SiteSetting.s3_region}.amazonaws.com/original/1X/#{upload.sha1}.#{upload.extension}?acl"
+    url = %r{https://#{SiteSetting.s3_upload_bucket}.s3.#{SiteSetting.s3_region}.amazonaws.com/original/\d+X.*#{upload.sha1}.#{upload.extension}\?acl}
     stub_request(:put, url)
   end
 


### PR DESCRIPTION
Since the uploads id sequence counter isn't reset before test runs, the
URL might not be /1X/

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
