### PR TITLE
DEV: Re-use main app registry for raw HBS view lookups

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -169,6 +169,10 @@ export function buildResolver(baseName) {
       return this.customResolve(parsedName) || this._super(parsedName);
     },
 
+    resolveRawView(parsedName) {
+      return this.customResolve(parsedName) || this._super(parsedName);
+    },
+
     resolveRoute(parsedName) {
       if (parsedName.fullNameWithoutType === "basic") {
         return requirejs("discourse/routes/discourse", null, null, true)

--- a/app/assets/javascripts/discourse/app/helpers/raw.js
+++ b/app/assets/javascripts/discourse/app/helpers/raw.js
@@ -2,20 +2,6 @@ import { helperContext, registerUnbound } from "discourse-common/lib/helpers";
 import { findRawTemplate } from "discourse-common/lib/raw-templates";
 import { htmlSafe } from "@ember/template";
 import { RUNTIME_OPTIONS } from "discourse-common/lib/raw-handlebars-helpers";
-import { buildResolver } from "discourse-common/resolver";
-
-let resolver;
-
-function lookupView(templateName) {
-  if (!resolver) {
-    resolver = buildResolver("discourse").create();
-  }
-
-  return resolver.customResolve({
-    type: "raw-view",
-    fullNameWithoutType: templateName,
-  });
-}
 
 function renderRaw(ctx, template, templateName, params) {
   params = Object.assign({}, params);
@@ -23,7 +9,7 @@ function renderRaw(ctx, template, templateName, params) {
 
   let context = helperContext();
   if (!params.view) {
-    const viewClass = lookupView(templateName);
+    const viewClass = context.registry.resolve(`raw-view:${templateName}`);
 
     if (viewClass) {
       params.view = viewClass.create(params, context);

--- a/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
+++ b/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
@@ -25,6 +25,7 @@ export function autoLoadModules(container, registry) {
     site: container.lookup("site:main"),
     session: container.lookup("session:main"),
     topicTrackingState: container.lookup("topic-tracking-state:main"),
+    registry,
   };
   setOwner(context, container);
 
@@ -35,5 +36,5 @@ export function autoLoadModules(container, registry) {
 
 export default {
   name: "auto-load-modules",
-  initialize: autoLoadModules,
+  initialize: (container) => autoLoadModules(container, container.registry),
 };

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -293,6 +293,7 @@ function setupTestsCommon(application, container, config) {
       siteSettings: settings,
       capabilities: {},
       site,
+      registry: app.__registry__,
     });
 
     PreloadStore.reset();


### PR DESCRIPTION
da6edc1 introduced the `lookupView` method, which initialized a fresh resolver, and used it to directly look up raw-views (with no caching). This worked well, but was not a clean solution. It required initializing an entirely new resolver, and did not have any caching.

This commit updates the `helperContext` to include access to the registry, and uses it to perform raw-view lookups. As well as re-using the registry, this also means we're making use of the resolver's built-in cache.

I haven't been able to measure any noticeable performance impact from this change, but there is certainly less work being done, so it may be beneficial on older devices.

Co-authored-by: Ayke Halder <rr-it@users.noreply.github.com>

For context, see https://meta.discourse.org/t/javascript-performance-optimization-on-fcp-and-lcp/213759/8?u=david