### PR TITLE
FIX: origins_to_regexes should always return an array

### DIFF
--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -17,7 +17,8 @@ module Onebox
     end
 
     def self.origins_to_regexes(origins)
-      return /.*/ if origins.include?("*")
+      return [/.*/] if origins.include?("*")
+
       origins.map do |origin|
         escaped_origin = Regexp.escape(origin)
         if origin.start_with?("*.", "https://*.", "http://*.")

--- a/spec/lib/onebox/engine_spec.rb
+++ b/spec/lib/onebox/engine_spec.rb
@@ -50,6 +50,18 @@ describe Onebox::Engine do
     end
   end
 
+  describe "origins_to_regexes" do
+    it "converts URLs to regexes" do
+      result = Onebox::Engine.origins_to_regexes(["https://example.com", "https://example2.com"])
+      expect(result).to eq([/\Ahttps:\/\/example\.com/i, /\Ahttps:\/\/example2\.com/i])
+    end
+
+    it "treats '*' as a catch-all" do
+      result = Onebox::Engine.origins_to_regexes(["https://example.com", "*", "https://example2.com"])
+      expect(result).to eq([/.*/])
+    end
+  end
+
   describe "handles_content_type?" do
     class OneboxEngineImages
       include Onebox::Engine


### PR DESCRIPTION
If the SiteSetting `allowed_onebox_iframes` contains a value of `*`, it will use the values of `all_iframe_origins` during the Oneboxing process. If `all_iframe_origins` itself contains a value of `*`, `origins_to_regexes` will try to return a "catch-all" regex.

Other code assumes `origins_to_regexes`will return an array, so this change ensures the `*` case will return an array containing only the catch-all regex.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
