### PR TITLE
DEV: API for adding consistency-check-exempt notification types

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -31,6 +31,21 @@ class Notification < ActiveRecord::Base
     self.high_priority = self.high_priority || Notification.high_priority_types.include?(self.notification_type)
   end
 
+  @@consistency_exempt_types = []
+
+  def self.register_consistency_exempt_type(type)
+    begin
+      type = type.to_i
+      @@consistency_exempt_types << type unless @@consistency_exempt_types.include?(type)
+    rescue => e
+      Discourse.warn_exception(e, message: "Failed to register '#{type}' as a consistency exempt notification type. Ensure the type is a valid notifcation type.")
+    end
+  end
+
+  def self.reset_consistency_exempt_types
+    @@consistency_exempt_types = []
+  end
+
   def self.consolidate_or_create!(notification_params)
     notification = new(notification_params)
     consolidation_planner = Notifications::ConsolidationPlanner.new
@@ -59,12 +74,18 @@ class Notification < ActiveRecord::Base
     SQL
   end
 
+  def self.consistency_exempt_sql
+    return "" if @@consistency_exempt_types.empty?
+
+    "AND notification_type NOT IN (#{@@consistency_exempt_types.join(", ")})"
+  end
+
   def self.ensure_consistency!
     DB.exec(<<~SQL)
       DELETE
         FROM notifications n
        WHERE high_priority
-         AND notification_type NOT IN (#{types[:chat_mention].to_i}, #{types[:chat_message].to_i})
+         #{consistency_exempt_sql}
          AND NOT EXISTS (
             SELECT 1
               FROM posts p

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -630,6 +630,10 @@ class Plugin::Instance
     Plugin::CustomEmoji.translate(from, to)
   end
 
+  def register_consistency_exempt_notification_type(type)
+    Notification.register_consistency_exempt_type(type)
+  end
+
   def automatic_assets
     css = styles.join("\n")
     js = javascripts.join("\n")

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -340,13 +340,17 @@ describe Notification do
       expect(Notification.count).to eq(2)
     end
 
-    it 'does not delete chat_message notifications' do
+    it 'does not delete consistency exempt notifications' do
+      chat_mention_type = Notification.types[:chat_mention]
+      Notification.register_consistency_exempt_type(chat_mention_type)
       Notification.create!(read: false, user_id: user.id, topic_id: nil, post_number: nil, data: '[]',
-                           notification_type: Notification.types[:chat_mention])
+                           notification_type: chat_mention_type, high_priority: true)
 
       expect {
         Notification.ensure_consistency!
       }.to_not change { Notification.count }
+
+      Notification.reset_consistency_exempt_types
     end
   end
 


### PR DESCRIPTION
We have consistency-check-exempt notification types hardcoded right now in the `ensure_consistency` sql. This removes those in favor of an API that plugins can use to add notification types to.