### PR TITLE
DEV: Cleanup topic thumbnail enqueuing

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -85,8 +85,7 @@ class Topic < ActiveRecord::Base
     if SiteSetting.create_thumbnails &&
        enqueue_if_missing &&
        records.length < thumbnail_sizes.length &&
-       Discourse.redis.set(thumbnail_job_redis_key(thumbnail_sizes), 1, nx: true, ex: 1.minute)
-
+       Discourse.redis.set(thumbnail_job_redis_key(extra_sizes), 1, nx: true, ex: 1.minute)
       Jobs.enqueue(:generate_topic_thumbnails, { topic_id: id, extra_sizes: extra_sizes })
     end
 

--- a/spec/integration/topic_thumbnail_spec.rb
+++ b/spec/integration/topic_thumbnail_spec.rb
@@ -37,13 +37,18 @@ describe "Topic Thumbnails" do
       end
 
       it "includes the theme specified resolutions" do
-        pending "We're creating two generate topic thumbnails jobs instead of one"
-
         topic_json = nil
 
         expect do
           topic_json = get_topic
-        end.to change { Jobs::GenerateTopicThumbnails.jobs.size }.by(1)
+        end.to change { Jobs::GenerateTopicThumbnails.jobs.size }.by(2)
+
+        expect(
+          Jobs::GenerateTopicThumbnails.jobs.map { |j| j["args"][0]["extra_sizes"] }
+        ).to eq([
+          nil, # Job for core/plugin sizes
+          [[10, 10], [20, 20], [30, 30]]] # Job for theme sizes
+        )
 
         thumbnails = topic_json["thumbnails"]
 
@@ -92,8 +97,6 @@ describe "Topic Thumbnails" do
       end
 
       it "includes the theme specified resolutions" do
-        pending "We're creating two generate topic thumbnails jobs instead of one"
-
         topic_json = nil
 
         expect do

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -70,7 +70,7 @@ describe TopicViewSerializer do
       it 'should have thumbnail jobs enqueued' do
         SiteSetting.create_thumbnails = true
 
-        Discourse.redis.del(topic.thumbnail_job_redis_key(Topic.thumbnail_sizes))
+        Discourse.redis.del(topic.thumbnail_job_redis_key([]))
         json = nil
 
         expect do


### PR DESCRIPTION
- Ensure only one job is enqueued when there are no extra sizes requested by themes
- Update and un-skip relevant tests

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
