### PR TITLE
FIX: Load short upload URLs only once

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/upload-short-url.js
+++ b/app/assets/javascripts/pretty-text/addon/upload-short-url.js
@@ -167,7 +167,7 @@ let queueResolve;
 
 function queuePop(ajax) {
   lookupUncachedUploadUrls(queueUrls, ajax).then(queueResolve);
-  queueUrls = queuePromise = queueResolve = null;
+  queueUrls = queueResolve = null;
 }
 
 function _loadShortUrls(uploads, ajax, siteSettings, opts) {


### PR DESCRIPTION
Loading did not work when it was used for multiple posts. Only the
short URLs from the first post were loaded.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
