### PR TITLE
UX: Move post date under title in share-modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-modal.hbs
@@ -16,7 +16,7 @@
             <h3 id="discourse-modal-title">{{title}}</h3>
 
             {{#if subtitle}}
-              <p>{{subtitle}}</p>
+              <p class="subtitle">{{subtitle}}</p>
             {{/if}}
           </div>
         {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
@@ -1,4 +1,7 @@
-{{#d-modal-body rawTitle=(if post (i18n "post.share.title" post_number=post.post_number) (i18n "topic.share.title"))}}
+{{#d-modal-body
+  rawTitle=(if post (i18n "post.share.title" post_number=post.post_number) (i18n "topic.share.title"))
+  rawSubtitle=(if post displayDate)
+}}
   <form>
     <div class="input-group invite-link">
       <label for="invite-link">
@@ -52,10 +55,6 @@
           {{/if}}
         {{/if}}
       </div>
-
-      {{#if post}}
-        <div class="date">{{displayDate}}</div>
-      {{/if}}
     </div>
   </form>
 {{/d-modal-body}}

--- a/app/assets/stylesheets/common/base/share_link.scss
+++ b/app/assets/stylesheets/common/base/share_link.scss
@@ -31,12 +31,6 @@
   .new-topic {
     margin-right: 0;
   }
-
-  .date {
-    color: var(--primary-med-or-secondary-med);
-    font-weight: normal;
-    margin-left: auto;
-  }
 }
 
 .share-twitter {
@@ -53,6 +47,12 @@
 // topic share modal
 
 .share-topic-modal {
+  .modal-header {
+    .subtitle {
+      color: var(--primary-med-or-secondary-med);
+    }
+  }
+
   form {
     margin-bottom: 0;
   }

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -111,6 +111,15 @@
 .create-invite-modal,
 .create-invite-bulk-modal,
 .share-topic-modal {
+  .title {
+    align-items: center;
+    display: flex;
+
+    .subtitle {
+      margin-left: 0.5em;
+    }
+  }
+
   &.modal .modal-body {
     margin: 1em;
     padding: unset;


### PR DESCRIPTION
The old position was less than ideal on mobile.

Before Desktop:

<img width="601" alt="image" src="https://user-images.githubusercontent.com/23153890/164069483-b60e88e2-0320-4030-b0a3-c0d5805f0abe.png">

Before Mobile:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/23153890/164069553-cb8e2df7-214b-4f57-80a4-93257424ef99.png">

After Desktop:

<img width="604" alt="image" src="https://user-images.githubusercontent.com/23153890/164068913-fe55b5dc-4caa-4e3f-9fb0-28799c231d71.png">

After Mobile:

<img width="289" alt="image" src="https://user-images.githubusercontent.com/23153890/162958140-9ed7d1fe-f98d-469b-a751-3801f34f30d4.png">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
