### PR TITLE
DEV: Don't mutate `Excon.defaults[:middlewares]`

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -202,7 +202,7 @@ class FinalDestination
     end
 
     headers = request_headers
-    middlewares = Excon.defaults[:middlewares]
+    middlewares = Excon.defaults[:middlewares].dup
     middlewares << Excon::Middleware::Decompress if @http_verb == :get
 
     request_start_time = Time.now


### PR DESCRIPTION
`Excon.defaults` and its middlewares array are constants that we shouldn't mutate everytime `FinalDestination#resolve` is called.