### PR TITLE
FIX: Use our header value instead of custom header on duplicates

### DIFF
--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -3,7 +3,7 @@
 class TestMailer < ActionMailer::Base
   include Email::BuildEmailHelper
 
-  def send_test(to_address)
-    build_email(to_address, template: 'test_mailer')
+  def send_test(to_address, opts = {})
+    build_email(to_address, template: 'test_mailer', **opts)
   end
 end

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -235,10 +235,13 @@ module Email
         # would conflict with our own.
         #
         # See https://datatracker.ietf.org/doc/html/rfc5322#section-3.6 and
-        # https://www.rubydoc.info/github/mikel/mail/Mail/Header
+        # https://github.com/mikel/mail/blob/8ef377d6a2ca78aa5bd7f739813f5a0648482087/lib/mail/header.rb#L109-L132
         custom_header = @message.header[key]
         if custom_header.is_a?(Array)
           our_value = custom_header.last.value
+
+          # Must be set to nil first otherwise another value is just added
+          # to the array of values for the header.
           @message.header[key] = nil
           @message.header[key] = our_value
         end
@@ -447,16 +450,18 @@ module Email
       end
     end
 
-    # NOTE: In most cases this is not a problem, but if a header has
-    # doubled up the header[] method will return an array. So we always
-    # get the last value of the array and assume that is the correct
-    # value.
-    #
-    # See https://www.rubydoc.info/github/mikel/mail/Mail/Header
     def header_value(name)
       header = @message.header[name]
       return nil unless header
+
+      # NOTE: In most cases this is not a problem, but if a header has
+      # doubled up the header[] method will return an array. So we always
+      # get the last value of the array and assume that is the correct
+      # value.
+      #
+      # See https://github.com/mikel/mail/blob/8ef377d6a2ca78aa5bd7f739813f5a0648482087/lib/mail/header.rb#L109-L132
       return header.last.value if header.is_a?(Array)
+
       header.value
     end
 

--- a/spec/integration/email_outbound_spec.rb
+++ b/spec/integration/email_outbound_spec.rb
@@ -12,14 +12,14 @@ describe "Outbound Email" do
   end
 
   context "email custom headers" do
-    it "discards the custom header if it is one that we have already set based on arguments" do
+    it "discards the custom header if it is one that has already been set based on arguments" do
       SiteSetting.email_custom_headers = "Precedence: bulk"
       post = Fabricate(:post)
       message, result = send_email(post_id: post.id, topic_id: post.topic_id)
       expect(message.header["Precedence"].value).to eq("list")
     end
 
-    it "does not discard unique custom headers" do
+    it "does send unique custom headers" do
       SiteSetting.email_custom_headers = "SuperUrgent: wow-cool"
       post = Fabricate(:post)
       message, result = send_email(post_id: post.id, topic_id: post.topic_id)

--- a/spec/integration/email_outbound_spec.rb
+++ b/spec/integration/email_outbound_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# We already have Email::Sender and Email::MessageBuilder specs along
+# with mailer specific mailer specs like UserEmail, but sometimes we need
+# to test things along the whole outbound flow including the MessageBuilder
+# and the Sender.
+describe "Outbound Email" do
+  def send_email(opts = {})
+    message = TestMailer.send_test("test@test.com", opts)
+    result = Email::Sender.new(message, :test_message).send
+    [message, result]
+  end
+
+  context "email custom headers" do
+    it "discards the custom header if it is one that we have already set based on arguments" do
+      SiteSetting.email_custom_headers = "Precedence: bulk"
+      post = Fabricate(:post)
+      message, result = send_email(post_id: post.id, topic_id: post.topic_id)
+      expect(message.header["Precedence"].value).to eq("list")
+    end
+
+    it "does not discard unique custom headers" do
+      SiteSetting.email_custom_headers = "SuperUrgent: wow-cool"
+      post = Fabricate(:post)
+      message, result = send_email(post_id: post.id, topic_id: post.topic_id)
+      expect(message.header["SuperUrgent"].value).to eq("wow-cool")
+    end
+  end
+end


### PR DESCRIPTION
When we build and send emails using MessageBuilder and Email::Sender
we add custom headers defined in SiteSetting.email_custom_headers.
However this was causing errors in cases where the custom headers
defined a header that we already specify in outbound emails (e.g.
the Precedence: list header for topic/post emails).

This commit makes it so we always use the header value defined in Discourse
core if there is a duplicate, discarding the custom header value
from the site setting.

cf. https://meta.discourse.org/t/email-notifications-fail-if-duplicate-headers-exist/222960/14
