### PR TITLE
FIX: Incorrect URL for bookmark quick action menu

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
@@ -62,7 +62,7 @@ createWidgetFrom(QuickAccessPanel, "quick-access-bookmarks", {
     ) {
       href = postUrl(bookmark.slug, bookmark.topic_id, postNumber);
     } else {
-      href = bookmark.bookmarkable_type;
+      href = bookmark.bookmarkable_url;
     }
 
     return this.attach("quick-access-item", {


### PR DESCRIPTION
The bookmarkable_type instead of the bookmarkable_url
was being used for the link to the bookmark for the quick
access menu, leading to links like /ChatMessage. This
fixes the issue, follow up PR with tests for the quick
access menu to follow.

