### PR TITLE
FIX: Validate permalink_normalizations setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2387,7 +2387,7 @@ en:
       email_polling_disabled: "You must enable either manual or POP3 polling before enabling reply by email."
       user_locale_not_enabled: "You must first enable 'allow user locale' before enabling this setting."
       invalid_regex: "Regex is invalid or not allowed."
-      invalid_regex_with_message: "Regex %{regex} is invalid: %{message}"
+      invalid_regex_with_message: "The regular expression '%{regex}' contains the following error: %{message}"
       email_editable_enabled: "You must disable 'email editable' before enabling this setting."
       staged_users_disabled: "You must first enable 'staged users' before enabling this setting."
       reply_by_email_disabled: "You must first enable 'reply by email' before enabling this setting."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2387,6 +2387,7 @@ en:
       email_polling_disabled: "You must enable either manual or POP3 polling before enabling reply by email."
       user_locale_not_enabled: "You must first enable 'allow user locale' before enabling this setting."
       invalid_regex: "Regex is invalid or not allowed."
+      invalid_regex_with_message: "Regex %{regex} is invalid: %{message}"
       email_editable_enabled: "You must disable 'email editable' before enabling this setting."
       staged_users_disabled: "You must first enable 'staged users' before enabling this setting."
       reply_by_email_disabled: "You must first enable 'reply by email' before enabling this setting."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2387,7 +2387,7 @@ en:
       email_polling_disabled: "You must enable either manual or POP3 polling before enabling reply by email."
       user_locale_not_enabled: "You must first enable 'allow user locale' before enabling this setting."
       invalid_regex: "Regex is invalid or not allowed."
-      invalid_regex_with_message: "The regular expression '%{regex}' contains the following error: %{message}"
+      invalid_regex_with_message: "The regex '%{regex}' has an error: %{message}"
       email_editable_enabled: "You must disable 'email editable' before enabling this setting."
       staged_users_disabled: "You must first enable 'staged users' before enabling this setting."
       reply_by_email_disabled: "You must first enable 'reply by email' before enabling this setting."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2134,6 +2134,7 @@ uncategorized:
     default: ""
     type: list
     list_type: simple
+    validator: "RegexpListValidator"
 
   max_similar_results: 5
   minimum_topics_similar: 50

--- a/lib/validators/regexp_list_validator.rb
+++ b/lib/validators/regexp_list_validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class RegexpListValidator
+  def initialize(opts = {})
+  end
+
+  def valid_value?(value)
+    value.split("|").all? do |regexp|
+      begin
+        Regexp.new(regexp)
+      rescue RegexpError => e
+        @regexp = regexp
+        @error_message = e.message
+        false
+      end
+    end
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.invalid_regex_with_message", regex: @regexp, message: @error_message)
+  end
+end

--- a/spec/lib/validators/regexp_list_validator_spec.rb
+++ b/spec/lib/validators/regexp_list_validator_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe RegexpListValidator do
+  subject { described_class.new }
+
+  it "allows lists of valid regular expressions" do
+    expect(subject.valid_value?('\d+|[0-9]?|\w+')).to eq(true)
+  end
+
+  it "does not allow lists of invalid regular expressions do" do
+    expect(subject.valid_value?('\d+|[0-9?|\w+')).to eq(false)
+    expect(subject.error_message).to eq(
+      I18n.t("site_settings.errors.invalid_regex_with_message", regex: '[0-9?', message: 'premature end of char-class: /[0-9?/')
+    )
+  end
+end


### PR DESCRIPTION
When an admin enters a badly formed regular expression in the
permalink_normalizations site setting, a RegexpError exception is
generated everytime a URL is normalized (see Permalink.normalize_url).

The new validator validates every regular expression present in the
setting value (delimited by '|').

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
