### PR TITLE
DEV: Remove use of Discourse application code in migration.

### DIFF
--- a/db/post_migrate/20220214224506_reset_custom_emoji_post_bakes_version_secure_fix.rb
+++ b/db/post_migrate/20220214224506_reset_custom_emoji_post_bakes_version_secure_fix.rb
@@ -2,7 +2,9 @@
 
 class ResetCustomEmojiPostBakesVersionSecureFix < ActiveRecord::Migration[6.1]
   def up
-    if SiteSetting.secure_media
+    secure_media_enabled = DB.query_single("SELECT value FROM site_settings WHERE name = 'secure_media'")
+
+    if secure_media_enabled.present? && secure_media_enabled[0] == "t"
       execute <<~SQL
         UPDATE posts SET baked_version = 0
         WHERE cooked LIKE '%emoji emoji-custom%' AND cooked LIKE '%secure-media-uploads%'


### PR DESCRIPTION
This makes the migration less brittle to changes in the future.

Follow-up to https://github.com/tgxworld/discourse/commit/21a356e3af34f15234d09cbe0e4bdb3eff408f5d