### PR TITLE
FIX: dev subfolder session cookies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
     r2 (0.2.7)
     racc (1.6.0)
     rack (2.2.3)
-    rack-mini-profiler (2.3.3)
+    rack-mini-profiler (2.3.4)
       rack (>= 1.2.0)
     rack-protection (2.2.0)
       rack

--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -68,6 +68,10 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
     Digest::MD5.hexdigest(id)
   end
 
+  # Cookie path should be set to the base path so Discourse's session cookie path
+  #  does not get clobbered.
+  Rack::MiniProfiler.config.cookie_path = Discourse.base_path
+
   Rack::MiniProfiler.config.position = 'left'
   Rack::MiniProfiler.config.backtrace_ignores ||= []
   Rack::MiniProfiler.config.backtrace_ignores << /lib\/rack\/message_bus.rb/


### PR DESCRIPTION
rack-mini-profiler was setting a cookie path of / which was clobbering
the session cookie path of Discourse.base_path.

Fixes some issues when local dev is unable to read or write from/to
the user session, such as during omniauth CSRF checks when base path is not /.
