### PR TITLE
DEV: use application-layout for crawler Chrome-Lighthouse

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,6 +68,7 @@ class ApplicationController < ActionController::Base
   def use_crawler_layout?
     @use_crawler_layout ||=
       request.user_agent &&
+      !request.user_agent.include?('Chrome-Lighthouse') &&
       (request.content_type.blank? || request.content_type.include?('html')) &&
       !['json', 'rss'].include?(params[:format]) &&
       (has_escaped_fragment? || params.key?("print") || show_browser_update? ||


### PR DESCRIPTION
Exclude user-agent Chrome-Lighthouse from crawlers and show it the real application view.

This enables [Lightouse](https://github.com/GoogleChrome/lighthouse) in Chrome DevTools and [PageSpeed Insights](https://pagespeed.web.dev/) to measure the performance of Discourse like viewed by an user.
Until now Lighthouse measured the performance for an user-device which is rendering the crawler-layout - this never happens in reality.