### PR TITLE
FIX: Clean review queue when flagged response to a flagged post is deleted

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2929,6 +2929,12 @@ en:
         %{flagged_post_raw_content}
         ```
 
+        To which you responded
+
+        ``` markdown
+        %{flagged_post_response_raw_content}
+        ```
+
         For more details on the reason for removal, please review our [community guidelines](%{base_url}/guidelines).
 
     usage_tips:

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -183,6 +183,7 @@ class PostDestroyer
       DB.after_commit do
         if @opts[:reviewable]
           notify_deletion(@opts[:reviewable], { notify_responders: @opts[:notify_responders], parent_post: @opts[:parent_post] })
+          ignore(@post.reviewable_flag) if @post.reviewable_flag && SiteSetting.notify_users_after_responses_deleted_on_flagged_post
         elsif reviewable = @post.reviewable_flag
           @opts[:defer_flags] ? ignore(reviewable) : agree(reviewable)
         end
@@ -332,6 +333,7 @@ class PostDestroyer
       message_type: notify_responders ? :flags_agreed_and_post_deleted_for_responders : :flags_agreed_and_post_deleted,
       message_options: {
         flagged_post_raw_content: notify_responders ? options[:parent_post].raw : @post.raw,
+        flagged_post_response_raw_content: @post.raw,
         url: notify_responders ? options[:parent_post].url : @post.url,
         flag_reason: I18n.t(
           "flag_reasons#{".responder" if notify_responders}.#{PostActionType.types[rs.reviewable_score_type]}",


### PR DESCRIPTION
- If a post is flagged and a admin chooses to delete it and all attached replies, ignore any flagged replies and remove them from the review queue
- Update notification for 'flags_agreed_and_post_deleted_for_responders' with response body

<img width="854" alt="Screen Shot 2022-01-05 at 10 43 14 AM" src="https://user-images.githubusercontent.com/50783505/148255959-25772293-b4ed-4852-a108-53d230c820f5.png">

