### PR TITLE
FIX: Build correct post and topic shareUrl

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-url.js
@@ -41,7 +41,7 @@ export function getURLWithCDN(url) {
 }
 
 export function getAbsoluteURL(path) {
-  return baseUrl + path;
+  return baseUrl + withoutPrefix(path);
 }
 
 export function isAbsoluteURL(url) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
@@ -18,10 +18,19 @@ module("Unit | Utility | get-url", function () {
   });
 
   test("getAbsoluteURL", function (assert) {
-    setupURL(null, "https://example.com", "/forum");
+    setupURL(null, "https://example.com", null);
     assert.strictEqual(
       getAbsoluteURL("/cool/path"),
       "https://example.com/cool/path"
+    );
+    setupURL(null, "https://example.com/forum", "/forum");
+    assert.strictEqual(
+      getAbsoluteURL("/cool/path"),
+      "https://example.com/forum/cool/path"
+    );
+    assert.strictEqual(
+      getAbsoluteURL("/forum/cool/path"),
+      "https://example.com/forum/cool/path"
     );
   });
 


### PR DESCRIPTION
The links returned by post.url and topic.url are relative, but contain
the subdirectory. When getAbsoluteURL is called to construct the
complete share URL, it adds the host and the subdirectory again. As a
result the created URLs contained the subdirectory twice.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
