### PR TITLE
FIX: keep `f` query param in menu items while navigate between.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-item.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-item.js
@@ -42,6 +42,7 @@ export default Component.extend(FilterModeMixin, {
 
     let href = content.get("href");
     let queryParams = [];
+    const currentRouteQueryParams = content.currentRouteQueryParams;
 
     // Include the category id if the option is present
     if (content.get("includeCategoryId")) {
@@ -54,11 +55,13 @@ export default Component.extend(FilterModeMixin, {
     // To reset the "filter" sticky param, at least one query param is needed.
     // If no query param is present, add an empty one to ensure a ? is
     // appended to the URL.
-    if (content.currentRouteQueryParams) {
-      if (content.currentRouteQueryParams.filter) {
-        if (queryParams.length === 0) {
-          queryParams.push("");
-        }
+    if (currentRouteQueryParams) {
+      if (currentRouteQueryParams.filter && queryParams.length === 0) {
+        queryParams.push("");
+      }
+
+      if (currentRouteQueryParams.f) {
+        queryParams.push(`f=${currentRouteQueryParams.f}`);
       }
     }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-topics-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-topics-section-test.js
@@ -155,6 +155,11 @@ acceptance("Sidebar - Topics Section", function (needs) {
         exists(".sidebar-section-topics .sidebar-section-link-tracked.active"),
         "the tracked link is marked as active"
       );
+
+      assert.strictEqual(
+        exists("#navigation-bar > li > a[href='/top?f=tracked']"),
+        "`f` query param kept in URL for `top` link"
+      );
     }
   );
 


### PR DESCRIPTION
When we click `Tracked` filter in sidebar it will add a `f` query string in URL. It was not sticky while navigate between new/unread/top menu items. This commit will fix that issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
