### PR TITLE
FIX: Fall back to clipboard.writeText if ClipboardItem not supported

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -325,9 +325,12 @@ discourseModule("Unit | Utilities | clipboard", function (hooks) {
   }
 
   test("clipboardCopyAsync - browser does not support window.ClipboardItem", function (assert) {
-    const done = assert.async();
-    sinon.stub(window, "ClipboardItem").value(null);
+    // without this check the stubbing will fail on Firefox
+    if (window.ClipboardItem) {
+      sinon.stub(window, "ClipboardItem").value(null);
+    }
 
+    const done = assert.async();
     clipboardCopyAsync(getPromiseFunction()).then(() => {
       assert.strictEqual(
         mockClipboard.writeText.calledWith("some text to copy"),
@@ -339,6 +342,13 @@ discourseModule("Unit | Utilities | clipboard", function (hooks) {
   });
 
   test("clipboardCopyAsync - browser does support window.ClipboardItem", function (assert) {
+    // without this check the test will fail on Firefox -- it cannot
+    // possibly pass because ClipboardItem is nonexistent there
+    if (!window.ClipboardItem) {
+      assert.strictEqual(true, true);
+      return;
+    }
+
     const done = assert.async();
     clipboardCopyAsync(getPromiseFunction()).then(() => {
       assert.strictEqual(


### PR DESCRIPTION
Firefox does not support window.ClipboardItem yet (it is behind
a flag (dom.events.asyncClipboard.clipboardItem) as at version 87.)
so we need to fall back to the normal non-async clipboard copy, that
works in every browser except Safari.

This commit also tests the clipboardCopyAsync function by stubbing out
the clipboard on the window.navigator.

This fixes an issue in the discourse-chat plugin, where the
"Quote in Topic" button errored in Firefox.