### PR TITLE
DEV: Update cppjieba_rb to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     cose (1.2.0)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
-    cppjieba_rb (0.3.3)
+    cppjieba_rb (0.4.2)
     crack (0.4.5)
       rexml
     crass (1.0.6)


### PR DESCRIPTION
Ruby 3.2 removes the constant rb_cData for C extensions. cppjieba_rb before version 0.4.2 uses that now-removed constant. This PR updates cppjieba_rb to a Ruby 3.2-compatible version.