### PR TITLE
PR: Add `index` to each helper for access within topic-list-items

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/topic-list-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-list-item.hbs
@@ -3,4 +3,5 @@
 {{plugin-outlet
   name="after-topic-list-item"
   args=(hash topic=topic)
+  index=index
 }}

--- a/app/assets/javascripts/discourse/app/templates/components/topic-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-list.hbs
@@ -29,7 +29,7 @@
  }}
 
 <tbody class="topic-list-body">
-  {{#each filteredTopics as |topic|}}
+  {{#each filteredTopics as |topic index|}}
     {{topic-list-item topic=topic
                       bulkSelectEnabled=bulkSelectEnabled
                       showTopicPostBadges=showTopicPostBadges
@@ -43,7 +43,8 @@
                       selected=selected
                       lastChecked=lastChecked
                       tagsForUser=tagsForUser
-                      focusLastVisitedTopic=focusLastVisitedTopic}}
+                      focusLastVisitedTopic=focusLastVisitedTopic
+                      index=index}}
     {{raw "list/visited-line" lastVisitedTopic=lastVisitedTopic topic=topic}}
   {{/each}}
 </tbody>


### PR DESCRIPTION
This PR will add `index` as an accessible piece of data within `topic-list-item`, as well as the `after-topic-list-item` plugin outlet. This will give theme-components access to the index of a `topic-list-item` in the topic list.

An example use-case would be to render an ad, banner, or other information after the `nth` topic-list-item. 
