### PR TITLE
DEV: Remove DiscourseRedis.namespace

### DIFF
--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -146,11 +146,6 @@ class DiscourseRedis
     RailsMultisite::ConnectionManagement.current_db
   end
 
-  def self.namespace
-    Rails.logger.warn("DiscourseRedis.namespace is going to be deprecated, do not use it!")
-    RailsMultisite::ConnectionManagement.current_db
-  end
-
   def self.new_redis_store
     Cache.new
   end


### PR DESCRIPTION
It was soft-deprecated 7 years ago.