### PR TITLE
FIX: update 'posted' column on post owner change

### DIFF
--- a/app/services/post_owner_changer.rb
+++ b/app/services/post_owner_changer.rb
@@ -28,7 +28,7 @@ class PostOwnerChanger
       PostActionDestroyer.destroy(@new_owner, post, :like, skip_delete_check: true)
 
       level = post.is_first_post? ? :watching : :tracking
-      TopicUser.change(@new_owner.id, @topic.id, notification_level: NotificationLevels.topic_levels[level])
+      TopicUser.change(@new_owner.id, @topic.id, notification_level: NotificationLevels.topic_levels[level], posted: true)
 
       if post == @topic.posts.order("post_number DESC").where("NOT hidden AND posts.deleted_at IS NULL").first
         @topic.last_poster = @new_owner

--- a/spec/services/post_owner_changer_spec.rb
+++ b/spec/services/post_owner_changer_spec.rb
@@ -85,6 +85,11 @@ describe PostOwnerChanger do
       expect(p4.reload.user).to eq(user_a)
     end
 
+    it "sets 'posted' for TopicUser to true" do
+      PostOwnerChanger.new(post_ids: [p1.id], topic_id: topic.id, new_owner: user_a, acting_user: editor).change_owner!
+      expect(TopicUser.find_by(topic_id: topic.id, user_id: user_a.id).posted).to eq(true)
+    end
+
     context "sets topic notification level for the new owner" do
       let(:p4) { create_post(post_number: 2, topic: topic) }
 


### PR DESCRIPTION
Fixes the issue where making a user x as owner of a post doesn't
cause the concerned topic to be listed in new owner's `My Posts`
top menu filter

per https://meta.discourse.org/t/199369

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
