### PR TITLE
UX: Remove loading spinner from emoji picker

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -81,7 +81,6 @@ export default Component.extend({
   onShow() {
     this.set("isLoading", true);
     this.set("recentEmojis", this.emojiStore.favorites);
-    this._applyFilter(this.initialFilter);
 
     schedule("afterRender", () => {
       this._applyFilter(this.initialFilter);

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -81,6 +81,7 @@ export default Component.extend({
   onShow() {
     this.set("isLoading", true);
     this.set("recentEmojis", this.emojiStore.favorites);
+    this._applyFilter(this.initialFilter);
 
     schedule("afterRender", () => {
       this._applyFilter(this.initialFilter);

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -36,7 +36,6 @@ export default Component.extend({
   recentEmojis: null,
   hoveredEmoji: null,
   isActive: false,
-  isLoading: true,
   usePopper: true,
   initialFilter: "",
 
@@ -79,7 +78,6 @@ export default Component.extend({
 
   @action
   onShow() {
-    this.set("isLoading", true);
     this.set("recentEmojis", this.emojiStore.favorites);
 
     schedule("afterRender", () => {
@@ -135,8 +133,6 @@ export default Component.extend({
       // this is a low-tech trick to prevent appending hundreds of emojis
       // of blocking the rendering of the picker
       later(() => {
-        this.set("isLoading", false);
-
         schedule("afterRender", () => {
           if (!this.site.isMobileDevice || this.isEditorFocused) {
             const filter = emojiPicker.querySelector("input.filter");

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
@@ -38,42 +38,40 @@
       <div class="emoji-picker-emoji-area" role="button" {{on "click" this.onEmojiSelection}} {{on "mouseover" this.onEmojiHover}}>
         <div class="results"></div>
 
-        {{#conditional-loading-spinner condition=isLoading}}
-          <div class="emojis-container">
-            {{#if recentEmojis.length}}
-              <div class="section recent" data-section="recent">
-                <div class="section-header">
-                  <span class="title">{{i18n "emoji_picker.recent"}}</span>
-                  {{d-button icon="trash-alt" action=(action "onClearRecents") class="trash-recent"}}
-                </div>
+        <div class="emojis-container">
+          {{#if recentEmojis.length}}
+            <div class="section recent" data-section="recent">
+              <div class="section-header">
+                <span class="title">{{i18n "emoji_picker.recent"}}</span>
+                {{d-button icon="trash-alt" action=(action "onClearRecents") class="trash-recent"}}
+              </div>
+              <div class="section-group">
+                {{#each recentEmojis as |emoji|}}
+                  {{replace-emoji (concat ":" emoji ":") (hash lazy=true)}}
+                {{/each}}
+              </div>
+            </div>
+          {{/if}}
+
+          {{emoji-group-sections}}
+
+          {{#each-in customEmojis as |group emojis|}}
+            <div class="section" data-section="custom-{{group}}">
+              <div class="section-header">
+                <span class="title">
+                  {{i18n (concat "emoji_picker." group)}}
+                </span>
+              </div>
+              {{#if emojis.length}}
                 <div class="section-group">
-                  {{#each recentEmojis as |emoji|}}
-                    {{replace-emoji (concat ":" emoji ":") (hash lazy=true)}}
+                  {{#each emojis as |emoji|}}
+                    <img title={{emoji.code}} width="20" height="20" loading="lazy" class="emoji" src={{emoji.src}}>
                   {{/each}}
                 </div>
-              </div>
-            {{/if}}
-
-            {{emoji-group-sections}}
-
-            {{#each-in customEmojis as |group emojis|}}
-              <div class="section" data-section="custom-{{group}}">
-                <div class="section-header">
-                  <span class="title">
-                    {{i18n (concat "emoji_picker." group)}}
-                  </span>
-                </div>
-                {{#if emojis.length}}
-                  <div class="section-group">
-                    {{#each emojis as |emoji|}}
-                      <img title={{emoji.code}} width="20" height="20" loading="lazy" class="emoji" src={{emoji.src}}>
-                    {{/each}}
-                  </div>
-                {{/if}}
-              </div>
-            {{/each-in}}
-          </div>
-        {{/conditional-loading-spinner}}
+              {{/if}}
+            </div>
+          {{/each-in}}
+        </div>
       </div>
 
       <div class="emoji-picker-footer">


### PR DESCRIPTION
Emoji picker doesn't load external data, so this didn't provide much value to users (and just delayed displaying the list by 50ms+)