### PR TITLE
FEATURE: Sortable json-editor items

### DIFF
--- a/app/assets/javascripts/discourse/app/components/json-editor.js
+++ b/app/assets/javascripts/discourse/app/components/json-editor.js
@@ -71,7 +71,7 @@ export default Component.extend({
 class DiscourseJsonSchemaEditorIconlib {
   constructor() {
     this.mapping = {
-      delete: "times",
+      delete: "trash-alt",
       add: "plus",
       moveup: "arrow-up",
       movedown: "arrow-down",

--- a/app/assets/javascripts/discourse/app/components/json-editor.js
+++ b/app/assets/javascripts/discourse/app/components/json-editor.js
@@ -29,8 +29,9 @@ export default Component.extend({
           schema: this.model.jsonSchema,
           disable_array_delete_all_rows: true,
           disable_array_delete_last_row: true,
-          disable_array_reorder: true,
-          disable_array_copy: true,
+          disable_array_reorder: false,
+          disable_array_copy: false,
+          enable_array_copy: true,
           disable_edit_json: true,
           disable_properties: true,
           disable_collapse: true,
@@ -72,6 +73,9 @@ class DiscourseJsonSchemaEditorIconlib {
     this.mapping = {
       delete: "times",
       add: "plus",
+      moveup: "arrow-up",
+      movedown: "arrow-down",
+      copy: "copy",
     };
   }
 

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -747,6 +747,17 @@
 
   .btn-group {
     margin-top: 0;
+    display: flex;
+    align-items: stretch;
+    gap: 0.5em;
+
+    .btn {
+      padding-block: 0.65em;
+
+      .d-icon {
+        margin-right: 0;
+      }
+    }
   }
 
   .json-editor-btn-delete {


### PR DESCRIPTION
# FEATURE: Sortable JSON Editor Items:

I really like the new `json_schema` setting. However, it is lacking in the ability to sort the items.

This feature adds the ability to sort items in the `json_schema`. 

Additionally, it improves the UX:
- matching the heights of the button groups to the input fields
- imitating Discourse's official style by using the `trash-alt` icon instead of the `times` icon (example used similarly in `/admin/logs/screened_ip_addresses`)

![Screen Shot 2022-04-06 at 3 57 48 PM](https://user-images.githubusercontent.com/30090424/162086397-ae8c17c4-448b-49c5-b333-1254d90aa400.png)

