### PR TITLE
DEV: Update to Sprockets 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,9 +31,7 @@ end
 
 gem 'json'
 
-# TODO: At the moment Discourse does not work with Sprockets 4, we would need to correct internals
-# This is a desired upgrade we should get to.
-gem 'sprockets', '3.7.2'
+gem 'sprockets'
 
 # this will eventually be added to rails,
 # allows us to precompile all our templates in the unicorn master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,7 +443,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sprockets (3.7.2)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -602,7 +602,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simplecov
-  sprockets (= 3.7.2)
+  sprockets
   sprockets-rails
   sshkey
   stackprof

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,1 @@
+//= link_tree ../images

--- a/config/application.rb
+++ b/config/application.rb
@@ -142,9 +142,9 @@ module Discourse
     config.assets.skip_minification = []
 
     # explicitly precompile any images in plugins ( /assets/images ) path
-    config.assets.precompile += [lambda do |filename, path|
-      path =~ /assets\/images/ && !%w(.js .css).include?(File.extname(filename))
-    end]
+    Dir.glob("#{config.root}/plugins/*/assets/images/**/*").each do |filename|
+      config.assets.precompile << filename if !%w(.js .css).include?(File.extname(filename))
+    end
 
     config.assets.precompile += %w{
       vendor.js
@@ -190,25 +190,6 @@ module Discourse
     unless GlobalSetting.try(:omit_base_locales)
       Dir.glob("#{config.root}/app/assets/javascripts/locales/*.js.erb").each do |file|
         config.assets.precompile << "locales/#{file.match(/([a-z_A-Z]+\.js)\.erb$/)[1]}"
-      end
-    end
-
-    # out of the box sprockets 3 grabs loose files that are hanging in assets,
-    # the exclusion list does not include hbs so you double compile all this stuff
-    initializer :fix_sprockets_loose_file_searcher, after: :set_default_precompile do |app|
-      app.config.assets.precompile.delete(Sprockets::Railtie::LOOSE_APP_ASSETS)
-
-      # We don't want application from node_modules, only from the root
-      app.config.assets.precompile.delete(/(?:\/|\\|\A)application\.(css|js)$/)
-      app.config.assets.precompile += ['application.js']
-
-      start_path = ::Rails.root.join("app/assets").to_s
-      exclude = ['.es6', '.hbs', '.hbr', '.js', '.css', '.lock', '.json', '.log', '.html', '']
-      app.config.assets.precompile << lambda do |logical_path, filename|
-        filename.start_with?(start_path) &&
-        !filename.include?("/node_modules/") &&
-        !filename.include?("/dist/") &&
-        !exclude.include?(File.extname(logical_path))
       end
     end
 
@@ -289,6 +270,11 @@ module Discourse
 
     Sprockets.register_mime_type 'application/javascript', extensions: ['.js', '.es6', '.js.es6'], charset: :unicode
     Sprockets.register_postprocessor 'application/javascript', DiscourseJsProcessor
+
+    # This class doesn't exist in Sprockets 4, but ember-rails tries to 'autoload' it
+    # Define an empty class to prevent an error
+    class Sprockets::Engines
+    end
 
     require 'discourse_redis'
     require 'logster/redis_store'

--- a/lib/freedom_patches/ember_sprockets_4.rb
+++ b/lib/freedom_patches/ember_sprockets_4.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# One of the initializers in `discourse-ember-rails/lib/ember_rails.rb` tries to set
+# the ember template compiler path based on a call to `Sprockets::Environment#resolve`
+# which started returning an array in Sprockets 4.
+# This doesn't seem to be needed - it was setting to the existing value, so we can just ignore it.
+Ember::Handlebars::Template.singleton_class.prepend(Module.new do
+  def setup_ember_template_compiler(path)
+    return if path.is_a? Array
+    super
+  end
+end)


### PR DESCRIPTION
The main difference is that Sprockets 4.0 no longer tries to compile everything by default. This is good for us, because we can remove all our custom 'exclusion' logic which was working around the old sprockets 3.0 behavior.

The other big change is that lambdas can no longer be added to the `config.assets.precompile` array. Instead, we can do the necessary globs ourselves, and add the desired files manually.

A small patch is required to make ember-rails compatible. Since we plan to remove this dependency in the near future, I do not intend to upstream this change.

I have compared the `bin/rake assets:precompile` output before and after this change, and verified that all files are present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
