### PR TITLE
DEV: Don't warn on missing git tags

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -667,7 +667,7 @@ module Discourse
 
   def self.full_version
     @full_version ||= begin
-      git_cmd = 'git describe --dirty --match "v[0-9]*"'
+      git_cmd = 'git describe --dirty --match "v[0-9]*" 2> /dev/null'
       self.try_git(git_cmd, 'unknown')
     end
   end


### PR DESCRIPTION
Fixes the following output in specs:

```
fatal: No names found, cannot describe anything.
```