### PR TITLE
UX: clear action snapshots when composer popup is canceled.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -23,6 +23,7 @@ import deprecated from "discourse-common/lib/deprecated";
 import { isEmpty } from "@ember/utils";
 import { propertyNotEqual } from "discourse/lib/computed";
 import { throwAjaxError } from "discourse/lib/ajax-error";
+import { _clearSnapshots } from "select-kit/components/composer-actions";
 
 let _customizations = [];
 export function registerCustomizationCallback(cb) {
@@ -919,6 +920,7 @@ const Composer = RestModel.extend({
       noBump: false,
       editConflict: false,
     });
+    _clearSnapshots();
   },
 
   @discourseComputed("editConflict", "originalText")

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -57,6 +57,18 @@ acceptance("Composer Actions", function (needs) {
       "toggle_topic_bump"
     );
     assert.strictEqual(composerActions.rowByIndex(5).value(), null);
+
+    await click("#reply-control .save-or-cancel .cancel");
+    await visit("/");
+    await click("#create-topic");
+    await composerActions.expand();
+
+    assert.strictEqual(
+      composerActions.rowByIndex(0).value(),
+      "reply_as_private_message"
+    );
+    assert.strictEqual(composerActions.rowByIndex(1).value(), "shared_draft");
+    assert.strictEqual(composerActions.rowByIndex(2).value(), null);
   });
 
   test("replying to post - reply_as_private_message", async function (assert) {


### PR DESCRIPTION
Previously, the composer kept the last visited topic in action snapshots even after the composer popup is canceled by the user.