### PR TITLE
DEV: Bump beta version to beta4

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -10,7 +10,7 @@ module Discourse
       MAJOR = 2
       MINOR = 9
       TINY  = 0
-      PRE   = 'beta3'
+      PRE   = 'beta4'
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
     end


### PR DESCRIPTION
beta3 was released a couple of weeks ago (22nd of March) and we've begun working on beta4 so the `main` branch should reflect that. This change makes it possible to target the latest beta release in `.discourse-compatibility` files of plugins/themes.

Internal ticket t64136.