### PR TITLE
UX: cleaner messages for empty state on the user activity topics page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/discourse.js
+++ b/app/assets/javascripts/discourse/app/routes/discourse.js
@@ -74,12 +74,21 @@ const DiscourseRoute = Route.extend({
     }
   },
 
+  // deprecated, use isCurrentUser() instead
   isAnotherUsersPage(user) {
     if (!this.currentUser) {
       return true;
     }
 
     return user.username !== this.currentUser.username;
+  },
+
+  isCurrentUser(user) {
+    if (!this.currentUser) {
+      return false; // the current user is anonymous
+    }
+
+    return user.id === this.currentUser.id;
   },
 
   isPoppedState(transition) {

--- a/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
@@ -11,7 +11,7 @@ export default DiscourseRoute.extend({
     return draftsStream.findItems(this.site).then(() => {
       return {
         stream: draftsStream,
-        isAnotherUsersPage: this.isAnotherUsersPage(user),
+        isAnotherUsersPage: !this.isCurrentUser(user),
         emptyState: this.emptyState(),
       };
     });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
@@ -16,7 +16,7 @@ export default DiscourseRoute.extend(ViewingActionType, {
 
     return {
       stream,
-      isAnotherUsersPage: this.isAnotherUsersPage(user),
+      isAnotherUsersPage: !this.isCurrentUser(user),
       emptyState: this.emptyState(),
       emptyStateOthers: this.emptyStateOthers,
     };

--- a/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
@@ -23,8 +23,15 @@ export default UserTopicListRoute.extend({
   },
 
   emptyState() {
+    const user = this.modelFor("user");
+    const title = this.isCurrentUser(user)
+      ? I18n.t("user_activity.no_topics_title")
+      : I18n.t("user_activity.no_topics_title_others", {
+          username: user.username,
+        });
+
     return {
-      title: I18n.t("user_activity.no_topics_title"),
+      title,
       body: "",
     };
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/user-activity-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-activity-topic-test.js
@@ -1,14 +1,18 @@
-import { acceptance, exists, queryAll } from "../helpers/qunit-helpers";
+import { acceptance, exists, query, queryAll } from "../helpers/qunit-helpers";
 import { test } from "qunit";
 import { click, visit } from "@ember/test-helpers";
 import userFixtures from "../fixtures/user-fixtures";
+import I18n from "I18n";
 
 acceptance("User Activity / Topics - bulk actions", function (needs) {
+  const currentUser = "eviltrout";
   needs.user();
 
   needs.pretender((server, helper) => {
-    server.get("/topics/created-by/:username.json", () => {
-      return helper.response(userFixtures["/topics/created-by/eviltrout.json"]);
+    server.get(`/topics/created-by/${currentUser}.json`, () => {
+      return helper.response(
+        userFixtures[`/topics/created-by/${currentUser}.json`]
+      );
     });
 
     server.put("/topics/bulk", () => {
@@ -17,7 +21,7 @@ acceptance("User Activity / Topics - bulk actions", function (needs) {
   });
 
   test("bulk topic closing works", async function (assert) {
-    await visit("/u/charlie/activity/topics");
+    await visit(`/u/${currentUser}/activity/topics`);
 
     await click("button.bulk-select");
     await click(queryAll("input.bulk-select")[0]);
@@ -34,6 +38,8 @@ acceptance("User Activity / Topics - bulk actions", function (needs) {
 });
 
 acceptance("User Activity / Topics - empty state", function (needs) {
+  const currentUser = "eviltrout";
+  const anotherUser = "charlie";
   needs.user();
 
   needs.pretender((server, helper) => {
@@ -43,13 +49,28 @@ acceptance("User Activity / Topics - empty state", function (needs) {
       },
     };
 
-    server.get("/topics/created-by/:username.json", () => {
+    server.get(`/topics/created-by/${currentUser}.json`, () => {
+      return helper.response(emptyResponse);
+    });
+
+    server.get(`/topics/created-by/${anotherUser}.json`, () => {
       return helper.response(emptyResponse);
     });
   });
 
-  test("It renders the empty state panel", async function (assert) {
-    await visit("/u/charlie/activity/topics");
-    assert.ok(exists("div.empty-state"));
+  test("When looking at the own activity page", async function (assert) {
+    await visit(`/u/${currentUser}/activity/topics`);
+    assert.equal(
+      query("div.empty-state span.empty-state-title").innerText,
+      I18n.t("user_activity.no_topics_title")
+    );
+  });
+
+  test("When looking at another user's activity page", async function (assert) {
+    await visit(`/u/${anotherUser}/activity/topics`);
+    assert.equal(
+      query("div.empty-state span.empty-state-title").innerText,
+      I18n.t("user_activity.no_topics_title_others", { username: anotherUser })
+    );
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3977,6 +3977,7 @@ en:
       no_likes_body: "A great way to jump in and start contributing is to start reading conversations that have already taken place, and select the %{heartIcon} on posts that you like!"
       no_likes_others: "No liked posts."
       no_topics_title: "You have not started any topics yet"
+      no_topics_title_others: "%{username} has not started any topics yet"
       no_read_topics_title: "You haven’t read any topics yet"
       no_read_topics_body: "Once you start reading discussions, you’ll see a list here. To start reading, look for topics that interest you in <a href='%{topUrl}'>Top</a> or <a href='%{categoriesUrl}'>Categories</a> or search by keyword %{searchIcon}"
 


### PR DESCRIPTION
We were using blank page copy with the word “you”, even when viewing someone else’s profile:

<img width="500" alt="Screenshot 2022-03-23 at 19 25 11" src="https://user-images.githubusercontent.com/1274517/159770373-7dfc0e45-de8f-47c6-939f-0177c630adc7.png">

After this fix we'll be showing "{username} hasn't started any topics yet" instead.

I also fixed a confusing API that I introduced myself some time ago. In this PR I introduced the `isCurrentUser` function instead of `isAnotherUsersPage`. I didn't remove `isAnotherUsersPage` yet because there exists a usage of it on a plugin. I'll take care of it after merging this PR.
