### PR TITLE
Using border-box was causing header misalignment

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -14,7 +14,6 @@
   backface-visibility: hidden; /** do magic for scrolling performance **/
 
   > .wrap {
-    box-sizing: border-box;
     width: 100%;
     height: 100%;
 


### PR DESCRIPTION
We can't use it here unless we also use it on page content too, should probably add `box-sizing: border-box` to a global CSS reset at some point to avoid problems like this.

(Note, on the right the content aligns with the click area of the button (visible on hover), and not the user avatar.)


Before:
![Screen Shot 2022-02-11 at 5 28 05 PM](https://user-images.githubusercontent.com/1681963/153679495-60c698bb-f371-414f-9da2-0b1d6dbaaa25.png)

After:
![Screen Shot 2022-02-11 at 5 27 34 PM](https://user-images.githubusercontent.com/1681963/153679465-73557d7d-727b-4770-9cca-5afcf9cdf64d.png)
