### PR TITLE
A11Y: Switch to using `autocomplete="off"`

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/admin-editable-field.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-editable-field.hbs
@@ -1,7 +1,7 @@
 <div class="field">{{i18n name}}</div>
 <div class="value">
   {{#if editing}}
-    {{text-field value=buffer autofocus="autofocus" autocomplete="discourse"}}
+    {{text-field value=buffer autofocus="autofocus" autocomplete="off"}}
   {{else}}
     <a href {{action "edit"}} class="inline-editable-field">
       <span>{{value}}</span>

--- a/app/assets/javascripts/admin/addon/templates/components/simple-list.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/simple-list.hbs
@@ -26,9 +26,10 @@
     value=newValue
     placeholderKey="admin.site_settings.simple_list.add_item"
     class="add-value-input"
-    autocomplete="discourse"
+    autocomplete="off"
     autocorrect="off"
-    autocapitalize="off"}}
+    autocapitalize="off"
+  }}
 
   {{d-button
       action=(action "addValue")

--- a/app/assets/javascripts/admin/addon/templates/components/themes-list.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/themes-list.hbs
@@ -20,7 +20,8 @@
       {{input
         class="filter-input"
         placeholder=(i18n "admin.customize.theme.filter_placeholder")
-        autocomplete="discourse"
+        autocomplete="off"
+        type="search"
         value=(mut filterTerm)
       }}
       {{d-icon "search"}}

--- a/app/assets/javascripts/discourse/app/components/search-text-field.js
+++ b/app/assets/javascripts/discourse/app/components/search-text-field.js
@@ -4,7 +4,7 @@ import TextField from "discourse/components/text-field";
 import { applySearchAutocomplete } from "discourse/lib/search";
 
 export default TextField.extend({
-  autocomplete: "discourse-search",
+  autocomplete: "off",
 
   @discourseComputed("searchService.searchContextEnabled")
   placeholder(searchContextEnabled) {

--- a/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-title.hbs
@@ -5,7 +5,7 @@
   placeholderKey=composer.titlePlaceholder
   aria-label=(I18n composer.titlePlaceholder)
   disabled=disabled
-  autocomplete="discourse"
+  autocomplete="off"
 }}
 
 {{popup-input-tip validation=validation}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
@@ -43,7 +43,7 @@
 
       {{conditional-loading-spinner condition=loading}}
       {{d-textarea
-        autocomplete="discourse"
+        autocomplete="off"
         tabindex=tabindex
         value=value
         class="d-editor-input"

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
@@ -24,7 +24,8 @@
           class="filter"
           name="filter"
           placeholder=(i18n "emoji_picker.filter_placeholder")
-          autocomplete="discourse"
+          autocomplete="off"
+          type="search"
           autocorrect="off"
           autocapitalize="off"
           input=(action "onFilter")

--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -4,7 +4,7 @@
       {{text-field
         value=filterInput
         placeholderKey=filterPlaceholder
-        autocomplete="discourse"
+        autocomplete="off"
         class="group-username-filter no-blur"
       }}
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -70,7 +70,7 @@
                 {{/if}}
 
                 <div class="input username-input input-group">
-                  {{input value=accountUsername class=(value-entered accountUsername) id="new-account-username" name="username" maxlength=maxUsernameLength autocomplete="discourse"}}
+                  {{input value=accountUsername class=(value-entered accountUsername) id="new-account-username" name="username" maxlength=maxUsernameLength autocomplete="off"}}
                   <label class="alt-placeholder" for="new-account-username">
                     {{i18n "user.username.title"}}
                     <span class="required">*</span>

--- a/app/assets/javascripts/discourse/app/templates/mobile/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/group-index.hbs
@@ -2,7 +2,7 @@
   {{text-field
     value=filterInput
     placeholderKey=filterPlaceholder
-    autocomplete="discourse"
+    autocomplete="off"
     class="group-username-filter no-blur"
   }}
 

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -49,7 +49,7 @@
                   maxlength=maxUsernameLength
                   aria-describedby="username-validation"
                   aria-invalid=usernameValidation.failed
-                  autocomplete="discourse"
+                  autocomplete="off"
                 }}
                 <label class="alt-placeholder" for="new-account-username">
                   {{i18n "user.username.title"}}

--- a/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/bookmarks.hbs
@@ -12,7 +12,9 @@
         value=searchTerm
         placeholder=(i18n "bookmarks.search_placeholder")
         enter=(action "search")
-        id="bookmark-search" autocomplete="discourse"}}
+        id="bookmark-search"
+        autocomplete="off"
+      }}
       {{d-button
         class="btn-primary"
         action=(action "search")

--- a/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-filter.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-filter.hbs
@@ -4,7 +4,7 @@
     tabindex=0
     class="filter-input"
     placeholder=placeholder
-    autocomplete="discourse"
+    autocomplete="off"
     autocorrect="off"
     autocapitalize="off"
     name="filter-input-search"
@@ -14,6 +14,7 @@
     paste=(action "onPaste")
     keyDown=(action "onKeydown")
     keyUp=(action "onKeyup")
+    type="search"
   }}
 
   {{#if selectKit.options.filterIcon}}

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -230,6 +230,14 @@ input {
   }
 }
 
+input[type="search"] {
+  &::-webkit-search-cancel-button,
+  &::-webkit-search-decoration {
+    -webkit-appearance: none;
+    appearance: none;
+  }
+}
+
 // Fixes Safari height inconsistency
 ::-webkit-datetime-edit {
   display: inline;


### PR DESCRIPTION
We've historically used `autocomplete="discourse"` to circumvent a stubborn Chrome issue where `autocomplete="off"` wasn't respected. But the circumvention does not work anymore either, and there are reports that for most cases, Chrome now supports `autocomplete="off"`. 