### PR TITLE
UX: Make full topic row clickable on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -258,6 +258,18 @@ export default Component.extend({
       return this.navigateToTopic(topic, e.target.getAttribute("href"));
     }
 
+    // make full row click target on mobile, due to size constraints
+    if (
+      this.site.mobileView &&
+      (e.target.classList.contains("right") ||
+        e.target.classList.contains("topic-item-stats"))
+    ) {
+      if (wantsNewWindow(e)) {
+        return true;
+      }
+      return this.navigateToTopic(topic, topic.lastUnreadUrl);
+    }
+
     if (e.target.closest("a.topic-status")) {
       this.topic.togglePinnedForUser();
       return false;

--- a/app/assets/javascripts/discourse/app/templates/mobile/list/topic-list-item.hbr
+++ b/app/assets/javascripts/discourse/app/templates/mobile/list/topic-list-item.hbr
@@ -38,13 +38,11 @@
         </div>
       {{/unless}}
       {{discourse-tags topic mode="list"}}
-      <div class="pull-right">
         <div class='num activity last'>
           <span class="age activity" title="{{topic.bumpedAtTitle}}"><a
               href="{{topic.lastPostUrl}}">{{format-date topic.bumpedAt format="tiny" noTitle="true"}}</a>
           </span>
         </div>
-      </div>
       <div class="clearfix"></div>
     </div>
   </div>

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -173,7 +173,7 @@
     display: flex;
     align-items: baseline;
     z-index: z("base");
-    margin-top: 0.25em;
+    margin-top: 0.5em;
     .category,
     .num,
     .last-poster {

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -123,15 +123,21 @@
     z-index: z("base") + 1; // Intentionally overlapping category to create bigger tap target
     font-size: var(--font-up-1);
     a.title {
+      display: block;
       color: var(--primary);
-      padding: 0.5em 0 1.2em 0;
+      padding: 0;
     }
     .topic-statuses {
+      padding: 0 0 0.5em 0;
       a {
         line-height: 0.8;
         color: var(--primary-medium);
       }
     }
+  }
+
+  .topic-featured-link {
+    padding: 0;
   }
 
   .badge-notification,
@@ -161,9 +167,12 @@
   }
 
   .topic-item-stats {
+    pointer-events: none;
     position: relative;
-    margin-top: 0.5em;
+    display: flex;
+    align-items: baseline;
     z-index: z("base");
+    margin-top: 0.5em;
     .category,
     .num,
     .last-poster {
@@ -177,14 +186,22 @@
     a:visited {
       color: var(--primary-med-or-secondary-med);
     }
+    .activity {
+      margin-left: auto;
+    }
+    .discourse-tags {
+      display: flex;
+      flex-wrap: nowrap;
+      flex: 0 1 auto;
+      overflow: hidden;
+    }
   }
 
   .age {
     white-space: nowrap;
     a {
-      // let's make all ages dim on mobile so we're not
-      // overwhelming people with info about each topic
-      color: var(--primary-low-mid-or-secondary-high) !important;
+      color: var(--primary-500);
+      font-size: var(--font-down-1);
     }
   }
 }
@@ -441,7 +458,7 @@ td .main-link {
     }
   }
   .num.activity a {
-    padding: 0;
+    padding: 0.5em 0;
   }
   // so the topic excerpt is full width
   // as the containing div is 80%

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -201,7 +201,7 @@
   .age {
     white-space: nowrap;
     a {
-      color: var(--primary-500);
+      color: var(--primary-600);
       font-size: var(--font-down-1);
     }
   }

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -167,6 +167,7 @@
   }
 
   .topic-item-stats {
+    // disabling clicks because these targets are too small on mobile
     pointer-events: none;
     position: relative;
     display: flex;

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -173,7 +173,7 @@
     display: flex;
     align-items: baseline;
     z-index: z("base");
-    margin-top: 0.5em;
+    margin-top: 0.25em;
     .category,
     .num,
     .last-poster {


### PR DESCRIPTION
1. Cleaning up some CSS
2. Adding some JS to make the full row to the right of the avatar click through to the topic (adapted from https://github.com/discourse/discourse-clickable-topic)
3. Adding `pointer-events: none` to `.topic-item-stats` because they're too-small click targets (this also allows an admin to make them clickable) 


Before/After
![Screen Shot 2022-04-11 at 5 43 31 PM](https://user-images.githubusercontent.com/1681963/162839071-a34725e8-fc3b-48bd-b465-9e75060460c7.png) ![Screen Shot 2022-04-11 at 5 47 09 PM](https://user-images.githubusercontent.com/1681963/162839073-ad74ce92-aa22-499d-bf30-eb79ede6eeab.png)

