### PR TITLE
FIX: Update and rebake uses of the old centralized avatar service

### DIFF
--- a/db/migrate/20220302163246_update_avatar_service_domain.rb
+++ b/db/migrate/20220302163246_update_avatar_service_domain.rb
@@ -2,12 +2,23 @@
 
 class UpdateAvatarServiceDomain < ActiveRecord::Migration[6.1]
   def up
-    execute <<~SQL
-      UPDATE site_settings
-      SET value = REPLACE(value, 'avatars.discourse.org', 'avatars.discourse-cdn.com')
-      WHERE name = 'external_system_avatars_url'
-      AND value LIKE '%avatars.discourse.org%'
-    SQL
+    existing_value = DB.query_single("SELECT value FROM site_settings WHERE name = 'external_system_avatars_url'")&.[](0)
+
+    if existing_value&.include?("avatars.discourse.org")
+      new_value = DB.query_single(<<~SQL)&.[](0)
+        UPDATE site_settings
+        SET value = REPLACE(value, 'avatars.discourse.org', 'avatars.discourse-cdn.com')
+        WHERE name = 'external_system_avatars_url'
+        AND value LIKE '%avatars.discourse.org%'
+        RETURNING value
+      SQL
+
+      DB.exec <<~SQL, previous: existing_value, new: new_value
+        INSERT INTO user_histories
+        (action, subject, previous_value, new_value, admin_only, updated_at, created_at, acting_user_id)
+        VALUES (3, 'external_system_avatars_url', :previous, :new, true, NOW(), NOW(), -1)
+      SQL
+    end
   end
 
   def down

--- a/db/migrate/20220302163246_update_avatar_service_domain.rb
+++ b/db/migrate/20220302163246_update_avatar_service_domain.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class UpdateAvatarServiceDomain < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      UPDATE site_settings
+      SET value = REPLACE(value, 'avatars.discourse.org', 'avatars.discourse-cdn.com')
+      WHERE name = 'external_system_avatars_url'
+      AND value LIKE '%avatars.discourse.org%'
+    SQL
+  end
+
+  def down
+    # Nothing to do
+  end
+end

--- a/db/post_migrate/20220302171443_rebake_old_avatar_service_urls.rb
+++ b/db/post_migrate/20220302171443_rebake_old_avatar_service_urls.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RebakeOldAvatarServiceUrls < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      UPDATE posts SET baked_version = 0
+      WHERE cooked LIKE '%avatars.discourse.org%'
+    SQL
+  end
+
+  def down
+    # Nothing to do
+  end
+end


### PR DESCRIPTION
This URL was originally updated in 89cb537fae8a563b22d873ea8efd3009fd32b042. However, some sites are not using the proxy, and have configured their forum to hotlink images directly to avatars.discourse.org.

We intend to shut down this domain in favor of `avatars.discourse-cdn.com`, so this migration will re-write any matching site setting values and queue affected posts for rebaking.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
