### PR TITLE
DEV: Fix flaky specs

### DIFF
--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -76,28 +76,28 @@ describe CategorySerializer do
       it "returns the right category group permissions for an anon user" do
         json = described_class.new(category, scope: Guardian.new, root: false).as_json
 
-        expect(json[:group_permissions]).to eq([
+        expect(json[:group_permissions]).to contain_exactly(
           { permission_type: CategoryGroup.permission_types[:readonly], group_name: group.name },
-        ])
+        )
       end
 
       it "returns the right category group permissions for a regular user" do
         json = described_class.new(category, scope: Guardian.new(user), root: false).as_json
 
-        expect(json[:group_permissions]).to eq([
+        expect(json[:group_permissions]).to contain_exactly(
           { permission_type: CategoryGroup.permission_types[:readonly], group_name: group.name },
           { permission_type: CategoryGroup.permission_types[:full], group_name: user_group.name },
-        ])
+        )
       end
 
       it "returns the right category group permission for a staff user" do
         json = described_class.new(category, scope: Guardian.new(admin), root: false).as_json
 
-        expect(json[:group_permissions]).to eq([
+        expect(json[:group_permissions]).to contain_exactly(
           { permission_type: CategoryGroup.permission_types[:readonly], group_name: group.name },
           { permission_type: CategoryGroup.permission_types[:full], group_name: private_group.name },
           { permission_type: CategoryGroup.permission_types[:full], group_name: user_group.name }
-        ])
+        )
       end
     end
   end


### PR DESCRIPTION
`group_permissions` are not serialized in a consistent order

Follow-up to dfaf9831f7e6f545b25b7ce00db5e0816a1414fb

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
