### PR TITLE
DEV: Don't check `this.element` in `@afterRender`

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/utils/decorators.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/decorators.js
@@ -20,7 +20,7 @@ export function afterRender(target, name, descriptor) {
   const originalFunction = descriptor.value;
   descriptor.value = function () {
     schedule("afterRender", () => {
-      if (this.element && !this.isDestroying && !this.isDestroyed) {
+      if (!this.isDestroying && !this.isDestroyed) {
         return originalFunction.apply(this, arguments);
       }
     });


### PR DESCRIPTION
This would allow to use the decorator in tag-less components and in controllers.