### PR TITLE
Update INSTALL-cloud.md to update guideline for setting multiple admin emails

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -81,7 +81,7 @@ Launch the setup tool at
 Answer the following questions when prompted:
 
     Hostname for your Discourse? [discourse.example.com]: 
-    Email address for admin account(s)? [me@example.com,you@example.com]: 
+    Email address for admin account(s)? me@example.com,you@example.com: 
     SMTP server address? [smtp.example.com]: 
     SMTP port? [587]: 
     SMTP user name? [user@example.com]: 


### PR DESCRIPTION
In the instructions, the square brackets around the admin email list persist into the UI, then upon initial registration, the admin is not able to select an email, because the dropdown list has these values (based on example)

```
<select name="email" id="email" class="combobox">
  <option selected="selected" value="[me@example.com">[me@example.com</option>
  <option value="you@example.com]">you@example.com]</option>
</select>
```