### PR TITLE
DEV: Register question_answer_user_commented notification type.

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/concerns/notification-types.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/concerns/notification-types.js
@@ -37,4 +37,5 @@ export const NOTIFICATION_TYPES = {
   chat_group_mention: 32,
   chat_quoted: 33,
   assigned: 34,
+  question_answer_user_commented: 35,
 };

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -111,7 +111,8 @@ class Notification < ActiveRecord::Base
                         chat_invitation: 31,
                         chat_group_mention: 32, # March 2022 - This is obsolete, as all chat_mentions use `chat_mention` type
                         chat_quoted: 33,
-                        assigned: 34
+                        assigned: 34,
+                        question_answer_user_commented: 35, # Used by https://github.com/discourse/discourse-question-answer
                        )
   end
 

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -109,6 +109,9 @@
         },
         "assigned": {
           "type": "integer"
+        },
+        "question_answer_user_commented": {
+          "type": "integer"
         }
       },
       "required": [


### PR DESCRIPTION
The notification type is used by https://github.com/discourse/discourse-question-answer