### PR TITLE
FIX: Add missing pluralization rules for Bosnian

### DIFF
--- a/lib/javascripts/locale/bs.js
+++ b/lib/javascripts/locale/bs.js
@@ -1,0 +1,10 @@
+MessageFormat.locale.bs = function (n) {
+  if ((n % 10) == 1 && (n % 100) != 11) {
+    return 'one';
+  }
+  if ((n % 10) >= 2 && (n % 10) <= 4 &&
+      ((n % 100) < 12 || (n % 100) > 14) && n == Math.floor(n)) {
+    return 'few';
+  }
+  return 'other';
+};


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
