### PR TITLE
FIX: Handle invalid JSON from downloaded_images custom fields

### DIFF
--- a/db/migrate/20220428094026_create_post_hotlinked_media.rb
+++ b/db/migrate/20220428094026_create_post_hotlinked_media.rb
@@ -46,6 +46,7 @@ class CreatePostHotlinkedMedia < ActiveRecord::Migration[6.1]
           JOIN json_each_text(pcf.value::json) obj ON true
           JOIN uploads ON obj.value::bigint = uploads.id
           WHERE name='downloaded_images'
+          ON CONFLICT (post_id, md5(url::text)) DO NOTHING
         SQL
 
         execute <<~SQL


### PR DESCRIPTION
custom_field data on some sites has duplicate values for a given url key in the JSON value. This is invalid, so we should drop the extra data.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
