### PR TITLE
Update wordpress scopes and add ``session/scopes`` endpoint

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -597,6 +597,15 @@ class SessionController < ApplicationController
     }
   end
 
+  def scopes
+    if is_api?
+      api_key = ApiKey.active.with_key(request.env['HTTP_API_KEY']).first
+      render_serialized(api_key.api_key_scopes, ApiKeyScopeSerializer, root: 'scopes')
+    else
+      render body: nil, status: 404
+    end
+  end
+
   protected
 
   def normalized_login_param

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -599,7 +599,8 @@ class SessionController < ApplicationController
 
   def scopes
     if is_api?
-      api_key = ApiKey.active.with_key(request.env['HTTP_API_KEY']).first
+      key = request.env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY]
+      api_key = ApiKey.active.with_key(key).first
       render_serialized(api_key.api_key_scopes, ApiKeyScopeSerializer, root: 'scopes')
     else
       render body: nil, status: 404

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -64,6 +64,7 @@ class ApiKey < ActiveRecord::Base
 
   def request_allowed?(env)
     return false if allowed_ips.present? && allowed_ips.none? { |ip| ip.include?(Rack::Request.new(env).ip) }
+    return true if RouteMatcher.new(methods: :get, actions: "session#scopes").match?(env: env)
 
     api_key_scopes.blank? || api_key_scopes.any? { |s| s.permits?(env) }
   end

--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -30,8 +30,7 @@ class ApiKeyScope < ActiveRecord::Base
           read_lists: {
             actions: list_actions, params: %i[category_id],
             aliases: { category_id: :category_slug_path_with_id }
-          },
-          wordpress: { actions: %w[topics#wordpress], params: %i[topic_id] }
+          }
         },
         posts: {
           edit: { actions: %w[posts#update], params: %i[id] }
@@ -75,6 +74,12 @@ class ApiKeyScope < ActiveRecord::Base
           list_user_badges: { actions: %w[user_badges#username], params: %i[username] },
           assign_badge_to_user: { actions: %w[user_badges#create], params: %i[username] },
           revoke_badge_from_user: { actions: %w[user_badges#destroy] },
+        },
+        wordpress: {
+          publishing: { actions: %w[site#site posts#create topics#update topics#status topics#show] },
+          commenting: { actions: %w[topics#wordpress] },
+          discourse_connect: { actions: %w[admin/users#sync_sso admin/users#log_out admin/users#index] },
+          utilities: { actions: %w[users#create groups#index] }
         }
       }
 

--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -78,7 +78,7 @@ class ApiKeyScope < ActiveRecord::Base
         wordpress: {
           publishing: { actions: %w[site#site posts#create topics#update topics#status topics#show] },
           commenting: { actions: %w[topics#wordpress] },
-          discourse_connect: { actions: %w[admin/users#sync_sso admin/users#log_out admin/users#index] },
+          discourse_connect: { actions: %w[admin/users#sync_sso admin/users#log_out admin/users#index users#show] },
           utilities: { actions: %w[users#create groups#index] }
         }
       }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4249,7 +4249,6 @@ en:
               write: Create a new topic or post to an existing one.
               update: Update a topic. Change the title, category, tags, etc.
               read_lists: Read topic lists like top, new, latest, etc. RSS is also supported.
-              wordpress: Necessary for the WordPress wp-discourse plugin to work.
             posts:
               edit: Edit any post or a specific one.
             categories:
@@ -4277,6 +4276,11 @@ en:
               list_user_badges: List user badges.
               assign_badge_to_user: Assign a badge to a user.
               revoke_badge_from_user: Revoke a badge from a user.
+            wordpress:
+              publishing: Necessary for the WP Discourse plugin publishing features (required).
+              commenting: Necessary for the WP Discourse plugin commenting features.
+              discourse_connect: Necessary for the WP Discourse plugin DiscourseConnect features.
+              utilities: Necessary if you use WP Discourse plugin Utilities.
 
       web_hooks:
         title: "Webhooks"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -383,6 +383,7 @@ Discourse::Application.routes.draw do
     if Rails.env.test?
       post "session/2fa/test-action" => "session#test_second_factor_restricted_route"
     end
+    get "session/scopes" => "session#scopes"
     get "composer_messages" => "composer_messages#index"
 
     resources :static

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -235,7 +235,7 @@ describe Admin::ApiController do
 
         scopes = response.parsed_body['scopes']
 
-        expect(scopes.keys).to contain_exactly('topics', 'users', 'email', 'posts', 'uploads', 'global', 'badges', 'categories')
+        expect(scopes.keys).to contain_exactly('topics', 'users', 'email', 'posts', 'uploads', 'global', 'badges', 'categories', 'wordpress')
       end
     end
   end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -2614,4 +2614,33 @@ describe SessionController do
       expect(response.status).to eq(401)
     end
   end
+
+  describe '#scopes' do
+    context "when not a valid api request" do
+      it "returns 404" do
+        get "/session/scopes.json"
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when a valid api request" do
+      let(:admin) { Fabricate(:admin) }
+      let(:scope) { ApiKeyScope.new(resource: 'topics', action: 'read', allowed_parameters: { topic_id: '3' }) }
+      let(:api_key) { Fabricate(:api_key, user: admin, api_key_scopes: [scope]) }
+
+      it "returns the scopes of the api key" do
+        get "/session/scopes.json", headers: {
+          "Api-Key": api_key.key,
+          "Api-Username": admin.username
+        }
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
+        expect(json['scopes'].size).to eq(1)
+        expect(json['scopes'].first["resource"]).to eq("topics")
+        expect(json['scopes'].first["action"]).to eq("read")
+        expect(json['scopes'].first["allowed_parameters"]).to eq({ "topic_id": "3" }.as_json)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I'm looking to add granular API key usage for the WP Discourse plugin. This involves:

- Updating the "wordpress" default mappings to reflect the actions being used by the plugin, grouped by the feature-set they relate to (note that the existing "wordpress" action in the "topic" resource only relates to comment retrieval in the plugin, and is somewhat confusing in its current state).
- Adding a ``session/scopes`` endpoint, which returns the scopes associated with the api key in the request.

This is the companion PR on the plugin, which will provide further context to this: https://github.com/discourse/wp-discourse/pull/431. See in particular [``validate_scopes``](https://github.com/discourse/wp-discourse/pull/431/files#diff-5fd9ce264afeb5f617119db36e34a2e5a33f605527ac6fa9ee761b8123f1a17eR185).

If this approach is acceptable, I'll do some more testing before moving this out of draft. Below are some Q/A explaining my thinking behind this.

### Why does the wordpress plugin need granular scopes?

Currently the plugin requires the use of a global key, but only uses a subset of the actions, creating more risk than necessary. [See for example](https://meta.discourse.org/t/what-scopes-exactly-does-the-wordpress-api-key-need/175812).

### Why group the scopes by feature set?

This is how people use the plugin. Some use only SSO, some only publishing, some without comments etc. If a user is not using SSO they should be able to use a key that doesn't include the ``admin/user`` actions SSO requires.

Currently the "publishing" feature set cannot be totally disabled in the plugin (hence the "(required)" in the action description), however the ability to disable it (and just use SSO) may be added.

### Why add a ``session/scopes`` endpoint?

The WP Discourse plugin currently sends a request to ``/users/:username`` to test its connection to Discourse. This may be successful even if the allowed scopes are insufficient for how the plugin is configured. 

A scopes endpoint tells the API consumer both whether the connection is successful and what scopes their key has. There's similar implementations in other APIs, e.g [Sendgrid](https://docs.sendgrid.com/api-reference/api-key-permissions/retrieve-a-list-of-scopes-for-which-this-user-has-access).

### Why add the ``scopes`` endpoint to the session controller?

The endpoint could go in a few different places. I figured it belonged there as essentially you're asking about the scopes in the session created when the api-authenticated request is made.

### Why not use a ``tokeninfo`` endpoint?

``tokeninfo`` endpoints are part of the OAuth 2.0 spec, which is not what we're dealing with here. Using it may be confusing.