### PR TITLE
DEV: Add `SKIP_DB_CREATE` option to docker:test

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -100,8 +100,10 @@ task 'docker:test' do
       puts "Starting background redis"
       @redis_pid = Process.spawn('redis-server --dir tmp/test_data/redis')
 
-      puts "Initializing postgres"
-      system("script/start_test_db.rb --skip-run", exception: true)
+      unless ENV['SKIP_DB_CREATE']
+        puts "Initializing postgres"
+        system("script/start_test_db.rb --skip-run", exception: true)
+      end
 
       puts "Starting postgres"
       @pg_pid = Process.spawn("script/start_test_db.rb --skip-setup --exec")
@@ -111,7 +113,9 @@ task 'docker:test' do
       # for js tests
       ENV["SKIP_MULTISITE"] = "1" if ENV["JS_ONLY"]
 
-      @good &&= run_or_fail("bundle exec rake db:create")
+      unless ENV['SKIP_DB_CREATE']
+        @good &&= run_or_fail("bundle exec rake db:create")
+      end
 
       if ENV['USE_TURBO']
         @good &&= run_or_fail("bundle exec rake parallel:create")


### PR DESCRIPTION
So that the database creation can be run separately from the specs.