### PR TITLE
FIX: Update group inbox notifications on archive/unarchive

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -596,6 +596,9 @@ class TopicsController < ApplicationController
       else
         UserArchivedMessage.move_to_inbox!(current_user.id, topic)
       end
+
+      current_user.reload
+      current_user.publish_notifications_state
     end
 
     if group_id

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -596,9 +596,6 @@ class TopicsController < ApplicationController
       else
         UserArchivedMessage.move_to_inbox!(current_user.id, topic)
       end
-
-      current_user.reload
-      current_user.publish_notifications_state
     end
 
     if group_id

--- a/app/jobs/regular/group_pm_alert.rb
+++ b/app/jobs/regular/group_pm_alert.rb
@@ -16,7 +16,7 @@ module Jobs
         "group_users.notification_level = :level",
         level: NotificationLevels.all[:tracking]
       ).find_each do |u|
-        alerter.notify_group_summary(u, post)
+        alerter.notify_group_summary(u, topic)
       end
 
       notification_data = {

--- a/app/jobs/regular/group_pm_update_summary.rb
+++ b/app/jobs/regular/group_pm_update_summary.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Jobs
+  class GroupPmUpdateSummary < ::Jobs::Base
+    def execute(args)
+      return unless group = Group.find_by(id: args[:group_id])
+      return unless topic = Topic.find_by(id: args[:topic_id])
+
+      group.set_message_default_notification_levels!(topic, ignore_existing: true)
+
+      alerter = PostAlerter.new
+
+      group.users.where(
+        "group_users.notification_level = :level",
+        level: NotificationLevels.all[:tracking]
+      ).find_each do |u|
+        alerter.notify_group_summary(u, topic)
+      end
+
+    end
+  end
+end

--- a/app/jobs/regular/group_pm_update_summary.rb
+++ b/app/jobs/regular/group_pm_update_summary.rb
@@ -14,7 +14,7 @@ module Jobs
         "group_users.notification_level = :level",
         level: NotificationLevels.all[:tracking]
       ).find_each do |u|
-        alerter.notify_group_summary(u, topic)
+        alerter.notify_group_summary(u, topic, acting_user_id: args[:acting_user_id])
       end
 
     end

--- a/app/models/group_archived_message.rb
+++ b/app/models/group_archived_message.rb
@@ -11,7 +11,12 @@ class GroupArchivedMessage < ActiveRecord::Base
     MessageBus.publish("/topic/#{topic_id}", { type: "move_to_inbox" }, group_ids: [group_id])
     publish_topic_tracking_state(topic, group_id, opts[:acting_user_id])
     set_imap_sync(topic_id) if !opts[:skip_imap_sync] && destroyed.present?
-    Jobs.enqueue(:group_pm_update_summary, group_id: group_id, topic_id: topic_id)
+    Jobs.enqueue(
+      :group_pm_update_summary,
+      group_id: group_id,
+      topic_id: topic_id,
+      acting_user_id: opts[:acting_user_id]
+    )
   end
 
   def self.archive!(group_id, topic, opts = {})
@@ -22,7 +27,12 @@ class GroupArchivedMessage < ActiveRecord::Base
     MessageBus.publish("/topic/#{topic_id}", { type: "archived" }, group_ids: [group_id])
     publish_topic_tracking_state(topic, group_id, opts[:acting_user_id])
     set_imap_sync(topic_id) if !opts[:skip_imap_sync] && destroyed.blank?
-    Jobs.enqueue(:group_pm_update_summary, group_id: group_id, topic_id: topic_id)
+    Jobs.enqueue(
+      :group_pm_update_summary,
+      group_id: group_id,
+      topic_id: topic_id,
+      acting_user_id: opts[:acting_user_id]
+    )
   end
 
   def self.trigger(event, group_id, topic_id)

--- a/app/models/group_archived_message.rb
+++ b/app/models/group_archived_message.rb
@@ -11,6 +11,7 @@ class GroupArchivedMessage < ActiveRecord::Base
     MessageBus.publish("/topic/#{topic_id}", { type: "move_to_inbox" }, group_ids: [group_id])
     publish_topic_tracking_state(topic, group_id, opts[:acting_user_id])
     set_imap_sync(topic_id) if !opts[:skip_imap_sync] && destroyed.present?
+    Jobs.enqueue(:group_pm_update_summary, group_id: group_id, topic_id: topic_id)
   end
 
   def self.archive!(group_id, topic, opts = {})
@@ -21,6 +22,7 @@ class GroupArchivedMessage < ActiveRecord::Base
     MessageBus.publish("/topic/#{topic_id}", { type: "archived" }, group_ids: [group_id])
     publish_topic_tracking_state(topic, group_id, opts[:acting_user_id])
     set_imap_sync(topic_id) if !opts[:skip_imap_sync] && destroyed.blank?
+    Jobs.enqueue(:group_pm_update_summary, group_id: group_id, topic_id: topic_id)
   end
 
   def self.trigger(event, group_id, topic_id)

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -315,7 +315,7 @@ class PostAlerter
     end
   end
 
-  def notify_group_summary(user, topic)
+  def notify_group_summary(user, topic, acting_user_id: nil)
     @group_stats ||= {}
     stats = (@group_stats[topic.id] ||= group_stats(topic))
     return unless stats
@@ -333,6 +333,7 @@ class PostAlerter
         Notification.consolidate_or_create!(
           notification_type: Notification.types[:group_message_summary],
           user_id: user.id,
+          read: user.id === acting_user_id ? true : false,
           data: {
             group_id: stat[:group_id],
             group_name: stat[:group_name],

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -140,16 +140,18 @@ describe PostAlerter do
         expect(updated_payload["group_name"]).to eq(group.name)
         expect(updated_payload["inbox_count"]).to eq(2)
 
-        # archiving the second PM updates the group summary count
-        GroupArchivedMessage.archive!(group.id, pm2)
+        # archiving the second PM quietly updates the group summary count for the acting user
+        GroupArchivedMessage.archive!(group.id, pm2, acting_user_id: user2.id)
         group_summary_notification = Notification.where(user_id: user2.id)
+        expect(group_summary_notification.first.read).to eq(true)
         updated_payload = JSON.parse(group_summary_notification.first.data)
 
         expect(updated_payload["inbox_count"]).to eq(1)
 
-        # moving to inbox the second PM updates the group summary count
-        GroupArchivedMessage.move_to_inbox!(group.id, pm2)
+        # moving to inbox the second PM quietly updates the group summary count for the acting user
+        GroupArchivedMessage.move_to_inbox!(group.id, pm2, acting_user_id: user2.id)
         group_summary_notification = Notification.where(user_id: user2.id)
+        expect(group_summary_notification.first.read).to eq(true)
         updated_payload = JSON.parse(group_summary_notification.first.data)
 
         expect(updated_payload["group_name"]).to eq(group.name)

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -86,7 +86,7 @@ describe PostAlerter do
     context "group inboxes" do
       fab!(:user1) { Fabricate(:user) }
       fab!(:user2) { Fabricate(:user) }
-      fab!(:group) { Fabricate(:group, users: [user2], name: "TestGroup") }
+      fab!(:group) { Fabricate(:group, users: [user2], name: "TestGroup", default_notification_level: 2) }
       fab!(:pm) { Fabricate(:topic, archetype: 'private_message', category_id: nil, allowed_groups: [group]) }
       fab!(:op) { Fabricate(:post, user: pm.user, topic: pm) }
 
@@ -102,6 +102,7 @@ describe PostAlerter do
       end
 
       it "triggers group summary notification" do
+        Jobs.run_immediately!
         TopicUser.change(user2.id, pm.id, notification_level: TopicUser.notification_levels[:tracking])
 
         PostAlerter.post_created(op)
@@ -112,6 +113,47 @@ describe PostAlerter do
 
         notification_payload = JSON.parse(group_summary_notification.first.data)
         expect(notification_payload["group_name"]).to eq(group.name)
+        expect(notification_payload["inbox_count"]).to eq(1)
+
+        # archiving the only PM clears the group summary notification
+        GroupArchivedMessage.archive!(group.id, pm)
+        expect(Notification.where(user_id: user2.id)).to be_blank
+
+        # moving to inbox the only PM restores the group summary notification
+        GroupArchivedMessage.move_to_inbox!(group.id, pm)
+        group_summary_notification = Notification.where(user_id: user2.id)
+        expect(group_summary_notification.first.notification_type).to eq(Notification.types[:group_message_summary])
+
+        updated_payload = JSON.parse(group_summary_notification.first.data)
+        expect(updated_payload["group_name"]).to eq(group.name)
+        expect(updated_payload["inbox_count"]).to eq(1)
+
+        # adding a second PM updates the count
+        pm2 = Fabricate(:topic, archetype: 'private_message', category_id: nil, allowed_groups: [group])
+        op2 = Fabricate(:post, user: pm2.user, topic: pm2)
+        TopicUser.change(user2.id, pm2.id, notification_level: TopicUser.notification_levels[:tracking])
+
+        PostAlerter.post_created(op2)
+        group_summary_notification = Notification.where(user_id: user2.id)
+        updated_payload = JSON.parse(group_summary_notification.first.data)
+
+        expect(updated_payload["group_name"]).to eq(group.name)
+        expect(updated_payload["inbox_count"]).to eq(2)
+
+        # archiving the second PM updates the group summary count
+        GroupArchivedMessage.archive!(group.id, pm2)
+        group_summary_notification = Notification.where(user_id: user2.id)
+        updated_payload = JSON.parse(group_summary_notification.first.data)
+
+        expect(updated_payload["inbox_count"]).to eq(1)
+
+        # moving to inbox the second PM updates the group summary count
+        GroupArchivedMessage.move_to_inbox!(group.id, pm2)
+        group_summary_notification = Notification.where(user_id: user2.id)
+        updated_payload = JSON.parse(group_summary_notification.first.data)
+
+        expect(updated_payload["group_name"]).to eq(group.name)
+        expect(updated_payload["inbox_count"]).to eq(2)
       end
 
       it 'updates the consolidated group summary inbox count and bumps the notification' do
@@ -168,7 +210,7 @@ describe PostAlerter do
         }.to change(user1.notifications, :count).by(1)
       end
 
-      it 'nofies a group member if someone quotes their post' do
+      it 'notifies a group member if someone quotes their post' do
         group.add(user1)
 
         post = Fabricate(:post, topic: pm, user: user1)


### PR DESCRIPTION
This fixes an issue with group inbox counts going stale. The issue was raised in https://meta.discourse.org/t/ios-app-admins-notice-not-updating/202350 but can also be reproduced more generally with group inboxes. Because we don't publish notifications when a group inbox PM is archived/unarchived currently, the "N messages in your ... inbox" notification goes out of sync until a new reply triggers a refresh for all subscribed users. 

This PR fixes most of these issues by updating the group summary notification when group inbox PMs are archived/unarchived.  If the group inbox is empty, all summary notifications are deleted (this fixes the original issue in the meta topic). If the group inbox is not empty, the `inbox_count` is updated. And for the acting user the summary notification is marked as read given that archiving/unarchiving redirects the user to the group inbox. 

Note that this will result in a bit more notification activity for non-acting users that are tracking the group inbox. The inbox notification bubble will get triggered more often. But I think it's a fin price to pay in exchange for better count accuracy. 