### PR TITLE
FIX: avoid validations when destroying posts

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -388,8 +388,7 @@ class PostDestroyer
     UserStatCountUpdater.decrement!(@post)
 
     if @post.created_at == author.last_posted_at
-      author.last_posted_at = author.posts.order('created_at DESC').first.try(:created_at)
-      author.save!
+      author.update_column(:last_posted_at, author.posts.order('created_at DESC').first.try(:created_at))
     end
 
     if @post.is_first_post? && @post.topic && !@post.topic.private_message?

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -185,6 +185,18 @@ describe PostDestroyer do
         .and change { post.topic.user_id }.to(Discourse.system_user.id)
     end
 
+    it "bypassed validation when updating users" do
+      post = create_post
+
+      # ensure user would fail validations
+      UserEmail.where(user_id: post.user_id).delete_all
+
+      PostDestroyer.new(admin, post.reload).destroy
+      PostDestroyer.new(admin, post.reload, force_destroy: true).destroy
+
+      expect(Post.with_deleted.find_by(id: post.id)).to eq(nil)
+    end
+
     describe "post_count recovery" do
       before do
         post


### PR DESCRIPTION
Previously email validations could fire when deleting posts if for
certain reasons any user validations fail on the user objects

This kind of condition could happen in core due to a corruption of a
user record, or via a plugin that introduces a new validation on User
