### PR TITLE
DEV: Mark inline styles as safe

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
@@ -1,5 +1,5 @@
 {{#each categories as |c|}}
-  <div data-notification-level={{c.notificationLevelString}} style={{unless noCategoryStyle (concat (border-color c.color) (category-color-variable c.color))}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
+  <div data-notification-level={{c.notificationLevelString}} style={{unless noCategoryStyle (html-safe (concat (border-color c.color) (category-color-variable c.color)))}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
     <div class="category-box-inner">
       <div class="category-box-heading">
         <a href={{c.url}}>
@@ -14,6 +14,7 @@
               }}
             {{/if}}
           {{/unless}}
+
           <h3>
             {{category-title-before category=c}}
             {{#if c.read_restricted}}
@@ -35,6 +36,7 @@
           {{/if}}
         </div>
       {{/unless}}
+
       {{plugin-outlet name="category-box-below-each-category" args=(hash category=c)}}
     </div>
   </div>

--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
@@ -1,6 +1,7 @@
 {{#each categories as |c|}}
   {{plugin-outlet name="category-box-before-each-box" args=(hash category=c)}}
-  <div style={{unless noCategoryStyle (concat (border-color c.color) (category-color-variable c.color))}} data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}} data-url={{c.url}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
+
+  <div style={{unless noCategoryStyle (html-safe (concat (border-color c.color) (category-color-variable c.color)))}} data-category-id={{c.id}} data-notification-level={{c.notificationLevelString}} data-url={{c.url}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if noCategoryStyle "no-category-boxes-style"}}">
     <div class="category-box-inner">
       {{#unless c.isMuted}}
         <div class="category-logo">
@@ -15,6 +16,7 @@
           {{/if}}
         </div>
       {{/unless}}
+
       <div class="category-details">
         <div class="category-box-heading">
           <a class="parent-box-link" href={{c.url}}>
@@ -32,6 +34,7 @@
           <div class="description">
             {{html-safe c.description_excerpt}}
           </div>
+
           {{#if c.isGrandParent}}
             {{#each c.subcategories as |subcategory|}}
               <div data-category-id={{subcategory.id}} data-notification-level={{subcategory.notificationLevelString}} style={{border-color subcategory.color}} class="subcategory with-subcategories {{if subcategory.uploaded_logo.url "has-logo" "no-logo"}}">
@@ -64,6 +67,7 @@
                         height=sc.uploaded_logo.height
                         alt=""}}
                   </span>
+
                   {{category-link sc hideParent="true"}}
                 </a>
               {{/each}}
@@ -71,9 +75,12 @@
           {{/if}}
         {{/unless}}
       </div>
+
       {{plugin-outlet name="category-box-below-each-category" args=(hash category=c)}}
     </div>
   </div>
+
   {{plugin-outlet name="category-box-after-each-box" args=(hash category=c)}}
 {{/each}}
+
 {{plugin-outlet name="category-boxes-after-boxes" args=(hash category=c)}}

--- a/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
@@ -1,14 +1,17 @@
 {{#unless isHidden}}
   {{plugin-outlet name="category-list-above-each-category" args=(hash category=category)}}
+
   <tr data-category-id={{category.id}} data-notification-level={{category.notificationLevelString}} class="{{if category.description_excerpt "has-description" "no-description"}} {{if category.uploaded_logo.url "has-logo" "no-logo"}}">
-    <td class="category {{if isMuted "muted"}} {{if noCategoryStyle "no-category-style"}}" style={{unless noCategoryStyle (concat (border-color category.color) (category-color-variable category.color))}}>
+    <td class="category {{if isMuted "muted"}} {{if noCategoryStyle "no-category-style"}}" style={{unless noCategoryStyle (html-safe (concat (border-color category.color) (category-color-variable category.color)))}}>
       {{category-title-link category=category}}
       {{plugin-outlet name="below-category-title-link" connectorTagName="div" args=(hash category=category)}}
+
       {{#if category.description_excerpt}}
         <div class="category-description">
           {{dir-span category.description_excerpt htmlSafe="true"}}
         </div>
       {{/if}}
+
       {{#if category.isGrandParent}}
         <table class="category-list subcategories-with-subcategories">
           <tbody>
@@ -25,10 +28,12 @@
         </div>
       {{/if}}
     </td>
+
     <td class="topics">
       <div title={{category.statTitle}}>{{html-safe category.stat}}</div>
       {{category-unread category=category tagName="div" class="unread-new"}}
     </td>
+
     {{#unless isMuted}}
       {{#if showTopics}}
         <td class="latest">


### PR DESCRIPTION
Fixes many Ember deprecation warnings like:

```
WARNING: Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see https://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes. Style affected: "border-color: #33B0B0; --category-color: #33B0B0;"
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
