### PR TITLE
DEV: Make load order consistent for `rake plugin:spec`

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -182,7 +182,7 @@ task 'plugin:spec', :plugin do |t, args|
   args.with_defaults(plugin: "*")
   params = ENV['RSPEC_FAILFAST'] ? '--profile --fail-fast' : '--profile'
   ruby = `which ruby`.strip
-  files = Dir.glob("./plugins/#{args[:plugin]}/spec/**/*_spec.rb")
+  files = Dir.glob("./plugins/#{args[:plugin]}/spec/**/*_spec.rb").sort
   if files.length > 0
     sh "LOAD_PLUGINS=1 #{ruby} -S rspec #{files.join(' ')} #{params}"
   else


### PR DESCRIPTION
`Dir.glob` doesn't guarantee any particular order for results. However, it does appear to be consistent on a given machine. This means that specs can consistently pass on one machine while consistently failing on another. This can lead to some very confusing situations!

This commit sorts the spec files alphabetically so that load order is consistent across environments.

Note that the order in which tests are **run** is not affected by this change. Run order is still randomized by RSpec

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
