### PR TITLE
A11Y: Focus last viewed topic in topic lists

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -1,4 +1,7 @@
-import discourseComputed, { observes } from "discourse-common/utils/decorators";
+import discourseComputed, {
+  bind,
+  observes,
+} from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
@@ -58,15 +61,10 @@ export default Component.extend({
         if (this.selected && this.selected.includes(this.topic)) {
           this.element.querySelector("input.bulk-select").checked = true;
         }
-        const mainLink = this.element.querySelector(".main-link");
-        const title = mainLink?.querySelector(".title");
-        if (mainLink && title) {
-          title.addEventListener("focus", () => {
-            mainLink.classList.add("focused");
-          });
-          title.addEventListener("blur", () => {
-            mainLink.classList.remove("focused");
-          });
+        const title = this.element.querySelector(".main-link .title");
+        if (title) {
+          title.addEventListener("focus", this._onTitleFocus);
+          title.addEventListener("blur", this._onTitleBlur);
         }
       });
     }
@@ -107,6 +105,11 @@ export default Component.extend({
 
     if (this.includeUnreadIndicator) {
       this.messageBus.unsubscribe(this.unreadIndicatorChannel);
+    }
+    const title = this.element?.querySelector(".main-link .title");
+    if (title) {
+      title.removeEventListener("focus", this._onTitleFocus);
+      title.removeEventListener("blur", this._onTitleBlur);
     }
   },
 
@@ -292,4 +295,20 @@ export default Component.extend({
       this.highlight();
     }
   }),
+
+  @bind
+  _onTitleFocus() {
+    if (this.element && !this.isDestroying && !this.isDestroyed) {
+      const mainLink = this.element.querySelector(".main-link");
+      mainLink.classList.add("focused");
+    }
+  },
+
+  @bind
+  _onTitleBlur() {
+    if (this.element && !this.isDestroying && !this.isDestroyed) {
+      const mainLink = this.element.querySelector(".main-link");
+      mainLink.classList.remove("focused");
+    }
+  },
 });

--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -58,6 +58,16 @@ export default Component.extend({
         if (this.selected && this.selected.includes(this.topic)) {
           this.element.querySelector("input.bulk-select").checked = true;
         }
+        const mainLink = this.element.querySelector(".main-link");
+        const title = mainLink?.querySelector(".title");
+        if (mainLink && title) {
+          title.addEventListener("focus", () => {
+            mainLink.classList.add("focused");
+          });
+          title.addEventListener("blur", () => {
+            mainLink.classList.remove("focused");
+          });
+        }
       });
     }
   },
@@ -267,7 +277,7 @@ export default Component.extend({
       this.element.addEventListener("animationend", () => {
         this.element.classList.remove("highlighted");
       });
-      this.element.querySelector(".tabLoc").focus();
+      this.element.querySelector(".main-link .title").focus();
     });
   },
 

--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -259,12 +259,15 @@ export default Component.extend({
         return;
       }
 
-      const $topic = $(this.element);
-      $topic
-        .addClass("highlighted")
-        .attr("data-islastviewedtopic", opts.isLastViewedTopic);
-
-      $topic.on("animationend", () => $topic.removeClass("highlighted"));
+      this.element.classList.add("highlighted");
+      this.element.setAttribute(
+        "data-islastviewedtopic",
+        opts.isLastViewedTopic
+      );
+      this.element.addEventListener("animationend", () => {
+        this.element.classList.remove("highlighted");
+      });
+      this.element.querySelector(".tabLoc").focus();
     });
   },
 

--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -16,6 +16,7 @@
   at the end of the link, preventing it from line wrapping onto its own line.
 --}}
 <td class='main-link clearfix topic-list-data' colspan="1">
+  <a href aria-hidden="true" tabindex="-1" class="tabLoc"></a>
   {{~raw-plugin-outlet name="topic-list-before-link"}}
   <span class='link-top-line'>
     {{~raw-plugin-outlet name="topic-list-before-status"}}

--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -16,7 +16,6 @@
   at the end of the link, preventing it from line wrapping onto its own line.
 --}}
 <td class='main-link clearfix topic-list-data' colspan="1">
-  <a href aria-hidden="true" tabindex="-1" class="tabLoc"></a>
   {{~raw-plugin-outlet name="topic-list-before-link"}}
   <span class='link-top-line'>
     {{~raw-plugin-outlet name="topic-list-before-status"}}

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -234,6 +234,15 @@
     .raw-topic-link > * {
       pointer-events: none;
     }
+
+    &.focused {
+      box-shadow: inset 3px 0 0 var(--tertiary);
+    }
+    /* we a custom focus indicator so we can remove the native one */
+    .title:focus,
+    .title:focus-visible {
+      outline: none;
+    }
   }
 
   .unread-indicator {

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -238,7 +238,7 @@
     &.focused {
       box-shadow: inset 3px 0 0 var(--tertiary);
     }
-    /* we a custom focus indicator so we can remove the native one */
+    /* we have a custom focus indicator so we can remove the native one */
     .title:focus,
     .title:focus-visible {
       outline: none;


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/discourse-with-a-screen-reader/178105/88?u=osama

This is another attempt to fix the same problem that https://github.com/discourse/discourse/pull/15300 was meant to fix, but it had to be reverted because the `focus()` call caused the topic title to have an outline on certain browsers:

![image](https://user-images.githubusercontent.com/17474474/159349977-30aa069d-35b6-4dd4-939c-b370cb09cf27.png)

This PR does mostly the same thing as the previous one, but the difference is that the focus is shifted to an empty `<a>` element near the topic title of the last visited topic. That way it's not possible for an unwanted outline to appear (because the element isn't visible) while still shifting the focus to (near) the right place. We use this pattern in the posts stream:

https://github.com/discourse/discourse/blob/581d435d09ad18528b5c347e3037c88a30faccc1/app/assets/javascripts/discourse/app/lib/utilities.js#L137