### PR TITLE
FEATURE: show the this weekend option on the bookmark modal

### DIFF
--- a/app/assets/javascripts/discourse/app/components/edit-topic-timer-form.js
+++ b/app/assets/javascripts/discourse/app/components/edit-topic-timer-form.js
@@ -14,12 +14,7 @@ import I18n from "I18n";
 import { action } from "@ember/object";
 import Component from "@ember/component";
 import { isEmpty } from "@ember/utils";
-import {
-  MOMENT_MONDAY,
-  now,
-  startOfDay,
-  thisWeekend,
-} from "discourse/lib/time-utils";
+import { MOMENT_MONDAY, now, startOfDay } from "discourse/lib/time-utils";
 import KeyboardShortcuts from "discourse/lib/keyboard-shortcuts";
 import { TIME_SHORTCUT_TYPES } from "discourse/lib/time-shortcut";
 import ItsATrap from "@discourse/itsatrap";
@@ -88,13 +83,6 @@ export default Component.extend({
   @discourseComputed()
   customTimeShortcutOptions() {
     return [
-      {
-        icon: "bed",
-        id: "this_weekend",
-        label: "time_shortcut.this_weekend",
-        time: thisWeekend(),
-        timeFormatKey: "dates.time_short_day",
-      },
       {
         icon: "far-clock",
         id: "two_weeks",

--- a/app/assets/javascripts/discourse/app/components/time-shortcut-picker.js
+++ b/app/assets/javascripts/discourse/app/components/time-shortcut-picker.js
@@ -1,5 +1,6 @@
 import {
   LATER_TODAY_CUTOFF_HOUR,
+  MOMENT_FRIDAY,
   MOMENT_THURSDAY,
   START_OF_DAY_HOUR,
   laterToday,
@@ -282,6 +283,10 @@ export default Component.extend({
 
     if (now(this.userTimezone).day() >= MOMENT_THURSDAY) {
       this._hideOption(options, TIME_SHORTCUT_TYPES.LATER_THIS_WEEK);
+    }
+
+    if (now(this.userTimezone).day() >= MOMENT_FRIDAY) {
+      this._hideOption(options, TIME_SHORTCUT_TYPES.THIS_WEEKEND);
     }
   },
 

--- a/app/assets/javascripts/discourse/app/lib/time-shortcut.js
+++ b/app/assets/javascripts/discourse/app/lib/time-shortcut.js
@@ -6,6 +6,7 @@ import {
   nextBusinessWeekStart,
   nextMonth,
   now,
+  thisWeekend,
   tomorrow,
 } from "discourse/lib/time-utils";
 import I18n from "I18n";
@@ -13,6 +14,7 @@ import I18n from "I18n";
 export const TIME_SHORTCUT_TYPES = {
   LATER_TODAY: "later_today",
   TOMORROW: "tomorrow",
+  THIS_WEEKEND: "this_weekend",
   NEXT_MONTH: "next_month",
   CUSTOM: "custom",
   RELATIVE: "relative",
@@ -45,6 +47,15 @@ export function defaultShortcutOptions(timezone) {
       label: "time_shortcut.later_this_week",
       time: laterThisWeek(timezone),
       timeFormatted: laterThisWeek(timezone).format(
+        I18n.t("dates.time_short_day")
+      ),
+    },
+    {
+      icon: "bed",
+      id: TIME_SHORTCUT_TYPES.THIS_WEEKEND,
+      label: "time_shortcut.this_weekend",
+      time: thisWeekend(timezone),
+      timeFormatted: thisWeekend(timezone).format(
         I18n.t("dates.time_short_day")
       ),
     },

--- a/app/assets/javascripts/discourse/app/lib/time-utils.js
+++ b/app/assets/javascripts/discourse/app/lib/time-utils.js
@@ -6,6 +6,7 @@ export const LATER_TODAY_MAX_HOUR = 18;
 export const MOMENT_SUNDAY = 0;
 export const MOMENT_MONDAY = 1;
 export const MOMENT_THURSDAY = 4;
+export const MOMENT_FRIDAY = 5;
 export const MOMENT_SATURDAY = 6;
 
 export function now(timezone) {

--- a/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
@@ -47,6 +47,7 @@ discourseModule(
           I18n.t("time_shortcut.later_today"),
           I18n.t("time_shortcut.tomorrow"),
           I18n.t("time_shortcut.later_this_week"),
+          I18n.t("time_shortcut.this_weekend"),
           I18n.t("time_shortcut.start_of_next_business_week"),
           I18n.t("time_shortcut.next_month"),
           I18n.t("time_shortcut.custom"),


### PR DESCRIPTION
We show the <kbd>This Weekend</kbd> option on the topic timer modal:

<img width="250" alt="Screenshot 2022-01-31 at 13 01 09" src="https://user-images.githubusercontent.com/1274517/151795585-c55358d1-34e4-4fa9-8f19-cf8cff469740.png">

For some reason, we don't show this option on the bookmark modal, which could be convenient. Looks like we just forgot to add it there, I don't see evidence that we did that consciously.

This PR adds this option to the bookmark modal.
