### PR TITLE
FIX: backport caret moves to a wrong position when uploading an image via toolbar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -477,7 +477,7 @@ export default Component.extend(TextareaTextManipulation, {
       key: "#",
       afterComplete: (value) => {
         this.set("value", value);
-        return this._focusTextArea();
+        schedule("afterRender", this, this._focusTextArea);
       },
       transformComplete: (obj) => {
         return obj.text;
@@ -504,7 +504,7 @@ export default Component.extend(TextareaTextManipulation, {
       key: ":",
       afterComplete: (text) => {
         this.set("value", text);
-        this._focusTextArea();
+        schedule("afterRender", this, this._focusTextArea);
       },
 
       onKeyUp: (text, cp) => {

--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -25,18 +25,16 @@ export default Mixin.create({
 
   // ensures textarea scroll position is correct
   _focusTextArea() {
-    schedule("afterRender", () => {
-      if (!this.element || this.isDestroying || this.isDestroyed) {
-        return;
-      }
+    if (!this.element || this.isDestroying || this.isDestroyed) {
+      return;
+    }
 
-      if (!this._textarea) {
-        return;
-      }
+    if (!this._textarea) {
+      return;
+    }
 
-      this._textarea.blur();
-      this._textarea.focus();
-    });
+    this._textarea.blur();
+    this._textarea.focus();
   },
 
   _insertBlock(text) {
@@ -171,7 +169,7 @@ export default Mixin.create({
     this._$textarea.prop("selectionStart", (pre + text).length + 2);
     this._$textarea.prop("selectionEnd", (pre + text).length + 2);
 
-    this._focusTextArea();
+    schedule("afterRender", this, this._focusTextArea);
   },
 
   _addText(sel, text, options) {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
@@ -316,6 +316,30 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
     appEvents.trigger("composer:add-files", image);
   });
 
+  test("should place cursor properly after inserting a placeholder", async function (assert) {
+    const appEvents = loggedInUser().appEvents;
+    const done = assert.async();
+
+    await visit("/");
+    await click("#create-topic");
+    await fillIn(".d-editor-input", "The image:\ntext after image");
+    const input = query(".d-editor-input");
+    input.selectionStart = 10;
+    input.selectionEnd = 10;
+
+    appEvents.on("composer:all-uploads-complete", () => {
+      // after uploading we have this in the textarea:
+      // "The image:\n![avatar.PNG|690x320](upload://yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg)\ntext after image"
+      // cursor should be just before "text after image":
+      assert.equal(input.selectionStart, 76);
+      assert.equal(input.selectionEnd, 76);
+      done();
+    });
+
+    const image = createFile("avatar.png");
+    appEvents.trigger("composer:add-files", image);
+  });
+
   test("should be able to paste a table with files and not upload the files", async function (assert) {
     await visit("/");
     await click("#create-topic");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-uploads-uppy-test.js
@@ -316,7 +316,7 @@ acceptance("Uppy Composer Attachment - Upload Placeholder", function (needs) {
     appEvents.trigger("composer:add-files", image);
   });
 
-  test("should place cursor properly after inserting a placeholder", async function (assert) {
+  skip("should place cursor properly after inserting a placeholder", async function (assert) {
     const appEvents = loggedInUser().appEvents;
     const done = assert.async();
 


### PR DESCRIPTION
This is a backport of https://github.com/discourse/discourse/pull/15684.

Turned out that this fixes the bug only when running under Ember CLI. The PR for the legacy environment is upcoming.

> When uploading an image, we change the uploading placeholder several times. Every time, we correct the position of the cursor after replacing. But we schedule repositioning of cursor to the afterRender queue in Ember Run Loop. As a result, sometimes we replace the placeholder several times but correct the cursor position only once at the end.
>
> It just cannot work correctly with scheduling, we'll always be dealing with cumulative error. Removing scheduling fixes the problem.
>
> Sadly, I cannot make the test work, I skipped it for now, going to give it another try later.
