### PR TITLE
DEV: Make Ember CLI assets the default in production

### DIFF
--- a/app/controllers/qunit_controller.rb
+++ b/app/controllers/qunit_controller.rb
@@ -23,7 +23,7 @@ class QunitController < ApplicationController
 
     @is_proxied = is_ember_cli_proxy?
     @legacy_ember = if Rails.env.production?
-      ENV['EMBER_CLI_PROD_ASSETS'] != "1"
+      ENV['EMBER_CLI_PROD_ASSETS'] == "0"
     else
       !@is_proxied
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -180,7 +180,7 @@ module Discourse
       discourse/tests/test_starter.js
     }
 
-    if ENV['EMBER_CLI_PROD_ASSETS'] != "1"
+    if ENV['EMBER_CLI_PROD_ASSETS'] == "0"
       config.assets.precompile += %w{
         discourse/tests/test-support-rails.js
         discourse/tests/test-helpers-rails.js

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -35,7 +35,7 @@ task 'assets:precompile:before' do
   require 'sprockets'
   require 'digest/sha1'
 
-  if ENV['EMBER_CLI_PROD_ASSETS'] == "1"
+  if ENV['EMBER_CLI_PROD_ASSETS'] != "0"
     # Remove the assets that Ember CLI will handle for us
     Rails.configuration.assets.precompile.reject! do |asset|
       asset.is_a?(String) &&
@@ -312,7 +312,7 @@ end
 
 task 'assets:precompile' => 'assets:precompile:before' do
 
-  copy_ember_cli_assets if ENV['EMBER_CLI_PROD_ASSETS'] == '1'
+  copy_ember_cli_assets if ENV['EMBER_CLI_PROD_ASSETS'] != '0'
 
   refresh_days = GlobalSetting.refresh_maxmind_db_during_precompile_days
 


### PR DESCRIPTION
This was reverted in e92f57255de429fcf12c4259235d88c5485d934f due to memory usage concerns. This memory issue was resolved by 4cceb55621aa5a25c72415d78a43bd62be68d68d.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
