### PR TITLE
DEV: Drop `enable_long_polling` and `long_polling_interval` settings

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/site-settings.js
+++ b/app/assets/javascripts/discourse/tests/helpers/site-settings.js
@@ -64,7 +64,6 @@ const ORIGINAL_SETTINGS = {
   allow_profile_backgrounds: true,
   allow_uploaded_avatars: "0",
   tl1_requires_read_posts: 30,
-  enable_long_polling: true,
   polling_interval: 3000,
   anon_polling_interval: 30000,
   flush_timings_secs: 5,

--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -119,16 +119,8 @@ end
 
 MessageBus.backend_instance.max_backlog_size = GlobalSetting.message_bus_max_backlog_size
 MessageBus.backend_instance.clear_every = GlobalSetting.message_bus_clear_every
-
-if SiteSetting.table_exists? && SiteSetting.where(name: ['enable_long_polling', 'long_polling_interval']).exists?
-  Discourse.deprecate("enable_long_polling/long_polling_interval have switched from site settings to global settings. Remove the override from the Site Settings UI, and use a config file or environment variables to set the global settings.", drop_from: '2.9.0')
-
-  MessageBus.long_polling_enabled = SiteSetting.enable_long_polling
-  MessageBus.long_polling_interval = SiteSetting.long_polling_interval
-else
-  MessageBus.long_polling_enabled = GlobalSetting.enable_long_polling.nil? ? true : GlobalSetting.enable_long_polling
-  MessageBus.long_polling_interval = GlobalSetting.long_polling_interval || 25000
-end
+MessageBus.long_polling_enabled = GlobalSetting.enable_long_polling.nil? ? true : GlobalSetting.enable_long_polling
+MessageBus.long_polling_interval = GlobalSetting.long_polling_interval || 25000
 
 if Rails.env == "test" || $0 =~ /rake$/
   # disable keepalive in testing

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1574,10 +1574,8 @@ en:
 
     enable_personal_messages: "Allow trust level 1 (configurable via min trust to send messages) users to create messages and reply to messages. Note that staff can always send messages no matter what."
     enable_system_message_replies: "Allows users to reply to system messages, even if personal messages are disabled"
-    enable_long_polling: "Message bus used for notification can use long polling"
     enable_chunked_encoding: "Enable chunked encoding responses by the server. This feature works on most setups however some proxies may buffer, causing responses to be delayed"
     long_polling_base_url: "Base URL used for long polling (when a CDN is serving dynamic content, be sure to set this to origin pull) eg: http://origin.site.com"
-    long_polling_interval: "Amount of time the server should wait before responding to clients when there is no data to send (logged on users only)"
     polling_interval: "When not long polling, how often should logged on clients poll in milliseconds"
     anon_polling_interval: "How often should anonymous clients poll in milliseconds"
     background_polling_interval: "How often should the clients poll in milliseconds (when the window is in the background)"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1883,18 +1883,10 @@ developer:
   port:
     hidden: true
     default: ""
-  enable_long_polling:
-    hidden: true
-    client: true
-    default: true
   enable_chunked_encoding:
     hidden: true
     client: true
     default: true
-  long_polling_interval:
-    hidden: true
-    default: 25000
-    max: 25000
   long_polling_base_url:
     hidden: true
     client: true

--- a/db/migrate/20220323141645_remove_polling_site_settings.rb
+++ b/db/migrate/20220323141645_remove_polling_site_settings.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RemovePollingSiteSettings < ActiveRecord::Migration[6.1]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'enable_long_polling'"
+    execute "DELETE FROM site_settings WHERE name = 'long_polling_interval'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Scheduled to drop in 2.9.