### PR TITLE
DEV: Deprecate OAuth2Authenticator and OAuth2UserInfo

### DIFF
--- a/app/models/oauth2_user_info.rb
+++ b/app/models/oauth2_user_info.rb
@@ -3,6 +3,9 @@
 class Oauth2UserInfo < ActiveRecord::Base
   belongs_to :user
 
+  after_initialize do
+    Discourse.deprecate("Oauth2UserInfo is deprecated. Use `ManagedAuthenticator` and `UserAssociatedAccount` instead. For more information, see https://meta.discourse.org/t/106695", drop_from: '2.9.0', output_in_test: true)
+  end
 end
 
 # == Schema Information

--- a/lib/auth/oauth2_authenticator.rb
+++ b/lib/auth/oauth2_authenticator.rb
@@ -8,6 +8,7 @@ class Auth::OAuth2Authenticator < Auth::Authenticator
 
   # only option at the moment is :trusted
   def initialize(name, opts = {})
+    Discourse.deprecate("OAuth2Authenticator is deprecated. Use `ManagedAuthenticator` and `UserAssociatedAccount` instead. For more information, see https://meta.discourse.org/t/106695", drop_from: '2.9.0', output_in_test: true)
     @name = name
     @opts = opts
   end

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -876,7 +876,7 @@ module Discourse
     digest = Digest::MD5.hexdigest(warning)
     redis_key = "deprecate-notice-#{digest}"
 
-    if !Discourse.redis.without_namespace.get(redis_key)
+    if Rails.logger && !Discourse.redis.without_namespace.get(redis_key)
       Rails.logger.warn(warning)
       begin
         Discourse.redis.without_namespace.setex(redis_key, 3600, "x")

--- a/spec/services/user_anonymizer_spec.rb
+++ b/spec/services/user_anonymizer_spec.rb
@@ -203,12 +203,10 @@ describe UserAnonymizer do
     it "removes external auth associations" do
       user.user_associated_accounts = [UserAssociatedAccount.create(user_id: user.id, provider_uid: "example", provider_name: "facebook")]
       user.single_sign_on_record = SingleSignOnRecord.create(user_id: user.id, external_id: "example", last_payload: "looks good")
-      user.oauth2_user_infos = [Oauth2UserInfo.create(user_id: user.id, uid: "example", provider: "example")]
       make_anonymous
       user.reload
       expect(user.user_associated_accounts).to be_empty
       expect(user.single_sign_on_record).to eq(nil)
-      expect(user.oauth2_user_infos).to be_empty
     end
 
     it "removes api key" do

--- a/spec/services/user_merger_spec.rb
+++ b/spec/services/user_merger_spec.rb
@@ -999,13 +999,11 @@ describe UserMerger do
 
   it "deletes external auth infos of source user" do
     UserAssociatedAccount.create(user_id: source_user.id, provider_name: "facebook", provider_uid: "1234")
-    Oauth2UserInfo.create(user_id: source_user.id, uid: "example", provider: "example")
     SingleSignOnRecord.create(user_id: source_user.id, external_id: "example", last_payload: "looks good")
 
     merge_users!
 
     expect(UserAssociatedAccount.where(user_id: source_user.id).count).to eq(0)
-    expect(Oauth2UserInfo.where(user_id: source_user.id).count).to eq(0)
     expect(SingleSignOnRecord.where(user_id: source_user.id).count).to eq(0)
   end
 


### PR DESCRIPTION
These have been superseded by ManagedAuthenticator and UserAssociatedAccount. For more information, see https://meta.discourse.org/t/106695

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
