### PR TITLE
DEV: Fix auto start for wizard qunit tests

### DIFF
--- a/app/assets/javascripts/wizard/test/test_helper.js
+++ b/app/assets/javascripts/wizard/test/test_helper.js
@@ -49,6 +49,13 @@ let createPretendServer = requirejs(
 ).default;
 
 let server;
+
+const queryParams = new URLSearchParams(window.location.search);
+
+if (queryParams.get("qunit_disable_auto_start") === "1") {
+  QUnit.config.autostart = false;
+}
+
 QUnit.testStart(function () {
   server = createPretendServer();
 });


### PR DESCRIPTION
`run-qunit.js` does not expect QUnit tests to start automatically but
our wizard QUnit setup did not respect the `qunit_disable_auto_start`
URL param. Hence, tests would start running automatically and when a
subsequent `QUnit.start()` function call is made, we ended up getting a
`QUnit.start cannot be called inside a test context.` error.

This error can be consistently reproduced in the `discourse:discourse_test` container but not in
the local development environment. I do not know why and did not feel
like it is important at this point in time to know why.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
