### PR TITLE
FIX: Handle duplicates in hotlinked_media migration

### DIFF
--- a/db/migrate/20220428094026_create_post_hotlinked_media.rb
+++ b/db/migrate/20220428094026_create_post_hotlinked_media.rb
@@ -60,6 +60,7 @@ class CreatePostHotlinkedMedia < ActiveRecord::Migration[6.1]
           FROM post_custom_fields pcf
           JOIN json_array_elements_text(pcf.value::json) url ON true
           WHERE name='broken_images'
+          ON CONFLICT (post_id, md5(url::text)) DO NOTHING
         SQL
 
         execute <<~SQL
@@ -74,6 +75,7 @@ class CreatePostHotlinkedMedia < ActiveRecord::Migration[6.1]
           FROM post_custom_fields pcf
           JOIN json_array_elements_text(pcf.value::json) url ON true
           WHERE name='large_images'
+          ON CONFLICT (post_id, md5(url::text)) DO NOTHING
         SQL
       end
     end


### PR DESCRIPTION
In the old custom_field-based system, it was possible for a url to be both 'downloaded' and 'broken'. The new table enforces uniqueness, so we need to drop invalid data.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
