### PR TITLE
FIX: Ensure floating quote button is not positioned under sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -246,7 +246,12 @@ export default Component.extend(KeyEnterEscape, {
         left = boundaryPosition.left;
 
         const safeRadius = 50;
-        const viewportEdgeMargin = 10;
+
+        const topicArea = document
+          .querySelector(".topic-area")
+          .getBoundingClientRect();
+        topicArea.x += document.documentElement.scrollLeft;
+        topicArea.y += document.documentElement.scrollTop;
 
         const endHandlePosition = boundaryPosition;
         const width = this.element.clientWidth;
@@ -270,12 +275,9 @@ export default Component.extend(KeyEnterEscape, {
         ];
 
         for (const pos of possiblePositions) {
-          // Ensure buttons are entirely within the viewport
-          pos.left = Math.max(viewportEdgeMargin, pos.left);
-          pos.left = Math.min(
-            window.innerWidth - viewportEdgeMargin - width,
-            pos.left
-          );
+          // Ensure buttons are entirely within the .topic-area
+          pos.left = Math.max(topicArea.left, pos.left);
+          pos.left = Math.min(topicArea.right - width, pos.left);
 
           let clearOfStartHandle = true;
           if (isAndroid) {


### PR DESCRIPTION
If themes/plugins introduce a sidebar on the left of the screen, the quote button would sometimes be positioned underneath. This commit ensures that the positioning logic keeps the floating buttons within the width of `.topic-area`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
