### PR TITLE
clarify that invites by staff bypass user approval

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1615,7 +1615,7 @@ en:
     markdown_linkify_tlds: "List of top level domains that get automatically treated as links"
     markdown_typographer_quotation_marks: "List of double and single quotes replacement pairs"
     post_undo_action_window_mins: "Number of minutes users are allowed to undo recent actions on a post (like, flag, etc)."
-    must_approve_users: "Staff must approve all new user accounts before they are allowed to access the site."
+    must_approve_users: "Staff must approve all new user accounts before they are allowed to access the site. Note: invites created by staff bypass this setting and do not require approval."
     invite_code: "User must type this code to be allowed account registration, ignored when empty (case-insensitive)"
     approve_suspect_users: "Add suspicious users to the review queue. Suspicious users have entered a bio/website but have no reading activity."
     review_every_post: "All posts must be reviewed. WARNING! NOT RECOMMENDED FOR BUSY SITES."


### PR DESCRIPTION
Goal with this change is to make it crystal clear that invites by staff bypass this setting. As discussed: https://meta.discourse.org/t/staff-generated-invites-bypass-the-must-approve-users-requirement/228199/10?u=tobiaseigen

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
