### PR TITLE
ignore .byebug_history file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ yarn-error.log
 
 # Generated API documentation files
 openapi/*
+
+# Byebug
+.byebug_history


### PR DESCRIPTION
I noticed this file existed and polluted my git status when I was debugging a plugin. Probably should ignore this so it doesn't get accidentally checked in. 
