### PR TITLE
FEATURE: Replace share post popup with share modal

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/initializers/topic-footer-buttons.js
@@ -18,7 +18,7 @@ export default {
       priority: SHARE_PRIORITY,
       label() {
         if (!this.get("topic.isPrivateMessage") || this.site.mobileView) {
-          return "topic.share.title";
+          return "footer_nav.share";
         }
       },
       title: "topic.share.help",

--- a/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
@@ -1,12 +1,14 @@
-{{#d-modal-body title="topic.share.title"}}
+{{#d-modal-body rawTitle=(if post (i18n "post.share.title" post_number=post.post_number) (i18n "topic.share.title"))}}
   <form>
     <div class="input-group invite-link">
-      <label for="invite-link">{{i18n "topic.share.instructions"}}</label>
+      <label for="invite-link">
+        {{if post (i18n "post.share.instructions" post_number=post.post_number) (i18n "topic.share.instructions")}}
+      </label>
       <div class="link-share-container">
         {{input
           name="invite-link"
           class="invite-link"
-          value=topicUrl
+          value=url
           readonly=true
         }}
         {{copy-button selector="input.invite-link"}}

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -414,6 +414,5 @@
     editPost=(action "editPost")
     topic=model
     composerVisible=composer.visible
-
   }}
 {{/discourse-topic}}

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -277,10 +277,6 @@ registerButton("share", (attrs) => {
     className: "share",
     title: "post.controls.share",
     icon: "d-post-share",
-    data: {
-      "share-url": attrs.shareUrl,
-      "post-number": attrs.post_number,
-    },
   };
 });
 

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -271,7 +271,7 @@ registerButton("replies", (attrs, state, siteSettings) => {
   };
 });
 
-registerButton("share", (attrs) => {
+registerButton("share", () => {
   return {
     action: "share",
     className: "share",

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -21,6 +21,8 @@ import { prioritizeNameInUx } from "discourse/lib/settings";
 import { relativeAgeMediumSpan } from "discourse/lib/formatter";
 import { transformBasicPost } from "discourse/lib/transform-post";
 import autoGroupFlairForUser from "discourse/lib/avatar-flair";
+import showModal from "discourse/lib/show-modal";
+import { nativeShare } from "discourse/lib/pwa-utils";
 
 function transformWithCallbacks(post) {
   let transformed = transformBasicPost(post);
@@ -539,6 +541,15 @@ createWidget("post-contents", {
   expandFirstPost() {
     const post = this.findAncestorModel();
     return post.expand().then(() => (this.state.expandedFirstPost = true));
+  },
+
+  share() {
+    const post = this.findAncestorModel();
+    nativeShare(this.capabilities, { url: post.shareUrl }).catch(() => {
+      const topic = post.topic;
+      const controller = showModal("share-topic", { model: topic.category });
+      controller.setProperties({ topic, post });
+    });
   },
 });
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -229,10 +229,7 @@ discourseModule("Integration | Component | Widget | post", function (hooks) {
       this.set("args", { shareUrl: "http://share-me.example.com" });
     },
     test(assert) {
-      assert.ok(
-        exists(".actions button[data-share-url]"),
-        "it renders a share button"
-      );
+      assert.ok(exists(".actions button.share"), "it renders a share button");
     },
   });
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -681,6 +681,10 @@ class TopicsController < ApplicationController
     users = User.where(username_lower: usernames.map(&:downcase))
     raise Discourse::InvalidParameters.new(:usernames) if usernames.size != users.size
 
+    post_number = 1
+    post_number = params[:post_number].to_i if params[:post_number].present?
+    raise Discourse::InvalidParameters.new(:post_number) if post_number < 1 || post_number > topic.highest_post_number
+
     topic.rate_limit_topic_invitation(current_user)
 
     users.find_each do |user|
@@ -693,11 +697,16 @@ class TopicsController < ApplicationController
       last_notification = user.notifications
         .where(notification_type: Notification.types[:invited_to_topic])
         .where(topic_id: topic.id)
-        .where(post_number: 1)
+        .where(post_number: post_number)
         .where('created_at > ?', 1.hour.ago)
 
       if !last_notification.exists?
-        topic.create_invite_notification!(user, Notification.types[:invited_to_topic], current_user.username)
+        topic.create_invite_notification!(
+          user,
+          Notification.types[:invited_to_topic],
+          current_user.username,
+          post_number: post_number
+        )
       end
     end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1751,14 +1751,14 @@ class Topic < ActiveRecord::Base
     email_addresses.to_a
   end
 
-  def create_invite_notification!(target_user, notification_type, username)
+  def create_invite_notification!(target_user, notification_type, username, post_number: 1)
     invited_by = User.find_by_username(username)
     ensure_can_invite!(target_user, invited_by)
 
     target_user.notifications.create!(
       notification_type: notification_type,
       topic_id: self.id,
-      post_number: 1,
+      post_number: post_number,
       data: {
         topic_title: self.title,
         display_username: username,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2837,7 +2837,7 @@ en:
         help: "begin composing a reply to this topic"
 
       share:
-        title: "Share"
+        title: "Share Topic"
         extended_title: "Share a link"
         help: "share a link to this topic"
         instructions: "Share a link to this topic:"
@@ -3278,6 +3278,10 @@ en:
         viewing_summary: "Viewing a summary of this topic"
         post_number: "%{username}, post #%{post_number}"
         show_all: "Show all"
+
+      share:
+        title: "Share Post #%{post_number}"
+        instructions: "Share a link to this post:"
 
     category:
       none: "(no category)"

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2825,6 +2825,10 @@ RSpec.describe TopicsController do
   end
 
   describe '#invite_notify' do
+    before do
+      topic.update!(highest_post_number: 1)
+    end
+
     it 'does not notify same user multiple times' do
       sign_in(user)
 


### PR DESCRIPTION
This uniformizes the topic share modal and the post link popup. It also introduces a new feature which can notify the user of a post.

<img width="617" alt="Screenshot 2022-02-09 at 10 27 12" src="https://user-images.githubusercontent.com/23153890/153155649-2428a352-9e4f-4bca-a822-7621294fe6a2.png">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
