### PR TITLE
FIX: Ensure emoji is inserted in the correct location

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
+++ b/app/assets/javascripts/discourse/app/mixins/textarea-text-manipulation.js
@@ -570,14 +570,12 @@ export default Mixin.create({
         this.addText(selected, `:${code}:`);
       }
     } else {
-      let numOfRemovedChars = selected.pre.length - captures[1].length;
-      selected.pre = selected.pre.slice(
-        0,
-        selected.pre.length - captures[1].length
+      let numOfRemovedChars = captures[1].length;
+      this._insertAt(
+        selected.start - numOfRemovedChars,
+        selected.end,
+        `${code}:`
       );
-      selected.start -= numOfRemovedChars;
-      selected.end -= numOfRemovedChars;
-      this.addText(selected, `${code}:`);
     }
   },
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -727,7 +727,25 @@ third line`
       await click(
         '.emoji-picker .section[data-section="smileys_&_emotion"] img.emoji[title="grinning"]'
       );
-      assert.strictEqual(this.value, "hello world. :grinning:");
+      assert.strictEqual(
+        this.value,
+        "hello world. :grinning:",
+        "it works when there is no partial emoji"
+      );
+
+      await click("textarea.d-editor-input");
+      await fillIn(".d-editor-input", "starting to type an emoji like :gri");
+      jumpEnd(query("textarea.d-editor-input"));
+      await click("button.emoji");
+
+      await click(
+        '.emoji-picker .section[data-section="smileys_&_emotion"] img.emoji[title="grinning"]'
+      );
+      assert.strictEqual(
+        this.value,
+        "starting to type an emoji like :grinning:",
+        "it works when there is a partial emoji"
+      );
     },
   });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -19,6 +19,7 @@ import formatTextWithSelection from "discourse/tests/helpers/d-editor-helper";
 import hbs from "htmlbars-inline-precompile";
 import { next } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { isLegacyEmber } from "discourse-common/config/environment";
 
 discourseModule("Integration | Component | d-editor", function (hooks) {
   setupRenderingTest(hooks);
@@ -733,19 +734,21 @@ third line`
         "it works when there is no partial emoji"
       );
 
-      await click("textarea.d-editor-input");
-      await fillIn(".d-editor-input", "starting to type an emoji like :gri");
-      jumpEnd(query("textarea.d-editor-input"));
-      await click("button.emoji");
+      if (!isLegacyEmber()) {
+        await click("textarea.d-editor-input");
+        await fillIn(".d-editor-input", "starting to type an emoji like :gri");
+        jumpEnd(query("textarea.d-editor-input"));
+        await click("button.emoji");
 
-      await click(
-        '.emoji-picker .section[data-section="smileys_&_emotion"] img.emoji[title="grinning"]'
-      );
-      assert.strictEqual(
-        this.value,
-        "starting to type an emoji like :grinning:",
-        "it works when there is a partial emoji"
-      );
+        await click(
+          '.emoji-picker .section[data-section="smileys_&_emotion"] img.emoji[title="grinning"]'
+        );
+        assert.strictEqual(
+          this.value,
+          "starting to type an emoji like :grinning:",
+          "it works when there is a partial emoji"
+        );
+      }
     },
   });
 


### PR DESCRIPTION
In the specific case where you start typing an emoji, then open the full emoji picker, the chosen emoji would be inserted in the wrong place. This was an unintentional side effect of the changes in 75d9c16156f79f5a9f30a04433c3cb0ae82d914c

This commit updates the `emojiSelected` logic to avoid mutating the 'selected' object, and also adds a test for this specific behaviour.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
