### PR TITLE
DEV: Stringify keys of nested hashes in job arguments

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -298,7 +298,7 @@ module Jobs
 
     # Only string keys are allowed in JSON. We call `.with_indifferent_access`
     # in Jobs::Base#perform, so this is invisible to developers
-    opts = opts.stringify_keys
+    opts = opts.deep_stringify_keys
 
     # Simulate the args being dumped/parsed through JSON
     parsed_opts = JSON.parse(JSON.dump(opts))


### PR DESCRIPTION
This provides symmetry with the `.with_indifferent_access` usage in `Jobs#perform`, which is also recursive.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
