### PR TITLE
REFACTOR: admin-user-field-item

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/admin-user-field-item.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/admin-user-field-item.hbs
@@ -1,65 +1,66 @@
-{{#if editing}}
-  {{#admin-form-row label="admin.user_fields.type"}}
-    {{combo-box
-      content=fieldTypes
-      value=buffered.field_type
-      onChange=(action (mut buffered.field_type))
-    }}
-  {{/admin-form-row}}
-
-  {{#admin-form-row label="admin.user_fields.name"}}
-    {{input value=buffered.name class="user-field-name" maxlength="255"}}
-  {{/admin-form-row}}
-
-  {{#admin-form-row label="admin.user_fields.description"}}
-    {{input value=buffered.description class="user-field-desc" maxlength="255"}}
-  {{/admin-form-row}}
-
-  {{#if bufferedFieldType.hasOptions}}
-    {{#admin-form-row label="admin.user_fields.options"}}
-      {{value-list values=buffered.options inputType="array"}}
+<div class="user-field">
+  {{#if (or isEditing (not userField.id))}}
+    {{#admin-form-row label="admin.user_fields.type"}}
+      {{combo-box
+        content=fieldTypes
+        value=buffered.field_type
+        onChange=(action (mut buffered.field_type))
+      }}
     {{/admin-form-row}}
+
+    {{#admin-form-row label="admin.user_fields.name"}}
+      {{input value=buffered.name class="user-field-name" maxlength="255"}}
+    {{/admin-form-row}}
+
+    {{#admin-form-row label="admin.user_fields.description"}}
+      {{input value=buffered.description class="user-field-desc" maxlength="255"}}
+    {{/admin-form-row}}
+
+    {{#if bufferedFieldType.hasOptions}}
+      {{#admin-form-row label="admin.user_fields.options"}}
+        {{value-list values=buffered.options inputType="array"}}
+      {{/admin-form-row}}
+    {{/if}}
+
+    {{#admin-form-row wrapLabel="true"}}
+      {{input type="checkbox" checked=buffered.editable}} <span>{{i18n "admin.user_fields.editable.title"}}</span>
+    {{/admin-form-row}}
+
+    {{#admin-form-row wrapLabel="true"}}
+      {{input type="checkbox" checked=buffered.required}} <span>{{i18n "admin.user_fields.required.title"}}</span>
+    {{/admin-form-row}}
+
+    {{#admin-form-row wrapLabel="true"}}
+      {{input type="checkbox" checked=buffered.show_on_profile}} <span>{{i18n "admin.user_fields.show_on_profile.title"}}</span>
+    {{/admin-form-row}}
+
+    {{#admin-form-row wrapLabel="true"}}
+      {{input type="checkbox" checked=buffered.show_on_user_card}} <span>{{i18n "admin.user_fields.show_on_user_card.title"}}</span>
+    {{/admin-form-row}}
+
+    {{#admin-form-row wrapLabel="true"}}
+      {{input type="checkbox" checked=buffered.searchable}} <span>{{i18n "admin.user_fields.searchable.title"}}</span>
+    {{/admin-form-row}}
+
+    {{#admin-form-row}}
+      {{d-button action=(action "save") class="btn-primary save" icon="check" label="admin.user_fields.save"}}
+      {{d-button action=(action "cancel") class="btn-danger cancel" icon="times" label="admin.user_fields.cancel"}}
+    {{/admin-form-row}}
+  {{else}}
+    <div class="row">
+      <div class="form-display">
+        <b class="name">{{userField.name}}</b>
+        <br>
+        <span class="description">{{html-safe userField.description}}</span>
+      </div>
+      <div class="form-display field-type">{{fieldName}}</div>
+      <div class="form-element controls">
+        {{d-button action=(action "edit") class="btn-default edit" icon="pencil-alt" label="admin.user_fields.edit"}}
+        {{d-button action=destroyAction actionParam=userField class="btn-danger cancel" icon="far-trash-alt" label="admin.user_fields.delete"}}
+        {{d-button action=moveUpAction actionParam=userField class="btn-default" icon="arrow-up" disabled=cantMoveUp}}
+        {{d-button action=moveDownAction actionParam=userField class="btn-default" icon="arrow-down" disabled=cantMoveDown}}
+      </div>
+    </div>
+    <div class="row">{{flags}}</div>
   {{/if}}
-
-  {{#admin-form-row wrapLabel="true"}}
-    {{input type="checkbox" checked=buffered.editable}} <span>{{i18n "admin.user_fields.editable.title"}}</span>
-  {{/admin-form-row}}
-
-  {{#admin-form-row wrapLabel="true"}}
-    {{input type="checkbox" checked=buffered.required}} <span>{{i18n "admin.user_fields.required.title"}}</span>
-  {{/admin-form-row}}
-
-  {{#admin-form-row wrapLabel="true"}}
-    {{input type="checkbox" checked=buffered.show_on_profile}} <span>{{i18n "admin.user_fields.show_on_profile.title"}}</span>
-  {{/admin-form-row}}
-
-  {{#admin-form-row wrapLabel="true"}}
-    {{input type="checkbox" checked=buffered.show_on_user_card}} <span>{{i18n "admin.user_fields.show_on_user_card.title"}}</span>
-  {{/admin-form-row}}
-
-  {{#admin-form-row wrapLabel="true"}}
-    {{input type="checkbox" checked=buffered.searchable}} <span>{{i18n "admin.user_fields.searchable.title"}}</span>
-  {{/admin-form-row}}
-
-  {{#admin-form-row}}
-    {{d-button action=(action "save") class="btn-primary" icon="check" label="admin.user_fields.save"}}
-    {{d-button action=(action "cancel") class="btn-danger" icon="times" label="admin.user_fields.cancel"}}
-  {{/admin-form-row}}
-{{else}}
-  <div class="row">
-    <div class="form-display">
-      <strong>{{userField.name}}</strong>
-      <br>
-      {{html-safe userField.description}}
-    </div>
-    <div class="form-display">{{fieldName}}</div>
-    <div class="form-element controls">
-      {{d-button action=(action "edit") class="btn-default" icon="pencil-alt" label="admin.user_fields.edit"}}
-      {{d-button action=destroyAction actionParam=userField class="btn-danger" icon="far-trash-alt" label="admin.user_fields.delete"}}
-      {{d-button action=moveUpAction actionParam=userField class="btn-default" icon="arrow-up" disabled=cantMoveUp}}
-      {{d-button action=moveDownAction actionParam=userField class="btn-default" icon="arrow-down" disabled=cantMoveDown}}
-    </div>
-  </div>
-  <div class="row">{{flags}}</div>
-{{/if}}
-<div class="clearfix"></div>
+</div>

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
@@ -38,7 +38,7 @@ discourseModule(
     });
 
     componentTest("edit action", {
-      template: hbs`{{admin-user-field-item isEditing=isEditing destroyAction=destroyAction userField=userField}}`,
+      template: hbs`{{admin-user-field-item destroyAction=destroyAction userField=userField}}`,
 
       beforeEach() {
         this.set("userField", { id: 1, field_type: "text" });

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
@@ -1,0 +1,75 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  discourseModule,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import I18n from "I18n";
+import { click } from "@ember/test-helpers";
+
+discourseModule(
+  "Integration | Component | admin-user-field-item",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("editing mode when not userField id", {
+      template: hbs`{{admin-user-field-item userField=userField}}`,
+
+      async test(assert) {
+        assert.ok(exists(".btn-primary"));
+      },
+    });
+
+    componentTest("cancel action", {
+      template: hbs`{{admin-user-field-item isEditing=isEditing destroyAction=destroyAction userField=userField}}`,
+
+      beforeEach() {
+        this.set("userField", { id: 1, field_type: "text" });
+        this.set("isEditing", true);
+      },
+
+      async test(assert) {
+        await click(".cancel");
+        assert.ok(exists(".edit"));
+      },
+    });
+
+    componentTest("edit action", {
+      template: hbs`{{admin-user-field-item isEditing=isEditing destroyAction=destroyAction userField=userField}}`,
+
+      beforeEach() {
+        this.set("userField", { id: 1, field_type: "text" });
+      },
+
+      async test(assert) {
+        await click(".edit");
+        assert.ok(exists(".save"));
+      },
+    });
+
+    componentTest("not editing mode when userField id", {
+      template: hbs`{{admin-user-field-item userField=userField}}`,
+
+      beforeEach() {
+        this.set("userField", {
+          id: 1,
+          field_type: "text",
+          name: "foo",
+          description: "what is foo",
+        });
+      },
+
+      async test(assert) {
+        assert.equal(query(".name").innerText, "foo");
+        assert.equal(query(".description").innerText, "what is foo");
+        assert.equal(
+          query(".field-type").innerText,
+          I18n.t("admin.user_fields.field_types.text")
+        );
+      },
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
@@ -15,11 +15,11 @@ discourseModule(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    componentTest("editing mode when not userField id", {
+    componentTest("user field without an id", {
       template: hbs`{{admin-user-field-item userField=userField}}`,
 
       async test(assert) {
-        assert.ok(exists(".btn-primary"));
+        assert.ok(exists(".save"), "displays editing mode");
       },
     });
 
@@ -50,7 +50,7 @@ discourseModule(
       },
     });
 
-    componentTest("not editing mode when userField id", {
+    componentTest("user field with an id", {
       template: hbs`{{admin-user-field-item userField=userField}}`,
 
       beforeEach() {
@@ -63,8 +63,11 @@ discourseModule(
       },
 
       async test(assert) {
-        assert.equal(query(".name").innerText, "foo");
-        assert.equal(query(".description").innerText, "what is foo");
+        assert.equal(query(".name").innerText, this.userField.name);
+        assert.equal(
+          query(".description").innerText,
+          this.userField.description
+        );
         assert.equal(
           query(".field-type").innerText,
           I18n.t("admin.user_fields.field_types.text")


### PR DESCRIPTION
- drops jquery
- removes a deprecation caused by overriding a computed property (isEditing)
- adds basic tests
- drops observers
- uses @action
- tagless

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
