### PR TITLE
DEV: Re-add polymorphic bookmark columns

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -4,8 +4,6 @@ class Bookmark < ActiveRecord::Base
   # these columns were here for a very short amount of time,
   # hence the very short ignore time
   self.ignored_columns = [
-    "bookmarkable_id", # TODO 2022-04-01 remove
-    "bookmarkable_type", # TODO 2022-04-01 remove
     "topic_id", # TODO 2022-04-01: remove
     "reminder_type" # TODO 2021-04-01: remove
   ]
@@ -181,9 +179,12 @@ end
 #  auto_delete_preference :integer          default(0), not null
 #  pinned                 :boolean          default(FALSE)
 #  for_topic              :boolean          default(FALSE), not null
+#  bookmarkable_id        :integer
+#  bookmarkable_type      :string
 #
 # Indexes
 #
+#  idx_bookmarks_user_polymorphic_unique                 (user_id,bookmarkable_type,bookmarkable_id) UNIQUE
 #  index_bookmarks_on_post_id                            (post_id)
 #  index_bookmarks_on_reminder_at                        (reminder_at)
 #  index_bookmarks_on_reminder_set_at                    (reminder_set_at)

--- a/db/migrate/20220322024216_add_bookmark_polymorphic_columns_again.rb
+++ b/db/migrate/20220322024216_add_bookmark_polymorphic_columns_again.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddBookmarkPolymorphicColumnsAgain < ActiveRecord::Migration[6.1]
+  def change
+    add_column :bookmarks, :bookmarkable_id, :integer
+    add_column :bookmarks, :bookmarkable_type, :string
+
+    add_index :bookmarks, [:user_id, :bookmarkable_type, :bookmarkable_id], name: "idx_bookmarks_user_polymorphic_unique", unique: true
+  end
+end


### PR DESCRIPTION
This commit is a redo of e21c640a3cb0fc6322ee90843a198ae2df7decf7
which we reverted to not include half-done work in a release.

This commit is slightly different though, in that it only includes
the creation of the new columns and index, and does not add any
triggers, backfilling, or new data.

A backfill will be done in the final PR when we switch this over.
Intermediate PRs will look something like this:

1. Add an experimental site setting for using polymorphic bookmarks,
   and make sure in the places where bookmarks are created or updated
   we fill in the columns. This setting will be used in subsequent
   PRs as well.
2. Listing and searching bookmarks based on polymorphic associations
3. Creating post and topic bookmarks using polymorphic associations,
   and changing special for_topic logic to just rely on the Topic
   bookmarkable_type
4. Querying bookmark reminders based on polymorphic associations
5. Make sure various other areas like importers, bookmark guardian,
   and others all rely on the associations
6. Prepare plugins that rely on the Bookmark model to use polymorphic
   associations

The final core PR will remove all the setting gates and switch over
to using the polymorphic associations, backfill the bookmarks
table columns, and ignore the old post_id and for_topic colummns.
Then it will just be a matter of dropping the old columns down the
line.
