### PR TITLE
FIX: Missing translation when translation override contained a `%{key}`

### DIFF
--- a/lib/freedom_patches/translate_accelerator.rb
+++ b/lib/freedom_patches/translate_accelerator.rb
@@ -23,6 +23,7 @@ module I18n
 
     def init_accelerator!(overrides_enabled: true)
       @overrides_enabled = overrides_enabled
+      reserve_key(:overrides)
       execute_reload
     end
 

--- a/spec/fixtures/i18n/translate_accelerator.de.yml
+++ b/spec/fixtures/i18n/translate_accelerator.de.yml
@@ -2,3 +2,4 @@ de:
   foo: "Foo in :de"
   bar: "Bar in :de"
   wat: "Hello %{count}"
+  foo_with_variable: "Foo in :de with %{variable}"

--- a/spec/fixtures/i18n/translate_accelerator.en.yml
+++ b/spec/fixtures/i18n/translate_accelerator.en.yml
@@ -2,6 +2,7 @@ en:
   got: "winter"
   foo: "Foo in :en"
   bar: "Bar in :en"
+  foo_with_variable: "Foo in :en with %{variable}"
   wat: "Hello %{count}"
   world: "Hello %{world}"
   items:

--- a/spec/lib/freedom_patches/translate_accelerator_spec.rb
+++ b/spec/lib/freedom_patches/translate_accelerator_spec.rb
@@ -221,6 +221,19 @@ describe "translate accelerator" do
       override_translation('en', 'fish', 'fake fish')
       expect(Fish.model_name.human).to eq('Fish')
     end
+
+    it "works when the override contains an interpolation key" do
+      expect(I18n.t("foo_with_variable")).to eq("Foo in :en with %{variable}")
+      I18n.with_locale(:de) { expect(I18n.t("foo_with_variable")).to eq("Foo in :de with %{variable}") }
+
+      override_translation("en", "foo_with_variable", "Override in :en with %{variable}")
+      expect(I18n.t("foo_with_variable")).to eq("Override in :en with %{variable}")
+      I18n.with_locale(:de) { expect(I18n.t("foo_with_variable")).to eq("Foo in :de with %{variable}") }
+
+      override_translation("de", "foo_with_variable", "Override in :de with %{variable}")
+      expect(I18n.t("foo_with_variable")).to eq("Override in :en with %{variable}")
+      I18n.with_locale(:de) { expect(I18n.t("foo_with_variable")).to eq("Override in :de with %{variable}") }
+    end
   end
 
   context "translation precedence" do


### PR DESCRIPTION
This happened only for languages other than "en" and when `I18n.t` was called without any interpolation keys. The lib still tried to interpolate keys because it interpreted the `overrides` option as interpolation key.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
