### PR TITLE
DEV: Ensure source-identifier works during theme qunit

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/source-identifier.js
+++ b/app/assets/javascripts/discourse/app/lib/source-identifier.js
@@ -52,7 +52,7 @@ export default function identifySource(error) {
 }
 
 export function getThemeInfo(id) {
-  const name = PreloadStore.get("activatedThemes")[id] || `(theme-id: ${id})`;
+  const name = PreloadStore.get("activatedThemes")?.[id] || `(theme-id: ${id})`;
   return {
     id,
     name,


### PR DESCRIPTION
The preload store is not populated with theme information during theme qunit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
