### PR TITLE
UX: Improve timeline touch hit areas

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -137,9 +137,8 @@
         width: 100px;
       }
       .timeline-scrollarea {
-        border-left: 0;
-        border-right-style: solid;
-        border-right-width: 1px;
+        border-right: 1px solid var(--tertiary-low-or-tertiary-high);
+        border-left: none;
         max-width: 120px;
 
         .timeline-scroller {
@@ -161,6 +160,11 @@
             position: relative;
             right: -6px;
           }
+        }
+
+        .timeline-padding {
+          margin-left: 0;
+          margin-right: -1em;
         }
       }
     }
@@ -214,8 +218,7 @@
     .timeline-scrollarea {
       margin-top: 0.5em;
       margin-left: 0.5em;
-      border-left: 1px solid;
-      border-color: var(--tertiary-low-or-tertiary-high);
+      border-left: 1px solid var(--tertiary-low-or-tertiary-high);
       position: relative;
       -webkit-transform: translate3d(0, 0, 0);
     }
@@ -223,6 +226,11 @@
     .timeline-padding {
       transition: height 0.15s ease-out;
       cursor: pointer;
+      // this element has a click event
+      // the negative margin lets this element overlap
+      // the scrollarea's vertical track and thus it
+      // enables taps on the track to work
+      margin-left: -1em;
       .widget-dragging & {
         transition: none;
       }


### PR DESCRIPTION
On mobile (or small-width desktop window sizes), we had an issue where a simple tap on the timeline track was not taking the user to the desired location. We have a `timeline-padding` element that has a click event, but its width ended just before the track, so tapping exactly on the track had no effect. 

This commit makes a simple CSS change to fix this issue, it adds a negative margin to `timeline-padding` so that it overlaps the track. 

Screenshot of the "after" state with the element selected in the inspector: 

<img width="395" alt="image" src="https://user-images.githubusercontent.com/368961/155353765-a0ce2888-2446-4170-ad62-ea3d8155ec90.png">

This PR also fixes a missing track on the fullscreen timeline on RTL languages (looks like the gem we use to translate stylesheets to RTL does not support `border-right-style` and `border-right-width`.) 