### PR TITLE
DEV: Apply Rails 6.1 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -97,6 +97,12 @@ module Discourse
     # tiny file needed by site settings
     require 'highlight_js'
 
+    config.load_defaults 6.1
+    config.active_record.cache_versioning = false # our custom cache class doesn’t support this
+    config.action_controller.forgery_protection_origin_check = false
+    config.active_record.belongs_to_required_by_default = false
+    config.active_record.legacy_connection_handling = true
+
     # we skip it cause we configure it in the initializer
     # the railtie for message_bus would insert it in the
     # wrong position

--- a/spec/integration/multisite_cookies_spec.rb
+++ b/spec/integration/multisite_cookies_spec.rb
@@ -4,7 +4,7 @@ describe 'multisite', type: [:multisite, :request] do
   it "works" do
     get "http://test.localhost/session/csrf.json"
     expect(response.status).to eq(200)
-    cookie = response.cookies["_forum_session"]
+    cookie = CGI.escape(response.cookies["_forum_session"])
     id1 = session["session_id"]
 
     get "http://test.localhost/session/csrf.json", headers: { "Cookie" => "_forum_session=#{cookie};" }

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -261,7 +261,7 @@ describe Auth::DefaultCurrentUserProvider do
     let(:cookie) do
       new_provider = provider('/')
       new_provider.log_on_user(user, {}, new_provider.cookie_jar)
-      new_provider.cookie_jar["_t"]
+      CGI.escape(new_provider.cookie_jar["_t"])
     end
 
     before do
@@ -367,6 +367,7 @@ describe Auth::DefaultCurrentUserProvider do
 
     cookie = @provider.cookie_jar["_t"]
     unhashed_token = decrypt_auth_cookie(cookie)[:token]
+    cookie = CGI.escape(cookie)
 
     token = UserAuthToken.find_by(user_id: user.id)
 
@@ -431,6 +432,7 @@ describe Auth::DefaultCurrentUserProvider do
       @provider.log_on_user(user, {}, @provider.cookie_jar)
       cookie = @provider.cookie_jar["_t"]
       unhashed_token = decrypt_auth_cookie(cookie)[:token]
+      cookie = CGI.escape(cookie)
       freeze_time 20.minutes.from_now
       provider2 = provider("/", "HTTP_COOKIE" => "_t=#{cookie}")
       provider2.refresh_session(user, {}, provider2.cookie_jar)
@@ -442,6 +444,7 @@ describe Auth::DefaultCurrentUserProvider do
       @provider.log_on_user(user, {}, @provider.cookie_jar)
       cookie = @provider.cookie_jar["_t"]
       unhashed_token = decrypt_auth_cookie(cookie)[:token]
+      cookie = CGI.escape(cookie)
       freeze_time 2.minutes.from_now
       provider2 = provider("/", "HTTP_COOKIE" => "_t=#{cookie}")
       provider2.refresh_session(user, {}, provider2.cookie_jar)
@@ -748,7 +751,7 @@ describe Auth::DefaultCurrentUserProvider do
       method: "GET",
     })
     @provider.log_on_user(user, {}, @provider.cookie_jar)
-    cookie = @provider.cookie_jar["_t"]
+    cookie = CGI.escape(@provider.cookie_jar["_t"])
 
     ip = "10.0.0.1"
     env = { "HTTP_COOKIE" => "_t=#{cookie}", "REMOTE_ADDR" => ip }


### PR DESCRIPTION
We never applied `config.load_defaults` since its inception (Rails 5.0) and doing so is necessary to properly upgrade to all the Rails 7 new defaults.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
