### PR TITLE
UX: allow themes to easily change in the lock icon in category-boxes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.js
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes-with-topics.js
@@ -10,6 +10,7 @@ export default Component.extend({
     "anyLogos:with-logos:no-logos",
   ],
   noCategoryStyle: equal("siteSettings.category_style", "none"),
+  lockIcon: "lock",
 
   @discourseComputed("categories.[].uploaded_logo.url")
   anyLogos() {

--- a/app/assets/javascripts/discourse/app/components/categories-boxes.js
+++ b/app/assets/javascripts/discourse/app/components/categories-boxes.js
@@ -11,6 +11,7 @@ export default Component.extend({
     "hasSubcategories:with-subcategories",
   ],
   noCategoryStyle: equal("siteSettings.category_style", "none"),
+  lockIcon: "lock",
 
   @discourseComputed("categories.[].uploaded_logo.url")
   anyLogos() {

--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
@@ -17,7 +17,7 @@
           <h3>
             {{category-title-before category=c}}
             {{#if c.read_restricted}}
-              {{d-icon "lock"}}
+              {{d-icon lockIcon}}
             {{/if}}
             {{c.name}}
           </h3>

--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
@@ -20,7 +20,7 @@
             <h3>
               {{category-title-before category=c}}
               {{#if c.read_restricted}}
-                {{d-icon "lock"}}
+                {{d-icon lockIcon}}
               {{/if}}
               {{c.name}}
             </h3>


### PR DESCRIPTION
Context: https://meta.discourse.org/t/unable-to-alter-the-lock-icon-in-category-boxes/212133

Instead of hardcoding the category lock icon, set it as a property that themes can override. This means that themes can avoid full template overrides. 

The category title link already does that here.

https://github.com/discourse/discourse/blob/1472e47aae5bfdfb6fd9abfe89beb186c751f514/app/assets/javascripts/discourse/app/components/category-title-link.js#L5

https://github.com/discourse/discourse/blob/70eca1dc4e04e94eb326482b51ea2617656fa8a8/app/assets/javascripts/discourse/app/templates/components/category-title-link.hbs#L5

This PR makes it so the `categories-boxes` and `categories-boxes-with-topics` also do the same.
