### PR TITLE
DEV: Fix flaky `tags-test`

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -499,7 +499,7 @@ acceptance("Tag info", function (needs) {
 
     await click(".category-breadcrumb li:nth-of-type(2) .category-drop-header");
     await click(
-      '.category-breadcrumb li:nth-of-type(2) .category-row[data-name="none"]'
+      '.category-breadcrumb li:nth-of-type(2) .category-row[data-value="no-categories"]'
     );
     assert.strictEqual(currentURL(), "/tags/c/feature/2/none/planters");
   });


### PR DESCRIPTION
The test was dependent on a translation string. Under certain seeds, the translation string for `{{category-drop}}`'s `noCategoriesLabel` is broken. This is because the value is calculated the first time a `{{category-drop}}` is rendered during the suite. If that first time happens to be during a test which is messing with `I18n.translations`, then it will cache a broken value. Maybe this should be fixed in a future commit... but for now moving to `data-value` will make the `tags-test` more robust and will stop the flakiness.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
