### PR TITLE
FIX: Menu panel position adjustment

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -338,11 +338,7 @@ const SiteHeaderComponent = MountWidget.extend(
       }
 
       const windowWidth = document.body.offsetWidth;
-      const headerWidth =
-        document.querySelector("#main-outlet .container").offsetWidth || 1100;
-      const remaining = (windowWidth - headerWidth) / 2;
-      const viewMode =
-        this.site.mobileView || remaining < 50 ? "slide-in" : "drop-down";
+      const viewMode = this.site.mobileView ? "slide-in" : "drop-down";
 
       menuPanels.forEach((panel) => {
         const headerCloak = document.querySelector(".header-cloak");


### PR DESCRIPTION
On sites with a brand header above the Discourse header, the menus were mispositioned for certain window sizes below 1000px, see screenshot: 

<img width="500" alt="image" src="https://user-images.githubusercontent.com/368961/146615960-bc372825-d49a-4610-b80d-33499b883ce0.png">

A similar issue also happens on iPad landscape in our DiscourseHub app (or on iPad Safari on sites with a banner component). 

This fixes that issue, and I don't believe there are side effects. 