### PR TITLE
FEATURE: add nofollow to RSS alternate link in topics and categories

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -142,7 +142,7 @@
 
 <% if @category %>
   <% content_for :head do %>
-    <%= auto_discovery_link_tag(:rss, { action: :category_feed }, title: t('rss_topics_in_category', category: @category.name)) %>
+    <%= auto_discovery_link_tag(:rss, { action: :category_feed }, rel: 'alternate nofollow', title: t('rss_topics_in_category', category: @category.name)) %>
     <%= raw crawlable_meta_data(title: @category.name, description: @category.description, image: @category.uploaded_logo&.url.presence) %>
   <% end %>
 <% elsif @tag_id %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -131,7 +131,7 @@
   <% end %>
 
   <% content_for :head do %>
-    <%= auto_discovery_link_tag(@topic_view, {action: :feed, slug: @topic_view.topic.slug, topic_id: @topic_view.topic.id}, title: t('rss_posts_in_topic', topic: @topic_view.title), type: 'application/rss+xml') %>
+    <%= auto_discovery_link_tag(@topic_view, {action: :feed, slug: @topic_view.topic.slug, topic_id: @topic_view.topic.id}, rel: 'alternate nofollow', title: t('rss_posts_in_topic', topic: @topic_view.title), type: 'application/rss+xml') %>
     <%= raw crawlable_meta_data(title: @topic_view.title, description: @topic_view.summary(strip_images: true), image: @topic_view.image_url, read_time: @topic_view.read_time, like_count: @topic_view.like_count, ignore_canonical: true, published_time: @topic_view.published_time) %>
 
     <% if @topic_view.prev_page || @topic_view.next_page %>

--- a/spec/views/list/list.erb_spec.rb
+++ b/spec/views/list/list.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "list/list.erb" do
+  fab!(:category) { Fabricate(:category) }
+
+  it "add nofollow to RSS alternate link for category" do
+    view.stubs(:include_crawler_content?).returns(false)
+    view.stubs(:url_for).returns('https://www.example.com/test.rss')
+    view.instance_variable_set("@rss", false)
+    view.instance_variable_set("@category", category)
+    render template: 'list/list', formats: []
+
+    expect(view.content_for(:head)).to match(/<link rel="alternate nofollow" type="application\/rss\+xml" title="[^"]+" href="https:\/\/www.example.com\/test\.rss" \/>/)
+  end
+
+end

--- a/spec/views/topics/show.html.erb_spec.rb
+++ b/spec/views/topics/show.html.erb_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+describe "topics/show.html.erb" do
+  fab!(:topic) { Fabricate(:topic) }
+
+  it "add nofollow to RSS alternate link for topic" do
+    topic_view = OpenStruct.new(
+      topic: topic,
+      posts: []
+    )
+    topic_view.stubs(:summary).returns('')
+    view.stubs(:crawler_layout?).returns(false)
+    view.stubs(:url_for).returns('https://www.example.com/test.rss')
+    view.instance_variable_set("@topic_view", topic_view)
+    render template: 'topics/show', formats: [:html]
+
+    expect(view.content_for(:head)).to match(/<link rel="alternate nofollow" type="application\/rss\+xml" title="[^"]+" href="https:\/\/www.example.com\/test\.rss" \/>/)
+  end
+
+end


### PR DESCRIPTION
The urls of RSS-feeds of topics and categories are already excluded by `robots.txt`.

But without `rel="alternate nofollow"` the search engine still extracts the url itself of a RSS-feed from the `<link rel="alterante" …>` tag inside the header of a topic or category page. Afterwards the search engine evaluates that this grabbed RSS-feed url is excluded by robots.txt and adds it to a 'noindex'-list.

With this change the RSS-feed url stays completely unknown to the search engine: it is neither extracted in the first place nor added to the 'noindex'-list afterwards. Thereby the number of topic-urls the search-engine has to handle gets halfed.
