### PR TITLE
DEV: Handle emoji-picker and d-editor being destroyed simultaneously

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -672,6 +672,13 @@ export default Component.extend(TextareaTextManipulation, {
     return true;
   },
 
+  @action
+  onEmojiPickerClose() {
+    if (!(this.isDestroyed || this.isDestroying)) {
+      this.set("emojiPickerIsActive", false);
+    }
+  },
+
   actions: {
     emoji() {
       if (this.disabled) {

--- a/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
@@ -74,5 +74,5 @@
   isEditorFocused=isEditorFocused
   initialFilter=this.emojiFilter
   emojiSelected=(action "emojiSelected")
-  onEmojiPickerClose=(action (mut emojiPickerIsActive) false)
+  onEmojiPickerClose=onEmojiPickerClose
 }}


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
