### PR TITLE
Add classes to user stats, move likes received

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/summary.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/summary.hbs
@@ -4,47 +4,47 @@
       <div class="top-section stats-section">
         <h3 class="stats-title">{{i18n "user.summary.stats"}}</h3>
         <ul>
-          <li>
+          <li class="stats-days-visited">
             {{user-stat value=model.days_visited label="user.summary.days_visited"}}
           </li>
-          <li>
+          <li class="stats-time-read">
             {{user-stat value=timeRead label="user.summary.time_read" type="string"}}
           </li>
           {{#if showRecentTimeRead}}
-            <li>
+            <li class="stats-recent-read">
               {{user-stat value=recentTimeRead label="user.summary.recent_time_read" type="string"}}
             </li>
           {{/if}}
-          <li>
+          <li class="stats-topics-entered">
             {{user-stat value=model.topics_entered label="user.summary.topics_entered"}}
           </li>
-          <li>
+          <li class="stats-posts-read">
             {{user-stat value=model.posts_read_count label="user.summary.posts_read"}}
           </li>
-          <li class="linked-stat">
+          <li class="stats-likes-given linked-stat">
             {{#link-to "userActivity.likesGiven"}}
               {{user-stat value=model.likes_given icon="heart" label="user.summary.likes_given"}}
             {{/link-to}}
           </li>
+          <li class="stats-likes-received">
+            {{user-stat value=model.likes_received icon="heart" label="user.summary.likes_received"}}
+          </li>
           {{#if model.bookmark_count}}
-            <li class="linked-stat">
+            <li class="stats-bookmark-count linked-stat">
               {{#link-to "userActivity.bookmarks"}}
                 {{user-stat value=model.bookmark_count label="user.summary.bookmark_count"}}
               {{/link-to}}
             </li>
           {{/if}}
-          <li class="linked-stat">
+          <li class="stats-topic-count linked-stat">
             {{#link-to "userActivity.topics"}}
               {{user-stat value=model.topic_count label="user.summary.topic_count"}}
             {{/link-to}}
           </li>
-          <li class="linked-stat">
+          <li class="stats-post-count linked-stat">
             {{#link-to "userActivity.replies"}}
               {{user-stat value=model.post_count label="user.summary.post_count"}}
             {{/link-to}}
-          </li>
-          <li>
-            {{user-stat value=model.likes_received icon="heart" label="user.summary.likes_received"}}
           </li>
           {{plugin-outlet name="user-summary-stat" connectorTagName="li" args=(hash model=model)}}
         </ul>


### PR DESCRIPTION
This makes these stats easier to target in themes. I also moved likes received because it seemed odd that it was separated from likes given

After:
<img width="1139" alt="Screen Shot 2022-02-10 at 1 42 27 PM" src="https://user-images.githubusercontent.com/1681963/153475189-ef75657f-d2a3-454b-b50c-da24dd9b4bb3.png">


Before:
<img width="1126" alt="Screen Shot 2022-02-10 at 1 32 46 PM" src="https://user-images.githubusercontent.com/1681963/153475188-64f717df-a855-4727-9a32-dea128528ae0.png">


