### PR TITLE
FIX: Close user/group card on esc key press

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -112,6 +112,7 @@ export default Mixin.create({
     });
 
     document.addEventListener("mousedown", this._clickOutsideHandler);
+    document.addEventListener("keyup", this._escListener);
 
     _cardClickListenerSelectors.forEach((selector) => {
       document
@@ -320,6 +321,7 @@ export default Mixin.create({
     this._super(...arguments);
 
     document.removeEventListener("mousedown", this._clickOutsideHandler);
+    document.removeEventListener("keyup", this._escListener);
 
     _cardClickListenerSelectors.forEach((selector) => {
       document
@@ -340,14 +342,6 @@ export default Mixin.create({
     this._hide();
   },
 
-  keyUp(e) {
-    if (e.key === "Escape") {
-      const target = this.cardTarget;
-      this._close();
-      target.focus();
-    }
-  },
-
   @bind
   _clickOutsideHandler(event) {
     if (this.visible) {
@@ -363,6 +357,16 @@ export default Mixin.create({
       this._close();
     }
 
+    return true;
+  },
+
+  @bind
+  _escListener(event) {
+    if (this.visible && event.key === "Escape") {
+      this._close();
+      this.cardTarget?.focus();
+      return;
+    }
     return true;
   },
 });

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -367,6 +367,5 @@ export default Mixin.create({
       this.cardTarget?.focus();
       return;
     }
-    return true;
   },
 });


### PR DESCRIPTION
`keyUp` is only invoked if the component's root element (or one of its descendants) has focus which isn't great for keyboard users because if they open a user card and want to close it, they have to tab through to the user card and only then will the Esc key actually close the card. This PR adds `keyup` event listener on the `document` for the Esc key so that the user card is closed (if it's open) no matter where the focus is.