### PR TITLE
FIX: Handle addressable error when parsing an invalid URL.

### DIFF
--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -14,13 +14,13 @@ class EmbeddableHost < ActiveRecord::Base
   self.ignored_columns = ["path_whitelist"]
 
   def self.record_for_url(uri)
-
     if uri.is_a?(String)
       uri = begin
         URI(UrlHelper.escape_uri(uri))
-      rescue URI::Error
+      rescue URI::Error, Addressable::URI::InvalidURIError
       end
     end
+
     return false unless uri.present?
 
     host = uri.host

--- a/spec/models/embeddable_host_spec.rb
+++ b/spec/models/embeddable_host_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 describe EmbeddableHost do
-
   it "trims http" do
     eh = EmbeddableHost.new(host: 'http://example.com')
     expect(eh).to be_valid
@@ -147,6 +146,18 @@ describe EmbeddableHost do
       host.destroy
 
       expect(SiteSetting.embed_post_limit).to eq(SiteSetting.defaults[:embed_post_limit])
+    end
+  end
+
+  describe '.record_for_url' do
+    fab!(:embeddable_host) { Fabricate(:embeddable_host) }
+
+    it 'returns the right record if given URL matches host' do
+      expect(EmbeddableHost.record_for_url("https://#{embeddable_host.host}")).to eq(embeddable_host)
+    end
+
+    it 'returns false if URL is malformed' do
+      expect(EmbeddableHost.record_for_url("@@@@@")).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Passing in an invalid URL would result in an `Addressable::URI::InvalidURIError` which we were not catching.