### PR TITLE
Fixes for translation precedence and translation overrides

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/localization.js
+++ b/app/assets/javascripts/discourse/app/initializers/localization.js
@@ -24,35 +24,28 @@ export default {
     }
 
     // Merge any overrides into our object
-    const overrides = I18n._overrides || {};
-    Object.keys(overrides).forEach((k) => {
-      const v = overrides[k];
-      k = k.replace("admin_js", "js");
+    for (const [locale, overrides] of Object.entries(I18n._overrides || {})) {
+      for (const [key, value] of Object.entries(overrides)) {
+        const segs = key.replace(/^admin_js\./, "js.admin.").split(".");
+        let node = I18n.translations[locale] || {};
 
-      const segs = k.split(".");
-
-      let node = I18n.translations[I18n.locale] || {};
-      let i = 0;
-
-      for (; i < segs.length - 1; i++) {
-        if (!(segs[i] in node)) {
-          node[segs[i]] = {};
+        for (let i = 0; i < segs.length - 1; i++) {
+          if (!(segs[i] in node)) {
+            node[segs[i]] = {};
+          }
+          node = node[segs[i]];
         }
-        node = node[segs[i]];
+
+        if (typeof node === "object") {
+          node[segs[segs.length - 1]] = value;
+        }
       }
+    }
 
-      if (typeof node === "object") {
-        node[segs[segs.length - 1]] = v;
-      }
-    });
-
-    const mfOverrides = I18n._mfOverrides || {};
-    Object.keys(mfOverrides).forEach((k) => {
-      const v = mfOverrides[k];
-
-      k = k.replace(/^[a-z_]*js\./, "");
-      I18n._compiledMFs[k] = v;
-    });
+    for (let [key, value] of Object.entries(I18n._mfOverrides || {})) {
+      key = key.replace(/^[a-z_]*js\./, "");
+      I18n._compiledMFs[key] = value;
+    }
 
     bootbox.addLocale(I18n.currentLocale(), {
       OK: I18n.t("composer.modal_ok"),

--- a/app/assets/javascripts/discourse/tests/unit/localization-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/localization-test.js
@@ -6,7 +6,10 @@ import { getApplication } from "@ember/test-helpers";
 module("initializer:localization", {
   _locale: I18n.locale,
   _translations: I18n.translations,
+  _extras: I18n.extras,
+  _compiledMFs: I18n._compiledMFs,
   _overrides: I18n._overrides,
+  _mfOverrides: I18n._mfOverrides,
 
   beforeEach() {
     I18n.locale = "fr";
@@ -15,16 +18,43 @@ module("initializer:localization", {
       fr: {
         js: {
           composer: {
-            reply: "Répondre",
+            both_languages1: "composer.both_languages1 (FR)",
+            both_languages2: "composer.both_languages2 (FR)",
           },
         },
       },
       en: {
         js: {
-          topic: {
-            reply: {
-              help: "begin composing a reply to this topic",
-            },
+          composer: {
+            both_languages1: "composer.both_languages1 (EN)",
+            both_languages2: "composer.both_languages2 (EN)",
+            only_english1: "composer.only_english1 (EN)",
+            only_english2: "composer.only_english2 (EN)",
+          },
+        },
+      },
+    };
+
+    I18n._compiledMFs = {
+      "user.messages.some_key_MF": () => "user.messages.some_key_MF (FR)",
+    };
+
+    I18n.extras = {
+      fr: {
+        admin: {
+          api: {
+            both_languages1: "admin.api.both_languages1 (FR)",
+            both_languages2: "admin.api.both_languages2 (FR)",
+          },
+        },
+      },
+      en: {
+        admin: {
+          api: {
+            both_languages1: "admin.api.both_languages1 (EN)",
+            both_languages2: "admin.api.both_languages2 (EN)",
+            only_english1: "admin.api.only_english1 (EN)",
+            only_english2: "admin.api.only_english2 (EN)",
           },
         },
       },
@@ -34,35 +64,115 @@ module("initializer:localization", {
   afterEach() {
     I18n.locale = this._locale;
     I18n.translations = this._translations;
+    I18n.extras = this._extras;
+    I18n._compiledMFs = this._compiledMFs;
     I18n._overrides = this._overrides;
+    I18n._mfOverrides = this._mfOverrides;
   },
 });
 
 test("translation overrides", function (assert) {
   I18n._overrides = {
-    "js.composer.reply": "WAT",
-    "js.topic.reply.help": "foobar",
+    fr: {
+      "js.composer.both_languages1": "composer.both_languages1 (FR override)",
+      "js.composer.only_english2": "composer.only_english2 (FR override)",
+    },
+    en: {
+      "js.composer.both_languages2": "composer.both_languages2 (EN override)",
+      "js.composer.only_english1": "composer.only_english1 (EN override)",
+    },
   };
   LocalizationInitializer.initialize(getApplication());
 
   assert.strictEqual(
-    I18n.t("composer.reply"),
-    "WAT",
+    I18n.t("composer.both_languages1"),
+    "composer.both_languages1 (FR override)",
     "overrides existing translation in current locale"
   );
+
   assert.strictEqual(
-    I18n.t("topic.reply.help"),
-    "foobar",
-    "overrides translation in default locale"
+    I18n.t("composer.only_english1"),
+    "composer.only_english1 (EN override)",
+    "overrides translation in fallback locale"
+  );
+
+  assert.strictEqual(
+    I18n.t("composer.only_english2"),
+    "composer.only_english2 (FR override)",
+    "overrides translation that doesn't exist in current locale"
+  );
+
+  assert.strictEqual(
+    I18n.t("composer.both_languages2"),
+    "composer.both_languages2 (FR)",
+    "prefers translation in current locale over override in fallback locale"
+  );
+});
+
+test("translation overrides (admin_js)", function (assert) {
+  I18n._overrides = {
+    fr: {
+      "admin_js.api.both_languages1": "admin.api.both_languages1 (FR override)",
+      "admin_js.api.only_english2": "admin.api.only_english2 (FR override)",
+    },
+    en: {
+      "admin_js.api.both_languages2": "admin.api.both_languages2 (EN override)",
+      "admin_js.api.only_english1": "admin.api.only_english1 (EN override)",
+    },
+  };
+  LocalizationInitializer.initialize(getApplication());
+
+  assert.strictEqual(
+    I18n.t("admin.api.both_languages1"),
+    "admin.api.both_languages1 (FR override)",
+    "overrides existing translation in current locale"
+  );
+
+  assert.strictEqual(
+    I18n.t("admin.api.only_english1"),
+    "admin.api.only_english1 (EN override)",
+    "overrides translation in fallback locale"
+  );
+
+  assert.strictEqual(
+    I18n.t("admin.api.only_english2"),
+    "admin.api.only_english2 (FR override)",
+    "overrides translation that doesn't exist in current locale"
+  );
+
+  assert.strictEqual(
+    I18n.t("admin.api.both_languages2"),
+    "admin.api.both_languages2 (FR)",
+    "prefers translation in current locale over override in fallback locale"
+  );
+});
+
+test("translation overrides for MessageFormat strings", function (assert) {
+  I18n._mfOverrides = {
+    "js.user.messages.some_key_MF": () =>
+      "user.messages.some_key_MF (FR override)",
+  };
+
+  LocalizationInitializer.initialize(getApplication());
+
+  assert.strictEqual(
+    I18n.messageFormat("user.messages.some_key_MF", {}),
+    "user.messages.some_key_MF (FR override)",
+    "overrides existing MessageFormat string"
   );
 });
 
 test("skip translation override if parent node is not an object", function (assert) {
   I18n._overrides = {
-    "js.composer.reply": "WAT",
-    "js.composer.reply.help": "foobar",
+    fr: {
+      "js.composer.both_languages1.foo":
+        "composer.both_languages1.foo (FR override)",
+    },
   };
   LocalizationInitializer.initialize(getApplication());
 
-  assert.strictEqual(I18n.t("composer.reply.help"), "[fr.composer.reply.help]");
+  assert.strictEqual(
+    I18n.t("composer.both_languages1.foo"),
+    "[fr.composer.both_languages1.foo]"
+  );
 });

--- a/app/controllers/admin/site_texts_controller.rb
+++ b/app/controllers/admin/site_texts_controller.rb
@@ -157,11 +157,6 @@ class Admin::SiteTextsController < Admin::AdminController
   end
 
   def record_for(key:, value: nil, locale:)
-    if key.ends_with?("_MF")
-      override = TranslationOverride.where(translation_key: key, locale: locale).pluck(:value)
-      value = override&.first
-    end
-
     value ||= I18n.with_locale(locale) { I18n.t(key) }
     { id: key, value: value, locale: locale }
   end

--- a/app/controllers/admin/site_texts_controller.rb
+++ b/app/controllers/admin/site_texts_controller.rb
@@ -183,7 +183,7 @@ class Admin::SiteTextsController < Admin::AdminController
   def find_translations(query, overridden, locale)
     translations = Hash.new { |hash, key| hash[key] = {} }
     search_results = I18n.with_locale(locale) do
-      I18n.search(query, overridden: overridden)
+      I18n.search(query, only_overridden: overridden)
     end
 
     search_results.each do |key, value|

--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -169,14 +169,14 @@ module I18n
 
       if !by_site.has_key?(locale)
         # Load overrides
-        translations_overrides = TranslationOverride.where(locale: locale).pluck(:translation_key, :value, :compiled_js)
+        translations_overrides = TranslationOverride.where(locale: locale).pluck(:translation_key, :value)
 
         if translations_overrides.empty?
           by_site[locale] = {}
         else
           translations_overrides.each do |tuple|
             by_locale = by_site[locale] ||= {}
-            by_locale[tuple[0]] = tuple[2] || tuple[1]
+            by_locale[tuple[0]] = tuple[1]
           end
         end
 

--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -72,19 +72,31 @@ module I18n
       execute_reload if @requires_reload
 
       locale = (opts[:locale] || config.locale).to_sym
-
       load_locale(locale) unless @loaded_locales.include?(locale)
-      opts ||= {}
 
-      target = opts[:backend] || backend
-      results = opts[:overridden] ? {} : target.search(locale, query)
-
+      results = {}
       regexp = I18n::Backend::DiscourseI18n.create_search_regexp(query)
-      (overrides_by_locale(locale) || {}).each do |k, v|
-        results.delete(k)
-        results[k] = v if (k =~ regexp || v =~ regexp)
+
+      if opts[:only_overridden]
+        add_if_matches(overrides_by_locale(locale), results, regexp)
+      else
+        target = opts[:backend] || backend
+
+        I18n.fallbacks[locale].reverse_each do |fallback|
+          add_if_matches(target.search(fallback, query), results, regexp)
+          add_if_matches(overrides_by_locale(fallback), results, regexp)
+        end
       end
+
       results
+    end
+
+    def add_if_matches(translations, results, regexp)
+      translations.each do |key, value|
+        if key =~ regexp || value =~ regexp
+          results[key] = value
+        end
+      end
     end
 
     def ensure_loaded!(locale)
@@ -144,7 +156,7 @@ module I18n
     end
 
     def overrides_by_locale(locale)
-      return unless @overrides_enabled
+      return {} unless @overrides_enabled
       return {} if GlobalSetting.skip_db?
       locale = locale.to_sym
 
@@ -191,30 +203,26 @@ module I18n
 
       if @overrides_enabled
         overrides = {}
-
-        # for now lets do all the expensive work for keys with count
-        # no choice really
-        has_override = !!options[:count]
+        has_count = options.has_key?(:count)
 
         I18n.fallbacks[locale].each do |l|
-          override = overrides[l] = overrides_by_locale(l)
-          has_override ||= override.key?(key)
+          overrides_for_locale = overrides_by_locale(l)
+          overrides[l] = overrides_for_locale if has_count || overrides_for_locale.key?(key)
         end
 
-        if has_override && overrides.present?
-          if options.present?
-            options[:overrides] = overrides
+        if overrides.present?
+          no_options = options.empty? || (options.size == 1 && options.has_key?(:locale))
 
-            # I18n likes to use throw...
-            catch(:exception) do
-              return backend.translate(locale, key, options)
-            end
-          else
-            overrides.each do |_k, v|
-              if result = v[key]
-                return result
-              end
-            end
+          # Shortcut if the current locale has an override and there are no options.
+          if no_options && (override = overrides.dig(locale, key))
+            return override
+          end
+
+          options[:overrides] = overrides
+
+          # I18n likes to use throw...
+          catch(:exception) do
+            return backend.translate(locale, key, options)
           end
         end
       end

--- a/lib/i18n/backend/discourse_i18n.rb
+++ b/lib/i18n/backend/discourse_i18n.rb
@@ -55,14 +55,8 @@ module I18n
       end
 
       def search(locale, query)
-        results = {}
         regexp = self.class.create_search_regexp(query)
-
-        I18n.fallbacks[locale].each do |fallback|
-          find_results(regexp, results, translations[fallback])
-        end
-
-        results
+        find_results(regexp, {}, translations[locale])
       end
 
       protected

--- a/spec/lib/i18n/discourse_i18n_spec.rb
+++ b/spec/lib/i18n/discourse_i18n_spec.rb
@@ -44,11 +44,6 @@ describe I18n::Backend::DiscourseI18n do
   end
 
   describe 'fallbacks' do
-    it 'uses fallback locales for searching' do
-      expect(backend.search(:de, 'bar')).to eq('bar' => 'Bar in :de')
-      expect(backend.search(:de, 'foo')).to eq('foo' => 'Foo in :en')
-    end
-
     it 'uses fallback locales for translating' do
       expect(backend.translate(:de, 'bar')).to eq('Bar in :de')
       expect(backend.translate(:de, 'foo')).to eq('Foo in :en')

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -138,6 +138,21 @@ RSpec.describe Admin::SiteTextsController do
         expect(response.parsed_body['site_texts']).to be_empty
       end
 
+      it "returns site text from fallback locale if current locale doesn't have a translation" do
+        TranslationOverride.upsert!(:en, 'js.summary.description_time_MF', 'description_time_MF override')
+        TranslationOverride.upsert!(:en, 'education.new-topic', 'education.new-topic override')
+
+        get "/admin/customize/site_texts.json", params: { q: 'js.summary.description_time_MF', locale: 'en_GB' }
+        expect(response.status).to eq(200)
+        value = response.parsed_body['site_texts'].find { |text| text['id'] == 'js.summary.description_time_MF' }['value']
+        expect(value).to eq('description_time_MF override')
+
+        get "/admin/customize/site_texts.json", params: { q: 'education.new-topic', locale: 'en_GB' }
+        expect(response.status).to eq(200)
+        value = response.parsed_body['site_texts'].find { |text| text['id'] == 'education.new-topic' }['value']
+        expect(value).to eq('education.new-topic override')
+      end
+
       context 'plural keys' do
         before do
           I18n.backend.store_translations(:en, colour: { one: '%{count} colour', other: '%{count} colours' })
@@ -270,6 +285,29 @@ RSpec.describe Admin::SiteTextsController do
       it 'fails if locale is not given' do
         get "/admin/customize/site_texts/js.topic.list.json"
         expect(response.status).to eq(400)
+      end
+
+      it "returns site text from fallback locale if current locale doesn't have a translation" do
+        TranslationOverride.upsert!(:en, 'js.summary.description_time_MF', 'description_time_MF override')
+        TranslationOverride.upsert!(:en, 'education.new-topic', 'education.new-topic override')
+
+        get "/admin/customize/site_texts/js.summary.description_time_MF.json", params: { locale: 'en_GB' }
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
+        site_text = json['site_text']
+
+        expect(site_text['id']).to eq('js.summary.description_time_MF')
+        expect(site_text['value']).to eq('description_time_MF override')
+
+        get "/admin/customize/site_texts/education.new-topic.json", params: { locale: 'en_GB' }
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
+        site_text = json['site_text']
+
+        expect(site_text['id']).to eq('education.new-topic')
+        expect(site_text['value']).to eq('education.new-topic override')
       end
 
       context 'plural keys' do

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -153,6 +153,19 @@ RSpec.describe Admin::SiteTextsController do
         expect(value).to eq('education.new-topic override')
       end
 
+      it "returns only overridden translations" do
+        TranslationOverride.upsert!(:en, 'education.new-topic', 'education.new-topic override')
+
+        get "/admin/customize/site_texts.json", params: { locale: 'en', overridden: true }
+        expect(response.status).to eq(200)
+
+        site_texts = response.parsed_body['site_texts']
+        expect(site_texts.size).to eq(1)
+
+        value = site_texts.find { |text| text['id'] == 'education.new-topic' }['value']
+        expect(value).to eq('education.new-topic override')
+      end
+
       context 'plural keys' do
         before do
           I18n.backend.store_translations(:en, colour: { one: '%{count} colour', other: '%{count} colours' })


### PR DESCRIPTION
This PR contains multiple commits that depend on each other.

**FIX: translation precedence was different on client and server**
As an example, the lookup order for German was:
1. override for de
2. override for en
3. value from de
4. value from en

After this change the lookup order is the same as on the client:
1. override for de
2. value from de
3. override for en
4. value from en

see /t/16381

---

**FIX: "Customize Text" showed compiled MessageFormat string for overridden `_MF` translations**

---

**FIX: Translation overrides from fallback locale didn't work on client**

Discourse sent only translation overrides for the current language to the client instead of sending overrides from fallback locales as well. This especially impacted en_GB -> en since most overrides would be done in English instead of English (UK).

This also adds lots of tests for previously untested code.

There's a small caveat: The client currently doesn't handle fallback locales for MessageFormat strings. That is why overrides for those strings always have a higher priority than regular translations. So, as an example, the lookup order for MessageFormat strings in German is:
1. override for de
2. override for en
3. value from de
4. value from en
