### PR TITLE
FIX: Show suspended by user

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -150,7 +150,8 @@ class Admin::UsersController < Admin::AdminController
         suspend_reason: params[:reason],
         full_suspend_reason: user_history.try(:details),
         suspended_till: @user.suspended_till,
-        suspended_at: @user.suspended_at
+        suspended_at: @user.suspended_at,
+        suspended_by: BasicUserSerializer.new(current_user, root: false).as_json
       }
     )
   end


### PR DESCRIPTION
Before ("Suspended by" is missing, "Silenced by" is rendering as expected):
<img width="988" alt="before_suspended_by_missing" src="https://user-images.githubusercontent.com/494182/170576200-aec09681-2fbd-4349-91ae-9a056860619e.png">

After:
<img width="1095" alt="after_suspended_by" src="https://user-images.githubusercontent.com/494182/170576327-1f385fa6-7147-4329-aca3-3c42393e5084.png">

I skipped tests as I followed the example of silenced_by and silenced_by behaviour isn't tested either. If this behaviour (and silenced_by) should be put under test let me know and I'm happy to add a specs for them.