### PR TITLE
UX: Fix a few WCAG color scheme contrast issues

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -106,37 +106,23 @@ html {
     background: var(--tertiary);
   }
 
+  .extra-info-wrapper {
+    --header_primary-high: var(--header_primary);
+  }
+
   // Topic list
 
   table th {
-    color: var(--primary-medium);
-  }
-
-  .coldmap {
-    &-high {
-      color: #6c77cc !important;
-    }
-
-    &-med {
-      color: #548eaa !important;
-    }
-
-    &-low {
-      color: #32a1a5 !important;
-    }
+    color: var(--primary-high);
   }
 
   .heatmap-high,
-  .heatmap-high a {
-    color: #dc3249 !important;
-  }
+  .heatmap-high a,
   .heatmap-med,
-  .heatmap-med a {
-    color: #ae5b54 !important;
-  }
+  .heatmap-med a,
   .heatmap-low,
   .heatmap-low a {
-    color: #8f6d5b !important;
+    color: var(--primary-medium) !important;
   }
 
   .badge-notification {
@@ -226,64 +212,9 @@ html {
 
   nav.post-controls {
     .actions {
-      .double-button {
-        &:hover {
-          button {
-            background: var(--primary-medium);
-            color: var(--secondary);
-            .d-icon {
-              color: var(--secondary);
-            }
-            &.has-like {
-              .d-icon {
-                color: var(--love-low);
-              }
-            }
-          }
-        }
-        button {
-          &.like {
-            // Like button with 0 likes
-            &.d-hover {
-              background: var(--love-low);
-              .d-icon {
-                color: var(--love-low);
-              }
-            }
-          }
-          &.has-like {
-            // Like button after I've liked
-            .d-icon {
-              color: var(--love);
-            }
-            &.d-hover {
-              background: var(--primary-medium);
-              .d-icon {
-                color: var(--secondary);
-              }
-            }
-          }
-
-          &.button-count {
-            &.d-hover {
-              background: var(--primary-medium);
-              color: var(--secondary);
-            }
-            + .toggle-like {
-              &.d-hover {
-                background: var(--primary-medium);
-                color: var(--secondary);
-              }
-            }
-          }
-        }
-      }
-      button.create {
+      button.create,
+      button.create .d-icon {
         color: var(--primary-high-or-secondary-low);
-
-        .d-icon {
-          color: var(--primary-high-or-secondary-low);
-        }
       }
       button {
         &.d-hover,
@@ -316,6 +247,16 @@ html {
               }
             }
           }
+        }
+      }
+      .double-button .button-count {
+        color: var(--primary-medium);
+      }
+      .double-button:hover {
+        button,
+        .d-icon,
+        button.has-like .d-icon {
+          color: var(--love);
         }
       }
     }


### PR DESCRIPTION
Fixes a few color contrast issues that failed the automated tests via WAVE (in Chrome, macOS). 

The most noticeable change is that reply, view and activity counts no longer get high/mid/low colors (in WCAG color schemes).

This addresses the following elements: 
- category + tag badge colors in header
- Like buttons in topic lists (default and hover states)
- table heading color in lists
- reply, view and activity count labels