### PR TITLE
DEV: Plugin API to add desktop notification handlers

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
+++ b/app/assets/javascripts/discourse/app/lib/desktop-notifications.js
@@ -19,6 +19,14 @@ const idleThresholdTime = 1000 * 10; // 10 seconds
 const context = "discourse_desktop_notifications_";
 const keyValueStore = new KeyValueStore(context);
 
+let desktopNotificationHandlers = [];
+export function registerDesktopNotificationHandler(handler) {
+  desktopNotificationHandlers.push(handler);
+}
+export function clearDesktopNotificationHandlers() {
+  desktopNotificationHandlers = [];
+}
+
 // Called from an initializer
 function init(messageBus, appEvents) {
   liveEnabled = false;
@@ -176,11 +184,14 @@ function onNotification(data, siteSettings, user) {
       icon: notificationIcon,
       tag: notificationTag,
     });
-
     notification.onclick = () => {
       DiscourseURL.routeTo(data.post_url);
       notification.close();
     };
+
+    desktopNotificationHandlers.forEach((handler) =>
+      handler(data, siteSettings, user)
+    );
   });
 }
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -81,6 +81,7 @@ import { registerCustomPostMessageCallback as registerCustomPostMessageCallback1
 import { registerHighlightJSLanguage } from "discourse/lib/highlight-syntax";
 import { registerTopicFooterButton } from "discourse/lib/register-topic-footer-button";
 import { registerTopicFooterDropdown } from "discourse/lib/register-topic-footer-dropdown";
+import { registerDesktopNotificationHandler } from "discourse/lib/desktop-notifications";
 import { replaceFormatter } from "discourse/lib/utilities";
 import { replaceTagRenderer } from "discourse/lib/render-tag";
 import { setNewCategoryDefaultColors } from "discourse/routes/new-category";
@@ -773,6 +774,19 @@ class PluginApi {
    **/
   registerTopicFooterDropdown(dropdownOptions) {
     registerTopicFooterDropdown(dropdownOptions);
+  }
+
+  /**
+   * Register a desktop notificaiton handler
+   *
+   * ```javascript
+   * api.registerDesktopNotificationHandler((data, siteSettings, user) => {
+   *   // Do something!
+   * });
+   * ```
+   **/
+  registerDesktopNotificationHandler(handler) {
+    registerDesktopNotificationHandler(handler);
   }
 
   /**

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -53,6 +53,7 @@ import { resetLastEditNotificationClick } from "discourse/models/post-stream";
 import { clearAuthMethods } from "discourse/models/login-method";
 import { clearTopicFooterDropdowns } from "discourse/lib/register-topic-footer-dropdown";
 import { clearTopicFooterButtons } from "discourse/lib/register-topic-footer-button";
+import { clearDesktopNotificationHandlers } from "discourse/lib/desktop-notifications";
 import {
   clearPresenceCallbacks,
   setTestPresence,
@@ -297,6 +298,7 @@ export function acceptance(name, optionsOrCallback) {
       cleanUpComposerUploadPreProcessor();
       clearTopicFooterDropdowns();
       clearTopicFooterButtons();
+      clearDesktopNotificationHandlers();
       resetLastEditNotificationClick();
       clearAuthMethods();
       setTestPresence(true);


### PR DESCRIPTION
This will be used by chat to hook into desktop notifications and play a sound if the notification_type is for chat, and the user has a chat sound enabled.