### PR TITLE
DEV: Create post actions without creating a notification and store custom data.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
@@ -106,7 +106,10 @@ export const DefaultNotificationItem = createWidget(
     },
 
     icon(notificationName) {
-      let icon = iconNode(`notification.${notificationName}`);
+      return iconNode(`notification.${notificationName}`);
+    },
+
+    _addA11yAttrsTo(icon, notificationName) {
       icon.properties.attributes["aria-label"] = I18n.t(
         `notifications.titles.${notificationName}`
       );
@@ -131,6 +134,7 @@ export const DefaultNotificationItem = createWidget(
       let { data } = attrs;
       let text = emojiUnescape(this.text(notificationName, data));
       let icon = this.icon(notificationName, data);
+      this._addA11yAttrsTo(icon, notificationName);
 
       const title = this.notificationTitle(notificationName, data);
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -473,6 +473,10 @@ class PostAlerter
       display_username: opts[:display_username] || post.user.username,
     }
 
+    if opts[:custom_data]&.is_a?(Hash)
+      opts[:custom_data].each { |k, v| notification_data[k] = v }
+    end
+
     if group = opts[:group]
       notification_data[:group_id] = group.id
       notification_data[:group_name] = group.name

--- a/lib/post_action_creator.rb
+++ b/lib/post_action_creator.rb
@@ -7,20 +7,21 @@ class PostActionCreator
 
   # Shortcut methods for easier invocation
   class << self
-    def create(created_by, post, action_key, message: nil, created_at: nil, reason: nil)
+    def create(created_by, post, action_key, message: nil, created_at: nil, reason: nil, silent: false)
       new(
         created_by,
         post,
         PostActionType.types[action_key],
         message: message,
         created_at: created_at,
-        reason: reason
+        reason: reason,
+        silent: silent
       ).perform
     end
 
     [:like, :off_topic, :spam, :inappropriate, :bookmark].each do |action|
-      define_method(action) do |created_by, post|
-        create(created_by, post, action)
+      define_method(action) do |created_by, post, silent = false|
+        create(created_by, post, action, silent: silent)
       end
     end
     [:notify_moderators, :notify_user].each do |action|
@@ -40,7 +41,8 @@ class PostActionCreator
     flag_topic: false,
     created_at: nil,
     queue_for_review: false,
-    reason: nil
+    reason: nil,
+    silent: false
   )
     @created_by = created_by
     @created_at = created_at || Time.zone.now
@@ -62,6 +64,8 @@ class PostActionCreator
     if reason.nil? && @queue_for_review
       @reason = 'queued_by_staff'
     end
+
+    @silent = silent
   end
 
   def post_can_act?
@@ -113,7 +117,7 @@ class PostActionCreator
         create_reviewable(result)
         enforce_rules
         UserActionManager.post_action_created(post_action)
-        PostActionNotifier.post_action_created(post_action)
+        PostActionNotifier.post_action_created(post_action) if !@silent
         notify_subscribers
 
         # agree with other flags

--- a/spec/components/post_action_creator_spec.rb
+++ b/spec/components/post_action_creator_spec.rb
@@ -80,6 +80,16 @@ describe PostActionCreator do
       expect(notification_data['display_username']).to eq(user.username)
       expect(notification_data['username2']).to eq(nil)
     end
+
+    it 'does not create a notification if silent mode is enabled' do
+      PostActionNotifier.enable
+
+      expect(
+        PostActionCreator.new(user, post, like_type_id, silent: true).perform.success
+      ).to eq(true)
+
+      expect(Notification.where(notification_type: Notification.types[:liked]).exists?).to eq(false)
+    end
   end
 
   context "flags" do

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1869,4 +1869,21 @@ describe PostAlerter do
       expect(email).to eq(last_email)
     end
   end
+
+  describe 'storing custom data' do
+    let(:custom_data) { 'custom_string' }
+
+    it 'stores custom data inside a notification' do
+      PostAlerter.new.create_notification(
+        admin,
+        Notification.types[:liked],
+        post,
+        custom_data: { custom_key: custom_data }
+      )
+
+      liked_notification = Notification.where(notification_type: Notification.types[:liked]).last
+
+      expect(liked_notification.data_hash[:custom_key]).to eq(custom_data)
+    end
+  end
 end


### PR DESCRIPTION
I plan to use this in an upcoming discourse-reactions PR, where I want to like a post without notifying the user, so I can instead create a reaction notification.

Additionally, we decouple the a11y attributes from the icon itself, which will let us extend the widget's icon without losing them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
