### PR TITLE
UX: Use committed date for GitHub oneboxes

### DIFF
--- a/lib/onebox/engine/github_commit_onebox.rb
+++ b/lib/onebox/engine/github_commit_onebox.rb
@@ -35,7 +35,7 @@ module Onebox
         result['title'] = lines.first
         result['body'], result['excerpt'] = compute_body(lines[1..lines.length].join("\n"))
 
-        committed_at = Time.parse(result['commit']['author']['date'])
+        committed_at = Time.parse(result['commit']['committer']['date'])
         result['committed_at'] = committed_at.strftime("%I:%M%p - %d %b %y %Z")
         result['committed_at_date'] = committed_at.strftime("%F")
         result['committed_at_time'] = committed_at.strftime("%T")

--- a/spec/lib/onebox/engine/github_commit_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_commit_onebox_spec.rb
@@ -38,7 +38,7 @@ describe Onebox::Engine::GithubCommitOnebox do
       end
 
       it "includes commit time and date" do
-        expect(html).to include("02:03AM - 02 Aug 13")
+        expect(html).to include("02:16AM - 02 Aug 13 UTC")
       end
 
       it "includes number of files changed" do
@@ -94,7 +94,7 @@ describe Onebox::Engine::GithubCommitOnebox do
       end
 
       it "includes commit time and date" do
-        expect(html).to include("02:03AM - 02 Aug 13")
+        expect(html).to include("02:16AM - 02 Aug 13 UTC")
       end
 
       it "includes number of files changed" do


### PR DESCRIPTION
Our copy says 'committed {date}`, but we were previously using the commit's authored date

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
