### PR TITLE
DEV: quick-access-panel setting for viewAllLabel

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
@@ -17,6 +17,9 @@ export default createWidget("quick-access-panel", {
   tagName: "div.quick-access-panel",
   emptyStatePlaceholderItemKey: null,
   emptyStateWidget: null,
+  settings: {
+    viewAllLabel: null,
+  },
 
   buildKey: () => {
     throw Error('Cannot attach abstract widget "quick-access-panel".');
@@ -128,6 +131,7 @@ export default createWidget("quick-access-panel", {
           title: "view_all",
           titleOptions: { tab },
           icon: "chevron-down",
+          label: this.settings.viewAllLabel,
           className: "btn btn-default btn-icon no-text show-all",
           "aria-label": "view_all",
           ariaLabelOptions: { tab },


### PR DESCRIPTION
To add the "more" text next to the down chevron shown here, currently you either need to do it in CSS with psudeo-selectors (not translatable) or you need to reopen this entire widget (seems bad for maintenance)

![Screen Shot 2022-06-02 at 9 40 07 AM](https://user-images.githubusercontent.com/1681963/171642450-93216280-ca82-4846-975a-4543d4953855.png)

This adds a widget setting to simplify. With this, now a theme could do something like this... rather than reopening the whole widget: 

```js
withPluginApi("0.10.1", (api) => {
  api.changeWidgetSetting(
    "quick-access-notifications",
    "viewAllLabel",
    "more"
  );
});
```
