### PR TITLE
UX: Change styling of admin bulk invite button

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
@@ -12,7 +12,7 @@
           {{#if canBulkInvite}}
             {{#if siteSettings.allow_bulk_invite}}
               {{#unless site.mobileView}}
-                {{d-button class="btn-default" icon="upload" action=(action "createInviteCsv") label="user.invited.bulk_invite.text"}}
+                {{d-button class="btn-flat" icon="upload" action=(action "createInviteCsv") label="user.invited.bulk_invite.text"}}
               {{/unless}}
             {{/if}}
           {{/if}}

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -277,6 +277,8 @@
     color: var(--primary-low-mid);
   }
   @include hover {
+    background: transparent;
+    color: var(--primary);
     .d-icon {
       color: var(--primary);
     }


### PR DESCRIPTION
Also ensures `btn-flat` buttons' hover styles do not get overriden by default `btn` styling.

