### PR TITLE
UX: Fix flair misalignment when more items are present in user card

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -144,6 +144,7 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
     }
     .user-card-avatar {
       margin-top: $avatar_margin;
+      max-height: $avatar_width;
     }
     .new-user a {
       color: var(--primary-low-mid);


### PR DESCRIPTION
When additional lines and buttons are present on the user card, the avatar flair was not correctly aligned with the avatar image. This PR fixes that.

### After
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30537603/147701547-1327802f-7c7a-48ff-88eb-2d82b1494bc4.png">

### Before
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30537603/147701571-fbb6419f-a40e-4946-992a-05307a6f377c.png">


