### PR TITLE
A couple of fixes for API scopes allowed URLs

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -120,7 +120,11 @@ class ApiKeyScope < ActiveRecord::Base
             defaults = route.defaults
             action = "#{defaults[:controller].to_s}##{defaults[:action]}"
             path = route.path.spec.to_s.gsub(/\(\.:format\)/, '')
-            api_supported_path = path.end_with?('.rss') || route.path.requirements[:format]&.match?('json')
+            api_supported_path = (
+              path.end_with?('.rss') ||
+              !route.path.requirements[:format] ||
+              route.path.requirements[:format].match?('json')
+            )
             excluded_paths = %w[/new-topic /new-message /exception]
 
             if actions.include?(action) && api_supported_path && !excluded_paths.include?(path)

--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -103,7 +103,7 @@ class ApiKeyScope < ActiveRecord::Base
     end
 
     def find_urls(actions:, methods:)
-      urls = []
+      urls = Set.new
 
       if actions.present?
         route_sets = [Rails.application.routes]
@@ -140,7 +140,7 @@ class ApiKeyScope < ActiveRecord::Base
         end
       end
 
-      urls
+      urls.to_a
     end
   end
 


### PR DESCRIPTION
Each commit in this PR has an explanation for what/why it does.

No tests because the bugs that these commits fix are apparent in API scopes added by the automation plugin and not in the default set of API scopes so it's not possible to write a failing test case without installing the automation plugin or adding a new scope to core that would have these problems.