### PR TITLE
DEV: apply `watched-words` rule before `linkify`

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
@@ -75,7 +75,7 @@ export function setup(helper) {
 
     const cache = new Map();
 
-    md.core.ruler.push("watched-words", (state) => {
+    md.core.ruler.before("linkify", "watched-words", (state) => {
       for (let j = 0, l = state.tokens.length; j < l; j++) {
         if (state.tokens[j].type !== "inline") {
           continue;


### PR DESCRIPTION
This allows the a watched word to be a link. Its useful for replacing spammy links
per https://meta.discourse.org/t/225668