### PR TITLE
DEV: Update more Jobs#enqueue calls to use strings

### DIFF
--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -157,7 +157,7 @@ class Admin::EmailController < Admin::AdminController
     retry_count = 0
 
     begin
-      Jobs.enqueue(:process_email, mail: email_raw, retry_on_rate_limit: true, source: :handle_mail)
+      Jobs.enqueue(:process_email, mail: email_raw, retry_on_rate_limit: true, source: "handle_mail")
     rescue JSON::GeneratorError, Encoding::UndefinedConversionError => e
       if retry_count == 0
         email_raw = email_raw.force_encoding('iso-8859-1').encode("UTF-8")

--- a/app/services/notification_emailer.rb
+++ b/app/services/notification_emailer.rb
@@ -59,11 +59,11 @@ class NotificationEmailer
       notification_type = Notification.types[notification.notification_type]
 
       hash = {
-        type: type,
+        type: type.to_s,
         user_id: notification.user_id,
         notification_id: notification.id,
         notification_data_hash: notification.data_hash,
-        notification_type: notification_type,
+        notification_type: notification_type.to_s,
       }
 
       hash[:post_id] = post_id if post_id > 0 && notification_type != :post_approved

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -223,7 +223,7 @@ after_initialize do
       Jobs.enqueue(:bot_input,
         user_id: user.id,
         post_id: post.id,
-        input: :reply
+        input: "reply"
       )
     end
   end
@@ -233,7 +233,7 @@ after_initialize do
       Jobs.enqueue(:bot_input,
         user_id: post.user.id,
         post_id: post.id,
-        input: :edit
+        input: "edit"
       )
     end
   end
@@ -244,7 +244,7 @@ after_initialize do
         user_id: user.id,
         post_id: post.id,
         topic_id: post.topic_id,
-        input: :delete
+        input: "delete"
       )
     end
   end
@@ -254,7 +254,7 @@ after_initialize do
       Jobs.enqueue(:bot_input,
         user_id: user.id,
         post_id: post.id,
-        input: :recover
+        input: "recover"
       )
     end
   end
@@ -264,11 +264,11 @@ after_initialize do
       input =
         case self.post_action_type_id
         when *PostActionType.flag_types.values
-          self.post_action_type_id == PostActionType.types[:inappropriate] ? :flag : :reply
+          self.post_action_type_id == PostActionType.types[:inappropriate] ? "flag" : "reply"
         when PostActionType.types[:like]
-          :like
+          "like"
         when PostActionType.types[:bookmark]
-          :bookmark
+          "bookmark"
         end
 
       if input
@@ -283,7 +283,7 @@ after_initialize do
 
   self.add_model_callback(Bookmark, :after_commit, on: :create) do
     if self.post && self.user.enqueue_narrative_bot_job?
-      Jobs.enqueue(:bot_input, user_id: self.user_id, post_id: self.post_id, input: :bookmark)
+      Jobs.enqueue(:bot_input, user_id: self.user_id, post_id: self.post_id, input: "bookmark")
     end
   end
 
@@ -294,7 +294,7 @@ after_initialize do
       Jobs.enqueue(:bot_input,
         user_id: user_id,
         topic_id: topic_id,
-        input: :topic_notification_level_changed
+        input: "topic_notification_level_changed"
       )
     end
   end


### PR DESCRIPTION
Symbols are converted to strings anyway, so there is no change in behaviour. The latest version of sidekiq introduced a warning for this.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
