### PR TITLE
Revert "A11Y: Focus last viewed topic in topic lists (#15300)"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -245,16 +245,12 @@ export default Component.extend({
         return;
       }
 
-      this.element.classList.add("highlighted");
-      this.element.setAttribute(
-        "data-islastviewedtopic",
-        opts.isLastViewedTopic
-      );
-      this.element.querySelector(".main-link .title").focus();
+      const $topic = $(this.element);
+      $topic
+        .addClass("highlighted")
+        .attr("data-islastviewedtopic", opts.isLastViewedTopic);
 
-      this.element.addEventListener("animationend", () => {
-        this.element.classList.remove("highlighted");
-      });
+      $topic.on("animationend", () => $topic.removeClass("highlighted"));
     });
   },
 


### PR DESCRIPTION
This reverts commit 76aeee6735ea06302dd9c09cf2bd2ce0e01e827e.

Sadly this breaks on non-screen readers on Chrome and Safari
