### PR TITLE
UX: Make the draft error exclamation in composer red

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -204,7 +204,7 @@
 
             <div class={{if isUploading "hidden"}} id="draft-status">
               {{#if model.draftStatus}}
-                <span title={{model.draftStatus}}>
+                <span class="draft-error" title={{model.draftStatus}}>
                   {{#if model.draftConflictUser}}
                     {{avatar model.draftConflictUser imageSize="small"}} {{d-icon "user-edit"}}
                   {{else}}

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -580,3 +580,7 @@ body:not(.ios-safari-composer-hacks) {
     color: var(--primary-medium);
   }
 }
+
+.draft-error {
+  color: var(--danger);
+}


### PR DESCRIPTION
### On desktop
Before:
<img width="700" alt="Screenshot 2022-01-06 at 14 27 19" src="https://user-images.githubusercontent.com/1274517/148391045-61bf152d-754c-4e5b-8e86-b4e1567ccb4d.png">

After:
<img width="700" alt="Screenshot 2022-01-06 at 14 26 24" src="https://user-images.githubusercontent.com/1274517/148391072-a0d5361c-7162-4564-8df1-3e9411aefee1.png">

### On mobile
Before:
<img width="300" alt="Screenshot 2022-01-06 at 14 28 32" src="https://user-images.githubusercontent.com/1274517/148391156-21156c3c-120a-412c-a385-b35e65dccc43.png">

After:
<img width="300" alt="Screenshot 2022-01-06 at 14 24 05" src="https://user-images.githubusercontent.com/1274517/148391169-ba286163-18ce-4072-bc12-db3eab759846.png">

