### PR TITLE
DEV: Cache database in GitHub actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       PGHOST: postgres
       PGUSER: discourse
       PGPASSWORD: discourse
+      USES_PARALLEL_DATABASES: ${{ matrix.build_type=='backend' && matrix.target=='core' }}
 
     strategy:
       fail-fast: false
@@ -109,11 +110,10 @@ jobs:
           path: tmp/app-cache
           key: >- # postgres version, hash of migrations, "parallel?"
             ${{ runner.os }}-
-            ${{ hashFiles('.github/workflows/*') }}-
+            ${{ hashFiles('.github/workflows/tests.yml') }}-
             ${{ matrix.postgres }}-
-            ${{ hashFiles('db/**/*') }}-
-            ${{ hashFiles('plugins/**/db/**/*') }}-
-            ${{ matrix.build_type=='backend' && matrix.target=='core' }}
+            ${{ hashFiles('db/**/*', 'plugins/**/db/**/*') }}-
+            ${{ env.USES_PARALLEL_DATABASES }}
 
       - name: Restore database from cache
         if: steps.app-cache.outputs.cache-hit == 'true'
@@ -131,8 +131,7 @@ jobs:
 
       - name: Create and migrate parallel databases
         if: >-
-          matrix.build_type == 'backend' &&
-          matrix.target == 'core' &&
+          env.USES_PARALLEL_DATABASES == 'true' &&
           steps.app-cache.outputs.cache-hit != 'true'
         run: |
           bin/rake parallel:create

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       PGHOST: postgres
       PGUSER: discourse
       PGPASSWORD: discourse
-      USES_PARALLEL_DATABASES: ${{ matrix.build_type=='backend' && matrix.target=='core' }}
+      USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' && matrix.target == 'core' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,16 +102,49 @@ jobs:
         if: matrix.target == 'plugins'
         run: bin/rake plugin:install_all_official
 
-      - name: Create database
+      - name: Fetch app state cache
+        uses: actions/cache@v2
+        id: app-cache
+        with:
+          path: tmp/app-cache
+          key: >- # postgres version, hash of migrations, "parallel?"
+            ${{ runner.os }}-
+            ${{ hashFiles('.github/workflows/*') }}-
+            ${{ matrix.postgres }}-
+            ${{ hashFiles('db/**/*') }}-
+            ${{ hashFiles('plugins/**/db/**/*') }}-
+            ${{ matrix.build_type=='backend' && matrix.target=='core' }}
+
+      - name: Restore database from cache
+        if: steps.app-cache.outputs.cache-hit == 'true'
+        run: psql -f tmp/app-cache/cache.sql postgres
+
+      - name: Restore uploads from cache
+        if: steps.app-cache.outputs.cache-hit == 'true'
+        run: rm -rf public/uploads && cp -r tmp/app-cache/uploads public/uploads
+
+      - name: Create and migrate database
+        if: steps.app-cache.outputs.cache-hit != 'true'
         run: |
           bin/rake db:create
           bin/rake db:migrate
 
-      - name: Create parallel databases
-        if: matrix.build_type == 'backend' && matrix.target == 'core'
+      - name: Create and migrate parallel databases
+        if: >-
+          matrix.build_type == 'backend' &&
+          matrix.target == 'core' &&
+          steps.app-cache.outputs.cache-hit != 'true'
         run: |
           bin/rake parallel:create
           bin/rake parallel:migrate
+
+      - name: Dump database for cache
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        run: mkdir -p tmp/app-cache && pg_dumpall > tmp/app-cache/cache.sql
+
+      - name: Dump uploads for cache
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        run: rm -rf tmp/app-cache/uploads && cp -r public/uploads tmp/app-cache/uploads
 
       - name: Core RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'core'


### PR DESCRIPTION
A cached database (and its uploads) will only be used if the current run has **exactly** the same set of migration files. Otherwise, the database will be migrated from scratch

This saves approximately 75s on the core backend specs and 45s on other runs.