### PR TITLE
FIX: Cleanup invalid historic site setting data

### DIFF
--- a/db/migrate/20220330160740_cleanup_selectable_avatars_data.rb
+++ b/db/migrate/20220330160740_cleanup_selectable_avatars_data.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CleanupSelectableAvatarsData < ActiveRecord::Migration[7.0]
+  def up
+    # This setting is invalid (a backup from 20200810194943_change_selectable_avatars_site_setting.rb)
+    execute <<~SQL
+      DELETE FROM site_settings
+      WHERE name = 'selectable_avatars_urls'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
`selectable_avatars_urls` contains invalid data (it's a backup from 20200810194943_change_selectable_avatars_site_setting.rb)

This migration is deliberately backdated so that it runs before `20220330160747_copy_site_settings_uploads_to_upload_references`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
