### PR TITLE
DEV: drop unused method

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
@@ -1,7 +1,6 @@
 import RawHtml from "discourse/widgets/raw-html";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import QuickAccessPanel from "discourse/widgets/quick-access-panel";
-import UserAction from "discourse/models/user-action";
 import { ajax } from "discourse/lib/ajax";
 import { createWidget, createWidgetFrom } from "discourse/widgets/widget";
 import { h } from "virtual-dom";
@@ -71,15 +70,5 @@ createWidgetFrom(QuickAccessPanel, "quick-access-bookmarks", {
     return ajax(`/u/${this.currentUser.username}/bookmarks.json`).then(
       ({ user_bookmark_list }) => user_bookmark_list.bookmarks
     );
-  },
-
-  loadUserActivityBookmarks() {
-    return ajax("/user_actions.json", {
-      data: {
-        username: this.currentUser.username,
-        filter: UserAction.TYPES.bookmarks,
-        no_results_help_key: "user_activity.no_bookmarks",
-      },
-    }).then(({ user_actions }) => user_actions);
   },
 });


### PR DESCRIPTION
There are no usages in Core and plugins.
The last usage was removed in https://github.com/discourse/discourse/pull/9369.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
