### PR TITLE
PERF: Bump message_bus to 4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
     lz4-ruby (0.3.3)
     maxminddb (0.1.22)
     memory_profiler (1.0.0)
-    message_bus (4.1.0)
+    message_bus (4.2.0)
       rack (>= 1.1.3)
     method_source (1.0.0)
     mini_mime (1.1.2)

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -200,6 +200,11 @@ relative_url_root =
 # message bus default cap is 1000, we are winding it down to 100
 message_bus_max_backlog_size = 100
 
+# how often the message-bus backlog should be cleared
+# lower values will make memory usage more consistent, but will
+# increase redis CPU demands
+message_bus_clear_every = 50
+
 # must be a 64 byte hex string, anything else will be ignored with a warning
 secret_key_base =
 

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -118,6 +118,7 @@ else
 end
 
 MessageBus.backend_instance.max_backlog_size = GlobalSetting.message_bus_max_backlog_size
+MessageBus.backend_instance.clear_every = GlobalSetting.message_bus_clear_every
 
 if SiteSetting.table_exists? && SiteSetting.where(name: ['enable_long_polling', 'long_polling_interval']).exists?
   Discourse.deprecate("enable_long_polling/long_polling_interval have switched from site settings to global settings. Remove the override from the Site Settings UI, and use a config file or environment variables to set the global settings.", drop_from: '2.9.0')


### PR DESCRIPTION
This includes upstream performance improvements. For details, see https://github.com/discourse/message_bus/commit/1baa1ea4a5422f7554b2dec03084f02f5a38c57a

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
