### PR TITLE
Revert "FEATURE: Include participants in PM search data (#16855)"

### DIFF
--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -115,13 +115,13 @@ class SearchIndexer
     )
   end
 
-  def self.update_posts_index(post_id:, topic_title:, category_name:, topic_tags:, cooked:, private_message:, allowed_users: nil)
+  def self.update_posts_index(post_id:, topic_title:, category_name:, topic_tags:, cooked:, private_message:)
     update_index(
       table: 'post',
       id: post_id,
       a_weight: topic_title,
       b_weight: category_name,
-      c_weight: "#{topic_tags} #{allowed_users&.join(" ")}",
+      c_weight: topic_tags,
       # The tsvector resulted from parsing a string can be double the size of
       # the original string. Since there is no way to estimate the length of
       # the expected tsvector, we limit the input to ~50% of the maximum
@@ -231,8 +231,7 @@ class SearchIndexer
           category_name: category_name,
           topic_tags: tag_names,
           cooked: obj.cooked,
-          private_message: topic.private_message?,
-          allowed_users: topic.allowed_users.pluck(:username, :name)
+          private_message: topic.private_message?
         )
 
         SearchIndexer.update_topics_index(topic.id, topic.title, obj.cooked) if obj.is_first_post?
@@ -255,8 +254,7 @@ class SearchIndexer
             category_name: category_name,
             topic_tags: tag_names,
             cooked: post.cooked,
-            private_message: obj.private_message?,
-            allowed_users: obj.allowed_users.pluck(:username, :name)
+            private_message: obj.private_message?
           )
 
           SearchIndexer.update_topics_index(obj.id, obj.title, post.cooked)

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -291,22 +291,6 @@ describe SearchIndexer do
       words = post_search_data.search_data.scan(/'([^']*)'/).map { |match| match[0] }
       expect(words).to contain_exactly('best', 'beig', 'obj', 'http', 'titl', 'long', 'enou', 'unca')
     end
-
-    context 'private messages' do
-      fab!(:user1) { Fabricate(:user, name: 'bloop', username: 'bloopdroop') }
-      fab!(:user2) { Fabricate(:user, name: 'two', username: 'twotone') }
-      let!(:pm_topic) { Fabricate(:private_message_topic,
-        topic_allowed_users: [
-          Fabricate.build(:topic_allowed_user, user: user1),
-          Fabricate.build(:topic_allowed_user, user: user2)
-        ]) }
-      let(:pm_post) { Fabricate(:post, topic: pm_topic) }
-
-      it 'includes participating users in a private message' do
-        search_data = pm_post.post_search_data.search_data
-        expect(search_data).to include("bloop", "bloopdroop", "two", "twoton")
-      end
-    end
   end
 
   describe '.queue_post_reindex' do


### PR DESCRIPTION
This reverts commit 71c74a262df25b6c59c74f3c1e3e63a86fd3e5fa. Including a PM topics' participants in each post adds too much noise to the index. 