### PR TITLE
DEV: do not trigger the user-status:changed event twice

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -113,7 +113,8 @@ export default {
       });
 
       bus.subscribe(`/user-status/${user.id}`, (data) => {
-        user.updateStatus(data);
+        user.set("status", data);
+        appEvents.trigger("user-status:changed");
       });
 
       const site = container.lookup("site:main");

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1002,11 +1002,6 @@ const User = RestModel.extend({
     this.appEvents.trigger("do-not-disturb:changed", this.do_not_disturb_until);
   },
 
-  updateStatus(status) {
-    this.set("status", status);
-    this.appEvents.trigger("user-status:changed");
-  },
-
   isInDoNotDisturb() {
     return (
       this.do_not_disturb_until &&

--- a/app/assets/javascripts/discourse/app/services/user-status.js
+++ b/app/assets/javascripts/discourse/app/services/user-status.js
@@ -11,7 +11,7 @@ export default class UserStatusService extends Service {
       data: { description: status.description },
     });
 
-    this.currentUser.updateStatus(status);
+    this.currentUser.set("status", status);
   }
 
   async clear() {
@@ -20,6 +20,6 @@ export default class UserStatusService extends Service {
       type: "DELETE",
     });
 
-    this.currentUser.updateStatus(null);
+    this.currentUser.set("status", null);
   }
 }


### PR DESCRIPTION
I've noticed this during debugging. With every change of user status the _user-status:changed_ event gets triggered twice:

<img width="250" alt="Screenshot 2022-05-30 at 17 26 04" src="https://user-images.githubusercontent.com/1274517/171004300-37b1d2b1-3377-4969-b4bd-c91c665b2bce.png">

The user status may be considered as set after a successful call to <kbd>PUT /user-status.json</kbd>. That method always sends a message bus event back to the client, so the cleanest solution here would be just triggering an appEvent in the handler of the message bus event.

By the way, when setting the DND mode we trigger the DnD event 4 times:

<img width="250" alt="Screenshot 2022-05-30 at 17 34 18" src="https://user-images.githubusercontent.com/1274517/171004311-6f3b3baa-737e-4306-8b3f-c206a340e516.png">

This PR doesn't fix the DnD event, but I'm going to take a look at it later.


