### PR TITLE
FIX: Return a 404 when a sitemap request doesn't have a format

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Discourse::Application.routes.draw do
     post "webhooks/sendgrid" => "webhooks#sendgrid"
     post "webhooks/sparkpost" => "webhooks#sparkpost"
 
-    scope path: nil, constraints: { format: :xml } do
+    scope path: nil, format: true, constraints: { format: :xml } do
       resources :sitemap, only: [:index]
       get "/sitemap_:page" => "sitemap#page", page: /[1-9][0-9]*/
       get "/sitemap_recent" => "sitemap#recent"

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -12,6 +12,12 @@ describe SitemapController do
 
       expect(response.status).to eq(404)
     end
+
+    it "returns a 404 if the request does't have a format" do
+      get '/news'
+
+      expect(response.status).to eq(404)
+    end
   end
 
   describe '#index' do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
