### PR TITLE
DEV: using send can be harmful, public_send is less risky

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -34,7 +34,7 @@ class Admin::SiteSettingsController < Admin::AdminController
     end
 
     update_existing_users = params[:update_existing_user].present?
-    previous_value = SiteSetting.send(id) || "" if update_existing_users
+    previous_value = SiteSetting.public_send(id) || "" if update_existing_users
 
     SiteSetting.set_and_log(id, value, current_user)
 


### PR DESCRIPTION
I can't see any harmful use case here, especially because only one param can be used ATM.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
