### PR TITLE
FIX: respect user timezone in emails about silencing and suspending

### DIFF
--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -161,12 +161,13 @@ class UserNotifications < ActionMailer::Base
         reason: user_history.details
       )
     else
+      silenced_till = user.silenced_till.in_time_zone(user.user_option.timezone)
       build_email(
         user.email,
         template: "user_notifications.account_silenced",
         locale: user_locale(user),
         reason: user_history.details,
-        silenced_till: I18n.l(user.silenced_till, format: :long)
+        silenced_till: I18n.l(silenced_till, format: :long)
       )
     end
   end

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -185,12 +185,13 @@ class UserNotifications < ActionMailer::Base
         reason: user_history.details
       )
     else
+      suspended_till = user.suspended_till.in_time_zone(user.user_option.timezone)
       build_email(
         user.email,
         template: "user_notifications.account_suspended",
         locale: user_locale(user),
         reason: user_history.details,
-        suspended_till: I18n.l(user.suspended_till, format: :long)
+        suspended_till: I18n.l(suspended_till, format: :long)
       )
     end
   end

--- a/spec/fabricators/user_history_fabricator.rb
+++ b/spec/fabricators/user_history_fabricator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+Fabricator(:user_history) do
+end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1216,4 +1216,36 @@ describe UserNotifications do
       end
     end
   end
+
+  describe ".account_suspended" do
+    fab!(:user_history) { Fabricate(:user_history, action: UserHistory.actions[:suspend_user]) }
+
+    it "adds the suspended_till date in user's timezone" do
+      user.user_option.timezone = "Asia/Tbilisi" # GMT+4
+      user.suspended_till = DateTime.parse("May 25, 2020, 12:00pm")
+
+      mail = UserNotifications.account_suspended(user, { user_history: user_history })
+
+      expect(mail.body).to include("May 25, 2020,  4:00pm")
+    end
+
+    context "user doesn't have timezone set" do
+      before do
+        user.user_option.timezone = nil
+      end
+
+      it "doesn't raise error" do
+        expect { UserNotifications.account_suspended(user) }.not_to raise_error
+      end
+
+      it "adds the suspended_till date in UTC" do
+        date = "May 25, 2020, 12:00pm"
+        user.suspended_till = DateTime.parse(date)
+
+        mail = UserNotifications.account_suspended(user, { user_history: user_history })
+
+        expect(mail.body).to include(date)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes one of the problems reported in https://meta.discourse.org/t/wrong-custom-date-and-time-in-silenced-and-suspended-warnings/226297/2.

When silencing or suspending a user, we send a date in UTC instead of sending a date in user's timezone, which is confusing.

For example a user in GMT+1 who was suspended until _8 May 2022 17:25_ will receive this email:

![aac0e0c441f8a516b244f3d30efa5c60cdeab65e](https://user-images.githubusercontent.com/1274517/170274510-61a4453d-c8e6-4bab-afb1-a334b700c879.png)

This PR fixes both silencing and suspending emails. Mails will be sent with date and time in user's timezone. If a user haven't set up timezone, dates will be sent in UTC.



