### PR TITLE
DEV: Add plugin outlet to `topic-list-item.hbs`

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-list-item.hbs
@@ -1,1 +1,6 @@
 {{topicListItemContents}}
+
+{{plugin-outlet
+  name="after-topic-list-item"
+  args=(hash topic=topic)
+}}


### PR DESCRIPTION
This PR adds a plugin outlet to the `topic-list-item.hbs` template, allowing the ability to inject custom components into each topic list item displayed on a topic-list.