### PR TITLE
FIX: Restore outlet in mobile views

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -133,9 +133,7 @@
       {{plugin-outlet name="above-timeline" connectorTagName="div"}}
 
       {{#topic-navigation class="topic-navigation" topic=model jumpToDate=(action "jumpToDate") jumpToIndex=(action "jumpToIndex") as |info|}}
-        {{#unless site.mobileView}}
-          {{plugin-outlet name="topic-navigation" connectorTagName="div" args=(hash topic=model)}}
-        {{/unless}}
+        {{plugin-outlet name="topic-navigation" connectorTagName="div" args=(hash topic=model)}}
 
         {{#if info.renderTimeline}}
           {{topic-timeline


### PR DESCRIPTION
This outlet is used on mobile by some theme components (like DiscoTOC). It was restricted to mobile only a few days ago in https://github.com/discourse/discourse/pull/15570, so this should be a safe change. 
