### PR TITLE
FIX: replaces discourseComputed by computed

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-colors-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-colors-show.js
@@ -1,18 +1,19 @@
 import Controller from "@ember/controller";
 import I18n from "I18n";
 import bootbox from "bootbox";
-import discourseComputed from "discourse-common/utils/decorators";
 import { later } from "@ember/runloop";
-import { action } from "@ember/object";
+import { action, computed } from "@ember/object";
 import { clipboardCopy } from "discourse/lib/utilities";
 
 export default class AdminCustomizeColorsShowController extends Controller {
-  @discourseComputed("model.colors", "onlyOverridden")
-  colors(allColors, onlyOverridden) {
-    if (onlyOverridden) {
-      return allColors.filterBy("overridden");
+  onlyOverridden = false;
+
+  @computed("model.colors.[]", "onlyOverridden")
+  get colors() {
+    if (this.onlyOverridden) {
+      return this.model.colors?.filterBy("overridden");
     } else {
-      return allColors;
+      return this.model.colors;
     }
   }
 


### PR DESCRIPTION
This was causing unexpected behaviors on production builds. And also on firefox on local environnement, however the issues were slightly different.

- production chrome: colors don't load
- dev firefox: colors don't change when selecting a different color set

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
