### PR TITLE
DEV: Modernise navigation-bar plugin-outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -3,7 +3,6 @@ import Component from "@ember/component";
 import DiscourseURL from "discourse/lib/url";
 import FilterModeMixin from "discourse/mixins/filter-mode";
 import { next } from "@ember/runloop";
-import { renderedConnectorsFor } from "discourse/lib/plugin-connectors";
 
 export default Component.extend(FilterModeMixin, {
   tagName: "ul",
@@ -12,7 +11,6 @@ export default Component.extend(FilterModeMixin, {
 
   init() {
     this._super(...arguments);
-    this.set("connectors", renderedConnectorsFor("extra-nav-item", null, this));
   },
 
   @discourseComputed("filterType", "navItems")

--- a/app/assets/javascripts/discourse/app/templates/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/navigation-bar.hbs
@@ -2,7 +2,4 @@
   {{navigation-item content=navItem filterMode=filterMode category=category}}
 {{/each}}
 {{custom-html name="extraNavItem" tagName="li"}}
-{{!- this is done to avoid DIV in the UL, originally {{plugin-outlet name="extra-nav-item"}}
-{{#each connectors as |c|}}
-  {{plugin-connector connector=c class=c.classNames tagName="li" args=(hash category=category filterMode=filterMode)}}
-{{/each}}
+{{plugin-outlet name="extra-nav-item" tagName="" connectorTagName="li" args=(hash category=category filterMode=filterMode)}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
@@ -9,8 +9,6 @@
     {{#each navItems as |navItem|}}
       {{navigation-item content=navItem filterMode=filterMode category=category}}
     {{/each}}
-    {{#each connectors as |c|}}
-      {{plugin-connector connector=c class=c.classNames tagName="li" args=(hash category=category filterMode=filterMode)}}
-    {{/each}}
+    {{plugin-outlet name="extra-nav-item" tagName="" connectorTagName="li" args=(hash category=category filterMode=filterMode)}}
   </ul>
 {{/if}}


### PR DESCRIPTION
This workaround was introduced before we had the ability to render components with no wrapper element. Now we can pass `tagName=""` to `plugin-outlet`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
