### PR TITLE
FIX: Ensure category/tag classes are added and removed correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/components/add-category-tag-classes.js
+++ b/app/assets/javascripts/discourse/app/components/add-category-tag-classes.js
@@ -1,22 +1,17 @@
 import Component from "@ember/component";
 import { scheduleOnce } from "@ember/runloop";
 
-export default Component.extend({
-  tagName: "",
-  currentClasses: null,
-
-  init() {
-    this.currentClasses = new Set();
-    this._super();
-  },
+export default class extends Component {
+  tagName = "";
+  currentClasses = new Set();
 
   didReceiveAttrs() {
     scheduleOnce("afterRender", this, this._updateClasses);
-  },
+  }
 
   willDestroyElement() {
     scheduleOnce("afterRender", this, this._removeClasses);
-  },
+  }
 
   _updateClasses() {
     if (this.isDestroying || this.isDestroyed) {
@@ -32,20 +27,18 @@ export default Component.extend({
     }
     this.tags?.forEach((t) => desiredClasses.add(`tag-${t}`));
 
-    const addClasses = [...desiredClasses].filter(
-      (c) => !this.currentClasses.has(c)
-    );
+    document.body.classList.add(...desiredClasses);
+
     const removeClasses = [...this.currentClasses].filter(
       (c) => !desiredClasses.has(c)
     );
 
-    document.body.classList.add(...addClasses);
     document.body.classList.remove(...removeClasses);
 
     this.currentClasses = desiredClasses;
-  },
+  }
 
   _removeClasses() {
     document.body.classList.remove(...this.currentClasses);
-  },
-});
+  }
+}

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -1,4 +1,4 @@
-{{add-category-tag-classes category=category tagName=""}}
+{{add-category-tag-classes category=category}}
 
 <section class="category-heading">
   {{#if category.uploaded_logo.url}}


### PR DESCRIPTION
The use of a `/g` regex was causing some surprising, seemingly random, behavior. (https://stackoverflow.com/a/1520853/5913559)

There was also a known issue which would cause inconsistent class behavior when running the 'loading slider' theme component.

This commit takes the opportunity to refactor the component to remove the use of observers and remove the regex-based class parsing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
