### PR TITLE
FIX: can_permanently_delete should check for admin

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -173,7 +173,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def include_can_permanently_delete?
-    SiteSetting.can_permanently_delete && object.deleted_at
+    SiteSetting.can_permanently_delete && scope.is_admin? && object.deleted_at
   end
 
   def can_recover

--- a/app/serializers/topic_view_details_serializer.rb
+++ b/app/serializers/topic_view_details_serializer.rb
@@ -112,7 +112,7 @@ class TopicViewDetailsSerializer < ApplicationSerializer
   end
 
   def include_can_permanently_delete?
-    SiteSetting.can_permanently_delete && object.topic.deleted_at
+    SiteSetting.can_permanently_delete && scope.is_admin? && object.topic.deleted_at
   end
 
   def include_can_recover?

--- a/spec/serializers/topic_view_details_serializer_spec.rb
+++ b/spec/serializers/topic_view_details_serializer_spec.rb
@@ -24,4 +24,30 @@ describe TopicViewDetailsSerializer do
       expect(allowed_users).to contain_exactly(participant.id)
     end
   end
+
+  describe "#can_permanently_delete" do
+    let(:post) do
+      Fabricate(:post).tap do |post|
+        PostDestroyer.new(Discourse.system_user, post).destroy
+      end
+    end
+
+    before do
+      SiteSetting.can_permanently_delete = true
+    end
+
+    it "is true for admins" do
+      admin = Fabricate(:admin)
+
+      serializer = described_class.new(TopicView.new(post.topic, admin), scope: Guardian.new(admin))
+      expect(serializer.as_json.dig(:topic_view_details, :can_permanently_delete)).to eq(true)
+    end
+
+    it "is not present for moderators" do
+      moderator = Fabricate(:moderator)
+
+      serializer = described_class.new(TopicView.new(post.topic, moderator), scope: Guardian.new(moderator))
+      expect(serializer.as_json.dig(:topic_view_details, :can_permanently_delete)).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
can_permanently_delete field in Post and TopicViewDetails serializers
cannot use Guardian's can_permanently_delete beause their use is
different. The field from the serializers is used to show the button
and the button is shown even if the post cannot be removed forever
because not enough time has passed since it was first deleted. The
guardian method is used by the controller to check that the post can
really be deleted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
