### PR TITLE
FIX: Use the category's text-only description in the category-chooser

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -68,6 +68,8 @@ export default {
           post_count: 1023,
           description:
             "Discussion about meta.discourse.org itself, the organization of this forum about Discourse, how it works, and how we can improve this site.",
+          description_text:
+            "Discussion about meta.discourse.org itself, the organization of this forum about Discourse, how it works, and how we can improve this site.",
           topic_url: "/t/category-definition-for-meta/24",
           read_restricted: false,
           permission: 1,
@@ -87,6 +89,8 @@ export default {
           post_count: 1022,
           description:
             "Tutorial topics that describe how to set up, configure, or install Discourse using a specific platform or environment. Topics in this category may only be created by trust level 2 and up. ",
+          description_text:
+            "Tutorial topics that describe how to set up, configure, or install Discourse using a specific platform or environment. Topics in this category may only be created by trust level 2 and up. ",
           topic_url: "/t/category-definition-for-howto/2629",
           read_restricted: false,
           permission: 1,
@@ -105,6 +109,8 @@ export default {
           post_count: 278,
           description:
             "My idea here is to have mini specs for features we would like built but have no bandwidth to build",
+          description_text:
+            "My idea here is to have mini specs for features we would like built but have no bandwidth to build",
           topic_url: "/t/about-the-spec-category/13965",
           read_restricted: false,
           permission: 1,
@@ -121,6 +127,8 @@ export default {
           topic_count: 481,
           post_count: 3575,
           description:
+            "This category is for topics related to hacking on Discourse: submitting pull requests, configuring development environments, coding conventions, and so forth.",
+          description_text:
             "This category is for topics related to hacking on Discourse: submitting pull requests, configuring development environments, coding conventions, and so forth.",
           topic_url: "/t/category-definition-for-dev/1026",
           read_restricted: false,
@@ -141,6 +149,8 @@ export default {
           post_count: 11075,
           description:
             "Support on configuring, using, and installing Discourse. Not for software development related topics, but for admins and end users configuring and using Discourse.",
+          description_text:
+            "Support on configuring, using, and installing Discourse. Not for software development related topics, but for admins and end users configuring and using Discourse.",
           topic_url: "/t/category-definition-for-support/389",
           read_restricted: false,
           permission: 1,
@@ -158,6 +168,7 @@ export default {
           topic_count: 13,
           post_count: 53,
           description: "An area for staff members to post shared drafts",
+          description_text: "An area for staff members to post shared drafts",
           topic_url: "/t/about-the-shared-drafts-category/13110",
           read_restricted: true,
           permission: 1,
@@ -174,6 +185,8 @@ export default {
           post_count: 33,
           description:
             'This is a special, temporary category to organize work on the <a href="http://www.meetup.com/torontoruby/events/192168702/">Discourse Hack Night</a> in Toronto. ',
+          description_text:
+            'This is a special, temporary category to organize work on the Discourse Hack Night in Toronto.',
           topic_url: "/t/about-the-hack-night-category/17878",
           read_restricted: false,
           permission: 1,
@@ -191,6 +204,8 @@ export default {
           post_count: 827,
           description:
             "This category is for discussion about localizing Discourse.",
+          description_text:
+            "This category is for discussion about localizing Discourse.",
           topic_url: "/t/about-the-translations-category/14549",
           read_restricted: false,
           permission: 1,
@@ -207,6 +222,8 @@ export default {
           topic_count: 48,
           post_count: 501,
           description:
+            "Topics that come up very often when discussing Discourse will eventually be classified into this Frequently Asked Questions category. Should only be added to popular topics.",
+          description_text:
             "Topics that come up very often when discussing Discourse will eventually be classified into this Frequently Asked Questions category. Should only be added to popular topics.",
           topic_url: "/t/category-definition-for-faq/25",
           read_restricted: false,
@@ -226,6 +243,8 @@ export default {
           post_count: 361,
           description:
             "About commercial Discourse related stuff: jobs or paid gigs, plugins, themes, hosting, etc.",
+          description_text:
+            "About commercial Discourse related stuff: jobs or paid gigs, plugins, themes, hosting, etc.",
           topic_url: "/t/category-definition-for-marketplace/5425",
           read_restricted: false,
           permission: 1,
@@ -244,6 +263,8 @@ export default {
           post_count: 164,
           description:
             "Topics about current or future Discourse Hub functionality at discourse.org including nickname registration, global user pages, and the site directory.",
+          description_text:
+            "Topics about current or future Discourse Hub functionality at discourse.org including nickname registration, global user pages, and the site directory.",
           topic_url: "/t/category-definition-for-discourse-hub/3038",
           read_restricted: false,
           permission: 1,
@@ -260,6 +281,8 @@ export default {
           topic_count: 22,
           post_count: 390,
           description:
+            "Discussion topics generated from the official Discourse Blog. These topics are linked from the bottom of each blog entry where the blog comments would normally be.",
+          description_text:
             "Discussion topics generated from the official Discourse Blog. These topics are linked from the bottom of each blog entry where the blog comments would normally be.",
           topic_url: "/t/category-definition-for-blog/5250",
           read_restricted: false,
@@ -278,6 +301,8 @@ export default {
           post_count: 1874,
           description:
             "Topics about extending the functionality of Discourse with plugins, themes, add-ons, or other mechanisms for extensibility.  ",
+          description_text:
+            "Topics about extending the functionality of Discourse with plugins, themes, add-ons, or other mechanisms for extensibility.  ",
           topic_url: "/t/about-the-extensibility-category/28",
           read_restricted: false,
           permission: 1,
@@ -294,6 +319,8 @@ export default {
           topic_count: 48,
           post_count: 357,
           description:
+            "Topics about logging in to Discourse, using any standard third party provider (Twitter, Facebook, Google), traditional username and password, or with a custom plugin.",
+          description_text:
             "Topics about logging in to Discourse, using any standard third party provider (Twitter, Facebook, Google), traditional username and password, or with a custom plugin.",
           topic_url: "/t/category-definition-for-login/2828",
           read_restricted: false,
@@ -312,6 +339,8 @@ export default {
           post_count: 466,
           description:
             "One post per plugin! Only plugin owners should post here. ",
+          description_text:
+            "One post per plugin! Only plugin owners should post here. ",
           topic_url: "/t/about-the-plugin-category/12648",
           read_restricted: false,
           permission: 1,
@@ -327,6 +356,8 @@ export default {
           topic_count: 1469,
           post_count: 9295,
           description:
+            "A bug report means something is broken, preventing normal/typical use of Discourse. Do be sure to search prior to submitting bugs. Include repro steps, and only describe one bug per topic please.",
+          description_text:
             "A bug report means something is broken, preventing normal/typical use of Discourse. Do be sure to search prior to submitting bugs. Include repro steps, and only describe one bug per topic please.",
           topic_url: "/t/category-definition-for-bug/2",
           read_restricted: false,
@@ -346,6 +377,8 @@ export default {
           post_count: 3090,
           description:
             "Topics that don't need a category, or don't fit into any other existing category.",
+          description_text:
+            "Topics that don't need a category, or don't fit into any other existing category.",
           topic_url: null,
           read_restricted: false,
           permission: 1,
@@ -363,6 +396,8 @@ export default {
           post_count: 135,
           description:
             'Support for the official Discourse WordPress plugin at <a href="https://github.com/discourse/wp-discourse">https://github.com/discourse/wp-discourse</a>',
+          description_text:
+            'Support for the official Discourse WordPress plugin at https://github.com/discourse/wp-discourse',
           topic_url: "/t/category-definition-for-wordpress/12282",
           read_restricted: false,
           permission: 1,
@@ -378,6 +413,8 @@ export default {
           topic_count: 100,
           post_count: 917,
           description:
+            "Topics about hosting Discourse, either on your own servers, in the cloud, or with specific hosting services.",
+          description_text:
             "Topics about hosting Discourse, either on your own servers, in the cloud, or with specific hosting services.",
           topic_url: "/t/category-definition-for-hosting/2626",
           read_restricted: false,
@@ -396,6 +433,8 @@ export default {
           post_count: 4472,
           description:
             "Discussion about the user interface of Discourse, how features are presented to the user in the client, including language and UI elements.",
+          description_text:
+            "Discussion about the user interface of Discourse, how features are presented to the user in the client, including language and UI elements.",
           topic_url: "/t/category-definition-for-ux/2628",
           read_restricted: false,
           permission: 1,
@@ -412,6 +451,8 @@ export default {
           topic_count: 1367,
           post_count: 11942,
           description:
+            "Discussion about features or potential features of Discourse: how they work, why they work, etc.",
+          description_text:
             "Discussion about features or potential features of Discourse: how they work, why they work, etc.",
           topic_url: "/t/category-definition-for-feature/11",
           read_restricted: false,
@@ -430,6 +471,7 @@ export default {
           topic_count: 137,
           post_count: 1142,
           description: "关于幸福的讨论",
+          description_text: "关于幸福的讨论",
           topic_url: "/t/category-definition-for-快乐的/11",
           read_restricted: false,
           permission: 1,
@@ -447,6 +489,7 @@ export default {
           topic_count: 137,
           post_count: 1142,
           description: "A restricted group",
+          description_text: "A restricted group",
           topic_url: "/t/category-definition-for-restricted-group/11",
           read_restricted: true,
           permission: 1,

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -306,7 +306,7 @@ discourseModule(
         store.createRecord("category", {
           id: 1,
           name: "cat-with-entities",
-          description: "baz &quot;bar ‘foo’",
+          description_text: "baz &quot;bar ‘foo’",
         });
       },
 

--- a/app/assets/javascripts/select-kit/addon/components/category-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-row.js
@@ -35,8 +35,6 @@ export default SelectKitRowComponent.extend({
   }),
   categoryName: reads("category.name"),
 
-  categoryDescription: reads("category.description"),
-
   categoryDescriptionText: reads("category.description_text"),
 
   category: computed("rowValue", "rowName", function () {
@@ -94,12 +92,12 @@ export default SelectKitRowComponent.extend({
 
   shouldDisplayDescription: computed(
     "displayCategoryDescription",
-    "categoryDescription",
+    "categoryDescriptionText",
     function () {
       return (
         this.displayCategoryDescription &&
-        this.categoryDescription &&
-        this.categoryDescription !== "null"
+        this.categoryDescriptionText &&
+        this.categoryDescriptionText !== "null"
       );
     }
   ),
@@ -107,12 +105,6 @@ export default SelectKitRowComponent.extend({
   descriptionText: computed("categoryDescriptionText", function () {
     if (this.categoryDescriptionText) {
       return this._formatDescription(this.categoryDescriptionText);
-    }
-  }),
-
-  description: computed("categoryDescription", function () {
-    if (this.categoryDescription) {
-      return this._formatDescription(this.categoryDescription);
     }
   }),
 

--- a/app/assets/javascripts/select-kit/addon/templates/components/category-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/category-row.hbs
@@ -9,7 +9,7 @@
   </div>
 
   {{#if shouldDisplayDescription}}
-    <div class="category-desc" aria-hidden="true">{{dir-span description htmlSafe="true"}}</div>
+    <div class="category-desc" aria-hidden="true">{{dir-span descriptionText  htmlSafe="true"}}</div>
   {{/if}}
 {{else}}
   {{html-safe label}}


### PR DESCRIPTION
The category description is derived from a topic's cooked text and contains HTML elements. When we display it inside the category chooser in places like the composer, we don't want these elements to alter the component in any way.

Context: https://meta.discourse.org/t/some-html-tags-not-stripped-from-category-description/215017

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
