### PR TITLE
FEATURE: Store dismissed state of topic nav popups

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-navigation-popup.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation-popup.js
@@ -6,18 +6,23 @@ export default Component.extend({
   tagName: "",
   hidden: false,
 
-  didInsertElement() {
+  init() {
     this._super(...arguments);
 
-    if (this.noticeKey && this.keyValueStore.getItem(this.noticeKey)) {
-      this.set("hidden", true);
+    if (this.popupKey) {
+      const value = this.keyValueStore.getItem(this.popupKey);
+      if (value === true || value > +new Date()) {
+        this.set("hidden", true);
+      } else {
+        this.keyValueStore.removeItem(this.popupKey);
+      }
     }
   },
 
-  @discourseComputed("noticeId")
-  noticeKey(noticeId) {
-    if (noticeId) {
-      return `dismiss_topic_nav_popup_${noticeId}`;
+  @discourseComputed("popupId")
+  popupKey(popupId) {
+    if (popupId) {
+      return `dismiss_topic_nav_popup_${popupId}`;
     }
   },
 
@@ -25,8 +30,13 @@ export default Component.extend({
   close() {
     this.set("hidden", true);
 
-    if (this.noticeId) {
-      this.keyValueStore.setItem(this.noticeKey, true);
+    if (this.popupKey) {
+      if (this.dismissDuration) {
+        const expiry = +new Date() + this.dismissDuration;
+        this.keyValueStore.setItem(this.popupKey, expiry);
+      } else {
+        this.keyValueStore.setItem(this.popupKey, true);
+      }
     }
   },
 });

--- a/app/assets/javascripts/discourse/app/components/topic-navigation-popup.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation-popup.js
@@ -1,12 +1,32 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
   tagName: "",
   hidden: false,
 
+  didInsertElement() {
+    this._super(...arguments);
+
+    if (this.noticeKey && this.keyValueStore.getItem(this.noticeKey)) {
+      this.set("hidden", true);
+    }
+  },
+
+  @discourseComputed("noticeId")
+  noticeKey(noticeId) {
+    if (noticeId) {
+      return `dismiss_topic_nav_popup_${noticeId}`;
+    }
+  },
+
   @action
   close() {
     this.set("hidden", true);
+
+    if (this.noticeId) {
+      this.keyValueStore.setItem(this.noticeKey, true);
+    }
   },
 });

--- a/app/assets/javascripts/discourse/app/components/topic-navigation-popup.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation-popup.js
@@ -4,6 +4,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
   tagName: "",
+  popupId: null,
   hidden: false,
 
   init() {

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -133,7 +133,9 @@
       {{plugin-outlet name="above-timeline" connectorTagName="div"}}
 
       {{#topic-navigation class="topic-navigation" topic=model jumpToDate=(action "jumpToDate") jumpToIndex=(action "jumpToIndex") as |info|}}
-        {{plugin-outlet name="topic-navigation" connectorTagName="div" args=(hash topic=model)}}
+        {{#unless site.mobileView}}
+          {{plugin-outlet name="topic-navigation" connectorTagName="div" args=(hash topic=model)}}
+        {{/unless}}
 
         {{#if info.renderTimeline}}
           {{topic-timeline


### PR DESCRIPTION
The dismissed state will be stored between sessions if noticeId
attribute is present.

Topic navigation popups will not show up anymore on mobile.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
