### PR TITLE
FIX: User option fields definition was being mutated on save

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -334,13 +334,16 @@ const User = RestModel.extend({
       userFields.filter((uf) => !fields || fields.indexOf(uf) !== -1)
     );
 
+    let filteredUserOptionFields = [];
     if (fields) {
-      userOptionFields = userOptionFields.filter(
+      filteredUserOptionFields = userOptionFields.filter(
         (uo) => fields.indexOf(uo) !== -1
       );
+    } else {
+      filteredUserOptionFields = userOptionFields;
     }
 
-    userOptionFields.forEach((s) => {
+    filteredUserOptionFields.forEach((s) => {
       data[s] = this.get(`user_option.${s}`);
     });
 

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -382,6 +382,10 @@ const User = RestModel.extend({
       }
     });
 
+    return this._saveUserData(data, updatedState);
+  },
+
+  _saveUserData(data, updatedState) {
     // TODO: We can remove this when migrated fully to rest model.
     this.set("isSaving", true);
     return ajax(userPath(`${this.username_lower}.json`), {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -2,7 +2,6 @@ import EmberObject from "@ember/object";
 import User from "discourse/models/user";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import sinon from "sinon";
-import pretender from "discourse/tests/helpers/create-pretender";
 import {
   acceptance,
   exists,
@@ -150,15 +149,14 @@ acceptance("User - Saving user options", function (needs) {
     disable_mailing_list_mode: false,
   });
 
-  test("saving user options", async function (assert) {
-    pretender.put("/u/eviltrout.json", () => {
-      return [
-        200,
-        { "Content-Type": "application/json" },
-        { success: true, user: {} },
-      ];
+  needs.pretender((server, helper) => {
+    server.put("/u/eviltrout.json", () => {
+      return helper.response(200, { user: {} });
     });
-    let spy = sinon.spy(User.current(), "_saveUserData");
+  });
+
+  test("saving user options", async function (assert) {
+    const spy = sinon.spy(User.current(), "_saveUserData");
 
     await visit("/u/eviltrout/preferences/emails");
     await click(".pref-mailing-list-mode input[type='checkbox']");

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -1,7 +1,7 @@
 import EmberObject from "@ember/object";
+import User from "discourse/models/user";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import sinon from "sinon";
-import * as ajaxlib from "discourse/lib/ajax";
 import pretender from "discourse/tests/helpers/create-pretender";
 import {
   acceptance,
@@ -158,17 +158,14 @@ acceptance("User - Saving user options", function (needs) {
         { success: true, user: {} },
       ];
     });
-    let spy = sinon.spy(ajaxlib, "ajax");
+    let spy = sinon.spy(User.current(), "_saveUserData");
 
     await visit("/u/eviltrout/preferences/emails");
     await click(".pref-mailing-list-mode input[type='checkbox']");
     await click(".save-changes");
 
     assert.ok(
-      spy.calledWithMatch("/u/eviltrout.json", {
-        data: { mailing_list_mode: true },
-        type: "PUT",
-      }),
+      spy.calledWithMatch({ mailing_list_mode: true }),
       "sends a PUT request to update the specified user option"
     );
 
@@ -177,10 +174,7 @@ acceptance("User - Saving user options", function (needs) {
     await click(".save-changes");
 
     assert.ok(
-      spy.calledWithMatch("/u/eviltrout.json", {
-        data: { email_messages_level: 2 },
-        type: "PUT",
-      }),
+      spy.calledWithMatch({ email_messages_level: 2 }),
       "is able to save a different user_option on a subsequent request"
     );
   });

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -1,10 +1,8 @@
 import * as ajaxlib from "discourse/lib/ajax";
-import EmberObject from "@ember/object";
-import pretender from "discourse/tests/helpers/create-pretender";
 import { module, test } from "qunit";
-import Group from "discourse/models/group";
-import User, { addSaveableUserOptionField } from "discourse/models/user";
 import sinon from "sinon";
+import Group from "discourse/models/group";
+import User from "discourse/models/user";
 
 module("Unit | Model | user", function () {
   test("staff", function (assert) {
@@ -125,55 +123,5 @@ module("Unit | Model | user", function () {
 
     assert.deepEqual(user.calculateMutedIds(0, 1, "muted_category_ids"), [1]);
     assert.deepEqual(user.calculateMutedIds(1, 1, "muted_category_ids"), []);
-  });
-
-  test("saving user options", function (assert) {
-    let user = User.create({
-      username: "chuck",
-      user_option: EmberObject.create({}),
-    });
-    User.resetCurrent(user);
-    pretender.put("/u/chuck.json", () => {
-      return [
-        200,
-        { "Content-Type": "application/json" },
-        { success: true, user },
-      ];
-    });
-    let spy = sinon.spy(ajaxlib, "ajax");
-
-    user.user_option.set("mailing_list_mode", true);
-    user.save("mailing_list_mode");
-
-    assert.ok(
-      spy.calledWith("/u/chuck.json", {
-        data: { mailing_list_mode: true },
-        type: "PUT",
-      }),
-      "sends a PUT request to update the specified user option"
-    );
-
-    user.user_option.set("text_size", "smallest");
-    user.save("text_size");
-
-    assert.ok(
-      spy.calledWith("/u/chuck.json", {
-        data: { text_size: "smallest" },
-        type: "PUT",
-      }),
-      "is able to save a different user_option on a subsequent request"
-    );
-
-    addSaveableUserOptionField("some_other_field");
-    user.user_option.set("some_other_field", "testdata");
-    user.save("some_other_field");
-
-    assert.ok(
-      spy.calledWith("/u/chuck.json", {
-        data: { some_other_field: "testdata" },
-        type: "PUT",
-      }),
-      "is able to save a user option field added via addSaveableUserOptionField"
-    );
   });
 });


### PR DESCRIPTION
In the commit d8bf2810ffe49619077371d854fc12cba81f80fa we hoisted
the userOptionFields array to a module-level variable, but kept
the code inside save() the same. This causes an issue where if
save() is called twice on the same user with some array of user
option fields, the userOptionFields array is mutated, which means
the second save is likely not saving the fields intended.

This commit fixes the issue by not mutating the array. We cannot
change them into consts though, because we have an API to add more
items to the array.
