### PR TITLE
UX: Updated button label to be more clear when duplicating a color palette

### DIFF
--- a/config/locales/client.bs_BA.yml
+++ b/config/locales/client.bs_BA.yml
@@ -3451,7 +3451,7 @@ bs_BA:
         delete_confirm: 'Jeste li sigurni da želite izbrisati "%{theme_name}"?'
         color: "Color"
         opacity: "Opacity"
-        copy: "Copy"
+        copy: "Duplicate"
         copy_to_clipboard: "Kopirati u clipboard"
         copied_to_clipboard: "Kopirano u međuspremnik"
         copy_to_clipboard_error: "Pogreška pri kopiranju podataka u međuspremnik"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4454,7 +4454,7 @@ en:
         delete_confirm: 'Are you sure you want to delete "%{theme_name}"?'
         color: "Color"
         opacity: "Opacity"
-        copy: "Copy"
+        copy: "Duplicate"
         copy_to_clipboard: "Copy to Clipboard"
         copied_to_clipboard: "Copied to Clipboard"
         copy_to_clipboard_error: "Error copying data to Clipboard"


### PR DESCRIPTION

### Before
<img width="810" alt="image" src="https://user-images.githubusercontent.com/2790986/158650769-ca37face-488a-48af-a49d-fc6e54527be0.png">


### After
<img width="809" alt="image" src="https://user-images.githubusercontent.com/2790986/158650601-34540697-25ad-4001-8960-b2b530dcd01f.png">
