### PR TITLE
FIX: Add more actions to the uploads API key scope

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -36,7 +36,17 @@ class ApiKeyScope < ActiveRecord::Base
           edit: { actions: %w[posts#update], params: %i[id] }
         },
         uploads: {
-          create: { actions: %w[uploads#create] }
+          create: {
+            actions: %w[
+              uploads#create
+              uploads#generate_presigned_put
+              uploads#complete_external_upload
+              uploads#create_multipart
+              uploads#batch_presign_multipart_parts
+              uploads#abort_multipart
+              uploads#complete_multipart
+            ]
+          }
         },
         users: {
           bookmarks: { actions: %w[users#bookmarks], params: %i[username] },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4210,7 +4210,7 @@ en:
             posts:
               edit: Edit any post or a specific one.
             uploads:
-              create: Upload a new file.
+              create: Upload a new file or initiate single or multipart direct uploads to external storage.
             users:
               bookmarks: List user bookmarks. It returns bookmark reminders when using the ICS format.
               sync_sso: Synchronize a user using DiscourseConnect.


### PR DESCRIPTION
The uploads API key create scope did not cover the
external upload API endpoints, or the direct S3
multipart endpoints, and this commit adds them.

cf. https://meta.discourse.org/t/upload-create-api-key-insufficient/211896
