### PR TITLE
FIX: Select topics instead of posts

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -406,7 +406,7 @@ export default Controller.extend({
     },
 
     selectAll() {
-      this.selected.addObjects(this.get("model.posts")).mapBy("topic");
+      this.selected.addObjects(this.get("model.posts").mapBy("topic"));
 
       // Doing this the proper way is a HUGE pain,
       // we can hack this to work by observing each on the array


### PR DESCRIPTION
A code error caused post objects to be added to the selected array.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
