### PR TITLE
UX: prevent group mention from wrapping

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1243,6 +1243,7 @@ span.mention {
 }
 
 a.mention-group {
+  display: inline-block;
   font-weight: bold;
   font-size: 0.93em;
   color: var(--primary);


### PR DESCRIPTION
This prevents group mentions from wrapping like this:

![Screen Shot 2022-04-25 at 6 10 10 PM](https://user-images.githubusercontent.com/1681963/165183255-eabcf5dd-7d67-4a05-a28b-b275efd5166a.png)

Instead wrapping will now be all or nothing. We already use `inline-block` on username mentions to do this.
