### PR TITLE
FIX: Don't attempt to focus .title in topic-list-item if it doesn't exist

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -285,7 +285,7 @@ export default Component.extend({
         this.element.classList.remove("highlighted");
       });
       if (opts.isLastViewedTopic && this._shouldFocusLastVisited()) {
-        this._titleElement().focus();
+        this._titleElement()?.focus();
       }
     });
   },


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/97e7bb1ce483498640f512c1bf9bfe704dc1d402

Themes/plugins may override the default `topic-list-item` and remove the `.main-link` or `.title` elements from the template. We shouldn't attempt to focus them if they don't exist.