### PR TITLE
FIX: Pass category and tag IDs to the emit webhook event job.

### DIFF
--- a/config/initializers/012-web_hook_events.rb
+++ b/config/initializers/012-web_hook_events.rb
@@ -117,5 +117,12 @@ end
 DiscourseEvent.on(:like_created) do |post_action|
   user = post_action.user
   group_ids = user.groups.map(&:id)
-  WebHook.enqueue_object_hooks(:like, post_action, :post_liked, WebHookLikeSerializer, group_ids: group_ids)
+  topic = Topic.includes(:tags).joins(:posts).find_by(posts: { id: post_action.post_id })
+  category_id = topic&.category_id
+  tag_ids = topic&.tags&.map(&:id)
+
+  WebHook.enqueue_object_hooks(:like,
+    post_action, :post_liked, WebHookLikeSerializer,
+    group_ids: group_ids, category_id: category_id, tag_ids: tag_ids
+  )
 end


### PR DESCRIPTION
Like webhooks won't fire when they're scoped to specific categories or tags because we're not passing the data to the job that emits it.

