### PR TITLE
DEV: Promote uppy backup uploader to primary uploader

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/backups-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/backups-index.hbs
@@ -1,22 +1,8 @@
 <div class="backup-options">
   {{#if localBackupStorage}}
-    {{#if siteSettings.enable_experimental_backup_uploader}}
-      {{uppy-backup-uploader done=(route-action "uploadSuccess") localBackupStorage=localBackupStorage}}
-    {{else}}
-      {{resumable-upload
-        target="/admin/backups/upload"
-        success=(route-action "uploadSuccess")
-        error=(route-action "uploadError")
-        uploadText=uploadLabel
-        title="admin.backups.upload.title"
-        class="btn-default"}}
-    {{/if}}
+    {{uppy-backup-uploader done=(route-action "uploadSuccess") localBackupStorage=localBackupStorage}}
   {{else}}
-    {{#if siteSettings.enable_experimental_backup_uploader}}
-      {{uppy-backup-uploader done=(route-action "remoteUploadSuccess")}}
-    {{else}}
-      {{backup-uploader done=(route-action "remoteUploadSuccess")}}
-    {{/if}}
+    {{uppy-backup-uploader done=(route-action "remoteUploadSuccess")}}
   {{/if}}
 
   {{#if site.isReadOnly}}

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -273,10 +273,6 @@ basic:
     client: true
     default: false
     hidden: true
-  enable_experimental_backup_uploader:
-    client: true
-    default: false
-    hidden: true
   enable_direct_s3_uploads:
     client: true
     default: false

--- a/db/migrate/20211220023034_remove_experimental_backup_uploader_setting.rb
+++ b/db/migrate/20211220023034_remove_experimental_backup_uploader_setting.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RemoveExperimentalBackupUploaderSetting < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      DELETE FROM site_settings
+      WHERE name = 'enable_experimental_backup_uploader'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This commit removes the enable_experimental_backup_uploader site
setting and the flags in backups-index.hbs to make the uppy
backup uploader the main one from now on.

A follow-up commit will delete the old backup uploader code and
also remove resumable.js from the project.

