### PR TITLE
FIX: show group in filter only if user can see the members list.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/users.js
@@ -69,12 +69,14 @@ export default Controller.extend({
   loadGroups() {
     if (this.currentUser) {
       return Group.findAll({ ignore_automatic: true }).then((groups) => {
-        const groupOptions = groups.map((group) => {
-          return {
-            name: group.full_name || group.name,
-            id: group.name,
-          };
-        });
+        const groupOptions = groups
+          .filter((group) => group.can_see_members)
+          .map((group) => {
+            return {
+              name: group.full_name || group.name,
+              id: group.name,
+            };
+          });
         this.set("groupOptions", groupOptions);
       });
     }


### PR DESCRIPTION
While switching to groups with hidden members it's creating a UI problem in users directory page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
