### PR TITLE
DEV: Move OAuth2UserInfo deprecation to after_save

### DIFF
--- a/app/models/oauth2_user_info.rb
+++ b/app/models/oauth2_user_info.rb
@@ -3,7 +3,7 @@
 class Oauth2UserInfo < ActiveRecord::Base
   belongs_to :user
 
-  after_initialize do
+  before_save do
     Discourse.deprecate("Oauth2UserInfo is deprecated. Use `ManagedAuthenticator` and `UserAssociatedAccount` instead. For more information, see https://meta.discourse.org/t/106695", drop_from: '2.9.0', output_in_test: true)
   end
 end


### PR DESCRIPTION
We initialize objects as part of the warmup process in production, so this was being logged on every boot. We only want to log if a plugin is actually using the model, so after_save is a safer bet.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
