### PR TITLE
FIX: Select best link from Atom feed

### DIFF
--- a/lib/feed_item_accessor.rb
+++ b/lib/feed_item_accessor.rb
@@ -12,6 +12,12 @@ class FeedItemAccessor
   end
 
   def link
+    if rss_item.respond_to?(:links) && links = rss_item.links
+      if link = links.find { |l| l.rel == "alternate" && l.type == "text/html" }
+        return link.href if link.respond_to?(:href)
+      end
+    end
+
     try_attribute_or_self(element(:link), :href)
   end
 

--- a/spec/components/feed_item_accessor_spec.rb
+++ b/spec/components/feed_item_accessor_spec.rb
@@ -32,4 +32,16 @@ describe FeedItemAccessor do
       it { expect(item_accessor.link).to eq(rss_feed_item.link) }
     end
   end
+
+  context 'with multiple links' do
+    let(:rss_feed) { RSS::Parser.parse(file_from_fixtures('multiple-links.atom', 'feed'), false) }
+    let(:rss_feed_item) { rss_feed.items.first }
+    let(:item_accessor) { FeedItemAccessor.new(rss_feed_item) }
+
+    describe '#link' do
+      it 'gets the web page link' do
+        expect(item_accessor.link).to eq('http://workspaceupdates.googleblog.com/2022/01/improved-editing-experience-in-google.html')
+      end
+    end
+  end
 end

--- a/spec/fixtures/feed/multiple-links.atom
+++ b/spec/fixtures/feed/multiple-links.atom
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+    xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"
+    xmlns:blogger="http://schemas.google.com/blogger/2008"
+    xmlns:georss="http://www.georss.org/georss"
+    xmlns:gd="http://schemas.google.com/g/2005"
+    xmlns:thr="http://purl.org/syndication/thread/1.0">
+    <id>tag:blogger.com,1999:blog-5245696872621940063</id>
+    <updated>2022-01-20T08:59:51.049-08:00</updated>
+    <category term="Google Chat" />
+    <title type="text">Google Workspace Updates</title>
+    <subtitle type="html">This official feed from the Google Workspace team provides essential information about new features and improvements for Google Workspace customers.</subtitle>
+    <link rel="alternate" type="text/html" href="http://workspaceupdates.googleblog.com/" />
+    <link rel="next" type="application/atom+xml" href="http://www.blogger.com/feeds/5245696872621940063/posts/default?start-index=26&amp;max-results=25&amp;redirect=false" />
+    <author>
+        <name>ewood</name>
+        <uri>http://www.blogger.com/profile/12341551220176883769</uri>
+        <email>noreply@blogger.com</email>
+        <gd:image rel="http://schemas.google.com/g/2005#thumbnail" width="16" height="16" src="https://img1.blogblog.com/img/b16-rounded.gif" />
+    </author>
+    <generator version="7.00" uri="http://www.blogger.com">Blogger</generator>
+    <openSearch:totalResults>2675</openSearch:totalResults>
+    <openSearch:startIndex>1</openSearch:startIndex>
+    <openSearch:itemsPerPage>25</openSearch:itemsPerPage>
+    <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" type="application/atom+xml" href="http://feeds.feedburner.com/GoogleAppsUpdates" />
+    <feedburner:info xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0" uri="googleappsupdates" />
+    <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/" />
+    <entry>
+        <id>tag:blogger.com,1999:blog-5245696872621940063.post-5639928758147944950</id>
+        <published>2022-01-20T08:58:00.001-08:00</published>
+        <updated>2022-01-20T08:59:19.910-08:00</updated>
+        <category scheme="http://www.blogger.com/atom/ns#" term="Google Chat" />
+        <title type="text">Improved editing experience in Google Chat on the web</title>
+        <content type="html">You now can add rich formatting to Chat messages, such as bold, italics, or underlines.</content>
+        <link rel="replies" type="application/atom+xml" href="http://workspaceupdates.googleblog.com/feeds/5639928758147944950/comments/default" title="Post Comments" />
+        <link rel="replies" type="text/html" href="http://workspaceupdates.googleblog.com/2022/01/improved-editing-experience-in-google.html#comment-form" title="0 Comments" />
+        <link rel="edit" type="application/atom+xml" href="http://www.blogger.com/feeds/5245696872621940063/posts/default/5639928758147944950" />
+        <link rel="self" type="application/atom+xml" href="http://www.blogger.com/feeds/5245696872621940063/posts/default/5639928758147944950" />
+        <link rel="alternate" type="text/html" href="http://workspaceupdates.googleblog.com/2022/01/improved-editing-experience-in-google.html" title="Improved editing experience in Google Chat on the web" />
+        <author>
+            <name>Unknown</name>
+            <email>noreply@blogger.com</email>
+            <gd:image rel="http://schemas.google.com/g/2005#thumbnail" width="16" height="16" src="https://img1.blogblog.com/img/b16-rounded.gif" />
+        </author>
+        <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="https://lh3.googleusercontent.com/eUfnXfExnqrkz01rOU9GcN4n3VTq4w4NnlVUKQgZHdpNccKaYYAu7RFSbNXTZOybZ5cSq5aGrr5bWI4ildN0CNl4_K-mhzpW5Zy2iziZufOaxJDWQRf9jmzISn95gsH2h67RnHDUnw=s72-w640-h95-c" height="72" width="72" />
+        <thr:total>0</thr:total>
+    </entry>
+</feed>


### PR DESCRIPTION
Some Atom feeds can contain more than one link and it used to return
only the first link.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
