### PR TITLE
FIX: prevents double user_badge_granted event

### DIFF
--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -495,7 +495,7 @@ class BadgeGranter
   end
 
   def self.send_notification(user_id, username, locale, badge)
-    notification = I18n.with_locale(notification_locale(locale)) do
+    I18n.with_locale(notification_locale(locale)) do
       Notification.create!(
         user_id: user_id,
         notification_type: Notification.types[:granted_badge],
@@ -508,10 +508,6 @@ class BadgeGranter
         }.to_json
       )
     end
-
-    DiscourseEvent.trigger(:user_badge_granted, badge, user_id)
-
-    notification
   end
 
   def self.suppress_notification?(badge, granted_at, skip_new_user_tips)


### PR DESCRIPTION
This bug was causing double events to be fired as :user_badge_granted is already called when a `user_badge` is created. More over the signature of the block in the UserBadge code is `badge_id, user_id` not `badge, user_id`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
