### PR TITLE
FIX: Remove length constraint of `fancy_title` in `topics`

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1887,7 +1887,7 @@ end
 #  excerpt                   :string
 #  pinned_globally           :boolean          default(FALSE), not null
 #  pinned_until              :datetime
-#  fancy_title               :string(400)
+#  fancy_title               :string
 #  highest_staff_post_number :integer          default(0), not null
 #  featured_link             :string
 #  reviewable_score          :float            default(0.0), not null

--- a/db/migrate/20211221164540_remove_limit_for_fancy_title_in_topics.rb
+++ b/db/migrate/20211221164540_remove_limit_for_fancy_title_in_topics.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveLimitForFancyTitleInTopics < ActiveRecord::Migration[6.1]
+  def change
+    change_column :topics, :fancy_title, :string, limit: nil
+  end
+end


### PR DESCRIPTION
The `fancy_title` column in the `topics` table currently has a constraint that limits the column to 400 characters. We need to remove that constraint because it causes some automatic topics/PMs from the system to fail when using Discourse in locales that need more than 400 characters to the translate the content of those automatic messages.

Internal ticket: t58030.