### PR TITLE
FIX: Use proper ActiveRecord method in import scripts

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -74,7 +74,7 @@ class BulkImport::Base
 
   def initialize
     charset = ENV["DB_CHARSET"] || "utf8"
-    db = ActiveRecord::Base.connection_config
+    db = ActiveRecord::Base.connection_db_config.configuration_hash
     @encoder = PG::TextEncoder::CopyRow.new
     @raw_connection = PG.connect(dbname: db[:database], port: db[:port])
     @uploader = ImportScripts::Uploader.new

--- a/script/bulk_import/discourse_merger.rb
+++ b/script/bulk_import/discourse_merger.rb
@@ -18,7 +18,7 @@ class BulkImport::DiscourseMerger < BulkImport::Base
 
   def initialize
     db_password = ENV["DB_PASS"] || 'import_password'
-    local_db = ActiveRecord::Base.connection_config
+    local_db = ActiveRecord::Base.connection_db_config.configuration_hash
     @raw_connection = PG.connect(dbname: local_db[:database], host: 'localhost', port: local_db[:port], user: 'postgres', password: db_password)
 
     @source_db_config = {


### PR DESCRIPTION
`ActiveRecord::Base.connection_config` has been deprecated since Rails 6.1 and was completely removed from Rails 7.
Instead we need to use `ActiveRecord::Base.connection_db_config.configuration_hash`.

Import scripts were forgotten when we did the Rails 7 upgrade, this PR fixes them.
