### PR TITLE
UX: display post count badge even when user has only two posts.

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-map.js
@@ -75,7 +75,7 @@ createWidget("topic-participant", {
       }),
     ];
 
-    if (attrs.post_count > 2) {
+    if (attrs.post_count > 1) {
       linkContents.push(h("span.post-count", attrs.post_count.toString()));
     }
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/topic-participant-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/topic-participant-test.js
@@ -37,7 +37,7 @@ discourseModule(
         this.set("args", {
           username: "test",
           avatar_template: "/images/avatar.png",
-          post_count: 5,
+          post_count: 2,
           primary_group_name: "devs",
           flair_name: "devs",
           flair_url: "/images/d-logo-sketch-small.png",


### PR DESCRIPTION
Previously, it only displayed the badge when a user has 3 or more posts.