### PR TITLE
DEV: Remove an obsolete config line

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -107,11 +107,6 @@ module Discourse
     multisite_config_path = ENV['DISCOURSE_MULTISITE_CONFIG_PATH'] || GlobalSetting.multisite_config_path
     config.multisite_config_path = File.absolute_path(multisite_config_path, Rails.root)
 
-    # Disable so this is only run manually
-    # we may want to change this later on
-    # issue is image_optim crashes on missing dependencies
-    config.assets.image_optim = false
-
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths << "#{root}/lib"
     config.autoload_paths << "#{root}/lib/guardian"


### PR DESCRIPTION
```
Post-install message from image_optim:
Rails image assets optimization is extracted into image_optim_rails gem
You can safely remove `config.assets.image_optim = false` if you are not going to use that gem
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
