### PR TITLE
DEV: Make Ember CLI assets the default in production

### DIFF
--- a/app/controllers/qunit_controller.rb
+++ b/app/controllers/qunit_controller.rb
@@ -23,7 +23,7 @@ class QunitController < ApplicationController
 
     @is_proxied = is_ember_cli_proxy?
     @legacy_ember = if Rails.env.production?
-      ENV['EMBER_CLI_PROD_ASSETS'] != "1"
+      ENV['EMBER_CLI_PROD_ASSETS'] == "0"
     else
       !@is_proxied
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -138,7 +138,7 @@ module ApplicationHelper
   def preload_vendor_scripts
     scripts = ["vendor"]
 
-    if ENV["EMBER_CLI_PROD_ASSETS"] == "1"
+    if ENV["EMBER_CLI_PROD_ASSETS"] != "0"
       @@vendor_chunks ||= begin
         all_assets = ActionController::Base.helpers.assets_manifest.assets
         all_assets.keys.filter_map { |name| name[/\A(chunk\..*)\.js\z/, 1] }

--- a/config/application.rb
+++ b/config/application.rb
@@ -180,7 +180,7 @@ module Discourse
       discourse/tests/test_starter.js
     }
 
-    if ENV['EMBER_CLI_PROD_ASSETS'] != "1"
+    if ENV['EMBER_CLI_PROD_ASSETS'] == "0"
       config.assets.precompile += %w{
         discourse/tests/test-support-rails.js
         discourse/tests/test-helpers-rails.js

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -35,7 +35,7 @@ task 'assets:precompile:before' do
   require 'sprockets'
   require 'digest/sha1'
 
-  if ENV['EMBER_CLI_PROD_ASSETS']
+  if ENV['EMBER_CLI_PROD_ASSETS'] != "0"
     # Remove the assets that Ember CLI will handle for us
     Rails.configuration.assets.precompile.reject! do |asset|
       asset.is_a?(String) &&
@@ -312,7 +312,7 @@ end
 
 task 'assets:precompile' => 'assets:precompile:before' do
 
-  copy_ember_cli_assets if ENV['EMBER_CLI_PROD_ASSETS']
+  copy_ember_cli_assets if ENV['EMBER_CLI_PROD_ASSETS'] != '0'
 
   refresh_days = GlobalSetting.refresh_maxmind_db_during_precompile_days
 


### PR DESCRIPTION
This can be disabled by setting `EMBER_CLI_PROD_ASSETS=0`, but this option will not be available for long. If your theme/plugin/site has issues under Ember CLI, please open a topic on https://meta.discourse.org

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
