### PR TITLE
UX: Fix layout issues with long category names

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -14,6 +14,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  max-width: 100%;
 }
 
 .d-editor-textarea-wrapper {

--- a/app/assets/stylesheets/common/select-kit/category-row.scss
+++ b/app/assets/stylesheets/common/select-kit/category-row.scss
@@ -1,6 +1,5 @@
 .select-kit {
   .category-row {
-    max-width: 345px;
     .category-status {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Fixes the two issues in the screenshot: 
<img width="300" alt="image" src="https://user-images.githubusercontent.com/368961/149699859-ace70210-de15-4b31-819d-0b756543149b.png">

See also bug report: https://meta.discourse.org/t/choosing-a-long-subcategory-hides-part-of-the-mobile-editor/215003