### PR TITLE
FIX: remove horizontal scoll from narrow screens

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -14,6 +14,7 @@
   backface-visibility: hidden; /** do magic for scrolling performance **/
 
   > .wrap {
+    box-sizing: border-box;
     width: 100%;
     height: 100%;
 

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -184,6 +184,7 @@ input {
 }
 
 #main-outlet-wrapper {
+  box-sizing: border-box;
   width: 100%;
   display: grid;
   grid-template-areas: "content";


### PR DESCRIPTION
Follow-up to 36dcf80aff944500c2cdd183613af466efe35591

On narrow screens, a vertical scroll appears due to padding. `border-box` fixes this. 

![Screen Shot 2022-05-05 at 11 27 22 AM](https://user-images.githubusercontent.com/1681963/166958171-728c882e-64af-4fa4-aa30-2afe4ac2cbe8.png)
 