### PR TITLE
DEV: Fix rake qunit logging

### DIFF
--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -109,16 +109,12 @@ async function runAllTests() {
     const message = response["args"][0].value;
 
     // Not finished yet, don't add a newline
-    if (message && message.startsWith && message.startsWith("↪")) {
+    if (message?.startsWith?.("↪")) {
       process.stdout.write(message);
-    } else if (
-      message &&
-      message.startsWith &&
-      message.startsWith("AUTOSPEC:")
-    ) {
+    } else if (message?.startsWith?.("AUTOSPEC:")) {
       fs.appendFileSync(QUNIT_RESULT, `${message.slice(10)}\n`);
     } else {
-      console.log(message);
+      console.log(...response["args"].map((m) => m.value));
     }
   });
 


### PR DESCRIPTION
It was logging just the first passed object, which resulted printing out empty lines instead of actual messages (e.g. deprecation warnings)