### PR TITLE
FIX: Disable service worker proxying in chrome 97

### DIFF
--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -13,11 +13,14 @@ var cacheVersion = "1";
 var discourseCacheName = "discourse-" + cacheVersion;
 var externalCacheName = "external-" + cacheVersion;
 
-// Cache all GET requests, so Discourse can be used while offline
+// Chrome 97 shipped with broken samesite cookie handling when proxying requests through service workers
+// https://bugs.chromium.org/p/chromium/issues/detail?id=1286367
+var isBrokenChrome97 = navigator.userAgent.indexOf("Chrome/97.0") !== -1;
 
+// Cache all GET requests, so Discourse can be used while offline
 workbox.routing.registerRoute(
   function(args) {
-    return args.url.origin === location.origin && !authUrls.some(u => args.url.pathname.startsWith(u));
+    return args.url.origin === location.origin && !authUrls.some(u => args.url.pathname.startsWith(u)) && !isBrokenChrome97;
   }, // Match all except auth routes
   new workbox.strategies.NetworkFirst({ // This will only use the cache when a network request fails
     cacheName: discourseCacheName,

--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -15,7 +15,8 @@ var externalCacheName = "external-" + cacheVersion;
 
 // Chrome 97 shipped with broken samesite cookie handling when proxying requests through service workers
 // https://bugs.chromium.org/p/chromium/issues/detail?id=1286367
-var isBrokenChrome97 = navigator.userAgent.indexOf("Chrome/97.0") !== -1;
+var chromeVersionMatch = navigator.userAgent.match(/Chrome\/97.0.(\d+)/);
+var isBrokenChrome97 = chromeVersionMatch && parseInt(chromeVersionMatch[1]) <= 4692;
 
 // Cache all GET requests, so Discourse can be used while offline
 workbox.routing.registerRoute(


### PR DESCRIPTION
Chrome 97 shipped with broken samesite cookie handling when proxying requests through service workers
https://bugs.chromium.org/p/chromium/issues/detail?id=1286367

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
