### PR TITLE
DEV: Add deprecation notice to discourse-common/utils/decorators

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/utils/macro-alias.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/macro-alias.js
@@ -1,4 +1,5 @@
 import isDescriptor from "discourse-common/utils/is-descriptor";
+import deprecated from "discourse-common/lib/deprecated";
 
 function handleDescriptor(target, property, desc, fn, params = []) {
   return {
@@ -16,6 +17,9 @@ export default function macroAlias(fn) {
     if (isDescriptor(params[params.length - 1])) {
       return handleDescriptor(...params, fn);
     } else {
+      deprecated(
+        `Importing ${fn.name} from 'discourse-common/utils/decorators' is deprecated. You should instead import it from '@ember/object/computed' directly.`
+      );
       return function (target, property, desc) {
         return handleDescriptor(target, property, desc, fn, params);
       };


### PR DESCRIPTION
<img width="606" alt="Screen Shot 2022-06-09 at 11 10 53 AM" src="https://user-images.githubusercontent.com/50783505/172895735-f38ebae9-28d7-419a-85c5-b1868b0e786c.png">

