### PR TITLE
UX: improve the list of options on the slow mode modal

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-slow-mode.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-slow-mode.js
@@ -112,17 +112,18 @@ export default Controller.extend(ModalFunctionality, {
   timeShortcuts() {
     const timezone = this.currentUser.resolvedTimezone(this.currentUser);
     const shortcuts = timeShortcuts(timezone);
+
+    const nextWeek = shortcuts.monday();
+    nextWeek.label = "time_shortcut.next_week";
+
     return [
       shortcuts.laterToday(),
       shortcuts.tomorrow(),
-      shortcuts.laterThisWeek(),
-      shortcuts.monday(),
+      shortcuts.twoDays(),
+      nextWeek,
       shortcuts.twoWeeks(),
       shortcuts.nextMonth(),
       shortcuts.twoMonths(),
-      shortcuts.threeMonths(),
-      shortcuts.fourMonths(),
-      shortcuts.sixMonths(),
     ];
   },
 

--- a/app/assets/javascripts/discourse/app/lib/time-shortcut.js
+++ b/app/assets/javascripts/discourse/app/lib/time-shortcut.js
@@ -17,6 +17,7 @@ import {
   thousandYears,
   threeMonths,
   tomorrow,
+  twoDays,
   twoMonths,
   twoWeeks,
 } from "discourse/lib/time-utils";
@@ -91,6 +92,15 @@ export function timeShortcuts(timezone) {
         icon: "far-sun",
         label: "time_shortcut.tomorrow",
         time: tomorrow(timezone),
+        timeFormatKey: "dates.time_short_day",
+      };
+    },
+    twoDays() {
+      return {
+        id: "two_days",
+        icon: "angle-right",
+        label: "time_shortcut.two_days",
+        time: twoDays(timezone),
         timeFormatKey: "dates.time_short_day",
       };
     },

--- a/app/assets/javascripts/discourse/app/lib/time-utils.js
+++ b/app/assets/javascripts/discourse/app/lib/time-utils.js
@@ -37,8 +37,12 @@ export function laterToday(timezone) {
     : later.add(30, "minutes").startOf("hour");
 }
 
-export function laterThisWeek(timezone) {
+export function twoDays(timezone) {
   return startOfDay(now(timezone).add(2, "days"));
+}
+
+export function laterThisWeek(timezone) {
+  return twoDays(timezone);
 }
 
 export function nextMonth(timezone) {

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-set-slow-mode-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-set-slow-mode-test.js
@@ -54,14 +54,11 @@ acceptance("Topic - Set Slow Mode", function (needs) {
     const expected = [
       I18n.t("time_shortcut.later_today"),
       I18n.t("time_shortcut.tomorrow"),
-      I18n.t("time_shortcut.later_this_week"),
-      I18n.t("time_shortcut.start_of_next_business_week_alt"),
+      I18n.t("time_shortcut.two_days"),
+      I18n.t("time_shortcut.next_week"),
       I18n.t("time_shortcut.two_weeks"),
       I18n.t("time_shortcut.next_month"),
       I18n.t("time_shortcut.two_months"),
-      I18n.t("time_shortcut.three_months"),
-      I18n.t("time_shortcut.four_months"),
-      I18n.t("time_shortcut.six_months"),
       I18n.t("time_shortcut.custom"),
     ];
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -642,6 +642,7 @@ en:
 
     time_shortcut:
       later_today: "Later today"
+      two_days: "Two days"
       next_business_day: "Next business day"
       tomorrow: "Tomorrow"
       post_local_date: "Date in post"
@@ -649,6 +650,7 @@ en:
       this_weekend: "This weekend"
       start_of_next_business_week: "Monday"
       start_of_next_business_week_alt: "Next Monday"
+      next_week: "Next week"
       two_weeks: "Two weeks"
       next_month: "Next month"
       two_months: "Two months"


### PR DESCRIPTION
On the slow mode modal instead of these options:

- later today
- tomorrow
- next week
- two weeks
- next month
- two months
- three months
- four months
- six months
- pick date and time

we want to show:

- later today
- tomorrow
- two days
- next week
- two weeks
- next month
- two months
- pick date and time

Here is how it looks:

<img width="400" alt="Screenshot 2022-04-26 at 13 14 25" src="https://user-images.githubusercontent.com/1274517/165266479-0a6204dd-6767-46b4-93a6-f50aea04b92a.png">


