### PR TITLE
FIX: Hide user's bio if profile is restricted

### DIFF
--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -101,7 +101,7 @@ module UserGuardian
   end
 
   def restrict_user_fields?(user)
-    user.trust_level == TrustLevel[0] && anonymous?
+    (user.trust_level == TrustLevel[0] && anonymous?) || !can_see_profile?(user)
   end
 
   def can_see_staff_info?(user)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3674,6 +3674,16 @@ describe UsersController do
       expect(response.body).to include(user1.username)
     end
 
+    it "should not be able to view a private user profile" do
+      user1.user_profile.update!(bio_raw: "Hello world!")
+      user1.user_option.update!(hide_profile_and_presence: true)
+
+      get "/u/#{user1.username}"
+
+      expect(response.status).to eq(200)
+      expect(response.body).not_to include("Hello world!")
+    end
+
     describe 'when username contains a period' do
       before_all do
         user1.update!(username: 'test.test')


### PR DESCRIPTION
The bio was sometimes visible in the meta tags even though it it should
not have been.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
