### PR TITLE
A11Y: Use dynamic type scaling on iOS devices

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -4,8 +4,13 @@
 
 html {
   color: var(--primary);
-  font-family: $base-font-family;
   font-size: $base-font-size;
+  // This is intentionally set after the font-size, but before font-family
+  @supports (font: -apple-system-body) and (-webkit-touch-callout: none) {
+    // only applied to iOS devices
+    font: -apple-system-body;
+  }
+  font-family: $base-font-family;
   line-height: $line-height-large;
   background-color: var(--secondary);
   overflow-y: scroll;


### PR DESCRIPTION
This takes advantage of `font: -apple-system-body;` to scale Discourse font-sizes along with the iOS system font scale setting. 

This has to be set in a particular way, after font-size and before font-family, because it only works with the CSS font shorthand, which sets size and font-family together. We only want to use this to adjust the font-size, and not to dictate the font-family. 

I needed to add supports to avoid applying this to macOS Safari... doing that results in too-small fonts on desktop. 

This shouldn't have any impact on themes, as any custom font declaration on `HTML` will appear later in the cascade and overrides it. 