### PR TITLE
DEV: Rename param passed to updateNotificationLevel

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -254,8 +254,8 @@ export default Controller.extend(CanCheckEmails, {
       bootbox.dialog(message, buttons, { classes: "delete-user-modal" });
     },
 
-    updateNotificationLevel(level) {
-      return this.model.updateNotificationLevel(level);
+    updateNotificationLevel(params) {
+      return this.model.updateNotificationLevel(params);
     },
   },
 });


### PR DESCRIPTION
`updateNotificationLevel` in models/user.js is expecting an object. The `level` param sent as an argument looks like it is not an object, but in fact it is see

https://github.com/discourse/discourse/blob/a3563336dbb419a0fc9f6fe9def09c396b4c1c16/app/assets/javascripts/select-kit/addon/components/user-notifications-dropdown.js#L51-L56

https://github.com/discourse/discourse/blob/a3563336dbb419a0fc9f6fe9def09c396b4c1c16/app/assets/javascripts/discourse/app/controllers/ignore-duration.js#L20-L23

This just changed the name of the variable so it doesn't look like a string is being passed in, but instead _some param_ (which is an object)