### PR TITLE
UX: Larger images in mobile emoji picker

### DIFF
--- a/app/assets/stylesheets/common/base/emoji.scss
+++ b/app/assets/stylesheets/common/base/emoji.scss
@@ -43,7 +43,7 @@ sup img.emoji {
 
   img.emoji {
     // custom emojis might import images of various sizes
-    // we don't want the picker to be difformed
+    // we don't want them to be deformed in the picker
     width: 20px !important;
     height: 20px !important;
   }

--- a/app/assets/stylesheets/mobile/emoji.scss
+++ b/app/assets/stylesheets/mobile/emoji.scss
@@ -10,7 +10,7 @@
   .emoji-picker-emoji-area {
     img.emoji {
       // custom emojis might import images of various sizes
-      // we don't want the picker to be difformed
+      // we don't want them to be deformed in the picker
       width: 28px !important;
       height: 28px !important;
     }

--- a/app/assets/stylesheets/mobile/emoji.scss
+++ b/app/assets/stylesheets/mobile/emoji.scss
@@ -6,4 +6,13 @@
   top: 0;
   left: 0;
   border-bottom: 1px solid var(--primary-low);
+  min-height: 50vh;
+  .emoji-picker-emoji-area {
+    img.emoji {
+      // custom emojis might import images of various sizes
+      // we don't want the picker to be difformed
+      width: 28px !important;
+      height: 28px !important;
+    }
+  }
 }


### PR DESCRIPTION
Better for hit area, plus it matches larger emoji sizes used in some contexts.

The small emoji size stood out for me when using chat. 

Before
<img width="200" alt="image" src="https://user-images.githubusercontent.com/368961/172208924-244b4e46-10b0-4022-a38c-542edf4b4078.png"><img width="200" alt="image" src="https://user-images.githubusercontent.com/368961/172208969-8bb23790-c2af-4498-a815-5630e01bd595.png">

After

<img width="200" alt="image" src="https://user-images.githubusercontent.com/368961/172209068-c675f275-8f4f-4cdd-984e-6903ef7d4b24.png"><img width="200" alt="image" src="https://user-images.githubusercontent.com/368961/172209080-7e55c385-3ebf-4839-babc-cfd272daef15.png">


