### PR TITLE
DEV: Fix flakey site.json rswag specs

### DIFF
--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -502,13 +502,22 @@
               "type": "integer"
             },
             "description": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "description_text": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "description_excerpt": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "topic_url": {
               "type": "string"
@@ -636,9 +645,6 @@
             "topic_count",
             "post_count",
             "position",
-            "description",
-            "description_text",
-            "description_excerpt",
             "topic_url",
             "read_restricted",
             "permission",


### PR DESCRIPTION
The category description fields as part of the rswag specs for the
site.json endpoint were flakey. Removing the `required` attribute allows
us to still document that these fields exists, but that depending on
certain site settings they may not be present in the response.
