### PR TITLE
FIX: Show footer at the end of topic list

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -36,11 +36,13 @@ const controllerOpts = {
   // We want them to bubble in DiscoveryTopicsController
   @action
   loadingBegan() {
+    this.set("application.showFooter", false);
     return true;
   },
 
   @action
   loadingComplete() {
+    this.set("application.showFooter", this.loadedAllItems);
     return true;
   },
 

--- a/app/assets/javascripts/discourse/app/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-categories.js
@@ -9,7 +9,6 @@ import TopicList from "discourse/models/topic-list";
 import { ajax } from "discourse/lib/ajax";
 import { defaultHomepage } from "discourse/lib/utilities";
 import { hash } from "rsvp";
-import { next } from "@ember/runloop";
 import showModal from "discourse/lib/show-modal";
 import getURL from "discourse-common/lib/get-url";
 import Session from "discourse/models/session";
@@ -152,12 +151,6 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
     } else {
       this.openComposer(this.controllerFor("discovery/categories"));
     }
-  },
-
-  @action
-  didTransition() {
-    next(() => this.controllerFor("application").set("showFooter", true));
-    return true;
   },
 });
 


### PR DESCRIPTION
Previously it wouldn't show up after all items were loaded.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
