### PR TITLE
DEV: Always run all three qunit partitions, even with earlier failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,16 +235,19 @@ jobs:
           sudo -E -u discourse -H yarn ember build --environment=test  -o /tmp/emberbuild
 
       - name: Core QUnit 1
+        if: ${{ always() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=1 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 20
 
       - name: Core QUnit 2
+        if: ${{ always() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=2 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 20
 
       - name: Core QUnit 3
+        if: ${{ always() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=3 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 20


### PR DESCRIPTION
Previously, if Core QUnit 1 failed, then QUnit 2/3 wouldn't even be attempted. When dealing with multiple failures, this can make the feedback cycle much slower. Setting `if: always()` ensures that the steps run regardless of any earlier failures. This is the same approach we take in the linting workflow.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
