### PR TITLE
FIX: Check 2FA is disabled before enabling DiscourseConnect.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2409,6 +2409,7 @@ en:
       google_oauth2_hd_groups: "You must first set 'google oauth2 hd' before enabling this setting."
       search_tokenize_chinese_enabled: "You must disable 'search_tokenize_chinese' before enabling this setting."
       search_tokenize_japanese_enabled: "You must disable 'search_tokenize_japanese' before enabling this setting."
+      discourse_connect_cannot_be_enabled_if_second_factor_enforced:  "You cannot enable DiscourseConnect if 2FA is enforced."
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -199,7 +199,7 @@ module SiteSettings::Validations
   end
 
   def validate_enforce_second_factor(new_val)
-    if SiteSetting.enable_discourse_connect?
+    if new_val != "no" && SiteSetting.enable_discourse_connect?
       return validate_error :second_factor_cannot_be_enforced_with_discourse_connect_enabled
     end
     if new_val == "all" && Discourse.enabled_auth_providers.count > 0

--- a/lib/validators/enable_sso_validator.rb
+++ b/lib/validators/enable_sso_validator.rb
@@ -7,12 +7,17 @@ class EnableSsoValidator
 
   def valid_value?(val)
     return true if val == 'f'
-    return false if SiteSetting.discourse_connect_url.blank? || SiteSetting.invite_only?
+    return false if SiteSetting.discourse_connect_url.blank? || SiteSetting.invite_only? || is_2fa_enforced?
     true
   end
 
   def error_message
     return I18n.t('site_settings.errors.discourse_connect_url_is_empty') if SiteSetting.discourse_connect_url.blank?
     return I18n.t('site_settings.errors.discourse_connect_invite_only') if SiteSetting.invite_only?
+    return I18n.t('site_settings.errors.discourse_connect_cannot_be_enabled_if_second_factor_enforced') if is_2fa_enforced?
+  end
+
+  def is_2fa_enforced?
+    SiteSetting.enforce_second_factor? != 'no'
   end
 end

--- a/spec/lib/validators/enable_sso_validator_spec.rb
+++ b/spec/lib/validators/enable_sso_validator_spec.rb
@@ -62,5 +62,22 @@ RSpec.describe EnableSsoValidator do
       end
     end
 
+    describe 'when 2FA is enforced' do
+      before do
+        SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+      end
+
+      it 'should be invalid' do
+        SiteSetting.enforce_second_factor = 'all'
+
+        expect(subject.valid_value?('t')).to eq(false)
+      end
+
+      it 'should be valid' do
+        SiteSetting.enforce_second_factor = 'no'
+
+        expect(subject.valid_value?('t')).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Both settings are incompatible. We validated that DiscourseConnect is disabled before enabling 2FA but were missing the other way around.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
