### PR TITLE
UX: Support `type=search` inputs in inline forms

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -167,13 +167,15 @@ input[type="submit"] {
     display: flex;
   }
 
-  > input[type="text"] {
+  > input[type="text"],
+  > input[type="search"] {
     display: inline-flex;
     flex: 1;
   }
 
   > .select-kit,
   > input[type="text"],
+  > input[type="search"],
   > label,
   > .btn,
   > .d-date-input {

--- a/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/atoms/05-input-fields.hbs
+++ b/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/atoms/05-input-fields.hbs
@@ -62,6 +62,12 @@
   </div>
 {{/styleguide-example}}
 
+{{#styleguide-example title="full-width inline-form with search type input"}}
+  <div class="inline-form full-width">
+    {{input placeholder="Search type input" type="search"}}
+  </div>
+{{/styleguide-example}}
+
 {{#styleguide-example title="category-notifications-button and regular button"}}
   <div class="inline-form">
     {{category-notifications-button category=dummy.categories.[0] value=1 onChange=(action "dummy")}}


### PR DESCRIPTION
We are using this in the assign plugin, see also https://github.com/discourse/discourse-assign/pull/290.