### PR TITLE
DEV: Use flex instead of float/clearfix for posts

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -585,7 +585,7 @@ createWidget("post-notice", {
 });
 
 createWidget("post-body", {
-  tagName: "div.topic-body.clearfix",
+  tagName: "div.topic-body",
 
   html(attrs, state) {
     const postContents = this.attach("post-contents", attrs);

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -882,10 +882,14 @@ aside.quote {
 }
 
 .topic-body {
-  // this is necessary for ANYTHING that extends past the right edge of
-  // the post body, such as an image in a deeply nested list, image in
-  // a deeply nested blockquote, and so on.. you get the idea.
+  .row {
+    display: flex;
+  }
+
   .cooked {
+    // this is necessary for ANYTHING that extends past the right edge of
+    // the post body, such as an image in a deeply nested list, image in
+    // a deeply nested blockquote, and so on.. you get the idea.
     overflow: hidden;
 
     .button-wrapper {

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -881,8 +881,14 @@ aside.quote {
   }
 }
 
+.topic-post .row {
+  align-items: flex-start;
+  display: flex;
+}
+
 .topic-body {
   .row {
+    align-items: flex-start;
     display: flex;
   }
 

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -474,10 +474,10 @@ blockquote {
 // variables are used to calculate the width of .gap
 .topic-body {
   width: calc(#{$topic-body-width} + (#{$topic-body-width-padding} * 2));
-  float: left;
   position: relative;
   border-top: 1px solid var(--primary-low);
   padding: 12px 0 0 0;
+
   .topic-meta-data {
     padding: 0 $topic-body-width-padding 0.25em $topic-body-width-padding;
   }
@@ -496,7 +496,6 @@ blockquote {
   border-top: 1px solid var(--primary-low);
   padding-top: 15px;
   width: $topic-avatar-width;
-  float: left;
   z-index: z("base") + 1;
 }
 


### PR DESCRIPTION
Should not result in any visual changes in the topic view, but should fix layout issues in discourse-docs for topics using discourseTOC, e.g. https://meta.discourse.org/docs?topic=63116 (notice the topic content is pushed below the avatar)