### PR TITLE
DEV: uses vanilla js to fetch csrf token instead of jquery

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/csrf-token.js
+++ b/app/assets/javascripts/discourse/app/initializers/csrf-token.js
@@ -8,7 +8,10 @@ export default {
   initialize(container) {
     // Add a CSRF token to all AJAX requests
     let session = container.lookup("session:main");
-    session.set("csrfToken", $("meta[name=csrf-token]").attr("content"));
+    session.set(
+      "csrfToken",
+      document.head.querySelector("meta[name=csrf-token]")?.content
+    );
 
     if (!installed) {
       $.ajaxPrefilter(callbacks.fire);


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
