### PR TITLE
FIX: Disable cast votes button for multiple polls with no min.

### DIFF
--- a/plugins/poll/assets/javascripts/widgets/discourse-poll.js
+++ b/plugins/poll/assets/javascripts/widgets/discourse-poll.js
@@ -813,8 +813,9 @@ export default createWidget("discourse-poll", {
   min() {
     let min = parseInt(this.attrs.poll.min, 10);
     if (isNaN(min) || min < 0) {
-      min = 0;
+      min = 1;
     }
+
     return min;
   },
 

--- a/plugins/poll/test/javascripts/widgets/discourse-poll-test.js
+++ b/plugins/poll/test/javascripts/widgets/discourse-poll-test.js
@@ -51,37 +51,6 @@ discourseModule(
       ];
     });
 
-    pretender.put("/polls/vote", () => {
-      ++requests;
-      return [
-        200,
-        { "Content-Type": "application/json" },
-        {
-          poll: {
-            name: "poll",
-            type: "regular",
-            status: "open",
-            results: "always",
-            options: [
-              {
-                id: "1f972d1df351de3ce35a787c89faad29",
-                html: "yes",
-                votes: 1,
-              },
-              {
-                id: "d7ebc3a9beea2e680815a1e4f57d6db6",
-                html: "no",
-                votes: 0,
-              },
-            ],
-            voters: 1,
-            chart_type: "bar",
-          },
-          vote: ["1f972d1df351de3ce35a787c89faad29"],
-        },
-      ];
-    });
-
     const template = hbs`{{mount-widget
                     widget="discourse-poll"
                     args=(hash id=id
@@ -178,6 +147,48 @@ discourseModule(
         );
         assert.strictEqual(requests, 0);
         assert.ok(!exists(".chosen"));
+      },
+    });
+
+    componentTest("voting on a multiple poll with no min attribute", {
+      template,
+
+      beforeEach() {
+        this.setProperties({
+          post: EmberObject.create({
+            id: 42,
+            topic: {
+              archived: false,
+            },
+          }),
+          poll: EmberObject.create({
+            name: "poll",
+            type: "multiple",
+            status: "open",
+            results: "always",
+            max: 2,
+            options: [
+              { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 0 },
+              { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
+            ],
+            voters: 0,
+            chart_type: "bar",
+          }),
+          vote: [],
+          groupableUserFields: [],
+        });
+      },
+
+      async test(assert) {
+        assert.ok(exists(".poll-buttons .cast-votes[disabled=true]"));
+
+        await click(
+          "li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29']"
+        );
+
+        await click(".poll-buttons .cast-votes");
+
+        assert.ok(exists(".chosen"));
       },
     });
   }


### PR DESCRIPTION
Multiple polls can be created without the min attribute but that means
the attribute defaults to 1. A default of 0 does not make any sense
because it is equivalent to saying that a user is not casting any votes.