### PR TITLE
PERF: Reduce anon_polling_interval to match long_polling_interval

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1899,7 +1899,7 @@ developer:
   anon_polling_interval:
     hidden: true
     client: true
-    default: 30000
+    default: 25000
     max: 99000
   flush_timings_secs:
     client: true


### PR DESCRIPTION
The 5s difference was causing anon clients to have ~5s gaps between their long-polling requests. On busy sites, this could be enough time for them to build up a backlog, which then becomes much more expensive for us on the server-side.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
