### PR TITLE
FIX: aria label for popup-input-tip

### DIFF
--- a/app/assets/javascripts/discourse/app/components/popup-input-tip.js
+++ b/app/assets/javascripts/discourse/app/components/popup-input-tip.js
@@ -5,7 +5,7 @@ import { getOwner } from "discourse-common/lib/get-owner";
 
 export default Component.extend({
   classNameBindings: [":popup-tip", "good", "bad", "lastShownAt::hide"],
-  attributeBindings: ["role"],
+  attributeBindings: ["role", "ariaLabel"],
   rerenderTriggers: ["validation.reason"],
   tipReason: null,
   lastShownAt: or("shownAt", "validation.lastShownAt"),
@@ -17,6 +17,11 @@ export default Component.extend({
     if (bad) {
       return "alert";
     }
+  },
+
+  @discourseComputed("validation.reason")
+  ariaLabel(reason) {
+    return reason?.replace(/(<([^>]+)>)/gi, "");
   },
 
   click() {


### PR DESCRIPTION
popup-input-tip is used for composer validation.
Aria label is essential to for accessibility.
Also, HTML tags have to be removed
