### PR TITLE
FIX: prevents tweets to lose format in onebox

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -612,6 +612,11 @@ aside.onebox.twitterstatus .onebox-body {
   .twitter-screen-name {
     font-size: var(--font-down-1);
   }
+
+  .tweet {
+    white-space: pre-line;
+  }
+
   p,
   .tweet {
     clear: left;


### PR DESCRIPTION
Before:
<img width="529" alt="Screenshot 2022-01-13 at 15 20 36" src="https://user-images.githubusercontent.com/339945/149347238-aa2fe8d7-abbf-4ce3-80f7-d56ec3efe3fb.png">

After:
<img width="528" alt="Screenshot 2022-01-13 at 15 20 30" src="https://user-images.githubusercontent.com/339945/149347255-b34115df-0098-4538-9476-fd7c9faa6560.png">

