### PR TITLE
FIX: Allow all subdomains of localhost in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -111,5 +111,5 @@ Discourse::Application.configure do
     end
   end
 
-  config.hosts << /\A(([a-z-]+)\.)*localhost(\:\d+)?\Z/
+  config.hosts << /\A(([a-z0-9-]+)\.)*localhost(\:\d+)?\Z/
 end


### PR DESCRIPTION
domains can contain numbers.

Follow-up-to: 00e756e35858c6fbc058b2e686eca47ae90bda90

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
