### PR TITLE
UX: Fix user nav overflow bug on ipad

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -13,6 +13,10 @@
     grid-column-end: 3;
     grid-row-start: 1;
     grid-row-end: 2;
+
+    .nav-pills {
+      flex-wrap: wrap;
+    }
   }
   .user-secondary-navigation {
     grid-column-start: 1;


### PR DESCRIPTION
Bug reported on the [design topic](https://dev.discourse.org/t/minor-design-to-dos-alignment-z-index-color-and-other-little-eyesores/44777/353?u=chapoi)

Fixing this: 
![image](https://user-images.githubusercontent.com/101828855/167658303-21a6f370-1f8c-4df2-b261-4d3168da80b5.png)

by wrapping this specific nav (to be safe) so it looks like:

<img width="761" alt="image" src="https://user-images.githubusercontent.com/101828855/167658891-76da89b4-e86a-46e1-a6a5-546ad61ae271.png">


