### PR TITLE
DEV: add app event for user-card:after-show

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -174,7 +174,7 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
       include_post_count_for: this.get("topic.id"),
     };
 
-    User.findByUsername(username, args)
+    return User.findByUsername(username, args)
       .then((user) => {
         if (user.topic_post_count) {
           this.set(

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -183,6 +183,7 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
           );
         }
         this.setProperties({ user });
+        return user;
       })
       .catch(() => this._close())
       .finally(() => this.set("loading", null));

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -86,7 +86,9 @@ export default Mixin.create({
     });
 
     this.appEvents.trigger("user-card:show", { username });
-    this._showCallback(username, $(target));
+    this._showCallback(username, $(target)).then(() => {
+      this.appEvents.trigger("user-card:after-show", { username });
+    });
 
     // We bind scrolling on mobile after cards are shown to hide them if user scrolls
     if (this.site.mobileView) {

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -86,8 +86,8 @@ export default Mixin.create({
     });
 
     this.appEvents.trigger("user-card:show", { username });
-    this._showCallback(username, $(target)).then(() => {
-      this.appEvents.trigger("user-card:after-show", { username });
+    this._showCallback(username, $(target)).then((user) => {
+      this.appEvents.trigger("user-card:after-show", { user });
     });
 
     // We bind scrolling on mobile after cards are shown to hide them if user scrolls


### PR DESCRIPTION
Adds event for when a usercard is fully loaded and shown.

I would also be OK with moving down the user-card:show app event after the load, but I wasn't sure how this one was being used in the wild. Figured a new event would be the safest.