### PR TITLE
FIX: update `can_see_members` attribute after leaving a group.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/group.js
+++ b/app/assets/javascripts/discourse/app/models/group.js
@@ -124,6 +124,7 @@ const Group = RestModel.extend({
     await ajax(`/groups/${this.id}/leave.json`, {
       type: "DELETE",
     });
+    this.set("can_see_members", this.members_visibility_level < 2);
     await this.reloadMembers({}, true);
   },
 


### PR DESCRIPTION
After leaving a group, it is trying to reload its member list. Previously, when the `members_visibility_level` attribute has a value of 2 or higher, it displayed an error popup since the `can_see_members` attribute was not updated.
