### PR TITLE
FIX: Apply censored words to inline onebox

### DIFF
--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -103,7 +103,7 @@ class WordWatcher
 
     doc = Nokogiri::HTML5::fragment(html)
     doc.traverse do |node|
-      node.content = censor_text(node.content) if node.text?
+      node.content = censor_text_with_regexp(node.content, regexp) if node.text?
     end
     doc.to_s
   end
@@ -112,15 +112,7 @@ class WordWatcher
     regexp = WordWatcher.word_matcher_regexp(:censor)
     return text if regexp.blank?
 
-    text = text.gsub(regexp) do |match|
-      # the regex captures leading whitespaces
-      padding = match.size - match.lstrip.size
-      if padding > 0
-        match[0..padding - 1] + REPLACEMENT_LETTER * (match.size - padding)
-      else
-        REPLACEMENT_LETTER * match.size
-      end
-    end
+    censor_text_with_regexp(text, regexp)
   end
 
   def self.clear_cache!
@@ -176,5 +168,19 @@ class WordWatcher
 
   def word_matches?(word)
     Regexp.new(WordWatcher.word_to_regexp(word, whole: true), Regexp::IGNORECASE).match?(@raw)
+  end
+
+  private
+
+  def self.censor_text_with_regexp(text, regexp)
+    text.gsub(regexp) do |match|
+      # the regex captures leading whitespaces
+      padding = match.size - match.lstrip.size
+      if padding > 0
+        match[0..padding - 1] + REPLACEMENT_LETTER * (match.size - padding)
+      else
+        REPLACEMENT_LETTER * match.size
+      end
+    end
   end
 end

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -103,19 +103,24 @@ class WordWatcher
 
     doc = Nokogiri::HTML5::fragment(html)
     doc.traverse do |node|
-      if node.text?
-        node.content = node.content.gsub(regexp) do |match|
-          # the regex captures leading whitespaces
-          padding = match.size - match.lstrip.size
-          if padding > 0
-            match[0..padding - 1] + REPLACEMENT_LETTER * (match.size - padding)
-          else
-            REPLACEMENT_LETTER * match.size
-          end
-        end
-      end
+      node.content = censor_text(node.content) if node.text?
     end
     doc.to_s
+  end
+
+  def self.censor_text(text)
+    regexp = WordWatcher.word_matcher_regexp(:censor)
+    return text if regexp.blank?
+
+    text = text.gsub(regexp) do |match|
+      # the regex captures leading whitespaces
+      padding = match.size - match.lstrip.size
+      if padding > 0
+        match[0..padding - 1] + REPLACEMENT_LETTER * (match.size - padding)
+      else
+        REPLACEMENT_LETTER * match.size
+      end
+    end
   end
 
   def self.clear_cache!

--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -108,6 +108,7 @@ class InlineOneboxer
       end
     end
     onebox = { url: url, title: title && Emoji.gsub_emoji_to_unicode(title) }
+    onebox[:title] = WordWatcher.censor_text(onebox[:title])
     Discourse.cache.write(cache_key(url), onebox, expires_in: 1.day) if !opts[:skip_cache]
     onebox
   end


### PR DESCRIPTION
Censored watched words were not censored inside the title of an inline
oneboxes. Malicious users could exploit this behaviour to insert bad
words. The same issue has been fixed for regular Oneboxes in commit
d184fe59ca7885741ed9f840d3209a9a5ed861ea.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
