### PR TITLE
FIX: update message-bus to remove self kill code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -614,4 +614,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.3.4
+   2.2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
     lz4-ruby (0.3.3)
     maxminddb (0.1.22)
     memory_profiler (1.0.0)
-    message_bus (3.3.8)
+    message_bus (3.4.0)
       rack (>= 1.1.3)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -614,4 +614,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.2.26
+   2.3.4


### PR DESCRIPTION
see: https://github.com/discourse/message_bus/commit/60eda3d783e4cb71e3f0a5ed6de949319503be3e

Previously if message bus stalled for 3 * keepalive (default 60 seconds)
it would terminate itself.
