### PR TITLE
Correct type for `locked`

### DIFF
--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -357,14 +357,14 @@ describe 'posts' do
       parameter name: :post_body, in: :body, schema: {
         type: :object,
         properties: {
-          locked: { type: :boolean }
+          locked: { type: :string }
         }, required: [ 'locked' ]
       }
 
       produces 'application/json'
       response '200', 'post updated' do
         schema type: :object, properties: {
-          locked: { type: :boolean },
+          locked: { type: :string },
         }
 
         let(:post_body) { { 'locked': 'true' } }


### PR DESCRIPTION
`locked` only works if it's a string, not boolean. I also wanted to add a description to make it more clear in the open API generated page. But I'm not sure how to do that.

The description could say something like

>**Note** that the value of `locked` is a `string`, not a `boolean`.

See this discussion https://meta.discourse.org/t/unable-to-lock-post-with-api/228974