### PR TITLE
FIX: Correctly deserialize mandrill_events property and detect smtp error code

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -50,7 +50,8 @@ class WebhooksController < ActionController::Base
   end
 
   def mandrill
-    events = JSON.parse(params["mandrill_events"])
+    # Only parse if mailchimp sends body url-encoded
+    events = params["mandrill_events"].is_a? String ? params["mandrill_events"] : JSON.parse(params["mandrill_events"])
     events.each do |event|
       message_id = event.dig("msg", "metadata", "message_id")
       to_address = event.dig("msg", "email")

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -50,7 +50,6 @@ class WebhooksController < ActionController::Base
   end
 
   def mandrill
-    # Only parse if mailchimp sends body url-encoded
     events = JSON.parse(params["mandrill_events"])
     events.each do |event|
       message_id = event.dig("msg", "metadata", "message_id")

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -51,11 +51,21 @@ class WebhooksController < ActionController::Base
 
   def mandrill
     # Only parse if mailchimp sends body url-encoded
-    events = params["mandrill_events"].is_a? String ? params["mandrill_events"] : JSON.parse(params["mandrill_events"])
+    events = JSON.parse(params["mandrill_events"])
     events.each do |event|
       message_id = event.dig("msg", "metadata", "message_id")
       to_address = event.dig("msg", "email")
-      error_code = event.dig("msg", "diag")
+      error_string = event.dig("msg", "diag")
+      error_code = nil
+
+      if error_string.is_a? String
+        error_match = error_string.match(/\s\d\.\d\.\d\s/)
+
+        if error_match.is_a? MatchData
+          error_code = error_match.to_s
+          error_code.strip!
+        end
+      end
 
       case event["event"]
       when "hard_bounce"

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "openssl"
 
 class WebhooksController < ActionController::Base
@@ -49,7 +50,7 @@ class WebhooksController < ActionController::Base
   end
 
   def mandrill
-    events = params["mandrill_events"]
+    events = JSON.parse(params["mandrill_events"])
     events.each do |event|
       message_id = event.dig("msg", "metadata", "message_id")
       to_address = event.dig("msg", "email")

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
 require "openssl"
 
 class WebhooksController < ActionController::Base

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -54,17 +54,7 @@ class WebhooksController < ActionController::Base
     events.each do |event|
       message_id = event.dig("msg", "metadata", "message_id")
       to_address = event.dig("msg", "email")
-      error_string = event.dig("msg", "diag")
-      error_code = nil
-
-      if error_string.is_a? String
-        error_match = error_string.match(/\s\d\.\d\.\d\s/)
-
-        if error_match.is_a? MatchData
-          error_code = error_match.to_s
-          error_code.strip!
-        end
-      end
+      error_code = event.dig("msg", "diag")
 
       case event["event"]
       when "hard_bounce"

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -132,18 +132,17 @@ describe WebhooksController do
       user = Fabricate(:user, email: email)
       email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
 
-      post "/webhooks/mandrill.json", params: {
+      post "/webhooks/mandrill", params: {
         mandrill_events: [{
           "event" => "hard_bounce",
           "msg" => {
             "email" => email,
-            "diag" => "5.1.1",
-            "bounce_description": "smtp; 550-5.1.1 The email account that you tried to reach does not exist.",
+            "diag" => "smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces.",
             "metadata" => {
               "message_id" => message_id
             }
           }
-        }]
+        }].to_json
       }
 
       expect(response.status).to eq(200)

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -132,7 +132,7 @@ describe WebhooksController do
       user = Fabricate(:user, email: email)
       email_log = Fabricate(:email_log, user: user, message_id: message_id, to_address: email)
 
-      post "/webhooks/mandrill", params: {
+      post "/webhooks/mandrill.json", params: {
         mandrill_events: [{
           "event" => "hard_bounce",
           "msg" => {

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -137,7 +137,8 @@ describe WebhooksController do
           "event" => "hard_bounce",
           "msg" => {
             "email" => email,
-            "diag" => "smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces.",
+            "diag" => "5.1.1",
+            "bounce_description": "smtp; 550-5.1.1 The email account that you tried to reach does not exist.",
             "metadata" => {
               "message_id" => message_id
             }
@@ -149,7 +150,7 @@ describe WebhooksController do
 
       email_log.reload
       expect(email_log.bounced).to eq(true)
-      expect(email_log.bounce_error_code).to eq("smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces.")
+      expect(email_log.bounce_error_code).to eq("5.1.1")
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
     end
   end

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -149,7 +149,7 @@ describe WebhooksController do
 
       email_log.reload
       expect(email_log.bounced).to eq(true)
-      expect(email_log.bounce_error_code).to eq("5.1.1")
+      expect(email_log.bounce_error_code).to eq("smtp;550 5.1.1 The email account that you tried to reach does not exist. Please try double-checking the recipient's email address for typos or unnecessary spaces.")
       expect(email_log.user.user_stat.bounce_score).to eq(SiteSetting.hard_bounce_score)
     end
   end


### PR DESCRIPTION
Mandrill sends webhook messages as a url-encoded body, with the `mandrill_events` property as an encoded JSON array. Because the property is one large string before parsing, reading the message events fails. This change will properly deserialize the encoded array before attempting to read event properties and correctly detect the smtp error code.