### PR TITLE
Remove a few words for clarity

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1421,7 +1421,7 @@ en:
       labels:
         user: User
         qtt_like: Likes Received
-      description: "Top 10 users who have been received more likes."
+      description: "Top 10 users who have received likes."
     top_users_by_likes_received_from_inferior_trust_level:
       title: "Top Users by likes received from a user with a lower trust level"
       labels:
@@ -1434,7 +1434,7 @@ en:
       labels:
         user: User
         qtt_like: Likes Received
-      description: "Top 10 users who have had the likes from a wide range of people."
+      description: "Top 10 users who have had likes from a wide range of people."
 
   dashboard:
     group_email_credentials_warning: 'There was an issue with the email credentials for the group <a href="%{base_path}/g/%{group_name}/manage/email">%{group_full_name}</a>. No emails will send from the group inbox until this problem is addressed. %{error}'


### PR DESCRIPTION
Remove extra words from two descriptions for user like reports

I noticed wording in the screenshot shared at https://meta.discourse.org/t/trust-level-wishlist-items/141349/21?u=maiki, and I don't think these changes require tests.

After clearing removing a couple of words from the description for top_users_by_likes_received I think it deserves a better description, but my brain can't think of anything so I leave it as a consideration for others. ^_^