### PR TITLE
FIX: Add another method to check binary file

### DIFF
--- a/lib/onebox/mixins/git_blob_onebox.rb
+++ b/lib/onebox/mixins/git_blob_onebox.rb
@@ -169,7 +169,7 @@ module Onebox
             else
               contents = URI.parse(self.raw_template(m)).open(read_timeout: timeout).read
 
-              if contents.encoding == Encoding::BINARY
+              if contents.encoding == Encoding::BINARY || contents.bytes.include?(0)
                 @raw = nil
                 @binary = true
                 return


### PR DESCRIPTION
This method looks for a NULL byte that is not usually contained in text
files. Follow up to 376799b1a49306be500be3419a327af8b03819ec.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
