### PR TITLE
FEATURE: Delete previous reviewable reminders.

### DIFF
--- a/app/services/group_message.rb
+++ b/app/services/group_message.rb
@@ -43,7 +43,7 @@ class GroupMessage
     end
   end
 
-  def delete_previous!
+  def delete_previous!(match_raw: true)
     posts = Post
       .joins(topic: { topic_allowed_groups: :group })
       .where(topic: {
@@ -57,7 +57,10 @@ class GroupMessage
         }
       })
       .where("posts.created_at > ?", RECENT_MESSAGE_PERIOD.ago)
-      .where(raw: I18n.t("system_messages.#{@message_type}.text_body_template", message_params).rstrip)
+
+    if match_raw
+      posts = posts.where(raw: I18n.t("system_messages.#{@message_type}.text_body_template", message_params).rstrip)
+    end
 
     posts.find_each do |post|
       PostDestroyer.new(Discourse.system_user, post).destroy

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2630,14 +2630,6 @@ en:
       one: "User %{username} has %{count} post in a public topic or personal message, so they can't be deleted."
       other: "User %{username} has %{count} posts in public topics or personal messages, so they can't be deleted."
 
-  reviewables_reminder:
-    submitted:
-      one: "Items were submitted over %{count} hour ago. [Please review them](%{base_path}/review)."
-      other: "Items were submitted over %{count} hours ago. [Please review them](%{base_path}/review)."
-    subject_template:
-      one: "%{count} item needs to be reviewed"
-      other: "%{count} items need to be reviewed"
-
   unsubscribe_mailer:
     title: "Unsubscribe Mailer"
     subject_template: "Confirm you no longer want to receive email updates from %{site_title}"
@@ -2829,6 +2821,12 @@ en:
     other: "This topic is temporarily closed for at least %{count} hours due to a large number of community flags."
 
   system_messages:
+    reviewables_reminder:
+      subject_template: "There're items in the review queue that need reviewing"
+      text_body_template:
+        one: "%{mentions} Items were submitted over %{count} hour ago. [Please review them](%{base_path}/review)."
+        other: "%{mentions} Items were submitted over %{count} hours ago. [Please review them](%{base_path}/review)."
+
     private_topic_title: "Topic #%{id}"
     contents_hidden: "Please visit the post to see its contents."
 

--- a/spec/jobs/pending_reviewables_reminder_spec.rb
+++ b/spec/jobs/pending_reviewables_reminder_spec.rb
@@ -74,5 +74,17 @@ describe Jobs::PendingReviewablesReminder do
         expect(execute.sent_reminder).to eq(true)
       end
     end
+
+    it 'deletes previous messages' do
+      GroupMessage.create(
+        Group[:moderators].name, 'reviewables_reminder',
+        { limit_once_per: false, message_params: { mentions: [], count: 1 } }
+      )
+
+      create_flag(49.hours.ago)
+      execute
+
+      expect(Topic.where(title: I18n.t("system_messages.reviewables_reminder.subject_template")).count).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
We send the reminder using the GroupMessage class, which supports removing previous messages. We can't match them by raw because they could mention different moderators. Also, I had to change the subject to remove dynamically generated values, which is necessary for finding them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
