### PR TITLE
FIX: Allow OAuth2Authenticator to handle existing associations

### DIFF
--- a/lib/auth/oauth2_authenticator.rb
+++ b/lib/auth/oauth2_authenticator.rb
@@ -45,13 +45,10 @@ class Auth::OAuth2Authenticator < Auth::Authenticator
 
   def after_create_account(user, auth)
     data = auth[:extra_data]
-    Oauth2UserInfo.create(
-      uid: data[:uid],
-      provider: data[:provider],
-      name: auth[:name],
-      email: auth[:email],
-      user_id: user.id
-    )
+    association = Oauth2UserInfo.find_or_initialize_by(provider: data[:provider], uid: data[:uid])
+    association.user = user
+    association.email = auth[:email]
+    association.save!
   end
 
   def description_for_user(user)


### PR DESCRIPTION
OAuth2Authenticator is considered deprecated, and isn't used in core. However, some plugins still depend on it, and this was breaking the signup of previously-staged users. There is no easy way to make an end-end test of this in core, but I will be adding an integration test in the SAML plugin.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
