### PR TITLE
FIX: whisper available when reply to topic

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1,5 +1,7 @@
 import { click, currentURL, fillIn, settled, visit } from "@ember/test-helpers";
 import { toggleCheckDraftPopup } from "discourse/controllers/composer";
+import { cloneJSON } from "discourse-common/lib/object";
+import TopicFixtures from "discourse/tests/fixtures/topic";
 import LinkLookup from "discourse/lib/link-lookup";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import Composer, {
@@ -42,6 +44,11 @@ acceptance("Composer", function (needs) {
         cannot_see: [],
         max_users_notified_per_group_mention: 100,
       });
+    });
+    server.get("/t/960.json", () => {
+      const topicList = cloneJSON(TopicFixtures["/t/9/1.json"]);
+      topicList.post_stream.posts[2].post_type = 4;
+      return helper.response(topicList);
     });
   });
 
@@ -570,6 +577,36 @@ acceptance("Composer", function (needs) {
     assert.ok(
       !exists(".reply-details .whisper"),
       "it should reset the state of the composer's model"
+    );
+  });
+
+  test("Composer can toggle whisper when switch from reply to whisper to reply to topic", async function (assert) {
+    await visit("/t/topic-with-whisper/960");
+
+    await click(".topic-post:nth-of-type(3) button.reply");
+    await click(".reply-details summary div");
+    assert.ok(
+      !exists('.reply-details li[data-value="toggle_whisper"]'),
+      "toggle whisper is not available when reply to whisper"
+    );
+    await click('.reply-details li[data-value="reply_to_topic"]');
+    await click(".reply-details summary div");
+    assert.ok(
+      exists('.reply-details li[data-value="toggle_whisper"]'),
+      "toggle whisper is available when reply to topic"
+    );
+  });
+
+  test("Composer can toggle whisper when click reply to topic after reply to whisper", async function (assert) {
+    await visit("/t/topic-with-whisper/960");
+
+    await click(".topic-post:nth-of-type(3) button.reply");
+    await click("#reply-control .save-or-cancel a.cancel");
+    await click(".topic-footer-main-buttons button.create");
+    await click(".reply-details summary div");
+    assert.ok(
+      exists('.reply-details li[data-value="toggle_whisper"]'),
+      "toggle whisper is available when reply to topic"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -580,7 +580,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer can toggle whisper when switch from reply to whisper to reply to topic", async function (assert) {
+  test("Composer can toggle whisper when switching from reply to whisper to reply to topic", async function (assert) {
     await visit("/t/topic-with-whisper/960");
 
     await click(".topic-post:nth-of-type(3) button.reply");

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -597,7 +597,7 @@ acceptance("Composer", function (needs) {
     );
   });
 
-  test("Composer can toggle whisper when click reply to topic after reply to whisper", async function (assert) {
+  test("Composer can toggle whisper when clicking reply to topic after reply to whisper", async function (assert) {
     await visit("/t/topic-with-whisper/960");
 
     await click(".topic-post:nth-of-type(3) button.reply");

--- a/app/assets/javascripts/select-kit/addon/components/composer-actions.js
+++ b/app/assets/javascripts/select-kit/addon/components/composer-actions.js
@@ -182,7 +182,8 @@ export default DropdownSelectBoxComponent.extend({
     // if answered post is a whisper, we can only answer with a whisper so no need for toggle
     if (
       this.canWhisper &&
-      (!_postSnapshot ||
+      (!this.replyOptions.postLink ||
+        !_postSnapshot ||
         _postSnapshot.post_type !== this.site.post_types.whisper)
     ) {
       items.push({


### PR DESCRIPTION
When user is answering a whisper comment they cannot change from whisper to regular answer.

However, user can click reply to topic. We keep `postSnapshot` so user can change mind and switch back to reply to post. In that case, a toggle whisper button should appear.

To make it happen, I am ensuring to display a toggle whisper button when user is replying to topic - `postLink` attribute is missing.

<img width="316" alt="Screen Shot 2022-06-10 at 9 30 54 am" src="https://user-images.githubusercontent.com/72780/172962545-92bce281-a535-4ccf-a4e6-2a6cafe0fc93.png">

