### PR TITLE
minor email group chooser alignment fix

### DIFF
--- a/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
@@ -15,7 +15,6 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      align-self: flex-end;
     }
     .avatar,
     .d-icon {


### PR DESCRIPTION
Username and name are slightly misaligned

before:
<img width="306" alt="Screen Shot 2022-04-15 at 11 36 34 AM" src="https://user-images.githubusercontent.com/1681963/163590754-da910f6b-2788-4921-9c49-96c922fcbe2c.png">

after:
<img width="303" alt="Screen Shot 2022-04-15 at 11 36 14 AM" src="https://user-images.githubusercontent.com/1681963/163590725-c9543361-6073-477f-919b-12cd71582768.png">