### PR TITLE
DEV: Slightly defer loading Discourse stylesheets

### DIFF
--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -18,6 +18,13 @@
     {{content-for "head"}}
   </head>
   <body>
+    <discourse-assets>
+      <discourse-assets-stylesheets>
+        <bootstrap-content key="discourse-stylesheets">
+        {{content-for "discourse-stylesheets"}}
+      </discourse-assets-stylesheets>
+    </discourse-assets>
+
     <bootstrap-content key="body">
     {{content-for "body"}}
 

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -64,26 +64,6 @@ function head(buffer, bootstrap, headers, baseURL) {
   });
   buffer.push(`<meta id="data-discourse-setup"${setupData} />`);
 
-  (bootstrap.stylesheets || []).forEach((s) => {
-    let attrs = [];
-    if (s.media) {
-      attrs.push(`media="${s.media}"`);
-    }
-    if (s.target) {
-      attrs.push(`data-target="${s.target}"`);
-    }
-    if (s.theme_id) {
-      attrs.push(`data-theme-id="${s.theme_id}"`);
-    }
-    if (s.class) {
-      attrs.push(`class="${s.class}"`);
-    }
-    let link = `<link rel="stylesheet" type="text/css" href="${
-      s.href
-    }" ${attrs.join(" ")}>`;
-    buffer.push(link);
-  });
-
   if (bootstrap.preloaded.currentUser) {
     let staff = JSON.parse(bootstrap.preloaded.currentUser).staff;
     if (staff) {
@@ -111,6 +91,28 @@ function beforeScriptLoad(buffer, bootstrap) {
   (bootstrap.extra_locales || []).forEach((l) =>
     buffer.push(`<script src="${l}"></script>`)
   );
+}
+
+function discourseStylesheets(buffer, bootstrap) {
+  (bootstrap.stylesheets || []).forEach((s) => {
+    let attrs = [];
+    if (s.media) {
+      attrs.push(`media="${s.media}"`);
+    }
+    if (s.target) {
+      attrs.push(`data-target="${s.target}"`);
+    }
+    if (s.theme_id) {
+      attrs.push(`data-theme-id="${s.theme_id}"`);
+    }
+    if (s.class) {
+      attrs.push(`class="${s.class}"`);
+    }
+    let link = `<link rel="stylesheet" type="text/css" href="${
+      s.href
+    }" ${attrs.join(" ")}>`;
+    buffer.push(link);
+  });
 }
 
 function body(buffer, bootstrap) {
@@ -156,6 +158,7 @@ const BUILDERS = {
   "before-script-load": beforeScriptLoad,
   head,
   body,
+  "discourse-stylesheets": discourseStylesheets,
   "hidden-login-form": hiddenLoginForm,
   preloaded,
   "body-footer": bodyFooter,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,6 @@
     <%= render partial: "layouts/head" %>
     <%= discourse_csrf_tags %>
 
-    <%= render partial: "common/discourse_stylesheet" %>
-
     <%- if SiteSetting.enable_escaped_fragments? %>
       <meta name="fragment" content="!">
     <%- end %>
@@ -67,6 +65,12 @@
   </head>
 
   <body class="<%= body_classes %>">
+    <div data-assets>
+      <div data-assets-css>
+        <%= render partial: "common/discourse_stylesheet" %>
+      </div>
+    </div>
+
     <%- if allow_plugins? %>
       <%= build_plugin_html 'server:after-body-open' %>
     <%- end -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,11 +65,11 @@
   </head>
 
   <body class="<%= body_classes %>">
-    <div data-assets>
-      <div data-assets-css>
+    <discourse-assets>
+      <discourse-assets-stylesheets>
         <%= render partial: "common/discourse_stylesheet" %>
-      </div>
-    </div>
+      </discourse-assets-stylesheets>
+    </discourse-assets>
 
     <%- if allow_plugins? %>
       <%= build_plugin_html 'server:after-body-open' %>


### PR DESCRIPTION
This is related to https://github.com/discourse/discourse/pull/17063 and is also a pre-request to the splash screen work. 

This PR introduces 0 visual or functional changes. It just relocates the stylesheets in the load order.
`.css` stylesheets block the browser render. We need to move those out of the `<head>` tag.

However, they still need to be loaded before core/plugin/theme rendered HTML to avoid FOUC.
I also opted to wrap them in a `data-assets` > ` data-assets-css` for two reasons. 

1. If we just add them without the wrapper divs, they clutter devTools. 

2. Long term, I want to move all `.css` and `.js` assets to that div.

    Something like this

    ```
    <div data-assets>
      <div data-assets-json>
        ...
      </div>
      <div data-assets-css>
        ...
      </div>
      <div data-assets-js>
        ...
      </div>
    </div>
    ```

    Or something like that. Those will be collapsed by default in devTools.