### PR TITLE
FIX: Liking whispers should not contribute to `Topic#like_count`.

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -239,8 +239,7 @@ class PostAction < ActiveRecord::Base
     end
 
     if column == "like_count"
-      topic_count = Post.where(topic_id: topic_id).sum(column)
-      Topic.where(id: topic_id).update_all ["#{column} = ?", topic_count]
+      Topic.find_by(id: topic_id)&.update_action_counts
     end
 
   end

--- a/db/migrate/20220125052845_fix_topic_like_count_including_whispers.rb
+++ b/db/migrate/20220125052845_fix_topic_like_count_including_whispers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class FixTopicLikeCountIncludingWhispers < ActiveRecord::Migration[6.0]
+  def up
+    whisper_post_type = 4
+
+    DB.exec(<<~SQL)
+      UPDATE topics SET like_count = tbl.like_count
+      FROM (
+        SELECT topic_id, SUM(like_count) like_count
+        FROM posts
+        WHERE deleted_at IS NULL
+        AND post_type <> #{whisper_post_type}
+        GROUP BY topic_id
+      ) AS tbl
+      WHERE topics.id = tbl.topic_id
+        AND topics.like_count <> tbl.like_count
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -456,6 +456,16 @@ describe PostAction do
       expect(notification.notification_type).to eq(Notification.types[:liked])
     end
 
+    it 'should not increase topic like count when liking a whisper' do
+      SiteSetting.set(:enable_whispers, true)
+      post.revise(admin, post_type: Post.types[:whisper])
+
+      PostActionCreator.like(admin, post)
+
+      expect(post.reload.like_count).to eq(1)
+      expect(post.topic.like_count).to eq(0)
+    end
+
     it 'should increase the `like_count` and `like_score` when a user likes something' do
       freeze_time Date.today
 


### PR DESCRIPTION
 Non-staff users are not allowed to see whisper so this change prevents
 non-staff user from seeing a like count that does not make sense to
 them. In the future, we might consider adding another like count column
 for staff user.
    
 Follow-up to 44927188643e26b58c41626be54df3596f0dfbe2