### PR TITLE
FIX: better error indicator when email is rejected for old notifications

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -216,7 +216,7 @@ module Email
 
         if post && Guardian.new(user).can_see_post?(post)
           if destination_too_old?(post)
-            raise OldDestinationError.new("#{Discourse.base_url}/p/#{post.id}")
+            raise OldDestinationError
           end
         end
 

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -98,6 +98,7 @@ describe Email::Receiver do
     expect { process(:old_destination) }.to raise_error(
       Email::Receiver::OldDestinationError
     )
+    expect(IncomingEmail.last.error).to eq("Email::Receiver::OldDestinationError")
 
     SiteSetting.disallow_reply_by_email_after_days = 0
     IncomingEmail.destroy_all


### PR DESCRIPTION
This commit brings the error message for "old notifications" in line with other errors when email is rejected.

https://meta.discourse.org/t/late-reply-by-email-rejection-label-is-url-rather-than-actual-description/145760
