### PR TITLE
FIX: Append /all to URL if default list is 'none'

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -507,7 +507,9 @@ export function getCategoryAndTagUrl(category, subcategories, tag) {
 
   if (category) {
     url = category.path;
-    if (!subcategories) {
+    if (subcategories && category.default_list_filter === "none") {
+      url += "/all";
+    } else if (!subcategories && category.default_list_filter === "all") {
       url += "/none";
     }
   }

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -104,7 +104,7 @@ module("Unit | Utility | url", function () {
     );
   });
 
-  test("getCategoryAndTagUrl", async function (assert) {
+  test("getCategoryAndTagUrl", function (assert) {
     assert.strictEqual(
       getCategoryAndTagUrl(
         { path: "/c/foo/1", default_list_filter: "all" },

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -1,4 +1,8 @@
-import DiscourseURL, { prefixProtocol, userPath } from "discourse/lib/url";
+import DiscourseURL, {
+  getCategoryAndTagUrl,
+  prefixProtocol,
+  userPath,
+} from "discourse/lib/url";
 import { module, test } from "qunit";
 import User from "discourse/models/user";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
@@ -97,6 +101,40 @@ module("Unit | Utility | url", function () {
     assert.strictEqual(
       prefixProtocol("www.discourse.org/mailto:foo"),
       "https://www.discourse.org/mailto:foo"
+    );
+  });
+
+  test("getCategoryAndTagUrl", async function (assert) {
+    assert.strictEqual(
+      getCategoryAndTagUrl(
+        { path: "/c/foo/1", default_list_filter: "all" },
+        true
+      ),
+      "/c/foo/1"
+    );
+
+    assert.strictEqual(
+      getCategoryAndTagUrl(
+        { path: "/c/foo/1", default_list_filter: "all" },
+        false
+      ),
+      "/c/foo/1/none"
+    );
+
+    assert.strictEqual(
+      getCategoryAndTagUrl(
+        { path: "/c/foo/1", default_list_filter: "none" },
+        true
+      ),
+      "/c/foo/1/all"
+    );
+
+    assert.strictEqual(
+      getCategoryAndTagUrl(
+        { path: "/c/foo/1", default_list_filter: "none" },
+        false
+      ),
+      "/c/foo/1"
     );
   });
 


### PR DESCRIPTION
It was impossible to select the 'all' filter for categories that have
the default list filter set to 'no subcategories'. This happens because
'/all' was not appended to the URL and in the absence of any list filter
('all' or 'none'), the default list filter ('none') was automatically
selected.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
