### PR TITLE
FEATURE: Custom unsubscribe options

### DIFF
--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -6,38 +6,17 @@ class EmailController < ApplicationController
   skip_before_action :check_xhr, :preload_json, :redirect_to_login_if_required
 
   def unsubscribe
-    @not_found = true
-    @watched_count = nil
+    key = UnsubscribeKey.find_by(key: params[:key])
+    @found = key.present?
 
-    if key = UnsubscribeKey.find_by(key: params[:key])
-      if @user = key.user
-        post = key.post
-        @topic = post&.topic || key.topic
-        @digest_unsubscribe = !@topic && !SiteSetting.disable_digest_emails
-        @type = key.unsubscribe_key_type
-        @not_found = false
+    if @found
+      UnsubscribeKey
+        .get_unsubscribe_strategy_for(key)
+        &.prepare_unsubscribe_options(self)
 
-        if current_user.present? && (@user != current_user)
-          @different_user = @user.name
-          @return_url = request.original_url
-        end
-
-        watching = TopicUser.notification_levels[:watching]
-
-        @unsubscribed_from_all = @user.user_option.unsubscribed_from_all?
-
-        if @topic
-          @watching_topic = TopicUser.exists?(user_id: @user.id, notification_level: watching, topic_id: @topic.id)
-          if @topic.category_id
-            if CategoryUser.exists?(user_id: @user.id, notification_level: CategoryUser.watching_levels, category_id: @topic.category_id)
-              @watched_count = TopicUser.joins(:topic)
-                .where(user: @user, notification_level: watching, "topics.category_id" => @topic.category_id)
-                .count
-            end
-          end
-        else
-          @digest_frequencies = digest_frequencies(@user)
-        end
+      if current_user.present? && (@user != current_user)
+        @different_user = @user.name
+        @return_url = request.original_url
       end
     end
   end
@@ -46,80 +25,24 @@ class EmailController < ApplicationController
     RateLimiter.new(nil, "unsubscribe_#{request.ip}", 10, 1.minute).performed!
 
     key = UnsubscribeKey.find_by(key: params[:key])
-    raise Discourse::NotFound unless key && key.user
-
-    topic = key&.post&.topic || key.topic
+    raise Discourse::NotFound if key.nil? || key.user.nil?
     user = key.user
+    updated = UnsubscribeKey.get_unsubscribe_strategy_for(key)
+      &.unsubscribe(params)
 
-    updated = false
+    if updated
+      cache_key = "unsub_#{SecureRandom.hex}"
+      Discourse.cache.write cache_key, user.email, expires_in: 1.hour
 
-    if topic
-      if params["unwatch_topic"]
-        TopicUser.where(topic_id: topic.id, user_id: user.id)
-          .update_all(notification_level: TopicUser.notification_levels[:tracking])
-        updated = true
-      end
-
-      if params["unwatch_category"] && topic.category_id
-        TopicUser.joins(:topic)
-          .where(:user => user,
-                 :notification_level => TopicUser.notification_levels[:watching],
-                 "topics.category_id" => topic.category_id)
-          .update_all(notification_level: TopicUser.notification_levels[:tracking])
-
-        CategoryUser.where(user_id: user.id,
-                           category_id: topic.category_id,
-                           notification_level: CategoryUser.watching_levels
-                         )
-          .destroy_all
-        updated = true
-      end
-
-      if params["mute_topic"]
-        TopicUser.where(topic_id: topic.id, user_id: user.id)
-          .update_all(notification_level: TopicUser.notification_levels[:muted])
-        updated = true
-      end
-    end
-
-    if params["disable_mailing_list"]
-      user.user_option.update_columns(mailing_list_mode: false)
-      updated = true
-    end
-
-    if params['digest_after_minutes']
-      digest_frequency = params['digest_after_minutes'].to_i
-
-      user.user_option.update_columns(
-        digest_after_minutes: digest_frequency,
-        email_digests: digest_frequency.positive?
-      )
-      updated = true
-    end
-
-    if params["unsubscribe_all"]
-      user.user_option.update_columns(email_digests: false,
-                                      email_level: UserOption.email_level_types[:never],
-                                      email_messages_level: UserOption.email_level_types[:never],
-                                      mailing_list_mode: false)
-      updated = true
-    end
-
-    unless updated
-      redirect_back fallback_location: path("/")
-    else
-
-      key = "unsub_#{SecureRandom.hex}"
-      Discourse.cache.write key, user.email, expires_in: 1.hour
-
-      url = path("/email/unsubscribed?key=#{key}")
-      if topic
-        url += "&topic_id=#{topic.id}"
+      url = path("/email/unsubscribed?key=#{cache_key}")
+      if key.associated_topic
+        url += "&topic_id=#{key.associated_topic.id}"
       end
 
       redirect_to url
+    else
+      redirect_back fallback_location: path("/")
     end
-
   end
 
   def unsubscribed
@@ -129,32 +52,5 @@ class EmailController < ApplicationController
     raise Discourse::NotFound unless user
     topic = Topic.find_by(id: params[:topic_id].to_i) if @topic_id
     @topic = topic if topic && Guardian.new(nil).can_see?(topic)
-  end
-
-  private
-
-  def digest_frequencies(user)
-    frequency_in_minutes = user.user_option.digest_after_minutes
-    email_digests = user.user_option.email_digests
-    frequencies = DigestEmailSiteSetting.values.dup
-    never = frequencies.delete_at(0)
-    allowed_frequencies = %w[never weekly every_month every_six_months]
-
-    result = frequencies.reduce(frequencies: [], current: nil, selected: nil, take_next: false) do |memo, v|
-      memo[:current] = v[:name] if v[:value] == frequency_in_minutes && email_digests
-      next(memo) unless allowed_frequencies.include?(v[:name])
-
-      memo.tap do |m|
-        m[:selected] = v[:value] if m[:take_next] && email_digests
-        m[:frequencies] << [I18n.t("unsubscribe.digest_frequency.#{v[:name]}"), v[:value]]
-        m[:take_next] = !m[:take_next] && m[:current]
-      end
-    end
-
-    result.slice(:frequencies, :current, :selected).tap do |r|
-      r[:frequencies] << [I18n.t("unsubscribe.digest_frequency.#{never[:name]}"), never[:value]]
-      r[:selected] ||= never[:value]
-      r[:current] ||= never[:name]
-    end
   end
 end

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -4,7 +4,7 @@ class SubscriptionMailer < ActionMailer::Base
   include Email::BuildEmailHelper
 
   def confirm_unsubscribe(user, opts = {})
-    unsubscribe_key = UnsubscribeKey.create_key_for(user, "all")
+    unsubscribe_key = UnsubscribeKey.create_key_for(user, UnsubscribeKey::ALL_TYPE)
     build_email user.email,
                 template: "unsubscribe_mailer",
                 site_title: SiteSetting.title,

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -216,6 +216,8 @@ class UserNotifications < ActionMailer::Base
 
   def digest(user, opts = {})
     build_summary_for(user)
+    @unsubscribe_key = UnsubscribeKey.create_key_for(@user, UnsubscribeKey::DIGEST_TYPE)
+
     min_date = opts[:since] || user.last_emailed_at || user.last_seen_at || 1.month.ago
 
     # Fetch some topics and posts to show
@@ -753,7 +755,6 @@ class UserNotifications < ActionMailer::Base
     @header_bgcolor  = ColorScheme.hex_for_name('header_background')
     @anchor_color    = ColorScheme.hex_for_name('tertiary')
     @markdown_linker = MarkdownLinker.new(@base_url)
-    @unsubscribe_key = UnsubscribeKey.create_key_for(@user, "digest")
     @disable_email_custom_styles = !SiteSetting.apply_custom_styles_to_digest
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -616,7 +616,9 @@ class Post < ActiveRecord::Base
   end
 
   def unsubscribe_url(user)
-    "#{Discourse.base_url}/email/unsubscribe/#{UnsubscribeKey.create_key_for(user, self)}"
+    key_value = UnsubscribeKey.create_key_for(user, UnsubscribeKey::TOPIC_TYPE, post: self)
+
+    "#{Discourse.base_url}/email/unsubscribe/#{key_value}"
   end
 
   def self.url(slug, topic_id, post_number, opts = nil)

--- a/app/views/email/unsubscribe.html.erb
+++ b/app/views/email/unsubscribe.html.erb
@@ -1,7 +1,7 @@
 <div class='container unsubscribe'>
-  <%- if @not_found || @different_user %>
+  <%- if !@found || @different_user %>
 
-    <%if @not_found%>
+    <%if !@found %>
       <p><%= t "unsubscribe.not_found_description" %></p>
     <%- else %>
       <p><%= t("unsubscribe.different_user_description").html_safe %></p>
@@ -77,6 +77,8 @@
           %>
           </p>
       <% end %>
+
+      <%= server_plugin_outlet "unsubscribe_options" %>
 
       <% unless @unsubscribed_from_all %>
         <p>

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -95,6 +95,8 @@ class DiscoursePluginRegistry
 
   define_filtered_register :notification_consolidation_plans
 
+  define_filtered_register :email_unsubscribers
+
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
   end

--- a/lib/email_controller_helper/base_email_unsubscriber.rb
+++ b/lib/email_controller_helper/base_email_unsubscriber.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# This class and its children are instantiated and used by the EmailController.
+module EmailControllerHelper
+  class BaseEmailUnsubscriber
+    def initialize(unsubscribe_key)
+      @unsubscribe_key = unsubscribe_key
+    end
+
+    attr_reader :unsubscribe_key
+
+    # Sets instance variables in the `EmailController#unsubscribe`, which are later available in the view.
+    # Don't forget to call super when extending this method.
+    def prepare_unsubscribe_options(controller)
+      controller.instance_variable_set(:@digest_unsubscribe, false)
+      controller.instance_variable_set(:@watched_count, nil)
+      controller.instance_variable_set(:@type, unsubscribe_key.unsubscribe_key_type)
+
+      controller.instance_variable_set(:@user, key_owner)
+
+      controller.instance_variable_set(
+        :@unsubscribed_from_all,
+        key_owner.user_option.unsubscribed_from_all?
+      )
+    end
+
+    # Called by the `EmailController#perform_unsubscribe` and defines what unsubscribing means.
+    #
+    # Receives the request params and returns a boolean indicating if any preferences were updated.
+    #
+    # Don't forget to call super when extending this method.
+    def unsubscribe(params)
+      updated = false
+
+      if params[:disable_mailing_list]
+        key_owner.user_option.update_columns(mailing_list_mode: false)
+        updated = true
+      end
+
+      if params[:unsubscribe_all]
+        key_owner.user_option.update_columns(email_digests: false,
+                                             email_level: UserOption.email_level_types[:never],
+                                             email_messages_level: UserOption.email_level_types[:never],
+                                             mailing_list_mode: false)
+        updated = true
+      end
+
+      updated
+    end
+
+    protected
+
+    def key_owner
+      unsubscribe_key.user
+    end
+  end
+end

--- a/lib/email_controller_helper/digest_email_unsubscriber.rb
+++ b/lib/email_controller_helper/digest_email_unsubscriber.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module EmailControllerHelper
+  class DigestEmailUnsubscriber < BaseEmailUnsubscriber
+    def prepare_unsubscribe_options(controller)
+      super(controller)
+      controller.instance_variable_set(:@digest_unsubscribe, !SiteSetting.disable_digest_emails)
+
+      frequency_in_minutes = key_owner.user_option.digest_after_minutes
+      email_digests = key_owner.user_option.email_digests
+      frequencies = DigestEmailSiteSetting.values.dup
+      never = frequencies.delete_at(0)
+      allowed_frequencies = %w[never weekly every_month every_six_months]
+
+      result = frequencies.reduce(frequencies: [], current: nil, selected: nil, take_next: false) do |memo, v|
+        memo[:current] = v[:name] if v[:value] == frequency_in_minutes && email_digests
+        next(memo) unless allowed_frequencies.include?(v[:name])
+
+        memo.tap do |m|
+          m[:selected] = v[:value] if m[:take_next] && email_digests
+          m[:frequencies] << [I18n.t("unsubscribe.digest_frequency.#{v[:name]}"), v[:value]]
+          m[:take_next] = !m[:take_next] && m[:current]
+        end
+      end
+
+      digest_frequencies = result.slice(:frequencies, :current, :selected).tap do |r|
+        r[:frequencies] << [I18n.t("unsubscribe.digest_frequency.#{never[:name]}"), never[:value]]
+        r[:selected] ||= never[:value]
+        r[:current] ||= never[:name]
+      end
+
+      controller.instance_variable_set(:@digest_frequencies, digest_frequencies)
+    end
+
+    def unsubscribe(params)
+      updated = super(params)
+
+      if params[:digest_after_minutes]
+        digest_frequency = params[:digest_after_minutes].to_i
+
+        unsubscribe_key.user.user_option.update_columns(
+          digest_after_minutes: digest_frequency,
+          email_digests: digest_frequency.positive?
+        )
+        updated = true
+      end
+
+      updated
+    end
+  end
+end

--- a/lib/email_controller_helper/topic_email_unsubscriber.rb
+++ b/lib/email_controller_helper/topic_email_unsubscriber.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module EmailControllerHelper
+  class TopicEmailUnsubscriber < BaseEmailUnsubscriber
+    def prepare_unsubscribe_options(controller)
+      super(controller)
+      watching = TopicUser.notification_levels[:watching]
+
+      topic = unsubscribe_key.associated_topic
+
+      controller.instance_variable_set(:@topic, topic)
+      controller.instance_variable_set(
+        :@watching_topic,
+        TopicUser.exists?(user: key_owner, notification_level: watching, topic_id: topic.id)
+      )
+
+      return if topic.category_id.blank?
+      return if !CategoryUser.exists?(user: key_owner, notification_level: CategoryUser.watching_levels, category_id: topic.category_id)
+
+      controller.instance_variable_set(
+        :@watched_count,
+        TopicUser.joins(:topic)
+          .where(user: key_owner, notification_level: watching).where(topics: { category_id: topic.category_id }).count
+      )
+    end
+
+    def unsubscribe(params)
+      updated = super(params)
+
+      topic = unsubscribe_key.associated_topic
+      return updated if topic.nil?
+
+      if params[:unwatch_topic]
+        TopicUser.where(topic_id: topic.id, user_id: key_owner.id)
+          .update_all(notification_level: TopicUser.notification_levels[:tracking])
+
+        updated = true
+      end
+
+      if params[:unwatch_category] && topic.category_id
+        TopicUser.joins(:topic)
+          .where(user: key_owner, notification_level: TopicUser.notification_levels[:watching])
+          .where(topics: { category_id: topic.category_id })
+          .update_all(notification_level: TopicUser.notification_levels[:tracking])
+
+        CategoryUser
+          .where(user_id: key_owner.id, category_id: topic.category_id, notification_level: CategoryUser.watching_levels)
+          .destroy_all
+
+        updated = true
+      end
+
+      if params[:mute_topic]
+        TopicUser.where(topic_id: topic.id, user_id: key_owner.id).update_all(notification_level: TopicUser.notification_levels[:muted])
+
+        updated = true
+      end
+
+      updated
+    end
+  end
+end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -720,4 +720,26 @@ describe Plugin::Instance do
       )
     end
   end
+
+  describe '#register_email_unsubscriber' do
+    let(:plugin) { Plugin::Instance.new }
+
+    after do
+      DiscoursePluginRegistry.reset_register!(:email_unsubscribers)
+    end
+
+    it "doesn't let you override core unsubscribers" do
+      expect { plugin.register_email_unsubscriber(UnsubscribeKey::ALL_TYPE, Object) }.to raise_error(ArgumentError)
+    end
+
+    it "finds the plugin's custom unsubscriber" do
+      new_unsubscriber_type = 'new_type'
+      key = UnsubscribeKey.new(unsubscribe_key_type: new_unsubscriber_type)
+      CustomUnsubscriber = Class.new(EmailControllerHelper::BaseEmailUnsubscriber)
+
+      plugin.register_email_unsubscriber(new_unsubscriber_type, CustomUnsubscriber)
+
+      expect(UnsubscribeKey.get_unsubscribe_strategy_for(key).class).to eq(CustomUnsubscriber)
+    end
+  end
 end

--- a/spec/models/unsubscribe_key_spec.rb
+++ b/spec/models/unsubscribe_key_spec.rb
@@ -20,7 +20,7 @@ describe UnsubscribeKey do
   describe 'key' do
 
     fab!(:user) { Fabricate(:user) }
-    let!(:key) { UnsubscribeKey.create_key_for(user, "digest") }
+    let!(:key) { UnsubscribeKey.create_key_for(user, UnsubscribeKey::DIGEST_TYPE) }
 
     it 'has a temporary key' do
       expect(key).to be_present

--- a/spec/services/user_merger_spec.rb
+++ b/spec/services/user_merger_spec.rb
@@ -646,9 +646,9 @@ describe UserMerger do
   end
 
   it "updates unsubscribe keys" do
-    UnsubscribeKey.create_key_for(source_user, "digest")
-    UnsubscribeKey.create_key_for(target_user, "digest")
-    UnsubscribeKey.create_key_for(walter, "digest")
+    UnsubscribeKey.create_key_for(source_user, UnsubscribeKey::DIGEST_TYPE)
+    UnsubscribeKey.create_key_for(target_user, UnsubscribeKey::DIGEST_TYPE)
+    UnsubscribeKey.create_key_for(walter, UnsubscribeKey::DIGEST_TYPE)
 
     merge_users!
 


### PR DESCRIPTION
With this change, plugins can create custom unsubscribe keys, extend the unsubscribe view with custom preferences, and decide how they are updated.

The new API will add a new method to the controller for setting instance variables, and one method in the `UnsubcribeKey` class. The existing unsubscribe mechanisms were refactored to also work this way.
