### PR TITLE
DEV: Use cloneJSON instead of spread operator

### DIFF
--- a/plugins/discourse-local-dates/test/javascripts/acceptance/download-calendar-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/download-calendar-test.js
@@ -8,6 +8,7 @@ import I18n from "I18n";
 import { test } from "qunit";
 import { fixturesByUrl } from "discourse/tests/helpers/create-pretender";
 import sinon from "sinon";
+import { cloneJSON } from "discourse-common/lib/object";
 
 acceptance(
   "Local Dates - Download calendar without default calendar option set",
@@ -15,7 +16,7 @@ acceptance(
     needs.user({ default_calendar: "none_selected" });
     needs.settings({ discourse_local_dates_enabled: true });
     needs.pretender((server, helper) => {
-      const response = { ...fixturesByUrl["/t/281.json"] };
+      const response = cloneJSON(fixturesByUrl["/t/281.json"]);
       const startDate = moment
         .tz("Africa/Cairo")
         .add(1, "days")
@@ -45,7 +46,7 @@ acceptance(
     needs.user({ default_calendar: "none_selected" });
     needs.settings({ discourse_local_dates_enabled: true });
     needs.pretender((server, helper) => {
-      const response = { ...fixturesByUrl["/t/281.json"] };
+      const response = cloneJSON(fixturesByUrl["/t/281.json"]);
       const startDate = moment
         .tz("Africa/Cairo")
         .subtract(1, "days")
@@ -71,7 +72,7 @@ acceptance(
     needs.user({ default_calendar: "google" });
     needs.settings({ discourse_local_dates_enabled: true });
     needs.pretender((server, helper) => {
-      const response = { ...fixturesByUrl["/t/281.json"] };
+      const response = cloneJSON(fixturesByUrl["/t/281.json"]);
       const startDate = moment
         .tz("Africa/Cairo")
         .add(1, "days")


### PR DESCRIPTION
Spread does shallow clone, so changes in these tests leak.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
