### PR TITLE
DEV: Stop full-reloading on SCSS changes locally

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -15,6 +15,8 @@ module.exports = function (defaults) {
   let vendorJs = discourseRoot + "/vendor/assets/javascripts/";
 
   const isProduction = EmberApp.env().includes("production");
+  const isTest = EmberApp.env().includes("test");
+
   let app = new EmberApp(defaults, {
     autoRun: false,
     "ember-qunit": {
@@ -91,7 +93,15 @@ module.exports = function (defaults) {
       sourceMapConfig: false,
     });
 
-    return mergeTrees([tests, testHelpers]);
+    if (isTest) {
+      return mergeTrees([
+        tests,
+        testHelpers,
+        discourseScss(`${discourseRoot}/app/assets/stylesheets`, "testem.scss"),
+      ]);
+    } else {
+      return mergeTrees([tests, testHelpers]);
+    }
   };
 
   // WARNING: We should only import scripts here if they are not in NPM.
@@ -110,7 +120,6 @@ module.exports = function (defaults) {
   );
 
   const mergedTree = mergeTrees([
-    discourseScss(`${discourseRoot}/app/assets/stylesheets`, "testem.scss"),
     createI18nTree(discourseRoot, vendorJs),
     app.toTree(),
     funnel(`${discourseRoot}/public/javascripts`, { destDir: "javascripts" }),


### PR DESCRIPTION
The `testem.scss` include triggers a full reload locally. We need these styles only when running `ember test --server`, so this PR switches to loading that stylesheet in the test environment only.
