### PR TITLE
A11Y: Use `autocomplete="off"` for composer title

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
@@ -5,7 +5,7 @@
   placeholderKey=composer.titlePlaceholder
   aria-label=(I18n composer.titlePlaceholder)
   disabled=disabled
-  autocomplete="discourse"
+  autocomplete="off"
 }}
 
 {{popup-input-tip validation=validation}}


### PR DESCRIPTION
We've historically used `autocomplete="discourse"` (and other variations) to circumvent a stubborn Chrome issue where `autocomplete="off"` wasn't respected. But the circumvention does not work anymore either, and there are reports that for most cases, the standard has better support in Chrome. See for example https://stackoverflow.com/questions/57367813/2019-chrome-76-approach-to-autocomplete-off/57810447#57810447 

We are slowly trying things in a few places, and if it works, we will be using `autocomplete="off"` across the board. 