### PR TITLE
DEV: allows to set a class on d-popover component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-popover.js
+++ b/app/assets/javascripts/discourse/app/components/d-popover.js
@@ -10,6 +10,8 @@ export default class DiscoursePopover extends Component {
 
   options = null;
 
+  class = null;
+
   didInsertElement() {
     this._super(...arguments);
 

--- a/app/assets/javascripts/discourse/app/templates/components/d-popover.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-popover.hbs
@@ -1,3 +1,3 @@
-<div id={{componentId}} class="d-popover {{if isExpanded "is-expanded"}}">
+<div id={{componentId}} class="d-popover {{class}} {{if isExpanded "is-expanded"}}">
   {{yield (hash isExpanded=isExpanded)}}
 </div>

--- a/app/assets/javascripts/discourse/tests/integration/components/d-popover-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-popover-test.js
@@ -73,4 +73,12 @@ discourseModule("Integration | Component | d-popover", function (hooks) {
       assert.ok(exists(".d-icon-chevron-up"));
     },
   });
+
+  componentTest("d-popover component accepts a class property", {
+    template: hbs`{{#d-popover class="foo"}}{{/d-popover}}`,
+
+    async test(assert) {
+      assert.ok(exists(".d-popover.foo"));
+    },
+  });
 });


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
