### PR TITLE
FIX: Lookup for aliases when checking if an emoji exists.

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -54,6 +54,10 @@ class Emoji
     is_toned = name.match?(/.+:t[1-6]/)
     normalized_name = name.gsub(/(.+):t[1-6]/, '\1')
 
+    Emoji.aliases.each do |original, aliases|
+      normalized_name = original if aliases.include?(normalized_name)
+    end
+
     Emoji.all.detect do |e|
       e.name == normalized_name &&
       (!is_toned || (is_toned && e.tonable))

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -85,6 +85,11 @@ describe Emoji do
       expect(Emoji.exists?("blonde_woman:t0")).to be(false)
       expect(Emoji.exists?("blonde_woman:t")).to be(false)
     end
+
+    it 'returns true when emoji is an alias' do
+      expect(Emoji.exists?(":thumbsup:")).to be(true)
+      expect(Emoji.exists?("thumbsup")).to be(true)
+    end
   end
 
   describe '.codes_to_img' do


### PR DESCRIPTION
Since the discourse-reactions plugin lets you use custom emojis, it needs to filter reactions with custom emojis that are no longer available using `Emoji#exists?`. This filter unintendedly filters those that use emoji aliases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
