### PR TITLE
DEV: Convert notify_about_flags_after to float

### DIFF
--- a/app/jobs/scheduled/pending_reviewables_reminder.rb
+++ b/app/jobs/scheduled/pending_reviewables_reminder.rb
@@ -3,7 +3,7 @@
 module Jobs
 
   class PendingReviewablesReminder < ::Jobs::Scheduled
-    every 1.hour
+    every 15.minutes
 
     attr_reader :sent_reminder
 

--- a/app/jobs/scheduled/pending_reviewables_reminder.rb
+++ b/app/jobs/scheduled/pending_reviewables_reminder.rb
@@ -14,7 +14,7 @@ module Jobs
         reviewable_ids = Reviewable
           .pending
           .default_visible
-          .where('latest_score < ?', SiteSetting.notify_about_flags_after.to_i.hours.ago)
+          .where('latest_score < ?', SiteSetting.notify_about_flags_after.to_f.hours.ago)
           .order('id DESC')
           .pluck(:id)
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2237,7 +2237,10 @@ uncategorized:
     default: -1
     hidden: true
 
-  notify_about_flags_after: 48
+  notify_about_flags_after:
+    type: float
+    default: 48
+    min: 0.25
 
   show_create_topics_notice:
     client: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2240,7 +2240,6 @@ uncategorized:
   notify_about_flags_after:
     type: float
     default: 48
-    min: 0.25
 
   show_create_topics_notice:
     client: true

--- a/spec/jobs/pending_reviewables_reminder_spec.rb
+++ b/spec/jobs/pending_reviewables_reminder_spec.rb
@@ -24,6 +24,20 @@ describe Jobs::PendingReviewablesReminder do
     end
   end
 
+  context "notify_about_flags_after accepts a float" do
+    before { SiteSetting.notify_about_flags_after = 0.25 }
+
+    it "doesn't send message when flags are less than 15 minutes old" do
+      create_flag(14.minutes.ago)
+      expect(execute.sent_reminder).to eq(true)
+    end
+
+    it "sends message when there is a flag older than 15 minutes" do
+      create_flag(16.minutes.ago)
+      expect(execute.sent_reminder).to eq(true)
+    end
+  end
+
   context "notify_about_flags_after is 48" do
     before do
       SiteSetting.notify_about_flags_after = 48

--- a/spec/jobs/pending_reviewables_reminder_spec.rb
+++ b/spec/jobs/pending_reviewables_reminder_spec.rb
@@ -29,7 +29,7 @@ describe Jobs::PendingReviewablesReminder do
 
     it "doesn't send message when flags are less than 15 minutes old" do
       create_flag(14.minutes.ago)
-      expect(execute.sent_reminder).to eq(true)
+      expect(execute.sent_reminder).to eq(false)
     end
 
     it "sends message when there is a flag older than 15 minutes" do


### PR DESCRIPTION
Add support for `notify_about_flags_after` to be set to a float.

The `PendingReviewablesReminder` job runs every fifteen minutes so I don't think it is necessary to have a custom validator to check for `0.25` increments. 
