### PR TITLE
FIX: ensures d-popover closes when clicking on popper

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/d-popover.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-popover.hbs
@@ -1,3 +1,4 @@
-<div id={{componentId}} class="d-popover {{class}} {{if isExpanded "is-expanded"}}">
+{{!-- template-lint-disable no-invalid-interactive --}}
+<div {{on "click" (action "close")}} id={{componentId}} class="d-popover {{class}} {{if isExpanded "is-expanded"}}">
   {{yield (hash isExpanded=isExpanded)}}
 </div>

--- a/app/assets/javascripts/discourse/tests/integration/components/d-popover-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-popover-test.js
@@ -39,16 +39,20 @@ discourseModule("Integration | Component | d-popover", function (hooks) {
   });
 
   componentTest("show/hide popover from component", {
-    template: hbs`{{#d-popover}}{{d-button icon="chevron-down"}}<ul><li class="test">foo</li></ul>{{/d-popover}}`,
+    template: hbs`{{#d-popover}}{{d-button class="trigger" icon="chevron-down"}}<ul><li class="test">foo</li><li>{{d-button icon="times" class="closer"}}</li></ul>{{/d-popover}}`,
 
     async test(assert) {
       assert.notOk(exists(".d-popover.is-expanded"));
       assert.notOk(exists(".test"));
 
-      await click(".btn");
+      await click(".trigger");
 
       assert.ok(exists(".d-popover.is-expanded"));
       assert.equal(query(".test").innerText.trim(), "foo");
+
+      await click(".closer");
+
+      assert.notOk(exists(".d-popover.is-expanded"));
     },
   });
 


### PR DESCRIPTION
I think the no-invalid-interaction is fine here as on click Is not actually used for an expected interaction but as an event bubbling barrier.