### PR TITLE
FEATURE: Change auto tracking to require 5 minutes vs 4

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2456,7 +2456,7 @@ user_preferences:
     default: 2880
   default_other_auto_track_topics_after_msecs:
     enum: "AutoTrackDurationSiteSetting"
-    default: 240000
+    default: 300000
   default_other_notification_level_when_replying:
     enum: "NotificationLevelWhenReplyingSiteSetting"
     default: 2


### PR DESCRIPTION
Per @codinghorror, we prefer to change this setting to 5 minutes to avoid
tracking topic automatically except for extremely exceptional situations.
