### PR TITLE
FIX: 99999 is not a valid TCP port

### DIFF
--- a/spec/lib/rate_limiter_spec.rb
+++ b/spec/lib/rate_limiter_spec.rb
@@ -105,7 +105,8 @@ describe RateLimiter do
 
     context 'handles readonly' do
       before do
-        Discourse.redis.without_namespace.slaveof '10.0.0.1', '99999'
+        # random IP address in the ULA range that does not exist
+        Discourse.redis.without_namespace.slaveof 'fdec:3f5d:d0b7:4c4b:472b:636a:4370:7ac5', '49999'
       end
 
       after do


### PR DESCRIPTION
Future versions of redis will validate this port number causing the tests
relying on this to fail with:

```
Redis::CommandError:
ERR Invalid master port
```

Also change from an IPv4 address that might feasibly be in use to an IPv6
random ULA address that almost *certainly* won't be.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
