### PR TITLE
DEV: Add include_all_pms option to TopicQuery

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -75,6 +75,7 @@ class TopicQuery
          guardian
          no_definitions
          destination_category_id
+         include_all_pms
          include_pms)
   end
 
@@ -709,8 +710,12 @@ class TopicQuery
 
     all_listable_topics = @guardian.filter_allowed_categories(Topic.unscoped.listable_topics)
 
-    if options[:include_pms]
-      all_pm_topics = Topic.unscoped.private_messages_for_user(@user)
+    if options[:include_pms] || options[:include_all_pms]
+      all_pm_topics = if options[:include_all_pms] && @guardian.is_admin?
+        Topic.unscoped.private_messages
+      else
+        Topic.unscoped.private_messages_for_user(@user)
+      end
       result = result.merge(all_listable_topics.or(all_pm_topics))
     else
       result = result.merge(all_listable_topics)

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -249,6 +249,19 @@ describe TopicQuery do
     end
   end
 
+  describe 'include_all_pms option' do
+    it "includes all pms in regular topic lists for admins" do
+      topic = Fabricate(:topic)
+      own_pm = Fabricate(:private_message_topic, user: user)
+      other_pm = Fabricate(:private_message_topic, user: Fabricate(:user))
+
+      expect(TopicQuery.new(user).list_latest.topics).to contain_exactly(topic)
+      expect(TopicQuery.new(admin).list_latest.topics).to contain_exactly(topic)
+      expect(TopicQuery.new(user, include_all_pms: true).list_latest.topics).to contain_exactly(topic, own_pm)
+      expect(TopicQuery.new(admin, include_all_pms: true).list_latest.topics).to contain_exactly(topic, own_pm, other_pm)
+    end
+  end
+
   context 'category filter' do
     let(:category) { Fabricate(:category_with_definition) }
     let(:diff_category) { Fabricate(:category_with_definition, name: "Different Category") }


### PR DESCRIPTION
This is intended for use by plugins which are building their own
topic lists, and want to include PMs alongside regular topics (e.g.
discourse-assign). It does not get used directly in core.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
