### PR TITLE
FIX: Don't share notification consolidation objects defined by plugins.

### DIFF
--- a/app/services/notifications/consolidation_planner.rb
+++ b/app/services/notifications/consolidation_planner.rb
@@ -13,9 +13,13 @@ module Notifications
 
     def plan_for(notification)
       consolidation_plans = [liked_by_two_users, liked, group_message_summary, group_membership]
-      consolidation_plans.concat(DiscoursePluginRegistry.notification_consolidation_plans)
+      consolidation_plans.concat(plugin_consolidation_plans)
 
       consolidation_plans.detect { |plan| plan.can_consolidate_data?(notification) }
+    end
+
+    def plugin_consolidation_plans
+      DiscoursePluginRegistry.notification_consolidation_plans.map(&:deep_dup)
     end
 
     def liked


### PR DESCRIPTION
While we instantiate core's consolidation plans every time someone calls `Notification#consolidate_or_create!`, the ones defined by plugins aren't because the API receives an object. This decision is that passing classes make the API and the whole feature much more difficult to use and extend. As a consequence, rules defined by plugins are not thread-safe, and their state can get changed when two `consolidate_or_create!` calls use the same rules concurrently.

We clone the plugin rules using Rails' deep_dup to fix this problem.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
