### PR TITLE
FIX: Ensure that login does not fail for users with invite records

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -32,7 +32,7 @@ class Invite < ActiveRecord::Base
   validates :email, email: true, allow_blank: true
   validate :ensure_max_redemptions_allowed
   validate :valid_domain, if: :will_save_change_to_domain?
-  validate :user_doesnt_already_exist
+  validate :user_doesnt_already_exist, if: :will_save_change_to_email?
 
   before_create do
     self.invite_key ||= SecureRandom.base58(10)


### PR DESCRIPTION
In the unlikely, but possible, scenario where a user has no email_tokens, and has an invite record for their email address, login would fail. This commit fixes the `Invite` `user_doesnt_already_exist` validation so that it only applies to new invites, or when changing the email address.

This regressed in d8fe0f4199b5bb44fa79fa489586b4029289242c (based on `git bisect`)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
