### PR TITLE
DEV: Drop bookmark trigger correctly

### DIFF
--- a/db/migrate/20220105024605_add_trigger_for_polymorphic_bookmark_columns_to_sync_data.rb
+++ b/db/migrate/20220105024605_add_trigger_for_polymorphic_bookmark_columns_to_sync_data.rb
@@ -2,30 +2,35 @@
 
 class AddTriggerForPolymorphicBookmarkColumnsToSyncData < ActiveRecord::Migration[6.1]
   def up
-    DB.exec <<~SQL
-      CREATE OR REPLACE FUNCTION sync_bookmarks_polymorphic_column_data()
-      RETURNS TRIGGER
-      LANGUAGE PLPGSQL AS $rcr$
-      BEGIN
-        IF NEW.for_topic
-        THEN
-          NEW.bookmarkable_id = (SELECT topic_id FROM posts WHERE posts.id = NEW.post_id);
-          NEW.bookmarkable_type = 'Topic';
-        ELSE
-          NEW.bookmarkable_id = NEW.post_id;
-          NEW.bookmarkable_type = 'Post';
-        END IF;
-        RETURN NEW;
-      END
-      $rcr$;
-    SQL
+    # Note from Martin:
+    #
+    # Addition to the note below, we don't want to delete this migration but
+    # we can stop it from creating things we are going to delete anyway.
+    #
+    # DB.exec <<~SQL
+    #   CREATE OR REPLACE FUNCTION sync_bookmarks_polymorphic_column_data()
+    #   RETURNS TRIGGER
+    #   LANGUAGE PLPGSQL AS $rcr$
+    #   BEGIN
+    #     IF NEW.for_topic
+    #     THEN
+    #       NEW.bookmarkable_id = (SELECT topic_id FROM posts WHERE posts.id = NEW.post_id);
+    #       NEW.bookmarkable_type = 'Topic';
+    #     ELSE
+    #       NEW.bookmarkable_id = NEW.post_id;
+    #       NEW.bookmarkable_type = 'Post';
+    #     END IF;
+    #     RETURN NEW;
+    #   END
+    #   $rcr$;
+    # SQL
 
-    DB.exec <<~SQL
-      CREATE TRIGGER bookmarks_polymorphic_data_sync
-      BEFORE INSERT OR UPDATE OF post_id, for_topic ON bookmarks
-      FOR EACH ROW
-      EXECUTE FUNCTION sync_bookmarks_polymorphic_column_data();
-    SQL
+    # DB.exec <<~SQL
+    #   CREATE TRIGGER bookmarks_polymorphic_data_sync
+    #   BEFORE INSERT OR UPDATE OF post_id, for_topic ON bookmarks
+    #   FOR EACH ROW
+    #   EXECUTE FUNCTION sync_bookmarks_polymorphic_column_data();
+    # SQL
 
     # sync data that already exists in the table
     #
@@ -50,7 +55,6 @@ class AddTriggerForPolymorphicBookmarkColumnsToSyncData < ActiveRecord::Migratio
   end
 
   def down
-    DB.exec("DROP TRIGGER IF EXISTS bookmarks_polymorphic_data_sync ON bookmarks")
-    DB.exec("DROP FUNCTION IF EXISTS sync_bookmarks_polymorphic_column_data")
+    DB.exec("DROP FUNCTION IF EXISTS sync_bookmarks_polymorphic_column_data CASCADE")
   end
 end

--- a/db/migrate/20220107011124_drop_bookmark_polymorphic_trigger.rb
+++ b/db/migrate/20220107011124_drop_bookmark_polymorphic_trigger.rb
@@ -2,8 +2,7 @@
 
 class DropBookmarkPolymorphicTrigger < ActiveRecord::Migration[6.1]
   def up
-    DB.exec("DROP TRIGGER IF EXISTS bookmarks_polymorphic_data_sync ON bookmarks")
-    DB.exec("DROP FUNCTION IF EXISTS sync_bookmarks_polymorphic_column_data")
+    DB.exec("DROP FUNCTION IF EXISTS sync_bookmarks_polymorphic_column_data CASCADE")
   end
 
   def down


### PR DESCRIPTION
Apparently `DROP FUNCTION X CASCADE` is the better way to
do this, we were running into cross-schema errors on try.

