### PR TITLE
FIX: `acted` state in post action like could desync with multiple likes

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post.js
+++ b/app/assets/javascripts/discourse/app/models/post.js
@@ -356,7 +356,8 @@ const Post = RestModel.extend({
   },
 
   updateLikeCount(count, userId, eventType) {
-    let ownLike = User.current()?.id === userId && eventType === "liked";
+    let ownAction = User.current()?.id === userId;
+    let ownLike = ownAction && eventType === "liked";
     let current_actions_summary = this.get("actions_summary");
     let likeActionID = Site.current().post_action_types.find(
       (a) => a.name_key === "like"
@@ -375,6 +376,10 @@ const Post = RestModel.extend({
       this.set("actionByName", json.actionByName);
       this.set("likeAction", json.likeAction);
     } else {
+      newActionObject.acted =
+        (ownLike || this.likeAction.acted) &&
+        !(eventType === "unliked" && ownAction);
+
       Object.assign(
         this.actions_summary.find((entry) => entry.id === likeActionID),
         newActionObject


### PR DESCRIPTION
If userA has multiple tab/devices on the same topic, and:

1. userA likes a post in tab1
2. userB likes the same post
3. userA post like `acted` attr would desync in tab2

This fix handles this case and also the reverse one when removing likes
interleaved with other users acting on the same post.

Reported in Meta at https://meta.discourse.org/t/-/227239/3
