### PR TITLE
FEATURE: custom d-wrap tag

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/d-wrap.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/d-wrap.js
@@ -3,12 +3,22 @@ import { parseBBCodeTag } from "pretty-text/engines/discourse-markdown/bbcode-bl
 const WRAP_CLASS = "d-wrap";
 
 function parseAttributes(tagInfo) {
-  const attributes = tagInfo.attrs._default || "";
+  const wrap = "wrap";
 
-  return (
-    parseBBCodeTag(`[wrap wrap=${attributes}]`, 0, attributes.length + 12)
-      .attrs || {}
-  );
+  if (tagInfo.tag === wrap) {
+    const attributes = tagInfo.attrs._default || tagInfo.attrs;
+    return (
+      parseBBCodeTag(
+        `[${wrap} ${wrap}=${attributes}]`,
+        0,
+        attributes.length + wrap.length * 2 + 4
+      ).attrs || {}
+    );
+  } else {
+    const attributes = tagInfo.attrs;
+    attributes[wrap] = tagInfo.tag;
+    return attributes;
+  }
 }
 
 function camelCaseToDash(str) {
@@ -22,50 +32,65 @@ function applyDataAttributes(token, state, attributes) {
       state.md.utils.escapeHtml(tag.replace(/[^A-Za-z\-0-9]/g, ""))
     );
 
-    if (value && tag && tag.length > 1) {
+    if (value && tag?.length) {
       token.attrs.push([`data-${tag}`, value]);
     }
   });
 }
 
-const blockRule = {
-  tag: "wrap",
+function blockRule(tag) {
+  return {
+    tag,
 
-  before(state, tagInfo) {
-    let token = state.push("wrap_open", "div", 1);
-    token.attrs = [["class", WRAP_CLASS]];
+    before(state, tagInfo) {
+      let token = state.push("wrap_open", "div", 1);
+      token.attrs = [["class", WRAP_CLASS]];
 
-    applyDataAttributes(token, state, parseAttributes(tagInfo));
-  },
+      applyDataAttributes(token, state, parseAttributes(tagInfo));
+    },
 
-  after(state) {
-    state.push("wrap_close", "div", -1);
-  },
-};
+    after(state) {
+      state.push("wrap_close", "div", -1);
+    },
+  };
+}
 
-const inlineRule = {
-  tag: "wrap",
+function inlineRule(tag) {
+  return {
+    tag,
 
-  replace(state, tagInfo, content) {
-    let token = state.push("wrap_open", "span", 1);
-    token.attrs = [["class", WRAP_CLASS]];
+    replace(state, tagInfo, content) {
+      let token = state.push("wrap_open", "span", 1);
+      token.attrs = [["class", WRAP_CLASS]];
 
-    applyDataAttributes(token, state, parseAttributes(tagInfo));
+      applyDataAttributes(token, state, parseAttributes(tagInfo));
 
-    if (content) {
-      token = state.push("text", "", 0);
-      token.content = content;
-    }
+      if (content) {
+        token = state.push("text", "", 0);
+        token.content = content;
+      }
 
-    state.push("wrap_close", "span", -1);
-    return true;
-  },
-};
+      state.push("wrap_close", "span", -1);
+      return true;
+    },
+  };
+}
 
 export function setup(helper) {
+  helper.registerOptions((opts, siteSettings) => {
+    opts.features.customWrapTags = [
+      ...new Set(
+        siteSettings.custom_wrap_tags.split("|").filter(Boolean).concat("wrap")
+      ),
+    ];
+  });
+
   helper.registerPlugin((md) => {
-    md.inline.bbcode.ruler.push("inline-wrap", inlineRule);
-    md.block.bbcode.ruler.push("block-wrap", blockRule);
+    const tags = md.options.discourse.features.customWrapTags;
+    tags.forEach((tag) => {
+      md.inline.bbcode.ruler.push("inline-wrap", inlineRule(tag));
+      md.block.bbcode.ruler.push("block-wrap", blockRule(tag));
+    });
   });
 
   helper.allowList([`div.${WRAP_CLASS}`, `span.${WRAP_CLASS}`, "span[data-*]"]);

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -937,6 +937,11 @@ posting:
   autohighlight_all_code:
     client: true
     default: false
+  custom_wrap_tags:
+    default: ""
+    type: list
+    client: true
+    list_type: compact
   highlighted_languages:
     default: "apache|bash|cs|cpp|css|coffeescript|diff|xml|http|ini|json|java|javascript|makefile|markdown|nginx|objectivec|ruby|perl|php|python|sql|handlebars"
     choices: "HighlightJs.languages"

--- a/spec/components/pretty_text/d_wrap_spec.rb
+++ b/spec/components/pretty_text/d_wrap_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'd-wrap' do
+  context 'default wrap syntax' do
+    it 'wraps it' do
+      cooked = PrettyText.cook("[wrap=foo bar=1]\n[/wrap]")
+      expect(cooked).to match_html("<div class=\"d-wrap\" data-wrap=\"foo\" data-bar=\"1\"></div>")
+
+      cooked = PrettyText.cook("[wrap=foo bar=1][/wrap]")
+      expect(cooked).to match_html("<p><span class=\"d-wrap\" data-wrap=\"foo\" data-bar=\"1\"></span></p>")
+    end
+  end
+
+  context 'custom wrap syntax' do
+    context 'custom tag is defined' do
+      before do
+        SiteSetting.custom_wrap_tags = 'foo'
+      end
+
+      it 'wraps it' do
+        cooked = PrettyText.cook("[foo bar=1]\n[/foo]")
+        expect(cooked).to match_html("<div class=\"d-wrap\" data-bar=\"1\" data-wrap=\"foo\"></div>")
+      end
+    end
+
+    context 'custom tag is not defined' do
+      it 'doesn’t wrap it' do
+        cooked = PrettyText.cook("[foo bar=1]\n[/foo]")
+        expect(cooked).to match_html("<p>[foo bar=1]<br>[/foo]</p>")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows to define custom wrap tags using the `custom_wrap_tags` site setting. Adding  `foo` as custom wrap tag will allow to write:

```
[foo bar=1]
[/foo]
```

instead of

```
[wrap=foo bar=1]
[/wrap]
```

Both will result in the same output.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
