### PR TITLE
FIX: Do not override mobile scroll on docked progress element

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -163,6 +163,10 @@ export default Component.extend(PanEvents, {
   },
 
   panStart(e) {
+    if (e.originalEvent.target.classList.contains("docked")) {
+      return;
+    }
+
     e.originalEvent.preventDefault();
     const center = e.center;
     const $centeredElement = $(document.elementFromPoint(center.x, center.y));


### PR DESCRIPTION
Context: https://meta.discourse.org/t/mobile-cant-scroll-in-area-next-to-pagination-scroller-widget/217324