### PR TITLE
DEV: Retroactively add test for ignoring flagged responses

### DIFF
--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -297,12 +297,24 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       expect(flagged_reply.reload.status).to eq(Reviewable.statuses[:ignored])
     end
 
-    it 'notifies users that responded to flagged post' do
-      SiteSetting.notify_users_after_responses_deleted_on_flagged_post = true
-      flagged_post.perform(moderator, :delete_and_agree_replies)
+    describe "notifies users that responded to flagged post" do
+      before do
+        SiteSetting.notify_users_after_responses_deleted_on_flagged_post = true
+      end
 
-      expect(Jobs::SendSystemMessage.jobs.size).to eq(2)
-      expect(Jobs::SendSystemMessage.jobs.last["args"].first["message_type"]).to eq("flags_agreed_and_post_deleted_for_responders")
+      it "works" do
+        flagged_post.perform(moderator, :delete_and_agree_replies)
+
+        expect(Jobs::SendSystemMessage.jobs.size).to eq(2)
+        expect(Jobs::SendSystemMessage.jobs.last["args"].first["message_type"]).to eq("flags_agreed_and_post_deleted_for_responders")
+      end
+
+      it "ignores flagged responses" do
+        flagged_reply = Fabricate(:reviewable_flagged_post, target: reply)
+        flagged_post.perform(moderator, :delete_and_agree_replies)
+
+        expect(flagged_reply.reload.status).to eq(Reviewable.statuses[:ignored])
+      end
     end
   end
 

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -297,24 +297,20 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       expect(flagged_reply.reload.status).to eq(Reviewable.statuses[:ignored])
     end
 
-    describe "notifies users that responded to flagged post" do
-      before do
-        SiteSetting.notify_users_after_responses_deleted_on_flagged_post = true
-      end
+    it "notifies users that responded to flagged post" do
+      SiteSetting.notify_users_after_responses_deleted_on_flagged_post = true
+      flagged_post.perform(moderator, :delete_and_agree_replies)
 
-      it "works" do
-        flagged_post.perform(moderator, :delete_and_agree_replies)
+      expect(Jobs::SendSystemMessage.jobs.size).to eq(2)
+      expect(Jobs::SendSystemMessage.jobs.last["args"].first["message_type"]).to eq("flags_agreed_and_post_deleted_for_responders")
+    end
 
-        expect(Jobs::SendSystemMessage.jobs.size).to eq(2)
-        expect(Jobs::SendSystemMessage.jobs.last["args"].first["message_type"]).to eq("flags_agreed_and_post_deleted_for_responders")
-      end
+    it "ignores flagged responses" do
+      SiteSetting.notify_users_after_responses_deleted_on_flagged_post = true
+      flagged_reply = Fabricate(:reviewable_flagged_post, target: reply)
+      flagged_post.perform(moderator, :delete_and_agree_replies)
 
-      it "ignores flagged responses" do
-        flagged_reply = Fabricate(:reviewable_flagged_post, target: reply)
-        flagged_post.perform(moderator, :delete_and_agree_replies)
-
-        expect(flagged_reply.reload.status).to eq(Reviewable.statuses[:ignored])
-      end
+      expect(flagged_reply.reload.status).to eq(Reviewable.statuses[:ignored])
     end
   end
 


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/15463#issuecomment-1006239517 for context

I can confirm this would fail without the fix that was added in the attached PR