### PR TITLE
DEV: Fix linting issue with emoji `keydown` event

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -89,6 +89,8 @@ export default Component.extend({
         return;
       }
 
+      emojiPicker.addEventListener("keydown", this._keyDown);
+
       const textareaWrapper = document.querySelector(
         ".d-editor-textarea-wrapper"
       );
@@ -137,6 +139,9 @@ export default Component.extend({
   @action
   onClose() {
     document.removeEventListener("click", this.handleOutsideClick);
+    document
+      .querySelector(".emoji-picker")
+      ?.removeEventListener("keydown", this._keyDown);
     this.onEmojiPickerClose && this.onEmojiPickerClose();
   },
 
@@ -215,8 +220,8 @@ export default Component.extend({
     section && section.scrollIntoView();
   },
 
-  @action
-  keydown(event) {
+  @bind
+  _keyDown(event) {
     if (event.code === "Escape") {
       this.onClose();
       return false;

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
@@ -1,5 +1,5 @@
 {{#if isActive}}
-  <div {{on "keydown" (action "keydown")}} class="emoji-picker {{if @isActive "opened"}}">
+  <div class="emoji-picker {{if @isActive "opened"}}">
     <div class="emoji-picker-category-buttons">
       {{#if recentEmojis.length}}
         <button type="button" data-section="recent" {{action "onCategorySelection" "recent"}} class="btn btn-default category-button emoji">


### PR DESCRIPTION
Followup to https://github.com/discourse/discourse/commit/e71cd73965f4ef08b27449b5c9747ee4c7f86d98, fixes linting, because `ember-template-lint` does not allow interacttion added to non-interactive element.