### PR TITLE
FIX: Ember test entries in discourse-loader

### DIFF
--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -164,10 +164,6 @@ var define, requirejs;
       "@ember/object/internals": {
         guidFor: Ember.guidFor,
       },
-      "@ember/test": {
-        registerWaiter: Ember.Test && Ember.Test.registerWaiter,
-        unregisterWaiter: Ember.Test && Ember.Test.unregisterWaiter,
-      },
       I18n: {
         // eslint-disable-next-line
         default: I18n,

--- a/app/assets/javascripts/discourse-loader.js
+++ b/app/assets/javascripts/discourse-loader.js
@@ -165,8 +165,8 @@ var define, requirejs;
         guidFor: Ember.guidFor,
       },
       "@ember/test": {
-        registerWaiter: Ember.Test.registerWaiter,
-        unregisterWaiter: Ember.Test.unregisterWaiter,
+        registerWaiter: Ember.Test && Ember.Test.registerWaiter,
+        unregisterWaiter: Ember.Test && Ember.Test.unregisterWaiter,
       },
       I18n: {
         // eslint-disable-next-line

--- a/app/assets/javascripts/test-shims.js
+++ b/app/assets/javascripts/test-shims.js
@@ -26,6 +26,16 @@ define("htmlbars-inline-precompile", () => {
   };
 });
 
+define("@ember/test", () => {
+  // eslint-disable-next-line no-undef, discourse-ember/global-ember
+  const { registerWaiter, unregisterWaiter } = Ember.Test;
+
+  return {
+    registerWaiter,
+    unregisterWaiter,
+  };
+});
+
 let _app;
 define("@ember/test-helpers", () => {
   let helpers = {


### PR DESCRIPTION
Those aren't available in the production build.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
