### PR TITLE
UX: Allow d-editor to be shrunk

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -24,6 +24,7 @@
   background-color: var(--secondary);
   position: relative;
   border: 1px solid var(--primary-medium);
+  min-height: 0;
 
   textarea {
     background: transparent;


### PR DESCRIPTION
…e.g. when resizing the composer. Previously it wouldn't go below a certain size and would overlap the element below it.