### PR TITLE
FIX: Defer scripts on theme-tests route

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-listen-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-listen-boot.js
@@ -1,4 +1,9 @@
-document.write(
-  "<style>#ember-testing-container { position: fixed; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; transform: translateZ(0)} #ember-testing { width: 200%; height: 200%; transform: scale(0.5); transform-origin: top left; }</style>"
+document.body.insertAdjacentHTML(
+  "afterbegin",
+  `
+  <style>#ember-testing-container { position: fixed; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; transform: translateZ(0)} #ember-testing { width: 200%; height: 200%; transform: scale(0.5); transform-origin: top left; }</style>
+  `
 );
+
+
 require('discourse/tests/test-boot-ember-cli');

--- a/app/helpers/qunit_helper.rb
+++ b/app/helpers/qunit_helper.rb
@@ -10,6 +10,6 @@ module QunitHelper
       "#{Discourse.base_path}" \
       "/theme-javascripts/tests/#{theme.id}-#{digest}.js" \
       "?__ws=#{Discourse.current_hostname}"
-    "<script src='#{src}'></script>".html_safe
+    "<script defer src='#{src}'></script>".html_safe
   end
 end

--- a/app/views/qunit/theme.html.erb
+++ b/app/views/qunit/theme.html.erb
@@ -30,7 +30,7 @@
       </style>
     <%- end %>
     <%- if params['testem'] %>
-      <script src="/assets/testem.js"></script>
+      <script defer src="/assets/testem.js"></script>
     <%- end %>
   </head>
   <body>


### PR DESCRIPTION
Small follow-up to https://github.com/discourse/discourse/pull/17063. That PR broke the theme tests route locally. 

This PR fixes that.