### PR TITLE
FEATURE: Scope search to PMs when in that context

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/search.js
+++ b/app/assets/javascripts/discourse/app/lib/search.js
@@ -118,7 +118,9 @@ function translateGroupedSearchResults(results, opts) {
       const name = pair[1];
       if (results[name].length > 0) {
         const componentName =
-          opts.searchContext && type === "topic" ? "post" : type;
+          opts.searchContext?.type === "topic" && type === "topic"
+            ? "post"
+            : type;
 
         const result = {
           results: results[name],

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -292,7 +292,7 @@ createWidget("search-menu-results", {
       return h("div.no-results", I18n.t("search.no_results"));
     }
 
-    if (!term) {
+    if (!term && !attrs.inPMInboxContext) {
       return this.attach("search-menu-initial-options", { term });
     }
 
@@ -364,7 +364,9 @@ createWidget("search-menu-results", {
     const content = [];
 
     if (!searchTopics) {
-      content.push(this.attach("search-menu-initial-options", { term }));
+      if (!attrs.inPMInboxContext) {
+        content.push(this.attach("search-menu-initial-options", { term }));
+      }
     } else {
       if (mainResultsContent.length) {
         content.push(mainResultsContent);

--- a/app/assets/javascripts/discourse/tests/acceptance/group-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-test.js
@@ -247,12 +247,9 @@ acceptance("Group - Authenticated", function (needs) {
     await click("#search-button");
     await fillIn("#search-term", "smth");
 
-    assert.strictEqual(
-      query(
-        ".search-menu .results .search-menu-assistant-item:first-child"
-      ).innerText.trim(),
-      "smth in:personal",
-      "contextual search is available as first option"
+    assert.ok(
+      query(".search-menu .btn.search-context"),
+      "'in messages' toggle is active by default"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-full-test.js
@@ -105,7 +105,7 @@ acceptance("Search - Full Page", function (needs) {
     });
   });
 
-  needs.hooks.afterEach(function () {
+  needs.hooks.afterEach(() => {
     searchResultClickTracked = false;
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -11,6 +11,13 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 import { DEFAULT_TYPE_FILTER } from "discourse/widgets/search-menu";
 
+const keyEnter = 13;
+const keyArrowDown = 40;
+const keyArrowUp = 38;
+const keyEsc = 27;
+const keyA = 65;
+const keyBackSpace = 8;
+
 acceptance("Search - Anonymous", function (needs) {
   needs.pretender((server, helper) => {
     server.get("/search/query", (request) => {
@@ -81,7 +88,7 @@ acceptance("Search - Anonymous", function (needs) {
       "shows matching user results"
     );
 
-    await triggerKeyEvent(".search-menu", "keydown", 40);
+    await triggerKeyEvent(".search-menu", "keydown", keyArrowDown);
     await click(document.activeElement);
 
     assert.ok(
@@ -195,7 +202,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     await fillIn("#search-term", "a proper");
     await query("input#search-term").focus();
-    await triggerKeyEvent(".search-menu", "keydown", 40);
+    await triggerKeyEvent(".search-menu", "keydown", keyArrowDown);
 
     await click(document.activeElement);
     assert.ok(
@@ -225,7 +232,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     await fillIn("#search-term", "dev");
     await query("input#search-term").focus();
-    await triggerKeyEvent(".search-menu", "keydown", 40);
+    await triggerKeyEvent(".search-menu", "keydown", keyArrowDown);
     await click(document.activeElement);
 
     assert.ok(
@@ -235,7 +242,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     await fillIn("#search-term", "");
     await query("input#search-term").focus();
-    await triggerKeyEvent("input#search-term", "keydown", 8); // backspace
+    await triggerKeyEvent("input#search-term", "keydown", keyBackSpace);
 
     assert.ok(
       !exists(".search-menu .search-context"),
@@ -259,7 +266,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     await fillIn("#search-term", "proper");
     await query("input#search-term").focus();
-    await triggerKeyEvent(".search-menu", "keydown", 40);
+    await triggerKeyEvent(".search-menu", "keydown", keyArrowDown);
     await click(document.activeElement);
 
     assert.ok(
@@ -394,7 +401,7 @@ acceptance("Search - Authenticated", function (needs) {
     await click("#search-button");
     await fillIn("#search-term", "plans");
     await query("input#search-term").focus();
-    await triggerKeyEvent(".search-menu", "keydown", 40);
+    await triggerKeyEvent(".search-menu", "keydown", keyArrowDown);
     await click(document.activeElement);
 
     assert.notStrictEqual(count(".search-menu .results .item"), 0);
@@ -407,11 +414,6 @@ acceptance("Search - Authenticated", function (needs) {
   });
 
   test("search dropdown keyboard navigation", async function (assert) {
-    const keyEnter = 13;
-    const keyArrowDown = 40;
-    const keyArrowUp = 38;
-    const keyEsc = 27;
-    const keyA = 65;
     const container = ".search-menu .results";
 
     await visit("/");
@@ -570,6 +572,147 @@ acceptance("Search - assistant", function (needs) {
   needs.user();
 
   needs.pretender((server, helper) => {
+    server.get("/search/query", (request) => {
+      if (request.queryParams["search_context[type]"] === "private_messages") {
+        // return only one result for PM search
+        return helper.response({
+          posts: [
+            {
+              id: 3833,
+              name: "Bill Dudney",
+              username: "bdudney",
+              avatar_template:
+                "/user_avatar/meta.discourse.org/bdudney/{size}/8343_1.png",
+              uploaded_avatar_id: 8343,
+              created_at: "2013-02-07T17:46:57.469Z",
+              cooked:
+                "<p>I've gotten vagrant up and running with a development environment but it's taking forever to load.</p>\n\n<p>For example <a href=\"http://192.168.10.200:3000/\" rel=\"nofollow\">http://192.168.10.200:3000/</a> takes tens of seconds to load.</p>\n\n<p>I'm running the whole stack on a new rMBP with OS X 10.8.2.</p>\n\n<p>Any ideas of what I've done wrong? Or is this just a function of being on the bleeding edge?</p>\n\n<p>Thanks,</p>\n\n<p>-bd</p>",
+              post_number: 1,
+              post_type: 1,
+              updated_at: "2013-02-07T17:46:57.469Z",
+              like_count: 0,
+              reply_count: 1,
+              reply_to_post_number: null,
+              quote_count: 0,
+              incoming_link_count: 4422,
+              reads: 327,
+              score: 21978.4,
+              yours: false,
+              topic_id: 2179,
+              topic_slug: "development-mode-super-slow",
+              display_username: "Bill Dudney",
+              primary_group_name: null,
+              version: 2,
+              can_edit: false,
+              can_delete: false,
+              can_recover: false,
+              user_title: null,
+              actions_summary: [
+                {
+                  id: 2,
+                  count: 0,
+                  hidden: false,
+                  can_act: false,
+                },
+                {
+                  id: 3,
+                  count: 0,
+                  hidden: false,
+                  can_act: false,
+                },
+                {
+                  id: 4,
+                  count: 0,
+                  hidden: false,
+                  can_act: false,
+                },
+                {
+                  id: 5,
+                  count: 0,
+                  hidden: true,
+                  can_act: false,
+                },
+                {
+                  id: 6,
+                  count: 0,
+                  hidden: false,
+                  can_act: false,
+                },
+                {
+                  id: 7,
+                  count: 0,
+                  hidden: false,
+                  can_act: false,
+                },
+                {
+                  id: 8,
+                  count: 0,
+                  hidden: false,
+                  can_act: false,
+                },
+              ],
+              moderator: false,
+              admin: false,
+              staff: false,
+              user_id: 1828,
+              hidden: false,
+              hidden_reason_id: null,
+              trust_level: 1,
+              deleted_at: null,
+              user_deleted: false,
+              edit_reason: null,
+              can_view_edit_history: true,
+              wiki: false,
+              blurb:
+                "I've gotten vagrant up and running with a development environment but it's taking forever to load. For example http://192.168.10.200:3000/ takes...",
+            },
+          ],
+          topics: [
+            {
+              id: 2179,
+              title: "Development mode super slow",
+              fancy_title: "Development mode super slow",
+              slug: "development-mode-super-slow",
+              posts_count: 72,
+              reply_count: 53,
+              highest_post_number: 73,
+              image_url: null,
+              created_at: "2013-02-07T17:46:57.262Z",
+              last_posted_at: "2015-04-17T08:08:26.671Z",
+              bumped: true,
+              bumped_at: "2015-04-17T08:08:26.671Z",
+              unseen: false,
+              pinned: false,
+              unpinned: null,
+              visible: true,
+              closed: false,
+              archived: false,
+              bookmarked: null,
+              liked: null,
+              views: 9538,
+              like_count: 45,
+              has_summary: true,
+              archetype: "regular",
+              last_poster_username: null,
+              category_id: 7,
+              pinned_globally: false,
+              posters: [],
+              tags: ["dev", "slow"],
+              tags_descriptions: {
+                dev: "dev description",
+                slow: "slow description",
+              },
+            },
+          ],
+          grouped_search_result: {
+            term: "emoji",
+            post_ids: [3833],
+          },
+        });
+      }
+      return helper.response(searchFixtures["search/query"]);
+    });
+
     server.get("/u/search/users", () => {
       return helper.response({
         users: [
@@ -665,5 +808,35 @@ acceptance("Search - assistant", function (needs) {
 
     await click(query(firstUser));
     assert.strictEqual(query("#search-term").value, `@${firstUsername}`);
+  });
+
+  test("shows 'in messages' button when in an inbox", async function (assert) {
+    await visit("/u/charlie/messages");
+    await click("#search-button");
+
+    assert.ok(exists(".btn.search-context"), "it shows the button");
+
+    await fillIn("#search-term", "");
+    await query("input#search-term").focus();
+    await triggerKeyEvent("input#search-term", "keydown", keyBackSpace);
+
+    assert.notOk(exists(".btn.search-context"), "it removes the button");
+
+    await click(".d-header");
+    await click("#search-button");
+    assert.ok(
+      exists(".btn.search-context"),
+      "it shows the button when reinvoking search"
+    );
+
+    await fillIn("#search-term", "emoji");
+    await query("input#search-term").focus();
+    await triggerKeyEvent("#search-term", "keydown", keyEnter);
+
+    assert.strictEqual(
+      count(".search-menu .search-result-topic"),
+      1,
+      "it passes the PM search context to the search query"
+    );
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2425,6 +2425,8 @@ en:
       in: "in"
       in_this_topic: "in this topic"
       in_this_topic_tooltip: "switch to searching all topics"
+      in_messages: "in messages"
+      in_messages_tooltip: "switch to searching regular topics"
       in_topics_posts: "in all topics and posts"
       enter_hint: "or press Enter"
       in_posts_by: "in posts by %{username}"


### PR DESCRIPTION
When the user is in a message inbox, the app currently shows a "in:personal" suggestion. Screenshot: 

<img width="400" alt="image" src="https://user-images.githubusercontent.com/368961/164486091-82380f6c-60b6-49b0-a68d-f7b874222edf.png">

This is a bit problematic. The label `in:personal` does not clearly convey that it enables searching only private messages and group inboxes. That lack of clarity makes users ignore this option entirely when searching. 

This PR introduces a new "in messages" toggle inside the search input: 

<img width="400" alt="image" src="https://user-images.githubusercontent.com/368961/164486737-b57d7ab2-b347-469e-8ff2-79f1c112887c.png">

This is active by default when users are in a private message context (which includes group inboxes). We already have a similar button when invoking ⌘+F on long topics, so UI-wise this matches that use case. 

Note that as of this PR the `in:personal` modifier remains unchanged. I think it makes sense to add a `in:messages` synonym here, so that `in:` suggestions in the UI match this new toggle. I'll add the synonym in a second PR. 

Reference: https://meta.discourse.org/t/offering-private-support-as-part-of-a-public-support-community/215151/24