### PR TITLE
DEV: Use discourse image for postgres in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ jobs:
       RAILS_ENV: test
       PGUSER: discourse
       PGPASSWORD: discourse
-      PG_MAJOR: 13
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' && matrix.target == 'core' }}
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,11 +54,7 @@ jobs:
       - name: Start Postgres
         run: |
           chown -R postgres /var/run/postgresql
-          sudo -u postgres /usr/lib/postgresql/${{ matrix.postgres }}/bin/initdb -D /tmp/test_data/pg
-          echo fsync = off >> /tmp/test_data/pg/postgresql.conf
-          echo full_page_writes = off >> /tmp/test_data/pg/postgresql.conf
-          echo shared_buffers = 500MB >> /tmp/test_data/pg/postgresql.conf
-          sudo -u postgres /usr/lib/postgresql/13/bin/pg_ctl -D /tmp/test_data/pg start
+          sudo -u postgres script/start_test_db.rb
           sudo -u postgres /usr/lib/postgresql/13/bin/createuser -s $PGUSER
           sudo -u postgres psql -c "ALTER USER $PGUSER PASSWORD '$PGPASSWORD'"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Start Postgres
         run: |
           chown -R postgres /var/run/postgresql
-          sudo -u postgres script/start_test_db.rb
+          sudo -E -u postgres script/start_test_db.rb
           sudo -u postgres /usr/lib/postgresql/13/bin/createuser -s $PGUSER
           sudo -u postgres psql -c "ALTER USER $PGUSER PASSWORD '$PGPASSWORD'"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
     name: ${{ matrix.target }} ${{ matrix.build_type }}
     runs-on: ubuntu-latest
     container: ${{ (matrix.build_type == 'frontend' && 'discourse/discourse_test:release' || 'discourse/base:slim') }}
-      
     timeout-minutes: 60
 
     env:
@@ -32,7 +31,6 @@ jobs:
       matrix:
         build_type: [backend, frontend, annotations]
         target: [core, plugins]
-        postgres: ["13"]
         exclude:
           - build_type: annotations
             target: plugins
@@ -55,8 +53,7 @@ jobs:
         run: |
           chown -R postgres /var/run/postgresql
           sudo -E -u postgres script/start_test_db.rb
-          sudo -u postgres /usr/lib/postgresql/13/bin/createuser -s $PGUSER
-          sudo -u postgres psql -c "ALTER USER $PGUSER PASSWORD '$PGPASSWORD'"
+          sudo -u postgres psql -c "CREATE ROLE $PGUSER LOGIN SUPERUSER PASSWORD '$PGPASSWORD';"
 
       - name: Bundler cache
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       RAILS_ENV: test
       PGUSER: discourse
       PGPASSWORD: discourse
+      PG_MAJOR: 13
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' && matrix.target == 'core' }}
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,13 @@ jobs:
     name: ${{ matrix.target }} ${{ matrix.build_type }}
     runs-on: ubuntu-latest
     container: ${{ (matrix.build_type == 'frontend' && 'discourse/discourse_test:release' || 'discourse/base:slim') }}
+      
     timeout-minutes: 60
 
     env:
       DISCOURSE_HOSTNAME: www.example.com
       RUBY_GLOBAL_METHOD_CACHE_SIZE: 131072
       RAILS_ENV: test
-      PGHOST: postgres
       PGUSER: discourse
       PGPASSWORD: discourse
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' && matrix.target == 'core' }}
@@ -37,22 +37,6 @@ jobs:
           - build_type: annotations
             target: plugins
 
-    services:
-      postgres:
-        image: postgres:${{ matrix.postgres }}
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: discourse
-          POSTGRES_PASSWORD: discourse
-          POSTGRES_DB: discourse_test
-        options: >-
-          --mount type=tmpfs,destination=/var/lib/postgresql/data
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - uses: actions/checkout@master
         with:
@@ -66,6 +50,17 @@ jobs:
       - name: Start redis
         run: |
           redis-server /etc/redis/redis.conf &
+
+      - name: Start Postgres
+        run: |
+          chown -R postgres /var/run/postgresql
+          sudo -u postgres /usr/lib/postgresql/${{ matrix.postgres }}/bin/initdb -D /tmp/test_data/pg
+          echo fsync = off >> /tmp/test_data/pg/postgresql.conf
+          echo full_page_writes = off >> /tmp/test_data/pg/postgresql.conf
+          echo shared_buffers = 500MB >> /tmp/test_data/pg/postgresql.conf
+          sudo -u postgres /usr/lib/postgresql/13/bin/pg_ctl -D /tmp/test_data/pg start
+          sudo -u postgres /usr/lib/postgresql/13/bin/createuser -s $PGUSER
+          sudo -u postgres psql -c "ALTER USER $PGUSER PASSWORD '$PGPASSWORD'"
 
       - name: Bundler cache
         uses: actions/cache@v2

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -102,16 +102,8 @@ task 'docker:test' do
       puts "Starting background redis"
       @redis_pid = Process.spawn('redis-server --dir tmp/test_data/redis')
 
-      @postgres_bin = "/usr/lib/postgresql/#{ENV['PG_MAJOR']}/bin/"
-      `#{@postgres_bin}initdb -D tmp/test_data/pg`
-
-      # speed up db, never do this in production mmmmk
-      `echo fsync = off >> tmp/test_data/pg/postgresql.conf`
-      `echo full_page_writes = off >> tmp/test_data/pg/postgresql.conf`
-      `echo shared_buffers = 500MB >> tmp/test_data/pg/postgresql.conf`
-
       puts "Starting postgres"
-      @pg_pid = Process.spawn("#{@postgres_bin}postmaster -D tmp/test_data/pg")
+      @pg_pid = Process.spawn("script/start_test_db.rb --exec")
 
       ENV["RAILS_ENV"] = "test"
       # this shaves all the creation of the multisite db off

--- a/script/start_test_db.rb
+++ b/script/start_test_db.rb
@@ -1,10 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'optparse'
-
 BIN = "/usr/lib/postgresql/#{ENV["PG_MAJOR"]}/bin"
-DATA = "tmp/test_data/pg"
+DATA = "/tmp/test_data/pg"
 
 def run(*args)
   system(*args, exception: true)

--- a/script/start_test_db.rb
+++ b/script/start_test_db.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+
+BIN = "/usr/lib/postgresql/#{ENV["PG_MAJOR"]}/bin"
+DATA = "tmp/test_data/pg"
+
+def run(*args)
+  system(*args, exception: true)
+end
+
+should_exec = false
+while a = ARGV.pop
+  if a == "--exec"
+    should_exec = true
+  else
+    raise "Unknown argument #{a}"
+  end
+end
+
+run "#{BIN}/initdb -D #{DATA}"
+
+run "echo fsync = off >> #{DATA}/postgresql.conf"
+run "echo full_page_writes = off >> #{DATA}/postgresql.conf"
+run "echo shared_buffers = 500MB >> #{DATA}/postgresql.conf"
+
+if should_exec
+  exec "#{BIN}/postmaster -D #{DATA}"
+else
+  run "#{BIN}/pg_ctl -D #{DATA} start"
+end


### PR DESCRIPTION
The discourse base image already contains a postgres installation, so pulling a separate `postgres` image is a little wasteful. This change saves about 20 seconds on every GitHub actions run.

This commit also sets a few Postgres flags to improve test performance. We use these flags in our `rake docker:test` task already (i.e. our internal CI system).