### PR TITLE
FIX: smaller pencil icon for edit tags

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
@@ -15,9 +15,9 @@
         </div>
       {{else}}
         <div class="tag-name-wrapper">
-          {{discourse-tag tagInfo.name tagName="div" size="large"}}
+          {{discourse-tag tagInfo.name tagName="div"}}
           {{#if canAdminTag}}
-            {{d-button action=(action "edit") class="btn-flat edit-tag" title="tagging.edit_tag" icon="pencil-alt" }}
+            <a href {{action "edit"}} class="edit-tag" title={{i18n "tagging.edit_tag"}}>{{d-icon "pencil-alt"}}</a>
           {{/if}}
         </div>
         <div class="tag-description-wrapper">

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -371,7 +371,7 @@ section.tag-info {
     }
     .edit-tag {
       color: var(--primary-high);
-      font-size: 0.8em;
+      font-size: $font-down-2;
       margin-left: 0.5em;
     }
   }

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -369,6 +369,11 @@ section.tag-info {
         }
       }
     }
+    .edit-tag {
+      color: var(--primary-high);
+      font-size: 0.8em;
+      margin-left: 0.5em;
+    }
   }
 
   .tag-description-wrapper {


### PR DESCRIPTION
Pencil icon should be same size as in edit topic title.

Before:
<img width="762" alt="Screen Shot 2022-01-04 at 10 44 29 am" src="https://user-images.githubusercontent.com/72780/148040278-21528964-ed76-47a2-b382-5bc389b989e0.png">

After:
<img width="773" alt="Screen Shot 2022-01-04 at 10 41 08 am" src="https://user-images.githubusercontent.com/72780/148040288-8385f140-1230-4824-9a6e-b0d4ba923f7a.png">

