### PR TITLE
DEV: Refactor popup-tip component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/popup-input-tip.js
+++ b/app/assets/javascripts/discourse/app/components/popup-input-tip.js
@@ -1,6 +1,7 @@
 import { alias, not } from "@ember/object/computed";
 import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 export default Component.extend({
   classNameBindings: [":popup-tip", "good", "bad", "lastShownAt::hide"],
@@ -16,8 +17,8 @@ export default Component.extend({
   },
 
   click() {
-    this.set("shownAt", null);
-    this.set("validation.lastShownAt", null);
+    const composer = getOwner(this).lookup("controller:composer");
+    composer.clearLastValidatedAt();
   },
 
   bad: alias("validation.failed"),

--- a/app/assets/javascripts/discourse/app/components/popup-input-tip.js
+++ b/app/assets/javascripts/discourse/app/components/popup-input-tip.js
@@ -1,4 +1,4 @@
-import { alias, not } from "@ember/object/computed";
+import { alias, not, or } from "@ember/object/computed";
 import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import { getOwner } from "discourse-common/lib/get-owner";
@@ -8,6 +8,9 @@ export default Component.extend({
   attributeBindings: ["role"],
   rerenderTriggers: ["validation.reason"],
   tipReason: null,
+  lastShownAt: or("shownAt", "validation.lastShownAt"),
+  bad: alias("validation.failed"),
+  good: not("bad"),
 
   @discourseComputed("bad")
   role(bad) {
@@ -17,16 +20,9 @@ export default Component.extend({
   },
 
   click() {
+    this.set("shownAt", null);
     const composer = getOwner(this).lookup("controller:composer");
     composer.clearLastValidatedAt();
-  },
-
-  bad: alias("validation.failed"),
-  good: not("bad"),
-
-  @discourseComputed("shownAt", "validation.lastShownAt")
-  lastShownAt(shownAt, lastShownAt) {
-    return shownAt || lastShownAt;
   },
 
   didReceiveAttrs() {

--- a/app/assets/javascripts/discourse/app/components/popup-input-tip.js
+++ b/app/assets/javascripts/discourse/app/components/popup-input-tip.js
@@ -1,16 +1,11 @@
 import { alias, not } from "@ember/object/computed";
-import discourseComputed, { observes } from "discourse-common/utils/decorators";
+import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
-import { iconHTML } from "discourse-common/lib/icon-library";
 
 export default Component.extend({
   classNameBindings: [":popup-tip", "good", "bad", "lastShownAt::hide"],
   attributeBindings: ["role"],
-  animateAttribute: null,
-  bouncePixels: 6,
-  bounceDelay: 100,
   rerenderTriggers: ["validation.reason"],
-  closeIcon: `${iconHTML("times-circle")}`.htmlSafe(),
   tipReason: null,
 
   @discourseComputed("bad")
@@ -33,21 +28,6 @@ export default Component.extend({
     return shownAt || lastShownAt;
   },
 
-  @observes("lastShownAt")
-  bounce() {
-    if (this.lastShownAt) {
-      let $elem = $(this.element);
-      if (!this.animateAttribute) {
-        this.animateAttribute = $elem.css("left") === "auto" ? "right" : "left";
-      }
-      if (this.animateAttribute === "left") {
-        this.bounceLeft($elem);
-      } else {
-        this.bounceRight($elem);
-      }
-    }
-  },
-
   didReceiveAttrs() {
     this._super(...arguments);
     let reason = this.get("validation.reason");
@@ -55,22 +35,6 @@ export default Component.extend({
       this.set("tipReason", `${reason}`.htmlSafe());
     } else {
       this.set("tipReason", null);
-    }
-  },
-
-  bounceLeft($elem) {
-    for (let i = 0; i < 5; i++) {
-      $elem
-        .animate({ left: "+=" + this.bouncePixels }, this.bounceDelay)
-        .animate({ left: "-=" + this.bouncePixels }, this.bounceDelay);
-    }
-  },
-
-  bounceRight($elem) {
-    for (let i = 0; i < 5; i++) {
-      $elem
-        .animate({ right: "-=" + this.bouncePixels }, this.bounceDelay)
-        .animate({ right: "+=" + this.bouncePixels }, this.bounceDelay);
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1415,4 +1415,8 @@ export default Controller.extend({
   visible(state) {
     return state && state !== "closed";
   },
+
+  clearLastValidatedAt() {
+    this.set("lastValidatedAt", null);
+  },
 });

--- a/app/assets/javascripts/discourse/app/templates/components/popup-input-tip.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/popup-input-tip.hbs
@@ -1,1 +1,1 @@
-<span class="close">{{closeIcon}}</span>{{tipReason}}
+{{tipReason}} {{d-icon "times-circle"}}

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -307,10 +307,6 @@
     z-index: z("composer", "dropdown");
   }
 
-  .popup-tip {
-    z-index: z("composer", "dropdown") + 1;
-  }
-
   .wmd-controls {
     position: relative;
     display: flex;

--- a/app/assets/stylesheets/common/input_tip.scss
+++ b/app/assets/stylesheets/common/input_tip.scss
@@ -11,10 +11,9 @@
 }
 
 .popup-tip {
+  @include form-item-sizing;
   position: absolute;
-  display: block;
-  padding: 0.5em;
-  z-index: z("tooltip");
+  z-index: z("composer", "dropdown") + 1;
   cursor: pointer;
   animation: 0.15s slidein 3;
 

--- a/app/assets/stylesheets/common/input_tip.scss
+++ b/app/assets/stylesheets/common/input_tip.scss
@@ -16,9 +16,7 @@
   padding: 0.5em;
   z-index: z("tooltip");
   cursor: pointer;
-  animation-duration: 0.15s;
-  animation-name: slidein;
-  animation-iteration-count: 3;
+  animation: 0.15s slidein 3;
 
   &.bad {
     background: var(--danger-medium);

--- a/app/assets/stylesheets/common/input_tip.scss
+++ b/app/assets/stylesheets/common/input_tip.scss
@@ -1,8 +1,25 @@
+@keyframes slidein {
+  0% {
+    transform: translateX(0px);
+  }
+  50% {
+    transform: translateX(5px);
+  }
+  100% {
+    transform: translateX(0px);
+  }
+}
+
 .popup-tip {
   position: absolute;
   display: block;
-  padding: 5px 10px;
+  padding: 0.5em;
   z-index: z("tooltip");
+  cursor: pointer;
+  animation-duration: 0.15s;
+  animation-name: slidein;
+  animation-iteration-count: 3;
+
   &.bad {
     background: var(--danger-medium);
     color: white;
@@ -12,15 +29,12 @@
   &.good {
     display: none;
   }
-  .close {
-    float: right;
+  .d-icon {
     color: var(--primary);
     opacity: 0.5;
-    font-size: $font-0;
-    margin: 0 0 0 4px;
-    cursor: pointer;
-  }
-  .close:hover {
-    opacity: 1;
+    font-size: var(--font-0);
+    &:hover {
+      opacity: 1;
+    }
   }
 }


### PR DESCRIPTION
Replaces jQuery animation with CSS.

And resets the validation in the composer controller when closing a popup tip, which translates into less aggressive messaging. For example, previously if you had multiple popup tips, you had to click each one to clear it, now the first click clears all of them. 