### PR TITLE
FEATURE: Allow sending group SMTP emails with from alias

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-smtp-email-settings.js
+++ b/app/assets/javascripts/discourse/app/components/group-smtp-email-settings.js
@@ -37,6 +37,7 @@ export default Component.extend({
       EmberObject.create({
         email_username: this.group.email_username,
         email_password: this.group.email_password,
+        email_from_alias: this.group.email_from_alias,
         smtp_server: this.group.smtp_server,
         smtp_port: (this.group.smtp_port || "").toString(),
         smtp_ssl: this.group.smtp_ssl,
@@ -73,6 +74,7 @@ export default Component.extend({
           smtp_port: this.form.smtp_port,
           smtp_ssl: this.form.smtp_ssl,
           email_username: this.form.email_username,
+          email_from_alias: this.form.email_from_alias,
           email_password: this.form.email_password,
         });
       })

--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -243,6 +243,7 @@ const Group = RestModel.extend({
       imap_mailbox_name: this.imap_mailbox_name,
       imap_enabled: this.imap_enabled,
       email_username: this.email_username,
+      email_from_alias: this.email_from_alias,
       email_password: this.email_password,
       flair_icon: null,
       flair_upload_id: null,

--- a/app/assets/javascripts/discourse/app/templates/components/group-manage-email-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-manage-email-settings.hbs
@@ -45,5 +45,5 @@
   </div>
 
   <br>
-  {{group-manage-save-button model=group disabled=(not emailSettingsValid) beforeSave=beforeSave afterSave=afterSave tabindex="14"}}
+  {{group-manage-save-button model=group disabled=(not emailSettingsValid) beforeSave=beforeSave afterSave=afterSave tabindex="15"}}
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/group-smtp-email-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-smtp-email-settings.hbs
@@ -8,11 +8,11 @@
 
       <div class="control-group">
         <label for="smtp_server">{{i18n "groups.manage.email.credentials.smtp_server"}}</label>
-        {{input type="text" name="smtp_server" value=form.smtp_server tabindex="3" onChange=(action "resetSettingsValid")}}
+        {{input type="text" name="smtp_server" value=form.smtp_server tabindex="4" onChange=(action "resetSettingsValid")}}
       </div>
 
       <label for="enable_ssl">
-        {{input type="checkbox" checked=form.smtp_ssl id="enable_ssl" tabindex="5" onChange=(action "resetSettingsValid")}}
+        {{input type="checkbox" checked=form.smtp_ssl id="enable_ssl" tabindex="6" onChange=(action "resetSettingsValid")}}
         {{i18n "groups.manage.email.credentials.smtp_ssl"}}
       </label>
     </div>
@@ -25,7 +25,15 @@
 
       <div class="control-group">
         <label for="smtp_port">{{i18n "groups.manage.email.credentials.smtp_port"}}</label>
-        {{input type="text" name="smtp_port" value=form.smtp_port tabindex="4" onChange=(action "resetSettingsValid" form.smtp_port)}}
+        {{input type="text" name="smtp_port" value=form.smtp_port tabindex="5" onChange=(action "resetSettingsValid" form.smtp_port)}}
+      </div>
+    </div>
+
+    <div>
+      <div class="control-group">
+        <label for="from_alias">{{i18n "groups.manage.email.settings.from_alias"}}</label>
+        {{input type="text" name="from_alias" id="from_alias" value=form.email_from_alias onChange=(action "resetSettingsValid") tabindex="3"}}
+        <p>{{i18n "groups.manage.email.settings.from_alias_hint"}}</p>
       </div>
     </div>
   </form>
@@ -43,7 +51,7 @@
     action=(action "testSmtpSettings")
     icon="cog"
     label="groups.manage.email.test_settings"
-    tabindex="6"
+    tabindex="7"
     title="groups.manage.email.settings_required"
     }}
 

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
@@ -106,6 +106,8 @@ acceptance(
 
       await fillIn('input[name="username"]', "myusername@gmail.com");
       await fillIn('input[name="password"]', "password@gmail.com");
+      await fillIn("#from_alias", "akasomegroup@example.com");
+
       await click(".test-smtp-settings");
 
       assert.ok(exists(".smtp-settings-ok"), "tested settings are ok");

--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -252,7 +252,7 @@ table.group-category-permissions {
 .group-imap-email-settings {
   .groups-form {
     display: grid;
-    grid-template-columns: 1fr 3fr;
+    grid-template-columns: 1fr 1fr 1fr;
     margin-bottom: 0;
 
     &.groups-form-imap {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -713,6 +713,7 @@ class GroupsController < ApplicationController
             :imap_updated_at,
             :email_username,
             :email_password,
+            :email_from_alias,
             :primary_group,
             :visibility_level,
             :members_visibility_level,

--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -48,7 +48,7 @@ class GroupSmtpMailer < ActionMailer::Base
       add_re_to_subject: true,
       locale: SiteSetting.default_locale,
       delivery_method_options: delivery_options,
-      from: from_group.email_username,
+      from: from_group.smtp_from_address,
       from_alias: I18n.t('email_from_without_site', user_name: group_name),
       html_override: html_override(post),
       cc: cc_addresses

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -110,7 +110,8 @@ class Group < ActiveRecord::Base
     "imap_port",
     "imap_ssl",
     "email_username",
-    "email_password"
+    "email_password",
+    "email_from_alias"
   ]
 
   ALIAS_LEVELS = {
@@ -288,6 +289,10 @@ class Group < ActiveRecord::Base
     else
       [ALIAS_LEVELS[:everyone]]
     end
+  end
+
+  def smtp_from_address
+    self.email_from_alias.present? ? self.email_from_alias : self.email_username
   end
 
   def downcase_incoming_email
@@ -708,7 +713,9 @@ class Group < ActiveRecord::Base
 
   def self.find_by_email(email)
     self.where(
-      "email_username = :email OR string_to_array(incoming_email, '|') @> ARRAY[:email]",
+      "email_username = :email OR
+        string_to_array(incoming_email, '|') @> ARRAY[:email] OR
+        email_from_alias = :email",
       email: Email.downcase(email)
     ).first
   end
@@ -1128,6 +1135,7 @@ end
 #  imap_enabled                       :boolean          default(FALSE)
 #  imap_updated_at                    :datetime
 #  imap_updated_by_id                 :integer
+#  email_from_alias                   :string
 #
 # Indexes
 #

--- a/app/serializers/group_show_serializer.rb
+++ b/app/serializers/group_show_serializer.rb
@@ -32,6 +32,7 @@ class GroupShowSerializer < BasicGroupSerializer
                    :imap_updated_by,
                    :email_username,
                    :email_password,
+                   :email_from_alias,
                    :imap_last_error,
                    :imap_old_emails,
                    :imap_new_emails,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -754,6 +754,8 @@ en:
             title: "Settings"
             allow_unknown_sender_topic_replies: "Allow unknown sender topic replies."
             allow_unknown_sender_topic_replies_hint: "Allows unknown senders to reply to group topics. If this is not enabled, replies from email addresses not already invited to the topic will create a new topic."
+            from_alias: "From Alias"
+            from_alias_hint: "Alias to use as the from address when sending group SMTP emails. Note this may not be supported by all mail providers, please consult your mail provider's documentation."
           mailboxes:
             synchronized: "Synchronized Mailbox"
             none_found: "No mailboxes were found in this email account."

--- a/db/migrate/20220124003259_add_email_from_alias_to_groups.rb
+++ b/db/migrate/20220124003259_add_email_from_alias_to_groups.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmailFromAliasToGroups < ActiveRecord::Migration[6.1]
+  def change
+    add_column :groups, :email_from_alias, :string, null: true
+  end
+end

--- a/spec/requests/api/schemas/json/group_response.json
+++ b/spec/requests/api/schemas/json/group_response.json
@@ -221,6 +221,12 @@
             "null"
           ]
         },
+        "email_from_alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "email_password": {
           "type": [
             "string",


### PR DESCRIPTION
This commit allows group SMTP emails to be sent with a
different from email address that has been set up as an
alias in the email provider. Emails from the alias will
be grouped correctly using Message-IDs in the mail client,
and replies to the alias go into the correct group inbox.

![image](https://user-images.githubusercontent.com/920448/150708700-3b267201-7b5f-492d-b527-b0f549d5e319.png)

