### PR TITLE
DEV: Deprecate /posts/:id/reply-ids/all

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -309,7 +309,7 @@ class PostsController < ApplicationController
   end
 
   def all_reply_ids
-    Discourse.deprecate("/posts/:id/reply-ids/all is deprecated.", drop_from: "3.0.0")
+    Discourse.deprecate("/posts/:id/reply-ids/all is deprecated.", drop_from: "3.0")
 
     post = find_post_from_params
     render json: post.reply_ids(guardian, only_replies_to_single_post: false).to_json

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -309,6 +309,8 @@ class PostsController < ApplicationController
   end
 
   def all_reply_ids
+    Discourse.deprecate("/posts/:id/reply-ids/all is deprecated.", drop_from: "3.0.0")
+
     post = find_post_from_params
     render json: post.reply_ids(guardian, only_replies_to_single_post: false).to_json
   end


### PR DESCRIPTION
It was added in https://github.com/discourse/discourse/commit/ed4c0c4a6385f1f238135f1a31140123ea259854 and its only use was removed in https://github.com/discourse/discourse/commit/b58867b6e936a5247304e9f06f827cf5012a92ed

Nothing in all-the* seems to be using this endpoint.