### PR TITLE
DEV: Add new user scopes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -220,6 +220,8 @@ class User < ActiveRecord::Base
   scope :suspended, -> { where('suspended_till IS NOT NULL AND suspended_till > ?', Time.zone.now) }
   scope :not_suspended, -> { where('suspended_till IS NULL OR suspended_till <= ?', Time.zone.now) }
   scope :activated, -> { where(active: true) }
+  scope :not_staged, -> { where(staged: false) }
+  scope :activated_not_suspended_not_staged, -> { self.activated.not_suspended.not_staged }
 
   scope :filter_by_username, ->(filter) do
     if filter.is_a?(Array)


### PR DESCRIPTION
Adds two new user scopes:

- `not_staged`
- `activated_not_suspended_not_staged`

This will allow us to easily grab activated users that are not suspended
or staged.

See this PR feedback:

https://github.com/discourse/discourse-chat/pull/913#discussion_r890692266
