### PR TITLE
DEV: Remove deprecated Codespace setting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,13 @@
 {
-	"name": "Discourse",
-	"image": "discourse/discourse_dev:release",
-	"workspaceMount": "source=${localWorkspaceFolder}/../..,target=/var/www/discourse,type=bind",
-	"workspaceFolder": "/var/www/discourse",
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
-	"postCreateCommand": "sudo /sbin/boot",
-	"extensions": ["rebornix.Ruby"],
-    "forwardPorts": [9292],
-	"remoteUser": "discourse"
+  "name": "Discourse",
+  "image": "discourse/discourse_dev:release",
+  "workspaceMount": "source=${localWorkspaceFolder}/../..,target=/var/www/discourse,type=bind",
+  "workspaceFolder": "/var/www/discourse",
+  "settings": {
+    "search.followSymlinks": false
+  },
+  "postCreateCommand": "sudo /sbin/boot",
+  "extensions": ["rebornix.Ruby"],
+  "forwardPorts": [9292],
+  "remoteUser": "discourse"
 }


### PR DESCRIPTION
And add `search.followSymlinks` so that js/adminjs results aren't duplicated by default (+ fix formatting)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
