### PR TITLE
FIX: Make watched words uploads work as intended

### DIFF
--- a/app/assets/javascripts/admin/addon/components/watched-word-uploader.js
+++ b/app/assets/javascripts/admin/addon/components/watched-word-uploader.js
@@ -3,7 +3,6 @@ import I18n from "I18n";
 import UppyUploadMixin from "discourse/mixins/uppy-upload";
 import { alias } from "@ember/object/computed";
 import bootbox from "bootbox";
-import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend(UppyUploadMixin, {
   type: "txt",
@@ -16,9 +15,8 @@ export default Component.extend(UppyUploadMixin, {
     return { skipValidation: true };
   },
 
-  @discourseComputed("actionKey")
-  data(actionKey) {
-    return { action_key: actionKey };
+  _perFileData() {
+    return { action_key: this.actionKey };
   },
 
   uploadDone() {

--- a/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
@@ -1,0 +1,55 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  createFile,
+  discourseModule,
+} from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import { click, waitFor } from "@ember/test-helpers";
+import { setupApplicationTest as EMBER_CLI_ENV } from "ember-qunit";
+
+discourseModule(
+  "Integration | Component | watched-word-uploader",
+  function (hooks) {
+    if (!EMBER_CLI_ENV) {
+      return; // helpers not available in legacy env
+    }
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      pretender.post("/admin/customize/watched_words/upload.json", function () {
+        return response(200, {});
+      });
+    });
+
+    componentTest("sets the proper action key on uploads", {
+      template: hbs`{{watched-word-uploader
+      id="watched-word-uploader"
+      actionKey=actionNameKey
+      done=doneUpload
+    }}`,
+
+      async test(assert) {
+        const done = assert.async();
+        this.set("actionNameKey", "flag");
+        this.set("doneUpload", function () {
+          assert.equal(
+            Object.entries(this._uppyInstance.getState().files)[0][1].meta
+              .action_key,
+            "flag"
+          );
+          done();
+        });
+
+        const words = createFile("watched-words.txt");
+        await this.container
+          .lookup("service:app-events")
+          .trigger("upload-mixin:watched-word-uploader:add-files", words);
+        await waitFor(".bootbox span.d-button-label");
+        await click(".bootbox span.d-button-label");
+      },
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
@@ -9,47 +9,47 @@ import hbs from "htmlbars-inline-precompile";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { click, waitFor } from "@ember/test-helpers";
 import { setupApplicationTest as EMBER_CLI_ENV } from "ember-qunit";
+import { isLegacyEmber } from "discourse-common/config/environment";
 
-discourseModule(
-  "Integration | Component | watched-word-uploader",
-  function (hooks) {
-    if (!EMBER_CLI_ENV) {
-      return; // helpers not available in legacy env
-    }
-    setupRenderingTest(hooks);
+if (!isLegacyEmber()) {
+  discourseModule(
+    "Integration | Component | watched-word-uploader",
+    function (hooks) {
+      setupRenderingTest(hooks);
 
-    hooks.beforeEach(function () {
-      pretender.post("/admin/customize/watched_words/upload.json", function () {
-        return response(200, {});
-      });
-    });
-
-    componentTest("sets the proper action key on uploads", {
-      template: hbs`{{watched-word-uploader
-      id="watched-word-uploader"
-      actionKey=actionNameKey
-      done=doneUpload
-    }}`,
-
-      async test(assert) {
-        const done = assert.async();
-        this.set("actionNameKey", "flag");
-        this.set("doneUpload", function () {
-          assert.equal(
-            Object.entries(this._uppyInstance.getState().files)[0][1].meta
-              .action_key,
-            "flag"
-          );
-          done();
+      hooks.beforeEach(function () {
+        pretender.post("/admin/customize/watched_words/upload.json", function () {
+          return response(200, {});
         });
+      });
 
-        const words = createFile("watched-words.txt");
-        await this.container
-          .lookup("service:app-events")
-          .trigger("upload-mixin:watched-word-uploader:add-files", words);
-        await waitFor(".bootbox span.d-button-label");
-        await click(".bootbox span.d-button-label");
-      },
-    });
-  }
-);
+      componentTest("sets the proper action key on uploads", {
+        template: hbs`{{watched-word-uploader
+        id="watched-word-uploader"
+        actionKey=actionNameKey
+        done=doneUpload
+      }}`,
+
+        async test(assert) {
+          const done = assert.async();
+          this.set("actionNameKey", "flag");
+          this.set("doneUpload", function () {
+            assert.equal(
+              Object.entries(this._uppyInstance.getState().files)[0][1].meta
+                .action_key,
+              "flag"
+            );
+            done();
+          });
+
+          const words = createFile("watched-words.txt");
+          await this.container
+            .lookup("service:app-events")
+            .trigger("upload-mixin:watched-word-uploader:add-files", words);
+          await waitFor(".bootbox span.d-button-label");
+          await click(".bootbox span.d-button-label");
+        },
+      });
+    }
+  );
+}

--- a/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
@@ -17,9 +17,12 @@ if (!isLegacyEmber()) {
       setupRenderingTest(hooks);
 
       hooks.beforeEach(function () {
-        pretender.post("/admin/customize/watched_words/upload.json", function () {
-          return response(200, {});
-        });
+        pretender.post(
+          "/admin/customize/watched_words/upload.json",
+          function () {
+            return response(200, {});
+          }
+        );
       });
 
       componentTest("sets the proper action key on uploads", {

--- a/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
@@ -8,7 +8,6 @@ import {
 import hbs from "htmlbars-inline-precompile";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { click, waitFor } from "@ember/test-helpers";
-import { setupApplicationTest as EMBER_CLI_ENV } from "ember-qunit";
 import { isLegacyEmber } from "discourse-common/config/environment";
 
 if (!isLegacyEmber()) {


### PR DESCRIPTION
Currently when we upload a file containing watched words, it will always add the words to the action that was initially selected: this is the `block` action by default but if changing manually the action in the URL to `flag` for example, then this action will be selected and uploaded watched words will be categorized as `flag` no matter what.

The problem lies with how the component works: it’s an Uppy object where extra data is defined to provide an action key to the server but when navigating to another listed action, while this action key is properly updated on the component itself, the underlying Uppy object has already been created and doesn’t care about the new value.

This patch solves this by using the `_perFileData` method instead of `data`: the former is merged just before uploading a file whereas the latter is used when the Uppy object is created.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
