### PR TITLE
FEATURE: allow moderators to bulk change ownership

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -1446,12 +1446,22 @@ export default Controller.extend(bufferedProperty("model"), {
 
   @discourseComputed(
     "currentUser.admin",
+    "currentUser.staff",
+    "siteSettings.moderators_change_post_ownership",
     "selectedPostsCount",
     "selectedPostsUsername"
   )
-  canChangeOwner(isAdmin, selectedPostsCount, selectedPostsUsername) {
+  canChangeOwner(
+    isAdmin,
+    isStaff,
+    modChangePostOwner,
+    selectedPostsCount,
+    selectedPostsUsername
+  ) {
     return (
-      isAdmin && selectedPostsCount > 0 && selectedPostsUsername !== undefined
+      (isAdmin || (modChangePostOwner && isStaff)) &&
+      selectedPostsCount > 0 &&
+      selectedPostsUsername !== undefined
     );
   },
 


### PR DESCRIPTION
https://meta.discourse.org/t/moderators-change-post-ownership-does-not-enable-the-change-button-in-top-wrench-menu/218685

This allows moderators to use the bulk select menu to change post ownership

![Screen Shot 2022-02-18 at 11 51 02 AM](https://user-images.githubusercontent.com/1681963/154726707-fe1c6866-22c3-4d5c-8037-97c6f5573d8d.png)
 