### PR TITLE
A11Y: Remove dupe label on signup confirm field

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/user-fields/confirm.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-fields/confirm.hbs
@@ -1,5 +1,5 @@
 {{#if this.field.name}}
-  <label class="control-label" for={{concat "user-" this.elementId}}>
+  <label class="control-label">
     {{html-safe this.field.name}} {{#if this.field.required}}<span class="required">*</span>{{/if}}
   </label>
 {{/if}}


### PR DESCRIPTION
Fixes an issue raised by A11Y automated test tools (like WAVE). Only affects sites with checkbox custom user fields shown on signup forms. 

Example: 

<img width="576" alt="image" src="https://user-images.githubusercontent.com/368961/145064243-685046c8-9a96-4328-8cfa-b10b2eeb3509.png">
