### PR TITLE
DEV: prefix group name when appended as class

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -1,6 +1,6 @@
 {{plugin-outlet name="before-group-container" tagName="span" connectorTagName="div" args=(hash group=model)}}
 
-<div class="container group {{model.name}}">
+<div class="container group-{{model.name}}">
   {{#if showTooltip}}
     <div class="group-delete-tooltip">
       <p>{{i18n "admin.groups.delete_automatic_group"}}</p>

--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -1,6 +1,6 @@
 {{plugin-outlet name="before-group-container" tagName="span" connectorTagName="div" args=(hash group=model)}}
 
-<div class="container group-{{model.name}}">
+<div class="container group group-{{model.name}}">
   {{#if showTooltip}}
     <div class="group-delete-tooltip">
       <p>{{i18n "admin.groups.delete_automatic_group"}}</p>


### PR DESCRIPTION
Previously if you named a group `hidden`, this will append the class `hidden` to the container, this results in a name collision with the `hidden` utility class, and hides all the page content. 

This changes the class name to be appended with `group-`, for example, `group-hidden` – and avoids this collision and other potential naming issues. 