### PR TITLE
FEATURE: Pull hotlinked images immediately after posting

### DIFF
--- a/app/jobs/regular/process_post.rb
+++ b/app/jobs/regular/process_post.rb
@@ -40,6 +40,8 @@ module Jobs
           end
         end
 
+        enqueue_pull_hotlinked_images(post) unless args[:skip_pull_hotlinked_images]
+
         if !post.user&.staff? && !post.user&.staged?
           s = post.raw
           s << " #{post.topic.title}" if post.post_number == 1
@@ -59,6 +61,11 @@ module Jobs
     def extract_links(post)
       TopicLink.extract_from(post)
       QuotedPost.extract_from(post)
+    end
+
+    def enqueue_pull_hotlinked_images(post)
+      Jobs.cancel_scheduled_job(:pull_hotlinked_images, post_id: post.id)
+      Jobs.enqueue(:pull_hotlinked_images, post_id: post.id)
     end
   end
 

--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -237,12 +237,7 @@ module Jobs
     protected
 
     def normalize_src(src)
-      uri = Addressable::URI.heuristic_parse(src)
-      uri.normalize!
-      uri.scheme = nil
-      uri.to_s
-    rescue URI::Error, Addressable::URI::InvalidURIError
-      src
+      PostHotlinkedMedia.normalize_src(src)
     end
   end
 

--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -10,16 +10,13 @@ module Jobs
     end
 
     def execute(args)
+      disable_if_low_on_disk_space
+
       @post_id = args[:post_id]
       raise Discourse::InvalidParameters.new(:post_id) if @post_id.blank?
 
       post = Post.find_by(id: @post_id)
-      return if post.blank?
-      return if post.topic.blank?
-      return if post.cook_method == Post.cook_methods[:raw_html]
-
-      raw = post.raw.dup
-      start_raw = raw.dup
+      return if post.nil? || post.topic.nil?
 
       hotlinked_map = post.post_hotlinked_media.map { |r| [r.url, r] }.to_h
 
@@ -55,29 +52,22 @@ module Jobs
           changed_hotlink_records = true
           hotlink_record.save!
         end
-
-        # have we successfully downloaded that file?
-        if upload = hotlink_record&.upload
-          raw = replace_in_raw(original_src: original_src, upload: upload, raw: raw)
-        end
       rescue => e
         raise e if Rails.env.test?
         log(:error, "Failed to pull hotlinked image (#{download_src}) post: #{@post_id}\n" + e.message + "\n" + e.backtrace.join("\n"))
       end
 
-      # If post changed while we were downloading images, never apply edits
-      post.reload
-      post_changed_elsewhere = (start_raw != post.raw)
-      raw_changed_here = (raw != post.raw)
-
-      if !post_changed_elsewhere && raw_changed_here
-        changes = { raw: raw, edit_reason: I18n.t("upload.edit_reason") }
-        post.revise(Discourse.system_user, changes, bypass_bump: true, skip_staff_log: true)
-      elsif changed_hotlink_records
+      if changed_hotlink_records
         post.trigger_post_process(
           bypass_bump: true,
           skip_pull_hotlinked_images: true # Avoid an infinite loop of job scheduling
         )
+      end
+
+      if hotlinked_map.size > 0
+        Jobs.cancel_scheduled_job(:update_hotlinked_raw, post_id: post.id)
+        update_raw_delay = SiteSetting.editing_grace_period + 1
+        Jobs.enqueue_in(update_raw_delay, :update_hotlinked_raw, post_id: post.id)
       end
     end
 
@@ -135,45 +125,6 @@ module Jobs
         log(:info, "Failed to persist downloaded hotlinked image for post: #{@post_id}: #{src} - #{upload.errors.full_messages.join("\n")}")
         raise UploadCreateError
       end
-    end
-
-    def replace_in_raw(original_src:, raw:, upload:)
-      raw = raw.dup
-      escaped_src = Regexp.escape(original_src)
-
-      replace_raw = ->(match, match_src, replacement, _index) {
-        if normalize_src(original_src) == normalize_src(match_src)
-          replacement =
-            if replacement.include?(InlineUploads::PLACEHOLDER)
-              replacement.sub(InlineUploads::PLACEHOLDER, upload.short_url)
-            elsif replacement.include?(InlineUploads::PATH_PLACEHOLDER)
-              replacement.sub(InlineUploads::PATH_PLACEHOLDER, upload.short_path)
-            end
-
-          raw = raw.gsub(
-            match,
-            replacement
-          )
-        end
-      }
-
-      # there are 6 ways to insert an image in a post
-      # HTML tag - <img src="http://...">
-      InlineUploads.match_img(raw, external_src: true, &replace_raw)
-
-      # BBCode tag - [img]http://...[/img]
-      InlineUploads.match_bbcode_img(raw, external_src: true, &replace_raw)
-
-      # Markdown linked image - [![alt](http://...)](http://...)
-      # Markdown inline - ![alt](http://...)
-      # Markdown inline - ![](http://... "image title")
-      # Markdown inline - ![alt](http://... "image title")
-      InlineUploads.match_md_inline_img(raw, external_src: true, &replace_raw)
-
-      # Direct link
-      raw.gsub!(/^#{escaped_src}(\s?)$/) { "![](#{upload.short_url})#{$1}" }
-
-      raw
     end
 
     def extract_images_from(html)
@@ -238,6 +189,30 @@ module Jobs
 
     def normalize_src(src)
       PostHotlinkedMedia.normalize_src(src)
+    end
+
+    def disable_if_low_on_disk_space
+      return if Discourse.store.external?
+      return if !SiteSetting.download_remote_images_to_local
+      return if available_disk_space >= SiteSetting.download_remote_images_threshold
+
+      SiteSetting.download_remote_images_to_local = false
+
+      # log the site setting change
+      reason = I18n.t("disable_remote_images_download_reason")
+      staff_action_logger = StaffActionLogger.new(Discourse.system_user)
+      staff_action_logger.log_site_setting_change("download_remote_images_to_local", true, false, details: reason)
+
+      # also send a private message to the site contact user notify_about_low_disk_space
+      notify_about_low_disk_space
+    end
+
+    def notify_about_low_disk_space
+      SystemMessage.create_from_system_user(Discourse.site_contact_user, :download_remote_images_disabled)
+    end
+
+    def available_disk_space
+      100 - DiskSpace.percent_free("#{Rails.root}/public/uploads")
     end
   end
 

--- a/app/jobs/regular/pull_user_profile_hotlinked_images.rb
+++ b/app/jobs/regular/pull_user_profile_hotlinked_images.rb
@@ -30,14 +30,14 @@ module Jobs
         rescue ImageBrokenError
           broken_image_urls << normalized_src
         end
-
-        # have we successfully downloaded that file?
-        if upload = downloaded_images[normalized_src]
-          user_profile.bio_raw = replace_in_raw(original_src: original_src, upload: upload, raw: user_profile.bio_raw)
-        end
       rescue => e
         raise e if Rails.env.test?
         log(:error, "Failed to pull hotlinked image (#{download_src}) user: #{@user_id}\n" + e.message + "\n" + e.backtrace.join("\n"))
+      end
+
+      user_profile.bio_raw = InlineUploads.replace_hotlinked_image_urls(raw: user_profile.bio_raw) do |match_src|
+        normalized_match_src = PostHotlinkedMedia.normalize_src(match_src)
+        downloaded_images[normalized_match_src]
       end
 
       user_profile.skip_pull_hotlinked_image = true

--- a/app/jobs/regular/update_hotlinked_raw.rb
+++ b/app/jobs/regular/update_hotlinked_raw.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Jobs
+  class UpdateHotlinkedRaw < ::Jobs::Base
+    sidekiq_options queue: 'low'
+
+    def execute(args)
+      @post_id = args[:post_id]
+      raise Discourse::InvalidParameters.new(:post_id) if @post_id.blank?
+
+      post = Post.find_by(id: @post_id)
+      return if post.nil?
+      return if post.cook_method == Post.cook_methods[:raw_html]
+
+      hotlinked_map = post.post_hotlinked_media.preload(:upload).map { |r| [r.url, r] }.to_h
+
+      raw = InlineUploads.replace_hotlinked_image_urls(raw: post.raw) do |match_src|
+        normalized_match_src = PostHotlinkedMedia.normalize_src(match_src)
+        hotlinked_map[normalized_match_src]&.upload
+      end
+
+      if post.raw != raw
+        changes = { raw: raw, edit_reason: I18n.t("upload.edit_reason") }
+        post.revise(Discourse.system_user, changes, bypass_bump: true, skip_staff_log: true)
+      end
+    end
+  end
+end

--- a/app/models/post_hotlinked_media.rb
+++ b/app/models/post_hotlinked_media.rb
@@ -9,6 +9,15 @@ class PostHotlinkedMedia < ActiveRecord::Base
     download_failed: "download_failed",
     upload_create_failed: "upload_create_failed"
   }
+
+  def self.normalize_src(src)
+    uri = Addressable::URI.heuristic_parse(src)
+    uri.normalize!
+    uri.scheme = nil
+    uri.to_s
+  rescue URI::Error, Addressable::URI::InvalidURIError
+    src
+  end
 end
 
 # == Schema Information

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -47,7 +47,6 @@ class CookedPostProcessor
       remove_user_ids
       update_post_image
       enforce_nofollow
-      pull_hotlinked_images
       grant_badges
       @post.link_post_uploads(fragments: @doc)
       DiscourseEvent.trigger(:post_process_cooked, @doc, @post)
@@ -360,41 +359,6 @@ class CookedPostProcessor
   def enforce_nofollow
     add_nofollow = !@omit_nofollow && SiteSetting.add_rel_nofollow_to_user_content
     PrettyText.add_rel_attributes_to_user_content(@doc, add_nofollow)
-  end
-
-  def pull_hotlinked_images
-    return if @opts[:skip_pull_hotlinked_images]
-    # have we enough disk space?
-    disable_if_low_on_disk_space # But still enqueue the job
-    # make sure no other job is scheduled
-    Jobs.cancel_scheduled_job(:pull_hotlinked_images, post_id: @post.id)
-    # schedule the job
-    delay = SiteSetting.editing_grace_period + 1
-    Jobs.enqueue_in(delay.seconds.to_i, :pull_hotlinked_images, post_id: @post.id)
-  end
-
-  def disable_if_low_on_disk_space
-    return if Discourse.store.external?
-    return if !SiteSetting.download_remote_images_to_local
-    return if available_disk_space >= SiteSetting.download_remote_images_threshold
-
-    SiteSetting.download_remote_images_to_local = false
-
-    # log the site setting change
-    reason = I18n.t("disable_remote_images_download_reason")
-    staff_action_logger = StaffActionLogger.new(Discourse.system_user)
-    staff_action_logger.log_site_setting_change("download_remote_images_to_local", true, false, details: reason)
-
-    # also send a private message to the site contact user notify_about_low_disk_space
-    notify_about_low_disk_space
-  end
-
-  def notify_about_low_disk_space
-    SystemMessage.create_from_system_user(Discourse.site_contact_user, :download_remote_images_disabled)
-  end
-
-  def available_disk_space
-    100 - DiskSpace.percent_free("#{Rails.root}/public/uploads")
   end
 
   private

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -145,18 +145,6 @@ class CookedPostProcessor
     @doc.css(".onebox.githubfolder img")
   end
 
-  def large_images
-    @large_images ||= @post&.post_hotlinked_media.select { |r| r.too_large? }.map(&:url)
-  end
-
-  def broken_images
-    @broken_images ||= @post&.post_hotlinked_media.select { |r| r.download_failed? }.map(&:url)
-  end
-
-  def downloaded_images
-    @downloaded_images ||= @post&.post_hotlinked_media.select { |r| r.downloaded? }.map { |r| [r.url, r.upload_id] }.to_h
-  end
-
   def convert_to_link!(img)
     w, h = img["width"].to_i, img["height"].to_i
     user_width, user_height = (w > 0 && h > 0 && [w, h]) ||
@@ -413,8 +401,29 @@ class CookedPostProcessor
 
   def post_process_images
     extract_images.each do |img|
-      convert_to_link!(img) unless add_image_placeholder!(img)
+      still_an_image = process_hotlinked_image(img)
+      convert_to_link!(img) if still_an_image
     end
+  end
+
+  def process_hotlinked_image(img)
+    @hotlinked_map ||= @post.post_hotlinked_media.preload(:upload).map { |r| [r.url, r] }.to_h
+    normalized_src = PostHotlinkedMedia.normalize_src(img["src"])
+    info = @hotlinked_map[normalized_src]
+
+    still_an_image = true
+
+    if info&.too_large?
+      add_large_image_placeholder!(img)
+      still_an_image = false
+    elsif info&.download_failed?
+      add_broken_image_placeholder!(img)
+      still_an_image = false
+    elsif info&.downloaded? && upload = info&.upload
+      img["src"] = UrlHelper.cook_url(upload.url, secure: @with_secure_media)
+    end
+
+    still_an_image
   end
 
   def is_svg?(img)


### PR DESCRIPTION
Previously, with the default `editing_grace_period`, hotlinked images were pulled 5 minutes after a post is created. This delay was added to reduce the chance of automated edits clashing with user edits.

This commit refactors things so that we can pull hotlinked images immediately. URLs are immediately updated in the post's `cooked` HTML. The post's raw markdown is updated later, after the `editing_grace_period`.

This involves a number of behind-the-scenes changes including:

- Schedule Jobs::PullHotlinkedImages immediately after Jobs::ProcessPost. Move scheduling to after the `update_column` call to avoid race conditions

- Move raw changes into a separate job, which is delayed until after the ninja-edit window

- Move disable_if_low_on_disk_space logic into the `pull_hotlinked_images` job

- Move raw-parsing/replacing logic into `InlineUpload` so it can be easily be shared between `UpdateHotlinkedRaw` and `PullUserProfileHotlinkedImages`