### PR TITLE
PERF: Only subscribe to `/new` when logged in

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -65,9 +65,9 @@ const TopicTrackingState = EmberObject.extend({
    * @method establishChannels
    */
   establishChannels() {
-    this.messageBus.subscribe("/new", this._processChannelPayload);
     this.messageBus.subscribe("/latest", this._processChannelPayload);
     if (this.currentUser) {
+      this.messageBus.subscribe("/new", this._processChannelPayload);
       this.messageBus.subscribe(`/unread`, this._processChannelPayload);
       this.messageBus.subscribe(
         `/unread/${this.currentUser.id}`,


### PR DESCRIPTION
The 'new' tab doesn't exist for anonymous users. Every 'new' topic also publishes a message on the `/latest` channel, so the blue banner at the top of the topic-list will still be functional

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
