### PR TITLE
stable bump

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -9,7 +9,7 @@ module Discourse
     module VERSION #:nodoc:
       MAJOR = 2
       MINOR = 8
-      TINY  = 3
+      TINY  = 4
       PRE   = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')


### PR DESCRIPTION
- SECURITY: Only redirect to our host by path on the login action
- SECURITY: User action route was returning too much data
- SECURITY: GitHub authenticator returning unverified emails
- Version bump to v1.0.1
- SECURITY: Limit passwords to 200 characters
- SECURITY: Malformed URL could crash V8
- SECURITY: Escape strings in logs
- FIX: Resend activation email was busted
- SECURITY: Stripping links could unescape html fragments
- SECURITY: rate limit change email requests
- Version bump to v1.0.2
- SECURITY: rate limit user/password login
- SECURITY: RegExp engine loopwith improperly formatted URLs.
- Version bump to v1.0.3
- FIX: prevent iframe in expended quote
- SECURITY: Don't allow redirects with periods in case you don't control other tlds on the same domain.
- Version bump to v1.0.4
- Version bump to v1.1.0
- fix pop up composer tips display for mobile
- FEATURE: don't limit registration from an IP address if a staff member has that IP address
- FIX: PM title not editable
- Version bump to v1.1.2
- SECURITY: prevent direct download of backups
- Version bump to v1.1.3
- SECURITY: Don't whitelist codepen as it is a potential vector for abuse
- SECURITY: The SSO `return_path` was an open redirect
- FIX: full user names were showing up in crawlers and rss feeds in spite enables_names setting being disabled
- Merge pull request #3192 from riking/patch-xss
- Version bump to v1.2.0
- URGENT: commit snuck in twice when merging master
- FIX: when allow uncategorized was off we were still showing uncat for admins/mods
- Revert "FIX: when allow uncategorized was off we were still showing uncat for admins/mods"
- FIX: 6to5 was renamed to Babel
- Version bump to v1.2.1
- S3 deprecation warning
- add classes to global-notices so they can be found with selectors
- add global notice for S3 deprecation warning
- Version bump to v1.2.2
- SECURITY: log off all existing sessions when resetting password
- Version bump to v1.2.3
- Revert "add global notice for S3 deprecation warning"
- Revert "S3 deprecation warning"
- Version bump to v1.2.4
- Version bump to v1.3.0
- Revert "Version bump to v1.3.0"
- Version bump to v1.3.0
- Version bump to v1.3.1 (skip 1.3.0)
- Never enqueue posts from staff
- SECURITY: expire all existing sessions if user changes passwords
- SECURITY: expire all existing email tokens on password reset
- fix minor alignment issues with expanded posts
- lighter quote controls
- update memory profiler, oj and lru redux
- we don't care about convert output/errors
- FEATURE: plugins can register a custom admin quick start topic that will be seeded into new sites
- FIX: staff should be immune to max_invites_per_day setting
- FEATURE: we need admin login always
- correct specs
- FEATURE: Use created_at to remove an ip if its last_match_at is null
- Simple "cook" for email imports from mailing lists
- new 'uploads:migrate_to_new_pattern' task
- FIX: missing emoji autocomplete
- FIX: send 404 error when unauthorized user tries to download user archive
- FIX: Bad page title for categories view by google crawler
- FIX: when sending private message emails do not check email_direct setting
- Attempt micro data using old vocubulary
- FEATURE: improve no-js topic list information
- PERF: production assets not minified
- SECURITY: Query @usernames in bulk
- FIX: fix category badge and link in email digest
- PERF: Debounce mention lookup, enforce minimum username
- Version bump to v1.3.2
- SECURITY: Remove email validation check bypass
- Version bump to v1.3.3
- SECURITY: Make sure export CSV is generated via a POST
- Version bump to v1.3.4
- SECURITY: fix possible XSS expanding quotes
- Version bump to v1.3.5
- Version bump to v1.4.0
- FIX: Double load sometimes on topic lists
- FIX: notifications & messages were missing from user profile
- FIX: properly filter badges when they're on a whisper
- Revert "FIX: properly filter badges when they're on a whisper"
- UX: always show logout link in user menu, use CSS to hide
- Revert "UX: always show logout link in user menu, use CSS to hide"
- update install guide for Discourse 1.4
- simplify install guide a tiny bit
- emphasize reading the admin quick start guide
- FIX: pikaday wasn't working when using the mouse with a touch-enabled monitor
- FIX: only disable the composer grip when the device is touch-only
- FIX: Category Logo preview should not repeat
- FIX: 1.4 welcome PM images needed update
- FIX: when replying to a expanded reply, correctly attribute author
- minor install guide tweaks
- minor install guide tweaks
- update readme images for 1.4
- tweaks to readme
- FIX: whispers should not be revealed in reply to, or reply expansion FEATURE: mark whisper as experimental FIX: badges should never apply to whispers
- FIX: disable cloaked view while running ios positioning hack
- FIX: replaceMarkdown should be smart about current caret position
- FIX: Replies to whispers *must* be whispers
- FIX: Allow mods/admins to search whispers
- FIX: `max_topics_per_day` was not working
- FIX: don't use Safari hack on Windows Phone
- Version bump to v1.4.1
- SECURITY: XSS in search results term
- SECURITY: Moderators should not see API keys
- FIX: Broken spec
- SECURITY: Unread post notifications should respect whispers
- Version bump to v1.4.2
- SECURITY: XSS Protection on Queued Posts
- SECURITY: Backported XSS fixes from Handlebars
- Version bump to v1.4.3
- SECURITY: Upgrade Ember to fix CVE-2015-7565
- Revert "SECURITY: Upgrade Ember to fix CVE-2015-7565"
- SECURITY: Upgrade Ember to fix CVE-2015-7565. Also upgrade Handlebars
- FIX: Precompiler should apply `get` magic too
- Version bump to v1.4.4
- SECURITY: fix XSS in lazyYT plugin
- SECURITY: topic titles can show up in user page unescaped when streamed in
- Version bump to v1.4.5
- SECURITY: hoist blocks using guids, not md5 hashes
- we still need md5
- fix eslint
- Backported PluginAPI for compatibility with plugins
- Version bump to v1.4.6
- FIX: unescape emojis in digests
- SECURITY: Backport XSS fix
- Version bump to v1.4.7
- merge master
- FIX: Bad auto merge
- Version bump to v1.5.0
- Update Translations
- Version bump to v1.5.1
- SECURITY: 2 XSSs in post gutter and local oneboxes
- SECURITY: update rack-mini-profiler
- Version bump to v1.5.2
- SECURITY: Unapproved, active users should not receive emails
- SECURITY: restrict constantize classes in search controller
- SECURITY: update logster
- Version bump to v1.5.3
- SECURITY: Possible SQL injection.
- Version bump to v1.5.4
- SECURITY: limit route access when using external avatars
- SECURITY: XSS in "Account Suspended" Messages and Badge Descriptions
- SECURITY: SQL Injection in Admin List Active Users
- SECURITY: Cross-Site Scripting in Category and Group Settings
- SECURITY: Make sure uploaded_urls have corresponding upload records
- FIX: Regression with escaping on badge page
- FIX: Broken test
- SECURITY: Avoid mass assignment on user create
- SECURITY: XSS issue on Admin users list
- Version bump to v1.6.0
- Revert "UX: Centering Badge notification styles on mobile."
- SECURITY: do cookie auth rate limiting earlier
- FIX: wasn't able to update category's settings
- SECURITY: Escape image title in lightbox.
- SECURITY: Escape HTML in filename.
- FIX: Travis failure
- Update Translations
- Version bump to v1.6.1
- SECUIRTY: Escape input made to system calls.
- SECURITY: Add filename validation for backup uploads.
- Version bump to v1.6.2
- FIX: Backup validation wasn't escaping hyphens
- Escape the hyphen
- Version bump to v1.6.3
- FIX: Make sure constant reflects the right backup extenstion.
- Version bump to v1.6.4
- FIX: Randomly failing specs try 2.
- FIX: User enabled readonly mode was not working.
- Version bump to v1.6.5
- update mini_racer to latest version
- FIX: mini_racer will no longer Dispose forked isolates
- Version bump to v1.6.6
- FIX: properly reset all contexts after forking
- fix oops
- Version bump to v1.6.7
- Backport `get-owner` API so plugins can use it safely
- Version bump to v1.6.8
- SECURITY: Update to latest onebox gem
- Version bump to v1.6.9
- SECURITY: protect upload params, only allow very strict filenames
- SECURITY: update onebox gem
- SECURITY: prevent reuse of password reset
- SECURITY: Users can only bookmark posts which they can see.
- Version bump to 1.6.10.
- SECURITY: Moderators should not be able to access customizations
- Version bump to v1.7.0
- FIX: don't onebox to IP addresses
- FIX: log backups download/destroy staff action
- Fix broken emojis.
- SECURITY: Prevent large onebox downloads, better timeout support
- Version bump to v1.7.2
- UX: less restrictive selector to allow for plugin outlets
- SECURITY: correctly validate input when admin searches for screened ips
- new: server plugin outlet for indexable robots.txt
- Version bump to v1.7.3
- SECURITY: inactive/suspended accounts should be banned from api
- SECURITY: Ensure that user has been authenticated.
- Revert "SECURITY: Ensure that user has been authenticated."
- SECURITY: Ensure oAuth authenticated email is the same as created user's email.
- FIX: Mobile topic timeline broken on Chrome 56.
- Revert "SECURITY: Ensure oAuth authenticated email is the same as created user's email."
- Version bump to v1.7.4
- FIX: Don't mark user as `active` if verified email is different.
- SECURITY: Only allow users to resend activation email with a valid session.
- FIX: Store user's id instead for sending activation email.
- SECURITY: always allow staff to resend activation mails
- SECURITY: Don't use backticks for exporting your archive
- SECURITY: Disallow symlinks when restoring uploads.
- Version bump to v1.7.5
- SECURITY: CSRF vulnerabilities in `Admin::BackupsController`.
- Version bump to v1.7.6
- FIX: Update omniauth facebook to fix facebook logins
- Version bump to v1.7.7
- SECURITY: do not send push notifications to suspended users
- SECURITY: prefer render plain/html to render text where possible
- Version bump to v1.7.8
- SECURITY: XSS issue in share popup if invalid link is passed in.
- FIX: Show share popup only for valid buttons.
- FIX: Regression when clicking on post date
- Disable failing JS tests first.
- Version bump to v1.7.9
- SECURITY: Validate the `entity` when downloading a CSV
- Version bump to v1.7.10
- Version bump to v1.8.0
- Revert "Load posts in batches while indexing problem posts."
- SECURITY: Vunerability in mail gem
- FIX: narrative bot on subfolder installs
- fix narrative bot for subfolder in translation files
- FIX: Don't run in testing mode
- Revert "Skip validations when Discobot creates new posts."
- FIX: automatic PNG-to-JPEG conversion should use a default white background
- FIX: PNG-to-JPEG conversion should only be done to images with at least 1 megapixels
- FIX: Bot should only respond to regular posts.
- FIX: Ensure that we cancel any timeout jobs when terminating a track.
- Move the constant as well.
- FIX: Bot mentioned check should be case insensitive.
- Version bump to v1.8.1
- padding below suggested topics on mobile
- FIX: If HEAD is not supported, try GET. Also set cookies
- FIX: Support for cookies in onebox redirects
- FIX: Onebox wasn't using correct uri
- FIX: Don't use `target=_blank` for local oneboxes
- FIX: Always allow the host the forum is hosted on
- FIX: Don't fail seed if avatar can't be downloaded
- Avoid monkey patching which causes weird reloading error in dev.
- UX: Don't send emails for discobot notifications.
- FIX: Create group membership request on behalf of user.
- FIX: Send request membership PM to last 5 active group owner.
- Switch to yarn for our travis build.
- Pin eslint to version 3.x on travis.
- FIX: image orientation wasn't properly working
- FIX: Topic Entrance wasn't showing up on some suggested topics
- FIX: include canonical meta tag on category pages
- Version bump to v1.8.2
- SECURITY: Remove disposable invite feature
- FIX: invited user should not be able to redeem invite as admin
- Version bump to v1.8.3
- FIX: Allow discourse app to link directly to wizard
- Revert "UX: Don't try to figure out root domain."
- FIX: Exclude `www` in topic map links.
- Version bump to v1.8.4
- SECURITY: Do not show latest/top topics on 404 for login_required sites
- Version bump to v1.8.5
- FIX: Group name was being reverted to non-localized version.
- FIX: Make .eslintrc file compatible with eslint 4
- FIX: Make .eslintrc file compatible with eslint 4 take 2
- SECURITY: do not include links from whispers in topic summary map
- Version bump to v1.8.6
- SECURITY: Only publish PM reply messagebus notifications to allowed users
- Version bump to v1.8.7
- SECURITY: Update Nokogiri.
- Version bump to v1.8.8
- SECURITY: verify that inviter can invite new user to a topics
- Version bump to v1.8.9
- SECURITY: signup without verified email using Google auth
- Version bump to v1.8.10
- SECURITY: prevent staged accounts from changing email
- SECURITY: Any group can be invited into a PM.
- Fix broken spec.
- Update `.travis.yml`.
- SECURITY: Don't pass email backup token to sidekiq as a parameter.
- Version bump to v1.8.11
- Version bump to v1.9.0
- Make rubocop happy.
- FIX: do not create duplicate topics
- FIX: correct shushing_face name
- FIX: render error message when backup download fails
- FIX: URI must be ascii only for URI.parse command
- FIX: handle invalid password reset token
- FIX: rescue login required / broken images
- Version bump to v1.9.1
- SECURITY: email domain whitelist could be bypassed
- Version bump to v1.9.2
- SECURITY: Prevent robots from indexing more routes
- SECURITY: correct local onebox category checks
- Version bump to v1.9.3
- SECURITY: ensure users have permission when moving categories
- SECURITY: sanitize topic title when staff is viewing a user's past flagged posts and deleted topics
- Version bump to v1.9.4
- Update libv8 from 5.9 to 6.3
- single quote password in restore command > Followup to #3283. Quotes passwords passed to shell for backup restore.
- FIX: Restore process for dump taken with `pg_dump` 10.3+.
- Fix version check in restorer.
- Improve grep pattern in restorer.
- FIX: Restorer was not extracting the patch version in dump file.
- restorer: clarify logging
- backup restorer: tidy pg_dump schema portability logic, add test
- Clean up unused function left in the database.
- Fix incorrect function name.
- FIX: Restorer wasn't rolling back if restore fails.
- Version bump to v1.9.5
- SECURITY: do not disclose topic titles on /unsubscribed page to unauthorized users
- SECURITY: escape HTML entities from topic title
- SECURITY: santize tags when creating new topic via URL
- SECURITY: prevent XSS when showing diffs
- SECURITY: do not show private topic title on /unsubscribed page
- Version bump to v1.9.6
- FIX: dragging of timeline was flaky on iOS
- improve prev hack
- clean up drag on iOS handling, we need it bound earlier
- Version bump to v1.9.7
- FIX: automatically fix image orientation
- envelope missing on invite page, long pre lines making modals wide
- safety so pre blocks can't break modal width
- Version bump to v2.0.0
- Update translations
- FIX: Allow a user to remove their title
- FIX: alignment for instructions on change email and 2FA fields
- FIX: Keyboard shortcuts didn't work on subfolders
- FIX: Protection against dangling category group records
- FIX: sharing popup not showing on macos/chrome
- FIX: unable to add new poll to post with a public poll
- FIX: Disconnects all connections in the pool before forking.
- FIX: Permalink route matcher should always be last.
- FIX: avatar_url includes upload_path twice when local storage used
- FIX: user-fields layout in mobile create account form
- FIX: removes buggy/unnecessary local-dates margin
- FIX: user-fields layout in desktop create account form
- FIX: makes format number round the value before using parseInt
- FIX: slightly safer rounding
- FIX: incorrect backup and update times on dashboard
- FIX: do not use number helper for charts Y value
- FIX: broken mailto href's in emails
- fix indent
- FIX: adjust max-width of social login buttons for non-English locals
- FIX: adjust 2FA input width in mobile login form
- FIX: Ensure we have proper timeout for MiniRacer.
- FIX: do not show SSO external_email to moderators
- UX: reworks dashboard problems section to be in line with new style
- Version bump to v2.0.1
- Monkey patch in https://github.com/ruby/ruby/commit/7830a950efa6d312e7c662beabaa0f8d7b4e0a23
- SECURITY: update sprockets for CVE-2018-3760
- Version bump to v2.0.2
- FIX: missing translations for mobile flag modal
- Link updated
- SECURITY: prevents XSS when showing tooltip
- SECURITY: category badges should HTML escape names
- SECURITY: Do not allow authentication with disabled plugin-supplied a… (#6071)
- SECURITY: extra CORS headers should be set on correct host
- FIX: returns provider_not_enabled error even if enabled
- FIX: update mini_racer in stable
- SECURITY: Consider `0.0.0.0` a private IP
- FIX: Remove `plugin.enabled?` checks at initialization time (#6166)
- SECURITY: force IM decoder based on file extension
- SECURITY: force IM decoder based on file extension - part 2
- SECURITY: force IM decoder based on file extension - part 3
- FIX: Remove return statement from inside block
- Version bump to v2.0.3
- SECURITY: prevent use of X-Forwarded-Host to perform XSS
- FIX: Compatibility with ImageMagick 7.
- Version bump to v2.0.4
- FIX: Broken specs
- Fix brittle spec.
- Fix linting on Travis for stable.
- Skip imagemagick tests on Travis.
- DEV: Export Tag class to modify methods in plugin
- SECURITY: Prevent users from modifying custom fields
- Version bump to v2.0.5
- SECURITY: correct edge case when SSO provides unvalidated emails
- Version bump to v2.1.0
- FIX: Uploads not being linked correctly to posts.
- FIX: ignore and log bad json values for custom fields
- FIX: don't index urls to local files
- Add extra protection in `Upload#get_from_url`.
- DEV: Print the error class in `uploads:list_posts_with_broken_images`.
- New rake task `uploads:recover`.
- Fix incorrect variable.
- Add dry run option to `UploadRecovery`.
- Fix s3 recovery from tombstone in `UploadRecovery`.
- Rescue errors when running dry run for `UploadRecovery`.
- Add basic test case for `UploadRecovery`.
- Fix the build.
- FIX: Do not try to recover invalid `Upload#short_url` in `UploadRecovery`.
- Accept custom AR relation for `UploadRecovery`.
- DEV: Avoid using `send` and make the method public instead.
- FIX: Onceoff job to recover missing post uploads.
- Version bump to v2.1.1
- Backward compatibility for dropping functions in `ColumnDropper`.
- SECURITY: remove admin memory diagnostics routes
- SECURITY: correct XSS on long topic titles
- FIX: required rbtrace upgrade
- FIX: in redis readonly raise an exception from DistributedMutex
- FIX: correct readonly timeout
- FIX: Onceoff job to fix missing user profile backgrounds.
- Fix onceoff job in https://github.com/discourse/discourse/commit/cfa7173da346ec9f31daac13b058ba82419771d9 not running.
- Fix `UploadRecovery` from S3 fails with bucket name containing sub-folder.
- Version bump to v2.1.2
- SECURITY: update loofah for CVE-2018-16468
- FEATURE: adds header text/background color to site (#6462)
- FEATURE: adds list#(unread|new) to user api key routes (#6494)
- FEATURE: adds latest to user-api-key session scope
- UX: bumps the user-api-key version to 3 (#6526)
- SECURITY: Add CSRF protections to OpenID callback
- Version bump to v2.1.3
- SECURITY: update rack from 2.0.5 to 2.0.6
- SECURITY: enforce hostname to match discourse hostname
- Version bump to v2.1.4
- SECURITY: Require groups to be given when inviting to a restricted category. (#6715)
- FIX: Do not serialize user fields unless they are specified for display (#6736)
- FIX: remove slow platform detection from server side
- SECURITY: do not delete avatars uploads when deleting accounts
- FIX: Only serialize group membership domains for administrators (#6771)
- Version bump to v2.1.5
- SECURITY: only allow picking of avatars created by self (#6417)
- SECURITY: Users can pick non-avatar uploads.
- Version bump to v2.1.6
- PERF: reduce workload when optimizing images
- Version bump to v2.1.7
- SECURITY: fix possible XSS with badges (#6912)
- Version bump to v2.1.8
- Merge diffs from master
- Version bump to v2.2.0
- Header icon focus color fix
- FIX: Login button icons should be white
- SECURITY: Escape HTML in dashboard report tables
- UX: Header icon color fix
- FIX: old migration was loading up invalid model schema
- Minor icon color fix
- FIX: Unpause Sidekiq before uploading backup to S3
- FIX: Register pan events for touch only
- FIX: Correctly process {{each}} in raw handlebars templates for themes
- UX: disable browser's autocomplete in search menu
- UX: Turn off autocomplete on composer title
- FIX: S3 endpoint broke bucket creation in non-default region
- DEV: update logster to stable release
- FIX: Rescue and display import errors when updating theme via git
- fix typo
- UX: Use translatedLabel for aria-label in buttons.
- FIX: in:title should work irrespective of the order. (#6968)
- UX: Minor button icon color fixes
- FIX: Fix delete button for Tag Groups. (#6965)
- UX: checkboxes were too close to other inputs
- Version bump to v2.2.1
- FIX: some posters were not getting added to topic_allowed_users when moving posts to a new PM
- FIX: Bump onebox version to include imgur security fix
- FIX: Bump onebox version to include imgur security fix
- SECURITY: Do not leak private group names. (#7008)
- FIX: Fix failing test.
- DEV: Improve test.
- FIX: unable to create new categories
- UX: Reduce font size on about pages
- REFACTOR: Proxy letter avatars in rails instead of nginx
- SECURITY: bypass long GET requests
- Version bump to v2.2.2
- SECURITY: Upgrading Rails version to 5.2.2.1
- Version bumped to v2.2.3
- FIX: Add helper file for compatibility with latest stable plugin
- FIX: lightbox wrapper within open details should show.
- FEATURE: Add plugin html hook to insert html before any other scripts
- FIX: remove extra periods (#6998)
- SECURITY: properly validate return URL for SSO
- Version bump to v2.2.4
- SECURITY: Update Handlebars to 4.1
- FEATURE: enable NGINX brotli support unconditionally
- SECURITY: jquery CVE-2019-11358
- SECURITY: Update nokogiri
- SECURITY: Fix tab nabbing.
- FIX: We need a newer mini_racer for ruby 2.6.3
- Version bump to v2.2.5
- SECURITY: Bump Handlebars to version 4.1.2
- Version bump to v2.2.6
- SECURITY: Add confirmation screen when logging in via email link
- Merge diffs from master
- Version bump to v2.3.0
- FIX: category-chooser search should be scoped to category (#7794)
- FIX: remove temporary hack for fixed iOS bug (#7773)
- FIX: use correct name for selectable_avatars_enabled site setting
- FIX: Do not refresh all settings on save for all settings, limit to only a few
- DEV: bump version on mini_scheduler
- Update translations
- Version bump to v2.3.1
- SECURITY: Escape email text for posts containing [details].
- SECURITY: XSS in routes
- FIX: prevents failure when TL was mutated on internal object (#7808)
- FIX: closes search-menu on escape (#7804)
- DEV: lint file
- DEV: Respond with error 400 to uploads requested via XHR
- FIX: Don't send notification email when user isn't allowed to see topic
- FIX: creating new badge is failing on empty SQL query (#7837)
- FIX: Remove misplaced outlet
- FIX: remove misplaced save button
- Revert "FIX: remove misplaced save button"
- FIX: iterate when clearing watched words cache
- SECURITY: Strip HTML from invite emails
- SECURITY: XSS with title selector on preferences page
- SECURITY: Upgrade lodash
- SECURITY: SQL injection with default categories
- SECURITY: XSS when displaying watched words in admin panel.
- Fix the build.
- Version bump to v2.3.2
- SECURITY: Validate backup chunk identifier
- SECURITY: Add confirmation screen when connecting associated accounts
- DEV: Correct merge conflicts for 9cfe3f99
- SECURITY: Sanitize email id for use as mutex key
- FIX: Hide live-loaded posts from ignored users
- Revert "FEATURE: add Noindex to robots.txt for disallowed routes"
- FIX: Composer preview on IE11 (#7970)
- FIX: Use unescaped title as combo-box id (#7979)
- FIX: Disallow user self-delete when user posted in PMs
- SECURITY: Restrict message-bus access on login_required sites
- SECURITY: don't reveal category details to users that do not have access
- SECURITY: add rate limiting to anon JS error reporting
- FIX: add_to_serializer not correctly accounting for inheritance chains
- SECURITY: Reset password when activating an account via auth provider
- FIX: When activating a user, ensure the change is reflected immediately
- FIX: When activating via omniauth, create tokens after password reset
- Feature/Fix: Flagged posts user notifications (#8041)
- Version bump to v2.3.3
- FEATURE: add before-topic-progress plugin outlet
- FIX: :reject_user_delete action can only be handled by ReviewableUser (#8068)
- DEV: plugin API to register User custom field types
- Use Discourse.getURL for /clicks/track so clicks can be tracked on relative URLs (#8079)
- FIX: IE grid layout issue on user's own activity page
- FIX: Improve protection against problematic usernames (#8097)
- SECURITY: XSS when oneboxing user profile location field
- SECURITY: update rack-mini-profiler to latest to correct XSS
- SECURITY: Don't allow base_uri as embeddable host if none exist
- Spec should not depend on aliases
- Version bump to v2.3.4
- FIX: change focus when application resumes in android
- DEV: Allow specifying button class in reviewable action definitions (#8093)
- SECURITY: mini profiler enabled incorrectly for admins
- DEV: Bump uglifyjs (#7834)
- Version bump to v2.3.5
- FIX: Narrative Bot certificates are ERB templates (#8174)
- FIX: Rate limit and hijack certificate generation. (#8215)
- FIX: Broken certificates
- SECURITY: Check permissions when autocompleting mentions
- FIX: Allow avatar downloads to follow redirects
- FIX: Handle nil case for avatar, just in case
- DEV: Update users controller spec following user_search update
- Version bump to v2.3.6
- DEV: use Discourse.cache over Rails.cache
- DEV: Implement a faster Discourse.cache
- DEV: s/\$redis/Discourse\.redis
- Version bump to v2.3.7
- SECURITY: Remove event handlers from SVG files
- SECURITY: Ensure only image uploads can be inlined
- SECURITY: upgrade rack-mini-profiler to avoid possible XSS (#8537)
- SECURITY: vulnerability in WildcardUrlChecker
- SECURITY: Correct permission check when revoking user API keys
- Version bump to v2.3.8
- FIX: Build was broken due to missing file
- FIX: Gemfile bundler was breaking build
- FIX: Use cached MaxMind DB for longer
- SECURITY: use strict JSON parsing when parsing backup metadata
- SECURITY: Do not create a notification if a staged user post gets quoted/linked inside a restricted category
- Version bump to v2.3.9
- FIX: Ensure sourcemap's source is correct. Uses the full assets path this time. (#8774)
- FEATURE: support MaxMind DB downloads using a license key
- DEV: Bump omniauth-github from 1.3.0 to 1.4.0 (#8924)
- Version bump to v2.3.10
- Merge diffs from master
- Version bump to v2.4.0
- Merge pull request from GHSA-vw39-6w7q-gfx5
- FIX: Prettier on iframed-html component (#9062)
- FIX: allows to select the action when agreeing with penalty (#9099)
- SECURITY: Ensure the invite JSON API matches the UX
- SECURITY: Add more restrictions on invite emails
- FIX: Polyfill Promise for IE11 (#9057)
- FIX: prevents row click event to be caught by filter input event (#9059)
- FIX: prevents loading to show during debouncing (#9060)
- DEV: Fix build
- FIX: Sync preload key format for category topic lists
- PERF: improve performance of category topic list
- FIX: Google Groups scraper failed to login
- FIX: prevents click on sk header to bubble (#9084)
- FIX: Stop infinite lookup-urls issue for video/audio on page (#9096)
- FIX: Restoring with `disable_emails: false` didn't work anymore
- Version bump to v2.4.1
- FIX: last ip address could point at wrong ip
- Let's not log the username/password
- FIX: ensures pinned-options header is showing correct state (#9156)
- FIX: throttles topic tracking shortcut and enforces topic id (#9159)
- FIX: Ensure show_short URLs handle secure uploads using multisite (#9212)
- DEV: Load plugin stylesheets before theme stylesheets (#9240)
- SECURITY: Respect topic permissions when loading draft metadata
- FEATURE: prevent accidental canceling when drafting penalties (#9129)
- FIX: consistency to show mute/ignore menu in user profile
- FIX: correctly remove authentication_data cookie on oauth login flow (#9238)
- SECURITY: Ensure user can see group and group members
- FEATURE: Unassign the review queue topic when a flag is handled
- FIX: claiming topics for the review queue
- FIX: backport reviewable topic claim not being shown correctly
- FIX: Staged users getting user_linked and user_quoted emails
- Version bump to v2.4.2
- SECURITY: Update onebox to add rel="noopener"
- Version bump to v2.4.3
- SECURITY: ERB execution in custom Email Style
- SECURITY: ensure embed_url contains valid http(s) uri
- Version bump to v2.4.4
- SECURITY: Use FinalDestination for topic embeds
- SECURITY: make find topic by slug adhere to SiteSetting.detailed_404 (#9898)
- Version bump to v2.4.5
- Merge diffs from master
- Version bump to v2.5.0
- FIX: published-page-header should be a sibling to published-page-body not a parent (#10126)
- FIX: Correct version comparison logic when comparing stable to beta (#10135)
- FIX: Uploads cannot be mapped due to the cook-text's element attr being null (#10136)
- FIX: Avoid marking notifications as seen in readonly mode.
- PERF: stop adding more topics to search when not needed
- FEATURE: allow disabling of extra term injection in search
- FIX: invalid urls should not break store.has_been_uploaded?
- FIX: match discobot triggers on cooked version
- FIX: Remove paths from robots.txt in favor of noindex header
- FIX: Broken specs
- FIX: Serialize an empty array if no suggested topics exist (#10134)
- FIX: identify slug-less topic urls everywhere
- FIX: update theme fields when updating from ThemesInstallTask (#10143)
- FIX: emoji_autocomplete_min_chars failing when not 0
- FIX: Sometimes not all output of psql was logged during restores
- PERF: cache all metadata for 60 seconds
- FIX: Search was not multisite aware
- FIX: Support root paths that omit the trailing slash and have QPs
- FIX: return cdn url for uploads if available.
- FIX: Delete related search data when record has been deleted.
- FIX: Negative limit values shouldn't cause error 500 (#10162)
- FIX: uploading an image as a site setting
- FIX: uploading an existing image as a site setting
- Support plugin and Theme compatibility version manifests (#9995)
- SECURITY: Add content-disposition: attachment for SVG uploads
- FEATURE: Add global rate limit for anon searches (#10208)
- DEV: Fix search rate limit tests
- DEV: upgrade mini_racer and libv8
- DEV: Refactor anonymouse cache spec.
- SECURITY: 413 for GET, HEAD or DELETE requests with payload.
- FIX: Exclude `DELETE` methods from invalid request with payload.
- Update rails_failover to 0.5.5.
- FIX: rewrite of `/my/`URL should work on sub directory site too.
- FEATURE: Allow the specification of an arbitrary unicorn listen address
- FIX: allow plugin pinning to fetch missing commits
- Version bump to v2.5.1
- SECURITY: Don't allow moderators to list PMs of all groups.
- SECURITY: Remove indication that a group exists if user can't see it.
- DEV: Address review comments for 5ed84d9885b.
- DEV: Correct use of `sanitize_sql_array` in `TopicQuery`.
- PERF: Don't load all poll_votes for a poll
- PERF: Add partial index on reviewables for topic view (#10492)
- SECURITY: return error on oversized images
- Version bump to v2.5.2
- DEV: deepMerge and deepEqual functions (#10764)
- DEV: Add support for `api-initializers` to reduce boilerplate.
- SECURITY: Ensure users can see the topic before setting a topic timer. (#10841)
- FIX: Confirm new email not sent for staff if email disabled with "non-staff" option (#10794)
- Version bump to v2.5.3
- FIX: Prevent slow bookmark first post reminder at query for topic (#11024)
- Version bump to v2.5.4
- FIX: Remove 4 month limit on IgnoredUser records (#11105)
- FIX: Add dummy themes:update task (#11262)
- Version bump to v2.5.5
- FIX: stop including GlobalPath in default context (#11323)
- FIX: correct cdn path (#11324)
- Merge diffs from master
- Version bump to v2.6.0
- FIX: Autoplay videos must always be muted (#11533)
- Bump onebox gem to 2.2.1
- Version bump to v2.6.1
- SECURITY: Rate limit MFA by login if possible (#11938)
- DEV: Move logic for rate limiting user second factor to one place (#11941)
- FIX: process new invites when existing users are already group members (#11971)
- SECURITY: Attach DiscourseConnect (SSO) nonce to current session (#12124)
- Version bump to v2.6.2
- FIX: NewPostManager should respect category_group_moderator settings (#12116)
- Version bump to v2.6.3
- SECURITY: Fix is_private_ip for RateLimiter to cover all cases (#12464)
- FIX: Add platforms to stable Gemfile (#12479)
- Version bump to v2.6.4
- FIX: automatically timeout long running image magick commands (#12670)
- SECURITY: Improve theme git import (#12695)
- Version bump to v2.6.5
- FIX: Replace use of regular expression (#12838)
- FIX: Gracefully handle inline images in emails (#12855)
- Version bump to v2.6.6
- SECURITY: Bump Rails to 6.0.3.7 (#12965)
- Version bump to v2.6.7
- Version bump to v2.7.0
- FIX: Disable lightboxing of animated images (#13099)
- FIX: Close hyperlink modal on ESC key (#13166)
- SECURITY: Do not allow unauthorized access to category edit UI (#13252)
- Version bump to v2.7.1
- Build(deps): Bump nokogiri from 1.11.3 to 1.11.4 (#13074)
- UX: Fix theme upload width, remove class clash, prettier (#13071)
- Build(deps): Bump nokogiri from 1.11.4 to 1.11.5 (#13107)
- A11Y: Fix post control and user-menu focus styles (#13118)
- UX: add ARIA region role to posts (#13130)
- FIX: Better focus support for modals (#13147)
- UX: provide a region for various topic actions (#13152)
- UX: Improve navigation on topic lists for screen readers (#13153)
- FIX: Make poll options tabbable (#13159)
- UX: Add auto focus to hamburger and user menu dropdowns (#13165)
- UX: unconditionally focus modals (#13179)
- Version bump to v2.7.2
- SECURITY: XSS in bookmarks list (#13311)
- Version bump to v2.7.3
- DEV: Enable optional chaining in all contexts (#13180)
- DEV: Add support for class properties in babel (#13189)
- Version bump to v2.7.4
- SECURITY: prevents onebox to hang too long on connect (#13481)
- FIX: TL4 users cannot delete others posts (#13554)
- SECURITY: do not follow canonical links
- Version bump to v2.7.5
- SECURITY: Sanitize YouTube Onebox data (stable) (#13749)
- Version bump to v2.7.6
- SECURITY: Do not reveal post whisperer in personal messages.
- SECURITY: Don't leak user of previous whisper post when deleting a topic.
- DEV: Make rubocop happy.
- Version bump to v2.7.7
- SECURITY: Sanitize d-popover attributes (#13958)
- SECURITY: Destroy `EmailToken` when `EmailChangeRequest` is destroyed (#13950)
- SECURITY: User's read state for topic is leaked to unauthorized clients.
- SECURITY: escape cat name (#14155)
- Version bump to v2.7.8
- SECURITY: Escape watched word in error message (#14434)
- SECURITY: Improve validation of SNS subscription confirm (#14672)
- Version bump to v2.7.9
- SECURITY: Disallow caching of MIME/Content-Type errors (#14939)
- SECURITY: Ensure _forum_session cookies cannot be reused between sites (stable) (#14949)
- Version bump to v2.7.10
- SECURITY: Strip unrendered unicode bidirectional chars in code blocks (#15032)
- SECURITY: Only show tags to users with permission (#15148)
- SECURITY: Remove ember-cli specific response from application routes (stable) (#15154)
- FIX: Validate number of votes allowed per poll per user (stable) (#15158)
- Version bump to v2.7.11
- SECURITY: Disable MessageBus::Diagnostics.
- Version bump to v2.7.12
- SECURITY: only show user suggestions with regular post (#15436)
- SECURITY: Hide user's bio if profile is restricted (#15448)
- SECURITY: Advanced group search did not respect visiblity of groups.
- FIX: LOAD_PLUGINS=0 in dev/prod, warn in plugin:pull_compatible_all (stable) (#15538)
- FIX: Bypass service worker on the SSO path (#15558) (#15560)
- SECURITY: Do not sign in unapproved users (#15552)
- Version bump to v2.7.13
- Merge diffs from main
- Version bump to v2.8.0
- DEV: Remove jQuery UI vendor dependencies (#15782)
- FIX: Only block domains at the final destination (#15689) (#15783)
- A11Y: Switch to using `autocomplete="off"` (#15802)
- FIX: Table pasting issues with uppy (#15787) (#15812)
- Update translations (stable) (#15819)
- FEATURE: RS512, RS384 and RS256 COSE algorithms (#15868)
- SECURITY: Onebox response timeout and size limit (#15927)
- Version bump to v2.8.1
- Fix bug regarding Chat on stable (#15954)
- FIX: Defer upload extension check for iOS (#15890)
- FIX: backport caret moves to a wrong position when uploading an image via toolbar (#15865)
- FIX: Handle `nil` values in `DistributedCache#defer_get_set` (stable) (#15980)
- DEV: Backport Github test workflow to stable. (#16210)
- DEV: Pull compatible version for plugins in Github test workflow. (#16212)
- DEV: Don't load bundler when installing plugin gem. (#16176)
- Version bump to v2.8.2
- SECURITY: Hide private categories in user activity export (#16276)
- SECURITY: Avoid leaking private group name when viewing category. (#16339)
- DEV: Fix flaky specs (#16340)
- DEV: Restore order assertion in category serializer tests. (#16344)
- FIX: Show restricted groups warning when necessary (#16236)
- DEV: Fix failing share topic tests (#16309)
- FIX: Serialize permissions for everyone group
- SECURITY: Category group permissions leaked to normal users.
- DEV: Add pretender endpoint for category visible groups.
- DEV: Don't check `this.element` in `@afterRender` (#16033)
- SECURITY: Update Nokogiri to 1.13.4.
- SECURITY: Ensure user-agent-based responses are cached separately (stable) (#16476)
- Version bump to v2.8.3
- FIX: Buggy topic scrolling on iOS 12 (#16422)
- DEV: Cleanup `body.scrollTop` usage (#16445)
- FIX: Ensure values are escaped in select-kit dropdowns (#16586)
- FIX: Ensure theme JavaScript cache get consistent SHA1 digest (stable backport) (#16669)
- SECURITY: Remove auto approval when redeeming an invite (#16976)
- DEV: Fix auto start for wizard qunit tests (#16988)
- FIX: Approves user when redeeming an invite for invites only sites (#16987)
- SECURITY: banner-info (#17071) (#17073)
- Version bump to v2.8.4
