### PR TITLE
DEV: Use string timestamp when enqueuing update_top_redirection

### DIFF
--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -106,7 +106,7 @@ class UserOption < ActiveRecord::Base
     Discourse.redis.expire(key, delay)
 
     # delay the update
-    Jobs.enqueue_in(delay / 2, :update_top_redirection, user_id: self.user_id, redirected_at: Time.zone.now)
+    Jobs.enqueue_in(delay / 2, :update_top_redirection, user_id: self.user_id, redirected_at: Time.zone.now.to_s)
   end
 
   def should_be_redirected_to_top


### PR DESCRIPTION
Job arguments go via JSON, and so DateTime objects will appear as strings in the Job's `#execute` method. The latest version of Sidekiq has started warning about this to reduce developer confusion.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
