### PR TITLE
DEV: Ensure a broken tag_group relation doesn't raise an error

### DIFF
--- a/app/serializers/category_required_tag_group_serializer.rb
+++ b/app/serializers/category_required_tag_group_serializer.rb
@@ -4,6 +4,6 @@ class CategoryRequiredTagGroupSerializer < ApplicationSerializer
   attributes :name, :min_count
 
   def name
-    object.tag_group.name
+    object.tag_group&.name
   end
 end

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -45,6 +45,20 @@ describe SiteSerializer do
     expect(c1[:required_tag_groups]).to eq([{ name: tag_group_2.name, min_count: 1 }])
   end
 
+  it "doesn't explode when category_required_tag_group is missing" do
+    tag = Fabricate(:tag)
+    tag_group = Fabricate(:tag_group)
+    crtg = CategoryRequiredTagGroup.new(tag_group: tag_group, min_count: 1)
+    category.update!(category_required_tag_groups: [ crtg ])
+
+    tag_group.delete # Bypassing hooks like this should never happen in the app
+
+    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    c1 = serialized[:categories].find { |c| c[:id] == category.id }
+
+    expect(c1[:required_tag_groups]).to eq([{ name: nil, min_count: 1 }])
+  end
+
   it "returns correct notification level for categories" do
     SiteSetting.mute_all_categories_by_default = true
     SiteSetting.default_categories_regular = category.id.to_s


### PR DESCRIPTION
A category_required_tag_group should always have an associated tag_group. However, this is only enforced at the application layer, so it's technically possible for the database to include a category_required_tag_group without a matching tag_group.

Previously that situation would cause the whole site to go offline. With this change, it will cause some unexpected behavior, but the site serializer will not raise an error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
