### PR TITLE
DEV: Fix "serialize to JSON safely" deprecation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -428,7 +428,7 @@ class User < ActiveRecord::Base
       user_id: id,
       message_type: 'welcome_staff',
       message_options: {
-        role: role
+        role: role.to_s
       }
     )
   end


### PR DESCRIPTION
Job arguments must match after a serialize-deserialize cycle. In
this case, the `role` was a symbol and they are converted to
strings during this process.