### PR TITLE
FIX: make User Status work with sidebar too

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -252,13 +252,6 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
         hasGroups,
       });
     },
-
-    setUserStatus() {
-      showModal("user-status", {
-        title: "user_status.set_custom_status",
-        modalClass: "user-status",
-      });
-    },
   },
 
   renderTemplate() {

--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -10,7 +10,6 @@
                 toggleAnonymous=(route-action "toggleAnonymous")
                 logout=(route-action "logout")
                 toggleSidebar=(route-action "toggleSidebar")
-                setUserStatus=(route-action "setUserStatus")
                 }}
   {{software-update-prompt}}
 

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
@@ -3,6 +3,7 @@ import { Promise } from "rsvp";
 import QuickAccessItem from "discourse/widgets/quick-access-item";
 import QuickAccessPanel from "discourse/widgets/quick-access-panel";
 import { createWidgetFrom } from "discourse/widgets/widget";
+import showModal from "discourse/lib/show-modal";
 
 const _extraItems = [];
 
@@ -46,7 +47,10 @@ createWidgetFrom(QuickAccessItem, "user-status-item", {
 
   hideMenuAndSetStatus() {
     this.sendWidgetAction("toggleUserMenu");
-    this.sendWidgetAction("setUserStatus");
+    showModal("user-status", {
+      title: "user_status.set_custom_status",
+      modalClass: "user-status",
+    });
   },
 });
 


### PR DESCRIPTION
Turned out, [User Status](https://github.com/discourse/discourse/pull/16875) doesn't work with sidebar. When pressing the <kbd>Set User Status</kbd> button, the modal doesn't show up. This PR fixes it and makes User Status work both with standard UI and the sidebar.

The reason was the call to `sendWidgetAction("actionName")`. In general, when calling `sendWidgetAction` it tries to find an action in widgets hierarchy and if it wasn't found it looks for the action in parent Ember components and eventually can even discover the action in the application route.

But when called in sidebar, `sendWidgetAction` can find actions only in widgets. Look like the sidebar is in a way "disconnected" from the Ember components hierarchy.

This PR fixes only User Status, but doesn't fix the sidebar itself.
