### PR TITLE
DEV: Improve phpBB3 import script

### DIFF
--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -636,9 +636,6 @@ class ImportScripts::Base
     skipped = 0
     total = opts[:total] || results.count
 
-    created_by = User.new
-    post = Post.new
-
     results.each do |result|
       params = yield(result)
 

--- a/script/import_scripts/base.rb
+++ b/script/import_scripts/base.rb
@@ -366,6 +366,7 @@ class ImportScripts::Base
       # try based on email
       if e.try(:record).try(:errors).try(:messages).try(:[], :primary_email).present?
         if existing = User.find_by_email(opts[:email].downcase)
+          existing.created_at = opts[:created_at] if opts[:created_at]
           existing.custom_fields["import_id"] = import_id
           existing.save!
           u = existing

--- a/script/import_scripts/phpbb3/database/database_3_0.rb
+++ b/script/import_scripts/phpbb3/database/database_3_0.rb
@@ -13,7 +13,7 @@ module ImportScripts::PhpBB3
       SQL
     end
 
-    def fetch_users(last_user_id, _)
+    def fetch_users(last_user_id, _profile_fields)
       query(<<-SQL, :user_id)
         SELECT u.user_id, u.user_email, u.username, u.user_password, u.user_regdate, u.user_lastvisit, u.user_ip,
           u.user_type, u.user_inactive_reason, g.group_name, b.ban_start, b.ban_end, b.ban_reason,

--- a/script/import_scripts/phpbb3/database/database_3_0.rb
+++ b/script/import_scripts/phpbb3/database/database_3_0.rb
@@ -233,6 +233,25 @@ module ImportScripts::PhpBB3
       SQL
     end
 
+    def count_likes
+      count(<<-SQL)
+        SELECT COUNT(*) AS count
+        FROM #{@table_prefix}thanks
+        WHERE user_id <> poster_id
+      SQL
+    end
+
+    def fetch_likes(last_post_id, last_user_id)
+      query(<<-SQL, :post_id, :user_id)
+        SELECT post_id, user_id, thanks_time
+        FROM #{@table_prefix}thanks
+        WHERE user_id <> poster_id
+          AND (post_id, user_id) > (#{last_post_id}, #{last_user_id})
+        ORDER BY post_id, user_id
+        LIMIT #{@batch_size}
+      SQL
+    end
+
     def get_smiley(smiley_code)
       query(<<-SQL).first
         SELECT emotion, smiley_url

--- a/script/import_scripts/phpbb3/database/database_3_0.rb
+++ b/script/import_scripts/phpbb3/database/database_3_0.rb
@@ -227,7 +227,7 @@ module ImportScripts::PhpBB3
         SELECT b.user_id, t.topic_first_post_id
         FROM #{@table_prefix}bookmarks b
           JOIN #{@table_prefix}topics t ON (b.topic_id = t.topic_id)
-        WHERE b.user_id > #{last_user_id}
+        WHERE (b.user_id, b.topic_id) > (#{last_user_id}, #{last_topic_id})
         ORDER BY b.user_id, b.topic_id
         LIMIT #{@batch_size}
       SQL

--- a/script/import_scripts/phpbb3/database/database_3_0.rb
+++ b/script/import_scripts/phpbb3/database/database_3_0.rb
@@ -13,7 +13,7 @@ module ImportScripts::PhpBB3
       SQL
     end
 
-    def fetch_users(last_user_id)
+    def fetch_users(last_user_id, _)
       query(<<-SQL, :user_id)
         SELECT u.user_id, u.user_email, u.username, u.user_password, u.user_regdate, u.user_lastvisit, u.user_ip,
           u.user_type, u.user_inactive_reason, g.group_name, b.ban_start, b.ban_end, b.ban_reason,

--- a/script/import_scripts/phpbb3/importer.rb
+++ b/script/import_scripts/phpbb3/importer.rb
@@ -174,7 +174,7 @@ module ImportScripts::PhpBB3
       importer = @importers.category_importer
 
       create_categories(rows) do |row|
-        next if @settings.category_mappings[row[:forum_id].to_s] == 'SKIP'
+        next if @settings.category_mappings.dig(row[:forum_id].to_s, :skip)
 
         importer.map_category(row)
       end

--- a/script/import_scripts/phpbb3/importer.rb
+++ b/script/import_scripts/phpbb3/importer.rb
@@ -38,6 +38,7 @@ module ImportScripts::PhpBB3
       import_posts
       import_private_messages if @settings.import_private_messages
       import_bookmarks if @settings.import_bookmarks
+      import_likes if @settings.import_likes
     end
 
     def change_site_settings
@@ -71,7 +72,7 @@ module ImportScripts::PhpBB3
       last_user_id = 0
 
       batches do |offset|
-        rows, last_user_id = @database.fetch_users(last_user_id)
+        rows, last_user_id = @database.fetch_users(last_user_id, @settings.custom_fields)
         rows = rows.to_a.uniq { |row| row[:user_id] }
         break if rows.size < 1
 
@@ -237,6 +238,25 @@ module ImportScripts::PhpBB3
           rescue => e
             log_error("Failed to map bookmark (#{row[:user_id]}, #{row[:topic_first_post_id]})", e)
           end
+        end
+      end
+    end
+
+    def import_likes
+      puts '', 'importing likes'
+      total_count = @database.count_likes
+      last_post_id = last_user_id = 0
+
+      batches do |offset|
+        rows, last_post_id, last_user_id = @database.fetch_likes(last_post_id, last_user_id)
+        break if rows.size < 1
+
+        create_likes(rows, total: total_count, offset: offset) do |row|
+          {
+            post_id: @settings.prefix(row[:post_id]),
+            user_id: @settings.prefix(row[:user_id]),
+            created_at: Time.zone.at(row[:thanks_time])
+          }
         end
       end
     end

--- a/script/import_scripts/phpbb3/importers/category_importer.rb
+++ b/script/import_scripts/phpbb3/importers/category_importer.rb
@@ -17,7 +17,7 @@ module ImportScripts::PhpBB3
       return if @settings.category_mappings[row[:forum_id].to_s]
 
       if row[:parent_id] && @settings.category_mappings[row[:parent_id].to_s]
-        puts "parent category (#{row[:parent_id]}) was mapped, but children was not (#{row[:forum_id]})"
+        puts "parent category (#{row[:parent_id]}) was mapped, but child was not (#{row[:forum_id]})"
       end
 
       {

--- a/script/import_scripts/phpbb3/settings.yml
+++ b/script/import_scripts/phpbb3/settings.yml
@@ -36,20 +36,25 @@ import:
 
   # Category mappings
   #
-  # For example, topics from phpBB category 1 and 2 will be imported
-  # in the new "Foo Category" category, topics from phpBB category 3
-  # will be imported in subcategory "Bar category", topics from phpBB
-  # category 4 will be merged into category 5 and category 6 will be
-  # skipped.
+  # * "source_category_id" is the forum ID in phpBB3
+  # * "target_category_id" is either a forum ID from phpBB3 or a "forum_id"
+  #   from the "new_categories" setting (see above)
+  # * "discourse_category_id" is a category ID from Discourse
+  # * "skip" allows you to ignore a category during import
   #
-  # category_mappings:
-  #   1: foo
-  #   2: foo
-  #   3: bar
-  #   4: 5
-  #   6: SKIP
+  # Use "target_category_id" if you want to merge categories and use
+  # "discourse_category_id" if you want to import a forum into an existing
+  # category in Discourse.
   #
-  category_mappings: {}
+  #  category_mappings:
+  #    - source_category_id: 1
+  #      target_category_id: foo
+  #    - source_category_id: 2
+  #      discourse_category_id: 42
+  #    - source_category_id: 6
+  #      skip: true
+  #
+  category_mappings: []
 
   # Tag mappings
   #

--- a/script/import_scripts/phpbb3/settings.yml
+++ b/script/import_scripts/phpbb3/settings.yml
@@ -122,6 +122,9 @@ import:
   private_messages: true
   polls: true
 
+  # Import likes from the phpBB's "Thanks for posts" extension
+  likes: false
+
   # When true: each imported user will have the original username from phpBB as its name
   # When false: the name of each imported user will be blank unless the username was changed during import
   username_as_name: false

--- a/script/import_scripts/phpbb3/settings.yml
+++ b/script/import_scripts/phpbb3/settings.yml
@@ -134,3 +134,12 @@ import:
     # here are two example mappings...
     smiley: [':D', ':-D', ':grin:']
     heart: ':love:'
+
+  # Map custom profile fields from phpBB to custom user fields in Discourse (works for phpBB 3.1+)
+  #
+  #  custom_fields:
+  #    - phpbb_field_name: "company_name"
+  #      discourse_field_name: "Company"
+  #    - phpbb_field_name: "facebook"
+  #      discourse_field_name: "Facebook"
+  custom_fields: []

--- a/script/import_scripts/phpbb3/support/settings.rb
+++ b/script/import_scripts/phpbb3/support/settings.rb
@@ -49,7 +49,7 @@ module ImportScripts::PhpBB3
       @site_name = import_settings['site_name']
 
       @new_categories = import_settings['new_categories']
-      @category_mappings = import_settings['category_mappings']
+      @category_mappings = import_settings.fetch('category_mappings', []).to_h { |m| [m[:source_category_id].to_s, m] }
       @tag_mappings = import_settings['tag_mappings']
       @rank_mapping = import_settings['rank_mapping']
 

--- a/script/import_scripts/phpbb3/support/settings.rb
+++ b/script/import_scripts/phpbb3/support/settings.rb
@@ -24,6 +24,7 @@ module ImportScripts::PhpBB3
     attr_reader :import_polls
     attr_reader :import_bookmarks
     attr_reader :import_passwords
+    attr_reader :import_likes
 
     attr_reader :import_uploaded_avatars
     attr_reader :import_remote_avatars
@@ -58,6 +59,7 @@ module ImportScripts::PhpBB3
       @import_polls = import_settings['polls']
       @import_bookmarks = import_settings['bookmarks']
       @import_passwords = import_settings['passwords']
+      @import_likes = import_settings['likes']
 
       avatar_settings = import_settings['avatars']
       @import_uploaded_avatars = avatar_settings['uploaded']

--- a/script/import_scripts/phpbb3/support/settings.rb
+++ b/script/import_scripts/phpbb3/support/settings.rb
@@ -38,6 +38,7 @@ module ImportScripts::PhpBB3
 
     attr_reader :username_as_name
     attr_reader :emojis
+    attr_reader :custom_fields
 
     attr_reader :database
 
@@ -72,6 +73,7 @@ module ImportScripts::PhpBB3
 
       @username_as_name = import_settings['username_as_name']
       @emojis = import_settings.fetch('emojis', [])
+      @custom_fields = import_settings.fetch('custom_fields', [])
 
       @database = DatabaseSettings.new(yaml['database'])
     end


### PR DESCRIPTION
* Optional import of custom user fields from phpBB 3.1+
* Optional import of likes from phpBB3
  Requires the phpBB "Thanks for posts" extension
* Fix import of bookmarks from phpBB3
* Update `created_at` of existing user
* Support mapping of phpBB forums to existing Discourse categories
  This is in addition to the ability of merging phpBB forums and importing into newly created Discourse categories.