### PR TITLE
DEV: Stop polluting all Ruby classes

### DIFF
--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -49,7 +49,7 @@ class ReviewableScore < ActiveRecord::Base
   # Generate `pending?`, `rejected?`, etc helper methods
   statuses.each do |name, id|
     define_method("#{name}?") { status == id }
-    self.class.define_method(name) { where(status: id) }
+    singleton_class.define_method(name) { where(status: id) }
   end
 
   def score_type


### PR DESCRIPTION
The `ReviewableScore` model was defining class methods on `self.class` from a singleton context so instead of defining methods on `ReviewableScore` it was defining them on `Class`, so basically on every existing class.

This PR resolves this issue. Using `enum` from `ActiveRecord` in the future will avoid this kind of problems.
