### PR TITLE
DEV: Explicitly allow NavItem customization

### DIFF
--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -17,27 +17,47 @@ import { reads } from "@ember/object/computed";
 
 const NavItem = EmberObject.extend({
   @discourseComputed("name")
-  title(name) {
-    return I18n.t("filters." + name.replace("/", ".") + ".help", {});
+  title: {
+    get(name) {
+      if (this._title) {
+        return this._title;
+      }
+
+      return I18n.t("filters." + name.replace("/", ".") + ".help", {});
+    },
+
+    set(value) {
+      this.set("_title", value);
+    },
   },
 
   @discourseComputed("name", "count")
-  displayName(name, count) {
-    count = count || 0;
+  displayName: {
+    get(name, count) {
+      if (this._displayName) {
+        return this._displayName;
+      }
 
-    if (
-      name === "latest" &&
-      (!Site.currentProp("mobileView") || this.tagId !== undefined)
-    ) {
-      count = 0;
-    }
+      count = count || 0;
 
-    let extra = { count };
-    const titleKey = count === 0 ? ".title" : ".title_with_count";
+      if (
+        name === "latest" &&
+        (!Site.currentProp("mobileView") || this.tagId !== undefined)
+      ) {
+        count = 0;
+      }
 
-    return emojiUnescape(
-      I18n.t(`filters.${name.replace("/", ".") + titleKey}`, extra)
-    );
+      let extra = { count };
+      const titleKey = count === 0 ? ".title" : ".title_with_count";
+
+      return emojiUnescape(
+        I18n.t(`filters.${name.replace("/", ".") + titleKey}`, extra)
+      );
+    },
+
+    set(value) {
+      this.set("_displayName", value);
+    },
   },
 
   @discourseComputed("filterType", "category", "noSubcategories", "tagId")


### PR DESCRIPTION
Allow overriding NavItem's title and displayName. Fixes multiple instances of `computed-property.override` warnings in plugins.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
