### PR TITLE
FIX: small J/K post stream navigation inconsistency

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -661,8 +661,8 @@ export default {
         .toArray()
         .find((article) =>
           direction > 0
-            ? article.getBoundingClientRect().top > offset
-            : article.getBoundingClientRect().bottom > offset
+            ? article.getBoundingClientRect().top >= offset
+            : article.getBoundingClientRect().bottom >= offset
         );
       if (!$selected) {
         $selected = $articles[$articles.length - 1];

--- a/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/keyboard-shortcuts-test.js
@@ -48,6 +48,27 @@ acceptance("Keyboard Shortcuts - Anonymous Users", function (needs) {
     await triggerKeyEvent(document, "keypress", "s".charCodeAt(0));
     assert.strictEqual(currentURL(), "/t/keyboard-shortcuts-are-awesome/27331");
   });
+
+  test("j/k navigation moves selection up/down", async function (assert) {
+    await visit("/t/this-is-a-test-topic/9");
+    await triggerKeyEvent(document, "keypress", "j".charCodeAt(0));
+    assert.ok(
+      exists(".post-stream .topic-post.selected #post_1"),
+      "first post is selected"
+    );
+
+    await triggerKeyEvent(document, "keypress", "j".charCodeAt(0));
+    assert.ok(
+      exists(".post-stream .topic-post.selected #post_2"),
+      "pressing j moves selection to next post"
+    );
+
+    await triggerKeyEvent(document, "keypress", "k".charCodeAt(0));
+    assert.ok(
+      exists(".post-stream .topic-post.selected #post_1"),
+      "pressing k moves selection to previous post"
+    );
+  });
 });
 
 acceptance("Keyboard Shortcuts - Authenticated Users", function (needs) {


### PR DESCRIPTION
This fixes a small inconsistent issue here pressing J/K at first would select the next (using J) or the previous (using K) post because the post that should have been selected was positioned exactly at the header offset. 

Because we can't correctly measure the header offset in test environments, we can't add a test for exactly this case. That said, I noticed that we had no tests at all for J/K navigation, so I added one. 