### PR TITLE
FIX: Ensure values are escaped in select-kit dropdowns (beta)

### DIFF
--- a/app/assets/javascripts/select-kit/addon/templates/components/selected-choice.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/selected-choice.hbs
@@ -4,7 +4,7 @@
     {{yield}}
   {{else}}
     <span class="d-button-label">
-      {{html-safe itemName}}
+      {{itemName}}
     </span>
   {{/if}}
 </button>


### PR DESCRIPTION
The values in Discourse dropdown menus only come from admin-defined strings, not unsanitised end-user input, so this lack of escaping was not exploitable.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
