### PR TITLE
FEATURE: Add fallback to suggested value when auth_overrides_username

### DIFF
--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -83,8 +83,8 @@ class Auth::Result
 
   def apply_user_attributes!
     change_made = false
-    if (SiteSetting.auth_overrides_username? || overrides_username) && username.present?
-      change_made = UsernameChanger.override(user, username)
+    if (SiteSetting.auth_overrides_username? || overrides_username) && (resolved_username = resolve_username).present?
+      change_made = UsernameChanger.override(user, resolved_username)
     end
 
     if (SiteSetting.auth_overrides_email || overrides_email || user&.email&.ends_with?(".invalid")) &&
@@ -213,6 +213,6 @@ class Auth::Result
       end
     end
 
-    UserNameSuggester.suggest(*username_suggester_attributes)
+    UserNameSuggester.suggest(*username_suggester_attributes, current_username: user&.username)
   end
 end

--- a/spec/lib/auth/result_spec.rb
+++ b/spec/lib/auth/result_spec.rb
@@ -51,6 +51,15 @@ describe Auth::Result do
     expect(user.name).to eq(new_name)
   end
 
+  it "overrides username with suggested value if missing" do
+    SiteSetting.auth_overrides_username = true
+
+    result.username = nil
+    result.apply_user_attributes!
+
+    expect(user.username).to eq("New_Name")
+  end
+
   it "updates the user's email if currently invalid" do
     user.update!(email: "someemail@discourse.org")
     expect { result.apply_user_attributes! }.not_to change { user.email }


### PR DESCRIPTION
If the identity provider does not provide a precise username value, then we should use our UserNameSuggester to generate one and use it for the override. This makes the override consistent with initial account creation.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
