### PR TITLE
DEV: Allow focusComposer to reply to existing topic

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -412,12 +412,22 @@ export default Controller.extend({
   // true or topic is provided
   @action
   focusComposer(opts = {}) {
-    if (this.get("model.viewOpen")) {
+    this._openComposerForFocus(opts).then(() => {
       this._focusAndInsertText(opts.insertText);
+    });
+  },
+
+  _openComposerForFocus(opts) {
+    if (this.get("model.viewOpen")) {
+      return Promise.resolve();
     } else {
       const opened = this.openIfDraft();
-      if (!opened && opts.topic) {
-        this.open(
+      if (opened) {
+        return Promise.resolve();
+      }
+
+      if (opts.topic) {
+        return this.open(
           Object.assign(
             {
               action: Composer.REPLY,
@@ -427,11 +437,9 @@ export default Controller.extend({
             },
             opts.openOpts || {}
           )
-        ).then(() => {
-          this._focusAndInsertText(opts.insertText);
-        });
+        );
       } else if (!opened && opts.fallbackToNewTopic) {
-        this.open(
+        return this.open(
           Object.assign(
             {
               action: Composer.CREATE_TOPIC,
@@ -439,11 +447,7 @@ export default Controller.extend({
             },
             opts.openOpts || {}
           )
-        ).then(() => {
-          this._focusAndInsertText(opts.insertText);
-        });
-      } else if (opened) {
-        this._focusAndInsertText(opts.insertText);
+        );
       }
     }
   },

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -438,7 +438,9 @@ export default Controller.extend({
             opts.openOpts || {}
           )
         );
-      } else if (opts.fallbackToNewTopic) {
+      }
+
+      if (opts.fallbackToNewTopic) {
         return this.open(
           Object.assign(
             {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -438,7 +438,7 @@ export default Controller.extend({
             opts.openOpts || {}
           )
         );
-      } else if (!opened && opts.fallbackToNewTopic) {
+      } else if (opts.fallbackToNewTopic) {
         return this.open(
           Object.assign(
             {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -402,18 +402,35 @@ export default Controller.extend({
   //
   // opts:
   //
-  // - fallbackToNewTopic: if true, and there is no draft, the composer will
-  // be opened with the create_topic action and a new topic draft key
+  // - topic: if this is present, the composer will be opened with the reply
+  // action and the current topic key and draft sequence
+  // - fallbackToNewTopic: if true, and there is no draft and no topic,
+  // the composer will be opened with the create_topic action and a new
+  // topic draft key
   // - insertText: the text to append to the composer once it is opened
   // - openOpts: this object will be passed to this.open if fallbackToNewTopic is
-  // true
+  // true or topic is provided
   @action
   focusComposer(opts = {}) {
     if (this.get("model.viewOpen")) {
       this._focusAndInsertText(opts.insertText);
     } else {
       const opened = this.openIfDraft();
-      if (!opened && opts.fallbackToNewTopic) {
+      if (!opened && opts.topic) {
+        this.open(
+          Object.assign(
+            {
+              action: Composer.REPLY,
+              draftKey: opts.topic.get("draft_key"),
+              draftSequence: opts.topic.get("draft_sequence"),
+              topic: opts.topic,
+            },
+            opts.openOpts || {}
+          )
+        ).then(() => {
+          this._focusAndInsertText(opts.insertText);
+        });
+      } else if (!opened && opts.fallbackToNewTopic) {
         this.open(
           Object.assign(
             {

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -626,7 +626,6 @@ const Composer = RestModel.extend({
   appendText(text, position, opts) {
     const reply = this.reply || "";
     position = typeof position === "number" ? position : reply.length;
-    text = text.trim();
 
     let before = reply.slice(0, position) || "";
     let after = reply.slice(position) || "";
@@ -664,6 +663,8 @@ const Composer = RestModel.extend({
     if (opts && opts.new_line) {
       if (before.length > 0) {
         text = "\n\n" + text.trim();
+      } else {
+        text = text.trim();
       }
     }
 

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -626,6 +626,7 @@ const Composer = RestModel.extend({
   appendText(text, position, opts) {
     const reply = this.reply || "";
     position = typeof position === "number" ? position : reply.length;
+    text = text.trim();
 
     let before = reply.slice(0, position) || "";
     let after = reply.slice(position) || "";
@@ -661,7 +662,9 @@ const Composer = RestModel.extend({
     }
 
     if (opts && opts.new_line) {
-      text = "\n\n" + text.trim();
+      if (before.length > 0) {
+        text = "\n\n" + text.trim();
+      }
     }
 
     this.set("reply", before + text + after);


### PR DESCRIPTION
Another use case for focusComposer() is if the user is
already inside a topic but another component (such as the
floating chat window) needs to open the composer. This
commit also fixes the appendText option to only prepend
2 new lines if there is text before the text to be appended.

Follow up 7850ee318fc480d820d256ab01e39cfc046f2d5b
