### PR TITLE
FIX: Add href to post-date link element

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/hooks.js
+++ b/app/assets/javascripts/discourse/app/widgets/hooks.js
@@ -65,6 +65,21 @@ export const WidgetMouseOverHook = buildHook(MOUSE_OVER_ATTRIBUTE_NAME);
 export const WidgetMouseOutHook = buildHook(MOUSE_OUT_ATTRIBUTE_NAME);
 export const WidgetTouchEndHook = buildHook(TOUCH_END_ATTRIBUTE_NAME);
 
+export class WidgetClickElementHook extends WidgetBaseHook {
+  constructor(widget, handler) {
+    super(widget);
+    this.handler = handler.bind(widget);
+  }
+
+  hook(node) {
+    node.addEventListener("click", this.handler);
+  }
+
+  unhook(node) {
+    node.removeEventListener("click", this.handler);
+  }
+}
+
 // `touchstart` and `touchmove` events are particularly performance sensitive because
 // they block scrolling on mobile. Therefore we want to avoid registering global non-passive
 // listeners for these events.

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -1,5 +1,6 @@
 import {
   WidgetChangeHook,
+  WidgetClickElementHook,
   WidgetClickHook,
   WidgetClickOutsideHook,
   WidgetDoubleClickHook,
@@ -418,6 +419,12 @@ export default class Widget {
     }
     if (this.click) {
       properties["widget-click"] = new WidgetClickHook(this);
+    }
+    if (this.clickElement) {
+      properties["widget-test"] = new WidgetClickElementHook(
+        this,
+        this.clickElement
+      );
     }
     if (this.doubleClick) {
       properties["widget-double-click"] = new WidgetDoubleClickHook(this);

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -60,7 +60,11 @@ acceptance("Share and Invite modal", function (needs) {
   test("Post date link", async function (assert) {
     await visit("/t/short-topic-with-two-posts/54077");
     await click("#post_2 .post-info.post-date a");
-
+    assert.ok(
+      query("#post_2 .post-info.post-date a").href.endsWith(
+        "/t/short-topic-with-two-posts/54077/2?u=eviltrout"
+      )
+    );
     assert.ok(exists(".share-topic-modal"), "it shows the share modal");
   });
 


### PR DESCRIPTION
The href was removed in commit 08a1f41582534c2793ca21d67df34ef6821b40d0,
but it was useful to quick copy the URL to the post.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
