### PR TITLE
FEATURE: Add page title to 404 pages

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -1226,6 +1226,7 @@ export default RestModel.extend({
 
     const json = error.jqXHR.responseJSON;
     if (json && json.extras && json.extras.html) {
+      topic.set("errorTitle", json.extras.title);
       topic.set("errorHtml", json.extras.html);
     } else {
       topic.set("errorMessage", I18n.t("topic.server_error.description"));

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -36,6 +36,10 @@ const TopicRoute = DiscourseRoute.extend({
   titleToken() {
     const model = this.modelFor("topic");
     if (model) {
+      if (model.get("errorHtml")) {
+        return model.get("errorTitle");
+      }
+
       const result = model.get("unicode_title") || model.get("title"),
         cat = model.get("category");
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -321,7 +321,11 @@ class ApplicationController < ActionController::Base
       with_resolved_locale(check_current_user: false) do
         # Include error in HTML format for topics#show.
         if (request.params[:controller] == 'topics' && request.params[:action] == 'show') || (request.params[:controller] == 'categories' && request.params[:action] == 'find_by_slug')
-          opts[:extras] = { html: build_not_found_page(error_page_opts), group: error_page_opts[:group] }
+          opts[:extras] = {
+            title: I18n.t('page_not_found.page_title'),
+            html: build_not_found_page(error_page_opts),
+            group: error_page_opts[:group]
+          }
         end
       end
 
@@ -896,6 +900,7 @@ class ApplicationController < ActionController::Base
     end
 
     @container_class = "wrap not-found-container"
+    @page_title = I18n.t("page_not_found.page_title")
     @title = opts[:title] || I18n.t("page_not_found.title")
     @group = opts[:group]
     @hide_search = true if SiteSetting.login_required

--- a/app/views/exceptions/not_found.html.erb
+++ b/app/views/exceptions/not_found.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title do %><%= @page_title %> - <%= SiteSetting.title %><% end %>
+
 <div class="page-not-found">
   <h1 class="title"><%= @title %></h1>
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4065,6 +4065,7 @@ en:
   site_setting_missing: "`%{name}` site setting has to be set."
 
   page_not_found:
+    page_title: "Page Not Found"
     title: "Oops! That page doesn’t exist or is private."
     popular_topics: "Popular"
     recent_topics: "Recent"

--- a/spec/requests/exceptions_controller_spec.rb
+++ b/spec/requests/exceptions_controller_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe ExceptionsController do
       expect(response.status).to eq(404)
 
       expect(response.body).to have_tag(
+        "title",
+        text: "#{I18n.t("page_not_found.page_title")} - #{SiteSetting.title}"
+      )
+
+      expect(response.body).to have_tag(
         "img",
         with: {
           src: SiteSetting.site_logo_url


### PR DESCRIPTION
The title had to be added both on the 404 page generated by the server
side, displayed when the user reaches a bad page directly and the 404
page rendered by Ember when a user reaches a missing topic while
navigating the forum.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
