### PR TITLE
Revert "FEATURE: Let reviewables override the score type title."

### DIFF
--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -53,7 +53,7 @@ class ReviewableScore < ActiveRecord::Base
   end
 
   def score_type
-    Reviewable::Collection::Item.new(reviewable_score_type, reason: reason)
+    Reviewable::Collection::Item.new(reviewable_score_type)
   end
 
   def took_action?

--- a/app/serializers/reviewable_score_type_serializer.rb
+++ b/app/serializers/reviewable_score_type_serializer.rb
@@ -5,8 +5,6 @@ class ReviewableScoreTypeSerializer < ApplicationSerializer
 
   # Allow us to share post action type translations for backwards compatibility
   def title
-    # Calling #try here because post action types don't have a reason method.
-    I18n.t("reviewables.reason_titles.#{object.try(:reason)}", default: nil) ||
     I18n.t("post_action_types.#{ReviewableScore.types[id]}.title", default: nil) ||
       I18n.t("reviewable_score_types.#{ReviewableScore.types[id]}.title")
   end

--- a/lib/reviewable/collection.rb
+++ b/lib/reviewable/collection.rb
@@ -4,11 +4,10 @@ class Reviewable < ActiveRecord::Base
   class Collection
     class Item
       include ActiveModel::Serialization
-      attr_reader :id, :reason
+      attr_reader :id
 
-      def initialize(id, reason: nil)
+      def initialize(id)
         @id = id
-        @reason = reason
       end
     end
 


### PR DESCRIPTION
Reverts discourse/discourse#16234

Not as easy as I thought. Because of how the data is structured, this only works if the score type has a custom ID, which we're trying to avoid. A proper fix requires more work.