### PR TITLE
FIX: Regression in timezone name localizations

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/timezone-input.js
+++ b/app/assets/javascripts/select-kit/addon/components/timezone-input.js
@@ -1,5 +1,4 @@
 import ComboBoxComponent from "select-kit/components/combo-box";
-import { computed } from "@ember/object";
 
 export default ComboBoxComponent.extend({
   pluginApiIdentifiers: ["timezone-input"],
@@ -10,17 +9,17 @@ export default ComboBoxComponent.extend({
     allowAny: false,
   },
 
-  nameProperty: computed(function () {
+  get nameProperty() {
     return this.isLocalized() ? "name" : null;
-  }),
+  },
 
-  valueProperty: computed(function () {
+  get valueProperty() {
     return this.isLocalized() ? "value" : null;
-  }),
+  },
 
-  content: computed(function () {
+  get content() {
     return this.isLocalized() ? moment.tz.localizedNames() : moment.tz.names();
-  }),
+  },
 
   isLocalized() {
     return (

--- a/app/assets/javascripts/select-kit/addon/components/timezone-input.js
+++ b/app/assets/javascripts/select-kit/addon/components/timezone-input.js
@@ -4,22 +4,27 @@ import { computed } from "@ember/object";
 export default ComboBoxComponent.extend({
   pluginApiIdentifiers: ["timezone-input"],
   classNames: ["timezone-input"],
-  nameProperty: null,
-  valueProperty: null,
 
   selectKitOptions: {
     filterable: true,
     allowAny: false,
   },
 
-  content: computed(function () {
-    if (
-      moment.locale() !== "en" &&
-      typeof moment.tz.localizedNames === "function"
-    ) {
-      return moment.tz.localizedNames().mapBy("value");
-    } else {
-      return moment.tz.names();
-    }
+  nameProperty: computed(function () {
+    return this.isLocalized() ? "name" : null;
   }),
+
+  valueProperty: computed(function () {
+    return this.isLocalized() ? "value" : null;
+  }),
+
+  content: computed(function () {
+    return this.isLocalized() ? moment.tz.localizedNames() : moment.tz.names();
+  }),
+
+  isLocalized() {
+    return (
+      moment.locale() !== "en" && typeof moment.tz.localizedNames === "function"
+    );
+  },
 });

--- a/app/assets/javascripts/select-kit/addon/components/timezone-input.js
+++ b/app/assets/javascripts/select-kit/addon/components/timezone-input.js
@@ -10,18 +10,18 @@ export default ComboBoxComponent.extend({
   },
 
   get nameProperty() {
-    return this.isLocalized() ? "name" : null;
+    return this.isLocalized ? "name" : null;
   },
 
   get valueProperty() {
-    return this.isLocalized() ? "value" : null;
+    return this.isLocalized ? "value" : null;
   },
 
   get content() {
-    return this.isLocalized() ? moment.tz.localizedNames() : moment.tz.names();
+    return this.isLocalized ? moment.tz.localizedNames() : moment.tz.names();
   },
 
-  isLocalized() {
+  get isLocalized() {
     return (
       moment.locale() !== "en" && typeof moment.tz.localizedNames === "function"
     );

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "GPL-2.0-only",
   "dependencies": {
     "@discourse/itsatrap": "^2.0.10",
+    "@discourse/moment-timezone-names-translations": "^1.0.0",
     "@fortawesome/fontawesome-free": "5.11.2",
     "@highlightjs/cdn-assets": "^10.7.0",
     "@json-editor/json-editor": "^2.6.1",
@@ -31,7 +32,6 @@
     "markdown-it": "10.0.0",
     "moment": "2.29.1",
     "moment-timezone": "0.5.31",
-    "moment-timezone-names-translations": "https://github.com/discourse/moment-timezone-names-translations",
     "pikaday": "1.8.0",
     "spectrum-colorpicker": "1.8.0",
     "workbox-cacheable-response": "^4.3.1",

--- a/plugins/discourse-local-dates/assets/javascripts/discourse/components/discourse-local-dates-create-form.js
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/components/discourse-local-dates-create-form.js
@@ -205,7 +205,7 @@ export default Component.extend({
 
   @computed("currentUserTimezone")
   formatedCurrentUserTimezone(timezone) {
-    return timezone.replace("_", " ").replace("Etc/", "").split("/");
+    return timezone.replace("_", " ").replace("Etc/", "").replace("/", ", ");
   },
 
   @computed("formats")
@@ -398,8 +398,10 @@ export default Component.extend({
     return new Promise((resolve) => {
       loadScript("/javascripts/pikaday.js").then(() => {
         const options = {
-          field: this.$(`.fake-input`)[0],
-          container: this.$(`#picker-container-${this.elementId}`)[0],
+          field: this.element.querySelector(".fake-input"),
+          container: this.element.querySelector(
+            `#picker-container-${this.elementId}`
+          ),
           bound: false,
           format: "YYYY-MM-DD",
           reposition: false,

--- a/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
@@ -7,7 +7,8 @@
     {{#if isValid}}
       {{#if timezoneIsDifferentFromUserTimezone}}
         <div class="preview alert alert-info">
-          <b>{{formatedCurrentUserTimezone}} </b>{{currentPreview}}
+          {{i18n "discourse_local_dates.create.form.current_timezone"}}
+          <b>{{formatedCurrentUserTimezone}}</b>{{currentPreview}}
         </div>
       {{/if}}
     {{else}}

--- a/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
+++ b/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
@@ -262,6 +262,7 @@
 
       b {
         margin-right: 0.5em;
+        margin-left: 0.5em;
       }
 
       b + p {

--- a/plugins/discourse-local-dates/config/locales/client.en.yml
+++ b/plugins/discourse-local-dates/config/locales/client.en.yml
@@ -25,6 +25,7 @@ en:
           format_title: Date format
           timezone: Timezone
           until: Until...
+          current_timezone: "Current timezone:"
           recurring:
             every_day: "Every day"
             every_week: "Every week"

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,11 @@
   resolved "https://registry.yarnpkg.com/@discourse/itsatrap/-/itsatrap-2.0.10.tgz#c7e750eeb32b54e769e952c4ecc472213eb1385a"
   integrity sha512-Jn1gdiyHMGUsmUfLFf4Q7VnTAv0l7NePbegU6pKhKHEmbzV3FosGxq30fTOYgVyTS1bxqGjlA6LvQttJpv3ROw==
 
+"@discourse/moment-timezone-names-translations@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@discourse/moment-timezone-names-translations/-/moment-timezone-names-translations-1.0.0.tgz#b22344456513d37c81baf384a41487b539b91534"
+  integrity sha512-4xr1QWQ0nzmFa2ZXQgWZA+dtE/BU2ePA+qkJWPFzNpq4ZnQi8MmMMAS2285t3rc2ySMBQqYaAArmcSUiufUgRA==
+
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
@@ -2964,10 +2969,6 @@ module-deps@^6.2.3:
     subarg "^1.0.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
-
-"moment-timezone-names-translations@https://github.com/discourse/moment-timezone-names-translations":
-  version "0.0.0"
-  resolved "https://github.com/discourse/moment-timezone-names-translations#5f576fc6355d8e636783bfb7b0214a5d74a5399d"
 
 moment-timezone@0.5.31:
   version "0.5.31"


### PR DESCRIPTION
This also switches to using the NPM package for better build stability. And adds a clearer label in the alert that is displayed to show your current timezone (when changing timezones), example: 

<img width="400" alt="image" src="https://user-images.githubusercontent.com/368961/151974730-6fc4531e-7bb3-425a-a329-60c6a5e4bd16.png">
