### PR TITLE
FEATURE: New plugin API to check if upload is used

### DIFF
--- a/app/jobs/scheduled/clean_up_uploads.rb
+++ b/app/jobs/scheduled/clean_up_uploads.rb
@@ -26,6 +26,8 @@ module Jobs
       s3_cdn_hostname = URI.parse(SiteSetting.Upload.s3_cdn_url || "").hostname
 
       result = Upload.by_users
+      Upload.unused_callbacks&.each { |handler| result = handler.call(result) }
+      result = result
         .where("uploads.retain_hours IS NULL OR uploads.created_at < current_timestamp - interval '1 hour' * uploads.retain_hours")
         .where("uploads.created_at < ?", grace_period.hour.ago)
         .where("uploads.access_control_post_id IS NULL")

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -72,12 +72,20 @@ class Upload < ActiveRecord::Base
     @unused_callbacks
   end
 
+  def self.reset_unused_callbacks
+    @unused_callbacks = []
+  end
+
   def self.add_in_use_callback(&block)
     (@in_use_callbacks ||= []) << block
   end
 
   def self.in_use_callbacks
     @in_use_callbacks
+  end
+
+  def self.reset_in_use_callbacks
+    @in_use_callbacks = []
   end
 
   def self.with_no_non_post_relations

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -64,6 +64,14 @@ class Upload < ActiveRecord::Base
     )
   end
 
+  def self.add_unused_callback(&block)
+    (@unused_callbacks ||= []) << block
+  end
+
+  def self.unused_callbacks
+    @unused_callbacks
+  end
+
   def self.add_in_use_callback(&block)
     (@in_use_callbacks ||= []) << block
   end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -64,6 +64,14 @@ class Upload < ActiveRecord::Base
     )
   end
 
+  def self.add_in_use_callback(&block)
+    (@in_use_callbacks ||= []) << block
+  end
+
+  def self.in_use_callbacks
+    @in_use_callbacks
+  end
+
   def self.with_no_non_post_relations
     scope = self
       .joins(<<~SQL)

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -252,6 +252,10 @@ class Plugin::Instance
     Site.add_categories_callbacks(&block)
   end
 
+  def register_upload_unused(&block)
+    Upload.add_unused_callback(&block)
+  end
+
   def register_upload_in_use(&block)
     Upload.add_in_use_callback(&block)
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -252,6 +252,10 @@ class Plugin::Instance
     Site.add_categories_callbacks(&block)
   end
 
+  def register_upload_in_use(&block)
+    Upload.add_in_use_callback(&block)
+  end
+
   def custom_avatar_column(column)
     reloadable_patch do |plugin|
       UserLookup.lookup_columns << column


### PR DESCRIPTION
This PR introduces two new APIs for handling unused uploads, one can be used to exclude uploads in bulk when the data model allow and the other one excludes uploads one by one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
