### PR TITLE
FIX: change event target on the select kit row component

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
@@ -136,10 +136,10 @@ export default Component.extend(UtilsMixin, {
   handleBlur(event) {
     if (
       (!this.isDestroying || !this.isDestroyed) &&
-      event.relatedTarget &&
+      event.target &&
       this.selectKit.mainElement()
     ) {
-      if (!this.selectKit.mainElement().contains(event.relatedTarget)) {
+      if (!this.selectKit.mainElement().contains(event.target)) {
         this.selectKit.close(event);
       }
     }


### PR DESCRIPTION
The select kit row component used`event.relatedTarget` and not `event.target`.
This caused an issue on Safari where clicking on the scrollbar closed the select box.

![ac71920d8382f612600e67d4b62b7382e5aa3f40](https://user-images.githubusercontent.com/3180866/171299602-b5bef60b-8dfe-4437-9f7a-2272c3039313.gif)

