### PR TITLE
DEV: Add backwards-compat for SiteSettings/User globals in ember-cli

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/inject-objects.js
+++ b/app/assets/javascripts/discourse/app/initializers/inject-objects.js
@@ -11,7 +11,6 @@ export default {
 
     // Backwards compatibility for Discourse.SiteSettings and Discourse.User
     if (!isLegacyEmber()) {
-      app.yolo = "abc";
       Object.defineProperty(app, "SiteSettings", {
         get() {
           deprecated(

--- a/app/assets/javascripts/discourse/app/initializers/inject-objects.js
+++ b/app/assets/javascripts/discourse/app/initializers/inject-objects.js
@@ -1,9 +1,41 @@
 import { setDefaultOwner } from "discourse-common/lib/get-owner";
+import { isLegacyEmber } from "discourse-common/config/environment";
+import User from "discourse/models/user";
+import deprecated from "discourse-common/lib/deprecated";
 
 export default {
   name: "inject-objects",
   initialize(container, app) {
     // This is required for Ember CLI tests to work
     setDefaultOwner(app.__container__);
+
+    // Backwards compatibility for Discourse.SiteSettings and Discourse.User
+    if (!isLegacyEmber()) {
+      app.yolo = "abc";
+      Object.defineProperty(app, "SiteSettings", {
+        get() {
+          deprecated(
+            `use injected siteSettings instead of Discourse.SiteSettings`,
+            {
+              since: "2.8",
+              dropFrom: "2.9",
+            }
+          );
+          return container.lookup("site-settings:main");
+        },
+      });
+      Object.defineProperty(app, "User", {
+        get() {
+          deprecated(
+            `import discourse/models/user instead of using Discourse.User`,
+            {
+              since: "2.8",
+              dropFrom: "2.9",
+            }
+          );
+          return User;
+        },
+      });
+    }
   },
 };


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
