### PR TITLE
UX: minor mobile topic list alignment adjustments

### DIFF
--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -117,27 +117,26 @@
     max-width: 300px;
   }
 
+  .avatar {
+    padding-top: 0.15em;
+  }
+
   .main-link {
     line-height: $line-height-medium;
     position: relative;
     z-index: z("base") + 1; // Intentionally overlapping category to create bigger tap target
     font-size: var(--font-up-1);
     a.title {
-      display: block;
       color: var(--primary);
       padding: 0;
     }
     .topic-statuses {
-      padding: 0 0 0.5em 0;
+      padding: 0;
       a {
         line-height: 0.8;
         color: var(--primary-medium);
       }
     }
-  }
-
-  .topic-featured-link {
-    padding: 0;
   }
 
   .badge-notification,

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -118,7 +118,7 @@
   }
 
   .avatar {
-    padding-top: 0.15em;
+    margin-top: 0.15em;
   }
 
   .main-link {


### PR DESCRIPTION
Fixes this issue with the new dot wrapping onto its own line:

![Screen Shot 2022-04-13 at 2 26 06 PM](https://user-images.githubusercontent.com/1681963/163246006-bcb68eff-695b-4fa3-aea6-9e2c02b7279c.png)

Follow-up to 0e88cffaf4ba6e079c94955e3fe076ab3fede377

I also added a little top-margin to the avatars to get the lining up with the text better. 