### PR TITLE
FIX: Allow users to select "regular" categories

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/categories.js
@@ -20,13 +20,10 @@ export default Controller.extend({
     "model.watchedCategories",
     "model.watchedFirstPostCategories",
     "model.trackedCategories",
-    "model.regularCategories",
     "model.mutedCategories"
   )
-  selectedCategories(watched, watchedFirst, tracked, regular, muted) {
-    return []
-      .concat(watched, watchedFirst, tracked, regular, muted)
-      .filter((t) => t);
+  selectedCategories(watched, watchedFirst, tracked, muted) {
+    return [].concat(watched, watchedFirst, tracked, muted).filter((t) => t);
   },
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/tests/fixtures/user-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/user-fixtures.js
@@ -178,7 +178,7 @@ export default {
       skip_new_user_tips: false,
       enable_quoting: true,
       muted_category_ids: [],
-      regular_category_ids: [],
+      regular_category_ids: [4],
       tracked_category_ids: [],
       watched_category_ids: [3],
       watched_first_post_category_ids: [],


### PR DESCRIPTION
Categories that had a CategoryUser record and the notification level
set to "Normal" were not selectable in any of the "Watched", "Tracked",
"Watching First Post" or "Muted" inputs. This happened because the
category seemed to be already selected in the "Normal" input, but that
does not exist (it is the default value if category is not present in
any of the other inputs).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
