### PR TITLE
DEV: Route Sidekiq logs to Rails logger

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -81,7 +81,16 @@ if Sidekiq.server?
   end
 end
 
-Sidekiq.logger = Sidekiq::Logger.new(STDERR, level: Logger::WARN)
+# Sidekiq#logger= applies patches to whichever logger we pass it.
+# Therefore something like Sidekiq.logger = Rails.logger will break
+# all logging in the application.
+#
+# Instead, this patch adds a dedicated logger instance and patches
+# the #add method to forward messages to Rails.logger.
+Sidekiq.logger = Logger.new(nil)
+Sidekiq.logger.define_singleton_method(:add) do |severity, message = nil, progname = nil, &blk|
+  Rails.logger.add(severity, message, progname, &blk)
+end
 
 class SidekiqLogsterReporter < Sidekiq::ExceptionHandler::Logger
   def call(ex, context = {})
@@ -111,8 +120,5 @@ class SidekiqLogsterReporter < Sidekiq::ExceptionHandler::Logger
   end
 end
 
-unless Rails.env.development?
-  Sidekiq.error_handlers.clear
-end
-
+Sidekiq.error_handlers.clear
 Sidekiq.error_handlers << SidekiqLogsterReporter.new

--- a/lib/demon/sidekiq.rb
+++ b/lib/demon/sidekiq.rb
@@ -27,11 +27,6 @@ class Demon::Sidekiq < ::Demon::Base
 
     puts "Loading Sidekiq in process id #{Process.pid}"
     require 'sidekiq/cli'
-    # CLI will close the logger, if we have one set we can be in big
-    # trouble, if STDOUT is closed in our process all sort of weird
-    # will ensue, resetting the logger ensures it will reinit correctly
-    # parent process is in charge of the file anyway.
-    Sidekiq.logger = Sidekiq::Logger.new(STDERR, level: Logger::WARN)
     cli = Sidekiq::CLI.instance
 
     # Unicorn uses USR1 to indicate that log files have been rotated


### PR DESCRIPTION
Most of our logging goes through Rails.logger, and therefore appears in Logster at `/logs` on a site. The Sidekiq logger was bypassing this and writing directly to STDERR.

Unfortunately it's not possible to do `Sidekiq.logger = Rails.logger` because `Sidekiq#logger=` applies a number of patches to the logger instance, causing our whole logging system to break.

Instead, this commit adds a dedicated Logger instance with no output, which is then patched to forward all messages directly to `Rails.logger`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
