### PR TITLE
DEV: prevents warnings with EMBER_CLI being redefined

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-EMBER_CLI = ENV["EMBER_CLI_PROD_ASSETS"] != "0" if EMBER_CLI.nil?
+if !defined?(EMBER_CLI)
+  EMBER_CLI = ENV["EMBER_CLI_PROD_ASSETS"] != "0"
+end
 
 task 'assets:precompile:before' do
 

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-EMBER_CLI = ENV["EMBER_CLI_PROD_ASSETS"] != "0"
+EMBER_CLI ||= ENV["EMBER_CLI_PROD_ASSETS"] != "0"
 
 task 'assets:precompile:before' do
 

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-EMBER_CLI ||= ENV["EMBER_CLI_PROD_ASSETS"] != "0"
+EMBER_CLI = ENV["EMBER_CLI_PROD_ASSETS"] != "0" if EMBER_CLI.nil?
 
 task 'assets:precompile:before' do
 


### PR DESCRIPTION
Example error:

```
/__w/discourse/discourse/lib/tasks/assets.rake:3: warning: already initialized constant EMBER_CLI
/__w/discourse/discourse/lib/tasks/assets.rake:3: warning: previous definition of EMBER_CLI was here
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
