### PR TITLE
UX: only apply link formats on paste to selections that do not contain bbcode-like tags

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -286,7 +286,10 @@ export default Mixin.create({
       plainText &&
       !handled &&
       selected.end > selected.start &&
-      !this._cachedLinkify.test(selectedValue)
+      // text selection does not contain url
+      !this._cachedLinkify.test(selectedValue) &&
+      // text selection does not contain a bbcode-like tag
+      !selectedValue.match(/\[\/?[a-z =]+?\]/g)
     ) {
       if (this._cachedLinkify.test(plainText)) {
         const match = this._cachedLinkify.match(plainText)[0];

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -846,6 +846,19 @@ third line`
     }
   );
 
+  testCase(
+    `pasting a url onto a selection that contains bbcode-like tags will use default paste behavior`,
+    async function (assert, textarea) {
+      this.set("value", "hello [url=foobar]foobar[/url]");
+      setTextareaSelection(textarea, 0, 30);
+      const element = query(".d-editor");
+      const event = await paste(element, "https://www.discourse.com/");
+      // Synthetic paste events do not manipulate document content.
+      assert.strictEqual(this.value, "hello [url=foobar]foobar[/url]");
+      assert.strictEqual(event.defaultPrevented, false);
+    }
+  );
+
   (() => {
     // Tests to check cursor/selection after replace-text event.
     const BEFORE = "red green blue";


### PR DESCRIPTION
This is a follow up to #15010, where WordPress-style link pasting was added. This PR updates behavior to testing if the current text selection has a bbcode-like tag. If it does, we should default to normal paste behavior even if the paste value contains a link.

This was discussed in https://meta.discourse.org/t/double-link-urls-when-pasting-over-bbcode-url-tags/211102/5

https://user-images.githubusercontent.com/1270189/144893955-e82a31e1-173f-4134-9556-088e72dfd42e.mp4

#### Dev notes

I used a looser regex `\[\/?[a-z =]+?\]/g` to test for bbcode tags. We're primarily interested in inferring user intent, rather than checking for valid bbcode tags. If someone is modifying a selection that looks like a bbcode tag, it's safer to default to default paste behavior. For actual bbcode parsing, see logic in https://github.com/discourse/discourse/blob/f3508065a3313735654def72872a08e825555bef/app/assets/javascripts/pretty-text/engines/discourse-markdown/bbcode-block.js#L203. The tokenizer basically checks for any `[` characters and parses to see if valid tags exist.

 