### PR TITLE
FIX: Polymorphic bookmarks for new user narrative bot

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -243,7 +243,6 @@ module DiscourseNarrativeBot
       post
     end
 
-    # TODO (martin) [POLYBOOK] Fix up narrative bot bookmark interactions in a separate PR.
     def missing_bookmark
       return unless valid_topic?(@post.topic_id)
       return if @post.user_id == self.discobot_user.id
@@ -254,7 +253,6 @@ module DiscourseNarrativeBot
       false
     end
 
-    # TODO (martin) [POLYBOOK] Fix up narrative bot bookmark interactions in a separate PR.
     def reply_to_bookmark
       return unless valid_topic?(@post.topic_id)
       return unless @post.user_id == self.discobot_user.id

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -281,10 +281,13 @@ after_initialize do
     end
   end
 
-  # TODO (martin) [POLYBOOK] Fix up narrative bot bookmark interactions in a separate PR.
   self.add_model_callback(Bookmark, :after_commit, on: :create) do
-    if self.post && self.user.enqueue_narrative_bot_job?
-      Jobs.enqueue(:bot_input, user_id: self.user_id, post_id: self.post_id, input: "bookmark")
+    if self.user.enqueue_narrative_bot_job?
+      if SiteSetting.use_polymorphic_bookmarks && self.bookmarkable_type == "Post"
+        Jobs.enqueue(:bot_input, user_id: self.user_id, post_id: self.bookmarkable_id, input: "bookmark")
+      elsif !SiteSetting.use_polymorphic_bookmarks && self.post.present?
+        Jobs.enqueue(:bot_input, user_id: self.user_id, post_id: self.post_id, input: "bookmark")
+      end
     end
   end
 


### PR DESCRIPTION
This commit allows the new user narrative bot to work
with polymorphic bookmarks, gated behind the
use_polymorphic_bookmarks site setting.