### PR TITLE
UX: prevent user grid blowout on full page search

### DIFF
--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -134,7 +134,7 @@
   .user-items {
     display: grid;
     gap: 2em 1em;
-    grid: auto-flow / repeat(4, 1fr);
+    grid: auto-flow / repeat(4, minmax(0, 1fr));
 
     @include breakpoint(medium) {
       grid: auto-flow / repeat(3, 1fr);
@@ -372,11 +372,13 @@
     .avatar {
       margin-right: 0.5em;
       min-width: 25px;
+      flex: 0 0 auto;
     }
     .user-titles {
       display: flex;
       flex-direction: column;
       max-width: 300px;
+      overflow: hidden;
       .name {
         color: var(--primary-high-or-secondary-low);
         font-size: var(--font-0);


### PR DESCRIPTION
Another chapter in the ongoing battle against the scourge of long usernames

Before: 
![Screen Shot 2022-05-06 at 5 19 31 PM](https://user-images.githubusercontent.com/1681963/167218003-3433cb19-6246-4339-95f1-86418c56cfb5.png)


After:
![Screen Shot 2022-05-06 at 5 19 23 PM](https://user-images.githubusercontent.com/1681963/167218018-f11b074b-2f7e-45aa-b6f2-e5341bda4d77.png)
