### PR TITLE
FIX: Tag watching for everyone tag groups

### DIFF
--- a/app/models/tag_user.rb
+++ b/app/models/tag_user.rb
@@ -11,6 +11,7 @@ class TagUser < ActiveRecord::Base
       .joins("LEFT OUTER JOIN tag_group_permissions ON tag_group_memberships.tag_group_id = tag_group_permissions.tag_group_id")
       .joins("LEFT OUTER JOIN group_users on group_users.user_id = tag_users.user_id")
       .where("(tag_group_permissions.group_id IS NULL
+               OR tag_group_permissions.group_id = 0
                OR tag_group_permissions.group_id = group_users.group_id
                OR group_users.group_id = :staff_group_id)
               AND tag_users.notification_level IN (:notification_levels)",

--- a/app/models/tag_user.rb
+++ b/app/models/tag_user.rb
@@ -11,8 +11,7 @@ class TagUser < ActiveRecord::Base
       .joins("LEFT OUTER JOIN tag_group_permissions ON tag_group_memberships.tag_group_id = tag_group_permissions.tag_group_id")
       .joins("LEFT OUTER JOIN group_users on group_users.user_id = tag_users.user_id")
       .where("(tag_group_permissions.group_id IS NULL
-               OR tag_group_permissions.group_id = 0
-               OR tag_group_permissions.group_id = group_users.group_id
+               OR tag_group_permissions.group_id IN (0, group_users.group_id)
                OR group_users.group_id = :staff_group_id)
               AND tag_users.notification_level IN (:notification_levels)",
              staff_group_id: Group::AUTO_GROUPS[:staff],

--- a/spec/models/tag_user_spec.rb
+++ b/spec/models/tag_user_spec.rb
@@ -40,12 +40,10 @@ describe TagUser do
 
     it "scopes to notification levels visible by tag group permission" do
       group1 = Fabricate(:group)
-      tag_group1 = Fabricate(:tag_group, tags: [tag1])
-      Fabricate(:tag_group_permission, tag_group: tag_group1, group: group1)
+      tag_group1 = Fabricate(:tag_group, tags: [tag1], permissions: { group1.name => 1 })
 
       group2 = Fabricate(:group)
-      tag_group2 = Fabricate(:tag_group, tags: [tag2])
-      Fabricate(:tag_group_permission, tag_group: tag_group2, group: group2)
+      tag_group2 = Fabricate(:tag_group, tags: [tag2], permissions: { group2.name => 1 })
 
       Fabricate(:group_user, group: group1, user: user1)
 
@@ -56,8 +54,7 @@ describe TagUser do
 
     it "scopes to notification levels visible because user is staff" do
       group2 = Fabricate(:group)
-      tag_group2 = Fabricate(:tag_group, tags: [tag2])
-      Fabricate(:tag_group_permission, tag_group: tag_group2, group: group2)
+      tag_group2 = Fabricate(:tag_group, tags: [tag2], permissions: { group2.name => 1 })
 
       staff_group = Group.find(Group::AUTO_GROUPS[:staff])
       Fabricate(:group_user, group: staff_group, user: user1)
@@ -330,8 +327,7 @@ describe TagUser do
 
       it "does not show a tag is tracked if the user does not belong to the tag group with permissions" do
         group = Fabricate(:group)
-        tag_group = Fabricate(:tag_group, tags: [tag2])
-        Fabricate(:tag_group_permission, tag_group: tag_group, group: group)
+        tag_group = Fabricate(:tag_group, tags: [tag2], permissions: { group.name => 1 })
 
         expect(TagUser.notification_levels_for(user).keys).to match_array([tag1.name, tag3.name, tag4.name])
       end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1972,8 +1972,7 @@ describe UsersController do
           }
 
           expect(response.status).to eq(200)
-          response_body = JSON.parse(response.body)
-          expect(response_body['user']['watched_tags'].count).to eq(2)
+          expect(response.parsed_body['user']['watched_tags'].count).to eq(2)
 
           user.reload
 
@@ -2015,8 +2014,7 @@ describe UsersController do
           }
 
           expect(response.status).to eq(200)
-          response_body = JSON.parse(response.body)
-          expect(response_body['user']['watched_tags'].count).to eq(2)
+          expect(response.parsed_body['user']['watched_tags'].count).to eq(2)
         end
 
         context 'a locale is chosen that differs from I18n.locale' do

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1429,8 +1429,7 @@ describe PostAlerter do
         end
 
         it "does not notify a user watching a tag with tag group permissions that he does not belong to" do
-          tag_group = Fabricate(:tag_group, tags: [tag])
-          Fabricate(:tag_group_permission, tag_group: tag_group, group: group)
+          tag_group = Fabricate(:tag_group, tags: [tag], permissions: { group.name => 1 })
 
           TagUser.change(user.id, tag.id, TagUser.notification_levels[notification_level])
 


### PR DESCRIPTION
Tags in tag groups that have permissions set to everyone were not able
to be saved correctly. A user on their preferences page would mark the
tags that they wanted to save, but the watched_tags in the response
would be empty. This did not apply to admins, just regular users. Even
though the watched tags were being saved in the db, the user serializer
response was filtering them out. When a user refreshed their preferences
pages it would show zero watched tags.

This appears to be a regression introduced by:

0f598ca51e7ada06f91a6a8717909627ee81a67c

The issue that needed to be fixed is that we don't track the "everyone"
group (which has an id of 0) in the group_users table. This is because
everyone has access to it, so why fill a row for every single user, that
would be a lot. The fix was to update the query to include tag groups
that had permissions set to the "everyone" group (group_id 0).

I also added another check to the existing spec for updating
watched tags for tags that aren't in a tag group so that it checks the
response body. I then added a new spec which updates watched tags for
tags in a tag group which has permissions set to everyone.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
