### PR TITLE
FIX: include crawler content on old mobile browsers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -393,7 +393,11 @@ module ApplicationHelper
   end
 
   def include_crawler_content?
-    crawler_layout? || !mobile_view?
+    crawler_layout? || !mobile_view? || !modern_mobile_device?
+  end
+
+  def modern_mobile_device?
+    MobileDetection.modern_mobile_device?(request.user_agent)
   end
 
   def mobile_device?

--- a/lib/mobile_detection.rb
+++ b/lib/mobile_detection.rb
@@ -23,4 +23,19 @@ module MobileDetection
     user_agent =~ /iPad|iPhone|iPod/
   end
 
+  MODERN_MOBILE_REGEX = %r{
+    \(.*iPhone\ OS\ 1[3-9].*\)|
+    \(.*iPad.*OS\ 1[3-9].*\)|
+    Chrome\/8[89]|
+    Chrome\/9[0-9]|
+    Chrome\/1[0-9][0-9]|
+    Firefox\/8[5-9]|
+    Firefox\/9[0-9]|
+    Firefox\/1[0-9][0-9]
+  }x
+
+  def self.modern_mobile_device?(user_agent)
+    user_agent.match?(MODERN_MOBILE_REGEX)
+  end
+
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -11,6 +11,22 @@ describe ApplicationHelper do
       HTML
     end
 
+    it "sends crawler content to old mobiles" do
+      controller.stubs(:use_crawler_layout?).returns(false)
+
+      helper.request.user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25"
+
+      expect(helper.include_crawler_content?).to eq(true)
+    end
+
+    it "does not send crawler content to new mobiles" do
+      controller.stubs(:use_crawler_layout?).returns(false)
+
+      helper.request.user_agent = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.60 Mobile Safari/537.36 (compatible"
+
+      expect(helper.include_crawler_content?).to eq(false)
+    end
+
     it "provides brotli links to brotli cdn" do
       set_cdn_url "https://awesome.com"
 

--- a/spec/lib/mobile_detection_spec.rb
+++ b/spec/lib/mobile_detection_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe MobileDetection do
+  let :old_user_agents do
+    (<<~STR).split("\n")
+      Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+      Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; PetalBot;+https://webmaster.petalsearch.com
+      Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; S
+      Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36 (compatible;
+      Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25
+      Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 (comp
+      Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.3626.121 Mobile Safari/537.36 (comp
+    STR
+  end
+
+  let :modern_user_agents do
+    (<<~STR).split("\n")
+      Mozilla/5.0 (iPhone; CPU iPhone OS 15_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3 Mobile/15E148 Safari/604.1
+      Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Mobile Safari/537.36 (compatible;
+      Mozilla/5.0 (iPhone; CPU iPhone OS 14_8_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1
+      Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.60 Mobile Safari/537.36 (compatible
+      Mozilla/5.0 (Android 12; Mobile; rv:98.0) Gecko/98.0 Firefox/98.0
+      Mozilla/5.0 (iPad; CPU OS 15_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/99.0.4844.59 Mobile/15E148 Safari/604.1
+      Mozilla/5.0 (Android 11; Mobile; rv:98.0) Gecko/98.0 Firefox/98.0
+      Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 Mobile Safari/537.36
+      Mozilla/5.0 (iPhone; CPU iPhone OS 15_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 DiscourseHub
+      Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 Mobile Safari/537.36
+      Mozilla/5.0 (Android 12; Mobile; rv:99.0) Gecko/99.0 Firefox/99.0
+Mozilla/5.0 (iPhone; CPU iPhone OS 14_8 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/99.0.4844.59 Mobile/15E148 Safari/604.1
+      Mozilla/5.0 (Linux; Android 12; Pixel 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 Mobile Safari/537.36
+      Mozilla/5.0 (Linux; Android 12; Pixel 4a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 Mobile Safari/537.36
+      Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.60 Mobile Safari/537.36
+      Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
+      STR
+  end
+
+  it "detects modern browsers correctly" do
+    modern_user_agents.each do |agent|
+      expect(MobileDetection.modern_mobile_device?(agent)).to eq(true)
+    end
+
+    old_user_agents.each do |agent|
+      expect(MobileDetection.modern_mobile_device?(agent)).to eq(false)
+    end
+  end
+
+end


### PR DESCRIPTION
Previous to this change an optimisation stripped crawler content from
all mobile browsers.

This had a side effect that meant that when we dropped support for an old
mobile platform we would stop rendering topic and topic list pages.

The new implementation ensures we only perform the optimisation on modern
mobile browsers.
