### PR TITLE
FEATURE: Extend plugin API to add multiple poster icons

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -383,7 +383,7 @@ class PluginApi {
    * or
    * * ```
    * api.addPosterIcons((cfs, attrs) => {
-   *   attrs.customers.forEach(({name}) => {
+   *   return attrs.customers.map(({name}) => {
    *     icon: 'user', className: 'customer', title: name
    *   })
    * });

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -96,7 +96,7 @@ import { downloadCalendar } from "discourse/lib/download-calendar";
 // based on Semantic Versioning 2.0.0. Please up the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-const PLUGIN_API_VERSION = "1.0.0";
+const PLUGIN_API_VERSION = "1.1.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -329,6 +329,9 @@ class PluginApi {
 
   /**
    * addPosterIcon(callback)
+   *
+   * This function is an alias of addPosterIcons, which the latter has the ability
+   * to add multiple icons at once.
    *
    * This function can be used to add an icon with a link that will be displayed
    * beside a poster's name. The `callback` is called with the post's user custom

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -331,29 +331,7 @@ class PluginApi {
    * addPosterIcon(callback)
    *
    * This function is an alias of addPosterIcons, which the latter has the ability
-   * to add multiple icons at once.
-   *
-   * This function can be used to add an icon with a link that will be displayed
-   * beside a poster's name. The `callback` is called with the post's user custom
-   * fields and post attributes. An icon will be rendered if the callback returns
-   * an object with the appropriate attributes.
-   *
-   * The returned object can have the following attributes:
-   *
-   *   icon        the font awesome icon to render
-   *   emoji       an emoji icon to render
-   *   className   (optional) a css class to apply to the icon
-   *   url         (optional) where to link the icon
-   *   title       (optional) the tooltip title for the icon on hover
-   *   text        (optional) text to display alongside the emoji or icon
-   *
-   * ```
-   * api.addPosterIcon((cfs, attrs) => {
-   *   if (cfs.customer) {
-   *     return { icon: 'user', className: 'customer', title: 'customer' };
-   *   }
-   * });
-   * ```
+   * to add multiple icons at once. Please refer to `addPosterIcons` for usage examples.
    **/
   addPosterIcon(cb) {
     this.addPosterIcons(cb);

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,13 @@ in this file..
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2021-12-15
+### Added
+- Adds `addPosterIcons`, which allows users to add multiple icons to a poster. The
+addition of this function also makes the existing `addPosterIcon` now an alias to this
+function. Users may now just use `addPosterIcons` for both one or many icons. This
+function allows users to now return many icons depending on an `attrs`.
+
 ## [1.0.0] - 2021-11-25
 ### Removed
 - Removes the `addComposerUploadProcessor` function, which is no longer used in


### PR DESCRIPTION
This adds `addPosterIcons` to the plugin which gives users the ability to loop through any decorator `attrs` to add multiple icons at once. This new method also is backwards compatible.

This change is tested by an internal plugin that is using it.