### PR TITLE
COPY: Use main instead of master for theme installation modal

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-install-theme.hbs
@@ -66,7 +66,7 @@
         {{#if advancedVisible}}
           <div class="branch">
             <div class="label">{{i18n "admin.customize.theme.remote_branch"}}</div>
-            {{input value=branch placeholder="master"}}
+            {{input value=branch placeholder="main"}}
           </div>
 
           <div class="check-private">


### PR DESCRIPTION
GitHub now uses main as the default branch so it makes sense to update the placeholder in the theme installation modal to use main instead of master.

The following will be updated to use "main" instead:

<img width="659" alt="Screen Shot 2022-06-08 at 10 59 33 AM" src="https://user-images.githubusercontent.com/22733864/172686410-751657a4-5461-4432-bfd8-71667d89c35a.png">

