### PR TITLE
FIX: remove avatars next to 'read more' in summary email

### DIFF
--- a/app/views/user_notifications/digest.html.erb
+++ b/app/views/user_notifications/digest.html.erb
@@ -169,13 +169,6 @@
         <img class="digest-icon" src="<%= email_image_url 'comment_dark.png' -%>" style="clear:both;display:inline-block;float:<%= rtl? ? 'right' : 'left' %>;height:20px;margin:0;max-width:100%;opacity:.4;outline:0;text-decoration:none;width:auto;display:none;" alt="likes" dm="dark-img">
         <span style="color:#8f8f8f;float:<%= rtl? ? 'right' : 'left' %>;line-height:1.3;margin:0 5px 10px 5px;padding:0;font-weight:400;">&nbsp;<%= t.posts_count - 1 -%></span>
       </td>
-      <td class="digest-topic-posters" style="padding:0 8px 16px 8px;white-space:nowrap;vertical-align:top;">
-        <% t.posters_summary.each do |ps| %>
-          <% if ps.user %>
-            <img src="<%= ps.user.small_avatar_url -%>" style="border-radius:50%;clear:both;display:inline-block;height:20px;width:20px;outline:0;text-decoration:none;" height="20" width="20" alt="<%= ps.user.username -%>">
-          <% end %>
-        <% end %>
-      </td>
       <td class="digest-read-more-wrap" style="line-height:1.3;padding:<%= rtl? ? '0 8px 0 16px' : '0 16px 0 8px' %>;text-align:<%= rtl? ? 'left' : 'right' %>;white-space:nowrap;vertical-align:top;">
         <span class="with_accent-colors mso-accent-link">
           <a href="<%= Discourse.base_url_no_prefix + t.relative_url %>" class="digest-button with-accent-colors" style="width:100%;text-decoration:none;padding:8px 16px;white-space:nowrap;">
@@ -324,13 +317,6 @@
         <p class="digest-new-topic-category" style="color:#0a0a0a;line-height:1.3;margin:0 0 10px 0;padding:0;">
           <%= category_badge(t.category, inline_style: true, absolute_url: true) %>
         </p>
-      </td>
-      <td class="digest-new-topic-posters with-dir" style="padding:8px;">
-        <% t.posters_summary[0,2].each do |ps| %>
-          <% if ps.user %>
-            <img src="<%= ps.user.small_avatar_url -%>" style="height:20px;width:20px;margin:<%= rtl? ? '0 0 5px 5px' : '0 5px 5px 0' %>;border-radius:50%;clear:both;display:inline-block;outline:0;text-decoration:none;" alt="<%= ps.user.username -%>">
-          <% end %>
-        <% end %>
       </td>
       <td class="digest-new-topic-stat with-dir" style="padding:8px;">
         <img class="digest-icon" src="<%= email_image_url 'heart.png' -%>" style="clear:both;display:inline-block;float:<%= rtl? ? 'right' : 'left' %>;height:20px;margin:0;max-width:100%;opacity:.4;outline:0;text-decoration:none;width:auto" alt="likes" dm="light-img">


### PR DESCRIPTION
Remove avatars pictured below

<img width="660" alt="Screen Shot 2022-04-11 at 1 44 57 PM" src="https://user-images.githubusercontent.com/50783505/162808076-fc498409-8b5b-4bdd-a3f4-2c836e8813b8.png">
