### PR TITLE
FIX: warn_exception expect hash as second arg

### DIFF
--- a/lib/svg_sprite/svg_sprite.rb
+++ b/lib/svg_sprite/svg_sprite.rb
@@ -258,7 +258,7 @@ module SvgSprite
             }
           rescue => e
             name = Theme.find(child_theme_id).name rescue nil
-            Discourse.warn_exception(e, "#{name} theme contains a corrupt svg upload")
+            Discourse.warn_exception(e, message: "#{name} theme contains a corrupt svg upload")
           end
 
         end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
