### PR TITLE
DEV: Fix "overridden" typos

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -72,46 +72,46 @@ acceptance("Admin - Site Settings", function (needs) {
       1,
       "filter returns 1 site setting"
     );
-    assert.ok(!exists(".row.setting.overridden"), "setting isn't overriden");
+    assert.ok(!exists(".row.setting.overridden"), "setting isn't overridden");
 
     await fillIn(".input-setting-string", "Test");
     await click("button.cancel");
     assert.ok(
       !exists(".row.setting.overridden"),
-      "canceling doesn't mark setting as overriden"
+      "canceling doesn't mark setting as overridden"
     );
 
     await fillIn(".input-setting-string", "Test");
     await click("button.ok");
     assert.ok(
       exists(".row.setting.overridden"),
-      "saving marks setting as overriden"
+      "saving marks setting as overridden"
     );
 
     await click("button.undo");
     assert.ok(
       !exists(".row.setting.overridden"),
-      "setting isn't marked as overriden after undo"
+      "setting isn't marked as overridden after undo"
     );
 
     await click("button.cancel");
     assert.ok(
       exists(".row.setting.overridden"),
-      "setting is marked as overriden after cancel"
+      "setting is marked as overridden after cancel"
     );
 
     await click("button.undo");
     await click("button.ok");
     assert.ok(
       !exists(".row.setting.overridden"),
-      "setting isn't marked as overriden after undo"
+      "setting isn't marked as overridden after undo"
     );
 
     await fillIn(".input-setting-string", "Test");
     await triggerKeyEvent(".input-setting-string", "keydown", ENTER_KEYCODE);
     assert.ok(
       exists(".row.setting.overridden"),
-      "saving via Enter key marks setting as overriden"
+      "saving via Enter key marks setting as overridden"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-list-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-list-plugin-api-test.js
@@ -6,7 +6,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 
 acceptance("Topic list plugin API", function () {
   function customLastUnreadUrl(context) {
-    return `${context.urlForPostNumber(1)}?overriden`;
+    return `${context.urlForPostNumber(1)}?overridden`;
   }
 
   test("Overrides lastUnreadUrl", async function (assert) {
@@ -20,7 +20,7 @@ acceptance("Topic list plugin API", function () {
         query(
           ".topic-list .topic-list-item:first-child a.raw-topic-link"
         ).getAttribute("href"),
-        "/t/error-after-upgrade-to-0-9-7-9/11557/1?overriden"
+        "/t/error-after-upgrade-to-0-9-7-9/11557/1?overridden"
       );
     } finally {
       clearCustomLastUnreadUrlCallbacks();

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
@@ -475,7 +475,7 @@ discourseModule("Integration | Component | Widget | base", function (hooks) {
     test(assert) {
       assert.ok(
         exists("section.override"),
-        "renders container with overrided tagName"
+        "renders container with overridden tagName"
       );
     },
   });

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -555,7 +555,7 @@
       width: 80px;
       margin-bottom: 0;
     }
-    th.overriden {
+    th.overridden {
       text-align: right;
     }
     .color-input {

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -2144,7 +2144,7 @@ HTML
   end
 
   context "enabling/disabling features" do
-    it "allows features to be overriden" do
+    it "allows features to be overridden" do
       cooked = PrettyText.cook(':grin: @mention', features_override: [])
 
       expect(cooked).to eq("<p>:grin: @mention</p>")

--- a/spec/lib/site_settings/defaults_provider_spec.rb
+++ b/spec/lib/site_settings/defaults_provider_spec.rb
@@ -61,7 +61,7 @@ describe SiteSettings::DefaultsProvider do
     end
 
     describe '.set_regardless_of_locale' do
-      let(:val) { 'env_overriden' }
+      let(:val) { 'env_overridden' }
 
       it 'sets the default value to a site setting regardless the locale' do
         settings.defaults.set_regardless_of_locale(:test_override, val)

--- a/spec/lib/site_settings/type_supervisor_spec.rb
+++ b/spec/lib/site_settings/type_supervisor_spec.rb
@@ -276,7 +276,7 @@ describe SiteSettings::TypeSupervisor do
     end
 
     describe '#to_rb_value' do
-      it 'the type can be overriden by a parameter' do
+      it 'the type can be overridden by a parameter' do
         expect(settings.type_supervisor.to_rb_value(:type_null, '1', SiteSetting.types[:integer])).to eq(1)
       end
 

--- a/spec/models/screened_email_spec.rb
+++ b/spec/models/screened_email_spec.rb
@@ -32,7 +32,7 @@ describe ScreenedEmail do
         expect(record.action_type).to eq(ScreenedEmail.actions[:block])
       end
 
-      it 'lets action_type be overriden' do
+      it 'lets action_type be overridden' do
         record = ScreenedEmail.block(email, action_type: ScreenedEmail.actions[:do_nothing])
         expect(record).not_to be_new_record
         expect(record.email).to eq(email)

--- a/spec/models/screened_url_spec.rb
+++ b/spec/models/screened_url_spec.rb
@@ -110,7 +110,7 @@ describe ScreenedUrl do
         expect(record.action_type).to eq(described_class.actions[:do_nothing])
       end
 
-      it 'lets action_type be overriden' do
+      it 'lets action_type be overridden' do
         record = described_class.watch(url, domain, action_type: described_class.actions[:block])
         expect(record).not_to be_new_record
         expect(record.action_type).to eq(described_class.actions[:block])

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -59,7 +59,7 @@ describe TranslationOverride do
             translation_override = TranslationOverride.upsert!(
               I18n.locale,
               "not_a_notification",
-              "Overriden %{key1} %{topic_title_url_encoded}",
+              "Overridden %{key1} %{topic_title_url_encoded}",
             )
             expect(translation_override.errors.full_messages).to include(I18n.t(
               "activerecord.errors.models.translation_overrides.attributes.value.invalid_interpolation_keys",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1692,7 +1692,7 @@ describe User do
     end
   end
 
-  context "when user preferences are overriden" do
+  context "when user preferences are overridden" do
 
     fab!(:category0) { Fabricate(:category) }
     fab!(:category1) { Fabricate(:category) }
@@ -1724,7 +1724,7 @@ describe User do
       SiteSetting.default_categories_regular = category4.id.to_s
     end
 
-    it "has overriden preferences" do
+    it "has overridden preferences" do
       user = Fabricate(:user)
       options = user.user_option
       expect(options.mailing_list_mode).to eq(true)

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -462,7 +462,7 @@ describe Admin::ThemesController do
       put "/admin/themes/#{theme.id}.json", params: {
         theme: {
           translations: {
-            "somegroup.somestring" => "overridenstring"
+            "somegroup.somestring" => "overriddenstring"
           }
         }
       }
@@ -470,7 +470,7 @@ describe Admin::ThemesController do
       # Response correct
       expect(response.status).to eq(200)
       json = response.parsed_body
-      expect(json["theme"]["translations"][0]["value"]).to eq("overridenstring")
+      expect(json["theme"]["translations"][0]["value"]).to eq("overriddenstring")
 
       # Database correct
       theme.reload


### PR DESCRIPTION
There are still some, but those are in actual code that's used outside core, so the change there would need to go through the deprecation cycle. That's a task for another day.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
