### PR TITLE
FIX: update dark mode emails styles

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -58,7 +58,8 @@ module EmailHelper
         h5,
         h6,
         p,
-        span {
+        span, 
+        td {
           color: #dddddd !important;
         }
 

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -342,6 +342,8 @@ module Email
       style(".digest-content, .header-popular-posts, .spacer, .popular-post-spacer, .popular-post-meta, .digest-new-header, .digest-new-topic, .body", nil, dm: "body")
       style(".with-accent-colors, .digest-content-header", nil, dm: "body_primary")
       style(".summary-footer", nil, dm: "text-color")
+      style(".digest-topic-body", "border-bottom: 1px solid #454545 !important;")
+      style('div.secure-media-notice', 'border: 5px solid #454545 !important;')
     end
 
     def replace_relative_urls


### PR DESCRIPTION
Update: 

- divider sometimes is too bright
- lists have dark text on dark copy
- border around the “secure media” message is bright