### PR TITLE
FIX: new indirectly muted category

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -122,6 +122,7 @@ export default {
             user.indirectly_muted_category_ids
           );
           if (
+            mutedCategoryIds &&
             mutedCategoryIds.includes(c.parent_category_id) &&
             !mutedCategoryIds.includes(c.id)
           ) {

--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -117,7 +117,21 @@ export default {
       const router = container.lookup("router:main");
 
       bus.subscribe("/categories", (data) => {
-        (data.categories || []).forEach((c) => site.updateCategory(c));
+        (data.categories || []).forEach((c) => {
+          const mutedCategoryIds = user.muted_category_ids?.concat(
+            user.indirectly_muted_category_ids
+          );
+          if (
+            mutedCategoryIds.includes(c.parent_category_id) &&
+            !mutedCategoryIds.includes(c.id)
+          ) {
+            user.set(
+              "indirectly_muted_category_ids",
+              user.indirectly_muted_category_ids.concat(c.id)
+            );
+          }
+          return site.updateCategory(c);
+        });
         (data.deleted_categories || []).forEach((id) =>
           site.removeCategory(id)
         );


### PR DESCRIPTION
When a new category is created and the parent category is muted or indirectly muted, the new category should be indirectly muted as well.
