### PR TITLE
DEV: Fix a nokogiri deprecation

### DIFF
--- a/lib/cooked_processor_mixin.rb
+++ b/lib/cooked_processor_mixin.rb
@@ -330,8 +330,9 @@ module CookedProcessorMixin
   end
 
   def create_node(tag_name, klass)
-    node = Nokogiri::XML::Node.new(tag_name, @doc)
+    node = @doc.document.create_element(tag_name)
     node["class"] = klass if klass.present?
+    @doc.add_child(node)
     node
   end
 


### PR DESCRIPTION
```
warning: Passing a Node as the second parameter to Node.new is deprecated. Please pass a Document instead, or prefer an alternative constructor like Node#add_child. This will become an error in a future release of Nokogiri.
```