### PR TITLE
FIX: Wait to display notice on topic timer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timer-info.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timer-info.js
@@ -75,6 +75,11 @@ export default Component.extend({
     const duration = moment.duration(statusUpdateAt - moment());
     const minutesLeft = duration.asMinutes();
     if (minutesLeft > 0 || isDeleteRepliesType || this.basedOnLastPost) {
+      // We don't want to display a notice before a topic timer time has been set
+      if (!this.executeAt) {
+        return;
+      }
+
       let durationMinutes = parseInt(this.durationMinutes, 10) || 0;
 
       let options = {


### PR DESCRIPTION
You can close the topic timer modal prior to actually setting a value, and you will still see the timer notice persist even though the topic was not actually closed.

<img width="932" alt="Screen Shot 2022-04-19 at 12 55 59 PM" src="https://user-images.githubusercontent.com/50783505/164066067-a5350a0a-344d-4612-acce-73e4f5d0607f.png">
<img width="943" alt="Screen Shot 2022-04-19 at 12 56 17 PM" src="https://user-images.githubusercontent.com/50783505/164066121-5512c63e-8139-4d88-82c3-11c9013bc256.png">

_see topic is not closed_

The notice will not be cleared until you hard refresh.

This PR only displays the notice in the case there is an `executeAt` value set. This works the same for `delete topic` behavior as well.

