### PR TITLE
FIX: makes conditional-loading-spinner tagless

### DIFF
--- a/app/assets/javascripts/discourse/app/components/conditional-loading-spinner.js
+++ b/app/assets/javascripts/discourse/app/components/conditional-loading-spinner.js
@@ -2,11 +2,9 @@ import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
-  classNameBindings: [
-    ":loading-container",
-    "containerClass",
-    "condition:visible",
-  ],
+  tagName: "",
+  size: null,
+  condition: null,
 
   @discourseComputed("size")
   containerClass(size) {

--- a/app/assets/javascripts/discourse/app/templates/components/conditional-loading-spinner.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/conditional-loading-spinner.hbs
@@ -1,5 +1,7 @@
 {{#if condition}}
-  <div class="spinner {{size}}"></div>
+  <div class="loading-container {{containerClass}}">
+    <div class="spinner {{size}}"></div>
+  </div>
 {{else}}
   {{yield}}
 {{/if}}

--- a/app/assets/javascripts/discourse/tests/integration/components/conditional-loading-spinner-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/conditional-loading-spinner-test.js
@@ -1,0 +1,51 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  discourseModule,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+
+discourseModule(
+  "Integration | Component | conditional-loading-spinner",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("condition is true", {
+      template: hbs`
+        {{#conditional-loading-spinner condition=true}}
+        {{/conditional-loading-spinner}}
+      `,
+
+      async test(assert) {
+        assert.ok(exists(".loading-container"));
+        assert.ok(exists(".loading-container .spinner"));
+      },
+    });
+
+    componentTest("condition is false", {
+      template: hbs`
+        {{#conditional-loading-spinner condition=false}}
+          <b>test</b>
+        {{/conditional-loading-spinner}}
+      `,
+
+      async test(assert) {
+        assert.deepEqual(query("b").innerText, "test");
+      },
+    });
+
+    componentTest("size is small", {
+      template: hbs`
+        {{#conditional-loading-spinner condition=true size="small"}}
+        {{/conditional-loading-spinner}}
+      `,
+
+      async test(assert) {
+        assert.ok(exists(".loading-container.inline-spinner .spinner.small"));
+      },
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/integration/components/conditional-loading-spinner-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/conditional-loading-spinner-test.js
@@ -33,6 +33,7 @@ discourseModule(
       `,
 
       async test(assert) {
+        assert.notOk(exists(".loading-container"));
         assert.deepEqual(query("b").innerText, "test");
       },
     });


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
