### PR TITLE
DEV: Remove jQuery animate calls

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1700,7 +1700,7 @@ export default Controller.extend(bufferedProperty("model"), {
             postNumberDifference > 0 &&
             postNumberDifference < 7
           ) {
-            this._scrollToPost(data.post_number);
+            this._scrollToDiscobotPost(data.post_number);
           }
         }
       },
@@ -1708,17 +1708,29 @@ export default Controller.extend(bufferedProperty("model"), {
     );
   },
 
-  _scrollToPost(postNumber) {
+  _scrollToDiscobotPost(postNumber) {
     discourseDebounce(
       this,
       function () {
-        const $post = $(`.topic-post article#post_${postNumber}`);
+        const post = document.querySelector(
+          `.topic-post article#post_${postNumber}`
+        );
 
-        if ($post.length === 0 || isElementInViewport($post[0])) {
+        if (!post || isElementInViewport(post)) {
           return;
         }
 
-        $("html, body").animate({ scrollTop: $post.offset().top }, 1000);
+        const headerOffset =
+          parseInt(
+            getComputedStyle(document.body).getPropertyValue("--header-offset"),
+            10
+          ) || 0;
+        const viewportOffset = post.getBoundingClientRect();
+
+        window.scrollTo({
+          top: window.scrollY + viewportOffset.top - headerOffset,
+          behavior: "smooth",
+        });
       },
       postNumber,
       500

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -708,10 +708,11 @@ export default {
     }
   },
 
-  _scrollTo(scrollTop, complete) {
-    $("html, body")
-      .stop(true, true)
-      .animate({ scrollTop }, { duration: animationDuration, complete });
+  _scrollTo(scrollTop) {
+    window.scrollTo({
+      top: scrollTop,
+      behavior: "smooth",
+    });
   },
 
   _scrollList($article) {
@@ -738,13 +739,7 @@ export default {
       scrollPos = 0;
     }
 
-    if (this._scrollAnimation) {
-      this._scrollAnimation.stop();
-    }
-    this._scrollAnimation = $("html, body").animate(
-      { scrollTop: scrollPos + "px" },
-      animationDuration
-    );
+    this._scrollTo(scrollPos);
   },
 
   categoriesTopicsList() {


### PR DESCRIPTION
Affects j/k navigation and PM interaction with @discobot. 

Note that Safari Technology Preview's current version supports `behavior: smooth` by default (in 15.1 it's a default off dev flag). We're a little early in adding this here, but Safari is the only outlier, all other current browsers support it.