### PR TITLE
PERF: perform all cached counting in background

### DIFF
--- a/app/models/concerns/cached_counting.rb
+++ b/app/models/concerns/cached_counting.rb
@@ -31,6 +31,11 @@ module CachedCounting
     @enabled = true
   end
 
+  def self.reset
+    clear_queue!
+    clear_flush_to_db_lock!
+  end
+
   def self.ensure_thread!
     return if !enabled?
 

--- a/app/models/concerns/cached_counting.rb
+++ b/app/models/concerns/cached_counting.rb
@@ -3,75 +3,152 @@
 module CachedCounting
   extend ActiveSupport::Concern
 
-  EXPIRE_CACHE_AFTER = 4.days.to_i
-
-  LUA_INCR_AND_EXPIRE = DiscourseRedis::EvalHelper.new <<~LUA
-    local result = redis.call("INCR", KEYS[1])
-
-    if result == 1 then
-      redis.call("EXPIRE", KEYS[1], ARGV[1])
-    end
+  LUA_GET_DEL = DiscourseRedis::EvalHelper.new <<~LUA
+    local result = redis.call("GET", KEYS[1])
+    redis.call("DEL", KEYS[1])
 
     return result
   LUA
 
-  included do
-    class << self
-      attr_accessor :autoflush, :autoflush_seconds, :last_flush
+  QUEUE = Queue.new
+  SLEEP_SECONDS = 1
+  FLUSH_DB_ITERATIONS = 60
+  MUTEX = Mutex.new
+
+  def self.disable
+    @enabled = false
+    if @thread && @thread.alive?
+      @thread.wakeup
+      @thread.join
+    end
+  end
+
+  def self.enabled?
+    @enabled != false
+  end
+
+  def self.enable
+    @enabled = true
+  end
+
+  def self.ensure_thread!
+    return if !enabled?
+
+    MUTEX.synchronize do
+      if !@thread&.alive?
+        @thread = nil
+      end
+      @thread ||= Thread.new { thread_loop }
+    end
+  end
+
+  def self.thread_loop
+    iterations = 0
+    while true
+      break if !enabled?
+
+      sleep SLEEP_SECONDS
+      flush_in_memory
+      if (iterations >= FLUSH_DB_ITERATIONS) || @flush
+        iterations = 0
+        flush_to_db
+        @flush = false
+      end
+      iterations += 1
+    end
+  end
+
+  def self.flush
+    @flush = true
+    @thread.wakeup
+    while @flush
+      sleep 0.001
+    end
+  end
+
+  COUNTER_PREFIX = "__DCC__"
+
+  def self.flush_in_memory
+    counts = nil
+    while QUEUE.length > 0
+      # only 1 consumer, no need to avoid blocking
+      key, klass, db = QUEUE.deq
+      _redis_key = "#{COUNTER_PREFIX},#{klass},#{db},#{key}"
+      counts ||= Hash.new(0)
+      counts[_redis_key] += 1
     end
 
-    # auto flush if backlog is larger than this
-    self.autoflush = 2000
+    if counts
+      counts.each do |redis_key, count|
+        # TODO this whole loop can be done in a single LUA script
+        # concerns:
+        # - Is there a limit of params, will we need to chunk it
+        # - Would this lock up redis for too long, chunk it due to that?
+        Discourse.redis.without_namespace.incrby(redis_key, count)
+      end
+    end
+  end
 
-    # auto flush if older than this
-    self.autoflush_seconds = 5.minutes
+  DB_FLUSH_COOLDOWN_SECONDS = 60
+  DB_COOLDOWN_KEY = "cached_counting_cooldown"
 
-    self.last_flush = Time.now.utc
+  def self.flush_to_db
+    redis = Discourse.redis.without_namespace
+    DistributedMutex.synchronize("flush_counters_to_db", redis: redis, validity: 5.minutes) do
+      if allowed_to_flush_to_db?
+        # TODO can be done in a single eval (including keys call)
+        # same concern as above
+        redis.keys("#{COUNTER_PREFIX}*").each do |key|
+
+          val = LUA_GET_DEL.eval(
+            redis,
+            [key]
+          ).to_i
+
+          _prefix, klass_name, db, local_key = key.split(",", 4)
+          klass = Module.const_get(klass_name)
+
+          RailsMultisite::ConnectionManagement.with_connection(db) do
+            klass.write_cache!(local_key, val)
+          end
+        end
+      end
+    end
+  end
+
+  def self.clear_flush_to_db_lock!
+    Discourse.redis.without_namespace.del(DB_COOLDOWN_KEY)
+  end
+
+  def self.flush_to_db_lock_ttl
+    Discourse.redis.without_namespace.ttl(DB_COOLDOWN_KEY)
+  end
+
+  def self.allowed_to_flush_to_db?
+    Discourse.redis.without_namespace.set(DB_COOLDOWN_KEY, "1", ex: DB_FLUSH_COOLDOWN_SECONDS, nx: true)
+  end
+
+  def self.queue(key, klass)
+    QUEUE.push([key, klass, RailsMultisite::ConnectionManagement.current_db])
+  end
+
+  def self.clear_queue!
+    QUEUE.clear
+    redis = Discourse.redis.without_namespace
+    redis.keys("#{COUNTER_PREFIX}*").each do |key|
+      redis.del(key)
+    end
   end
 
   class_methods do
-    def perform_increment!(key, opts = nil)
-      val = DiscourseRedis.ignore_readonly do
-        LUA_INCR_AND_EXPIRE.eval(
-          Discourse.redis.without_namespace,
-          [Discourse.redis.namespace_key(key)],
-          [EXPIRE_CACHE_AFTER]
-        ).to_i
-      end
-
-      # readonly mode it is going to be nil, skip
-      return if val.nil?
-
-      autoflush = (opts && opts[:autoflush]) || self.autoflush
-      if autoflush > 0 && val >= autoflush
-        write_cache!
-        return
-      end
-
-      if (Time.now.utc - last_flush).to_i > autoflush_seconds
-        write_cache!
-      end
+    def perform_increment!(key)
+      CachedCounting.ensure_thread!
+      CachedCounting.queue(key, self)
     end
 
-    def write_cache!(date = nil)
+    def write_cache!(key, count)
       raise NotImplementedError
     end
 
-    # this may seem a bit fancy but in so it allows
-    # for concurrent calls without double counting
-    def get_and_reset(key)
-      Discourse.redis.set(key, '0', ex: EXPIRE_CACHE_AFTER, get: true).to_i
-    end
-
-    def request_id(query_params, retries = 0)
-      id = where(query_params).pluck_first(:id)
-      id ||= create!(query_params.merge(count: 0)).id
-    rescue # primary key violation
-      if retries == 0
-        request_id(query_params, 1)
-      else
-        raise
-      end
-    end
   end
 end

--- a/app/models/web_crawler_request.rb
+++ b/app/models/web_crawler_request.rb
@@ -12,13 +12,10 @@ class WebCrawlerRequest < ActiveRecord::Base
   self.max_record_age = 30.days
 
   def self.increment!(user_agent)
-    perform_increment!(redis_key(user_agent))
+    perform_increment!(user_agent)
   end
 
-  def self.write_cache!(key, count)
-    date, user_agent = key.split(":", 2)
-    date = Date.strptime(date, "%Y%m%d")
-
+  def self.write_cache!(user_agent, count, date)
     where(id: request_id(date: date, user_agent: user_agent))
       .update_all(["count = count + ?", count])
   end
@@ -28,10 +25,6 @@ class WebCrawlerRequest < ActiveRecord::Base
   end
 
   protected
-
-  def self.redis_key(user_agent, time = Time.now.utc)
-    "#{time.strftime('%Y%m%d')}:#{user_agent}"
-  end
 
   def self.request_id(date:, user_agent:, retries: 0)
     id = where(date: date, user_agent: user_agent).pluck_first(:id)

--- a/app/models/web_crawler_request.rb
+++ b/app/models/web_crawler_request.rb
@@ -15,13 +15,9 @@ class WebCrawlerRequest < ActiveRecord::Base
     perform_increment!(user_agent)
   end
 
-  def self.write_cache!(user_agent, count, date)
+  def self.write_cache!(key, count, date)
     where(id: request_id(date: date, user_agent: user_agent))
       .update_all(["count = count + ?", count])
-  end
-
-  def self.clear_cache!(date = nil)
-    raise "not implemented"
   end
 
   protected

--- a/app/models/web_crawler_request.rb
+++ b/app/models/web_crawler_request.rb
@@ -15,7 +15,7 @@ class WebCrawlerRequest < ActiveRecord::Base
     perform_increment!(user_agent)
   end
 
-  def self.write_cache!(key, count, date)
+  def self.write_cache!(user_agent, count, date)
     where(id: request_id(date: date, user_agent: user_agent))
       .update_all(["count = count + ?", count])
   end

--- a/spec/lib/concern/cached_counting_spec.rb
+++ b/spec/lib/concern/cached_counting_spec.rb
@@ -38,8 +38,7 @@ describe CachedCounting do
 
     context "with a test counting class" do
       before do
-        CachedCounting.clear_queue!
-        CachedCounting.clear_flush_to_db_lock!
+        CachedCounting.reset
         TestCachedCounting.clear!
       end
 
@@ -77,8 +76,7 @@ describe CachedCounting do
     end
 
     before do
-      CachedCounting.clear_queue!
-      CachedCounting.clear_flush_to_db_lock!
+      CachedCounting.reset
       CachedCounting.enable
     end
 

--- a/spec/lib/concern/cached_counting_spec.rb
+++ b/spec/lib/concern/cached_counting_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class TestCachedCounting
+  def self.clear!
+    @data = nil
+  end
+
+  def self.data
+    @data ||= {}
+  end
+
+  def self.write_cache!(key, count)
+    data[key] = count
+  end
+end
+
+describe CachedCounting do
+
+  it "should be default disabled in test" do
+    expect(CachedCounting.enabled?).to eq(false)
+  end
+
+  context "backing implementation" do
+
+    it "can correctly check for flush to db lock" do
+      CachedCounting.clear_flush_to_db_lock!
+
+      expect(CachedCounting.allowed_to_flush_to_db?).to eq(true)
+      expect(CachedCounting.allowed_to_flush_to_db?).to eq(false)
+      t = CachedCounting::DB_FLUSH_COOLDOWN_SECONDS
+      # let expiry be between 2 seconds to allow for slow calls and so on
+      expect(CachedCounting.flush_to_db_lock_ttl).to be_between(t - 2, t)
+
+      CachedCounting.clear_flush_to_db_lock!
+    end
+
+    context "with a test counting class" do
+      before do
+        CachedCounting.clear_queue!
+        CachedCounting.clear_flush_to_db_lock!
+        TestCachedCounting.clear!
+      end
+
+      it "can dispatch counts to backing class" do
+
+        CachedCounting.queue("a,a", TestCachedCounting)
+        CachedCounting.queue("a,a", TestCachedCounting)
+        CachedCounting.queue("b", TestCachedCounting)
+
+        CachedCounting.flush_in_memory
+        CachedCounting.flush_to_db
+
+        expect(TestCachedCounting.data).to eq({ "a,a" => 2, "b" => 1 })
+
+      end
+    end
+  end
+
+  context "active record" do
+    class RailsCacheCounter < ActiveRecord::Base
+      include CachedCounting
+      self.table_name = "posts"
+
+      def self.cache_data
+        @cache_data ||= {}
+      end
+
+      def self.clear_cache_data
+        @cache_data = nil
+      end
+
+      def self.write_cache!(key, val)
+        cache_data[key] = val
+      end
+    end
+
+    before do
+      CachedCounting.clear_queue!
+      CachedCounting.clear_flush_to_db_lock!
+      CachedCounting.enable
+    end
+
+    after do
+      CachedCounting.disable
+    end
+
+    it "can dispatch data via background thread" do
+      RailsCacheCounter.perform_increment!("a,a")
+      RailsCacheCounter.perform_increment!("b")
+      20.times do
+        RailsCacheCounter.perform_increment!("a,a")
+      end
+
+      CachedCounting.flush
+
+      expect(RailsCacheCounter.cache_data).to eq({ "a,a" => 21, "b" => 1 })
+    end
+  end
+end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -22,7 +22,7 @@ describe Middleware::RequestTracker do
 
   after do
     ApplicationRequest.disable
-    CachedCounting.enable
+    CachedCounting.disable
   end
 
   context "full request" do

--- a/spec/models/application_request_spec.rb
+++ b/spec/models/application_request_spec.rb
@@ -5,114 +5,44 @@ require 'rails_helper'
 describe ApplicationRequest do
   before do
     ApplicationRequest.enable
-    ApplicationRequest.last_flush = Time.now.utc
+    CachedCounting.clear_queue!
+    CachedCounting.clear_flush_to_db_lock!
+    CachedCounting.enable
   end
 
   after do
     ApplicationRequest.disable
-    ApplicationRequest.clear_cache!
+    CachedCounting.disable
   end
 
-  def inc(key, opts = nil)
-    ApplicationRequest.increment!(key, opts)
+  def inc(key)
+    ApplicationRequest.increment!(key)
   end
 
-  def disable_date_flush!
-    freeze_time(Time.now)
-    ApplicationRequest.last_flush = Time.now.utc
-  end
+  it "can log app requests" do
+    freeze_time
+    d1 = Time.now.utc.to_date
 
-  context "readonly test" do
-    it 'works even if redis is in readonly' do
-      disable_date_flush!
-
-      inc(:http_total)
-      inc(:http_total)
-
-      Discourse.redis.without_namespace.stubs(:eval).raises(Redis::CommandError.new("READONLY"))
-      Discourse.redis.without_namespace.stubs(:evalsha).raises(Redis::CommandError.new("READONLY"))
-      Discourse.redis.without_namespace.stubs(:set).raises(Redis::CommandError.new("READONLY"))
-
-      # flush will be deferred no error raised
-      inc(:http_total, autoflush: 3)
-      ApplicationRequest.write_cache!
-
-      Discourse.redis.without_namespace.unstub(:eval)
-      Discourse.redis.without_namespace.unstub(:evalsha)
-      Discourse.redis.without_namespace.unstub(:set)
-
-      inc(:http_total, autoflush: 3)
-      expect(ApplicationRequest.http_total.first.count).to eq(3)
+    4.times do
+      inc("http_2xx")
     end
-  end
 
-  it 'logs nothing for an unflushed increment' do
-    ApplicationRequest.increment!(:page_view_anon)
-    expect(ApplicationRequest.count).to eq(0)
-  end
+    inc("http_background")
 
-  it 'can automatically flush' do
-    disable_date_flush!
+    freeze_time 1.day.from_now
+    d2 = Time.now.utc.to_date
 
-    inc(:http_total)
-    inc(:http_total)
-    inc(:http_total, autoflush: 3)
+    inc("page_view_crawler")
+    inc("http_2xx")
 
-    expect(ApplicationRequest.http_total.first.count).to eq(3)
+    CachedCounting.flush
 
-    inc(:http_total)
-    inc(:http_total)
-    inc(:http_total, autoflush: 3)
+    expect(ApplicationRequest.find_by(date: d1, req_type: "http_2xx").count).to eq(4)
+    expect(ApplicationRequest.find_by(date: d1, req_type: "http_background").count).to eq(1)
 
-    expect(ApplicationRequest.http_total.first.count).to eq(6)
-  end
-
-  it 'can flush based on time' do
-    t1 = Time.now.utc.at_midnight
-    freeze_time(t1)
-    ApplicationRequest.write_cache!
-    inc(:http_total)
-    expect(ApplicationRequest.count).to eq(0)
-
-    freeze_time(t1 + ApplicationRequest.autoflush_seconds + 1)
-    inc(:http_total)
-
-    expect(ApplicationRequest.count).to eq(1)
-  end
-
-  it 'flushes yesterdays results' do
-    t1 = Time.now.utc.at_midnight
-    freeze_time(t1)
-    inc(:http_total)
-    freeze_time(t1.tomorrow)
-    inc(:http_total)
-
-    ApplicationRequest.write_cache!
-    expect(ApplicationRequest.count).to eq(2)
-  end
-
-  it 'clears cache correctly' do
-    # otherwise we have test pollution
-    inc(:page_view_anon)
-    ApplicationRequest.clear_cache!
-    ApplicationRequest.write_cache!
-
-    expect(ApplicationRequest.count).to eq(0)
-  end
-
-  it 'logs a few counts once flushed' do
-    time = Time.now.at_midnight
-    freeze_time(time)
-
-    3.times { inc(:http_total) }
-    2.times { inc(:http_2xx) }
-    4.times { inc(:http_3xx) }
-
-    ApplicationRequest.write_cache!
-
-    expect(ApplicationRequest.http_total.first.count).to eq(3)
-    expect(ApplicationRequest.http_2xx.first.count).to eq(2)
-    expect(ApplicationRequest.http_3xx.first.count).to eq(4)
+    expect(ApplicationRequest.find_by(date: d2, req_type: "page_view_crawler").count).to eq(1)
+    expect(ApplicationRequest.find_by(date: d2, req_type: "http_2xx").count).to eq(1)
 
   end
+
 end

--- a/spec/models/application_request_spec.rb
+++ b/spec/models/application_request_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 describe ApplicationRequest do
   before do
     ApplicationRequest.enable
-    CachedCounting.clear_queue!
-    CachedCounting.clear_flush_to_db_lock!
+    CachedCounting.reset
     CachedCounting.enable
   end
 

--- a/spec/models/web_crawler_request_spec.rb
+++ b/spec/models/web_crawler_request_spec.rb
@@ -4,115 +4,38 @@ require 'rails_helper'
 
 describe WebCrawlerRequest do
   before do
-    WebCrawlerRequest.last_flush = Time.now.utc
-    WebCrawlerRequest.clear_cache!
+    CachedCounting.clear_queue!
+    CachedCounting.clear_flush_to_db_lock!
+    CachedCounting.enable
   end
 
   after do
-    WebCrawlerRequest.clear_cache!
+    CachedCounting.disable
   end
 
-  def inc(user_agent, opts = nil)
-    WebCrawlerRequest.increment!(user_agent, opts)
+  it "can log crawler requests" do
+    freeze_time
+    d1 = Time.now.utc.to_date
+
+    4.times do
+      WebCrawlerRequest.increment!("Googlebot")
+    end
+
+    WebCrawlerRequest.increment!("Bingbot")
+
+    freeze_time 1.day.from_now
+    d2 = Time.now.utc.to_date
+
+    WebCrawlerRequest.increment!("Googlebot")
+    WebCrawlerRequest.increment!("Superbot")
+
+    CachedCounting.flush
+
+    expect(WebCrawlerRequest.find_by(date: d2, user_agent: "Googlebot").count).to eq(1)
+    expect(WebCrawlerRequest.find_by(date: d2, user_agent: "Superbot").count).to eq(1)
+
+    expect(WebCrawlerRequest.find_by(date: d1, user_agent: "Googlebot").count).to eq(4)
+    expect(WebCrawlerRequest.find_by(date: d1, user_agent: "Bingbot").count).to eq(1)
   end
 
-  def disable_date_flush!
-    freeze_time(Time.now)
-    WebCrawlerRequest.last_flush = Time.now.utc
-  end
-
-  def web_crawler_request(user_agent)
-    WebCrawlerRequest.where(user_agent: user_agent).first
-  end
-
-  it 'works even if redis is in readonly' do
-    disable_date_flush!
-
-    inc('Googlebot')
-    inc('Googlebot')
-
-    Discourse.redis.without_namespace.stubs(:eval).raises(Redis::CommandError.new("READONLY"))
-    Discourse.redis.without_namespace.stubs(:evalsha).raises(Redis::CommandError.new("READONLY"))
-    Discourse.redis.without_namespace.stubs(:set).raises(Redis::CommandError.new("READONLY"))
-
-    inc('Googlebot', autoflush: 3)
-    WebCrawlerRequest.write_cache!
-
-    Discourse.redis.without_namespace.unstub(:eval)
-    Discourse.redis.without_namespace.unstub(:evalsha)
-    Discourse.redis.without_namespace.unstub(:set)
-
-    inc('Googlebot', autoflush: 3)
-    expect(web_crawler_request('Googlebot').count).to eq(3)
-  end
-
-  it 'logs nothing for an unflushed increment' do
-    WebCrawlerRequest.increment!('Googlebot')
-    expect(WebCrawlerRequest.count).to eq(0)
-  end
-
-  it 'can automatically flush' do
-    disable_date_flush!
-
-    inc('Googlebot', autoflush: 3)
-    expect(web_crawler_request('Googlebot')).to_not be_present
-    expect(WebCrawlerRequest.count).to eq(0)
-    inc('Googlebot', autoflush: 3)
-    expect(web_crawler_request('Googlebot')).to_not be_present
-    inc('Googlebot', autoflush: 3)
-    expect(web_crawler_request('Googlebot').count).to eq(3)
-    expect(WebCrawlerRequest.count).to eq(1)
-
-    3.times { inc('Googlebot', autoflush: 3) }
-    expect(web_crawler_request('Googlebot').count).to eq(6)
-    expect(WebCrawlerRequest.count).to eq(1)
-  end
-
-  it 'can flush based on time' do
-    t1 = Time.now.utc.at_midnight
-    freeze_time(t1)
-    WebCrawlerRequest.write_cache!
-    inc('Googlebot')
-    expect(WebCrawlerRequest.count).to eq(0)
-
-    freeze_time(t1 + WebCrawlerRequest.autoflush_seconds + 1)
-    inc('Googlebot')
-
-    expect(WebCrawlerRequest.count).to eq(1)
-  end
-
-  it 'flushes yesterdays results' do
-    t1 = Time.now.utc.at_midnight
-    freeze_time(t1)
-    inc('Googlebot')
-    freeze_time(t1.tomorrow)
-    inc('Googlebot')
-
-    WebCrawlerRequest.write_cache!
-    expect(WebCrawlerRequest.count).to eq(2)
-  end
-
-  it 'clears cache correctly' do
-    inc('Googlebot')
-    inc('Twitterbot')
-    WebCrawlerRequest.clear_cache!
-    WebCrawlerRequest.write_cache!
-
-    expect(WebCrawlerRequest.count).to eq(0)
-  end
-
-  it 'logs a few counts once flushed' do
-    time = Time.now.at_midnight
-    freeze_time(time)
-
-    3.times { inc('Googlebot') }
-    2.times { inc('Twitterbot') }
-    4.times { inc('Bingbot') }
-
-    WebCrawlerRequest.write_cache!
-
-    expect(web_crawler_request('Googlebot').count).to eq(3)
-    expect(web_crawler_request('Twitterbot').count).to eq(2)
-    expect(web_crawler_request('Bingbot').count).to eq(4)
-  end
 end

--- a/spec/models/web_crawler_request_spec.rb
+++ b/spec/models/web_crawler_request_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 
 describe WebCrawlerRequest do
   before do
-    CachedCounting.clear_queue!
-    CachedCounting.clear_flush_to_db_lock!
+    CachedCounting.reset
     CachedCounting.enable
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -194,6 +194,8 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = true
 
   config.before(:suite) do
+    CachedCounting.disable
+
     begin
       ActiveRecord::Migration.check_pending!
     rescue ActiveRecord::PendingMigrationError


### PR DESCRIPTION
Previously cached counting made redis calls in main thread and performed
the flush in main thread.

This could lead to pathological states in extreme heavy load.

This refactor reduces load and cleans up the interface
