### PR TITLE
DEV: Remove notify user from topic share modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
@@ -21,13 +21,6 @@
           {{share-source source=s title=topic.title action=(action "share")}}
         {{/each}}
 
-        {{d-button
-          class="btn-default notify"
-          label="topic.share.notify_users.title"
-          icon="hand-point-right"
-          action=(action "toggleNotifyUsers")
-        }}
-
         {{#if allowInvites}}
           {{d-button
             class="btn-default invite"
@@ -37,29 +30,6 @@
           }}
         {{/if}}
       </div>
-
-      {{#if showNotifyUsers}}
-        <div class="input-group invite-users">
-          <label for="invite-users">{{i18n "topic.share.notify_users.instructions"}}</label>
-          <div class="notify-user-input">
-            {{user-chooser
-              value=users
-              onChange=(action "onChangeUsers")
-              options=(hash
-                      topicId=topic.id
-                      maximum=(unless currentUser.staff 1)
-                      excludeCurrentUser=true
-                      )
-            }}
-            {{d-button
-              icon="check"
-              class="btn-primary"
-              disabled=(if users false true)
-              action=(action "notifyUsers")
-            }}
-          </div>
-        </div>
-      {{/if}}
     </div>
   </form>
 {{/d-modal-body}}

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -1,7 +1,6 @@
 import { click, visit } from "@ember/test-helpers";
 import {
   acceptance,
-  count,
   exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -28,12 +27,6 @@ acceptance("Share and Invite modal", function (needs) {
         .val()
         .includes("/t/internationalization-localization/280?u=eviltrout"),
       "it shows the topic sharing url"
-    );
-
-    assert.ok(count("button[class*='share-']") > 1, "it shows social sources");
-    assert.ok(
-      exists(".link-share-actions .notify"),
-      "it shows the notify button"
     );
 
     assert.ok(

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2851,12 +2851,6 @@ en:
         restricted_groups:
           one: "Only visible to members of group: %{groupNames}"
           other: "Only visible to members of groups: %{groupNames}"
-        notify_users:
-          title: "Notify"
-          instructions: "Notify the following users about this topic:"
-          success:
-            one: "Successfully notified %{username} about this topic."
-            other: "Successfully notified all users about this topic."
         invite_users: "Invite"
 
       print:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -848,7 +848,6 @@ Discourse::Application.routes.draw do
     post "t/:topic_id/timings" => "topics#timings", constraints: { topic_id: /\d+/ }
     post "t/:topic_id/invite" => "topics#invite", constraints: { topic_id: /\d+/ }
     post "t/:topic_id/invite-group" => "topics#invite_group", constraints: { topic_id: /\d+/ }
-    post "t/:topic_id/invite-notify" => "topics#invite_notify", constraints: { topic_id: /\d+/ }
     post "t/:topic_id/move-posts" => "topics#move_posts", constraints: { topic_id: /\d+/ }
     post "t/:topic_id/merge-topic" => "topics#merge_topic", constraints: { topic_id: /\d+/ }
     post "t/:topic_id/change-owner" => "topics#change_post_owners", constraints: { topic_id: /\d+/ }

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2850,46 +2850,6 @@ RSpec.describe TopicsController do
     end
   end
 
-  describe '#invite_notify' do
-    before do
-      topic.update!(highest_post_number: 1)
-    end
-
-    it 'does not notify same user multiple times' do
-      sign_in(user)
-
-      expect { post "/t/#{topic.id}/invite-notify.json", params: { usernames: [user_2.username] } }
-        .to change { Notification.count }.by(1)
-      expect(response.status).to eq(200)
-
-      expect { post "/t/#{topic.id}/invite-notify.json", params: { usernames: [user_2.username] } }
-        .to change { Notification.count }.by(0)
-      expect(response.status).to eq(200)
-
-      freeze_time 1.day.from_now
-
-      expect { post "/t/#{topic.id}/invite-notify.json", params: { usernames: [user_2.username] } }
-        .to change { Notification.count }.by(1)
-      expect(response.status).to eq(200)
-    end
-
-    it 'does not let regular users to notify multiple users' do
-      sign_in(user)
-
-      expect { post "/t/#{topic.id}/invite-notify.json", params: { usernames: [admin.username, user_2.username] } }
-        .to change { Notification.count }.by(0)
-      expect(response.status).to eq(400)
-    end
-
-    it 'lets staff to notify multiple users' do
-      sign_in(admin)
-
-      expect { post "/t/#{topic.id}/invite-notify.json", params: { usernames: [user.username, user_2.username] } }
-        .to change { Notification.count }.by(2)
-      expect(response.status).to eq(200)
-    end
-  end
-
   describe '#invite_group' do
     let!(:admins) { Group[:admins] }
 


### PR DESCRIPTION
This feature was rarely used, could be used for spamming users and was
impossible to add a context to why the user was notified of a topic. A
simple private messages that includes the link and personalized message
can be used instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
