### PR TITLE
DEV: Use the --no-rebase option of `git pull`

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -102,7 +102,7 @@ task 'plugin:update', :plugin do |t, args|
     `git -C '#{plugin_path}' branch -u origin/main main`
   end
 
-  update_status = system("git -C '#{plugin_path}' pull")
+  update_status = system("git -C '#{plugin_path}' pull --no-rebase")
   abort("Unable to pull latest version of plugin #{plugin_path}") unless update_status
 end
 


### PR DESCRIPTION
…to avoid repeatedly printed notes:

```
hint: Pulling without specifying how to reconcile divergent branches is
hint: discouraged. You can squelch this message by running one of the following
hint: commands sometime before your next pull:
hint:
hint:   git config pull.rebase false  # merge (the default strategy)
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint:
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
