### PR TITLE
DEV: pass user to badge page outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/badges.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.hbs
@@ -16,6 +16,6 @@
         filterUser="true"
       }}
     {{/each}}
-    {{plugin-outlet name="after-user-profile-badges"}}
+    {{plugin-outlet name="after-user-profile-badges" args=(hash user=user.model)}}
   </div>
 {{/d-section}}


### PR DESCRIPTION
Using this in a customer theme to avoid a template override. 