### PR TITLE
FEATURE: Easily show content on specific routes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/route-control.js
+++ b/app/assets/javascripts/discourse/app/components/route-control.js
@@ -1,0 +1,34 @@
+import Component from "@ember/component";
+import { inject as service } from "@ember/service";
+import discourseComputed from "discourse-common/utils/decorators";
+import { defaultHomepage } from "discourse/lib/utilities";
+
+export default Component.extend({
+  tagName: "div",
+  router: service(),
+
+  @discourseComputed("router.currentRouteName", "showOn")
+  canDisplay(currentRouteName, showOn) {
+    if (showOn === "homepage") {
+      return this.handleHomepageRoute(currentRouteName);
+    } else if (showOn === currentRouteName) {
+      return true;
+    } else {
+      return false;
+    }
+  },
+
+  handleHomepageRoute(currentRouteName) {
+    const topMenu = this.siteSettings.top_menu;
+
+    if (currentRouteName === `discovery.${defaultHomepage()}`) {
+      return true;
+    } else if (
+      topMenu.split("|").any((m) => `discovery.${m}` === currentRouteName)
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  },
+});

--- a/app/assets/javascripts/discourse/app/templates/components/route-control.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/route-control.hbs
@@ -1,0 +1,3 @@
+{{#if canDisplay}}
+  {{yield}}
+{{/if}}


### PR DESCRIPTION
This PR adds a component to the Discourse codebase to easily show content on a specific route. This is especially helpful for theme/plugin developers to easily show certain content on a specific page (without having to always rewrite some sort of route handling code).

Developers can easily add a wrapper block around their code and specify which route the content should be shown on. This can be used for example in certain plugin outlet connectors like so:

Example: `connectors/below-site-header/my-additions.hbs`:

```hbs
{{#route-control showOn="discovery.category"}}
  <h1>Hello Everybody! These are my additions</h1>
{{/route-control}}
```

There is also a shorthand to show content only on the homepage:

```hbs
{{#route-control showOn="homepage"}}
  <h1>Hello Everybody! These are my additions</h1>
{{/route-control}}
```

This will dynamically show content on the main homepage as well as other top menu routes that have been set in the `top_menu` setting.