### PR TITLE
UX: Add time_shortcut.now translation

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -641,6 +641,7 @@ en:
       relative: "Relative"
 
     time_shortcut:
+      now: "Now"
       later_today: "Later today"
       two_days: "Two days"
       next_business_day: "Next business day"


### PR DESCRIPTION
When using `future-date-input` with the option of `includeNow=true` we need to have a translation for `time_shortcut.now`.
