### PR TITLE
DEV: Remove 'classify' string prototype extensions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -3,7 +3,7 @@ import Component from "@ember/component";
 import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import bootbox from "bootbox";
-import { dasherize } from "@ember/string";
+import { classify, dasherize } from "@ember/string";
 import discourseComputed, { bind } from "discourse-common/utils/decorators";
 import optionalService from "discourse/lib/optional-service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -168,7 +168,7 @@ export default Component.extend({
     };
 
     if (action.client_action) {
-      let actionMethod = this[`client${action.client_action.classify()}`];
+      let actionMethod = this[`client${classify(action.client_action)}`];
       if (actionMethod) {
         return actionMethod.call(this, reviewable, performAction);
       } else {

--- a/app/assets/javascripts/discourse/app/controllers/flag.js
+++ b/app/assets/javascripts/discourse/app/controllers/flag.js
@@ -11,6 +11,7 @@ import discourseComputed, { bind } from "discourse-common/utils/decorators";
 import { not } from "@ember/object/computed";
 import optionalService from "discourse/lib/optional-service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { classify } from "@ember/string";
 
 export default Controller.extend(ModalFunctionality, {
   adminTools: optionalService(),
@@ -225,7 +226,7 @@ export default Controller.extend(ModalFunctionality, {
       };
 
       if (action.client_action) {
-        let actionMethod = this[`client${action.client_action.classify()}`];
+        let actionMethod = this[`client${classify(action.client_action)}`];
         if (actionMethod) {
           return actionMethod.call(this, () =>
             performAction({ skipClose: true })


### PR DESCRIPTION
## Ember Upgrades

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions