### PR TITLE
Revert "DEV: Run Ember CLI tests in random order"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,15 +232,15 @@ jobs:
 
       - name: Core QUnit 1
         working-directory: ./app/assets/javascripts/discourse
-        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=1 --launch "${{ matrix.browser }}" --random
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=1 --launch "${{ matrix.browser }}"
         timeout-minutes: 20
 
       - name: Core QUnit 2
         working-directory: ./app/assets/javascripts/discourse
-        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=2 --launch "${{ matrix.browser }}" --random
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=2 --launch "${{ matrix.browser }}"
         timeout-minutes: 20
 
       - name: Core QUnit 3
         working-directory: ./app/assets/javascripts/discourse
-        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=3 --launch "${{ matrix.browser }}" --random
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=3 --launch "${{ matrix.browser }}"
         timeout-minutes: 20

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -34,13 +34,6 @@ document.addEventListener("discourse-booted", () => {
   setup(QUnit.assert);
   setupTests(config.APP);
   let loader = loadEmberExam();
-
-  if (loader.urlParams.size === 0 && !QUnit.config.seed) {
-    // If we're running in browser, default to random order. Otherwise, let Ember Exam
-    // handle randomization.
-    QUnit.config.seed = true;
-  }
-
   loader.loadModules();
   start({
     setupTestContainer: false,


### PR DESCRIPTION
This reverts commit f43bba8d597f511b6c6eeab77045f332ca6d906a.

Adding randomness has introduced a lot of flakiness in our ember-cli tests. We should fix those issues at the source. However, given the upcoming stable release, this randomness has been reverted so that the stable release includes a stable test suite. Having a stable test suite on stable will make backporting future commits much easier.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
