### PR TITLE
FEATURE: Allow category moderators to post consecutively

### DIFF
--- a/lib/validators/post_validator.rb
+++ b/lib/validators/post_validator.rb
@@ -140,6 +140,9 @@ class PostValidator < ActiveModel::Validator
     topic = post.topic
     return if topic&.ordered_posts&.first&.user == post.user
 
+    guardian = Guardian.new(post.acting_user)
+    return if guardian.is_category_group_moderator?(post.topic&.category)
+
     last_posts_count = DB.query_single(<<~SQL, topic_id: post.topic_id, user_id: post.acting_user.id, max_replies: SiteSetting.max_consecutive_replies).first
       SELECT COUNT(*)
       FROM (
@@ -155,7 +158,6 @@ class PostValidator < ActiveModel::Validator
     SQL
     return if last_posts_count < SiteSetting.max_consecutive_replies
 
-    guardian = Guardian.new(post.acting_user)
     if guardian.can_edit?(topic.ordered_posts.last)
       post.errors.add(:base, I18n.t(:max_consecutive_replies, count: SiteSetting.max_consecutive_replies))
     end

--- a/spec/lib/validators/post_validator_spec.rb
+++ b/spec/lib/validators/post_validator_spec.rb
@@ -299,6 +299,22 @@ describe PostValidator do
       end
     end
 
+    it "should allow category moderators to post more than 2 consecutive replies" do
+      SiteSetting.enable_category_group_moderation = true
+      group = Fabricate(:group)
+      GroupUser.create(group: group, user: user)
+      category = Fabricate(:category, reviewable_by_group_id: group.id)
+      topic.update!(category: category)
+
+      Post.create!(user: other_user, topic: topic, raw: "post number 1", post_number: 1)
+      Post.create!(user: user, topic: topic, raw: "post number 2", post_number: 2)
+      Post.create!(user: user, topic: topic, raw: "post number 3", post_number: 3)
+
+      post = Post.new(user: user, topic: topic, raw: "post number 4", post_number: 4)
+      validator.force_edit_last_validator(post)
+      expect(post.errors.count).to eq(0)
+    end
+
     it "should not allow posting more than 2 consecutive replies" do
       Post.create!(user: user, topic: topic, raw: "post number 2", post_number: 2)
       Post.create!(user: user, topic: topic, raw: "post number 3", post_number: 3)


### PR DESCRIPTION
First posters and staff are already allowed to have unlimited
consecutive posts. This adds the same capabilities to category
moderators.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
