### PR TITLE
FIX: Prevent admin theme settings from blowing up

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -187,7 +187,7 @@ input {
   width: 100%;
   display: grid;
   grid-template-areas: "content";
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
   gap: 0;
 
   &.has-sidebar {


### PR DESCRIPTION
Only the theme page is blowing up and overflowing due to `display: grid`. It can be prevented by simply setting a max for the grid column.