### PR TITLE
DEV: Add uppyReady hook to uppy mixins

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -337,7 +337,13 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
     this._setupUIPlugins();
 
     this.uploadTargetBound = true;
+    this._uppyReady();
   },
+
+  // This should be overridden in a child component if you need to
+  // hook into uppy events and be sure that everything is already
+  // set up for _uppyInstance.
+  _uppyReady() {},
 
   @bind
   _handleUploadError(file, error, response) {

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -224,7 +224,14 @@ export default Mixin.create(UppyS3Multipart, {
         this._useXHRUploads();
       }
     }
+
+    this._uppyReady();
   },
+
+  // This should be overridden in a child component if you need to
+  // hook into uppy events and be sure that everything is already
+  // set up for _uppyInstance.
+  _uppyReady() {},
 
   _startUpload() {
     if (!this.filesAwaitingUpload) {
@@ -233,6 +240,7 @@ export default Mixin.create(UppyS3Multipart, {
     if (!this._uppyInstance?.getFiles().length) {
       return;
     }
+    this.set("uploading", true);
     return this._uppyInstance?.upload();
   },
 


### PR DESCRIPTION
This should be overridden in a child component if you need to
hook into uppy events and be sure that everything is already
set up for _uppyInstance.