### PR TITLE
FIX: Accept HEAD requests for mandrill webhook

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -66,6 +66,12 @@ class WebhooksController < ActionController::Base
     success
   end
 
+  def mandrill_head
+    # Mailchimp sends a HEAD request to validate the webhook before saving
+    # Rails interprets it as a GET request
+    success
+  end
+
   def postmark
     # see https://postmarkapp.com/developer/webhooks/bounce-webhook#bounce-webhook-data
     # and https://postmarkapp.com/developer/api/bounce-api#bounce-types

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -67,7 +67,7 @@ class WebhooksController < ActionController::Base
   end
 
   def mandrill_head
-    # Mailchimp sends a HEAD request to validate the webhook before saving
+    # Mandrill sends a HEAD request to validate the webhook before saving
     # Rails interprets it as a GET request
     success
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Discourse::Application.routes.draw do
     post "webhooks/mailgun"  => "webhooks#mailgun"
     post "webhooks/mailjet"  => "webhooks#mailjet"
     post "webhooks/mandrill" => "webhooks#mandrill"
+    get "webhooks/mandrill" => "webhooks#mandrill_head"
     post "webhooks/postmark" => "webhooks#postmark"
     post "webhooks/sendgrid" => "webhooks#sendgrid"
     post "webhooks/sparkpost" => "webhooks#sparkpost"

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -155,6 +155,14 @@ describe WebhooksController do
     end
   end
 
+  context "mandrill_head" do
+    it "works" do
+      head "/webhooks/mandrill.json"
+
+      expect(response.status).to eq(200)
+    end
+  end
+
   context "postmark" do
     it "works" do
       user = Fabricate(:user, email: email)


### PR DESCRIPTION
When saving a webhook in mandrill, a head request is sent to ensure the webhook is reachable. As Discourse returns a 404, mandrill considers the webhook to not be reachable. This change registers a method to handle those validation requests from mandrill.