### PR TITLE
FIX: Jittery topic progress on some window sizes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -159,22 +159,35 @@ export default Component.extend({
       return;
     }
 
+    const composerH =
+      document.querySelector("#reply-control")?.clientHeight || 0;
+
+    // on desktop, pin this element to the composer
+    // otherwise the grid layout will change too much when toggling the composer
+    // and jitter when the viewport is near the topic bottom
+    if (!this.site.mobileView && composerH) {
+      this.set("docked", false);
+      this.element.style.setProperty("bottom", `${composerH}px`);
+      return;
+    }
+
     if (entries[0].isIntersecting === true) {
       this.set("docked", true);
+      this.element.style.removeProperty("bottom");
     } else {
       if (entries[0].boundingClientRect.top > 0) {
         this.set("docked", false);
-        const wrapper = document.querySelector("#topic-progress-wrapper");
-        const composerH =
-          document.querySelector("#reply-control")?.clientHeight || 0;
         if (composerH === 0) {
           const filteredPostsHeight =
             document.querySelector(".posts-filtered-notice")?.clientHeight || 0;
           filteredPostsHeight === 0
-            ? wrapper.style.removeProperty("bottom")
-            : wrapper.style.setProperty("bottom", `${filteredPostsHeight}px`);
+            ? this.element.style.removeProperty("bottom")
+            : this.element.style.setProperty(
+                "bottom",
+                `${filteredPostsHeight}px`
+              );
         } else {
-          wrapper.style.setProperty("bottom", `${composerH}px`);
+          this.element.style.setProperty("bottom", `${composerH}px`);
         }
       }
     }


### PR DESCRIPTION
In some window sizes (around 950px wide), we were seeing some jittery behaviour when scrolling and having the composer open in a topic. This was most visible when using a theme with a sidebar (or a theme that uses a different container width for the posts) and when the scroll position was near the bottom of the topic. 

The root cause is a loop caused by the intersection observer changing the underlying layout of the post stream by toggling the topic progress element from a grid-positioned element to a fixed-positioned element. On screen sizes between 900 and 11100px (roughly), this triggered a layout change for the whole stream, which in turn, triggered the observer back and forth. 

This commit fixes the problem by basically avoiding it. When there is a composer on desktop and the topic progress element is visible, this commit switches to pinning the topic progress element to the composer. This causes a lot less jitter because there are no layout changes in the stream. 

There is a conceptual downside though, the topic progress element will sometimes be shown outside of the post stream, for example: 

<img width="700" alt="image" src="https://user-images.githubusercontent.com/368961/148255472-85c2208b-aec0-4a63-bec5-5fd7be58c96d.png">

This doesn't look great in a screenshot, but I think it's not a problem in actual usage, given that there are fewer UI elements moving around. 