### PR TITLE
FIX: Add missing translations for medium format

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -1,5 +1,6 @@
 import {
   autoUpdatingRelativeAge,
+  duration,
   durationTiny,
   longDate,
   number,
@@ -358,6 +359,114 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
       durationTiny(86400 * 822),
       "> 2y",
       "822 days shows as > 2y"
+    );
+  });
+
+  test("duration (medium format)", function (assert) {
+    assert.strictEqual(
+      duration(undefined, { format: "medium" }),
+      "&mdash;",
+      "undefined is a dash"
+    );
+    assert.strictEqual(
+      duration(null, { format: "medium" }),
+      "&mdash;",
+      "null is a dash"
+    );
+    assert.strictEqual(
+      duration(0, { format: "medium" }),
+      "less than 1 min",
+      "0 seconds shows as less than 1 min"
+    );
+    assert.strictEqual(
+      duration(59, { format: "medium" }),
+      "less than 1 min",
+      "59 seconds shows as less than 1 min"
+    );
+    assert.strictEqual(
+      duration(60, { format: "medium" }),
+      "1 min",
+      "60 seconds shows as 1 min"
+    );
+    assert.strictEqual(
+      duration(90, { format: "medium" }),
+      "2 mins",
+      "90 seconds shows as 2 mins"
+    );
+    assert.strictEqual(
+      duration(120, { format: "medium" }),
+      "2 mins",
+      "120 seconds shows as 2 mins"
+    );
+    assert.strictEqual(
+      duration(60 * 45, { format: "medium" }),
+      "about 1 hour",
+      "45 minutes shows as about 1 hour"
+    );
+    assert.strictEqual(
+      duration(60 * 60, { format: "medium" }),
+      "about 1 hour",
+      "60 minutes shows as about 1 hour"
+    );
+    assert.strictEqual(
+      duration(60 * 90, { format: "medium" }),
+      "about 2 hours",
+      "90 minutes shows as about 2 hours"
+    );
+    assert.strictEqual(
+      duration(3600 * 23, { format: "medium" }),
+      "about 23 hours",
+      "23 hours shows as about 23 hours"
+    );
+    assert.strictEqual(
+      duration(3600 * 24 - 29, { format: "medium" }),
+      "1 day",
+      "23 hours 31 mins shows as 1 day"
+    );
+    assert.strictEqual(
+      duration(3600 * 24 * 89, { format: "medium" }),
+      "89 days",
+      "89 days shows as 89 days"
+    );
+    assert.strictEqual(
+      duration(60 * (525600 - 1), { format: "medium" }),
+      "12 months",
+      "364 days shows as 12 months"
+    );
+    assert.strictEqual(
+      duration(60 * 525600, { format: "medium" }),
+      "about 1 year",
+      "365 days shows as about 1 year"
+    );
+    assert.strictEqual(
+      duration(86400 * 456, { format: "medium" }),
+      "about 1 year",
+      "456 days shows as about 1 year"
+    );
+    assert.strictEqual(
+      duration(86400 * 457, { format: "medium" }),
+      "over 1 year",
+      "457 days shows as over 1 year"
+    );
+    assert.strictEqual(
+      duration(86400 * 638, { format: "medium" }),
+      "over 1 year",
+      "638 days shows as over 1 year"
+    );
+    assert.strictEqual(
+      duration(86400 * 639, { format: "medium" }),
+      "almost 2 years",
+      "639 days shows as almost 2 years"
+    );
+    assert.strictEqual(
+      duration(86400 * 821, { format: "medium" }),
+      "about 2 years",
+      "821 days shows as about 2 years"
+    );
+    assert.strictEqual(
+      duration(86400 * 822, { format: "medium" }),
+      "over 2 years",
+      "822 days shows as over 2 years"
     );
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -92,15 +92,33 @@ en:
         # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
         date_year: "MMM 'YY"
       medium:
+        less_than_x_minutes:
+          one: "less than %{count} min"
+          other: "less than %{count} mins"
         x_minutes:
           one: "%{count} min"
           other: "%{count} mins"
         x_hours:
           one: "%{count} hour"
           other: "%{count} hours"
+        about_x_hours:
+          one: "about %{count} hour"
+          other: "about %{count} hours"
         x_days:
           one: "%{count} day"
           other: "%{count} days"
+        x_months:
+          one: "%{count} month"
+          other: "%{count} months"
+        about_x_years:
+          one: "about %{count} year"
+          other: "about %{count} years"
+        over_x_years:
+          one: "over %{count} year"
+          other: "over %{count} years"
+        almost_x_years:
+          one: "almost %{count} year"
+          other: "almost %{count} years"
         # Use Moment.js format string: https://momentjs.com/docs/#/displaying/format/
         date_year: "MMM D, 'YY"
       medium_with_ago:


### PR DESCRIPTION
Commit 68497bddf252e4a04f563dac97ec9b295f5a0a0e implemented a function
to format durations in a medium format, similar to how durationTiny did.
The existent translation strings do not cover all cases and this commit
adds the missing translation strings.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
