### PR TITLE
FIX: cache_critical_dns - add TLS support for Redis healthcheck

### DIFF
--- a/script/cache_critical_dns
+++ b/script/cache_critical_dns
@@ -116,11 +116,18 @@ class HealthyCache
 end
 
 def redis_healthcheck(host:, password:)
-  client = Redis.new(
+  client_opts = {
     host: host,
     password: password,
     timeout: 1,
-  )
+  }
+  if !nilempty(ENV['DISCOURSE_REDIS_USE_SSL']).nil? then
+    client_opts[:ssl] = true
+    client_opts[:ssl_params] = {
+      verify_mode: OpenSSL::SSL::VERIFY_NONE,
+    }
+  end
+  client = Redis.new(**client_opts)
   response = client.ping
   response == "PONG"
 rescue


### PR DESCRIPTION
For Redis connections that operate over TLS, we need to ensure that we
are setting the correct arguments for the Redis client. We can utilise
the existing environment variable `DISCOURSE_REDIS_USE_SSL` to toggle
this behaviour.

No SSL verification is performed for two reasons:
- the Discourse application will perform a verification against any FQDN
  as specified for the Redis host
- the healthcheck is run against the _resolved_ IP address for the Redis
  hostname, and any SSL verification will always fail against a direct
  IP address

If no SSL arguments are provided, the IP address is never cached against
the hostname as no healthy address is ever found in the HealthyCache.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
