### PR TITLE
FIX: timeout Excon request for Onebox

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -203,13 +203,15 @@ class FinalDestination
     middlewares = Excon.defaults[:middlewares]
     middlewares << Excon::Middleware::Decompress if @http_verb == :get
 
-    response = Excon.public_send(@http_verb,
-      @uri.to_s,
-      read_timeout: timeout,
-      connect_timeout: timeout,
-      headers: headers,
-      middlewares: middlewares
-    )
+    response = Timeout::timeout(timeout) {
+      Excon.public_send(@http_verb,
+                        @uri.to_s,
+                        read_timeout: timeout,
+                        connect_timeout: timeout,
+                        headers: headers,
+                        middlewares: middlewares
+                       )
+    }
 
     location = nil
     response_headers = nil

--- a/spec/components/final_destination_spec.rb
+++ b/spec/components/final_destination_spec.rb
@@ -402,6 +402,12 @@ describe FinalDestination do
         expect(final.status).to eq(:resolved)
       end
     end
+
+    it 'raises Timeout::Error' do
+      stub_request(:head, "https://eviltrout.com/this/is/an/image").to_return(lambda { |request| sleep 5; image_response })
+      final = FinalDestination.new("https://eviltrout.com/this/is/an/image", opts.merge({ timeout: 0.0000001 }))
+      expect { final.resolve }.to raise_error(Timeout::Error)
+    end
   end
 
   describe '.get' do


### PR DESCRIPTION
If Excon stuck with stream request, we should time out and return empty string.