### PR TITLE
FIX: Post migration to fix custom emojis with secure URL

### DIFF
--- a/db/post_migrate/20220214224506_reset_custom_emoji_post_bakes_version_secure_fix.rb
+++ b/db/post_migrate/20220214224506_reset_custom_emoji_post_bakes_version_secure_fix.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ResetCustomEmojiPostBakesVersionSecureFix < ActiveRecord::Migration[6.1]
+  def up
+    if SiteSetting.secure_media
+      execute <<~SQL
+        UPDATE posts SET baked_version = 0
+        WHERE cooked LIKE '%emoji emoji-custom%' AND cooked LIKE '%secure-media-uploads%'
+      SQL
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Follow up to 88a8584348ed93a28286839bfc1c32b06bd50b3f. Sets
the baked version of all posts with custom emoji and a secure
media URL in the cooked content to 0. Then our periodic rebake
posts job will rebake them to apply the fix in the linked
commit. This only matters on sites with secure media enabled.