### PR TITLE
FIX: Handle `nil` values in `DistributedCache#defer_get_set` (stable)

### DIFF
--- a/lib/distributed_cache.rb
+++ b/lib/distributed_cache.rb
@@ -21,7 +21,7 @@ class DistributedCache < MessageBus::DistributedCache
   end
 
   def defer_get_set(k, &block)
-    return self[k] if self[k]
+    return self[k] if hash.key? k
     value = block.call
     self.defer_set(k, value)
     value

--- a/spec/lib/distributed_cache_spec.rb
+++ b/spec/lib/distributed_cache_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "DistributedCache extensions" do
+  let(:cache) { DistributedCache.new('mytest') }
+
+  it "can defer_get_set" do
+    messages = MessageBus.track_publish("/distributed_hash") do
+      cache.defer_get_set("key") { "value" }
+    end
+    expect(messages.size).to eq(1)
+    expect(cache["key"]).to eq("value")
+  end
+
+  it "works correctly for nil values" do
+    block_called_counter = 0
+    messages = MessageBus.track_publish("/distributed_hash") do
+      2.times do
+        cache.defer_get_set("key") do
+          block_called_counter += 1
+          nil
+        end
+      end
+    end
+
+    expect(block_called_counter).to eq(1)
+    expect(messages.size).to eq(1)
+    expect(cache["key"]).to eq(nil)
+  end
+end


### PR DESCRIPTION
Themes often cache `nil` values in a DistributedCache. This bug meant that we were re-calculating some values on every request, AND triggering message-bus publishing on every request.

This fix should provide a significant performance improvement for busy sites.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
