### PR TITLE
FIX: Serialize permissions for everyone group

### DIFF
--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -37,7 +37,7 @@ class CategorySerializer < SiteCategorySerializer
         .category_groups
         .joins(:group)
         .includes(:group)
-        .merge(Group.visible_groups(scope&.user, "groups.name ASC"))
+        .merge(Group.visible_groups(scope&.user, "groups.name ASC", include_everyone: true))
         .map do |cg|
           {
             permission_type: cg.permission_type,

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -98,7 +98,19 @@ describe CategorySerializer do
         expect(json[:group_permissions]).to eq([
           { permission_type: CategoryGroup.permission_types[:readonly], group_name: group.name },
           { permission_type: CategoryGroup.permission_types[:full], group_name: private_group.name },
-          { permission_type: CategoryGroup.permission_types[:full], group_name: user_group.name }
+          { permission_type: CategoryGroup.permission_types[:full], group_name: user_group.name },
+          { permission_type: CategoryGroup.permission_types[:readonly], group_name: 'everyone' },
+        ])
+      end
+
+      it "returns the group permissions for everyone group too" do
+        category.set_permissions(everyone: :readonly)
+        category.save!
+
+        json = described_class.new(category, scope: Guardian.new(admin), root: false).as_json
+
+        expect(json[:group_permissions]).to eq([
+          { permission_type: CategoryGroup.permission_types[:readonly], group_name: 'everyone' },
         ])
       end
     end


### PR DESCRIPTION
The permissions for the 'everyone' group were not serialized because
the list of groups a user can view did not include it. This bug was
introduced in commit dfaf9831f7e6f545b25b7ce00db5e0816a1414fb.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
