### PR TITLE
DEV: Backport Github test workflow to stable.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+      - beta
+      - stable
 
 concurrency:
   group: tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
@@ -36,8 +38,6 @@ jobs:
             target: plugins
           - build_type: frontend
             target: core # Handled by core_frontend_tests job (below)
-          - build_type: frontend
-            target: plugins # Not yet passing in Ember CLI
         include:
           - build_type: frontend
             target: core-plugins
@@ -232,15 +232,15 @@ jobs:
 
       - name: Core QUnit 1
         working-directory: ./app/assets/javascripts/discourse
-        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=1 --launch "${{ matrix.browser }}"
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=1 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 20
 
       - name: Core QUnit 2
         working-directory: ./app/assets/javascripts/discourse
-        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=2 --launch "${{ matrix.browser }}"
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=2 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 20
 
       - name: Core QUnit 3
         working-directory: ./app/assets/javascripts/discourse
-        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=3 --launch "${{ matrix.browser }}"
+        run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=3 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 20


### PR DESCRIPTION
Per https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#about-workflow-triggers, the workflow file needs to be kept in sync between branches. 

![Screenshot from 2022-03-17 13-32-33](https://user-images.githubusercontent.com/4335742/158743610-6c4a4ca3-c022-40c3-97c5-14d6e2028237.png)

I'm trying to fix the problem where our Github workflow is no longer running on the `stable` branch: 

![Screenshot from 2022-03-17 13-34-10](https://user-images.githubusercontent.com/4335742/158743760-38afd564-8681-4fc1-8bf5-11f91a7413c8.png)

Green ticks stopped appearing something back.