### PR TITLE
FEATURE: Partial match aliases in emoji filter

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
@@ -158,4 +158,11 @@ discourseModule("Unit | Utility | emoji", function () {
 
     assert.deepEqual(matches, ["bowing_man"]);
   });
+
+  test("search does partial-match on emoji aliases", function (assert) {
+    const matches = emojiSearch("instru");
+
+    assert.ok(matches.includes("woman_teacher"));
+    assert.ok(matches.includes("violin"));
+  });
 });

--- a/app/assets/javascripts/pretty-text/addon/emoji.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji.js
@@ -222,9 +222,11 @@ export function emojiSearch(term, options) {
     }
   }
 
-  if (searchAliases[term]) {
-    for (const emoji of searchAliases[term]) {
-      addResult(emoji);
+  for (const [key, value] of Object.entries(searchAliases)) {
+    if (key.startsWith(term)) {
+      for (const emoji of value) {
+        addResult(emoji);
+      }
     }
   }
 


### PR DESCRIPTION
This fixes cases where typing a longer emoji search phrase could give more results than with a shorter one:

Before

<img width="250" alt="image" src="https://user-images.githubusercontent.com/66961/149814760-1d442bd5-371c-4ee9-881a-dc6e40bbf050.png"> <img width="250" alt="image" src="https://user-images.githubusercontent.com/66961/149814664-4cfa5307-3b11-41ea-807c-a0def7acc792.png"> <img width="250" alt="image" src="https://user-images.githubusercontent.com/66961/149814695-ff6fa790-2a7b-41a4-9193-d7746b76d8fb.png">

After

<img width="250" alt="image" src="https://user-images.githubusercontent.com/66961/149815296-ad754ad4-ea63-425f-93a6-1ac841d1c273.png"> <img width="250" alt="image" src="https://user-images.githubusercontent.com/66961/149815339-1a23a9c5-9bc6-4f6c-a33f-8c0c0771195f.png"> <img width="250" alt="image" src="https://user-images.githubusercontent.com/66961/149815390-c70d124d-cc1b-4f9b-96d1-ab2b6181c757.png">

(Note: I have a slight refactor and a potential perf improvement to `pretty-text/addon/emoji.js` lined up to push out after this PR is merged)