### PR TITLE
UX: Fix topic status icon size in mobile search results

### DIFF
--- a/app/assets/stylesheets/mobile/search.scss
+++ b/app/assets/stylesheets/mobile/search.scss
@@ -21,4 +21,7 @@
 .fps-result {
   padding-left: 0;
   padding-right: 0;
+  .search-link .topic-statuses {
+    font-size: 1.1em;
+  }
 }


### PR DESCRIPTION
**Before**

<img width="363" alt="image" src="https://user-images.githubusercontent.com/368961/145460999-70ab7f2e-685b-4757-8a81-ec3f6a88bc78.png">

**After**

<img width="360" alt="image" src="https://user-images.githubusercontent.com/368961/145460940-07c0f41e-7404-427e-8c00-7236ceedded7.png">
