### PR TITLE
FIX: Client app should be able to route ID-less topic URLs

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/topic-by-slug-or-id.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-by-slug-or-id.js
@@ -9,7 +9,9 @@ export default DiscourseRoute.extend({
     if (params.slugOrId.match(ID_CONSTRAINT)) {
       return { url: `/t/topic/${params.slugOrId}` };
     } else {
-      return Topic.idForSlug(params.slugOrId);
+      return Topic.idForSlug(params.slugOrId).then((data) => {
+        return { url: `/t/${data.slug}/${data.topic_id}` };
+      });
     }
   },
 


### PR DESCRIPTION
The topic ID portion of the topic URL is optional in Discourse as long as the topic slug is unique across the site. If you navigate to a topic without the ID in the URL, Discourse will redirect you to the canonical version of the URL that includes the ID.

However, we have a now regression where the client app doesn't correctly handle ID-less topic URLs displays an error message when the user clicks on such URL. The regression was introduced https://github.com/discourse/discourse/commit/b537d591b361915498abb582926c00a77044dfe2 when we switched from `DiscourseURL.routeTo` to using Ember's router to perform the redirecting to the canonical version of the URL, but the problem is that the canonical version comes from the server and it contains the hostname which the Ember router doesn't understand because it expects a relative URL.

This PR fixes the problem by constructing a relative URL that contains the topic slug and ID and passing that to the Ember route.