### PR TITLE
UX: Add text-decoration to <ins> and <del>

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -144,17 +144,17 @@ $quote-share-maxwidth: 150px;
     word-wrap: break-word;
   }
 
-  del,
-  ins,
   mark {
     text-decoration: none;
   }
 
   ins {
     background-color: var(--success-low);
+    text-decoration: underline;
   }
   del {
     background-color: var(--danger-low);
+    text-decoration: line-through;
   }
   mark {
     background-color: var(--highlight);


### PR DESCRIPTION
My naive stab at https://meta.discourse.org/t/styling-of-ins-and-del/208017, adding underline and strikethrough styling to `<ins>` and `<del>` elements in post content.

I dug around in `spec` and found some assertions dealing with those elements in content, but not their styling. I didn't see a way to test styling on the client side, so haven't included a test with this change. I'll be happy to try and add one if someone can point out an existing test to crib from.

My main question is whether this style change will inadvertently change how `<ins>` and `<del>` are styled in other contexts where text decoration may not be wanted.

From a brief `git grep` in `app/assets/stylesheets`, the only other stylesheet I see with a stanza for `<ins>` is `common/base/history.scss`. Both `<ins>` and `<del>` have `text-decoration: none;` there, so I am holding out hope there will be no conflict.

I don't see other use of literal `<ins>` in the codebase, outside of tests and the diff implementation.