### PR TITLE
DEV: Use nested form for `FreedomPatches` module

### DIFF
--- a/lib/freedom_patches/mail_disable_starttls.rb
+++ b/lib/freedom_patches/mail_disable_starttls.rb
@@ -6,16 +6,18 @@
 #
 # This should be fixed in an upcoming release of the Mail gem (probably 2.8),
 # when this patch is merged: https://github.com/mikel/mail/pull/1435
-module FreedomPatches::MailDisableStarttls
-  def build_smtp_session
-    super.tap do |smtp|
-      unless settings[:enable_starttls_auto]
-        if smtp.respond_to?(:disable_starttls)
-          smtp.disable_starttls
+module FreedomPatches
+  module MailDisableStarttls
+    def build_smtp_session
+      super.tap do |smtp|
+        unless settings[:enable_starttls_auto]
+          if smtp.respond_to?(:disable_starttls)
+            smtp.disable_starttls
+          end
         end
       end
     end
-  end
 
-  ::Mail::SMTP.prepend(self)
+    ::Mail::SMTP.prepend(self)
+  end
 end


### PR DESCRIPTION
It seems that not using the nested form for the `FreedomPatches` namespace is breaking stuff in some dev env.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
