### PR TITLE
DEV: Restore tests for inserting images as separate paragraphs

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
@@ -16,7 +16,8 @@ function pretender(server, helper) {
   server.post("/uploads/lookup-urls", () => {
     return helper.response([
       {
-        url: "//testbucket.s3.dualstack.us-east-2.amazonaws.com/original/1X/f1095d89269ff22e1818cf54b73e857261851019.jpeg",
+        url:
+          "//testbucket.s3.dualstack.us-east-2.amazonaws.com/original/1X/f1095d89269ff22e1818cf54b73e857261851019.jpeg",
         short_path: "/uploads/short-url/yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg",
         short_url: "upload://yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg",
       },
@@ -38,7 +39,8 @@ function pretender(server, helper) {
         short_url: "upload://yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg",
         thumbnail_height: 320,
         thumbnail_width: 690,
-        url: "//testbucket.s3.dualstack.us-east-2.amazonaws.com/original/1X/f1095d89269ff22e1818cf54b73e857261851019.jpeg",
+        url:
+          "//testbucket.s3.dualstack.us-east-2.amazonaws.com/original/1X/f1095d89269ff22e1818cf54b73e857261851019.jpeg",
         width: 1920,
       });
     },


### PR DESCRIPTION
These tests were removed (probably accidentally) when migrating to uppy uploader (see https://github.com/discourse/discourse/pull/15058). This PR restores tests and make them work with our new uppy-based uploader.
