### PR TITLE
DEV: Skip timers when loading topic route in tests

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-progress.js
+++ b/app/assets/javascripts/discourse/app/components/topic-progress.js
@@ -3,6 +3,9 @@ import Component from "@ember/component";
 import { alias } from "@ember/object/computed";
 import { later, scheduleOnce } from "@ember/runloop";
 import { action } from "@ember/object";
+import { isTesting } from "discourse-common/config/environment";
+
+const CSS_TRANSITION_DELAY = isTesting() ? 0 : 500;
 
 export default Component.extend({
   elementId: "topic-progress-wrapper",
@@ -74,7 +77,7 @@ export default Component.extend({
 
     // start CSS transitions a tiny bit later
     // to avoid jumpiness on initial topic load
-    later(this._addCssTransitions, 500);
+    later(this._addCssTransitions, CSS_TRANSITION_DELAY);
   },
 
   willDestroyElement() {

--- a/app/assets/javascripts/discourse/app/mixins/docking.js
+++ b/app/assets/javascripts/discourse/app/mixins/docking.js
@@ -1,6 +1,10 @@
 import Mixin from "@ember/object/mixin";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { cancel, later } from "@ember/runloop";
+import { isTesting } from "discourse-common/config/environment";
+
+const INITIAL_DELAY_MS = isTesting() ? 0 : 50;
+const DEBOUNCE_MS = isTesting() ? 0 : 5;
 
 export default Mixin.create({
   queueDockCheck: null,
@@ -10,7 +14,11 @@ export default Mixin.create({
   init() {
     this._super(...arguments);
     this.queueDockCheck = () => {
-      this._queuedTimer = discourseDebounce(this, this.safeDockCheck, 5);
+      this._queuedTimer = discourseDebounce(
+        this,
+        this.safeDockCheck,
+        DEBOUNCE_MS
+      );
     };
   },
 
@@ -30,7 +38,7 @@ export default Mixin.create({
     });
 
     // dockCheck might happen too early on full page refresh
-    this._initialTimer = later(this, this.safeDockCheck, 50);
+    this._initialTimer = later(this, this.safeDockCheck, INITIAL_DELAY_MS);
   },
 
   willDestroyElement() {

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -7,8 +7,9 @@ import { isEmpty } from "@ember/utils";
 import { inject as service } from "@ember/service";
 import { setTopicId } from "discourse/lib/topic-list-tracker";
 import showModal from "discourse/lib/show-modal";
+import { isTesting } from "discourse-common/config/environment";
 
-const SCROLL_DELAY = 500;
+const SCROLL_DELAY = isTesting() ? 0 : 500;
 
 const TopicRoute = DiscourseRoute.extend({
   screenTrack: service(),
@@ -230,7 +231,7 @@ const TopicRoute = DiscourseRoute.extend({
           this,
           "_replaceUnlessScrolling",
           postUrl,
-          Ember.Test ? 0 : SCROLL_DELAY
+          SCROLL_DELAY
         ),
       });
     }


### PR DESCRIPTION
The test environment will wait for all timers to settle before continuing. These timers were causing all tests involving `/t/*` routes to spend 500ms doing nothing.

Fun fact: we load the topic route 214 times during the core test suite. That means that this commit saves a total of around 107s across the whole suite. On my machine, that's a 30% improvement in runtime.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
