### PR TITLE
FIX: Allow `@ember/test` import in embercli prod builds

### DIFF
--- a/app/assets/javascripts/discourse/lib/rfc176-shims/index.js
+++ b/app/assets/javascripts/discourse/lib/rfc176-shims/index.js
@@ -40,7 +40,11 @@ module.exports = {
         m = modules[entry.module] = [];
       }
 
-      m.push(entry);
+      if (entry.module === "@ember/test") {
+        m.push({ ...entry, global: `(Ember.Test && ${entry.global})` });
+      } else {
+        m.push(entry);
+      }
     }
 
     let output = "";


### PR DESCRIPTION
This matches the behavior of legacy discourse-loader and the regular Ember resolver.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
