### PR TITLE
FIX: update filtered replies when replies exist

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -436,8 +436,11 @@ createWidget("post-contents", {
     if (this.siteSettings.enable_filtered_replies_view) {
       const topicController = this.register.lookup("controller:topic");
 
-      defaultState.filteredRepliesShown =
-        topicController.replies_to_post_number === attrs.post_number.toString();
+      if (attrs.post_number) {
+        defaultState.filteredRepliesShown =
+          topicController.replies_to_post_number ===
+          attrs.post_number.toString();
+      }
     }
 
     return defaultState;


### PR DESCRIPTION
The `discourse-docs` plugin was throwing a [error](https://meta.discourse.org/t/error-in-docs-when-open-a-topic/225869) when a doc (that had replies when it was a topic prior to be converted to a doc) was initially loaded.

I don't think there are plugin specific changes to be made here, rather the change should update how we only update the `post-contents`. To only update when `post-contents-${attrs.id}` exists