### PR TITLE
DEV: introduces setup for d-popover

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/d-popover.js
+++ b/app/assets/javascripts/discourse/app/lib/d-popover.js
@@ -37,7 +37,7 @@ export function hidePopover(event) {
 export function showPopover(event, options = {}) {
   const instance = event.target._tippy
     ? event.target._tippy
-    : this.setup(event.target, options);
+    : setup(event.target, options);
 
   // hangs on legacy ember
   if (!isLegacyEmber) {

--- a/app/assets/javascripts/discourse/app/lib/d-popover.js
+++ b/app/assets/javascripts/discourse/app/lib/d-popover.js
@@ -54,7 +54,7 @@ export function showPopover(event, options = {}) {
   }
 }
 
-// target is the element trigger the display of the popover
+// target is the element that triggers the display of the popover
 // options accepts all tippy.js options as defined in their documentation
 // https://atomiks.github.io/tippyjs/v6/all-props/
 export default function setup(target, options) {

--- a/app/assets/javascripts/discourse/app/lib/d-popover.js
+++ b/app/assets/javascripts/discourse/app/lib/d-popover.js
@@ -26,35 +26,18 @@ export const hideOnEscapePlugin = {
   },
 };
 
+// legacy, shouldn't be needed with setup
 export function hidePopover(event) {
   if (event?.target?._tippy) {
     showPopover(event);
   }
 }
 
-// options accepts all tippy.js options as defined in their documentation
-// https://atomiks.github.io/tippyjs/v6/all-props/
+// legacy, setup() should be used
 export function showPopover(event, options = {}) {
-  const tippyOptions = Object.assign(
-    {
-      arrow: iconHTML("tippy-rounded-arrow"),
-      content: options.textContent || options.htmlContent,
-      allowHTML: options?.htmlContent?.length,
-      trigger: "mouseenter click",
-      hideOnClick: true,
-      zIndex: 1400,
-      plugins: [hideOnEscapePlugin],
-    },
-    options
-  );
-
-  // legacy support
-  delete tippyOptions.textContent;
-  delete tippyOptions.htmlContent;
-
   const instance = event.target._tippy
     ? event.target._tippy
-    : tippy(event.target, tippyOptions);
+    : this.setup(event.target, options);
 
   // hangs on legacy ember
   if (!isLegacyEmber) {
@@ -69,4 +52,29 @@ export function showPopover(event, options = {}) {
   } else {
     instance.show();
   }
+}
+
+// target is the element trigger the display of the popover
+// options accepts all tippy.js options as defined in their documentation
+// https://atomiks.github.io/tippyjs/v6/all-props/
+export default function setup(target, options) {
+  const tippyOptions = Object.assign(
+    {
+      arrow: iconHTML("tippy-rounded-arrow"),
+      content: options.textContent || options.htmlContent,
+      allowHTML: options?.htmlContent?.length,
+      trigger: "mouseenter click",
+      hideOnClick: true,
+      zIndex: 1400,
+      plugins: [hideOnEscapePlugin],
+      touch: ["hold", 500],
+    },
+    options
+  );
+
+  // legacy support
+  delete tippyOptions.textContent;
+  delete tippyOptions.htmlContent;
+
+  return tippy(target, tippyOptions);
 }


### PR DESCRIPTION
This new function get rids of previous showPopover/hidePopover API and is only a very thin wrapper around tippy with defaults for Discourse project

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
