### PR TITLE
FIX: new-topic feature was broken when 'Default List Filter' was set to 'no subcategories'

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -56,7 +56,8 @@ export default (filterArg, params) => {
       if (
         (!params || params.no_subcategories === undefined) &&
         category.default_list_filter === "none" &&
-        filterArg === "default"
+        filterArg === "default" &&
+        modelParams
       ) {
         return this.replaceWith("discovery.categoryNone", {
           category,


### PR DESCRIPTION
https://meta.discourse.org/t/directly-linking-to-new-topic-not-working-when-default-list-filter-no-sub-categories/197447
