### PR TITLE
DEV: Convert notify_about_queued_posts_after to accept a float

### DIFF
--- a/app/jobs/scheduled/pending_queued_posts_reminder.rb
+++ b/app/jobs/scheduled/pending_queued_posts_reminder.rb
@@ -3,7 +3,7 @@
 module Jobs
   class PendingQueuedPostsReminder < ::Jobs::Scheduled
 
-    every 1.hour
+    every 15.minutes
 
     def execute(args)
       return true unless SiteSetting.notify_about_queued_posts_after > 0
@@ -28,7 +28,7 @@ module Jobs
 
     def should_notify_ids
       ReviewableQueuedPost.where(status: Reviewable.statuses[:pending]).where(
-        'created_at < ?', SiteSetting.notify_about_queued_posts_after.hours.ago
+        'created_at < ?', SiteSetting.notify_about_queued_posts_after.to_f.hours.ago
       ).pluck(:id)
     end
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -989,6 +989,7 @@ posting:
   approve_unless_staged:
     default: false
   notify_about_queued_posts_after:
+    type: float
     default: 24
   auto_close_messages_post_count:
     default: 500

--- a/spec/jobs/pending_queued_posts_reminder_spec.rb
+++ b/spec/jobs/pending_queued_posts_reminder_spec.rb
@@ -17,24 +17,18 @@ describe Jobs::PendingQueuedPostsReminder do
   context "notify_about_queued_posts_after accepts a float" do
     before do
       SiteSetting.notify_about_queued_posts_after = 0.25
+      job.last_notified_id = nil
     end
 
-    context "when we haven't been notified in a while" do
-
-      before do
-        job.last_notified_id = nil
-      end
-
-      it "creates system message if there are new queued posts" do
-        Fabricate(:reviewable_queued_post, created_at: 16.minutes.ago)
-        Fabricate(:reviewable_queued_post, created_at: 14.minutes.ago)
-        # expect 16 minute post to be picked up but not 14 min post
-        expect { job.execute({}) }.to change { Post.count }.by(1)
-        expect(Topic.where(
-          subtype: TopicSubtype.system_message,
-          title: I18n.t('system_messages.queued_posts_reminder.subject_template', count: 1)
-        ).exists?).to eq(true)
-      end
+    it "creates system message if there are new queued posts" do
+      Fabricate(:reviewable_queued_post, created_at: 16.minutes.ago)
+      Fabricate(:reviewable_queued_post, created_at: 14.minutes.ago)
+      # expect 16 minute post to be picked up but not 14 min post
+      expect { job.execute({}) }.to change { Post.count }.by(1)
+      expect(Topic.where(
+        subtype: TopicSubtype.system_message,
+        title: I18n.t('system_messages.queued_posts_reminder.subject_template', count: 1)
+      ).exists?).to eq(true)
     end
   end
 

--- a/spec/jobs/pending_queued_posts_reminder_spec.rb
+++ b/spec/jobs/pending_queued_posts_reminder_spec.rb
@@ -14,6 +14,30 @@ describe Jobs::PendingQueuedPostsReminder do
     end
   end
 
+  context "notify_about_queued_posts_after accepts a float" do
+    before do
+      SiteSetting.notify_about_queued_posts_after = 0.25
+    end
+
+    context "when we haven't been notified in a while" do
+
+      before do
+        job.last_notified_id = nil
+      end
+
+      it "creates system message if there are new queued posts" do
+        Fabricate(:reviewable_queued_post, created_at: 16.minutes.ago)
+        Fabricate(:reviewable_queued_post, created_at: 14.minutes.ago)
+        # expect 16 minute post to be picked up but not 14 min post
+        expect { job.execute({}) }.to change { Post.count }.by(1)
+        expect(Topic.where(
+          subtype: TopicSubtype.system_message,
+          title: I18n.t('system_messages.queued_posts_reminder.subject_template', count: 1)
+        ).exists?).to eq(true)
+      end
+    end
+  end
+
   context "notify_about_queued_posts_after is 24" do
     before do
       SiteSetting.notify_about_queued_posts_after = 24


### PR DESCRIPTION
Add support for `notify_about_queued_posts_after` to be set to a float to allow for 15 min increments