### PR TITLE
FEATURE: Site setting to cap the recipient list in notification emails

### DIFF
--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -36,7 +36,7 @@ class GroupSmtpMailer < ActionMailer::Base
       only_reply_by_email: true,
       use_from_address_for_reply_to: SiteSetting.enable_smtp && from_group.smtp_enabled?,
       private_reply: post.topic.private_message?,
-      participants: participants(post, recipient_user),
+      participants: UserNotifications.participants(post, recipient_user, reveal_staged_email: true),
       include_respond_instructions: true,
       template: 'user_notifications.user_posted_pm',
       use_topic_title_subject: true,
@@ -67,25 +67,5 @@ class GroupSmtpMailer < ActionMailer::Base
         reply_above_line: true
       }
     )
-  end
-
-  def participants(post, recipient_user)
-    list = []
-
-    post.topic.allowed_groups.each do |g|
-      list.push("[#{g.name_full_preferred}](#{g.full_url})")
-    end
-
-    post.topic.allowed_users.each do |u|
-      next if u.id == recipient_user.id
-
-      if u.staged?
-        list.push("#{u.email}")
-      else
-        list.push("[#{u.display_name}](#{u.full_url})")
-      end
-    end
-
-    list.join(', ')
   end
 end

--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -21,12 +21,8 @@ class GroupSmtpMailer < ActionMailer::Base
       enable_starttls_auto: from_group.smtp_ssl
     }
 
-    user_name = post.user.username
-    if SiteSetting.enable_names && SiteSetting.display_name_on_email_from
-      user_name = post.user.name unless post.user.name.blank?
-    end
-
     group_name = from_group.name_full_preferred
+
     build_email(
       to_address,
       message: post.raw,
@@ -49,7 +45,7 @@ class GroupSmtpMailer < ActionMailer::Base
       locale: SiteSetting.default_locale,
       delivery_method_options: delivery_options,
       from: from_group.smtp_from_address,
-      from_alias: I18n.t('email_from_without_site', user_name: group_name),
+      from_alias: I18n.t('email_from_without_site', group_name: group_name),
       html_override: html_override(post),
       cc: cc_addresses
     )

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -552,19 +552,7 @@ class UserNotifications < ActionMailer::Base
           I18n.t('subject_pm')
         end
 
-      participants = ""
-      participant_list = []
-
-      post.topic.allowed_groups.each do |g|
-        participant_list.push "[#{g.name} (#{g.users.count})](#{g.full_url})"
-      end
-
-      post.topic.allowed_users.each do |u|
-        next if u.id == user.id
-        participant_list.push "[#{u.display_name}](#{u.full_url})"
-      end
-
-      participants += participant_list.join(", ")
+      participants = self.class.participants(post, user)
     end
 
     if SiteSetting.private_email?
@@ -695,6 +683,51 @@ class UserNotifications < ActionMailer::Base
     TopicUser.change(user.id, post.topic_id, last_emailed_post_number: post.post_number)
 
     build_email(user.email, email_opts)
+  end
+
+  def self.participants(post, recipient_user, reveal_staged_email: false)
+    list = []
+
+    allowed_groups = post.topic.allowed_groups.order("user_count DESC")
+
+    allowed_groups.each do |g|
+      list.push("[#{g.name_full_preferred} (#{g.user_count})](#{g.full_url})")
+      break if list.size >= SiteSetting.max_participant_names
+    end
+
+    recent_posts_query = post.topic.posts
+      .select("user_id, MAX(post_number) AS post_number")
+      .where(post_type: Post.types[:regular], post_number: ..post.post_number)
+      .where.not(user_id: recipient_user.id)
+      .group(:user_id)
+      .order("post_number DESC")
+      .limit(SiteSetting.max_participant_names)
+      .to_sql
+
+    allowed_users = post.topic.allowed_users
+      .joins("LEFT JOIN (#{recent_posts_query}) pu ON topic_allowed_users.user_id = pu.user_id")
+      .order("post_number DESC NULLS LAST", :id)
+      .where.not(id: recipient_user.id)
+      .human_users
+
+    allowed_users.each do |u|
+      break if list.size >= SiteSetting.max_participant_names
+
+      if reveal_staged_email && u.staged?
+        list.push("#{u.email}")
+      else
+        list.push("[#{u.display_name}](#{u.full_url})")
+      end
+    end
+
+    participants = list.join(I18n.t("word_connector.comma"))
+    others_count = allowed_groups.size + allowed_users.size - list.size
+
+    if others_count > 0
+      I18n.t("user_notifications.more_pm_participants", participants: participants, count: others_count)
+    else
+      participants
+    end
   end
 
   private

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3520,6 +3520,9 @@ en:
     posted_by: "Posted by %{username} on %{post_date}"
 
     pm_participants: "Participants: %{participants}"
+    more_pm_participants:
+      one: "%{participants} and %{count} other"
+      other: "%{participants} and %{count} others"
 
     invited_group_to_private_message_body: |
       %{username} invited @%{group_name} to a message

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3496,7 +3496,7 @@ en:
   subject_re: "Re: "
   subject_pm: "[PM] "
   email_from: "%{user_name} via %{site_name}"
-  email_from_without_site: "%{user_name}"
+  email_from_without_site: "%{group_name}"
 
   user_notifications:
     previous_discussion: "Previous Replies"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1260,6 +1260,9 @@ email:
     client: true
     default: true
     hidden: true
+  max_participant_names:
+    default: 10
+    hidden: true
 
 files:
   max_image_size_kb:

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -28,18 +28,18 @@ describe GroupSmtpMailer do
 
   let(:email) do
     <<~EMAIL
-    Delivered-To: bugs@gmail.com
-    MIME-Version: 1.0
-    From: John Doe <john@doe.com>
-    Date: Tue, 01 Jan 2019 12:00:00 +0200
-    Message-ID: <a52f67a3d3560f2a35276cda8519b10b595623bcb66912bb92df6651ad5f75be@mail.gmail.com>
-    Subject: Hello from John
-    To: "bugs@gmail.com" <bugs@gmail.com>
-    Content-Type: text/plain; charset="UTF-8"
+      Delivered-To: bugs@gmail.com
+      MIME-Version: 1.0
+      From: John Doe <john@doe.com>
+      Date: Tue, 01 Jan 2019 12:00:00 +0200
+      Message-ID: <a52f67a3d3560f2a35276cda8519b10b595623bcb66912bb92df6651ad5f75be@mail.gmail.com>
+      Subject: Hello from John
+      To: "bugs@gmail.com" <bugs@gmail.com>
+      Content-Type: text/plain; charset="UTF-8"
 
-    Hello,
+      Hello,
 
-    How are you doing?
+      How are you doing?
     EMAIL
   end
 
@@ -78,6 +78,19 @@ describe GroupSmtpMailer do
     expect(sent_mail.reply_to).to eq(nil)
     expect(sent_mail.subject).to eq('Re: Hello from John')
     expect(sent_mail.to_s).to include(raw)
+  end
+
+  it "includes the participants list in the email" do
+    Fabricate(:staged, email: "james.bond@gmail.com")
+    topic = receiver.incoming_email.topic
+    topic.invite(Discourse.system_user, "james.bond@gmail.com")
+
+    PostCreator.create(user, topic_id: topic.id, raw: raw)
+
+    expect(ActionMailer::Base.deliveries.size).to eq(1)
+
+    sent_mail = ActionMailer::Base.deliveries[0]
+    expect(sent_mail.to_s).to include("[Testers Group (1)](http://test.localhost/g/Testers), james.bond@gmail.com")
   end
 
   it "uses the OP incoming email subject for the subject over topic title" do


### PR DESCRIPTION
* Adds a hidden site setting: `max_participant_names`
* Replaces duplicate code in `GroupSmtpMailer` and `UserNotifications`
* Groups are sorted by the number of users (decreasing)
* Replaces the query to count users of each group with `Group#user_count`)
* Users are sorted by their last reply in the topic (most recent first)
* Adds lots of tests
* Removes unused code and rename interpolation key in translation