### PR TITLE
DOC: tighten directory permissions in cloud installation

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -45,6 +45,7 @@ Clone the [Official Discourse Docker Image][dd] into `/var/discourse`.
     sudo -s
     git clone https://github.com/discourse/discourse_docker.git /var/discourse
     cd /var/discourse
+    chmod 700 containers
 
 You will need to be root through the rest of the setup and bootstrap process.
 


### PR DESCRIPTION
The files in the containers directory may include secrets -- such as
credentials for sending email. Previously, those could be world-
readable depending on umask.
