### PR TITLE
DEV: Fix openapi definition logo URL

### DIFF
--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -103,7 +103,7 @@ RSpec.configure do |config|
       info: {
         title: 'Discourse API Documentation',
         'x-logo': {
-          url: 'https://discourse-meta.s3-us-west-1.amazonaws.com/optimized/3X/9/d/9d543e92b15b06924249654667a81441a55867eb_1_690x184.png',
+          url: 'https://docs.discourse.org/logo.svg',
         },
         version: 'latest',
         description: api_docs_description,


### PR DESCRIPTION
See https://github.com/discourse/discourse_api_docs/commit/887e4087d5eddefad23ba9ee67a251b925d57ed4

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
