### PR TITLE
FIX: Add `/session/sso` service-worker workaround for chrome 97

### DIFF
--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -7,7 +7,7 @@ workbox.setConfig({
   debug: false
 });
 
-var authUrls = ["auth", "session/sso_login"].map(path => `<%= Discourse.base_path %>/${path}`);
+var authUrls = ["auth", "session/sso_login", "session/sso"].map(path => `<%= Discourse.base_path %>/${path}`);
 
 var cacheVersion = "1";
 var discourseCacheName = "discourse-" + cacheVersion;


### PR DESCRIPTION
Followup to 2278c7f82dd8e7f24dc6dc66bc6fea02e598c6d0. Depending on the site's SSO implementation, this route is also used as part of a redirect sequence and needs to be able to set cookies.

Chrome bug reference: https://bugs.chromium.org/p/chromium/issues/detail?id=1286367

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
