### PR TITLE
UX: Tweak the "new" badge size, position, color

### DIFF
--- a/app/assets/stylesheets/common/components/badges.scss
+++ b/app/assets/stylesheets/common/components/badges.scss
@@ -192,10 +192,10 @@
 
   &.new-topic::before {
     content: "";
-    background: var(--tertiary-high);
+    background: var(--tertiary-med-or-tertiary);
     display: inline-block;
-    height: 0.4em;
-    width: 0.4em;
+    height: 8px;
+    width: 8px;
     border-radius: 50%;
   }
 

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -55,9 +55,10 @@
   .badge-notification {
     position: relative;
     top: -2px;
+
     &.new-topic {
       top: -1px;
-      padding-left: 5px;
+      padding-left: 2px;
     }
   }
 


### PR DESCRIPTION
Before / After
<img width="490" alt="Screen Shot 2022-03-12 at 13 19 55" src="https://user-images.githubusercontent.com/66961/158017855-bad8a5ab-f5de-4824-a5cc-e7f222c4f278.png">
<img width="490" alt="Screen Shot 2022-03-12 at 13 19 29" src="https://user-images.githubusercontent.com/66961/158017860-ad8f5663-b5ec-487f-95d3-56076add4c6e.png">

