### PR TITLE
FIX: subcategory filter limits results

### DIFF
--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -542,12 +542,16 @@ Category.reopenClass({
 
   search(term, opts) {
     let limit = 5;
+    let parentCategoryId;
 
     if (opts) {
       if (opts.limit === 0) {
         return [];
       } else if (opts.limit) {
         limit = opts.limit;
+      }
+      if (opts.parentCategoryId) {
+        parentCategoryId = opts.parentCategoryId;
       }
     }
 
@@ -569,13 +573,21 @@ Category.reopenClass({
       return data.length === limit;
     };
 
+    const validCategoryParent = (category) => {
+      return (
+        !parentCategoryId ||
+        category.get("parent_category_id") === parentCategoryId
+      );
+    };
+
     for (i = 0; i < length && !done(); i++) {
       const category = categories[i];
       if (
-        (emptyTerm && !category.get("parent_category_id")) ||
-        (!emptyTerm &&
-          (category.get("name").toLowerCase().indexOf(term) === 0 ||
-            category.get("slug").toLowerCase().indexOf(slugTerm) === 0))
+        ((emptyTerm && !category.get("parent_category_id")) ||
+          (!emptyTerm &&
+            (category.get("name").toLowerCase().indexOf(term) === 0 ||
+              category.get("slug").toLowerCase().indexOf(slugTerm) === 0))) &&
+        validCategoryParent(category)
       ) {
         data.push(category);
       }
@@ -586,9 +598,10 @@ Category.reopenClass({
         const category = categories[i];
 
         if (
-          !emptyTerm &&
-          (category.get("name").toLowerCase().indexOf(term) > 0 ||
-            category.get("slug").toLowerCase().indexOf(slugTerm) > 0)
+          ((!emptyTerm &&
+            category.get("name").toLowerCase().indexOf(term) > 0) ||
+            category.get("slug").toLowerCase().indexOf(slugTerm) > 0) &&
+          validCategoryParent(category)
         ) {
           if (data.indexOf(category) === -1) {
             data.push(category);

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -276,9 +276,17 @@ module("Unit | Model | category", function () {
         id: 2,
         name: "middle term",
         slug: "another-different-slug",
+      }),
+      subcategory = store.createRecord("category", {
+        id: 3,
+        name: "middle term",
+        slug: "another-different-slug2",
+        parent_category_id: 2,
       });
 
-    sinon.stub(Category, "listByActivity").returns([category1, category2]);
+    sinon
+      .stub(Category, "listByActivity")
+      .returns([category1, category2, subcategory]);
 
     assert.deepEqual(
       Category.search("term", { limit: 0 }),
@@ -292,22 +300,28 @@ module("Unit | Model | category", function () {
     );
     assert.deepEqual(
       Category.search("term"),
-      [category1, category2],
+      [category1, category2, subcategory],
       "orders by activity"
     );
 
     category2.set("name", "TeRm start");
     assert.deepEqual(
       Category.search("tErM"),
-      [category2, category1],
+      [category2, category1, subcategory],
       "ignores case of category name and search term"
     );
 
     category2.set("name", "term start");
     assert.deepEqual(
       Category.search("term"),
-      [category2, category1],
+      [category2, category1, subcategory],
       "orders matching begin with and then contains"
+    );
+
+    assert.deepEqual(
+      Category.search("term", { parentCategoryId: 2 }),
+      [subcategory],
+      "search only subcategories belonging to specific parent category"
     );
 
     sinon.restore();

--- a/app/assets/javascripts/select-kit/addon/components/category-drop.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-drop.js
@@ -131,7 +131,10 @@ export default ComboBoxComponent.extend({
 
   search(filter) {
     if (filter) {
-      let results = Category.search(filter);
+      let opts = {
+        parentCategoryId: this.options.parentCategory?.id,
+      };
+      let results = Category.search(filter, opts);
       results = this._filterUncategorized(results).sort((a, b) => {
         if (a.parent_category_id && !b.parent_category_id) {
           return 1;


### PR DESCRIPTION
When the subcategory dropdown is searched, it should only display categories belonging to the same parent category.

Before:
<img width="669" alt="Screen Shot 2022-01-20 at 2 10 50 pm" src="https://user-images.githubusercontent.com/72780/150265694-4a808b1d-cea8-4995-aacc-9f40aa33392b.png">

After:
<img width="642" alt="Screen Shot 2022-01-20 at 2 09 16 pm" src="https://user-images.githubusercontent.com/72780/150265705-d96ae7d3-ad5e-4dd6-b330-a95bc6e0b330.png">
