### PR TITLE
PERF: Speed up admin user list main query

### DIFF
--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -4,7 +4,7 @@ class AdminUserIndexQuery
 
   def initialize(params = {}, klass = User, trust_levels = TrustLevel.levels)
     @params = params
-    @query = initialize_query_with_order(klass.joins(:primary_email))
+    @query = initialize_query_with_order(klass)
     @trust_levels = trust_levels
   end
 
@@ -53,7 +53,7 @@ class AdminUserIndexQuery
 
     if !custom_order.present?
       if params[:query] == "active"
-        order << "COALESCE(users.last_seen_at, to_date('1970-01-01', 'YYYY-MM-DD')) DESC"
+        order << "users.last_seen_at DESC NULLS LAST"
       else
         order << "users.created_at DESC"
       end

--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -93,7 +93,7 @@ class AdminUserIndexQuery
 
   def filter_by_search
     if params[:email].present?
-      return @query.where('user_emails.email = ?', params[:email].downcase)
+      return @query.joins(:primary_email).where('user_emails.email = ?', params[:email].downcase)
     end
 
     filter = params[:filter]


### PR DESCRIPTION
This drops the join with the emails table since primary emails is already
on the users table.

Makes query 10x faster on large (6M+ users) sites.

Before

```
QUERY PLAN                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=568026.71..568038.37 rows=100 width=335) (actual time=4362.162..4363.081 rows=100 loops=1)
   ->  Gather Merge  (cost=568026.71..1094357.29 rows=4511090 width=335) (actual time=4362.161..4363.071 rows=100 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=567026.68..572665.54 rows=2255545 width=335) (actual time=4358.207..4358.220 rows=80 loops=3)
               Sort Key: (COALESCE(users.last_seen_at, (to_date('1970-01-01'::text, 'YYYY-MM-DD'::text))::timestamp without time zone)) DESC, users.username
               Sort Method: top-N heapsort  Memory: 76kB
               Worker 0:  Sort Method: top-N heapsort  Memory: 77kB
               Worker 1:  Sort Method: top-N heapsort  Memory: 76kB
               ->  Merge Join  (cost=20.47..480821.37 rows=2255545 width=335) (actual time=0.661..3488.468 rows=1804106 loops=3)
                     Merge Cond: (users.id = user_emails.user_id)
                     ->  Parallel Index Scan using users_pkey on users  (cost=0.43..286566.08 rows=2524402 width=327) (actual time=0.010..629.287 rows=2022052 loops=3)
                     ->  Index Only Scan using index_user_emails_on_user_id_and_primary on user_emails  (cost=0.43..140592.07 rows=5413309 width=4) (actual time=0.015..1555.287 rows=5411932 loops=3)
                           Heap Fetches: 4975
 Planning Time: 0.288 ms
 Execution Time: 4363.136 ms
(16 rows)
```

After:

```
QUERY PLAN                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=240098.87..240110.54 rows=100 width=327) (actual time=454.887..456.382 rows=100 loops=1)
   ->  Gather Merge  (cost=240098.87..829167.13 rows=5048804 width=327) (actual time=454.887..456.373 rows=100 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=239098.85..245409.85 rows=2524402 width=327) (actual time=452.775..452.783 rows=79 loops=3)
               Sort Key: last_seen_at DESC NULLS LAST, username
               Sort Method: top-N heapsort  Memory: 74kB
               Worker 0:  Sort Method: top-N heapsort  Memory: 68kB
               Worker 1:  Sort Method: top-N heapsort  Memory: 73kB
               ->  Parallel Seq Scan on users  (cost=0.00..142618.02 rows=2524402 width=327) (actual time=0.006..173.213 rows=2022064 loops=3)
 Planning Time: 0.119 ms
 Execution Time: 456.420 ms
(12 rows)
```
