### PR TITLE
PR: Inline code block styling edits

### DIFF
--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -119,8 +119,10 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 p > code,
 li > code,
 pre > code {
-  color: var(--primary-very-high);
-  background: var(--hljs-bg);
+  color: var(--danger);
+  background: var(--secondary-very-high);
+  padding: 3px 5px 2px 5px;
+  border-radius: 5px;
 }
 
 // removed some unnecessary styles here


### PR DESCRIPTION
This PR styles the inline codeblock a little differently for better visiblity.

## After
**In a topic**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/162039675-a20127f1-e852-41fe-95ba-203dc2b6b99c.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/162040716-55177ac3-41ce-46de-9805-0a834b2ec64d.png">

**In chat**
<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/162039750-042fb933-def1-43c0-81c1-032faf5f0d88.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/162041202-6db11e17-4448-413b-a25c-01da4f15a25f.png">


## Before
**In a topic**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/162039858-0ccf8d3e-9cc6-4307-9b26-40940ec191bd.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/162041299-a7a0027d-70fc-4b75-a2d7-8b5e4b10c5f5.png">


**In chat**
<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/162039900-8aba6416-7623-473c-9c28-a1434bdf2a20.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/162041331-04cdf66e-1090-4c48-a09b-5a4414dcdc17.png">



