### PR TITLE
FIX: Limit pan event handler to fix scrolling in TOC

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -168,14 +168,18 @@ export default Component.extend(PanEvents, {
   },
 
   panStart(e) {
-    if (e.originalEvent.target.classList.contains("docked")) {
+    const target = e.originalEvent.target;
+
+    if (
+      target.classList.contains("docked") ||
+      !target.closest(".timeline-container")
+    ) {
       return;
     }
 
     e.originalEvent.preventDefault();
-    const center = e.center;
-    const $centeredElement = $(document.elementFromPoint(center.x, center.y));
-    if ($centeredElement.parents(".timeline-scrollarea-wrapper").length) {
+    const centeredElement = document.elementFromPoint(e.center.x, e.center.y);
+    if (centeredElement.closest(".timeline-scrollarea-wrapper").length) {
       this.isPanning = false;
     } else if (e.direction === "up" || e.direction === "down") {
       this.isPanning = true;

--- a/app/assets/javascripts/discourse/app/components/topic-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/topic-navigation.js
@@ -179,7 +179,7 @@ export default Component.extend(PanEvents, {
 
     e.originalEvent.preventDefault();
     const centeredElement = document.elementFromPoint(e.center.x, e.center.y);
-    if (centeredElement.closest(".timeline-scrollarea-wrapper").length) {
+    if (centeredElement.closest(".timeline-scrollarea-wrapper")) {
       this.isPanning = false;
     } else if (e.direction === "up" || e.direction === "down") {
       this.isPanning = true;


### PR DESCRIPTION
Pan events in the mobile topic progress element currently apply to any child element of topic navigation, including elements added by components like DiscoTOC. And because of `e.originalEvent.preventDefault();`, you can't scroll the DiscoTOC element on touch devices. 

This PR limits pan events to the core element (anything under `timeline-container`), therefore allowing DiscoTOC elements to be scrolled without impediment. 