### PR TITLE
PR: Adjustments to the crawler view

### DIFF
--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -1,4 +1,5 @@
 body.crawler {
+  font-family: "Times New Roman", Times, serif;
   > header {
     width: 100%;
     top: 0;
@@ -15,6 +16,7 @@ body.crawler {
   }
 
   div#main-outlet {
+    padding: 10px;
     div.post {
       word-break: break-word;
       img {
@@ -28,7 +30,17 @@ body.crawler {
     table-layout: fixed;
     overflow: hidden;
     margin-bottom: 1em;
+    td {
+      padding: 10px 0;
+      &.posters {
+        padding: 10px 20px;
+      }
+    }
+    th:first-of-type {
+      padding-left: 0;
+    }
     @media (max-width: 850px) {
+      table-layout: auto;
       td {
         word-break: break-all;
         &.posters {

--- a/app/views/layouts/crawler.html.erb
+++ b/app/views/layouts/crawler.html.erb
@@ -25,11 +25,7 @@
     <%= theme_lookup("header") %>
     <header>
       <a href="<%= path "/" %>">
-        <%- if SiteSetting.site_logo_url.present? %>
-          <img src="<%=SiteSetting.site_logo_url%>" alt="<%=SiteSetting.title%>" id="site-logo" style="max-width: 150px;">
-        <%- else %>
-          <h1><%=SiteSetting.title%></h1>
-        <% end %>
+        <h1><%=SiteSetting.title%></h1>
       </a>
     </header>
     <div id="main-outlet" class="wrap">


### PR DESCRIPTION
This PR makes minor adjustments to the crawler view for better readability of the topic-list on older devices.

- Add padding to topic-list items to create whitespace
- remove logo & replace with site title text

### After
**Desktop**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/161352877-7ce8bfd8-89f1-4d22-aed7-e7341622b3f3.png">

**Mobile**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/30537603/161352909-27e3fe61-ffab-457d-a3c8-c6df93402491.png">

### Before
**Desktop**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/161353021-ce18fe66-b624-4d8b-a2c7-75da8c622887.png">


**Mobile**
<img width="250" alt="image" src="https://user-images.githubusercontent.com/30537603/161352998-62651480-280c-4ef7-b80f-a31e7404e96b.png">


