### PR TITLE
FIX: some options on the topic timer modal weren't timezone aware

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-topic-timer-form.js
+++ b/app/assets/javascripts/discourse/app/components/edit-topic-timer-form.js
@@ -86,26 +86,27 @@ export default Component.extend({
 
   @discourseComputed()
   customTimeShortcutOptions() {
+    const timezone = this.currentUser.resolvedTimezone(this.currentUser);
     return [
       {
         icon: "bed",
         id: "this_weekend",
         label: "time_shortcut.this_weekend",
-        time: thisWeekend(),
+        time: thisWeekend(timezone),
         timeFormatKey: "dates.time_short_day",
       },
       {
         icon: "far-clock",
         id: "two_weeks",
         label: "time_shortcut.two_weeks",
-        time: startOfDay(now().add(2, "weeks").day(MOMENT_MONDAY)),
+        time: startOfDay(now(timezone).add(2, "weeks").day(MOMENT_MONDAY)),
         timeFormatKey: "dates.long_no_year",
       },
       {
         icon: "far-calendar-plus",
         id: "six_months",
         label: "time_shortcut.six_months",
-        time: startOfDay(now().add(6, "months").startOf("month")),
+        time: startOfDay(now(timezone).add(6, "months").startOf("month")),
         timeFormatKey: "dates.long_no_year",
       },
     ];


### PR DESCRIPTION
These options weren't timezone aware:
- Two Weeks
- Six Months

Here is the repro:

https://user-images.githubusercontent.com/1274517/151623359-7e494a72-a398-4016-b14f-af922bc3baf4.mov

After choosing an option that's timezone aware, I can open the topic timer modal and see that the timer was set to 8:00 AM:

<img width="250" alt="Screenshot 2022-01-28 at 22 12 36" src="https://user-images.githubusercontent.com/1274517/151623667-fa9664a5-6be1-47ea-9381-c68dfedd0d6a.png">

But if I choose, for example, two weeks, I see that the timer is set to 10:00 AM:

<img width="250" alt="Screenshot 2022-01-28 at 22 12 21" src="https://user-images.githubusercontent.com/1274517/151623455-278314cd-c930-45bf-b296-411ec900fabd.png">







