### PR TITLE
FIX: Handling of `/p/###` URLs within Ember

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/post.js
+++ b/app/assets/javascripts/discourse/app/routes/post.js
@@ -1,17 +1,14 @@
 import DiscourseRoute from "discourse/routes/discourse";
-import { ajax } from "discourse/lib/ajax";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
-  beforeModel({ params, _discourse_anchor }) {
-    return ajax(`/p/${params.post.id}`).then((t) => {
-      const transition = this.transitionTo(
-        "topic.fromParamsNear",
-        t.slug,
-        t.id,
-        t.current_post_number
-      );
+  router: service(),
 
-      transition._discourse_anchor = _discourse_anchor;
-    });
+  model(params) {
+    return this.store.find("post", params.id);
+  },
+
+  afterModel(post) {
+    this.router.transitionTo(post.url);
   },
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -588,6 +588,7 @@ acceptance("Navigating between topics", function (needs) {
     firstPost.cooked += `\n<a class='same-topic-slugless-post' href='/t/280/3'>Link 2</a>`;
     firstPost.cooked += `\n<a class='diff-topic-slugless' href='/t/281'>Link 3</a>`;
     firstPost.cooked += `\n<a class='diff-topic-slugless-post' href='/t/281/3'>Link 3</a>`;
+    firstPost.cooked += `\n<a class='by-post-id' href='/p/${firstPost.id}'>Link to Post</a>`;
 
     server.get("/t/280.json", () => helper.response(topicResponse));
     server.get("/t/280/:post_number.json", () =>
@@ -616,5 +617,11 @@ acceptance("Navigating between topics", function (needs) {
 
     await click("a.diff-topic-slugless-post");
     assert.ok(currentURL().includes("/281"));
+  });
+
+  test("clicking post URLs", async function (assert) {
+    await visit("/t/-/280");
+    await click("a.by-post-id");
+    assert.ok(currentURL().includes("/280"));
   });
 });


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
