### PR TITLE
FIX: Always include the first poster when converting to PM

### DIFF
--- a/app/models/topic_converter.rb
+++ b/app/models/topic_converter.rb
@@ -63,7 +63,7 @@ class TopicConverter
   private
 
   def posters
-    @posters ||= @topic.posts.where("post_number > 1").distinct.pluck(:user_id)
+    @posters ||= @topic.posts.distinct.pluck(:user_id)
   end
 
   def increment_users_post_count

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -200,6 +200,11 @@ describe TopicConverter do
         expect(private_message.topic_allowed_users.count).to eq(1)
       end
 
+      it "includes the poster of a single-post topic" do
+        moderator = Fabricate(:moderator)
+        private_message = topic.convert_to_private_message(moderator)
+        expect(private_message.allowed_users).to match_array([topic.user, moderator])
+      end
     end
 
     context 'topic has replies' do


### PR DESCRIPTION
Regressed in #15626