### PR TITLE
UX: Show all pie legend options for long polls

### DIFF
--- a/plugins/poll/assets/stylesheets/common/poll.scss
+++ b/plugins/poll/assets/stylesheets/common/poll.scss
@@ -130,7 +130,6 @@ div.poll {
   }
 
   .pie-chart-legends {
-    display: flex;
     justify-content: center;
     text-align: center;
     margin-top: 0.5em;
@@ -138,7 +137,7 @@ div.poll {
     .legend {
       align-items: center;
       cursor: pointer;
-      display: flex;
+      display: inline-flex;
       flex-direction: row;
       margin-left: 1em;
       font-size: var(--font-down-0);


### PR DESCRIPTION
Results pie chart of polls with very many options were wider than the
post and most of their content was hidden.

Before:

<img width="769" alt="image" src="https://user-images.githubusercontent.com/23153890/164078202-4ee8fd87-336b-457f-b0c1-e2f137a89fc2.png">

<img width="765" alt="image" src="https://user-images.githubusercontent.com/23153890/164078261-97e6a70e-8a03-4c9d-abc0-a5c92c96f114.png">

After:

<img width="763" alt="Screenshot 2022-04-19 at 21 51 38" src="https://user-images.githubusercontent.com/23153890/164075561-0ec4a8b1-fc04-4c98-9bff-ea4290e0c8ad.png">

<img width="772" alt="Screenshot 2022-04-19 at 21 52 00" src="https://user-images.githubusercontent.com/23153890/164075569-c820ddca-ec50-4d9a-b9c6-2ef9bff187bb.png">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
