### PR TITLE
Fix uglifier to use JS harmony

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -126,6 +126,7 @@ def compress_ruby(from, to)
   data = File.read("#{assets_path}/#{from}")
 
   uglified, map = Uglifier.new(comments: :none,
+                               harmony: true,
                                source_map: {
                                  filename: File.basename(from),
                                  output_filename: File.basename(to)

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -341,7 +341,7 @@ task 'javascript:update' => 'clean_up' do
     end
 
     if f[:uglify]
-      File.write(dest, Uglifier.new.compile(File.read(src)))
+      File.write(dest, Uglifier.new(harmony: true).compile(File.read(src)))
     else
       FileUtils.cp_r(src, dest)
     end


### PR DESCRIPTION
Some Javascript assets use harmony features like const and
numerical separators like 20_000 and thus require the harmony flag.

