### PR TITLE
DEV: Improve stability of Tests

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -103,6 +103,13 @@ function preventKeyboardEvent(event) {
 
 export default {
   init(keyTrapper, container) {
+    // Sometimes the keyboard shortcut initializer is not torn down. This makes sure
+    // we clear any previous test state.
+    if (this.keyTrapper) {
+      this.keyTrapper.destroy();
+      this.keyTrapper = null;
+    }
+
     this.keyTrapper = new keyTrapper();
     this.container = container;
     this._stopCallback();
@@ -174,7 +181,6 @@ export default {
       this.keyTrapper.paused = true;
       return;
     }
-
     combinations.forEach((combo) => this.keyTrapper.unbind(combo));
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -13,6 +13,7 @@ acceptance("Keyboard Shortcuts - Anonymous Users", function (needs) {
   needs.pretender((server, helper) => {
     server.get("/t/27331/4.json", () => helper.response({}));
     server.get("/t/27331.json", () => helper.response({}));
+    server.get("/t/27331/last.json", () => helper.response({}));
 
     // No suggested topics exist.
     server.get("/t/9/last.json", () => helper.response({}));

--- a/app/assets/javascripts/discourse/tests/unit/lib/uppy-checksum-plugin-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uppy-checksum-plugin-test.js
@@ -1,5 +1,5 @@
 import UppyChecksum from "discourse/lib/uppy-checksum-plugin";
-import { module, test } from "qunit";
+import { module, skip, test } from "qunit";
 import { createFile } from "discourse/tests/helpers/qunit-helpers";
 import sinon from "sinon";
 
@@ -43,6 +43,8 @@ class FakeUppy {
   }
 }
 
+let withCrypto = window.crypto.subtle ? test : skip;
+
 module("Unit | Utility | UppyChecksum Plugin", function () {
   test("sets the options passed in", function (assert) {
     const capabilities = {};
@@ -54,51 +56,53 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
     assert.strictEqual(plugin.capabilities, capabilities);
   });
 
-  test("it does nothing if not running in a secure context", function (assert) {
-    const capabilities = {};
-    const fakeUppy = new FakeUppy();
-    const plugin = new UppyChecksum(fakeUppy, {
-      capabilities,
-    });
-    plugin.install();
-    const done = assert.async();
+  withCrypto(
+    "it does nothing if not running in a secure context",
+    function (assert) {
+      const capabilities = {};
+      const fakeUppy = new FakeUppy();
+      const plugin = new UppyChecksum(fakeUppy, {
+        capabilities,
+      });
+      plugin.install();
 
-    sinon.stub(plugin, "_secureContext").returns(false);
+      sinon.stub(plugin, "_secureContext").returns(false);
 
-    const fileId =
-      "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
-    plugin.uppy.preprocessors[0]([fileId]).then(() => {
-      assert.strictEqual(
-        plugin.uppy.emitted.length,
-        1,
-        "only the complete event was fired by the checksum plugin because it skipped the file"
-      );
-      done();
-    });
-  });
+      const fileId =
+        "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
+      return plugin.uppy.preprocessors[0]([fileId]).then(() => {
+        assert.strictEqual(
+          plugin.uppy.emitted.length,
+          1,
+          "only the complete event was fired by the checksum plugin because it skipped the file"
+        );
+      });
+    }
+  );
 
-  test("it does nothing if the crypto object + cipher is not available", function (assert) {
-    const capabilities = {};
-    const fakeUppy = new FakeUppy();
-    const plugin = new UppyChecksum(fakeUppy, {
-      capabilities,
-    });
-    plugin.install();
-    const done = assert.async();
+  withCrypto(
+    "it does nothing if the crypto object + cipher is not available",
+    function (assert) {
+      const capabilities = {};
+      const fakeUppy = new FakeUppy();
+      const plugin = new UppyChecksum(fakeUppy, {
+        capabilities,
+      });
+      plugin.install();
 
-    sinon.stub(plugin, "_hasCryptoCipher").returns(false);
+      sinon.stub(plugin, "_hasCryptoCipher").returns(false);
 
-    const fileId =
-      "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
-    plugin.uppy.preprocessors[0]([fileId]).then(() => {
-      assert.strictEqual(
-        plugin.uppy.emitted.length,
-        1,
-        "only the complete event was fired by the checksum plugin because it skipped the file"
-      );
-      done();
-    });
-  });
+      const fileId =
+        "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
+      return plugin.uppy.preprocessors[0]([fileId]).then(() => {
+        assert.strictEqual(
+          plugin.uppy.emitted.length,
+          1,
+          "only the complete event was fired by the checksum plugin because it skipped the file"
+        );
+      });
+    }
+  );
 
   test("it does nothing if the browser is IE11", function (assert) {
     const capabilities = { isIE11: true };
@@ -107,103 +111,99 @@ module("Unit | Utility | UppyChecksum Plugin", function () {
       capabilities,
     });
     plugin.install();
-    const done = assert.async();
 
     const fileId =
       "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764";
-    plugin.uppy.preprocessors[0]([fileId]).then(() => {
+    return plugin.uppy.preprocessors[0]([fileId]).then(() => {
       assert.strictEqual(
         plugin.uppy.emitted.length,
         1,
         "only the complete event was fired by the checksum plugin because it skipped the file"
       );
-      done();
     });
   });
 
-  test("it does nothing if the file is > 100MB", function (assert) {
+  withCrypto("it does nothing if the file is > 100MB", function (assert) {
     const capabilities = {};
     const fakeUppy = new FakeUppy();
     const plugin = new UppyChecksum(fakeUppy, {
       capabilities,
     });
     plugin.install();
-    const done = assert.async();
 
     const fileId =
       "uppy-test/file/mnb3/jfhrg43x/blah3/png-1d-1d-2v-1d-1e-image/jpeg-111111-1837921727764";
-    plugin.uppy.preprocessors[0]([fileId]).then(() => {
+    return plugin.uppy.preprocessors[0]([fileId]).then(() => {
       assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
       assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-complete");
       assert.strictEqual(
         plugin.uppy.getFile(fileId).meta.sha1_checksum,
         undefined
       );
-      done();
     });
   });
 
-  test("it gets a sha1 hash of each file and adds it to the file meta", function (assert) {
-    const capabilities = {};
-    const fakeUppy = new FakeUppy();
-    const plugin = new UppyChecksum(fakeUppy, {
-      capabilities,
-    });
-    plugin.install();
-    const done = assert.async();
+  withCrypto(
+    "it gets a sha1 hash of each file and adds it to the file meta",
+    function (assert) {
+      const capabilities = {};
+      const fakeUppy = new FakeUppy();
+      const plugin = new UppyChecksum(fakeUppy, {
+        capabilities,
+      });
+      plugin.install();
 
-    const fileIds = [
-      "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764",
-      "uppy-test/file/blah1/ads37x2/blah1/png-1d-1d-2v-1d-1e-image/jpeg-99999-1837921727764",
-    ];
-    plugin.uppy.preprocessors[0](fileIds).then(() => {
-      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-progress");
-      assert.strictEqual(plugin.uppy.emitted[2].event, "preprocess-complete");
-      assert.strictEqual(plugin.uppy.emitted[3].event, "preprocess-complete");
+      const fileIds = [
+        "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764",
+        "uppy-test/file/blah1/ads37x2/blah1/png-1d-1d-2v-1d-1e-image/jpeg-99999-1837921727764",
+      ];
+      return plugin.uppy.preprocessors[0](fileIds).then(() => {
+        assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+        assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-progress");
+        assert.strictEqual(plugin.uppy.emitted[2].event, "preprocess-complete");
+        assert.strictEqual(plugin.uppy.emitted[3].event, "preprocess-complete");
 
-      // these checksums are the actual SHA1 hashes of the test file names
-      assert.strictEqual(
-        plugin.uppy.getFile(fileIds[0]).meta.sha1_checksum,
-        "2aa31a700d084c78cecbf030b041ad63eb4f6e8a"
-      );
-      assert.strictEqual(
-        plugin.uppy.getFile(fileIds[1]).meta.sha1_checksum,
-        "dfa8c725a5a6710ce4467f29655ec9d26a8de3d0"
-      );
+        // these checksums are the actual SHA1 hashes of the test file names
+        assert.strictEqual(
+          plugin.uppy.getFile(fileIds[0]).meta.sha1_checksum,
+          "2aa31a700d084c78cecbf030b041ad63eb4f6e8a"
+        );
+        assert.strictEqual(
+          plugin.uppy.getFile(fileIds[1]).meta.sha1_checksum,
+          "dfa8c725a5a6710ce4467f29655ec9d26a8de3d0"
+        );
+      });
+    }
+  );
 
-      done();
-    });
-  });
+  withCrypto(
+    "it does nothing if the window.crypto.subtle.digest function throws an error / rejects",
+    function (assert) {
+      const capabilities = {};
+      const fakeUppy = new FakeUppy();
+      const plugin = new UppyChecksum(fakeUppy, {
+        capabilities,
+      });
+      plugin.install();
 
-  test("it does nothing if the window.crypto.subtle.digest function throws an error / rejects", function (assert) {
-    const capabilities = {};
-    const fakeUppy = new FakeUppy();
-    const plugin = new UppyChecksum(fakeUppy, {
-      capabilities,
-    });
-    plugin.install();
-    const done = assert.async();
+      const fileIds = [
+        "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764",
+        "uppy-test/file/blah1/ads37x2/blah1/png-1d-1d-2v-1d-1e-image/jpeg-99999-1837921727764",
+      ];
 
-    const fileIds = [
-      "uppy-test/file/vv2/xvejg5w/blah/png-1d-1d-2v-1d-1e-image/jpeg-9043429-1624921727764",
-      "uppy-test/file/blah1/ads37x2/blah1/png-1d-1d-2v-1d-1e-image/jpeg-99999-1837921727764",
-    ];
+      sinon
+        .stub(window.crypto.subtle, "digest")
+        .rejects({ message: "Algorithm: Unrecognized name" });
 
-    sinon
-      .stub(window.crypto.subtle, "digest")
-      .rejects({ message: "Algorithm: Unrecognized name" });
+      return plugin.uppy.preprocessors[0](fileIds).then(() => {
+        assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
+        assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-progress");
+        assert.strictEqual(plugin.uppy.emitted[2].event, "preprocess-complete");
+        assert.strictEqual(plugin.uppy.emitted[3].event, "preprocess-complete");
 
-    plugin.uppy.preprocessors[0](fileIds).then(() => {
-      assert.strictEqual(plugin.uppy.emitted[0].event, "preprocess-progress");
-      assert.strictEqual(plugin.uppy.emitted[1].event, "preprocess-progress");
-      assert.strictEqual(plugin.uppy.emitted[2].event, "preprocess-complete");
-      assert.strictEqual(plugin.uppy.emitted[3].event, "preprocess-complete");
-
-      assert.deepEqual(plugin.uppy.getFile(fileIds[0]).meta, {});
-      assert.deepEqual(plugin.uppy.getFile(fileIds[1]).meta, {});
-
-      done();
-    });
-  });
+        assert.deepEqual(plugin.uppy.getFile(fileIds[0]).meta, {});
+        assert.deepEqual(plugin.uppy.getFile(fileIds[1]).meta, {});
+      });
+    }
+  );
 });


### PR DESCRIPTION
* The current evaluation of uppy promises is causing the entire suite to fail
if there's an exception. Instead of using `done` we use the simpler
pattern of returning the promise from the test to force Qunit to wait
until it's completed.

* In some browser conditions `/last.json` will be requested depending on the
particular scroll / performance. This causes the tests not to fail if
that is the case.

* Keyboard shortcuts were not being fully cleared between runs,
  resulting in tests failures.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
