### PR TITLE
FIX: Approves user when redeeming an invite for invites only sites

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -40,7 +40,9 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
       registration_ip_address: ip_address
     }
 
-    if SiteSetting.must_approve_users? && EmailValidator.can_auto_approve_user?(user.email)
+    if (!SiteSetting.must_approve_users && SiteSetting.invite_only) ||
+       (SiteSetting.must_approve_users? && EmailValidator.can_auto_approve_user?(user.email))
+
       ReviewableUser.set_approved_fields!(user, Discourse.system_user)
     end
 
@@ -79,7 +81,6 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
     authenticator.finish
 
     if invite.emailed_status != Invite.emailed_status_types[:not_required] && email == invite.email && invite.email_token.present? && email_token == invite.email_token
-      user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:signup])
       user.activate
     end
 


### PR DESCRIPTION
When a site has `SiteSetting.invite_only` enabled, we create a
`ReviewableUser`record when activating a user if the user is not
approved. Therefore, we need to approve the user when redeeming an
invite.

There are some uncertainties surrounding why a `ReviewableRecord` is
created for a user in an invites only site but this commit does not seek
to address that.

Follow-up to 7c4e2d33fa4b922354c177ffc880a2f2701a91f9

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
