### PR TITLE
DEV: Ensure Ember CLI sourcemaps are uploaded to S3

### DIFF
--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -59,9 +59,9 @@ def assets
     fullpath = (Rails.root + "public/assets/#{path}").to_s
 
     # Ignore files we can't find the mime type of, like yarn.lock
-    if mime = MiniMime.lookup_by_filename(fullpath)
-      content_type = mime.content_type
-
+    content_type = MiniMime.lookup_by_filename(fullpath)&.content_type
+    content_type ||= "application/json" if fullpath.end_with?(".map")
+    if content_type
       asset_path = "assets/#{path}"
       results << [fullpath, asset_path, content_type]
 


### PR DESCRIPTION
Ember CLI gives sourcemaps their own digest. Our `s3.rake` logic assumes that the digest portion of sourcemap filenames remains the same.

The Ember CLI sourcemaps are included in the manifest file, so we can ensure they are uploaded by letting them past the MiniMime check.

Followup to abefb1beffce079bbf54fb9cefc2e1dbf7bbad43

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
