### PR TITLE
DEV: Simplify emoji-uploader tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
@@ -17,7 +17,7 @@ discourseModule("Integration | Component | emoji-uploader", function (hooks) {
 
   const template = hbs` {{emoji-uploader
     emojiGroups=emojiGroups
-    done=(action "emojiUploaded")
+    done=doneUpload
     id="emoji-uploader"
   }}`;
 
@@ -25,11 +25,6 @@ discourseModule("Integration | Component | emoji-uploader", function (hooks) {
     requestNumber = 1;
     this.setProperties({
       emojiGroups: ["default", "coolemojis"],
-      actions: {
-        emojiUploaded: (upload, group) => {
-          this.doneUpload(upload, group);
-        },
-      },
     });
 
     pretender.post("/admin/customize/emojis.json", () => {


### PR DESCRIPTION
Removes one layer of indirection in the tests. `emoji-uploader`'s
`uploadDone` can call the test handler directly without going through
an additional action method.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
