### PR TITLE
DEV: Remove remnants of nginx-perf-report plugin

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -48,7 +48,6 @@ class Plugin::Metadata
     "discourse-math",
     "discourse-moderator-attention",
     "discourse-narrative-bot",
-    "discourse-nginx-performance-report",
     "discourse-no-bump",
     "discourse-oauth2-basic",
     "discourse-openid-connect",

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -6,7 +6,6 @@ desc 'install all official plugins (use GIT_WRITE=1 to pull with write access)'
 task 'plugin:install_all_official' do
   skip = Set.new([
     'customer-flair',
-    'discourse-nginx-performance-report',
     'lazy-yt',
     'poll'
   ])


### PR DESCRIPTION
The plugin is no longer official as of Nov 18, 2019 (e2ccb0c6082d7692a7bd7e4ecdd092d3e4811c61)