### PR TITLE
DEV: migrate audio cloak-prevention to decorateCookedElement

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -53,7 +53,7 @@ export default {
             });
           });
         },
-        {id: "discourse-audio"}
+        { id: "discourse-audio" }
       );
 
       const caps = container.lookup("capabilities:main");

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -44,7 +44,7 @@ export default {
           elem.querySelectorAll("audio").forEach((player) => {
             player.addEventListener("play", () => {
               const postId = parseInt(
-                elem.closest("article").dataset.postId,
+                elem.closest("article")?.dataset.postId,
                 10
               );
               if (postId) {

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -39,22 +39,21 @@ export default {
 
       nativeLazyLoading(api);
 
-      api.decorateCooked(
-        ($elem) => {
-          const players = $("audio", $elem);
-          if (players.length) {
-            players.on("play", () => {
+      api.decorateCookedElement(
+        (elem) => {
+          elem.querySelectorAll("audio").forEach((player) => {
+            player.addEventListener("play", () => {
               const postId = parseInt(
-                $elem.closest("article").data("post-id"),
+                elem.closest("article").dataset.postId,
                 10
               );
               if (postId) {
                 api.preventCloak(postId);
               }
             });
-          }
+          });
         },
-        { id: "discourse-audio" }
+        {id: "discourse-audio"}
       );
 
       const caps = container.lookup("capabilities:main");


### PR DESCRIPTION
Migrate deprecated decorateCooked to decorateCookedElement for audio cloak-prevention.

This might give a minimal performance boost: running audio cloak-prevention for 20 (non-audio) posts takes 1 ms and not 15 ms.