### PR TITLE
DEV: Remove site setting for dark mode emails

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -29,8 +29,8 @@ module EmailHelper
     EmailStyle.new.html
       .sub('%{email_content}') { capture { yield } }
       .gsub('%{html_lang}', html_lang)
-      .gsub('%{dark_mode_meta_tags}', SiteSetting.dark_mode_emails_active ? dark_mode_meta_tags : "")
-      .gsub('%{dark_mode_styles}', SiteSetting.dark_mode_emails_active ? dark_mode_styles : "")
+      .gsub('%{dark_mode_meta_tags}', dark_mode_meta_tags)
+      .gsub('%{dark_mode_styles}', dark_mode_styles)
       .html_safe
   end
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -283,9 +283,6 @@ basic:
     type: enum
     enum: "ColorSchemeSetting"
     client: true
-  dark_mode_emails_active:
-    default: false
-    hidden: true    
   relative_date_duration:
     client: true
     default: 30

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -238,7 +238,7 @@ module Email
 
       onebox_styles
       plugin_styles
-      dark_mode_styles if SiteSetting.dark_mode_emails_active
+      dark_mode_styles
 
       style('.post-excerpt img', "max-width: 50%; max-height: #{MAX_IMAGE_DIMENSION}px;")
 

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -157,10 +157,6 @@ describe Email::Styles do
   end
 
   context "dark mode emails" do
-    before do
-      SiteSetting.dark_mode_emails_active = true
-    end
-
     it "adds dark_mode_styles when site setting active" do
       frag = html_fragment('<div class="body">test</div>')
       styler = Email::Styles.new(frag)


### PR DESCRIPTION
Enable dark mode emails by default