### PR TITLE
FIX: Remove svg icons from webmanifest shortcuts

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -65,49 +65,21 @@ class MetadataController < ApplicationController
           name: I18n.t('js.topic.create_long'),
           short_name: I18n.t('js.topic.create'),
           url: "#{Discourse.base_path}/new-topic",
-          icons: [
-            {
-              src: "#{icon_url_base}/plus.svg",
-              sizes: "131x150",
-              type: "image/svg"
-            }
-          ]
         },
         {
           name: I18n.t('js.user.messages.inbox'),
           short_name: I18n.t('js.user.messages.inbox'),
           url: "#{Discourse.base_path}/my/messages",
-          icons: [
-            {
-              src: "#{icon_url_base}/envelope.svg",
-              sizes: "150x150",
-              type: "image/svg"
-            }
-          ]
         },
         {
           name: I18n.t('js.user.bookmarks'),
           short_name: I18n.t('js.user.bookmarks'),
           url: "#{Discourse.base_path}/my/activity/bookmarks",
-          icons: [
-            {
-              src: "#{icon_url_base}/bookmark.svg",
-              sizes: "113x150",
-              type: "image/svg"
-            }
-          ]
         },
         {
           name: I18n.t('js.filters.top.title'),
           short_name: I18n.t('js.filters.top.title'),
           url: "#{Discourse.base_path}/top",
-          icons: [
-            {
-              src: "#{icon_url_base}/signal.svg",
-              sizes: "188x150",
-              type: "image/svg"
-            }
-          ]
         }
       ]
     }

--- a/spec/requests/metadata_controller_spec.rb
+++ b/spec/requests/metadata_controller_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe MetadataController do
       expect(response.status).to eq(200)
       manifest = JSON.parse(response.body)
       expect(manifest["shortcuts"].size).to be > 0
-      expect { URI.parse(manifest["shortcuts"][0]["icons"][0]["src"]) }.not_to raise_error
+      expect { URI.parse(manifest["shortcuts"][0]["url"]) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
While SVGs are valid in the webmanifest, Chromium has not implemented
support for it in this specific manifest member.

Revert when https://bugs.chromium.org/p/chromium/issues/detail?id=1091612
lands.
