### PR TITLE
FIX: Do not attempt to pull_hotlinked_image for raw_html

### DIFF
--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -16,6 +16,7 @@ module Jobs
       post = Post.find_by(id: @post_id)
       return if post.blank?
       return if post.topic.blank?
+      return if post.cook_method == Post.cook_methods[:raw_html]
 
       raw = post.raw.dup
       start_raw = raw.dup

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -197,6 +197,18 @@ describe Jobs::PullHotlinkedImages do
       expect(post.uploads).to contain_exactly(upload)
     end
 
+    it "skips raw_html posts" do
+      raw = "<img src=\"#{image_url}\">"
+      post = Fabricate(:post, raw: raw, cook_method: Post.cook_methods[:raw_html])
+      stub_image_size
+      expect do
+        post.rebake!
+        post.reload
+      end.not_to change { Upload.count }
+
+      expect(post.raw).to eq(raw)
+    end
+
     context "when secure media enabled for an upload that has already been downloaded and exists" do
       it "doesnt redownload the secure upload" do
         setup_s3


### PR DESCRIPTION
raw_html posts (i.e. those which are pulled as part of our comments integration) don't go through our markdown pipeline, so `upload://` URLs are not supported. Running pull_hotlinked_images will break any images in the post.

In future we may add support for pulling hotlinked images in these posts. But for now, disabling it will stop it breaking images.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
