### PR TITLE
DEV: Update :critical_user_email calls to use strings

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -127,7 +127,7 @@ class Admin::UsersController < Admin::AdminController
     if message.present?
       Jobs.enqueue(
         :critical_user_email,
-        type: :account_suspended,
+        type: "account_suspended",
         user_id: @user.id,
         user_history_id: user_history.id
       )
@@ -368,7 +368,7 @@ class Admin::UsersController < Admin::AdminController
     if silencer.silence
       Jobs.enqueue(
         :critical_user_email,
-        type: :account_silenced,
+        type: "account_silenced",
         user_id: @user.id,
         user_history_id: silencer.user_history.id
       )
@@ -412,7 +412,7 @@ class Admin::UsersController < Admin::AdminController
 
     Jobs.enqueue(
       :critical_user_email,
-      type: :account_second_factor_disabled,
+      type: "account_second_factor_disabled",
       user_id: @user.id
     )
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1535,7 +1535,7 @@ class UsersController < ApplicationController
 
     Jobs.enqueue(
       :critical_user_email,
-      type: :account_second_factor_disabled,
+      type: "account_second_factor_disabled",
       user_id: current_user.id
     )
 

--- a/app/jobs/scheduled/activation_reminder_emails.rb
+++ b/app/jobs/scheduled/activation_reminder_emails.rb
@@ -16,7 +16,7 @@ module Jobs
         email_token = user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:signup])
         ::Jobs.enqueue(
           :user_email,
-          type: :activation_reminder,
+          type: "activation_reminder",
           user_id: user.id,
           email_token: email_token.token
         )

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -95,7 +95,7 @@ class EmailToken < ActiveRecord::Base
   def self.enqueue_signup_email(email_token, to_address: nil)
     Jobs.enqueue(
       :critical_user_email,
-      type: :signup,
+      type: "signup",
       user_id: email_token.user_id,
       email_token: email_token.token,
       to_address: to_address

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -31,7 +31,7 @@ class ReviewableUser < Reviewable
     if args[:send_email] != false && SiteSetting.must_approve_users?
       Jobs.enqueue(
         :critical_user_email,
-        type: :signup_after_approval,
+        type: "signup_after_approval",
         user_id: target.id
       )
     end

--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -68,10 +68,10 @@ class EmailUpdater
 
     if @change_req.change_state == EmailChangeRequest.states[:authorizing_old]
       @change_req.old_email_token = @user.email_tokens.create!(email: @user.email, scope: EmailToken.scopes[:email_update])
-      send_email(add ? :confirm_old_email_add : :confirm_old_email, @change_req.old_email_token)
+      send_email(add ? "confirm_old_email_add" : "confirm_old_email", @change_req.old_email_token)
     elsif @change_req.change_state == EmailChangeRequest.states[:authorizing_new]
       @change_req.new_email_token = @user.email_tokens.create!(email: email, scope: EmailToken.scopes[:email_update])
-      send_email(:confirm_new_email, @change_req.new_email_token)
+      send_email("confirm_new_email", @change_req.new_email_token)
     end
 
     @change_req.save!
@@ -102,7 +102,7 @@ class EmailUpdater
           change_state: EmailChangeRequest.states[:authorizing_new],
           new_email_token: @user.email_tokens.create!(email: @change_req.new_email, scope: EmailToken.scopes[:email_update])
         )
-        send_email(:confirm_new_email, @change_req.new_email_token)
+        send_email("confirm_new_email", @change_req.new_email_token)
         confirm_result = :authorizing_new
       when EmailChangeRequest.states[:authorizing_new]
         @change_req.update!(change_state: EmailChangeRequest.states[:complete])
@@ -144,7 +144,7 @@ class EmailUpdater
   def send_email_notification(old_email, new_email)
     Jobs.enqueue :critical_user_email,
                  to_address: @user.email,
-                 type: old_email ? :notify_old_email : :notify_old_email_add,
+                 type: old_email ? "notify_old_email" : "notify_old_email_add",
                  user_id: @user.id,
                  new_email: new_email
   end


### PR DESCRIPTION
Symbols are converted to strings anyway, so there is no change in behaviour. The latest version of sidekiq introduced a warning for this.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
