### PR TITLE
FIX: link to "recently used devices" in suspicious_login email notifi…

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4059,7 +4059,7 @@ en:
 
         If this was you, great! There’s nothing else you need to do.
 
-        If this was not you, please [review your existing sessions](%{base_url}/my/preferences/account) and consider changing your password.
+        If this was not you, please [review your existing sessions](%{base_url}/my/preferences/security) and consider changing your password.
 
     post_approved:
       title: "Your post was approved"


### PR DESCRIPTION
…cation

The link used to point to `/my/preferences/account` but the list of recently used devices now lives in `/my/preferences/security`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
