### PR TITLE
DEV: Fix missing test paths for Ember CLI

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -74,7 +74,9 @@ module.exports = function (defaults) {
       inputFiles: [
         "**/tests/acceptance/*.js",
         "**/tests/integration/*.js",
-        "**tests/unit/*.js",
+        "**/tests/integration/**/*.js",
+        "**/tests/unit/*.js",
+        "**/tests/unit/**/*.js",
       ],
       headerFiles: ["vendor/ember-cli/tests-prefix.js"],
       footerFiles: ["vendor/ember-cli/app-config.js"],


### PR DESCRIPTION
Since 6272edd1219652a8e1c9c33e16229b029cec603c some tests were
not loading for Ember CLI, this commit adds the missing paths so
all the tests load.
