### PR TITLE
DEV: Mark discourse-group-tracker as official

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -41,6 +41,7 @@ class Plugin::Metadata
     "discourse-github",
     "discourse-gradle-issue",
     "discourse-graphviz",
+    "discourse-group-tracker",
     "discourse-invite-tokens",
     "discourse-local-dates",
     "discourse-login-with-amazon",


### PR DESCRIPTION
This ensures that https://github.com/discourse/discourse-group-tracker has the green checkmark in the admin plugin list to note that it's official.