### PR TITLE
PERF: Fix n+1 for categories + featured topics

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -62,7 +62,7 @@ class CategoryList
 
     category_featured_topics = CategoryFeaturedTopic.select([:category_id, :topic_id]).order(:rank)
 
-    @all_topics = Topic.where(id: category_featured_topics.map(&:topic_id))
+    @all_topics = Topic.where(id: category_featured_topics.map(&:topic_id)).includes(:shared_draft, :category)
 
     if @guardian.authenticated?
       @all_topics = @all_topics

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -181,4 +181,17 @@ module Helpers
     target.send(:remove_const, const)
     target.const_set(const, old)
   end
+
+  def track_sql_queries
+    queries = []
+    callback = ->(*, payload) {
+      queries << payload.fetch(:sql) unless ["CACHE", "SCHEMA"].include?(payload.fetch(:name))
+    }
+
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      yield
+    end
+
+    queries
+  end
 end


### PR DESCRIPTION
`topic.featured_topic` and `topic.category` are used by `TopicGuardian#can_see_topic?`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
