### PR TITLE
FIX: Selected group cleared between emoji uploads

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-uploader.js
@@ -56,6 +56,6 @@ export default Component.extend(UppyUploadMixin, {
 
   uploadDone(upload) {
     this.done(upload, this.group);
-    this.setProperties({ name: null, group: DEFAULT_GROUP });
+    this.setProperties({ name: null });
   },
 });

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-uploader.hbs
@@ -19,6 +19,7 @@
     <div class="input">
       {{combo-box
         name="group"
+        id="emoji-group-selector"
         value=group
         content=newEmojiGroups
         onChange=(action "createEmojiGroup")

--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
@@ -1,0 +1,89 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import {
+  createFile,
+  discourseModule,
+} from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import pretender from "discourse/tests/helpers/create-pretender";
+
+discourseModule("Integration | Component | emoji-uploader", function (hooks) {
+  setupRenderingTest(hooks);
+
+  const template = hbs` {{emoji-uploader
+    emojiGroups=emojiGroups
+    done=(action "emojiUploaded")
+    id="emoji-uploader"
+  }}`;
+
+  hooks.beforeEach(function () {
+    this.setProperties({
+      emojiGroups: ["default", "coolemojis"],
+      actions: {
+        emojiUploaded: (upload, group) => {
+          this.doneUpload(upload, group);
+        },
+      },
+    });
+
+    pretender.post("/admin/customize/emojis.json", () => {
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        {
+          group: "default",
+          name: "test",
+          url:
+            "//upload.s3.dualstack.us-east-2.amazonaws.com/original/1X/123.png",
+        },
+      ];
+    });
+  });
+
+  componentTest("uses the selected group for the upload", {
+    template,
+
+    async test(assert) {
+      const done = assert.async();
+      await selectKit("#emoji-group-selector").expand();
+      await selectKit("#emoji-group-selector").selectRowByValue("coolemojis");
+
+      this.set("doneUpload", (upload, group) => {
+        assert.equal("coolemojis", group);
+        done();
+      });
+      const image = createFile("avatar.png");
+      await this.container
+        .lookup("service:app-events")
+        .trigger("upload-mixin:emoji-uploader:add-files", image);
+    },
+  });
+
+  componentTest("does not clear the selected group between multiple uploads", {
+    template,
+
+    async test(assert) {
+      const done = assert.async();
+      await selectKit("#emoji-group-selector").expand();
+      await selectKit("#emoji-group-selector").selectRowByValue("coolemojis");
+
+      let uploadDoneCount = 0;
+      this.set("doneUpload", (upload, group) => {
+        uploadDoneCount += 1;
+        assert.equal("coolemojis", group);
+
+        if (uploadDoneCount === 2) {
+          done();
+        }
+      });
+
+      const image = createFile("avatar.png");
+      const image2 = createFile("avatar2.png");
+      await this.container
+        .lookup("service:app-events")
+        .trigger("upload-mixin:emoji-uploader:add-files", [image, image2]);
+    },
+  });
+});


### PR DESCRIPTION
When uploading multiple emoji in Admin/Customize/Emojis
with an emoji Group selected, the group was cleared between
each file uploaded, making bulk uploading of emojis a chore
if anything but the default group was needed.

This commit fixes the issue, introduces tests for emoji-uploader,
and also adds `add-files` appEvents for uppy-upload mixin, same
as the composer-upload-uppy mixin, for interop with tests and so
we don't have to rely on a file upload element's change event.
