### PR TITLE
DEV: Drop `TrackingLogger` for `FakeLogger`

### DIFF
--- a/spec/lib/scheduler/defer_spec.rb
+++ b/spec/lib/scheduler/defer_spec.rb
@@ -25,21 +25,24 @@ describe Scheduler::Defer do
   it "supports timeout reporting" do
     @defer.timeout = 0.05
 
-    m = track_log_messages do |messages|
+    logger = track_log_messages do |logger|
       10.times do
         @defer.later("fast job") {}
       end
+
       @defer.later "weird slow job" do
         sleep
       end
 
       wait_for(200) do
-        messages.length == 1
+        logger.errors.length == 1
       end
     end
 
-    expect(m.length).to eq(1)
-    expect(m[0][2]).to include("weird slow job")
+    expect(logger.warnings.length).to eq(0)
+    expect(logger.fatals.length).to eq(0)
+    expect(logger.errors.length).to eq(1)
+    expect(logger.errors).to include(/'weird slow job' is still running/)
   end
 
   it "can pause and resume" do

--- a/spec/lib/scheduler/defer_spec.rb
+++ b/spec/lib/scheduler/defer_spec.rb
@@ -25,7 +25,7 @@ describe Scheduler::Defer do
   it "supports timeout reporting" do
     @defer.timeout = 0.05
 
-    logger = track_log_messages do |logger|
+    logger = track_log_messages do |l|
       10.times do
         @defer.later("fast job") {}
       end
@@ -35,7 +35,7 @@ describe Scheduler::Defer do
       end
 
       wait_for(200) do
-        logger.errors.length == 1
+        l.errors.length == 1
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -429,25 +429,11 @@ ensure
   STDOUT.unstub(:write)
 end
 
-class TrackingLogger < ::Logger
-  attr_reader :messages
-  def initialize(level: nil)
-    super(nil)
-    @messages = []
-    @level = level
-  end
-  def add(*args, &block)
-    if !level || args[0].to_i >= level
-      @messages << args
-    end
-  end
-end
-
-def track_log_messages(level: nil)
+def track_log_messages
   old_logger = Rails.logger
-  logger = Rails.logger = TrackingLogger.new(level: level)
-  yield logger.messages
-  logger.messages
+  logger = Rails.logger = FakeLogger.new
+  yield logger
+  logger
 ensure
   Rails.logger = old_logger
 end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -591,11 +591,13 @@ describe SessionController do
       sso.external_id = '   '
       sso.username = 'sam'
 
-      messages = track_log_messages(level: Logger::WARN) do
+      logger = track_log_messages do
         get "/session/sso_login", params: Rack::Utils.parse_query(sso.payload), headers: headers
       end
 
-      expect(messages.length).to eq(0)
+      expect(logger.warnings.length).to eq(0)
+      expect(logger.errors.length).to eq(0)
+      expect(logger.fatals.length).to eq(0)
       expect(response.status).to eq(500)
       expect(response.body).to include(I18n.t('discourse_connect.blank_id_error'))
     end
@@ -607,11 +609,13 @@ describe SessionController do
       sso.external_id = '123'
       sso.username = 'sam'
 
-      messages = track_log_messages(level: Logger::WARN) do
+      logger = track_log_messages do
         get "/session/sso_login", params: Rack::Utils.parse_query(sso.payload), headers: headers
       end
 
-      expect(messages.length).to eq(0)
+      expect(logger.warnings.length).to eq(0)
+      expect(logger.errors.length).to eq(0)
+      expect(logger.fatals.length).to eq(0)
       expect(response.status).to eq(500)
       expect(response.body).to include(I18n.t("discourse_connect.email_error", email: ERB::Util.html_escape("test@test.com")))
     end

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -85,10 +85,10 @@ describe UserDestroyer do
 
     context 'context is missing' do
       it "logs warning message if context is missing" do
-        messages = track_log_messages(level: Logger::WARN) do
+        logger = track_log_messages do
           UserDestroyer.new(admin).destroy(user)
         end
-        expect(messages[0][2]).to include("User destroyed without context from:")
+        expect(logger.warnings).to include(/User destroyed without context from:/)
       end
     end
 

--- a/spec/support/fake_logger.rb
+++ b/spec/support/fake_logger.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
 class FakeLogger
-  attr_reader :warnings, :errors, :infos, :fatals
+  attr_reader :debug, :infos, :warnings, :errors, :fatals
   attr_accessor :level
 
   def initialize
-    @warnings = []
-    @errors = []
     @debug = []
     @infos = []
+    @warnings = []
+    @errors = []
     @fatals = []
+  end
+
+  def debug(message)
+    @debug << message
   end
 
   def info(message = nil)
@@ -26,10 +30,6 @@ class FakeLogger
 
   def fatal(message)
     @fatals << message
-  end
-
-  def debug(message)
-    @debug << message
   end
 
   def formatter


### PR DESCRIPTION
Together with #16640 this reduces three test loggers to only one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
