### PR TITLE
DEV: Do not manually require ip_addr

### DIFF
--- a/app/controllers/admin/screened_ip_addresses_controller.rb
+++ b/app/controllers/admin/screened_ip_addresses_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_dependency 'ip_addr'
-
 class Admin::ScreenedIpAddressesController < Admin::AdminController
 
   before_action :fetch_screened_ip_address, only: [:update, :destroy]


### PR DESCRIPTION
This used to be the necessary, but now it is autoloaded.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
