### PR TITLE
FIX: do not log category custom fields changes if the value is unchanged

### DIFF
--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -455,6 +455,7 @@ class StaffActionLogger
 
     if old_custom_fields && category_params[:custom_fields]
       category_params[:custom_fields].each do |key, value|
+        next if old_custom_fields[key] == value
         changed_attributes["custom_fields[#{key}]"] = [old_custom_fields[key], value]
       end
     end

--- a/spec/services/staff_action_logger_spec.rb
+++ b/spec/services/staff_action_logger_spec.rb
@@ -387,6 +387,38 @@ describe StaffActionLogger do
       expect(UserHistory.count).to eq(1)
       expect(UserHistory.find_by_subject('name').category).to eq(category)
     end
+
+    it "logs custom fields changes" do
+      attributes = {
+        custom_fields: { "auto_populated" => "t" }
+      }
+      category.update!(attributes)
+
+      logger.log_category_settings_change(
+        category,
+        attributes,
+        old_permissions: category.permissions_params,
+        old_custom_fields: {}
+      )
+
+      expect(UserHistory.count).to eq(1)
+    end
+
+    it "does not log custom fields changes if value is unchanged" do
+      attributes = {
+        custom_fields: { "auto_populated" => "t" }
+      }
+      category.update!(attributes)
+
+      logger.log_category_settings_change(
+        category,
+        attributes,
+        old_permissions: category.permissions_params,
+        old_custom_fields: { "auto_populated" => "t" }
+      )
+
+      expect(UserHistory.count).to eq(0)
+    end
   end
 
   describe 'log_category_deletion' do


### PR DESCRIPTION
Currently we are logging the category custom fields changes even if the
value is not changed. This commit skips logging changes for custom
fields that are not changed.
