### PR TITLE
DEV: Remove child theme settings/variables from parent compilation

### DIFF
--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -565,36 +565,6 @@ HTML
     expect(json["my_upload"]).to eq("http://cdn.localhost#{upload.url}")
   end
 
-  it 'handles child settings correctly' do
-    Theme.destroy_all
-
-    expect(included_settings(theme.id)).to eq("{}")
-
-    theme.set_field(target: :settings, name: "yaml", value: "boolean_setting: true")
-    theme.save!
-    expect(included_settings(theme.id)).to match(/\"boolean_setting\":true/)
-
-    theme.settings.first.value = "false"
-    theme.save!
-    expect(included_settings(theme.id)).to match(/\"boolean_setting\":false/)
-
-    child.set_field(target: :settings, name: "yaml", value: "integer_setting: 54")
-
-    child.save!
-    theme.add_relative_theme!(:child, child)
-
-    json = included_settings(theme.id)
-    expect(json).to match(/\"boolean_setting\":false/)
-    expect(json).to match(/\"integer_setting\":54/)
-
-    expect(included_settings(child.id)).to eq("{\"integer_setting\":54}")
-
-    child.destroy!
-    json = included_settings(theme.id)
-    expect(json).not_to match(/\"integer_setting\":54/)
-    expect(json).to match(/\"boolean_setting\":false/)
-  end
-
   describe "convert_settings" do
 
     it 'can migrate a list field to a string field with json schema' do

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -650,7 +650,7 @@ describe Admin::ThemesController do
       expect(response.parsed_body["bg"]).to eq("green")
 
       theme.reload
-      expect(theme.included_settings[:bg]).to eq("green")
+      expect(theme.cached_settings[:bg]).to eq("green")
       user_history = UserHistory.last
 
       expect(user_history.action).to eq(
@@ -663,7 +663,7 @@ describe Admin::ThemesController do
       theme.reload
 
       expect(response.status).to eq(200)
-      expect(theme.included_settings[:bg]).to eq("")
+      expect(theme.cached_settings[:bg]).to eq("")
     end
   end
 end


### PR DESCRIPTION
aa1442fdc3 split theme stylesheets so that every component gets its own stylesheet. Therefore, there is now no need for parent themes to collate the settings/variables of its children during scss compilation.

Technically this is a breaking change for any themes which depend on the settings/variables of their child components. That was never a supported/recommended arrangement, so we don't expect this to cause issues.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
