### PR TITLE
FIX: Add email to admin user list when show_emails is enabled

### DIFF
--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -69,7 +69,7 @@ class AdminUserIndexQuery
       query = query.includes(:user_stat)
     end
 
-    query = query.joins(:primary_email) if params[:show_emails]
+    query = query.joins(:primary_email) if params[:show_emails] == "true"
 
     query
   end

--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -69,6 +69,8 @@ class AdminUserIndexQuery
       query = query.includes(:user_stat)
     end
 
+    query = query.joins(:primary_email) if params[:show_emails]
+
     query
   end
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe Admin::UsersController do
         end.to change { UserHistory.where(action: UserHistory.actions[:check_email], acting_user_id: admin.id).count }.by(1)
         expect(response.status).to eq(200)
       end
+
+      it "can be ordered by emails" do
+        get "/admin/users/list.json", params: { show_emails: "true", order: "email" }
+        expect(response.status).to eq(200)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes a regression on be519d2 where this case wasn't accounted for.

Reported at https://meta.discourse.org/t/-/226094
