### PR TITLE
FIX: Prefer email when resetting password

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -429,7 +429,7 @@ const User = RestModel.extend({
   changePassword() {
     return ajax("/session/forgot_password", {
       dataType: "json",
-      data: { login: this.username },
+      data: { login: this.email },
       type: "POST",
     });
   },

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -434,32 +434,24 @@ class SessionController < ApplicationController
     RateLimiter.new(nil, "forgot-password-hr-#{request.remote_ip}", 6, 1.hour).performed!
     RateLimiter.new(nil, "forgot-password-min-#{request.remote_ip}", 3, 1.minute).performed!
 
-    if SiteSetting.hide_email_address_taken
-      user = User.find_by_email(Email.downcase(normalized_login_param))
+    user = if SiteSetting.hide_email_address_taken
+      raise Discourse::InvalidParameters.new(:login) if EmailValidator.email_regex !~ normalized_login_param
+      User.real.where(staged: false).find_by_email(Email.downcase(normalized_login_param))
     else
-      user = User.find_by_username_or_email(normalized_login_param)
+      User.real.where(staged: false).find_by_username_or_email(normalized_login_param)
     end
 
     if user
       RateLimiter.new(nil, "forgot-password-login-day-#{user.username}", 6, 1.day).performed!
+      email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:password_reset])
+      Jobs.enqueue(:critical_user_email, type: :forgot_password, user_id: user.id, email_token: email_token.token)
     else
       RateLimiter.new(nil, "forgot-password-login-hour-#{normalized_login_param}", 5, 1.hour).performed!
     end
 
-    user_presence = user.present? && user.human? && !user.staged
-    if user_presence
-      email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:password_reset])
-      Jobs.enqueue(:critical_user_email, type: :forgot_password, user_id: user.id, email_token: email_token.token)
-    end
-
     json = success_json
-
-    if !SiteSetting.hide_email_address_taken
-      json[:user_found] = user_presence
-    end
-
+    json[:user_found] = user.present? if !SiteSetting.hide_email_address_taken
     render json: json
-
   rescue RateLimiter::LimitExceeded
     render_json_error(I18n.t("rate_limiter.slow_down"))
   end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -2068,7 +2068,7 @@ describe SessionController do
         post "/session/forgot_password.json",
           params: { login: user.username }
 
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(400)
         expect(Jobs::CriticalUserEmail.jobs.size).to eq(0)
       end
 


### PR DESCRIPTION
The UI used to request a password reset by username when the user was
logged in. This did not work when hide_email_already_taken site setting
was enabled, which disables the lookup-by-username functionality.

This commit also introduces a check to ensure that the parameter is an
email when hide_email_already_taken is enabled as the single allowed
type is email (no usernames are allowed).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
