### PR TITLE
Only block domains at the final destination

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -44,9 +44,9 @@ class FinalDestination
     @opts[:max_redirects] ||= 5
     @opts[:lookup_ip] ||= lambda { |host| FinalDestination.lookup_ip(host) }
 
-    @ignored = @opts[:ignore_hostnames] || []
     @limit = @opts[:max_redirects]
 
+    @ignored = []
     if @limit > 0
       ignore_redirects = [Discourse.base_url_no_prefix]
 

--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -61,7 +61,7 @@ class InlineOneboxer
       if uri.present? &&
         uri.hostname.present? &&
         (always_allow || allowed_domains.include?(uri.hostname)) &&
-        !domain_is_blocked?(uri.hostname)
+        !Onebox::DomainChecker.is_blocked?(uri.hostname)
         title = RetrieveTitle.crawl(url)
         title = nil if title && title.length < MIN_TITLE_LENGTH
         return onebox_for(url, title, opts)
@@ -72,12 +72,6 @@ class InlineOneboxer
   end
 
   private
-
-  def self.domain_is_blocked?(hostname)
-    SiteSetting.blocked_onebox_domains&.split('|').any? do |blocked|
-      hostname == blocked || hostname.end_with?(".#{blocked}")
-    end
-  end
 
   def self.onebox_for(url, title, opts)
     title = title && Emoji.gsub_emoji_to_unicode(title)

--- a/lib/onebox/domain_checker.rb
+++ b/lib/onebox/domain_checker.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Onebox
+  class DomainChecker
+    def self.is_blocked?(hostname)
+      SiteSetting.blocked_onebox_domains&.split('|').any? do |blocked|
+        hostname == blocked || hostname.end_with?(".#{blocked}")
+      end
+    end
+  end
+end

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -379,10 +379,6 @@ module Oneboxer
     end
   end
 
-  def self.blocked_domains
-    SiteSetting.blocked_onebox_domains.split("|")
-  end
-
   def self.preserve_fragment_url_hosts
     @preserve_fragment_url_hosts ||= ['http://github.com']
   end
@@ -420,7 +416,7 @@ module Oneboxer
         return error_box
       end
 
-      return blank_onebox if uri.blank? || blocked_domains.any? { |hostname| uri.hostname.match?(hostname) }
+      return blank_onebox if uri.blank? || Onebox::DomainChecker.is_blocked?(uri.hostname)
 
       onebox_options = {
         max_width: 695,
@@ -538,7 +534,6 @@ module Oneboxer
   def self.get_final_destination_options(url, strategy = nil)
     fd_options = {
       ignore_redirects: ignore_redirects,
-      ignore_hostnames: blocked_domains,
       force_get_hosts: force_get_hosts,
       force_custom_user_agent_hosts: force_custom_user_agent_hosts,
       preserve_fragment_url_hosts: preserve_fragment_url_hosts,

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -60,7 +60,7 @@ module RetrieveTitle
     encoding = nil
 
     fd.get do |_response, chunk, uri|
-      if (uri.present? && InlineOneboxer.domain_is_blocked?(uri.hostname))
+      if (uri.present? && Onebox::DomainChecker.is_blocked?(uri.hostname))
         throw :done
       end
 

--- a/spec/components/retrieve_title_spec.rb
+++ b/spec/components/retrieve_title_spec.rb
@@ -110,7 +110,6 @@ describe RetrieveTitle do
       stub_request(:get, "https://wikipedia.com/amazing")
         .to_return(status: 200, body: "<html><title>very amazing</title>", headers: {})
 
-      IPSocket.stubs(:getaddress).returns('100.2.3.4')
       expect(RetrieveTitle.crawl("http://foobar.com/amazing")).to eq(nil)
     end
 
@@ -126,7 +125,6 @@ describe RetrieveTitle do
       stub_request(:get, "https://cat.com/meow")
         .to_return(status: 200, body: "<html><title>very amazing</title>", headers: {})
 
-      IPSocket.stubs(:getaddress).returns('100.2.3.4')
       expect(RetrieveTitle.crawl("http://foobar.com/amazing")).to eq("very amazing")
     end
   end

--- a/spec/lib/onebox/domain_checker_spec.rb
+++ b/spec/lib/onebox/domain_checker_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Onebox::DomainChecker do
+  describe '.is_blocked?' do
+    before do
+      SiteSetting.blocked_onebox_domains = "api.cat.org|kitten.cloud"
+    end
+
+    describe "returns true when entirely matched" do
+      it { expect(described_class.is_blocked?("api.cat.org")).to be(true) }
+      it { expect(described_class.is_blocked?("kitten.cloud")).to be(true) }
+      it { expect(described_class.is_blocked?("api.dog.org")).to be(false) }
+      it { expect(described_class.is_blocked?("puppy.cloud")).to be(false) }
+    end
+
+    describe "returns true when ends with domain with . period" do
+      it { expect(described_class.is_blocked?("dev.api.cat.org")).to be(true) }
+      it { expect(described_class.is_blocked?(".api.cat.org")).to be(true) }
+      it { expect(described_class.is_blocked?("dev.kitten.cloud")).to be(true) }
+      it { expect(described_class.is_blocked?(".kitten.cloud")).to be(true) }
+      it { expect(described_class.is_blocked?("xapi.cat.org")).to be(false) }
+      it { expect(described_class.is_blocked?("xkitten.cloud")).to be(false) }
+    end
+  end
+end

--- a/spec/lib/onebox/domain_checker_spec.rb
+++ b/spec/lib/onebox/domain_checker_spec.rb
@@ -15,7 +15,7 @@ describe Onebox::DomainChecker do
       it { expect(described_class.is_blocked?("puppy.cloud")).to be(false) }
     end
 
-    describe "returns true when ends with domain with . period" do
+    describe "returns true when ends with .<domain>" do
       it { expect(described_class.is_blocked?("dev.api.cat.org")).to be(true) }
       it { expect(described_class.is_blocked?(".api.cat.org")).to be(true) }
       it { expect(described_class.is_blocked?("dev.kitten.cloud")).to be(true) }


### PR DESCRIPTION
Context: In an earlier [PR](https://github.com/discourse/discourse/pull/15656), we decided that we only want to block a domain if 
the blocked domain in the SiteSetting is the final destination (/t/59305). That 
PR used `FinalDestination#get`. `resolve` however is used several places
 but blocks domains along the redirect chain when certain options are provided.

This commit changes the default options for `resolve` to not do that. Existing
users of `FinalDestination#resolve` are
- `Oneboxer#external_onebox`
- our onebox helper `fetch_html_doc`, which is used in amazon, standard embed 
and youtube
  - these folks already go through `Oneboxer#external_onebox` which already
  blocks correctly

Related note:
The next thing to do in another PR is to consolidate resolution of canonical URLs 
and make sure they are blocked the same way.