### PR TITLE
DEV: Bump rack-mini-profiler to 3.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
     r2 (0.2.7)
     racc (1.6.0)
     rack (2.2.3)
-    rack-mini-profiler (2.3.4)
+    rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
     rack-protection (2.2.0)
       rack


### PR DESCRIPTION
This version improves the performance of Mini Profiler's snapshots page. For more details see https://github.com/MiniProfiler/rack-mini-profiler/commit/3e6f7e561b2b4bb94829ae29152337dc8b64e22f.