### PR TITLE
FIX: Limits for PM and group header search

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -60,7 +60,6 @@ class SearchController < ApplicationController
 
     if rate_limit_errors
       result = Search::GroupedSearchResults.new(
-        type_filter: search_args[:type_filter],
         term: @search_term,
         search_context: context
       )
@@ -68,7 +67,6 @@ class SearchController < ApplicationController
       result.error = I18n.t("rate_limiter.slow_down")
     elsif site_overloaded?
       result = Search::GroupedSearchResults.new(
-        type_filter: search_args[:type_filter],
         term: @search_term,
         search_context: context
       )
@@ -122,7 +120,6 @@ class SearchController < ApplicationController
 
     if rate_limit_errors
       result = Search::GroupedSearchResults.new(
-        type_filter: search_args[:type_filter],
         term: params[:term],
         search_context: context
       )
@@ -130,7 +127,6 @@ class SearchController < ApplicationController
       result.error = I18n.t("rate_limiter.slow_down")
     elsif site_overloaded?
       result = GroupedSearchResults.new(
-        type_filter: search_args["type_filter"],
         term: params[:term],
         search_context: context
       )

--- a/lib/search/grouped_search_results.rb
+++ b/lib/search/grouped_search_results.rb
@@ -12,7 +12,6 @@ class Search
     end
 
     attr_reader(
-      :type_filter,
       :posts,
       :categories,
       :users,
@@ -31,8 +30,7 @@ class Search
 
     BLURB_LENGTH = 200
 
-    def initialize(type_filter:, term:, search_context:, blurb_length: nil, blurb_term: nil)
-      @type_filter = type_filter
+    def initialize(is_header_search: false, term:, search_context:, blurb_length: nil, blurb_term: nil)
       @term = term
       @blurb_term = blurb_term || term
       @search_context = search_context
@@ -43,6 +41,7 @@ class Search
       @tags = []
       @groups = []
       @error = nil
+      @is_header_search = is_header_search
     end
 
     def error=(error)
@@ -85,10 +84,9 @@ class Search
 
     def add(object)
       type = object.class.to_s.downcase.pluralize
-
-      if @type_filter.present? && public_send(type).length == Search.per_filter
+      if !@is_header_search && public_send(type).length == Search.per_filter
         @more_full_page_results = true
-      elsif !@type_filter.present? && public_send(type).length == Search.per_facet
+      elsif @is_header_search && public_send(type).length == Search.per_facet
         instance_variable_set("@more_#{type}".to_sym, true)
       else
         (self.public_send(type)) << object

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2195,24 +2195,26 @@ describe Search do
     let!(:post3) { Fabricate(:post, raw: 'hello hello hello') }
     let!(:post4) { Fabricate(:post, raw: 'hello hello') }
     let!(:post5) { Fabricate(:post, raw: 'hello') }
+
     before do
       Search.stubs(:per_filter).returns(number_of_results)
     end
 
     it 'returns more results flag' do
-      results = Search.execute('hello', type_filter: 'topic')
-      results2 = Search.execute('hello', type_filter: 'topic', page: 2)
+      results = Search.execute('hello', search_type: :full_page, type_filter: 'topic')
+      results2 = Search.execute('hello', search_type: :full_page, type_filter: 'topic', page: 2)
 
       expect(results.posts.length).to eq(number_of_results)
       expect(results.posts.map(&:id)).to eq([post1.id, post2.id])
       expect(results.more_full_page_results).to eq(true)
+
       expect(results2.posts.length).to eq(number_of_results)
       expect(results2.posts.map(&:id)).to eq([post3.id, post4.id])
       expect(results2.more_full_page_results).to eq(true)
     end
 
     it 'correctly search with page parameter' do
-      search = Search.new('hello', type_filter: 'topic', page: 3)
+      search = Search.new('hello', search_type: :full_page, type_filter: 'topic', page: 3)
       results = search.execute
 
       expect(search.offset).to eq(2 * number_of_results)
@@ -2221,6 +2223,36 @@ describe Search do
       expect(results.more_full_page_results).to eq(nil)
     end
 
+    it 'returns more results flag' do
+      results = Search.execute('hello', search_type: :header)
+      expect(results.posts.length).to eq(Search.per_facet)
+      expect(results.more_posts).to eq(nil) # not 6 posts yet
+
+      post6 = Fabricate(:post, raw: 'hello post #6')
+
+      results = Search.execute('hello', search_type: :header)
+      expect(results.posts.length).to eq(Search.per_facet)
+      expect(results.more_posts).to eq(true)
+    end
+  end
+
+  context 'header in-topic search' do
+    let!(:topic) { Fabricate(:topic, title: 'This is a topic with a bunch of posts') }
+    let!(:post1) { Fabricate(:post, topic: topic, raw: 'hola amiga') }
+    let!(:post2) { Fabricate(:post, topic: topic, raw: 'hola amigo') }
+    let!(:post3) { Fabricate(:post, topic: topic, raw: 'hola chica') }
+    let!(:post4) { Fabricate(:post, topic: topic, raw: 'hola chico') }
+    let!(:post5) { Fabricate(:post, topic: topic, raw: 'hola hermana') }
+    let!(:post6) { Fabricate(:post, topic: topic, raw: 'hola hermano') }
+    let!(:post7) { Fabricate(:post, topic: topic, raw: 'hola chiquito') }
+
+    it 'does not trigger pagination early' do
+      search = Search.new('hola', search_type: :header, search_context: topic)
+      results = search.execute
+
+      expect(results.posts.length).to eq(7)
+      expect(results.more_posts).to eq(nil)
+    end
   end
 
   context 'in:tagged' do

--- a/spec/requests/api/search_spec.rb
+++ b/spec/requests/api/search_spec.rb
@@ -30,9 +30,10 @@ describe 'groups' do
           - `after:`: `yyyy-mm-dd`
           - `order:`: `latest`, `likes`, `views`, `latest_topic`
           - `assigned:`: username (without `@`)
-          - `in:`: `title`, `likes`, `personal`, `seen`, `unseen`, `posted`, `created`, `watching`, `tracking`, `bookmarks`, `assigned`, `unassigned`, `first`, `pinned`, `wiki`
+          - `in:`: `title`, `likes`, `personal`, `messages`, `seen`, `unseen`, `posted`, `created`, `watching`, `tracking`, `bookmarks`, `assigned`, `unassigned`, `first`, `pinned`, `wiki`
           - `with:`: `images`
           - `status:`: `open`, `closed`, `public`, `archived`, `noreplies`, `single_user`, `solved`, `unsolved`
+          - `group_messages:`: groupname
           - `min_posts:`: 1
           - `max_posts:`: 10
           - `min_views:`: 1


### PR DESCRIPTION
When searching for PMs or PMs in a group inbox, results in the header search were not being limited to 5 with a "More" link to the full page search. This PR fixes that. 

It also simplifies the logic and updates the search API docs to include recently added `in:messages` and "group_messages:groupname` options.