### PR TITLE
FIX: Seed multisite dbs after migrating in development

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -230,14 +230,10 @@ task 'db:migrate' => ['load_config', 'environment', 'set_locale'] do |_, args|
 
     ActiveRecord::Tasks::DatabaseTasks.migrate
 
-    if !Discourse.is_parallel_test?
-      Rake::Task['db:_dump'].invoke
-    end
-
     SeedFu.quiet = true
     SeedFu.seed(SeedHelper.paths, SeedHelper.filter)
 
-    if Rails.env.development?
+    if Rails.env.development? && !ENV["RAILS_DB"]
       Rake::Task['db:schema:cache:dump'].invoke
     end
 


### PR DESCRIPTION
Dumping the schema cache reset the current_db and we only need to do
this once.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
