### PR TITLE
DEV: Bump Theme::BASE_COMPILER_VERSION.

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -152,7 +152,8 @@ class Theme < ActiveRecord::Base
     SvgSprite.expire_cache
   end
 
-  BASE_COMPILER_VERSION = 51
+  BASE_COMPILER_VERSION = 53
+
   def self.compiler_version
     get_set_cache "compiler_version" do
       dependencies = [


### PR DESCRIPTION
In 8e5b945b0ffd8ab5f5156ae52e460cef0136a551, we reverted the commit but
at the same time resulted in Theme::BASE_COMPILER_VERSION going
backwards which caused problems with themes caching.

This commit bumps the version to clear all the caches.

Follow-up to 8e5b945b0ffd8ab5f5156ae52e460cef0136a551