### PR TITLE
DEV: Ensure `delay_for` and `queue` are not passed as job arguments

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -297,8 +297,7 @@ module Jobs
 
     if ::Jobs.run_later?
       hash = {
-        'class' => klass,
-        'args' => [opts.deep_stringify_keys]
+        'class' => klass
       }
 
       if delay = opts.delete(:delay_for)
@@ -310,6 +309,8 @@ module Jobs
       if queue = opts.delete(:queue)
         hash['queue'] = queue
       end
+
+      hash['args'] = [opts.deep_stringify_keys]
 
       DB.after_commit { klass.client_push(hash) }
     else


### PR DESCRIPTION
This regressed in 3a85c4d680 because deep_stringify_keys makes a copy of the `opts` hash

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
