### PR TITLE
DEV: Fix a flaky validation message

### DIFF
--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -166,7 +166,7 @@ module DiscourseTagging
           "tags.required_tags_from_group",
           count: category.min_tags_from_required_group,
           tag_group_name: category.required_tag_group.name,
-          tags: category.required_tag_group.tags.pluck(:name).join(", ")
+          tags: category.required_tag_group.tags.order(:id).pluck(:name).join(", ")
         )
       )
       false


### PR DESCRIPTION
The order of tags in the validation error message could be random, which we don't really care about, but it made the specs flake out once in a while.

The flaky specs were:

```
spec/lib/discourse_tagging_spec.rb:511
spec/lib/discourse_tagging_spec.rb:519
```