### PR TITLE
FIX: Buggy topic scrolling on iOS 12

### DIFF
--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -103,7 +103,8 @@ export default MountWidget.extend({
     const slack = Math.round(windowHeight * 5);
     const onscreen = [];
     const nearby = [];
-    const windowTop = document.documentElement.scrollTop;
+    const windowTop =
+      document.documentElement.scrollTop || document.body.scrollTop;
     const postsWrapperTop = domUtils.offset(
       document.querySelector(".posts-wrapper")
     ).top;


### PR DESCRIPTION
`document.documentElement.scrollTop` always returns `0` on iOS 12, so we need to add a fallback. 