### PR TITLE
DEV: Improve test paths pattern for Ember CLI.

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -71,13 +71,7 @@ module.exports = function (defaults) {
     });
 
     let tests = concat(appTestTrees, {
-      inputFiles: [
-        "**/tests/acceptance/*.js",
-        "**/tests/integration/*.js",
-        "**/tests/integration/**/*.js",
-        "**/tests/unit/*.js",
-        "**/tests/unit/**/*.js",
-      ],
+      inputFiles: ["**/tests/**/*-test.js"],
       headerFiles: ["vendor/ember-cli/tests-prefix.js"],
       footerFiles: ["vendor/ember-cli/app-config.js"],
       outputFile: "/assets/core-tests.js",


### PR DESCRIPTION
Ember tests follows a convention where test files have a postfix of
`-test.js`. This ensures that any files in the tests folder which
follows this pattern is included.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
