### PR TITLE
DEV: optionally removes links/avatars from user-info

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-info.js
+++ b/app/assets/javascripts/discourse/app/components/user-info.js
@@ -13,6 +13,8 @@ export default Component.extend({
   attributeBindings: ["data-username"],
   size: "small",
   "data-username": alias("user.username"),
+  includeLink: true,
+  includeAvatar: true,
 
   @discourseComputed("user.username")
   userPath(username) {

--- a/app/assets/javascripts/discourse/app/templates/components/user-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-info.hbs
@@ -1,14 +1,32 @@
-<div class="user-image">
-  <div class="user-image-inner">
-    <a href={{this.userPath}} data-user-card={{@user.username}}>{{avatar @user imageSize="large"}}</a>
-    {{user-avatar-flair user=@user}}
+{{#if includeAvatar}}
+  <div class="user-image">
+    <div class="user-image-inner">
+      <a href={{this.userPath}} data-user-card={{@user.username}}>{{avatar @user imageSize="large"}}</a>
+      {{user-avatar-flair user=@user}}
+    </div>
   </div>
-</div>
+{{/if}}
 
 <div class="user-detail">
   <div class="name-line">
-    <span class={{if nameFirst "name bold" "username bold"}}><a href={{this.userPath}} data-user-card={{@user.username}}>{{if nameFirst this.name (format-username @user.username)}}</a></span>
-    <span class={{if nameFirst "username margin" "name margin"}}><a href={{this.userPath}} data-user-card={{@user.username}}>{{if nameFirst (format-username @user.username) this.name}}</a></span>
+    <span class={{if nameFirst "name bold" "username bold"}}>
+      {{#if includeLink}}
+        <a href={{this.userPath}} data-user-card={{@user.username}}>
+          {{if nameFirst this.name (format-username @user.username)}}
+        </a>
+      {{else}}
+        {{if nameFirst this.name (format-username @user.username)}}
+      {{/if}}
+    </span>
+    <span class={{if nameFirst "username margin" "name margin"}}>
+      {{#if includeLink}}
+        <a href={{this.userPath}} data-user-card={{@user.username}}>
+          {{if nameFirst (format-username @user.username) this.name}}
+        </a>
+      {{else}}
+        {{if nameFirst (format-username @user.username) this.name}}
+      {{/if}}
+    </span>
     {{plugin-outlet name="after-user-name" tagName="span" connectorTagName="span" args=(hash user=user)}}
   </div>
   <div class="title">{{@user.title}}</div>

--- a/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
@@ -1,0 +1,39 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
+
+discourseModule("Integration | Component | user-info", function (hooks) {
+  setupRenderingTest(hooks);
+
+  componentTest("includeLink", {
+    template: hbs`{{user-info user=currentUser includeLink=includeLink}}`,
+
+    async test(assert) {
+      this.set("includeLink", true);
+
+      assert.ok(exists(`.username a[href="/u/${this.currentUser.username}"]`));
+
+      this.set("includeLink", false);
+
+      assert.notOk(
+        exists(`.username a[href="/u/${this.currentUser.username}"]`)
+      );
+    },
+  });
+
+  componentTest("includeAvatar", {
+    template: hbs`{{user-info user=currentUser includeAvatar=includeAvatar}}`,
+
+    async test(assert) {
+      this.set("includeAvatar", true);
+
+      assert.ok(exists(".user-image"));
+
+      this.set("includeAvatar", false);
+
+      assert.notOk(exists(".user-image"));
+    },
+  });
+});


### PR DESCRIPTION
Usage:

```
{{user-info user=user includeLink=false includeAvatar=false}}
```

This is useful when using user-info in a dropdown list for example.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
