### PR TITLE
DEV: Move sidekiq code out of initializers and into freedom patch

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -15,17 +15,6 @@ Sidekiq.configure_server do |config|
 end
 
 if Sidekiq.server?
-
-  module Sidekiq
-    class CLI
-      private
-
-      def print_banner
-        # banner takes up too much space
-      end
-    end
-  end
-
   # defer queue should simply run in sidekiq
   Scheduler::Defer.async = false
 

--- a/lib/freedom_patches/sidekiq.rb
+++ b/lib/freedom_patches/sidekiq.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  class CLI
+    private
+
+    def print_banner
+      # banner takes up too much space
+    end
+  end
+end


### PR DESCRIPTION
This code fits more naturally in a freedom patch.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
