### PR TITLE
DEV: allow running plugin tests for server_plugin_outlet

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -450,8 +450,7 @@ module ApplicationHelper
   end
 
   def server_plugin_outlet(name, locals: {})
-    # Don't evaluate plugins in test
-    return "" if Rails.env.test?
+    return "" if !GlobalSetting.load_plugins?
 
     matcher = Regexp.new("/connectors/#{name}/.*\.html\.erb$")
     erbs = ApplicationHelper.all_connectors.select { |c| c =~ matcher }


### PR DESCRIPTION
This commit allows us to run plugin tests for `server_plugin_outlet` method.