### PR TITLE
DEV: make sure we handle staged users correctly in DiscourseConnect

### DIFF
--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -390,6 +390,54 @@ describe DiscourseSingleSignOn do
     expect(user.username).to eq "bill3"
   end
 
+  it "uses name if it's present in payload" do
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    name = "John"
+    sso.name = name
+    sso.email = "mail@mail.com"
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.name).to eq name
+  end
+
+  it "uses username for name suggestions if name isn't present in payload" do
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    sso.name = ""
+    sso.username = "user_john"
+    sso.email = "mail@mail.com"
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.name).to eq "User John"
+  end
+
+  it "uses username for username suggestions if it's present in payload" do
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    username = "user_john"
+    sso.username = username
+    sso.email = "mail@mail.com"
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.username).to eq username
+  end
+
+  it "uses name for username suggestions if username isn't present in payload" do
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    sso.username = ""
+    sso.name = "John Smith"
+    sso.email = "mail@mail.com"
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.username).to eq "John_Smith"
+  end
+
   it "doesn't use email as a source for username suggestions by default" do
     sso = new_discourse_sso
     sso.external_id = "100"

--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -1075,4 +1075,38 @@ describe DiscourseSingleSignOn do
     end
   end
 
+  context "when user is staged" do
+    it "uses username of the staged user if username is not present in payload" do
+      staged_username = "staged_user"
+      email = "staged@user.com"
+      Fabricate(:user, staged: true, username: staged_username, email: email)
+
+      sso = new_discourse_sso
+      sso.email = email
+      sso.external_id = "B"
+
+      user = sso.lookup_or_create_user(ip_address)
+      user.reload
+
+      expect(user.username).to eq(staged_username)
+    end
+
+    it "uses username of the staged user if username in payload is the same" do
+      # it's important to check this, because we had regressions
+      # where usernames were changed to the same username with "1" added at the end
+      staged_username = "staged_user"
+      email = "staged@user.com"
+      Fabricate(:user, staged: true, username: staged_username, email: email)
+
+      sso = new_discourse_sso
+      sso.username = staged_username
+      sso.email = email
+      sso.external_id = "B"
+
+      user = sso.lookup_or_create_user(ip_address)
+      user.reload
+
+      expect(user.username).to eq(staged_username)
+    end
+  end
 end

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -916,6 +916,9 @@ RSpec.describe Users::OmniauthCallbacksController do
       end
 
       it "should use username of the staged user if username in payload is the same" do
+        # it's important to check this, because we had regressions
+        # when usernames were changed to the same username with "1" added at the end
+
         mock_auth(staged_user.email, staged_user.username)
 
         get "/auth/google_oauth2/callback.json"


### PR DESCRIPTION
Some time ago, we made this fix to external authentication – [FIX: Suggest current username for staged users ](https://github.com/discourse/discourse/pull/13706). We didn't address [Discourse Connect](https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045) at that moment, so I wanted to fix it for Discourse Connect as well.

Turned out though that Discourse Connect doesn't contain this problem and already handles staged users correctly. This PR adds tests that confirm it. Also, I've extracted two functions in Discourse Connect implementation along the way and decided to merge this refactoring too (the refactoring is supported with tests).
