### PR TITLE
DEV: Drop old hotlinked image data from post_custom_fields

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -72,20 +72,11 @@ class Post < ActiveRecord::Base
   # We can pass several creating options to a post via attributes
   attr_accessor :image_sizes, :quoted_post_numbers, :no_bump, :invalidate_oneboxes, :cooking_options, :skip_unique_check, :skip_validation
 
-  LARGE_IMAGES            ||= "large_images"
-  BROKEN_IMAGES           ||= "broken_images"
-  DOWNLOADED_IMAGES       ||= "downloaded_images"
   MISSING_UPLOADS         ||= "missing uploads"
   MISSING_UPLOADS_IGNORED ||= "missing uploads ignored"
   NOTICE                  ||= "notice"
 
   SHORT_POST_CHARS ||= 1200
-
-  # TODO: Drop the data from these three custom fields,
-  # drop the indexes, and remove the relavent constants
-  register_custom_field_type(LARGE_IMAGES, :json)
-  register_custom_field_type(BROKEN_IMAGES, :json)
-  register_custom_field_type(DOWNLOADED_IMAGES, :json)
 
   register_custom_field_type(MISSING_UPLOADS, :json)
   register_custom_field_type(MISSING_UPLOADS_IGNORED, :boolean)

--- a/app/models/post_custom_field.rb
+++ b/app/models/post_custom_field.rb
@@ -23,7 +23,4 @@ end
 #  index_post_custom_fields_on_post_id           (post_id) UNIQUE WHERE ((name)::text = 'missing uploads'::text)
 #  index_post_custom_fields_on_post_id_and_name  (post_id,name)
 #  index_post_id_where_missing_uploads_ignored   (post_id) UNIQUE WHERE ((name)::text = 'missing uploads ignored'::text)
-#  post_custom_field_broken_images_idx           (post_id) UNIQUE WHERE ((name)::text = 'broken_images'::text)
-#  post_custom_field_downloaded_images_idx       (post_id) UNIQUE WHERE ((name)::text = 'downloaded_images'::text)
-#  post_custom_field_large_images_idx            (post_id) UNIQUE WHERE ((name)::text = 'large_images'::text)
 #

--- a/db/post_migrate/20220429164301_delete_hotlinked_image_custom_fields.rb
+++ b/db/post_migrate/20220429164301_delete_hotlinked_image_custom_fields.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class DeleteHotlinkedImageCustomFields < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+      DELETE FROM post_custom_fields
+      WHERE name IN (
+        'downloaded_images',
+        'broken_images',
+        'large_images'
+      )
+    SQL
+
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS post_custom_field_broken_images_idx
+    SQL
+
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS post_custom_field_downloaded_images_idx
+    SQL
+
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS post_custom_field_large_images_idx
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
`20220428094026_create_post_hotlinked_media` moved this data into a dedicated table

(to be merged after #16585)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
