### PR TITLE
FIX: review queue scrolling is not working after take an action.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/review-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/review-index.js
@@ -111,7 +111,7 @@ export default Controller.extend({
       if (newList.length === 0) {
         this.refreshModel();
       } else {
-        this.set("reviewables", newList);
+        this.reviewables.setObjects(newList);
       }
     },
 


### PR DESCRIPTION
`reject` method for `Reviewable` model is returning an array. So if we use `this.set` method to update `reviewables` attribute in controller then it replaces the model with an array of objects wrongly. This is now fixed by using the `setObjects` method of the model.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
