### PR TITLE
DEV: Remove 'dasherize' string prototype extensions

### DIFF
--- a/app/assets/javascripts/admin/addon/components/embedding-setting.js
+++ b/app/assets/javascripts/admin/addon/components/embedding-setting.js
@@ -1,12 +1,13 @@
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
+import { dasherize } from "@ember/string";
 
 export default Component.extend({
   classNames: ["embed-setting"],
 
   @discourseComputed("field")
   inputId(field) {
-    return field.dasherize();
+    return dasherize(field);
   },
 
   @discourseComputed("field")

--- a/app/assets/javascripts/discourse-common/addon/lib/helpers.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/helpers.js
@@ -2,6 +2,7 @@ import Helper from "@ember/component/helper";
 import RawHandlebars from "discourse-common/lib/raw-handlebars";
 import { get } from "@ember/object";
 import { htmlSafe } from "@ember/template";
+import { dasherize } from "@ember/string";
 
 export function makeArray(obj) {
   if (obj === null || obj === undefined) {
@@ -36,7 +37,7 @@ export function registerHelper(name, fn) {
 }
 
 export function findHelper(name) {
-  return _helpers[name] || _helpers[name.dasherize()];
+  return _helpers[name] || _helpers[dasherize(name)];
 }
 
 export function registerHelpers(registry) {

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -12,6 +12,7 @@ import { durationTiny } from "discourse/lib/formatter";
 import { getURLWithCDN } from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
 import { prioritizeNameInUx } from "discourse/lib/settings";
+import { dasherize } from "@ember/string";
 
 export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
   elementId: "user-card",
@@ -104,7 +105,7 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
         .filterBy("show_on_user_card", true)
         .sortBy("position")
         .map((field) => {
-          set(field, "dasherized_name", field.get("name").dasherize());
+          set(field, "dasherized_name", dasherize(field.get("name")));
           const value = userFields ? userFields[field.get("id")] : null;
           return isEmpty(value) ? null : EmberObject.create({ value, field });
         })

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -12,6 +12,7 @@ import { isEmpty } from "@ember/utils";
 import optionalService from "discourse/lib/optional-service";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { inject as service } from "@ember/service";
+import { dasherize } from "@ember/string";
 
 export default Controller.extend(CanCheckEmails, {
   router: service(),
@@ -147,7 +148,7 @@ export default Controller.extend(CanCheckEmails, {
         .filterBy("show_on_profile", true)
         .sortBy("position")
         .map((field) => {
-          set(field, "dasherized_name", field.get("name").dasherize());
+          set(field, "dasherized_name", dasherize(field.get("name")));
           const value = userFields
             ? userFields[field.get("id").toString()]
             : null;

--- a/app/assets/javascripts/discourse/app/helpers/dasherize.js
+++ b/app/assets/javascripts/discourse/app/helpers/dasherize.js
@@ -1,7 +1,8 @@
 import Helper from "@ember/component/helper";
+import { dasherize as emberDasherize } from "@ember/string";
 
 function dasherize([value]) {
-  return (value || "").replace(".", "-").dasherize();
+  return emberDasherize((value || "").replace(".", "-"));
 }
 
 export default Helper.helper(dasherize);

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-notifications.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-notifications.js
@@ -6,6 +6,7 @@ import { ajax } from "discourse/lib/ajax";
 import { createWidget, createWidgetFrom } from "discourse/widgets/widget";
 import { h } from "virtual-dom";
 import I18n from "I18n";
+import { dasherize } from "@ember/string";
 
 const ICON = "bell";
 
@@ -53,7 +54,7 @@ createWidgetFrom(QuickAccessPanel, "quick-access-notifications", {
     ];
 
     return this.attach(
-      `${notificationName.dasherize()}-notification-item`,
+      `${dasherize(notificationName)}-notification-item`,
       notification,
       {},
       { fallbackWidgetName: "default-notification-item" }

--- a/app/assets/javascripts/discourse/app/widgets/user-notifications-large.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-notifications-large.js
@@ -1,6 +1,7 @@
 import { createWidget } from "discourse/widgets/widget";
 import { dateNode } from "discourse/helpers/node";
 import { h } from "virtual-dom";
+import { dasherize } from "@ember/string";
 
 createWidget("large-notification-item", {
   tagName: "li",
@@ -20,7 +21,7 @@ createWidget("large-notification-item", {
 
     return [
       this.attach(
-        `${notificationName.dasherize()}-notification-item`,
+        `${dasherize(notificationName)}-notification-item`,
         attrs,
         {},
         {

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
@@ -6,6 +6,7 @@ import { guidFor } from "@ember/object/internals";
 import layout from "select-kit/templates/components/select-kit/select-kit-row";
 import { makeArray } from "discourse-common/lib/helpers";
 import { reads } from "@ember/object/computed";
+import { dasherize } from "@ember/string";
 
 export default Component.extend(UtilsMixin, {
   layout,
@@ -72,7 +73,7 @@ export default Component.extend(UtilsMixin, {
   }),
 
   dasherizedTitle: computed("title", function () {
-    return (this.title || "").replace(".", "-").dasherize();
+    return dasherize((this.title || "").replace(".", "-"));
   }),
 
   label: computed("rowLabel", "item.label", "title", "rowName", function () {


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions