### PR TITLE
PERF: Reduce number of EXPIRE calls from CachedCounting

### DIFF
--- a/spec/models/application_request_spec.rb
+++ b/spec/models/application_request_spec.rb
@@ -29,14 +29,16 @@ describe ApplicationRequest do
       inc(:http_total)
       inc(:http_total)
 
-      Discourse.redis.without_namespace.stubs(:incr).raises(Redis::CommandError.new("READONLY"))
+      Discourse.redis.without_namespace.stubs(:eval).raises(Redis::CommandError.new("READONLY"))
+      Discourse.redis.without_namespace.stubs(:evalsha).raises(Redis::CommandError.new("READONLY"))
       Discourse.redis.without_namespace.stubs(:set).raises(Redis::CommandError.new("READONLY"))
 
       # flush will be deferred no error raised
       inc(:http_total, autoflush: 3)
       ApplicationRequest.write_cache!
 
-      Discourse.redis.without_namespace.unstub(:incr)
+      Discourse.redis.without_namespace.unstub(:eval)
+      Discourse.redis.without_namespace.unstub(:evalsha)
       Discourse.redis.without_namespace.unstub(:set)
 
       inc(:http_total, autoflush: 3)

--- a/spec/models/web_crawler_request_spec.rb
+++ b/spec/models/web_crawler_request_spec.rb
@@ -31,13 +31,15 @@ describe WebCrawlerRequest do
     inc('Googlebot')
     inc('Googlebot')
 
-    Discourse.redis.without_namespace.stubs(:incr).raises(Redis::CommandError.new("READONLY"))
+    Discourse.redis.without_namespace.stubs(:eval).raises(Redis::CommandError.new("READONLY"))
+    Discourse.redis.without_namespace.stubs(:evalsha).raises(Redis::CommandError.new("READONLY"))
     Discourse.redis.without_namespace.stubs(:set).raises(Redis::CommandError.new("READONLY"))
 
     inc('Googlebot', autoflush: 3)
     WebCrawlerRequest.write_cache!
 
-    Discourse.redis.without_namespace.unstub(:incr)
+    Discourse.redis.without_namespace.unstub(:eval)
+    Discourse.redis.without_namespace.unstub(:evalsha)
     Discourse.redis.without_namespace.unstub(:set)
 
     inc('Googlebot', autoflush: 3)


### PR DESCRIPTION
Previously we were calling `EXPIRE` every time we incremented a given key. Instead, we can call EXPIRE once when the key is first populated. A LUA script is used to make this as efficient as possible.

Consumers of this Concern use daily keys. Since we're now calling EXPIRE only at the beginning of the day, rather than throughout the day, the expire time has been increased from 3 to 4 days.

(requires #15957)
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
