### PR TITLE
DEV: Add hook for plugins modify how slugs are computed

### DIFF
--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -270,6 +270,37 @@ describe Topic do
         end
       end
     end
+
+    context 'slug computed hooks' do
+      before do
+        invert_slug = ->(topic, slug, title) { slug.reverse }
+        Topic.slug_computed_callbacks << invert_slug
+      end
+
+      let!(:title) { "hello test topic" }
+      let!(:slug) { "hello-test-topic".reverse }
+      let!(:other_title) { "other title" }
+      let!(:other_slug) { "other-title".reverse }
+      let!(:topic) { Fabricate.build(:topic, title: title) }
+
+      it "returns a reversed slug for a title" do
+        expect(topic.title).to eq(title)
+        expect(topic.slug).to eq(slug)
+      end
+
+      it "returns a reversed slug after the title is changed" do
+        expect(topic.title).to eq(title)
+        expect(topic.slug).to eq(slug)
+
+        topic.title = other_title
+        expect(topic.title).to eq(other_title)
+        expect(topic.slug).to eq(other_slug)
+      end
+
+      after do
+        Topic.slug_computed_callbacks.clear
+      end
+    end
   end
 
   context "updating a title to be shorter" do


### PR DESCRIPTION
Allows plugins to hook into and change how topic slugs are computed.

Use case: https://github.com/discourse/discourse-prepend-tags-in-topic-slug