### PR TITLE
FIX: InlineOneboxer watched word censor error

### DIFF
--- a/lib/inline_oneboxer.rb
+++ b/lib/inline_oneboxer.rb
@@ -107,8 +107,14 @@ class InlineOneboxer
         )
       end
     end
-    onebox = { url: url, title: title && Emoji.gsub_emoji_to_unicode(title) }
-    onebox[:title] = WordWatcher.censor_text(onebox[:title])
+
+    title = title && Emoji.gsub_emoji_to_unicode(title)
+    if title.present?
+      title = WordWatcher.censor_text(title)
+    end
+
+    onebox = { url: url, title: title }
+
     Discourse.cache.write(cache_key(url), onebox, expires_in: 1.day) if !opts[:skip_cache]
     onebox
   end

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -458,20 +458,20 @@ module Oneboxer
       user_agent_override = SiteSetting.cache_onebox_user_agent if Oneboxer.cache_response_body?(url) && SiteSetting.cache_onebox_user_agent.present?
       onebox_options[:user_agent] = user_agent_override if user_agent_override
 
-      r = Onebox.preview(uri.to_s, onebox_options)
+      preview_result = Onebox.preview(uri.to_s, onebox_options)
       result = {
-        onebox: WordWatcher.censor(r.to_s),
-        preview: WordWatcher.censor(r&.placeholder_html.to_s)
+        onebox: WordWatcher.censor(preview_result.to_s),
+        preview: WordWatcher.censor(preview_result&.placeholder_html.to_s)
       }
 
-      # NOTE: Call r.errors after calling placeholder_html
-      if r.errors.any?
-        error_keys = r.errors.keys
+      # NOTE: Call preview_result.errors after calling placeholder_html
+      if preview_result.errors.any?
+        error_keys = preview_result.errors.keys
         skip_if_only_error = [:image]
         unless error_keys.length == 1 && skip_if_only_error.include?(error_keys.first)
           missing_attributes = error_keys.map(&:to_s).sort.join(I18n.t("word_connector.comma"))
           error_message = I18n.t("errors.onebox.missing_data", missing_attributes: missing_attributes, count: error_keys.size)
-          args = r.verified_data.merge(error_message: error_message)
+          args = preview_result.verified_data.merge(error_message: error_message)
 
           if result[:preview].blank?
             result[:preview] = preview_error_onebox(args)

--- a/spec/lib/inline_oneboxer_spec.rb
+++ b/spec/lib/inline_oneboxer_spec.rb
@@ -331,6 +331,24 @@ describe InlineOneboxer do
       expect(onebox[:url]).to eq("https://eviltrout.com/some-path")
       expect(onebox[:title]).to eq("welcome to ■■ blog")
     end
+
+    it "does not try and censor external oneboxes returning a blank title" do
+      Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "my")
+
+      SiteSetting.enable_inline_onebox_on_all_domains = true
+
+      stub_request(:get, "https://eviltrout.com/some-path").
+        to_return(status: 404, body: "")
+
+      onebox = InlineOneboxer.lookup(
+        "https://eviltrout.com/some-path",
+        skip_cache: true
+      )
+
+      expect(onebox).to be_present
+      expect(onebox[:url]).to eq("https://eviltrout.com/some-path")
+      expect(onebox[:title]).to eq(nil)
+    end
   end
 
   context "register_local_handler" do


### PR DESCRIPTION
In 7328a2bfb056915efc1e42dd1eea64da28b11f12 we changed the
InlineOneboxer#onebox_for method to run the title of the
onebox through WatchedWord#censor_text. However, it is
allowable for the title to be nil, which was causing this
error in production:

> NoMethodError : undefined method gsub for nil:NilClass

We just need to check whether the title is nil before trying
to censor it.
