### PR TITLE
FIX: save email rejection error class names for incoming email logs

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -83,9 +83,7 @@ module Email
 
           post
         rescue Exception => e
-          error = e.to_s
-          error = e.class.name if error.blank?
-          @incoming_email.update_columns(error: error) if @incoming_email
+          @incoming_email.update_columns(error: e.class.name) if @incoming_email
           delete_staged_users
           raise
         end

--- a/spec/lib/email/processor_spec.rb
+++ b/spec/lib/email/processor_spec.rb
@@ -120,7 +120,7 @@ describe Email::Processor do
         expect(errors.first).to include("boom")
 
         incoming_email = IncomingEmail.last
-        expect(incoming_email.error).to eq("boom")
+        expect(incoming_email.error).to eq("RuntimeError")
         expect(incoming_email.rejection_message).to be_present
 
         expect(EmailLog.last.email_type).to eq("email_reject_unrecognized_error")

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -98,6 +98,7 @@ describe Email::Receiver do
     expect { process(:old_destination) }.to raise_error(
       Email::Receiver::OldDestinationError
     )
+    expect(IncomingEmail.last.error).to eq("Email::Receiver::OldDestinationError")
 
     SiteSetting.disallow_reply_by_email_after_days = 0
     IncomingEmail.destroy_all


### PR DESCRIPTION
Since we already save error class names for most of the email rejection errors it's better to save class names for all the errors to avoid confusion.

For example in case of "Email::Receiver::OldDestinationError" error we were saving the error message which was the short link for post. This type of message is not useful at all and it's better to show the error class name here instead.

Issue initially reported on meta: https://meta.discourse.org/t/late-reply-by-email-rejection-label-is-url-rather-than-actual-description/145760

