### PR TITLE
DEV: Be more lenient in CLI confirmation

### DIFF
--- a/script/discourse
+++ b/script/discourse
@@ -45,7 +45,7 @@ class DiscourseCLI < Thor
     puts "THIS TASK WILL REWRITE DATA, ARE YOU SURE (type YES)"
     puts "WILL RUN ON ALL #{RailsMultisite::ConnectionManagement.all_dbs.length} DBS" if options[:global]
     text = STDIN.gets
-    if text.strip != "YES"
+    if text.strip.upcase != "YES"
       puts "aborting."
       exit 1
     end


### PR DESCRIPTION
If someone types `yes` rather than `YES`, continue anyway.

The chance of typing `yes`, when you actually want to stop, is non-existent. The chance of typing `yes` when you meant `YES` is  high, and it's very frustrating when the script quits because you got the case wrong!

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
