### PR TITLE
FIX: twitter onebox keeps whitespace for expanded links

### DIFF
--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -96,15 +96,17 @@ class TwitterApi
 
     def link_handles_in(text)
       text.gsub(/(?:^|\s)@\w+/) do |match|
-        handle = match.strip[1..]
-        "<a href='https://twitter.com/#{handle}' target='_blank'>@#{handle}</a>"
+        whitespace = match[0] == " " ? " " : ""
+        handle     = match.strip[1..]
+        "#{whitespace}<a href='https://twitter.com/#{handle}' target='_blank'>@#{handle}</a>"
       end.strip
     end
 
     def link_hashtags_in(text)
       text.gsub(/(?:^|\s)#\w+/) do |match|
-        hashtag = match.strip[1..]
-        "<a href='https://twitter.com/search?q=%23#{hashtag}' target='_blank'>##{hashtag}</a>"
+        whitespace = match[0] == " " ? " " : ""
+        hashtag    = match.strip[1..]
+        "#{whitespace}<a href='https://twitter.com/search?q=%23#{hashtag}' target='_blank'>##{hashtag}</a>"
       end.strip
     end
 


### PR DESCRIPTION
Previously, we were eating the whitespace on handle and hashtag links, which made oneboxes look like (ie.):

![image](https://user-images.githubusercontent.com/44642328/172978564-a7c13e6f-4db5-4403-9d9f-912f601ddf59.png)

```
NEVER has a<a href="https://twitter.com/Docker" target="_blank" rel="noopener">@Docker</a> container name ever been more appropriate<a href="https://twitter.com/search?q=%23docker" target="_blank" rel="noopener">#docker</a>...
```

The original tweet is properly spaced: https://twitter.com/Supermathie/status/898651027423055872

The best way I could find to resolve this simply is to check if the leading character in the match is a space and add it back in as necessary. Open to suggestions here.

I did a rough test of this as seen here: https://gist.github.com/gabenp/9d527fc93ce5516625e833acf5dbdc9a

Which results in properly spaced links:
```
Test <a href='https://twitter.com/Discourse' target='_blank'>@Discourse</a> test tweet <a href='https://twitter.com/search?q=%23discourse' target='_blank'>#discourse</a>

<a href='https://twitter.com/Discourse' target='_blank'>@Discourse</a> test tweet <a href='https://twitter.com/search?q=%23discourse' target='_blank'>#discourse</a>

<a href='https://twitter.com/search?q=%23discourse' target='_blank'>#discourse</a> test tweet <a href='https://twitter.com/discourse' target='_blank'>@discourse</a>
```