### PR TITLE
DEV: Update GitHub workflows to use slim discourse_test images

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: run
     runs-on: ubuntu-latest
-    container: discourse/discourse_test:release
+    container: discourse/discourse_test:slim-browsers
     timeout-minutes: 60
 
     strategy:

--- a/.github/workflows/ember_with_plugins.yml
+++ b/.github/workflows/ember_with_plugins.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: run
     runs-on: ubuntu-latest
-    container: discourse/discourse_test:release
+    container: discourse/discourse_test:slim-browsers
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: run
     runs-on: ubuntu-latest
-    container: discourse/discourse_test:release
+    container: discourse/discourse_test:slim
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: ${{ matrix.target }} ${{ matrix.build_type }}
     runs-on: ubuntu-latest
-    container: ${{ (matrix.build_type == 'frontend' && 'discourse/discourse_test:release' || 'discourse/base:slim') }}
+    container: discourse/discourse_test:slim${{ matrix.build_type == 'frontend' && '-browsers' || '' }}
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
These images save abour 30-40s per run, compared to the full `discourse_test:release` images