### PR TITLE
DEV: Update Discord API domain

### DIFF
--- a/lib/auth/discord_authenticator.rb
+++ b/lib/auth/discord_authenticator.rb
@@ -6,7 +6,7 @@ class Auth::DiscordAuthenticator < Auth::ManagedAuthenticator
     option :scope, 'identify email guilds'
 
     option :client_options,
-            site: 'https://discordapp.com/api',
+            site: 'https://discord.com/api',
             authorize_url: 'oauth2/authorize',
             token_url: 'oauth2/token'
 


### PR DESCRIPTION
`discordapp.com` is being deprecated in favour of `discord.com`: https://github.com/discord/discord-api-docs/discussions/4510

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
