### PR TITLE
PERF: resolve the view for each template name only once

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/raw.js
+++ b/app/assets/javascripts/discourse/app/helpers/raw.js
@@ -5,21 +5,21 @@ import { RUNTIME_OPTIONS } from "discourse-common/lib/raw-handlebars-helpers";
 import { buildResolver } from "discourse-common/resolver";
 
 let resolver;
-let viewsByTemplateName = [];
+let viewsByTemplateName = new Map();
 
 function lookupView(templateName) {
-  if (!(templateName in viewsByTemplateName)) {
+  if (!viewsByTemplateName.has(templateName)) {
     if (!resolver) {
       resolver = buildResolver("discourse").create();
     }
 
-    viewsByTemplateName[templateName] = resolver.customResolve({
+    viewsByTemplateName.set(templateName, resolver.customResolve({
       type: "raw-view",
       fullNameWithoutType: templateName,
-    });
+    }));
   }
 
-  return viewsByTemplateName[templateName];
+  return viewsByTemplateName.get(templateName);
 }
 
 function renderRaw(ctx, template, templateName, params) {

--- a/app/assets/javascripts/discourse/app/helpers/raw.js
+++ b/app/assets/javascripts/discourse/app/helpers/raw.js
@@ -5,16 +5,21 @@ import { RUNTIME_OPTIONS } from "discourse-common/lib/raw-handlebars-helpers";
 import { buildResolver } from "discourse-common/resolver";
 
 let resolver;
+let viewsByTemplateName = [];
 
 function lookupView(templateName) {
-  if (!resolver) {
-    resolver = buildResolver("discourse").create();
+  if (!(templateName in viewsByTemplateName)) {
+    if (!resolver) {
+      resolver = buildResolver("discourse").create();
+    }
+
+    viewsByTemplateName[templateName] = resolver.customResolve({
+      type: "raw-view",
+      fullNameWithoutType: templateName,
+    });
   }
 
-  return resolver.customResolve({
-    type: "raw-view",
-    fullNameWithoutType: templateName,
-  });
+  return viewsByTemplateName[templateName];
 }
 
 function renderRaw(ctx, template, templateName, params) {


### PR DESCRIPTION
The function lookupView is called multiple times for each template name while booting up. Calling resolver.customResolve is expensive. Re-using already looked up views improves First Contentful Paint (FCP) and Largest Contentful Paint (LCP) .

Does not include test coverage as change might be a no-brainer.