### PR TITLE
DEV: Expand UploadMarkdown generation capabilities

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -222,7 +222,7 @@ export function isImage(path) {
 }
 
 export function isVideo(path) {
-  return /\.(mov|mp4|webm|m4v|3gp|ogv|avi|mpeg|ogv)$/i.test(path);
+  return /\.(mov|mp4|webm|m4v|3gp|ogv|avi|mpeg)$/i.test(path);
 }
 
 export function isAudio(path) {

--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -17,12 +17,24 @@ class FileHelper
     filename.match?(supported_images_regexp)
   end
 
+  def self.is_supported_video?(filename)
+    filename.match?(supported_video_regexp)
+  end
+
+  def self.is_supported_audio?(filename)
+    filename.match?(supported_audio_regexp)
+  end
+
   def self.is_inline_image?(filename)
     filename.match?(inline_images_regexp)
   end
 
   def self.is_supported_media?(filename)
     filename.match?(supported_media_regexp)
+  end
+
+  def self.is_supported_playable_media?(filename)
+    filename.match?(supported_playable_media_regexp)
   end
 
   class FakeIO
@@ -151,11 +163,19 @@ class FileHelper
   end
 
   def self.supported_audio
-    @@supported_audio ||= Set.new %w{mp3 ogg wav m4a}
+    @@supported_audio ||= Set.new %w{mp3 ogg oga opus wav m4a m4b m4p m4r aac flac}
   end
 
   def self.supported_video
-    @@supported_video ||= Set.new %w{mov mp4 webm ogv}
+    @@supported_video ||= Set.new %w{mov mp4 webm ogv m4v 3gp avi mpeg}
+  end
+
+  def self.supported_video_regexp
+    @@supported_video_regexp ||= /\.(#{supported_video.to_a.join("|")})$/i
+  end
+
+  def self.supported_audio_regexp
+    @@supported_audio_regexp ||= /\.(#{supported_audio.to_a.join("|")})$/i
   end
 
   def self.supported_images_regexp
@@ -170,6 +190,14 @@ class FileHelper
     @@supported_media_regexp ||=
       begin
         media = supported_images | supported_audio | supported_video
+        /\.(#{media.to_a.join("|")})$/i
+      end
+  end
+
+  def self.supported_playable_media_regexp
+    @@supported_playable_media_regexp ||=
+      begin
+        media = supported_audio | supported_video
         /\.(#{media.to_a.join("|")})$/i
       end
   end

--- a/lib/upload_markdown.rb
+++ b/lib/upload_markdown.rb
@@ -8,6 +8,8 @@ class UploadMarkdown
   def to_markdown(display_name: nil)
     if FileHelper.is_supported_image?(@upload.original_filename)
       image_markdown
+    elsif FileHelper.is_supported_playable_media?(@upload.original_filename)
+      playable_media_markdown
     else
       attachment_markdown(display_name: display_name)
     end
@@ -22,5 +24,16 @@ class UploadMarkdown
     display_name ||= @upload.original_filename
 
     "[#{display_name}|attachment](#{@upload.short_url})#{human_filesize}"
+  end
+
+  def playable_media_markdown
+    type = \
+      if FileHelper.is_supported_audio?(@upload.original_filename)
+        "audio"
+      elsif FileHelper.is_supported_video?(@upload.original_filename)
+        "video"
+      end
+    return attachment_markdown if !type
+    "![#{@upload.original_filename}|#{type}](#{@upload.short_url})"
   end
 end

--- a/spec/lib/upload_markdown_spec.rb
+++ b/spec/lib/upload_markdown_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UploadMarkdown do
+  it "generates markdown for each different upload type (attachment, image, video, audio)" do
+    SiteSetting.authorized_extensions = "mp4|mp3|pdf|jpg|mmmppp444"
+    video = Fabricate(:upload, original_filename: "test_video.mp4", extension: "mp4")
+    audio = Fabricate(:upload, original_filename: "test_audio.mp3", extension: "mp3")
+    attachment = Fabricate(:upload, original_filename: "test_file.pdf", extension: "pdf")
+    image = Fabricate(:upload, width: 100, height: 200, original_filename: "test_img.jpg", extension: "jpg")
+
+    expect(UploadMarkdown.new(video).to_markdown).to eq(<<~MD.chomp)
+    ![test_video.mp4|video](#{video.short_url})
+    MD
+    expect(UploadMarkdown.new(audio).to_markdown).to eq(<<~MD.chomp)
+    ![test_audio.mp3|audio](#{audio.short_url})
+    MD
+    expect(UploadMarkdown.new(attachment).to_markdown).to eq(<<~MD.chomp)
+    [test_file.pdf|attachment](#{attachment.short_url}) (#{attachment.human_filesize})
+    MD
+    expect(UploadMarkdown.new(image).to_markdown).to eq(<<~MD.chomp)
+    ![test_img.jpg|100x200](#{image.short_url})
+    MD
+
+    unknown = Fabricate(:upload, original_filename: "test_video.mmmppp444", extension: "mmmppp444")
+    expect(UploadMarkdown.new(unknown).playable_media_markdown).to eq(<<~MD.chomp)
+    [test_video.mmmppp444|attachment](#{unknown.short_url}) (#{unknown.human_filesize})
+    MD
+  end
+end


### PR DESCRIPTION
The chat quoting mechanism will need to be able to generate
markdown for all kinds of uploads. The UploadMarkdown class
was missing generation for video and audio uploads. This
commit adds that in, and also expands the server-side regex
recognition of FileHelper types to match those in uploads.js,
and adds a spec for UploadMarkdown