### PR TITLE
FIX: properly clean Thunderbird emails, don't remove links

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -471,7 +471,9 @@ module Email
     def extract_from_mozilla(doc)
       # Mozilla (Thunderbird ?) properly identifies signature and forwarded emails
       # Remove them and anything that comes after
-      elided = doc.css("*[class^='moz-'], *[class^='moz-'] ~ *").remove
+      elided = doc.css("*[class^='moz-cite'], *[class^='moz-cite'] ~ *, " \
+                       "*[class^='moz-signature'], *[class^='moz-signature'] ~ *, " \
+                       "*[class^='moz-forward'], *[class^='moz-forward'] ~ *").remove
       to_markdown(doc.to_html, elided.to_html)
     end
 


### PR DESCRIPTION
Mozilla Thunderbird email client add links into HTML as follows:

`<p>The link: <a class="moz-txt-link-freetext" href="https://google.com">https://google.com</a></p>`

Current filtering rules strip out the link, leaving only `<p>The link: </p>`.
Properly strip only unnecessary information: quote prefix, signature, forwarded message header.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
