### PR TITLE
DEV: remove the includeMidFuture option in future-date-input

### DIFF
--- a/app/assets/javascripts/discourse/app/components/future-date-input.js
+++ b/app/assets/javascripts/discourse/app/components/future-date-input.js
@@ -79,7 +79,6 @@ export default Component.extend({
       now,
       day: now.day(),
       includeWeekend: this.includeWeekend,
-      includeMidFuture: this.includeMidFuture || true,
       includeFarFuture: this.includeFarFuture,
       includeDateTime: this.includeDateTime,
       canScheduleNow: this.includeNow || false,

--- a/app/assets/javascripts/discourse/app/lib/timeframes-builder.js
+++ b/app/assets/javascripts/discourse/app/lib/timeframes-builder.js
@@ -68,7 +68,7 @@ const TIMEFRAMES = [
   buildTimeframe({
     id: "two_months",
     format: "MMM D",
-    enabled: (opts) => opts.includeMidFuture,
+    enabled: () => true,
     when: (time, timeOfDay) =>
       time.add(2, "month").startOf("month").hour(timeOfDay).minute(0),
     icon: "briefcase",
@@ -76,7 +76,7 @@ const TIMEFRAMES = [
   buildTimeframe({
     id: "three_months",
     format: "MMM D",
-    enabled: (opts) => opts.includeMidFuture,
+    enabled: () => true,
     when: (time, timeOfDay) =>
       time.add(3, "month").startOf("month").hour(timeOfDay).minute(0),
     icon: "briefcase",
@@ -84,7 +84,7 @@ const TIMEFRAMES = [
   buildTimeframe({
     id: "four_months",
     format: "MMM D",
-    enabled: (opts) => opts.includeMidFuture,
+    enabled: () => true,
     when: (time, timeOfDay) =>
       time.add(4, "month").startOf("month").hour(timeOfDay).minute(0),
     icon: "briefcase",
@@ -92,7 +92,7 @@ const TIMEFRAMES = [
   buildTimeframe({
     id: "six_months",
     format: "MMM D",
-    enabled: (opts) => opts.includeMidFuture,
+    enabled: () => true,
     when: (time, timeOfDay) =>
       time.add(6, "month").startOf("month").hour(timeOfDay).minute(0),
     icon: "briefcase",

--- a/app/assets/javascripts/discourse/app/templates/components/future-date-input.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/future-date-input.hbs
@@ -9,7 +9,6 @@
       includeDateTime=includeDateTime
       includeWeekend=includeWeekend
       includeFarFuture=includeFarFuture
-      includeMidFuture=includeMidFuture
       includeNow=includeNow
       clearable=clearable
       onChangeInput=onChangeInput

--- a/app/assets/javascripts/discourse/app/templates/components/invite-link-panel.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/invite-link-panel.hbs
@@ -35,7 +35,6 @@
       </label>
       {{future-date-input
         includeDateTime=true
-        includeMidFuture=true
         clearable=true
         onChangeInput=(action (mut inviteExpiresAt))
       }}

--- a/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
@@ -124,7 +124,6 @@
           displayLabel=(i18n "user.invited.invite.expires_at")
           statusType="close"
           includeDateTime=true
-          includeMidFuture=true
           clearable=true
           input=buffered.expires_at
           onChangeInput=(action (mut buffered.expires_at))

--- a/app/assets/javascripts/discourse/app/templates/modal/ignore-duration-with-username.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/ignore-duration-with-username.hbs
@@ -15,7 +15,6 @@
     input=(readonly ignoredUntil)
     includeWeekend=true
     includeDateTime=false
-    includeMidFuture=true
     includeFarFuture=true
     onChangeInput=(action (mut ignoredUntil))
   }}

--- a/app/assets/javascripts/discourse/app/templates/modal/ignore-duration.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/ignore-duration.hbs
@@ -4,7 +4,6 @@
     input=ignoredUntil
     includeWeekend=true
     includeDateTime=false
-    includeMidFuture=true
     includeFarFuture=true
     onChangeInput=(action (mut ignoredUntil))
   }}

--- a/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
@@ -4,7 +4,6 @@ import buildTimeframes from "discourse/lib/timeframes-builder";
 
 const DEFAULT_OPTIONS = {
   includeWeekend: null,
-  includeMidFuture: true,
   includeFarFuture: null,
   includeDateTime: null,
   canScheduleNow: false,

--- a/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
@@ -29,7 +29,6 @@ export default ComboBoxComponent.extend(DatetimeMixin, {
       now,
       day: now.day(),
       includeWeekend: this.includeWeekend,
-      includeMidFuture: this.includeMidFuture || true,
       includeFarFuture: this.includeFarFuture,
       includeDateTime: this.includeDateTime,
       canScheduleNow: this.includeNow || false,

--- a/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/atoms/date-time-inputs.hbs
+++ b/plugins/styleguide/assets/javascripts/discourse/templates/styleguide/atoms/date-time-inputs.hbs
@@ -22,7 +22,6 @@
   {{future-date-input
     displayLabelIcon="far-clock"
     includeDateTime=true
-    includeMidFuture=true
     clearable=true
   }}
 {{/styleguide-example}}


### PR DESCRIPTION
This option was always on. Essentially, we set it only in two places and always use `|| true` with it:

https://github.com/discourse/discourse/blob/fe5bfc8d3bd6bafdb45a4b44183433ccf1aef53b/app/assets/javascripts/discourse/app/components/future-date-input.js#L82

https://github.com/discourse/discourse/blob/fe5bfc8d3bd6bafdb45a4b44183433ccf1aef53b/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js#L32

Note that we're going to switch `future-date-input-selector` to [another source of time shortcuts](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/time-shortcut.js) and also change its API to make it more customizable. Removing the `includeMidFuture` option is a part of that change.



