### PR TITLE
UX: consistent spacing on group interaction form

### DIFF
--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -166,6 +166,10 @@
       width: 100%;
     }
   }
+
+  .groups-form-incoming-email {
+    margin-bottom: 1em;
+  }
 }
 
 .group-manage-logs-controls {


### PR DESCRIPTION
Before:

<img width="572" alt="Screenshot 2022-05-17 at 16 21 41" src="https://user-images.githubusercontent.com/11170663/168796301-d4cbdb3c-ec60-4b6b-ae66-8186cc564618.png">

After:

<img width="568" alt="Screenshot 2022-05-17 at 16 24 35" src="https://user-images.githubusercontent.com/11170663/168796311-09e69ed9-9ea0-4183-ae0b-b80af2087083.png">
