### PR TITLE
UX: align the trash button on the bookmark modal

### DIFF
--- a/app/assets/stylesheets/common/components/bookmark-modal.scss
+++ b/app/assets/stylesheets/common/components/bookmark-modal.scss
@@ -10,6 +10,7 @@
 
     .delete-bookmark {
       margin-left: auto;
+      margin-right: 0;
     }
   }
   .modal-body {


### PR DESCRIPTION
Before:

<img width="250" alt="Screenshot 2022-05-20 at 17 46 17" src="https://user-images.githubusercontent.com/1274517/169542333-7afe6f83-6b22-42b0-b4b8-21b37b960275.png">

after:

<img width="250" alt="Screenshot 2022-05-20 at 17 47 14" src="https://user-images.githubusercontent.com/1274517/169542347-b5ffe222-23b6-47e1-a6d5-0b0343b08701.png">


