### PR TITLE
FIX: Respect blocked domains list when redirecting

### DIFF
--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -51,7 +51,6 @@ class InlineOneboxer
 
     always_allow = SiteSetting.enable_inline_onebox_on_all_domains
     allowed_domains = SiteSetting.allowed_inline_onebox_domains&.split('|') unless always_allow
-    blocked_domains = SiteSetting.blocked_onebox_domains&.split('|')
 
     if always_allow || allowed_domains
       uri = begin
@@ -62,7 +61,7 @@ class InlineOneboxer
       if uri.present? &&
         uri.hostname.present? &&
         (always_allow || allowed_domains.include?(uri.hostname)) &&
-        !blocked_domains.include?(uri.hostname)
+        !domain_is_blocked?(uri.hostname)
         title = RetrieveTitle.crawl(url)
         title = nil if title && title.length < MIN_TITLE_LENGTH
         return onebox_for(url, title, opts)
@@ -73,6 +72,12 @@ class InlineOneboxer
   end
 
   private
+
+  def self.domain_is_blocked?(hostname)
+    SiteSetting.blocked_onebox_domains&.split('|').any? do |blocked|
+      hostname.match("(^|\\.)#{Regexp.quote(blocked)}$")
+    end
+  end
 
   def self.onebox_for(url, title, opts)
     title = title && Emoji.gsub_emoji_to_unicode(title)

--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -75,7 +75,7 @@ class InlineOneboxer
 
   def self.domain_is_blocked?(hostname)
     SiteSetting.blocked_onebox_domains&.split('|').any? do |blocked|
-      hostname.match("(^|\\.)#{Regexp.quote(blocked)}$")
+      hostname == blocked || hostname.end_with?(".#{blocked}")
     end
   end
 

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -60,6 +60,10 @@ module RetrieveTitle
     encoding = nil
 
     fd.get do |_response, chunk, uri|
+      if (uri.present? && InlineOneboxer.domain_is_blocked?(uri.hostname))
+        throw :done
+      end
+
       unless Net::HTTPRedirection === _response
         if current
           current << chunk

--- a/spec/components/retrieve_title_spec.rb
+++ b/spec/components/retrieve_title_spec.rb
@@ -100,6 +100,19 @@ describe RetrieveTitle do
       IPSocket.stubs(:getaddress).returns('100.2.3.4')
       expect(RetrieveTitle.crawl("http://foobar.com/amazing")).to eq("very amazing")
     end
+
+    it "returns empty title if redirect uri is in blacklist" do
+      SiteSetting.blocked_onebox_domains = "wikipedia.com"
+
+      stub_request(:get, "http://foobar.com/amazing")
+        .to_return(status: 301, body: "", headers: { "location" => "https://wikipedia.com/amazing" })
+
+      stub_request(:get, "https://wikipedia.com/amazing")
+        .to_return(status: 200, body: "<html><title>very amazing</title>", headers: {})
+
+      IPSocket.stubs(:getaddress).returns('100.2.3.4')
+      expect(RetrieveTitle.crawl("http://foobar.com/amazing")).to eq(nil)
+    end
   end
 
   context 'fetch_title' do

--- a/spec/components/retrieve_title_spec.rb
+++ b/spec/components/retrieve_title_spec.rb
@@ -113,6 +113,22 @@ describe RetrieveTitle do
       IPSocket.stubs(:getaddress).returns('100.2.3.4')
       expect(RetrieveTitle.crawl("http://foobar.com/amazing")).to eq(nil)
     end
+
+    it "returns title if 'midway redirect' is blocked but final redirect uri is not blocked" do
+      SiteSetting.blocked_onebox_domains = "wikipedia.com"
+
+      stub_request(:get, "http://foobar.com/amazing")
+        .to_return(status: 301, body: "", headers: { "location" => "https://wikipedia.com/amazing" })
+
+      stub_request(:get, "https://wikipedia.com/amazing")
+        .to_return(status: 301, body: "", headers: { "location" => "https://cat.com/meow" })
+
+      stub_request(:get, "https://cat.com/meow")
+        .to_return(status: 200, body: "<html><title>very amazing</title>", headers: {})
+
+      IPSocket.stubs(:getaddress).returns('100.2.3.4')
+      expect(RetrieveTitle.crawl("http://foobar.com/amazing")).to eq("very amazing")
+    end
   end
 
   context 'fetch_title' do


### PR DESCRIPTION
/t/59305

Our previous implementation used a simple `blocked_domain_array.include?(hostname)`
so some values were not matching. Additionally, in some configurations like ours, we'd used
"cat.*.dog.com" with the assumption we'd support globbing.

This change implicitly allows globbing by blocking "http://a.b.com" if "b.com" is a blocked 
domain but does not actively do anything for "*".

An upcoming change might include frontend validation for values that can be inserted.

<img width="710" alt="Screenshot 2022-01-20 at 12 11 51 PM" src="https://user-images.githubusercontent.com/1555215/150272070-229808e7-e639-4ca8-af6e-09f1ae8f07f4.png">
