### PR TITLE
FIX: don't trigger `topic_created` event for reply posts via email.

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -1306,7 +1306,7 @@ module Email
                              import_mode: options[:import_mode],
                              post_alert_options: options[:post_alert_options]
                             ).enqueue_jobs
-        DiscourseEvent.trigger(:topic_created, result.post.topic, options, user)
+        DiscourseEvent.trigger(:topic_created, result.post.topic, options, user) if result.post.is_first_post?
         DiscourseEvent.trigger(:post_created, result.post, options, user)
       end
 

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -340,7 +340,7 @@ describe Email::Receiver do
       expect { process(:like) }.to raise_error(Email::Receiver::InvalidPostAction)
     end
 
-    it "works" do
+    it "creates a new reply post" do
       handler_calls = 0
       handler = proc { |_| handler_calls += 1 }
 

--- a/spec/components/email/receiver_spec.rb
+++ b/spec/components/email/receiver_spec.rb
@@ -341,6 +341,11 @@ describe Email::Receiver do
     end
 
     it "works" do
+      handler_calls = 0
+      handler = proc { |_| handler_calls += 1 }
+
+      DiscourseEvent.on(:topic_created, &handler)
+
       expect { process(:text_reply) }.to change { topic.posts.count }
       expect(topic.posts.last.raw).to eq("This is a text reply :)\n\nEmail parsing should not break because of a UTF-8 character: ’")
       expect(topic.posts.last.via_email).to eq(true)
@@ -348,6 +353,9 @@ describe Email::Receiver do
 
       expect { process(:html_reply) }.to change { topic.posts.count }
       expect(topic.posts.last.raw).to eq("This is a **HTML** reply ;)")
+
+      DiscourseEvent.off(:topic_created, &handler)
+      expect(handler_calls).to eq(0)
     end
 
     it "stores the created_via source against the incoming email" do


### PR DESCRIPTION
Previously, we incorrectly triggered `topic_created` events when the posts are created via email since we didn't check the post number.