### PR TITLE
FIX: References header leading to broken email threading

### DIFF
--- a/lib/email/message_id_service.rb
+++ b/lib/email/message_id_service.rb
@@ -37,14 +37,18 @@ module Email
         "<topic/#{post.topic_id}/#{post.id}.#{random_suffix}@#{host}>"
       end
 
-      def generate_for_topic(topic, use_incoming_email_if_present: false)
+      def generate_for_topic(topic, use_incoming_email_if_present: false, canonical: false)
         first_post = topic.ordered_posts.first
 
         if use_incoming_email_if_present && first_post.incoming_email&.message_id.present?
           return "<#{first_post.incoming_email.message_id}>"
         end
 
-        "<topic/#{topic.id}.#{random_suffix}@#{host}>"
+        if canonical
+          "<topic/#{topic.id}@#{host}>"
+        else
+          "<topic/#{topic.id}.#{random_suffix}@#{host}>"
+        end
       end
 
       def find_post_from_message_ids(message_ids)

--- a/spec/lib/message_id_service_spec.rb
+++ b/spec/lib/message_id_service_spec.rb
@@ -24,14 +24,20 @@ describe Email::MessageIdService do
 
   describe "#generate_for_topic" do
     it "generates for the topic using the message_id on the first post's incoming_email" do
-      Fabricate(:incoming_email, message_id: "test@test.localhost", post: post)
+      Fabricate(:incoming_email, message_id: "test213428@somemailservice.com", post: post)
       post.reload
-      expect(subject.generate_for_topic(topic, use_incoming_email_if_present: true)).to eq("<test@test.localhost>")
+      expect(subject.generate_for_topic(topic, use_incoming_email_if_present: true)).to eq("<test213428@somemailservice.com>")
     end
 
     it "generates for the topic without an incoming_email record" do
       expect(subject.generate_for_topic(topic)).to match(subject.message_id_topic_id_regexp)
       expect(subject.generate_for_topic(topic, use_incoming_email_if_present: true)).to match(subject.message_id_topic_id_regexp)
+    end
+
+    it "generates canonical for the topic" do
+      canonical_topic_id = subject.generate_for_topic(topic, canonical: true)
+      expect(canonical_topic_id).to match(subject.message_id_topic_id_regexp)
+      expect(canonical_topic_id).to eq("<topic/#{topic.id}@test.localhost>")
     end
   end
 


### PR DESCRIPTION
Since 3b13f1146b2a406238c50d6b45bc9aa721094f46 the email threading
in mail clients has been broken, because the random suffix meant
that the References header would always be different for non-group
SMTP email notifications sent out.

This commit fixes the issue by always using the "canonical" topic
reference ID inside the References header in the format:

topic/TOPIC_ID@HOST

Which was the old format. We also add the References header to
notifications sent for the first post arriving, so the threading
works for subsequent emails. The Message-ID header is still random
as per the previous change.

