### PR TITLE
UX: remove style that breaks composer on pm page

### DIFF
--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -272,11 +272,6 @@ table.user-invite-list {
   .show-mores {
     position: absolute;
   }
-
-  #reply-control .mini-tag-chooser {
-    width: 100%;
-    margin: 0;
-  }
 }
 
 .user-messages {


### PR DESCRIPTION
This removes an old style that is no longer needed due to some recent PM composer layout fixes. All this does now is break the topic composer if you're on a PM page 🙀 

Before:
<img width="786" alt="Screen Shot 2021-12-03 at 8 44 18 PM" src="https://user-images.githubusercontent.com/1681963/144692432-1d540252-842d-47a1-b4eb-95b19d10a883.png">


After:
<img width="781" alt="Screen Shot 2021-12-03 at 8 44 03 PM" src="https://user-images.githubusercontent.com/1681963/144692430-6e95ebbf-59a6-41b8-ba13-bec33ad3bc9e.png">
