### PR TITLE
FEATURE: New plugin outlets for categories-boxes template

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
@@ -1,4 +1,5 @@
 {{#each categories as |c|}}
+  {{plugin-outlet name="category-box-before-each-box" args=(hash category=c)}}
   <div style={{unless noCategoryStyle (border-color c.color)}} data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}} data-url={{c.url}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
     <div class="category-box-inner">
       {{#unless c.isMuted}}
@@ -73,4 +74,5 @@
       {{plugin-outlet name="category-box-below-each-category" args=(hash category=c)}}
     </div>
   </div>
+  {{plugin-outlet name="category-box-after-each-box" args=(hash category=c)}}
 {{/each}}


### PR DESCRIPTION
Adds new `category-box-before-each-box` and `category-box-after-each-box` outlets to improve flexibility with customizations.

For example, this provides support for using the "Boxes with Subcategories" desktop category page layout with the [Category Previews](https://meta.discourse.org/t/category-previews/155296) component:

<img width="1184" alt="Screen Shot 2022-02-01 at 4 01 51 PM" src="https://user-images.githubusercontent.com/22733864/152071896-bc8170ee-e3ad-475b-8bf6-3378dd587b61.png">

