### PR TITLE
DEV: Update add_column migration to remove transaction

### DIFF
--- a/db/migrate/20220505191131_add_last_seen_reviewable_id_to_user.rb
+++ b/db/migrate/20220505191131_add_last_seen_reviewable_id_to_user.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class AddLastSeenReviewableIdToUser < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   def change
-    add_column :users, :last_seen_reviewable_id, :integer
+    add_column :users, :last_seen_reviewable_id, :integer, if_not_exists: true
   end
 end


### PR DESCRIPTION
This migration is failing to acquire a lock under some production conditions. We're only performing one action, so removing the transaction is safe and may help to resolve the issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
