### PR TITLE
FEATURE: Restore scroll on user activity pages

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-list.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.js
@@ -2,7 +2,6 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import { schedule } from "@ember/runloop";
 import bootbox from "bootbox";
-import discourseDebounce from "discourse-common/lib/debounce";
 import { openBookmarkModal } from "discourse/controllers/bookmark";
 import { ajax } from "discourse/lib/ajax";
 import {
@@ -28,18 +27,12 @@ export default Component.extend(Scrolling, {
   },
 
   scrollToLastPosition() {
-    let scrollTo = this.session.bookmarkListScrollPosition;
-    if (scrollTo && scrollTo >= 0) {
+    const scrollTo = this.session.bookmarkListScrollPosition;
+    if (scrollTo > 0) {
       schedule("afterRender", () => {
-        discourseDebounce(
-          this,
-          function () {
-            if (this.element && !this.isDestroying && !this.isDestroyed) {
-              window.scrollTo(0, scrollTo + 1);
-            }
-          },
-          0
-        );
+        if (this.element && !this.isDestroying && !this.isDestroyed) {
+          window.scrollTo(0, scrollTo + 1);
+        }
       });
     }
   },

--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
@@ -13,8 +13,8 @@ export default Component.extend(UrlRefresh, LoadMore, {
   @on("didInsertElement")
   @observes("model")
   _readjustScrollPosition() {
-    const scrollTo = this.session.get("topicListScrollPosition");
-    if (scrollTo && scrollTo >= 0) {
+    const scrollTo = this.session.topicListScrollPosition;
+    if (scrollTo > 0) {
       schedule("afterRender", () => $(window).scrollTop(scrollTo + 1));
     } else {
       scheduleOnce("afterRender", this, this.loadMoreUnlessFull);

--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -2,7 +2,6 @@ import { alias, and, reads } from "@ember/object/computed";
 import discourseComputed, { observes } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import LoadMore from "discourse/mixins/load-more";
-import discourseDebounce from "discourse-common/lib/debounce";
 import { on } from "@ember/object/evented";
 import { schedule } from "@ember/runloop";
 import showModal from "discourse/lib/show-modal";
@@ -75,18 +74,12 @@ export default Component.extend(LoadMore, {
       return;
     }
 
-    let scrollTo = this.session.get("topicListScrollPosition");
-    if (scrollTo && scrollTo >= 0) {
+    const scrollTo = this.session.topicListScrollPosition;
+    if (scrollTo > 0) {
       schedule("afterRender", () => {
-        discourseDebounce(
-          this,
-          function () {
-            if (this.element && !this.isDestroying && !this.isDestroyed) {
-              $(window).scrollTop(scrollTo + 1);
-            }
-          },
-          0
-        );
+        if (this.element && !this.isDestroying && !this.isDestroyed) {
+          $(window).scrollTop(scrollTo + 1);
+        }
       });
     }
   },

--- a/app/assets/javascripts/discourse/app/components/user-stream.js
+++ b/app/assets/javascripts/discourse/app/components/user-stream.js
@@ -7,7 +7,6 @@ import LoadMore from "discourse/mixins/load-more";
 import Post from "discourse/models/post";
 import { NEW_TOPIC_KEY } from "discourse/models/composer";
 import bootbox from "bootbox";
-import discourseDebounce from "discourse-common/lib/debounce";
 import { getOwner } from "discourse-common/lib/get-owner";
 import { observes } from "discourse-common/utils/decorators";
 import { on } from "@ember/object/evented";
@@ -74,18 +73,12 @@ export default Component.extend(LoadMore, {
   },
 
   _scrollToLastPosition() {
-    let scrollTo = this.session.userStreamScrollPosition;
-    if (scrollTo && scrollTo >= 0) {
+    const scrollTo = this.session.userStreamScrollPosition;
+    if (scrollTo > 0) {
       schedule("afterRender", () => {
-        discourseDebounce(
-          this,
-          function () {
-            if (this.element && !this.isDestroying && !this.isDestroyed) {
-              window.scrollTo(0, scrollTo + 1);
-            }
-          },
-          0
-        );
+        if (this.element && !this.isDestroying && !this.isDestroyed) {
+          window.scrollTo(0, scrollTo + 1);
+        }
       });
     }
   },

--- a/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-stream.js
@@ -23,6 +23,10 @@ export default DiscourseRoute.extend(ViewingActionType, {
   },
 
   afterModel(model, transition) {
+    if (!this.isPoppedState(transition)) {
+      this.session.set("userStreamScrollPosition", null);
+    }
+
     return model.stream.filterBy({
       filter: this.userActionType,
       actingUsername: transition.to.queryParams.acting_username,

--- a/app/assets/javascripts/discourse/app/routes/user-activity.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity.js
@@ -10,6 +10,12 @@ export default DiscourseRoute.extend({
     return user;
   },
 
+  afterModel(_model, transition) {
+    if (!this.isPoppedState(transition)) {
+      this.session.set("userStreamScrollPosition", null);
+    }
+  },
+
   setupController(controller, user) {
     this.controllerFor("user-activity").set("model", user);
   },


### PR DESCRIPTION
The scroll position was reset everytime the user pressed the back button
and returned to a user activity page. This fix applies only to pages
that uses the user-stream component. Pages with topic lists already had
this functionality implemented.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
