### PR TITLE
DEV: add empty state placeholder to styleguide

### DIFF
--- a/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/molecules/empty-state-placeholder.hbs
+++ b/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/molecules/empty-state-placeholder.hbs
@@ -1,0 +1,6 @@
+{{#styleguide-example title="empty-state-placeholder"}}
+  {{empty-state
+    title=dummy.sentence
+    body=dummy.short_sentence
+  }}
+{{/styleguide-example}}

--- a/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/molecules/empty-state.hbs
+++ b/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/molecules/empty-state.hbs
@@ -1,4 +1,4 @@
-{{#styleguide-example title="empty-state-placeholder"}}
+{{#styleguide-example title="empty-state"}}
   {{empty-state
     title=dummy.sentence
     body=dummy.short_sentence

--- a/plugins/styleguide/config/locales/client.en.yml
+++ b/plugins/styleguide/config/locales/client.en.yml
@@ -81,3 +81,5 @@ en:
           title: "Header Icons"
         spinners:
           title: "Spinners"
+        empty_state_placeholder:
+          title: "Empty State Placeholder"

--- a/plugins/styleguide/config/locales/client.en.yml
+++ b/plugins/styleguide/config/locales/client.en.yml
@@ -81,5 +81,5 @@ en:
           title: "Header Icons"
         spinners:
           title: "Spinners"
-        empty_state_placeholder:
-          title: "Empty State Placeholder"
+        empty_state:
+          title: "Empty State"


### PR DESCRIPTION
Here is how it looks:

<img width="650" alt="Screenshot 2022-01-17 at 22 03 19" src="https://user-images.githubusercontent.com/1274517/149836878-ad6ba0d0-231a-4fdf-875b-06fd120e394b.png">

Now after I added this to styleguide I see that we have inconsistency in names here. The name of the component is <kbd>empty-state</kbd>, but  I think in styleguide it's better to use the title  <kbd>Empty State Placeholder</kbd> for it. Probably it's worth renaming the component to <kbd>empty-state-placeholder</kbd> then. 

And even more importantly - we actually use the name <kbd>empty-state</kbd> only in code. When we speak about pages without items that we want to improve with this placeholder, we say "blank page syndrome". So, probably it's a good idea to rename the component to <kbd>blank-page-placeholder</kbd>.

But I think for now we can leave it as is, it's not so big source of confusion.


