### PR TITLE
DEV: Don't install plugin gems twice

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -127,7 +127,6 @@ end
 
 desc 'pull a compatible plugin version'
 task 'plugin:pull_compatible', :plugin do |t, args|
-
   plugin = ENV['PLUGIN'] || ENV['plugin'] || args[:plugin]
   plugin_path = plugin
   plugin = File.basename(plugin)
@@ -154,26 +153,18 @@ end
 
 desc 'install all plugin gems'
 task 'plugin:install_all_gems' do |t|
-  plugins = Dir.glob(File.expand_path('plugins/*')).select { |f| File.directory? f }
-  plugins.each do |plugin|
-    Rake::Task['plugin:install_gems'].invoke(plugin)
-    Rake::Task['plugin:install_gems'].reenable
-  end
+  # Left intentionally blank.
+  # When the app is being loaded, all missing gems are installed
+  # See: lib/plugin_gem.rb
+  puts "Done"
 end
 
 desc 'install plugin gems'
 task 'plugin:install_gems', :plugin do |t, args|
-  plugin = ENV['PLUGIN'] || ENV['plugin'] || args[:plugin]
-  plugin_path = plugin + "/plugin.rb"
-
-  if File.file?(plugin_path)
-    File.open(plugin_path).each do |l|
-      next if !l.start_with? "gem"
-      next unless /gem\s['"](.*)['"],\s['"](.*)['"]/.match(l)
-      puts "gem install #{$1} -v #{$2} -i #{plugin}/gems/#{RUBY_VERSION} --no-document --ignore-dependencies --no-user-install"
-      system("gem install #{$1} -v #{$2} -i #{plugin}/gems/#{RUBY_VERSION} --no-document --ignore-dependencies --no-user-install")
-    end
-  end
+  # Left intentionally blank.
+  # When the app is being loaded, all missing gems are installed
+  # See: lib/plugin_gem.rb
+  puts "Done"
 end
 
 desc 'run plugin specs'


### PR DESCRIPTION
Missing plugin gems are installed when the app is being loaded.

That means when you run `bin/rails plugin:install_all_gems` it first installs missing gems and then reinstalls all gems…

Also, the method these rake tasks were using to install gems was very crude, and the regex there was incorrect which resulted in failures in certain cases. Though that didn't matter since those gems were being installed using a correct method just moments before…