### PR TITLE
SECURITY: Update Nokogiri to 1.13.4.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
       rack (>= 1.1.3)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     mini_racer (0.6.1)
       libv8-node (~> 16.10.0.0)
     mini_scheduler (0.13.0)
@@ -249,14 +249,16 @@ GEM
     multipart-post (2.1.1)
     mustache (1.1.1)
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.4)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.12.5-arm64-darwin)
+    nokogiri (1.13.4-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (1.13.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-linux)
+    nokogiri (1.13.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     oauth (0.5.8)
     oauth2 (1.4.7)
@@ -618,4 +620,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.3.4
+   2.3.5


### PR DESCRIPTION
Nokogiri 1.13.4 updates zlib to 1.2.12 to address CVE-2018-25032.

https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-v6gp-9mmm-c6p5
https://nvd.nist.gov/vuln/detail/CVE-2018-25032

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
