### PR TITLE
DEV: Improve lefthook config and remove some slow hooks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,11 +9,13 @@ app/assets/javascripts/discourse/lib/autosize.js
 lib/javascripts/locale/
 lib/javascripts/messageformat.js
 lib/highlight_js/
+lib/pretty_text/
 plugins/**/lib/javascripts/locale
 public/
 vendor/
 app/assets/javascripts/discourse/tests/test-boot-rails.js
 app/assets/javascripts/discourse/tests/fixtures
 node_modules/
+spec/
 dist/
 tmp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,6 +24,7 @@ public/
 vendor/
 app/assets/javascripts/discourse/tests/test-boot-rails.js
 app/assets/javascripts/discourse/tests/fixtures
+spec/
 node_modules/
 dist/
 **/*.rb

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,21 +1,25 @@
+skip_output:
+  - meta
+  - success
+
 pre-commit:
   parallel: true
   commands:
     rubocop:
       glob: "*.rb"
-      run: bundle exec rubocop --parallel {staged_files}
+      run: bundle exec rubocop --parallel --force-exclusion {staged_files}
     prettier:
       glob: "*.js"
-      include: "app/assets/javascripts|test/javascripts"
+      include: "app/assets/javascripts|plugins/.+?/assets/javascripts"
       run: yarn pprettier --list-different {staged_files}
     prettier-scss:
       glob: "*.scss"
-      include: "app/assets/stylesheets"
+      include: "app/assets/stylesheets|plugins/.+?/assets/stylesheets"
       run: yarn pprettier --list-different {staged_files}
     eslint:
       glob: "*.js"
-      include: "app/assets/javascripts|test/javascripts"
-      run: yarn eslint -f compact {staged_files}
+      include: "app/assets/javascripts|plugins/.+?/assets/javascripts"
+      run: yarn eslint -f compact --quiet {staged_files}
     ember-template-lint:
       run: yarn run ember-template-lint {staged_files}
     yaml-syntax:
@@ -27,46 +31,25 @@ pre-commit:
       glob: "**/{client,server}.en.yml"
       run: bundle exec ruby script/i18n_lint.rb {staged_files}
 
-commands: &commands
-  bundle-install:
-    files: git diff --name-only HEAD main
-    glob: "{Gemfile,Gemfile.lock,*.gemspec}"
-    run: bundle install
-  yarn-install:
-    files: git diff --name-only HEAD main
-    glob: "{package.json,yarn.lock}"
-    run: yarn install
-
-post-checkout:
-  commands: *commands
-
-post-merge:
-  commands: *commands
-
-post-rewrite:
-  commands: *commands
-
 lints:
   parallel: true
   commands:
     rubocop:
+      glob: "*.rb"
       run: bundle exec rubocop --parallel
     prettier:
-      glob: "*.js"
-      include: "app/assets/javascripts|test/javascripts"
-      run: yarn pprettier --list-different {all_files}
+      run: yarn pprettier --list-different **/*.js
     prettier-scss:
-      glob: "*.scss"
-      include: "app/assets/stylesheets"
-      run: yarn pprettier --list-different {all_files}
-    eslint-assets-js:
-      run: yarn eslint app/assets/javascripts
-    eslint-test-js:
-      run: yarn eslint test/javascripts
-    eslint-plugins-assets:
-      run: yarn eslint plugins/**/assets/javascripts
-    eslint-plugins-test:
-      run: yarn eslint plugins/**/test/javascripts
+      run: yarn pprettier --list-different **/*.scss
+    eslint:
+      run: yarn eslint -f compact --quiet --ext .js .
+    ember-template-lint:
+      run: yarn run ember-template-lint .
+    yaml-syntax:
+      glob: "*.{yaml,yml}"
+      # database.yml is an erb file not a yaml file
+      exclude: "database.yml"
+      run: bundle exec yaml-lint {all_files}
     i18n-lint:
       glob: "**/{client,server}.en.yml"
       run: bundle exec ruby script/i18n_lint.rb {all_files}


### PR DESCRIPTION
They were slowing down post-checkout, post-merge and post-rewrite.
This also cleans up the "lints" section which was running into problems with `{all_files}` being to much for some tools to handle. And it makes sure that eslint and prettier runs for core plugins as well.