### PR TITLE
FIX: Regression in topic list kbd navigation

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -694,7 +694,8 @@ export default {
       selectedArticle: article,
     });
 
-    const articleTop = domUtils.offset(article).top;
+    const articleTop = domUtils.offset(article).top,
+      articleTopPosition = articleTop - headerOffset();
     if (!fast && direction < 0 && article.offsetHeight > window.innerHeight) {
       // Scrolling to the last "page" of the previous post if post has multiple
       // "pages" (if its height does not fit in the screen).
@@ -703,16 +704,21 @@ export default {
       );
     } else if (article.classList.contains("topic-post")) {
       return this._scrollTo(
-        article.querySelector("#post_1") ? 0 : articleTop - headerOffset(),
+        article.querySelector("#post_1") ? 0 : articleTopPosition,
         { focusTabLoc: true }
       );
     }
 
-    // Otherwise scroll through the suggested topic list.
-    article.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-    });
+    // Otherwise scroll through the topic list.
+    if (
+      articleTopPosition > window.pageYOffset &&
+      articleTop + article.offsetHeight <
+        window.pageYOffset + window.innerHeight
+    ) {
+      return;
+    }
+
+    this._scrollTo(articleTopPosition - window.innerHeight * 0.25);
   },
 
   _scrollTo(scrollTop, opts = {}) {

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -718,7 +718,8 @@ export default {
       return;
     }
 
-    this._scrollTo(articleTopPosition - window.innerHeight * 0.25);
+    const scrollRatio = direction > 0 ? 0.2 : 0.7;
+    this._scrollTo(articleTopPosition - window.innerHeight * scrollRatio);
   },
 
   _scrollTo(scrollTop, opts = {}) {


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/discourse/discourse/commit/1ed2520589d988cc3299f8a85c8a20ade502f45d, most noticeable in Safari. 

The main issue is that Safari doesn't support the options parameter for `element.scrollIntoView`, so the following code: 

```
    article.scrollIntoView({
       behavior: "smooth",
       block: "center",
     });
```

would result in the article being scrolled to the very top of the window (in Safari only), and below the header. 

This commit restores some of the previous logic to fix this issue. It also ensures that when scrolling downwards the scroll position of the selected article is set at the top third of the page, and conversely, when scrolling upwards, the position is set in the bottom third. 