### PR TITLE
DEV: Drop unused column email_tokens.token

### DIFF
--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -13,7 +13,6 @@ class EmailToken < ActiveRecord::Base
   after_initialize do
     if self.token_hash.blank?
       @token ||= SecureRandom.hex
-      self.token = @token
       self.token_hash = self.class.hash_token(@token)
     end
   end
@@ -36,6 +35,9 @@ class EmailToken < ActiveRecord::Base
     end
   end
 
+  # TODO(2022-01-01): Remove
+  self.ignored_columns = %w{token}
+
   def self.scopes
     @scopes ||= Enum.new(
       signup: 1,
@@ -47,7 +49,8 @@ class EmailToken < ActiveRecord::Base
 
   def token
     raise TokenAccessError.new if @token.blank?
-    self[:token]
+
+    @token
   end
 
   def self.confirm(token, scope: nil, skip_reviewable: false)
@@ -111,7 +114,6 @@ end
 #  id         :integer          not null, primary key
 #  user_id    :integer          not null
 #  email      :string           not null
-#  token      :string           not null
 #  confirmed  :boolean          default(FALSE), not null
 #  expired    :boolean          default(FALSE), not null
 #  created_at :datetime         not null
@@ -121,7 +123,6 @@ end
 #
 # Indexes
 #
-#  index_email_tokens_on_token       (token) UNIQUE
 #  index_email_tokens_on_token_hash  (token_hash) UNIQUE
 #  index_email_tokens_on_user_id     (user_id)
 #

--- a/db/post_migrate/20211206160212_drop_token_from_email_tokens.rb
+++ b/db/post_migrate/20211206160212_drop_token_from_email_tokens.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DropTokenFromEmailTokens < ActiveRecord::Migration[6.1]
+  DROPPED_COLUMNS ||= {
+    email_tokens: %i{token}
+  }
+
+  def up
+    DROPPED_COLUMNS.each do |table, columns|
+      Migration::ColumnDropper.execute_drop(table, columns)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -664,13 +664,13 @@ describe InvitesController do
               expect(Jobs::InvitePasswordInstructionsEmail.jobs.size).to eq(0)
               expect(Jobs::CriticalUserEmail.jobs.size).to eq(1)
 
-              tokens = EmailToken.where(user_id: invited_user.id, confirmed: false, expired: false).pluck(:token)
+              tokens = EmailToken.where(user_id: invited_user.id, confirmed: false, expired: false)
               expect(tokens.size).to eq(1)
 
               job_args = Jobs::CriticalUserEmail.jobs.first['args'].first
               expect(job_args['type']).to eq('signup')
               expect(job_args['user_id']).to eq(invited_user.id)
-              expect(job_args['email_token']).to eq(tokens.first)
+              expect(EmailToken.hash_token(job_args['email_token'])).to eq(tokens.first.token_hash)
             end
           end
         end
@@ -695,13 +695,13 @@ describe InvitesController do
         expect(Jobs::InvitePasswordInstructionsEmail.jobs.size).to eq(0)
         expect(Jobs::CriticalUserEmail.jobs.size).to eq(1)
 
-        tokens = EmailToken.where(user_id: invited_user.id, confirmed: false, expired: false).pluck(:token)
+        tokens = EmailToken.where(user_id: invited_user.id, confirmed: false, expired: false)
         expect(tokens.size).to eq(1)
 
         job_args = Jobs::CriticalUserEmail.jobs.first['args'].first
         expect(job_args['type']).to eq('signup')
         expect(job_args['user_id']).to eq(invited_user.id)
-        expect(job_args['email_token']).to eq(tokens.first)
+        expect(EmailToken.hash_token(job_args['email_token'])).to eq(tokens.first.token_hash)
       end
     end
 


### PR DESCRIPTION
email_tokens.token_hash is used instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
