### PR TITLE
FIX: 500 error when creating a user with an integer username

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -273,7 +273,7 @@ class User < ActiveRecord::Base
   end
 
   def self.normalize_username(username)
-    username.unicode_normalize.downcase if username.present?
+    username.to_s.unicode_normalize.downcase if username.present?
   end
 
   def self.username_available?(username, email = nil, allow_reserved_username: false)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,6 +50,12 @@ describe User do
         expect(user.errors.full_messages.first)
           .to include(user_error_message(:username, :same_as_password))
       end
+
+      describe 'when a username is an integer' do
+        it 'is converted to a string on normalization' do
+          expect(User.normalize_username(123)).to eq("123") # This is possible via the API
+        end
+      end
     end
 
     describe 'name' do


### PR DESCRIPTION
Via the API it is possible to create a user with an integer username. So
123 instead of "123". This causes the following 500 error:

```
NoMethodError (undefined method `unicode_normalize' for 1:Integer)
app/models/user.rb:276:in `normalize_username'
```

See: https://meta.discourse.org/t/222281
