### PR TITLE
DEV: Add API scope for categories endpoint

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -36,6 +36,10 @@ class ApiKeyScope < ActiveRecord::Base
         posts: {
           edit: { actions: %w[posts#update], params: %i[id] }
         },
+        categories: {
+          list: { actions: %w[categories#index] },
+          show: { actions: %w[categories#show], params: %i[id] }
+        },
         uploads: {
           create: {
             actions: %w[

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4218,6 +4218,9 @@ en:
               wordpress: Necessary for the WordPress wp-discourse plugin to work.
             posts:
               edit: Edit any post or a specific one.
+            categories:
+              list: Get a list of categories.
+              show: Get a single category by id.
             uploads:
               create: Upload a new file or initiate single or multipart direct uploads to external storage.
             users:

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -235,7 +235,7 @@ describe Admin::ApiController do
 
         scopes = response.parsed_body['scopes']
 
-        expect(scopes.keys).to contain_exactly('topics', 'users', 'email', 'posts', 'uploads', 'global', 'badges')
+        expect(scopes.keys).to contain_exactly('topics', 'users', 'email', 'posts', 'uploads', 'global', 'badges', 'categories')
       end
     end
   end


### PR DESCRIPTION
This change adds support for the categories endpoint to have an api
scope. Only adds GET scope for listing categories and for fetching a
single category.

See: https://meta.discourse.org/t/218080/4

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
