### PR TITLE
FEATURE: Restrict link invites to email domain

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -142,6 +142,12 @@ export function emailValid(email) {
   return re.test(email);
 }
 
+export function hostnameValid(hostname) {
+  // see:  https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
+  const re = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+  return hostname && re.test(hostname);
+}
+
 export function extractDomainFromUrl(url) {
   if (url.indexOf("://") > -1) {
     url = url.split("/")[2];

--- a/app/assets/javascripts/discourse/app/models/invite.js
+++ b/app/assets/javascripts/discourse/app/models/invite.js
@@ -49,6 +49,11 @@ const Invite = EmberObject.extend({
     return topicData ? Topic.create(topicData) : null;
   },
 
+  @discourseComputed("email", "domain")
+  emailOrDomain(email, domain) {
+    return email || domain;
+  },
+
   topicId: alias("topics.firstObject.id"),
   topicTitle: alias("topics.firstObject.title"),
 });

--- a/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
@@ -37,12 +37,21 @@
     {{/if}}
 
     <div class="input-group input-email">
-      <label for="invite-email">{{d-icon "envelope"}}{{i18n "user.invited.invite.restrict_email"}}</label>
+      <label for="invite-email">
+        {{d-icon "envelope"}}
+        {{#if isEmail}}
+          {{i18n "user.invited.invite.restrict_email"}}
+        {{else if isDomain}}
+          {{i18n "user.invited.invite.restrict_domain"}}
+        {{else}}
+          {{i18n "user.invited.invite.restrict_email_or_domain"}}
+        {{/if}}
+      </label>
       <div class="invite-email-container">
         {{input
           id="invite-email"
-          value=buffered.email
-          placeholderKey="topic.invite_reply.email_placeholder"
+          value=buffered.emailOrDomain
+          placeholderKey="user.invited.invite.email_or_domain_placeholder"
         }}
         {{#if capabilities.hasContactPicker}}
           {{d-button

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -134,6 +134,7 @@ class InvitesController < ApplicationController
     begin
       invite = Invite.generate(current_user,
         email: params[:email],
+        domain: params[:domain],
         skip_email: params[:skip_email],
         invited_by: current_user,
         custom_message: params[:custom_message],
@@ -209,6 +210,17 @@ class InvitesController < ApplicationController
           else
             Invite.emailed_status_types[:not_required]
           end
+        end
+
+        invite.domain = nil if invite.email.present?
+      end
+
+      if params.has_key?(:domain)
+        invite.domain = params[:domain]
+
+        if invite.domain.present?
+          invite.email = nil
+          invite.emailed_status = Invite.emailed_status_types[:not_required]
         end
       end
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -15,6 +15,7 @@ class Invite < ActiveRecord::Base
   }
 
   BULK_INVITE_EMAIL_LIMIT = 200
+  HOSTNAME_REGEX = /\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\z/
 
   rate_limit :limit_invites_per_day
 
@@ -30,7 +31,7 @@ class Invite < ActiveRecord::Base
   validates_presence_of :invited_by_id
   validates :email, email: true, allow_blank: true
   validate :ensure_max_redemptions_allowed
-  validate :valid_domain
+  validate :valid_domain, if: :will_save_change_to_domain?
   validate :user_doesnt_already_exist
 
   before_create do
@@ -238,11 +239,7 @@ class Invite < ActiveRecord::Base
 
   def self.invalidate_for_email(email)
     invite = Invite.find_by(email: Email.downcase(email))
-
-    if invite
-      invite.invalidated_at = Time.zone.now
-      invite.save
-    end
+    invite.update!(invalidated_at: Time.zone.now) if invite
 
     invite
   end
@@ -293,15 +290,11 @@ class Invite < ActiveRecord::Base
   def valid_domain
     return if self.domain.blank?
 
-    self.domain = domain.downcase
+    self.domain.downcase!
 
-    if self.domain !~ Invite.hostname_regex
-      self.errors.add(:base, I18n.t('invite.invalid_domain', domain: self.domain))
+    if self.domain !~ Invite::HOSTNAME_REGEX
+      self.errors.add(:base, I18n.t('invite.domain_not_allowed', domain: self.domain))
     end
-  end
-
-  def self.hostname_regex
-    /\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])\z/
   end
 end
 

--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -19,9 +19,9 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
       available_username = UserNameSuggester.suggest(email)
     end
 
-    if email.present?
+    if email.present? && invite.domain.present?
       username, domain = email.split('@')
-      if invite.domain.present? && domain.present? && invite.domain != domain
+      if domain.present? && invite.domain != domain
         raise ActiveRecord::RecordNotSaved.new(I18n.t('invite.domain_not_allowed'))
       end
     end

--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -19,6 +19,13 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
       available_username = UserNameSuggester.suggest(email)
     end
 
+    if email.present?
+      username, domain = email.split('@')
+      if invite.domain.present? && domain.present? && invite.domain != domain
+        raise ActiveRecord::RecordNotSaved.new(I18n.t('invite.domain_not_allowed'))
+      end
+    end
+
     user = User.where(staged: true).with_email(email.strip.downcase).first
     user.unstage! if user
     user ||= User.new

--- a/app/serializers/invite_serializer.rb
+++ b/app/serializers/invite_serializer.rb
@@ -5,6 +5,7 @@ class InviteSerializer < ApplicationSerializer
              :invite_key,
              :link,
              :email,
+             :domain,
              :emailed,
              :max_redemptions_allowed,
              :redemption_count,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1621,7 +1621,10 @@ en:
           show_advanced: "Show Advanced Options"
           hide_advanced: "Hide Advanced Options"
 
+          restrict_email_or_domain: "Restrict to email or domain"
+          email_or_domain_placeholder: "name@example.com or example.com"
           restrict_email: "Restrict to email"
+          restrict_domain: "Restrict to domain"
 
           max_redemptions_allowed: "Max uses"
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -259,6 +259,7 @@ en:
       discourse_connect_enabled: "Invites are disabled because DiscourseConnect is enabled."
       invalid_access: "You are not permitted to view the requested resource."
     requires_groups: "Invite saved. To give access to the specified topic, add one of the following groups: %{groups}."
+    domain_not_allowed: "Your email cannot be used to redeem this invite."
 
   bulk_invite:
     file_should_be_csv: "The uploaded file should be of csv format."

--- a/db/migrate/20211207130646_add_domain_to_invites.rb
+++ b/db/migrate/20211207130646_add_domain_to_invites.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDomainToInvites < ActiveRecord::Migration[6.1]
+  def change
+    add_column :invites, :domain, :string
+  end
+end

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -677,6 +677,31 @@ describe InvitesController do
       end
     end
 
+    context 'with a domain invite' do
+      fab!(:invite) { Fabricate(:invite, email: nil, emailed_status: Invite.emailed_status_types[:not_required], domain: 'example.com') }
+
+      it 'creates an user if email ests' do
+        expect { put "/invites/show/#{invite.invite_key}.json", params: { email: 'test@example.com', password: 'verystrongpassword' } }
+          .to change { User.count }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body['message']).to eq(I18n.t('invite.confirm_email'))
+        expect(invite.reload.redemption_count).to eq(1)
+
+        invited_user = User.find_by_email('test@example.com')
+        expect(invited_user).to be_present
+      end
+
+      it 'creates an user if email ests' do
+        expect { put "/invites/show/#{invite.invite_key}.json", params: { email: 'test@example2.com', password: 'verystrongpassword' } }
+          .not_to change { User.count }
+
+        expect(response.status).to eq(412)
+        expect(response.parsed_body['message']).to eq(I18n.t('invite.domain_not_allowed'))
+        expect(invite.reload.redemption_count).to eq(0)
+      end
+    end
+
     context 'with an invite link' do
       fab!(:invite) { Fabricate(:invite, email: nil, emailed_status: Invite.emailed_status_types[:not_required]) }
 

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -680,7 +680,7 @@ describe InvitesController do
     context 'with a domain invite' do
       fab!(:invite) { Fabricate(:invite, email: nil, emailed_status: Invite.emailed_status_types[:not_required], domain: 'example.com') }
 
-      it 'creates an user if email ests' do
+      it 'creates an user if email matches domain' do
         expect { put "/invites/show/#{invite.invite_key}.json", params: { email: 'test@example.com', password: 'verystrongpassword' } }
           .to change { User.count }
 
@@ -692,7 +692,7 @@ describe InvitesController do
         expect(invited_user).to be_present
       end
 
-      it 'creates an user if email ests' do
+      it 'does not create an user if email does not match domain' do
         expect { put "/invites/show/#{invite.invite_key}.json", params: { email: 'test@example2.com', password: 'verystrongpassword' } }
           .not_to change { User.count }
 


### PR DESCRIPTION
Allow multiple emails to redeem a link invite only if the email domain
name matches the one specified in the link invite.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
