### PR TITLE
DEV: Remove RTLit gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,6 @@ end
 # Allow everywhere for now cause we are allowing asset debugging in production
 group :assets do
   gem 'uglifier'
-  gem 'rtlit', require: false # for css rtling
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,7 +413,6 @@ GEM
       activesupport (>= 3.1, < 7.1)
       json-schema (~> 2.2)
       railties (>= 3.1, < 7.1)
-    rtlit (0.0.5)
     rubocop (1.28.2)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -615,7 +614,6 @@ DEPENDENCIES
   rspec-rails
   rss
   rswag-specs
-  rtlit
   rubocop-discourse
   ruby-prof
   ruby-readability

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -179,9 +179,6 @@ serve_static_assets = false
 # number of sidekiq workers (launched via unicorn master)
 sidekiq_workers = 5
 
-# adjust stylesheets to rtl (requires "rtlit" gem)
-rtl_css = false
-
 # connection reaping helps keep connection counts down, postgres
 # will not work properly with huge numbers of open connections
 # reap connections from pool that are older than 30 seconds


### PR DESCRIPTION
Its only use was removed 7 years ago in #3377.