### PR TITLE
DEV: Add last_seen_reviewable_id to the users table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1835,6 +1835,7 @@ end
 #  manual_locked_trust_level :integer
 #  secure_identifier         :string
 #  flair_group_id            :integer
+#  last_seen_reviewable_id   :integer
 #
 # Indexes
 #

--- a/db/migrate/20220505191131_add_last_seen_reviewable_id_to_user.rb
+++ b/db/migrate/20220505191131_add_last_seen_reviewable_id_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastSeenReviewableIdToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :last_seen_reviewable_id, :integer
+  end
+end


### PR DESCRIPTION
We're adding this column now in preparation for a future commit(s) that will
redesign the avatar/notifications menu. The reason the column is added in a
separate commit is because the redesign changes are going to be complex with a
high risk of getting (temporarily) revereted and if they included a database
migration, they wouldn't revert cleanly/easily.

Internal ticket: t65045.