### PR TITLE
DEV: Hide `content_security_policy_collect_reports` setting

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1704,6 +1704,7 @@ security:
     default: false
   content_security_policy_collect_reports:
     default: false
+    hidden: true
   content_security_policy_frame_ancestors:
     default: true
   content_security_policy_script_src:


### PR DESCRIPTION
CSP reports have lots of false positives. This setting can be useful sometimes, for example when initially enabling CSP on a site. But given that CSP is on by default in Discourse (and has been for at least a year) and enabling this setting on production sites can cause a lot of noise in `/logs`, it is better to hide it, that way inexperienced site admins don't enable it by mistake and forget it enabled, thus polluting the site's Logster queue. 