### PR TITLE
DEV: Don't leave loadScript tests hanging

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/load-script.js
+++ b/app/assets/javascripts/discourse/app/lib/load-script.js
@@ -20,6 +20,11 @@ function loadWithTag(path, cb) {
     registerWaiter(() => finished);
   }
 
+  // Don't leave it hanging if something goes wrong
+  s.onerror = function () {
+    finished = true;
+  };
+
   s.onload = s.onreadystatechange = function (_, abort) {
     finished = true;
     if (


### PR DESCRIPTION
…when anything goes wrong. Let it move on instead of waiting for global test timeout.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
