### PR TITLE
DEV: Add a discourse-booted performance mark

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/start-app.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/start-app.js
@@ -1,4 +1,5 @@
 document.addEventListener("discourse-booted", (e) => {
+  performance.mark("discourse-booted");
   const config = e.detail;
   const app = require(`${config.modulePrefix}/app`)["default"].create(config);
   app.start();


### PR DESCRIPTION
This is useful when analysing performance in developer tools, and can also be used for analytics plugins

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
