### PR TITLE
FIX: Better virtual keyboard detect on Android

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -553,6 +553,9 @@ body:not(.ios-safari-composer-hacks) {
       min-height: calc(var(--min-height) - 4em);
     }
     padding-bottom: var(--composer-ipad-padding);
+    padding-bottom: calc(
+      10px + env(keyboard-inset-height) / 2
+    ); // Remove /2 after https://bugs.chromium.org/p/chromium/issues/detail?id=1331275&q=component%3AUI%3EInput%3EVirtualKeyboard&can=2&sort=-opened is fixed and merge
   }
 }
 

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -24,6 +24,9 @@
 
   .keyboard-visible &.open {
     height: 100%; // Android: Reduces composer jumpiness when the keyboard toggles
+    height: calc(
+      100% - (10px + env(keyboard-inset-height) / 2)
+    ); // Remove /2 after https://bugs.chromium.org/p/chromium/issues/detail?id=1331275&q=component%3AUI%3EInput%3EVirtualKeyboard&can=2&sort=-opened is fixed and merge
   }
 
   .keyboard-visible body.ios-safari-composer-hacks &.open {


### PR DESCRIPTION
Firefox has a bug where *sometimes* the visualViewport.height won't be
updated when the keyboard pops up until you scroll, making our composer
stay hidden behind the keyboard. This commit uses both window.innerHeight and  window.visualViewport.height using the minimum of both to check for height changes.

For Chrome/Edge we feature detect the new VirtualKeyboard API and
opt-into it when the composer opens and use it to detect if a keyboard
is being draw. Opting into the API changes how the viewport is
calculated so we have to also change how the full height composer is
calculated. To minimize breakage we opt-out when the composer component
is destroyed.

This commit also moves the `--composer-ipad-padding` to only happen on
iPads.

Bug report at https://meta.discourse.org/t/-/228382


Depends on https://bugs.chromium.org/p/chromium/issues/detail?id=1331275&q=component%3AUI%3EInput%3EVirtualKeyboard&can=2&sort=-opened being fixed.
