### PR TITLE
FEATURE: Add ENV to control themes:update errors

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -71,7 +71,7 @@ def update_themes
       raise RemoteTheme::ImportError.new(remote_theme.last_error_text) if remote_theme.last_error_text.present?
     rescue => e
       STDERR.puts "Failed to update '#{theme.name}': #{e}"
-      raise if RailsMultisite::ConnectionManagement.current_db == "default"
+      raise if ENV["RAISE_THEME_ERRORS"] != "0" && (ENV["RAISE_THEME_ERRORS"] == "1" || RailsMultisite::ConnectionManagement.current_db == "default")
     end
   end
 


### PR DESCRIPTION
This commit introduces a new environment variable `RAISE_THEME_ERRORS`
that can control what happens when `theme:update` Rake task errors. It
can have three possible values: `0` to always print errors, `1` to
always raise on error, or be absent to use the default behavior which
raises errors only for default sites.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
