### PR TITLE
DEV: adds missing id to login button on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
@@ -56,6 +56,7 @@
     {{#if canLoginLocal}}
       {{#unless showSecurityKey }}
         {{d-button action=(action "login")
+          id="login-button"
           icon="unlock"
           label=loginButtonLabel
           disabled=loginDisabled


### PR DESCRIPTION
The login button inside the login modal on desktop has an id like so `id="login-button"` 

This id is missing in the mobile template. This PR adds that.  

