### PR TITLE
FIX: keep composer draft when go back and forth between PM and New Topic.

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -871,7 +871,8 @@ const Composer = RestModel.extend({
       this.set("title", opts.title);
     }
 
-    this.set("originalText", opts.draft ? "" : this.reply);
+    const isDraft = opts.draft || opts.skipDraftCheck;
+    this.set("originalText", isDraft ? "" : this.reply);
 
     if (this.canEditTitle) {
       if (isEmpty(this.title) && this.title !== "") {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -38,6 +38,12 @@ acceptance("Composer Actions", function (needs) {
 
     assert.ok(queryAll("#reply-title").val(), "this is the title");
     assert.ok(queryAll(".d-editor-input").val(), "this is the reply");
+
+    await click("#reply-control a.cancel");
+    assert.ok(
+      exists(".discard-draft-modal.modal"),
+      "it pops up the discard drafts modal"
+    );
   });
 
   test("replying to post", async function (assert) {


### PR DESCRIPTION
Previously, draft get destroyed accidentally when we switch to PM with the below steps
1. Click “New Topic”
2. Type in the body
3. Switch to “New Message”
4. Click “cancel”

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
