### PR TITLE
DEV: Make clipboardCopy util available for import

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-permalinks.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-permalinks.js
@@ -5,6 +5,7 @@ import Permalink from "admin/models/permalink";
 import bootbox from "bootbox";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { observes } from "discourse-common/utils/decorators";
+import { copyToClipboard } from "discourse/lib/utilities";
 
 export default Controller.extend({
   loading: false,
@@ -29,12 +30,7 @@ export default Controller.extend({
 
     copyUrl(pl) {
       let linkElement = document.querySelector(`#admin-permalink-${pl.id}`);
-      let textArea = document.createElement("textarea");
-      textArea.value = linkElement.textContent;
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand("Copy");
-      textArea.remove();
+      copyToClipboard(linkElement.textContent);
     },
 
     destroy(record) {

--- a/app/assets/javascripts/admin/addon/controllers/admin-permalinks.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-permalinks.js
@@ -5,7 +5,7 @@ import Permalink from "admin/models/permalink";
 import bootbox from "bootbox";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { observes } from "discourse-common/utils/decorators";
-import { copyToClipboard } from "discourse/lib/utilities";
+import { clipboardCopy } from "discourse/lib/utilities";
 
 export default Controller.extend({
   loading: false,
@@ -30,7 +30,7 @@ export default Controller.extend({
 
     copyUrl(pl) {
       let linkElement = document.querySelector(`#admin-permalink-${pl.id}`);
-      copyToClipboard(linkElement.textContent);
+      clipboardCopy(linkElement.textContent);
     },
 
     destroy(record) {

--- a/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
@@ -28,6 +28,25 @@ export default {
         _fadeCopyCodeblocksRunners = {};
       }
 
+      function _copyComplete(button) {
+        button.classList.add("copied");
+        const state = button.innerHTML;
+        button.innerHTML = I18n.t("copy_codeblock.copied");
+
+        const commandId = guidFor(button);
+
+        if (_fadeCopyCodeblocksRunners[commandId]) {
+          cancel(_fadeCopyCodeblocksRunners[commandId]);
+          delete _fadeCopyCodeblocksRunners[commandId];
+        }
+
+        _fadeCopyCodeblocksRunners[commandId] = later(() => {
+          button.classList.remove("copied");
+          button.innerHTML = state;
+          delete _fadeCopyCodeblocksRunners[commandId];
+        }, 3000);
+      }
+
       function _handleClick(event) {
         if (!event.target.classList.contains("copy-cmd")) {
           return;
@@ -45,23 +64,13 @@ export default {
             )
             .trim();
 
-          if (clipboardCopy(text)) {
-            button.classList.add("copied");
-            const state = button.innerHTML;
-            button.innerHTML = I18n.t("copy_codeblock.copied");
-
-            const commandId = guidFor(button);
-
-            if (_fadeCopyCodeblocksRunners[commandId]) {
-              cancel(_fadeCopyCodeblocksRunners[commandId]);
-              delete _fadeCopyCodeblocksRunners[commandId];
-            }
-
-            _fadeCopyCodeblocksRunners[commandId] = later(() => {
-              button.classList.remove("copied");
-              button.innerHTML = state;
-              delete _fadeCopyCodeblocksRunners[commandId];
-            }, 3000);
+          const result = clipboardCopy(text);
+          if (result.then) {
+            result.then(() => {
+              _copyComplete(button);
+            });
+          } else if (result) {
+            _copyComplete(button);
           }
         }
       }

--- a/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
@@ -45,7 +45,7 @@ export default {
             )
             .trim();
 
-          clipboardCopy(text).then(() => {
+          if (clipboardCopy(text)) {
             button.classList.add("copied");
             const state = button.innerHTML;
             button.innerHTML = I18n.t("copy_codeblock.copied");
@@ -62,7 +62,7 @@ export default {
               button.innerHTML = state;
               delete _fadeCopyCodeblocksRunners[commandId];
             }, 3000);
-          });
+          }
         }
       }
 

--- a/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
+++ b/app/assets/javascripts/discourse/app/initializers/copy-codeblocks.js
@@ -1,60 +1,9 @@
 import { cancel, later } from "@ember/runloop";
 import I18n from "I18n";
-import { Promise } from "rsvp";
 import { guidFor } from "@ember/object/internals";
+import { clipboardCopy } from "discourse/lib/utilities";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import { withPluginApi } from "discourse/lib/plugin-api";
-
-// http://github.com/feross/clipboard-copy
-function clipboardCopy(text) {
-  // Use the Async Clipboard API when available.
-  // Requires a secure browsing context (i.e. HTTPS)
-  if (navigator.clipboard) {
-    return navigator.clipboard.writeText(text).catch(function (err) {
-      throw err !== undefined
-        ? err
-        : new DOMException("The request is not allowed", "NotAllowedError");
-    });
-  }
-
-  // ...Otherwise, use document.execCommand() fallback
-
-  // Put the text to copy into a <span>
-  const span = document.createElement("span");
-  span.textContent = text;
-
-  // Preserve consecutive spaces and newlines
-  span.style.whiteSpace = "pre";
-
-  // Add the <span> to the page
-  document.body.appendChild(span);
-
-  // Make a selection object representing the range of text selected by the user
-  const selection = window.getSelection();
-  const range = window.document.createRange();
-  selection.removeAllRanges();
-  range.selectNode(span);
-  selection.addRange(range);
-
-  // Copy text to the clipboard
-  let success = false;
-  try {
-    success = window.document.execCommand("copy");
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.log("error", err);
-  }
-
-  // Cleanup
-  selection.removeAllRanges();
-  window.document.body.removeChild(span);
-
-  return success
-    ? Promise.resolve()
-    : Promise.reject(
-        new DOMException("The request is not allowed", "NotAllowedError")
-      );
-}
 
 let _copyCodeblocksClickHandlers = {};
 let _fadeCopyCodeblocksRunners = {};

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -1,4 +1,5 @@
 import getURL, { getURLWithCDN } from "discourse-common/lib/get-url";
+import { Promise } from "rsvp";
 import Handlebars from "handlebars";
 import I18n from "I18n";
 import { deepMerge } from "discourse-common/lib/object";
@@ -504,13 +505,55 @@ export function translateModKey(string) {
   return string;
 }
 
-export function copyToClipboard(text) {
-  let textArea = document.createElement("textarea");
-  textArea.value = text;
-  document.body.appendChild(textArea);
-  textArea.select();
-  document.execCommand("copy");
-  textArea.remove();
+// http://github.com/feross/clipboard-copy
+export function clipboardCopy(text) {
+  // Use the Async Clipboard API when available.
+  // Requires a secure browsing context (i.e. HTTPS)
+  if (navigator.clipboard) {
+    return navigator.clipboard.writeText(text).catch(function (err) {
+      throw err !== undefined
+        ? err
+        : new DOMException("The request is not allowed", "NotAllowedError");
+    });
+  }
+
+  // ...Otherwise, use document.execCommand() fallback
+
+  // Put the text to copy into a <span>
+  const span = document.createElement("span");
+  span.textContent = text;
+
+  // Preserve consecutive spaces and newlines
+  span.style.whiteSpace = "pre";
+
+  // Add the <span> to the page
+  document.body.appendChild(span);
+
+  // Make a selection object representing the range of text selected by the user
+  const selection = window.getSelection();
+  const range = window.document.createRange();
+  selection.removeAllRanges();
+  range.selectNode(span);
+  selection.addRange(range);
+
+  // Copy text to the clipboard
+  let success = false;
+  try {
+    success = window.document.execCommand("copy");
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log("error", err);
+  }
+
+  // Cleanup
+  selection.removeAllRanges();
+  window.document.body.removeChild(span);
+
+  return success
+    ? Promise.resolve()
+    : Promise.reject(
+        new DOMException("The request is not allowed", "NotAllowedError")
+      );
 }
 
 // This prevents a mini racer crash

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -503,5 +503,15 @@ export function translateModKey(string) {
 
   return string;
 }
+
+export function copyToClipboard(text) {
+  let textArea = document.createElement("textarea");
+  textArea.value = text;
+  document.body.appendChild(textArea);
+  textArea.select();
+  document.execCommand("copy");
+  textArea.remove();
+}
+
 // This prevents a mini racer crash
 export default {};

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -1,5 +1,4 @@
 import getURL, { getURLWithCDN } from "discourse-common/lib/get-url";
-import { Promise } from "rsvp";
 import Handlebars from "handlebars";
 import I18n from "I18n";
 import { deepMerge } from "discourse-common/lib/object";
@@ -548,12 +547,7 @@ export function clipboardCopy(text) {
   // Cleanup
   selection.removeAllRanges();
   window.document.body.removeChild(span);
-
-  return success
-    ? Promise.resolve()
-    : Promise.reject(
-        new DOMException("The request is not allowed", "NotAllowedError")
-      );
+  return success;
 }
 
 // This prevents a mini racer crash


### PR DESCRIPTION
We need this in other places, this commit moves clipboardCopy
to the utilities.js lib. Had to remove use of Promise as well because
lib/utilities cannot import it, otherwise it will cause a mini racer error.