### PR TITLE
FIX: hide user notifications tab for moderator users.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -116,9 +116,9 @@ export default Controller.extend(CanCheckEmails, {
     );
   },
 
-  @discourseComputed("viewingSelf", "currentUser.staff")
-  showNotificationsTab(viewingSelf, staff) {
-    return viewingSelf || staff;
+  @discourseComputed("viewingSelf", "currentUser.admin")
+  showNotificationsTab(viewingSelf, isAdmin) {
+    return viewingSelf || isAdmin;
   },
 
   @discourseComputed("model.name")

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -59,11 +59,17 @@ acceptance("User Routes", function (needs) {
 
     updateCurrentUser({ moderator: true, admin: false });
     await visit("/u/charlie/summary");
-    assert.notOk(exists(".user-nav > .user-notifications"), "does not have the notifications tab");
+    assert.notOk(
+      exists(".user-nav > .user-notifications"),
+      "does not have the notifications tab"
+    );
 
     updateCurrentUser({ moderator: false, admin: true });
     await visit("/u/charlie/summary");
-    assert.ok(exists(".user-nav > .user-notifications"), "has the notifications tab");
+    assert.ok(
+      exists(".user-nav > .user-notifications"),
+      "has the notifications tab"
+    );
   });
 
   test("Root URL - Viewing Self", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -63,7 +63,7 @@ acceptance("User Routes", function (needs) {
 
     updateCurrentUser({ moderator: false, admin: true });
     await visit("/u/charlie/summary");
-    assert.ok($(".user-nav > .user-notifications").length, "has the notifications tab");
+    assert.ok(exists(".user-nav > .user-notifications"), "has the notifications tab");
   });
 
   test("Root URL - Viewing Self", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -59,7 +59,7 @@ acceptance("User Routes", function (needs) {
 
     updateCurrentUser({ moderator: true, admin: false });
     await visit("/u/charlie/summary");
-    assert.notOk($(".user-nav > .user-notifications").length, "does not have the notifications tab");
+    assert.notOk(exists(".user-nav > .user-notifications"), "does not have the notifications tab");
 
     updateCurrentUser({ moderator: false, admin: true });
     await visit("/u/charlie/summary");

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -8,6 +8,7 @@ import {
   exists,
   query,
   queryAll,
+  updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, currentRouteName, visit } from "@ember/test-helpers";
 import { cloneJSON } from "discourse-common/lib/object";
@@ -55,6 +56,14 @@ acceptance("User Routes", function (needs) {
         "/u/eviltrout/notifications/likes-received?acting_username=aquaman"
       )
     );
+
+    updateCurrentUser({ moderator: true, admin: false });
+    await visit("/u/charlie/summary");
+    assert.notOk($(".user-nav > .user-notifications").length, "does not have the notifications tab");
+
+    updateCurrentUser({ moderator: false, admin: true });
+    await visit("/u/charlie/summary");
+    assert.ok($(".user-nav > .user-notifications").length, "has the notifications tab");
   });
 
   test("Root URL - Viewing Self", async function (assert) {


### PR DESCRIPTION
Moderators doesn't have access to notifications of other users. So we shouldn't display the notifications tab on other user profiles for them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
