### PR TITLE
PERF: Skip running 'auto_leave' during every PresenceChannel method

### DIFF
--- a/lib/presence_channel.rb
+++ b/lib/presence_channel.rb
@@ -129,8 +129,6 @@ class PresenceChannel
         release_mutex(mutex_value)
       end
     end
-
-    auto_leave
   end
 
   # Immediately mark a user's client as leaving the channel
@@ -151,16 +149,12 @@ class PresenceChannel
         release_mutex(mutex_value)
       end
     end
-
-    auto_leave
   end
 
   # Fetch a {PresenceChannel::State} instance representing the current state of this
   #
   # @param [Boolean] count_only set true to skip fetching the list of user ids from redis
   def state(count_only: config.count_only)
-    auto_leave
-
     if count_only
       last_id, count = retry_on_mutex_error do
         PresenceChannel.redis_eval(

--- a/spec/components/presence_channel_spec.rb
+++ b/spec/components/presence_channel_spec.rb
@@ -74,6 +74,8 @@ describe PresenceChannel do
 
     freeze_time Time.zone.now + 1 + PresenceChannel::DEFAULT_TIMEOUT
 
+    Jobs::PresenceChannelAutoLeave.new.execute({})
+
     expect(channel.count).to eq(0)
   end
 


### PR DESCRIPTION
These calls were originally introduced to ensure that any stale users were cleaned up regularly. This is quite an expensive process to run on every `GET /presence/get` call, and will also cause errors during readonly mode.

Since the original introduction of this logic, we added the `Jobs::PresenceChannelAutoLeave` which runs every minute. That should be enough to clean up any stale users.

Note that users which explicitly `leave` a channel are still removed immediately. This auto_leave logic just takes care of clients which have disappeared without leaving.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
