### PR TITLE
FEATURE: Highlight None option by default for bookmarks

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -12,7 +12,7 @@ import {
 import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import bootbox from "bootbox";
-import discourseComputed, { bind, on } from "discourse-common/utils/decorators";
+import discourseComputed, { bind } from "discourse-common/utils/decorators";
 import { formattedReminderTime } from "discourse/lib/bookmark";
 import { and, notEmpty } from "@ember/object/computed";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -42,8 +42,9 @@ export default Component.extend({
   model: null,
   afterSave: null,
 
-  @on("init")
-  _setup() {
+  init() {
+    this._super(...arguments);
+
     this.setProperties({
       errorMessage: null,
       selectedReminderType: TIME_SHORTCUT_TYPES.NONE,
@@ -71,8 +72,9 @@ export default Component.extend({
     this._loadPostLocalDates();
   },
 
-  @on("didInsertElement")
-  _prepareUI() {
+  didInsertElement() {
+    this._super(...arguments);
+
     later(() => {
       if (this.site.isMobileDevice) {
         document.getElementById("bookmark-name").blur();
@@ -83,6 +85,8 @@ export default Component.extend({
     // knows they have set these options previously.
     if (this.model.id) {
       this.set("showOptions", true);
+    } else {
+      document.getElementById("tap_tile_none").classList.add("active");
     }
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bookmarks-test.js
@@ -111,6 +111,10 @@ acceptance("Bookmarking", function (needs) {
       exists("#bookmark-reminder-modal"),
       "it shows the bookmark modal"
     );
+    assert.ok(
+      exists("#tap_tile_none.active"),
+      "it highlights the None option by default"
+    );
   });
 
   test("Bookmarks modal selecting reminder type", async function (assert) {


### PR DESCRIPTION
Since the default for the bookmark modal is to have no
reminder if you create a bookmark by clicking out of
the modal or pressing the Save button, this commit highlights
None by default.

Also changes the bookmark component to not use @on for Ember
lifecycle, we don't use that style.

![image](https://user-images.githubusercontent.com/920448/170898922-0c069e5e-b63f-492a-8e96-cd9eef80e5d9.png)

