### PR TITLE
FEATURE: Export topics to markdown

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -41,11 +41,10 @@ class PostsController < ApplicationController
     elsif params[:post_number].present?
       markdown Post.find_by(topic_id: params[:topic_id].to_i, post_number: params[:post_number].to_i)
     else
-      topic = Topic.find_by(id: params[:topic_id].to_i)
-      raise Discourse::NotFound unless guardian.can_see?(topic)
-      offset = [((params[:page] || 1).to_i * MARKDOWN_TOPIC_PAGE_SIZE) - MARKDOWN_TOPIC_PAGE_SIZE, 0].max
-      posts = topic.posts.order(:post_number).limit(MARKDOWN_TOPIC_PAGE_SIZE).offset(offset)
-      content = posts.map do |p|
+      opts = params.slice(:page)
+      opts[:limit] = MARKDOWN_TOPIC_PAGE_SIZE
+      topic_view = TopicView.new(params[:topic_id], current_user, opts)
+      content = topic_view.posts.map do |p|
         <<~HEREDOC
           #{p.user.username} | #{p.updated_at} | ##{p.post_number}
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1888,6 +1888,16 @@ describe PostsController do
       expect(response.status).to eq(200)
       expect(response.body).to eq("123456789")
     end
+
+    it "can show whole topics" do
+      topic = Fabricate(:topic)
+      post = Fabricate(:post, topic: topic, post_number: 1, raw: "123456789")
+      post_2 = Fabricate(:post, topic: topic, post_number: 2, raw: "abcdefghij")
+      post.save
+      get "/raw/#{topic.id}"
+      expect(response.status).to eq(200)
+      expect(response.body).to include("123456789", "abcdefghij")
+    end
   end
 
   describe '#short_link' do


### PR DESCRIPTION
The route `/raw/TOPIC_ID` will now export whole topics (paginated to 100
posts) in a markdown format.

See https://meta.discourse.org/t/-/152185/12
