### PR TITLE
DEV: emoji picker - make it possible to choose picker's placement and add a dedicated class for an anchor

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -38,6 +38,7 @@ export default Component.extend({
   hoveredEmoji: null,
   isActive: false,
   usePopper: true,
+  placement: "auto", // one of popper.js' placements, see https://popper.js.org/docs/v2/constructors/#options
   initialFilter: "",
 
   init() {
@@ -111,7 +112,10 @@ export default Component.extend({
           },
         ];
 
-        if (window.innerWidth < popperAnchor.clientWidth * 2) {
+        if (
+          this.placement === "auto" &&
+          window.innerWidth < popperAnchor.clientWidth * 2
+        ) {
           modifiers.push({
             name: "computeStyles",
             enabled: true,
@@ -130,7 +134,7 @@ export default Component.extend({
         }
 
         this._popper = createPopper(popperAnchor, emojiPicker, {
-          placement: "auto",
+          placement: this.placement,
         });
       }
 

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -96,11 +96,9 @@ export default Component.extend({
         return;
       }
 
-      const textareaWrapper = document.querySelector(
-        ".d-editor-textarea-wrapper"
-      );
+      const popperAnchor = this._getPopperAnchor();
 
-      if (!this.site.isMobileDevice && this.usePopper && textareaWrapper) {
+      if (!this.site.isMobileDevice && this.usePopper && popperAnchor) {
         const modifiers = [
           {
             name: "preventOverflow",
@@ -113,7 +111,7 @@ export default Component.extend({
           },
         ];
 
-        if (window.innerWidth < textareaWrapper.clientWidth * 2) {
+        if (window.innerWidth < popperAnchor.clientWidth * 2) {
           modifiers.push({
             name: "computeStyles",
             enabled: true,
@@ -131,9 +129,8 @@ export default Component.extend({
           });
         }
 
-        this._popper = createPopper(textareaWrapper, emojiPicker, {
+        this._popper = createPopper(popperAnchor, emojiPicker, {
           placement: "auto",
-          modifiers,
         });
       }
 
@@ -336,6 +333,10 @@ export default Component.extend({
       },
       { threshold: 1 }
     );
+  },
+
+  _getPopperAnchor() {
+    return document.querySelector(".d-editor-textarea-wrapper");
   },
 
   @bind

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -336,7 +336,12 @@ export default Component.extend({
   },
 
   _getPopperAnchor() {
-    return document.querySelector(".d-editor-textarea-wrapper");
+    // .d-editor-textarea-wrapper is only for backward compatibility here
+    // in new code use .emoji-picker-anchor
+    return (
+      document.querySelector(".emoji-picker-anchor") ??
+      document.querySelector(".d-editor-textarea-wrapper")
+    );
   },
 
   @bind

--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-picker-test.js
@@ -1,0 +1,52 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import { click } from "@ember/test-helpers";
+
+discourseModule("Integration | Component | emoji-picker", function (hooks) {
+  setupRenderingTest(hooks);
+
+  componentTest("when placement == bottom, places the picker on the bottom", {
+    template: hbs`
+      {{d-button class="emoji-picker-anchor" action=showEmojiPicker}}
+      {{emoji-picker isActive=pickerIsActive placement="bottom"}}
+    `,
+
+    beforeEach() {
+      this.set("showEmojiPicker", () => {
+        this.set("pickerIsActive", true);
+      });
+    },
+
+    async test(assert) {
+      await click(".emoji-picker-anchor");
+      assert.equal(
+        query(".emoji-picker.opened").getAttribute("data-popper-placement"),
+        "bottom"
+      );
+    },
+  });
+
+  componentTest("when placement == right, places the picker on the right", {
+    template: hbs`
+      {{d-button class="emoji-picker-anchor" action=showEmojiPicker}}
+      {{emoji-picker isActive=pickerIsActive placement="right"}}
+    `,
+
+    beforeEach() {
+      this.set("showEmojiPicker", () => {
+        this.set("pickerIsActive", true);
+      });
+    },
+
+    async test(assert) {
+      await click(".emoji-picker-anchor");
+      assert.equal(
+        query(".emoji-picker.opened").getAttribute("data-popper-placement"),
+        "right"
+      );
+    },
+  });
+});


### PR DESCRIPTION
This PR doesn't change the behavior of emoji-picker, only improves its API and adds an additional setting to it.

Note that all these changes apply to desktop only, we don't use popper for showing emoji-picker on mobile.

We use [popper.js](https://popper.js.org/) to show emoji-picker in a popup.  This library places a popup next to a special anchor element (they call that element _reference_ in their API). To mark this anchor element, we use class `d-editor-textarea-wrapper` (this is probably left from days when we used emoji-picker only with d-editor). 

This class name isn't ideal, we may want to show emoji-picker next to something else, a button for example. Also, `d-editor-textarea-wrapper` isn't just a marker class, it comes with actual styles:

https://github.com/discourse/discourse/blob/333c58dd05030cc413b5c3283f35d07b7ec3a67b/app/assets/stylesheets/common/d-editor.scss#L20

so you need to do something about those styles if you don't need them on your anchor.

This PR adds a special dedicated class for this – `emoji-picker-anchor`. The class added in a backward compatible way, `d-editor-textarea-wrapper` still works, but we need to migrate from it.

So, let's say I want to show emoji-picker next to a button, I should do this then:
```hbs
{{d-button class="emoji-picker-anchor"}}
{{emoji-picker}}
```

This PR also adds the ability to choose  placement of a popup. We used only auto-placement before. Now it's possible to pass another  placement to the picker (`auto` is still the default option):
```hbs
{{emoji-picker placement="bottom"}}
```

The list of available placements is [here](https://popper.js.org/docs/v2/constructors/#options).

