### PR TITLE
FIX: apple-app-site-association moved to .well-known

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2182,7 +2182,7 @@ en:
     native_app_install_banner_android: "Displays DiscourseHub app banner on Android devices to regular users (trust level 1 and up)."
 
     app_association_android: "Contents of <a href='%{base_path}/.well-known/assetlinks.json'>.well-known/assetlinks.json</a> endpoint, used for Google's Digital Asset Links API."
-    app_association_ios: "Contents of <a href='%{base_path}/apple-app-site-association'>apple-app-site-association</a> endpoint, used to create Universal Links between this site and iOS apps."
+    app_association_ios: "Contents of <a href='%{base_path}/.well-known/apple-app-site-association'>.well-known/apple-app-site-association</a> endpoint, used to create Universal Links between this site and iOS apps."
 
     share_anonymized_statistics: "Share anonymized usage statistics."
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -924,7 +924,7 @@ Discourse::Application.routes.draw do
     get "manifest.webmanifest" => "metadata#manifest", as: :manifest
     get "manifest.json" => "metadata#manifest"
     get ".well-known/assetlinks.json" => "metadata#app_association_android"
-    get "apple-app-site-association" => "metadata#app_association_ios", format: false
+    get ".well-known/apple-app-site-association" => "metadata#app_association_ios", format: false
     get "opensearch" => "metadata#opensearch", constraints: { format: :xml }
 
     scope '/tag/:tag_id' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -924,6 +924,7 @@ Discourse::Application.routes.draw do
     get "manifest.webmanifest" => "metadata#manifest", as: :manifest
     get "manifest.json" => "metadata#manifest"
     get ".well-known/assetlinks.json" => "metadata#app_association_android"
+    get "apple-app-site-association" => "metadata#app_association_ios", format: false
     get ".well-known/apple-app-site-association" => "metadata#app_association_ios", format: false
     get "opensearch" => "metadata#opensearch", constraints: { format: :xml }
 

--- a/spec/requests/metadata_controller_spec.rb
+++ b/spec/requests/metadata_controller_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe MetadataController do
 
   describe '#app_association_ios' do
     it 'returns 404 by default' do
-      get "/apple-app-site-association"
+      get "/.well-known/apple-app-site-association"
       expect(response.status).to eq(404)
     end
 
@@ -155,14 +155,14 @@ RSpec.describe MetadataController do
           }
         }
       JSON
-      get "/apple-app-site-association"
+      get "/.well-known/apple-app-site-association"
 
       expect(response.status).to eq(200)
       expect(response.body).to include("applinks")
       expect(response.media_type).to eq('application/json')
       expect(response.headers["Cache-Control"]).to eq('max-age=60, private')
 
-      get "/apple-app-site-association.json"
+      get "/.well-known/apple-app-site-association.json"
       expect(response.status).to eq(404)
     end
   end


### PR DESCRIPTION
According to documentation, `apple-app-site-association` should be under .well-known/ similar to Android.

https://developer.apple.com/documentation/xcode/supporting-associated-domains