### PR TITLE
DEV(cache_critical_dns): improve postgres_healthcheck

### DIFF
--- a/script/cache_critical_dns
+++ b/script/cache_critical_dns
@@ -158,16 +158,18 @@ ensure
 end
 
 def postgres_healthcheck(host:, user:, password:, dbname:)
-  response = PG::Connection.ping(
+  client = PG::Connection.new(
     host: host,
     user: user,
     password: password,
     dbname: dbname,
     connect_timeout: 2,  # minimum
   )
-  response == PG::Constants::PQPING_OK
+  client.exec(';').none?
 rescue
   false
+ensure
+  client.close if client
 end
 
 HEALTH_CHECKS = {


### PR DESCRIPTION
The `PG::Connection#ping` method is only reliable for checking if the
given host is accepting connections, and not if the authentication
details are valid.

This extends the healthcheck to confirm that the auth details are
able to both create a connection and execute queries against the
database.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
