### PR TITLE
DEV: Pull compatible version for plugins in Github test workflow.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,10 @@ jobs:
         if: matrix.target == 'plugins'
         run: bin/rake plugin:install_all_official
 
+      - name: Pull compatible versions of plugins
+        if: matrix.target == 'plugins'
+        run: bin/rake plugin:pull_compatible_all
+
       - name: Fetch app state cache
         uses: actions/cache@v2
         id: app-cache


### PR DESCRIPTION
We have 3 branches which we care about, `main`, `beta` and `stable`.
However, each of this branch has different compatibilties with plugins
and we want to respect that.
