### PR TITLE
UX: Fix status icon size in suggested topics

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -359,13 +359,6 @@ pre.codeblock-buttons:hover {
   }
 }
 
-.suggested-topics .topic-statuses .topic-status {
-  padding: 0;
-  .d-icon {
-    font-size: 1em;
-  }
-}
-
 span.post-count {
   background: var(--primary);
   color: var(--secondary);


### PR DESCRIPTION
Small cleanup, `padding: 0` has no effect (it doesn't override anything) and setting a font-size for the icon makes it stay small on larger zoom levels. 