### PR TITLE
FIX: Correctly handle invalid auth cookies

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -77,8 +77,9 @@ class Auth::DefaultCurrentUserProvider
   ]
 
   def self.find_v0_auth_cookie(request)
-    cookie = request.cookies[TOKEN_COOKIE].presence
-    if cookie && cookie.size == TOKEN_SIZE
+    cookie = request.cookies[TOKEN_COOKIE]
+
+    if cookie.valid_encoding? && cookie.present? && cookie.size == TOKEN_SIZE
       cookie
     end
   end
@@ -88,8 +89,10 @@ class Auth::DefaultCurrentUserProvider
 
     env[DECRYPTED_AUTH_COOKIE] = begin
       request = ActionDispatch::Request.new(env)
+      cookie = request.cookies[TOKEN_COOKIE]
+
       # don't even initialize a cookie jar if we don't have a cookie at all
-      if request.cookies[TOKEN_COOKIE].present?
+      if cookie.valid_encoding? && cookie.present?
         request.cookie_jar.encrypted[TOKEN_COOKIE]&.with_indifferent_access
       end
     end

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -79,7 +79,7 @@ class Auth::DefaultCurrentUserProvider
   def self.find_v0_auth_cookie(request)
     cookie = request.cookies[TOKEN_COOKIE]
 
-    if cookie?.valid_encoding? && cookie.present? && cookie.size == TOKEN_SIZE
+    if cookie&.valid_encoding? && cookie.present? && cookie.size == TOKEN_SIZE
       cookie
     end
   end
@@ -92,7 +92,7 @@ class Auth::DefaultCurrentUserProvider
       cookie = request.cookies[TOKEN_COOKIE]
 
       # don't even initialize a cookie jar if we don't have a cookie at all
-      if cookie?.valid_encoding? && cookie.present?
+      if cookie&.valid_encoding? && cookie.present?
         request.cookie_jar.encrypted[TOKEN_COOKIE]&.with_indifferent_access
       end
     end

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -79,7 +79,7 @@ class Auth::DefaultCurrentUserProvider
   def self.find_v0_auth_cookie(request)
     cookie = request.cookies[TOKEN_COOKIE]
 
-    if cookie.valid_encoding? && cookie.present? && cookie.size == TOKEN_SIZE
+    if cookie?.valid_encoding? && cookie.present? && cookie.size == TOKEN_SIZE
       cookie
     end
   end
@@ -92,7 +92,7 @@ class Auth::DefaultCurrentUserProvider
       cookie = request.cookies[TOKEN_COOKIE]
 
       # don't even initialize a cookie jar if we don't have a cookie at all
-      if cookie.valid_encoding? && cookie.present?
+      if cookie?.valid_encoding? && cookie.present?
         request.cookie_jar.encrypted[TOKEN_COOKIE]&.with_indifferent_access
       end
     end

--- a/spec/lib/middleware/anonymous_cache_spec.rb
+++ b/spec/lib/middleware/anonymous_cache_spec.rb
@@ -29,6 +29,7 @@ describe Middleware::AnonymousCache do
       it "is true if it has an invalid auth cookie" do
         cookie = create_auth_cookie(token: SecureRandom.hex, issued_at: 5.minutes.ago)
         cookie = swap_2_different_characters(cookie)
+        cookie.prepend("%a0%a1") # an invalid byte sequence
         expect(new_helper("HTTP_COOKIE" => "jack=1; _t=#{cookie}; jill=2").cacheable?).to eq(true)
       end
 
@@ -376,5 +377,4 @@ describe Middleware::AnonymousCache do
       expect(@status).to eq(403)
     end
   end
-
 end


### PR DESCRIPTION
Previously it would blow up on invalid utf byte sequences. This was a source of spec flakyness.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
