### PR TITLE
Options to allow discourse to build in lower memory environments.

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -14,6 +14,8 @@ module.exports = function (defaults) {
   let discourseRoot = resolve("../../../..");
   let vendorJs = discourseRoot + "/vendor/assets/javascripts/";
 
+  const lowMem = process.env.DISCOURSE_LOW_MEM;
+
   const isProduction = EmberApp.env().includes("production");
   let app = new EmberApp(defaults, {
     autoRun: false,
@@ -40,7 +42,7 @@ module.exports = function (defaults) {
     },
 
     "ember-cli-terser": {
-      enabled: isProduction,
+      enabled: !lowMem && isProduction,
       exclude: [
         "**/test-*.js",
         "**/core-tests*.js",

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -245,7 +245,8 @@ def copy_ember_cli_assets
   files = {}
 
   log_task_duration('ember build -prod') {
-    unless system("yarn --cwd #{ember_dir} run ember build -prod")
+    ember_env = ENV.slice("DISCOURSE_LOW_MEM").merge("JOBS" => "1")
+    unless system(ember_env, "yarn --cwd #{ember_dir} run ember build -prod")
       STDERR.puts "Error running ember build"
       exit 1
     end


### PR DESCRIPTION
* We pass `JOBS=1` to ember build which saves ~500MB of RAM.
* We have an option, `DISCOURSE_LOW_MEM=1` which disables terser.
  * In the future, this will likely disable source maps too.