### PR TITLE
DEV: Do not use hard-coded everyone group id

### DIFF
--- a/app/models/tag_user.rb
+++ b/app/models/tag_user.rb
@@ -11,10 +11,11 @@ class TagUser < ActiveRecord::Base
       .joins("LEFT OUTER JOIN tag_group_permissions ON tag_group_memberships.tag_group_id = tag_group_permissions.tag_group_id")
       .joins("LEFT OUTER JOIN group_users on group_users.user_id = tag_users.user_id")
       .where("(tag_group_permissions.group_id IS NULL
-               OR tag_group_permissions.group_id IN (0, group_users.group_id)
+               OR tag_group_permissions.group_id IN (:everyone_group_id, group_users.group_id)
                OR group_users.group_id = :staff_group_id)
               AND tag_users.notification_level IN (:notification_levels)",
              staff_group_id: Group::AUTO_GROUPS[:staff],
+             everyone_group_id: Group::AUTO_GROUPS[:everyone],
              notification_levels: notification_levels)
   }
 


### PR DESCRIPTION
Follow up to: 12f041de5d5ff147e82ab3d16132f0f5ad06d389

Probably best to lookup the "everyone" group_id instead of hard-coding
it to `0`. Also now its more clear what this `0` means.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
