### PR TITLE
UX: Add discourse-follow to official plugin list

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -32,6 +32,7 @@ class Plugin::Metadata
     "discourse-details",
     "discourse-docs",
     "discourse-encrypt",
+    "discourse-follow",
     "discourse-fontawesome-pro",
     "discourse-footnote",
     "discourse-github",


### PR DESCRIPTION
The follow plugin is an official plugin: https://meta.discourse.org/t/follow-plugin/110579?u=osama.