### PR TITLE
DEV: Add category-color variable

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/border-color.js
+++ b/app/assets/javascripts/discourse/app/helpers/border-color.js
@@ -1,3 +1,3 @@
 import { htmlHelper } from "discourse-common/lib/helpers";
 
-export default htmlHelper((color) => `border-color: #${color}`);
+export default htmlHelper((color) => `border-color: #${color}; `);

--- a/app/assets/javascripts/discourse/app/helpers/category-color-variable.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-color-variable.js
@@ -1,0 +1,3 @@
+import { htmlHelper } from "discourse-common/lib/helpers";
+
+export default htmlHelper((color) => `--category-color: #${color}`);

--- a/app/assets/javascripts/discourse/app/helpers/category-color-variable.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-color-variable.js
@@ -1,3 +1,3 @@
 import { htmlHelper } from "discourse-common/lib/helpers";
 
-export default htmlHelper((color) => `--category-color: #${color}`);
+export default htmlHelper((color) => `--category-color: #${color};`);

--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
@@ -1,5 +1,5 @@
 {{#each categories as |c|}}
-  <div data-notification-level={{c.notificationLevelString}} style={{unless noCategoryStyle (border-color c.color)}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
+  <div data-notification-level={{c.notificationLevelString}} style={{unless noCategoryStyle (concat (border-color c.color) (category-color-variable c.color))}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
     <div class="category-box-inner">
       <div class="category-box-heading">
         <a href={{c.url}}>

--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
@@ -1,6 +1,6 @@
 {{#each categories as |c|}}
   {{plugin-outlet name="category-box-before-each-box" args=(hash category=c)}}
-  <div style={{unless noCategoryStyle (border-color c.color)}} data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}} data-url={{c.url}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
+  <div style={{unless noCategoryStyle (concat (border-color c.color) (category-color-variable c.color))}} data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}} data-url={{c.url}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
     <div class="category-box-inner">
       {{#unless c.isMuted}}
         <div class="category-logo">

--- a/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
@@ -1,7 +1,7 @@
 {{#unless isHidden}}
   {{plugin-outlet name="category-list-above-each-category" args=(hash category=category)}}
   <tr data-category-id={{category.id}} data-notification-level={{category.notificationLevelString}} class="{{if category.description_excerpt "has-description" "no-description"}} {{if category.uploaded_logo.url "has-logo" "no-logo"}}">
-    <td class="category {{if isMuted "muted"}} {{if noCategoryStyle "no-category-style"}}" style={{unless noCategoryStyle (concat (border-color c.color) (category-color-variable c.color))}}>
+    <td class="category {{if isMuted "muted"}} {{if noCategoryStyle "no-category-style"}}" style={{unless noCategoryStyle (concat (border-color category.color) (category-color-variable category.color))}}>
       {{category-title-link category=category}}
       {{plugin-outlet name="below-category-title-link" connectorTagName="div" args=(hash category=category)}}
       {{#if category.description_excerpt}}

--- a/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
@@ -1,7 +1,7 @@
 {{#unless isHidden}}
   {{plugin-outlet name="category-list-above-each-category" args=(hash category=category)}}
   <tr data-category-id={{category.id}} data-notification-level={{category.notificationLevelString}} class="{{if category.description_excerpt "has-description" "no-description"}} {{if category.uploaded_logo.url "has-logo" "no-logo"}}">
-    <td class="category {{if isMuted "muted"}} {{if noCategoryStyle "no-category-style"}}" style={{unless noCategoryStyle (border-color category.color)}}>
+    <td class="category {{if isMuted "muted"}} {{if noCategoryStyle "no-category-style"}}" style={{unless noCategoryStyle (concat (border-color c.color) (category-color-variable c.color))}}>
       {{category-title-link category=category}}
       {{plugin-outlet name="below-category-title-link" connectorTagName="div" args=(hash category=category)}}
       {{#if category.description_excerpt}}


### PR DESCRIPTION
This PR adds a `--category-color` CSS variable into `category` elements on the category page. This allows children inside of these elements to use its parent's respective `category-color` for increased customization in themes.

An example can be seen here, where I am removing the `border-color` with custom CSS, and adding in an inside separator, using each categories color using only the following css.

```css
.category-boxes .description:before {
    content: "";
    display: block;
    margin: 0.5em auto 0.33em;
    width: 28px;
    height: 4px;
    background: var(--category-color);
}
```

![image](https://user-images.githubusercontent.com/30537603/152408599-30cef20c-51c5-4d2a-831b-e45fd58929d6.png)
