### PR TITLE
UX: prevent crawler view topic-list overflow

### DIFF
--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -25,6 +25,8 @@ body.crawler {
   }
 
   .topic-list {
+    table-layout: fixed;
+    overflow: hidden;
     margin-bottom: 1em;
     @media (max-width: 850px) {
       td {


### PR DESCRIPTION
This avoids an issue where Google Search Console throws an error due to overflowing content on mobile. The issue in this case seems to be category names, but this should prevent any long content from causing the problem. 

![image](https://user-images.githubusercontent.com/1681963/148476202-f802aa7d-1045-4524-a519-e3a0eaa45cf6.png)
