### PR TITLE
DEV: Allow running theme-qunit tests via testem

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -68,8 +68,20 @@ module.exports = {
   reporter: Reporter,
 };
 
-if (shouldLoadPluginTestJs()) {
-  const target = `http://localhost:${process.env.UNICORN_PORT || "3000"}`;
+const target = `http://localhost:${process.env.UNICORN_PORT || "3000"}`;
+
+if (process.argv.includes("-t")) {
+  // Running testem without ember cli. Probably for theme-qunit
+  const testPage = process.argv[process.argv.indexOf("-t") + 1];
+
+  module.exports.proxies = {};
+  module.exports.proxies[`/*/theme-qunit`] = {
+    target: `${target}${testPage}`,
+    ignorePath: true,
+  };
+  module.exports.proxies["/*/*"] = { target };
+} else if (shouldLoadPluginTestJs()) {
+  // Running with ember cli, but we want to pass through plugin request to Rails
   module.exports.proxies = {
     "/assets/discourse/tests/active-plugins.js": {
       target,

--- a/app/views/qunit/theme.html.erb
+++ b/app/views/qunit/theme.html.erb
@@ -28,6 +28,9 @@
         }
       </style>
     <%- end %>
+    <%- if params['testem'] %>
+      <script src="/testem.js"></script>
+    <%- end %>
   </head>
   <body>
     <%- if !@suggested_themes %>


### PR DESCRIPTION
This allows `QUNIT_EMBER_CLI=1 bin/rake theme:qunit[...]` to test themes using `testem` with Ember-CLI-generated assets

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
