### PR TITLE
FIX: prefers computed over discourseComputed

### DIFF
--- a/app/assets/javascripts/discourse/app/components/badge-button.js
+++ b/app/assets/javascripts/discourse/app/components/badge-button.js
@@ -1,13 +1,16 @@
 import Component from "@ember/component";
-import discourseComputed from "discourse-common/utils/decorators";
+import { computed } from "@ember/object";
 import domFromString from "discourse-common/lib/dom-from-string";
 
 export default class BadgeButtonComponent extends Component {
   tagName = "";
   badge = null;
 
-  @discourseComputed("badge.description")
-  title(badgeDescription) {
-    return domFromString(`<div>${badgeDescription}</div>`)[0].innerText;
+  @computed("badge.description")
+  get title() {
+    if (this.badge?.description) {
+      return domFromString(`<div>${this.badge?.description}</div>`)[0]
+        .innerText;
+    }
   }
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-button-test.js
@@ -56,6 +56,14 @@ discourseModule("Integration | Component | badge-button", function (hooks) {
 
     async test(assert) {
       assert.equal(query(".user-badge").title, "a good run", "it strips html");
+
+      this.set("badge", { description: "a bad run" });
+
+      assert.equal(
+        query(".user-badge").title,
+        "a bad run",
+        "it updates title when changing description"
+      );
     },
   });
 


### PR DESCRIPTION
We have unexpected behaviors ATM under ember-cli when using @discourseComputed in a native class.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
