### PR TITLE
FIX: Use CSS transition to make room for composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -62,6 +62,16 @@ export default Component.extend(KeyEnterEscape, {
     this.appEvents.trigger("composer:resized");
   },
 
+  @observes("composeState")
+  _setMainOutletPaddingBottom() {
+    const mainOutletElement = document.querySelector("#main-outlet");
+    if (this.composeState === Composer.OPEN) {
+      mainOutletElement.style.paddingBottom = "300px";
+    } else if (this.composeState === Composer.CLOSED) {
+      mainOutletElement.style.paddingBottom = "";
+    }
+  },
+
   @observes("composeState", "composer.{action,canEditTopicFeaturedLink}")
   resize() {
     schedule("afterRender", () => {

--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -66,7 +66,8 @@ export default Component.extend(KeyEnterEscape, {
   _setMainOutletPaddingBottom() {
     const mainOutletElement = document.querySelector("#main-outlet");
     if (this.composeState === Composer.OPEN) {
-      mainOutletElement.style.paddingBottom = "300px";
+      mainOutletElement.style.paddingBottom =
+        this.element.style.height || "300px";
     } else if (this.composeState === Composer.CLOSED) {
       mainOutletElement.style.paddingBottom = "";
     }

--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -103,13 +103,12 @@ export default Component.extend(KeyEnterEscape, {
 
     let size = this.origComposerSize + (this.lastMousePos - currentMousePos);
     size = Math.min(size, window.innerHeight - headerOffset());
-
     const minHeight = parseInt(getComputedStyle(this.element).minHeight, 10);
     size = Math.max(minHeight, size);
 
-    ["--composer-height", "--composer-height-title"].forEach((prop) => {
-      document.documentElement.style.setProperty(prop, size ? `${size}px` : "");
-    });
+    ["--reply-composer-height", "--new-topic-composer-height"].forEach((prop) =>
+      document.documentElement.style.setProperty(prop, size ? `${size}px` : "")
+    );
 
     this._triggerComposerResized();
   },

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -5,6 +5,7 @@
 html.composer-open {
   #main-outlet {
     padding-bottom: var(--reply-composer-height);
+    transition: padding-bottom 250ms ease;
   }
 }
 #reply-control {

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1,3 +1,12 @@
+:root {
+  --composer-height: 300px;
+  --composer-height-title: 400px;
+}
+html.composer-open {
+  #main-outlet {
+    padding-bottom: var(--composer-height);
+  }
+}
 #reply-control {
   position: fixed;
   display: flex;
@@ -43,9 +52,9 @@
   }
 
   &.open {
-    height: 300px;
+    height: var(--composer-height);
     &.edit-title {
-      height: 400px; // more room when editing the title
+      height: var(--composer-height-title); // more room when editing the title
     }
   }
 

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1,10 +1,10 @@
 :root {
-  --composer-height: 300px;
-  --composer-height-title: 400px;
+  --reply-composer-height: 300px;
+  --new-topic-composer-height: 400px;
 }
 html.composer-open {
   #main-outlet {
-    padding-bottom: var(--composer-height);
+    padding-bottom: var(--reply-composer-height);
   }
 }
 #reply-control {
@@ -52,9 +52,10 @@ html.composer-open {
   }
 
   &.open {
-    height: var(--composer-height);
+    height: var(--reply-composer-height);
     &.edit-title {
-      height: var(--composer-height-title); // more room when editing the title
+      // more room when editing the title
+      height: var(--new-topic-composer-height);
     }
   }
 

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -651,7 +651,6 @@ table {
 
 #main-outlet {
   padding-top: 2.5em;
-  transition: padding-bottom 250ms ease;
 }
 
 #main {

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -651,6 +651,7 @@ table {
 
 #main-outlet {
   padding-top: 2.5em;
+  transition: padding-bottom 250ms ease;
 }
 
 #main {


### PR DESCRIPTION
The composer is displayed over the bottom part of the page. To make sure
that no content is covered by the composer, a bottom padding is added
equal to the height of the composer. When the composer is opened or
closed that padding is added after around 300ms because of a debounce.

This commit makes sure that the padding is added as soon as the composer
state changes and uses a CSS transition for a smooth user interface.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
