### PR TITLE
SECURITY: Onebox response timeout and size limit

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -8,6 +8,8 @@ require 'url_helper'
 
 # Determine the final endpoint for a Web URI, following redirects
 class FinalDestination
+  MAX_REQUEST_TIME_SECONDS = 10
+  MAX_REQUEST_SIZE_BYTES = 1_048_576 # 1024 * 1024
 
   def self.clear_https_cache!(domain)
     key = redis_https_key(domain)
@@ -203,12 +205,21 @@ class FinalDestination
     middlewares = Excon.defaults[:middlewares]
     middlewares << Excon::Middleware::Decompress if @http_verb == :get
 
+    request_start_time = Time.now
+    response_body = +""
+    request_validator = lambda do |chunk, _remaining_bytes, _total_bytes|
+      response_body << chunk
+      raise Excon::Errors::ExpectationFailed.new("response size too big: #{@uri.to_s}") if response_body.bytesize > MAX_REQUEST_SIZE_BYTES
+      raise Excon::Errors::ExpectationFailed.new("connect timeout reached: #{@uri.to_s}") if Time.now - request_start_time > MAX_REQUEST_TIME_SECONDS
+    end
+
     response = Excon.public_send(@http_verb,
       @uri.to_s,
       read_timeout: timeout,
       connect_timeout: timeout,
       headers: headers,
-      middlewares: middlewares
+      middlewares: middlewares,
+      response_block: request_validator
     )
 
     location = nil
@@ -220,12 +231,12 @@ class FinalDestination
       # Cache body of successful `get` requests
       if @http_verb == :get
         if Oneboxer.cache_response_body?(@uri)
-          Oneboxer.cache_response_body(@uri.to_s, response.body)
+          Oneboxer.cache_response_body(@uri.to_s, response_body)
         end
       end
 
       if @follow_canonical
-        next_url = fetch_canonical_url(response.body)
+        next_url = fetch_canonical_url(response_body)
 
         if next_url.to_s.present? && next_url != @uri
           @follow_canonical = false

--- a/spec/components/final_destination_spec.rb
+++ b/spec/components/final_destination_spec.rb
@@ -49,6 +49,13 @@ describe FinalDestination do
     }
   end
 
+  let(:body_response) do
+    {
+      status: 200,
+      body: "<body>test</body>"
+    }
+  end
+
   def canonical_follow(from, dest)
     stub_request(:get, from).to_return(
       status: 200,
@@ -180,6 +187,20 @@ describe FinalDestination do
         expect(final.redirected?).to eq(false)
         expect(final.status).to eq(:resolved)
       end
+    end
+
+    it 'raises error when response is too big' do
+      stub_const(described_class, "MAX_REQUEST_SIZE_BYTES", 1) do
+        stub_request(:get, "https://codinghorror.com/blog").to_return(body_response)
+        final = FinalDestination.new('https://codinghorror.com/blog', opts.merge(follow_canonical: true))
+        expect { final.resolve }.to raise_error(Excon::Errors::ExpectationFailed, "response size too big: https://codinghorror.com/blog")
+      end
+    end
+
+    it 'raises error when response is too slow' do
+      stub_request(:get, "https://codinghorror.com/blog").to_return(lambda { |request| freeze_time(11.seconds.from_now) ; body_response })
+      final = FinalDestination.new('https://codinghorror.com/blog', opts.merge(follow_canonical: true))
+      expect { final.resolve }.to raise_error(Excon::Errors::ExpectationFailed, "connect timeout reached: https://codinghorror.com/blog")
     end
 
     context 'follows canonical links' do


### PR DESCRIPTION
Validation to ensure that Onebox request is no longer than 10 seconds and response size is not bigger than 1 MB