### PR TITLE
FIX: Actually save fields on themes:update

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -60,6 +60,7 @@ def update_themes
 
       puts "Updating '#{theme.name}' for '#{RailsMultisite::ConnectionManagement.current_db}'..."
       remote_theme.update_from_remote
+      theme.save!
 
       raise RemoteTheme::ImportError.new(remote_theme.last_error_text) if remote_theme.last_error_text.present?
     rescue => e


### PR DESCRIPTION
`RemoteTheme#update_from_remote` does not save theme fields on its own.

Fixes theme/theme component autoupdates working only partially.
