### PR TITLE
DEV: Fix `this.clearRender` deprecation warning

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import { clearRender } from "@ember/test-helpers";
 import discourseComputed, {
   afterRender,
 } from "discourse-common/utils/decorators";
@@ -55,7 +56,7 @@ discourseModule("Unit | Utils | decorators", function (hooks) {
       assert.ok(exists(document.querySelector(".foo-component")));
       assert.strictEqual(this.baz, 1);
 
-      await this.clearRender();
+      await clearRender();
 
       assert.ok(!exists(document.querySelector(".foo-component")));
       assert.strictEqual(this.baz, 1);


### PR DESCRIPTION
```
{"type":"warn","text":"DEPRECATION: Using this.clearRender has been deprecated, consider using `clearRender` imported from `@ember/test-helpers`. [deprecation id: ember-test-helpers.setup-rendering-context.clearRender]"}
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
