### PR TITLE
UX: Change wording for 'regular' categories to 'normal'

### DIFF
--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -150,7 +150,7 @@ export default Mixin.create({
       "default_categories_tracking",
       "default_categories_muted",
       "default_categories_watching_first_post",
-      "default_categories_regular",
+      "default_categories_normal",
       "default_tags_watching",
       "default_tags_tracking",
       "default_tags_muted",

--- a/app/assets/javascripts/discourse/app/lib/notification-levels.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-levels.js
@@ -1,5 +1,6 @@
 const MUTED = 0;
 const REGULAR = 1;
+const NORMAL = 1; // alias for REGULAR
 const TRACKING = 2;
 const WATCHING = 3;
 const WATCHING_FIRST_POST = 4;
@@ -9,6 +10,7 @@ export const NotificationLevels = {
   WATCHING,
   TRACKING,
   REGULAR,
+  NORMAL,
   MUTED,
 };
 

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -216,7 +216,7 @@ class Admin::SiteSettingsController < Admin::AdminController
       NotificationLevels.all[:muted]
     when "default_categories_watching_first_post"
       NotificationLevels.all[:watching_first_post]
-    when "default_categories_regular"
+    when "default_categories_normal"
       NotificationLevels.all[:regular]
     end
   end

--- a/app/models/category_user.rb
+++ b/app/models/category_user.rb
@@ -209,7 +209,7 @@ class CategoryUser < ActiveRecord::Base
         SiteSetting.default_categories_watching.split("|"),
         SiteSetting.default_categories_tracking.split("|"),
         SiteSetting.default_categories_watching_first_post.split("|"),
-        SiteSetting.default_categories_regular.split("|")
+        SiteSetting.default_categories_normal.split("|")
       ].flatten.map do |id|
         [id.to_i, self.notification_levels[:regular]]
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1671,9 +1671,9 @@ class User < ActiveRecord::Base
     # * default_categories_watching
     # * default_categories_tracking
     # * default_categories_watching_first_post
-    # * default_categories_regular
+    # * default_categories_normal
     # * default_categories_muted
-    %w{watching watching_first_post tracking regular muted}.each do |setting|
+    %w{watching watching_first_post tracking normal muted}.each do |setting|
       category_ids = SiteSetting.get("default_categories_#{setting}").split("|").map(&:to_i)
       category_ids.each do |category_id|
         next if category_id == 0

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1204,7 +1204,7 @@ en:
       muted_categories: "Muted"
       muted_categories_instructions: "You will not be notified of anything about new topics in these categories, and they will not appear on the categories or latest pages."
       muted_categories_instructions_dont_hide: "You will not be notified of anything about new topics in these categories."
-      regular_categories: "Regular"
+      regular_categories: "Normal"
       regular_categories_instructions: "You will see these categories in the “Latest” and “Top” topic lists."
       no_category_access: "As a moderator you have limited category access, save is disabled."
       delete_account: "Delete My Account"
@@ -3777,7 +3777,7 @@ en:
         edit: "%{shortcut} Edit post"
         delete: "%{shortcut} Delete post"
         mark_muted: "%{shortcut} Mute topic"
-        mark_regular: "%{shortcut} Regular (default) topic"
+        mark_regular: "%{shortcut} Normal (default) topic"
         mark_tracking: "%{shortcut} Track topic"
         mark_watching: "%{shortcut} Watch topic"
         print: "%{shortcut} Print topic"
@@ -3921,7 +3921,7 @@ en:
           title: "Tracking"
           description: "You will automatically track all topics with this tag. A count of unread and new posts will appear next to the topic."
         regular:
-          title: "Regular"
+          title: "Normal"
           description: "You will be notified if someone mentions your @name or replies to your post."
         muted:
           title: "Muted"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2295,7 +2295,7 @@ en:
     default_categories_tracking: "List of categories that are tracked by default."
     default_categories_muted: "List of categories that are muted by default."
     default_categories_watching_first_post: "List of categories in which first post in each new topic will be watched by default."
-    default_categories_regular: "List of categories that are not muted by default. Useful when `mute_all_categories_by_default` site setting is enabled."
+    default_categories_normal: "List of categories that are not muted by default. Useful when `mute_all_categories_by_default` site setting is enabled."
     mute_all_categories_by_default: "Set the default notification level of all the categories to muted. Require users opt-in to categories for them to appear in 'latest' and 'categories' pages. If you wish to amend the defaults for anonymous users set 'default_categories_' settings."
 
     default_tags_watching: "List of tags that are watched by default."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2485,7 +2485,7 @@ user_preferences:
   default_categories_watching_first_post:
     type: category_list
     default: ""
-  default_categories_regular:
+  default_categories_normal:
     type: category_list
     default: ""
   mute_all_categories_by_default:

--- a/db/post_migrate/20220617151846_rename_default_categories_regular_setting.rb
+++ b/db/post_migrate/20220617151846_rename_default_categories_regular_setting.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RenameDefaultCategoriesRegularSetting < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'default_categories_normal'
+      WHERE name = 'default_categories_regular'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'default_categories_regular'
+      WHERE name = 'default_categories_normal'
+    SQL
+  end
+end

--- a/lib/notification_levels.rb
+++ b/lib/notification_levels.rb
@@ -4,6 +4,7 @@ module NotificationLevels
   def self.all
     @all_levels ||= Enum.new(muted: 0,
                              regular: 1,
+                             normal: 1, # alias for regular
                              tracking: 2,
                              watching: 3,
                              watching_first_post: 4)

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -6,6 +6,7 @@ module SiteSettings::DeprecatedSettings
   SETTINGS = [
     # [<old setting>, <new_setting>, <override>, <version to drop>]
     ['search_tokenize_chinese_japanese_korean', 'search_tokenize_chinese', true, '2.9'],
+    ['default_categories_regular', 'default_categories_normal', true, '3.0'],
   ]
 
   def setup_deprecated_methods

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -46,7 +46,7 @@ module SiteSettings::Validations
       SiteSetting.default_categories_tracking.split("|"),
       SiteSetting.default_categories_muted.split("|"),
       SiteSetting.default_categories_watching_first_post.split("|"),
-      SiteSetting.default_categories_regular.split("|")
+      SiteSetting.default_categories_normal.split("|")
     ].flatten.map(&:to_i).to_set
 
     validate_default_categories(category_ids, default_categories_selected)
@@ -59,7 +59,7 @@ module SiteSettings::Validations
       SiteSetting.default_categories_watching.split("|"),
       SiteSetting.default_categories_muted.split("|"),
       SiteSetting.default_categories_watching_first_post.split("|"),
-      SiteSetting.default_categories_regular.split("|")
+      SiteSetting.default_categories_normal.split("|")
     ].flatten.map(&:to_i).to_set
 
     validate_default_categories(category_ids, default_categories_selected)
@@ -72,7 +72,7 @@ module SiteSettings::Validations
       SiteSetting.default_categories_watching.split("|"),
       SiteSetting.default_categories_tracking.split("|"),
       SiteSetting.default_categories_watching_first_post.split("|"),
-      SiteSetting.default_categories_regular.split("|")
+      SiteSetting.default_categories_normal.split("|")
     ].flatten.map(&:to_i).to_set
 
     validate_default_categories(category_ids, default_categories_selected)
@@ -85,7 +85,7 @@ module SiteSettings::Validations
       SiteSetting.default_categories_watching.split("|"),
       SiteSetting.default_categories_tracking.split("|"),
       SiteSetting.default_categories_muted.split("|"),
-      SiteSetting.default_categories_regular.split("|")
+      SiteSetting.default_categories_normal.split("|")
     ].flatten.map(&:to_i).to_set
 
     validate_default_categories(category_ids, default_categories_selected)

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -866,7 +866,7 @@ class TopicQuery
         SiteSetting.default_categories_watching.split("|"),
         SiteSetting.default_categories_tracking.split("|"),
         SiteSetting.default_categories_watching_first_post.split("|"),
-        SiteSetting.default_categories_regular.split("|")
+        SiteSetting.default_categories_normal.split("|")
       ].flatten.map(&:to_i)
       category_ids << category_id if category_id.present? && category_ids.exclude?(category_id)
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -549,7 +549,7 @@ describe TopicQuery do
     end
 
     it 'should include default regular category topics in latest list for anonymous users' do
-      SiteSetting.default_categories_regular = category.id.to_s
+      SiteSetting.default_categories_normal = category.id.to_s
       expect(TopicQuery.new.list_latest.topics.map(&:id)).to include(topic.id)
     end
 

--- a/spec/models/category_user_spec.rb
+++ b/spec/models/category_user_spec.rb
@@ -232,7 +232,7 @@ describe CategoryUser do
         SiteSetting.default_categories_watching = category1.id.to_s
         SiteSetting.default_categories_tracking = category2.id.to_s
         SiteSetting.default_categories_watching_first_post = category3.id.to_s
-        SiteSetting.default_categories_regular = category4.id.to_s
+        SiteSetting.default_categories_normal = category4.id.to_s
         SiteSetting.default_categories_muted = category5.id.to_s
       end
       it "every category from the default_categories_* site settings get overridden to regular, except for muted" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1727,7 +1727,7 @@ RSpec.describe User do
       SiteSetting.default_categories_tracking = category1.id.to_s
       SiteSetting.default_categories_muted = category2.id.to_s
       SiteSetting.default_categories_watching_first_post = category3.id.to_s
-      SiteSetting.default_categories_regular = category4.id.to_s
+      SiteSetting.default_categories_normal = category4.id.to_s
     end
 
     it "has overridden preferences" do

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -61,7 +61,7 @@ describe SiteSerializer do
 
   it "returns correct notification level for categories" do
     SiteSetting.mute_all_categories_by_default = true
-    SiteSetting.default_categories_regular = category.id.to_s
+    SiteSetting.default_categories_normal = category.id.to_s
 
     serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
     categories = serialized[:categories]


### PR DESCRIPTION
At some point in the past we decided to rename the 'regular' notification state of topics/categories to 'normal'. However, some UI copy was missed when the initial renaming was done so this PR changes the spots that were missed to the new name.