### PR TITLE
FIX: prevents self-reference to discoveryTopics from discoveryTopics

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -15,14 +15,13 @@ import { action } from "@ember/object";
 
 const controllerOpts = {
   discovery: controller(),
-  discoveryTopics: controller("discovery/topics"),
   router: service(),
 
   period: null,
   canCreateTopicOnCategory: null,
 
   canStar: alias("currentUser.id"),
-  showTopicPostBadges: not("discoveryTopics.new"),
+  showTopicPostBadges: not("new"),
   redirectedReason: alias("currentUser.redirected_to_top.reason"),
 
   expandGloballyPinned: false,


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
