### PR TITLE
FIX: Improve emoji upload UI

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-emojis.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-emojis.js
@@ -44,6 +44,19 @@ export default Controller.extend({
     },
   }),
 
+  _highlightEmojiList() {
+    const customEmojiListEl = document.querySelector("#custom_emoji");
+    if (
+      customEmojiListEl &&
+      !customEmojiListEl.classList.contains("highlighted")
+    ) {
+      customEmojiListEl.classList.add("highlighted");
+      customEmojiListEl.addEventListener("animationend", () => {
+        customEmojiListEl.classList.remove("highlighted");
+      });
+    }
+  },
+
   @action
   filterGroups(value) {
     this.set("filter", value);
@@ -54,6 +67,7 @@ export default Controller.extend({
     emoji.url += "?t=" + new Date().getTime();
     emoji.group = group;
     this.model.pushObject(EmberObject.create(emoji));
+    this._highlightEmojiList();
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/components/emoji-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-uploader.js
@@ -1,9 +1,10 @@
 import Component from "@ember/component";
+import I18n from "I18n";
 import { isEmpty } from "@ember/utils";
 import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
-import { notEmpty } from "@ember/object/computed";
+import { equal, notEmpty } from "@ember/object/computed";
 
 const DEFAULT_GROUP = "default";
 
@@ -23,10 +24,7 @@ export default Component.extend(UppyUploadMixin, {
     this.set("newEmojiGroups", this.emojiGroups);
   },
 
-  @discourseComputed("uploading")
-  addDisabled() {
-    return this.uploading;
-  },
+  addDisabled: equal("uploading", true),
 
   @action
   createEmojiGroup(group) {
@@ -69,5 +67,23 @@ export default Component.extend(UppyUploadMixin, {
   @action
   chooseFiles() {
     this.fileInputEl.click();
+  },
+
+  @discourseComputed("uploading", "uploadProgress")
+  buttonLabel(uploading, uploadProgress) {
+    if (uploading) {
+      return `${I18n.t("admin.emoji.uploading")} ${uploadProgress}%`;
+    } else {
+      return I18n.t("admin.emoji.add");
+    }
+  },
+
+  @discourseComputed("uploading")
+  buttonIcon(uploading) {
+    if (uploading) {
+      return "spinner";
+    } else {
+      return "plus";
+    }
   },
 });

--- a/app/assets/javascripts/discourse/app/components/emoji-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-uploader.js
@@ -4,7 +4,7 @@ import { isEmpty } from "@ember/utils";
 import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
-import { equal, notEmpty } from "@ember/object/computed";
+import { notEmpty } from "@ember/object/computed";
 
 const DEFAULT_GROUP = "default";
 
@@ -23,8 +23,6 @@ export default Component.extend(UppyUploadMixin, {
     this._super(...arguments);
     this.set("newEmojiGroups", this.emojiGroups);
   },
-
-  addDisabled: equal("uploading", true),
 
   @action
   createEmojiGroup(group) {

--- a/app/assets/javascripts/discourse/app/components/emoji-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-uploader.js
@@ -23,9 +23,9 @@ export default Component.extend(UppyUploadMixin, {
     this.set("newEmojiGroups", this.emojiGroups);
   },
 
-  @discourseComputed("hasName", "uploading")
+  @discourseComputed("uploading")
   addDisabled() {
-    return !this.hasName || this.uploading;
+    return this.uploading;
   },
 
   @action
@@ -64,5 +64,10 @@ export default Component.extend(UppyUploadMixin, {
   uploadDone(upload) {
     this.done(upload, this.group);
     this.set("name", null);
+  },
+
+  @action
+  chooseFiles() {
+    this.fileInputEl.click();
   },
 });

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-uploader.hbs
@@ -40,15 +40,7 @@
         type="file"
         multiple="true"
         accept=".png,.gif">
-      {{#d-button class="btn-primary" action=(action "chooseFiles") disabled=uploading}}
-        {{#if uploading}}
-          {{d-icon "spinner" class="loading-icon"}} &nbsp;
-          <span>{{i18n "admin.emoji.uploading"}} {{uploadProgress}}%</span>
-        {{else}}
-          {{d-icon "plus"}} &nbsp;
-          <span>{{i18n "admin.emoji.add"}}</span>
-        {{/if}}
-      {{/d-button}}
+      {{d-button class="btn-primary" computedLabel=buttonLabel icon="plus" action=(action "chooseFiles") disabled=uploading}}
     </div>
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-uploader.hbs
@@ -34,21 +34,21 @@
   </div>
   <div class="control-group">
     <div class="input">
-      <label class="btn btn-default btn-primary {{if addDisabled "disabled"}}">
+      <input
+        class="hidden-upload-field"
+        disabled={{uploading}}
+        type="file"
+        multiple="true"
+        accept=".png,.gif">
+      {{#d-button class="btn-primary" action=(action "chooseFiles") disabled=uploading}}
         {{#if uploading}}
-          {{d-icon "spinner" class="loading-icon"}}
+          {{d-icon "spinner" class="loading-icon"}} &nbsp;
           <span>{{i18n "admin.emoji.uploading"}} {{uploadProgress}}%</span>
         {{else}}
-          {{d-icon "plus"}}
+          {{d-icon "plus"}} &nbsp;
           <span>{{i18n "admin.emoji.add"}}</span>
         {{/if}}
-        <input
-          class="hidden-upload-field"
-          disabled={{addDisabled}}
-          type="file"
-          multiple="true"
-          accept=".png,.gif">
-      </label>
+      {{/d-button}}
     </div>
   </div>
 </div>

--- a/app/assets/stylesheets/common/admin/admin_emojis.scss
+++ b/app/assets/stylesheets/common/admin/admin_emojis.scss
@@ -13,4 +13,8 @@
   .uppy-is-drag-over {
     box-shadow: 0 0px 52px 0 #ffffff, 0px 7px 33px 0 var(--tertiary-low);
   }
+  #custom_emoji.highlighted {
+    background: var(--tertiary-very-low);
+    animation: background-fade-highlight 2.5s ease-out;
+  }
 }

--- a/app/assets/stylesheets/common/admin/admin_emojis.scss
+++ b/app/assets/stylesheets/common/admin/admin_emojis.scss
@@ -6,4 +6,11 @@
   #custom_emoji td.action {
     text-align: right;
   }
+  #emoji-uploader {
+    padding: 10px;
+    transition: box-shadow ease-in-out 0.25s;
+  }
+  .uppy-is-drag-over {
+    box-shadow: 0 0px 52px 0 #ffffff, 0px 7px 33px 0 var(--tertiary-low);
+  }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5481,8 +5481,9 @@ en:
 
       emoji:
         title: "Emoji"
-        help: "Add new emoji that will be available to everyone. Drag and drop multiple files at once without entering a name to create emojis using their file names."
+        help: "Add new emoji that will be available to everyone. Drag and drop multiple files at once without entering a name to create emojis using their file names. The selected group will be used for all files that are added at the same time. You can also click 'Add New Emoji' to open the file picker."
         add: "Add New Emoji"
+        choose_files: "Choose Files"
         uploading: "Uploading..."
         name: "Name"
         group: "Group"


### PR DESCRIPTION
This commit adds a hover effect for drag and drop in
the admin emoji uploader. It also changes the "Add New
Emoji" button to open the file selector; previously it
was useless because it was disabled unless a name was
entered (which is not even a requirement for the emoji)
and also it didn't actually do anything on click even
if it wasn't disabled.

Now we have a way of adding files without having to drag
and drop them, which is nice.

![image](https://user-images.githubusercontent.com/920448/149684937-e7ae82a6-6fc2-4961-8b90-a35ef2c8c603.png)

Also in this PR, there was no indication before that the upload was
complete apart from the button becoming enabled again.
This commit adds the highlight class to the emoji list
and removes it once the highlight fade animation is done,
like we do for new posts.