### PR TITLE
DEV: Remove this chained user scope

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,7 +221,6 @@ class User < ActiveRecord::Base
   scope :not_suspended, -> { where('suspended_till IS NULL OR suspended_till <= ?', Time.zone.now) }
   scope :activated, -> { where(active: true) }
   scope :not_staged, -> { where(staged: false) }
-  scope :activated_not_suspended_not_staged, -> { self.activated.not_suspended.not_staged }
 
   scope :filter_by_username, ->(filter) do
     if filter.is_a?(Array)


### PR DESCRIPTION
This reverts one of the changes introduced just now in:

27d7b0c6de73cb0cd2bd5137b5a58c151bd83289

I don't think we need this `activated_not_suspended_not_staged` scope
because we can just compose it ourselves via method chaining like
`User.activated.not_suspended.not_staged`.
