### PR TITLE
DEV: Do not include CDN domain in the sourceMappingURL

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -105,7 +105,7 @@ def compress_node(from, to)
   assets = cdn_relative_path("/assets")
   assets_additional_path = (d = File.dirname(from)) == "." ? "" : "/#{d}"
   source_map_root = assets + assets_additional_path
-  source_map_url = cdn_path "/assets/#{to}.map"
+  source_map_url = "#{File.basename(to)}.map"
   base_source_map = assets_path + assets_additional_path
 
   cmd = <<~EOS


### PR DESCRIPTION
If no path is supplied, browsers will look for the map on the same path as the JS file itself. This fixes two problems that we see in production:

1. When compiling assets against one CDN, and then re-using them on a site with a different CDN, the sourceMappingUrls would be incorrect and print warnings in the console

2. If both an S3 CDN and an app CDN are configured, we were using the S3 CDN for the JS and the app CDN for the map. This commit will make sure we use the S3 CDN for both.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
