### PR TITLE
FIX: Show invite button if users can be invited

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/initializers/topic-footer-buttons.js
@@ -27,7 +27,10 @@ export default {
           model: this.topic.category,
         });
         controller.setProperties({
-          allowInvites: this.canInviteTo && !this.inviteDisabled,
+          allowInvites:
+            this.currentUser.can_invite_to_forum &&
+            this.canInviteTo &&
+            !this.inviteDisabled,
           topic: this.topic,
         });
       },


### PR DESCRIPTION
This used to be shown regardless new users could be invited to the
forum. `can_invite_to_forum` tells if new users can be invited while
`can_invite_to` tells if existing users can be invited to the topic.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
