### PR TITLE
DEV: Accept `force_respect_seen_recently` argument in UserEmail job

### DIFF
--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -131,14 +131,14 @@ module Jobs
       end
 
       seen_recently = (user.last_seen_at.present? && user.last_seen_at > SiteSetting.email_time_window_mins.minutes.ago)
-      if !args[:force_skip_if_seen_recently] &&
+      if !args[:force_respect_seen_recently] &&
           (always_email_regular?(user, type) || always_email_private_message?(user, type) || user.staged)
         seen_recently = false
       end
 
       email_args = {}
 
-      if (post || notification || notification_type || args[:force_skip_if_seen_recently]) &&
+      if (post || notification || notification_type || args[:force_respect_seen_recently]) &&
          (seen_recently && !user.suspended?)
 
         return skip_message(SkippedEmailLog.reason_types[:user_email_seen_recently])

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -147,7 +147,7 @@ describe Jobs::UserEmail do
       )
     end
 
-    it "doesn't send an email even if email_level is set to always if `ignore_core_email_preferences` arg is true" do
+    it "doesn't send an email even if email_level is set to always if `force_respect_seen_recently` arg is true" do
       user.user_option.update(email_level: UserOption.email_level_types[:always])
       PostTiming.create!(topic_id: post.topic_id, post_number: post.post_number, user_id: user.id, msecs: 100)
 
@@ -156,7 +156,7 @@ describe Jobs::UserEmail do
         user_id: user.id,
         post_id: post.id,
         notification_id: notification.id,
-        force_skip_if_seen_recently: true
+        force_respect_seen_recently: true
       )
       expect(ActionMailer::Base.deliveries).to eq([])
     end

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -147,6 +147,20 @@ describe Jobs::UserEmail do
       )
     end
 
+    it "doesn't send an email even if email_level is set to always if `ignore_core_email_preferences` arg is true" do
+      user.user_option.update(email_level: UserOption.email_level_types[:always])
+      PostTiming.create!(topic_id: post.topic_id, post_number: post.post_number, user_id: user.id, msecs: 100)
+
+      Jobs::UserEmail.new.execute(
+        type: :user_replied,
+        user_id: user.id,
+        post_id: post.id,
+        notification_id: notification.id,
+        force_skip_if_seen_recently: true
+      )
+      expect(ActionMailer::Base.deliveries).to eq([])
+    end
+
     it "sends an email with no gsub substitution bugs" do
       upload = Fabricate(:upload)
 


### PR DESCRIPTION
This argument is useful when you want to enqueue a `UserEmail` job and want to ignore a user's email preference (of for all activity). This is going to be used first by the chat plugin to enqueue chat notification emails. The chat plugin has it's own user preference for emails, and we want to bypass the `always` send check in core with this new param.

Also makes some logic easier to read by removing nested `ifs` by using a guard.