### PR TITLE
FIX: The service observer was using `this` incorrectly

### DIFF
--- a/app/assets/javascripts/discourse/app/components/global-notice.js
+++ b/app/assets/javascripts/discourse/app/components/global-notice.js
@@ -220,6 +220,7 @@ export default Component.extend({
 
   @bind
   _handleLogsNoticeUpdate() {
+    const { logsNoticeService } = this;
     const logNotice = Notice.create({
       text: htmlSafe(this.logsNoticeService.message),
       id: "alert-logs-notice",
@@ -227,13 +228,10 @@ export default Component.extend({
         dismissable: true,
         persistentDismiss: false,
         visibility() {
-          return !this.logsNoticeService.hidden;
+          return !logsNoticeService.hidden;
         },
         onDismiss() {
-          this.logsNoticeService.setProperties({
-            hidden: true,
-            text: "",
-          });
+          logsNoticeService.set("text", "");
         },
       },
     });


### PR DESCRIPTION
It was pointing at nothing due to context.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
