### PR TITLE
FIX: improve the way highlight-js is loaded

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
+++ b/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
@@ -11,6 +11,13 @@ export default function highlightSyntax(elem, siteSettings, session) {
   const selector = siteSettings.autohighlight_all_code
     ? "pre code"
     : "pre code[class]";
+
+  const codeblocks = elem.querySelectorAll(selector);
+
+  if (!codeblocks.length) {
+    return;
+  }
+
   const path = session.highlightJsPath;
 
   if (!path) {
@@ -20,7 +27,7 @@ export default function highlightSyntax(elem, siteSettings, session) {
   return loadScript(path).then(() => {
     customHighlightJSLanguages();
 
-    elem.querySelectorAll(selector).forEach((e) => {
+    codeblocks.forEach((e) => {
       // Large code blocks can cause crashes or slowdowns
       if (e.innerHTML.length > 30000) {
         return;

--- a/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
+++ b/app/assets/javascripts/discourse/app/lib/highlight-syntax.js
@@ -1,4 +1,3 @@
-import deprecated from "discourse-common/lib/deprecated";
 import loadScript from "discourse/lib/load-script";
 
 /*global hljs:true */
@@ -13,19 +12,6 @@ export default function highlightSyntax(elem, siteSettings, session) {
     ? "pre code"
     : "pre code[class]";
   const path = session.highlightJsPath;
-
-  // eslint-disable-next-line no-undef
-  if (elem instanceof jQuery) {
-    deprecated(
-      "highlightSyntax now takes a DOM node instead of a jQuery object.",
-      {
-        since: "2.6.0",
-        dropFrom: "2.7.0",
-      }
-    );
-
-    elem = elem[0];
-  }
 
   if (!path) {
     return;


### PR DESCRIPTION
This is very similar to https://github.com/discourse/discourse/pull/15348, and there's a lot of context there.

This PR improves the way highlight-js is loaded. Right now, it's being loaded unconditionally on the homepage. This PR fixes that. 

Nothing changes as far as functionality anywhere, except... highlight-js won't be loaded until it's needed. There are three cases where that happens. 

1. user visits a topic, and a post has a code-block.
2. user visits the `/admin/customize/embedding` page, and there's a code-block visible there.
3. anytime `highlightSyntax()` is called on an element that has valid descendants.

Otherwise, it's not loaded.

The savings are 64kb (gzip)... one less HTTP request, and most importantly, Google won't complain about unused code.

The PR also removes an old deprecation/workaround for jQuery, which hasn't been "supported" since 2.7.0