### PR TITLE
FIX: Ensure theme names are escaped in HTML attributes

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -195,7 +195,7 @@ class Stylesheet::Manager
       theme_id = stylesheet[:theme_id]
       data_theme_id = theme_id ? "data-theme-id=\"#{theme_id}\"" : ""
       theme_name = stylesheet[:theme_name]
-      data_theme_name = theme_name ? "data-theme-name=\"#{theme_name}\"" : ""
+      data_theme_name = theme_name ? "data-theme-name=\"#{CGI.escapeHTML(theme_name)}\"" : ""
       %[<link href="#{href}" media="#{media}" rel="stylesheet" data-target="#{target}" #{data_theme_id} #{data_theme_name}/>]
     end.join("\n").html_safe
   end

--- a/spec/components/stylesheet/manager_spec.rb
+++ b/spec/components/stylesheet/manager_spec.rb
@@ -135,6 +135,20 @@ describe Stylesheet::Manager do
       )
     end
 
+    it "includes the escaped theme name" do
+      manager = manager(theme.id)
+
+      theme.update(name: "a strange name\"with a quote in it")
+
+      tag = manager.stylesheet_link_tag(:desktop_theme)
+      expect(tag).to have_tag("link", with: {
+        "data-theme-name" => theme.name.downcase
+      })
+      expect(tag).to have_tag("link", with: {
+        "data-theme-name" => child_theme.name.downcase
+      })
+    end
+
     context "stylesheet order" do
       let(:z_child_theme) do
         Fabricate(:theme, component: true, name: "ze component").tap do |z|


### PR DESCRIPTION
If a theme name contained a double-quote, this problem could lead to invalid/unexpected HTML in the `<head>`

Note that this is not considered a security issue because themes can only be installed/named by administrators, and themes/administrators already have the ability to run arbitrary javascript.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
