### PR TITLE
DEV: Fix SMTP bounce regexp

### DIFF
--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -15,7 +15,7 @@ class EmailLog < ActiveRecord::Base
   }
 
   # cf. https://www.iana.org/assignments/smtp-enhanced-status-codes/smtp-enhanced-status-codes.xhtml
-  SMTP_ERROR_CODE_REGEXP = Regexp.new(/\d\.\d\.\d|\d\d\d/).freeze
+  SMTP_ERROR_CODE_REGEXP = Regexp.new(/\d\.\d\.\d+|\d{3}/).freeze
 
   belongs_to :user
   belongs_to :post

--- a/db/post_migrate/20220220234155_conform_bounce_error_code.rb
+++ b/db/post_migrate/20220220234155_conform_bounce_error_code.rb
@@ -2,7 +2,7 @@
 #
 class ConformBounceErrorCode < ActiveRecord::Migration[6.1]
   def up
-    DB.exec(<<~SQL, regexp: '\d\.\d\.\d|\d\d\d')
+    DB.exec(<<~SQL, regexp: '\d\.\d\.\d+|\d{3}')
       UPDATE email_logs
       SET bounce_error_code = (
         SELECT array_to_string(

--- a/spec/models/email_log_spec.rb
+++ b/spec/models/email_log_spec.rb
@@ -168,6 +168,8 @@ describe EmailLog do
     it "makes sure the bounce_error_code is in the format X.X.X or XXX" do
       email_log.update!(bounce_error_code: "5.1.1")
       expect(email_log.reload.bounce_error_code).to eq("5.1.1")
+      email_log.update!(bounce_error_code: "5.2.23")
+      expect(email_log.reload.bounce_error_code).to eq("5.2.23")
       email_log.update!(bounce_error_code: "5.0.0 (permanent failure)")
       expect(email_log.reload.bounce_error_code).to eq("5.0.0")
       email_log.update!(bounce_error_code: "422")


### PR DESCRIPTION
Never trust me with regexp. Follow up to
01ef1d08fc0a87be606bc4b0dbbd2a73defffc02,
which did not take into account codes in
the format X.X.XX (with the 2 digits on the end)

