### PR TITLE
UX: Ensure `#main-outlet-wrapper` takes full width.

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -184,6 +184,7 @@ input {
 }
 
 #main-outlet-wrapper {
+  width: 100%;
   display: grid;
   grid-template-areas: "content";
   grid-template-columns: 1fr;


### PR DESCRIPTION
For some reason, we're seeing inconsistency between production and
development environment where the computed width of #main-outlet-wrapper
is not taking the full width of the grid column in production.

Follow-up to b35cf7cc0c5845924b57399f418d7f5e58887a65.