### PR TITLE
DEV: In themes:update, only update themes which are out-of-date

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -112,6 +112,10 @@ class RemoteTheme < ActiveRecord::Base
     self.joined_remotes.where("last_error_text IS NOT NULL").pluck("themes.name", "themes.id")
   end
 
+  def out_of_date?
+    commits_behind > 0 || remote_version != local_version
+  end
+
   def update_remote_version
     return unless is_git?
     importer = ThemeStore::GitImporter.new(remote_url, private_key: private_key, branch: branch)

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -58,9 +58,15 @@ def update_themes
       remote_theme = theme.remote_theme
       next if remote_theme.blank? || remote_theme.remote_url.blank?
 
-      puts "Updating '#{theme.name}' for '#{RailsMultisite::ConnectionManagement.current_db}'..."
-      remote_theme.update_from_remote
-      theme.save!
+      print "Checking '#{theme.name}' for '#{RailsMultisite::ConnectionManagement.current_db}'... "
+      remote_theme.update_remote_version
+      if remote_theme.out_of_date?
+        puts "updating from #{remote_theme.local_version[0..7]} to #{remote_theme.remote_version[0..7]}"
+        remote_theme.update_from_remote
+        theme.save!
+      else
+        puts "up to date"
+      end
 
       raise RemoteTheme::ImportError.new(remote_theme.last_error_text) if remote_theme.last_error_text.present?
     rescue => e


### PR DESCRIPTION
Running `update_from_remote` and `save!` cause a number of side-effects, including instructing all clients to reload CSS files. If there are no changes, then this is wasteful, and can even cause a 'flicker' effect on clients as they reload CSS.

This commit checks if any updates are available before triggering `update_from_remote` / `save!`. This should be much faster, and stop the 'flickering' UX from happening on every themes:update run.

It also improves the output of the command to include the from/to commit hashes, which may be useful for debugging issues. For example:

```
Checking 'Alien Night | A Dark Discourse Theme' for 'default'... already up to date
Checking 'Star Wars' for 'default'... updating from d8a170dd to 66b9756f
Checking 'Media Overlay' for 'default'... already up to date
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
