### PR TITLE
FEATURE: Add a sidekiq job for syncing S3 ACLs

### DIFF
--- a/app/jobs/regular/sync_acls_for_uploads.rb
+++ b/app/jobs/regular/sync_acls_for_uploads.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Jobs
+  # Sometimes we need to update a _lot_ of ACLs on S3 (such as when secure media
+  # is enabled), and since it takes ~1s per upload to update the ACL, this is
+  # best spread out over many jobs instead of having to do the whole thing serially.
+  class SyncAclsForUploads < ::Jobs::Base
+    def execute(args)
+      return if !Discourse.store.external?
+      return if !args.key?(:upload_ids)
+
+      # TODO (martin) Change the logging here to debug after acl_stale implemented.
+      #
+      # Note...these log messages are set to warn to ensure this is working
+      # as intended in initial production trials, this will be set to debug
+      # after an acl_stale column is added to uploads.
+      time = Benchmark.measure do
+        Rails.logger.warn("Syncing ACL for upload ids: #{args[:upload_ids].join(", ")}")
+        Upload.includes(:optimized_images).where(id: args[:upload_ids]).find_in_batches do |uploads|
+          uploads.each do |upload|
+            Discourse.store.update_upload_ACL(upload, optimized_images_preloaded: true)
+          end
+        end
+        Rails.logger.warn("Completed syncing ACL for upload ids in #{time.to_s}. IDs: #{args[:upload_ids].join(", ")}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometimes we need to update a _lot_ of ACLs on S3 (such as when secure media
is enabled), and since it takes ~1s per upload to update the ACL, this is
best spread out over many jobs instead of having to do the whole thing serially.

In future, it will be better to have a job that can be run based on
a column on uploads (e.g. acl_stale) so we can track progress, similar
to how we can set the baked_version to nil to rebake posts.