### PR TITLE
DEV: Ignore dropped Bookmark columns.

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -4,8 +4,10 @@ class Bookmark < ActiveRecord::Base
   # these columns were here for a very short amount of time,
   # hence the very short ignore time
   self.ignored_columns = [
-    "bookmarkable_id", # TODO (martin) 2022-01-12 remove
-    "bookmarkable_type" # TODO (martin) 2022-01-12 remove
+    "bookmarkable_id", # TODO 2022-04-01 remove
+    "bookmarkable_type", # TODO 2022-04-01 remove
+    "topic_id", # TODO 2022-04-01: remove
+    "reminder_type" # TODO 2021-04-01: remove
   ]
 
   belongs_to :user


### PR DESCRIPTION
This is a partial revert of 099b679fc58b909d3800bc3f7a336982eedf4824.
`Bookmark#topic_id` and `Bookmark#reminder_type` was dropped in
b22450c7a8d378b32291743ca602cbc477dea106 so we need to continue ignoring
the dropped columns so as to ensure a seamless deploy. Otherwise,
ActiveRecord's schema cache will still contain references to
`Bookmark#topic_id` when the column is dropped in a post migration.