### PR TITLE
FIX: Restore automatic style preview in wizard

### DIFF
--- a/app/assets/javascripts/wizard/lib/preview.js
+++ b/app/assets/javascripts/wizard/lib/preview.js
@@ -4,6 +4,7 @@ import { Promise } from "rsvp";
 import getUrl from "discourse-common/lib/get-url";
 import { htmlSafe } from "@ember/template";
 import { scheduleOnce } from "@ember/runloop";
+import { observes } from "discourse-common/utils/decorators";
 
 export const LOREM = `
 Lorem ipsum dolor sit amet,
@@ -52,6 +53,13 @@ export function createPreviewComponent(width, height, obj) {
         this.ctx = c.getContext("2d");
         this.ctx.scale(scale, scale);
         this.reload();
+      },
+
+      @observes(
+        "step.fieldsById.{color_scheme,body_font,heading_font,homepage_style}.value"
+      )
+      themeChanged() {
+        this.triggerRepaint();
       },
 
       images() {},


### PR DESCRIPTION
Updating the homepage/style preview regressed in #16994.

This uses an observer which will be eventually refactored away, but that requires bigger changes and can wait until the general wizard redesign.