### PR TITLE
FIX: Enable used PostgreSQL extensions during `db:migrate`

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -215,6 +215,8 @@ task 'db:migrate' => ['load_config', 'environment', 'set_locale'] do |_, args|
     raise "Migration #{migrations.last.version} is timestamped in the future" if migrations.last.version > now_timestamp
     raise "Migration #{migrations.first.version} is timestamped before the epoch" if migrations.first.version < epoch_timestamp
 
+    %i[pg_trgm unaccent].each { |extension| DB.exec "CREATE EXTENSION IF NOT EXISTS #{extension}" }
+
     ActiveRecord::Tasks::DatabaseTasks.migrate
 
     if !Discourse.is_parallel_test?


### PR DESCRIPTION
Enabled extensions are not saved in backups and thus not re-enabled
after a backup was restored.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
