### PR TITLE
DEV: Run some specs with fake S3 implementation instead of stubs

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -196,21 +196,24 @@ class UploadCreator
           Upload.generate_digest(@file) != sha1_before_changes
         end
 
-      if @opts[:existing_external_upload_key] && Discourse.store.external?
+      store = Discourse.store
+
+      if @opts[:existing_external_upload_key] && store.external?
         should_move = external_upload_too_big || !upload_changed
       end
 
       if should_move
         # move the file in the store instead of reuploading
-        url = Discourse.store.move_existing_stored_upload(
+        url = store.move_existing_stored_upload(
           existing_external_upload_key: @opts[:existing_external_upload_key],
           upload: @upload
         )
       else
         # store the file and update its url
         File.open(@file.path) do |f|
-          url = Discourse.store.store_upload(f, @upload)
+          url = store.store_upload(f, @upload)
         end
+        store.delete_file(@opts[:existing_external_upload_key]) if @opts[:existing_external_upload_key]
       end
 
       if url.present?

--- a/spec/support/fake_s3.rb
+++ b/spec/support/fake_s3.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+class FakeS3
+  attr_reader :s3_client
+
+  def self.create
+    s3 = self.new
+    s3.stub_bucket(SiteSetting.s3_upload_bucket) if SiteSetting.s3_upload_bucket.present?
+    s3.stub_bucket(File.join(SiteSetting.s3_backup_bucket, RailsMultisite::ConnectionManagement.current_db)) if SiteSetting.s3_backup_bucket.present?
+    s3.stub_s3_helper
+    s3
+  end
+
+  def initialize
+    @buckets = {}
+    @operations = []
+    @s3_client = Aws::S3::Client.new(stub_responses: true, region: SiteSetting.s3_region)
+
+    stub_methods
+  end
+
+  def bucket(bucket_name)
+    bucket_name, _prefix = bucket_name.split("/", 2)
+    @buckets[bucket_name]
+  end
+
+  def stub_bucket(full_bucket_name)
+    bucket_name, _prefix = full_bucket_name.split("/", 2)
+
+    s3_helper = S3Helper.new(
+      full_bucket_name,
+      Rails.configuration.multisite ? FileStore::S3Store.new.multisite_tombstone_prefix : FileStore::S3Store::TOMBSTONE_PREFIX,
+      client: @s3_client
+    )
+    @buckets[bucket_name] = FakeS3Bucket.new(full_bucket_name, s3_helper)
+  end
+
+  def stub_s3_helper
+    @buckets.each do |bucket_name, bucket|
+      S3Helper.stubs(:new)
+        .with { |b| b == bucket_name || b == bucket.name }
+        .returns(bucket.s3_helper)
+    end
+  end
+
+  def operation_called?(name)
+    @operations.any? do |operation|
+      operation[:name] == name && (block_given? ? yield(operation) : true)
+    end
+  end
+
+  private
+
+  def find_bucket(params)
+    bucket(params[:bucket])
+  end
+
+  def find_object(params)
+    bucket = find_bucket(params)
+    bucket&.find_object(params[:key])
+  end
+
+  def log_operation(context)
+    @operations << {
+      name: context.operation_name,
+      params: context.params.dup
+    }
+  end
+
+  def calculate_etag(context)
+    # simple, reproducible ETag calculation
+    Digest::MD5.hexdigest(context.params.to_json)
+  end
+
+  def stub_methods
+    @s3_client.stub_responses(:head_object, -> (context) do
+      log_operation(context)
+
+      if object = find_object(context.params)
+        { content_length: object[:size], last_modified: object[:last_modified], metadata: object[:metadata] }
+      else
+        { status_code: 404, headers: {}, body: "" }
+      end
+    end)
+
+    @s3_client.stub_responses(:get_object, -> (context) do
+      log_operation(context)
+
+      if object = find_object(context.params)
+        { content_length: object[:size], body: "" }
+      else
+        { status_code: 404, headers: {}, body: "" }
+      end
+    end)
+
+    @s3_client.stub_responses(:delete_object, -> (context) do
+      log_operation(context)
+
+      find_bucket(context.params)&.delete_object(context.params[:key])
+      nil
+    end)
+
+    @s3_client.stub_responses(:copy_object, -> (context) do
+      log_operation(context)
+
+      source_bucket_name, source_key = context.params[:copy_source].split("/", 2)
+      copy_source = { bucket: source_bucket_name, key: source_key }
+
+      if context.params[:metadata_directive] == "REPLACE"
+        attribute_overrides = context.params.except(:copy_source, :metadata_directive)
+      else
+        attribute_overrides = context.params.slice(:key, :bucket)
+      end
+
+      new_object = find_object(copy_source).dup.merge(attribute_overrides)
+      find_bucket(new_object).put_object(new_object)
+
+      { copy_object_result: { etag: calculate_etag(context) } }
+    end)
+
+    @s3_client.stub_responses(:create_multipart_upload, -> (context) do
+      log_operation(context)
+
+      find_bucket(context.params).put_object(context.params)
+      { upload_id: SecureRandom.hex }
+    end)
+
+    @s3_client.stub_responses(:put_object, -> (context) do
+      log_operation(context)
+
+      find_bucket(context.params).put_object(context.params)
+      { etag: calculate_etag(context) }
+    end)
+  end
+end
+
+class FakeS3Bucket
+  attr_reader :name, :s3_helper
+
+  def initialize(bucket_name, s3_helper)
+    @name = bucket_name
+    @s3_helper = s3_helper
+    @objects = {}
+  end
+
+  def put_object(obj)
+    @objects[obj[:key]] = obj
+  end
+
+  def delete_object(key)
+    @objects.delete(key)
+  end
+
+  def find_object(key)
+    @objects[key]
+  end
+end


### PR DESCRIPTION
This adds a new `FakeS3` class that can be used to fake a real S3 store. It operates in memory and the most important S3 methods are implemented.

This PR switches the specs for `ExternalUploadManager` and some of the specs for `S3Store` from stubs to `FakeS3`. That allows testing the behavior instead of testing that certain S3 methods are called with the correct parameters. It should be less brittle and helped in discovering a mismatch between spec and implementation in `UploadCreator`.

That's why there is also a fix included, because `UploadCreator` didn't delete the upload stub when a new upload is created. It also makes a slight improvement by reusing `Discourse.store` to prevent creation of multiple new store objects within `UploadCreator#create_for`.