### PR TITLE
FEATURE: enable canonical url indexing

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1605,7 +1605,7 @@ security:
   enable_escaped_fragments: true
   allow_index_in_robots_txt: true
   allow_indexing_non_canonical_urls:
-    default: false
+    default: true
     hidden: true
   moderators_manage_categories_and_groups: false
   moderators_change_post_ownership:


### PR DESCRIPTION
We rolled out a change to disable canonical indexing.

The goal behind it was to limit crawl budget by Google being spent
scanning non canonical topic links.

Since this change was applied we rolled out 2 fixes that made the change
no longer needed.

1. Topic RSS feeds are no longer followed, links in the RSS feeds are
not followed.

2. Post RSS feeds now contain canonical links.

Combined these two changes mean crawlers no longer discover a large
amount on non-canonical links on Discourse sites.
