### PR TITLE
DEV: Add pretender endpoint for category visible groups.

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -1125,6 +1125,8 @@ export function applyDefaultHandlers(pretender) {
   pretender.get("/tag_groups/filter/search", () =>
     response(fixturesByUrl["/tag_groups/filter/search"])
   );
+
+  pretender.get("/c/:id/visible_groups.json", () => response({ groups: [] }));
 }
 
 export function resetPretender() {


### PR DESCRIPTION
This was causing our build to become flaky.