### PR TITLE
update hljs-builtin-name highlight

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -111,7 +111,7 @@
   --hljs-attribute: #{$hljs-attribute};
   --hljs-symbol: #{$hljs-symbol};
   --hljs-bg: #{$hljs-bg};
-
+  --hljs-builtin-name: #{dark-light-choose(var(--tertiary-high), #65b9db)};
   --google: #{$google};
   --google-hover: #{$google-hover};
   --instagram: #{$instagram};

--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -111,7 +111,7 @@
   --hljs-attribute: #{$hljs-attribute};
   --hljs-symbol: #{$hljs-symbol};
   --hljs-bg: #{$hljs-bg};
-  --hljs-builtin-name: #{dark-light-choose(var(--tertiary-high), #65b9db)};
+  --hljs-builtin-name: #{$hljs-builtin-name};
   --google: #{$google};
   --google-hover: #{$google-hover};
   --instagram: #{$instagram};

--- a/app/assets/stylesheets/common/base/code_highlighting.scss
+++ b/app/assets/stylesheets/common/base/code_highlighting.scss
@@ -90,7 +90,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .lisp .hljs-title,
 .clojure .hljs-built_in,
 .hljs-builtin-name {
-  color: var(--tertiary-high);
+  color: var(--hljs-builtin-name);
 }
 
 .meta {

--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -154,3 +154,7 @@ $hljs-attribute: dark-light-choose(
 ) !default;
 $hljs-symbol: dark-light-choose(unquote("#990073"), unquote("#fbe")) !default;
 $hljs-bg: dark-light-choose(unquote("#f8f8f8"), unquote("#333")) !default;
+$hljs-builtin-name: dark-light-choose(
+  $tertiary-high,
+  unquote("#65b9db")
+) !default;


### PR DESCRIPTION
Colour for hljs-builtin-name highlight wasn't very readable in dark mode
https://meta.discourse.org/t/almost-unreadable-code-highlighting-in-dark-mode/226334/8

before ("tuple" & "map"):
<img width="697" alt="image" src="https://user-images.githubusercontent.com/101828855/169048399-356745d5-f5c8-40d5-8816-8742a4c7eff5.png">

after:
<img width="712" alt="image" src="https://user-images.githubusercontent.com/101828855/169048330-e8edcf6d-8635-482d-8f76-b4946dba880e.png">
