### PR TITLE
FIX: Ensure method exists before calling

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
+++ b/app/assets/javascripts/discourse/app/mixins/uppy-upload.js
@@ -133,9 +133,11 @@ export default Mixin.create(UppyS3Multipart, {
           return false;
         }
 
-        Object.values(files).forEach((file) => {
-          deepMerge(file.meta, this._perFileData());
-        });
+        if (this._perFileData) {
+          Object.values(files).forEach((file) => {
+            deepMerge(file.meta, this._perFileData());
+          });
+        }
       },
     });
 


### PR DESCRIPTION
`_perFileData` is not always defined and uploads failed when it is not.

I could not find a way to test this behavior because I cannot simulate a change event on the `<input type="file" />` element from QUnit.