### PR TITLE
FIX: Ensure all/none subcategory filters work correctly with tags

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/dynamic-route-builders.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/dynamic-route-builders.js
@@ -61,6 +61,9 @@ export default {
     app["TagsShowCategoryNoneRoute"] = TagShowRoute.extend({
       noSubcategories: true,
     });
+    app["TagsShowCategoryAllRoute"] = TagShowRoute.extend({
+      noSubcategories: false,
+    });
 
     site.get("filters").forEach(function (filter) {
       app["TagShow" + filter.capitalize() + "Route"] = TagShowRoute.extend({
@@ -70,8 +73,11 @@ export default {
         "TagsShowCategory" + filter.capitalize() + "Route"
       ] = TagShowRoute.extend({ navMode: filter });
       app[
-        "TagsShowNoneCategory" + filter.capitalize() + "Route"
+        "TagsShowCategoryNone" + filter.capitalize() + "Route"
       ] = TagShowRoute.extend({ navMode: filter, noSubcategories: true });
+      app[
+        "TagsShowCategoryAll" + filter.capitalize() + "Route"
+      ] = TagShowRoute.extend({ navMode: filter, noSubcategories: false });
     });
   },
 };

--- a/app/assets/javascripts/discourse/app/routes/app-route-map.js
+++ b/app/assets/javascripts/discourse/app/routes/app-route-map.js
@@ -225,6 +225,9 @@ export default function () {
     this.route("showCategory", {
       path: "/c/*category_slug_path_with_id/:tag_id",
     });
+    this.route("showCategoryAll", {
+      path: "/c/*category_slug_path_with_id/all/:tag_id",
+    });
     this.route("showCategoryNone", {
       path: "/c/*category_slug_path_with_id/none/:tag_id",
     });
@@ -232,6 +235,9 @@ export default function () {
     Site.currentProp("filters").forEach((filter) => {
       this.route("showCategory" + filter.capitalize(), {
         path: "/c/*category_slug_path_with_id/:tag_id/l/" + filter,
+      });
+      this.route("showCategoryAll" + filter.capitalize(), {
+        path: "/c/*category_slug_path_with_id/all/:tag_id/l/" + filter,
       });
       this.route("showCategoryNone" + filter.capitalize(), {
         path: "/c/*category_slug_path_with_id/none/:tag_id/l/" + filter,

--- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -75,8 +75,8 @@ export default DiscourseRoute.extend(FilterModeMixin, {
       category.setupGroupsAndPermissions();
       filter = `tags/c/${Category.slugFor(category)}/${category.id}`;
 
-      if (this.noSubcategories) {
-        filter += "/none";
+      if (this.noSubcategories !== undefined) {
+        filter += this.noSubcategories ? "/none" : "/all";
       }
 
       filter += `/${tagId}/l/${topicFilter}`;
@@ -120,12 +120,17 @@ export default DiscourseRoute.extend(FilterModeMixin, {
   },
 
   setupController(controller, model) {
+    const noSubcategories =
+      this.noSubcategories === undefined
+        ? model.category?.default_list_filter === "none"
+        : this.noSubcategories;
+
     this.controllerFor("tag.show").setProperties({
       model: model.tag,
       ...model,
       period: model.list.for_period,
       navMode: this.navMode,
-      noSubcategories: this.noSubcategories,
+      noSubcategories,
       loading: false,
     });
     this.searchService.set("searchContext", model.tag.searchContext);

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -288,25 +288,31 @@ acceptance("Tag info", function (needs) {
       });
     });
 
-    server.get("/tags/c/faq/4/planters/l/latest.json", () => {
-      return helper.response({
-        users: [],
-        primary_groups: [],
-        topic_list: {
-          can_create_topic: true,
-          draft: null,
-          draft_key: "new_topic",
-          draft_sequence: 1,
-          per_page: 30,
-          tags: [
-            {
-              id: 1,
-              name: "planters",
-              topic_count: 1,
-            },
-          ],
-          topics: [],
-        },
+    [
+      "/tags/c/faq/4/planters/l/latest.json",
+      "/tags/c/feature/2/planters/l/latest.json",
+      "/tags/c/feature/2/none/planters/l/latest.json",
+    ].forEach((url) => {
+      server.get(url, () => {
+        return helper.response({
+          users: [],
+          primary_groups: [],
+          topic_list: {
+            can_create_topic: true,
+            draft: null,
+            draft_key: "new_topic",
+            draft_sequence: 1,
+            per_page: 30,
+            tags: [
+              {
+                id: 1,
+                name: "planters",
+                topic_count: 1,
+              },
+            ],
+            topics: [],
+          },
+        });
       });
     });
 
@@ -482,6 +488,20 @@ acceptance("Tag info", function (needs) {
     await click('.category-breadcrumb .category-row[data-name="faq"]');
 
     assert.strictEqual(currentURL(), "/tags/c/faq/4/planters");
+  });
+
+  test("can switch between all/none subcategories", async function (assert) {
+    await visit("/tag/planters");
+
+    await click(".category-breadcrumb .category-drop-header");
+    await click('.category-breadcrumb .category-row[data-name="feature"]');
+    assert.strictEqual(currentURL(), "/tags/c/feature/2/planters");
+
+    await click(".category-breadcrumb li:nth-of-type(2) .category-drop-header");
+    await click(
+      '.category-breadcrumb li:nth-of-type(2) .category-row[data-name="none"]'
+    );
+    assert.strictEqual(currentURL(), "/tags/c/feature/2/none/planters");
   });
 
   test("admin can manage tags", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-fixtures.js
@@ -461,6 +461,7 @@ export default {
           show_subcategory_list: true,
           default_view: "latest",
           subcategory_list_style: "boxes",
+          default_list_filter: "all",
         },
         {
           id: 240,

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -375,14 +375,15 @@ class TagsController < ::ApplicationController
       @filter_on_category = Category.query_category(slug_or_id, nil)
     end
 
-    guardian.ensure_can_see!(@filter_on_category)
-
     if !@filter_on_category
       permalink = Permalink.find_by_url("c/#{params[:category_slug_path_with_id]}")
       if permalink.present? && permalink.category_id
         return redirect_to "#{Discourse::base_path}/tags#{permalink.target_url}/#{params[:tag_id]}", status: :moved_permanently
       end
+    end
 
+    if !(@filter_on_category && guardian.can_see?(@filter_on_category))
+      # 404 on 'access denied' to avoid leaking existence of category
       raise Discourse::NotFound
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -952,9 +952,11 @@ Discourse::Application.routes.draw do
         scope path: '/c/*category_slug_path_with_id' do
           Discourse.filters.each do |filter|
             get "/none/:tag_id/l/#{filter}" => "tags#show_#{filter}", as: "tag_category_none_show_#{filter}", defaults: { no_subcategories: true }
+            get "/all/:tag_id/l/#{filter}" => "tags#show_#{filter}", as: "tag_category_all_show_#{filter}", defaults: { no_subcategories: false }
           end
 
           get '/none/:tag_id' => 'tags#show', as: 'tag_category_none_show', defaults: { no_subcategories: true }
+          get '/all/:tag_id' => 'tags#show', as: 'tag_category_all_show', defaults: { no_subcategories: false }
 
           Discourse.filters.each do |filter|
             get "/:tag_id/l/#{filter}" => "tags#show_#{filter}", as: "tag_category_show_#{filter}"

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -285,6 +285,19 @@ describe TagsController do
         expect(response.parsed_body['topic_list']['more_topics_url'])
           .to start_with("/tags/c/#{category.slug_path.join('/')}/#{category.id}/#{tag.name}")
       end
+
+      it "should 404 for invalid category path" do
+        get "/tags/c/#{category.slug_path.join("/")}/#{category.id}/somerandomstring/#{tag.name}.json?per_page=1"
+
+        expect(response.status).to eq(404)
+      end
+
+      it "should 404 for secure categories" do
+        c = Fabricate(:private_category, group: Fabricate(:group))
+        get "/tags/c/#{c.slug_path.join("/")}/#{c.id}/#{tag.name}.json"
+
+        expect(response.status).to eq(404)
+      end
     end
 
     context "with a subcategory in the path" do


### PR DESCRIPTION
(see commit messages)

The motivation here was to fix the broken category dropdown at https://meta.discourse.org/tags/c/theme/61/all/theme-component

<img width="459" alt="Screenshot 2022-03-22 at 15 10 52" src="https://user-images.githubusercontent.com/6270921/159514553-d1ae35b1-b7ce-4cc2-a62d-3ab0d42a09fc.png">

