### PR TITLE
PERF: uses innerHTML to decide if fast-edit is possible

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -191,9 +191,8 @@ export default Component.extend(KeyEnterEscape, {
         "_canEditPost",
         this.topic.postStream.findLoadedPost(postId)?.can_edit
       );
-
       const regexp = new RegExp(regexSafeStr(quoteState.buffer), "gi");
-      const matches = postBody.match(regexp);
+      const matches = cooked.innerHTML.match(regexp);
 
       if (
         quoteState.buffer.length < 1 ||


### PR DESCRIPTION
We don't need raw to decide if we can fast edit or not, we will fetch the raw later when we do the replacement, but this step can be done directly from innerHTML.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
