### PR TITLE
FEATURE: Don't show the 'Next Month' option in date pickers at the end of the month 2

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/timeframes-builder.js
+++ b/app/assets/javascripts/discourse/app/lib/timeframes-builder.js
@@ -60,7 +60,10 @@ const TIMEFRAMES = [
   buildTimeframe({
     id: "next_month",
     format: "MMM D",
-    enabled: (opts) => opts.now.date() !== moment().endOf("month").date(),
+    enabled: (opts) => {
+      const now = opts.now.clone();
+      return opts.now.endOf("month").diff(now, "days") >= 7;
+    },
     when: (time, timeOfDay) =>
       time.add(1, "month").startOf("month").hour(timeOfDay).minute(0),
     icon: "briefcase",

--- a/app/assets/javascripts/discourse/app/lib/timeframes-builder.js
+++ b/app/assets/javascripts/discourse/app/lib/timeframes-builder.js
@@ -62,7 +62,7 @@ const TIMEFRAMES = [
     format: "MMM D",
     enabled: (opts) => {
       const now = opts.now.clone();
-      return opts.now.endOf("month").diff(now, "days") >= 7;
+      return opts.now.endOf("month").diff(now, "days") >= 8;
     },
     when: (time, timeOfDay) =>
       time.add(1, "month").startOf("month").hour(timeOfDay).minute(0),

--- a/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
@@ -26,7 +26,7 @@ module("Unit | Lib | timeframes-builder", function (hooks) {
     }
   });
 
-  test("default options", function (assert) {
+  test("outputs default options", function (assert) {
     const timezone = moment.tz.guess();
     this.clock = fakeTime("2100-06-07T08:00:00", timezone, true); // Monday
 
@@ -142,9 +142,17 @@ module("Unit | Lib | timeframes-builder", function (hooks) {
     assert.not(timeframes.includes("later_this_week"));
   });
 
-  test("doesn't output 'Next Month' on the last day of the month", function (assert) {
+  test("outputs 'Next Month' if it is in more than 7 days from now", function (assert) {
     const timezone = moment.tz.guess();
-    this.clock = fakeTime("2100-04-30 18:00:00", timezone, true); // The last day of April
+    this.clock = fakeTime("2100-01-24", timezone, true);
+    const timeframes = buildTimeframes(buildOptions(moment())).mapBy("id");
+
+    assert.ok(timeframes.includes("next_month"));
+  });
+
+  test("doesn't output 'Next Month' if it is in 7 or fewer days from now", function (assert) {
+    const timezone = moment.tz.guess();
+    this.clock = fakeTime("2100-01-25", timezone, true);
     const timeframes = buildTimeframes(buildOptions(moment())).mapBy("id");
 
     assert.not(timeframes.includes("next_month"));

--- a/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
@@ -142,17 +142,17 @@ module("Unit | Lib | timeframes-builder", function (hooks) {
     assert.not(timeframes.includes("later_this_week"));
   });
 
-  test("outputs 'Next Month' if it is in more than 7 days from now", function (assert) {
+  test("outputs 'Next Month' if it is in more than 8 days from now", function (assert) {
     const timezone = moment.tz.guess();
-    this.clock = fakeTime("2100-01-24", timezone, true);
+    this.clock = fakeTime("2100-01-23", timezone, true);
     const timeframes = buildTimeframes(buildOptions(moment())).mapBy("id");
 
     assert.ok(timeframes.includes("next_month"));
   });
 
-  test("doesn't output 'Next Month' if it is in 7 or fewer days from now", function (assert) {
+  test("doesn't output 'Next Month' if it is in 8 or fewer days from now", function (assert) {
     const timezone = moment.tz.guess();
-    this.clock = fakeTime("2100-01-25", timezone, true);
+    this.clock = fakeTime("2100-01-24", timezone, true);
     const timeframes = buildTimeframes(buildOptions(moment())).mapBy("id");
 
     assert.not(timeframes.includes("next_month"));


### PR DESCRIPTION
The second step for the fix I've done in https://github.com/discourse/discourse/pull/15492.

That PR addresses date-time pickers on
- the bookmark modal
- the topic timer modal

This PR does the same job for other pickers (for example, for the picker on the slow mode modal).
