### PR TITLE
UX: remove extra whitespace in github onebox

### DIFF
--- a/lib/onebox/templates/githubblob.mustache
+++ b/lib/onebox/templates/githubblob.mustache
@@ -39,15 +39,14 @@
     </style>
     }}
 
-    <pre class="onebox">
-      <code class="{{lang}}">
-        <ol class="start lines" start="{{cr_results.from}}" style="counter-reset: li-counter {{cr_results.from_minus_one}} ;">
-          {{#lines}}
-            <li{{#selected}} class="selected"{{/selected}}>{{data}}</li>
-          {{/lines}}
-        </ol>
-      </code>
-    </pre>
+    {{!-- pre and code are intentionally on the same line to control whitespace --}}
+    <pre class="onebox"><code class="{{lang}}">
+      <ol class="start lines" start="{{cr_results.from}}" style="counter-reset: li-counter {{cr_results.from_minus_one}} ;">
+        {{#lines}}
+          <li{{#selected}} class="selected"{{/selected}}>{{data}}</li>
+        {{/lines}}
+      </ol>
+    </code></pre>
   {{/has_lines}}
 {{/binary}}
 


### PR DESCRIPTION
Before: 
![Screen Shot 2022-06-16 at 1 05 17 PM](https://user-images.githubusercontent.com/1681963/174126864-0b169244-e6ed-4b6b-8fe9-6fd27f48c6fa.png)

After:
![Screen Shot 2022-06-16 at 1 03 48 PM](https://user-images.githubusercontent.com/1681963/174126896-897e9be0-f547-4476-963a-75a12e625b81.png)

