### PR TITLE
DEV: add comments that Discourse SSO was renamed to DiscourseConnect

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# This class is a part of DiscourseConnect.
+# We renamed Discourse Single Sign On to DiscourseConnect in the documentation and
+# the site settings but this class still have the old name
+# see https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045
 class DiscourseSingleSignOn < SingleSignOn
 
   class BlankExternalId < StandardError; end

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# This class is a part of DiscourseConnect.
+# We renamed Discourse Single Sign On to DiscourseConnect in the documentation and
+# the site settings but this class still have the old name
+# see https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045
 class SingleSignOn
 
   class ParseError < RuntimeError; end

--- a/lib/single_sign_on_provider.rb
+++ b/lib/single_sign_on_provider.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# This class is a part of DiscourseConnect.
+# We renamed Discourse Single Sign On to DiscourseConnect in the documentation and
+# the site settings but this class still have the old name
+# see https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045
 class SingleSignOnProvider < SingleSignOn
   class BlankSecret < RuntimeError; end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
