### PR TITLE
FIX: correctly uses the name helper for selected content

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/single-select-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/single-select-header.js
@@ -26,7 +26,7 @@ export default SelectKitHeaderComponent.extend(UtilsMixin, {
   name: computed("selectedContent.name", function () {
     if (this.selectedContent) {
       return I18n.t("select_kit.filter_by", {
-        name: this.selectedContent.name,
+        name: this.getName(this.selectedContent),
       });
     } else {
       return I18n.t("select_kit.select_to_filter");


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
