### PR TITLE
Fix bug regarding Chat on stable

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -107,7 +107,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
       this.fileInputEl,
       this._addFiles
     );
-    this.editorEl.addEventListener("paste", this.pasteEventListener);
+    this.editorEl?.addEventListener("paste", this.pasteEventListener);
 
     this._uppyInstance = new Uppy({
       id: this.uppyId,


### PR DESCRIPTION
The chat plugin works well on stable, but in commit 7dd9dd848a92cf801c4d527c8a6d6111be689fb2 an issue was introduced causing a `TypeError: this.editorEl is null` error. This commit fixes that issue.