### PR TITLE
FIX: Add href to post-date link element

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -19,6 +19,7 @@ import { iconNode } from "discourse-common/lib/icon-library";
 import { postTransformCallbacks } from "discourse/widgets/post-stream";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { relativeAgeMediumSpan } from "discourse/lib/formatter";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { transformBasicPost } from "discourse/lib/transform-post";
 import autoGroupFlairForUser from "discourse/lib/avatar-flair";
 import showModal from "discourse/lib/show-modal";
@@ -352,22 +353,25 @@ createWidget("post-date", {
   tagName: "div.post-info.post-date",
 
   html(attrs) {
-    const attributes = { class: "post-date" };
-    let date;
-    if (attrs.wiki && attrs.lastWikiEdit) {
+    const attributes = { href: attrs.shareUrl, class: "post-date" };
+    let date = attrs.created_at;
+    if (attrs.lastWikiEdit) {
       attributes["class"] += " last-wiki-edit";
-      date = new Date(attrs.lastWikiEdit);
-    } else {
-      date = new Date(attrs.created_at);
+      date = attrs.lastWikiEdit;
     }
-    return h("a", { attributes }, dateNode(date));
+    return h("a", { attributes }, dateNode(new Date(date)));
   },
 
   click() {
+    if (wantsNewWindow(event)) {
+      return;
+    }
+
     const post = this.findAncestorModel();
     const topic = post.topic;
     const controller = showModal("share-topic", { model: topic.category });
     controller.setProperties({ topic, post });
+    event.preventDefault();
   },
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -59,7 +59,12 @@ acceptance("Share and Invite modal", function (needs) {
 
   test("Post date link", async function (assert) {
     await visit("/t/short-topic-with-two-posts/54077");
-    await click("#post_2 .post-info.post-date a");
+    await click("#post_2 .post-info.post-date");
+    assert.ok(
+      query("#post_2 .post-info.post-date a").href.endsWith(
+        "/t/short-topic-with-two-posts/54077/2?u=eviltrout"
+      )
+    );
 
     assert.ok(exists(".share-topic-modal"), "it shows the share modal");
   });


### PR DESCRIPTION
The href was removed in commit 08a1f41582534c2793ca21d67df34ef6821b40d0,
but it was useful to quick copy the URL to the post.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
