### PR TITLE
DEV: Drop env-based SiteSetting deprecation errors

### DIFF
--- a/lib/site_settings/yaml_loader.rb
+++ b/lib/site_settings/yaml_loader.rb
@@ -15,14 +15,8 @@ class SiteSettings::YamlLoader
           # Get default value for the site setting:
           value = hash.delete('default')
 
-          if value.is_a?(Hash)
-            raise Discourse::Deprecation, "The site setting `#{setting_name}` can no longer be set based on Rails environment. See also `config/environments/<env>.rb`."
-          elsif value.nil?
+          if value.nil?
             raise StandardError, "The site setting `#{setting_name}` in '#{@file}' is missing default value."
-          end
-
-          if hash['hidden']&.is_a?(Hash)
-            raise Discourse::Deprecation, "The site setting `#{setting_name}`'s hidden property can no longer be set based on Rails environment. It can only be either `true` or `false`."
           end
 
           yield category, setting_name, value, hash.deep_symbolize_keys!

--- a/spec/components/site_settings/yaml_loader_spec.rb
+++ b/spec/components/site_settings/yaml_loader_spec.rb
@@ -72,14 +72,6 @@ describe SiteSettings::YamlLoader do
     receiver.load_yaml(enum_client)
   end
 
-  it "raises deprecation when load settings based on environment" do
-    expect { receiver.load_yaml(deprecated_env) }.to raise_error(Discourse::Deprecation)
-  end
-
-  it "raises deprecation when hidden property is based on environment" do
-    expect { receiver.load_yaml(deprecated_hidden) }.to raise_error(Discourse::Deprecation)
-  end
-
   it "raises invalid parameter when default value is not present" do
     expect { receiver.load_yaml(nil_default) }.to raise_error(StandardError)
   end


### PR DESCRIPTION
These were deprecated ~4 years ago. No need to keep the errors anymore.