### PR TITLE
DEV: Readonly Redis support for `DiscourseRedis#multi/pipelined`

### DIFF
--- a/lib/discourse_redis.rb
+++ b/lib/discourse_redis.rb
@@ -151,22 +151,26 @@ class DiscourseRedis
   end
 
   def multi
-    if block_given?
-      @redis.multi do |transaction|
-        yield DiscourseRedis.new(@config, namespace: @namespace, raw_redis: transaction)
+    DiscourseRedis.ignore_readonly do
+      if block_given?
+        @redis.multi do |transaction|
+          yield DiscourseRedis.new(@config, namespace: @namespace, raw_redis: transaction)
+        end
+      else
+        @redis.multi
       end
-    else
-      @redis.multi
     end
   end
 
   def pipelined
-    if block_given?
-      @redis.pipelined do |transaction|
-        yield DiscourseRedis.new(@config, namespace: @namespace, raw_redis: transaction)
+    DiscourseRedis.ignore_readonly do
+      if block_given?
+        @redis.pipelined do |transaction|
+          yield DiscourseRedis.new(@config, namespace: @namespace, raw_redis: transaction)
+        end
+      else
+        @redis.pipelined
       end
-    else
-      @redis.pipelined
     end
   end
 


### PR DESCRIPTION
Follow-up to 2df3c65ba90a3a7c6ca27e1733502521c5f6243a