### PR TITLE
FIX: Make user themes sort order case insensitive

### DIFF
--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -42,7 +42,7 @@ class SiteSerializer < ApplicationSerializer
     cache_fragment("user_themes") do
       Theme.where('id = :default OR user_selectable',
                     default: SiteSetting.default_theme_id)
-        .order(:name)
+        .order("lower(name)")
         .pluck(:id, :name, :color_scheme_id)
         .map { |id, n, cs| { theme_id: id, name: n, default: id == SiteSetting.default_theme_id, color_scheme_id: cs } }
         .as_json


### PR DESCRIPTION
That's the order they appear in a dropdown in user preferences.