### PR TITLE
FEATURE: Don't show the 'Next Month' option in date pickers at the end of the month

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -330,11 +330,7 @@ export default Component.extend({
     editingExistingBookmark,
     existingBookmarkHasReminder
   ) {
-    if (!editingExistingBookmark) {
-      return [];
-    }
-
-    if (!existingBookmarkHasReminder) {
+    if (editingExistingBookmark && !existingBookmarkHasReminder) {
       return [TIME_SHORTCUT_TYPES.NONE];
     }
 

--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -1,11 +1,9 @@
 import {
   LATER_TODAY_CUTOFF_HOUR,
   MOMENT_THURSDAY,
-  laterToday,
   now,
   parseCustomDatetime,
   startOfDay,
-  tomorrow,
 } from "discourse/lib/time-utils";
 import { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
 import Component from "@ember/component";
@@ -341,13 +339,7 @@ export default Component.extend({
   additionalTimeShortcutOptions() {
     let additional = [];
 
-    if (
-      !laterToday(this.userTimezone).isSame(
-        tomorrow(this.userTimezone),
-        "date"
-      ) &&
-      now(this.userTimezone).hour() < LATER_TODAY_CUTOFF_HOUR
-    ) {
+    if (now(this.userTimezone).hour() < LATER_TODAY_CUTOFF_HOUR) {
       additional.push(TIME_SHORTCUT_TYPES.LATER_TODAY);
     }
 

--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -1,10 +1,4 @@
-import {
-  LATER_TODAY_CUTOFF_HOUR,
-  MOMENT_THURSDAY,
-  now,
-  parseCustomDatetime,
-  startOfDay,
-} from "discourse/lib/time-utils";
+import { now, parseCustomDatetime, startOfDay } from "discourse/lib/time-utils";
 import { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
 import Component from "@ember/component";
 import I18n from "I18n";
@@ -333,21 +327,6 @@ export default Component.extend({
     }
 
     return [];
-  },
-
-  @discourseComputed()
-  additionalTimeShortcutOptions() {
-    let additional = [];
-
-    if (now(this.userTimezone).hour() < LATER_TODAY_CUTOFF_HOUR) {
-      additional.push(TIME_SHORTCUT_TYPES.LATER_TODAY);
-    }
-
-    if (now(this.userTimezone).day() < MOMENT_THURSDAY) {
-      additional.push(TIME_SHORTCUT_TYPES.LATER_THIS_WEEK);
-    }
-
-    return additional;
   },
 
   @discourseComputed("model.reminderAt")

--- a/app/assets/javascripts/discourse/app/components/edit-topic-timer-form.js
+++ b/app/assets/javascripts/discourse/app/components/edit-topic-timer-form.js
@@ -21,6 +21,7 @@ import {
   thisWeekend,
 } from "discourse/lib/time-utils";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
+import { TIME_SHORTCUT_TYPES } from "discourse/lib/time-shortcut";
 import ItsATrap from "@discourse/itsatrap";
 
 export default Component.extend({
@@ -113,7 +114,11 @@ export default Component.extend({
 
   @discourseComputed
   hiddenTimeShortcutOptions() {
-    return ["none"];
+    return [
+      TIME_SHORTCUT_TYPES.NONE,
+      TIME_SHORTCUT_TYPES.LATER_TODAY,
+      TIME_SHORTCUT_TYPES.LATER_THIS_WEEK,
+    ];
   },
 
   isCustom: equal("timerType", "custom"),

--- a/app/assets/javascripts/discourse/app/components/time-shortcut-picker.js
+++ b/app/assets/javascripts/discourse/app/components/time-shortcut-picker.js
@@ -1,4 +1,6 @@
 import {
+  LATER_TODAY_CUTOFF_HOUR,
+  MOMENT_THURSDAY,
   START_OF_DAY_HOUR,
   laterToday,
   now,
@@ -57,7 +59,6 @@ export default Component.extend({
   selectedDatetime: null,
   prefilledDatetime: null,
 
-  additionalOptionsToShow: null,
   hiddenOptions: null,
   customOptions: null,
 
@@ -76,7 +77,6 @@ export default Component.extend({
     this.setProperties({
       customTime: this.defaultCustomReminderTime,
       userTimezone: this.currentUser.resolvedTimezone(this.currentUser),
-      additionalOptionsToShow: this.additionalOptionsToShow || [],
       hiddenOptions: this.hiddenOptions || [],
       customOptions: this.customOptions || [],
       customLabels: this.customLabels || {},
@@ -168,38 +168,24 @@ export default Component.extend({
   },
 
   @discourseComputed(
-    "additionalOptionsToShow",
     "hiddenOptions",
     "customOptions",
     "customLabels",
     "userTimezone"
   )
-  options(
-    additionalOptionsToShow,
-    hiddenOptions,
-    customOptions,
-    customLabels,
-    userTimezone
-  ) {
+  options(hiddenOptions, customOptions, customLabels, userTimezone) {
     this._loadLastUsedCustomDatetime();
 
     let options = defaultShortcutOptions(userTimezone);
-
-    if (additionalOptionsToShow.length > 0) {
-      options.forEach((opt) => {
-        if (additionalOptionsToShow.includes(opt.id)) {
-          opt.hidden = false;
-        }
-      });
-    }
+    this._hideDynamicOptions(options);
 
     customOptions.forEach((opt) => {
       if (!opt.timeFormatted && opt.time) {
         opt.timeFormatted = opt.time.format(I18n.t(opt.timeFormatKey));
       }
     });
-
     options = options.concat(customOptions);
+
     options.sort((a, b) => {
       if (a.time < b.time) {
         return -1;
@@ -287,5 +273,20 @@ export default Component.extend({
     if (this.onTimeSelected) {
       this.onTimeSelected(type, dateTime);
     }
+  },
+
+  _hideDynamicOptions(options) {
+    if (now(this.userTimezone).hour() >= LATER_TODAY_CUTOFF_HOUR) {
+      this._hideOption(options, TIME_SHORTCUT_TYPES.LATER_TODAY);
+    }
+
+    if (now(this.userTimezone).day() >= MOMENT_THURSDAY) {
+      this._hideOption(options, TIME_SHORTCUT_TYPES.LATER_THIS_WEEK);
+    }
+  },
+
+  _hideOption(options, optionId) {
+    const option = options.findBy("id", optionId);
+    option.hidden = true;
   },
 });

--- a/app/assets/javascripts/discourse/app/components/time-shortcut-picker.js
+++ b/app/assets/javascripts/discourse/app/components/time-shortcut-picker.js
@@ -3,6 +3,7 @@ import {
   MOMENT_THURSDAY,
   START_OF_DAY_HOUR,
   laterToday,
+  nextMonth,
   now,
   parseCustomDatetime,
 } from "discourse/lib/time-utils";
@@ -276,12 +277,18 @@ export default Component.extend({
   },
 
   _hideDynamicOptions(options) {
-    if (now(this.userTimezone).hour() >= LATER_TODAY_CUTOFF_HOUR) {
+    const _now = now(this.userTimezone);
+
+    if (_now.hour() >= LATER_TODAY_CUTOFF_HOUR) {
       this._hideOption(options, TIME_SHORTCUT_TYPES.LATER_TODAY);
     }
 
-    if (now(this.userTimezone).day() >= MOMENT_THURSDAY) {
+    if (_now.day() >= MOMENT_THURSDAY) {
       this._hideOption(options, TIME_SHORTCUT_TYPES.LATER_THIS_WEEK);
+    }
+
+    if (nextMonth(this.userTimezone).diff(_now, "days") < 7) {
+      this._hideOption(options, TIME_SHORTCUT_TYPES.NEXT_MONTH);
     }
   },
 

--- a/app/assets/javascripts/discourse/app/lib/time-shortcut.js
+++ b/app/assets/javascripts/discourse/app/lib/time-shortcut.js
@@ -30,7 +30,6 @@ export function defaultShortcutOptions(timezone) {
       label: "time_shortcut.later_today",
       time: laterToday(timezone),
       timeFormatted: laterToday(timezone).format(I18n.t("dates.time")),
-      hidden: true,
     },
     {
       icon: "far-sun",
@@ -47,7 +46,6 @@ export function defaultShortcutOptions(timezone) {
       timeFormatted: laterThisWeek(timezone).format(
         I18n.t("dates.time_short_day")
       ),
-      hidden: true,
     },
     {
       icon: "briefcase",

--- a/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
@@ -41,7 +41,6 @@
         customOptions=customTimeShortcutOptions
         hiddenOptions=hiddenTimeShortcutOptions
         customLabels=customTimeShortcutLabels
-        additionalOptionsToShow=additionalTimeShortcutOptions
         _itsatrap=_itsatrap
       }}
     {{else}}

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -1,16 +1,8 @@
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-import {
-  discourseModule,
-  exists,
-  fakeTime,
-  query,
-  queryAll,
-} from "discourse/tests/helpers/qunit-helpers";
-import I18n from "I18n";
+import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
 import hbs from "htmlbars-inline-precompile";
-import { click } from "@ember/test-helpers";
 
 discourseModule("Integration | Component | bookmark", function (hooks) {
   setupRenderingTest(hooks);
@@ -34,127 +26,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     });
   });
 
-  hooks.afterEach(function () {
-    if (this.clock) {
-      this.clock.restore();
-    }
-  });
-
-  componentTest("shows correct options", {
-    template,
-
-    beforeEach() {
-      const tuesday = "2100-06-08T08:00:00";
-      this.clock = fakeTime(tuesday, this.currentUser._timezone, true);
-    },
-
-    async test(assert) {
-      const expected = [
-        I18n.t("time_shortcut.later_today"),
-        I18n.t("time_shortcut.tomorrow"),
-        I18n.t("time_shortcut.later_this_week"),
-        I18n.t("time_shortcut.start_of_next_business_week"),
-        I18n.t("time_shortcut.next_month"),
-        I18n.t("time_shortcut.custom"),
-        I18n.t("time_shortcut.none"),
-      ];
-
-      const options = Array.from(
-        queryAll(
-          "div.control-group div.tap-tile-grid div.tap-tile-title"
-        ).map((_, div) => div.innerText.trim())
-      );
-
-      assert.deepEqual(options, expected);
-    },
-  });
-
-  componentTest("show later this week option if today is < Thursday", {
-    template,
-
-    beforeEach() {
-      const monday = "2100-06-07T08:00:00";
-      this.clock = fakeTime(monday, this.currentUser._timezone, true);
-    },
-
-    test(assert) {
-      assert.ok(exists("#tap_tile_later_this_week"), "it has later this week");
-    },
-  });
-
-  componentTest(
-    "does not show later this week option if today is >= Thursday",
-    {
-      template,
-
-      beforeEach() {
-        const thursday = "2100-06-10T08:00:00";
-        this.clock = fakeTime(thursday, this.currentUser._timezone, true);
-      },
-
-      test(assert) {
-        assert.notOk(
-          exists("#tap_tile_later_this_week"),
-          "it does not have later this week"
-        );
-      },
-    }
-  );
-
-  componentTest("later today does not show if later today is tomorrow", {
-    template,
-
-    beforeEach() {
-      this.clock = fakeTime(
-        "2100-12-11T22:00:00",
-        this.currentUser._timezone,
-        true
-      );
-    },
-
-    test(assert) {
-      assert.notOk(
-        exists("#tap_tile_later_today"),
-        "it does not have later today"
-      );
-    },
-  });
-
-  componentTest("later today shows if it is before 5pm", {
-    template,
-
-    beforeEach() {
-      this.clock = fakeTime(
-        "2100-12-11T16:50:00",
-        this.currentUser._timezone,
-        true
-      );
-    },
-
-    test(assert) {
-      assert.ok(exists("#tap_tile_later_today"), "it does have later today");
-    },
-  });
-
-  componentTest("later today does not show if it is after 5pm", {
-    template,
-
-    beforeEach() {
-      this.clock = fakeTime(
-        "2100-12-11T17:00:00",
-        this.currentUser._timezone,
-        true
-      );
-    },
-
-    test(assert) {
-      assert.notOk(
-        exists("#tap_tile_later_today"),
-        "it does not have later today"
-      );
-    },
-  });
-
   componentTest("prefills the custom reminder type date and time", {
     template,
 
@@ -173,35 +44,4 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
       assert.strictEqual(query("#custom-time").value, "09:45");
     },
   });
-
-  componentTest("defaults to 08:00 for custom time", {
-    template,
-
-    async test(assert) {
-      await click("#tap_tile_custom");
-      assert.strictEqual(query("#custom-time").value, "08:00");
-    },
-  });
-
-  componentTest(
-    "the 'Next Month' option points to the first day of the next month",
-    {
-      template,
-
-      beforeEach() {
-        this.clock = fakeTime(
-          "2100-01-01T08:00:00",
-          this.currentUser._timezone,
-          true
-        );
-      },
-
-      async test(assert) {
-        assert.strictEqual(
-          query("div#tap_tile_next_month div.tap-tile-date").innerText,
-          "Feb 1, 8:00 am"
-        );
-      },
-    }
-  );
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -120,12 +120,12 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     },
   });
 
-  componentTest("later today shows if it is after 5pm but before 6pm", {
+  componentTest("later today shows if it is before 5pm", {
     template,
 
     beforeEach() {
       this.clock = fakeTime(
-        "2100-12-11T14:30:00",
+        "2100-12-11T16:50:00",
         this.currentUser._timezone,
         true
       );
@@ -152,22 +152,6 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
         exists("#tap_tile_later_today"),
         "it does not have later today"
       );
-    },
-  });
-
-  componentTest("later today does show if it is before the end of the day", {
-    template,
-
-    beforeEach() {
-      this.clock = fakeTime(
-        "2100-12-11T13:00:00",
-        this.currentUser._timezone,
-        true
-      );
-    },
-
-    test(assert) {
-      assert.ok(exists("#tap_tile_later_today"), "it does have later today");
     },
   });
 
@@ -199,22 +183,25 @@ discourseModule("Integration | Component | bookmark", function (hooks) {
     },
   });
 
-  componentTest("Next Month points to the first day of the next month", {
-    template,
+  componentTest(
+    "the 'Next Month' option points to the first day of the next month",
+    {
+      template,
 
-    beforeEach() {
-      this.clock = fakeTime(
-        "2100-01-01T08:00:00",
-        this.currentUser._timezone,
-        true
-      );
-    },
+      beforeEach() {
+        this.clock = fakeTime(
+          "2100-01-01T08:00:00",
+          this.currentUser._timezone,
+          true
+        );
+      },
 
-    async test(assert) {
-      assert.strictEqual(
-        query("div#tap_tile_next_month div.tap-tile-date").innerText,
-        "Feb 1, 8:00 am"
-      );
-    },
-  });
+      async test(assert) {
+        assert.strictEqual(
+          query("div#tap_tile_next_month div.tap-tile-date").innerText,
+          "Feb 1, 8:00 am"
+        );
+      },
+    }
+  );
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
@@ -160,6 +160,33 @@ discourseModule(
       },
     });
 
+    componentTest("shows 'Next Month' if it is in 7 days or more from now", {
+      template,
+
+      beforeEach() {
+        this.clock = fakeTime("2100-01-25", this.currentUser._timezone, true);
+      },
+
+      test(assert) {
+        assert.ok(exists("#tap_tile_next_month"));
+      },
+    });
+
+    componentTest(
+      "does not show 'Next Month' if it is in less than 7 days from now",
+      {
+        template,
+
+        beforeEach() {
+          this.clock = fakeTime("2100-01-26", this.currentUser._timezone, true);
+        },
+
+        test(assert) {
+          assert.notOk(exists("#tap_tile_next_month"));
+        },
+      }
+    );
+
     componentTest(
       "the 'Next Month' option points to the first day of the next month",
       {

--- a/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
@@ -1,0 +1,185 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  discourseModule,
+  exists,
+  fakeTime,
+  query,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
+import I18n from "I18n";
+import hbs from "htmlbars-inline-precompile";
+import { click } from "@ember/test-helpers";
+
+discourseModule(
+  "Integration | Component | time-shortcut-picker",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    const template = hbs`{{time-shortcut-picker _itsatrap=itsatrap}}`;
+
+    hooks.beforeEach(function () {
+      const itsatrapStub = {
+        bind: () => {},
+        unbind: () => {},
+      };
+
+      this.setProperties({
+        itsatrap: itsatrapStub,
+      });
+    });
+
+    hooks.afterEach(function () {
+      if (this.clock) {
+        this.clock.restore();
+      }
+    });
+
+    componentTest("shows default options", {
+      template,
+
+      beforeEach() {
+        const tuesday = "2100-06-08T08:00:00";
+        this.clock = fakeTime(tuesday, this.currentUser._timezone, true);
+      },
+
+      async test(assert) {
+        const expected = [
+          I18n.t("time_shortcut.later_today"),
+          I18n.t("time_shortcut.tomorrow"),
+          I18n.t("time_shortcut.later_this_week"),
+          I18n.t("time_shortcut.start_of_next_business_week"),
+          I18n.t("time_shortcut.next_month"),
+          I18n.t("time_shortcut.custom"),
+          I18n.t("time_shortcut.none"),
+        ];
+
+        const options = Array.from(
+          queryAll("div.tap-tile-grid div.tap-tile-title").map((_, div) =>
+            div.innerText.trim()
+          )
+        );
+
+        assert.deepEqual(options, expected);
+      },
+    });
+
+    componentTest("show 'Later This Week' if today is < Thursday", {
+      template,
+
+      beforeEach() {
+        const monday = "2100-06-07T08:00:00";
+        this.clock = fakeTime(monday, this.currentUser._timezone, true);
+      },
+
+      test(assert) {
+        assert.ok(
+          exists("#tap_tile_later_this_week"),
+          "it has later this week"
+        );
+      },
+    });
+
+    componentTest("does not show 'Later This Week' if today is >= Thursday", {
+      template,
+
+      beforeEach() {
+        const thursday = "2100-06-10T08:00:00";
+        this.clock = fakeTime(thursday, this.currentUser._timezone, true);
+      },
+
+      test(assert) {
+        assert.notOk(
+          exists("#tap_tile_later_this_week"),
+          "it does not have later this week"
+        );
+      },
+    });
+
+    componentTest("does not show 'Later Today' if 'Later Today' is tomorrow", {
+      template,
+
+      beforeEach() {
+        this.clock = fakeTime(
+          "2100-12-11T22:00:00", // + 3 hours is tomorrow
+          this.currentUser._timezone,
+          true
+        );
+      },
+
+      test(assert) {
+        assert.notOk(
+          exists("#tap_tile_later_today"),
+          "it does not have later today"
+        );
+      },
+    });
+
+    componentTest("shows 'Later Today' if it is before 5pm", {
+      template,
+
+      beforeEach() {
+        this.clock = fakeTime(
+          "2100-12-11T16:50:00",
+          this.currentUser._timezone,
+          true
+        );
+      },
+
+      test(assert) {
+        assert.ok(exists("#tap_tile_later_today"), "it does have later today");
+      },
+    });
+
+    componentTest("does not show 'Later Today' if it is after 5pm", {
+      template,
+
+      beforeEach() {
+        this.clock = fakeTime(
+          "2100-12-11T17:00:00",
+          this.currentUser._timezone,
+          true
+        );
+      },
+
+      test(assert) {
+        assert.notOk(
+          exists("#tap_tile_later_today"),
+          "it does not have later today"
+        );
+      },
+    });
+
+    componentTest("defaults to 08:00 for custom time", {
+      template,
+
+      async test(assert) {
+        await click("#tap_tile_custom");
+        assert.strictEqual(query("#custom-time").value, "08:00");
+      },
+    });
+
+    componentTest(
+      "the 'Next Month' option points to the first day of the next month",
+      {
+        template,
+
+        beforeEach() {
+          this.clock = fakeTime(
+            "2100-01-01T08:00:00",
+            this.currentUser._timezone,
+            true
+          );
+        },
+
+        async test(assert) {
+          assert.strictEqual(
+            query("div#tap_tile_next_month div.tap-tile-date").innerText,
+            "Feb 1, 8:00 am"
+          );
+        },
+      }
+    );
+  }
+);


### PR DESCRIPTION
This PR affects only date-time pickers on the bookmark modal and the topic timer modal.

At the end of the month, the <kbd>Monday</kbd> option and the <kbd>Next Month</kbd> can point to the same day or the <kbd>Next Month</kbd> option can even appear _before_ the <kbd>Monday</kbd> option (in most cases the order is opposite):

![1](https://user-images.githubusercontent.com/1274517/148594250-c9b58856-17b2-43b7-b549-fe4da3bc35b8.png)

This PR makes the <kbd>Next Month</kbd> option disappear if it is in less than 7 days from now.

Also, I did some refactoring in this PR, all steps can be seen in the commit history. The most serious step is https://github.com/discourse/discourse/commit/9f1c575e24423b5580d2d3fe98898a17bc97c117. In this commit:

- I moved hiding of dynamic options like <kbd>Later Today</kbd> and <kbd>Later This Week</kbd> to the `time-shortcut-picker` component. This way we won't need to write this code again and again on every form that needs it.
- Get rid of `additionalOptionsToShow` setting of the `time-shortcut-picker` component. This setting was confusing. The component had default options to pick and these settings:
    - **hiddenOptions** (default options that should be hidden)
    - **customOptions** (additional options)
    - **additionalOptionsToShow** - list of _default options that hidden by default_ but can be shown if they listed in this setting

The last one is very confusing, if the option is _default_ it shouldn't be hidden by default. Also, it's enough to have just `hiddenOptions` and `customOptions`



