### PR TITLE
DEV: Remove "empty" template code

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/initializers/live-development.js
@@ -51,10 +51,6 @@ export default {
     messageBus.subscribe(
       "/file-change",
       (data) => {
-        if (Handlebars.compile && !Ember.TEMPLATES.empty) {
-          // hbs notifications only happen in dev
-          Ember.TEMPLATES.empty = Handlebars.compile("<div></div>");
-        }
         data.forEach((me) => {
           if (me === "refresh") {
             // Refresh if necessary

--- a/app/assets/javascripts/discourse/app/initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/initializers/live-development.js
@@ -1,5 +1,4 @@
 import DiscourseURL from "discourse/lib/url";
-import Handlebars from "handlebars";
 import { isDevelopment } from "discourse-common/config/environment";
 
 //  Use the message bus for live reloading of components for faster development.


### PR DESCRIPTION
Its only use seems to have been removed back in 2016 in a9ed15e11ac11371ba3ab73fa571879e6c89259d.