### PR TITLE
FIX: Resetting selectable avatars was failing

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -508,6 +508,8 @@ module SiteSettingExtension
           value = current[name]
         end
 
+        return [] if value.empty?
+
         value = value.split("|").map(&:to_i)
         uploads_list = Upload.where(id: value).to_a
         uploads[name] = uploads_list if uploads_list

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -254,14 +254,23 @@ describe SiteSettingExtension do
   end
 
   describe "remove_override" do
+    fab!(:upload) { Fabricate(:upload) }
+
     before do
       settings.setting(:test_override, "test")
+      settings.setting(:image_list_test, "", type: :uploaded_image_list)
       settings.refresh!
     end
     it "correctly nukes overrides" do
       settings.test_override = "bla"
       settings.remove_override!(:test_override)
       expect(settings.test_override).to eq("test")
+    end
+
+    it "correctly nukes overrides for image list type setting" do
+      settings.image_list_test = "#{upload.id}"
+      settings.remove_override!(:image_list_test)
+      expect(settings.image_list_test).to be_empty
     end
   end
 


### PR DESCRIPTION
Fix applies to `uploaded_image_list` site setting types. In core, only selectable avatars use that type. 

Initial report: https://meta.discourse.org/t/reset-the-user-selectable-avatar-ops-error-500/222032