### PR TITLE
FEATURE: Site setting for blocking onebox of URLs that redirect

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1539,6 +1539,7 @@ en:
     show_pinned_excerpt_desktop: "Show excerpt on pinned topics in desktop view."
     post_onebox_maxlength: "Maximum length of a oneboxed Discourse post in characters."
     blocked_onebox_domains: "A list of domains that will never be oneboxed e.g. wikipedia.org\n(Wildcard symbols * ? not supported)"
+    block_onebox_on_redirect: "Block onebox for URLs that redirect."
     allowed_inline_onebox_domains: "A list of domains that will be oneboxed in miniature form if linked without a title"
     enable_inline_onebox_on_all_domains: "Ignore inline_onebox_domain_allowlist site setting and allow inline onebox on all domains."
     force_custom_user_agent_hosts: "Hosts for which to use the custom onebox user agent on all requests. (Especially useful for hosts that limit access by user agent)."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1742,6 +1742,8 @@ onebox:
   facebook_app_access_token:
     default: ""
     secret: true
+  block_onebox_on_redirect:
+    default: false
   cache_onebox_response_body:
     default: false
     hidden: true

--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -62,7 +62,14 @@ class InlineOneboxer
         uri.hostname.present? &&
         (always_allow || allowed_domains.include?(uri.hostname)) &&
         !Onebox::DomainChecker.is_blocked?(uri.hostname)
-        title = RetrieveTitle.crawl(url)
+        if SiteSetting.block_onebox_on_redirect
+          max_redirects = 0
+        end
+        title = RetrieveTitle.crawl(
+          url,
+          max_redirects: max_redirects,
+          initial_https_redirect_ignore_limit: SiteSetting.block_onebox_on_redirect
+        )
         title = nil if title && title.length < MIN_TITLE_LENGTH
         return onebox_for(url, title, opts)
       end

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -397,9 +397,16 @@ module Oneboxer
       available_strategies ||= Oneboxer.ordered_strategies(uri.hostname)
       strategy = available_strategies.shift
 
+      if SiteSetting.block_onebox_on_redirect
+        max_redirects = 0
+      end
       fd = FinalDestination.new(
         url,
-        get_final_destination_options(url, strategy).merge(stop_at_blocked_pages: true)
+        get_final_destination_options(url, strategy).merge(
+          stop_at_blocked_pages: true,
+          max_redirects: max_redirects,
+          initial_https_redirect_ignore_limit: SiteSetting.block_onebox_on_redirect
+        )
       )
       uri = fd.resolve
 

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -3,8 +3,12 @@
 module RetrieveTitle
   CRAWL_TIMEOUT = 1
 
-  def self.crawl(url)
-    fetch_title(url)
+  def self.crawl(url, max_redirects: nil, initial_https_redirect_ignore_limit: false)
+    fetch_title(
+      url,
+      max_redirects: max_redirects,
+      initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit
+    )
   rescue Exception => ex
     raise if Rails.env.test?
     Rails.logger.error(ex)
@@ -53,8 +57,14 @@ module RetrieveTitle
   end
 
   # Fetch the beginning of a HTML document at a url
-  def self.fetch_title(url)
-    fd = FinalDestination.new(url, timeout: CRAWL_TIMEOUT, stop_at_blocked_pages: true)
+  def self.fetch_title(url, max_redirects: nil, initial_https_redirect_ignore_limit: false)
+    fd = FinalDestination.new(
+      url,
+      timeout: CRAWL_TIMEOUT,
+      stop_at_blocked_pages: true,
+      max_redirects: max_redirects,
+      initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit
+    )
 
     current = nil
     title = nil

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -243,6 +243,97 @@ describe Oneboxer do
       end
     end
 
+    context "when block_onebox_on_redirect setting is enabled" do
+      before do
+        Discourse.cache.clear
+        SiteSetting.block_onebox_on_redirect = true
+      end
+
+      after do
+        FinalDestination.clear_https_cache!("redirects2.com")
+        FinalDestination.clear_https_cache!("redirects3.com")
+        FinalDestination.clear_https_cache!("redirects4.com")
+      end
+
+      it "doesn't return onebox if the URL redirects" do
+        stub_request(:head, "https://redirects2.com/full-onebox")
+          .to_return(
+            status: 301,
+            body: "",
+            headers: { "location" => "https://redirects2.com/real-full-onebox" }
+          )
+        stub_request(:get, "https://redirects2.com/full-onebox")
+          .to_return(
+            status: 301,
+            body: "",
+            headers: { "location" => "https://redirects2.com/real-full-onebox" }
+          )
+        result = Oneboxer.external_onebox("https://redirects2.com/full-onebox")
+        expect(result[:onebox]).to be_blank
+      end
+
+      it "allows an initial http -> https redirect if the redirect URL is identical to the original" do
+        stub_request(:get, "http://redirects3.com/full-onebox")
+          .to_return(
+            status: 301,
+            body: "",
+            headers: { "location" => "https://redirects3.com/full-onebox" }
+          )
+        stub_request(:head, "http://redirects3.com/full-onebox")
+          .to_return(
+            status: 301,
+            body: "",
+            headers: { "location" => "https://redirects3.com/full-onebox" }
+          )
+
+        stub_request(:get, "https://redirects3.com/full-onebox")
+          .to_return(
+            status: 200,
+            body: html
+          )
+        stub_request(:head, "https://redirects3.com/full-onebox")
+          .to_return(
+            status: 200,
+            body: "",
+          )
+        result = Oneboxer.external_onebox("http://redirects3.com/full-onebox")
+        onebox = result[:onebox]
+        expect(onebox).to include("https://redirects3.com/full-onebox")
+        expect(onebox).to include("Cats")
+        expect(onebox).to include("Meow")
+      end
+
+      it "doesn't allow an initial http -> https redirect if the redirect URL is different to the original" do
+        stub_request(:get, "http://redirects4.com/full-onebox")
+          .to_return(
+            status: 301,
+            body: "",
+            headers: { "location" => "https://redirects4.com/full-onebox/2" }
+          )
+        stub_request(:head, "http://redirects4.com/full-onebox")
+          .to_return(
+            status: 301,
+            body: "",
+            headers: { "location" => "https://redirects4.com/full-onebox/2" }
+          )
+
+        stub_request(:get, "https://redirects4.com/full-onebox")
+          .to_return(
+            status: 301,
+            body: "",
+            headers: { "location" => "https://redirects4.com/full-onebox/2" }
+          )
+        stub_request(:head, "https://redirects4.com/full-onebox")
+          .to_return(
+            status: 301,
+            body: "",
+            headers: { "location" => "https://redirects4.com/full-onebox/2" }
+          )
+        result = Oneboxer.external_onebox("http://redirects4.com/full-onebox")
+        expect(result[:onebox]).to be_blank
+      end
+    end
+
     it "censors external oneboxes" do
       Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "bad word")
 


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/prevent-to-linkify-when-there-is-a-redirect/226964/2?u=osama.

This PR adds a new site setting `block_onebox_on_redirect` (default off) for blocking oneboxes (full and inline) of URLs that redirect. Note that an initial http → https redirect is still allowed if the redirect location is identical to the source (minus the scheme of course). For example, if a user includes a link to `http://example.com/page` and the link resolves to `https://example.com/page`, then the link will onebox (assuming it can be oneboxed) even if the setting is enabled. The reason for this is a user may type out a URL (i.e. the URL is short and memorizable) with http and since a lot of sites support TLS with http traffic automatically redirected to https, so we should still allow the URL to onebox.