### PR TITLE
UX: Extend user hyperlink in staff action logs

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/logs/staff-action-logs.hbs
+++ b/app/assets/javascripts/admin/addon/templates/logs/staff-action-logs.hbs
@@ -62,8 +62,10 @@
               <td class="staff-users">
                 <div class="staff-user">
                   {{#if item.acting_user}}
-                    {{#link-to "adminUser" item.acting_user}}{{avatar item.acting_user imageSize="tiny"}}{{/link-to}}
-                    <a href {{action "filterByStaffUser" item.acting_user}}>{{item.acting_user.username}}</a>
+                    {{#link-to "adminUser" item.acting_user}}
+                      {{avatar item.acting_user imageSize="tiny"}}
+                      {{item.acting_user.username}}
+                    {{/link-to}}
                   {{else}}
                     <span class="deleted-user" title={{i18n "admin.user.deleted"}}>
                       {{d-icon "far-trash-alt"}}


### PR DESCRIPTION
The avatar hyperlink redirected to admin user page and the username
hyperlink applied a filter. Now both hyperlinks redirect to admin user
page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
