### PR TITLE
FIX: Make sure html_raw is hoisted in custom markdown cook function

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
+++ b/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
@@ -337,9 +337,7 @@ function buildCustomMarkdownCookFunction(engineOpts, defaultEngineOpts) {
   // we don't need the whole engine as a consumer, just a cook function
   // will do
   return function customRenderFn(contentToRender) {
-    return newOpts.discourse
-      .sanitizer(newOpts.engine.render(contentToRender))
-      .trim();
+    return cook(contentToRender, newOpts);
   };
 }
 


### PR DESCRIPTION
When returning the customRenderFn from within buildCustomMarkdownCookFunction
for custom markdown engines (such as the one used by the [chat] transcripts)
we were not hoisting/unhoisting the `html_raw` tokens created by the
transcript, which meant that opts.discourse.hoisted could end up in
a state where it was null, and which caused errors and general unpleasantness.

Instead, we can just call the `cook` function that is already exported
from discourse-markdown-it, that takes care of what we did previously
plus the hoisting.

There is a companion chat commit that adds tests for this, there are
no custom markdown engine usages in core to test with.
