### PR TITLE
FIX: Further refine duplicate bookmark delete query

### DIFF
--- a/db/migrate/20220512011522_backfill_polymorphic_bookmarks_and_make_default.rb
+++ b/db/migrate/20220512011522_backfill_polymorphic_bookmarks_and_make_default.rb
@@ -22,7 +22,7 @@ class BackfillPolymorphicBookmarksAndMakeDefault < ActiveRecord::Migration[7.0]
         INNER JOIN posts ON bookmarks.post_id = posts.id
         WHERE bookmarks.for_topic
         GROUP BY (bookmarks.user_id, posts.topic_id)
-      )
+      ) AND bookmarks.for_topic
     SQL
 
     DB.exec(<<~SQL)


### PR DESCRIPTION
In f00e28206727da7a80d7a415cf825e746fd8d186 we added this
DELETE query to delete duplicate for_topic bookmarks, we
just need this further refinement to the WHERE clause to
avoid deleting post bookmarks.

