### PR TITLE
FEATURE: Add settings to scale daily flags limit

### DIFF
--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -177,8 +177,8 @@ class PostAction < ActiveRecord::Base
       if public_send("is_#{type}?")
         limit = SiteSetting.get("max_#{type}s_per_day")
 
-        if is_like? && user && user.trust_level >= 2
-          multiplier = SiteSetting.get("tl#{user.trust_level}_additional_likes_per_day_multiplier").to_f
+        if (is_flag? || is_like?) && user && user.trust_level >= 2
+          multiplier = SiteSetting.get("tl#{user.trust_level}_additional_#{type}s_per_day_multiplier").to_f
           multiplier = 1.0 if multiplier < 1.0
 
           limit = (limit * multiplier).to_i

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1595,6 +1595,9 @@ en:
     tl2_additional_edits_per_day_multiplier: "Increase limit of edits per day for tl2 (member) by multiplying with this number"
     tl3_additional_edits_per_day_multiplier: "Increase limit of edits per day for tl3 (regular) by multiplying with this number"
     tl4_additional_edits_per_day_multiplier: "Increase limit of edits per day for tl4 (leader) by multiplying with this number"
+    tl2_additional_flags_per_day_multiplier: "Increase limit of flags per day for tl2 (member) by multiplying with this number"
+    tl3_additional_flags_per_day_multiplier: "Increase limit of flags per day for tl3 (regular) by multiplying with this number"
+    tl4_additional_flags_per_day_multiplier: "Increase limit of flags per day for tl4 (leader) by multiplying with this number"
 
     num_users_to_silence_new_user: "If a new user's posts get num_spam_flags_to_silence_new_user spam flags from this many different users, hide all their posts and prevent future posting. 0 to disable."
     num_tl3_flags_to_silence_new_user: "If a new user's posts get this many flags from num_tl3_users_to_silence_new_user different trust level 3 users, hide all their posts and prevent future posting. 0 to disable."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1828,6 +1828,9 @@ rate_limits:
   tl2_additional_edits_per_day_multiplier: 1.5
   tl3_additional_edits_per_day_multiplier: 2
   tl4_additional_edits_per_day_multiplier: 3
+  tl2_additional_flags_per_day_multiplier: 1.5
+  tl3_additional_flags_per_day_multiplier: 2
+  tl4_additional_flags_per_day_multiplier: 3
   alert_admins_if_errors_per_minute:
     client: true
     default: 0

--- a/spec/models/post_action_spec.rb
+++ b/spec/models/post_action_spec.rb
@@ -937,28 +937,49 @@ describe PostAction do
 
   describe "rate limiting" do
 
-    def limiter(tl)
+    def limiter(tl, type)
       user = Fabricate.build(:user)
       user.trust_level = tl
-      action = PostAction.new(user: user, post_action_type_id: PostActionType.types[:like])
+      action = PostAction.new(user: user, post_action_type_id: PostActionType.types[type])
       action.post_action_rate_limiter
     end
 
-    it "should scale up like limits depending on liker" do
-      expect(limiter(0).max).to eq SiteSetting.max_likes_per_day
-      expect(limiter(1).max).to eq SiteSetting.max_likes_per_day
-      expect(limiter(2).max).to eq (SiteSetting.max_likes_per_day * SiteSetting.tl2_additional_likes_per_day_multiplier).to_i
-      expect(limiter(3).max).to eq (SiteSetting.max_likes_per_day * SiteSetting.tl3_additional_likes_per_day_multiplier).to_i
-      expect(limiter(4).max).to eq (SiteSetting.max_likes_per_day * SiteSetting.tl4_additional_likes_per_day_multiplier).to_i
+    it "should scale up likes limits depending on trust level" do
+      expect(limiter(0, :like).max).to eq SiteSetting.max_likes_per_day
+      expect(limiter(1, :like).max).to eq SiteSetting.max_likes_per_day
+      expect(limiter(2, :like).max).to eq (SiteSetting.max_likes_per_day * SiteSetting.tl2_additional_likes_per_day_multiplier).to_i
+      expect(limiter(3, :like).max).to eq (SiteSetting.max_likes_per_day * SiteSetting.tl3_additional_likes_per_day_multiplier).to_i
+      expect(limiter(4, :like).max).to eq (SiteSetting.max_likes_per_day * SiteSetting.tl4_additional_likes_per_day_multiplier).to_i
 
       SiteSetting.tl2_additional_likes_per_day_multiplier = -1
-      expect(limiter(2).max).to eq SiteSetting.max_likes_per_day
+      expect(limiter(2, :like).max).to eq SiteSetting.max_likes_per_day
 
       SiteSetting.tl2_additional_likes_per_day_multiplier = 0.8
-      expect(limiter(2).max).to eq SiteSetting.max_likes_per_day
+      expect(limiter(2, :like).max).to eq SiteSetting.max_likes_per_day
 
       SiteSetting.tl2_additional_likes_per_day_multiplier = "bob"
-      expect(limiter(2).max).to eq SiteSetting.max_likes_per_day
+      expect(limiter(2, :like).max).to eq SiteSetting.max_likes_per_day
+    end
+
+    it "should scale up flag limits depending on trust level" do
+      %i(off_topic inappropriate spam notify_moderators).each do |type|
+        SiteSetting.tl2_additional_flags_per_day_multiplier = 1.5
+
+        expect(limiter(0, type).max).to eq SiteSetting.max_flags_per_day
+        expect(limiter(1, type).max).to eq SiteSetting.max_flags_per_day
+        expect(limiter(2, type).max).to eq (SiteSetting.max_flags_per_day * SiteSetting.tl2_additional_flags_per_day_multiplier).to_i
+        expect(limiter(3, type).max).to eq (SiteSetting.max_flags_per_day * SiteSetting.tl3_additional_flags_per_day_multiplier).to_i
+        expect(limiter(4, type).max).to eq (SiteSetting.max_flags_per_day * SiteSetting.tl4_additional_flags_per_day_multiplier).to_i
+
+        SiteSetting.tl2_additional_flags_per_day_multiplier = -1
+        expect(limiter(2, type).max).to eq SiteSetting.max_flags_per_day
+
+        SiteSetting.tl2_additional_flags_per_day_multiplier = 0.8
+        expect(limiter(2, type).max).to eq SiteSetting.max_flags_per_day
+
+        SiteSetting.tl2_additional_flags_per_day_multiplier = "bob"
+        expect(limiter(2, type).max).to eq SiteSetting.max_flags_per_day
+      end
     end
 
   end


### PR DESCRIPTION
Similar site settings exist for likes and edits and the new ones work
in a similar way.

By default, users below TL2 have a limit of 20, the limit is increased
by 1.5 for TL2 users up to 30, by 2 for TL3 users up to 40 and by 3 for
TL4 users up to 60.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
