### PR TITLE
DEV: Remove flaky acceptance test

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/jump-to-test.js
@@ -36,18 +36,4 @@ acceptance("Jump to", function (needs) {
       "it jumps to the correct post"
     );
   });
-
-  test("invalid date", async function (assert) {
-    await visit("/t/internationalization-localization/280");
-    await click("nav#topic-progress .nums");
-    await click("button.jump-to-post");
-    await fillIn("input.date-picker", "2094-02-24");
-    await click(".jump-to-post-modal .btn-primary");
-
-    assert.strictEqual(
-      currentURL(),
-      "/t/internationalization-localization/280/20",
-      "it jumps to the last post if no post found"
-    );
-  });
 });


### PR DESCRIPTION
The test was un-skipped in 6f25f1736031184ac05fc4059edde772a7e3bf56 but
has since been flaky again. Removing the test completely as it has
resulted in more pain for us than the value the test provides.