### PR TITLE
UX: Fix hover state for flat buttons in WCAG schemes

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -8,8 +8,8 @@
 }
 
 html.discourse-no-touch {
-  .btn-default,
-  .btn-icon {
+  .btn-default:not(.btn-flat),
+  .btn-icon:not(.btn-flat) {
     &.btn-default {
       .d-icon {
         color: var(--primary-medium);


### PR DESCRIPTION
Before (hover state of the authors reply checkbox)
<img width="300" alt="image" src="https://user-images.githubusercontent.com/368961/166309427-8ad0d43a-613c-489d-9d38-4d28842ca596.png">

After
<img width="300" alt="image" src="https://user-images.githubusercontent.com/368961/166309519-4fb7c716-4df6-4329-849a-b36717df39a3.png">
