### PR TITLE
FIX: Single line emojis has emoji metadata indexed twice.

### DIFF
--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -328,7 +328,7 @@ class SearchIndexer
         end
       end
 
-      document.css("img[class='emoji']").each do |node|
+      document.css("img.emoji").each do |node|
         node.remove_attribute("alt")
       end
 

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -61,8 +61,10 @@ describe SearchIndexer do
   end
 
   it 'extracts emoji name from emoji image' do
-    html = %Q|<img src="#{Discourse.base_url_no_prefix}/images/emoji/twitter/wink.png?v=9" title=":wink:" class="emoji" alt=":wink:">|
+    emoji = Emoji["wink"]
+    html = %Q|<img src=\"#{URI.join(Discourse.base_url_no_prefix, emoji.url)}\" title=\":wink:\" class=\"emoji only-emoji\" alt=\":wink:\">|
     scrubbed = scrub(html)
+
     expect(scrubbed).to eq(':wink:')
   end
 


### PR DESCRIPTION
This commit fixes a bug where we our `HTMLScrubber` was only searching
for emoji img tags which contains only the "emoji" class. However, our emoji image tags
may contain more than just the "emoji" class like "only-emoji" when an
emoji exists by itself on a single line.