### PR TITLE
DEV: Add force_quote_link option to PrettyText

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/pretty-text.js
+++ b/app/assets/javascripts/pretty-text/addon/pretty-text.js
@@ -15,6 +15,9 @@ export function registerOption() {
   );
 }
 
+// see also: __optInput in PrettyText#cook and PrettyText#markdown,
+// the options are passed here and must be explicitly allowed with
+// the const options & state below
 export function buildOptions(state) {
   const {
     siteSettings,
@@ -23,6 +26,7 @@ export function buildOptions(state) {
     lookupPrimaryUserGroup,
     getTopicInfo,
     topicId,
+    forceQuoteLink,
     categoryHashtagLookup,
     userId,
     getCurrentUser,
@@ -57,6 +61,7 @@ export function buildOptions(state) {
     lookupPrimaryUserGroup,
     getTopicInfo,
     topicId,
+    forceQuoteLink,
     categoryHashtagLookup,
     userId,
     getCurrentUser,

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/quotes.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/quotes.js
@@ -90,11 +90,11 @@ const rule = {
     }
 
     if (username) {
+      let forOtherTopic = options.topicId && topicId !== options.topicId;
       let offTopicQuote =
-        options.topicId &&
         postNumber &&
         options.getTopicInfo &&
-        topicId !== options.topicId;
+        (forOtherTopic || options.forceQuoteLink);
 
       // on topic quote
       token = state.push("quote_header_open", "div", 1);

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -175,6 +175,8 @@ module PrettyText
   #                      enabled when rendering markdown.
   #  topic_id          - Topic id for the post being cooked.
   #  user_id           - User id for the post being cooked.
+  #  force_quote_link  - Always create the link to the quoted topic for [quote] bbcode. Normally this only happens
+  #                      if the topic_id provided is different from the [quote topic:X].
   def self.markdown(text, opts = {})
     # we use the exact same markdown converter as the client
     # TODO: use the same extensions on both client and server (in particular the template for mentions)
@@ -187,6 +189,9 @@ module PrettyText
       custom_emoji = {}
       Emoji.custom.map { |e| custom_emoji[e.name] = e.url }
 
+      # note, any additional options added to __optInput here must be
+      # also be added to the buildOptions function in pretty-text.js,
+      # otherwise they will be discarded
       buffer = +<<~JS
         __optInput = {};
         __optInput.siteSettings = #{SiteSetting.client_settings_json};
@@ -214,6 +219,10 @@ module PrettyText
 
       if opts[:topic_id]
         buffer << "__optInput.topicId = #{opts[:topic_id].to_i};\n"
+      end
+
+      if opts[:force_quote_link]
+        buffer << "__optInput.forceQuoteLink = #{opts[:force_quote_link]};\n"
       end
 
       if opts[:user_id]

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -214,6 +214,25 @@ describe PrettyText do
         expect(cook("[quote=\"maja, post:3, topic:#{topic.id}\"]\nI have nothing to say.\n[/quote]", topic_id: 1)).to eq(n(expected))
       end
 
+      it "do off topic quoting with the force_quote_link opt and no topic_id opt provided" do
+        topic = Fabricate(:topic, title: "This is an off-topic topic")
+
+        expected = <<~HTML
+          <aside class="quote no-group" data-username="maja" data-post="3" data-topic="#{topic.id}">
+          <div class="title">
+          <div class="quote-controls"></div>
+          <a href="http://test.localhost/t/this-is-an-off-topic-topic/#{topic.id}/3">#{topic.title}</a>
+          </div>
+          <blockquote>
+          <p>I have nothing to say.</p>
+          </blockquote>
+          </aside>
+        HTML
+
+        cooked = cook("[quote=\"maja, post:3, topic:#{topic.id}\"]\nI have nothing to say.\n[/quote]", force_quote_link: true)
+        expect(cooked).to eq(n(expected))
+      end
+
       it "indifferent about missing quotations" do
         md = <<~MD
           [quote=#{user.username}, post:123, topic:456, full:true]


### PR DESCRIPTION
This option will make it so the [quote] bbcode will always
include the HTML link to the quoted post, even if a topic_id
is not provided in the PrettyText#cook options. This is so
[quote] bbcode can be used in other places, like chat messages,
that always need the link and do not have an "off-topic" ID
to use.
