### PR TITLE
DEV: Show yml key in import site settings error logs

### DIFF
--- a/app/services/site_settings_task.rb
+++ b/app/services/site_settings_task.rb
@@ -27,7 +27,7 @@ class SiteSettingsTask
             log << "Changed #{key} FROM: #{result.previous_value} TO: #{result.new_value}"
             counts[:updated] += 1
           rescue => e
-            log << "ERROR: #{e.message}"
+            log << "ERROR #{key}: #{e.message}"
             counts[:errors] += 1
           end
         end


### PR DESCRIPTION
When importing site settings it can be difficult to deduce wich keys failed to import from the logs we capture. Adding the yaml key that had an error should help.
