### PR TITLE
FIX: Allowed URLs for API scopes added by plugins

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -101,7 +101,14 @@ class ApiKeyScope < ActiveRecord::Base
       urls = []
 
       if actions.present?
-        Rails.application.routes.routes.each do |route|
+        routes = Rails.application.routes.routes.to_a
+        Rails::Engine.descendants.each do |engine|
+          next if engine == Rails::Application # abstract engine, can't call routes on it
+          next if engine == Discourse::Application # equiv. to Rails.application
+          routes.concat(engine.routes.routes.to_a)
+        end
+
+        routes.each do |route|
           defaults = route.defaults
           action = "#{defaults[:controller].to_s}##{defaults[:action]}"
           path = route.path.spec.to_s.gsub(/\(\.:format\)/, '')


### PR DESCRIPTION
We allow plugins to add new scopes to the default set of API scopes and they correctly show up on the API keys page when an admin tries to create a new key. Here is an example of a scope added by the data explorer plugin:

![image](https://user-images.githubusercontent.com/17474474/150398401-f80673ab-2313-4395-8fb0-0a4fa96dff5f.png)

However, is one minor issue/difference between core and plugins scopes which is that the <kbd>🔗</kbd> button is meant to show all the URLs that the scope grants access to, a.k.a "Allowed URLs", but plugins that a scope(s) for routes/paths defined in their engines don't display any allowed URLs. For example, these are all the allowed URLs of the `topics:read` scope (which is core scope):

<img width="60%" src="https://user-images.githubusercontent.com/17474474/150398852-0fee92c4-ad72-44ab-b18f-e420f587b9cd.png">

And nothing for the scope added by the data explorer plugin:

<img width="60%" src="https://user-images.githubusercontent.com/17474474/150400890-5bcba909-46b5-4013-b6a0-00f4dd915824.png">

The reason for this is when we determine the allowed URLs for a scope, we only consider the `Rails.application` engine which only includes the routes of the main app's engine and not the routes of plugin engines. So to fix this we need to consider plugin engines and check all their routes when we're determining the allowed URLs for a scope.

I'm using `Rails::Engine.descendants` to find the plugins engines, which I don't think is perfect because it returns all the engines defined in app including engines defined in gems, however I couldn't find a better alternative. If you have a better solution please let me know!

Related to https://github.com/discourse/discourse-data-explorer/pull/154.