### PR TITLE
Top level replies

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -63,7 +63,7 @@ class TopicsController < ApplicationController
     # arrays are not supported
     params[:page] = params[:page].to_i rescue 1
 
-    opts = params.slice(:username_filters, :filter, :page, :post_number, :show_deleted, :replies_to_post_number, :filter_upwards_post_id)
+    opts = params.slice(:username_filters, :filter, :page, :post_number, :show_deleted, :replies_to_post_number, :filter_upwards_post_id, :filter_top_level_replies)
     username_filters = opts[:username_filters]
 
     opts[:print] = true if params[:print].present?
@@ -1221,7 +1221,7 @@ class TopicsController < ApplicationController
       scope: guardian,
       root: false,
       include_raw: !!params[:include_raw],
-      exclude_suggested_and_related: !!params[:replies_to_post_number] || !!params[:filter_upwards_post_id]
+      exclude_suggested_and_related: !!params[:replies_to_post_number] || !!params[:filter_upwards_post_id] || !!params[:filter_top_level_replies]
     )
 
     respond_to do |format|

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -860,6 +860,14 @@ class TopicView
       @contains_gaps = true
     end
 
+    # Show Only Top Level Replies
+    if @filter_top_level_replies.present?
+      @filtered_posts = @filtered_posts.where('
+        posts.post_number > 1
+        AND posts.reply_to_post_number IS NULL
+      ')
+    end
+
     # Filtering upwards
     if @filter_upwards_post_id.present?
       post = Post.find(@filter_upwards_post_id)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2430,6 +2430,29 @@ RSpec.describe TopicsController do
         end
       end
 
+      describe 'filter by top level replies' do
+        fab!(:post3) { Fabricate(:post, user: post_author3, topic: topic, reply_to_post_number: post2.post_number) }
+        fab!(:post4) { Fabricate(:post, user: post_author4, topic: topic, reply_to_post_number: post2.post_number) }
+        fab!(:post5) { Fabricate(:post, user: post_author5, topic: topic) }
+        fab!(:post6) { Fabricate(:post, user: post_author4, topic: topic, reply_to_post_number: post5.post_number) }
+
+        it 'should return the right posts' do
+          get "/t/#{topic.id}.json", params: {
+            filter_top_level_replies: true
+          }
+
+          expect(response.status).to eq(200)
+
+          body = response.parsed_body
+
+          expect(body.has_key?("suggested_topics")).to eq(false)
+          expect(body.has_key?("related_messages")).to eq(false)
+
+          ids = body["post_stream"]["posts"].map { |p| p["id"] }
+          expect(ids).to eq([post2.id, post5.id])
+        end
+      end
+
       describe 'filter upwards by post id' do
         fab!(:post3) { Fabricate(:post, user: post_author3, topic: topic) }
         fab!(:post4) { Fabricate(:post, user: post_author4, topic: topic, reply_to_post_number: post3.post_number) }


### PR DESCRIPTION
Adds a new query param to the topic view so that we can filter out posts
that aren't top level replies. If a post is a reply to another post
instead of the original topic post we should not include it in the
response if the `filter_top_level_replies` query param is present.

Even though there are 14 posts in this topic, with this filter applied only the two top level reply posts are included in the json response. 

![image](https://user-images.githubusercontent.com/1490496/156429465-83622e5a-b17c-42b5-8438-efdb7825816b.png)

This feature is to aid in reducing the number of API calls needed to fetch only the top level replies of a topic. If a topic has hundreds of posts we have to crawl the whole topic with pagination. With this filter only the top level replies are included in the post_stream so we know exactly which posts to fetch for pagination with the `/t/{id}/posts.json` endpoint reducing the number of API calls needed.
