### PR TITLE
DEV: Make add_api_parameter_route parameter deprecations errors

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -907,14 +907,14 @@ class Plugin::Instance
                               format: nil, formats: nil)
 
     if Array(format).include?("*")
-      Discourse.deprecate("* is no longer a valid api_parameter_route format matcher. Use `nil` instead", drop_from: "2.7")
+      Discourse.deprecate("* is no longer a valid api_parameter_route format matcher. Use `nil` instead", drop_from: "2.7", raise_error: true)
       # Old API used * as wildcard. New api uses `nil`
       format = nil
     end
 
     # Backwards compatibility with old parameter names:
     if method || route || format
-      Discourse.deprecate("method, route and format parameters for api_parameter_routes are deprecated. Use methods, actions and formats instead.", drop_from: "2.7")
+      Discourse.deprecate("method, route and format parameters for api_parameter_routes are deprecated. Use methods, actions and formats instead.", drop_from: "2.7", raise_error: true)
       methods ||= method
       actions ||= route
       formats ||= format

--- a/spec/integration/api_keys_spec.rb
+++ b/spec/integration/api_keys_spec.rb
@@ -51,7 +51,7 @@ describe 'api keys' do
   context "with a plugin registered filter" do
     before do
       plugin = Plugin::Instance.new
-      plugin.add_api_parameter_route method: :get, route: "session#current", format: "*"
+      plugin.add_api_parameter_route methods: [:get], actions: ["session#current"]
     end
 
     it 'allows parameter access to the registered route' do


### PR DESCRIPTION
Since we said we would remove support in 2.7, this is overdue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
