### PR TITLE
DEV: Move preloaded `json` into `<discourse-assets>` element

### DIFF
--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -25,6 +25,9 @@
         <bootstrap-content key="discourse-stylesheets">
         {{content-for "discourse-stylesheets"}}
       </discourse-assets-stylesheets>
+      <discourse-assets-json>
+        <bootstrap-content key="preloaded">
+      </discourse-assets-json>
     </discourse-assets>
 
     <bootstrap-content key="body">
@@ -34,7 +37,6 @@
     </section>
 
     <bootstrap-content key="hidden-login-form">
-    <bootstrap-content key="preloaded">
 
     <script defer src="{{rootURL}}assets/start-discourse.js"></script>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,6 +75,9 @@
       <discourse-assets-stylesheets>
         <%= render partial: "common/discourse_stylesheet" %>
       </discourse-assets-stylesheets>
+      <discourse-assets-json>
+        <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
+      </discourse-assets-json>
     </discourse-assets>
 
     <%- if allow_plugins? %>
@@ -114,7 +117,6 @@
       </form>
     <% end %>
 
-    <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
 
     <script defer src="<%= script_asset_path "start-discourse" %>"></script>
 


### PR DESCRIPTION
This PR introduces 0 visual or functional changes. The only thing that it changes is that it moves the `data-preloaded` div (which has the app boot `json` into the `<discourse-assets>` element.

See https://github.com/discourse/discourse/pull/17078 for a bit more context. 

The reason behind this change is that it makes devTools element view a little bit less cluttered. 

Before 

<img height=500 src="https://d11a6trkgmumsb.cloudfront.net/original/4X/8/8/6/886e84b323af2bfba669be88f9ba3e2cdda4030b.jpeg">

After

<img height=500 src="https://d11a6trkgmumsb.cloudfront.net/original/4X/e/b/e/ebe5ae70540cf6e55af3fd4bd3df6dd1f4a4e848.png">

Note that the `#data-preloaded` element is still there, however, it's now rendered inside the `<discourse-assets>` element which is collapsed by default.