### PR TITLE
PERF: Remove total for time to first response report.

### DIFF
--- a/app/models/concerns/reports/time_to_first_response.rb
+++ b/app/models/concerns/reports/time_to_first_response.rb
@@ -17,8 +17,6 @@ module Reports::TimeToFirstResponse
         report.data << { x: r['date'], y: r['hours'].to_f.round(2) }
       end
 
-      report.total = Topic.time_to_first_response_total(category_id: category_id, include_subcategories: include_subcategories)
-
       report.prev30Days = Topic.time_to_first_response_total(start_date: report.start_date - 30.days, end_date: report.start_date, category_id: category_id, include_subcategories: include_subcategories)
     end
   end


### PR DESCRIPTION
The query is very inefficient without any constraints on large sites and
the average of all time to first response since the beginning of time is
not useful as well.