### PR TITLE
FIX: Cooking custom emojis should not use a secure URL

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -415,7 +415,10 @@ class CookedPostProcessor
 
     %w{src data-small-upload}.each do |selector|
       @doc.css("img[#{selector}]").each do |img|
-        img[selector] = UrlHelper.cook_url(img[selector].to_s, secure: @post.with_secure_media?)
+        custom_emoji = img["class"]&.include?("emoji-custom") && Emoji.custom?(img["title"])
+        img[selector] = UrlHelper.cook_url(
+          img[selector].to_s, secure: @post.with_secure_media? && !custom_emoji
+        )
       end
     end
   end


### PR DESCRIPTION
When a site has secure media enabled and a post is with secure
media, we were incorrectly cooking custom emoji URLs and using the
secure URL for those emojis, even though they should not be
considered secure (their corresponding upload records in the
database are _not_ secure). Now instead of the blanket
post.with_secure_media? boolean for the secure: param, we also
want to make sure the image whose URL is being cooked is also
_not_ a custom emoji.

