### PR TITLE
DEV: Allow all subdomains of localhost in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -110,4 +110,6 @@ Discourse::Application.configure do
       Bullet.rails_logger = true
     end
   end
+
+  config.hosts << /\A(([a-z-]+)\.)*localhost(\:\d+)?\Z/
 end


### PR DESCRIPTION
By default in rails, it looks like only one level deep is allowed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
