### PR TITLE
FIX: Create email token with correct scope

### DIFF
--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -27,7 +27,7 @@ task "admin:invite", [:email] => [:environment] do |_, args|
   user.email_tokens.update_all confirmed: true
 
   puts "Sending email!"
-  email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:signup])
+  email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:password_reset])
   Jobs.enqueue(:user_email, type: :account_created, user_id: user.id, email_token: email_token.token)
 end
 


### PR DESCRIPTION
`account_created` email contains a URL to /u/password-reset/TOKEN which
means that the correct scope for the email token is `password_reset`,
not `signup`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
