### PR TITLE
FIX: Only display the first listed price

### DIFF
--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -124,7 +124,7 @@ module Onebox
         elsif !raw.css("#priceblock_ourprice").inner_text.empty?
           raw.css("#priceblock_ourprice").inner_text
         else
-          result = raw.css('#corePrice_feature_div .a-price .a-offscreen').inner_text
+          result = raw.css('#corePrice_feature_div .a-price .a-offscreen').first&.inner_text
           if result.blank?
             result = raw.css(".mediaMatrixListItem.a-active .a-color-price").inner_text
           end


### PR DESCRIPTION
Multiple prices may be returned by Amazon (e.g. for new, and also for used). We should only display the first price.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
