### PR TITLE
DEV: Remove 'htmlSafe' string prototype extensions

### DIFF
--- a/app/assets/javascripts/discourse/app/models/site.js
+++ b/app/assets/javascripts/discourse/app/models/site.js
@@ -10,6 +10,7 @@ import deprecated from "discourse-common/lib/deprecated";
 import discourseComputed from "discourse-common/utils/decorators";
 import { getOwner } from "discourse-common/lib/get-owner";
 import { isEmpty } from "@ember/utils";
+import { htmlSafe } from "@ember/template";
 
 const Site = RestModel.extend({
   isReadOnly: alias("is_readonly"),
@@ -48,7 +49,7 @@ const Site = RestModel.extend({
     if (!isEmpty(siteFields)) {
       return siteFields.map((f) => {
         let value = fields ? fields[f.id.toString()] : null;
-        value = value || "&mdash;".htmlSafe();
+        value = value || htmlSafe("&mdash;");
         return { name: f.name, value };
       });
     }

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -30,6 +30,7 @@ import { isEmpty } from "@ember/utils";
 import { longDate } from "discourse/lib/formatter";
 import { url } from "discourse/lib/computed";
 import { userPath } from "discourse/lib/url";
+import { htmlSafe } from "@ember/template";
 
 export const SECOND_FACTOR_METHODS = {
   TOTP: 1,
@@ -176,9 +177,9 @@ const User = RestModel.extend({
   @discourseComputed("profile_background_upload_url")
   profileBackgroundUrl(bgUrl) {
     if (isEmpty(bgUrl) || !this.siteSettings.allow_profile_backgrounds) {
-      return "".htmlSafe();
+      return htmlSafe("");
     }
-    return ("background-image: url(" + getURLWithCDN(bgUrl) + ")").htmlSafe();
+    return htmlSafe("background-image: url(" + getURLWithCDN(bgUrl) + ")");
   },
 
   @discourseComputed()

--- a/app/assets/javascripts/discourse/app/routes/build-private-messages-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-private-messages-route.js
@@ -5,6 +5,7 @@ import { findOrResetCachedTopicList } from "discourse/lib/cached-topic-list";
 import { action } from "@ember/object";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import getURL from "discourse-common/lib/get-url";
+import { htmlSafe } from "@ember/template";
 
 export const NEW_FILTER = "new";
 export const UNREAD_FILTER = "unread";
@@ -85,10 +86,12 @@ export default (inboxType, path, filter) => {
 
     emptyState() {
       const title = I18n.t("user.no_messages_title");
-      const body = I18n.t("user.no_messages_body", {
-        aboutUrl: getURL("/about"),
-        icon: iconHTML("envelope"),
-      }).htmlSafe();
+      const body = htmlSafe(
+        I18n.t("user.no_messages_body", {
+          aboutUrl: getURL("/about"),
+          icon: iconHTML("envelope"),
+        })
+      );
       return { title, body };
     },
 

--- a/app/assets/javascripts/discourse/app/routes/user-activity-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-index.js
@@ -2,18 +2,21 @@ import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import getURL from "discourse-common/lib/get-url";
 import I18n from "I18n";
+import { htmlSafe } from "@ember/template";
 
 export default UserActivityStreamRoute.extend({
   userActionType: null,
 
   emptyState() {
     const title = I18n.t("user_activity.no_activity_title");
-    const body = I18n.t("user_activity.no_activity_body", {
-      topUrl: getURL("/top"),
-      categoriesUrl: getURL("/categories"),
-      preferencesUrl: getURL("/my/preferences"),
-      heartIcon: iconHTML("heart"),
-    }).htmlSafe();
+    const body = htmlSafe(
+      I18n.t("user_activity.no_activity_body", {
+        topUrl: getURL("/top"),
+        categoriesUrl: getURL("/categories"),
+        preferencesUrl: getURL("/my/preferences"),
+        heartIcon: iconHTML("heart"),
+      })
+    );
 
     return { title, body };
   },


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions