### PR TITLE
FIX: Handle empty string in theme_settings for upload_references

### DIFF
--- a/db/migrate/20220404212716_copy_theme_settings_uploads_to_upload_references.rb
+++ b/db/migrate/20220404212716_copy_theme_settings_uploads_to_upload_references.rb
@@ -7,7 +7,7 @@ class CopyThemeSettingsUploadsToUploadReferences < ActiveRecord::Migration[6.1]
       SELECT theme_settings.value::int, 'ThemeSetting', theme_settings.id, uploads.created_at, uploads.updated_at
       FROM theme_settings
       JOIN uploads ON uploads.id = theme_settings.value::int
-      WHERE data_type = 6 AND theme_settings.value IS NOT NULL
+      WHERE data_type = 6 AND theme_settings.value IS NOT NULL AND theme_settings.value != ''
       ON CONFLICT DO NOTHING
     SQL
   end


### PR DESCRIPTION
Follow up to 9db8f00b3dd6f2881adf1b786e29426889225e7a,
the theme_settings.value field is not an integer and so
can be '', we need to account for this in the migration
otherwise we get this error:

> PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type integer: ""
