### PR TITLE
FIX: improve the way magnific popup is loaded

### DIFF
--- a/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
@@ -2,7 +2,6 @@ import Component from "@ember/component";
 import { or } from "@ember/object/computed";
 import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import discourseComputed, { on } from "discourse-common/utils/decorators";
-import { isTesting } from "discourse-common/config/environment";
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
 import lightbox from "discourse/lib/lightbox";
@@ -76,7 +75,7 @@ export default Component.extend(UppyUploadMixin, {
 
   @on("willDestroyElement")
   _closeOnRemoval() {
-    if (isTesting() && $.magnificPopup?.instance) {
+    if ($.magnificPopup?.instance) {
       $.magnificPopup.instance.close();
     }
   },

--- a/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
@@ -1,31 +1,15 @@
 import Component from "@ember/component";
 import { or } from "@ember/object/computed";
 import UppyUploadMixin from "discourse/mixins/uppy-upload";
-import { ajax } from "discourse/lib/ajax";
-import discourseComputed from "discourse-common/utils/decorators";
+import discourseComputed, { on } from "discourse-common/utils/decorators";
+import { isTesting } from "discourse-common/config/environment";
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
 import lightbox from "discourse/lib/lightbox";
 import { next } from "@ember/runloop";
-import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Component.extend(UppyUploadMixin, {
   classNames: ["image-uploader"],
-  loadingLightbox: false,
-
-  init() {
-    this._super(...arguments);
-    this._applyLightbox();
-  },
-
-  willDestroyElement() {
-    this._super(...arguments);
-    const elem = $("a.lightbox");
-    if (elem && typeof elem.magnificPopup === "function") {
-      $("a.lightbox").magnificPopup("close");
-    }
-  },
-
   uploadingOrProcessing: or("uploading", "processing"),
 
   @discourseComputed("imageUrl", "placeholderUrl")
@@ -75,8 +59,6 @@ export default Component.extend(UppyUploadMixin, {
       imageHeight: upload.height,
     });
 
-    this._applyLightbox();
-
     // the value of the property used for imageUrl should be set
     // in this callback. this should be done in cases where imageUrl
     // is bound to a computed property of the parent component.
@@ -87,42 +69,21 @@ export default Component.extend(UppyUploadMixin, {
     }
   },
 
-  _openLightbox() {
-    next(() =>
-      $(this.element.querySelector("a.lightbox")).magnificPopup("open")
-    );
+  @on("didRender")
+  _applyLightbox() {
+    next(() => lightbox(this.element, this.siteSettings));
   },
 
-  _applyLightbox() {
-    if (this.imageUrl) {
-      next(() => lightbox(this.element, this.siteSettings));
+  @on("willDestroyElement")
+  _closeOnRemoval() {
+    if (isTesting() && $.magnificPopup?.instance) {
+      $.magnificPopup.instance.close();
     }
   },
 
   actions: {
     toggleLightbox() {
-      if (this.imageFilename) {
-        this._openLightbox();
-      } else {
-        this.set("loadingLightbox", true);
-
-        ajax(`/uploads/lookup-metadata`, {
-          type: "POST",
-          data: { url: this.imageUrl },
-        })
-          .then((json) => {
-            this.setProperties({
-              imageFilename: json.original_filename,
-              imageFilesize: json.human_filesize,
-              imageWidth: json.width,
-              imageHeight: json.height,
-            });
-
-            this._openLightbox();
-            this.set("loadingLightbox", false);
-          })
-          .catch(popupAjaxError);
-      }
+      $(this.element.querySelector("a.lightbox"))?.magnificPopup("open");
     },
 
     trash() {

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -30,7 +30,7 @@ export default {
         },
         { id: "discourse-lightbox" }
       );
-      api.decorateCookedElement(lightbox, { id: "discourse-lightbox" });
+
       if (siteSettings.support_mixed_text_direction) {
         api.decorateCookedElement(setTextDirections, {
           id: "discourse-text-direction",

--- a/app/assets/javascripts/discourse/app/lib/lightbox.js
+++ b/app/assets/javascripts/discourse/app/lib/lightbox.js
@@ -9,6 +9,7 @@ import loadScript from "discourse/lib/load-script";
 import { renderIcon } from "discourse-common/lib/icon-library";
 import { spinnerHTML } from "discourse/helpers/loading-spinner";
 import { helperContext } from "discourse-common/lib/helpers";
+import { isTesting } from "discourse-common/config/environment";
 
 export default function (elem, siteSettings) {
   if (!elem) {
@@ -30,7 +31,7 @@ export default function (elem, siteSettings) {
     $(lightboxes).magnificPopup({
       type: "image",
       closeOnContentClick: false,
-      removalDelay: 300,
+      removalDelay: isTesting() ? 0 : 300,
       mainClass: "mfp-zoom-in",
       tClose: I18n.t("lightbox.close"),
       tLoading: spinnerHTML,

--- a/app/assets/javascripts/discourse/app/lib/lightbox.js
+++ b/app/assets/javascripts/discourse/app/lib/lightbox.js
@@ -15,14 +15,18 @@ export default function (elem, siteSettings) {
     return;
   }
 
+  const lightboxes = elem.querySelectorAll(
+    "*:not(.spoiler):not(.spoiled) a.lightbox"
+  );
+
+  if (!lightboxes.length) {
+    return;
+  }
+
   const caps = helperContext().capabilities;
   const imageClickNavigation = caps.touch;
 
   loadScript("/javascripts/jquery.magnific-popup.min.js").then(function () {
-    const lightboxes = elem.querySelectorAll(
-      "*:not(.spoiler):not(.spoiled) a.lightbox"
-    );
-
     $(lightboxes).magnificPopup({
       type: "image",
       closeOnContentClick: false,


### PR DESCRIPTION
Story time: 

If you visit the homepage of any Discourse site and check the `<head>` tag. You'll notice that the Magnific popup vendor script is already loaded even when there are no lightboxes on that page. Check the very bottom of the `<head>` tag on https://meta.discourse.org/

Ok, why does this happen? It happens because the Discourse Lightbox lib only checks if there's eligible elements _after_ the script has already loaded. 

https://github.com/discourse/discourse/blob/1472e47aae5bfdfb6fd9abfe89beb186c751f514/app/assets/javascripts/discourse/app/lib/lightbox.js#L21-L24

**Change 1:**  This PR moves that check to make it happen before loading the script. The parent container (a post, for example) is already available.

Ok, but that doesn't explain why the `lightbox` method is called in the first place. For this, we have to look at the `discourse-banner` component. When that component is rendered, we apply the same decorators we have for posts.

https://github.com/discourse/discourse/blob/254689b1fbf51fd432b5f33c4740615c5a667563/app/assets/javascripts/discourse/app/initializers/post-decorations.js#L27-L32

and 

https://github.com/discourse/discourse/blob/77781f9a11b499e45a5a5d7fbe73fbe5e17d88ee/app/assets/javascripts/discourse/app/lib/plugin-api.js#L316
 
 The Discourse lightbox lib already checks if the target element is unavailable and bails. 
 
 https://github.com/discourse/discourse/blob/1472e47aae5bfdfb6fd9abfe89beb186c751f514/app/assets/javascripts/discourse/app/lib/lightbox.js#L14-L16
 
The issue is that the `discourse-banner` component is not rendered conditionally; only its contents are. So, it will always have an element (Ember wrapper div), and so it passes the check. Change 1 fixes this issue. Check for lightboxes before loading Magnific popup. 

<hr>

While looking at this, I noticed that there's an erroneous duplicate decorator here. You can see the legit decorator as well as the dupe here.

https://github.com/discourse/discourse/blob/254689b1fbf51fd432b5f33c4740615c5a667563/app/assets/javascripts/discourse/app/initializers/post-decorations.js#L27-L33

**Change 2:** This PR removes the dupe decorator. It's not doing anything since it doesn't pass an element.

<hr>

The changes above don't work with the current lightbox implementation in the `uppy-image-uploader`. 

**Change 3:** This PR simplifies the lightbox implementation in `uppy-image-uploader` component while maintaining 100% of the current functionality.

The changes have been tested everywhere the component is used on both desktop and mobile.

* user profile background 
* user card background
* admin settings
* group avatar flair
* category logo
* category background
* badge image uploader

<hr> 

**The end result:** 

Nothing changes as far as functionality anywhere, but... Magnific popup is only loaded when it's actually needed. 

The cases where it will be loaded are as follows:

* if there's a global banner and it contains lightboxes
* if a user visits a topic and a post has lightboxes
* if the image uploader is rendered and it has an image (not empty) 
* any time the lightbox decorator is called on an element that contains lightboxes

Otherwise, it's not loaded. 

The savings are ~7kb (gzip) and one less HTTP request until Magnific popup is actually needed. Plus... Google won't complain about unused JavaScript.

<hr>

Tiny note: Merging from the UI removes the prefix I add to PRs. If you merge this, kindly add the `FIX` prefix to the title. 
