### PR TITLE
FIX: Display composer popovers over dropdowns

### DIFF
--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -90,9 +90,9 @@ $z-layers: (
   "footer-nav": 900,
   "tooltip": 600,
   "composer": (
-    "popover": 700,
-    "dropdown": 600,
-    "tooltip": 500,
+    "dropdown": 700,
+    "tooltip": 600,
+    "popover": 500,
     "content": 400,
   ),
   "dropdown": 300,

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -90,9 +90,9 @@ $z-layers: (
   "footer-nav": 900,
   "tooltip": 600,
   "composer": (
-    "dropdown": 700,
-    "tooltip": 600,
-    "popover": 500,
+    "popover": 700,
+    "dropdown": 600,
+    "tooltip": 500,
     "content": 400,
   ),
   "dropdown": 300,

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -88,14 +88,10 @@
   bottom: 8px;
   right: 8px;
   overflow-y: auto;
-  z-index: z("composer", "popover");
+  z-index: z("composer", "dropdown") + 1;
   padding: 1.5em;
   box-shadow: shadow("dropdown");
   background: var(--highlight-medium);
-
-  .hide-preview & {
-    z-index: z("composer", "dropdown") + 1;
-  }
 
   &.urgent {
     background: var(--danger-low);


### PR DESCRIPTION
This matches the "modal" z-index order (same file, lines 81-82)