### PR TITLE
FIX: validate markdown_linkify_tlds setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2404,6 +2404,7 @@ en:
         leading_trailing_slash: "The regular expression must not start and end with a slash."
       unicode_usernames_avatars: "The internal system avatars do not support Unicode usernames."
       list_value_count: "The list must contain exactly %{count} values."
+      markdown_linkify_tlds: "You cannot include a value of '*'."
       google_oauth2_hd_groups: "You must first set 'google oauth2 hd' before enabling this setting."
       search_tokenize_chinese_enabled: "You must disable 'search_tokenize_chinese' before enabling this setting."
       search_tokenize_japanese_enabled: "You must disable 'search_tokenize_japanese' before enabling this setting."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -847,6 +847,7 @@ posting:
     type: list
     default: "com|net|org|io|onion|co|tv|ru|cn|us|uk|me|de|fr|fi|gov"
     list_type: compact
+    validator: "MarkdownLinkifyTldsValidator"
   markdown_typographer_quotation_marks:
     client: true
     type: list

--- a/lib/validators/markdown_linkify_tlds_validator.rb
+++ b/lib/validators/markdown_linkify_tlds_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class MarkdownLinkifyTldsValidator
+
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(value)
+    !value.include?("*")
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.markdown_linkify_tlds")
+  end
+end


### PR DESCRIPTION
Prevent adding `*` as a value to markdown_linkify_tlds site setting

See https://meta.discourse.org/t/javascript-errors-and-site-half-broken-if-we-add-in-markdown-linkify-tlds-setting/219119?u=isaacjanzen for context.

