### PR TITLE
DEV: Add `after-topic-progress` plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/topic-progress.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-progress.hbs
@@ -18,3 +18,5 @@
   </div>
   <div class="bg"></div>
 </nav>
+
+{{plugin-outlet name="after-topic-progress" tagName="" connectorTagName="div"}}


### PR DESCRIPTION
Example usage: the Table of Contents component can add a mobile toggle button here.
