### PR TITLE
DEV: Add ability to populate private messages

### DIFF
--- a/lib/discourse_dev/post.rb
+++ b/lib/discourse_dev/post.rb
@@ -14,7 +14,7 @@ module DiscourseDev
 
       category = topic.category
       @max_likes_count = DiscourseDev.config.post[:max_likes_count]
-      unless category.groups.blank?
+      unless category&.groups.blank?
         group_ids = category.groups.pluck(:id)
         @user_ids = ::GroupUser.where(group_id: group_ids).pluck(:user_id)
         @user_count = @user_ids.count
@@ -54,7 +54,7 @@ module DiscourseDev
     end
 
     def user
-      return User.random if topic.category.groups.blank?
+      return User.random if topic.category&.groups.blank?
       return Discourse.system_user if @user_ids.blank?
 
       position = Faker::Number.between(from: 0, to: @user_count - 1)

--- a/lib/discourse_dev/post.rb
+++ b/lib/discourse_dev/post.rb
@@ -14,7 +14,7 @@ module DiscourseDev
 
       category = topic.category
       @max_likes_count = DiscourseDev.config.post[:max_likes_count]
-      unless category&.groups.blank?
+      if category&.groups.present?
         group_ids = category.groups.pluck(:id)
         @user_ids = ::GroupUser.where(group_id: group_ids).pluck(:user_id)
         @user_count = @user_ids.count

--- a/lib/discourse_dev/record.rb
+++ b/lib/discourse_dev/record.rb
@@ -69,8 +69,8 @@ module DiscourseDev
       model.count
     end
 
-    def self.populate!
-      self.new.populate!
+    def self.populate!(*args)
+      self.new(*args).populate!
     end
 
     def self.random(model, use_existing_records: true)

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -22,7 +22,23 @@ end
 
 desc 'Creates sample topics'
 task 'topics:populate' => ['db:load_config'] do |_, args|
-  DiscourseDev::Topic.populate!
+  if ENV['IGNORE_CURRENT_COUNT'] == "true"
+    DiscourseDev::Topic.populate!(ignore_current_count: true)
+  else
+    DiscourseDev::Topic.populate!
+  end
+end
+
+desc 'Creates sample private messages'
+task 'private_messages:populate', [:recipient] => ['db:load_config'] do |_, args|
+  args.with_defaults(type: 'string')
+
+  if !args[:recipient]
+    puts "ERROR: Expecting rake private_messages:populate[recipient]"
+    exit 1
+  end
+
+  DiscourseDev::Topic.populate!(private_messages: true, recipient: args[:recipient], ignore_current_count: true)
 end
 
 desc 'Create post revisions'


### PR DESCRIPTION
Two changes included here: 

- new rake task to generate private messages, `bin/rake private_messages:populate[username]` where username = the recipient of the PMs
- small modification to `topics:populate` to allow for more topics to be created without starting from scratch, via `bin/rake topics:populate IGNORE_CURRENT_COUNT=true`