### PR TITLE
Use Xorcist.xor! instead of refinements

### DIFF
--- a/lib/pbkdf2.rb
+++ b/lib/pbkdf2.rb
@@ -5,11 +5,8 @@
 
 require 'openssl'
 require 'xorcist'
-require 'xorcist/refinements'
 
 class Pbkdf2
-  using Xorcist::Refinements
-
   def self.hash_password(password, salt, iterations, algorithm = "sha256")
 
     h = OpenSSL::Digest.new(algorithm)
@@ -18,7 +15,7 @@ class Pbkdf2
 
     2.upto(iterations) do
       u = prf(h, password, u)
-      ret.xor!(u)
+      Xorcist.xor!(ret, u)
     end
 
     ret.bytes.map { |b| ("0" + b.to_s(16))[-2..-1] }.join("")


### PR DESCRIPTION
Ruby 3.2+ removes Refinement-include, so using the Xorcist refinements fails. But it's straightforward to call Xorcist directly.

This functionality is used by all existing tests that hash passwords, e.g. spec/models/user.rb and spec/models/user_spec.rb, which test specific hex values as results.
