### PR TITLE
FIX: topic tracking state for tags

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -127,6 +127,13 @@ export default Controller.extend(BulkTopicSelection, FilterModeMixin, {
       );
     },
 
+    showInserted() {
+      const tracker = this.topicTrackingState;
+      this.list.loadBefore(tracker.get("newIncoming"), true);
+      tracker.resetTracking();
+      return false;
+    },
+
     changeSort(order) {
       if (order === this.order) {
         this.toggleProperty("ascending");

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -62,6 +62,14 @@
                 <div class="top-lists">
                   {{period-chooser period=period action=(action "changePeriod") fullDay=false}}
                 </div>
+              {{else}}
+                {{#if topicTrackingState.hasIncoming}}
+                  <div class="show-more {{if hasTopics "has-topics"}}">
+                    <a tabindex="0" href {{action "showInserted"}} class="alert alert-info clickable">
+                      {{count-i18n key="topic_count_" suffix=topicTrackingState.filter count=topicTrackingState.incomingCount}}
+                    </a>
+                  </div>
+                {{/if}}
               {{/if}}
 
               {{#if list.topics}}

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -519,6 +519,28 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         );
       });
 
+      test("correct tag and category filters for different lists", function (assert) {
+        trackingState.trackIncoming("unread");
+        assert.strictEqual(trackingState.filterCategory, undefined);
+        assert.strictEqual(trackingState.filterTag, undefined);
+        assert.strictEqual(trackingState.filter, "unread");
+
+        trackingState.trackIncoming("tag/test/l/latest");
+        assert.strictEqual(trackingState.filterCategory, undefined);
+        assert.strictEqual(trackingState.filterTag, "test");
+        assert.strictEqual(trackingState.filter, "latest");
+
+        trackingState.trackIncoming("c/cat/subcat/6/l/latest");
+        assert.strictEqual(trackingState.filterCategory.id, 6);
+        assert.strictEqual(trackingState.filterTag, undefined);
+        assert.strictEqual(trackingState.filter, "latest");
+
+        trackingState.trackIncoming("tags/c/cat/subcat/6/test/l/latest");
+        assert.strictEqual(trackingState.filterCategory.id, 6);
+        assert.strictEqual(trackingState.filterTag, "test");
+        assert.strictEqual(trackingState.filter, "latest");
+      });
+
       test("adds incoming in the categories latest topics list", function (assert) {
         trackingState.trackIncoming("categories");
         const unreadCategoriesLatestTopicsPayload = {


### PR DESCRIPTION
TopicTrackingState should correctly set filterCategory and filterTag for all different configurations.

When filterTag exists and new_topic message arrives, it ensures that filterTag is included in payload tags

If filterTag is part of payload tags, message that new topics are available is displayed and after click, new topics are included in the list.
