### PR TITLE
FIX: Refresh logic in discovery topic lists

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -11,6 +11,7 @@ import { endWith } from "discourse/lib/computed";
 import { routeAction } from "discourse/helpers/route-action";
 import { inject as service } from "@ember/service";
 import { userPath } from "discourse/lib/url";
+import { action } from "@ember/object";
 
 const controllerOpts = {
   discovery: controller(),
@@ -31,6 +32,18 @@ const controllerOpts = {
   ascending: readOnly("model.params.ascending"),
 
   selected: null,
+
+  // Remove these actions which are defined in `DiscoveryController`
+  // We want them to bubble in DiscoveryTopicsController
+  @action
+  loadingBegan() {
+    return true;
+  },
+
+  @action
+  loadingComplete() {
+    return true;
+  },
 
   @discourseComputed("model.filter", "model.topics.length")
   showDismissRead(filter, topicsLength) {


### PR DESCRIPTION
Before 6e0e6014, the flow looked something like:

1. `discovery/topics` controller (which extends `discovery` controller) `afterRefresh()` calls `.send("loadingComplete")`
2. Bubbles to [`discovery` route](https://github.com/discourse/discourse/blob/554ff07786a81ed55c902c074d5ba787cfda0a3b/app/assets/javascripts/discourse/app/routes/discovery.js#L58)
3. Discovery route calls `controllerFor('discovery').loadingComplete()`. `loading` is set false, and the spinner disappears

Now that `discovery/topics` defines `loadingComplete` as an action, the `discovery/topics` controller runs its own `loadingComplete` handler logic in step 1, and the action does not bubble any further.

This commit adds action overrides in `discovery/topics`, so that the new actions only apply to the main `discovery` controller. The need for this does suggest some more radical refactoring is required, but these are very critical routes, and we are very close to a major release.

Meta topic: https://meta.discourse.org/t/topic-list-loads-forever-in-some-circumstances/214042

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
