### PR TITLE
FIX: Image sizes were slightly off in some cases

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -191,7 +191,6 @@ $quote-share-maxwidth: 150px;
 
   img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji) {
     max-width: 100%;
-    height: auto;
   }
 }
 


### PR DESCRIPTION
This fixes rare cases of layout shift caused by images appearing slightly smaller after being loaded.

For example, a 371x1031 image is uploaded. It gets lightboxed, with the generated thumbnail of size 179x500. `height: auto` changes that thumbnail's size (only after being loaded) to 179x497, causing a 3px shift.

I did not observe any regressions with this change.