### PR TITLE
DEV: Ensure ember-cli `rake theme:qunit` works with CSP enabled

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -78,8 +78,20 @@ if (process.argv.includes("-t")) {
   module.exports.proxies[`/*/theme-qunit`] = {
     target: `${target}${testPage}`,
     ignorePath: true,
+    xfwd: true,
   };
-  module.exports.proxies["/*/*"] = { target };
+  module.exports.proxies["/*/*"] = { target, xfwd: true };
+
+  module.exports.middleware = [
+    function (app) {
+      // Make the testem.js file available under /assets
+      // so it's within the app's CSP
+      app.get("/assets/testem.js", function (req, res, next) {
+        req.url = "/testem.js";
+        next();
+      });
+    },
+  ];
 } else if (shouldLoadPluginTestJs()) {
   // Running with ember cli, but we want to pass through plugin request to Rails
   module.exports.proxies = {

--- a/app/views/qunit/theme.html.erb
+++ b/app/views/qunit/theme.html.erb
@@ -29,7 +29,7 @@
       </style>
     <%- end %>
     <%- if params['testem'] %>
-      <script src="/testem.js"></script>
+      <script src="/assets/testem.js"></script>
     <%- end %>
   </head>
   <body>


### PR DESCRIPTION
- Make proxy pass `x-forward...` headers, so that Rails can set the host/port correctly in the csp
- Make `testem.js` available on a route which is within the app's default CSP

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
