### PR TITLE
UX: flat-btn should also respond to Enter

### DIFF
--- a/app/assets/javascripts/discourse/app/components/flat-button.js
+++ b/app/assets/javascripts/discourse/app/components/flat-button.js
@@ -14,7 +14,15 @@ export default Component.extend({
     }
   },
 
+  keyDown(event) {
+    if (event.key === "Enter") {
+      this.action?.();
+      return false;
+    }
+  },
+
   click() {
-    return this.attrs.action();
+    this.action?.();
+    return false;
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/flat-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/flat-button-test.js
@@ -1,0 +1,47 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
+import { click, triggerKeyEvent } from "@ember/test-helpers";
+import hbs from "htmlbars-inline-precompile";
+
+discourseModule("Integration | Component | flat-button", function (hooks) {
+  setupRenderingTest(hooks);
+
+  componentTest("press Enter", {
+    template: hbs`{{flat-button action=action}}`,
+
+    beforeEach() {
+      this.set("foo", null);
+      this.set("action", () => {
+        this.set("foo", "bar");
+      });
+    },
+
+    async test(assert) {
+      await triggerKeyEvent(".btn-flat", "keydown", 32);
+
+      assert.strictEqual(this.foo, null);
+
+      await triggerKeyEvent(".btn-flat", "keydown", 13);
+
+      assert.strictEqual(this.foo, "bar");
+    },
+  });
+  componentTest("click", {
+    template: hbs`{{flat-button action=action}}`,
+
+    beforeEach() {
+      this.set("foo", null);
+      this.set("action", () => {
+        this.set("foo", "bar");
+      });
+    },
+
+    async test(assert) {
+      await click(".btn-flat");
+
+      assert.strictEqual(this.foo, "bar");
+    },
+  });
+});


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
