### PR TITLE
FIX: Allow staff to reset passwords by username

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -429,7 +429,7 @@ const User = RestModel.extend({
   changePassword() {
     return ajax("/session/forgot_password", {
       dataType: "json",
-      data: { login: this.email },
+      data: { login: this.email || this.username },
       type: "POST",
     });
   },

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -434,7 +434,7 @@ class SessionController < ApplicationController
     RateLimiter.new(nil, "forgot-password-hr-#{request.remote_ip}", 6, 1.hour).performed!
     RateLimiter.new(nil, "forgot-password-min-#{request.remote_ip}", 3, 1.minute).performed!
 
-    user = if SiteSetting.hide_email_address_taken
+    user = if SiteSetting.hide_email_address_taken && !current_user&.staff?
       raise Discourse::InvalidParameters.new(:login) if EmailValidator.email_regex !~ normalized_login_param
       User.real.where(staged: false).find_by_email(Email.downcase(normalized_login_param))
     else

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -2072,6 +2072,16 @@ describe SessionController do
         expect(Jobs::CriticalUserEmail.jobs.size).to eq(0)
       end
 
+      it 'allows for username when staff' do
+        sign_in(Fabricate(:admin))
+
+        post "/session/forgot_password.json",
+          params: { login: user.username }
+
+        expect(response.status).to eq(200)
+        expect(Jobs::CriticalUserEmail.jobs.size).to eq(1)
+      end
+
       it 'allows for email' do
         post "/session/forgot_password.json",
           params: { login: user.email }


### PR DESCRIPTION
When staff visits the user profile of another user, the `email` field
in the model is empty. In this case, staff cannot send the reset email
password because nothing is passed in the `login` field.

This commit changes the behavior for staff users to allow resetting
password by username instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
