### PR TITLE
DEV: Ensure `custom_fields_clean?` returns false when values change

### DIFF
--- a/app/models/concerns/has_custom_fields.rb
+++ b/app/models/concerns/has_custom_fields.rb
@@ -301,7 +301,7 @@ protected
       self.class.append_custom_field(target, key, value)
     end
     @custom_fields_orig = target
-    @custom_fields = @custom_fields_orig.dup
+    @custom_fields = @custom_fields_orig.deep_dup
   end
 
 end

--- a/spec/lib/concern/has_custom_fields_spec.rb
+++ b/spec/lib/concern/has_custom_fields_spec.rb
@@ -307,6 +307,35 @@ describe HasCustomFields do
       expect(test_item.reload.custom_fields).to eq(expected)
     end
 
+    it 'determines clean state correctly for mutable fields' do
+      json_field = "json_field"
+      array_field = "array_field"
+      CustomFieldsTestItem.register_custom_field_type(json_field, :json)
+      CustomFieldsTestItem.register_custom_field_type(array_field, :array)
+
+      item_with_array = CustomFieldsTestItem.new
+      expect(item_with_array.custom_fields_clean?).to eq(true)
+      item_with_array.custom_fields[array_field] = [1]
+      expect(item_with_array.custom_fields_clean?).to eq(false)
+      item_with_array.save!
+      expect(item_with_array.custom_fields_clean?).to eq(true)
+      item_with_array.custom_fields[array_field] << 2
+      expect(item_with_array.custom_fields_clean?).to eq(false)
+      item_with_array.save!
+      expect(item_with_array.custom_fields_clean?).to eq(true)
+
+      item_with_json = CustomFieldsTestItem.new
+      expect(item_with_json.custom_fields_clean?).to eq(true)
+      item_with_json.custom_fields[json_field] = { "hello" => "world" }
+      expect(item_with_json.custom_fields_clean?).to eq(false)
+      item_with_json.save!
+      expect(item_with_json.custom_fields_clean?).to eq(true)
+      item_with_json.custom_fields[json_field]["hello"] = "world2"
+      expect(item_with_json.custom_fields_clean?).to eq(false)
+      item_with_json.save!
+      expect(item_with_json.custom_fields_clean?).to eq(true)
+    end
+
     describe "create_singular" do
       it "creates new records" do
         item = CustomFieldsTestItem.create!


### PR DESCRIPTION
We were calling `dup` on the hash and using that to check for changes. However, we were not duplicating the values, so changes to arrays or nested hashes would not be detected.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
