### PR TITLE
FIX: Add safari 12 to ember-cli build targets in production

### DIFF
--- a/app/assets/javascripts/discourse/config/targets.js
+++ b/app/assets/javascripts/discourse/config/targets.js
@@ -1,10 +1,18 @@
 "use strict";
 
+const isCI = !!process.env.CI;
+const isProduction = process.env.EMBER_ENV === "production";
+
 const browsers = [
   "last 1 Chrome versions",
   "last 1 Firefox versions",
   "last 1 Safari versions",
 ];
+
+if (isCI || isProduction) {
+  // https://meta.discourse.org/t/224747
+  browsers.push("Safari 12");
+}
 
 module.exports = {
   browsers,


### PR DESCRIPTION
cf273ec6 removed ie11 as a target. A side effect is that this also removed support for Safari 12, which we will be maintaining support for until January 2023

https://meta.discourse.org/t/224747

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
