### PR TITLE
DEV: Remove customer flair from being an official plugin

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -9,7 +9,6 @@ class Plugin::Metadata
     # TODO: Remove this after everyone upgraded `discourse-canned-replies`
     # to the renamed version.
     "Canned Replies",
-    "customer-flair",
     "discourse-adplugin",
     "discourse-affiliate",
     "discourse-akismet",

--- a/spec/components/plugin/metadata_spec.rb
+++ b/spec/components/plugin/metadata_spec.rb
@@ -44,7 +44,6 @@ TEXT
   end
 
   it "correctly detects official vs unofficial plugins" do
-    official("customer-flair")
     official("discourse-adplugin")
     official("discourse-akismet")
     official("discourse-cakeday")


### PR DESCRIPTION
Since `customer-flair` is only used by meta and so can be removed as an "official" plugin.