### PR TITLE
UX: Add back link on taggroup page

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/tag-groups.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag-groups.hbs
@@ -1,4 +1,4 @@
-<a href="/tags">{{d-icon "chevron-left"}}{{i18n "tagging.groups.back_btn"}}</a>
+<a href="/tags">{{d-icon "chevron-left"}}<span>{{i18n "tagging.groups.back_btn"}}</span></a>
 
 <div class="container tag-groups-container">
   <h2>{{i18n "tagging.groups.title"}}</h2>

--- a/app/assets/javascripts/discourse/app/templates/tag-groups.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag-groups.hbs
@@ -1,4 +1,7 @@
-<a href="/tags">{{d-icon "chevron-left"}}<span>{{i18n "tagging.groups.back_btn"}}</span></a>
+<a href="/tags">
+  {{d-icon "chevron-left"}}
+  <span>{{i18n "tagging.groups.back_btn"}}</span>
+</a>
 
 <div class="container tag-groups-container">
   <h2>{{i18n "tagging.groups.title"}}</h2>

--- a/app/assets/javascripts/discourse/app/templates/tag-groups.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag-groups.hbs
@@ -1,3 +1,5 @@
+<a href="/tags">{{d-icon "chevron-left"}}{{i18n "tagging.groups.back_btn"}}</a>
+
 <div class="container tag-groups-container">
   <h2>{{i18n "tagging.groups.title"}}</h2>
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3923,6 +3923,7 @@ en:
           description: "You will not be notified of anything about new topics with this tag, and they will not appear on your unread tab."
 
       groups:
+        back_btn: "Back to all tags"
         title: "Tag Groups"
         about_heading: "Select a tag group or create a new one"
         about_heading_empty: "Create a new tag group to get started"


### PR DESCRIPTION
Added link as requested on the minor design fix topic

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/101828855/168550408-29e1b706-3785-4d43-a404-92d31631e959.png">

<img width="366" alt="image" src="https://user-images.githubusercontent.com/101828855/168550461-bb9267ca-9c22-4512-8e1a-9a0a4f77b1d8.png">

