### PR TITLE
DEV: Replace postCreateCommand with postStartCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "settings": {
     "search.followSymlinks": false
   },
-  "postCreateCommand": "sudo /sbin/boot",
+  "postStartCommand": "sudo /sbin/boot",
   "extensions": ["rebornix.Ruby"],
   "forwardPorts": [9292],
   "remoteUser": "discourse",


### PR DESCRIPTION
The boot script should be run whenever the container is started. Otherwise, when you restart a stopped container you don't have the database running.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
