### PR TITLE
FIX: use `prev_period` data if `prev30Days` value is not available.

### DIFF
--- a/app/assets/javascripts/admin/addon/models/report.js
+++ b/app/assets/javascripts/admin/addon/models/report.js
@@ -163,9 +163,23 @@ const Report = EmberObject.extend({
     return this._computeTrend(prev, total, higherIsBetter);
   },
 
-  @discourseComputed("prev30Days", "lastThirtyDaysCount", "higher_is_better")
-  thirtyDaysTrend(prev30Days, lastThirtyDaysCount, higherIsBetter) {
-    return this._computeTrend(prev30Days, lastThirtyDaysCount, higherIsBetter);
+  @discourseComputed(
+    "prev30Days",
+    "prev_period",
+    "lastThirtyDaysCount",
+    "higher_is_better"
+  )
+  thirtyDaysTrend(
+    prev30Days,
+    prev_period,
+    lastThirtyDaysCount,
+    higherIsBetter
+  ) {
+    return this._computeTrend(
+      prev30Days ?? prev_period,
+      lastThirtyDaysCount,
+      higherIsBetter
+    );
   },
 
   @discourseComputed("type")
@@ -236,10 +250,15 @@ const Report = EmberObject.extend({
     );
   },
 
-  @discourseComputed("prev30Days", "lastThirtyDaysCount")
-  thirtyDaysCountTitle(prev30Days, lastThirtyDaysCount) {
+  @discourseComputed("prev30Days", "prev_period")
+  canDisplayTrendIcon(prev30Days, prev_period) {
+    return prev30Days ?? prev_period;
+  },
+
+  @discourseComputed("prev30Days", "prev_period", "lastThirtyDaysCount")
+  thirtyDaysCountTitle(prev30Days, prev_period, lastThirtyDaysCount) {
     return this.changeTitle(
-      prev30Days,
+      prev30Days ?? prev_period,
       lastThirtyDaysCount,
       "in the previous 30 day period"
     );

--- a/app/assets/javascripts/admin/addon/templates/components/admin-report-counters.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-report-counters.hbs
@@ -18,7 +18,7 @@
 <div class="cell value thirty-days-count {{model.thirtyDaysTrend}}" title={{model.thirtyDaysCountTitle}}>
   {{number model.lastThirtyDaysCount}}
 
-  {{#if model.prev30Days}}
+  {{#if model.canDisplayTrendIcon}}
     {{d-icon model.thirtyDaysTrendIcon}}
   {{/if}}
 </div>

--- a/app/assets/javascripts/discourse/tests/unit/models/report-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/report-test.js
@@ -109,12 +109,19 @@ module("Unit | Model | report", function () {
   });
 
   test("thirtyDaysCountTitle", function (assert) {
-    const report = reportWithData([5, 5, 5, 5]);
+    let report = reportWithData([5, 5, 5, 5]);
     report.set("prev30Days", 10);
-    const title = report.get("thirtyDaysCountTitle");
+    let title = report.get("thirtyDaysCountTitle");
 
     assert.ok(title.indexOf("+50%") !== -1);
     assert.ok(title.match(/Was 10/));
+
+    report = reportWithData([5, 5, 5, 5]);
+    report.set("prev_period", 20);
+    title = report.get("thirtyDaysCountTitle");
+
+    assert.ok(title.indexOf("-25%") !== -1);
+    assert.ok(title.match(/Was 20/));
   });
 
   test("sevenDaysTrend", function (assert) {


### PR DESCRIPTION
Previously, reports of likes and flags don't include the 30 days trend icon and title.