### PR TITLE
SECURITY: Disable MessageBus::Diagnostics.

### DIFF
--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -130,7 +130,6 @@ else
 end
 
 MessageBus.cache_assets = !Rails.env.development?
-MessageBus.enable_diagnostics
 
 if Rails.env == "test" || $0 =~ /rake$/
   # disable keepalive in testing


### PR DESCRIPTION
MessageBus::Diagnostics allows anyone with access to carry out certain
operations that may result in a denial of service. The impact of this is
greater on multisiite clusters.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
