### PR TITLE
FIX: Href attribute for post-date link

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -19,7 +19,6 @@ import { iconNode } from "discourse-common/lib/icon-library";
 import { postTransformCallbacks } from "discourse/widgets/post-stream";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { relativeAgeMediumSpan } from "discourse/lib/formatter";
-import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { transformBasicPost } from "discourse/lib/transform-post";
 import autoGroupFlairForUser from "discourse/lib/avatar-flair";
 import showModal from "discourse/lib/show-modal";
@@ -353,25 +352,22 @@ createWidget("post-date", {
   tagName: "div.post-info.post-date",
 
   html(attrs) {
-    const attributes = { href: attrs.shareUrl, class: "post-date" };
-    let date = attrs.created_at;
-    if (attrs.lastWikiEdit) {
+    const attributes = { class: "post-date" };
+    let date;
+    if (attrs.wiki && attrs.lastWikiEdit) {
       attributes["class"] += " last-wiki-edit";
-      date = attrs.lastWikiEdit;
+      date = new Date(attrs.lastWikiEdit);
+    } else {
+      date = new Date(attrs.created_at);
     }
-    return h("a", { attributes }, dateNode(new Date(date)));
+    return h("a", { attributes }, dateNode(date));
   },
 
   click() {
-    if (wantsNewWindow(event)) {
-      return;
-    }
-
     const post = this.findAncestorModel();
     const topic = post.topic;
     const controller = showModal("share-topic", { model: topic.category });
     controller.setProperties({ topic, post });
-    event.preventDefault();
   },
 });
 

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -19,6 +19,7 @@ import { iconNode } from "discourse-common/lib/icon-library";
 import { postTransformCallbacks } from "discourse/widgets/post-stream";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { relativeAgeMediumSpan } from "discourse/lib/formatter";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { transformBasicPost } from "discourse/lib/transform-post";
 import autoGroupFlairForUser from "discourse/lib/avatar-flair";
 import showModal from "discourse/lib/show-modal";
@@ -352,22 +353,25 @@ createWidget("post-date", {
   tagName: "div.post-info.post-date",
 
   html(attrs) {
-    const attributes = { class: "post-date" };
-    let date;
-    if (attrs.wiki && attrs.lastWikiEdit) {
+    const attributes = { href: attrs.shareUrl, class: "post-date" };
+    let date = attrs.created_at;
+    if (attrs.lastWikiEdit) {
       attributes["class"] += " last-wiki-edit";
-      date = new Date(attrs.lastWikiEdit);
-    } else {
-      date = new Date(attrs.created_at);
+      date = attrs.lastWikiEdit;
     }
-    return h("a", { attributes }, dateNode(date));
+    return h("a", { attributes }, dateNode(new Date(date)));
   },
 
   click() {
+    if (wantsNewWindow(event)) {
+      return;
+    }
+
     const post = this.findAncestorModel();
     const topic = post.topic;
     const controller = showModal("share-topic", { model: topic.category });
     controller.setProperties({ topic, post });
+    event.preventDefault();
   },
 });
 

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -19,7 +19,6 @@ import { iconNode } from "discourse-common/lib/icon-library";
 import { postTransformCallbacks } from "discourse/widgets/post-stream";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { relativeAgeMediumSpan } from "discourse/lib/formatter";
-import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { transformBasicPost } from "discourse/lib/transform-post";
 import autoGroupFlairForUser from "discourse/lib/avatar-flair";
 import showModal from "discourse/lib/show-modal";
@@ -353,25 +352,30 @@ createWidget("post-date", {
   tagName: "div.post-info.post-date",
 
   html(attrs) {
-    const attributes = { href: attrs.shareUrl, class: "post-date" };
-    let date = attrs.created_at;
-    if (attrs.lastWikiEdit) {
-      attributes["class"] += " last-wiki-edit";
-      date = attrs.lastWikiEdit;
+    let date,
+      linkClassName = "post-date";
+
+    if (attrs.wiki && attrs.lastWikiEdit) {
+      linkClassName += " last-wiki-edit";
+      date = new Date(attrs.lastWikiEdit);
+    } else {
+      date = new Date(attrs.created_at);
     }
-    return h("a", { attributes }, dateNode(new Date(date)));
+    return this.attach("link", {
+      rawLabel: dateNode(date),
+      className: linkClassName,
+      omitSpan: true,
+      title: "post.sr_date",
+      href: attrs.shareUrl,
+      action: "showShareModal",
+    });
   },
 
-  click() {
-    if (wantsNewWindow(event)) {
-      return;
-    }
-
+  showShareModal() {
     const post = this.findAncestorModel();
     const topic = post.topic;
     const controller = showModal("share-topic", { model: topic.category });
     controller.setProperties({ topic, post });
-    event.preventDefault();
   },
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -1,6 +1,6 @@
 import CategoryFixtures from "discourse/tests/fixtures/category-fixtures";
 import I18n from "I18n";
-import { click, visit } from "@ember/test-helpers";
+import { click, currentURL, visit } from "@ember/test-helpers";
 import {
   acceptance,
   exists,
@@ -59,14 +59,19 @@ acceptance("Share and Invite modal", function (needs) {
 
   test("Post date link", async function (assert) {
     await visit("/t/short-topic-with-two-posts/54077");
-    await click("#post_2 .post-info.post-date");
     assert.ok(
       query("#post_2 .post-info.post-date a").href.endsWith(
         "/t/short-topic-with-two-posts/54077/2?u=eviltrout"
       )
     );
 
+    await click("#post_2 a.post-date");
     assert.ok(exists(".share-topic-modal"), "it shows the share modal");
+    assert.deepEqual(
+      currentURL(),
+      "/t/short-topic-with-two-posts/54077",
+      "it does not route to post #2"
+    );
   });
 
   test("Share topic in a restricted category", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -59,7 +59,12 @@ acceptance("Share and Invite modal", function (needs) {
 
   test("Post date link", async function (assert) {
     await visit("/t/short-topic-with-two-posts/54077");
-    await click("#post_2 .post-info.post-date a");
+    await click("#post_2 .post-info.post-date");
+    assert.ok(
+      query("#post_2 .post-info.post-date a").href.endsWith(
+        "/t/short-topic-with-two-posts/54077/2?u=eviltrout"
+      )
+    );
 
     assert.ok(exists(".share-topic-modal"), "it shows the share modal");
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -59,12 +59,7 @@ acceptance("Share and Invite modal", function (needs) {
 
   test("Post date link", async function (assert) {
     await visit("/t/short-topic-with-two-posts/54077");
-    await click("#post_2 .post-info.post-date");
-    assert.ok(
-      query("#post_2 .post-info.post-date a").href.endsWith(
-        "/t/short-topic-with-two-posts/54077/2?u=eviltrout"
-      )
-    );
+    await click("#post_2 .post-info.post-date a");
 
     assert.ok(exists(".share-topic-modal"), "it shows the share modal");
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -67,7 +67,7 @@ acceptance("Share and Invite modal", function (needs) {
 
     await click("#post_2 a.post-date");
     assert.ok(exists(".share-topic-modal"), "it shows the share modal");
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       "/t/short-topic-with-two-posts/54077",
       "it does not route to post #2"

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -67,7 +67,7 @@ acceptance("Share and Invite modal", function (needs) {
 
     await click("#post_2 a.post-date");
     assert.ok(exists(".share-topic-modal"), "it shows the share modal");
-    assert.deepEqual(
+    assert.equal(
       currentURL(),
       "/t/short-topic-with-two-posts/54077",
       "it does not route to post #2"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3066,6 +3066,7 @@ en:
       deleted_by_author_simple: "(post deleted by author)"
       collapse: "collapse"
       sr_collapse_replies: "Collapse embedded replies"
+      sr_date: "Post date"
       sr_expand_replies:
         one: "This post has %{count} reply. Click to expand"
         other: "This post has %{count} replies. Click to expand"


### PR DESCRIPTION
This updates the fix in commit eb70ea44780ad6d31db82baec4845b6eb4b8e804. to fix an issue reported in https://meta.discourse.org/t/post-date-cant-be-right-clicked-to-copy-link-anymore/223457/8

