### PR TITLE
FEATURE: Automatically select share URL

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/share-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/share-topic.js
@@ -61,9 +61,9 @@ export default Controller.extend(
     sources(topic) {
       const privateContext =
         this.siteSettings.login_required ||
-        (topic && topic.isPrivateMessage) ||
-        (topic && topic.invisible) ||
-        (topic && topic.category && topic.category.read_restricted);
+        topic?.isPrivateMessage ||
+        topic?.invisible ||
+        topic?.category?.read_restricted;
 
       return Sharing.activeSources(
         this.siteSettings.share_links,

--- a/app/assets/javascripts/discourse/app/controllers/share-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/share-topic.js
@@ -10,6 +10,7 @@ import { bufferedProperty } from "discourse/mixins/buffered-content";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import I18n from "I18n";
 import Category from "discourse/models/category";
+import { scheduleOnce } from "@ember/runloop";
 
 export default Controller.extend(
   ModalFunctionality,
@@ -32,6 +33,17 @@ export default Controller.extend(
       if (this.model && this.model.read_restricted) {
         this.restrictedGroupWarning();
       }
+
+      scheduleOnce("afterRender", this, this.selectUrl);
+    },
+
+    selectUrl() {
+      const input = document.querySelector("input.invite-link");
+      if (!this.site.mobileView) {
+        // if the input is auto-focused on mobile, iOS requires two taps of the copy button
+        input.setSelectionRange(0, this.url.length);
+        input.focus();
+      }
     },
 
     @discourseComputed("post.shareUrl", "topic.shareUrl")
@@ -51,7 +63,7 @@ export default Controller.extend(
         this.siteSettings.login_required ||
         (topic && topic.isPrivateMessage) ||
         (topic && topic.invisible) ||
-        topic.category.read_restricted;
+        (topic && topic.category && topic.category.read_restricted);
 
       return Sharing.activeSources(
         this.siteSettings.share_links,

--- a/app/assets/javascripts/discourse/app/controllers/share-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/share-topic.js
@@ -39,7 +39,7 @@ export default Controller.extend(
 
     selectUrl() {
       const input = document.querySelector("input.invite-link");
-      if (!this.site.mobileView) {
+      if (input && !this.site.mobileView) {
         // if the input is auto-focused on mobile, iOS requires two taps of the copy button
         input.setSelectionRange(0, this.url.length);
         input.focus();

--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -8,6 +8,7 @@
   }
   input,
   .select-kit {
+    cursor: auto;
     width: 100%;
     margin-bottom: 0;
   }


### PR DESCRIPTION
The URL will be selected for easy copying immediately after the share
popup shows up.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
