### PR TITLE
Revert "DEV: supports actionClick for small actions (#15331)"

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -79,23 +79,8 @@ export default createWidget("post-small-action", {
   },
 
   buildClasses(attrs) {
-    const classes = [];
-
-    if (attrs.actionClick) {
-      classes.push("clickable");
-    }
-
     if (attrs.deleted) {
-      classes.push("deleted");
-    }
-
-    return classes;
-  },
-
-  click(event) {
-    if (this.attrs.actionClick) {
-      event.preventDefault();
-      this.attrs.actionClick();
+      return "deleted";
     }
   },
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-small-action-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-small-action-test.js
@@ -3,7 +3,6 @@ import componentTest, {
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
 import hbs from "htmlbars-inline-precompile";
-import { click } from "@ember/test-helpers";
 
 discourseModule(
   "Integration | Component | Widget | post-small-action",
@@ -32,24 +31,6 @@ discourseModule(
           exists(".small-action-desc > .small-action-edit"),
           "it adds the edit small action button"
         );
-      },
-    });
-
-    componentTest("is clickable if actionClick", {
-      template: hbs`{{mount-widget widget="post-small-action" args=args}}`,
-      beforeEach() {
-        this.set("args", {
-          id: 123,
-          actionClick: () => {
-            document.querySelector(".small-action").style.background = "red";
-          },
-        });
-      },
-      async test(assert) {
-        const clickable = document.querySelector(".small-action.clickable");
-        await click(clickable);
-
-        assert.equal(clickable.style.background, "red", "it calls the action");
       },
     });
 


### PR DESCRIPTION
This reverts commit 022dba4727ebd030c7f3d0d24206d4828dfc672a.

It creates a case of nested interactive which I don't like, it needs a better solution.
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
