### PR TITLE
DEV: Log response headers when getting rate limit errors during smoke tests

### DIFF
--- a/test/smoke_test.js
+++ b/test/smoke_test.js
@@ -76,6 +76,13 @@ const path = require("path");
       console.log(
         "FAILED HTTP REQUEST TO " + resp.url() + " Status is: " + resp.status()
       );
+      if (resp.status() === 429) {
+        const headers = resp.headers();
+        console.log("Response headers:");
+        Object.keys(headers).forEach((key) => {
+          console.log(`${key}: ${headers[key]}`);
+        });
+      }
     }
     return resp;
   });


### PR DESCRIPTION
We've recently added diagnostic headers that Discourse includes in the response when it rate limits a request. This PR makes our smoke tests runner log the response headers it encounters a rate limit error so we can get a better visibility into what caused the rate limit.