### PR TITLE
DEV: Skip Ember OnError validation for plugin qunit tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/test-helper.js
+++ b/app/assets/javascripts/discourse/tests/test-helper.js
@@ -9,6 +9,8 @@ setEnvironment("testing");
 
 document.addEventListener("discourse-booted", () => {
   let setupTests = require("discourse/tests/setup-tests").default;
+  const skippingCore =
+    new URLSearchParams(window.location.search).get("qunit_skip_core") === "1";
   Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION = false;
 
   document.body.insertAdjacentHTML(
@@ -26,5 +28,9 @@ document.addEventListener("discourse-booted", () => {
   setupTests(config.APP);
   let loader = loadEmberExam();
   loader.loadModules();
-  start({ setupTestContainer: false, loadTests: false });
+  start({
+    setupTestContainer: false,
+    loadTests: false,
+    setupEmberOnerrorValidation: !skippingCore,
+  });
 });


### PR DESCRIPTION
If the Ember OnError validation test is added, it breaks the "no tests were run" detection (since at least 1 test is always run). This is particularly important when running tests scoped to a single plugin, because there is no indication that you have typo'd the `qunit_single_plugin` query parameter.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
