### PR TITLE
FIX: Respect the cooldown window when editing a flagged topic.

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -159,13 +159,7 @@ module PostGuardian
 
       return false if @user.silenced?
 
-      if post.hidden?
-        return false if post.hidden_at.present? &&
-                        post.hidden_at >= SiteSetting.cooldown_minutes_after_hiding_posts.minutes.ago
-
-        # If it's your own post and it's hidden, you can still edit it
-        return true
-      end
+      return can_edit_hidden_post?(post) if post.hidden?
 
       if post.is_first_post? && post.topic.category_allows_unlimited_owner_edits_on_first_post?
         return true
@@ -179,6 +173,11 @@ module PostGuardian
     end
 
     false
+  end
+
+  def can_edit_hidden_post?(post)
+    return false if post.nil?
+    post.hidden_at.nil? || post.hidden_at < SiteSetting.cooldown_minutes_after_hiding_posts.minutes.ago
   end
 
   def can_delete_post_or_topic?(post)

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -85,7 +85,10 @@ module TopicGuardian
   def can_edit_topic?(topic)
     return false if Discourse.static_doc_topic_ids.include?(topic.id) && !is_admin?
     return false unless can_see?(topic)
-    return false if topic.first_post&.locked? && !is_staff?
+
+    first_post = topic.first_post
+
+    return false if first_post&.locked? && !is_staff?
 
     return true if is_admin?
     return true if is_moderator? && can_create_post?(topic)
@@ -130,9 +133,11 @@ module TopicGuardian
     )
 
     return false if topic.archived
+
     is_my_own?(topic) &&
       !topic.edit_time_limit_expired?(user) &&
-      !Post.where(topic_id: topic.id, post_number: 1).where.not(locked_by_id: nil).exists?
+      !first_post&.locked? &&
+      (!first_post&.hidden? || can_edit_hidden_post?(first_post))
   end
 
   def can_recover_topic?(topic)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -1641,6 +1641,17 @@ describe Guardian do
         expect(Guardian.new(coding_horror).can_edit?(topic)).to be_falsey
       end
 
+      context 'first post is hidden' do
+        let!(:topic) { Fabricate(:topic, user: user) }
+        let!(:post) { Fabricate(:post, topic: topic, user: topic.user, hidden: true, hidden_at: Time.zone.now) }
+
+        it 'returns false for editing your own post while inside the cooldown window' do
+          SiteSetting.cooldown_minutes_after_hiding_posts = 30
+
+          expect(Guardian.new(topic.user).can_edit?(topic)).to eq(false)
+        end
+      end
+
       context "locked" do
         let(:post) { Fabricate(:post, locked_by_id: admin.id) }
         let(:topic) { post.topic }


### PR DESCRIPTION
When staff decides to hide a flagged post, and it's the first post on the topic, the post owner shouldn't be able to edit either of them until the cooldown finishes. Edit either of them automatically, unhides the post, and makes the topic visible when there's a flag involved.

Reported on meta: https://meta.discourse.org/t/users-can-edit-flagged-topic-title-when-they-should-not-be-able-to/217796

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
