### PR TITLE
FIX: Do not show raw HTML in error message.

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
@@ -2,7 +2,7 @@
   <div id="modal-alert" role="alert" class="alert alert-{{flashClass}}">
     {{#if flashLink}}
       <div class="input-group invite-link">
-        <label for="invite-link">{{flashText}} {{i18n "user.invited.invite.instructions"}}</label>
+        <label for="invite-link">{{html-safe flashText}} {{i18n "user.invited.invite.instructions"}}</label>
         <div class="link-share-container">
           {{input
             name="invite-link"
@@ -14,7 +14,7 @@
         </div>
       </div>
     {{else}}
-      {{flashText}}
+      {{html-safe flashText}}
     {{/if}}
   </div>
 {{/if}}


### PR DESCRIPTION
The server returns the error as HTML when a user with the same email
already exists.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
