### PR TITLE
FIX: Email logs not finding attached incoming email

### DIFF
--- a/app/controllers/admin/email_controller.rb
+++ b/app/controllers/admin/email_controller.rb
@@ -209,6 +209,14 @@ class Admin::EmailController < Admin::AdminController
         incoming_email = IncomingEmail.find_by(to_addresses: bounced_to_address)
       end
 
+      # Temporary fix until all old format of emails has been purged via lib/email/cleaner.rb
+      if incoming_email.nil?
+        email_local_part, email_domain = SiteSetting.reply_by_email_address.split('@')
+        subdomain, root_domain, extension = email_domain&.split('.')
+        bounced_to_address = "#{subdomain}+verp-#{email_log.bounce_key}@#{root_domain}.#{extension}"
+        incoming_email = IncomingEmail.find_by(to_addresses: bounced_to_address)
+      end
+
       raise Discourse::NotFound if incoming_email.nil?
 
       serializer = IncomingEmailDetailsSerializer.new(incoming_email, root: false)

--- a/spec/requests/admin/email_controller_spec.rb
+++ b/spec/requests/admin/email_controller_spec.rb
@@ -306,6 +306,21 @@ describe Admin::EmailController do
         expect(json["error"]).to eq(error_message)
       end
 
+      it 'returns an incoming email sent to the notification_email address' do
+        SiteSetting.reply_by_email_address = "replies+%{reply_key}@subdomain.example.com"
+        Fabricate(:incoming_email,
+                  is_bounce: true,
+                  error: error_message,
+                  to_addresses: "subdomain+verp-#{email_log.bounce_key}@example.com"
+        )
+
+        get "/admin/email/incoming_from_bounced/#{email_log.id}.json"
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
+        expect(json["error"]).to eq(error_message)
+      end
+
       it 'raises an error if the bounce_key is blank' do
         email_log.update(bounce_key: nil)
 


### PR DESCRIPTION
This fix handles the old SiteSetting.reply_by_email_address format
outlined in this public announcement:

https://meta.discourse.org/t/outgoing-incoming-email-changes-for-our-hosted-customers/218489

Before it was changed so that if anyone is looking at old email logs
they can still locate the attached incoming email record. Without this
fix a 404 error will occur even though the incoming email record still
exists in the db.
