### PR TITLE
DEV: Fix not being able to boot Sidekiq server in development

### DIFF
--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -27,10 +27,10 @@ if Sidekiq.server?
     end
   end
 
-  # defer queue should simply run in sidekiq
-  Scheduler::Defer.async = false
-
   Rails.application.config.after_initialize do
+    # defer queue should simply run in sidekiq
+    Scheduler::Defer.async = false
+
     # warm up AR
     RailsMultisite::ConnectionManagement.safe_each_connection do
       (ActiveRecord::Base.connection.tables - %w[schema_migrations versions]).each do |table|

--- a/config/initializers/100-sidekiq.rb
+++ b/config/initializers/100-sidekiq.rb
@@ -49,17 +49,17 @@ if Sidekiq.server?
       end
     end
   end
-end
-
-# Sidekiq#logger= applies patches to whichever logger we pass it.
-# Therefore something like Sidekiq.logger = Rails.logger will break
-# all logging in the application.
-#
-# Instead, this patch adds a dedicated logger instance and patches
-# the #add method to forward messages to Rails.logger.
-Sidekiq.logger = Logger.new(nil)
-Sidekiq.logger.define_singleton_method(:add) do |severity, message = nil, progname = nil, &blk|
-  Rails.logger.add(severity, message, progname, &blk)
+else
+  # Sidekiq#logger= applies patches to whichever logger we pass it.
+  # Therefore something like Sidekiq.logger = Rails.logger will break
+  # all logging in the application.
+  #
+  # Instead, this patch adds a dedicated logger instance and patches
+  # the #add method to forward messages to Rails.logger.
+  Sidekiq.logger = Logger.new(nil)
+  Sidekiq.logger.define_singleton_method(:add) do |severity, message = nil, progname = nil, &blk|
+    Rails.logger.add(severity, message, progname, &blk)
+  end
 end
 
 Sidekiq.error_handlers.clear


### PR DESCRIPTION
`bundle exec sidekiq` fails with two errors which are being fixed in this PR:

```
tgxworld ~/work/discourse* fix_lauching_sidekiq_in_development $ RAILS_ENV=development bundle exec sidekiq
2022-05-10T06:54:40.958Z pid=104511 tid=2jr7 INFO: Booting Sidekiq 6.4.2 with redis options {:host=>"localhost", :port=>6379, :namespace=>"sidekiq"}
2022-05-10T06:54:40.960Z pid=104511 tid=2jr7 WARN: NameError: uninitialized constant Scheduler
Did you mean?  MiniScheduler
```

and 

```
tgxworld ~/work/discourse* remove_custom_sidekiq_logger $ RAILS_ENV=development bundle exec sidekiq
2022-05-10T06:56:42.164Z pid=105622 tid=2kh6 INFO: Booting Sidekiq 6.4.2 with redis options {:host=>"localhost", :port=>6379, :namespace=>"sidekiq"}
bundler: failed to load command: sidekiq (/home/tgxworld/.asdf/installs/ruby/2.7.5/bin/sidekiq)
Traceback (most recent call last):
	8926: from /home/tgxworld/.asdf/installs/ruby/2.7.5/bin/bundle:23:in `<main>'
	8925: from /home/tgxworld/.asdf/installs/ruby/2.7.5/bin/bundle:23:in `load'
	8924: from /home/tgxworld/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.3.5/exe/bundle:36:in `<top (required)>'
	8923: from /home/tgxworld/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.3.5/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
	8922: from /home/tgxworld/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.3.5/exe/bundle:48:in `block in <top (required)>'
	8921: from /home/tgxworld/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.3.5/lib/bundler/cli.rb:25:in `start'
	8920: from /home/tgxworld/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.3.5/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	8919: from /home/tgxworld/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.3.5/lib/bundler/cli.rb:31:in `dispatch'
	 ... 8914 levels...
	   4: from /home/tgxworld/work/discourse/config/initializers/100-sidekiq.rb:56:in `block in <main>'
	   3: from /home/tgxworld/work/discourse/config/initializers/100-sidekiq.rb:56:in `block in <main>'
	   2: from /home/tgxworld/work/discourse/config/initializers/100-sidekiq.rb:56:in `block in <main>'
	   1: from /home/tgxworld/work/discourse/config/initializers/100-sidekiq.rb:56:in `block in <main>'
/home/tgxworld/work/discourse/config/initializers/100-sidekiq.rb:56:in `block in <main>': stack level too deep (SystemStackError)
```