### PR TITLE
DEV: Ensure Sidekiq warnings are logged to STDERR

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -81,7 +81,7 @@ if Sidekiq.server?
   end
 end
 
-Sidekiq.logger.level = Logger::WARN
+Sidekiq.logger = Sidekiq::Logger.new(STDERR, level: Logger::WARN)
 
 class SidekiqLogsterReporter < Sidekiq::ExceptionHandler::Logger
   def call(ex, context = {})

--- a/lib/demon/sidekiq.rb
+++ b/lib/demon/sidekiq.rb
@@ -31,7 +31,7 @@ class Demon::Sidekiq < ::Demon::Base
     # trouble, if STDOUT is closed in our process all sort of weird
     # will ensue, resetting the logger ensures it will reinit correctly
     # parent process is in charge of the file anyway.
-    Sidekiq.logger = nil
+    Sidekiq.logger = Sidekiq::Logger.new(STDERR, level: Logger::WARN)
     cli = Sidekiq::CLI.instance
 
     # Unicorn uses USR1 to indicate that log files have been rotated


### PR DESCRIPTION
The default configuration will log to STOUT, which pollutes the output of scripts/rake-tasks

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
