### PR TITLE
FIX: calculate docking - include offset of main

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -196,7 +196,10 @@ const SiteHeaderComponent = MountWidget.extend(
         document.documentElement.style.setProperty("--header-offset", newValue);
       }
 
-      if (window.pageYOffset >= this.docAt) {
+      const main = document.querySelector("#main");
+      const offsetTop = main ? main.offsetTop : 0;
+      const offset = window.pageYOffset - offsetTop;
+      if (offset >= this.docAt) {
         if (!this.dockedHeader) {
           document.body.classList.add("docked");
           this.dockedHeader = true;


### PR DESCRIPTION
Include a calculation of offset in main - this allows docking
to be calculated (again) using global offsets, in case there is a
custom header outside of Discourse that pushes forum content down.