### PR TITLE
UX: ask for confirmation when deleting a post using shortcut

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -702,6 +702,19 @@ export default Controller.extend(bufferedProperty("model"), {
       }
     },
 
+    deletePostWithConfirmation(post, opts) {
+      bootbox.confirm(
+        I18n.t("post.confirm_delete"),
+        I18n.t("no_value"),
+        I18n.t("yes_value"),
+        (confirmed) => {
+          if (confirmed) {
+            this.send("deletePost", post, opts);
+          }
+        }
+      );
+    },
+
     permanentlyDeletePost(post) {
       return bootbox.confirm(
         I18n.t("post.controls.permanently_delete_confirmation"),

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -49,7 +49,7 @@ const DEFAULT_BINDINGS = {
   "command+right": { handler: "webviewKeyboardForward", anonymous: true },
   "command+]": { handler: "webviewKeyboardForward", anonymous: true },
   "mod+p": { handler: "printTopic", anonymous: true },
-  d: { postAction: "deletePost" },
+  d: { postAction: "deletePostWithConfirmation" },
   e: { handler: "editPost" },
   end: { handler: "goToLastPost", anonymous: true },
   "command+down": { handler: "goToLastPost", anonymous: true },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3053,6 +3053,7 @@ en:
       deleted_by_author_simple: "(topic deleted by author)"
 
     post:
+      confirm_delete: "Are you sure you want to delete this post?"
       quote_reply: "Quote"
       quote_reply_shortcut: "Or press q"
       quote_edit: "Edit"


### PR DESCRIPTION
It's possible to delete a post using the keyboard only. To do so you need to navigate to a post using the <kbd>j</kbd> / <kbd>k</kbd> keys and then press <kbd>d</kbd>.

We want to ask for confirmation when deleting posts using the shortcut (and only when using the shortcut). This PR implements this, we'll be showing this modal:

<img width="400" alt="Screenshot 2022-04-21 at 16 37 58" src="https://user-images.githubusercontent.com/1274517/164462497-f2f90972-d348-4823-a746-147a2811c95c.png">

