### PR TITLE
DEV: Fix mini-profiler location for custom (or missing) d-headers

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -372,7 +372,7 @@ table {
 }
 
 .profiler-results.profiler-left {
-  top: 60px !important;
+  top: var(--header-offset) !important;
 }
 
 .flex-center-align {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
