### PR TITLE
DEV: Ensure service-worker sourcemap logic works with brotli/gzip

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -204,9 +204,11 @@ class StaticController < ApplicationController
           response.headers["Last-Modified"] = File.ctime(path).httpdate
         end
         content = Rails.application.assets_manifest.find_sources('service-worker.js').first
+
+        base_url = File.dirname(helpers.script_asset_path('service-worker'))
         content = content.sub(
           /^\/\/# sourceMappingURL=(service-worker-.+\.map)$/
-        ) { "//# sourceMappingURL=#{helpers.script_asset_path('service-worker')}.map" }
+        ) { "//# sourceMappingURL=#{base_url}/#{Regexp.last_match(1)}" }
         render(
           plain: content,
           content_type: 'application/javascript'

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -417,10 +417,22 @@ describe StaticController do
         JS
       ])
 
-      get "/service-worker.js"
-      expect(response.status).to eq(200)
-      expect(response.content_type).to start_with("application/javascript")
-      expect(response.body).to include("sourceMappingURL=/assets/service-worker.js.map\n")
+      {
+        '/assets/service-worker.js' => '/assets/service-worker-abcde.js.map',
+        '/assets/service-worker.js.br' => '/assets/service-worker-abcde.js.map',
+        '/assets/service-worker.br.js' => '/assets/service-worker-abcde.js.map',
+        '/assets/service-worker.js.gz' => '/assets/service-worker-abcde.js.map',
+        '/assets/service-worker.gz.js' => '/assets/service-worker-abcde.js.map',
+        'https://example.com/assets/service-worker.js' => 'https://example.com/assets/service-worker-abcde.js.map',
+        'https://example.com/subfolder/assets/service-worker.js' => 'https://example.com/subfolder/assets/service-worker-abcde.js.map',
+      }.each do |asset_path, expected_map_url|
+        ActionController::Base.helpers.stubs(:asset_path).with("service-worker.js").returns(asset_path)
+
+        get "/service-worker.js"
+        expect(response.status).to eq(200)
+        expect(response.content_type).to start_with("application/javascript")
+        expect(response.body).to include("sourceMappingURL=#{expected_map_url}\n")
+      end
     end
   end
 end


### PR DESCRIPTION
The logic in 06893380 only works for `.js` files. It breaks down for `.br.js` and `.gz.js` files. This commit makes things more robust by extracting only the base_url from the service-worker JS, and taking the map filename from the original `sourceMappingURL` comment.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
