### PR TITLE
PERF: limit number of posts in topic for very first paint

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -5,6 +5,7 @@ import {
   acceptance,
   exists,
   query,
+  waitFor,
 } from "discourse/tests/helpers/qunit-helpers";
 import DiscoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
 import { test } from "qunit";
@@ -32,20 +33,27 @@ acceptance("Keyboard Shortcuts - Anonymous Users", function (needs) {
 
   test("go to first suggested topic", async function (assert) {
     await visit("/t/this-is-a-test-topic/9");
-    await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
-    await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
-    assert.strictEqual(currentURL(), "/t/this-is-a-test-topic/9");
+    // Only #post_1 and #post_2 are visible after very first paint of topic view.
+    // Wait for all posts and widgets to appear in post-stream.
+    await waitFor(assert, async () => {
+      await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
+      await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
+      assert.strictEqual(currentURL(), "/t/this-is-a-test-topic/9");
 
-    // Suggested topics elements exist.
-    await visit("/t/internationalization-localization/280");
-    await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
-    await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
-    assert.strictEqual(currentURL(), "/t/polls-are-still-very-buggy/27331/4");
+      // Suggested topics elements exist.
+      await visit("/t/internationalization-localization/280");
+      await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
+      await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
+      assert.strictEqual(currentURL(), "/t/polls-are-still-very-buggy/27331/4");
 
-    await visit("/t/1-3-0beta9-no-rate-limit-popups/28830");
-    await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
-    await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
-    assert.strictEqual(currentURL(), "/t/keyboard-shortcuts-are-awesome/27331");
+      await visit("/t/1-3-0beta9-no-rate-limit-popups/28830");
+      await triggerKeyEvent(document, "keypress", "g".charCodeAt(0));
+      await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
+      assert.strictEqual(
+        currentURL(),
+        "/t/keyboard-shortcuts-are-awesome/27331"
+      );
+    });
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -7,6 +7,7 @@ import {
   queryAll,
   selectText,
   visible,
+  waitFor,
 } from "discourse/tests/helpers/qunit-helpers";
 import {
   click,
@@ -329,23 +330,28 @@ acceptance("Topic featured links", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");
-    await click("#post_3 .select-below");
 
-    assert.ok(
-      queryAll(".selected-posts")
-        .html()
-        .includes(I18n.t("topic.multi_select.description", { count: 18 })),
-      "it should select the right number of posts"
-    );
+    // Only #post_1 and #post_2 are visible after very first paint of topic view.
+    // Wait for all posts and widgets to appear in post-stream.
+    await waitFor(assert, async () => {
+      await click("#post_3 .select-below");
 
-    await click("#post_2 .select-below");
+      assert.ok(
+        queryAll(".selected-posts")
+          .html()
+          .includes(I18n.t("topic.multi_select.description", { count: 18 })),
+        "it should select the right number of posts"
+      );
 
-    assert.ok(
-      queryAll(".selected-posts")
-        .html()
-        .includes(I18n.t("topic.multi_select.description", { count: 19 })),
-      "it should select the right number of posts"
-    );
+      await click("#post_2 .select-below");
+
+      assert.ok(
+        queryAll(".selected-posts")
+          .html()
+          .includes(I18n.t("topic.multi_select.description", { count: 19 })),
+        "it should select the right number of posts"
+      );
+    });
   });
 
   test("View Hidden Replies", async function (assert) {
@@ -541,17 +547,21 @@ acceptance("Topic last visit line", function (needs) {
   test("visit topic", async function (assert) {
     await visit("/t/-/280");
 
-    assert.ok(
-      exists(".topic-post-visited-line.post-10"),
-      "shows the last visited line on the right post"
-    );
+    // Only #post_1 and #post_2 are visible after very first paint of topic view.
+    // Wait for all posts and widgets to appear in post-stream.
+    await waitFor(assert, async () => {
+      assert.ok(
+        exists(".topic-post-visited-line.post-10"),
+        "shows the last visited line on the right post"
+      );
 
-    await visit("/t/-/9");
+      await visit("/t/-/9");
 
-    assert.ok(
-      !exists(".topic-post-visited-line"),
-      "does not show last visited line if post is the last post"
-    );
+      assert.ok(
+        !exists(".topic-post-visited-line"),
+        "does not show last visited line if post is the last post"
+      );
+    });
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/unknown-test.js
@@ -1,4 +1,8 @@
-import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  exists,
+  waitFor,
+} from "discourse/tests/helpers/qunit-helpers";
 import { click, currentURL, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
@@ -15,12 +19,16 @@ acceptance("Category 404", function (needs) {
   test("Navigating to a bad category link does not break the router", async function (assert) {
     await visit("/t/internationalization-localization/280");
 
-    await click('[data-for-test="category-404"]');
-    assert.strictEqual(currentURL(), "/404");
+    // Only #post_1 and #post_2 are visible after very first paint of topic view.
+    // Wait for all posts and widgets to appear in post-stream.
+    await waitFor(assert, async () => {
+      await click('[data-for-test="category-404"]');
+      assert.strictEqual(currentURL(), "/404");
 
-    // See that we can navigate away
-    await click("#site-logo");
-    assert.strictEqual(currentURL(), "/");
+      // See that we can navigate away
+      await click("#site-logo");
+      assert.strictEqual(currentURL(), "/");
+    });
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -7,6 +7,7 @@ import {
   exists,
   query,
   queryAll,
+  waitFor,
 } from "discourse/tests/helpers/qunit-helpers";
 import {
   getTextareaSelection,
@@ -698,13 +699,17 @@ third line`
     },
 
     async test(assert) {
-      jumpEnd(query("textarea.d-editor-input"));
-      await click("button.emoji");
+      // Only #post_1 and #post_2 are visible after very first paint of topic view.
+      // Wait for all posts and widgets to appear in stream.
+      await waitFor(assert, async () => {
+        jumpEnd(query("textarea.d-editor-input"));
+        await click("button.emoji");
 
-      await click(
-        '.emoji-picker .section[data-section="smileys_&_emotion"] img.emoji[title="grinning"]'
-      );
-      assert.strictEqual(this.value, "hello world. :grinning:");
+        await click(
+          '.emoji-picker .section[data-section="smileys_&_emotion"] img.emoji[title="grinning"]'
+        );
+        assert.strictEqual(this.value, "hello world. :grinning:");
+      });
     },
   });
 


### PR DESCRIPTION
First-time visitors from search engines have a high page loading time for topics with many posts.

This tries to fastly show a visitor some meaningful content on the very first page view by only showing 2 of 20 posts plus 18 placeholder posts. When the first two posts are painted and displayed by the browser, then it immediately starts rendering the other 18 posts.

After discourse is fully loaded it does not interfere with any subsequent topic views anymore.