### PR TITLE
Fix some regexes that leaded to inaccurate results in php3 migration scripts

### DIFF
--- a/script/import_scripts/phpbb3/support/smiley_processor.rb
+++ b/script/import_scripts/phpbb3/support/smiley_processor.rb
@@ -18,7 +18,7 @@ module ImportScripts::PhpBB3
 
     def replace_smilies(text)
       # :) is encoded as <!-- s:) --><img src="{SMILIES_PATH}/icon_e_smile.gif" alt=":)" title="Smile" /><!-- s:) -->
-      text.gsub!(/<!-- s(\S+) --><img src="\{SMILIES_PATH\}\/.+?" alt=".*?" title=".*?" \/><!-- s?:\S+ -->/) do
+      text.gsub!(/<!-- s(\S+) --><img src="\{SMILIES_PATH\}\/.+?" alt=".*?" title=".*?" \/><!-- s?\S+ -->/) do
         emoji($1)
       end
     end

--- a/script/import_scripts/phpbb3/support/text_processor.rb
+++ b/script/import_scripts/phpbb3/support/text_processor.rb
@@ -78,10 +78,10 @@ module ImportScripts::PhpBB3
       # Many phpbb bbcode tags have a hash attached to them. Examples:
       #   [url=https&#58;//google&#46;com:1qh1i7ky]click here[/url:1qh1i7ky]
       #   [quote=&quot;cybereality&quot;:b0wtlzex]Some text.[/quote:b0wtlzex]
-      text.gsub!(/:(?:\w{8})\]/, ']')
+      text.gsub!(/:(?:\w{5,8})\]/, ']')
 
       # remove color tags
-      text.gsub!(/\[\/?color(=#[a-z0-9]*)?\]/i, "")
+      text.gsub!(/\[\/?color(=#?[a-z0-9]*)?\]/i, "")
     end
 
     def bbcode_to_md(text)


### PR DESCRIPTION
1. bbcode hashes don't always have exactly 8 characters.

2. colors aren't always hex values, it can be a color string ("red", "blue", etc).

3. The closing tag of smileys doesn't always starts a `:` character (the start of the regex was already right for this particular issue)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
