### PR TITLE
FIX: Skip pulling hotlinked images for nil user bio

### DIFF
--- a/app/jobs/regular/pull_user_profile_hotlinked_images.rb
+++ b/app/jobs/regular/pull_user_profile_hotlinked_images.rb
@@ -7,7 +7,7 @@ module Jobs
       raise Discourse::InvalidParameters.new(:user_id) if @user_id.blank?
 
       user_profile = UserProfile.find_by(user_id: @user_id)
-      return if user_profile.blank?
+      return if user_profile.blank? || user_profile.bio_cooked.nil?
 
       large_image_urls = []
       broken_image_urls = []

--- a/spec/jobs/pull_user_profile_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_user_profile_hotlinked_images_spec.rb
@@ -21,5 +21,10 @@ describe Jobs::PullUserProfileHotlinkedImages do
       expect { Jobs::PullUserProfileHotlinkedImages.new.execute(user_id: user.id) }.to change { Upload.count }.by(1)
       expect(user.user_profile.reload.bio_cooked).to include(Upload.last.url)
     end
+
+    it 'handles nil bio' do
+      expect { Jobs::PullUserProfileHotlinkedImages.new.execute(user_id: user.id) }.to change { Upload.count }.by(0)
+      expect(user.user_profile.reload.bio_cooked).to eq(nil)
+    end
   end
 end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
