### PR TITLE
FIX: Use fresh theme setting values when compiling stylesheets

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -155,7 +155,7 @@ class Theme < ActiveRecord::Base
     SvgSprite.expire_cache
   end
 
-  BASE_COMPILER_VERSION = 54
+  BASE_COMPILER_VERSION = 55
   def self.compiler_version
     get_set_cache "compiler_version" do
       dependencies = [
@@ -563,10 +563,10 @@ class Theme < ActiveRecord::Base
     hash = {}
 
     Theme.where(id: Theme.transform_ids(id)).each do |theme|
-      hash.merge!(theme.cached_settings)
+      hash.merge!(theme.build_settings_hash)
     end
 
-    hash.merge!(self.cached_settings)
+    hash.merge!(self.build_settings_hash)
     hash
   end
 

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -378,7 +378,6 @@ class ThemeField < ActiveRecord::Base
       DB.after_commit { Stylesheet::Manager.clear_theme_cache! }
     elsif settings_field?
       validate_yaml!
-      theme.clear_cached_settings!
       DB.after_commit { CSP::Extension.clear_theme_extensions_cache! }
       DB.after_commit { SvgSprite.expire_cache }
       self.value_baked = "baked"

--- a/app/models/theme_translation_override.rb
+++ b/app/models/theme_translation_override.rb
@@ -5,7 +5,6 @@ class ThemeTranslationOverride < ActiveRecord::Base
 
   after_commit do
     theme.theme_fields.where(target_id: Theme.targets[:translations]).update_all(value_baked: nil)
-    theme.clear_cached_settings!
     theme.remove_from_cache!
   end
 end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -341,6 +341,18 @@ HTML
       expect(scss).to include('font-size:"#{$fakeinterpolatedvariable}\a andanothervalue \'withquotes\'; margin: 0;\a"')
     end
 
+    it "can use a setting straight away after introducing it" do
+      theme.set_field(target: :common, name: :scss, value: 'body {background-color: red;}')
+      theme.save!
+
+      theme.reload
+      theme.set_field(target: :settings, name: :yaml, value: "background_color: red\nfont_size: 25px")
+      theme.set_field(target: :common, name: :scss, value: 'body {background-color: $background_color;}')
+      theme.save!
+
+      expect(theme.theme_fields.find_by(target_id: Theme.targets[:common], name: "scss").error).to eq(nil)
+    end
+
     it "allows values to be used in JS" do
       theme.name = 'awesome theme"'
       theme.set_field(target: :settings, name: :yaml, value: "name: bob")
@@ -440,6 +452,10 @@ HTML
   end
 
   def cached_settings(id)
+    Theme.find_by(id: id).cached_settings.to_json
+  end
+
+  def included_settings(id)
     Theme.find_by(id: id).included_settings.to_json
   end
 
@@ -549,32 +565,32 @@ HTML
     expect(json["my_upload"]).to eq("http://cdn.localhost#{upload.url}")
   end
 
-  it 'handles settings cache correctly' do
+  it 'handles child settings correctly' do
     Theme.destroy_all
 
-    expect(cached_settings(theme.id)).to eq("{}")
+    expect(included_settings(theme.id)).to eq("{}")
 
     theme.set_field(target: :settings, name: "yaml", value: "boolean_setting: true")
     theme.save!
-    expect(cached_settings(theme.id)).to match(/\"boolean_setting\":true/)
+    expect(included_settings(theme.id)).to match(/\"boolean_setting\":true/)
 
     theme.settings.first.value = "false"
     theme.save!
-    expect(cached_settings(theme.id)).to match(/\"boolean_setting\":false/)
+    expect(included_settings(theme.id)).to match(/\"boolean_setting\":false/)
 
     child.set_field(target: :settings, name: "yaml", value: "integer_setting: 54")
 
     child.save!
     theme.add_relative_theme!(:child, child)
 
-    json = cached_settings(theme.id)
+    json = included_settings(theme.id)
     expect(json).to match(/\"boolean_setting\":false/)
     expect(json).to match(/\"integer_setting\":54/)
 
-    expect(cached_settings(child.id)).to eq("{\"integer_setting\":54}")
+    expect(included_settings(child.id)).to eq("{\"integer_setting\":54}")
 
     child.destroy!
-    json = cached_settings(theme.id)
+    json = included_settings(theme.id)
     expect(json).not_to match(/\"integer_setting\":54/)
     expect(json).to match(/\"boolean_setting\":false/)
   end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -512,7 +512,7 @@ HTML
     theme.save!
 
     Upload.find(upload.id).destroy
-    theme.clear_cached_settings!
+    theme.remove_from_cache!
 
     json = JSON.parse(cached_settings(theme.id))
     expect(json).to be_empty


### PR DESCRIPTION
**DEV: Use the theme cache helper for settings**

The previous Discourse.cache usage was different to how other theme-related caching is handled, and also requires reaching out to redis every time. The common theme cache is held in memory (as a DistributedCache)

---

**FIX: Use fresh theme setting values when compiling stylesheets**

If a theme is updated to introduce a new setting AND immediately make use of it in a stylesheet, then an error was being shown. This is because the stylesheet compilation was using the theme's cached settings, and the cache is only cleared **after** the theme has finished compiling.

This commit updates the SCSS compilation to use uncached values for settings. A similar fix was applied to other parts of theme compilation back in 2020: (a51b8d9c66)