### PR TITLE
DEV: Clear custom field preload proxy on preload_custom_fields

### DIFF
--- a/spec/components/concern/has_custom_fields_spec.rb
+++ b/spec/components/concern/has_custom_fields_spec.rb
@@ -31,6 +31,33 @@ describe HasCustomFields do
       Object.send(:remove_const, :CustomFieldsTestItemCustomField)
     end
 
+    it "allows preloading of custom fields" do
+      test_item = CustomFieldsTestItem.new
+      CustomFieldsTestItem.preload_custom_fields([test_item], ["test_field"])
+      expect(test_item.preloaded_custom_fields).to eq({ "test_field" => nil })
+    end
+
+    it "errors if a custom field is not preloaded" do
+      test_item = CustomFieldsTestItem.new
+      CustomFieldsTestItem.preload_custom_fields([test_item], ["test_field"])
+      expect { test_item.custom_fields["other_field"] }.to raise_error(HasCustomFields::NotPreloadedError)
+    end
+
+    it "resets the preloaded_custom_fields if preload_custom_fields is called twice" do
+      test_item = CustomFieldsTestItem.new
+      CustomFieldsTestItem.preload_custom_fields([test_item], ["test_field"])
+      CustomFieldsTestItem.preload_custom_fields([test_item], ["other_field"])
+      expect(test_item.preloaded_custom_fields).to eq({ "other_field" => nil })
+    end
+
+    it "does not error with NotPreloadedError if preload_custom_fields is called twice" do
+      test_item = CustomFieldsTestItem.new
+      CustomFieldsTestItem.preload_custom_fields([test_item], ["test_field"])
+      expect { test_item.custom_fields["test_field"] }.not_to raise_error
+      CustomFieldsTestItem.preload_custom_fields([test_item], ["other_field"])
+      expect { test_item.custom_fields["other_field"] }.not_to raise_error
+    end
+
     it "allows simple modification of custom fields" do
       test_item = CustomFieldsTestItem.new
 
@@ -355,24 +382,24 @@ describe HasCustomFields do
         test_item.custom_fields["bob"] = "marley"
         test_item.custom_fields["jack"] = "black"
 
-         # In memory
-         expect(test_item.custom_fields[:bob]).to eq('marley')
-         expect(test_item.custom_fields[:jack]).to eq('black')
+        # In memory
+        expect(test_item.custom_fields[:bob]).to eq('marley')
+        expect(test_item.custom_fields[:jack]).to eq('black')
 
-         # Persisted
-         test_item.save
-         test_item.reload
-         expect(test_item.custom_fields[:bob]).to eq('marley')
-         expect(test_item.custom_fields[:jack]).to eq('black')
+        # Persisted
+        test_item.save
+        test_item.reload
+        expect(test_item.custom_fields[:bob]).to eq('marley')
+        expect(test_item.custom_fields[:jack]).to eq('black')
 
-         # Update via string index again
-         test_item.custom_fields['bob'] = 'the builder'
+        # Update via string index again
+        test_item.custom_fields['bob'] = 'the builder'
 
-         expect(test_item.custom_fields[:bob]).to eq('the builder')
-         test_item.save
-         test_item.reload
+        expect(test_item.custom_fields[:bob]).to eq('the builder')
+        test_item.save
+        test_item.reload
 
-         expect(test_item.custom_fields[:bob]).to eq('the builder')
+        expect(test_item.custom_fields[:bob]).to eq('the builder')
       end
     end
   end


### PR DESCRIPTION
If a model class calls preload_custom_fields twice then
we have to clear this otherwise the fields are cached inside the
already existing proxy and no new ones are added, so when we check
for custom_fields[KEY] an error is likely to occur