### PR TITLE
FEATURE: make the use_email_for_username_and_name_suggestions setting visible and on by default on existing sites

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2344,7 +2344,7 @@ en:
     create_revision_on_bulk_topic_moves: "Create revision for first posts when topics are moved into a new category in bulk."
 
     allow_changing_staged_user_tracking: "Allow a staged user's category and tag notification preferences to be changed by an admin user."
-    use_email_for_username_and_name_suggestions: "Use the first part of email addresses for username and name suggestions. Note that this makes it easier for the public to guess full user email addresses (because a large proportion of people share common services like `gmail.com`).
+    use_email_for_username_and_name_suggestions: "Use the first part of email addresses for username and name suggestions. Note that this makes it easier for the public to guess full user email addresses (because a large proportion of people share common services like `gmail.com`)."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2344,6 +2344,7 @@ en:
     create_revision_on_bulk_topic_moves: "Create revision for first posts when topics are moved into a new category in bulk."
 
     allow_changing_staged_user_tracking: "Allow a staged user's category and tag notification preferences to be changed by an admin user."
+    use_email_for_username_and_name_suggestions: "Use email for username and name suggestions. Please note that enabling this setting is dangerous since using emails for username suggestions makes user emails easily guessable."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2344,7 +2344,7 @@ en:
     create_revision_on_bulk_topic_moves: "Create revision for first posts when topics are moved into a new category in bulk."
 
     allow_changing_staged_user_tracking: "Allow a staged user's category and tag notification preferences to be changed by an admin user."
-    use_email_for_username_and_name_suggestions: "Use email for username and name suggestions. Please note that enabling this setting is dangerous since using emails for username suggestions makes user emails easily guessable."
+    use_email_for_username_and_name_suggestions: "Use the first part of email addresses for username and name suggestions. Note that this makes it easier for the public to guess full user email addresses (because a large proportion of people share common services like `gmail.com`).
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -686,7 +686,7 @@ users:
     default: 2000
     hidden: true
   use_email_for_username_and_name_suggestions:
-    hidden: true
+    hidden: false
     default: false
 
 groups:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -686,7 +686,6 @@ users:
     default: 2000
     hidden: true
   use_email_for_username_and_name_suggestions:
-    hidden: false
     default: false
 
 groups:

--- a/db/migrate/20220130192155_set_use_email_for_username_and_name_suggestions_on_existing_sites.rb
+++ b/db/migrate/20220130192155_set_use_email_for_username_and_name_suggestions_on_existing_sites.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SetUseEmailForUsernameAndNameSuggestionsOnExistingSites < ActiveRecord::Migration[6.1]
+  def up
+    result = execute <<~SQL
+      SELECT created_at
+      FROM schema_migration_details
+      ORDER BY created_at
+      LIMIT 1
+    SQL
+
+    # keep tagging disabled for existing sites
+    if result.first['created_at'].to_datetime < 1.hour.ago
+      execute <<~SQL
+        INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+        VALUES('use_email_for_username_and_name_suggestions', 5, 't', NOW(), NOW())
+        ON CONFLICT (name) DO NOTHING
+      SQL
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20220130192155_set_use_email_for_username_and_name_suggestions_on_existing_sites.rb
+++ b/db/migrate/20220130192155_set_use_email_for_username_and_name_suggestions_on_existing_sites.rb
@@ -9,7 +9,7 @@ class SetUseEmailForUsernameAndNameSuggestionsOnExistingSites < ActiveRecord::Mi
       LIMIT 1
     SQL
 
-    # keep tagging disabled for existing sites
+    # make setting enabled for existing sites
     if result.first['created_at'].to_datetime < 1.hour.ago
       execute <<~SQL
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)


### PR DESCRIPTION
We want to avoid using emails for username suggestions until this is explicitly enabled in site settings. We already disabled it for Discourse Connect (https://github.com/discourse/discourse/pull/14541) and introduced a hidden setting for enabling using emails for username suggestions (https://github.com/discourse/discourse/pull/14623).

Now we're going to disable using emails for username suggestions by default for other authentication methods, including SAML. Pull requests:
- https://github.com/discourse/discourse/pull/15586
- https://github.com/discourse/discourse-saml/pull/64

But before merging those, we need to merge this one firstly. To avoid breaking authentication on existing sites, this PR sets the `use_email_for_username_and_name_suggestions` setting to `true` on old sites. Also, this PR makes the setting visible. 

We already used this pattern for changing site settings on existing sites at least once in https://github.com/discourse/discourse/pull/13175.
