### PR TITLE
UX: fix the empty state copy on the user activity page

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3988,7 +3988,7 @@ en:
 
     user_activity:
       no_activity_title: "No activity yet"
-      no_activity_body: "Welcome to our community! You are brand new here and have not yet contributed to discussions. As a first step, visit <a href='%{topUrl}'>Top</a> or <a href='%{categoriesUrl}'>Categories</a> and just start reading! Select %{heartIcon} on posts that you like or want to learn more about. If you have not already done so, help others get to know you by adding a picture and bio in your <a href='%{preferencesUrl}'>user preferences</a>."
+      no_activity_body: "Welcome to our community! You are brand new here and have not yet contributed to discussions. As a first step, visit <a href='%{topUrl}'>Top</a> or <a href='%{categoriesUrl}'>Categories</a> and just start reading! Select %{heartIcon} on posts that you like or want to learn more about. As you participate, your activity will be listed here."
       no_activity_others: "No activity."
       no_replies_title: "You have not replied to any topics yet"
       no_replies_others: "No replies."


### PR DESCRIPTION
We're changing the last sentence, since it has nothing to do with activity. Before:

<img width="600" alt="Screenshot 2022-04-02 at 16 04 25" src="https://user-images.githubusercontent.com/1274517/161382770-8a33a456-497a-4303-a02b-47ef4f1cb023.png">

After:

<img width="600" alt="Screenshot 2022-04-02 at 16 04 00" src="https://user-images.githubusercontent.com/1274517/161382777-02feb993-2ddc-4639-a000-02b60aedc4f4.png">

