### PR TITLE
FIX: Email Send post has already been taken error

### DIFF
--- a/app/models/post_reply_key.rb
+++ b/app/models/post_reply_key.rb
@@ -6,7 +6,7 @@ class PostReplyKey < ActiveRecord::Base
 
   before_validation { self.reply_key ||= self.class.generate_reply_key }
 
-  validates :post_id, presence: true, uniqueness: { scope: :user_id }
+  validates :post_id, presence: true
   validates :user_id, presence: true
   validates :reply_key, presence: true
 

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -767,6 +767,14 @@ describe Email::Sender do
           expect(post_reply_key.post_id).to eq(post.id)
           expect { email_sender.send }.to change { PostReplyKey.count }.by(0)
         end
+
+        it 'should not have ActiveRecord::RecordInvalid: Validation failed: Post has already been taken' do
+          a_post_reply_key = PostReplyKey.create(post_id: post.id, user_id: user.id)
+          expect { email_sender.send }.to change { PostReplyKey.count }.by(0)
+          post_reply_key = PostReplyKey.last
+          expect(post_reply_key).to eq(a_post_reply_key)
+        end
+
       end
     end
   end

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -768,11 +768,11 @@ describe Email::Sender do
           expect { email_sender.send }.to change { PostReplyKey.count }.by(0)
         end
 
-        it 'should not have ActiveRecord::RecordInvalid: Validation failed: Post has already been taken' do
-          a_post_reply_key = PostReplyKey.create(post_id: post.id, user_id: user.id)
+        it 'should find existing key' do
+          existing_post_reply_key = PostReplyKey.create(post_id: post.id, user_id: user.id)
           expect { email_sender.send }.to change { PostReplyKey.count }.by(0)
           post_reply_key = PostReplyKey.last
-          expect(post_reply_key).to eq(a_post_reply_key)
+          expect(post_reply_key).to eq(existing_post_reply_key)
         end
 
       end


### PR DESCRIPTION
Adding a failing test first before coming up with a good solution.

Related: 357011eb3b4e9c5fb860a34ecbb2f5cb89e89a7a

The above commit changed

```
PostReplyKey.find_or_create_by_safe!
```

to

```
PostReplyKey.create_or_find_by!
```

But I don't think it is working as a 1-1 replacement because of the
`Validation failed: Post has already been taken` error we are receiving
with this change. Also we need to make sure we don't re-introduce any
concurrency issues.

Reported: https://meta.discourse.org/t/224706/13
