### PR TITLE
FIX: Predict draftSequence on draft save

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -1223,16 +1223,19 @@ const Composer = RestModel.extend({
       data.originalText = this.originalText;
     }
 
+    const draftSequence = this.draftSequence;
+    this.set("draftSequence", this.draftSequence + 1);
+
     return Draft.save(
       this.draftKey,
-      this.draftSequence,
+      draftSequence,
       data,
       this.messageBus.clientId,
       { forceSave: this.draftForceSave }
     )
       .then((result) => {
         if (result.draft_sequence) {
-          this.draftSequence = result.draft_sequence;
+          this.set("draftSequence", result.draft_sequence);
         }
         if (result.conflict_user) {
           this.setProperties({


### PR DESCRIPTION
The new draft sequence is returned after the draft is saved and usually
it is the old draft sequence plus one and this way the new draft
sequence can be predicted.

Sometimes drafts are saved at odd times or the request is slower than
usual which can create a race condition. This prediction can fix this
problem.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
