### PR TITLE
DEV: Clean up HTML state between tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -347,7 +347,7 @@ function setupTestsCommon(application, container, config) {
       e.remove()
     );
     document.body.removeAttribute("class");
-    let html = document.getElementsByTagName("html")[0];
+    let html = document.documentElement;
     html.removeAttribute("class");
     html.removeAttribute("style");
     let testing = document.getElementById("ember-testing");

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -342,8 +342,20 @@ function setupTestsCommon(application, container, config) {
     resetPretender();
     clearPresenceState();
 
-    // Destroy any modals
-    $(".modal-backdrop").remove();
+    // Clean up the DOM. Some tests might leave extra classes or elements behind.
+    Array.from(document.getElementsByClassName("modal-backdrop")).forEach((e) =>
+      e.remove()
+    );
+    document.body.removeAttribute("class");
+    let html = document.getElementsByTagName("html")[0];
+    html.removeAttribute("class");
+    html.removeAttribute("style");
+    let testing = document.getElementById("ember-testing");
+    testing.removeAttribute("class");
+    testing.removeAttribute("style");
+    let testContainer = document.getElementById("ember-testing-container");
+    testContainer.scrollTop = 0;
+
     flushMap();
 
     MessageBus.unsubscribe("*");


### PR DESCRIPTION
A bunch of tests were leaving leftovers in the DOM like class names,
custom styles and scroll positions. This ensures they are cleared
between tests.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
