### PR TITLE
FIX: Redirect user to topic they were invited to

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1065,10 +1065,27 @@ class UsersController < ApplicationController
         @user.enqueue_welcome_message('welcome_user') if @user.send_welcome_message
         log_on_user(@user)
 
+        # invites#perform_accept_invitation already sets destination_url, but
+        # sometimes it is lost (user changes browser, uses incognito, etc)
+        #
+        # The code below checks if the user was invited and redirects them to
+        # the topic they were originally invited to.
+        destination_url = cookies.delete(:destination_url)
+        if destination_url.blank?
+          topic = Invite
+            .joins(:invited_users)
+            .find_by(invited_users: { user_id: @user.id })
+            &.topics
+            &.first
+
+          if @user.guardian.can_see?(topic)
+            destination_url = path(topic.relative_url)
+          end
+        end
+
         if Wizard.user_requires_completion?(@user)
           return redirect_to(wizard_path)
-        elsif destination_url = cookies[:destination_url]
-          cookies[:destination_url] = nil
+        elsif destination_url.present?
           return redirect_to(destination_url)
         elsif SiteSetting.enable_discourse_connect_provider && payload = cookies.delete(:sso_payload)
           return redirect_to(session_sso_provider_url + "?" + payload)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -147,6 +147,23 @@ describe UsersController do
         expect(response).to redirect_to(destination_url)
       end
     end
+
+    context 'when cookies does not contain a destination URL but users was invited to topic' do
+      let(:invite) { Fabricate(:invite) }
+      let(:topic) { Fabricate(:topic) }
+
+      before do
+        TopicInvite.create!(topic: topic, invite: invite)
+        Fabricate(:invited_user, invite: invite, user: email_token.user)
+        invite.reload
+      end
+
+      it 'should redirect to the topic' do
+        put "/u/activate-account/#{email_token.token}"
+
+        expect(response).to redirect_to(topic.relative_url)
+      end
+    end
   end
 
   describe '#password_reset' do


### PR DESCRIPTION
This did not work properly everytime because the destination URL was
saved in a cookie and that can be lost for various reasons. This commit
redirects the user to invited topic if it exists.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
