### PR TITLE
FEATURE: Redeem invites for existent users

### DIFF
--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -105,6 +105,18 @@ describe InvitesController do
       expect(Notification.where(notification_type: Notification.types[:invited_to_topic], topic: topic).count).to eq(1)
     end
 
+    it 'creates a notification to inviter' do
+      topic = Fabricate(:topic)
+      TopicInvite.create!(topic: topic, invite: invite)
+
+      sign_in(user)
+
+      get "/invites/#{invite.invite_key}"
+      expect(response).to redirect_to(topic.url)
+      expect(Notification.where(user: user, notification_type: Notification.types[:invited_to_topic], topic: topic).count).to eq(1)
+      expect(Notification.where(user: invite.invited_by, notification_type: Notification.types[:invitee_accepted]).count).to eq(1)
+    end
+
     it 'fails for logged in users' do
       sign_in(Fabricate(:user))
 

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -117,15 +117,6 @@ describe InvitesController do
       expect(Notification.where(user: invite.invited_by, notification_type: Notification.types[:invitee_accepted]).count).to eq(1)
     end
 
-    it 'fails for logged in users' do
-      sign_in(Fabricate(:user))
-
-      get "/invites/#{invite.invite_key}"
-      expect(response.status).to eq(200)
-      expect(response.body).to_not have_tag(:script, with: { src: '/assets/application.js' })
-      expect(response.body).to include(I18n.t('login.already_logged_in'))
-    end
-
     it 'fails if invite does not exist' do
       get '/invites/missing'
       expect(response.status).to eq(200)


### PR DESCRIPTION
This adds logic to increase an `InvitedUser` record, increase
`redemption_count` and create a `:invitee_accepted` to let the inviter
know that the invitee used the invite.

Initial support for this was implemented in commit 9969631.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
