### PR TITLE
FIX: Apply 'allowed_href_schemes' to all src/srcset attributes

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/allow-lister.js
+++ b/app/assets/javascripts/pretty-text/addon/allow-lister.js
@@ -176,6 +176,7 @@ export const DEFAULT_LIST = [
   "img[title]",
   "img[width]",
   "img[data-thumbnail]",
+  // img[src] handled by sanitizer.js
   "ins",
   "kbd",
   "li",
@@ -203,14 +204,13 @@ export const DEFAULT_LIST = [
   "sub",
   "sup",
   "source[data-orig-src]",
-  "source[src]",
-  "source[srcset]",
+  // source[src] and source[srcset] handled by sanitizer.js
   "source[type]",
   "track",
   "track[default]",
   "track[label]",
   "track[kind]",
-  "track[src]",
+  // track[src] handled by sanitizer.js
   "track[srclang]",
   "ul",
   "video",


### PR DESCRIPTION
Previously we were only applying the restriction to `a[href]` and `img[src]`. This commit ensures we apply the same logic to all allowlisted media src attributes.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
