### PR TITLE
A11Y: do not use duplicate IDs

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-only.hbs
@@ -29,14 +29,14 @@
       <table class="category-list {{if showTopics "with-topics"}} {{unless showMutedCategories "hidden"}}">
         <thead>
           <tr>
-            <th class="category"><span aria-role="heading" aria-level="2" id="categories-only-category">{{i18n "categories.category"}}</span></th>
+            <th class="category"><span aria-role="heading" aria-level="2" id="categories-only-category-muted">{{i18n "categories.category"}}</span></th>
             <th class="topics">{{i18n "categories.topics"}}</th>
             {{#if showTopics}}
               <th class="latest">{{i18n "categories.latest"}}</th>
             {{/if}}
           </tr>
         </thead>
-        <tbody aria-labelledby="categories-only-category">
+        <tbody aria-labelledby="categories-only-category-muted">
           {{#each categories as |category|}}
             {{parent-category-row category=category showTopics=showTopics listType="muted"}}
           {{/each}}


### PR DESCRIPTION
We don't use this id in our CSS, so should be fairly safe. If themes use it, this change should only impact the muted category list. 