### PR TITLE
DEV: Do not log API key scope and/or source-ip mismatches

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -369,8 +369,7 @@ class Auth::DefaultCurrentUserProvider
     if api_key = ApiKey.active.with_key(api_key_value).includes(:user).first
       api_username = header_api_key? ? @env[HEADER_API_USERNAME] : request[API_USERNAME]
 
-      unless api_key.request_allowed?(@env)
-        Rails.logger.warn("[Unauthorized API Access] username: #{api_username}, IP address: #{request.ip}")
+      if !api_key.request_allowed?(@env)
         return nil
       end
 


### PR DESCRIPTION
Using an incorrectly-scoped API key is something which should be fixed by the client - no need to log errors on the server-side.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
