### PR TITLE
FIX: prevents error with emoji autocomplete

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -576,11 +576,15 @@ export default Component.extend(TextareaTextManipulation, {
 
           return resolve(options);
         })
-          .then((list) =>
-            list.map((code) => {
+          .then((list) => {
+            if (list === "skip") {
+              return [];
+            }
+
+            return list.map((code) => {
               return { code, src: emojiUrlFor(code) };
-            })
-          )
+            });
+          })
           .then((list) => {
             if (list.length) {
               list.push({ label: I18n.t("composer.more_emoji"), term });

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -577,7 +577,7 @@ export default Component.extend(TextareaTextManipulation, {
           return resolve(options);
         })
           .then((list) => {
-            if (list === "skip") {
+            if (list === SKIP) {
               return [];
             }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-test.js
@@ -1,9 +1,10 @@
 import {
   acceptance,
+  exists,
   normalizeHtml,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 
@@ -35,5 +36,24 @@ acceptance("Emoji", function (needs) {
         `<p>this is an emoji <img src="/images/emoji/google_classic/blonde_woman/5.png?v=${v}" title=":blonde_woman:t5:" class="emoji" alt=":blonde_woman:t5:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"></p>`
       )
     );
+  });
+
+  needs.settings({
+    emoji_autocomplete_min_chars: 2,
+  });
+
+  test("siteSetting:emoji_autocomplete_min_chars", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-footer-buttons .btn.create");
+
+    await fillIn(".d-editor-input", ":s");
+    await triggerKeyEvent(".d-editor-input", "keyup", 40); // ensures a keyup is triggered
+
+    assert.notOk(exists(".autocomplete.ac-emoji"));
+
+    await fillIn(".d-editor-input", ":sw");
+    await triggerKeyEvent(".d-editor-input", "keyup", 40); // ensures a keyup is triggered
+
+    assert.ok(exists(".autocomplete.ac-emoji"));
   });
 });


### PR DESCRIPTION
The error would happen when emoji_autocomplete_min_chars site setting is set to anything superior to 0, in this case until we reach the min chars length, emojiSearch would return "skip" and the code was currently expecting an array.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
