### PR TITLE
FEATURE: Promote the "delete group" staff action log.

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -45,10 +45,8 @@ class Admin::GroupsController < Admin::AdminController
     if group.automatic
       can_not_modify_automatic
     else
-      details = { name: group.name }
-      details[:grant_trust_level] = group.grant_trust_level if group.grant_trust_level
+      StaffActionLogger.new(current_user).log_group_deletetion(group)
 
-      StaffActionLogger.new(current_user).log_custom('delete_group', details)
       group.destroy!
       render json: success_json
     end

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -116,7 +116,8 @@ class UserHistory < ActiveRecord::Base
       post_staff_note_create: 95,
       post_staff_note_destroy: 96,
       watched_word_create: 97,
-      watched_word_destroy: 98
+      watched_word_destroy: 98,
+      delete_group: 99
     )
   end
 
@@ -209,7 +210,8 @@ class UserHistory < ActiveRecord::Base
       :post_staff_note_create,
       :post_staff_note_destroy,
       :watched_word_create,
-      :watched_word_destroy
+      :watched_word_destroy,
+      :delete_group
     ]
   end
 

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -831,6 +831,25 @@ class StaffActionLogger
     )
   end
 
+  def log_group_deletetion(group)
+    raise Discourse::InvalidParameters.new(:group) if group.nil?
+
+    details = [
+      "name: #{group.name}",
+      "id: #{group.id}"
+    ]
+
+    if group.grant_trust_level
+      details << "grant_trust_level: #{group.grant_trust_level}"
+    end
+
+    UserHistory.create!(
+      acting_user_id: @admin.id,
+      action: UserHistory.actions[:delete_group],
+      details: details.join(', ')
+    )
+  end
+
   private
 
   def get_changes(changes)

--- a/db/migrate/20220505133851_migrate_custom_group_deletion_logs.rb
+++ b/db/migrate/20220505133851_migrate_custom_group_deletion_logs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class MigrateCustomGroupDeletionLogs < ActiveRecord::Migration[7.0]
+  def up
+    DB.exec(<<~SQL, group_deleted_id: 99, custom_action_id: 23)
+      UPDATE user_histories
+      SET action = :group_deleted_id, custom_type = NULL
+      WHERE action = :custom_action_id AND custom_type = 'delete_group'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/requests/admin/groups_controller_spec.rb
+++ b/spec/requests/admin/groups_controller_spec.rb
@@ -274,6 +274,7 @@ RSpec.describe Admin::GroupsController do
 
       expect(history).to be_present
       expect(history.details).to include("name: #{group.name}")
+      expect(history.details).to include("id: #{group.id}")
     end
 
     it 'logs the grant_trust_level attribute' do


### PR DESCRIPTION
We used to log group deletion as custom, which means we can't later search for them. Include group ID in the details.

