### PR TITLE
FEATURE Add reset bump dates bulk action

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic-bulk-actions.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic-bulk-actions.js
@@ -81,7 +81,7 @@ addBulkButton("resetBumpDateTopics", "reset_bump_dates", {
   class: "btn-default",
   buttonVisible() {
     return this.currentUser.canManageTopic;
-  }
+  },
 });
 addBulkButton("showTagTopics", "change_tags", {
   icon: "tag",

--- a/app/assets/javascripts/discourse/app/controllers/topic-bulk-actions.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic-bulk-actions.js
@@ -76,6 +76,13 @@ addBulkButton("relistTopics", "relist_topics", {
   buttonVisible: (topics) =>
     topics.some((t) => !t.visible) && !topics.some((t) => t.isPrivateMessage),
 });
+addBulkButton("resetBumpDateTopics", "reset_bump_dates", {
+  icon: "anchor",
+  class: "btn-default",
+  buttonVisible() {
+    return this.currentUser.canManageTopic;
+  }
+});
 addBulkButton("showTagTopics", "change_tags", {
   icon: "tag",
   class: "btn-default",
@@ -288,6 +295,10 @@ export default Controller.extend(ModalFunctionality, {
 
     relistTopics() {
       this.forEachPerformed({ type: "relist" }, (t) => t.set("visible", true));
+    },
+
+    resetBumpDateTopics() {
+      this.performAndRefresh({ type: "reset_bump_dates" });
     },
 
     changeCategory() {

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-bulk-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-bulk-actions-test.js
@@ -79,6 +79,13 @@ acceptance("Topic - Bulk Actions", function (needs) {
     assert.ok(
       queryAll(".bulk-buttons")
         .html()
+        .includes(I18n.t("topics.bulk.reset_bump_dates")),
+      "it shows an option to reset bump dates"
+    );
+
+    assert.ok(
+      queryAll(".bulk-buttons")
+        .html()
         .includes(I18n.t("topics.bulk.change_tags")),
       "it shows an option to replace tags"
     );

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2538,6 +2538,7 @@ en:
         clear_all: "Clear All"
         unlist_topics: "Unlist Topics"
         relist_topics: "Relist Topics"
+        reset_bump_dates: "Reset bump dates"
         defer: "Defer"
         delete: "Delete Topics"
         dismiss: "Dismiss"

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -14,7 +14,7 @@ class TopicsBulkAction
     @operations ||= %w(change_category close archive change_notification_level
                        destroy_post_timing dismiss_posts delete unlist archive_messages
                        move_messages_to_inbox change_tags append_tags remove_tags
-                       relist dismiss_topics)
+                       relist dismiss_topics reset_bump_dates)
   end
 
   def self.register_operation(name, &block)
@@ -161,6 +161,15 @@ class TopicsBulkAction
     topics.each do |t|
       if guardian.can_moderate?(t)
         t.update_status('visible', true, @user)
+        @changed_ids << t.id
+      end
+    end
+  end
+
+  def reset_bump_dates
+    if guardian.can_update_bumped_at?
+      topics.each do |t|
+        t.reset_bumped_at
         @changed_ids << t.id
       end
     end


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/is-it-possible-to-add-reset-bump-date-to-the-mass-action/137364

Screenshot with added bulk action "Reset bump dates" (2nd row, right side):

<img width="700" alt="bulk-actions" src="https://user-images.githubusercontent.com/494182/169550966-f581a1af-d438-451d-9c4d-6e17971dda03.png">

