### PR TITLE
UX: prevent timeline overflow in extreme cases

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -148,6 +148,9 @@
           padding-right: 1.5em;
           justify-content: flex-end;
           .timeline-scroller-content {
+            box-sizing: border-box;
+            max-width: 100%;
+            overflow: hidden;
             text-align: right;
             padding-left: 0;
             padding-right: 1em;
@@ -233,6 +236,9 @@
     }
 
     .timeline-scroller-content {
+      box-sizing: border-box;
+      max-width: 100%;
+      overflow: hidden;
       padding-left: 1em;
       position: absolute; // prevents text length from impacting width
     }
@@ -257,6 +263,8 @@
     }
 
     .timeline-replies {
+      overflow: hidden;
+      overflow-wrap: break-word;
       font-weight: bold;
     }
 


### PR DESCRIPTION
This prevents overflow due to wide timeline content in cases of a long translation or due to large counts in megatopics (note the missing timeline handle in the screenshot below). 

![Screen Shot 2021-12-14 at 5 51 23 PM](https://user-images.githubusercontent.com/1681963/146092278-d4c34ed8-fd2e-47a3-bc76-d508a6af9fca.png)

