### PR TITLE
DEV: Enable the use of Glimmer components

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer.js
@@ -1,0 +1,81 @@
+import GlimmerComponent from "@glimmer/component";
+import { cached } from "@glimmer/tracking";
+import { getOwner } from "@ember/application";
+import { inject as service } from "@ember/service";
+import { DEBUG } from "@glimmer/env";
+
+/*
+  Glimmer components are not EmberObjects, and therefore do not support automatic
+  injection of the things defined in `pre-initializers/inject-discourse-objects`.
+
+  This base class provides an alternative. All these references are looked up lazily,
+  so the performance impact should be negligible
+*/
+
+export default class DiscourseGlimmerComponent extends GlimmerComponent {
+  @service appEvents;
+  @service store;
+  @service("search") searchService;
+
+  @cached
+  get siteSettings() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("site-settings:main");
+  }
+
+  @cached
+  get currentUser() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("current-user:main");
+  }
+
+  @cached
+  get messageBus() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("message-bus:main");
+  }
+
+  @cached
+  get topicTrackingState() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("topic-tracking-state:main");
+  }
+
+  @cached
+  get pmTopicTrackingState() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("pm-topic-tracking-state:main");
+  }
+
+  @cached
+  get site() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("site:main");
+  }
+
+  @cached
+  get store() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("store:main");
+  }
+
+  @cached
+  get session() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("session:main");
+  }
+
+  @cached
+  get keyValueStore() {
+    const applicationInstance = getOwner(this);
+    return applicationInstance.lookup("key-value-store:main");
+  }
+}
+
+// This little hack will trick our outdated Ember GlobalResolver into
+// accepting glimmer components in debug mode.
+// https://github.com/emberjs/ember.js/blob/d4dc4b4cc5/packages/%40ember/application/globals-resolver.js#L142-L165
+// We can remove it once we've updated our resolver to a more recent implementation
+if (DEBUG) {
+  DiscourseGlimmerComponent.isComponentFactory = true;
+}

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -20,7 +20,8 @@
     "@discourse/itsatrap": "^2.0.10",
     "@ember/optional-features": "^1.1.0",
     "@ember/test-helpers": "^2.2.0",
-    "@glimmer/component": "^1.0.0",
+    "@glimmer/component": "^1.0.4",
+    "@glimmer/tracking": "^1.0.4",
     "@popperjs/core": "2.10.2",
     "@uppy/aws-s3": "^2.0.4",
     "@uppy/aws-s3-multipart": "^2.1.0",
@@ -36,6 +37,7 @@
     "discourse-widget-hbs": "^1.0.0",
     "ember-auto-import": "^2.2.4",
     "ember-buffered-proxy": "^2.0.0-beta.0",
+    "ember-cached-decorator-polyfill": "^0.1.4",
     "ember-cli": "~3.25.3",
     "ember-cli-app-version": "^4.0.0",
     "ember-cli-babel": "^7.23.1",
@@ -85,6 +87,7 @@
     ]
   },
   "devDependencies": {
+    "ember-cached-decorator-polyfill": "^0.1.4",
     "ember-exam": "^7.0.1"
   }
 }

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -1919,7 +1919,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@glimmer/component@^1.0.0":
+"@glimmer/component@^1.0.0", "@glimmer/component@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.0.4.tgz#1c85a5181615a6647f6acfaaed68e28ad7e9626e"
   integrity sha512-sS4N8wtcKfYdUJ6O3m8nbTut6NjErdz94Ap8VB1ekcg4WSD+7sI7Nmv6kt2rdPoe363nUdjUbRBzHNWhLzraBw==
@@ -2023,6 +2023,14 @@
     handlebars "^4.5.1"
     simple-html-tokenizer "^0.5.9"
 
+"@glimmer/tracking@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.0.4.tgz#f1bc1412fe5e2236d0f8d502994a8f88af1bbb21"
+  integrity sha512-F+oT8I55ba2puSGIzInmVrv/8QA2PcK1VD+GWgFMhF6WC97D+uZX7BFg+a3s/2N4FVBq5KHE+QxZzgazM151Yw==
+  dependencies:
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/validator" "^0.44.0"
+
 "@glimmer/util@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.2.tgz#9ca1631e42766ea6059f4b49d0bdfb6095aad2c4"
@@ -2040,6 +2048,11 @@
   dependencies:
     "@glimmer/env" "0.1.7"
     "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/validator@^0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
+  integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
 "@glimmer/vm@^0.42.2":
   version "0.42.2"
@@ -5993,6 +6006,26 @@ ember-buffered-proxy@^2.0.0-beta.0:
     ember-cli-babel "^7.11.1"
     ember-cli-htmlbars "^4.0.5"
     ember-notify-property-change-polyfill "^0.0.1"
+
+ember-cache-primitive-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cache-primitive-polyfill/-/ember-cache-primitive-polyfill-1.0.1.tgz#a27075443bd87e5af286c1cd8a7df24e3b9f6715"
+  integrity sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-version-checker "^5.1.1"
+    ember-compatibility-helpers "^1.2.1"
+    silent-error "^1.1.1"
+
+ember-cached-decorator-polyfill@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-0.1.4.tgz#f1e2c65cc78d0d9c4ac0e047e643af477eb85ace"
+  integrity sha512-JOK7kBCWsTVCzmCefK4nr9BACDJk0owt9oIUaVt6Q0UtQ4XeAHmoK5kQ/YtDcxQF1ZevHQFdGhsTR3JLaHNJgA==
+  dependencies:
+    "@glimmer/tracking" "^1.0.4"
+    ember-cache-primitive-polyfill "^1.0.1"
+    ember-cli-babel "^7.21.0"
+    ember-cli-babel-plugin-helpers "^1.1.1"
 
 ember-cli-app-version@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Glimmer components won't be functional under the 'legacy' Ember environment, but the introduction of this commit won't introduce any errors. Errors will only happen if something attempts to render a Glimmer component in the legacy environment.

We're merging this now to unlock development work with Glimmer components behind feature flags. These flags will not be enabled-by-default until after the legacy environment is removed.

A small hack is required to make the Resolver work in development mode. In future, when we move to a more recent version of the Ember Resolver, this hack will not be required.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
