### PR TITLE
FIX: Update has_topic_draft when draft is updated

### DIFF
--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -207,16 +207,19 @@ class UserStat < ActiveRecord::Base
 
   def self.update_draft_count(user_id = nil)
     if user_id.present?
-      draft_count = DB.query_single <<~SQL, user_id: user_id
+      draft_count, has_topic_draft = DB.query_single <<~SQL, user_id: user_id, new_topic: Draft::NEW_TOPIC
         UPDATE user_stats
         SET draft_count = (SELECT COUNT(*) FROM drafts WHERE user_id = :user_id)
         WHERE user_id = :user_id
-        RETURNING draft_count
+        RETURNING draft_count, (SELECT 1 FROM drafts WHERE draft_key = :new_topic)
       SQL
 
       MessageBus.publish(
         '/user',
-        { draft_count: draft_count.first },
+        {
+          draft_count: draft_count,
+          has_topic_draft: !!has_topic_draft
+        },
         user_ids: [user_id]
       )
     else

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -180,16 +180,18 @@ describe Draft do
 
   it 'updates draft count when a draft is created or destroyed' do
     messages = MessageBus.track_publish("/user") do
-      Draft.set(user, "test", 0, "data")
+      Draft.set(user, Draft::NEW_TOPIC, 0, "data")
     end
 
     expect(messages.first.data[:draft_count]).to eq(1)
+    expect(messages.first.data[:has_topic_draft]).to eq(true)
 
     messages = MessageBus.track_publish("/user") do
       Draft.where(user: user).destroy_all
     end
 
     expect(messages.first.data[:draft_count]).to eq(0)
+    expect(messages.first.data[:has_topic_draft]).to eq(false)
   end
 
   describe '#stream' do


### PR DESCRIPTION
Current user state regarding the new topic draft was not updated when
the draft was created or destroyed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
