### PR TITLE
FIX: Show links with 0 clicks in top links section

### DIFF
--- a/app/models/user_summary.rb
+++ b/app/models/user_summary.rb
@@ -40,7 +40,6 @@ class UserSummary
       .merge(Topic.listable_topics.visible.secured(@guardian))
       .where(user: @user)
       .where(internal: false, reflection: false, quote: false)
-      .where('clicks > 0')
       .order('clicks DESC, topic_links.created_at DESC')
       .limit(MAX_SUMMARY_RESULTS)
   end

--- a/spec/models/user_summary_spec.rb
+++ b/spec/models/user_summary_spec.rb
@@ -93,11 +93,4 @@ describe UserSummary do
     expect(summary.top_categories.first[:topic_count]).to eq(1)
     expect(summary.top_categories.first[:post_count]).to eq(1)
   end
-
-  it "does not include summaries with no clicks" do
-    post = Fabricate(:post, raw: "[example](https://example.com)")
-    TopicLink.extract_from(post)
-    summary = UserSummary.new(post.user, Guardian.new)
-    expect(summary.links.length).to eq(0)
-  end
 end


### PR DESCRIPTION
This is useful to moderators to see if users post spam links.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
