### PR TITLE
DEV: allow nulls in email_tokens token column

### DIFF
--- a/db/migrate/20211213060445_email_tokens_token_to_nullable.rb
+++ b/db/migrate/20211213060445_email_tokens_token_to_nullable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class EmailTokensTokenToNullable < ActiveRecord::Migration[6.1]
+  def up
+    # ensure column is nullable in case any inserts happen
+    # prior to post migrations
+    #
+    # using this somewhat verbose pattern to avoid impacting people who
+    # drifted on main
+    begin
+      Migration::SafeMigrate.disable!
+      if DB.query_single(<<~SQL).length > 0
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE table_name = 'email_tokens' AND column_name = 'token'
+      SQL
+        execute <<~SQL
+          ALTER TABLE email_tokens ALTER COLUMN token DROP NOT NULL
+        SQL
+      end
+    ensure
+      Migration::SafeMigrate.enable!
+    end
+  end
+
+  def down
+    # do nothing, does not matter
+  end
+end


### PR DESCRIPTION
This column was dropped in a previous commit, in post migrations.
Unfortunatly that causes smoke tests to fail as there is a period between
migration and post migrations where records can not be inserted into the
table.
