### PR TITLE
DEV: Remove scoped order warning in PostDestroyer.

### DIFF
--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -47,7 +47,7 @@ class UserDestroyer
       # Add info about the user to staff action logs
       UserHistory.staff_action_records(
         Discourse.system_user, acting_user: user.username
-      ).find_each do |log|
+      ).unscope(:order).find_each do |log|
         log.details ||= ''
         log.details = (log.details.split("\n") +
             ["user_id: #{user.id}", "username: #{user.username}"]


### PR DESCRIPTION
`Scoped order is ignored, it's forced to be batch order.`

`find_each` ignores the `order` scope and triggers a warning in
production which is noisy.

Follow-up to 7a284164ceb457baca1c95411e377236ff403e65