### PR TITLE
FIX: LOAD_PLUGINS=0 in dev/prod, warn in plugin:pull_compatible_all (stable)

### DIFF
--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -359,4 +359,15 @@ class GlobalSetting
     end
   end
 
+  def self.load_plugins?
+    if ENV["LOAD_PLUGINS"] == "1"
+      true
+    elsif ENV["LOAD_PLUGINS"] == "0"
+      false
+    elsif Rails.env.test?
+      false
+    else
+      true
+    end
+  end
 end

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -20,7 +20,7 @@ class SiteSetting < ActiveRecord::Base
 
   load_settings(File.join(Rails.root, 'config', 'site_settings.yml'))
 
-  unless Rails.env.test? && ENV['LOAD_PLUGINS'] != "1"
+  if GlobalSetting.load_plugins?
     Dir[File.join(Rails.root, "plugins", "*", "config", "settings.yml")].each do |file|
       load_settings(file, plugin: file.split("/")[-3])
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -303,7 +303,7 @@ module Discourse
       config.relative_url_root = GlobalSetting.relative_url_root
     end
 
-    if Rails.env == "test" && GlobalSetting.load_plugins?
+    if Rails.env.test? && GlobalSetting.load_plugins?
       Discourse.activate_plugins!
     elsif GlobalSetting.load_plugins?
       plugin_initialization_guard do

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ require_relative '../lib/plugin_gem'
 # Global config
 require_relative '../app/models/global_setting'
 GlobalSetting.configure!
-unless Rails.env.test? && ENV['LOAD_PLUGINS'] != "1"
+if GlobalSetting.load_plugins?
   require_relative '../lib/custom_setting_providers'
 end
 GlobalSetting.load_defaults
@@ -303,11 +303,9 @@ module Discourse
       config.relative_url_root = GlobalSetting.relative_url_root
     end
 
-    if Rails.env == "test"
-      if ENV['LOAD_PLUGINS'] == "1"
-        Discourse.activate_plugins!
-      end
-    else
+    if Rails.env == "test" && GlobalSetting.load_plugins?
+      Discourse.activate_plugins!
+    elsif GlobalSetting.load_plugins?
       plugin_initialization_guard do
         Discourse.activate_plugins!
       end

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -109,6 +109,13 @@ end
 
 desc 'pull compatible plugin versions for all plugins'
 task 'plugin:pull_compatible_all' do |t|
+  if GlobalSetting.load_plugins?
+    STDERR.puts <<~TEXT
+      WARNING: Plugins were activated before running `rake plugin:pull_compatible_all`
+        You should prefix this command with LOAD_PLUGINS=0
+    TEXT
+  end
+
   # Loop through each directory
   plugins = Dir.glob(File.expand_path('plugins/*')).select { |f| File.directory? f }
   # run plugin:pull_compatible


### PR DESCRIPTION
(stable backport of #15537)

The `plugin:pull_compatible_all` task is intended to take incompatible plugins and downgrade them to an earlier version. Problem is, when running the rake task in development/production environments, the plugins have already been activated. If an incompatible plugin raises an error in `plugin.rb` then the rake task will be unable to start.

This commit centralises our LOAD_PLUGINS detection, adds support for LOAD_PLUGINS=0 in dev/prod, and adds a warning to `plugin:pull_compatible_all` if it's run with plugins enabled.

I will follow up with a commit to `discourse/discourse_docker` to add the `LOAD_PLUGINS=0` flag to the rake task call.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
