### PR TITLE
FIX: Don't allow DiscourseConnect logins in readonly mode

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -121,6 +121,7 @@ class SessionController < ApplicationController
   end
 
   def sso_login
+    return render_sso_error(text: I18n.t("read_only_mode_enabled"), status: 503) if @readonly_mode
     raise Discourse::NotFound.new unless SiteSetting.enable_discourse_connect
 
     params.require(:sso)

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -1112,6 +1112,20 @@ describe SessionController do
         expect(logged_on_user.email).to eq(@user.email)
       end
     end
+
+    context "in readonly mode" do
+      use_redis_snapshotting
+
+      before do
+        Discourse.enable_readonly_mode
+      end
+
+      it "disallows requests" do
+        get "/session/sso_login"
+
+        expect(response.status).to eq(503)
+      end
+    end
   end
 
   describe '#sso_provider' do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
