### PR TITLE
DEV: Ensure Sidekiq job arguments have stringified keys

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -444,7 +444,7 @@ class SessionController < ApplicationController
     if user
       RateLimiter.new(nil, "forgot-password-login-day-#{user.username}", 6, 1.day).performed!
       email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:password_reset])
-      Jobs.enqueue(:critical_user_email, type: :forgot_password, user_id: user.id, email_token: email_token.token)
+      Jobs.enqueue(:critical_user_email, type: "forgot_password", user_id: user.id, email_token: email_token.token)
     else
       RateLimiter.new(nil, "forgot-password-login-hour-#{normalized_login_param}", 5, 1.hour).performed!
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -737,7 +737,7 @@ class UsersController < ApplicationController
       session["user_created_message"] = activation.success_message
 
       if existing_user = User.find_by_email(user.primary_email&.email)
-        Jobs.enqueue(:critical_user_email, type: :account_exists, user_id: existing_user.id)
+        Jobs.enqueue(:critical_user_email, type: "account_exists", user_id: existing_user.id)
       end
 
       render json: {
@@ -932,7 +932,7 @@ class UsersController < ApplicationController
 
       if user = User.with_email(params[:email]).admins.human_users.first
         email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:email_login])
-        Jobs.enqueue(:critical_user_email, type: :admin_login, user_id: user.id, email_token: email_token.token)
+        Jobs.enqueue(:critical_user_email, type: "admin_login", user_id: user.id, email_token: email_token.token)
         @message = I18n.t("admin_login.success")
       else
         @message = I18n.t("admin_login.errors.unknown_email_address")
@@ -967,7 +967,7 @@ class UsersController < ApplicationController
         email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:email_login])
 
         Jobs.enqueue(:critical_user_email,
-          type: :email_login,
+          type: "email_login",
           user_id: user.id,
           email_token: email_token.token
         )

--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -298,7 +298,7 @@ module Jobs
     if ::Jobs.run_later?
       hash = {
         'class' => klass,
-        'args' => [opts]
+        'args' => [opts.deep_stringify_keys]
       }
 
       if delay = opts.delete(:delay_for)

--- a/app/jobs/regular/suspicious_login.rb
+++ b/app/jobs/regular/suspicious_login.rb
@@ -13,7 +13,7 @@ module Jobs
                           client_ip: args[:client_ip])
 
         ::Jobs.enqueue(:critical_user_email,
-                     type: :suspicious_login,
+                     type: "suspicious_login",
                      user_id: args[:user_id],
                      client_ip: args[:client_ip],
                      user_agent: args[:user_agent])

--- a/app/jobs/scheduled/enqueue_digest_emails.rb
+++ b/app/jobs/scheduled/enqueue_digest_emails.rb
@@ -10,7 +10,7 @@ module Jobs
       users = target_user_ids
 
       users.each do |user_id|
-        ::Jobs.enqueue(:user_email, type: :digest, user_id: user_id)
+        ::Jobs.enqueue(:user_email, type: "digest", user_id: user_id)
       end
     end
 

--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -24,7 +24,7 @@ class EmailUpdater
 
     if existing_user = User.find_by_email(email)
       if SiteSetting.hide_email_address_taken
-        Jobs.enqueue(:critical_user_email, type: :account_exists, user_id: existing_user.id)
+        Jobs.enqueue(:critical_user_email, type: "account_exists", user_id: existing_user.id)
       else
         error_message = +'change_email.error'
         error_message << '_staged' if existing_user.staged?

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -28,7 +28,7 @@ task "admin:invite", [:email] => [:environment] do |_, args|
 
   puts "Sending email!"
   email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:password_reset])
-  Jobs.enqueue(:user_email, type: :account_created, user_id: user.id, email_token: email_token.token)
+  Jobs.enqueue(:user_email, type: "account_created", user_id: user.id, email_token: email_token.token)
 end
 
 desc "Creates a forum administrator"


### PR DESCRIPTION
(to be rebased-and-merged)

---

**DEV: Ensure Sidekiq job arguments have stringified keys**

The latest version of Sidekiq introduced a warning when jobs are queued with arguments which 'do not stringify to JSON safely'. In the vast majority of cases, this is because a hash is passed with symbols as keys. When those args are passed to the job, the keys will be stringified.

Our job wrapper already takes care of this issue by calling '.with_indifferent_access' on the args before passing them to `#execute`, so we don't need to change anything about our use. All we need to do is satisfy Sidekiq's warning system by 'stringifying' all the keys before enqueuing the job.

---

**DEV: Use strings for :user_email job type argument**

Job arguments go via JSON, and so symbols will appear as strings in the Job's `#execute` method. The latest version of Sidekiq has started warning about this to reduce developer confusion.