### PR TITLE
FEATURE: Show warning if user won't be mentioned

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -22,6 +22,7 @@ import {
   linkSeenHashtags,
 } from "discourse/lib/link-hashtags";
 import {
+  cannotSee,
   fetchUnseenMentions,
   linkSeenMentions,
 } from "discourse/lib/link-mentions";
@@ -540,7 +541,7 @@ export default Component.extend(ComposerUploadUppy, {
                   `.mention.cannot-see[data-name="${name}"]`
                 )?.length > 0
               ) {
-                this.cannotSeeMention([{ name }]);
+                this.cannotSeeMention([{ name, reason: cannotSee[name] }]);
                 found.push(name);
               }
             },

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -696,16 +696,12 @@ export default Controller.extend({
 
     cannotSeeMention(mentions) {
       mentions.forEach((mention) => {
-        const translation = this.get("model.topic.isPrivateMessage")
-          ? "composer.cannot_see_mention.private"
-          : "composer.cannot_see_mention.category";
-        const body = I18n.t(translation, {
-          username: `@${mention.name}`,
-        });
         this.appEvents.trigger("composer-messages:create", {
           extraClass: "custom-body",
           templateName: "custom-body",
-          body,
+          body: I18n.t(`composer.cannot_see_mention.${mention.reason}`, {
+            username: mention.name,
+          }),
         });
       });
     },

--- a/app/assets/javascripts/discourse/app/lib/link-mentions.js
+++ b/app/assets/javascripts/discourse/app/lib/link-mentions.js
@@ -46,7 +46,7 @@ const found = {};
 const foundGroups = {};
 const mentionableGroups = {};
 const checked = {};
-const cannotSee = [];
+export const cannotSee = {};
 
 function updateFound(mentions, usernames) {
   mentions.forEach((mention, index) => {
@@ -101,7 +101,9 @@ export function fetchUnseenMentions(usernames, topic_id) {
     r.valid.forEach((v) => (found[v] = true));
     r.valid_groups.forEach((vg) => (foundGroups[vg] = true));
     r.mentionable_groups.forEach((mg) => (mentionableGroups[mg.name] = mg));
-    r.cannot_see.forEach((cs) => (cannotSee[cs] = true));
+    Object.entries(r.cannot_see).forEach(
+      ([username, reason]) => (cannotSee[username] = reason)
+    );
     maxGroupMention = r.max_users_notified_per_group_mention;
     usernames.forEach((u) => (checked[u] = true));
     return r;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -540,7 +540,7 @@ class UsersController < ApplicationController
         end
 
         if !guardian.is_staff? && cannot_see_reason.present? && cannot_see_reason != :private && cannot_see_reason != :category
-          cannot_see_reason = :unknown
+          cannot_see_reason = nil # do not leak private information
         end
 
         cannot_see[username] = cannot_see_reason if cannot_see_reason.present?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2110,7 +2110,6 @@ en:
         private: "You mentioned @%{username} but they won't be notified because they are unable to see this personal message. You will need to invite them to this personal message."
         muted_topic: "You mentioned @%{username} but they won't be notified because they muted this topic."
         not_allowed: "You mentioned @%{username} but they won't be notified because they were not invited to this topic."
-        unknown: "You mentioned @%{username} but they won't be notified."
       here_mention:
         one: "By mentioning <b>@%{here}</b>, you are about to notify %{count} user – are you sure?"
         other: "By mentioning <b>@%{here}</b>, you are about to notify %{count} users – are you sure?"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2106,8 +2106,11 @@ en:
         one: "By mentioning %{group}, you are about to notify <a href='%{group_link}'>%{count} person</a> – are you sure?"
         other: "By mentioning %{group}, you are about to notify <a href='%{group_link}'>%{count} people</a> – are you sure?"
       cannot_see_mention:
-        category: "You mentioned %{username} but they won't be notified because they do not have access to this category. You will need to add them to a group that has access to this category."
-        private: "You mentioned %{username} but they won't be notified because they are unable to see this personal message. You will need to invite them to this PM."
+        category: "You mentioned @%{username} but they won't be notified because they do not have access to this category. You will need to add them to a group that has access to this category."
+        private: "You mentioned @%{username} but they won't be notified because they are unable to see this personal message. You will need to invite them to this PM."
+        muted_topic: "You mentioned @%{username} but they won't be notified because they muted this topic."
+        not_allowed: "You mentioned @%{username} but they won't be notified because they were not invited to this topic."
+        unknown: "You mentioned @%{username} but they won't be notified."
       here_mention:
         one: "By mentioning <b>@%{here}</b>, you are about to notify %{count} user – are you sure?"
         other: "By mentioning <b>@%{here}</b>, you are about to notify %{count} users – are you sure?"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2107,7 +2107,7 @@ en:
         other: "By mentioning %{group}, you are about to notify <a href='%{group_link}'>%{count} people</a> – are you sure?"
       cannot_see_mention:
         category: "You mentioned @%{username} but they won't be notified because they do not have access to this category. You will need to add them to a group that has access to this category."
-        private: "You mentioned @%{username} but they won't be notified because they are unable to see this personal message. You will need to invite them to this PM."
+        private: "You mentioned @%{username} but they won't be notified because they are unable to see this personal message. You will need to invite them to this personal message."
         muted_topic: "You mentioned @%{username} but they won't be notified because they muted this topic."
         not_allowed: "You mentioned @%{username} but they won't be notified because they were not invited to this topic."
         unknown: "You mentioned @%{username} but they won't be notified."

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3099,7 +3099,7 @@ describe UsersController do
       get "/u/is_local_username.json", params: { usernames: [user1.username, "system"] }
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body["valid"]).to contain_exactly(user.username, "system")
+      expect(response.parsed_body["valid"]).to contain_exactly(user1.username, "system")
     end
 
     it "never includes staged accounts" do
@@ -3119,7 +3119,7 @@ describe UsersController do
       }
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body["cannot_see"][user.username]).to eq("category")
+      expect(response.parsed_body["cannot_see"][user1.username]).to eq("category")
     end
 
     it "never returns a user who can see the topic" do
@@ -3137,7 +3137,7 @@ describe UsersController do
       }
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body["cannot_see"][user.username]).to eq("private")
+      expect(response.parsed_body["cannot_see"][user1.username]).to eq("private")
     end
 
     it "never returns a user who can see the topic" do
@@ -3150,15 +3150,15 @@ describe UsersController do
     end
 
     it "returns the appropriate reason why user cannot see the topic" do
-      TopicUser.create!(user_id: user.id, topic_id: topic.id, notification_level: TopicUser.notification_levels[:muted])
+      TopicUser.create!(user_id: user1.id, topic_id: topic.id, notification_level: TopicUser.notification_levels[:muted])
 
       sign_in(admin)
       get "/u/is_local_username.json", params: {
-        usernames: [user.username], topic_id: topic.id
+        usernames: [user1.username], topic_id: topic.id
       }
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body["cannot_see"][user.username]).to eq("muted_topic")
+      expect(response.parsed_body["cannot_see"][user1.username]).to eq("muted_topic")
     end
   end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3140,6 +3140,17 @@ describe UsersController do
       expect(response.parsed_body["cannot_see"][user1.username]).to eq("private")
     end
 
+    it "returns user who was not invited to topic" do
+      sign_in(Fabricate(:admin))
+
+      get "/u/is_local_username.json", params: {
+        usernames: [admin.username], topic_id: private_topic.id
+      }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["cannot_see"][admin.username]).to eq("not_allowed")
+    end
+
     it "never returns a user who can see the topic" do
       get "/u/is_local_username.json", params: {
         usernames: [allowed_user.username], topic_id: private_topic.id

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3076,34 +3076,30 @@ describe UsersController do
       get "/u/is_local_username.json", params: { username: user1.username }
 
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["valid"][0]).to eq(user1.username)
+      expect(response.parsed_body["valid"][0]).to eq(user1.username)
     end
 
     it "finds the group" do
       sign_in(user1)
       get "/u/is_local_username.json", params: { username: group.name }
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["valid_groups"]).to include(group.name)
-      expect(json["mentionable_groups"].find { |g| g['name'] == group.name }).to be_present
+      expect(response.parsed_body["valid_groups"]).to include(group.name)
+      expect(response.parsed_body["mentionable_groups"].find { |g| g['name'] == group.name }).to be_present
     end
 
     it "finds unmentionable groups" do
       sign_in(user1)
       get "/u/is_local_username.json", params: { username: unmentionable.name }
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["valid_groups"]).to include(unmentionable.name)
-      expect(json["mentionable_groups"]).to be_blank
+      expect(response.parsed_body["valid_groups"]).to include(unmentionable.name)
+      expect(response.parsed_body["mentionable_groups"]).to be_blank
     end
 
     it "supports multiples usernames" do
       get "/u/is_local_username.json", params: { usernames: [user1.username, "system"] }
 
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["valid"].size).to eq(2)
+      expect(response.parsed_body["valid"]).to contain_exactly(user.username, "system")
     end
 
     it "never includes staged accounts" do
@@ -3112,8 +3108,7 @@ describe UsersController do
       get "/u/is_local_username.json", params: { usernames: [staged.username] }
 
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["valid"].size).to eq(0)
+      expect(response.parsed_body["valid"]).to be_blank
     end
 
     it "returns user who cannot see topic" do
@@ -3124,44 +3119,46 @@ describe UsersController do
       }
 
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["cannot_see"].size).to eq(1)
+      expect(response.parsed_body["cannot_see"][user.username]).to eq("category")
     end
 
     it "never returns a user who can see the topic" do
-      Guardian.any_instance.expects(:can_see?).with(topic).returns(true)
-
       get "/u/is_local_username.json", params: {
         usernames: [user1.username], topic_id: topic.id
       }
 
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["cannot_see"].size).to eq(0)
+      expect(response.parsed_body["cannot_see"]).to be_blank
     end
 
     it "returns user who cannot see a private topic" do
-      Guardian.any_instance.expects(:can_see?).with(private_topic).returns(false)
-
       get "/u/is_local_username.json", params: {
         usernames: [user1.username], topic_id: private_topic.id
       }
 
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["cannot_see"].size).to eq(1)
+      expect(response.parsed_body["cannot_see"][user.username]).to eq("private")
     end
 
     it "never returns a user who can see the topic" do
-      Guardian.any_instance.expects(:can_see?).with(private_topic).returns(true)
-
       get "/u/is_local_username.json", params: {
         usernames: [allowed_user.username], topic_id: private_topic.id
       }
 
       expect(response.status).to eq(200)
-      json = response.parsed_body
-      expect(json["cannot_see"].size).to eq(0)
+      expect(response.parsed_body["cannot_see"]).to be_blank
+    end
+
+    it "returns the appropriate reason why user cannot see the topic" do
+      TopicUser.create!(user_id: user.id, topic_id: topic.id, notification_level: TopicUser.notification_levels[:muted])
+
+      sign_in(admin)
+      get "/u/is_local_username.json", params: {
+        usernames: [user.username], topic_id: topic.id
+      }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["cannot_see"][user.username]).to eq("muted_topic")
     end
   end
 


### PR DESCRIPTION
The new warnings cover more cases and more accurate. Most of the
warnings will be visible only to staff members because otherwise they
would leak information about user's preferences.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
