### PR TITLE
FIX: Save draftSequence when it is 0

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -1234,7 +1234,7 @@ const Composer = RestModel.extend({
       { forceSave: this.draftForceSave }
     )
       .then((result) => {
-        if (result.draft_sequence) {
+        if ("draft_sequence" in result) {
           this.set("draftSequence", result.draft_sequence);
         }
         if (result.conflict_user) {


### PR DESCRIPTION
The first draftSequence value is 0 and that was not recognized as a
valid value by the client.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
