### PR TITLE
DEV: add class name to nav-bar nav items

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/navigation-bar.hbs
@@ -1,5 +1,5 @@
 {{#each navItems as |navItem|}}
-  {{navigation-item content=navItem filterMode=filterMode category=category}}
+  {{navigation-item content=navItem filterMode=filterMode category=category class=(concat "nav-item_" navItem.name)}}
 {{/each}}
 {{custom-html name="extraNavItem" tagName="li"}}
 {{plugin-outlet name="extra-nav-item" connectorTagName="li" args=(hash category=category filterMode=filterMode)}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
@@ -7,7 +7,7 @@
 {{#if expanded}}
   <ul class="drop">
     {{#each navItems as |navItem|}}
-      {{navigation-item content=navItem filterMode=filterMode category=category}}
+      {{navigation-item content=navItem filterMode=filterMode category=category class=(concat "nav-item_" navItem.name)}}
     {{/each}}
     {{plugin-outlet name="extra-nav-item" connectorTagName="li" args=(hash category=category filterMode=filterMode)}}
   </ul>


### PR DESCRIPTION
This adds a class to the `li` of each respective item, like `nav-item_latest` and `nav-item_top`


![Screen Shot 2022-06-01 at 1 10 22 PM](https://user-images.githubusercontent.com/1681963/171462080-8733a01e-ae28-47bc-b2be-022544f207f6.png)
 