### PR TITLE
Revert "A11Y: Make the views column in topics lists tabbable"

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/topic-list-item.hbr
@@ -73,7 +73,7 @@
   </td>
 {{/if}}
 
-<td class="num views {{topic.viewsHeat}} topic-list-data" aria-label='{{i18n "views_long" count=topic.views}}' tabindex="0">
+<td class="num views {{topic.viewsHeat}} topic-list-data">
   {{raw-plugin-outlet name="topic-list-before-view-count"}}
   {{number topic.views numberKey="views_long"}}
 </td>


### PR DESCRIPTION
This partially reverts commit 771dddb711b97c10baf9ac5fd23d769f06f38e7e.

This was a mistake; non-interactive element should not be included in tab navigation.