### PR TITLE
FIX: Approves user when redeeming an invite for invites only sites

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -40,7 +40,9 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
       registration_ip_address: ip_address
     }
 
-    if SiteSetting.must_approve_users? && EmailValidator.can_auto_approve_user?(user.email)
+    if (!SiteSetting.must_approve_users && SiteSetting.invite_only) ||
+       (SiteSetting.must_approve_users? && EmailValidator.can_auto_approve_user?(user.email))
+
       ReviewableUser.set_approved_fields!(user, Discourse.system_user)
     end
 
@@ -79,7 +81,6 @@ InviteRedeemer = Struct.new(:invite, :email, :username, :name, :password, :user_
     authenticator.finish
 
     if invite.emailed_status != Invite.emailed_status_types[:not_required] && email == invite.email && invite.email_token.present? && email_token == invite.email_token
-      user.email_tokens.create!(email: user.email, scope: EmailToken.scopes[:signup])
       user.activate
     end
 

--- a/spec/models/invite_redeemer_spec.rb
+++ b/spec/models/invite_redeemer_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 describe InviteRedeemer do
+  fab!(:admin) { Fabricate(:admin) }
 
   describe '.create_user_from_invite' do
     it "should be created correctly" do
@@ -84,6 +85,32 @@ describe InviteRedeemer do
       expect(user.email).to eq('walter.white@email.com')
       expect(user.approved).to eq(false)
       expect(user.active).to eq(false)
+    end
+
+    it "approves and actives user when redeeming an invite with email token and SiteSetting.invite_only is enabled" do
+      SiteSetting.invite_only = true
+      Jobs.run_immediately!
+
+      invite = Fabricate(:invite,
+        invited_by: admin,
+        email: 'walter.white@email.com',
+        emailed_status: Invite.emailed_status_types[:sent],
+      )
+
+      user = InviteRedeemer.create_user_from_invite(
+        invite: invite,
+        email: invite.email,
+        email_token: invite.email_token,
+        username: 'walter',
+        name: 'Walter White'
+      )
+
+      expect(user.name).to eq("Walter White")
+      expect(user.username).to eq("walter")
+      expect(user.email).to eq("walter.white@email.com")
+      expect(user.approved).to eq(true)
+      expect(user.active).to eq(true)
+      expect(ReviewableUser.count).to eq(0)
     end
   end
 


### PR DESCRIPTION
When a site has `SiteSetting.invite_only` enabled, we create a
`ReviewableUser`record when activating a user if the user is not
approved. Therefore, we need to approve the user when redeeming an
invite.

There are some uncertainties surrounding why a `ReviewableRecord` is
created for a user in an invites only site but this commit does not seek
to address that.

Follow-up to 7c4e2d33fa4b922354c177ffc880a2f2701a91f9

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
