### PR TITLE
DEV: Refactor model/post-stream to support any filter.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -1,4 +1,4 @@
-import { and, not, or } from "@ember/object/computed";
+import { and, equal, not, or } from "@ember/object/computed";
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 import PostsWithPlaceholders from "discourse/lib/posts-with-placeholders";
@@ -37,7 +37,6 @@ export default RestModel.extend({
   posts: null,
   stream: null,
   userFilters: null,
-  summary: null,
   loaded: null,
   loadingAbove: null,
   loadingBelow: null,
@@ -48,6 +47,7 @@ export default RestModel.extend({
   timelineLookup: null,
   filterRepliesToPostNumber: null,
   filterUpwardsPostID: null,
+  filter: null,
 
   init() {
     this._identityMap = {};
@@ -62,7 +62,6 @@ export default RestModel.extend({
       postsWithPlaceholders,
       stream: [],
       userFilters: [],
-      summary: false,
       filterRepliesToPostNumber:
         parseInt(this.get("topic.replies_to_post_number"), 10) || false,
       filterUpwardsPostID: false,
@@ -77,6 +76,8 @@ export default RestModel.extend({
 
   loading: or("loadingAbove", "loadingBelow", "loadingFilter", "stagingPost"),
   notLoading: not("loading"),
+
+  summary: equal("filter", "summary"),
 
   @discourseComputed(
     "isMegaTopic",
@@ -137,7 +138,7 @@ export default RestModel.extend({
     params for the stream.
   **/
   @discourseComputed(
-    "summary",
+    "filter",
     "userFilters.[]",
     "filterRepliesToPostNumber",
     "filterUpwardsPostID"
@@ -145,8 +146,8 @@ export default RestModel.extend({
   streamFilters() {
     const result = {};
 
-    if (this.summary) {
-      result.filter = "summary";
+    if (this.filter) {
+      result.filter = this.filter;
     }
 
     const userFilters = this.userFilters;
@@ -235,10 +236,10 @@ export default RestModel.extend({
   cancelFilter() {
     this.setProperties({
       userFilters: [],
-      summary: false,
       filterRepliesToPostNumber: false,
       filterUpwardsPostID: false,
       mixedHiddenPosts: false,
+      filter: null,
     });
   },
 
@@ -252,7 +253,7 @@ export default RestModel.extend({
 
   showSummary() {
     this.cancelFilter();
-    this.set("summary", true);
+    this.set("filter", "summary");
     return this.refreshAndJumptoSecondVisible();
   },
 

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -277,7 +277,7 @@ const TopicRoute = DiscourseRoute.extend({
 
   setupParams(topic, params) {
     const postStream = topic.get("postStream");
-    postStream.set("summary", get(params, "filter") === "summary");
+    postStream.set("filter", get(params, "filter"));
 
     const usernames = get(params, "username_filters"),
       userFilters = postStream.get("userFilters");

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -237,7 +237,7 @@ module("Unit | Model | post-stream", function () {
 
     sinon.stub(postStream, "refresh").returns(Promise.resolve());
 
-    postStream.set("summary", true);
+    postStream.set("filter", "summary");
     postStream.cancelFilter();
     assert.ok(!postStream.get("summary"), "summary is cancelled");
 
@@ -391,7 +391,7 @@ module("Unit | Model | post-stream", function () {
       "there are no filters by default"
     );
 
-    postStream.set("summary", true);
+    postStream.set("filter", "summary");
     assert.deepEqual(
       postStream.get("streamFilters"),
       { filter: "summary" },


### PR DESCRIPTION
The current implementation ties the filter query params tightly to the
`summary` attribute on the post stream model making it hard to support
other filters.