### PR TITLE
FIX: showing icons on future-date-input options

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
+++ b/app/assets/javascripts/select-kit/addon/components/future-date-input-selector.js
@@ -42,6 +42,7 @@ export default ComboBoxComponent.extend({
         name: I18n.t(tf.label),
         time: tf.time,
         timeFormatted: tf.timeFormatted,
+        icon: tf.icon,
       };
     });
   }),

--- a/app/assets/javascripts/select-kit/addon/templates/components/future-date-input-selector/future-date-input-selector-row.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/future-date-input-selector/future-date-input-selector-row.hbs
@@ -1,4 +1,4 @@
-{{#if item.icons}}
+{{#if item.icon}}
   <div class="future-date-input-selector-icons">
     {{d-icon item.icon}}
   </div>


### PR DESCRIPTION
I accidentally broke showing icons on future-date-input's options:

<img width="225" alt="Screenshot 2022-04-21 at 17 07 39" src="https://user-images.githubusercontent.com/1274517/164464803-1c6c57e8-3b56-461c-b309-a52a70938fad.png">

This fix returns icons back:

<img width="250" alt="Screenshot 2022-04-21 at 17 05 16" src="https://user-images.githubusercontent.com/1274517/164464832-b8008db4-76cc-40f9-94ef-c47415ee70c4.png">


