### PR TITLE
FIX: Drop the use of add_reference in DB migrations.

### DIFF
--- a/app/models/javascript_cache.rb
+++ b/app/models/javascript_cache.rb
@@ -40,8 +40,3 @@ end
 #  index_javascript_caches_on_theme_field_id  (theme_field_id)
 #  index_javascript_caches_on_theme_id        (theme_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (theme_field_id => theme_fields.id) ON DELETE => cascade
-#  fk_rails_...  (theme_id => themes.id) ON DELETE => cascade
-#

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -188,9 +188,3 @@ end
 #  index_user_profiles_on_granted_title_badge_id        (granted_title_badge_id)
 #  index_user_profiles_on_profile_background_upload_id  (profile_background_upload_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (card_background_upload_id => uploads.id)
-#  fk_rails_...  (granted_title_badge_id => badges.id)
-#  fk_rails_...  (profile_background_upload_id => uploads.id)
-#

--- a/app/models/user_security_key.rb
+++ b/app/models/user_security_key.rb
@@ -40,7 +40,3 @@ end
 #  index_user_security_keys_on_public_key               (public_key)
 #  index_user_security_keys_on_user_id                  (user_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (user_id => users.id)
-#

--- a/db/migrate/20120427154330_create_vestal_versions.rb
+++ b/db/migrate/20120427154330_create_vestal_versions.rb
@@ -3,8 +3,10 @@
 class CreateVestalVersions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :versions do |t|
-      t.belongs_to :versioned, polymorphic: true
-      t.belongs_to :user, polymorphic: true
+      t.integer :versioned_id, null: false
+      t.string :versioned_type, null: false
+      t.integer :user_id, null: false
+      t.string :user_type, null: false
       t.string  :user_name
       t.text    :modifications
       t.integer :number

--- a/db/migrate/20120622200242_create_notifications.rb
+++ b/db/migrate/20120622200242_create_notifications.rb
@@ -4,7 +4,7 @@ class CreateNotifications < ActiveRecord::Migration[4.2]
   def change
     create_table :notifications do |t|
       t.integer :notification_type, null: false
-      t.references :user, null: false
+      t.integer :user_id, null: false
       t.string :data, null: false
       t.boolean :read, default: false, null: false
       t.timestamps null: false

--- a/db/migrate/20120702211427_create_replies.rb
+++ b/db/migrate/20120702211427_create_replies.rb
@@ -3,7 +3,7 @@
 class CreateReplies < ActiveRecord::Migration[4.2]
   def change
     create_table :post_replies, id: false do |t|
-      t.references :post
+      t.integer :post_id
       t.integer :reply_id
       t.timestamps null: false
     end

--- a/db/migrate/20120713201324_create_category_featured_threads.rb
+++ b/db/migrate/20120713201324_create_category_featured_threads.rb
@@ -3,8 +3,8 @@
 class CreateCategoryFeaturedThreads < ActiveRecord::Migration[4.2]
   def change
     create_table :category_featured_threads, id: false do |t|
-      t.references :category, null: false
-      t.references :forum_thread, null: false
+      t.integer :category_id, null: false
+      t.integer :forum_thread_id, null: false
       t.timestamps null: false
     end
 

--- a/db/migrate/20120813201426_create_forum_thread_link_clicks.rb
+++ b/db/migrate/20120813201426_create_forum_thread_link_clicks.rb
@@ -3,8 +3,8 @@
 class CreateForumThreadLinkClicks < ActiveRecord::Migration[4.2]
   def change
     create_table :forum_thread_link_clicks do |t|
-      t.references :forum_thread_link, null: false
-      t.references :user, null: true
+      t.integer :forum_thread_link_id, null: false
+      t.integer :user_id, null: true
       t.integer :ip, null: false, limit: 8
       t.timestamps null: false
     end

--- a/db/migrate/20120824171908_create_category_featured_users.rb
+++ b/db/migrate/20120824171908_create_category_featured_users.rb
@@ -3,8 +3,8 @@
 class CreateCategoryFeaturedUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :category_featured_users do |t|
-      t.references :category
-      t.references :user
+      t.integer :category_id, null: false
+      t.integer :user_id, null: false
       t.timestamps null: false
     end
 

--- a/db/migrate/20120828204624_create_post_onebox_renders.rb
+++ b/db/migrate/20120828204624_create_post_onebox_renders.rb
@@ -3,8 +3,8 @@
 class CreatePostOneboxRenders < ActiveRecord::Migration[4.2]
   def change
     create_table :post_onebox_renders, id: false do |t|
-      t.references :post, null: false
-      t.references :onebox_render, null: false
+      t.integer :post_id, null: false
+      t.integer :onebox_render_id, null: false
       t.timestamps null: false
     end
     add_index :post_onebox_renders, [:post_id, :onebox_render_id], unique: true

--- a/db/migrate/20120921163606_create_archetype_options.rb
+++ b/db/migrate/20120921163606_create_archetype_options.rb
@@ -3,7 +3,7 @@
 class CreateArchetypeOptions < ActiveRecord::Migration[4.2]
   def change
     create_table :archetype_options do |t|
-      t.references :archetype, null: false
+      t.integer :archetype_id, null: false
       t.string :key, null: false
       t.integer :option_type, null: false
       t.timestamps null: false

--- a/db/migrate/20121121205215_create_topic_invites.rb
+++ b/db/migrate/20121121205215_create_topic_invites.rb
@@ -3,8 +3,8 @@
 class CreateTopicInvites < ActiveRecord::Migration[4.2]
   def change
     create_table :topic_invites do |t|
-      t.references :topic, null: false
-      t.references :invite, null: false
+      t.integer :topic_id, null: false
+      t.integer :invite_id, null: false
       t.timestamps null: false
     end
 

--- a/db/migrate/20121129160035_create_email_tokens.rb
+++ b/db/migrate/20121129160035_create_email_tokens.rb
@@ -3,7 +3,7 @@
 class CreateEmailTokens < ActiveRecord::Migration[4.2]
   def change
     create_table :email_tokens do |t|
-      t.references :user, null: false
+      t.integer :user_id, null: false
       t.string :email, null: false
       t.string :token, null: false
       t.boolean :confirmed, null: false, default: false

--- a/db/migrate/20130911182437_create_user_stats.rb
+++ b/db/migrate/20130911182437_create_user_stats.rb
@@ -3,7 +3,7 @@
 class CreateUserStats < ActiveRecord::Migration[4.2]
   def up
     create_table :user_stats, id: false do |t|
-      t.references :user, null: false
+      t.integer :user_id, null: false
       t.boolean :has_custom_avatar, default: false, null: false
     end
     execute "ALTER TABLE user_stats ADD PRIMARY KEY (user_id)"

--- a/db/migrate/20131015131652_create_post_details.rb
+++ b/db/migrate/20131015131652_create_post_details.rb
@@ -3,7 +3,7 @@
 class CreatePostDetails < ActiveRecord::Migration[4.2]
   def change
     create_table :post_details do |t|
-      t.belongs_to :post
+      t.integer    :post_id
       t.string     :key
       t.string     :value, size: 512
       t.text       :extra

--- a/db/migrate/20131209091702_create_post_revisions.rb
+++ b/db/migrate/20131209091702_create_post_revisions.rb
@@ -3,8 +3,8 @@
 class CreatePostRevisions < ActiveRecord::Migration[4.2]
   def up
     create_table :post_revisions do |t|
-      t.belongs_to :user
-      t.belongs_to :post
+      t.integer :user_id
+      t.integer :post_id
       t.text :modifications
       t.integer :number
       t.timestamps null: false

--- a/db/migrate/20131209091742_create_topic_revisions.rb
+++ b/db/migrate/20131209091742_create_topic_revisions.rb
@@ -3,8 +3,8 @@
 class CreateTopicRevisions < ActiveRecord::Migration[4.2]
   def up
     create_table :topic_revisions do |t|
-      t.belongs_to :user
-      t.belongs_to :topic
+      t.integer :user_id, null: false
+      t.integer :topic_id, null: false
       t.text :modifications
       t.integer :number
       t.timestamps null: false

--- a/db/migrate/20131223171005_create_top_topics.rb
+++ b/db/migrate/20131223171005_create_top_topics.rb
@@ -6,7 +6,7 @@ class CreateTopTopics < ActiveRecord::Migration[4.2]
 
   def change
     create_table :top_topics, force: true do |t|
-      t.belongs_to :topic
+      t.integer :topic_id
 
       PERIODS.each do |period|
         SORT_ORDERS.each do |sort|

--- a/db/migrate/20140527163207_create_user_profiles.rb
+++ b/db/migrate/20140527163207_create_user_profiles.rb
@@ -3,7 +3,7 @@
 class CreateUserProfiles < ActiveRecord::Migration[4.2]
   def up
     create_table :user_profiles, id: false do |t|
-      t.references :user
+      t.integer :user_id, null: false
       t.string :location
     end
     execute "ALTER TABLE user_profiles ADD PRIMARY KEY (user_id)"

--- a/db/migrate/20140905171733_create_warnings.rb
+++ b/db/migrate/20140905171733_create_warnings.rb
@@ -3,8 +3,8 @@
 class CreateWarnings < ActiveRecord::Migration[4.2]
   def change
     create_table :warnings do |t|
-      t.references :topic, null: false
-      t.references :user, null: false
+      t.integer :topic_id, null: false
+      t.integer :user_id, null: false
       t.integer :created_by_id, null: false
       t.timestamps null: false
     end

--- a/db/migrate/20150318143915_create_directory_items.rb
+++ b/db/migrate/20150318143915_create_directory_items.rb
@@ -4,7 +4,7 @@ class CreateDirectoryItems < ActiveRecord::Migration[4.2]
   def change
     create_table :directory_items, force: true do |t|
       t.integer :period_type, null: false
-      t.references :user, null: false
+      t.integer :user_id, null: false
       t.integer :likes_received, null: false
       t.integer :likes_given, null: false
       t.integer :topics_entered, null: false

--- a/db/migrate/20150727193414_create_user_field_options.rb
+++ b/db/migrate/20150727193414_create_user_field_options.rb
@@ -3,7 +3,7 @@
 class CreateUserFieldOptions < ActiveRecord::Migration[4.2]
   def change
     create_table :user_field_options, force: true do |t|
-      t.references :user_field, null: false
+      t.integer :user_field_id, null: false
       t.string :value, null: false
       t.timestamps null: false
     end

--- a/db/migrate/20160503205953_create_tags.rb
+++ b/db/migrate/20160503205953_create_tags.rb
@@ -9,14 +9,14 @@ class CreateTags < ActiveRecord::Migration[4.2]
     end
 
     create_table :topic_tags do |t|
-      t.references :topic, null: false
-      t.references :tag,   null: false
+      t.integer :topic_id, null: false
+      t.integer :tag_id, null: false
       t.timestamps null: false
     end
 
     create_table :tag_users do |t|
-      t.references :tag,  null: false
-      t.references :user, null: false
+      t.integer :tag_id, null: false
+      t.integer :user_id, null: false
       t.integer    :notification_level, null: false
       t.timestamps null: false
     end

--- a/db/migrate/20160527191614_create_category_tags.rb
+++ b/db/migrate/20160527191614_create_category_tags.rb
@@ -3,8 +3,8 @@
 class CreateCategoryTags < ActiveRecord::Migration[4.2]
   def change
     create_table :category_tags do |t|
-      t.references :category, null: false
-      t.references :tag,      null: false
+      t.integer :category_id, null: false
+      t.integer :tag_id, null: false
       t.timestamps null: false
     end
 

--- a/db/migrate/20160602164008_create_tag_groups.rb
+++ b/db/migrate/20160602164008_create_tag_groups.rb
@@ -9,8 +9,8 @@ class CreateTagGroups < ActiveRecord::Migration[4.2]
     end
 
     create_table :tag_group_memberships do |t|
-      t.references :tag,       null: false
-      t.references :tag_group, null: false
+      t.integer :tag_id, null: false
+      t.integer :tag_group_id, null: false
       t.timestamps null: false
     end
 

--- a/db/migrate/20160606204319_create_category_tag_groups.rb
+++ b/db/migrate/20160606204319_create_category_tag_groups.rb
@@ -3,8 +3,8 @@
 class CreateCategoryTagGroups < ActiveRecord::Migration[4.2]
   def change
     create_table :category_tag_groups do |t|
-      t.references :category,  null: false
-      t.references :tag_group, null: false
+      t.integer :category_id, null: false
+      t.integer :tag_group_id, null: false
       t.timestamps null: false
     end
 

--- a/db/migrate/20160905084502_create_web_hook_events.rb
+++ b/db/migrate/20160905084502_create_web_hook_events.rb
@@ -3,7 +3,7 @@
 class CreateWebHookEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :web_hook_events do |t|
-      t.belongs_to :web_hook, null: false, index: true
+      t.integer    :web_hook_id, null: false
       t.string     :headers
       t.text       :payload
       t.integer    :status, default: 0
@@ -13,5 +13,7 @@ class CreateWebHookEvents < ActiveRecord::Migration[4.2]
 
       t.timestamps null: false
     end
+
+    add_index :web_hook_events, :web_hook_id
   end
 end

--- a/db/migrate/20180207163946_create_category_tag_stats.rb
+++ b/db/migrate/20180207163946_create_category_tag_stats.rb
@@ -3,12 +3,14 @@
 class CreateCategoryTagStats < ActiveRecord::Migration[5.1]
   def change
     create_table :category_tag_stats do |t|
-      t.references :category, null: false
-      t.references :tag, null: false
+      t.bigint :category_id, null: false
+      t.bigint :tag_id, null: false
       t.integer :topic_count, default: 0, null: false
     end
 
     add_index :category_tag_stats, [:category_id, :topic_count]
     add_index :category_tag_stats, [:category_id, :tag_id], unique: true
+    add_index :category_tag_stats, :category_id
+    add_index :category_tag_stats, :tag_id
   end
 end

--- a/db/migrate/20180323154826_create_tag_group_permissions.rb
+++ b/db/migrate/20180323154826_create_tag_group_permissions.rb
@@ -3,10 +3,13 @@
 class CreateTagGroupPermissions < ActiveRecord::Migration[5.1]
   def change
     create_table :tag_group_permissions do |t|
-      t.references :tag_group,  null: false
-      t.references :group, null: false
+      t.bigint :tag_group_id, null: false
+      t.bigint :group_id, null: false
       t.integer :permission_type, default: 1, null: false
       t.timestamps null: false
     end
+
+    add_index :tag_group_permissions, :tag_group_id
+    add_index :tag_group_permissions, :group_id
   end
 end

--- a/db/migrate/20180927135248_create_javascript_caches.rb
+++ b/db/migrate/20180927135248_create_javascript_caches.rb
@@ -3,10 +3,12 @@
 class CreateJavascriptCaches < ActiveRecord::Migration[5.2]
   def change
     create_table :javascript_caches do |t|
-      t.references :theme_field, null: false
+      t.bigint :theme_field_id, null: false
       t.string :digest, null: true, index: true
       t.text :content, null: false
       t.timestamps
     end
+
+    add_index :javascript_caches, :theme_field_id
   end
 end

--- a/db/migrate/20190513143015_add_theme_id_to_javascript_cache.rb
+++ b/db/migrate/20190513143015_add_theme_id_to_javascript_cache.rb
@@ -22,7 +22,8 @@ class AddThemeIdToJavascriptCache < ActiveRecord::Migration[5.2]
   private
 
   def make_changes
-    add_reference :javascript_caches, :theme, foreign_key: { on_delete: :cascade }
+    add_column :javascript_caches, :theme_id, :bigint, null: true
+    add_index :javascript_caches, :theme_id
     add_foreign_key :javascript_caches, :theme_fields, on_delete: :cascade
 
     begin

--- a/db/migrate/20190904104533_create_user_security_keys.rb
+++ b/db/migrate/20190904104533_create_user_security_keys.rb
@@ -3,7 +3,7 @@
 class CreateUserSecurityKeys < ActiveRecord::Migration[5.2]
   def up
     create_table :user_security_keys do |t|
-      t.references :user, null: false, index: true, foreign_key: true
+      t.bigint :user_id, null: false
       t.string :credential_id, null: false
       t.string :public_key, null: false, index: true
       t.integer :factor_type, null: false, default: 0, index: true
@@ -15,6 +15,7 @@ class CreateUserSecurityKeys < ActiveRecord::Migration[5.2]
     end
 
     add_index :user_security_keys, :credential_id, unique: true
+    add_index :user_security_keys, :user_id
     add_index :user_security_keys, :last_used
   end
 

--- a/db/migrate/20191031052711_add_granted_title_badge_id_to_user_profile.rb
+++ b/db/migrate/20191031052711_add_granted_title_badge_id_to_user_profile.rb
@@ -2,7 +2,8 @@
 
 class AddGrantedTitleBadgeIdToUserProfile < ActiveRecord::Migration[6.0]
   def up
-    add_reference :user_profiles, :granted_title_badge, foreign_key: { to_table: :badges }, index: true, null: true
+    add_column :user_profiles, :granted_title_badge_id, :bigint, null: true
+    add_index :user_profiles, :granted_title_badge_id
 
     # update all the regular badge derived titles based
     # on the normal badge name

--- a/db/migrate/20191205100434_create_standalone_bookmarks_table.rb
+++ b/db/migrate/20191205100434_create_standalone_bookmarks_table.rb
@@ -3,9 +3,9 @@
 class CreateStandaloneBookmarksTable < ActiveRecord::Migration[6.0]
   def up
     create_table :bookmarks do |t|
-      t.references :user, index: true, foreign_key: true, null: false
-      t.references :topic, index: true, foreign_key: true, null: true
-      t.references :post, index: true, foreign_key: true, null: false
+      t.bigint :user_id, null: false
+      t.bigint :topic_id, null: false
+      t.bigint :post_id, null: false
       t.string :name, null: true
       t.integer :reminder_type, null: true, index: true
       t.datetime :reminder_at, null: true, index: true
@@ -14,6 +14,9 @@ class CreateStandaloneBookmarksTable < ActiveRecord::Migration[6.0]
     end
 
     add_index :bookmarks, [:user_id, :post_id], unique: true
+    add_index :bookmarks, :user_id
+    add_index :bookmarks, :topic_id
+    add_index :bookmarks, :post_id
   end
 
   def down

--- a/db/migrate/20191230055237_add_access_control_columns_to_upload.rb
+++ b/db/migrate/20191230055237_add_access_control_columns_to_upload.rb
@@ -2,7 +2,8 @@
 
 class AddAccessControlColumnsToUpload < ActiveRecord::Migration[6.0]
   def up
-    add_reference :uploads, :access_control_post, foreign_key: { to_table: :posts }, index: true, null: true
+    add_column :uploads, :access_control_post_id, :bigint, null: true
+    add_index :uploads, :access_control_post_id
     add_column :uploads, :original_sha1, :string, null: true
     add_index :uploads, :original_sha1
   end

--- a/db/migrate/20200302120829_add_theme_modifier_set.rb
+++ b/db/migrate/20200302120829_add_theme_modifier_set.rb
@@ -2,10 +2,12 @@
 class AddThemeModifierSet < ActiveRecord::Migration[6.0]
   def change
     create_table(:theme_modifier_sets) do |t|
-      t.references :theme, index: { unique: true }, null: false
+      t.bigint :theme_id, null: false
       t.column :serialize_topic_excerpts, :boolean
       t.column :csp_extensions, :string, array: true
       t.column :svg_icons, :string, array: true
     end
+
+    add_index :theme_modifier_sets, :theme_id, unique: true
   end
 end

--- a/db/migrate/20200401172023_create_published_pages.rb
+++ b/db/migrate/20200401172023_create_published_pages.rb
@@ -3,11 +3,12 @@
 class CreatePublishedPages < ActiveRecord::Migration[6.0]
   def change
     create_table :published_pages do |t|
-      t.references :topic, null: false, index: { unique: true }
+      t.bigint :topic_id, null: false
       t.string :slug, null: false
       t.timestamps
     end
 
+    add_index :published_pages, :topic_id, unique: true
     add_index :published_pages, :slug, unique: true
   end
 end

--- a/db/migrate/20200429095034_add_topic_thumbnail_information.rb
+++ b/db/migrate/20200429095034_add_topic_thumbnail_information.rb
@@ -30,13 +30,15 @@ class AddTopicThumbnailInformation < ActiveRecord::Migration[6.0]
       add_column :theme_modifier_sets, :topic_thumbnail_sizes, :string, array: true
 
       create_table :topic_thumbnails do |t|
-        t.references :upload, null: false
-        t.references :optimized_image, null: true
+        t.bigint :upload_id, null: false
+        t.bigint :optimized_image_id
         t.integer :max_width, null: false
         t.integer :max_height, null: false
       end
 
       add_index :topic_thumbnails, [:upload_id, :max_width, :max_height], name: :unique_topic_thumbnails, unique: true
+      add_index :topic_thumbnails, :upload_id
+      add_index :topic_thumbnails, :optimized_image_id
     end
   end
 

--- a/db/migrate/20200520001619_remove_fks_from_bookmarks.rb
+++ b/db/migrate/20200520001619_remove_fks_from_bookmarks.rb
@@ -2,8 +2,8 @@
 
 class RemoveFksFromBookmarks < ActiveRecord::Migration[6.0]
   def change
-    remove_foreign_key :bookmarks, :topics
-    remove_foreign_key :bookmarks, :posts
-    remove_foreign_key :bookmarks, :users
+    remove_foreign_key(:bookmarks, :topics) if foreign_key_exists?(:bookmarks, :topics)
+    remove_foreign_key(:bookmarks, :users) if foreign_key_exists?(:bookmarks, :users)
+    remove_foreign_key(:bookmarks, :posts) if foreign_key_exists?(:bookmarks, :posts)
   end
 end

--- a/db/migrate/20200522004855_remove_access_control_post_fk.rb
+++ b/db/migrate/20200522004855_remove_access_control_post_fk.rb
@@ -2,6 +2,6 @@
 
 class RemoveAccessControlPostFk < ActiveRecord::Migration[6.0]
   def change
-    remove_foreign_key :uploads, column: :access_control_post_id
+    remove_foreign_key(:uploads, column: :access_control_post_id) if foreign_key_exists?(:uploads, column: :access_control_post_id)
   end
 end

--- a/db/migrate/20211106085527_create_user_associated_groups.rb
+++ b/db/migrate/20211106085527_create_user_associated_groups.rb
@@ -2,12 +2,14 @@
 class CreateUserAssociatedGroups < ActiveRecord::Migration[6.1]
   def change
     create_table :user_associated_groups do |t|
-      t.references :user, null: false
-      t.references :associated_group, null: false
+      t.bigint :user_id, null: false
+      t.bigint :associated_group_id, null: false
 
       t.timestamps
     end
 
     add_index :user_associated_groups, %i[user_id associated_group_id], unique: true, name: 'index_user_associated_groups'
+    add_index :user_associated_groups, :user_id
+    add_index :user_associated_groups, :associated_group_id
   end
 end

--- a/db/migrate/20211106085605_create_group_associated_groups.rb
+++ b/db/migrate/20211106085605_create_group_associated_groups.rb
@@ -2,12 +2,14 @@
 class CreateGroupAssociatedGroups < ActiveRecord::Migration[6.1]
   def change
     create_table :group_associated_groups do |t|
-      t.references :group, null: false
-      t.references :associated_group, null: false
+      t.bigint :group_id, null: false
+      t.bigint :associated_group_id, null: false
 
       t.timestamps
     end
 
     add_index :group_associated_groups, %i[group_id associated_group_id], unique: true, name: 'index_group_associated_groups'
+    add_index :group_associated_groups, :group_id
+    add_index :group_associated_groups, :associated_group_id
   end
 end

--- a/db/post_migrate/20220325031652_clean_up_foreign_keys.rb
+++ b/db/post_migrate/20220325031652_clean_up_foreign_keys.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CleanUpForeignKeys < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key(:user_security_keys, :users) if foreign_key_exists?(:user_security_keys, :users)
+    remove_foreign_key(:javascript_caches, :themes) if foreign_key_exists?(:javascript_caches, :themes)
+    remove_foreign_key(:javascript_caches, :theme_fields) if foreign_key_exists?(:javascript_caches, :theme_fields)
+    remove_foreign_key(:user_profiles, column: :granted_title_badge_id) if foreign_key_exists?(:user_profiles, column: :granted_title_badge_id)
+    remove_foreign_key(:user_profiles, column: :card_background_upload_id) if foreign_key_exists?(:user_profiles, column: :card_background_upload_id)
+    remove_foreign_key(:user_profiles, column: :profile_background_upload_id) if foreign_key_exists?(:user_profiles, column: :profile_background_upload_id)
+  end
+end


### PR DESCRIPTION
Discourse has never relied on a schema file when creating new sites
    and instead reruns all migrations from scratch each time we're setting
    up a new database. However, this means we want our migrations to be as
    stable as possible to prevent any possible schema drifts between sites.
    The use of `refereces` and its associated family of methods has not been
    ideal for us because it relies on the data type of whatever
    Rails defaults to. Bugs in Rails like
    https://github.com/rails/rails/pull/42350 can also result in the data
    type of columns changing between Rails releases. Instead, we've decided
    to be more explicit by specifying the data type in our migrations.
    
We've also decided to drop the foreign key constraints that were
    generated previously because we've decided not to use foreign key
    constraints in Discourse as they provided little to no benefits for us.
    This commit does not seek to drop all foreign key constraints but only
    those that are affected by this commit.
