### PR TITLE
FIX: destroys instance when hiding date popover

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -268,6 +268,9 @@ export default {
       allowHTML: true,
       interactive: true,
       appendTo: "parent",
+      onHidden: (instance) => {
+        instance.destroy();
+      },
     });
   },
 


### PR DESCRIPTION
This fix attempts to fix an issue where the preview was not updated after changing timezone. Changing time would work as it would recreate the date DOM element and as a result, reset the popper.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
