### PR TITLE
FEATURE: Optionally skip using real name when suggesting usernames

### DIFF
--- a/app/models/discourse_connect.rb
+++ b/app/models/discourse_connect.rb
@@ -373,7 +373,8 @@ class DiscourseConnect < DiscourseConnectBase
   end
 
   def resolve_username
-    suggester_input = [username, name]
+    suggester_input = [username]
+    suggester_input << name if SiteSetting.use_name_for_username_suggestions
     suggester_input << email if SiteSetting.use_email_for_username_and_name_suggestions
     UserNameSuggester.suggest(*suggester_input)
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2356,6 +2356,7 @@ en:
 
     allow_changing_staged_user_tracking: "Allow a staged user's category and tag notification preferences to be changed by an admin user."
     use_email_for_username_and_name_suggestions: "Use the first part of email addresses for username and name suggestions. Note that this makes it easier for the public to guess full user email addresses (because a large proportion of people share common services like `gmail.com`)."
+    use_name_for_username_suggestions: "Use a user's full name when suggesting usernames."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -691,6 +691,8 @@ users:
     hidden: true
   use_email_for_username_and_name_suggestions:
     default: false
+  use_name_for_username_suggestions:
+    default: true
 
 groups:
   enable_group_directory:

--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -196,7 +196,8 @@ class Auth::Result
   end
 
   def username_suggester_attributes
-    attributes = [username, name]
+    attributes = [username]
+    attributes << name if SiteSetting.use_name_for_username_suggestions
     attributes << email if SiteSetting.use_email_for_username_and_name_suggestions
     attributes
   end

--- a/spec/models/discourse_connect_spec.rb
+++ b/spec/models/discourse_connect_spec.rb
@@ -450,6 +450,20 @@ describe DiscourseConnect do
     expect(user.username).to eq sso.name
   end
 
+  it "stops using name as a source for username suggestions when disabled" do
+    SiteSetting.use_name_for_username_suggestions = false
+
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    sso.username = nil
+    sso.name = "John Smith"
+    sso.email = "mail@mail.com"
+
+    user = sso.lookup_or_create_user(ip_address)
+    expect(user.username).to eq "user"
+  end
+
   it "doesn't use email as a source for username suggestions by default" do
     sso = new_discourse_sso
     sso.external_id = "100"

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -266,6 +266,19 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(data["username"]).to eq("billmailbox")
       end
 
+      it 'stops using name for username suggestions if disabled in settings' do
+        SiteSetting.use_name_for_username_suggestions = false
+        username = ""
+        name = "John Smith"
+        email = "billmailbox@test.com"
+        mock_auth(email, username, name)
+
+        get "/auth/google_oauth2/callback.json"
+        data = JSON.parse(cookies[:authentication_data])
+
+        expect(data["username"]).to eq("user1")
+      end
+
       describe 'when site is invite_only' do
         before do
           SiteSetting.invite_only = true


### PR DESCRIPTION
This commit introduces a new site setting: `use_name_for_username_suggestions` (default true)

Admins can disable it if they want to stop using Name values when generating usernames for users. This can be useful if you want to keep real names private-by-default or, when used in conjunction with the `use_email_for_username_and_name_suggestions` setting, you would prefer to use email-based username suggestions.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
