### PR TITLE
DEV: Lock logster to 2.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -231,7 +231,7 @@ gem 'cppjieba_rb', require: false
 gem 'lograge', require: false
 gem 'logstash-event', require: false
 gem 'logstash-logger', require: false
-gem 'logster'
+gem 'logster', '2.11.0'
 
 # NOTE: later versions of sassc are causing a segfault, possibly dependent on processer architecture
 # and until resolved should be locked at 2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    logster (2.11.2)
+    logster (2.11.0)
     loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -563,7 +563,7 @@ DEPENDENCIES
   lograge
   logstash-event
   logstash-logger
-  logster
+  logster (= 2.11.0)
   loofah
   lru_redux
   lz4-ruby


### PR DESCRIPTION
2.11.1+ is not compatible with DiscourseRedis implementation. This fixes error reporting.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
