### PR TITLE
FEATURE: decorate username in email-group-user-chooser-row

### DIFF
--- a/app/assets/javascripts/select-kit/addon/templates/components/email-group-user-chooser-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/email-group-user-chooser-row.hbs
@@ -2,6 +2,7 @@
   {{avatar item imageSize="tiny"}}
   <span class="identifier">{{format-username item.id}}</span>
   <span class="name">{{item.name}}</span>
+  {{decorate-username-selector item.id}}
 {{else if item.isGroup}}
   {{d-icon "users"}}
   <span class="identifier">{{item.id}}</span>


### PR DESCRIPTION
We are allowing plugins to decorate username selector:

https://github.com/discourse/discourse/blob/1f1aa6a0d8061df078f7b746d70510a365bddb50/app/assets/javascripts/discourse/app/lib/plugin-api.js#L1154

https://github.com/discourse/discourse/blob/1472e47aae5bfdfb6fd9abfe89beb186c751f514/app/assets/javascripts/discourse/app/templates/user-selector-autocomplete.hbr#L9

The same decoration can be beneficial for email-group-user-chooser-row. An example use case is to show the icon that a user is on holiday when assigning a user to post/topic.