### PR TITLE
FIX: Validate asset url before replacing base url

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/get-url.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-url.js
@@ -38,7 +38,7 @@ export function getURLWithCDN(url) {
   // only relative urls
   if (cdn && /^\/[^\/]/.test(url)) {
     url = cdn + url;
-  } else if (S3CDN) {
+  } else if (S3CDN && url.startsWith(S3BaseUrl)) {
     url = url.replace(S3BaseUrl, S3CDN);
   }
   return url;

--- a/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/get-url-test.js
@@ -172,4 +172,12 @@ module("Unit | Utility | get-url", function () {
 
     assert.strictEqual(getURLWithCDN(url), expected, "at correct path");
   });
+
+  test("getURLWithCDN when URL includes protocol", function (assert) {
+    setupS3CDN("//awesome.cdn/site", "https://awesome.cdn/site");
+
+    let url = "https://awesome.cdn/site/awesome.png";
+
+    assert.strictEqual(getURLWithCDN(url), url, "at correct path");
+  });
 });


### PR DESCRIPTION
When opening the view for drafting a post the `markdown-it` library is loaded on demand. When a S3 CDN is configured the function `getURLWithCDN()` is called with the full URL of this library, such as `https://bucket.us-east-1.linodeobjects.com/assets/markdown-it-bundle-59fb5d5f9715c17e686a2c56a0b9656d446a48334a576df5e52f3668279b6229.gz.js`. The `getURLWithCDN()` function will then make an invalid replacement.

This function will be called with the following variables.

```javascript
S3BaseUrl = "//bucket.us-east-1.linodeobjects.com"
S3CDN = "https://bucket.us-east-1.linodeobjects.com"
url = "https://bucket.us-east-1.linodeobjects.com/assets/markdown-it-bundle-59fb5d5f9715c17e686a2c56a0b9656d446a48334a576df5e52f3668279b6229.gz.js"
```

The line `url.replace(S3BaseUrl, S3CDN)` will then transform `https://bucket.us-east-1.linodeobjects.com/assets/markdown-it-bundle-59fb5d5f9715c17e686a2c56a0b9656d446a48334a576df5e52f3668279b6229.gz.js` into an invalid URL with two leading https prefixes `https:https://bucket.us-east-1.linodeobjects.com/assets/markdown-it-bundle-59fb5d5f9715c17e686a2c56a0b9656d446a48334a576df5e52f3668279b6229.gz.js`.

The use of `url.replace(S3BaseUrl, S3CDN)` appears to be to transform a protocol relative URL into a full URL. Such as `//bucket.us-east-1.linodeobjects.com/assets/example.js` into `https://bucket.us-east-1.linodeobjects.com/assets/example.js`. But this causes an error when providing a URL that already contains the protocol prefix. To fix this the function should first validate that the `url` has the `S3BaseUrl` prefix before doing the replacement.

This error will be visible on Discourse server with a `Content Security Policy` error. Chrome will transform the invalid URL into `https://forum.domain.com/https://bucket.us-east-1.linodeobjects.com/assets/markdown-it-bundle-59fb5d5f9715c17e686a2c56a0b9656d446a48334a576df5e52f3668279b6229.gz.js` the loading of this URL will then be blocked from the policy in the `Content-Security-Policy` header. After this fails to load the post preview will not be displayed.