### PR TITLE
FIX: unable to filter user directory when sorted by user field.

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -38,8 +38,7 @@ class DirectoryItemsController < ApplicationController
       user_field = UserField.find_by(name: params[:order])
       if user_field
         result = result
-          .joins(:user)
-          .joins("LEFT OUTER JOIN user_custom_fields ON user_custom_fields.user_id = users.id AND user_custom_fields.name = 'user_field_#{user_field.id}'")
+          .where("user_custom_fields.name = 'user_field_#{user_field.id}' OR user_custom_fields.name IS NULL")
           .order("user_custom_fields.name = 'user_field_#{user_field.id}' ASC, user_custom_fields.value #{dir}")
       end
     end

--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -38,7 +38,8 @@ class DirectoryItemsController < ApplicationController
       user_field = UserField.find_by(name: params[:order])
       if user_field
         result = result
-          .where("user_custom_fields.name = 'user_field_#{user_field.id}' OR user_custom_fields.name IS NULL")
+          .references(:user)
+          .joins("LEFT OUTER JOIN user_custom_fields ON user_custom_fields.user_id = users.id AND user_custom_fields.name = 'user_field_#{user_field.id}'")
           .order("user_custom_fields.name = 'user_field_#{user_field.id}' ASC, user_custom_fields.value #{dir}")
       end
     end

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -136,6 +136,38 @@ describe DirectoryItemsController do
       expect(json['directory_items'][1]['user']['username']).to eq(evil_trout.username) | eq(stage_user.username)
     end
 
+    it "orders users by user fields" do
+      group.add(walter_white)
+      field = Fabricate(:user_field, searchable: true)
+
+      UserCustomField.create!(
+        user_id: walter_white.id,
+        name: "user_field_#{field.id}",
+        value: "Yellow"
+      )
+      UserCustomField.create!(
+        user_id: stage_user.id,
+        name: "user_field_#{field.id}",
+        value: "Apple"
+      )
+      UserCustomField.create!(
+        user_id: evil_trout.id,
+        name: "custom_field",
+        value: "Moon"
+      )
+
+      get '/directory_items.json', params: { period: 'all', group: group.name, order: field.name, user_field_ids: field.id.to_s, asc: true }
+      expect(response.status).to eq(200)
+
+      json = response.parsed_body
+      expect(json).to be_present
+      expect(json['directory_items'].length).to eq(3)
+      expect(json['meta']['total_rows_directory_items']).to eq(3)
+      expect(json['directory_items'][0]['user']['username']).to eq(stage_user.username)
+      expect(json['directory_items'][1]['user']['username']).to eq(walter_white.username)
+      expect(json['directory_items'][2]['user']['username']).to eq(evil_trout.username)
+    end
+
     it "checks group permissions" do
       group.update!(visibility_level: Group.visibility_levels[:members])
 

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -138,34 +138,37 @@ describe DirectoryItemsController do
 
     it "orders users by user fields" do
       group.add(walter_white)
-      field = Fabricate(:user_field, searchable: true)
+      field1 = Fabricate(:user_field, searchable: true)
+      field2 = Fabricate(:user_field, searchable: true)
 
-      UserCustomField.create!(
-        user_id: walter_white.id,
-        name: "user_field_#{field.id}",
-        value: "Yellow"
-      )
-      UserCustomField.create!(
-        user_id: stage_user.id,
-        name: "user_field_#{field.id}",
-        value: "Apple"
-      )
-      UserCustomField.create!(
-        user_id: evil_trout.id,
-        name: "custom_field",
-        value: "Moon"
-      )
+      user_fields = [
+        { user: walter_white, field: field1, value: "Yellow", order: 1 },
+        { user: stage_user, field: field1, value: "Apple", order: 0 },
+        { user: evil_trout, field: field2, value: "Moon", order: 2 }
+      ]
 
-      get '/directory_items.json', params: { period: 'all', group: group.name, order: field.name, user_field_ids: field.id.to_s, asc: true }
+      user_fields.each do |data|
+        UserCustomField.create!(
+          user_id: data[:user].id,
+          name: "user_field_#{data[:field].id}",
+          value: data[:value]
+        )
+      end
+
+      get '/directory_items.json', params: { period: 'all', group: group.name, order: field1.name, user_field_ids: "#{field1.id}|#{field2.id}", asc: true }
       expect(response.status).to eq(200)
 
       json = response.parsed_body
       expect(json).to be_present
-      expect(json['directory_items'].length).to eq(3)
+      items = json['directory_items']
+      expect(items.length).to eq(3)
       expect(json['meta']['total_rows_directory_items']).to eq(3)
-      expect(json['directory_items'][0]['user']['username']).to eq(stage_user.username)
-      expect(json['directory_items'][1]['user']['username']).to eq(walter_white.username)
-      expect(json['directory_items'][2]['user']['username']).to eq(evil_trout.username)
+
+      user_fields.each do |data|
+        user = items[data[:order]]['user']
+        expect(user['username']).to eq(data[:user].username)
+        expect(user['user_fields']).to eq({ data[:field].id.to_s => data[:value] })
+      end
     end
 
     it "checks group permissions" do


### PR DESCRIPTION
Since the "users" table is already added in the "`includes`" method it gives unexpected results while using it again in the "`joins`" method.