### PR TITLE
DEV: Allow click-interceptor in tests and add navigation test

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/click-interceptor.js
+++ b/app/assets/javascripts/discourse/app/initializers/click-interceptor.js
@@ -3,8 +3,9 @@ import interceptClick from "discourse/lib/intercept-click";
 
 export default {
   name: "click-interceptor",
-  initialize() {
-    $("#main").on("click.discourse", "a", interceptClick);
+  initialize(container, app) {
+    this.selector = app.rootElement;
+    $(this.selector).on("click.discourse", "a", interceptClick);
     window.addEventListener("hashchange", this.hashChanged);
   },
 
@@ -13,7 +14,7 @@ export default {
   },
 
   teardown() {
-    $("#main").off("click.discourse", "a", interceptClick);
+    $(this.selector).off("click.discourse", "a", interceptClick);
     window.removeEventListener("hashchange", this.hashChanged);
   },
 };

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -2,13 +2,14 @@ import {
   acceptance,
   exists,
   publishToMessageBus,
+  query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import DiscourseURL from "discourse/lib/url";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import sinon from "sinon";
 import { test } from "qunit";
-import { visit } from "@ember/test-helpers";
+import { click, currentURL, visit } from "@ember/test-helpers";
 
 acceptance("Topic Discovery", function (needs) {
   needs.settings({
@@ -133,5 +134,26 @@ acceptance("Topic Discovery", function (needs) {
       DiscourseURL.routeTo.calledWith("/top?f=foo&d=bar&period=yearly"),
       "it keeps the query params"
     );
+  });
+
+  test("switching between tabs", async function (assert) {
+    await visit("/latest");
+    assert.strictEqual(
+      query(".topic-list-body .topic-list-item:first-of-type").dataset.topicId,
+      "11557",
+      "shows the correct latest topics"
+    );
+
+    await click(".navigation-container a[href='/top']");
+    assert.strictEqual(currentURL(), "/top", "switches to top");
+
+    assert.deepEqual(
+      query(".topic-list-body .topic-list-item:first-of-type").dataset.topicId,
+      "13088",
+      "shows the correct top topics"
+    );
+
+    await click(".navigation-container a[href='/categories']");
+    assert.strictEqual(currentURL(), "/categories", "switches to categories");
   });
 });


### PR DESCRIPTION
The app's wrapper element ID is different in tests. `app.rootElement` allows us to consistently obtain the selector in the initializer, so it works correctly regardless of the app's configuration.

(Requires #15498)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
