### PR TITLE
UX: Remove limit for emoji search in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -262,7 +262,6 @@ export default Component.extend({
 
     if (filter) {
       results.innerHTML = emojiSearch(filter.toLowerCase(), {
-        maxResults: 20,
         diversity: this.emojiStore.diversity,
       })
         .map(this._replaceEmoji)


### PR DESCRIPTION
When searching for a common word like "face", we were cutting off results to 20 items, which wasn't very helpful. I suspect we initially added this for performance reasons, but we load all emojis by default, so I'm not sure how much of a performance helper this is. 