### PR TITLE
FIX: Site setting changes for boolean should be logged as true/false

### DIFF
--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -182,8 +182,8 @@ class StaffActionLogger
     UserHistory.create!(params(opts).merge(
       action: UserHistory.actions[:change_site_setting],
       subject: setting_name,
-      previous_value: previous_value,
-      new_value: new_value
+      previous_value: previous_value&.to_s,
+      new_value: new_value&.to_s
     ))
   end
 

--- a/spec/services/staff_action_logger_spec.rb
+++ b/spec/services/staff_action_logger_spec.rb
@@ -145,6 +145,18 @@ describe StaffActionLogger do
     it "creates a new UserHistory record" do
       expect { logger.log_site_setting_change('title', 'Discourse', 'My Site') }.to change { UserHistory.count }.by(1)
     end
+
+    it "logs boolean values" do
+      log_record = logger.log_site_setting_change("allow_user_locale", true, false)
+      expect(log_record.previous_value).to eq("true")
+      expect(log_record.new_value).to eq("false")
+    end
+
+    it "logs nil values" do
+      log_record = logger.log_site_setting_change("title", nil, nil)
+      expect(log_record.previous_value).to be_nil
+      expect(log_record.new_value).to be_nil
+    end
   end
 
   describe "log_theme_change" do


### PR DESCRIPTION
Previously true/false sometimes was logged as t or f

Before:
![image](https://user-images.githubusercontent.com/473736/169715487-1047be2f-f1ea-4703-97bb-ed70d7e9b4ff.png)

After:
![image](https://user-images.githubusercontent.com/473736/169715515-d7a9a515-503e-4f76-b48a-3ef54f997368.png)
