### PR TITLE
UX: control whitespace on categories topic list

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/latest-topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/latest-topic-list-item.hbs
@@ -9,10 +9,10 @@
   <div class="top-row">
     {{raw "topic-status" topic=topic}}
     {{topic-link topic}}
-    {{#if topic.featured_link}}
+    {{~#if topic.featured_link}}
       {{topic-featured-link topic}}
     {{/if}}
-    {{topic-post-badges unreadPosts=topic.unread_posts unseen=topic.unseen url=topic.lastUnreadUrl}}
+    {{~topic-post-badges unreadPosts=topic.unread_posts unseen=topic.unseen url=topic.lastUnreadUrl}}
   </div>
   <div class="bottom-row">
     {{category-link topic.category}}{{discourse-tags topic mode="list"}}{{! intentionally inline to avoid whitespace}}


### PR DESCRIPTION
This prevents notification badges from wrapping onto their own line. We already do this on the main topic lists like `/latest`

Before:
![Screen Shot 2022-02-15 at 6 02 48 PM](https://user-images.githubusercontent.com/1681963/154164569-bc958efe-cea8-4c5f-a0c6-1fce4a7a2fd4.png)

After:
![Screen Shot 2022-02-15 at 6 01 55 PM](https://user-images.githubusercontent.com/1681963/154164580-94534e81-7a4e-47d7-80ec-757d1b496530.png)
