### PR TITLE
DEV: Allow disabling composer submit

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -120,6 +120,25 @@ export default Controller.extend({
     this.set("showPreview", val === "true");
   },
 
+  @computed(
+    "model.loading",
+    "isUploading",
+    "isProcessingUpload",
+    "_disableSubmit"
+  )
+  get disableSubmit() {
+    return (
+      this.model.loading ||
+      this.isUploading ||
+      this.isProcessingUpload ||
+      this._disableSubmit
+    );
+  },
+
+  set disableSubmit(value) {
+    this.set("_disableSubmit", value);
+  },
+
   @discourseComputed("showPreview")
   toggleText(showPreview) {
     return showPreview
@@ -802,8 +821,6 @@ export default Controller.extend({
       );
     },
   },
-
-  disableSubmit: or("model.loading", "isUploading", "isProcessingUpload"),
 
   save(force, options = {}) {
     if (this.disableSubmit) {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -128,7 +128,7 @@ export default Controller.extend({
   )
   get disableSubmit() {
     return (
-      this.model.loading ||
+      this.model?.loading ||
       this.isUploading ||
       this.isProcessingUpload ||
       this._disableSubmit


### PR DESCRIPTION
…without overriding the computed property. Will fix warnings in discourse-perspective-api plugin.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
