### PR TITLE
FIX: escape youtube title when constructing onebox preview html

### DIFF
--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -42,7 +42,7 @@ module Onebox
           result = parse_embed_response
           result ||= get_opengraph.data
 
-          "<img src='#{result[:image]}' width='#{WIDTH}' height='#{HEIGHT}' title='#{result[:title]}'>"
+          "<img src='#{result[:image]}' width='#{WIDTH}' height='#{HEIGHT}' title='#{CGI::escapeHTML(result[:title])}'>"
         else
           to_html
         end

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -384,7 +384,7 @@ describe Oneboxer do
       <<~HTML
         <html>
         <head>
-          <meta property="og:title" content="Onebox1">
+          <meta property="og:title" content="Onebox1 - ceci n'est pas un titre">
           <meta property="og:description" content="this is bodycontent">
           <meta property="og:image" content="https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg">
         </head>
@@ -415,6 +415,11 @@ describe Oneboxer do
       SiteSetting.allowed_onebox_iframes = "https://www.youtube.com"
       output = Oneboxer.onebox("https://www.youtube.com/watch?v=dQw4w9WgXcQ", invalidate_oneboxes: true)
       expect(output).to include("<iframe") # Regular youtube onebox
+    end
+
+    it "appropriately escapes youtube titles" do
+      preview = Oneboxer.preview("https://www.youtube.com/watch?v=dQw4w9WgXcQ", invalidate_oneboxes: true)
+      expect(preview).to include("ceci n'est pas un titre")
     end
   end
 


### PR DESCRIPTION
Fixes bug mentioned here: https://meta.discourse.org/t/pasting-a-link-in-the-composers-title-field-trims-the-title-if-theres-a-quote-character-in-it/228668