### PR TITLE
FIX: update email dark mode styles

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -63,6 +63,10 @@ module EmailHelper
           color: #dddddd !important;
         }
 
+        [data-stripped-secure-media] {
+          border-color: #454545 !important;
+        }
+
         [dm='text-color'] {
           color: #dddddd;
         }
@@ -85,17 +89,13 @@ module EmailHelper
           color: #dddddd !important;
         }
 
-        [dm='secure-media-notice'] {
-          border-color: #454545 !important;
-        }
-
         [dm='body_primary'] {
           background: #062e3d !important;
           color: #dddddd !important;
         }
 
         [dm='bg'] {
-          background: #232323 !important;
+          background: #323232 !important;
           border-color: #454545 !important;
         }
       }

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -343,7 +343,6 @@ module Email
       style(".with-accent-colors, .digest-content-header", nil, dm: "body_primary")
       style(".digest-topic-body", nil, dm: "topic-body")
       style(".summary-footer", nil, dm: "text-color")
-      style(".secure-media-notice", nil, dm: "secure-media-notice")
       style("code, pre code, blockquote", nil, dm: "bg")
     end
 


### PR DESCRIPTION
Update dark mode styles for:
- secure media
- code blocks (they were too dark and had bad contrast)