### PR TITLE
DEV: Only raise `rake themes:update` errors when flag provided

### DIFF
--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -71,7 +71,7 @@ def update_themes
       raise RemoteTheme::ImportError.new(remote_theme.last_error_text) if remote_theme.last_error_text.present?
     rescue => e
       STDERR.puts "Failed to update '#{theme.name}': #{e}"
-      raise if ENV["RAISE_THEME_ERRORS"] != "0" && (ENV["RAISE_THEME_ERRORS"] == "1" || RailsMultisite::ConnectionManagement.current_db == "default")
+      raise if ENV["RAISE_THEME_ERRORS"] == "1"
     end
   end
 


### PR DESCRIPTION
Switching behavior based on multisite/single-site configuration can create some difficult-to-debug situations. The flag is much more obvious.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
