### PR TITLE
UX: No border-radius on textarea

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -255,6 +255,8 @@ textarea {
   height: auto;
   background-color: var(--secondary);
   border: 1px solid var(--primary-medium);
+  border-radius: 0;
+
   &:focus {
     @include default-focus;
   }


### PR DESCRIPTION
We already set border-radius to 0 on all input elements, but we didn't do that for textarea, which resulted in some of those elements appearing rounded on some browsers (iOS Safari)