### PR TITLE
DEV: Safari's `window.innerWidth` doesn't match CSS

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -45,6 +45,11 @@ export default Component.extend(PanEvents, {
 
     let info = this.info;
 
+    // Safari's window.innerWidth doesn't match CSS media queries
+    let windowWidth = this.capabilities.isSafari
+      ? document.documentElement.clientWidth
+      : window.innerWidth;
+
     if (info.get("topicProgressExpanded")) {
       info.set("renderTimeline", true);
     } else {
@@ -55,7 +60,7 @@ export default Component.extend(PanEvents, {
 
         if (composer) {
           renderTimeline =
-            window.innerWidth > MIN_WIDTH_TIMELINE &&
+            windowWidth > MIN_WIDTH_TIMELINE &&
             window.innerHeight - composer.offsetHeight - headerOffset() >
               MIN_HEIGHT_TIMELINE;
         }


### PR DESCRIPTION
So in most browsers `window.innerWidth` is equivalent to the values used in CSS media queries, but not Safari!

Due to the combination of `window.innerWidth` and CSS media queries used, there's about a 15px gap where the timeline becomes invisible before the progress bar shows (from 910 - 924 browser width if you're using your web inspector). Apparently Safari media queries match `document.documentElement.clientWidth`... so here's a PR that fixes the gap. 

Related: 
https://stackoverflow.com/questions/33289557/osx-safari-applying-media-query-15-pixels-early