### PR TITLE
FIX: Align progress text

### DIFF
--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -991,6 +991,7 @@ body.wizard {
       color: var(--secondary-or-primary);
       z-index: 13;
       left: 1.5em;
+      line-height: 1.4em;
     }
 
     .screen {


### PR DESCRIPTION
This very small PR makes a slight adjustment to the alignment of the progress text in the site setup wizard.

### After
<img width="296" alt="image" src="https://user-images.githubusercontent.com/30537603/152891238-51c7361c-1c2f-4175-9b0c-a14e1e1cf6ac.png">

### Before
<img width="423" alt="image" src="https://user-images.githubusercontent.com/30537603/152891271-f48cb2a2-14d2-4d3c-82ca-7c9ab7ca6f54.png">
