### PR TITLE
FIX: Ensure lazy-load-images does not remove entire `img.style`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -18,11 +18,16 @@ export function nativeLazyLoading(api) {
           if (!img.complete) {
             if (!img.onload) {
               img.onload = () => {
-                img.removeAttribute("style");
+                img.style.removeProperty("background-image");
+                img.style.removeProperty("background-size");
               };
             }
 
-            img.style = `background-image: url(${img.dataset.smallUpload}); background-size: cover;`;
+            img.style.setProperty(
+              "background-image",
+              `url(${img.dataset.smallUpload});`
+            );
+            img.style.setProperty("background-size", "cover");
           }
         }
       }),


### PR DESCRIPTION
Other things may have added things to the style attribute (e.g. the `image-aspect-ratio` decorator).

Unfortunately this is difficult to add a test for because `lazy-load-images` leans on the `onload` event. We have no control over image loading in tests, so race conditions would be very likely.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
