### PR TITLE
DEV: Prefix deprecation notices with plugin name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -241,7 +241,7 @@ module Discourse
     config.assets.enabled = true
 
     # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.2.4'
+    config.assets.version = '1.2.5'
 
     # see: http://stackoverflow.com/questions/11894180/how-does-one-correctly-add-custom-sql-dml-in-migrations/11894420#11894420
     config.active_record.schema_format = :sql

--- a/lib/discourse_js_processor.rb
+++ b/lib/discourse_js_processor.rb
@@ -19,7 +19,14 @@ class DiscourseJsProcessor
 
     # add sourceURL until we can do proper source maps
     unless Rails.env.production?
-      data = "eval(#{data.inspect} + \"\\n//# sourceURL=#{logical_path}\");\n"
+      plugin_name = root_path[/\/plugins\/([\w-]+)\/assets/, 1]
+      source_url = if plugin_name
+        "plugins/#{plugin_name}/assets/javascripts/#{logical_path}"
+      else
+        logical_path
+      end
+
+      data = "eval(#{data.inspect} + \"\\n//# sourceURL=#{source_url}\");\n"
     end
 
     { data: data }


### PR DESCRIPTION
To make this possible in development mode, the `sourceURL=` implementation needs to include something plugin-specific. This has no effect on production.

The asset version is bumped in order to trigger a re-compilation of plugin JS assets.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
