### PR TITLE
UX: let mobile post controls scroll on overflow

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -37,7 +37,11 @@ span.badge-posts {
     }
     .actions {
       display: flex;
-      justify-content: flex-end;
+      // using an auto margin on first-child instead of justify-content on the parent
+      // because justify-content breaks overflow scrolling
+      :first-child {
+        margin-left: auto;
+      }
 
       // Handles the like and flag buttons in the post menu.
       .double-button {


### PR DESCRIPTION
In extreme cases with lots of buttons the post controls on mobile should scroll horizontally; this regressed at some point. This fixes it and leaves a note. 