### PR TITLE
FIX: Applying default user options didn't work for boolean flags

### DIFF
--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -11,6 +11,8 @@ class UserOption < ActiveRecord::Base
 
   after_save :update_tracked_topics
 
+  scope :human_users, -> { where('user_id > 0') }
+
   enum default_calendar: { none_selected: 0, ics: 1, google: 2 }, _scopes: false
 
   def self.ensure_consistency!


### PR DESCRIPTION
It also ensures that only human users are updated and replaces usage of `send` with `public_send`. Also, it adds more specs for existing code.