### PR TITLE
DEV: Use EmailSettingsValidator in more places

### DIFF
--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -80,30 +80,22 @@ task 'emails:test', [:email] => [:environment] do |_, args|
 
     puts "Testing sending to #{email} using #{smtp[:address]}:#{smtp[:port]}, username:#{smtp[:user_name]} with #{smtp[:authentication]} auth."
 
-    # TODO (martin, post-2.7 release) Change to use EmailSettingsValidator
-    # EmailSettingsValidator.validate_smtp(
-    #   host: smtp[:address],
-    #   port: smtp[:port],
-    #   domain: smtp[:domain] || 'localhost',
-    #   username: smtp[:user_name],
-    #   password: smtp[:password],
-    #   authentication: smtp[:authentication] || 'plain'
-    # )
-
-    # We would like to do this, but Net::SMTP errors out using starttls
-    #Net::SMTP.start(smtp[:address], smtp[:port]) do |s|
-    #  s.starttls if !!smtp[:enable_starttls_auto] && s.capable_starttls?
-    #  s.auth_login(smtp[:user_name], smtp[:password])
-    #end
-
-    Net::SMTP.start(smtp[:address], smtp[:port], smtp[:domain] || 'localhost',  smtp[:user_name], smtp[:password], smtp[:authentication])
-
+    # We are not formatting the messages using EmailSettingsExceptionHandler here
+    # because we are doing custom messages in the rake task with more details.
+    EmailSettingsValidator.validate_smtp(
+      host: smtp[:address],
+      port: smtp[:port],
+      domain: smtp[:domain] || 'localhost',
+      username: smtp[:user_name],
+      password: smtp[:password],
+      authentication: smtp[:authentication] || 'plain'
+    )
   rescue Exception => e
 
     if e.to_s.match(/execution expired/)
       message = <<~STR
         ======================================== ERROR ========================================
-        Connection to port #{ENV["DISCOURSE_SMTP_PORT"]} failed.
+        Connection to port #{smtp[:port]} failed.
         ====================================== SOLUTION =======================================
         The most likely problem is that your server has outgoing SMTP traffic blocked.
         If you are using a service like Mailgun or Sendgrid, try using port 2525.

--- a/lib/validators/pop3_polling_enabled_setting_validator.rb
+++ b/lib/validators/pop3_polling_enabled_setting_validator.rb
@@ -33,20 +33,16 @@ class POP3PollingEnabledSettingValidator
   private
 
   def authentication_works?
-    # TODO (martin, post-2.7 release) Change to use EmailSettingsValidator
-    # EmailSettingsValidator.validate_pop3(
-    #   host: SiteSetting.pop3_polling_host,
-    #   port: SiteSetting.pop3_polling_port,
-    #   ssl: SiteSetting.pop3_polling_ssl,
-    #   username: SiteSetting.pop3_polling_username,
-    #   password: SiteSetting.pop3_polling_password,
-    #   openssl_verify: SiteSetting.pop3_polling_openssl_verify
-    # )
     @authentication_works ||= begin
-      pop3 = Net::POP3.new(SiteSetting.pop3_polling_host, SiteSetting.pop3_polling_port)
-      pop3.enable_ssl(OpenSSL::SSL::VERIFY_NONE) if SiteSetting.pop3_polling_ssl
-      pop3.auth_only(SiteSetting.pop3_polling_username, SiteSetting.pop3_polling_password)
-    rescue Net::POPAuthenticationError
+      EmailSettingsValidator.validate_pop3(
+        host: SiteSetting.pop3_polling_host,
+        port: SiteSetting.pop3_polling_port,
+        ssl: SiteSetting.pop3_polling_ssl,
+        username: SiteSetting.pop3_polling_username,
+        password: SiteSetting.pop3_polling_password,
+        openssl_verify: SiteSetting.pop3_polling_openssl_verify
+      )
+    rescue *EmailSettingsExceptionHandler::EXPECTED_EXCEPTIONS => err
       false
     else
       true


### PR DESCRIPTION
Clears out a long-standing TODO I added back in
3d2cace94f0aa0e1a5a3b33dc6bbc9668b8808b0, this way we are only
validating these settings using one central class.