### PR TITLE
Revert "FIX: Image sizes were slightly off in some cases (#15678)"

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -191,6 +191,7 @@ $quote-share-maxwidth: 150px;
 
   img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji) {
     max-width: 100%;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
This reverts commit eff0106efbf1cec02d46a13460fcd686591e64d8. It causes visible layout issues, especially on mobile.
