### PR TITLE
FIX: Correctly handle nested quotes in to-markdown

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/to-markdown.js
+++ b/app/assets/javascripts/discourse/app/lib/to-markdown.js
@@ -167,7 +167,7 @@ export class Tag {
         }
 
         let text = Element.parse([blockquote], this.element) || "";
-        text = text.trim().replace(/^>/g, "");
+        text = text.trim().replaceAll(/^> /gm, "").trim();
         if (text.length === 0) {
           return "";
         }
@@ -181,7 +181,7 @@ export class Tag {
             ? `[quote="${username}, post:${post}, topic:${topic}"]`
             : "[quote]";
 
-        return `\n\n${prefix}\n${text}\n[/quote]\n\n`;
+        return `\n${prefix}\n${text}\n[/quote]\n`;
       }
     };
   }

--- a/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/to-markdown-test.js
@@ -426,6 +426,33 @@ there is a quote above
     assert.strictEqual(toMarkdown(html), markdown.trim());
   });
 
+  test("converts nested quotes to markdown", function (assert) {
+    let html = `
+      <aside class="quote no-group">
+        <blockquote>
+          <aside class="quote no-group">
+            <blockquote>
+              <p dir="ltr">test</p>
+            </blockquote>
+          </aside>
+          <p dir="ltr">test2</p>
+        </blockquote>
+      </aside>
+    `;
+
+    let markdown = `
+[quote]
+[quote]
+test
+[/quote]
+
+test2
+[/quote]
+`;
+
+    assert.strictEqual(toMarkdown(html), markdown.trim());
+  });
+
   test("strips base64 image URLs", function (assert) {
     const html =
       '<img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD/7AARRHVja3kAAQAEAAAAPAAA/+4AJkFkb2JlAGTAAAAAAQMAFQQDBgoNAAABywAAAgsAAAJpAAACyf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoKDBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8IAEQgAEAAQAwERAAIRAQMRAf/EAJQAAQEBAAAAAAAAAAAAAAAAAAMFBwEAAwEAAAAAAAAAAAAAAAAAAAEDAhAAAQUBAQAAAAAAAAAAAAAAAgABAwQFESARAAIBAwIHAAAAAAAAAAAAAAERAgAhMRIDQWGRocEiIxIBAAAAAAAAAAAAAAAAAAAAIBMBAAMAAQQDAQAAAAAAAAAAAQARITHwQVGBYXGR4f/aAAwDAQACEQMRAAAB0UlMciEJn//aAAgBAQABBQK5bGtFn6pWi2K12wWTRkjb/9oACAECAAEFAvH/2gAIAQMAAQUCIuIJOqRndRiv/9oACAECAgY/Ah//2gAIAQMCBj8CH//aAAgBAQEGPwLWQzwHepfNbcUNfM4tUIbA9QL4AvnxTlAxacpWJReOlf/aAAgBAQMBPyHZDveuCyu4B4lz2lDKto2ca5uclPK0aoq32x8xgTSLeSgbyzT65n//2gAIAQIDAT8hlQjP/9oACAEDAwE/IaE9GcZFJ//aAAwDAQACEQMRAAAQ5F//2gAIAQEDAT8Q1oowKccI3KTdAWkPLw2ssIrwKYUzuJoUJsIHOCoG23ISlja+rU9QvCx//9oACAECAwE/EAuNIiKf/9oACAEDAwE/ECujJzHf7iwHOv5NhK+8efH50z//2Q==" />';


### PR DESCRIPTION
Given this html:

```
<aside class="quote no-group">
  <blockquote>
    <aside class="quote no-group">
      <blockquote>
        <p dir="ltr">test</p>
      </blockquote>
    </aside>
    <p dir="ltr">test2</p>
  </blockquote>
</aside>
```

The result was an invalid markdown:

```
[quote]
[quote]
> test
> [/quote]
>
>
>
> test2
[/quote]
```

Now the result is:

```
[quote]
[quote]
test
[/quote]

test2
[/quote]
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
