### PR TITLE
UX: try select-kit filter autocomplete Chrome fix

### DIFF
--- a/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-filter.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-filter.hbs
@@ -4,7 +4,7 @@
     tabindex=0
     class="filter-input"
     placeholder=placeholder
-    autocomplete="discourse"
+    autocomplete="off"
     autocorrect="off"
     autocapitalize="off"
     name="filter-input-search"
@@ -14,6 +14,7 @@
     paste=(action "onPaste")
     keyDown=(action "onKeydown")
     keyUp=(action "onKeyup")
+    type="search"
   }}
 
   {{#if selectKit.options.filterIcon}}

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -230,6 +230,14 @@ input {
   }
 }
 
+input[type="search"] {
+  &::-webkit-search-cancel-button,
+  &::-webkit-search-decoration {
+    -webkit-appearance: none;
+    appearance: none;
+  }
+}
+
 // Fixes Safari height inconsistency
 ::-webkit-datetime-edit {
   display: inline;


### PR DESCRIPTION
This attempts to prevent Chrome from very aggressively showing autocomplete suggestions in select-kit dropdowns like this: 

<img width="260" alt="image" src="https://user-images.githubusercontent.com/368961/151722323-5b4f5df8-4df6-4022-ab08-40f2db890216.png">

Normally, only `autocomplete="off"` should be enough, but we've seen many cases where it doesn't work, so here we are trying with `type="search"` as well. (Which makes sense for these filter inputs because they are indeed search fields.)

The styling prevents Chrome/Safari from adding an "x" button that clears the input. 