### PR TITLE
Update plugin handling in Ember CLI `testem` environment

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -7,6 +7,7 @@ const cleanBaseURL = require("clean-base-url");
 const path = require("path");
 const { promises: fs } = require("fs");
 const { JSDOM } = require("jsdom");
+const { shouldLoadPluginTestJs } = require("discourse/lib/plugin-js");
 
 // via https://stackoverflow.com/a/6248722/165668
 function generateUID() {
@@ -296,6 +297,14 @@ module.exports = {
 
   isDevelopingAddon() {
     return true;
+  },
+
+  contentFor: function (type, config) {
+    if (shouldLoadPluginTestJs() && type === "test-plugin-js") {
+      return `<script src="${config.rootURL}assets/discourse/tests/active-plugins.js"></script>`;
+    } else if (shouldLoadPluginTestJs() && type === "test-plugin-tests-js") {
+      return `<script id="plugin-test-script" src="${config.rootURL}assets/discourse/tests/plugin-tests.js"></script>`;
+    }
   },
 
   serverMiddleware(config) {

--- a/app/assets/javascripts/discourse/lib/plugin-js.js
+++ b/app/assets/javascripts/discourse/lib/plugin-js.js
@@ -1,0 +1,7 @@
+const EmberApp = require("ember-cli/lib/broccoli/ember-app");
+
+module.exports = {
+  shouldLoadPluginTestJs() {
+    return EmberApp.env() === "development" || process.env.LOAD_PLUGINS === "1";
+  },
+};

--- a/app/assets/javascripts/discourse/lib/translation-plugin.js
+++ b/app/assets/javascripts/discourse/lib/translation-plugin.js
@@ -6,6 +6,7 @@ const mergeTrees = require("broccoli-merge-trees");
 const MessageFormat = require("messageformat");
 const deepmerge = require("deepmerge");
 const glob = require("glob");
+const { shouldLoadPluginTestJs } = require("discourse/lib/plugin-js");
 
 let built = false;
 
@@ -92,11 +93,15 @@ module.exports = function translatePlugin(...params) {
 };
 
 module.exports.createI18nTree = function (discourseRoot, vendorJs) {
-  let translations = [discourseRoot + "/config/locales"].concat(
-    glob
-      .sync(discourseRoot + "/plugins/*/config/locales/client.en.yml")
-      .map((f) => f.replace(/\/client\.en\.yml$/, ""))
-  );
+  let translations = [discourseRoot + "/config/locales"];
+
+  if (shouldLoadPluginTestJs()) {
+    translations = translations.concat(
+      glob
+        .sync(discourseRoot + "/plugins/*/config/locales/client.en.yml")
+        .map((f) => f.replace(/\/client\.en\.yml$/, ""))
+    );
+  }
 
   let en = new TranslationPlugin(translations, "client.en.yml");
 

--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -1,4 +1,5 @@
 const TapReporter = require("testem/lib/reporters/tap_reporter");
+const { shouldLoadPluginTestJs } = require("discourse/lib/plugin-js");
 
 class Reporter {
   constructor() {
@@ -25,8 +26,8 @@ class Reporter {
 module.exports = {
   test_page: "tests/index.html?hidepassed",
   disable_watching: true,
-  launch_in_ci: ["Chrome", "Firefox", "Headless Firefox"], // Firefox is old ESR version, Headless Firefox is up-to-date evergreen version
-  launch_in_dev: ["Chrome"],
+  launch_in_ci: ["Chrome"],
+  // launch_in_dev: ["Chrome"] // Ember-CLI always launches testem in 'CI' mode
   tap_failed_tests_only: process.env.CI,
   parallel: 1, // disable parallel tests for stability
   browser_start_timeout: 120,
@@ -51,3 +52,15 @@ module.exports = {
   },
   reporter: Reporter,
 };
+
+if (shouldLoadPluginTestJs()) {
+  const target = `http://localhost:${process.env.UNICORN_PORT || "3000"}`;
+  module.exports.proxies = {
+    "/assets/discourse/tests/active-plugins.js": {
+      target,
+    },
+    "/assets/discourse/tests/plugin-tests.js": {
+      target,
+    },
+  };
+}

--- a/app/assets/javascripts/discourse/tests/index.html
+++ b/app/assets/javascripts/discourse/tests/index.html
@@ -50,11 +50,11 @@
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/discourse.js"></script>
     <script src="{{rootURL}}assets/discourse-markdown.js"></script>
-    <script src="{{rootURL}}assets/discourse/tests/active-plugins.js"></script>
+    {{content-for "test-plugin-js"}}
     <script src="{{rootURL}}assets/admin.js"></script>
     <script src="{{rootURL}}assets/test-helpers.js"></script>
     <script src="{{rootURL}}assets/core-tests.js"></script>
-    <script src="{{rootURL}}assets/discourse/tests/plugin-tests.js"></script>
+    {{content-for "test-plugin-tests-js"}}
     <script>
       require('discourse/tests/test-boot-ember-cli');
     </script>

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -8,6 +8,13 @@ import { setup } from "qunit-dom";
 setEnvironment("testing");
 
 document.addEventListener("discourse-booted", () => {
+  const script = document.getElementById("plugin-test-script");
+  if (script && !requirejs.entries["discourse/tests/active-plugins"]) {
+    throw new Error(
+      `Plugin JS payload failed to load from ${script.src}. Is the Rails server running?`
+    );
+  }
+
   let setupTests = require("discourse/tests/setup-tests").default;
   const skippingCore =
     new URLSearchParams(window.location.search).get("qunit_skip_core") === "1";

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -194,7 +194,7 @@ desc 'run plugin qunit tests'
 task 'plugin:qunit', [:plugin, :timeout] do |t, args|
   args.with_defaults(plugin: "*")
 
-  rake = `which rake`.strip
+  rake = "#{Rails.root}/bin/rake"
 
   cmd = 'LOAD_PLUGINS=1 '
   cmd += 'QUNIT_SKIP_CORE=1 '
@@ -209,7 +209,8 @@ task 'plugin:qunit', [:plugin, :timeout] do |t, args|
   cmd += "#{rake} qunit:test"
   cmd += "[#{args[:timeout]}]" if args[:timeout]
 
-  sh cmd
+  system cmd
+  exit $?.exitstatus
 end
 
 desc 'run all migrations of a plugin'

--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -58,15 +58,9 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
     "UNICORN_TIMEOUT" => "90",
   }
 
-  cmd = if ember_cli
-    "#{Rails.root}/bin/ember-cli -u --port #{port} --proxy http://localhost:#{unicorn_port} -lr false"
-  else
-    "#{Rails.root}/bin/unicorn"
-  end
-
   pid = Process.spawn(
     env,
-    cmd,
+    "#{Rails.root}/bin/unicorn",
     pgroup: true
   )
 
@@ -74,9 +68,8 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
     success = true
     test_path = "#{Rails.root}/test"
     qunit_path = args[:qunit_path]
-    qunit_path ||= "/tests" if ember_cli
-    qunit_path ||= "/qunit"
-    cmd = "node #{test_path}/run-qunit.js http://localhost:#{port}#{qunit_path}"
+    qunit_path ||= "/qunit" if !ember_cli
+
     options = { seed: (ENV["QUNIT_SEED"] || Random.new.seed), hidepassed: 1 }
 
     %w{module filter qunit_skip_core qunit_single_plugin theme_name theme_url theme_id}.each do |arg|
@@ -87,11 +80,7 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
       options['report_requests'] = '1'
     end
 
-    cmd += "?#{options.to_query.gsub('+', '%20').gsub("&", '\\\&')}"
-
-    if args[:timeout].present?
-      cmd += " #{args[:timeout]}"
-    end
+    query = options.to_query
 
     @now = Time.now
     def elapsed
@@ -100,7 +89,8 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
 
     # wait for server to accept connections
     require 'net/http'
-    uri = URI("http://localhost:#{port}/#{qunit_path}")
+    warmup_path = ember_cli ? "/assets/discourse/tests/active-plugins.js" : "/qunit"
+    uri = URI("http://localhost:#{unicorn_port}/#{warmup_path}")
     puts "Warming up Rails server"
     begin
       Net::HTTP.get(uri)
@@ -112,7 +102,18 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
     end
     puts "Rails server is warmed up"
 
-    sh(cmd)
+    if ember_cli
+      Dir.chdir("#{Rails.root}/app/assets/javascripts/discourse") do # rubocop:disable Discourse/NoChdir because this is not part of the app
+        cmd = ["env", "UNICORN_PORT=#{unicorn_port}", "yarn", "ember", "test", "--query", query]
+        cmd += ["--test-page", qunit_path.delete_prefix("/")] if qunit_path
+        system(*cmd)
+      end
+    else
+      cmd = "node #{test_path}/run-qunit.js http://localhost:#{port}#{qunit_path}"
+      cmd += "?#{query.gsub('+', '%20').gsub("&", '\\\&')}"
+      cmd += " #{args[:timeout]}" if args[:timeout].present?
+      system(cmd)
+    end
     success &&= $?.success?
   ensure
     # was having issues with HUP


### PR DESCRIPTION
(to be rebased-and-merged)

---

#### DEV: Update plugin JS loading in Ember CLI testem environment

Previously we were adding `/assets/discourse/tests/core_plugin_tests.js` to the test html all the time. This works in development mode, but fails silently when using testem via the `ember test` CLI, because there is no proxy running.

This commit makes a few changes to fix this, and make it more useful:

- Only renders the plugin `<script>` when in development mode, or when `LOAD_PLUGINS=1` (matching core's behavior)
- Only loads plugin translations based on the same logic
- When running via testem, and the above conditions are met, testem is configured to proxy `core_plugin_tests.js` through to a rails server. (port based on the `UNICORN_PORT` env variable)
- Adds a descriptive error if the plugin `<script>` fails to load. This can happen if the rails server hasn't been started
- Updates the logic for testem browsers. Ember CLI always launches testem in "CI" mode, and we don't really want 3 browsers opening by default. Our CI explicitly specifies the 3 browsers at runtime

---

#### DEV: Update `rake qunit:test` and `rake plugin:qunit` to use `testem`

For now this is still gated behind a `QUNIT_EMBER_CLI=1` environment variable, but will eventually become the default so that we can remove `run-qunit.js`.
