### PR TITLE
FIX: Precompile start-discourse.js

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -37,6 +37,7 @@ Rails.application.config.assets.precompile += %w{
   google-tag-manager.js
   google-universal-analytics-v3.js
   google-universal-analytics-v4.js
+  start-discourse.js
   print-page.js
   activate-account.js
   auto-redirect.js


### PR DESCRIPTION
This was inadvertently removed in 1b4692039e89392731ca5f75cfc4c4febaa3fa9a

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
