### PR TITLE
UX: update chat menu popover styling

### DIFF
--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -4,8 +4,8 @@ $d-popover-border: var(--primary-medium);
 .tippy-box {
   color: var(--primary);
   background: $d-popover-background;
-  box-shadow: shadow("card");
-  border: 1px solid $d-popover-border;
+  border: 1px solid var(--primary-low);
+  box-shadow: shadow("menu-panel");
 }
 
 .tippy-box[data-placement^="top"] .tippy-svg-arrow > svg {


### PR DESCRIPTION
Update styling of popover to match other menu/chat related items

<img width="527" alt="image" src="https://user-images.githubusercontent.com/101828855/171012046-f04affae-0b23-4175-8d60-689b9174414e.png">

