### PR TITLE
UX: Fix alignment on full page search

### DIFF
--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -256,26 +256,30 @@
 
   .topic {
     padding-bottom: 0.25em;
-    max-width: 700px;
     display: grid;
     grid-template-areas:
       "bulk-select title"
       "meta meta";
     grid-template-columns: auto 1fr;
-    align-items: baseline;
+
     .bulk-select {
       position: absolute;
       left: 0.5em;
       top: 0.75em;
       padding: 0.25em 0.5em;
       background-color: var(--tertiary-low);
+
       input[type="checkbox"] {
         margin: 0;
       }
     }
+
     .search-link {
+      align-items: baseline;
+      display: flex;
       grid-area: title;
     }
+
     .search-category {
       grid-area: meta;
     }
@@ -336,6 +340,7 @@
     }
     .topic-statuses {
       display: inline-block;
+      flex-shrink: 0;
       font-size: 1.3em;
       line-height: $line-height-medium;
       color: var(--primary-medium);


### PR DESCRIPTION
Also removed the max-width, because it unnecessarily wrapped the topic title at an earlier point than the snippet below it.

Before / After
<img width="911" alt="Screen Shot 2022-02-18 at 01 36 50" src="https://user-images.githubusercontent.com/66961/154596008-4ecff2d8-d606-4f5a-aba5-3bd374b9240a.png">
<img width="911" alt="Screen Shot 2022-02-18 at 01 41 20" src="https://user-images.githubusercontent.com/66961/154596014-493fc5db-f6e8-4e4a-bb49-05f32ff3fb41.png">
