### PR TITLE
UX: fix topic admin menu layout for short screens

### DIFF
--- a/app/assets/stylesheets/mobile/topic.scss
+++ b/app/assets/stylesheets/mobile/topic.scss
@@ -144,6 +144,14 @@ sub sub {
         grid-template-columns: 1fr 1fr;
       }
 
+      ul {
+        display: contents;
+      }
+
+      .d-button-label {
+        @include ellipsis;
+      }
+
       .popup-menu-btn {
         @include ellipsis;
       }


### PR DESCRIPTION
Follow-up to 415740330857a3ddfa352aacd173e6b31a1eae08

before:
![Screen Shot 2022-04-26 at 9 50 39 AM](https://user-images.githubusercontent.com/1681963/165315158-765f0957-8015-41ad-9f21-3d470a4674f7.png)



after:

![Screen Shot 2022-04-26 at 9 50 55 AM](https://user-images.githubusercontent.com/1681963/165315186-60785e88-9e51-424b-ab16-d115fe2b7915.png)