### PR TITLE
FIX: Tests should never cloak posts

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -7,7 +7,6 @@ import { createWidget } from "discourse/widgets/widget";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { h } from "virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
-import { isTesting } from "discourse-common/config/environment";
 import transformPost from "discourse/lib/transform-post";
 
 let transformCallbacks = null;
@@ -25,19 +24,23 @@ export function addPostTransformCallback(callback) {
   transformCallbacks.push(callback);
 }
 
-const CLOAKING_ENABLED = !isTesting();
+let _enabled = true;
 const DAY = 1000 * 60 * 60 * 24;
 
 const _dontCloak = {};
 let _cloaked = {};
 let _heights = {};
 
+export function disableCloaking() {
+  _enabled = false;
+}
+
 export function preventCloak(postId) {
   _dontCloak[postId] = true;
 }
 
 export function cloak(post, component) {
-  if (!CLOAKING_ENABLED || _cloaked[post.id] || _dontCloak[post.id]) {
+  if (!_enabled || _cloaked[post.id] || _dontCloak[post.id]) {
     return;
   }
 
@@ -50,7 +53,7 @@ export function cloak(post, component) {
 }
 
 export function uncloak(post, component) {
-  if (!CLOAKING_ENABLED || !_cloaked[post.id]) {
+  if (!_enabled || !_cloaked[post.id]) {
     return;
   }
   _cloaked[post.id] = null;

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -34,6 +34,7 @@ import { registerObjects } from "discourse/pre-initializers/inject-discourse-obj
 import sinon from "sinon";
 import { run } from "@ember/runloop";
 import { isLegacyEmber } from "discourse-common/config/environment";
+import { disableCloaking } from "discourse/widgets/post-stream";
 import { clearState as clearPresenceState } from "discourse/tests/helpers/presence-pretender";
 
 const Plugin = $.fn.modal;
@@ -183,6 +184,8 @@ function writeSummaryLine(message) {
 }
 
 function setupTestsCommon(application, container, config) {
+  disableCloaking();
+
   QUnit.config.hidepassed = true;
 
   application.rootElement = "#ember-testing";


### PR DESCRIPTION
Depending on the load order of modules, the post cloaking code might
not be disabled properly in test mode, which results in flakey failures.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
