### PR TITLE
DEV: Remove the last use of `NO_EMBER_CLI`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,12 +101,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def ember_cli_required?
-    Rails.env.development? && ENV['NO_EMBER_CLI'] != '1' && request.headers['X-Discourse-Ember-CLI'] != 'true'
-  end
-
   def application_layout
-    ember_cli_required? ? "ember_cli" : "application"
+    if Rails.env.development? && ENV["EMBER_CLI_PROD_ASSETS"] != "0" && request.headers["X-Discourse-Ember-CLI"] != "true"
+      "ember_cli"
+    else
+      "application"
+    end
   end
 
   def set_layout


### PR DESCRIPTION
It was already mostly replaced by `EMBER_CLI_PROD_ASSETS`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
