### PR TITLE
FIX: when composing a message do not suggest deleted posts users

### DIFF
--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -83,7 +83,7 @@ class UserSearch
     # 2. in topic
     if @topic_id
       in_topic = filtered_by_term_users
-        .where('users.id IN (SELECT user_id FROM posts WHERE topic_id = ? AND post_type = ?)', @topic_id, Post.types[:regular])
+        .where('users.id IN (SELECT user_id FROM posts WHERE topic_id = ? AND post_type = ? AND deleted_at IS NULL)', @topic_id, Post.types[:regular])
 
       if @searching_user.present?
         in_topic = in_topic.where('users.id <> ?', @searching_user.id)

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -176,6 +176,12 @@ describe UserSearch do
       expect(results).to eq [mr_blue.username]
     end
 
+    it "does not include deleted posts users" do
+      post4.trash!
+      results = search_for("", topic_id: topic.id)
+      expect(results).to eq [mr_orange, mr_b].map(&:username)
+    end
+
     it "only reveals topic participants to people with permission" do
       pm_topic = Fabricate(:private_message_post).topic
 


### PR DESCRIPTION
This commit fixes the issue where deleted posts populates the user suggestion field when beginning a message to a user within a topic.