### PR TITLE
FIX: Use basic meta description if other description tags are missing

### DIFF
--- a/lib/onebox/engine/standard_embed.rb
+++ b/lib/onebox/engine/standard_embed.rb
@@ -58,7 +58,12 @@ module Onebox
         end
 
         favicon = get_favicon
-        @raw["favicon".to_sym] = favicon unless Onebox::Helpers::blank?(favicon)
+        @raw[:favicon] = favicon unless Onebox::Helpers::blank?(favicon)
+
+        unless @raw[:description]
+          description = get_description
+          @raw[:description] = description unless Onebox::Helpers::blank?(description)
+        end
 
         @raw
       end
@@ -104,6 +109,15 @@ module Onebox
         favicon = favicon.nil? ? nil : (favicon['href'].nil? ? nil : favicon['href'].strip)
 
         Onebox::Helpers::get_absolute_image_url(favicon, url)
+      end
+
+      def get_description
+        return nil unless html_doc
+
+        description = html_doc.at("meta[name='description']").to_h['content']
+        description ||= html_doc.at("meta[name='Description']").to_h['content']
+
+        description
       end
 
       def get_json_response

--- a/spec/fixtures/onebox/basic_description.response
+++ b/spec/fixtures/onebox/basic_description.response
@@ -1,0 +1,17 @@
+<html lang="en" data-ember-extension="1">
+<head>
+    <title>My Page Title</title>
+    <meta name="description" content="basic meta description">
+    <link rel="canonical" href="https://www.example.com/content">
+    <meta property="og:site_name" content="My Site">
+    <meta property="twitter:site" content="@example">
+    <meta property="og:title" content="My Page Title">
+    <meta property="og:url" content="https://www.example.com/content">
+    <meta property="og:image" content="https://www.example.com/content/image.png">
+    <meta property="og:image:width" content="512">
+    <meta property="og:image:height" content="256">
+<body>
+  <h1>Welcome</h1>
+  <p>Body content goes here</p>
+</body>
+</html>

--- a/spec/lib/onebox/engine/allowlisted_generic_onebox_spec.rb
+++ b/spec/lib/onebox/engine/allowlisted_generic_onebox_spec.rb
@@ -184,6 +184,25 @@ describe Onebox::Engine::AllowlistedGenericOnebox do
         expect(onebox.to_html).to include("People are fostering and adopting pets during the pandemic")
       end
     end
+
+    context 'uses basic meta description when necessary' do
+      before do
+        stub_request(:get, "https://www.reddit.com/r/colors/comments/b4d5xm/literally_nothing_black_edition/")
+          .to_return(status: 200, body: onebox_response('reddit_image'))
+        stub_request(:get, "https://www.example.com/content")
+          .to_return(status: 200, body: onebox_response('basic_description'))
+      end
+
+      it 'uses opengraph tags when present' do
+        onebox = described_class.new("https://www.reddit.com/r/colors/comments/b4d5xm/literally_nothing_black_edition/")
+        expect(onebox.to_html).to include("4 votes and 1 comment so far on Reddit")
+      end
+
+      it 'fallback to basic meta description if other description tags are missing' do
+        onebox = described_class.new("https://www.example.com/content")
+        expect(onebox.to_html).to include("basic meta description")
+      end
+    end
   end
 
   describe 'article html hosts' do


### PR DESCRIPTION
When attempting to Onebox a page if there is no `meta property="og:description"` tag but there is a  `meta name="description"` tag, Onebox should try to use that value.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
