### PR TITLE
DEV: remove wrap from discovery-list-container-top

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/discovery.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery.hbs
@@ -29,7 +29,7 @@
   <div class="row">
     <div class="full-width">
       <div id="list-area">
-        {{plugin-outlet name="discovery-list-container-top" tagName="span" connectorTagName="div"
+        {{plugin-outlet name="discovery-list-container-top" tagName="" connectorTagName="span"
                         args=(hash category=category listLoading=loading)}}
         {{outlet "list-container"}}
       </div>


### PR DESCRIPTION
I'm not sure if there's a specific reason this is a `span` with a `div` child, but the parent `span` was classless so a little fragile to target with CSS. 

This removes the classless parent and changes the (formerly child,  now parent) `div` to a `span`. So anything that was relying on that `span` should still be able to do so, and the connector now gets the `discovery-list-container-top` class. 

So

Before:
```xml
<span id="ember769" class="ember-view">  
  <div id="ember771" class="discovery-list-container-top-outlet ember-view">
    example content
  </div>
</span>
```

After:  
```xml
<span id="ember771" class="discovery-list-container-top-outlet ember-view">
  example content
</span>
```