### PR TITLE
DEV: Prevent extraneous log message in specs

### DIFF
--- a/spec/lib/backup_restore/backuper_spec.rb
+++ b/spec/lib/backup_restore/backuper_spec.rb
@@ -41,7 +41,7 @@ describe BackupRestore::Backuper do
       SiteSetting.max_post_length = 250
 
       silence_stdout do
-        backuper = silence_stdout { BackupRestore::Backuper.new(Discourse.system_user.id) }
+        backuper = BackupRestore::Backuper.new(Discourse.system_user.id)
 
         expect { backuper.send(:notify_user) }
           .to change { Topic.private_messages.count }.by(1)


### PR DESCRIPTION
Yo dawg, I put `silence_stdout` in your `silence_stdout` so you can still write to stdout?