### PR TITLE
DEV: use structured data in topic-list for referencing only

### DIFF
--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -57,14 +57,9 @@
       <% @list.topics.each_with_index do |t,i| %>
         <tr class="topic-list-item">
           <td class="main-link" itemprop='itemListElement' itemscope itemtype='http://schema.org/ListItem'>
-            <meta itemprop='name' content='<%= t.title %>'>
-            <meta itemprop='url' content='<%= t.url %>'>
-            <% if t.image_url.present? %>
-              <meta itemprop='image' content='<%= t.image_url %>'>
-            <% end %>
             <meta itemprop='position' content='<%= i + 1 %>'>
             <span class="link-top-line">
-              <a href='<%= t.url %>' class='title raw-link raw-topic-link'><%= t.title %></a>
+              <a itemprop='url' href='<%= t.url %>' class='title raw-link raw-topic-link'><%= t.title %></a>
             </span>
             <div class="link-bottom-line">
               <% if (!@category || @category.has_children?) && t.category && !t.category.uncategorized? %>

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe ListController do
 
       expect(response.body).to have_tag "title", text: "Discourse - Best community"
     end
+
+    it "returns structured data" do
+      get "/latest"
+
+      expect(response.status).to eq(200)
+      topic_list = Nokogiri::HTML5(response.body).css('.topic-list')
+      first_item = topic_list.css('[itemprop="itemListElement"]')
+      expect(first_item.css('[itemprop="position"]')[0]['content']).to eq('1')
+      expect(first_item.css('[itemprop="url"]')[0]['href']).to eq(topic.url)
+    end
   end
 
   describe "categories and X" do

--- a/spec/views/list/list.erb_spec.rb
+++ b/spec/views/list/list.erb_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe "list/list.erb" do
   fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic) }
 
   it "add nofollow to RSS alternate link for category" do
     view.stubs(:include_crawler_content?).returns(false)
@@ -15,4 +16,16 @@ RSpec.describe "list/list.erb" do
     expect(view.content_for(:head)).to match(/<link rel="alternate nofollow" type="application\/rss\+xml" title="[^"]+" href="https:\/\/www.example.com\/test\.rss" \/>/)
   end
 
+  it "adds sturctured data" do
+    view.stubs(:include_crawler_content?).returns(true)
+    topic.posters = []
+    assign(:list, OpenStruct.new(topics: [topic]))
+
+    render template: 'list/list', formats: []
+
+    topic_list = Nokogiri::HTML5::fragment(rendered).css('.topic-list')
+    first_item = topic_list.css('[itemprop="itemListElement"]')
+    expect(first_item.css('[itemprop="position"]')[0]['content']).to eq('1')
+    expect(first_item.css('[itemprop="url"]')[0]['href']).to eq(topic.url)
+  end
 end


### PR DESCRIPTION
This simplifies the ItemList to only be a point of reference to the actual DiscussionForumPosting objects.

See "Summary page": https://developers.google.com/search/docs/advanced/structured-data/carousel?hl=en#summary-page