### PR TITLE
UX: Hide group avatar flair if it's empty

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -9,16 +9,16 @@
 
   <div class="group-details-container">
     <div class="group-info">
-      <div class="group-avatar-flair">
-        {{#if (or model.flair_icon model.flair_url model.flair_bg_color)}}
+      {{#if (or model.flair_icon model.flair_url model.flair_bg_color)}}
+        <div class="group-avatar-flair">
           {{avatar-flair
             flairName=model.name
             flairUrl=(or model.flair_icon model.flair_url)
             flairBgColor=model.flair_bg_color
             flairColor=model.flair_color
           }}
-        {{/if}}
-      </div>
+        </div>
+      {{/if}}
 
       <div class="group-info-names">
         <span class="group-info-name">{{groupName}}</span>


### PR DESCRIPTION
There's an extra space on the group info name causing misalignment with the content below.

### Before
<img width="352" alt="image" src="https://user-images.githubusercontent.com/2790986/158217637-14ff9a00-5171-48fc-83df-872251962424.png">

### After
<img width="359" alt="image" src="https://user-images.githubusercontent.com/2790986/158217527-c94e8e7f-4993-4f9d-9f67-c6250fe7986a.png">
