### PR TITLE
FIX: flips popper when top position is chosen incorrectly

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1,4 +1,3 @@
-import { headerOffset } from "discourse/lib/offset-calculator";
 import { INPUT_DELAY } from "discourse-common/config/environment";
 import EmberObject, { computed, get } from "@ember/object";
 import PluginApiMixin, {
@@ -875,7 +874,15 @@ export default Component.extend(
               name: "flip",
               enabled: !inModal,
               options: {
-                padding: { top: headerOffset() },
+                padding: {
+                  top:
+                    parseInt(
+                      document.documentElement.style.getPropertyValue(
+                        "--header-offset"
+                      ),
+                      10
+                    ) || 0,
+                },
               },
             },
             {

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1,3 +1,4 @@
+import { headerOffset } from "discourse/lib/offset-calculator";
 import { INPUT_DELAY } from "discourse-common/config/environment";
 import EmberObject, { computed, get } from "@ember/object";
 import PluginApiMixin, {
@@ -870,6 +871,13 @@ export default Component.extend(
           strategy,
           placement: this.selectKit.options.placement,
           modifiers: [
+            {
+              name: "flip",
+              enabled: !inModal,
+              options: {
+                padding: { top: headerOffset() },
+              },
+            },
             {
               name: "offset",
               options: {


### PR DESCRIPTION
More precisely, if popper can't position something at the bottom, it will automatically attempt to position it at the top. However we should ensure it doesn’t consider the space under the d-header as valid space, when header's height is taken into consideration if top space is not enough, we should force bottom, and flip it back.

This logic is not necessary on modals as the d-header is not present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
