### PR TITLE
DEV: Drop old bookmark columns

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -20,20 +20,6 @@ class Bookmark < ActiveRecord::Base
     )
   end
 
-  # TODO (martin) (2021-12-01) Remove this once plugins are not using it.
-  def self.reminder_types
-    @reminder_types ||= Enum.new(
-      later_today: 1,
-      next_business_day: 2,
-      tomorrow: 3,
-      next_week: 4,
-      next_month: 5,
-      custom: 6,
-      start_of_next_business_week: 7,
-      later_this_week: 8
-    )
-  end
-
   validate :unique_per_post_for_user,
     on: [:create, :update],
     if: Proc.new { |b| b.will_save_change_to_post_id? || b.will_save_change_to_user_id? }

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -182,7 +182,6 @@ end
 #  index_bookmarks_on_post_id                            (post_id)
 #  index_bookmarks_on_reminder_at                        (reminder_at)
 #  index_bookmarks_on_reminder_set_at                    (reminder_set_at)
-#  index_bookmarks_on_topic_id                           (topic_id)
 #  index_bookmarks_on_user_id                            (user_id)
 #  index_bookmarks_on_user_id_and_post_id_and_for_topic  (user_id,post_id,for_topic) UNIQUE
 #

--- a/db/post_migrate/20211224010204_drop_old_bookmark_columns.rb
+++ b/db/post_migrate/20211224010204_drop_old_bookmark_columns.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'migration/column_dropper'
+
+class DropOldBookmarkColumns < ActiveRecord::Migration[6.1]
+  DROPPED_COLUMNS ||= {
+    bookmarks: %i{
+      topic_id
+      reminder_type
+    }
+  }
+
+  def up
+    DROPPED_COLUMNS.each do |table, columns|
+      Migration::ColumnDropper.execute_drop(table, columns)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/bookmark_manager.rb
+++ b/lib/bookmark_manager.rb
@@ -33,11 +33,9 @@ class BookmarkManager
   #                        See Bookmark.auto_delete_preferences,
   #                        this is used to determine when to delete a bookmark
   #                        automatically.
-  # TODO (martin) (2021-12-01) Remove reminder_type keyword argument once plugins are not using it.
   def create(
     post_id:,
     name: nil,
-    reminder_type: nil,
     reminder_at: nil,
     for_topic: false,
     options: {}
@@ -100,8 +98,7 @@ class BookmarkManager
     BookmarkReminderNotificationHandler.send_notification(bookmark)
   end
 
-  # TODO (martin) (2021-12-01) Remove reminder_type keyword argument once plugins are not using it.
-  def update(bookmark_id:, name:, reminder_at:, reminder_type: nil, options: {})
+  def update(bookmark_id:, name:, reminder_at:, options: {})
     bookmark = find_bookmark_and_check_access(bookmark_id)
 
     success = bookmark.update(


### PR DESCRIPTION
As per https://github.com/discourse/discourse/commit/22208836c5f2adcf8c85a62d27b67968743b20f0
these are no longer needed, a follow up commit will remove the ignored
columns.
