### PR TITLE
UX: fix various login modal issues on mobile

### DIFF
--- a/app/assets/stylesheets/mobile/login.scss
+++ b/app/assets/stylesheets/mobile/login.scss
@@ -35,14 +35,15 @@
     flex: 1 0 auto;
     flex-wrap: wrap;
     justify-content: center;
-    padding: 1em;
+    padding: 0 1em;
     margin: 0;
+    gap: 0 0.25em;
 
     .btn {
-      padding: 0.53em 0.53em 0.53em 0.43em;
+      padding: 0.5em;
       border: 1px solid var(--primary-low);
       flex: 1 1 47%;
-      margin: 0 0.5em 0.5em 0;
+      font-size: var(--font-down-1);
       white-space: nowrap;
       &:last-child {
         margin-right: 0;
@@ -144,6 +145,13 @@
 
 // Styles for the
 // login modal only
+
+#discourse-modal {
+  &.d-modal.login-modal:not(.hidden) .modal-body {
+    max-height: 68vh !important; // overrides another important
+  }
+}
+
 .d-modal.login-modal {
   #credentials {
     width: 100%;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1999,20 +1999,20 @@ en:
         sr_title: "Sign in with Twitter"
       instagram:
         name: "Instagram"
-        title: "Login with Instagram"
-        sr_title: "Login with Instagram"
+        title: "Log in with Instagram"
+        sr_title: "Log in with Instagram"
       facebook:
         name: "Facebook"
-        title: "Login with Facebook"
-        sr_title: "Login with Facebook"
+        title: "Log in with Facebook"
+        sr_title: "Log in with Facebook"
       github:
         name: "GitHub"
-        title: "Login with GitHub"
-        sr_title: "Login with GitHub"
+        title: "Log in with GitHub"
+        sr_title: "Log in with GitHub"
       discord:
         name: "Discord"
-        title: "Login with Discord"
-        sr_title: "Login with Discord"
+        title: "Log in with Discord"
+        sr_title: "Log in with Discord"
       second_factor_toggle:
         totp: "Use an authenticator app instead"
         backup_code: "Use a backup code instead"


### PR DESCRIPTION
Social login buttons now have "log in" prepended due to Google rules, so they're much larger. 

Some adjustments: 

1. Made the button text smaller to accommodate and allow 2 buttons per row (when space allows) 
2. Reduced some vertical padding
3. Switched from `margin` to `gap` on social login buttons, this is so when buttons don't wrap, at least they're the same width (previously every other button had right margin, even when wrapped to one button per line)
4. Adjusted the modal max-height so the addition of an error message doesn't make the log in button inaccessible 
5. Updated the translations from "login" to "log in" to be more consistent with other text  

Before:
![Screen Shot 2022-05-10 at 5 55 05 PM](https://user-images.githubusercontent.com/1681963/167728965-8d341cd5-2ca1-4eb4-bdf9-9a2c4ee4e23a.png)

After:
![Screen Shot 2022-05-10 at 5 52 24 PM](https://user-images.githubusercontent.com/1681963/167728971-cd3e349e-fbac-49a2-9e7d-2ae0d34a412a.png)

modals are the wooOoOoorst 🎶 
