### PR TITLE
DEV: Send message to DiscourseHub when dismissing

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
@@ -3,6 +3,7 @@ import { Promise } from "rsvp";
 import Session from "discourse/models/session";
 import { createWidget } from "discourse/widgets/widget";
 import { h } from "virtual-dom";
+import { postRNWebviewMessage } from "discourse/lib/utilities";
 
 /**
  * This tries to enforce a consistent flow of fetching, caching, refreshing,
@@ -75,6 +76,7 @@ export default createWidget("quick-access-panel", {
   markRead() {
     return this.markReadRequest().then(() => {
       this.refreshNotifications(this.state);
+      postRNWebviewMessage("markRead", "1");
     });
   },
 


### PR DESCRIPTION
This lets the DiscourseHub app know that the user has dismissed their notifications. The app then can refresh its internal data and update the app's count badge. 