### PR TITLE
DEV: Add :before_email_login event for plugins

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -928,6 +928,8 @@ class UsersController < ApplicationController
       RateLimiter.new(nil, "email-login-min-#{user.id}", 3, 1.minute).performed!
 
       if user_presence
+        DiscourseEvent.trigger(:before_email_login, user)
+
         email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:email_login])
 
         Jobs.enqueue(:critical_user_email,


### PR DESCRIPTION
Intended to remove the need for overrides like https://github.com/discourse/discourse-saml/blob/bd02343f2a110f5d96707d48d97f361fe2af3c5f/plugin.rb#L49-L69

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
