### PR TITLE
DEV: Disallow `Ember` global usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "currentURL": "off",
     "currentUser": "off",
     "Discourse": "off",
+    "Ember": "off",
     "exists": "off",
     "fillIn": "off",
     "find": "off",

--- a/app/assets/javascripts/app-boot.js
+++ b/app/assets/javascripts/app-boot.js
@@ -13,8 +13,10 @@
   ).__DISCOURSE_RAW_TEMPLATES;
 
   // required for addons to work without Ember CLI
+  // eslint-disable-next-line no-undef
   Object.keys(Ember.TEMPLATES).forEach((k) => {
     if (k.indexOf("select-kit") === 0) {
+      // eslint-disable-next-line no-undef
       let template = Ember.TEMPLATES[k];
       define(k, () => template);
     }

--- a/app/assets/javascripts/discourse-common/addon/config/environment.js
+++ b/app/assets/javascripts/discourse-common/addon/config/environment.js
@@ -11,10 +11,12 @@ export function setEnvironment(e) {
 }
 
 export function isTesting() {
+  // eslint-disable-next-line no-undef
   return Ember.testing || environment === "testing";
 }
 
 // Generally means "before we migrated to Ember CLI"
+// eslint-disable-next-line no-undef
 let _isLegacy = Ember.VERSION.startsWith("3.12");
 export function isLegacyEmber() {
   return _isLegacy;

--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import { classify, dasherize } from "@ember/string";
 import deprecated from "discourse-common/lib/deprecated";
 import { findHelper } from "discourse-common/lib/helpers";

--- a/app/assets/javascripts/discourse/app/components/discourse-root.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-root.js
@@ -2,7 +2,8 @@ import Component from "@ember/component";
 
 let componentArgs = { tagName: "div" };
 
-// TODO: Once we've moved to Ember CLI completely we can remove this.
+// TODO: Once we've moved to Ember CLI completely we can remove this block
+// eslint-disable-next-line no-undef
 if (!Ember.FEATURES.EMBER_GLIMMER_SET_COMPONENT_TEMPLATE) {
   componentArgs = { tagName: "" };
 }

--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.js
@@ -1,7 +1,9 @@
+import Component from "@ember/component";
 import {
   buildArgsWithDeprecations,
   renderedConnectorsFor,
 } from "discourse/lib/plugin-connectors";
+
 /**
    A plugin outlet is an extension point for templates where other templates can
    be inserted by plugins.
@@ -33,8 +35,6 @@ import {
    The list of disabled plugins is returned via the `Site` singleton.
 
 **/
-import Component from "@ember/component";
-
 export default Component.extend({
   tagName: "",
   connectorTagName: "",

--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -107,7 +107,9 @@ export default Component.extend({
     let dasherized = dasherize(type);
     let templatePath = `components/${dasherized}`;
     let template =
+      // eslint-disable-next-line no-undef
       Ember.TEMPLATES[`${templatePath}`] ||
+      // eslint-disable-next-line no-undef
       Ember.TEMPLATES[`javascripts/${templatePath}`];
     _components[type] = template ? dasherized : null;
     return _components[type];

--- a/app/assets/javascripts/discourse/app/initializers/ember-events.js
+++ b/app/assets/javascripts/discourse/app/initializers/ember-events.js
@@ -10,6 +10,7 @@ export default {
       return;
     }
 
+    // eslint-disable-next-line no-undef
     Ember.EventDispatcher.reopen({
       events: {
         touchend: "touchEnd",

--- a/app/assets/javascripts/discourse/app/initializers/ember-link-component-extension.js
+++ b/app/assets/javascripts/discourse/app/initializers/ember-link-component-extension.js
@@ -8,6 +8,7 @@ export default {
       return;
     }
 
+    // eslint-disable-next-line no-undef
     Ember.LinkComponent.reopen({
       attributeBindings: ["name"],
     });

--- a/app/assets/javascripts/discourse/app/lib/lightbox.js
+++ b/app/assets/javascripts/discourse/app/lib/lightbox.js
@@ -34,6 +34,7 @@ export default function (elem, siteSettings) {
       mainClass: "mfp-zoom-in",
       tClose: I18n.t("lightbox.close"),
       tLoading: spinnerHTML,
+      // eslint-disable-next-line no-undef
       prependTo: Ember.testing && document.getElementById("ember-testing"),
 
       gallery: {

--- a/app/assets/javascripts/discourse/app/lib/load-script.js
+++ b/app/assets/javascripts/discourse/app/lib/load-script.js
@@ -13,9 +13,9 @@ function loadWithTag(path, cb) {
   let finished = false;
   let s = document.createElement("script");
   s.src = path;
-  if (Ember.Test) {
-    Ember.Test.registerWaiter(() => finished);
-  }
+
+  // eslint-disable-next-line no-undef
+  Ember.Test?.registerWaiter(() => finished);
 
   s.onload = s.onreadystatechange = function (_, abort) {
     finished = true;

--- a/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
@@ -60,12 +60,14 @@ function findClass(outletName, uniqueName) {
 function buildConnectorCache() {
   _connectorCache = {};
 
+  // eslint-disable-next-line no-undef
   findOutlets(Ember.TEMPLATES, (outletName, resource, uniqueName) => {
     _connectorCache[outletName] = _connectorCache[outletName] || [];
 
     _connectorCache[outletName].push({
       outletName,
       templateName: resource.replace("javascripts/", ""),
+      // eslint-disable-next-line no-undef
       template: Ember.TEMPLATES[resource],
       classNames: `${outletName}-outlet ${uniqueName}`,
       connectorClass: findClass(outletName, uniqueName),

--- a/app/assets/javascripts/discourse/app/pre-initializers/theme-errors-handler.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/theme-errors-handler.js
@@ -51,6 +51,8 @@ function reportToLogster(name, error) {
     stacktrace: error.stack,
   };
 
+  // TODO: To be moved out into a logster-provided lib
+  // eslint-disable-next-line no-undef
   Ember.$.ajax(getURL("/logs/report_js_error"), {
     data,
     type: "POST",

--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -5,10 +5,12 @@ import { visit } from "@ember/test-helpers";
 
 acceptance("CustomHTML template", function (needs) {
   needs.hooks.beforeEach(() => {
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES["top"] = hbs`<span class='top-span'>TOP</span>`;
   });
 
   needs.hooks.afterEach(() => {
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES["top"];
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -53,6 +53,7 @@ acceptance("Modal", function (needs) {
     await triggerKeyEvent("#main-outlet", "keydown", 27);
     assert.ok(!exists(".d-modal:visible"), "ESC should close the modal");
 
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[
       "modal/not-dismissable"
     ] = hbs`{{#d-modal-body title="" class="" dismissable=false}}test{{/d-modal-body}}`;
@@ -77,6 +78,7 @@ acceptance("Modal", function (needs) {
   });
 
   test("rawTitle in modal panels", async function (assert) {
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES["modal/test-raw-title-panels"] = hbs``;
     const panels = [
       { id: "test1", rawTitle: "Test 1" },
@@ -95,7 +97,9 @@ acceptance("Modal", function (needs) {
   });
 
   test("modal title", async function (assert) {
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES["modal/test-title"] = hbs``;
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[
       "modal/test-title-with-body"
     ] = hbs`{{#d-modal-body}}test{{/d-modal-body}}`;

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -48,23 +48,29 @@ acceptance("Plugin Outlet - Connector Class", function (needs) {
       },
     });
 
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[
       `${PREFIX}/user-profile-primary/hello`
     ] = hbs`<span class='hello-username'>{{model.username}}</span>
         <button class='say-hello' {{action "sayHello"}}></button>
         <span class='hello-result'>{{hello}}</span>`;
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[
       `${PREFIX}/user-profile-primary/hi`
     ] = hbs`<button class='say-hi' {{action "sayHi"}}></button>
         <span class='hi-result'>{{hi}}</span>`;
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[
       `${PREFIX}/user-profile-primary/dont-render`
     ] = hbs`I'm not rendered!`;
   });
 
   needs.hooks.afterEach(() => {
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES[`${PREFIX}/user-profile-primary/hello`];
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES[`${PREFIX}/user-profile-primary/hi`];
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES[`${PREFIX}/user-profile-primary/dont-render`];
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -14,7 +14,9 @@ acceptance("Plugin Outlet - Decorator", function (needs) {
   needs.user();
 
   needs.hooks.beforeEach(() => {
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[`${PREFIX}/discovery-list-container-top/foo`] = hbs`FOO`;
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[`${PREFIX}/discovery-list-container-top/bar`] = hbs`BAR`;
 
     withPluginApi("0.8.38", (api) => {
@@ -37,7 +39,9 @@ acceptance("Plugin Outlet - Decorator", function (needs) {
   });
 
   needs.hooks.afterEach(() => {
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES[`${PREFIX}/discovery-list-container-top/foo`];
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES[`${PREFIX}/discovery-list-container-top/bar`];
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -15,12 +15,16 @@ const GOODBYE =
 acceptance("Plugin Outlet - Multi Template", function (needs) {
   needs.hooks.beforeEach(() => {
     clearCache();
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[HELLO] = hbs`<span class='hello-span'>Hello</span>`;
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[GOODBYE] = hbs`<span class='bye-span'>Goodbye</span>`;
   });
 
   needs.hooks.afterEach(() => {
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES[HELLO];
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES[GOODBYE];
     clearCache();
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -12,12 +12,14 @@ const CONNECTOR =
 
 acceptance("Plugin Outlet - Single Template", function (needs) {
   needs.hooks.beforeEach(() => {
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[
       CONNECTOR
     ] = hbs`<span class='hello-username'>{{model.username}}</span>`;
   });
 
   needs.hooks.afterEach(() => {
+    // eslint-disable-next-line no-undef
     delete Ember.TEMPLATES[CONNECTOR];
   });
 

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -18,6 +18,7 @@ document.addEventListener("discourse-booted", () => {
   let setupTests = require("discourse/tests/setup-tests").default;
   const skippingCore =
     new URLSearchParams(window.location.search).get("qunit_skip_core") === "1";
+  // eslint-disable-next-line no-undef
   Ember.ENV.LOG_STACKTRACE_ON_DEPRECATION = false;
 
   document.body.insertAdjacentHTML(

--- a/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
@@ -12,6 +12,7 @@ function lookupTemplate(assert, name, expectedTemplate, message) {
 
 function setTemplates(lookupTemplateStrings) {
   lookupTemplateStrings.forEach(function (lookupTemplateString) {
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES[lookupTemplateString] = lookupTemplateString;
   });
 }
@@ -20,13 +21,16 @@ const DiscourseResolver = buildResolver("discourse");
 
 module("Unit | Ember | resolver", function (hooks) {
   hooks.beforeEach(function () {
+    // eslint-disable-next-line no-undef
     originalTemplates = Ember.TEMPLATES;
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES = {};
 
     resolver = DiscourseResolver.create();
   });
 
   hooks.afterEach(function () {
+    // eslint-disable-next-line no-undef
     Ember.TEMPLATES = originalTemplates;
   });
 

--- a/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
@@ -66,6 +66,7 @@ discourseModule("Unit | Utils | decorators", function (hooks) {
     template: hbs`<NativeComponent @name="Jarek" />`,
 
     beforeEach() {
+      // eslint-disable-next-line no-undef
       Ember.TEMPLATES[
         "components/native-component"
       ] = hbs`<span class="native-component">{{this.text}}</span>`;
@@ -73,6 +74,7 @@ discourseModule("Unit | Utils | decorators", function (hooks) {
     },
 
     afterEach() {
+      // eslint-disable-next-line no-undef
       delete Ember.TEMPLATES["components/native-component"];
     },
 

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -20,6 +20,7 @@ define("ember-qunit", () => {
 define("htmlbars-inline-precompile", () => {
   return {
     default: function (str) {
+      // eslint-disable-next-line no-undef
       return Ember.HTMLBars.compile(str[0]);
     },
   };

--- a/app/assets/javascripts/wizard/test/test_helper.js
+++ b/app/assets/javascripts/wizard/test/test_helper.js
@@ -39,6 +39,7 @@ if (window.Logster) {
 } else {
   window.Logster = { enabled: false };
 }
+// eslint-disable-next-line no-undef
 Ember.Test.adapter = window.QUnitAdapter.create();
 
 let createPretendServer = requirejs(

--- a/app/assets/javascripts/wizard/wizard.js
+++ b/app/assets/javascripts/wizard/wizard.js
@@ -7,8 +7,10 @@ export default Application.extend({
 
   start() {
     // required for select kit to work without Ember CLI
+    // eslint-disable-next-line no-undef
     Object.keys(Ember.TEMPLATES).forEach((k) => {
       if (k.indexOf("select-kit") === 0) {
+        // eslint-disable-next-line no-undef
         let template = Ember.TEMPLATES[k];
         define(k, () => template);
       }

--- a/lib/javascripts/widget-hbs-compiler.js
+++ b/lib/javascripts/widget-hbs-compiler.js
@@ -281,6 +281,7 @@ class Compiler {
   }
 }
 
+// eslint-disable-next-line no-undef
 const loader = typeof Ember !== "undefined" ? Ember.__loader.require : require;
 
 function compile(template, glimmer) {
@@ -363,6 +364,7 @@ const WidgetHbsCompiler = function (babel) {
             compile(template, WidgetHbsCompiler.glimmer)
           );
         } catch (e) {
+          // eslint-disable-next-line no-console
           console.error("widget hbs error", e.toString());
           return error(path, state, e.toString());
         }

--- a/plugins/styleguide/assets/javascripts/discourse/lib/styleguide.js
+++ b/plugins/styleguide/assets/javascripts/discourse/lib/styleguide.js
@@ -29,6 +29,7 @@ export function allCategories() {
   let paths = CATEGORIES.join("|");
 
   // Find a list of sections based on what templates are available
+  // eslint-disable-next-line no-undef
   Object.keys(Ember.TEMPLATES).forEach((e) => {
     let regexp = new RegExp(`styleguide\/(${paths})\/(\\d+)?\\-?([^\\/]+)$`);
     let matches = e.match(regexp);


### PR DESCRIPTION
…and sprinkle `// eslint-disable-next-line no-undef` throughout the code where is unavoidable for now 👀 

(this is in preparation for the linting config bump)