### PR TITLE
UX: update category-navigation scaling & wrapping

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -1,16 +1,6 @@
 // Topic list navigation & controls
 
 .list-controls {
-  .btn {
-    &:not(:first-child) {
-      margin-left: 0.5em;
-    }
-  }
-
-  .notifications-button {
-    margin-left: 0.5em;
-  }
-
   a.badge-category {
     padding: 3px 12px;
     font-size: $font-up-1;
@@ -22,6 +12,7 @@
     border: 1px solid var(--primary-medium);
     font-size: $font-0;
     transition: none;
+    height: 100%;
     &:focus {
       border-color: var(--tertiary);
     }
@@ -41,14 +32,15 @@
 }
 
 .category-breadcrumb {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--nav-space) 0; // used if the breadcrumb dropdowns wrap
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 0 0 var(--nav-space) 0;
   > li {
     // only target the top-level li, not dropdowns
     display: flex;
-    float: left;
     margin-right: 0.5em;
     margin-bottom: 0;
   }
@@ -64,10 +56,18 @@
 
 .navigation-controls {
   display: flex;
+  flex-wrap: wrap;
   align-items: stretch;
   margin-bottom: var(--nav-space);
+  gap: var(--nav-space) 0; // used if the buttons wrap
   > * {
     white-space: nowrap;
+    &:not(:last-child) {
+      margin-right: 0.5em;
+    }
+  }
+  .select-kit-header {
+    height: 100%;
   }
   @include breakpoint(mobile-large) {
     .edit-category {

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -183,13 +183,9 @@ button.dismiss-read {
 
 .category-breadcrumb {
   // only target the top-level li, not dropdowns
-  > li {
-    height: 100%;
-  }
   .select-kit {
     align-self: stretch;
     height: 100%;
-    margin-bottom: var(--nav-space);
   }
 }
 

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -88,19 +88,18 @@
   margin-left: 0;
 }
 
-ol.category-breadcrumb {
-  margin: 0 -3px 5px -3px;
-  display: flex;
-  flex-wrap: wrap;
-  flex: 1 1 100%;
-  li.select-kit {
+.category-breadcrumb {
+  width: 100%;
+  gap: 0.5em;
+  li {
     flex: 1 1 33%;
-    margin: 0 3px 5px 3px;
-    .select-kit-header .selected-name {
-      max-width: 80vw;
-      .badge-wrapper {
-        max-width: 100%;
-      }
+    margin: 0;
+    details {
+      width: 100%;
+    }
+    .name,
+    .category-name {
+      @include ellipsis;
     }
   }
 }


### PR DESCRIPTION
This improves some spacing and wrapping, especially in themes and on mobile devices. 

The aim is to allow the 3 direct children of `.category-navigation` (`.category-breadcrumb`, `#navigation-bar`, and `.navigation-controls`) to contain any number of menus and buttons, and for those elements to wrap well. This is important as themes can add a lot of navigation here. 

Some examples: 

![Screen Shot 2021-12-20 at 3 54 31 PM](https://user-images.githubusercontent.com/1681963/146836133-20d150d0-6dec-4dc4-a4f0-22d529beffe9.png)

![Screen Shot 2021-12-20 at 3 55 42 PM](https://user-images.githubusercontent.com/1681963/146836144-8d98138d-a244-4fdc-b077-e88db3b15c00.png)


This also keeps everything in any given row at a consistent height, for example... when themes may increase button or nav pill height: 


Before:
![Screen Shot 2021-12-20 at 4 38 59 PM](https://user-images.githubusercontent.com/1681963/146836076-582e2a6c-3402-4738-a7bb-dbec72861137.png)


After:
![Screen Shot 2021-12-20 at 3 54 52 PM](https://user-images.githubusercontent.com/1681963/146836022-fd11acd0-6bfc-4d2d-a0f2-3e3bc2f54a4d.png)


I've also improved mobile spacing, which regressed due to select-kit changes

Before:
![Screen Shot 2021-12-20 at 4 34 22 PM](https://user-images.githubusercontent.com/1681963/146836251-4b525505-9ad9-4bfd-a4c4-95f20ae44477.png)

After:
![Screen Shot 2021-12-20 at 4 34 33 PM](https://user-images.githubusercontent.com/1681963/146836274-3219f4ab-0af9-4944-8bb7-989c19559cca.png)

