### PR TITLE
DEV: Moves SVG sprite to `<discourse-assets>` element

### DIFF
--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -28,6 +28,8 @@
       <discourse-assets-json>
         <bootstrap-content key="preloaded">
       </discourse-assets-json>
+      <discourse-assets-icons>
+      </discourse-assets-icons>
     </discourse-assets>
 
     <bootstrap-content key="body">

--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -28,8 +28,7 @@
       <discourse-assets-json>
         <bootstrap-content key="preloaded">
       </discourse-assets-json>
-      <discourse-assets-icons>
-      </discourse-assets-icons>
+      <discourse-assets-icons></discourse-assets-icons>
     </discourse-assets>
 
     <bootstrap-content key="body">

--- a/app/assets/javascripts/discourse/app/lib/svg-sprite-loader.js
+++ b/app/assets/javascripts/discourse/app/lib/svg-sprite-loader.js
@@ -7,7 +7,8 @@ export function loadSprites(spritePath, spriteName) {
   if (!spriteContainer) {
     spriteContainer = document.createElement("div");
     spriteContainer.id = SVG_CONTAINER_ID;
-    document.body.appendChild(spriteContainer);
+    const spriteWrapper = document.querySelector("discourse-assets-icons");
+    spriteWrapper?.appendChild(spriteContainer);
   }
 
   let sprites = spriteContainer.querySelector(`.${spriteName}`);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,6 +78,8 @@
       <discourse-assets-json>
         <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
       </discourse-assets-json>
+      <discourse-assets-icons>
+      </discourse-assets-icons>
     </discourse-assets>
 
     <%- if allow_plugins? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,8 +78,7 @@
       <discourse-assets-json>
         <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
       </discourse-assets-json>
-      <discourse-assets-icons>
-      </discourse-assets-icons>
+      <discourse-assets-icons></discourse-assets-icons>
     </discourse-assets>
 
     <%- if allow_plugins? %>


### PR DESCRIPTION
Similar to https://github.com/discourse/discourse/pull/17145

This PR moves the SVG sprite container to the `<discourse-assets>` element.

There is 0 visual or functional changes in this PR. It just tidies up the element view in devTools.