### PR TITLE
FIX: Display pending posts in a moderated category

### DIFF
--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -244,7 +244,7 @@ class TopicViewSerializer < ApplicationSerializer
   alias_method :include_is_shared_draft?, :include_destination_category_id?
 
   def include_pending_posts?
-    scope.authenticated? && object.queued_posts_enabled
+    scope.authenticated? && object.queued_posts_enabled?
   end
 
   def queued_posts_count
@@ -252,7 +252,7 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def include_queued_posts_count?
-    scope.is_staff? && object.queued_posts_enabled
+    scope.is_staff? && object.queued_posts_enabled?
   end
 
   def show_read_indicator

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -35,6 +35,7 @@ class TopicView
     :personal_message,
     :can_review_topic
   )
+  alias queued_posts_enabled? queued_posts_enabled
 
   attr_accessor(
     :draft,
@@ -44,6 +45,9 @@ class TopicView
     :post_custom_fields,
     :post_number
   )
+
+  delegate :category, to: :topic, allow_nil: true, private: true
+  delegate :require_reply_approval?, to: :category, prefix: true, allow_nil: true, private: true
 
   def self.print_chunk_size
     1000
@@ -146,7 +150,7 @@ class TopicView
     @draft_sequence = DraftSequence.current(@user, @draft_key)
 
     @can_review_topic = @guardian.can_review_topic?(@topic)
-    @queued_posts_enabled = NewPostManager.queue_enabled?
+    @queued_posts_enabled = NewPostManager.queue_enabled? || category_require_reply_approval?
     @personal_message = @topic.private_message?
   end
 


### PR DESCRIPTION
Currently we display pending posts in topics (both for author and staff members) but the feature is only enabled when there’s an enabled global site setting related to moderation.

This PR allows to have the same behavior for a site where there’s nothing enabled globally but where a moderated category exists. So when browsing a topic of a moderated category, the presence of pending posts will be checked whereas nothing will happen in a normal category.
