### PR TITLE
FIX: two dates with break are not a range

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -69,6 +69,13 @@ function _rangeElements(element) {
   if (!element.parentElement) {
     return [];
   }
+  if (
+    Array.from(element.parentElement.children).some(
+      (child) => child.tagName === "BR"
+    )
+  ) {
+    return [element];
+  }
   return Array.from(element.parentElement.children).filter(
     (span) => span.dataset.date
   );

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -69,11 +69,7 @@ function _rangeElements(element) {
   if (!element.parentElement) {
     return [];
   }
-  if (
-    Array.from(element.parentElement.children).some(
-      (child) => child.tagName === "BR"
-    )
-  ) {
+  if (element.parentElement.children.length !== 2) {
     return [element];
   }
   return Array.from(element.parentElement.children).filter(


### PR DESCRIPTION
When there are new lines between two dates in the post, we should not consider them as a range

Valid range:
![Screen Shot 2022-01-04 at 1 19 12 pm](https://user-images.githubusercontent.com/72780/148058172-6bc715a1-ddff-4880-8c32-6a937b90f208.png)

Invalid range:
![Screen Shot 2022-01-04 at 1 19 19 pm](https://user-images.githubusercontent.com/72780/148058189-74366d88-8b7d-4786-a6e7-7144e616f3d3.png)

