### PR TITLE
FIX: inline onebox for github

### DIFF
--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -41,12 +41,10 @@ module RetrieveTitle
   private
 
   def self.max_chunk_size(uri)
-
-    # Amazon and YouTube leave the title until very late. Exceptions are bad
-    # but these are large sites.
-    return 500 if uri.host =~ /amazon\.(com|ca|co\.uk|es|fr|de|it|com\.au|com\.br|cn|in|co\.jp|com\.mx)$/
-    return 300 if uri.host =~ /youtube\.com$/ || uri.host =~ /youtu.be/
-    return 50 if uri.host =~ /github\.com$/
+    # Exception for sites that leave the title until very late.
+    return 500 if uri.host =~ /(^|\.)amazon\.(com|ca|co\.uk|es|fr|de|it|com\.au|com\.br|cn|in|co\.jp|com\.mx)$/
+    return 300 if uri.host =~ /(^|\.)youtube\.com$/ || uri.host =~ /(^|\.)youtu\.be$/
+    return 50 if uri.host =~ /(^|\.)github\.com$/
 
     # default is 20k
     20

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -46,6 +46,7 @@ module RetrieveTitle
     # but these are large sites.
     return 500 if uri.host =~ /amazon\.(com|ca|co\.uk|es|fr|de|it|com\.au|com\.br|cn|in|co\.jp|com\.mx)$/
     return 300 if uri.host =~ /youtube\.com$/ || uri.host =~ /youtu.be/
+    return 50 if uri.host =~ /github\.com$/
 
     # default is 20k
     20


### PR DESCRIPTION
Increase size of downloaded HTML for GitHub when getting title for
inline Onebox.
