### PR TITLE
FIX: Tag show - hide no topics footer until there are no topics

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -69,10 +69,6 @@ export default Controller.extend(BulkTopicSelection, FilterModeMixin, {
     return true;
   },
 
-  loadMoreTopics() {
-    return this.list.loadMore();
-  },
-
   @observes("list.canLoadMore")
   _showFooter() {
     this.set("application.showFooter", !this.get("list.canLoadMore"));

--- a/app/assets/javascripts/discourse/app/templates/tags/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/show.hbs
@@ -88,9 +88,11 @@
               {{topic-dismiss-buttons position="bottom" selectedTopics=selected
               model=model showResetNew=showResetNew showDismissRead=showDismissRead resetNew=(action "resetNew")}}
 
-              {{#footer-message education=footerEducation message=footerMessage}}
-                {{#link-to "tags"}} {{i18n "topic.browse_all_tags"}}{{/link-to}} {{i18n "or"}} {{#link-to "discovery.latest"}}{{i18n "topic.view_latest_topics"}}{{/link-to}}.
-              {{/footer-message}}
+              {{#unless list.canLoadMore}}
+                {{#footer-message education=footerEducation message=footerMessage}}
+                  {{#link-to "tags"}} {{i18n "topic.browse_all_tags"}}{{/link-to}} {{i18n "or"}} {{#link-to "discovery.latest"}}{{i18n "topic.view_latest_topics"}}{{/link-to}}.
+                {{/footer-message}}
+              {{/unless}}
             </footer>
           {{/unless}}
 

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -522,3 +522,46 @@ acceptance("Tag info", function (needs) {
     assert.strictEqual(composer.get("model").tags, undefined);
   });
 });
+
+acceptance(
+  "Tag show - topic list with `more_topics_url` present",
+  function (needs) {
+    needs.pretender((server, helper) => {
+      server.get("/tag/:tagName/l/latest.json", () =>
+        helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            topics: [],
+            more_topics_url: "...",
+          },
+        })
+      );
+      server.put("/topics/bulk", () => helper.response({}));
+    });
+
+    test("load more footer message is present", async function (assert) {
+      await visit("/tag/planters");
+      assert.notOk(exists(".topic-list-bottom .footer-message"));
+    });
+  }
+);
+
+acceptance("Tag show - topic list without `more_topics_url`", function (needs) {
+  needs.pretender((server, helper) => {
+    server.get("/tag/:tagName/l/latest.json", () =>
+      helper.response({
+        users: [],
+        primary_groups: [],
+        topic_list: {
+          topics: [],
+        },
+      })
+    );
+    server.put("/topics/bulk", () => helper.response({}));
+  });
+  test("load more footer message is not present", async function (assert) {
+    await visit("/tag/planters");
+    assert.ok(exists(".topic-list-bottom .footer-message"));
+  });
+});


### PR DESCRIPTION
Deleted function was from 6 years ago, and it is not being called to load more topics.

Tests are kinda dumb here but.. it's tests the change!