### PR TITLE
FIX: closes popover when downloading calendar

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -246,6 +246,13 @@ export default {
           endsAt: dataset.endsAt,
         },
       ]);
+
+      // TODO: remove this when rewriting preview as a component
+      const parentPopover = event.target.closest("[data-tippy-root]");
+      if (parentPopover?._tippy) {
+        parentPopover?._tippy.hide();
+      }
+
       return;
     }
 

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -250,7 +250,7 @@ export default {
       // TODO: remove this when rewriting preview as a component
       const parentPopover = event.target.closest("[data-tippy-root]");
       if (parentPopover?._tippy) {
-        parentPopover?._tippy.hide();
+        parentPopover._tippy.hide();
       }
 
       return;


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
