### PR TITLE
FIX: Do not wrap unaccent around tsqueries

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1144,8 +1144,18 @@ class Search
 
   def self.to_tsquery(ts_config: nil, term:, joiner: nil)
     ts_config = ActiveRecord::Base.connection.quote(ts_config) if ts_config
-    tsquery = "TO_TSQUERY(#{ts_config || default_ts_config}, '#{self.escape_string(term)}')"
-    tsquery = "REPLACE(#{tsquery}::text, '&', '#{self.escape_string(joiner)}')::tsquery" if joiner
+
+    # unaccent can be used only when a joiner is present because the
+    # additional processing and the final conversion to tsquery does not
+    # work well with characters that are converted to quotes by unaccent.
+    if joiner
+      tsquery = "TO_TSQUERY(#{ts_config || default_ts_config}, '#{self.escape_string(term)}')"
+      tsquery = "REPLACE(#{tsquery}::text, '&', '#{self.escape_string(joiner)}')::tsquery"
+    else
+      escaped_term = Search.wrap_unaccent("'#{self.escape_string(term)}'")
+      tsquery = "TO_TSQUERY(#{ts_config || default_ts_config}, #{escaped_term})"
+    end
+
     tsquery
   end
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1144,8 +1144,7 @@ class Search
 
   def self.to_tsquery(ts_config: nil, term:, joiner: nil)
     ts_config = ActiveRecord::Base.connection.quote(ts_config) if ts_config
-    escaped_term = Search.wrap_unaccent("'#{self.escape_string(term)}'")
-    tsquery = "TO_TSQUERY(#{ts_config || default_ts_config}, #{escaped_term})"
+    tsquery = "TO_TSQUERY(#{ts_config || default_ts_config}, '#{self.escape_string(term)}')"
     tsquery = "REPLACE(#{tsquery}::text, '&', '#{self.escape_string(joiner)}')::tsquery" if joiner
     tsquery
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -580,6 +580,11 @@ describe Topic do
       end
     end
 
+    it 'does not result in a syntax error when removing accents' do
+      SiteSetting.search_ignore_accents = true
+      expect(Topic.similar_to('something', 'it\'s')).to eq([])
+    end
+
     it 'does not result in a syntax error when raw is blank after cooking' do
       expect(Topic.similar_to('some title', '#')).to eq([])
     end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -582,7 +582,7 @@ describe Topic do
 
     it 'does not result in a syntax error when removing accents' do
       SiteSetting.search_ignore_accents = true
-      expect(Topic.similar_to('something', 'it\'s')).to eq([])
+      expect(Topic.similar_to('something', "it's")).to eq([])
     end
 
     it 'does not result in a syntax error when raw is blank after cooking' do


### PR DESCRIPTION
Fixes tsqueries that contain characters that when unaccented become
quotes. The problem is that quotes are part of tsquery syntax and
when these characters are unaccented they create an invalid syntax.