### PR TITLE
DEV: Allow changing APP_ROOT for puma via ENV variable

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -3,7 +3,7 @@
 if ENV['RAILS_ENV'] == 'production'
 
   # First, you need to change these below to your situation.
-  APP_ROOT = '/home/discourse/discourse'
+  APP_ROOT = ENV["APP_ROOT"] || '/home/discourse/discourse'
   num_workers = ENV["NUM_WEBS"].to_i > 0 ? ENV["NUM_WEBS"].to_i : 4
 
   # Second, you can choose how many threads that you are going to run at same time.


### PR DESCRIPTION
This changes makes it possible to change the application's root by an environment variable. Useful for source installations - although it's official not supported but with the default value it should not cause any harm.