### PR TITLE
UX: Show group card with animated loading state

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/group-card-contents.js
@@ -44,7 +44,7 @@ export default Component.extend(CardContentsBase, CleansUp, {
     this._positionCard($target);
     this.setProperties({ visible: true, loading: true });
 
-    this.store
+    return this.store
       .find("group", username)
       .then((group) => {
         this.setProperties({ group });

--- a/app/assets/javascripts/discourse/app/components/group-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/group-card-contents.js
@@ -41,11 +41,13 @@ export default Component.extend(CardContentsBase, CleansUp, {
   },
 
   _showCallback(username, $target) {
+    this._positionCard($target);
+    this.setProperties({ visible: true, loading: true });
+
     this.store
       .find("group", username)
       .then((group) => {
-        this.setProperties({ group, visible: true });
-        this._positionCard($target);
+        this.setProperties({ group });
         if (!group.flair_url && !group.flair_bg_color) {
           group.set("flair_url", "fa-users");
         }

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -63,7 +63,7 @@ export default Mixin.create({
     }
 
     const closestArticle = target.closest("article");
-    const postId = closestArticle ? closestArticle.dataset.postId : null;
+    const postId = closestArticle?.dataset?.postId || null;
     const wasVisible = this.visible;
     const previousTarget = this.cardTarget;
 
@@ -164,9 +164,9 @@ export default Mixin.create({
     return false;
   },
 
-  _topicHeaderTrigger(username, $target) {
+  _topicHeaderTrigger(username, target) {
     this.setProperties({ isFixed: true, isDocked: true });
-    return this._show(username, $target);
+    return this._show(username, target);
   },
 
   _bindMobileScroll() {

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -4,7 +4,6 @@ import DiscourseURL from "discourse/lib/url";
 import Mixin from "@ember/object/mixin";
 import afterTransition from "discourse/lib/after-transition";
 import { escapeExpression } from "discourse/lib/utilities";
-import headerOutletHeights from "discourse/lib/header-outlet-height";
 import { inject as service } from "@ember/service";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { bind } from "discourse-common/utils/decorators";
@@ -234,22 +233,9 @@ export default Mixin.create({
               }
             }
 
-            const headerOffset = parseInt(
-              getComputedStyle(document.body).getPropertyValue(
-                "--header-offset"
-              ),
-              0
-            );
-            const headerHeight = document
-              .querySelector("header.d-header")
-              .getBoundingClientRect().height;
+            // It looks better to have the card aligned slightly higher
+            position.top -= 24;
 
-            position.top -= this._calculateTopOffset(
-              $("#main-outlet").offset(),
-              headerOutletHeights(),
-              headerOffset,
-              headerHeight
-            );
             if (isFixed) {
               position.top -= $("html").scrollTop();
               //if content is fixed and will be cut off on the bottom, display it above...
@@ -297,20 +283,6 @@ export default Mixin.create({
       }
     });
   },
-
-  // some plugins/themes modify the page layout and may
-  // need to override this calculation for the card to
-  // position correctly
-  /* eslint-disable no-unused-vars */
-  _calculateTopOffset(
-    mainOutletOffset,
-    outletHeights,
-    headerOffset,
-    headerHeight
-  ) {
-    return 24;
-  },
-  /* eslint-enable */
 
   @bind
   _hide() {

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -234,9 +234,21 @@ export default Mixin.create({
               }
             }
 
+            const headerOffset = parseInt(
+              getComputedStyle(document.body).getPropertyValue(
+                "--header-offset"
+              ),
+              0
+            );
+            const headerHeight = document
+              .querySelector("header.d-header")
+              .getBoundingClientRect().height;
+
             position.top -= this._calculateTopOffset(
               $("#main-outlet").offset(),
-              headerOutletHeights()
+              headerOutletHeights(),
+              headerOffset,
+              headerHeight
             );
             if (isFixed) {
               position.top -= $("html").scrollTop();
@@ -289,9 +301,16 @@ export default Mixin.create({
   // some plugins/themes modify the page layout and may
   // need to override this calculation for the card to
   // position correctly
-  _calculateTopOffset(mainOutletOffset, outletHeights) {
-    return mainOutletOffset.top - outletHeights;
+  /* eslint-disable no-unused-vars */
+  _calculateTopOffset(
+    mainOutletOffset,
+    outletHeights,
+    headerOffset,
+    headerHeight
+  ) {
+    return 24;
   },
+  /* eslint-enable */
 
   @bind
   _hide() {

--- a/app/assets/javascripts/discourse/app/templates/components/group-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-card-contents.hbs
@@ -1,69 +1,81 @@
 {{#if visible}}
   <div class="card-content">
-    <div class="card-row first-row">
-      <div class="group-card-avatar">
-        <a href={{groupPath}} {{action "showGroup" group}} class="card-huge-avatar">
-          {{avatar-flair
-            flairName=group.name
-            flairUrl=group.flair_url
-            flairBgColor=group.flair_bg_color
-            flairColor=group.flair_color
-          }}
-        </a>
+    {{#if this.loading}}
+      <div class="card-row first-row">
+        <div class="group-card-avatar">
+          <div class="card-avatar-placeholder animated-placeholder placeholder-animation"></div>
+        </div>
       </div>
-      <div class="names">
-        <span>
-          <h1 class={{group.name}}>
-            <a href={{groupPath}} {{action "showGroup" group}} class="group-page-link">{{group.name}}</a>
-          </h1>
-          {{#if group.full_name}}
-            <h2 class="full-name">{{group.full_name}}</h2>
-          {{else}}
-            <h2 class="username">{{group.name}}</h2>
-          {{/if}}
-        </span>
-      </div>
-      <ul class="usercard-controls group-details-button">
-        <li>
-          {{group-membership-button
-             model=group
-             showLogin=(route-action "showLogin")
-           }}
-        </li>
-        {{#if group.messageable}}
-          <li>
-            {{d-button
-              action=(action "messageGroup")
-              class="btn-primary group-message-button inline"
-              icon="envelope"
-              label="groups.message"
-            }}
-          </li>
-        {{/if}}
-      </ul>
-    </div>
 
-    {{#if this.group.bio_excerpt}}
       <div class="card-row second-row">
-        <div class="bio">
-          {{html-safe this.group.bio_excerpt}}
-        </div>
+        <div class="animated-placeholder placeholder-animation"></div>
       </div>
-    {{/if}}
-
-    {{#if group.members}}
-      <div class="card-row third-row">
-        <div class="members metadata">
-          {{#each group.members as |user|}}
-            <a {{action "close"}} href={{user.path}} class="card-tiny-avatar">{{bound-avatar user "tiny"}}</a>
-          {{/each}}
-          {{#if showMoreMembers}}
-            <a href={{groupPath}} {{action "showGroup" group}} class="more-members-link">
-              <span class="more-members-count">+{{moreMembersCount}} {{i18n "more"}}</span>
-            </a>
+    {{else}}
+      <div class="card-row first-row">
+        <div class="group-card-avatar">
+          <a href={{groupPath}} {{action "showGroup" group}} class="card-huge-avatar">
+            {{avatar-flair
+              flairName=group.name
+              flairUrl=group.flair_url
+              flairBgColor=group.flair_bg_color
+              flairColor=group.flair_color
+            }}
+          </a>
+        </div>
+        <div class="names">
+          <span>
+            <h1 class={{group.name}}>
+              <a href={{groupPath}} {{action "showGroup" group}} class="group-page-link">{{group.name}}</a>
+            </h1>
+            {{#if group.full_name}}
+              <h2 class="full-name">{{group.full_name}}</h2>
+            {{else}}
+              <h2 class="username">{{group.name}}</h2>
+            {{/if}}
+          </span>
+        </div>
+        <ul class="usercard-controls group-details-button">
+          <li>
+            {{group-membership-button
+               model=group
+               showLogin=(route-action "showLogin")
+             }}
+          </li>
+          {{#if group.messageable}}
+            <li>
+              {{d-button
+                action=(action "messageGroup")
+                class="btn-primary group-message-button inline"
+                icon="envelope"
+                label="groups.message"
+              }}
+            </li>
           {{/if}}
-        </div>
+        </ul>
       </div>
+
+      {{#if this.group.bio_excerpt}}
+        <div class="card-row second-row">
+          <div class="bio">
+            {{html-safe this.group.bio_excerpt}}
+          </div>
+        </div>
+      {{/if}}
+
+      {{#if group.members}}
+        <div class="card-row third-row">
+          <div class="members metadata">
+            {{#each group.members as |user|}}
+              <a {{action "close"}} href={{user.path}} class="card-tiny-avatar">{{bound-avatar user "tiny"}}</a>
+            {{/each}}
+            {{#if showMoreMembers}}
+              <a href={{groupPath}} {{action "showGroup" group}} class="more-members-link">
+                <span class="more-members-count">+{{moreMembersCount}} {{i18n "more"}}</span>
+              </a>
+            {{/if}}
+          </div>
+        </div>
+      {{/if}}
     {{/if}}
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
@@ -46,11 +46,10 @@ createWidget("topic-header-participant", {
   },
 
   click(e) {
-    const $target = $(e.target);
     this.appEvents.trigger(
       `topic-header:trigger-${this.attrs.type}-card`,
       this.attrs.username,
-      $target
+      e.target
     );
     e.preventDefault();
   },


### PR DESCRIPTION
Showing the animated loading state before rending the actual content prevents an
awkward scroll position jump when displaying this card.

This mimics the behaviour of the user card (which uses the same `CardContentsBase` mixin).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
