### PR TITLE
FIX: Add translations for 'subcategories_with_featured_topics'

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4985,9 +4985,11 @@ en:
               categories_and_top_topics:
                 label: "Categories and Top Topics"
               categories_boxes:
-                label: "Categories boxes"
+                label: "Categories Boxes"
               categories_boxes_with_topics:
-                label: "Categories boxes with Topics"
+                label: "Categories Boxes with Topics"
+              subcategories_with_featured_topics:
+                label: "Subcategories with Featured Topics"
 
       logos:
         title: "Logos"


### PR DESCRIPTION
Going through the setup wizard, the last option for home page style was `subcategories_with_featured_topics`. Fixed some capitalization too.

### Before
![image](https://user-images.githubusercontent.com/2790986/166999783-b49f0f5d-829e-4878-9709-a5c9e94db956.png)

### After
![image](https://user-images.githubusercontent.com/2790986/166999906-177e8159-0f2b-4840-a9e4-b9ce9395ff8f.png)
