### PR TITLE
FIX: Do not error when json-serialized cookies are used

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -90,7 +90,7 @@ class Auth::DefaultCurrentUserProvider
       request = ActionDispatch::Request.new(env)
       # don't even initialize a cookie jar if we don't have a cookie at all
       if request.cookies[TOKEN_COOKIE].present?
-        request.cookie_jar.encrypted[TOKEN_COOKIE]
+        request.cookie_jar.encrypted[TOKEN_COOKIE]&.with_indifferent_access
       end
     end
   end


### PR DESCRIPTION
We intend to switch to the `:json` serializer, which will stringify all keys. However, we need a clean revert path. This commit ensures that our `_t` cookie handling works with both marshal (the current default) and json (the new default) serialization.

This change is cherry-picked from the Rails 7 branch: https://github.com/discourse/discourse/blob/64440cc0c566371e7315fd1b0206e5927bf661bd/lib/auth/default_current_user_provider.rb#L93

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
