### PR TITLE
DEV: Add context in `AdminConstraint`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,8 +32,8 @@ Discourse::Application.routes.draw do
         mount Logster::Web => "/logs"
       else
         # only allow sidekiq in master site
-        mount Sidekiq::Web => "/sidekiq", constraints: AdminConstraint.new(require_master: true)
-        mount Logster::Web => "/logs", constraints: AdminConstraint.new
+        mount Sidekiq::Web => "/sidekiq", constraints: AdminConstraint.new(require_master: true, context: "sidekiq")
+        mount Logster::Web => "/logs", constraints: AdminConstraint.new(context: "logster")
       end
     end
 

--- a/lib/admin_constraint.rb
+++ b/lib/admin_constraint.rb
@@ -4,12 +4,16 @@ class AdminConstraint
 
   def initialize(options = {})
     @require_master = options[:require_master]
+    # @context isn't used here, but it exists to give plugins extra context
+    # about the destination of the request.
+    # possible values are: sidekiq, logster and app (default).
+    @context = options[:context] || "app"
   end
 
   def matches?(request)
     return false if @require_master && RailsMultisite::ConnectionManagement.current_db != "default"
-    current_user = CurrentUser.lookup_from_env(request.env)
-    current_user&.admin? && custom_admin_check(request)
+    @current_user = CurrentUser.lookup_from_env(request.env)
+    @current_user&.admin? && custom_admin_check(request)
   rescue Discourse::InvalidAccess, Discourse::ReadOnly
     false
   end


### PR DESCRIPTION
This allows plugins to override the permissions required to access
specific things like the Logster and Sidekiq web UI without the changes
leaking to the rest of Discourse routes.