### PR TITLE
DEV: Remove hardcoded ID in test fabrication.

### DIFF
--- a/spec/lib/validators/post_validator_spec.rb
+++ b/spec/lib/validators/post_validator_spec.rb
@@ -231,7 +231,7 @@ describe PostValidator do
   end
 
   describe "unique_post_validator" do
-    fab!(:user) { Fabricate(:user, id: 999) }
+    fab!(:user) { Fabricate(:user) }
     fab!(:post) { Fabricate(:post, user: user, topic: topic) }
 
     before do


### PR DESCRIPTION
This hardcoded ID can cause fabrication to fail once we create 999
users across the entire test suite.