### PR TITLE
FIX: Don't allow NULL values for `notification_level` in `category_users`

### DIFF
--- a/app/models/category_user.rb
+++ b/app/models/category_user.rb
@@ -243,7 +243,7 @@ end
 #  id                 :integer          not null, primary key
 #  category_id        :integer          not null
 #  user_id            :integer          not null
-#  notification_level :integer
+#  notification_level :integer          not null
 #  last_seen_at       :datetime
 #
 # Indexes

--- a/db/migrate/20211224111749_not_null_notification_level_in_category_users.rb
+++ b/db/migrate/20211224111749_not_null_notification_level_in_category_users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class NotNullNotificationLevelInCategoryUsers < ActiveRecord::Migration[6.1]
+  def change
+    up_only do
+      execute("DELETE FROM category_users WHERE notification_level IS NULL")
+    end
+    change_column_null :category_users, :notification_level, false
+  end
+end

--- a/spec/jobs/export_user_archive_spec.rb
+++ b/spec/jobs/export_user_archive_spec.rb
@@ -331,7 +331,7 @@ describe Jobs::ExportUserArchive do
           .category_users
           .where(category_id: category_id)
           .first_or_initialize
-          .update!(last_seen_at: reset_at)
+          .update!(last_seen_at: reset_at, notification_level: NotificationLevels.all[:regular])
       end
 
       # Set Watching First Post on announcements, Tracking on subcategory, Muted on deleted, nothing on subsubcategory
@@ -355,7 +355,7 @@ describe Jobs::ExportUserArchive do
 
       expect(data[1][:category_id]).to eq(subsubcategory.id.to_s)
       expect(data[1][:category_names]).to eq("#{category.name}|#{subcategory.name}|#{subsubcategory.name}")
-      expect(data[1][:notification_level]).to eq('') # empty string, not 'normal'
+      expect(data[1][:notification_level]).to eq('regular')
       expect(DateTime.parse(data[1][:dismiss_new_timestamp])).to eq(reset_at)
 
       expect(data[2][:category_id]).to eq(announcements.id.to_s)

--- a/spec/models/topic_list_spec.rb
+++ b/spec/models/topic_list_spec.rb
@@ -50,7 +50,11 @@ describe TopicList do
 
   describe '#load_topics' do
     it 'loads additional data for serialization' do
-      category_user = CategoryUser.create!(user: user, category: topic.category)
+      category_user = CategoryUser.create!(
+        user: user,
+        category: topic.category,
+        notification_level: NotificationLevels.all[:regular]
+      )
 
       topic = topic_list.load_topics.first
 

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -354,18 +354,6 @@ describe TopicTrackingState do
     expect(report.length).to eq(1)
   end
 
-  it "correctly handles category_users with null notification level" do
-    post
-
-    report = TopicTrackingState.report(user)
-    expect(report.length).to eq(1)
-
-    CategoryUser.create!(user_id: user.id, category_id: post.topic.category_id)
-
-    report = TopicTrackingState.report(user)
-    expect(report.length).to eq(1)
-  end
-
   it "works when categories are default muted" do
     SiteSetting.mute_all_categories_by_default = true
 


### PR DESCRIPTION
The application expects the notification level for a category to be an integer value and belong to the set defined here:

https://github.com/discourse/discourse/blob/a2637432689c957d53568c1f939fa644d9d0c44c/lib/notification_levels.rb#L4-L10

Having NULL as the notification level confuses the application and causes weird bugs when users try to change their notification levels. To prevent this from happening ever again, this PR adds a `NOT NULL` constraint to the `notification_level` column of `category_users`. The `tag_users` table also has a `notification_level` column, but it already has a `NOT NULL` constraint.

Internal ticket: t58032.