### PR TITLE
DEV: add smtp_should_reject to the receive_emails api key scope

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -64,7 +64,7 @@ class ApiKeyScope < ActiveRecord::Base
           list: { actions: %w[admin/users#index] },
         },
         email: {
-          receive_emails: { actions: %w[admin/email#handle_mail] }
+          receive_emails: { actions: %w[admin/email#handle_mail admin/email#smtp_should_reject] }
         },
         badges: {
           create: { actions: %w[admin/badges#create] },


### PR DESCRIPTION
[Meta context](https://meta.discourse.org/t/admin-email-smtp-should-reject-endpoint-not-permitted-by-email-receive-emails-scope/229483)