### PR TITLE
UX: don't tether popper to the viewport if reference is out of the viewport

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -889,7 +889,7 @@ export default Component.extend(
               name: "preventOverflow",
               options: {
                 altAxis: !this?.site?.mobileView,
-                tetherOffset: ({ popper, reference }) =>
+                tetherOffset: ({ reference }) =>
                   Math.max(reference.y, document.documentElement.scrollTop),
               },
             },

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -889,6 +889,8 @@ export default Component.extend(
               name: "preventOverflow",
               options: {
                 altAxis: !this?.site?.mobileView,
+                tetherOffset: ({ popper, reference }) =>
+                  Math.max(reference.y, document.documentElement.scrollTop),
               },
             },
             {


### PR DESCRIPTION
followup to 

https://github.com/discourse/discourse/pull/16504

Internal

`/t/64811`

public

`/t/228953`