### PR TITLE
FIX: uppy-image-uploader and uppy-upload mixin minor issues

### DIFF
--- a/app/assets/javascripts/discourse/app/components/pick-files-button.js
+++ b/app/assets/javascripts/discourse/app/components/pick-files-button.js
@@ -20,6 +20,7 @@ import I18n from "I18n";
 export default Component.extend({
   fileInputId: null,
   fileInputClass: null,
+  fileInputDisabled: false,
   classNames: ["pick-files-button"],
   acceptedFormatsOverride: null,
   allowMultiple: false,

--- a/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
+++ b/app/assets/javascripts/discourse/app/components/uppy-image-uploader.js
@@ -50,6 +50,12 @@ export default Component.extend(UppyUploadMixin, {
     return { imagesOnly: true };
   },
 
+  _uppyReady() {
+    this._onPreProcessComplete(() => {
+      this.set("processing", false);
+    });
+  },
+
   uploadDone(upload) {
     this.setProperties({
       imageFilesize: upload.human_filesize,

--- a/app/assets/javascripts/discourse/app/templates/components/pick-files-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/pick-files-button.hbs
@@ -2,7 +2,7 @@
   {{d-button action=(action "openSystemFilePicker") label=label icon=icon}}
 {{/if}}
 {{#if acceptsAllFormats}}
-  <input type="file" id={{fileInputId}} class={{fileInputClass}} multiple={{allowMultiple}}>
+  <input type="file" id={{fileInputId}} class={{fileInputClass}} multiple={{allowMultiple}} disabled={{fileInputDisabled}}>
 {{else}}
-  <input type="file" id={{fileInputId}} class={{fileInputClass}} accept={{acceptedFormats}} multiple={{allowMultiple}}>
+  <input type="file" id={{fileInputId}} class={{fileInputClass}} accept={{acceptedFormats}} multiple={{allowMultiple}} disabled={{fileInputDisabled}}>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/uppy-image-uploader.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/uppy-image-uploader.hbs
@@ -5,7 +5,7 @@
   <div class="image-upload-controls">
     <label class="btn btn-default pad-left no-text {{if uploadingOrProcessing "disabled"}}">
       {{d-icon "far-image"}}
-      <input class="hidden-upload-field" disabled={{uploadingOrProcessing}} type="file" accept="image/*">
+      {{pick-files-button fileInputDisabled=uploadingOrProcessing fileInputClass="hidden-upload-field" acceptedFormatsOverride="image/*" }}
     </label>
 
     {{#if imageUrl}}


### PR DESCRIPTION
Follow up to ac672cfcc6726b9309904857dd246f5ee54b20a8. Fixes a
small issue with uppy-image-uploader where the Processing label
was shown for the whole upload. Also adds a couple of options to
pick-files-button to allow for it to be used in the uppy-image-uploader.

Also fixes an issue where the uppy-upload mixin was resetting prematurely
when all uploads in progress were complete, but it should have been doing
that on the uppy `complete` event instead.