### PR TITLE
FIX: --header-offset didn't account for overscroll

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -183,9 +183,13 @@ const SiteHeaderComponent = MountWidget.extend(
       }
 
       const offset = info.offset();
-      const headerRect = header.getBoundingClientRect(),
-        headerOffset = headerRect.top + headerRect.height,
-        doc = document.documentElement;
+      const headerRect = header.getBoundingClientRect();
+      const headerOffset = headerRect.top + headerRect.height;
+      const doc = document.documentElement;
+
+      if (window.scrollY < 0) {
+        headerOffset -= window.scrollY;
+      }
 
       const newValue = `${headerOffset}px`;
       if (newValue !== this.currentHeaderOffsetValue) {

--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -184,8 +184,8 @@ const SiteHeaderComponent = MountWidget.extend(
 
       const offset = info.offset();
       const headerRect = header.getBoundingClientRect();
-      const headerOffset = headerRect.top + headerRect.height;
       const doc = document.documentElement;
+      let headerOffset = headerRect.top + headerRect.height;
 
       if (window.scrollY < 0) {
         headerOffset -= window.scrollY;


### PR DESCRIPTION
Fixes miniprofiler badge sliding away from the header when you rubber-band overscroll on the top of the page (in Safari)