### PR TITLE
UX: Tweak emoji picker css

### DIFF
--- a/app/assets/stylesheets/common/base/emoji.scss
+++ b/app/assets/stylesheets/common/base/emoji.scss
@@ -65,11 +65,15 @@ sup img.emoji {
     background: var(--secondary);
 
     .section {
-      margin-bottom: 1em;
+      margin: 0 0 1em;
 
       .trash-recent {
         background: none;
         font-size: $font-down-1;
+
+        &:hover .d-icon {
+          color: var(--danger-hover);
+        }
       }
     }
 
@@ -95,6 +99,11 @@ sup img.emoji {
 
     .results {
       padding: 0.25em 0;
+
+      &:empty {
+        display: none;
+      }
+
       img.emoji {
         padding: 0.5em;
       }


### PR DESCRIPTION
1. Hide the results element when empty (and set top-margin of section to 0, which fixes some custom themes)
2. Fixed the on-hover color of .trash-recent

Before/After
<img width="400" alt="Screen Shot 2022-01-09 at 23 31 42" src="https://user-images.githubusercontent.com/66961/148703844-e9705825-4f2c-4b3e-9ec4-7507d237e1c7.png"> <img width="400" alt="Screen Shot 2022-01-09 at 23 29 53" src="https://user-images.githubusercontent.com/66961/148703849-2dc36d69-b3a6-4ab7-b5e3-2322786da8f8.png">

