### PR TITLE
FIX: auto margins cause too-narrow content

### DIFF
--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -116,6 +116,11 @@ blockquote {
 
 // Special elements
 
+#main-outlet-wrapper {
+  margin-left: unset;
+  margin-right: unset;
+}
+
 #main-outlet {
   padding-top: 1.25em;
 }


### PR DESCRIPTION
This is dependent on topic list content, but sometimes auto margins on `#main-outlet-wrapper` cause the content to be too narrow:

Before: 
<img width="373" alt="Screen Shot 2022-05-11 at 5 37 41 PM" src="https://user-images.githubusercontent.com/1681963/167952146-f4ac3bf4-fcf1-4f35-b204-fbb05c6741e3.png">



After:
<img width="372" alt="Screen Shot 2022-05-11 at 5 38 05 PM" src="https://user-images.githubusercontent.com/1681963/167952119-d23a0f56-5ef1-4ba2-94f4-ea5cb4cc1df4.png">
