### PR TITLE
DEV: Fewer jQuery calls in offset calculation 

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -8,7 +8,7 @@ import Composer from "discourse/models/composer";
 import KeyEnterEscape from "discourse/mixins/key-enter-escape";
 import afterTransition from "discourse/lib/after-transition";
 import discourseDebounce from "discourse-common/lib/debounce";
-import { headerOffset } from "discourse/components/site-header";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import positioningWorkaround from "discourse/lib/safari-hacks";
 
 const START_DRAG_EVENTS = ["touchstart", "mousedown"];

--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -7,6 +7,7 @@ import Docking from "discourse/mixins/docking";
 import MountWidget from "discourse/components/mount-widget";
 import ItsATrap from "@discourse/itsatrap";
 import RerenderOnDoNotDisturbChange from "discourse/mixins/rerender-on-do-not-disturb-change";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import { observes } from "discourse-common/utils/decorators";
 import { topicTitleDecorators } from "discourse/components/topic-title";
 
@@ -437,15 +438,6 @@ const SiteHeaderComponent = MountWidget.extend(
 export default SiteHeaderComponent.extend({
   classNames: ["d-header-wrap"],
 });
-
-export function headerOffset() {
-  return (
-    parseInt(
-      document.documentElement.style.getPropertyValue("--header-offset"),
-      10
-    ) || 0
-  );
-}
 
 export function headerTop() {
   const header = document.querySelector("header.d-header");

--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -5,7 +5,7 @@ import PanEvents, {
 import Component from "@ember/component";
 import EmberObject from "@ember/object";
 import discourseDebounce from "discourse-common/lib/debounce";
-import { headerOffset } from "discourse/components/site-header";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import { later, next } from "@ember/runloop";
 import { observes } from "discourse-common/utils/decorators";
 import showModal from "discourse/lib/show-modal";

--- a/app/assets/javascripts/discourse/app/components/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline.js
@@ -1,6 +1,6 @@
 import Docking from "discourse/mixins/docking";
 import MountWidget from "discourse/components/mount-widget";
-import { headerOffset } from "discourse/components/site-header";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import { next } from "@ember/runloop";
 import { observes } from "discourse-common/utils/decorators";
 import optionalService from "discourse/lib/optional-service";

--- a/app/assets/javascripts/discourse/app/lib/lock-on.js
+++ b/app/assets/javascripts/discourse/app/lib/lock-on.js
@@ -1,5 +1,5 @@
 import { bind } from "discourse-common/utils/decorators";
-import { minimumOffset } from "discourse/lib/offset-calculator";
+import { headerOffset } from "discourse/lib/offset-calculator";
 
 // Dear traveller, you are entering a zone where we are at war with the browser.
 // The browser is insisting on positioning scrollTop per the location it was in
@@ -50,7 +50,7 @@ export default class LockOn {
       }
     }
 
-    return offset - minimumOffset();
+    return offset - headerOffset();
   }
 
   clearLock() {

--- a/app/assets/javascripts/discourse/app/lib/offset-calculator.js
+++ b/app/assets/javascripts/discourse/app/lib/offset-calculator.js
@@ -17,8 +17,17 @@ export function minimumOffset() {
     : 0;
 }
 
+export function headerOffset() {
+  return (
+    parseInt(
+      document.documentElement.style.getPropertyValue("--header-offset"),
+      10
+    ) || 0
+  );
+}
+
 export default function offsetCalculator() {
-  const min = minimumOffset();
+  const min = headerOffset();
 
   // on mobile, just use the header
   if (document.querySelector("html").classList.contains("mobile-view")) {

--- a/app/assets/javascripts/discourse/app/lib/offset-calculator.js
+++ b/app/assets/javascripts/discourse/app/lib/offset-calculator.js
@@ -1,8 +1,18 @@
+import deprecated from "discourse-common/lib/deprecated";
+
 export function scrollTopFor(y) {
   return y - offsetCalculator();
 }
 
 export function minimumOffset() {
+  deprecated(
+    "The minimumOffset() helper is deprecated, please use headerOffset() instead.",
+    {
+      since: "2.8.0.beta10",
+      dropFrom: "2.9.0.beta2",
+    }
+  );
+
   const header = document.querySelector("header.d-header"),
     iPadNav = document.querySelector(".footer-nav-ipad .footer-nav"),
     iPadNavHeight = iPadNav ? iPadNav.offsetHeight : 0;

--- a/app/assets/javascripts/discourse/app/lib/sticky-avatars.js
+++ b/app/assets/javascripts/discourse/app/lib/sticky-avatars.js
@@ -1,7 +1,7 @@
 import { addWidgetCleanCallback } from "discourse/components/mount-widget";
 import Site from "discourse/models/site";
 import { bind } from "discourse-common/utils/decorators";
-import { headerOffset } from "discourse/components/site-header";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import { schedule } from "@ember/runloop";
 
 export default class StickyAvatars {

--- a/app/assets/javascripts/discourse/app/lib/sticky-avatars.js
+++ b/app/assets/javascripts/discourse/app/lib/sticky-avatars.js
@@ -79,6 +79,9 @@ export default class StickyAvatars {
   @bind
   _initIntersectionObserver() {
     schedule("afterRender", () => {
+      const headerOffsetInPx =
+        headerOffset() <= 0 ? "0px" : `-${headerOffset()}px`;
+
       this.intersectionObserver = new IntersectionObserver(
         (entries) => {
           entries.forEach((entry) => {
@@ -99,7 +102,7 @@ export default class StickyAvatars {
         },
         {
           threshold: [0.0, 1.0],
-          rootMargin: `-${headerOffset()}px 0px 0px 0px`,
+          rootMargin: `${headerOffsetInPx} 0px 0px 0px`,
         }
       );
     });

--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
@@ -1,6 +1,6 @@
 import { ajax } from "discourse/lib/ajax";
 import discourseDebounce from "discourse-common/lib/debounce";
-import { headerOffset } from "discourse/components/site-header";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import isElementInViewport from "discourse/lib/is-element-in-viewport";
 import { withPluginApi } from "discourse/lib/plugin-api";
 


### PR DESCRIPTION
- Moves `headerOffset` helper into `lib/offset-calculator`
- Replaces `minimumOffset` helper with `headerOffset` where used
- Deprecates `minimumOffset` helper
- Removes some jQuery used in keyboard j/k navigation
- Fixes a regression where topic focus was not being set correctly when using `j/k` keyboard navigation using a screen reader