### PR TITLE
FIX: Topic view breaks with topic timer to publish to restricted category.

### DIFF
--- a/app/models/topic_timer.rb
+++ b/app/models/topic_timer.rb
@@ -116,6 +116,10 @@ class TopicTimer < ActiveRecord::Base
     true
   end
 
+  def publishing_to_category?
+    self.status_type.to_i == TopicTimer.types[:publish_to_category]
+  end
+
   private
 
   def duration_in_range?
@@ -140,10 +144,6 @@ class TopicTimer < ActiveRecord::Base
     errors.add(:execute_at, I18n.t(
       'activerecord.errors.models.topic_timer.attributes.execute_at.in_the_past'
     ))
-  end
-
-  def publishing_to_category?
-    self.status_type.to_i == TopicTimer.types[:publish_to_category]
   end
 
   def schedule_auto_delete_replies_job

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -203,6 +203,14 @@ class TopicViewSerializer < ApplicationSerializer
   end
 
   def topic_timer
+    topic_timer = object.topic.public_topic_timer
+
+    return nil if topic_timer.blank?
+
+    if topic_timer.publishing_to_category?
+      return nil if !scope.can_see_category?(Category.find_by(id: topic_timer.category_id))
+    end
+
     TopicTimerSerializer.new(object.topic.public_topic_timer, root: false)
   end
 


### PR DESCRIPTION
When a user views a topic that contains a topic timer to publish to a
restricted category, an error occurs on the client side because the user
does not have access to information about the category.

This commit fixes it such that the topic timer is not shown to the user
if the user does not have access to the category.