### PR TITLE
FIX: Skip CSRF token check on webhook routes

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -3,6 +3,7 @@
 require "openssl"
 
 class WebhooksController < ActionController::Base
+  skip_before_action :verify_authenticity_token
 
   def mailgun
     return mailgun_failure if SiteSetting.mailgun_api_key.blank?

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -15,6 +15,11 @@ describe WebhooksController do
 
     before do
       SiteSetting.mailgun_api_key = "key-8221462f0c915af3f6f2e2df7aa5a493"
+      ActionController::Base.allow_forgery_protection = true # Ensure the endpoint works, even with CSRF protection generally enabled
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = false
     end
 
     it "works (deprecated)" do


### PR DESCRIPTION
Requests to webhook routes were getting blocked and returned a `422 Unprocessable Entity` with an error of `ActionPack::InvalidAuthenticityToken` in logs.