### PR TITLE
UX: Differentiate 'emails disabled' notice for 'yes' and 'non-staff'

### DIFF
--- a/app/assets/javascripts/discourse/app/components/global-notice.js
+++ b/app/assets/javascripts/discourse/app/components/global-notice.js
@@ -121,10 +121,17 @@ export default Component.extend({
       );
     }
 
-    if (disableEmails === "yes" || disableEmails === "non-staff") {
+    if (disableEmails === "yes") {
       notices.push(
         Notice.create({
           text: I18n.t("emails_are_disabled"),
+          id: "alert-emails-disabled",
+        })
+      );
+    } else if (disableEmails === "non-staff") {
+      notices.push(
+        Notice.create({
+          text: I18n.t("emails_are_disabled_non_staff"),
           id: "alert-emails-disabled",
         })
       );

--- a/app/assets/javascripts/discourse/tests/acceptance/email-notice-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/email-notice-test.js
@@ -1,10 +1,12 @@
 import {
   acceptance,
   exists,
+  query,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
+import I18n from "I18n";
 
 acceptance("Email Disabled Banner", function (needs) {
   needs.user();
@@ -25,6 +27,11 @@ acceptance("Email Disabled Banner", function (needs) {
       exists(".alert-emails-disabled"),
       "alert is displayed when email disabled"
     );
+    assert.strictEqual(
+      query(".alert-emails-disabled").innerText,
+      I18n.t("emails_are_disabled"),
+      "alert uses the correct text"
+    );
   });
 
   test("when non-staff", async function (assert) {
@@ -34,12 +41,22 @@ acceptance("Email Disabled Banner", function (needs) {
       exists(".alert-emails-disabled"),
       "alert is displayed when email disabled for non-staff"
     );
+    assert.strictEqual(
+      query(".alert-emails-disabled").innerText,
+      I18n.t("emails_are_disabled_non_staff"),
+      "alert uses the correct text"
+    );
 
     updateCurrentUser({ moderator: true });
     await visit("/");
     assert.ok(
       exists(".alert-emails-disabled"),
       "alert is displayed to staff when email disabled for non-staff"
+    );
+    assert.strictEqual(
+      query(".alert-emails-disabled").innerText,
+      I18n.t("emails_are_disabled_non_staff"),
+      "alert uses the correct text"
     );
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -182,6 +182,7 @@ en:
 
     wizard_required: "Welcome to your new Discourse! Let’s get started with <a href='%{url}' data-auto-route='true'>the setup wizard</a> ✨"
     emails_are_disabled: "All outgoing email has been globally disabled by an administrator. No email notifications of any kind will be sent."
+    emails_are_disabled_non_staff: "Outgoing email has been disabled for non-staff users."
 
     software_update_prompt:
       message: "We've updated this site, <span>please refresh</span>, or you may experience unexpected behavior."


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
