### PR TITLE
FIX: Tone down admin dashboard critical problem messaging

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/dashboard-problems.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/dashboard-problems.hbs
@@ -1,17 +1,10 @@
 {{#if foundProblems}}
   <div class="section dashboard-problems">
     <div class="section-title">
-      {{#if highPriorityProblems.length}}
-        <h2>
-          {{d-icon "exclamation-triangle"}}
-          {{i18n "admin.dashboard.critical_problems_found"}}
-        </h2>
-      {{else}}
-        <h2>
-          {{d-icon "heart"}}
-          {{i18n "admin.dashboard.problems_found"}}
-        </h2>
-      {{/if}}
+      <h2>
+        {{d-icon "heart"}}
+        {{i18n "admin.dashboard.problems_found"}}
+      </h2>
     </div>
 
     <div class="section-body">
@@ -20,7 +13,9 @@
           <div class="problem-messages priority-high">
             <ul>
               {{#each highPriorityProblems as |problem|}}
-                <li class={{concat "dashboard-problem " "priority-" problem.priority}}>{{html-safe problem.message}}</li>
+                <li class={{concat "dashboard-problem " "priority-" problem.priority}}>
+                  {{d-icon "exclamation-triangle"}} {{html-safe problem.message}}
+                </li>
               {{/each}}
             </ul>
           </div>

--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -238,7 +238,7 @@
     margin-bottom: 2em;
 
     .problem-messages {
-      margin-bottom: 1.25em;
+      margin-bottom: 1em;
 
       &.priority-high {
         background-color: var(--danger-low);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4005,7 +4005,6 @@ en:
         installed_version: "Installed"
         latest_version: "Latest"
         problems_found: "Some advice based on your current site settings"
-        critical_problems_found: "You have some high priority problems that must be addressed"
         new_features:
           title: "🎁 New Features"
           dismiss: "Dismiss"


### PR DESCRIPTION
Keep the title the same as it used to be and only
show the exclamation icon on the critical problems in
the list.

