### PR TITLE
FIX: Add replaceAll to browser-detect

### DIFF
--- a/app/assets/javascripts/browser-detect.js
+++ b/app/assets/javascripts/browser-detect.js
@@ -1,4 +1,9 @@
-if (!window.WeakMap || !window.Promise || typeof globalThis === "undefined") {
+if (
+  !window.WeakMap ||
+  !window.Promise ||
+  typeof globalThis === "undefined" ||
+  !String.prototype.replaceAll
+) {
   window.unsupportedBrowser = true;
 } else {
   // Some implementations of `WeakMap.prototype.has` do not accept false


### PR DESCRIPTION
We're using replaceAll in a few places. If it's not supported, we should fall back to the basic-html view.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
