### PR TITLE
DEV: Remove JQuery from click-interceptor

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/click-interceptor.js
+++ b/app/assets/javascripts/discourse/app/initializers/click-interceptor.js
@@ -5,7 +5,9 @@ export default {
   name: "click-interceptor",
   initialize(container, app) {
     this.selector = app.rootElement;
-    $(this.selector).on("click.discourse", "a", interceptClick);
+    document
+      .querySelector(this.selector)
+      .addEventListener("click", interceptClick);
     window.addEventListener("hashchange", this.hashChanged);
   },
 
@@ -14,7 +16,9 @@ export default {
   },
 
   teardown() {
-    $(this.selector).off("click.discourse", "a", interceptClick);
+    document
+      .querySelector(this.selector)
+      .removeEventListener("click", interceptClick);
     window.removeEventListener("hashchange", this.hashChanged);
   },
 };

--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -1,6 +1,6 @@
 import DiscourseURL from "discourse/lib/url";
 
-export function wantsNewWindow(e) {
+export function wantsNewWindow(e, currentTarget = e.currentTarget) {
   return (
     e.defaultPrevented ||
     (e.isDefaultPrevented && e.isDefaultPrevented()) ||
@@ -8,7 +8,7 @@ export function wantsNewWindow(e) {
     e.metaKey ||
     e.ctrlKey ||
     (e.button && e.button !== 0) ||
-    (e.currentTarget && e.currentTarget.target === "_blank")
+    (currentTarget && currentTarget.target === "_blank")
   );
 }
 
@@ -18,15 +18,16 @@ export function wantsNewWindow(e) {
   This jQuery code intercepts clicks on those links and routes them properly.
 **/
 export default function interceptClick(e) {
-  if (!e.target.closest("a")) {
+  const currentTarget = e.target.closest("a");
+
+  if (!currentTarget) {
     return;
   }
 
-  if (wantsNewWindow(e)) {
+  if (wantsNewWindow(e, currentTarget)) {
     return;
   }
 
-  const currentTarget = e.currentTarget;
   const href = currentTarget.getAttribute("href");
 
   if (

--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -15,7 +15,7 @@ export function wantsNewWindow(e, currentTarget = e.currentTarget) {
 /**
   Discourse does some server side rendering of HTML, such as the `cooked` contents of
   posts. The downside of this in an Ember app is the links will not go through the router.
-  This jQuery code intercepts clicks on those links and routes them properly.
+  This code intercepts clicks on those links and routes them properly.
 **/
 export default function interceptClick(e) {
   const currentTarget = e.target.closest("a");

--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -18,6 +18,10 @@ export function wantsNewWindow(e) {
   This jQuery code intercepts clicks on those links and routes them properly.
 **/
 export default function interceptClick(e) {
+  if (!e.target.closest("a")) {
+    return;
+  }
+
   if (wantsNewWindow(e)) {
     return;
   }


### PR DESCRIPTION
This is a little more complex because we were using the JQuery selector filter so that the callback only ran for events bubbled from `a` elements. This commit re-implements that logic using the `Element.closest` API.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
