### PR TITLE
FIX: Show 404 html on /posts/:id/raw and /p/:id

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -31,7 +31,7 @@ class PostsController < ApplicationController
   MARKDOWN_TOPIC_PAGE_SIZE ||= 100
 
   def markdown_id
-    markdown Post.find(params[:id].to_i)
+    markdown Post.find_by(id: params[:id].to_i)
   end
 
   def markdown_num
@@ -55,14 +55,6 @@ class PostsController < ApplicationController
         MD
       end
       render plain: content.join
-    end
-  end
-
-  def markdown(post)
-    if post && guardian.can_see?(post)
-      render plain: post.raw
-    else
-      raise Discourse::NotFound
     end
   end
 
@@ -168,10 +160,12 @@ class PostsController < ApplicationController
   end
 
   def short_link
-    post = Post.find(params[:post_id].to_i)
+    post = Post.find_by(id: params[:post_id].to_i)
+    raise Discourse::NotFound unless post
+
     # Stuff the user in the request object, because that's what IncomingLink wants
     if params[:user_id]
-      user = User.find(params[:user_id].to_i)
+      user = User.find_by(id: params[:user_id].to_i)
       request['u'] = user.username_lower if user
     end
 
@@ -628,6 +622,14 @@ class PostsController < ApplicationController
   end
 
   protected
+
+  def markdown(post)
+    if post && guardian.can_see?(post)
+      render plain: post.raw
+    else
+      raise Discourse::NotFound
+    end
+  end
 
   # We can't break the API for making posts. The new, queue supporting API
   # doesn't return the post as the root JSON object, but as a nested object.

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1925,6 +1925,12 @@ describe PostsController do
       expect(response.status).to eq(200)
       expect(response.body).to eq("123456789")
     end
+
+    it "renders a 404 page" do
+      get "/posts/0/raw"
+      expect(response.status).to eq(404)
+      expect(response.body).to include(I18n.t("page_not_found.title"))
+    end
   end
 
   describe '#markdown_num' do
@@ -1961,6 +1967,12 @@ describe PostsController do
       post = Fabricate(:private_message_post)
       get "/p/#{post.id}.json"
       expect(response).to be_forbidden
+    end
+
+    it "renders a 404 page" do
+      get "/p/0"
+      expect(response.status).to eq(404)
+      expect(response.body).to include(I18n.t("page_not_found.title"))
     end
   end
 


### PR DESCRIPTION
It returned a blank page before.