### PR TITLE
FIX: Correct email_tokens_token_to_nullable migration

### DIFF
--- a/db/migrate/20211213060445_email_tokens_token_to_nullable.rb
+++ b/db/migrate/20211213060445_email_tokens_token_to_nullable.rb
@@ -11,7 +11,9 @@ class EmailTokensTokenToNullable < ActiveRecord::Migration[6.1]
       Migration::SafeMigrate.disable!
       if DB.query_single(<<~SQL).length > 0
         SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE table_name = 'email_tokens' AND column_name = 'token'
+        WHERE table_schema='public'
+        AND table_name = 'email_tokens'
+        AND column_name = 'token'
       SQL
         execute <<~SQL
           ALTER TABLE email_tokens ALTER COLUMN token DROP NOT NULL


### PR DESCRIPTION
We were checking for the existence of the column in any schema, including the `backup` schema. This can cause 'column does not exist' errors. In fact, we should only be checking in the `public` schema.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
