### PR TITLE
FIX: Clean required category tag groups with invalid tag_group ids

### DIFF
--- a/db/migrate/20220401130745_create_category_required_tag_groups.rb
+++ b/db/migrate/20220401130745_create_category_required_tag_groups.rb
@@ -17,7 +17,8 @@ class CreateCategoryRequiredTagGroups < ActiveRecord::Migration[6.1]
       (category_id, tag_group_id, min_count, updated_at, created_at)
       SELECT c.id, c.required_tag_group_id, c.min_tags_from_required_group, NOW(), NOW()
       FROM categories c
-      WHERE c.required_tag_group_id IS NOT NULL
+      INNER JOIN tag_groups tg ON tg.id = c.required_tag_group_id
+      WHERE tg.id IS NOT NULL
     SQL
   end
 

--- a/db/post_migrate/20220407195246_remove_category_required_tag_groups_without_tag_groups.rb
+++ b/db/post_migrate/20220407195246_remove_category_required_tag_groups_without_tag_groups.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RemoveCategoryRequiredTagGroupsWithoutTagGroups < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      DELETE FROM category_required_tag_groups
+      WHERE id IN (
+        SELECT crtg.id
+        FROM category_required_tag_groups crtg
+        LEFT OUTER JOIN tag_groups tg ON crtg.tag_group_id = tg.id
+        WHERE tg.id IS NULL
+      )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The category table's required_tag_group_id contained references to deleted tag groups, which we copied to the new table. The new serializer tries to get the associated tag group name but fails because the tag group is nil.

This PR adds an inner join in the original migration to make sure tag groups still exist and adds a new post-migration to fix already migrated sites.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
