### PR TITLE
FEATURE: A notification consolidation plan for keeping the latest one.

### DIFF
--- a/app/services/notifications/consolidation_plan.rb
+++ b/app/services/notifications/consolidation_plan.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Notifications
+  class ConsolidationPlan
+    def set_precondition(precondition_blk: nil)
+      @precondition_blk = precondition_blk
+
+      self
+    end
+
+    def set_mutations(set_data_blk: nil)
+      @set_data_blk = set_data_blk
+
+      self
+    end
+
+    def can_consolidate_data?(_notification)
+      raise NotImplementedError
+    end
+
+    def consolidate_or_save!(_notification)
+      raise NotImplementedError
+    end
+
+    protected
+
+    def consolidated_data(notification)
+      return notification.data_hash if @set_data_blk.nil?
+      @set_data_blk.call(notification)
+    end
+
+    def user_notifications(notification, type)
+      notification.user.notifications.where(notification_type: type)
+    end
+  end
+end

--- a/app/services/notifications/delete_previous_notifications.rb
+++ b/app/services/notifications/delete_previous_notifications.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Create a new notification while deleting previous versions of it.
+#
+# Constructor arguments:
+#
+# - type: The notification type. e.g. `Notification.types[:private_message]`
+# - previous_query_blk: A block with the query we'll use to find previous notifications.
+#
+# Need to call #set_precondition to configure this:
+#
+# - precondition_blk: A block that receives the mutated data and returns true if we have everything we need to consolidate.
+#
+# Need to call #set_mutations to configure this:
+#
+# - set_data_blk: A block that receives the notification data hash and mutates it, adding additional data needed for consolidation.
+
+module Notifications
+  class DeletePreviousNotifications < ConsolidationPlan
+    def initialize(type:, previous_query_blk:)
+      @type = type
+      @previous_query_blk = previous_query_blk
+    end
+
+    def can_consolidate_data?(notification)
+      return false if notification.notification_type != type
+
+      @data = consolidated_data(notification)
+
+      precondition_blk.nil? || precondition_blk.call(notification.data_hash)
+    end
+
+    def consolidate_or_save!(notification)
+      @data ||= consolidated_data(notification)
+      return unless can_consolidate_data?(notification)
+
+      notifications = user_notifications(notification, type)
+      if previous_query_blk.present?
+        notifications = previous_query_blk.call(notifications, data)
+      end
+
+      Notification.transaction do
+        notifications.destroy_all
+        notification.save!
+      end
+
+      notification
+    end
+
+    private
+
+    attr_reader :type, :data, :precondition_blk, :previous_query_blk
+  end
+end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -986,10 +986,11 @@ class Plugin::Instance
   #
   # The rule object is quite complex. We strongly recommend you write tests to ensure your plugin consolidates notifications correctly.
   #
-  # - Plan's documentation: https://github.com/discourse/discourse/blob/main/app/services/notifications/consolidate_notifications.rb
+  # - Threshold and time window consolidation plan: https://github.com/discourse/discourse/blob/main/app/services/notifications/consolidate_notifications.rb
+  # - Create a new notification and delete previous versions plan: https://github.com/discourse/discourse/blob/main/app/services/notifications/delete_previous_notifications.rb
   # - Base plans: https://github.com/discourse/discourse/blob/main/app/services/notifications/consolidation_planner.rb
   def register_notification_consolidation_plan(plan)
-    raise ArgumentError.new("Not a consolidation plan") if plan.class != Notifications::ConsolidateNotifications
+    raise ArgumentError.new("Not a consolidation plan") if !plan.class.ancestors.include?(Notifications::ConsolidationPlan)
     DiscoursePluginRegistry.register_notification_consolidation_plan(plan, self)
   end
 

--- a/spec/jobs/dashboard_stats_spec.rb
+++ b/spec/jobs/dashboard_stats_spec.rb
@@ -33,23 +33,6 @@ describe ::Jobs::DashboardStats do
     expect(new_topic.title).to eq(old_topic.title)
   end
 
-  it 'consolidates notifications when not tracking admins group' do
-    Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
-    Jobs.run_immediately!
-
-    admin = Fabricate(:admin)
-    Group[:admins].add(admin)
-
-    described_class.new.execute({})
-    clear_recently_sent!
-    new_topic = described_class.new.execute({}).topic
-    notifications = Notification.where(user: admin, notification_type: Notification.types[:private_message])
-
-    expect(notifications.count).to eq(1)
-    from_topic_id = Post.select(:topic_id).find_by(id: notifications.last.data_hash[:original_post_id]).topic_id
-    expect(from_topic_id).to eq(new_topic.id)
-  end
-
   it 'duplicates message if previous one has replies' do
     Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
     expect { described_class.new.execute({}) }.to change { Topic.count }.by(1)


### PR DESCRIPTION
We previously used `ConsolidateNotifications` with a threshold of 1 to re-use an existing notification and bump it to the top instead of creating a new one. It produces some jumpiness in the user notification list, and it relies on updating the `created_at` attribute, which is a bit hacky.

As a better alternative, we're introducing a new plan that deletes all the previous versions of the notification, then creates a new one.

