### PR TITLE
Revert "DEV: Update add_column migration to remove transaction (#16715)"

### DIFF
--- a/db/migrate/20220505191131_add_last_seen_reviewable_id_to_user.rb
+++ b/db/migrate/20220505191131_add_last_seen_reviewable_id_to_user.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class AddLastSeenReviewableIdToUser < ActiveRecord::Migration[7.0]
-  disable_ddl_transaction!
-
   def change
-    add_column :users, :last_seen_reviewable_id, :integer, if_not_exists: true
+    add_column :users, :last_seen_reviewable_id, :integer
   end
 end


### PR DESCRIPTION
This reverts commit e599b5b08f4323d50fb2dd584dbb06333d60b995.

This didn't solve the problem we were trying to fix - reverting back to the standard migration pattern

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
