### PR TITLE
FIX: DiscourseConnect login did not auto approve based on email domain

### DIFF
--- a/app/models/discourse_connect.rb
+++ b/app/models/discourse_connect.rb
@@ -238,6 +238,7 @@ class DiscourseConnect < DiscourseConnectBase
     # the same email payload
     DistributedMutex.synchronize("discourse_single_sign_on_#{email}") do
       user = User.find_by_email(email) if !require_activation
+
       if !user
         user_params = {
           primary_email: UserEmail.new(email: email, primary: true),
@@ -250,7 +251,13 @@ class DiscourseConnect < DiscourseConnectBase
           user_params[:locale] = locale
         end
 
-        user = User.create!(user_params)
+        user = User.new(user_params)
+
+        if SiteSetting.must_approve_users && EmailValidator.can_auto_approve_user?(email)
+          ReviewableUser.set_approved_fields!(user, Discourse.system_user)
+        end
+
+        user.save!
 
         if SiteSetting.verbose_discourse_connect_logging
           Rails.logger.warn("Verbose SSO log: New User (user_id: #{user.id}) Params: #{user_params} User Params: #{user.attributes} User Errors: #{user.errors.full_messages} Email: #{user.primary_email.attributes} Email Error: #{user.primary_email.errors.full_messages}")


### PR DESCRIPTION
This commit resolves a bug where users are not auto approved based on
`SiteSetting.auto_approve_email_domains` when
`SiteSetting.must_approve_users` has been enabled.