### PR TITLE
DEV: Handle CORS and other fetch failures for media-optimization-worker

### DIFF
--- a/public/javascripts/media-optimization-worker.js
+++ b/public/javascripts/media-optimization-worker.js
@@ -148,8 +148,12 @@ onmessage = async function (e) {
       }
       break;
     case "install":
-      await loadLibs(e.data.settings);
-      postMessage({ type: "installed" });
+      try {
+        await loadLibs(e.data.settings);
+        postMessage({ type: "installed" });
+      } catch (error) {
+        postMessage({ type: "installFailed", errorMessage: error.message });
+      }
       break;
     default:
       logIfDebug(`Sorry, we are out of ${e}.`);


### PR DESCRIPTION
Occasionally there will be a misconfigured CORS rule or a different
network failure when loading one of the media optimization WASM scripts.
This commit handles load failures and sends a new installFailed message
from the service worker, so that we don't error and hold up the rest
of the uploads if this occurs; the worker will just not process anything
and will keep trying to install itself with subsequent uploads until it succeeds.

This commit also removes the redundant useUppy variable in the worker
this should have been removed a while ago in f70e6c302fddd38595a1fc90e24964a2cb0716bb