### PR TITLE
DEV: Include exception class in Discourse.warn_exception log

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -835,7 +835,7 @@ module Discourse
       # logster
       Rails.logger.add_with_opts(
         ::Logger::Severity::WARN,
-        "#{message} : #{e}",
+        "#{message} : #{e.class.name} : #{e}",
         "discourse-exception",
         backtrace: e.backtrace.join("\n"),
         env: env


### PR DESCRIPTION
Sometimes, the 'message' portion of an exception isn't enough to work out what's happening. In these cases, including the exception class name can help with debugging.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
