### PR TITLE
DEV: Ensure that Discourse global is available for widget init

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
+++ b/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
@@ -36,5 +36,6 @@ export function autoLoadModules(container, registry) {
 
 export default {
   name: "auto-load-modules",
+  after: "inject-objects",
   initialize: (container) => autoLoadModules(container, container.registry),
 };

--- a/app/assets/javascripts/discourse/app/initializers/inject-objects.js
+++ b/app/assets/javascripts/discourse/app/initializers/inject-objects.js
@@ -6,6 +6,7 @@ import deprecated from "discourse-common/lib/deprecated";
 
 export default {
   name: "inject-objects",
+  after: isLegacyEmber() ? null : "export-application-global",
   initialize(container, app) {
     // This is required for Ember CLI tests to work
     setDefaultOwner(app.__container__);


### PR DESCRIPTION
Under ember-cli, we rely on the `ember-export-application-global` addon to make `window.Discourse` available. This happens in an initializer. Previously this inititalizer would run after `auto-load-modules`, and so any widget/helper modules would not be able to access it. This commit sets some `after` parameters on the `auto-load-modules` and `inject-objects` initializers to ensure that `export-application-global` is run first.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
