### PR TITLE
Use non-builtin net-pop, net-imap and net-smtp for Ruby 3.1+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,14 @@ gem 'cose', require: false
 gem 'addressable'
 gem 'json_schemer'
 
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1")
+  # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1
+  gem "net-smtp", "~> 0.2.1", require: false
+  gem "net-imap", "~> 0.2.1", require: false
+  gem "net-pop", "~> 0.1.1", require: false
+  gem "digest", "3.0.0", require: false
+end
+
 # Gems used only for assets and not required in production environments by default.
 # Allow everywhere for now cause we are allowing asset debugging in production
 group :assets do


### PR DESCRIPTION
Ruby 3.1+ do not include net-pop, net-imap or net-smtp as builtin gems. This uses non-builtin gems for them for Ruby 3.1+. The non-builtin digest gem is a transitive dependency - it will be listed in Gemfile.lock when the non-builtin net-pop, etc. are used. I list it here to make sure we get a good compatible version of it with net-pop, etc.

This shouldn't change the Gemfile.lock for pre-3.1 Ruby, though it does for 3.1 and up.