### PR TITLE
DEV: Use slim container for backend tests in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: ${{ matrix.target }} ${{ matrix.build_type }}
     runs-on: ubuntu-latest
-    container: discourse/discourse_test:release
+    container: ${{ (matrix.build_type == 'frontend' && 'discourse/discourse_test:release' || 'discourse/base:slim') }}
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
This shaves about 1 minute off our backend test workflows. The slim image skips bundler/yarn dependencies, and doesn't ship Firefox/Chrome.