### PR TITLE
DEV: Run tests on push to beta and stable branch too.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+      - beta
+      - stable
 
 concurrency:
   group: tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}


### PR DESCRIPTION
This PR is meant to keep our Github action files in sync between branches. See https://github.com/discourse/discourse/pull/16210 for more details. 

Also I have no idea why Github actions are running on `beta`, `tests-passed` even though we do not specify those branches. 