### PR TITLE
DEV: Change `locationType` to `history`

### DIFF
--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: "discourse",
     environment,
     rootURL: process.env.DISCOURSE_RELATIVE_URL_ROOT || "/",
-    locationType: "auto",
+    locationType: "history",
     historySupportMiddleware: false,
     EmberENV: {
       FEATURES: {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
       modulePrefix: "discourse",
       environment: Rails.env,
       rootURL: Discourse.base_path,
-      locationType: "auto",
+      locationType: "history",
       historySupportMiddleware: false,
       EmberENV: {
         FEATURES: {},


### PR DESCRIPTION
`auto` value is deprecated, and we never really supported `hash` (which was the type `auto` was falling back into)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
