### PR TITLE
DEV: disallow theme-javascripts for crawler bots

### DIFF
--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -13,6 +13,7 @@ class RobotsTxtController < ApplicationController
     /assets/browser-update*.js
     /email/
     /session
+    /theme-javascripts/
     /user-api-key
     /*?api_key*
     /*?*api_key*


### PR DESCRIPTION
For crawlers there is a special static view and therefore no need for any JS.

This saves crawler ressources on:
+ number of urls/scripts to fetch
+ time spent loading/parsing/running scripts

See https://developers.google.com/search/docs/advanced/crawling/large-site-managing-crawl-budget?hl=en#improve_crawl_efficiency
"[…] the time needed to render pages, matters, including load and run time for embedded resources such as images and scripts."