### PR TITLE
A11Y: fix WCAG contrast for notification header

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -35,6 +35,13 @@ html.discourse-no-touch {
   .btn-flat.delete.d-hover {
     background: var(--danger);
   }
+  .menu-links-header {
+    .btn-icon:hover {
+      .d-icon {
+        color: var(--primary);
+      }
+    }
+  }
 }
 
 html {


### PR DESCRIPTION
Previously when hovering the icon color was matching the background, as seen here:

<img width="186" alt="Screen Shot 2022-04-19 at 11 25 35 AM" src="https://user-images.githubusercontent.com/1681963/164039495-73f23c8b-b0f6-400b-ad22-ca731e06d78b.png">
