### PR TITLE
DEV: Ensure service-worker sourcemap URLs do not duplicate extension

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -206,7 +206,7 @@ class StaticController < ApplicationController
         content = Rails.application.assets_manifest.find_sources('service-worker.js').first
         content = content.sub(
           /^\/\/# sourceMappingURL=(service-worker-.+\.map)$/
-        ) { "//# sourceMappingURL=#{helpers.script_asset_path(Regexp.last_match(1))}" }
+        ) { "//# sourceMappingURL=#{helpers.script_asset_path('service-worker')}.map" }
         render(
           plain: content,
           content_type: 'application/javascript'

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -420,7 +420,7 @@ describe StaticController do
       get "/service-worker.js"
       expect(response.status).to eq(200)
       expect(response.content_type).to start_with("application/javascript")
-      expect(response.body).to include("sourceMappingURL=/assets/service-worker-abcde.js.map")
+      expect(response.body).to include("sourceMappingURL=/assets/service-worker.js.map\n")
     end
   end
 end


### PR DESCRIPTION
`script_asset_path('.../blah.js.map')` was appending `.js`, which would result in a filename like `.js.map.js`. It would also lose the `/assets` prefix, since the map files are not included in the sprockets manifest.

This commit updates the sourceMappingURL rewriting logic to calculate the service-worker's own JS url, and then append `.map`.
