### PR TITLE
DEV: Ensure Mini Profiler's `cookie_path` is not empty or nil

### DIFF
--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -70,7 +70,7 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
 
   # Cookie path should be set to the base path so Discourse's session cookie path
   #  does not get clobbered.
-  Rack::MiniProfiler.config.cookie_path = Discourse.base_path
+  Rack::MiniProfiler.config.cookie_path = Discourse.base_path.presence || "/"
 
   Rack::MiniProfiler.config.position = 'left'
   Rack::MiniProfiler.config.backtrace_ignores ||= []


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/9c50c69bd22b8017bc5e83c661045ac865f859b4.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
