### PR TITLE
FIX: Count clicks on links with query params

### DIFF
--- a/app/models/topic_link_click.rb
+++ b/app/models/topic_link_click.rb
@@ -70,17 +70,17 @@ class TopicLinkClick < ActiveRecord::Base
       end
     end
 
-    link = TopicLink.select([:id, :user_id])
-
     # test for all possible URLs
-    link = link.where(Array.new(urls.count, "url = ?").join(" OR "), *urls)
+    link = TopicLink.select([:id, :user_id]).where(url: urls)
 
     # Find the forum topic link
     link = link.where(post_id: args[:post_id]) if args[:post_id].present?
 
     # If we don't have a post, just find the first occurrence of the link
     link = link.where(topic_id: args[:topic_id]) if args[:topic_id].present?
-    link = link.first
+
+    # select the TopicLink associated to first url
+    link = link.order("array_position(ARRAY[#{urls.map { |s| "#{ActiveRecord::Base.connection.quote(s)}" }.join(',')}], url)").first
 
     # If no link is found...
     unless link.present?

--- a/spec/models/topic_link_click_spec.rb
+++ b/spec/models/topic_link_click_spec.rb
@@ -238,6 +238,27 @@ describe TopicLinkClick do
         end
       end
 
+      context 'same base URL with different query' do
+        it 'are handled differently' do
+          post = Fabricate(:post, raw: <<~RAW)
+            no query param: http://example.com/a
+            with query param: http://example.com/a?b=c
+            with two query params: http://example.com/a?b=c&d=e
+          RAW
+
+          TopicLink.extract_from(post)
+
+          TopicLinkClick.create_from(url: 'http://example.com/a', post_id: post.id, ip: '127.0.0.1', user: Fabricate(:user))
+          TopicLinkClick.create_from(url: 'http://example.com/a?b=c', post_id: post.id, ip: '127.0.0.2', user: Fabricate(:user))
+          TopicLinkClick.create_from(url: 'http://example.com/a?b=c&d=e', post_id: post.id, ip: '127.0.0.3', user: Fabricate(:user))
+          TopicLinkClick.create_from(url: 'http://example.com/a?b=c', post_id: post.id, ip: '127.0.0.4', user: Fabricate(:user))
+
+          expect(TopicLink.where("url LIKE '%example.com%'").pluck(:url, :clicks)).to contain_exactly(
+            ['http://example.com/a', 1], ['http://example.com/a?b=c', 2], ['http://example.com/a?b=c&d=e', 1]
+          )
+        end
+      end
+
       context 'with a google analytics tracking code and a hash' do
         before do
           @url = TopicLinkClick.create_from(url: 'http://discourse.org?_ga=1.16846778.221554446.1071987018#faq',


### PR DESCRIPTION
This did not work sometimes if a topic had the same URL with and without
query params because it did not try to select the best matching URL.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
