### PR TITLE
FIX: Defer topic/post created events until emails have been added

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -1275,6 +1275,7 @@ module Email
       # emails, we skip the jobs here and enqueue them only _after_
       # the incoming email has been updated with the post and topic.
       options[:skip_jobs] = true
+      options[:skip_events] = true
       result = NewPostManager.new(user, options).perform
 
       errors = result.errors.full_messages
@@ -1305,6 +1306,8 @@ module Email
                              import_mode: options[:import_mode],
                              post_alert_options: options[:post_alert_options]
                             ).enqueue_jobs
+        DiscourseEvent.trigger(:topic_created, result.post.topic, options, user)
+        DiscourseEvent.trigger(:post_created, result.post, options, user)
       end
 
       result.post


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
