### PR TITLE
DEV: Remove mock_redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -158,7 +158,6 @@ end
 
 group :test, :development do
   gem 'rspec'
-  gem 'mock_redis'
   gem 'listen', require: false
   gem 'certified', require: false
   gem 'fabrication', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,8 +241,6 @@ GEM
       ffi (~> 1.9)
     minitest (5.15.0)
     mocha (1.13.0)
-    mock_redis (0.29.0)
-      ruby2_keywords
     msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -556,7 +554,6 @@ DEPENDENCIES
   mini_suffix
   minitest
   mocha
-  mock_redis
   multi_json
   mustache
   nokogiri

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -99,16 +99,6 @@ ENV['DISCOURSE_DEV_ALLOW_ANON_TO_IMPERSONATE'] = '1'
 module TestSetup
   # This is run before each test and before each before_all block
   def self.test_setup(x = nil)
-    # TODO not sure about this, we could use a mock redis implementation here:
-    #   this gives us really clean "flush" semantics, however the side-effect is that
-    #   we are no longer using a clean redis implementation, a preferable solution may
-    #   be simply flushing before tests, trouble is that redis may be reused with dev
-    #   so that would mean the dev would act weird
-    #
-    #   perf benefit seems low (shaves 20 secs off a 4 minute test suite)
-    #
-    # Discourse.redis = DiscourseMockRedis.new
-
     RateLimiter.disable
     PostActionNotifier.disable
     SearchIndexer.disable
@@ -247,16 +237,6 @@ RSpec.configure do |config|
     def initialize
       super
       self.current_site = "test"
-    end
-  end
-
-  class DiscourseMockRedis < MockRedis
-    def without_namespace
-      self
-    end
-
-    def delete_prefixed(prefix)
-      keys("#{prefix}*").each { |k| del(k) }
     end
   end
 


### PR DESCRIPTION
Was used just in one spec file. And we prefer to run specs against a real redis server.