### PR TITLE
DEV: Use hybrid cookies instead of marshal ones

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -81,7 +81,7 @@ Rails.application.config.action_controller.raise_on_open_redirects = true
 # If you have configured the serializer elsewhere, you can remove this.
 #
 # See https://guides.rubyonrails.org/action_controller_overview.html#cookies for more information.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid
 
 # Enable parameter wrapping for JSON.
 # Previously this was set in an initializer. It's fine to keep using that initializer if you've customized it.


### PR DESCRIPTION
Now that we’re sure about not reverting from Rails 7, we can enable the hybrid cookie serializer to convert our cookies automatically.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
