### PR TITLE
DEV: Supress logs when RetrieveTitle.crawl fails with Net::ReadTimeout errors

### DIFF
--- a/app/jobs/regular/crawl_topic_link.rb
+++ b/app/jobs/regular/crawl_topic_link.rb
@@ -36,7 +36,7 @@ module Jobs
 
         unless crawled
           # Fetch the beginning of the document to find the title
-          title = RetrieveTitle.crawl(topic_link.url)
+          title = RetrieveTitle.crawl(topic_link.url, log_errors: false)
           if title.present?
             crawled = (TopicLink.where(id: topic_link.id).update_all(['title = ?, crawled_at = CURRENT_TIMESTAMP', title[0..254]]) == 1)
           end

--- a/app/jobs/regular/crawl_topic_link.rb
+++ b/app/jobs/regular/crawl_topic_link.rb
@@ -36,7 +36,7 @@ module Jobs
 
         unless crawled
           # Fetch the beginning of the document to find the title
-          title = RetrieveTitle.crawl(topic_link.url, log_errors: false)
+          title = RetrieveTitle.crawl(topic_link.url)
           if title.present?
             crawled = (TopicLink.where(id: topic_link.id).update_all(['title = ?, crawled_at = CURRENT_TIMESTAMP', title[0..254]]) == 1)
           end

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -3,15 +3,15 @@
 module RetrieveTitle
   CRAWL_TIMEOUT = 1
 
-  def self.crawl(url, max_redirects: nil, initial_https_redirect_ignore_limit: false)
+  def self.crawl(url, max_redirects: nil, initial_https_redirect_ignore_limit: false, log_errors: true)
     fetch_title(
       url,
       max_redirects: max_redirects,
       initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit
     )
   rescue Exception => ex
+    Rails.logger.error(ex) if log_errors
     raise if Rails.env.test?
-    Rails.logger.error(ex)
     nil
   end
 

--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -3,16 +3,14 @@
 module RetrieveTitle
   CRAWL_TIMEOUT = 1
 
-  def self.crawl(url, max_redirects: nil, initial_https_redirect_ignore_limit: false, log_errors: true)
+  def self.crawl(url, max_redirects: nil, initial_https_redirect_ignore_limit: false)
     fetch_title(
       url,
       max_redirects: max_redirects,
       initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit
     )
-  rescue Exception => ex
-    Rails.logger.error(ex) if log_errors
-    raise if Rails.env.test?
-    nil
+  rescue Net::ReadTimeout
+    # do nothing for Net::ReadTimeout errors
   end
 
   def self.extract_title(html, encoding = nil)

--- a/spec/lib/retrieve_title_spec.rb
+++ b/spec/lib/retrieve_title_spec.rb
@@ -143,18 +143,16 @@ describe RetrieveTitle do
       expect(RetrieveTitle.crawl("https://example.com")).to eq(nil)
     end
 
-    it "logs errors by default" do
-      stub_request(:get, "https://example.com").to_timeout
+    it "it raises errors other than Net::ReadTimeout, e.g. NoMethodError" do
+      stub_request(:get, "https://example.com").to_raise(NoMethodError)
 
-      Rails.logger.expects(:error).once
-      expect { RetrieveTitle.crawl("https://example.com") }.to raise_error(Net::OpenTimeout)
+      expect { RetrieveTitle.crawl("https://example.com") }.to raise_error(NoMethodError)
     end
 
-    it "it doesn't log errors when flag :log_erros is set to false" do
-      stub_request(:get, "https://example.com").to_timeout
+    it "it ignores Net::ReadTimeout errors" do
+      stub_request(:get, "https://example.com").to_raise(Net::ReadTimeout)
 
-      Rails.logger.expects(:error).never
-      expect { RetrieveTitle.crawl("https://example.com", log_errors: false) }.to raise_error(Net::OpenTimeout)
+      expect { RetrieveTitle.crawl("https://example.com") }.not_to raise_error(Net::ReadTimeout)
     end
   end
 

--- a/spec/lib/retrieve_title_spec.rb
+++ b/spec/lib/retrieve_title_spec.rb
@@ -142,6 +142,20 @@ describe RetrieveTitle do
 
       expect(RetrieveTitle.crawl("https://example.com")).to eq(nil)
     end
+
+    it "logs errors by default" do
+      stub_request(:get, "https://example.com").to_timeout
+
+      Rails.logger.expects(:error).once
+      expect { RetrieveTitle.crawl("https://example.com") }.to raise_error(Net::OpenTimeout)
+    end
+
+    it "it doesn't log errors when flag :log_erros is set to false" do
+      stub_request(:get, "https://example.com").to_timeout
+
+      Rails.logger.expects(:error).never
+      expect { RetrieveTitle.crawl("https://example.com", log_errors: false) }.to raise_error(Net::OpenTimeout)
+    end
   end
 
   context 'fetch_title' do


### PR DESCRIPTION
There are a lot of `Net::ReadTimeout` log noise in Logster that is generated in `RetrieveTitle.crawl` 

This PR changes the rescue block to rescue only Net::TimeoutError exceptions and let other errors bubble up because they're errors we probably want to know about