### PR TITLE
FIX: prepare data before creating chart to avoid side effect

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
@@ -54,7 +54,13 @@ export default Component.extend({
 
     const context = chartCanvas.getContext("2d");
 
-    const chartData = makeArray(model.get("chartData") || model.get("data"));
+    const chartData = makeArray(model.chartData || model.data).map((cd) => {
+      return {
+        label: cd.label,
+        color: cd.color,
+        data: Report.collapse(model, cd.data),
+      };
+    });
 
     const data = {
       labels: chartData[0].data.mapBy("x"),
@@ -62,7 +68,7 @@ export default Component.extend({
         return {
           label: cd.label,
           stack: "pageviews-stack",
-          data: Report.collapse(model, cd.data),
+          data: cd.data,
           backgroundColor: cd.color,
         };
       }),


### PR DESCRIPTION
Before this change, we were using the labels from the original chartData to the chart builder, and we would then apply our collapse function on each dataset which could change the labels and cause a mismatch.

This was very visible when using quarterly periods on consolidated pageviews.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
