### PR TITLE
FEATURE: cache last post number

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
+++ b/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
@@ -1,8 +1,25 @@
 import { Promise } from "rsvp";
 let model, currentTopicId;
 
+let highestReadCache = {};
+
 export function setTopicList(incomingModel) {
   model = incomingModel;
+
+  model?.topics?.forEach((topic) => {
+    let highestReadFromCache = highestReadCache[topic.id];
+    if (
+      highestReadCache &&
+      highestReadFromCache >= topic.last_read_post_number
+    ) {
+      let count = Math.max(topic.highest_post_number - highestReadFromCache, 0);
+      topic.setProperties({
+        unread_posts: count,
+        new_posts: count,
+      });
+    }
+    deleteHighestReadCache(topic.id);
+  });
   currentTopicId = null;
 }
 
@@ -12,6 +29,18 @@ export function nextTopicUrl() {
 
 export function previousTopicUrl() {
   return urlAt(-1);
+}
+
+export function setHighestReadCache(topicId, postNumber) {
+  highestReadCache[topicId] = postNumber;
+}
+
+export function getHighestReadCache(topicId) {
+  return highestReadCache[topicId];
+}
+
+export function deleteHighestReadCache(topicId) {
+  delete highestReadCache[topicId];
 }
 
 function urlAt(delta) {

--- a/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
+++ b/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
@@ -1,18 +1,15 @@
 import { Promise } from "rsvp";
 let model, currentTopicId;
 
-let highestReadCache = {};
+let highestReadCache = new Map();
 
 export function setTopicList(incomingModel) {
   model = incomingModel;
 
   model?.topics?.forEach((topic) => {
-    let highestReadFromCache = highestReadCache[topic.id];
-    if (
-      highestReadFromCache &&
-      highestReadFromCache >= topic.last_read_post_number
-    ) {
-      let count = Math.max(topic.highest_post_number - highestReadFromCache, 0);
+    let highestRead = getHighestReadCache(topic.id);
+    if (highestRead && highestRead >= topic.last_read_post_number) {
+      let count = Math.max(topic.highest_post_number - highestRead, 0);
       topic.setProperties({
         unread_posts: count,
         new_posts: count,
@@ -32,19 +29,19 @@ export function previousTopicUrl() {
 }
 
 export function setHighestReadCache(topicId, postNumber) {
-  highestReadCache[topicId] = postNumber;
+  highestReadCache.set(topicId, postNumber);
 }
 
 export function getHighestReadCache(topicId) {
-  return highestReadCache[topicId];
+  return highestReadCache.get(topicId);
 }
 
 export function deleteHighestReadCache(topicId) {
-  delete highestReadCache[topicId];
+  highestReadCache.delete(topicId);
 }
 
 export function resetHighestReadCache() {
-  highestReadCache = {};
+  highestReadCache.clear();
 }
 
 function urlAt(delta) {

--- a/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
+++ b/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
@@ -1,7 +1,7 @@
 import { Promise } from "rsvp";
 let model, currentTopicId;
 
-let highestReadCache = new Map();
+let lastTopicId, lastHighestRead;
 
 export function setTopicList(incomingModel) {
   model = incomingModel;
@@ -14,8 +14,8 @@ export function setTopicList(incomingModel) {
         unread_posts: count,
         new_posts: count,
       });
+      resetHighestReadCache();
     }
-    deleteHighestReadCache(topic.id);
   });
   currentTopicId = null;
 }
@@ -29,19 +29,19 @@ export function previousTopicUrl() {
 }
 
 export function setHighestReadCache(topicId, postNumber) {
-  highestReadCache.set(topicId, postNumber);
+  lastTopicId = topicId;
+  lastHighestRead = postNumber;
 }
 
 export function getHighestReadCache(topicId) {
-  return highestReadCache.get(topicId);
-}
-
-export function deleteHighestReadCache(topicId) {
-  highestReadCache.delete(topicId);
+  if (topicId === lastTopicId) {
+    return lastHighestRead;
+  }
 }
 
 export function resetHighestReadCache() {
-  highestReadCache.clear();
+  lastTopicId = undefined;
+  lastHighestRead = undefined;
 }
 
 function urlAt(delta) {

--- a/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
+++ b/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
@@ -43,6 +43,10 @@ export function deleteHighestReadCache(topicId) {
   delete highestReadCache[topicId];
 }
 
+export function resetHighestReadCache() {
+  highestReadCache = {};
+}
+
 function urlAt(delta) {
   if (!model || !model.topics) {
     return Promise.resolve(null);

--- a/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
+++ b/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
@@ -9,7 +9,7 @@ export function setTopicList(incomingModel) {
   model?.topics?.forEach((topic) => {
     let highestReadFromCache = highestReadCache[topic.id];
     if (
-      highestReadCache &&
+      highestReadFromCache &&
       highestReadFromCache >= topic.last_read_post_number
     ) {
       let count = Math.max(topic.highest_post_number - highestReadFromCache, 0);

--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -3,8 +3,8 @@ import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse-common/utils/decorators";
 import { isTesting } from "discourse-common/config/environment";
 import {
-  deleteHighestReadCache,
   getHighestReadCache,
+  resetHighestReadCache,
   setHighestReadCache,
 } from "discourse/lib/topic-list-tracker";
 
@@ -193,7 +193,7 @@ export default class ScreenTrack extends Service {
             cachedHighestRead &&
             cachedHighestRead <= postNumbers.lastObject
           ) {
-            deleteHighestReadCache(topicId);
+            resetHighestReadCache(topicId);
           }
         }
         this.appEvents.trigger("topic:timings-sent", data);

--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -199,7 +199,7 @@ export default class ScreenTrack extends Service {
         this.appEvents.trigger("topic:timings-sent", data);
       })
       .catch((e) => {
-        if (ALLOWED_AJAX_FAILURES.indexOf(e.jqXHR.status) > -1) {
+        if (e.jqXHR && ALLOWED_AJAX_FAILURES.indexOf(e.jqXHR.status) > -1) {
           const delay = AJAX_FAILURE_DELAYS[this._ajaxFailures];
           this._ajaxFailures += 1;
 
@@ -210,7 +210,7 @@ export default class ScreenTrack extends Service {
           }
         }
 
-        if (window.console && window.console.warn) {
+        if (window.console && window.console.warn && e.jqXHR) {
           window.console.warn(
             `Failed to update topic times for topic ${topicId} due to ${e.jqXHR.status} error`
           );

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -39,7 +39,10 @@ import { resetCardClickListenerSelector } from "discourse/mixins/card-contents-b
 import { resetComposerCustomizations } from "discourse/models/composer";
 import { resetQuickSearchRandomTips } from "discourse/widgets/search-menu-results";
 import sessionFixtures from "discourse/tests/fixtures/session-fixtures";
-import { setTopicList } from "discourse/lib/topic-list-tracker";
+import {
+  resetHighestReadCache,
+  setTopicList,
+} from "discourse/lib/topic-list-tracker";
 import sinon from "sinon";
 import siteFixtures from "discourse/tests/fixtures/site-fixtures";
 import { clearResolverOptions } from "discourse-common/resolver";
@@ -160,6 +163,7 @@ function testCleanup(container, app) {
   resetOneboxCache();
   resetCustomPostMessageCallbacks();
   resetUserSearchCache();
+  resetHighestReadCache();
   resetCardClickListenerSelector();
   resetComposerCustomizations();
   resetQuickSearchRandomTips();

--- a/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
@@ -7,15 +7,27 @@ discourseModule("Unit | Service | screen-track", function () {
 
     tracker.consolidateTimings({ 1: 10, 2: 5 }, 10, 1);
     tracker.consolidateTimings({ 1: 5, 3: 1 }, 3, 1);
-    const consolidated = tracker.consolidateTimings({ 1: 5, 3: 1 }, 3, 2);
+    const consolidated = tracker.consolidateTimings({ 1: 5, 3: 1, 4: 5 }, 3, 2);
 
     assert.deepEqual(
       consolidated,
       [
         { timings: { 1: 15, 2: 5, 3: 1 }, topicTime: 13, topicId: 1 },
-        { timings: { 1: 5, 3: 1 }, topicTime: 3, topicId: 2 },
+        { timings: { 1: 5, 3: 1, 4: 5 }, topicTime: 3, topicId: 2 },
       ],
       "expecting consolidated timings to match correctly"
+    );
+
+    tracker.sendNextConsolidatedTiming();
+    assert.equal(
+      tracker.highestReadFromCache(1),
+      3,
+      "caches highest read post number for first topic"
+    );
+    assert.equal(
+      tracker.highestReadFromCache(2),
+      4,
+      "caches highest read post number for second topic"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
@@ -20,11 +20,6 @@ discourseModule("Unit | Service | screen-track", function () {
 
     tracker.sendNextConsolidatedTiming();
     assert.equal(
-      tracker.highestReadFromCache(1),
-      3,
-      "caches highest read post number for first topic"
-    );
-    assert.equal(
       tracker.highestReadFromCache(2),
       4,
       "caches highest read post number for second topic"


### PR DESCRIPTION
Instead of relaying on /timings request, we should cache last read post number. That should protect from having incorrect unread counter when going back to topic list.

This additional cache is very temporary as once /timings request is finished, serializer will have a correct result.

Simplified flow is:
1. Store in cache information about last seen post number before /timings request is sent
2. When getting back to topic list compare value of last seen post number returned by /latest request and information in cache. If cache number is higher, than use it instead of information returned by /latest. In addition delete cache item as there is high chance that `/timings` request already finished.
3. Optionally, delete cache when timings request is done and topic list was not yet visited.

Keeping cache reasonably small should not affect performance.


