### PR TITLE
FIX: When loading more topics, `showFooter` was not updated properly

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
@@ -5,7 +5,7 @@ import LoadMore from "discourse/mixins/load-more";
 import UrlRefresh from "discourse/mixins/url-refresh";
 import { inject as service } from "@ember/service";
 
-const DiscoveryTopicsListComponent = Component.extend(UrlRefresh, LoadMore, {
+export default Component.extend(UrlRefresh, LoadMore, {
   classNames: ["contents"],
   eyelineSelector: ".topic-list-item",
   documentTitle: service(),
@@ -60,9 +60,10 @@ const DiscoveryTopicsListComponent = Component.extend(UrlRefresh, LoadMore, {
         if (moreTopicsUrl && $(window).height() >= $(document).height()) {
           this.send("loadMore");
         }
+        if (this.loadingComplete) {
+          this.loadingComplete();
+        }
       });
     },
   },
 });
-
-export default DiscoveryTopicsListComponent;

--- a/app/assets/javascripts/discourse/app/controllers/discovery.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery.js
@@ -1,5 +1,6 @@
 import Controller, { inject as controller } from "@ember/controller";
 import { alias, equal, not } from "@ember/object/computed";
+import { action } from "@ember/object";
 import Category from "discourse/models/category";
 import DiscourseURL from "discourse/lib/url";
 import { inject as service } from "@ember/service";
@@ -20,11 +21,13 @@ export default Controller.extend({
 
   loadedAllItems: not("discoveryTopics.model.canLoadMore"),
 
+  @action
   loadingBegan() {
     this.set("loading", true);
     this.set("application.showFooter", false);
   },
 
+  @action
   loadingComplete() {
     this.set("loading", false);
     this.set("application.showFooter", this.loadedAllItems);

--- a/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
@@ -19,6 +19,7 @@ model=model showResetNew=showResetNew showDismissRead=showDismissRead resetNew=(
 {{#discovery-topics-list
   model=model
   refresh=(action "refresh")
+  loadingComplete=(action "loadingComplete")
   incomingCount=topicTrackingState.incomingCount
   autoAddTopicsToBulkSelect=autoAddTopicsToBulkSelect
   bulkSelectEnabled=bulkSelectEnabled


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

As reported here: https://meta.discourse.org/t/easy-responsive-footer/95818/148?u=eviltrout