### PR TITLE
DEV: Allow emoji picker to disable popper for itself

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -37,6 +37,7 @@ export default Component.extend({
   hoveredEmoji: null,
   isActive: false,
   isLoading: true,
+  usePopper: true,
 
   init() {
     this._super(...arguments);
@@ -91,7 +92,7 @@ export default Component.extend({
       const textareaWrapper = document.querySelector(
         ".d-editor-textarea-wrapper"
       );
-      if (!this.site.isMobileDevice && textareaWrapper) {
+      if (!this.site.isMobileDevice && this.usePopper && textareaWrapper) {
         this._popper = createPopper(textareaWrapper, emojiPicker, {
           placement: "auto",
           modifiers: [


### PR DESCRIPTION
For chat, when the reaction emoji picker is opened when the composer is open, the chat emoji picker is repositioned because of the selector in `emoji-picker`. This allows passing `usePopper: false` in the chat template to allow manual positioning.