### PR TITLE
DEV: addPrettyTextAdditionalOptions plugin API

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -36,6 +36,7 @@ import {
   registerIconRenderer,
   replaceIcon,
 } from "discourse-common/lib/icon-library";
+import { addPrettyTextOptions } from "discourse/lib/text";
 import Composer, {
   registerCustomizationCallback,
 } from "discourse/models/composer";
@@ -97,7 +98,7 @@ import { downloadCalendar } from "discourse/lib/download-calendar";
 // based on Semantic Versioning 2.0.0. Please up the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-const PLUGIN_API_VERSION = "1.1.0";
+const PLUGIN_API_VERSION = "1.2.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {
@@ -1598,6 +1599,35 @@ class PluginApi {
    */
   customizeComposerText(callbacks) {
     registerCustomizationCallback(callbacks);
+  }
+
+  /**
+   * When writing markdown rules and features, additional options not part of
+   * the main options payload may be needed for the rule. Rules cannot access
+   * things like the Site or current User objects which can have serialized data
+   * which may be useful when rendering markdown rules.
+   *
+   *
+   * ```
+   * const site = api.container.lookup("site:main");
+   * api.addPrettyTextAdditionalOptions({
+   *   someSiteOption: site.some_option
+   * })
+   * ```
+   *
+   * These options are passed down to several of the markdown helper functions
+   * created by discourse-markdown-it extensions, such as registerPlugin and registerOptions,
+   * and can be accessed like so:
+   *
+   * ```
+   * opts.discourse.additionalOptions.someSiteOption
+   * ```
+   *
+   * These options are held in a separate additionalOptions namespace because
+   * they are _not_ meant to override the core pretty-text options.
+   */
+  addPrettyTextAdditionalOptions(pluginId, options) {
+    addPrettyTextOptions(pluginId, options);
   }
 }
 

--- a/app/assets/javascripts/discourse/app/lib/text.js
+++ b/app/assets/javascripts/discourse/app/lib/text.js
@@ -40,7 +40,9 @@ function getOpts(opts) {
       watchedWordsLink: context.site.watched_words_link,
     },
     opts,
-    { additionalOptions: additionalPrettyTextOptions }
+    {
+      additionalOptions: additionalPrettyTextOptions,
+    }
   );
 
   return buildOptions(opts);

--- a/app/assets/javascripts/discourse/app/lib/text.js
+++ b/app/assets/javascripts/discourse/app/lib/text.js
@@ -10,6 +10,21 @@ import { htmlSafe } from "@ember/template";
 import loadScript from "discourse/lib/load-script";
 import { sanitize as textSanitize } from "pretty-text/sanitizer";
 
+let additionalPrettyTextOptions = {};
+
+export function cleanUpAdditionalPrettyTextOptions() {
+  additionalPrettyTextOptions = {};
+}
+
+export function addPrettyTextOptions(pluginNamespace, additionalOptions) {
+  additionalPrettyTextOptions[pluginNamespace] =
+    additionalPrettyTextOptions[pluginNamespace] || {};
+  Object.assign(
+    additionalPrettyTextOptions[pluginNamespace],
+    additionalOptions
+  );
+}
+
 function getOpts(opts) {
   let context = helperContext();
 
@@ -24,7 +39,8 @@ function getOpts(opts) {
       watchedWordsReplace: context.site.watched_words_replace,
       watchedWordsLink: context.site.watched_words_link,
     },
-    opts
+    opts,
+    { additionalOptions: additionalPrettyTextOptions }
   );
 
   return buildOptions(opts);
@@ -83,7 +99,7 @@ function loadMarkdownIt() {
   });
 }
 
-function createPrettyText(options) {
+export function createPrettyText(options) {
   return new PrettyText(getOpts(options));
 }
 

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -27,6 +27,7 @@ import { resetPostMenuExtraButtons } from "discourse/widgets/post-menu";
 import { isEmpty } from "@ember/utils";
 import { resetCustomPostMessageCallbacks } from "discourse/controllers/topic";
 import { resetDecorators } from "discourse/widgets/widget";
+import { cleanUpAdditionalPrettyTextOptions } from "discourse/lib/text";
 import { resetCache as resetOneboxCache } from "pretty-text/oneboxer";
 import { resetDecorators as resetPluginOutletDecorators } from "discourse/components/plugin-connector";
 import { resetDecorators as resetPostCookedDecorators } from "discourse/widgets/post-cooked";
@@ -173,6 +174,7 @@ function testCleanup(container, app) {
   clearDesktopNotificationHandlers();
   resetLastEditNotificationClick();
   clearAuthMethods();
+  cleanUpAdditionalPrettyTextOptions();
   setTestPresence(true);
   if (!LEGACY_ENV) {
     clearPresenceCallbacks();

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1,4 +1,5 @@
 import PrettyText, { buildOptions } from "pretty-text/pretty-text";
+import { addPrettyTextOptions, createPrettyText } from "discourse/lib/text";
 import {
   applyCachedInlineOnebox,
   deleteCachedInlineOnebox,
@@ -1755,6 +1756,20 @@ var bar = 'bar';
       opts,
       `<p>${"you".repeat(maxMatches)}one</p>`,
       "does not loop infinitely"
+    );
+  });
+
+  test("additionalPrettyTextOptions adds more options under a plugin namespace", function (assert) {
+    addPrettyTextOptions("pluginA", { someOption: "test" });
+    addPrettyTextOptions("pluginB", { doorNumberTwo: "other thing" });
+    const prettyText = createPrettyText();
+    assert.equal(
+      prettyText.opts.discourse.additionalOptions.pluginA.someOption,
+      "test"
+    );
+    assert.equal(
+      prettyText.opts.discourse.additionalOptions.pluginB.doorNumberTwo,
+      "other thing"
     );
   });
 });

--- a/app/assets/javascripts/pretty-text/addon/pretty-text.js
+++ b/app/assets/javascripts/pretty-text/addon/pretty-text.js
@@ -40,6 +40,7 @@ export function buildOptions(state) {
     watchedWordsLink,
     featuresOverride,
     markdownItRules,
+    additionalOptions,
   } = state;
 
   let features = {};
@@ -80,6 +81,7 @@ export function buildOptions(state) {
     watchedWordsLink,
     featuresOverride,
     markdownItRules,
+    additionalOptions,
   };
 
   // note, this will mutate options due to the way the API is designed

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,15 @@ in this file..
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2021-01-27
+### Added
+- Adds `addPrettyTextAdditionalOptions`. When writing markdown rules and features,
+additional options not part of the main options payload may be needed for the rule.
+Rules cannot access things like the Site or current User objects which can have
+serialized data which may be useful when rendering markdown rules. These additional
+options are added beneath an `additionalOptions.pluginId` namespace on `opts.discourse` when
+passed to markdown rules.
+
 ## [1.1.0] - 2021-12-15
 ### Added
 - Adds `addPosterIcons`, which allows users to add multiple icons to a poster. The

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -95,6 +95,8 @@ class DiscoursePluginRegistry
 
   define_filtered_register :notification_consolidation_plans
 
+  define_filtered_register :pretty_text_additional_options
+
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -956,6 +956,12 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_push_notification_filter(block, self)
   end
 
+  # Registers additional options passed to pretty-text at compile time,
+  # companion to additionalOptions in JS.
+  def register_pretty_text_additional_option(namespace, options)
+    DiscoursePluginRegistry.register_pretty_text_additional_option({ namespace => options }, self)
+  end
+
   # Register a ReviewableScore setting_name associated with a reason.
   # We'll use this to build a site setting link and add it to the reason's translation.
   #

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -179,6 +179,8 @@ module PrettyText
       custom_emoji = {}
       Emoji.custom.map { |e| custom_emoji[e.name] = e.url }
 
+      additional_options = Hash[*DiscoursePluginRegistry.pretty_text_additional_options]
+
       buffer = +<<~JS
         __optInput = {};
         __optInput.siteSettings = #{SiteSetting.client_settings_json};
@@ -201,6 +203,7 @@ module PrettyText
         __optInput.censoredRegexp = #{WordWatcher.word_matcher_regexp(:censor)&.source.to_json};
         __optInput.watchedWordsReplace = #{WordWatcher.word_matcher_regexps(:replace).to_json};
         __optInput.watchedWordsLink = #{WordWatcher.word_matcher_regexps(:link).to_json};
+        __optInput.additionalOptions = #{additional_options.to_json};
       JS
 
       if opts[:topic_id]


### PR DESCRIPTION
When writing markdown rules and features, additional options not part of
the main options payload may be needed for the rule. Rules cannot access
things like the Site or current User objects which can have serialized data
which may be useful when rendering markdown rules.

```
const site = api.container.lookup("site:main");
api.addPrettyTextAdditionalOptions({
 someSiteOption: site.some_option
})
```

These options are passed down to several of the markdown helper functions
created by discourse-markdown-it extensions, such as registerPlugin and registerOptions,
and can be accessed like so:

```
opts.discourse.additionalOptions.someSiteOption
```

These options are held in a separate additionalOptions namespace because
they are _not_ meant to override the core pretty-text options.

-----

The main motivation for adding this is the chat plugin, which stores
`chat_pretty_text_features` and `chat_pretty_text_markdown_rules` on
the Site object via additions to the serializer, and the Site object is
not accessible to import via markdown rules (either through
Site.current() or through container.lookup)

