### PR TITLE
FEATURE: Use new topic-chooser for invite modal

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-invite.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-invite.js
@@ -18,6 +18,7 @@ export default Controller.extend(
   bufferedProperty("invite"),
   {
     allGroups: null,
+    topics: null,
 
     flashText: null,
     flashClass: null,
@@ -48,6 +49,7 @@ export default Controller.extend(
       });
 
       this.setProperties({
+        topics: [],
         flashText: null,
         flashClass: null,
         flashLink: false,
@@ -72,7 +74,7 @@ export default Controller.extend(
     },
 
     setInvite(invite) {
-      this.set("invite", invite);
+      this.setProperties({ invite, topics: invite.topics });
     },
 
     save(opts) {
@@ -200,6 +202,12 @@ export default Controller.extend(
       getNativeContact(this.capabilities, ["email"], false).then((result) => {
         this.set("buffered.email", result[0].email[0]);
       });
+    },
+
+    @action
+    onChangeTopic(topicId, topic) {
+      this.set("topics", [topic]);
+      this.set("buffered.topicId", topicId);
     },
   }
 );

--- a/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
@@ -85,12 +85,14 @@
 
     {{#if currentUser.staff}}
       <div class="input-group invite-to-topic">
-        {{choose-topic
-          selectedTopicId=buffered.topicId
-          topicTitle=buffered.topicTitle
-          additionalFilters="status:public"
-          labelIcon="hand-point-right"
-          label="user.invited.invite.invite_to_topic"
+        <label for="invite-topic">{{d-icon "hand-point-right"}}{{i18n "user.invited.invite.invite_to_topic"}}</label>
+        {{topic-chooser
+          value=buffered.topicId
+          content=topics
+          onChange=(action "onChangeTopic")
+          options=(hash
+            additionalFilters="status:public"
+          )
         }}
       </div>
     {{else if buffered.topicTitle}}

--- a/app/assets/javascripts/select-kit/addon/components/topic-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/topic-chooser.js
@@ -1,0 +1,45 @@
+import { isEmpty } from "@ember/utils";
+import { searchForTerm } from "discourse/lib/search";
+import ComboBoxComponent from "select-kit/components/combo-box";
+
+export default ComboBoxComponent.extend({
+  pluginApiIdentifiers: ["topic-chooser"],
+  classNames: ["topic-chooser"],
+
+  nameProperty: "fancy_title",
+  labelProperty: "title",
+  titleProperty: "title",
+
+  selectKitOptions: {
+    clearable: true,
+    filterable: true,
+    filterPlaceholder: "choose_topic.title.placeholder",
+    additionalFilters: "",
+  },
+
+  modifyComponentForRow() {
+    return "topic-row";
+  },
+
+  search(filter) {
+    if (isEmpty(filter) && isEmpty(this.selectKit.options.additionalFilters)) {
+      return [];
+    }
+
+    const searchParams = {};
+    if (!isEmpty(filter)) {
+      searchParams.typeFilter = "topic";
+      searchParams.restrictToArchetype = "regular";
+      searchParams.searchForId = true;
+    }
+
+    return searchForTerm(
+      `${filter} ${this.selectKit.options.additionalFilters}`,
+      searchParams
+    ).then((results) => {
+      if (results?.posts?.length > 0) {
+        return results.posts.mapBy("topic");
+      }
+    });
+  },
+});

--- a/app/assets/javascripts/select-kit/addon/components/topic-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/topic-row.js
@@ -1,0 +1,7 @@
+import SelectKitRowComponent from "select-kit/components/select-kit/select-kit-row";
+import layout from "select-kit/templates/components/topic-row";
+
+export default SelectKitRowComponent.extend({
+  layout,
+  classNames: ["topic-row"],
+});

--- a/app/assets/javascripts/select-kit/addon/templates/components/topic-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/topic-row.hbs
@@ -1,0 +1,9 @@
+{{topic-status topic=item disableActions=true}}
+<div class="topic-title">{{replace-emoji item.fancy_title}}</div>
+<div class="topic-categories">
+  {{bound-category-link item.category
+    recursive=true
+    hideParent=true
+    link=false
+  }}
+</div>

--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -187,6 +187,7 @@
     textarea#invite-message,
     &.invite-to-topic input[type="text"],
     .group-chooser,
+    .topic-chooser,
     .user-chooser,
     .future-date-input-selector,
     .future-date-input-date-picker,

--- a/app/assets/stylesheets/common/select-kit/_index.scss
+++ b/app/assets/stylesheets/common/select-kit/_index.scss
@@ -23,5 +23,6 @@
 @import "tag-chooser";
 @import "tag-drop";
 @import "toolbar-popup-menu-options";
+@import "topic-chooser";
 @import "topic-notifications-button";
 @import "user-row";

--- a/app/assets/stylesheets/common/select-kit/topic-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/topic-chooser.scss
@@ -1,0 +1,9 @@
+.select-kit {
+  &.combo-box {
+    &.topic-chooser {
+      .select-kit-row {
+        display: initial;
+      }
+    }
+  }
+}


### PR DESCRIPTION
The old choose-topic component did not have the same style as the rest
of the create invite modal and was not very suitable to use in the modal
because it introduced the search results in modal's body.

The new topic-chooser is built using select-kit and provides a more
polished user experience.

![image](https://user-images.githubusercontent.com/4147664/153396808-57e150de-560c-48ed-b9c1-60a47fb22f8a.png)

![image](https://user-images.githubusercontent.com/4147664/153397196-4e4adcb3-b6bb-4119-b02b-34c89c75fd2a.png)

![image](https://user-images.githubusercontent.com/4147664/153396230-3c08dd33-2bfc-461a-9893-a577b3166236.png)

![image](https://user-images.githubusercontent.com/4147664/153396299-1ed834a4-dcea-4d43-8a70-3dbfe6779996.png)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
