### PR TITLE
FIX: Do not show visibility warning if visible

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -255,7 +255,12 @@ class CategoriesController < ApplicationController
 
   def visible_groups
     @guardian.ensure_can_see!(@category)
-    render json: success_json.merge(groups: @category.groups.merge(Group.visible_groups(current_user)).pluck("name"))
+
+    groups = if !@category.groups.exists?(id: Group::AUTO_GROUPS[:everyone])
+      @category.groups.merge(Group.visible_groups(current_user)).pluck("name")
+    end
+
+    render json: success_json.merge(groups: groups || [])
   end
 
   private

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -758,7 +758,6 @@ describe CategoriesController do
       sign_in(admin)
 
       category.set_permissions(
-        "everyone" => :readonly,
         private_group.name => :full,
         public_group.name => :full,
         user_only_group.name => :full,
@@ -773,6 +772,24 @@ describe CategoriesController do
     end
 
     it "returns the names of the groups that are visible to a user and excludes the everyone group" do
+      private_group.add(user)
+      sign_in(user)
+
+      category.set_permissions(
+        private_group.name => :full,
+        public_group.name => :full,
+        user_only_group.name => :full,
+      )
+
+      category.save!
+
+      get "/c/#{category.id}/visible_groups.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["groups"]).to eq([public_group.name])
+    end
+
+    it "returns no groups if everyone can see it" do
       sign_in(user)
 
       category.set_permissions(
@@ -787,7 +804,7 @@ describe CategoriesController do
       get "/c/#{category.id}/visible_groups.json"
 
       expect(response.status).to eq(200)
-      expect(response.parsed_body["groups"]).to eq([public_group.name])
+      expect(response.parsed_body["groups"]).to eq([])
     end
   end
 end


### PR DESCRIPTION
It used to show the warning that said only members of certain groups
could view the topic even if the group "everyone" was listed in
category's permission list.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
