### PR TITLE
DEV: Support `registerWaiter` import in legacy env

### DIFF
--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -164,6 +164,10 @@ var define, requirejs;
       "@ember/object/internals": {
         guidFor: Ember.guidFor,
       },
+      "@ember/test": {
+        registerWaiter: Ember.Test.registerWaiter,
+        unregisterWaiter: Ember.Test.unregisterWaiter,
+      },
       I18n: {
         // eslint-disable-next-line
         default: I18n,

--- a/app/assets/javascripts/discourse/app/lib/load-script.js
+++ b/app/assets/javascripts/discourse/app/lib/load-script.js
@@ -3,6 +3,8 @@ import { PUBLIC_JS_VERSIONS } from "discourse/lib/public-js-versions";
 import { Promise } from "rsvp";
 import { ajax } from "discourse/lib/ajax";
 import { run } from "@ember/runloop";
+import { isTesting } from "discourse-common/config/environment";
+import { registerWaiter } from "@ember/test";
 
 const _loaded = {};
 const _loading = {};
@@ -14,8 +16,9 @@ function loadWithTag(path, cb) {
   let s = document.createElement("script");
   s.src = path;
 
-  // eslint-disable-next-line no-undef
-  Ember.Test?.registerWaiter(() => finished);
+  if (isTesting()) {
+    registerWaiter(() => finished);
+  }
 
   s.onload = s.onreadystatechange = function (_, abort) {
     finished = true;

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -49,8 +49,6 @@ define("@ember/test-helpers", () => {
     "fillIn",
     "setResolver",
     "triggerEvent",
-    "registerWaiter",
-    "unregisterWaiter",
   ].forEach((attr) => {
     helpers[attr] = function () {
       return window[attr](...arguments);

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -49,6 +49,7 @@ define("@ember/test-helpers", () => {
     "fillIn",
     "setResolver",
     "triggerEvent",
+    "registerWaiter",
   ].forEach((attr) => {
     helpers[attr] = function () {
       return window[attr](...arguments);

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -50,6 +50,7 @@ define("@ember/test-helpers", () => {
     "setResolver",
     "triggerEvent",
     "registerWaiter",
+    "unregisterWaiter",
   ].forEach((attr) => {
     helpers[attr] = function () {
       return window[attr](...arguments);


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
