### PR TITLE
FIX: Increase FinalDestination MAX_REQUEST_SIZE_BYTES

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -9,7 +9,7 @@ require 'url_helper'
 # Determine the final endpoint for a Web URI, following redirects
 class FinalDestination
   MAX_REQUEST_TIME_SECONDS = 10
-  MAX_REQUEST_SIZE_BYTES = 1_048_576 # 1024 * 1024
+  MAX_REQUEST_SIZE_BYTES = 5_242_880 # 1024 * 1024 * 5
 
   def self.clear_https_cache!(domain)
     key = redis_https_key(domain)


### PR DESCRIPTION
The default of 1Mb was preventing some valid Onebox requests from successfully completing.

Increasing this to 5Mb should reduce the number of unexpected failures.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
