### PR TITLE
UX: update hljs-builtin-name colour

### DIFF
--- a/app/assets/stylesheets/common/foundation/color_transformations.scss
+++ b/app/assets/stylesheets/common/foundation/color_transformations.scss
@@ -154,7 +154,4 @@ $hljs-attribute: dark-light-choose(
 ) !default;
 $hljs-symbol: dark-light-choose(unquote("#990073"), unquote("#fbe")) !default;
 $hljs-bg: dark-light-choose(unquote("#f8f8f8"), unquote("#333")) !default;
-$hljs-builtin-name: dark-light-choose(
-  $tertiary-high,
-  unquote("#65b9db")
-) !default;
+$hljs-builtin-name: dark-light-choose($tertiary-high, $tertiary-hover) !default;


### PR DESCRIPTION
I am an idiot. Forgot I already agreed with Kris to use this colour instead (so to not create an obsolete new one). 🤦🏻‍♀️ 

<img width="787" alt="image" src="https://user-images.githubusercontent.com/101828855/169118233-1a452344-f2be-49d8-bf40-8f90ed4f8e11.png">
