### PR TITLE
FIX: Ensure ActiveSupport::Inflector is used by Zeitwerk

### DIFF
--- a/config/initializers/000-zeitwerk.rb
+++ b/config/initializers/000-zeitwerk.rb
@@ -3,16 +3,25 @@
 # This custom inflector is needed because of our jobs directory structure.
 # Ideally, we should not prefix our jobs with a `Jobs` namespace but instead
 # have a `Job` suffix to follow the Rails conventions on naming.
-class DiscourseInflector < Zeitwerk::Inflector
-  def camelize(basename, abspath)
+#
+# Based on:
+# https://github.com/rails/rails/blob/75e6c0ac/railties/lib/rails/autoloaders/inflector.rb#L7-L19
+module DiscourseInflector
+  @overrides = {}
+
+  def self.camelize(basename, abspath)
     return basename.camelize if abspath.ends_with?("onceoff.rb")
     return 'Jobs' if abspath.ends_with?("jobs/base.rb")
-    super
+    @overrides[basename] || basename.camelize
+  end
+
+  def self.inflect(overrides)
+    @overrides.merge!(overrides)
   end
 end
 
 Rails.autoloaders.each do |autoloader|
-  autoloader.inflector = DiscourseInflector.new
+  autoloader.inflector = DiscourseInflector
 
   # We have filenames that do not follow Zeitwerk's camelization convention. Maintain an inflections for these files
   # for now until we decide to fix them one day.


### PR DESCRIPTION
We want our autoloading to respect custom inflections registered with ActiveSupport::Inflector. `Zeitwek::Inflector` does not call out to ActiveSupport.

Instead, we can define our own DiscourseInflector based on the super-simple Inflector in rails core.

Follow-up to 5743a6ec

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
