### PR TITLE
FIX: post mover validation color and message

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/move-to-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/move-to-topic.js
@@ -169,7 +169,7 @@ export default Controller.extend(ModalFunctionality, {
           DiscourseURL.routeTo(result.url);
         })
         .catch((xhr) => {
-          this.flash(extractError(xhr, I18n.t("topic.move_to.error")));
+          this.flash(extractError(xhr, I18n.t("topic.move_to.error")), "error");
         })
         .finally(() => {
           this.set("saving", false);

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -839,7 +839,7 @@ class TopicsController < ApplicationController
 
     destination_topic = move_posts_to_destination(topic)
     render_topic_changes(destination_topic)
-  rescue ActiveRecord::RecordInvalid => ex
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => ex
     render_json_error(ex)
   end
 

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -165,7 +165,7 @@ class PostMover
       guardian: Guardian.new(user),
       skip_jobs: true
     )
-    new_post = @post_creator.create
+    new_post = @post_creator.create!
 
     move_email_logs(post, new_post)
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -326,6 +326,19 @@ RSpec.describe TopicsController do
           expect(result['success']).to eq(false)
           expect(result['url']).to be_blank
         end
+
+        it 'returns validation error' do
+          PostCreator.any_instance.stubs(:skip_validations?).returns(false)
+          p1.update_columns(raw: "i", cooked: "")
+          post "/t/#{topic.id}/move-posts.json", params: {
+            post_ids: [p1.id],
+            destination_topic_id: dest_topic.id
+          }
+
+          expect(response.status).to eq(422)
+          result = response.parsed_body
+          expect(result['errors']).to eq(["Body is too short (minimum is 5 characters) and Body seems unclear, is it a complete sentence?"])
+        end
       end
     end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -327,8 +327,10 @@ RSpec.describe TopicsController do
           expect(result['url']).to be_blank
         end
 
-        it 'returns validation error' do
+        it 'returns plugin validation error' do
+          # stub here is to simulate validation added by plugin which would be triggered when post is moved
           PostCreator.any_instance.stubs(:skip_validations?).returns(false)
+
           p1.update_columns(raw: "i", cooked: "")
           post "/t/#{topic.id}/move-posts.json", params: {
             post_ids: [p1.id],


### PR DESCRIPTION
When the record is not saved, we should display a proper message.
One potential reason can be plugins for example discourse-calendar is specifying that only first post can contain event.

Before
<img width="585" alt="Screen Shot 2022-01-24 at 2 46 31 pm" src="https://user-images.githubusercontent.com/72780/150719196-57827051-ca10-4407-9283-acaaec882743.png">

After
<img width="688" alt="Screen Shot 2022-01-24 at 2 36 40 pm" src="https://user-images.githubusercontent.com/72780/150719189-ce205c7e-8e58-4aea-bfb9-9e998a75030d.png">



