### PR TITLE
FIX: Remove leftover uses of ember_jquery

### DIFF
--- a/app/views/users/password_reset.html.erb
+++ b/app/views/users/password_reset.html.erb
@@ -17,7 +17,6 @@
 
 <%- content_for(:no_ember_head) do %>
   <meta name="referrer" content="never">
-  <%= preload_script "ember_jquery" %>
   <%= render_google_universal_analytics_code %>
 <%- end %>
 

--- a/app/views/users_email/show_confirm_new_email.html.erb
+++ b/app/views/users_email/show_confirm_new_email.html.erb
@@ -77,11 +77,12 @@
     <%end%>
   <% end%>
 
+  <%= preload_script "vendor" %>
   <%= preload_script "locales/#{I18n.locale}" %>
   <%- if ExtraLocalesController.client_overrides_exist? %>
     <%= preload_script_url ExtraLocalesController.url('overrides') %>
   <%- end %>
-  <%= preload_script 'ember_jquery' %>
+  <% # TODO: move all this logic into the ember app %>
   <%= preload_script "discourse/app/lib/webauthn" %>
   <%= preload_script "confirm-new-email/confirm-new-email" %>
   <%= preload_script "confirm-new-email/bootstrap" %>


### PR DESCRIPTION
On the password_reset error screen, it was totally unused

On the show_confirm_new_email screen, we can load the `vendor` bundle instead. Eventually we should move all this logic into the Ember app

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
