### PR TITLE
FIX: add support for pipelined and multi redis commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -230,7 +230,7 @@ gem 'cppjieba_rb', require: false
 gem 'lograge', require: false
 gem 'logstash-event', require: false
 gem 'logstash-logger', require: false
-gem 'logster', '2.11.0'
+gem 'logster'
 
 # NOTE: later versions of sassc are causing a segfault, possibly dependent on processer architecture
 # and until resolved should be locked at 2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    logster (2.11.0)
+    logster (2.11.2)
     loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -560,7 +560,7 @@ DEPENDENCIES
   lograge
   logstash-event
   logstash-logger
-  logster (= 2.11.0)
+  logster
   loofah
   lru_redux
   lz4-ruby
@@ -638,4 +638,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.3.5
+   2.3.13

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -181,10 +181,10 @@ class Site
     json = MultiJson.dump(SiteSerializer.new(site, root: false, scope: guardian))
 
     if guardian.anonymous?
-      Discourse.redis.multi do
-        Discourse.redis.setex 'site_json', 1800, json
-        Discourse.redis.set 'site_json_seq', seq
-        Discourse.redis.set 'site_json_version', Discourse.git_version
+      Discourse.redis.multi do |transaction|
+        transaction.setex 'site_json', 1800, json
+        transaction.set 'site_json_seq', seq
+        transaction.set 'site_json_version', Discourse.git_version
       end
     end
 

--- a/app/services/random_topic_selector.rb
+++ b/app/services/random_topic_selector.rb
@@ -40,9 +40,9 @@ class RandomTopicSelector
     key = cache_key(category)
 
     if results.present?
-      Discourse.redis.multi do
-        Discourse.redis.rpush(key, results)
-        Discourse.redis.expire(key, 2.days)
+      Discourse.redis.multi do |transaction|
+        transaction.rpush(key, results)
+        transaction.expire(key, 2.days)
       end
     end
 
@@ -56,9 +56,9 @@ class RandomTopicSelector
 
     return results if count < 1
 
-    results = Discourse.redis.multi do
-      Discourse.redis.lrange(key, 0, count - 1)
-      Discourse.redis.ltrim(key, count, -1)
+    results = Discourse.redis.multi do |transaction|
+      transaction.lrange(key, 0, count - 1)
+      transaction.ltrim(key, count, -1)
     end
 
     if !results.is_a?(Array) # Redis is in readonly mode

--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -14,9 +14,9 @@ class DiscourseRedis
     GlobalSetting.redis_config
   end
 
-  def initialize(config = nil, namespace: true)
+  def initialize(config = nil, namespace: true, raw_redis: nil)
     @config = config || DiscourseRedis.config
-    @redis = DiscourseRedis.raw_connection(@config.dup)
+    @redis = raw_redis || DiscourseRedis.raw_connection(@config.dup)
     @namespace = namespace
   end
 
@@ -148,6 +148,26 @@ class DiscourseRedis
 
   def self.new_redis_store
     Cache.new
+  end
+
+  def multi
+    if block_given?
+      @redis.multi do |transaction|
+        yield DiscourseRedis.new(@config, namespace: @namespace, raw_redis: transaction)
+      end
+    else
+      @redis.multi
+    end
+  end
+
+  def pipelined
+    if block_given?
+      @redis.pipelined do |transaction|
+        yield DiscourseRedis.new(@config, namespace: @namespace, raw_redis: transaction)
+      end
+    else
+      @redis.pipelined
+    end
   end
 
   private

--- a/lib/redis_snapshot.rb
+++ b/lib/redis_snapshot.rb
@@ -14,9 +14,9 @@ class RedisSnapshot
     keys = redis.keys
 
     values =
-      redis.pipelined do
+      redis.pipelined do |batch|
         keys.each do |key|
-          redis.dump(key)
+          batch.dump(key)
         end
       end
 
@@ -28,11 +28,11 @@ class RedisSnapshot
   end
 
   def restore(redis = Discourse.redis)
-    redis.pipelined do
-      redis.flushdb
+    redis.pipelined do |batch|
+      batch.flushdb
 
       @dump.each do |key, value|
-        redis.restore(key, 0, value)
+        batch.restore(key, 0, value)
       end
     end
 

--- a/lib/tasks/redis.rake
+++ b/lib/tasks/redis.rake
@@ -15,13 +15,13 @@ task 'redis:clean_up' => ['environment'] do
     cursor, keys = redis.scan(cursor)
     cursor = cursor.to_i
 
-    redis.multi do
+    redis.multi do |transaction|
       keys.each do |key|
         if match = key.match(regexp)
           db_name = match[:message_bus] || match[:namespace]
 
           if !dbs.include?(db_name)
-            redis.del(key)
+            transaction.del(key)
           end
         end
       end


### PR DESCRIPTION
Latest redis interoduces a block form of multi / pipelined, this was incorrectly
passed through and not namespaced previously.

Fix also updates logster, we held off on upgrading it due to missing functions
