### PR TITLE
SECURITY: Ensure user-agent-based responses are cached separately

### DIFF
--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -12,6 +12,8 @@ module Middleware
       @@cache_key_segments ||= {
         m: 'key_is_mobile?',
         c: 'key_is_crawler?',
+        o: 'key_is_old_browser?',
+        d: 'key_is_modern_mobile_device?',
         b: 'key_has_brotli?',
         t: 'key_cache_theme_ids',
         ca: 'key_compress_anon',
@@ -119,6 +121,14 @@ module Middleware
         @is_crawler == :true
       end
       alias_method :key_is_crawler?, :is_crawler?
+
+      def key_is_modern_mobile_device?
+        MobileDetection.modern_mobile_device?(@env[USER_AGENT]) if @env[USER_AGENT]
+      end
+
+      def key_is_old_browser?
+        CrawlerDetection.show_browser_update?(@env[USER_AGENT]) if @env[USER_AGENT]
+      end
 
       def cache_key
         return @cache_key if defined?(@cache_key)

--- a/spec/lib/middleware/anonymous_cache_spec.rb
+++ b/spec/lib/middleware/anonymous_cache_spec.rb
@@ -78,6 +78,20 @@ describe Middleware::AnonymousCache do
       end
     end
 
+    it "handles old browsers" do
+      SiteSetting.browser_update_user_agents = "my_old_browser"
+
+      key1 = new_helper("HTTP_USER_AGENT" => "my_old_browser").cache_key
+      key2 = new_helper("HTTP_USER_AGENT" => "my_new_browser").cache_key
+      expect(key1).not_to eq(key2)
+    end
+
+    it "handles modern mobile browsers" do
+      key1 = new_helper("HTTP_USER_AGENT" => "Safari (iPhone OS 7)").cache_key
+      key2 = new_helper("HTTP_USER_AGENT" => "Safari (iPhone OS 15)").cache_key
+      expect(key1).not_to eq(key2)
+    end
+
     context "cached" do
       let!(:helper) do
         new_helper("ANON_CACHE_DURATION" => 10)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
