### PR TITLE
FIX: handle quote rendering for external Discourse instance

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -273,26 +273,35 @@ export default class PostCooked {
 
     $quotes.each((index, e) => {
       const $aside = $(e);
+
       if ($aside.data("post")) {
-        const quoteId = `quote-id-${$aside.data("topic")}-${$aside.data(
-          "post"
-        )}-${index}`;
-        $aside.find("blockquote").attr("id", quoteId);
+        ajax(`/posts/by_number/${$aside.data("topic")}/${$aside.data("post")}`)
+          .then(() => {
+            const quoteId = `quote-id-${$aside.data("topic")}-${$aside.data(
+              "post"
+            )}-${index}`;
+            $aside.find("blockquote").attr("id", quoteId);
 
-        this._updateQuoteElements($aside, "chevron-down");
-        const $title = $(".title", $aside);
+            this._updateQuoteElements($aside, "chevron-down");
+            const $title = $(".title", $aside);
 
-        // Unless it's a full quote, allow click to expand
-        if (!($aside.data("full") || $title.data("has-quote-controls"))) {
-          $title.on("click", (e2) => {
-            let $target = $(e2.target);
-            if ($target.closest("a").length) {
-              return true;
+            // Unless it's a full quote, allow click to expand
+            if (!($aside.data("full") || $title.data("has-quote-controls"))) {
+              $title.on("click", (e2) => {
+                let $target = $(e2.target);
+                if ($target.closest("a").length) {
+                  return true;
+                }
+                this._toggleQuote($aside);
+              });
+              $title.data("has-quote-controls", true);
             }
-            this._toggleQuote($aside);
+          })
+          .catch((error) => {
+            if ([403, 404].includes(error.jqXHR.status)) {
+              return $aside.find(".title").remove();
+            }
           });
-          $title.data("has-quote-controls", true);
-        }
       }
     });
   }

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -557,6 +557,23 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
   });
 });
 
+acceptance("External instance quote handling", function (needs) {
+  needs.user();
+
+  test("Does not display user in title", async function (assert) {
+    await visit("/t/short-topic-with-two-posts/54079");
+    await click("article#post_2 button.reply");
+    const quote =
+      "[quote='random_guy, post:700, topic:225486']\nthis quote is not from discourse\n[/quote]";
+    await fillIn(".d-editor-input", quote);
+
+    assert.strictEqual(
+      queryAll(".d-editor-preview .quote .title").text().trim(),
+      ""
+    );
+  });
+});
+
 acceptance("Prioritize Username", function (needs) {
   needs.user();
   needs.settings({

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/quotes.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/quotes.js
@@ -112,6 +112,7 @@ const rule = {
         postNumber &&
         options.getTopicInfo &&
         (forOtherTopic || options.forceQuoteLink);
+      let externalInstanceQuote = !offTopicQuote;
 
       // on topic quote
       token = state.push("quote_header_open", "div", 1);
@@ -160,7 +161,7 @@ const rule = {
         }
       } else {
         token = state.push("text", "", 0);
-        token.content = ` ${displayName}:`;
+        token.content = externalInstanceQuote ? "" : ` ${displayName}:`;
       }
 
       state.push("quote_header_close", "div", -1);


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
