### PR TITLE
FIX: auth incorrectly handles duplicate usernames

### DIFF
--- a/app/services/username_changer.rb
+++ b/app/services/username_changer.rb
@@ -19,7 +19,7 @@ class UsernameChanger
       UsernameChanger.change(user, new_username, user)
       true
     elsif user.username != UserNameSuggester.fix_username(new_username)
-      suggested_username = UserNameSuggester.suggest(new_username)
+      suggested_username = UserNameSuggester.suggest(new_username, user.username)
       UsernameChanger.change(user, suggested_username, user)
       true
     else

--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -6,6 +6,7 @@ module UserNameSuggester
 
   def self.suggest(name_or_email,  current_username = nil)
     name = parse_name_from_email(name_or_email)
+    name = fix_username(name)
     find_available_username_based_on(name, current_username)
   end
 
@@ -21,7 +22,6 @@ module UserNameSuggester
   end
 
   def self.find_available_username_based_on(name, current_username = nil)
-    name = fix_username(name)
     offset = nil
     i = 1
 

--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -4,9 +4,9 @@ module UserNameSuggester
   GENERIC_NAMES = ['i', 'me', 'info', 'support', 'admin', 'webmaster', 'hello', 'mail', 'office', 'contact', 'team']
   LAST_RESORT_USERNAME = "user"
 
-  def self.suggest(name_or_email)
+  def self.suggest(name_or_email,  current_username = nil)
     name = parse_name_from_email(name_or_email)
-    find_available_username_based_on(name)
+    find_available_username_based_on(name, current_username)
   end
 
   def self.parse_name_from_email(name_or_email)
@@ -20,13 +20,22 @@ module UserNameSuggester
     name
   end
 
-  def self.find_available_username_based_on(name)
+  def self.find_available_username_based_on(name, current_username = nil)
     name = fix_username(name)
     offset = nil
     i = 1
 
     attempt = name
-    until User.username_available?(attempt) || i > 100
+    normalized_attempt = User.normalize_username(attempt)
+
+    original_allowed_username = current_username
+    current_username = User.normalize_username(current_username) if current_username
+
+    until (
+      normalized_attempt == current_username ||
+        User.username_available?(attempt) ||
+        i > 100
+    )
 
       if offset.nil?
         normalized = User.normalize_username(name)
@@ -42,7 +51,8 @@ module UserNameSuggester
 
           params = {
             count: count + 10,
-            name: normalized
+            name: normalized,
+            allowed_normalized: current_username || ''
           }
 
           # increasing the search space a bit to allow for some extra noise
@@ -50,7 +60,11 @@ module UserNameSuggester
             WITH numbers AS (SELECT generate_series(1, :count) AS n)
 
             SELECT n FROM numbers
-            LEFT JOIN users ON (username_lower = :name || n::varchar)
+            LEFT JOIN users ON (
+              username_lower = :name || n::varchar
+            ) AND (
+              username_lower <> :allowed_normalized
+            )
             WHERE users.id IS NULL
             ORDER by n ASC
             LIMIT 1
@@ -68,15 +82,21 @@ module UserNameSuggester
 
       max_length = User.username_length.end - suffix.length
       attempt = "#{truncate(name, max_length)}#{suffix}"
+      normalized_attempt = User.normalize_username(attempt)
       i += 1
     end
 
-    until User.username_available?(attempt) || i > 200
+    until normalized_attempt == current_username || User.username_available?(attempt) || i > 200
       attempt = SecureRandom.hex[1..SiteSetting.max_username_length]
+      normalized_attempt = User.normalize_username(attempt)
       i += 1
     end
 
-    attempt
+    if current_username == normalized_attempt
+      original_allowed_username
+    else
+      attempt
+    end
   end
 
   def self.fix_username(name)

--- a/spec/components/user_name_suggester_spec.rb
+++ b/spec/components/user_name_suggester_spec.rb
@@ -118,6 +118,21 @@ describe UserNameSuggester do
       expect(UserNameSuggester.suggest('uuuuuuu_u')).to eq('uuuuuuu1')
     end
 
+    it 'preserves current username' do
+      # if several users have username "bill" on the external site,
+      # they will have usernames bill, bill1, bill2 etc in Discourse:
+      Fabricate(:user, username: "bill")
+      Fabricate(:user, username: "bill1")
+      Fabricate(:user, username: "bill2")
+      Fabricate(:user, username: "bill3")
+      Fabricate(:user, username: "bill4")
+
+      # the number should be preserved, bill3 should remain bill3
+      suggestion = UserNameSuggester.suggest("bill", "bill3")
+
+      expect(suggestion).to eq "bill3"
+    end
+
     context "with Unicode usernames disabled" do
       before { SiteSetting.unicode_usernames = false }
 

--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -366,6 +366,30 @@ describe DiscourseSingleSignOn do
     expect(user.username).to eq "testuser"
   end
 
+  it 'should preserve username when several users login with the same username' do
+    SiteSetting.auth_overrides_username = true
+
+    # if several users have username "bill" on the external site,
+    # they will have usernames bill, bill1, bill2 etc in Discourse:
+    Fabricate(:user, username: "bill")
+    Fabricate(:user, username: "bill1")
+    Fabricate(:user, username: "bill2")
+    Fabricate(:user, username: "bill4")
+
+    # the number should be preserved during subsequent logins
+    # bill3 should remain bill3
+    sso = new_discourse_sso
+    sso.username = "bill3"
+    sso.email = "test@test.com"
+    sso.external_id = "100"
+    sso.lookup_or_create_user(ip_address)
+
+    sso.username = "bill"
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.username).to eq "bill3"
+  end
+
   it "doesn't use email as a source for username suggestions by default" do
     sso = new_discourse_sso
     sso.external_id = "100"


### PR DESCRIPTION
If the `auth_overrides_username` setting is enabled, and a username is used by more than two users on the SSO provider site, users other than the first user to register on Discourse with the username will have the digit that’s appended to their username changed when they logout and log back into Discourse. For example, if there are three users with the username _bob_ on the SSO provider site and the Discourse user _bob1_ logs into Discourse via SSO, they are likely to have their Discourse username updated to _bob3_.

This is an edge case, but we were handling it correctly in the past. A part of my changes in https://github.com/discourse/discourse/pull/14531 broke that handling. Turned out, this edge case was the reason why we needed the `allowed_username = nil` parameter in `UserNameSuggester.suggest`. I removed this parameter in that PR and introduced the regression.

In this PR, I've returned the second parameter to `UserNameSuggester.suggest`. I've named it `current_username` this time, in my opinion the previous name `allowed_username` was a bit confusing:

```ruby
# the second parameter is confusing, 
# why call username suggester at all if we already know an allowed username?
# we can just use the allowed username
def suggest(name_or_email, allowed_username = nil)
...
end
```

Also, I've added test cases that explicitly document this edge case.

I was thinking of going even further, but I'm on the fence here. We can remove the `suggest` method and create two new methods:

```ruby
module UserNameSuggester
  def self.suggest_for_new_user(name_or_email)
  end

  def self.suggest_for_existent_user(name_or_email,  current_username)
  end
end
```

This way, clients will always be enforced to
1. Decide consciously if they need a suggestion for a new user or for an old one
2. Always pass the current username for existent users

Without passing the current username for existent users, we'll always be seeing the same bug. It would be fine to enforce it.
