### PR TITLE
FEATURE: Let reviewables override the score type title.

### DIFF
--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -53,7 +53,7 @@ class ReviewableScore < ActiveRecord::Base
   end
 
   def score_type
-    Reviewable::Collection::Item.new(reviewable_score_type)
+    Reviewable::Collection::Item.new(reviewable_score_type, reason: reason)
   end
 
   def took_action?

--- a/app/serializers/reviewable_score_type_serializer.rb
+++ b/app/serializers/reviewable_score_type_serializer.rb
@@ -5,6 +5,8 @@ class ReviewableScoreTypeSerializer < ApplicationSerializer
 
   # Allow us to share post action type translations for backwards compatibility
   def title
+    # Calling #try here because post action types don't have a reason method.
+    I18n.t("reviewables.reason_titles.#{object.try(:reason)}", default: nil) ||
     I18n.t("post_action_types.#{ReviewableScore.types[id]}.title", default: nil) ||
       I18n.t("reviewable_score_types.#{ReviewableScore.types[id]}.title")
   end

--- a/lib/reviewable/collection.rb
+++ b/lib/reviewable/collection.rb
@@ -4,10 +4,11 @@ class Reviewable < ActiveRecord::Base
   class Collection
     class Item
       include ActiveModel::Serialization
-      attr_reader :id
+      attr_reader :id, :reason
 
-      def initialize(id)
+      def initialize(id, reason: nil)
         @id = id
+        @reason = reason
       end
     end
 


### PR DESCRIPTION
Plugins like chat add custom score type to override the title in the UI, but that should be reserved for situations when you need to manage the flag priority separately, which is configurable in the queue settings page.

Currently, if a plugin creates a custom score type, it won't be able to associate a priority, so there's no real gain from doing so. Priorities are tightly related to post-action types, which is something we might want to revise. For now, this change lets plugins move away from custom score types without compromises.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
