### PR TITLE
DEV: Ensure stylesheet sourcemap URLs include __ws hostname param

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -225,7 +225,7 @@ class Stylesheet::Manager
 
           next if builder.theme&.component && !scss_checker.has_scss(theme_id)
           builder.compile unless File.exist?(builder.stylesheet_fullpath)
-          href = builder.stylesheet_path
+          href = builder.stylesheet_absolute_url
 
           data[:new_href] = href
           stylesheets << data
@@ -243,7 +243,7 @@ class Stylesheet::Manager
       else
         builder = Builder.new(target: target, manager: self)
         builder.compile unless File.exist?(builder.stylesheet_fullpath)
-        href = builder.stylesheet_path
+        href = builder.stylesheet_absolute_url
 
         data = { target: target, new_href: href }
         stylesheets << data
@@ -287,7 +287,7 @@ class Stylesheet::Manager
 
     builder.compile unless File.exist?(builder.stylesheet_fullpath)
 
-    href = builder.stylesheet_path
+    href = builder.stylesheet_absolute_url
     stylesheet[:new_href] = href
     cache.defer_set(cache_key, stylesheet.freeze)
     stylesheet

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -225,7 +225,7 @@ class Stylesheet::Manager
 
           next if builder.theme&.component && !scss_checker.has_scss(theme_id)
           builder.compile unless File.exist?(builder.stylesheet_fullpath)
-          href = builder.stylesheet_path(current_hostname)
+          href = builder.stylesheet_path
 
           data[:new_href] = href
           stylesheets << data
@@ -243,7 +243,7 @@ class Stylesheet::Manager
       else
         builder = Builder.new(target: target, manager: self)
         builder.compile unless File.exist?(builder.stylesheet_fullpath)
-        href = builder.stylesheet_path(current_hostname)
+        href = builder.stylesheet_path
 
         data = { target: target, new_href: href }
         stylesheets << data
@@ -287,7 +287,7 @@ class Stylesheet::Manager
 
     builder.compile unless File.exist?(builder.stylesheet_fullpath)
 
-    href = builder.stylesheet_path(current_hostname)
+    href = builder.stylesheet_path
     stylesheet[:new_href] = href
     cache.defer_set(cache_key, stylesheet.freeze)
     stylesheet

--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -73,6 +73,10 @@ class Stylesheet::Manager::Builder
     css
   end
 
+  def current_hostname
+    Discourse.current_hostname
+  end
+
   def cache_fullpath
     Stylesheet::Manager.cache_fullpath
   end
@@ -86,19 +90,19 @@ class Stylesheet::Manager::Builder
   end
 
   def source_map_filename
-    "#{stylesheet_filename}.map"
+    "#{stylesheet_filename}.map?__ws=#{current_hostname}"
   end
 
   def stylesheet_fullpath_no_digest
     "#{cache_fullpath}/#{stylesheet_filename_no_digest}"
   end
 
-  def stylesheet_cdnpath(hostname)
-    "#{GlobalSetting.cdn_url}#{stylesheet_relpath}?__ws=#{hostname}"
+  def stylesheet_cdnpath
+    "#{GlobalSetting.cdn_url}#{stylesheet_relpath}?__ws=#{current_hostname}"
   end
 
-  def stylesheet_path(hostname)
-    stylesheet_cdnpath(hostname)
+  def stylesheet_path
+    stylesheet_cdnpath
   end
 
   def root_path
@@ -177,7 +181,7 @@ class Stylesheet::Manager::Builder
   end
 
   def theme_digest
-    Digest::SHA1.hexdigest(scss_digest.to_s + color_scheme_digest.to_s + settings_digest + uploads_digest)
+    Digest::SHA1.hexdigest(scss_digest.to_s + color_scheme_digest.to_s + settings_digest + uploads_digest + current_hostname)
   end
 
   # this protects us from situations where new versions of a plugin removed a file
@@ -225,7 +229,7 @@ class Stylesheet::Manager::Builder
   end
 
   def default_digest
-    Digest::SHA1.hexdigest "default-#{Stylesheet::Manager.last_file_updated}-#{plugins_digest}"
+    Digest::SHA1.hexdigest "default-#{Stylesheet::Manager.last_file_updated}-#{plugins_digest}-#{current_hostname}"
   end
 
   def color_scheme_digest
@@ -241,18 +245,18 @@ class Stylesheet::Manager::Builder
 
     fonts = "#{SiteSetting.base_font}-#{SiteSetting.heading_font}"
 
+    digest_string = "#{current_hostname}-"
     if cs || categories_updated > 0
       theme_color_defs = resolve_baked_field(:common, :color_definitions)
-      Digest::SHA1.hexdigest "#{RailsMultisite::ConnectionManagement.current_db}-#{cs&.id}-#{cs&.version}-#{theme_color_defs}-#{Stylesheet::Manager.last_file_updated}-#{categories_updated}-#{fonts}"
+      digest_string += "#{RailsMultisite::ConnectionManagement.current_db}-#{cs&.id}-#{cs&.version}-#{theme_color_defs}-#{Stylesheet::Manager.last_file_updated}-#{categories_updated}-#{fonts}"
     else
-      digest_string = "defaults-#{Stylesheet::Manager.last_file_updated}-#{fonts}"
+      digest_string += "defaults-#{Stylesheet::Manager.last_file_updated}-#{fonts}"
 
       if cdn_url = GlobalSetting.cdn_url
-        digest_string = "#{digest_string}-#{cdn_url}"
+        digest_string += "-#{cdn_url}"
       end
-
-      Digest::SHA1.hexdigest digest_string
     end
+    Digest::SHA1.hexdigest digest_string
   end
 
   def resolve_baked_field(target, name)

--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -36,7 +36,7 @@ class Stylesheet::Manager::Builder
          rtl: rtl,
          theme_id: theme&.id,
          theme_variables: theme&.scss_variables.to_s,
-         source_map_file: source_map_filename,
+         source_map_file: source_map_url_relative_from_stylesheet,
          color_scheme_id: @color_scheme&.id,
          load_paths: load_paths
       )
@@ -90,19 +90,19 @@ class Stylesheet::Manager::Builder
   end
 
   def source_map_filename
-    "#{stylesheet_filename}.map?__ws=#{current_hostname}"
+    "#{stylesheet_filename}.map"
+  end
+
+  def source_map_url_relative_from_stylesheet
+    "#{source_map_filename}?__ws=#{current_hostname}"
   end
 
   def stylesheet_fullpath_no_digest
     "#{cache_fullpath}/#{stylesheet_filename_no_digest}"
   end
 
-  def stylesheet_cdnpath
+  def stylesheet_absolute_url
     "#{GlobalSetting.cdn_url}#{stylesheet_relpath}?__ws=#{current_hostname}"
-  end
-
-  def stylesheet_path
-    stylesheet_cdnpath
   end
 
   def root_path


### PR DESCRIPTION
Without this parameter, requests for sourcemaps on shared-CDN multisites will not be routed to the correct database, resulting in a 404.

The stylesheet content now depends on the site hostname, so the hostname has been added to the digest.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
