### PR TITLE
FIX: Validate category tag restrictions before sending new topics to review

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -933,6 +933,10 @@ class Category < ActiveRecord::Base
     end
   end
 
+  def has_restricted_tags?
+    tags.count > 0 || tag_groups.count > 0
+  end
+
   private
 
   def should_update_reviewables?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4810,6 +4810,12 @@ en:
         other: '"%{tag_name}" is restricted to the following categories: %{category_names}'
       synonym: 'Synonyms are not allowed. Use "%{tag_name}" instead.'
       has_synonyms: '"%{tag_name}" cannot be used because it has synonyms.'
+      restricted_tags_cannot_be_used_in_category:
+        one: 'The "%{tags}" tag cannot be used in the "%{category}" category. Please remove it.'
+        other: 'The following tags cannot be used in the "%{category}" category: %{tags}. Please remove them.'
+      category_does_not_allow_tags:
+        one: 'The "%{category}" category does not allow the "%{tags}" tag. Please remove it.'
+        other: 'The "%{category}" category does not allow the following tags: "%{tags}". Please remove them.'
     required_tags_from_group:
       one: "You must include at least %{count} %{tag_group_name} tag. The tags in this group are: %{tags}."
       other: "You must include at least %{count} %{tag_group_name} tags. The tags in this group are: %{tags}."

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -33,6 +33,7 @@ class TopicCreator
       # both add to topic.errors
       DiscourseTagging.validate_min_required_tags_for_category(guardian, topic, category, valid_tags)
       DiscourseTagging.validate_required_tags_from_group(guardian, topic, category, existing_tags)
+      DiscourseTagging.validate_category_restricted_tags(guardian, topic, category, valid_tags)
     end
 
     DiscourseEvent.trigger(:after_validate_topic, topic, self)

--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -30,7 +30,7 @@ class TopicCreator
       existing_tags = tags.present? ? Tag.where(name: tags) : []
       valid_tags = guardian.can_create_tag? ? tags : existing_tags
 
-      # both add to topic.errors
+      # all add to topic.errors
       DiscourseTagging.validate_min_required_tags_for_category(guardian, topic, category, valid_tags)
       DiscourseTagging.validate_required_tags_from_group(guardian, topic, category, existing_tags)
       DiscourseTagging.validate_category_restricted_tags(guardian, topic, category, valid_tags)

--- a/spec/lib/topic_creator_spec.rb
+++ b/spec/lib/topic_creator_spec.rb
@@ -193,8 +193,8 @@ describe TopicCreator do
           tc = TopicCreator.new(
             user,
             Guardian.new(user),
-            title: "hello this is a test topic with tags",
-            raw: "hello this is a test topic with tags",
+            title: "hello this is a test topic without tags",
+            raw: "hello this is a test topic without tags",
             category: category.id,
           )
           expect(tc.valid?).to eq(true)


### PR DESCRIPTION
Tags (and tag groups) can be configured so that they can only be used in specific categories and (optionally) restrict topics in these categories to be able to add/use only these tags. These restrictions work as expected when a topic is created without going through the review queue; however, if the topic has to be reviewed by a moderator then these restrictions currently aren't checked before the topic is sent to the review queue, but they're checked later when a moderator tries to approve the topic. This is because if a user manages to submit a topic that doesn't meet the restrictions, moderators won't be able to approve and it'll be stuck in the review queue.

This PR prevents topics that don't meet the tags requirements from being sent to the review queue and shows the poster an error message that indicates which tags that cannot be used.

Internal ticket: t60562.