### PR TITLE
 FIX: Reset last sent for existent bookmarks

### DIFF
--- a/app/jobs/scheduled/bookmark_reminder_notifications.rb
+++ b/app/jobs/scheduled/bookmark_reminder_notifications.rb
@@ -18,7 +18,7 @@ module Jobs
     end
 
     def execute(args = nil)
-      bookmarks = Bookmark.pending_reminders.includes(:user).where(reminder_last_sent_at: nil).order('reminder_at ASC')
+      bookmarks = Bookmark.pending_reminders.includes(:user).order('reminder_at ASC')
       bookmarks.limit(BookmarkReminderNotifications.max_reminder_notifications_per_run).each do |bookmark|
         BookmarkReminderNotificationHandler.send_notification(bookmark)
       end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -112,7 +112,7 @@ class Bookmark < ActiveRecord::Base
   end
 
   scope :pending_reminders, ->(before_time = Time.now.utc) do
-    with_reminders.where("reminder_at <= :before_time", before_time: before_time)
+    with_reminders.where("reminder_at <= ?", before_time).where(reminder_last_sent_at: nil)
   end
 
   scope :pending_reminders_for_user, ->(user) do

--- a/db/migrate/20220316150247_reset_bookmarks_reminder_last_sent_at.rb
+++ b/db/migrate/20220316150247_reset_bookmarks_reminder_last_sent_at.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ResetBookmarksReminderLastSentAt < ActiveRecord::Migration[6.1]
+  def up
+    DB.exec <<~SQL
+      UPDATE bookmarks
+      SET reminder_last_sent_at = NULL
+      WHERE reminder_last_sent_at < reminder_at
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20220316150247_reset_bookmarks_reminder_last_sent_at.rb
+++ b/db/migrate/20220316150247_reset_bookmarks_reminder_last_sent_at.rb
@@ -10,5 +10,6 @@ class ResetBookmarksReminderLastSentAt < ActiveRecord::Migration[6.1]
   end
 
   def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end


### PR DESCRIPTION
The meaning of reminder_at and reminder_last_sent_at changed after
commit 6d422a8033fb31821203f2725a7fb667ef031e65. A bookmark reminder
will fire only if reminder_last_sent_at is null, but before that it
fired everytime reminder_at was set. This is no longer true because
sometimes reminder_at continues to exist even after a reminder fired.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
