### PR TITLE
FIX: on mobile, overflow on post controls if there are many buttons

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -33,10 +33,9 @@ nav.post-controls {
   --control-space: 0.58em;
   --control-space-small: calc(var(--control-space) / 2);
   --control-space-large: calc(var(--control-space) * 1.3);
-  &.expanded {
-    // on small devices with many buttons this can overflow
-    overflow-x: scroll;
-  }
+  // on small devices with many buttons this can overflow
+  overflow-x: scroll;
+
   .actions {
     // using an auto margin on first-child instead of justify-content on the parent
     // because justify-content breaks overflow scrolling


### PR DESCRIPTION
### Before
![post-controls-mobile-before](https://user-images.githubusercontent.com/2790986/155785934-50e3aa88-59d1-4439-ba87-072ed8ef10a1.gif)

### After
![post-controls-mobile-after](https://user-images.githubusercontent.com/2790986/155786315-53acd748-0321-4497-a949-226bfafb4c15.gif)

