### PR TITLE
DEV: Change images-uploader to use Uppy

### DIFF
--- a/app/assets/javascripts/discourse/app/components/images-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/images-uploader.js
@@ -1,15 +1,15 @@
 import Component from "@ember/component";
 import I18n from "I18n";
-import UploadMixin from "discourse/mixins/upload";
+import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import discourseComputed from "discourse-common/utils/decorators";
 
-export default Component.extend(UploadMixin, {
+export default Component.extend(UppyUploadMixin, {
   type: "avatar",
   tagName: "span",
 
-  @discourseComputed("uploading")
-  uploadButtonText(uploading) {
-    return uploading ? I18n.t("uploading") : I18n.t("upload");
+  @discourseComputed("uploadingOrProcessing")
+  uploadButtonText(uploadingOrProcessing) {
+    return uploadingOrProcessing ? I18n.t("uploading") : I18n.t("upload");
   },
 
   validateUploadedFilesOptions() {

--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -1,4 +1,5 @@
 import Mixin from "@ember/object/mixin";
+import { or } from "@ember/object/computed";
 import EmberObject from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import {
@@ -41,6 +42,8 @@ export default Mixin.create(UppyS3Multipart, {
   validateUploadedFilesOptions() {
     return {};
   },
+
+  uploadingOrProcessing: or("uploading", "processing"),
 
   @on("willDestroyElement")
   _destroy() {

--- a/app/assets/javascripts/discourse/app/templates/components/images-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/images-uploader.hbs
@@ -1,7 +1,7 @@
-<label class="btn" disabled={{uploading}} title={{i18n "admin.site_settings.uploaded_image_list.upload.title"}}>
+<label class="btn" disabled={{uploadingOrProcessing}} title={{i18n "admin.site_settings.uploaded_image_list.upload.title"}}>
   {{d-icon "far-image"}}&nbsp;{{uploadButtonText}}
   <input class="hidden-upload-field" disabled={{uploading}} type="file" accept="image/*" multiple>
 </label>
-{{#if uploading}}
+{{#if uploadingOrProcessing}}
   <span>{{i18n "upload_selector.uploading"}} {{uploadProgress}}%</span>
 {{/if}}


### PR DESCRIPTION
Missed this one, it is only used for the selectable_avatars
site setting.