### PR TITLE
DEV: Allow access to ember-computed-decorators under ember-cli

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
@@ -14,7 +14,7 @@ define("ember-addons/ember-computed-decorators", [
 ], function (decorators, deprecated) {
   deprecated.default(
     "ember-addons/ember-computed-decorators is deprecated. Use discourse-common/utils/decorators instead.",
-    { since: "v2.4", dropFrom: "v3.0" }
+    { since: "2.4", dropFrom: "3.0" }
   );
   return decorators;
 });

--- a/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
@@ -7,3 +7,14 @@ define("htmlbars-inline-precompile", ["exports"], function (exports) {
     return Ember.Handlebars.compile(strings[0]);
   };
 });
+
+define("ember-addons/ember-computed-decorators", [
+  "discourse-common/utils/decorators",
+  "discourse-common/lib/deprecated",
+], function (decorators, deprecated) {
+  deprecated.default(
+    "ember-addons/ember-computed-decorators is deprecated. Use discourse-common/utils/decorators instead.",
+    { since: "v2.4", dropFrom: "v3.0" }
+  );
+  return decorators;
+});


### PR DESCRIPTION
This was deprecated in Discourse 2.4, but no end version was put on the deprecation. Many plugins/themes are still using it. This commit restores it under ember-cli so that it does not block the Ember CLI rollout, and can be removed in a future commit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
