### PR TITLE
UX: Reset `mark` element highlight for WCAG schemes

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -291,4 +291,9 @@ html {
       color: var(--secondary);
     }
   }
+
+  .cooked mark,
+  .d-editor-preview mark {
+    background-color: yellow; // resets to browser default
+  }
 }


### PR DESCRIPTION
The WCAG Light and WCAG Dark schemes override the `--highlight` colors to fix contrast issues. However, this causes the `mark` element to look like this: 

<img width="300" alt="image" src="https://user-images.githubusercontent.com/368961/165979026-0168d764-a129-44c3-b8d8-260b119618fb.png">

Technically this doesn't fail WCAG, but it's jarring. This PR reverts to the browser default for these highlights in WCAG schemes: 

<img width="300" alt="image" src="https://user-images.githubusercontent.com/368961/165979161-1b6a97b0-abae-4e61-be8f-f05a5b7f66a8.png">

