### PR TITLE
FIX: Show restricted groups warning when necessary

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/share-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/share-topic.js
@@ -28,11 +28,40 @@ export default Controller.extend(
         allowInvites: false,
       });
 
-      if (this.model && this.model.read_restricted) {
-        this.restrictedGroupWarning();
-      }
+      this.appEvents.on(
+        "modal:body-shown",
+        this,
+        this.showRestrictedGroupWarning
+      );
 
       scheduleOnce("afterRender", this, this.selectUrl);
+    },
+
+    onClose() {
+      this.appEvents.off(
+        "modal:body-shown",
+        this,
+        this.showRestrictedGroupWarning
+      );
+    },
+
+    showRestrictedGroupWarning() {
+      Category.reloadBySlugPath(this.model.slug).then((result) => {
+        const restrictedGroups = result.category.group_permissions.map(
+          (group) => group.group_name
+        );
+
+        if (
+          restrictedGroups &&
+          !restrictedGroups.any((x) => x === "everyone")
+        ) {
+          const message = I18n.t("topic.share.restricted_groups", {
+            count: restrictedGroups.length,
+            groupNames: restrictedGroups.join(", "),
+          });
+          this.flash(message, "warning");
+        }
+      });
     },
 
     selectUrl() {
@@ -104,25 +133,6 @@ export default Controller.extend(
       const topicController = getOwner(this).lookup("controller:topic");
       topicController.actions.replyAsNewTopic.call(topicController, post);
       this.send("closeModal");
-    },
-
-    restrictedGroupWarning() {
-      this.appEvents.on("modal:body-shown", () => {
-        let restrictedGroups;
-        Category.reloadBySlugPath(this.model.slug).then((result) => {
-          restrictedGroups = result.category.group_permissions.map(
-            (g) => g.group_name
-          );
-
-          if (restrictedGroups) {
-            const message = I18n.t("topic.share.restricted_groups", {
-              count: restrictedGroups.length,
-              groupNames: restrictedGroups.join(", "),
-            });
-            this.flash(message, "warning");
-          }
-        });
-      });
     },
   }
 );

--- a/app/assets/javascripts/discourse/app/controllers/share-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/share-topic.js
@@ -47,17 +47,11 @@ export default Controller.extend(
 
     showRestrictedGroupWarning() {
       Category.reloadBySlugPath(this.model.slug).then((result) => {
-        const restrictedGroups = result.category.group_permissions.map(
-          (group) => group.group_name
-        );
-
-        if (
-          restrictedGroups &&
-          !restrictedGroups.any((x) => x === "everyone")
-        ) {
+        const groups = result.category.group_permissions.mapBy("group_name");
+        if (groups && !groups.any((x) => x === "everyone")) {
           const message = I18n.t("topic.share.restricted_groups", {
-            count: restrictedGroups.length,
-            groupNames: restrictedGroups.join(", "),
+            count: groups.length,
+            groups: groups.join(", "),
           });
           this.flash(message, "warning");
         }

--- a/app/assets/javascripts/discourse/app/controllers/share-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/share-topic.js
@@ -49,11 +49,13 @@ export default Controller.extend(
       Category.reloadBySlugPath(this.model.slug).then((result) => {
         const groups = result.category.group_permissions.mapBy("group_name");
         if (groups && !groups.any((x) => x === "everyone")) {
-          const message = I18n.t("topic.share.restricted_groups", {
-            count: groups.length,
-            groups: groups.join(", "),
-          });
-          this.flash(message, "warning");
+          this.flash(
+            I18n.t("topic.share.restricted_groups", {
+              count: groups.length,
+              groups: groups.join(", "),
+            }),
+            "warning"
+          );
         }
       });
     },

--- a/app/assets/javascripts/discourse/app/controllers/share-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/share-topic.js
@@ -46,6 +46,10 @@ export default Controller.extend(
     },
 
     showRestrictedGroupWarning() {
+      if (!this.model) {
+        return;
+      }
+
       Category.reloadBySlugPath(this.model.slug).then((result) => {
         const groups = result.category.group_permissions.mapBy("group_name");
         if (groups && !groups.any((x) => x === "everyone")) {

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -1,3 +1,4 @@
+import CategoryFixtures from "discourse/tests/fixtures/category-fixtures";
 import { click, visit } from "@ember/test-helpers";
 import {
   acceptance,
@@ -9,6 +10,12 @@ import { test } from "qunit";
 
 acceptance("Share and Invite modal", function (needs) {
   needs.user();
+
+  needs.pretender((server, helper) => {
+    server.get("/c/feature/find_by_slug.json", () =>
+      helper.response(200, CategoryFixtures["/c/1/show.json"])
+    );
+  });
 
   test("Topic footer button", async function (assert) {
     await visit("/t/internationalization-localization/280");

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-test.js
@@ -21,10 +21,14 @@ import { test } from "qunit";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import topicFixtures from "discourse/tests/fixtures/topic";
 import { cloneJSON } from "discourse-common/lib/object";
+import CategoryFixtures from "discourse/tests/fixtures/category-fixtures";
 
 acceptance("Topic", function (needs) {
   needs.user();
   needs.pretender((server, helper) => {
+    server.get("/c/feature/find_by_slug.json", () => {
+      return helper.response(200, CategoryFixtures["/c/1/show.json"]);
+    });
     server.put("/posts/398/wiki", () => {
       return helper.response({});
     });


### PR DESCRIPTION
It was displayed for the "everyone" group too, but that was not
necessary.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
