### PR TITLE
DEV: Wait for initdb to complete in `docker.rake`

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -102,8 +102,11 @@ task 'docker:test' do
       puts "Starting background redis"
       @redis_pid = Process.spawn('redis-server --dir tmp/test_data/redis')
 
+      puts "Initializing postgres"
+      system("script/start_test_db.rb --skip-run", exception: true)
+
       puts "Starting postgres"
-      @pg_pid = Process.spawn("script/start_test_db.rb --exec")
+      @pg_pid = Process.spawn("script/start_test_db.rb --skip-setup --exec")
 
       ENV["RAILS_ENV"] = "test"
       # this shaves all the creation of the multisite db off

--- a/script/start_test_db.rb
+++ b/script/start_test_db.rb
@@ -8,23 +8,31 @@ def run(*args)
   system(*args, exception: true)
 end
 
+should_setup = true
+should_run = true
 should_exec = false
 while a = ARGV.pop
-  if a == "--exec"
+  if a == "--skip-setup"
+    should_setup = false
+  elsif a == "--skip-run"
+    should_run = false
+  elsif a == "--exec"
     should_exec = true
   else
     raise "Unknown argument #{a}"
   end
 end
 
-run "#{BIN}/initdb -D #{DATA}"
+if should_setup
+  run "#{BIN}/initdb -D #{DATA}"
 
-run "echo fsync = off >> #{DATA}/postgresql.conf"
-run "echo full_page_writes = off >> #{DATA}/postgresql.conf"
-run "echo shared_buffers = 500MB >> #{DATA}/postgresql.conf"
+  run "echo fsync = off >> #{DATA}/postgresql.conf"
+  run "echo full_page_writes = off >> #{DATA}/postgresql.conf"
+  run "echo shared_buffers = 500MB >> #{DATA}/postgresql.conf"
+end
 
 if should_exec
   exec "#{BIN}/postmaster -D #{DATA}"
-else
+elsif should_run
   run "#{BIN}/pg_ctl -D #{DATA} start"
 end


### PR DESCRIPTION
On slower hardware it can take a while to init the database. If we don't wait, the `rake db:create` step will fail.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
