### PR TITLE
FIX: Validate post's polls as acting user

### DIFF
--- a/plugins/poll/lib/post_validator.rb
+++ b/plugins/poll/lib/post_validator.rb
@@ -9,7 +9,7 @@ module DiscoursePoll
     def validate_post
       min_trust_level = SiteSetting.poll_minimum_trust_level_to_create
 
-      if @post&.acting_user&.staff? || @post&.acting_user&.trust_level >= TrustLevel[min_trust_level] || @post&.topic&.pm_with_non_human_user?
+      if (@post.acting_user && (@post.acting_user.staff? || @post.acting_user.trust_level >= TrustLevel[min_trust_level])) || @post.topic&.pm_with_non_human_user?
         true
       else
         @post.errors.add(:base, I18n.t("poll.insufficient_rights_to_create"))

--- a/plugins/poll/lib/post_validator.rb
+++ b/plugins/poll/lib/post_validator.rb
@@ -9,7 +9,7 @@ module DiscoursePoll
     def validate_post
       min_trust_level = SiteSetting.poll_minimum_trust_level_to_create
 
-      if @post&.user&.staff? || @post&.user&.trust_level >= TrustLevel[min_trust_level] || @post&.topic&.pm_with_non_human_user?
+      if @post&.acting_user&.staff? || @post&.acting_user&.trust_level >= TrustLevel[min_trust_level] || @post&.topic&.pm_with_non_human_user?
         true
       else
         @post.errors.add(:base, I18n.t("poll.insufficient_rights_to_create"))


### PR DESCRIPTION
It used to validate the post from the perspective of the user who
created the post. That did not work well when an admin attempted to
add a poll to a post created by a user who cannot create posts because
it said the user cannot create polls.

The problem was that it used post.user for the validation process
instead of post.acting_user.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
