### PR TITLE
DEV: Allow `ember server --environment production` to be used

### DIFF
--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -17,6 +17,7 @@ module.exports = function (environment) {
         Date: false,
       },
     },
+    exportApplicationGlobal: true,
 
     APP: {
       // Here you can pass flags/options to your application instance

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -28,14 +28,16 @@ module.exports = function (defaults) {
     autoImport: {
       forbidEval: true,
     },
+    fingerprint: {
+      // Disabled here, but handled manually below when in production mode.
+      // This is so we can apply a single AssetRev operation over the application and our additional trees
+      enabled: false,
+    },
+    SRI: {
+      // We don't use SRI in Rails. Disable here to match:
+      enabled: false,
+    },
   });
-
-  // Ember CLI does this by default for the app tree, but for our extra bundles we
-  // need to do it ourselves in production mode.
-  const isProduction = EmberApp.env().includes("production");
-  function digest(tree) {
-    return isProduction ? new AssetRev(tree) : tree;
-  }
 
   // WARNING: We should only import scripts here if they are not in NPM.
   // For example: our very specific version of bootstrap-modal.
@@ -48,7 +50,7 @@ module.exports = function (defaults) {
   });
   app.import(discourseRoot + "/app/assets/javascripts/polyfills.js");
 
-  return mergeTrees([
+  const mergedTree = mergeTrees([
     discourseScss(`${discourseRoot}/app/assets/stylesheets`, "testem.scss"),
     createI18nTree(discourseRoot, vendorJs),
     app.toTree(),
@@ -57,18 +59,28 @@ module.exports = function (defaults) {
       files: ["highlight-test-bundle.min.js"],
       destDir: "assets/highlightjs",
     }),
-    digest(
-      concat(mergeTrees([app.options.adminTree]), {
-        outputFile: `assets/admin.js`,
-      })
-    ),
-    digest(prettyTextEngine(vendorJs, "discourse-markdown")),
-    digest(
-      concat("public/assets/scripts", {
-        outputFile: `assets/start-discourse.js`,
-        headerFiles: [`start-app.js`],
-        inputFiles: [`discourse-boot.js`],
-      })
-    ),
+    concat(mergeTrees([app.options.adminTree]), {
+      outputFile: `assets/admin.js`,
+    }),
+    prettyTextEngine(vendorJs, "discourse-markdown"),
+    concat("public/assets/scripts", {
+      outputFile: `assets/start-discourse.js`,
+      headerFiles: [`start-app.js`],
+      inputFiles: [`discourse-boot.js`],
+    }),
   ]);
+
+  const isProduction = EmberApp.env().includes("production");
+  if (isProduction) {
+    return new AssetRev(mergedTree, {
+      exclude: [
+        "javascripts/**/*",
+        "assets/test-i18n*",
+        "assets/highlightjs",
+        "assets/testem.css",
+      ],
+    });
+  } else {
+    return mergedTree;
+  }
 };


### PR DESCRIPTION
Running in production mode is useful when doing performance-sensitive work.

- Set the `exportApplicationGlobal` flag, so we get the `Discourse` global in production mode. It defaults to only adding the global in development mode. Note that, when generating ember-cli assets via rails, we set this in `ApplicationHelper#discourse_config_environment`.

- Refactor the `AssetRev` logic in `ember-cli-build.js`, so that our custom bundle hashes are find/replaced into index.html. Without this change, our custom bundles (e.g. `start-discourse.js`) remain without their hash in `index.html`, and do not function.

  I have confirmed that the only diff in the `/dist` out following this change is to the `index.html` file. All other filenames and contents remain identical.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
