### PR TITLE
FIX: Ensure post_hotlinked_media index does not exceed size limit

### DIFF
--- a/app/models/post_hotlinked_media.rb
+++ b/app/models/post_hotlinked_media.rb
@@ -25,5 +25,5 @@ end
 #
 # Indexes
 #
-#  index_post_hotlinked_media_on_post_id_and_url  (post_id,url) UNIQUE
+#  index_post_hotlinked_media_on_post_id_and_url_md5  (post_id, md5((url)::text)) UNIQUE
 #

--- a/db/migrate/20220428094026_create_post_hotlinked_media.rb
+++ b/db/migrate/20220428094026_create_post_hotlinked_media.rb
@@ -22,8 +22,14 @@ class CreatePostHotlinkedMedia < ActiveRecord::Migration[6.1]
       t.bigint :upload_id
       t.timestamps
 
-      t.index [:post_id, :url], unique: true
+      # Failed on some installations due to index size. Repaired in 20220428094027
+      # t.index [:post_id, :url], unique: true
     end
+
+    execute <<~SQL
+      CREATE UNIQUE INDEX index_post_hotlinked_media_on_post_id_and_url_md5
+      ON post_hotlinked_media (post_id, md5(url));
+    SQL
 
     reversible do |dir|
       dir.up do

--- a/db/migrate/20220428094027_fix_post_hotlinked_media_index.rb
+++ b/db/migrate/20220428094027_fix_post_hotlinked_media_index.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class FixPostHotlinkedMediaIndex < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS index_post_hotlinked_media_on_post_id_and_url_md5
+      ON post_hotlinked_media (post_id, md5(url));
+    SQL
+
+    # Failed index introduced in 20220428094026_create_post_hotlinked_media. On some installations it succeeded,
+    # so we need to clean it up.
+    execute <<~SQL
+      DROP INDEX CONCURRENTLY IF EXISTS index_post_hotlinked_media_on_post_id_and_url;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
On some installations, this would fail with 'index row size exceeds btree version 4 maximum'. This commit replaces the `(post_id, url)` index with a `(post_id, md5(url))` index, which is much more space efficient.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
