### PR TITLE
FIX: Markdown handling failed on empty attribute value

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/upload-protocol.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/upload-protocol.js
@@ -7,7 +7,7 @@ function addImage(uploads, token) {
   if (token.attrs) {
     for (let i = 0; i < token.attrs.length; i++) {
       const value = token.attrs[i][1];
-      if (value?.indexOf("upload://") === 0) {
+      if (value?.startsWith("upload://")) {
         uploads.push({ token, srcIndex: i, origSrc: value });
         break;
       }


### PR DESCRIPTION
Seems to only be a problem when a markdown.it rule inserts links without a attribute value. There's no test, because it's not reproducible with the markdown rules in core.