### PR TITLE
DEV: allow min_posts to be automatically passed

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery-sortable.js
@@ -8,6 +8,7 @@ export const queryParams = {
   state: { replace: true, refreshModel: true },
   search: { replace: true, refreshModel: true },
   max_posts: { replace: true, refreshModel: true },
+  min_posts: { replace: true, refreshModel: true },
   q: { replace: true, refreshModel: true },
   before: { replace: true, refreshModel: true },
   bumped_before: { replace: true, refreshModel: true },


### PR DESCRIPTION
Using this in a feature for a theme component: https://github.com/discourse/discourse-unanswered-filter/pull/1