### PR TITLE
FIX: Users with unicode usernames unable to load more topics in activity

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -424,12 +424,21 @@ class ListController < ApplicationController
       end
 
     opts = opts.dup
+
     if SiteSetting.unicode_usernames && opts[:group_name]
       opts[:group_name] = UrlHelper.encode_component(opts[:group_name])
     end
+
     opts.delete(:category) if page_params.include?(:category_slug_path_with_id)
 
-    public_send(method, opts.merge(page_params)).sub('.json?', '?')
+    url = public_send(method, opts.merge(page_params)).sub('.json?', '?')
+
+    # Unicode usernames need to be encoded when calling Rails' path helper. However, it means that the already
+    # encoded username are encoded again which we do not want. As such, we unencode the url once when unicode usernames
+    # have been enabled.
+    url = UrlHelper.unencode(url) if SiteSetting.unicode_usernames
+
+    url
   end
 
   def ensure_can_see_profile!(target_user = nil)

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -638,6 +638,26 @@ RSpec.describe ListController do
       expect(json["topic_list"]["topics"].size).to eq(2)
     end
 
+    context "unicode usernames" do
+      before do
+        SiteSetting.unicode_usernames = true
+      end
+
+      it "should return the more_topics_url in the encoded form" do
+        stub_const(TopicQuery, "DEFAULT_PER_PAGE_COUNT", 1) do
+          user.update!(username: "快快快")
+
+          get "/topics/created-by/#{UrlHelper.encode(user.username)}.json"
+
+          expect(response.status).to eq(200)
+
+          json = response.parsed_body
+
+          expect(json["topic_list"]["more_topics_url"]).to eq("/topics/created-by/%E5%BF%AB%E5%BF%AB%E5%BF%AB?page=1")
+        end
+      end
+    end
+
     context 'when `hide_profile_and_presence` is true' do
       before do
         user.user_option.update_columns(hide_profile_and_presence: true)


### PR DESCRIPTION
This was due to a server side bug when unicode usernames have been
enabled. We were double encoding the unicode username in the URL
resulting in a invalid URL.