### PR TITLE
FIX: Harmonise category body class generation on server/client

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -181,7 +181,7 @@ module ApplicationHelper
     result = ApplicationHelper.extra_body_classes.to_a
 
     if @category && @category.url.present?
-      result << "category-#{@category.url.sub(/^\/c\//, '').gsub(/\//, '-')}"
+      result << "category-#{@category.slug_path.join('-')}"
     end
 
     if current_user.present? &&

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -941,4 +941,15 @@ RSpec.describe ListController do
       expect(response.parsed_body['topic_list']['topics'].map { |t| t['id'] }).to contain_exactly(topic2.id)
     end
   end
+
+  describe "body class" do
+    it "pre-renders the correct body class for categories" do
+      c = Fabricate(:category, slug: 'myparentslug')
+      sub_c = Fabricate(:category, parent_category: c, slug: 'mychildslug')
+
+      get "/c/#{c.slug}/#{sub_c.slug}/#{sub_c.id}"
+
+      expect(response.body).to have_tag "body", with: { class: "category-myparentslug-mychildslug" }
+    end
+  end
 end


### PR DESCRIPTION
The server-side implementation had unintentionally changed to include `-{id}` at the end of the body class name. This change meant that the JS client was unaware of the class, and didn't remove it when navigating away from the category page.

This commit fixes the server-side implementation to match the client

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
