### PR TITLE
FIX: Check if bookmarkable column exists before adding

### DIFF
--- a/db/migrate/20220322024216_add_bookmark_polymorphic_columns.rb
+++ b/db/migrate/20220322024216_add_bookmark_polymorphic_columns.rb
@@ -2,9 +2,16 @@
 
 class AddBookmarkPolymorphicColumns < ActiveRecord::Migration[6.1]
   def change
-    add_column :bookmarks, :bookmarkable_id, :integer
-    add_column :bookmarks, :bookmarkable_type, :string
+    if !column_exists?(:bookmarks, :bookmarkable_id)
+      add_column :bookmarks, :bookmarkable_id, :integer
+    end
 
-    add_index :bookmarks, [:user_id, :bookmarkable_type, :bookmarkable_id], name: "idx_bookmarks_user_polymorphic_unique", unique: true
+    if !column_exists?(:bookmarks, :bookmarkable_type)
+      add_column :bookmarks, :bookmarkable_type, :string
+    end
+
+    if !index_exists?(:bookmarks, [:user_id, :bookmarkable_type, :bookmarkable_id])
+      add_index :bookmarks, [:user_id, :bookmarkable_type, :bookmarkable_id], name: "idx_bookmarks_user_polymorphic_unique", unique: true
+    end
   end
 end


### PR DESCRIPTION
Because in 8040b95e8c4abeab1ab9fe50826f92c52995a814 we removed
a previous post migrate file, some people may not have had those
original polymorphic bookmark columns removed, and the migration
from this PR running will cause duplicate column errors.

cf. https://meta.discourse.org/t/duplicatecolumn-and-multisite-migrate-failed/224480