### PR TITLE
DEV: Remove old enable_experimental_composer_uploader site setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -267,12 +267,6 @@ basic:
     client: true
     default: true
     hidden: true
-  # TODO (martin) (2022-02-01) Remove this setting once plugins relying on
-  # it have been changed.
-  enable_experimental_composer_uploader:
-    client: true
-    default: false
-    hidden: true
   enable_direct_s3_uploads:
     client: true
     default: false

--- a/db/migrate/20211224011511_delete_experimental_composer_upload_setting.rb
+++ b/db/migrate/20211224011511_delete_experimental_composer_upload_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DeleteExperimentalComposerUploadSetting < ActiveRecord::Migration[6.1]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'enable_experimental_composer_uploader'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
No longer used, the uppy method is now the default for
composer uploads and the old code is deleted.