### PR TITLE
DEV: Drop padStart, padEnd and Regexp.flags polyfills

### DIFF
--- a/app/assets/javascripts/polyfills.js
+++ b/app/assets/javascripts/polyfills.js
@@ -1,52 +1,5 @@
 /* eslint-disable */
 
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags#Polyfill
-// IE and EDGE
-if (RegExp.prototype.flags === undefined) {
-  Object.defineProperty(RegExp.prototype, "flags", {
-    configurable: true,
-    get: function () {
-      return this.toString().match(/[gimsuy]*$/)[0];
-    },
-  });
-}
-
-// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
-if (!String.prototype.padStart) {
-  String.prototype.padStart = function padStart(targetLength, padString) {
-    targetLength = targetLength >> 0; //truncate if number, or convert non-number to 0;
-    padString = String(typeof padString !== "undefined" ? padString : " ");
-    if (this.length >= targetLength) {
-      return String(this);
-    } else {
-      targetLength = targetLength - this.length;
-      if (targetLength > padString.length) {
-        padString += padString.repeat(targetLength / padString.length); //append to original to ensure we are longer than needed
-      }
-      return padString.slice(0, targetLength) + String(this);
-    }
-  };
-}
-
-// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd
-if (!String.prototype.padEnd) {
-  String.prototype.padEnd = function padEnd(targetLength, padString) {
-    targetLength = targetLength >> 0; //floor if number or convert non-number to 0;
-    padString = String(typeof padString !== "undefined" ? padString : " ");
-    if (this.length > targetLength) {
-      return String(this);
-    } else {
-      targetLength = targetLength - this.length;
-      if (targetLength > padString.length) {
-        padString += padString.repeat(targetLength / padString.length); //append to original to ensure we are longer than needed
-      }
-      return String(this) + padString.slice(0, targetLength);
-    }
-  };
-}
-
 // Needed for Safari 15.2 and below
 // from: https://github.com/iamdustan/smoothscroll
 (function () {


### PR DESCRIPTION
These methods have been natively supported in all our target browsers for many years. We're now feature-detecting `String.prototype.replaceAll`, which is a much more recent addition. If a browser has `replaceAll`, it'll have `padStart` and `padEnd`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
