### PR TITLE
UX: prevent user menu overflow on tiny screens

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -394,6 +394,9 @@
           grid-gap: 0 1em;
           a {
             @include ellipsis;
+            > div {
+              display: block;
+            }
           }
           button {
             span:not(.relative-date) {

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -51,10 +51,10 @@
     // accounts for menu "ears" 4px + border 1px
     padding: 0.75em calc(0.5em + 4px + 1px);
     margin: 0.25em;
-    @media screen and (max-height: 380px) {
+    @media screen and (max-height: 500px) {
       // reduce padding to avoid scroll
-      padding-top: 0.5em;
-      padding-bottom: 0.5em;
+      padding-top: 0.25em;
+      padding-bottom: 0.25em;
     }
   }
 }


### PR DESCRIPTION
Increasing the breakpoint and decreasing the padding to get full coverage. Only applies to very tiny devices (even smaller than iPhone SE) 

Before (note that "log out" is truncated and not here at all):
![Screen Shot 2022-02-15 at 5 42 36 PM](https://user-images.githubusercontent.com/1681963/154162235-805df1e8-782d-4cb2-b508-17d2cdc1127f.png)

After:
![Screen Shot 2022-02-15 at 5 42 47 PM](https://user-images.githubusercontent.com/1681963/154162236-9f062fb1-7f95-44dc-95a2-07207f0b1849.png)
:

https://meta.discourse.org/t/several-user-menu-items-not-present-in-smartphones/216852