### PR TITLE
UX: minor adjustment to login/signup close position

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -45,8 +45,8 @@
     border-bottom: none;
     padding: 0;
     position: absolute;
-    top: 1em;
-    right: 1em;
+    top: 0.75em;
+    right: 0.75em;
     z-index: z("max");
   }
   #modal-alert {
@@ -83,7 +83,7 @@
     .waving-hand {
       width: 35px;
       height: 35px;
-      margin-left: 1em;
+      margin-left: 0.5em;
       align-self: center;
     }
   }


### PR DESCRIPTION
Avoiding a slight overlap

Before:
<img width="309" alt="Screen Shot 2022-04-15 at 11 59 42 AM" src="https://user-images.githubusercontent.com/1681963/163593100-1f61edb6-b6c8-4082-9e54-ea84bb2d6ca2.png">

After:
<img width="308" alt="Screen Shot 2022-04-15 at 11 59 33 AM" src="https://user-images.githubusercontent.com/1681963/163593118-83a6d208-0926-4c1f-ad0c-384e970ca7d7.png">

