### PR TITLE
DEV: Don't cache watched words in test env

### DIFF
--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -520,11 +520,12 @@ describe Report do
 
       before do
         freeze_time
-
-        PostActionCreator.new(flagger, post, PostActionType.types[:spam], message: 'bad').perform
       end
 
       it "returns a report with data" do
+        result = PostActionCreator.new(flagger, post, PostActionType.types[:spam], message: 'bad').perform
+
+        expect(result.success).to eq(true)
         expect(report.data).to be_present
 
         row = report.data[0]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -105,6 +105,7 @@ module TestSetup
     UserActionManager.disable
     NotificationEmailer.disable
     SiteIconManager.disable
+    WordWatcher.disable_cache
 
     SiteSetting.provider.all.each do |setting|
       SiteSetting.remove_override!(setting.name)


### PR DESCRIPTION
The cache was causing state to leak between tests since the `WatchedWord` record in the DB would have been rolled back but `WordWatcher` still had the word in the cache.