### PR TITLE
DEV: Fix position of avatar flair to be based on the actual avatar.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -186,18 +186,22 @@ createWidget("post-avatar", {
       });
     }
 
-    const result = [body];
+    const postAvatarBody = [body];
 
     if (attrs.flair_url || attrs.flair_bg_color) {
-      result.push(this.attach("avatar-flair", attrs));
+      postAvatarBody.push(this.attach("avatar-flair", attrs));
     } else {
       const autoFlairAttrs = autoGroupFlairForUser(this.site, attrs);
+
       if (autoFlairAttrs) {
-        result.push(this.attach("avatar-flair", autoFlairAttrs));
+        postAvatarBody.push(this.attach("avatar-flair", autoFlairAttrs));
       }
     }
 
-    result.push(h("div.poster-avatar-extra"));
+    const result = [
+      h("div.post-avatar", postAvatarBody),
+      h("div.poster-avatar-extra"),
+    ];
 
     if (this.settings.displayPosterName) {
       result.push(this.attach("post-avatar-user-info", attrs));

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -482,6 +482,7 @@ aside.quote {
   }
 }
 
+.post-avatar,
 .topic-avatar,
 .user-card-avatar {
   position: relative;


### PR DESCRIPTION
Previously, it was based on the container of the avatar. However, the
container of the avatar can be extended to contain more than just the
avatar itself. This resulted in the positioning of the avatar flair to
be off.

### Example of a plugin decorating the `post-avatar` widget with `post-avatar:after` 

![Screenshot from 2021-12-08 12-38-53](https://user-images.githubusercontent.com/4335742/145149181-2c727279-7aef-4ce4-b4d0-45b6e77cecf8.png)
