### PR TITLE
UX: Require a password for invited users

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/invites-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/invites-show.js
@@ -1,4 +1,4 @@
-import { alias, notEmpty, or, readOnly } from "@ember/object/computed";
+import { alias, not, or, readOnly } from "@ember/object/computed";
 import Controller, { inject as controller } from "@ember/controller";
 import DiscourseURL from "discourse/lib/url";
 import EmberObject from "@ember/object";
@@ -33,7 +33,7 @@ export default Controller.extend(
     emailVerifiedByLink: alias("model.email_verified_by_link"),
     differentExternalEmail: alias("model.different_external_email"),
     accountUsername: alias("model.username"),
-    passwordRequired: notEmpty("accountPassword"),
+    passwordRequired: not("externalAuthsOnly"),
     successMessage: null,
     errorMessage: null,
     userFields: null,

--- a/app/assets/javascripts/discourse/app/templates/invites/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/invites/show.hbs
@@ -97,10 +97,11 @@
                     {{password-field value=accountPassword class=(value-entered accountPassword) type="password" id="new-account-password" capsLockOn=capsLockOn}}
                     <label class="alt-placeholder" for="new-account-password">
                       {{i18n "invites.password_label"}}
+                      <span class="required">*</span>
                     </label>
                     {{input-tip validation=passwordValidation}}
                     <div class="instructions">
-                      {{passwordInstructions}} {{i18n "invites.optional_description"}}
+                      {{passwordInstructions}}
                       <div class="caps-lock-warning {{unless capsLockOn "invisible"}}">
                         {{d-icon "exclamation-triangle"}} {{i18n "login.caps_lock_warning"}}
                       </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/invite-accept-test.js
@@ -119,6 +119,12 @@ acceptance("Invite accept", function (needs) {
     );
 
     await fillIn("#new-account-email", "john.doe@example.com");
+    assert.ok(
+      exists(".invites-show .btn-primary:disabled"),
+      "submit is disabled because password is not filled"
+    );
+
+    await fillIn("#new-account-password", "top$ecret");
     assert.notOk(
       exists(".invites-show .btn-primary:disabled"),
       "submit is enabled"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1997,7 +1997,6 @@ en:
       success: "Your account has been created and you're now logged in."
       name_label: "Name"
       password_label: "Password"
-      optional_description: "(optional)"
 
     password_reset:
       continue: "Continue to %{site_name}"


### PR DESCRIPTION
Invited users were allowed to accept invites without entering a
password. When this happened, instead of receiving an activation email,
they received a password reset email. Basically, a user could postpone
choosing a password until after registration.

Unfortunately, this led to a confusing user experience and this commit
attempts to fix that by making the client require a password. There is
a single case when users do not need to input a password: when they sign
up using an external authenticator and password field is completely
hidden. In this case, the third party handles the password logic.

Technically, invites can still be redeemed without a password, but that
functionality was kept to preserve backwards compatibility.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
