### PR TITLE
DEV: Minor linting fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,3 +16,4 @@ app/assets/javascripts/discourse/tests/test-boot-rails.js
 app/assets/javascripts/discourse/tests/fixtures
 node_modules/
 dist/
+tmp/

--- a/lib/tasks/smoke_test.rake
+++ b/lib/tasks/smoke_test.rake
@@ -82,7 +82,7 @@ task "smoke:test" do
 
   next if api_key.blank? && api_username.blank? && theme_url.blank?
 
-  puts "Running QUnit tests for theme #{theme_url.inspect} using API key #{api_key[0..3]}… and username #{api_username.inspect}"
+  puts "Running QUnit tests for theme #{theme_url.inspect} using API key #{api_key[0..3]}... and username #{api_username.inspect}"
 
   query_params = {
     seed: Random.new.seed,

--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -128,7 +128,7 @@ async function runAllTests() {
     const urlObj = new URL(url);
     Fetch.requestPaused((data) => {
       const requestURL = new URL(data.request.url);
-      if (requestURL.hostname != urlObj.hostname) {
+      if (requestURL.hostname !== urlObj.hostname) {
         Fetch.continueRequest({
           requestId: data.requestId,
         });
@@ -207,6 +207,7 @@ runAllTests().catch((e) => {
 // The following functions are converted to strings
 // And then sent to chrome to be evaluated
 function logQUnit() {
+  const QUnit = window.QUnit;
   let testErrors = [];
   let assertionErrors = [];
 
@@ -319,6 +320,7 @@ function logQUnit() {
 
     window.qunitDone = context;
   });
+
   QUnit.start();
 }
 let qunit_script = logQUnit.toString();


### PR DESCRIPTION
1. `test/run-qunit.js` wasn't eslinted
2. "…" utf character isn't rendered correctly in Jenkins
3. Don't try to lint `tmp` when doing `eslint .`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
