### PR TITLE
DEV: drop unused column `flair_url` from groups table.

### DIFF
--- a/db/post_migrate/20220621164914_drop_flair_url_from_groups.rb
+++ b/db/post_migrate/20220621164914_drop_flair_url_from_groups.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DropFlairUrlFromGroups < ActiveRecord::Migration[7.0]
+  DROPPED_COLUMNS ||= {
+    groups: %i{flair_url}
+  }
+
+  def up
+    DROPPED_COLUMNS.each do |table, columns|
+      Migration::ColumnDropper.execute_drop(table, columns)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
It's already included in the `ignored_columns` list in group model. https://github.com/discourse/discourse/blob/03ffb0bf27d76a47ef5a3049ea76a4240b5dc3b8/app/models/group.rb#L9

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
