### PR TITLE
DEV: declare post position as simple number in structured data

### DIFF
--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -188,9 +188,12 @@ body > noscript {
     @include breakpoint(tablet, min-width) {
       float: right;
     }
-    .position {
+    [itemprop="position"] {
       float: left;
       margin-right: 0.5em;
+      &:before {
+        content: "#";
+      }
     }
   }
 

--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -188,7 +188,7 @@ body > noscript {
     @include breakpoint(tablet, min-width) {
       float: right;
     }
-    [itemprop="position"] {
+    .position {
       float: left;
       margin-right: 0.5em;
     }

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -75,7 +75,7 @@
             <% else %>
               <meta itemprop='dateModified' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
             <% end %>
-          <span itemprop='position'>#<%= post.post_number %></span>
+            <span class='position'>#<span itemprop='position'><%= post.post_number %></span></span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -75,7 +75,7 @@
             <% else %>
               <meta itemprop='dateModified' content='<%= post.created_at.to_formatted_s(:iso8601) %>'>
             <% end %>
-            <span class='position'>#<span itemprop='position'><%= post.post_number %></span></span>
+          <span itemprop='position'><%= post.post_number %></span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>

--- a/spec/fixtures/onebox/discourse_topic.response
+++ b/spec/fixtures/onebox/discourse_topic.response
@@ -253,7 +253,7 @@ And that too in just over an year, way to go! [boom]">
               <time itemprop='dateModified' datetime='2015-06-19T06:45:49Z' class='post-time'>
                 June 19, 2015,  6:45am
               </time>
-            <span class='position'>#<span itemprop='position'>1</span></span>
+          <span itemprop='position'>1</span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>
@@ -292,7 +292,7 @@ And that too in just over an year, way to go! [boom]">
               <time itemprop='datePublished' datetime='2014-02-06T05:27:06Z' class='post-time'>
                 February 6, 2014,  5:27am
               </time>
-            <span class='position'>#<span itemprop='position'>2</span></span>
+          <span itemprop='position'>2</span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>

--- a/spec/fixtures/onebox/discourse_topic.response
+++ b/spec/fixtures/onebox/discourse_topic.response
@@ -253,7 +253,7 @@ And that too in just over an year, way to go! [boom]">
               <time itemprop='dateModified' datetime='2015-06-19T06:45:49Z' class='post-time'>
                 June 19, 2015,  6:45am
               </time>
-          <span itemprop='position'>#1</span>
+            <span class='position'>#<span itemprop='position'>1</span></span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>
@@ -292,7 +292,7 @@ And that too in just over an year, way to go! [boom]">
               <time itemprop='datePublished' datetime='2014-02-06T05:27:06Z' class='post-time'>
                 February 6, 2014,  5:27am
               </time>
-          <span itemprop='position'>#2</span>
+            <span class='position'>#<span itemprop='position'>2</span></span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>

--- a/spec/fixtures/onebox/discourse_topic_reply.response
+++ b/spec/fixtures/onebox/discourse_topic_reply.response
@@ -249,7 +249,7 @@ And that too in just over an year, way to go! [boom]">
               <time itemprop='dateModified' datetime='2015-06-19T06:45:49Z' class='post-time'>
                 June 19, 2015,  6:45am
               </time>
-          <span itemprop='position'>#1</span>
+            <span class='position'>#<span itemprop='position'>1</span></span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>
@@ -288,7 +288,7 @@ And that too in just over an year, way to go! [boom]">
               <time itemprop='datePublished' datetime='2014-02-06T05:27:06Z' class='post-time'>
                 February 6, 2014,  5:27am
               </time>
-          <span itemprop='position'>#2</span>
+            <span class='position'>#<span itemprop='position'>2</span></span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>

--- a/spec/fixtures/onebox/discourse_topic_reply.response
+++ b/spec/fixtures/onebox/discourse_topic_reply.response
@@ -249,7 +249,7 @@ And that too in just over an year, way to go! [boom]">
               <time itemprop='dateModified' datetime='2015-06-19T06:45:49Z' class='post-time'>
                 June 19, 2015,  6:45am
               </time>
-            <span class='position'>#<span itemprop='position'>1</span></span>
+          <span itemprop='position'>1</span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>
@@ -288,7 +288,7 @@ And that too in just over an year, way to go! [boom]">
               <time itemprop='datePublished' datetime='2014-02-06T05:27:06Z' class='post-time'>
                 February 6, 2014,  5:27am
               </time>
-            <span class='position'>#<span itemprop='position'>2</span></span>
+          <span itemprop='position'>2</span>
           </span>
         </div>
         <div class='post' itemprop='articleBody'>


### PR DESCRIPTION
This replaces the position declared as `#123` with the more simple version `123`.

The property position may be of type Integer or Text. A value of type Integer, or more precise of type Text which simply casts to integer, is sufficient here.
See: https://schema.org/position

In category-view the topic-list already uses this notation for the position of topics:
`<meta itemprop="position" content="123">`