### PR TITLE
FIX: Allow none category if default is none

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/site-settings/category.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/site-settings/category.hbs
@@ -2,6 +2,9 @@
   value=value
   allowUncategorized=true
   onChange=(action (mut value))
+  options=(hash
+    none=(eq setting.default "")
+  )
 }}
 {{setting-validation-message message=validationMessage}}
 <div class="desc">{{html-safe setting.description}}</div>


### PR DESCRIPTION
Even if the site setting's default value is none by default, it did not
allow admins to select it again after it was changed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
