### PR TITLE
DEV: output sitelinks search tag on homepage only

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -333,17 +333,19 @@ module ApplicationHelper
   end
 
   def render_sitelinks_search_tag
-    json = {
-      '@context' => 'http://schema.org',
-      '@type' => 'WebSite',
-      url: Discourse.base_url,
-      potentialAction: {
-        '@type' => 'SearchAction',
-        target: "#{Discourse.base_url}/search?q={search_term_string}",
-        'query-input' => 'required name=search_term_string',
+    if current_page?('/') || current_page?(Discourse.base_path)
+      json = {
+        '@context' => 'http://schema.org',
+        '@type' => 'WebSite',
+        url: Discourse.base_url,
+        potentialAction: {
+          '@type' => 'SearchAction',
+          target: "#{Discourse.base_url}/search?q={search_term_string}",
+          'query-input' => 'required name=search_term_string',
+        }
       }
-    }
-    content_tag(:script, MultiJson.dump(json).html_safe, type: 'application/ld+json')
+      content_tag(:script, MultiJson.dump(json).html_safe, type: 'application/ld+json')
+    end
   end
 
   def gsub_emoji_to_unicode(str)

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -12,7 +12,7 @@
 <meta name="discourse-base-uri" content="<%= Discourse.base_path %>">
 <% end %>
 <%= canonical_link_tag %>
-<%- if current_page?('/') || current_page?("#{Discourse.base_path}") %>
+<%- if current_page?('/') || current_page?(Discourse.base_path) %>
 <%= render_sitelinks_search_tag %>
 <%- end %>
 <link rel="search" type="application/opensearchdescription+xml" href="<%= Discourse.base_url %>/opensearch.xml" title="<%= SiteSetting.title %> Search">

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -12,5 +12,7 @@
 <meta name="discourse-base-uri" content="<%= Discourse.base_path %>">
 <% end %>
 <%= canonical_link_tag %>
+<%- if current_page?('/') || current_page?("#{Discourse.base_path}") %>
 <%= render_sitelinks_search_tag %>
+<%- end %>
 <link rel="search" type="application/opensearchdescription+xml" href="<%= Discourse.base_url %>/opensearch.xml" title="<%= SiteSetting.title %> Search">

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -12,7 +12,5 @@
 <meta name="discourse-base-uri" content="<%= Discourse.base_path %>">
 <% end %>
 <%= canonical_link_tag %>
-<%- if current_page?('/') || current_page?(Discourse.base_path) %>
 <%= render_sitelinks_search_tag %>
-<%- end %>
 <link rel="search" type="application/opensearchdescription+xml" href="<%= Discourse.base_url %>/opensearch.xml" title="<%= SiteSetting.title %> Search">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -87,6 +87,45 @@ describe ApplicationHelper do
     end
   end
 
+  describe "render_sitelinks_search_tag" do
+    context "for non-subfolder install" do
+      context "when on homepage" do
+        it "will return sitelinks search tag" do
+          helper.stubs(:current_page?).returns(false)
+          helper.stubs(:current_page?).with('/').returns(true)
+          expect(helper.render_sitelinks_search_tag).to include('"@type":"SearchAction"')
+        end
+      end
+      context "when not on homepage" do
+        it "will not return sitelinks search tag" do
+          helper.stubs(:current_page?).returns(true)
+          helper.stubs(:current_page?).with('/').returns(false)
+          helper.stubs(:current_page?).with(Discourse.base_path).returns(false)
+          expect(helper.render_sitelinks_search_tag).to be_nil
+        end
+      end
+    end
+    context "for subfolder install" do
+      context "when on homepage" do
+        it "will return sitelinks search tag" do
+          Discourse.stubs(:base_path).returns('/subfolder-base-path/')
+          helper.stubs(:current_page?).returns(false)
+          helper.stubs(:current_page?).with(Discourse.base_path).returns(true)
+          expect(helper.render_sitelinks_search_tag).to include('"@type":"SearchAction"')
+        end
+      end
+      context "when not on homepage" do
+        it "will not return sitelinks search tag" do
+          Discourse.stubs(:base_path).returns('/subfolder-base-path/')
+          helper.stubs(:current_page?).returns(true)
+          helper.stubs(:current_page?).with('/').returns(false)
+          helper.stubs(:current_page?).with(Discourse.base_path).returns(false)
+          expect(helper.render_sitelinks_search_tag).to be_nil
+        end
+      end
+    end
+  end
+
   describe "application_logo_url" do
     context "when a dark color scheme is active" do
       before do


### PR DESCRIPTION
Without this change the structured data element on every *subpage* declares the *homepage-url* instead of *subpage-url*.

See https://developers.google.com/search/docs/advanced/structured-data/sitelinks-searchbox?hl=en#adding-structured-data
> 2. Implement the WebSite structured data element **on the homepage** for your site.
> - Add this markup **only** to the homepage, **not to any other pages**.

Discussion on [meta.discourse.org](https://meta.discourse.org/t/remove-wrong-structured-data-from-every-subpage-add-sitelinks-search-box-to-the-homepage-only/219299)
