### PR TITLE
DEV: Adds missing defer attribute to wizard js in dev layout

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -73,7 +73,7 @@ function head(buffer, bootstrap, headers, baseURL) {
     }
 
     if (admin) {
-      buffer.push(`<script src="${baseURL}assets/wizard.js"></script>`);
+      buffer.push(`<script defer src="${baseURL}assets/wizard.js"></script>`);
     }
   }
 


### PR DESCRIPTION
Small followup to https://github.com/discourse/discourse/pull/17063

The wizard `js` file slipped through the cracks. This only affected dev installs.