### PR TITLE
FIX: Ensure that extract_upload_ids works with all short URLs

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -515,7 +515,7 @@ class Upload < ActiveRecord::Base
       sha1s << match[0]
     end
 
-    raw.scan(/\/([a-zA-Z0-9]{27})/).each do |match|
+    raw.scan(/\/([a-zA-Z0-9]+)/).each do |match|
       sha1s << Upload.sha1_from_base62_encoded(match[0])
     end
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -520,9 +520,7 @@ describe Upload do
   describe '.extract_upload_ids' do
     let(:upload) { Fabricate(:upload) }
 
-    # This spec fails when upload has a sha1 of "035839d28676a96fda268562e6aa93c57b11113c".
-    # When the sha1 is converted to hex, the leading 0 is ignored so the base62 encoding will be 26 chars long.
-    skip 'works with short URLs' do
+    it 'works with short URLs' do
       ids = Upload.extract_upload_ids("This URL #{upload.short_url} is an upload")
       expect(ids).to contain_exactly(upload.id)
     end
@@ -532,10 +530,15 @@ describe Upload do
       expect(ids).to contain_exactly(upload.id)
     end
 
-    # This spec fails when upload has a sha1 of "035839d28676a96fda268562e6aa93c57b11113c".
-    # When the sha1 is converted to hex, the leading 0 is ignored so the base62 encoding will be 26 chars long.
-    skip 'works with Base62 hashes' do
+    it 'works with Base62 hashes' do
       ids = Upload.extract_upload_ids("This URL /#{Upload.base62_sha1(upload.sha1)} is an upload")
+      expect(ids).to contain_exactly(upload.id)
+    end
+
+    it 'works with shorter base62 hashes (when sha1 has leading 0s)' do
+      upload.update(sha1: "0000c513e1da04f7b4e99230851ea2aafeb8cc4e")
+      base62 = Upload.base62_sha1(upload.sha1).delete_prefix("0")
+      ids = Upload.extract_upload_ids("This URL /#{base62} is an upload")
       expect(ids).to contain_exactly(upload.id)
     end
   end


### PR DESCRIPTION
We do not zero-pad our base62 short URLs, so there is no guarantee that the length is 27. Instead, let's greedily match all consecutive base62 characters and look for a matching upload.

This reverts bd3265615712fb60063958e8d87475c845f058bb and 36f5d5eada78ca11f08ad579b6320c0c10292ae1.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
