### PR TITLE
DEV: migrate routes to the new @action pattern

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-activity-likes-given.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-likes-given.js
@@ -2,6 +2,7 @@ import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import I18n from "I18n";
+import { action } from "@ember/object";
 
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["likes_given"],
@@ -16,10 +17,9 @@ export default UserActivityStreamRoute.extend({
     return { title, body };
   },
 
-  actions: {
-    didTransition() {
-      this.controllerFor("application").set("showFooter", true);
-      return true;
-    },
+  @action
+  didTransition() {
+    this.controllerFor("application").set("showFooter", true);
+    return true;
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
@@ -1,6 +1,7 @@
 import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import I18n from "I18n";
+import { action } from "@ember/object";
 
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["posts"],
@@ -12,10 +13,9 @@ export default UserActivityStreamRoute.extend({
     return { title, body };
   },
 
-  actions: {
-    didTransition() {
-      this.controllerFor("application").set("showFooter", true);
-      return true;
-    },
+  @action
+  didTransition() {
+    this.controllerFor("application").set("showFooter", true);
+    return true;
   },
 });


### PR DESCRIPTION
After this fix we have only two routes that use the old "actions:" pattern:
- route:application
- route:discourse

I'll migrate them soon.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
