### PR TITLE
FIX: no need to hide "Later This Week" when showing "Later Today"

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/timeframes-builder.js
+++ b/app/assets/javascripts/discourse/app/lib/timeframes-builder.js
@@ -33,7 +33,7 @@ const TIMEFRAMES = [
   buildTimeframe({
     id: "later_this_week",
     format: "ddd, h a",
-    enabled: (opts) => !opts.canScheduleToday && opts.day > 0 && opts.day < 4,
+    enabled: (opts) => opts.day > 0 && opts.day < 4,
     when: (time, timeOfDay) => time.add(2, "day").hour(timeOfDay).minute(0),
   }),
   buildTimeframe({

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-silence-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-silence-user-test.js
@@ -34,6 +34,7 @@ acceptance("Admin - Silence User", function (needs) {
     const expected = [
       I18n.t("topic.auto_update_input.later_today"),
       I18n.t("topic.auto_update_input.tomorrow"),
+      I18n.t("topic.auto_update_input.later_this_week"),
       I18n.t("topic.auto_update_input.next_week"),
       I18n.t("topic.auto_update_input.two_weeks"),
       I18n.t("topic.auto_update_input.next_month"),

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-suspend-user-test.js
@@ -133,6 +133,7 @@ acceptance("Admin - Suspend User - timeframe choosing", function (needs) {
     const expected = [
       I18n.t("topic.auto_update_input.later_today"),
       I18n.t("topic.auto_update_input.tomorrow"),
+      I18n.t("topic.auto_update_input.later_this_week"),
       I18n.t("topic.auto_update_input.next_week"),
       I18n.t("topic.auto_update_input.two_weeks"),
       I18n.t("topic.auto_update_input.next_month"),

--- a/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
@@ -213,6 +213,7 @@ acceptance(
       const expected = [
         I18n.t("topic.auto_update_input.later_today"),
         I18n.t("topic.auto_update_input.tomorrow"),
+        I18n.t("topic.auto_update_input.later_this_week"),
         I18n.t("topic.auto_update_input.next_week"),
         I18n.t("topic.auto_update_input.two_weeks"),
         I18n.t("topic.auto_update_input.next_month"),

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-set-slow-mode-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-set-slow-mode-test.js
@@ -53,6 +53,7 @@ acceptance("Topic - Set Slow Mode", function (needs) {
     const expected = [
       I18n.t("topic.auto_update_input.later_today"),
       I18n.t("topic.auto_update_input.tomorrow"),
+      I18n.t("topic.auto_update_input.later_this_week"),
       I18n.t("topic.auto_update_input.next_week"),
       I18n.t("topic.auto_update_input.two_weeks"),
       I18n.t("topic.auto_update_input.next_month"),

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-notifications-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-notifications-test.js
@@ -138,6 +138,7 @@ acceptance("User Notifications - Users - Ignore User", function (needs) {
     const expected = [
       I18n.t("topic.auto_update_input.later_today"),
       I18n.t("topic.auto_update_input.tomorrow"),
+      I18n.t("topic.auto_update_input.later_this_week"),
       I18n.t("topic.auto_update_input.this_weekend"),
       I18n.t("topic.auto_update_input.next_week"),
       I18n.t("topic.auto_update_input.two_weeks"),

--- a/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
@@ -113,9 +113,9 @@ module("Unit | Lib | timeframes-builder", function (hooks) {
     assert.ok(timeframes.includes("later_this_week"));
   });
 
-  test("doesn't output 'Later This Week' on Tuesdays", function (assert) {
+  test("doesn't output 'Later This Week' on Thursdays", function (assert) {
     const timezone = moment.tz.guess();
-    this.clock = fakeTime("2100-04-22 18:00:00", timezone, true); // Tuesday evening
+    this.clock = fakeTime("2100-04-22 18:00:00", timezone, true); // Thursday evening
     const timeframes = buildTimeframes(buildOptions(moment())).mapBy("id");
 
     assert.notOk(timeframes.includes("later_this_week"));

--- a/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/timeframes-builder-test.js
@@ -32,6 +32,7 @@ module("Unit | Lib | timeframes-builder", function (hooks) {
     const expected = [
       "later_today",
       "tomorrow",
+      "later_this_week",
       "next_week",
       "two_weeks",
       "next_month",


### PR DESCRIPTION
We have an old piece of logic that hides the <kbd>Later This Week</kbd> option on old data-pickers when the <kbd>Later Today</kbd> option is shown. There is no point in hiding it, and we don't do that on modal with the new date-picker (on the bookmark and the topic timer modal).

This PR fixes the old `future-date-input`, now the <kbd>Later This Week</kbd> and the <kbd>Later Today</kbd> options will be available at the same time. For example, on the slow mode modal:

<img width="500" alt="Screenshot 2022-04-04 at 14 48 45" src="https://user-images.githubusercontent.com/1274517/161529749-c14b4b8b-942b-41d0-a538-7434de3f13d9.png">

