### PR TITLE
FIX: Replace Twitter handles one at a time

### DIFF
--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -95,14 +95,14 @@ class TwitterApi
     protected
 
     def link_handles_in(text)
-      text.gsub(/(?:^|\s)@(\w+)/) do |match|
+      text.gsub(/(?:^|\s)@\w+/) do |match|
         handle = match.strip[1..]
         "<a href='https://twitter.com/#{handle}' target='_blank'>@#{handle}</a>"
       end.strip
     end
 
     def link_hashtags_in(text)
-      text.gsub(/(?:^|\s)#(\w+)/) do |match|
+      text.gsub(/(?:^|\s)#\w+/) do |match|
         hashtag = match.strip[1..]
         "<a href='https://twitter.com/search?q=%23#{hashtag}' target='_blank'>##{hashtag}</a>"
       end.strip

--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -95,28 +95,17 @@ class TwitterApi
     protected
 
     def link_handles_in(text)
-      text.scan(/(?:^|\s)@(\w+)/).flatten.uniq.each do |handle|
-        text.gsub!(/(?:^|\s)@#{handle}/, [
-          " <a href='https://twitter.com/#{handle}' target='_blank'>",
-            "@#{handle}",
-          "</a>"
-        ].join)
-      end
-
-      text.strip
+      text.gsub(/(?:^|\s)@(\w+)/) do |match|
+        handle = match.strip[1..]
+        "<a href='https://twitter.com/#{handle}' target='_blank'>@#{handle}</a>"
+      end.strip
     end
 
     def link_hashtags_in(text)
-      text.scan(/(?:^|\s)#(\w+)/).flatten.uniq.each do |hashtag|
-        text.gsub!(/(?:^|\s)##{hashtag}/, [
-          " <a href='https://twitter.com/search?q=%23#{hashtag}' ",
-          "target='_blank'>",
-            "##{hashtag}",
-          "</a>"
-        ].join)
-      end
-
-      text.strip
+      text.gsub(/(?:^|\s)#(\w+)/) do |match|
+        hashtag = match.strip[1..]
+        "<a href='https://twitter.com/search?q=%23#{hashtag}' target='_blank'>##{hashtag}</a>"
+      end.strip
     end
 
     def user_timeline_uri_for(screen_name)

--- a/spec/lib/twitter_api_spec.rb
+++ b/spec/lib/twitter_api_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TwitterApi do
+  context '.link_handles_in' do
+    it 'correctly replaces handles' do
+      expect(TwitterApi.send(:link_handles_in, "@foo @foobar")).to match_html <<~HTML
+        <a href='https://twitter.com/foo' target='_blank'>@foo</a> <a href='https://twitter.com/foobar' target='_blank'>@foobar</a>
+      HTML
+    end
+  end
+
+  context '.link_hashtags_in' do
+    it 'correctly replaces hashtags' do
+      expect(TwitterApi.send(:link_hashtags_in, "#foo #foobar")).to match_html <<~HTML
+        <a href='https://twitter.com/search?q=%23foo' target='_blank'>#foo</a> <a href='https://twitter.com/search?q=%23foobar' target='_blank'>#foobar</a>
+      HTML
+    end
+  end
+end


### PR DESCRIPTION
Previously, all handles and hashtags were replaced in one go which could
result in a wrong result if a handle was a substring of another one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
