### PR TITLE
FEATURE: mute subcategory when parent category is muted

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -27,6 +27,7 @@ export default Component.extend(FilterModeMixin, {
   categoryNotificationLevel(notificationLevel) {
     if (
       this.currentUser &&
+      this.currentUser.indirectly_muted_category_ids &&
       this.currentUser.indirectly_muted_category_ids.includes(this.category.id)
     ) {
       return NotificationLevels.MUTED;

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -26,9 +26,9 @@ export default Component.extend(FilterModeMixin, {
   @discourseComputed("category.notification_level")
   categoryNotificationLevel(notificationLevel) {
     if (
-      this.currentUser &&
-      this.currentUser.indirectly_muted_category_ids &&
-      this.currentUser.indirectly_muted_category_ids.includes(this.category.id)
+      this.currentUser?.indirectly_muted_category_ids?.includes(
+        this.category.id
+      )
     ) {
       return NotificationLevels.MUTED;
     } else {

--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -3,6 +3,7 @@ import FilterModeMixin from "discourse/mixins/filter-mode";
 import NavItem from "discourse/models/nav-item";
 import bootbox from "bootbox";
 import discourseComputed from "discourse-common/utils/decorators";
+import { NotificationLevels } from "discourse/lib/notification-levels";
 import { inject as service } from "@ember/service";
 
 export default Component.extend(FilterModeMixin, {
@@ -20,6 +21,18 @@ export default Component.extend(FilterModeMixin, {
   @discourseComputed("category")
   showCategoryNotifications(category) {
     return category && this.currentUser;
+  },
+
+  @discourseComputed("category.notification_level")
+  categoryNotificationLevel(notificationLevel) {
+    if (
+      this.currentUser &&
+      this.currentUser.indirectly_muted_category_ids.includes(this.category.id)
+    ) {
+      return NotificationLevels.MUTED;
+    } else {
+      return notificationLevel;
+    }
   },
 
   // don't show tag notification menu on tag intersections

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -324,8 +324,6 @@ const Category = RestModel.extend({
   },
 
   setNotification(notification_level) {
-    this.set("notification_level", notification_level);
-
     User.currentProp(
       "muted_category_ids",
       User.current().calculateMutedIds(
@@ -336,7 +334,16 @@ const Category = RestModel.extend({
     );
 
     const url = `/category/${this.id}/notifications`;
-    return ajax(url, { data: { notification_level }, type: "POST" });
+    return ajax(url, { data: { notification_level }, type: "POST" }).then(
+      (data) => {
+        User.current().set(
+          "indirectly_muted_category_ids",
+          data.indirectly_muted_category_ids
+        );
+        this.set("notification_level", notification_level);
+        this.notifyPropertyChange("notification_level");
+      }
+    );
   },
 
   @discourseComputed("id")

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -473,14 +473,9 @@ const TopicTrackingState = EmberObject.extend({
       ? new Set([categoryId])
       : this.getSubCategoryIds(categoryId);
 
-    let mutedCategoryIds =
-      this.currentUser && this.currentUser.muted_category_ids;
-
-    if (mutedCategoryIds) {
-      mutedCategoryIds = mutedCategoryIds.concat(
-        this.currentUser.indirectly_muted_category_ids
-      );
-    }
+    const mutedCategoryIds = this.currentUser?.muted_category_ids?.concat(
+      this.currentUser.indirectly_muted_category_ids
+    );
     let filterFn = type === "new" ? isNew : isUnread;
 
     return Array.from(this.states.values()).filter(
@@ -779,12 +774,9 @@ const TopicTrackingState = EmberObject.extend({
     }
 
     if (["new_topic", "latest"].includes(data.message_type)) {
-      let mutedCategoryIds = User.currentProp("muted_category_ids");
-      if (mutedCategoryIds) {
-        mutedCategoryIds = mutedCategoryIds.concat(
-          User.currentProp("indirectly_muted_category_ids")
-        );
-      }
+      const mutedCategoryIds = User.currentProp("muted_category_ids")?.concat(
+        User.currentProp("indirectly_muted_category_ids")
+      );
 
       if (
         mutedCategoryIds &&

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -472,8 +472,12 @@ const TopicTrackingState = EmberObject.extend({
     const subcategoryIds = noSubcategories
       ? new Set([categoryId])
       : this.getSubCategoryIds(categoryId);
+
     const mutedCategoryIds =
-      this.currentUser && this.currentUser.muted_category_ids;
+      this.currentUser &&
+      this.currentUser.muted_category_ids.concat(
+        this.currentUser.indirectly_muted_category_ids
+      );
     let filterFn = type === "new" ? isNew : isUnread;
 
     return Array.from(this.states.values()).filter(
@@ -772,10 +776,13 @@ const TopicTrackingState = EmberObject.extend({
     }
 
     if (["new_topic", "latest"].includes(data.message_type)) {
-      const muted_category_ids = User.currentProp("muted_category_ids");
+      const mutedCategoryIds = User.currentProp("muted_category_ids").concat(
+        User.currentProp("indirectly_muted_category_ids")
+      );
+
       if (
-        muted_category_ids &&
-        muted_category_ids.includes(data.payload.category_id)
+        mutedCategoryIds &&
+        mutedCategoryIds.includes(data.payload.category_id)
       ) {
         return;
       }

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -473,11 +473,14 @@ const TopicTrackingState = EmberObject.extend({
       ? new Set([categoryId])
       : this.getSubCategoryIds(categoryId);
 
-    const mutedCategoryIds =
-      this.currentUser &&
-      this.currentUser.muted_category_ids.concat(
+    let mutedCategoryIds =
+      this.currentUser && this.currentUser.muted_category_ids;
+
+    if (mutedCategoryIds) {
+      mutedCategoryIds = mutedCategoryIds.concat(
         this.currentUser.indirectly_muted_category_ids
       );
+    }
     let filterFn = type === "new" ? isNew : isUnread;
 
     return Array.from(this.states.values()).filter(
@@ -776,9 +779,12 @@ const TopicTrackingState = EmberObject.extend({
     }
 
     if (["new_topic", "latest"].includes(data.message_type)) {
-      const mutedCategoryIds = User.currentProp("muted_category_ids").concat(
-        User.currentProp("indirectly_muted_category_ids")
-      );
+      let mutedCategoryIds = User.currentProp("muted_category_ids");
+      if (mutedCategoryIds) {
+        mutedCategoryIds = mutedCategoryIds.concat(
+          User.currentProp("indirectly_muted_category_ids")
+        );
+      }
 
       if (
         mutedCategoryIds &&

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -67,7 +67,7 @@
       {{!-- don't show category notification menu on tag pages --}}
       {{#if showCategoryNotifications}}
         {{category-notifications-button
-          value=category.notification_level
+          value=categoryNotificationLevel
           category=category
           onChange=(action "changeCategoryNotificationLevel")
         }}

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -661,6 +661,19 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         );
       });
 
+      test("topics in indirectly muted categories do not get added to the state", function (assert) {
+        trackingState.currentUser.setProperties({
+          muted_category_ids: [],
+          indirectly_muted_category_ids: [123],
+        });
+        publishToMessageBus("/new", newTopicPayload);
+        assert.strictEqual(
+          trackingState.findState(222),
+          undefined,
+          "the new topic is not in the state"
+        );
+      });
+
       test("topics in muted tags do not get added to the state", function (assert) {
         trackingState.currentUser.set("muted_tag_ids", [44]);
         publishToMessageBus("/new", newTopicPayload);

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -211,7 +211,7 @@ class CategoriesController < ApplicationController
     notification_level = params[:notification_level].to_i
 
     CategoryUser.set_notification_level_for_category(current_user, notification_level, category_id)
-    render json: success_json
+    render json: success_json.merge({ indirectly_muted_category_ids: CategoryUser.indirectly_muted_category_ids(current_user) })
   end
 
   def destroy

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -28,6 +28,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :redirected_to_top,
              :custom_fields,
              :muted_category_ids,
+             :indirectly_muted_category_ids,
              :regular_category_ids,
              :tracked_category_ids,
              :watched_first_post_category_ids,
@@ -200,6 +201,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def muted_category_ids
     categories_with_notification_level(:muted)
+  end
+
+  def indirectly_muted_category_ids
+    CategoryUser.indirectly_muted_category_ids(object)
   end
 
   def regular_category_ids

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -847,7 +847,7 @@ class TopicQuery
         .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{user.id}")
         .where("topics.category_id = :category_id
                 OR
-                (COALESCE(category_users.notification_level, :default) <> :muted AND topics.category_id NOT IN(:indirectly_muted_category_ids))
+                (COALESCE(category_users.notification_level, :default) <> :muted AND (topics.category_id IS NULL OR topics.category_id NOT IN(:indirectly_muted_category_ids)))
                 OR tu.notification_level > :regular",
                 category_id: category_id || -1,
                 default: CategoryUser.default_notification_level,

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -846,10 +846,12 @@ class TopicQuery
         .references("cu")
         .joins("LEFT JOIN category_users ON category_users.category_id = topics.category_id AND category_users.user_id = #{user.id}")
         .where("topics.category_id = :category_id
-                OR COALESCE(category_users.notification_level, :default) <> :muted
+                OR
+                (COALESCE(category_users.notification_level, :default) <> :muted AND topics.category_id NOT IN(:indirectly_muted_category_ids))
                 OR tu.notification_level > :regular",
                 category_id: category_id || -1,
                 default: CategoryUser.default_notification_level,
+                indirectly_muted_category_ids: CategoryUser.indirectly_muted_category_ids(user).presence || [-1],
                 muted: CategoryUser.notification_levels[:muted],
                 regular: TopicUser.notification_levels[:regular])
     elsif SiteSetting.mute_all_categories_by_default

--- a/spec/models/category_user_spec.rb
+++ b/spec/models/category_user_spec.rb
@@ -289,12 +289,15 @@ describe CategoryUser do
       end
     end
     context "max category nesting 3" do
-      fab!(:category1) { Fabricate(:category) }
-      fab!(:category2) { Fabricate(:category, parent_category: category1) }
-      fab!(:category3) { Fabricate(:category, parent_category: category2) }
+      let(:category1) { Fabricate(:category) }
+      let(:category2) { Fabricate(:category, parent_category: category1) }
+      let(:category3) { Fabricate(:category, parent_category: category2) }
 
       before do
         SiteSetting.max_category_nesting = 3
+        category1
+        category2
+        category3
       end
       it "calculates muted categories based on parent category state" do
         expect(CategoryUser.indirectly_muted_category_ids(user)).to eq([])

--- a/spec/models/category_user_spec.rb
+++ b/spec/models/category_user_spec.rb
@@ -268,4 +268,50 @@ describe CategoryUser do
       end
     end
   end
+
+  describe "#indirectly_muted_category_ids" do
+    context "max category nesting 2" do
+      fab!(:category1) { Fabricate(:category) }
+      fab!(:category2) { Fabricate(:category, parent_category: category1) }
+      fab!(:category3) { Fabricate(:category, parent_category: category1) }
+
+      it "calculates muted categories based on parent category state" do
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to eq([])
+
+        category_user = CategoryUser.create!(user: user, category: category1, notification_level: CategoryUser.notification_levels[:muted])
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to contain_exactly(category2.id, category3.id)
+
+        CategoryUser.create!(user: user, category: category3, notification_level: CategoryUser.notification_levels[:muted])
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to contain_exactly(category2.id)
+
+        category_user.update(notification_level: CategoryUser.notification_levels[:regular])
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to eq([])
+      end
+    end
+    context "max category nesting 3" do
+      fab!(:category1) { Fabricate(:category) }
+      fab!(:category2) { Fabricate(:category, parent_category: category1) }
+      fab!(:category3) { Fabricate(:category, parent_category: category2) }
+
+      before do
+        SiteSetting.max_category_nesting = 3
+      end
+      it "calculates muted categories based on parent category state" do
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to eq([])
+
+        CategoryUser.create!(user: user, category: category1, notification_level: CategoryUser.notification_levels[:muted])
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to contain_exactly(category2.id, category3.id)
+
+        category_user3 = CategoryUser.create!(user: user, category: category3, notification_level: CategoryUser.notification_levels[:muted])
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to contain_exactly(category2.id)
+
+        category_user3.destroy
+        category_user2 = CategoryUser.create!(user: user, category: category2, notification_level: CategoryUser.notification_levels[:muted])
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to contain_exactly(category3.id)
+
+        category_user2.update(notification_level: CategoryUser.notification_levels[:regular])
+        expect(CategoryUser.indirectly_muted_category_ids(user)).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
When parent category or grandparent category is muted, then category should be muted as well.

Still, it can be overridden by setting individual subcategory notification level.

CategoryUser record is not created, mute for subcategories is purely virtual.
