### PR TITLE
UX: Highlight "Users" link when on adminUser path

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin.hbs
@@ -7,7 +7,7 @@
           {{#if currentUser.admin}}
             {{nav-item route="adminSiteSettings" label="admin.site_settings.title"}}
           {{/if}}
-          {{nav-item route="adminUsersList" label="admin.users.title"}}
+          {{nav-item route="adminUsers" label="admin.users.title"}}
           {{#if showGroups}}
             {{nav-item route="groups" label="admin.groups.title"}}
           {{/if}}

--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -10,9 +10,9 @@ $mobile-breakpoint: 700px;
   display: inline-flex;
   position: relative;
   width: 100%;
-  height: auto;
   overflow: hidden;
   height: 100%;
+
   @include breakpoint(tablet) {
     width: calc(100% + 10px);
     margin-left: -10px;


### PR DESCRIPTION
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/66961/151451965-821b3370-990a-4861-a396-164b32188f54.png">
