### PR TITLE
FIX: Limit max word length in search index

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2028,6 +2028,9 @@ search:
     default: false
     hidden: true
     client: true
+  search_max_indexed_word_length:
+    default: 100
+    hidden: true
   search_ranking_normalization:
     default: "0"
     hidden: true


### PR DESCRIPTION
Long words bloat the index for little benefit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
