### PR TITLE
DEV: Make DiscourseRedis#del support deleting multiple keys

### DIFF
--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -76,10 +76,11 @@ class DiscourseRedis
     DiscourseRedis.ignore_readonly { @redis.mget(*args) }
   end
 
-  def del(k)
+  def del(*keys)
     DiscourseRedis.ignore_readonly do
-      k = "#{namespace}:#{k}"  if @namespace
-      @redis.del k
+      keys = keys.flatten(1)
+      keys.map! { |k| "#{namespace}:#{k}" } if @namespace
+      @redis.del(*keys)
     end
   end
 


### PR DESCRIPTION
Redis supports deleting multiple keys at once using the `del` command and so does the `redis` gem: https://github.com/redis/redis-rb/blob/21ec1dec064f43def1f47983431861e6491b770e/lib/redis/commands/keys.rb#L188-L193. However, our wrapper around the `del` method currently accepts only one argument and expects it to be a string so it's impossible to delete multiple keys at once.

This PR changes the signature of the `DiscourseRedis#del` method so it accepts any number of arguments and makes sure all keys are properly namespaced before calling the `del` implementation of the `redis` gem.