### PR TITLE
UX: crawler view always shows 0 votes, hide count

### DIFF
--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -143,3 +143,8 @@ body.crawler {
     padding: 0.5em 1em 0.5em 0;
   }
 }
+
+.poll-info {
+  // crawler vote count always shows 0
+  display: none;
+}


### PR DESCRIPTION
Before: 
<img width="783" alt="Screen Shot 2022-02-10 at 10 39 22 PM" src="https://user-images.githubusercontent.com/1681963/153534169-b41a917e-df76-44b6-93ac-d7fcaedfd205.png">

After:
<img width="745" alt="Screen Shot 2022-02-10 at 10 38 15 PM" src="https://user-images.githubusercontent.com/1681963/153534148-118493e6-ca3a-4bc8-a248-8ac5c03be745.png">