### PR TITLE
UX: Skip special paste handling in email-group-user-chooser when maximum is 1

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/email-group-user-chooser-filter.js
+++ b/app/assets/javascripts/select-kit/addon/components/email-group-user-chooser-filter.js
@@ -6,6 +6,10 @@ export default MultiSelectFilterComponent.extend({
 
   @action
   onPaste(event) {
+    if (this.selectKit.options.maximum === 1) {
+      return;
+    }
+
     const data = event.originalEvent.clipboardData;
 
     if (!data) {


### PR DESCRIPTION
`email-group-user-chooser` currently handles paste events to allow users to paste multiple entries at once instead of entering them one by one. This behavior makes sense when the component is used in scenarios where it makes sense to provide multiple entries such as the recipients field when creating a PM. However, for instances where the component accepts only 1 entry, it doesn't make a lot of sense to do custom handling of paste events.

This PR makes our paste event handler a NOOP when the component is configured to accept only 1 entry in which case pasting will simply input the value into the component's search field.