### PR TITLE
FIX: gives composer options to post:highlight trigger

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discourse-topic.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-topic.js
@@ -1,3 +1,4 @@
+import { isBlank } from "@ember/utils";
 import { later, schedule, scheduleOnce, throttle } from "@ember/runloop";
 import AddArchetypeClass from "discourse/mixins/add-archetype-class";
 import ClickTrack from "discourse/lib/click-track";
@@ -48,8 +49,10 @@ export default Component.extend(
       }
     },
 
-    _highlightPost(postNumber) {
-      scheduleOnce("afterRender", null, highlightPost, postNumber);
+    _highlightPost(postNumber, options = {}) {
+      if (isBlank(options.jump) || options.jump !== false) {
+        scheduleOnce("afterRender", null, highlightPost, postNumber);
+      }
     },
 
     _hideTopicInHeader() {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -894,7 +894,11 @@ export default Controller.extend({
 
         if (result.responseJson.action === "create_post") {
           this.appEvents.trigger("composer:created-post");
-          this.appEvents.trigger("post:highlight", result.payload.post_number);
+          this.appEvents.trigger(
+            "post:highlight",
+            result.payload.post_number,
+            options
+          );
         }
 
         if (this.get("model.draftKey") === Composer.NEW_TOPIC_KEY) {


### PR DESCRIPTION
This change allows to prevent page jump, when jump is prevented, due to highlightPost causing a `focus()`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
