### PR TITLE
DEV: Stop logging error response body in FileHelper

### DIFF
--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -73,7 +73,7 @@ class FileHelper
             # attempt error API compatibility
             io = FakeIO.new
             io.status = [response.code, ""]
-            raise OpenURI::HTTPError.new("#{response.code} Error: #{response.body}", io)
+            raise OpenURI::HTTPError.new("#{response.code} Error", io)
           else
             log(:error, "FinalDestination did not work for: #{url}") if verbose
             throw :done

--- a/spec/lib/file_helper_spec.rb
+++ b/spec/lib/file_helper_spec.rb
@@ -29,7 +29,7 @@ describe FileHelper do
           expect(e.io.status[0]).to eq("404")
           raise
         end
-      end.to raise_error(OpenURI::HTTPError, "404 Error: 404")
+      end.to raise_error(OpenURI::HTTPError, "404 Error")
     end
 
     it "does not follow redirects if instructed not to" do


### PR DESCRIPTION
This doesn't cope well with gzipped, binary, or large responses. Ideally we would teach FinalDestination to safely retrieve and decode some of the response body. But for now, let's remove the broken implementation.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
