### PR TITLE
FIX: In [DELETE] /admin/user/:id.json, parse boolean block_* parameter correctly

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -410,8 +410,10 @@ class Admin::UsersController < Admin::AdminController
     user = User.find_by(id: params[:id].to_i)
     guardian.ensure_can_delete_user!(user)
 
-    options = params.slice(:block_email, :block_urls, :block_ip, :context, :delete_as_spammer)
-    options[:delete_posts] = ActiveModel::Type::Boolean.new.cast(params[:delete_posts])
+    options = params.slice(:context, :delete_as_spammer)
+    [:delete_posts, :block_email, :block_urls, :block_ip].each do |param_name|
+      options[param_name] = ActiveModel::Type::Boolean.new.cast(params[param_name])
+    end
     options[:prepare_for_destroy] = true
 
     hijack do

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -822,7 +822,7 @@ RSpec.describe Admin::UsersController do
       expect(ScreenedEmail.exists?(email: user_emails)).to eq(true)
     end
 
-    it "don't block the e-mails if block_email param is is false" do
+    it "does not block the e-mails if block_email param is is false" do
       user_emails = delete_me.user_emails.pluck(:email)
 
       delete "/admin/users/#{delete_me.id}.json", params: { block_email: false }
@@ -830,7 +830,7 @@ RSpec.describe Admin::UsersController do
       expect(ScreenedEmail.exists?(email: user_emails)).to eq(false)
     end
 
-    it "don't block the e-mails by default" do
+    it "does not block the e-mails by default" do
       user_emails = delete_me.user_emails.pluck(:email)
 
       delete "/admin/users/#{delete_me.id}.json"
@@ -846,7 +846,7 @@ RSpec.describe Admin::UsersController do
       expect(ScreenedIpAddress.exists?(ip_address: ip_address)).to eq(true)
     end
 
-    it "don't block the ip address if block_ip param is false" do
+    it "does not block the ip address if block_ip param is false" do
       ip_address = delete_me.ip_address
 
       delete "/admin/users/#{delete_me.id}.json", params: { block_ip: false }
@@ -854,7 +854,7 @@ RSpec.describe Admin::UsersController do
       expect(ScreenedIpAddress.exists?(ip_address: ip_address)).to eq(false)
     end
 
-    it "don't block the ip address by default" do
+    it "does not block the ip address by default" do
       ip_address = delete_me.ip_address
 
       delete "/admin/users/#{delete_me.id}.json"
@@ -878,13 +878,13 @@ RSpec.describe Admin::UsersController do
         expect(ScreenedUrl.exists?(url: @urls)).to eq(true)
       end
 
-      it "don't block the urls if block_url param is false" do
+      it "does not block the urls if block_url param is false" do
         delete "/admin/users/#{delete_me.id}.json", params: { delete_posts: true, block_urls: false }
         expect(response.status).to eq(200)
         expect(ScreenedUrl.exists?(url: @urls)).to eq(false)
       end
 
-      it "don't block the urls by default" do
+      it "does not block the urls by default" do
         delete "/admin/users/#{delete_me.id}.json", params: { delete_posts: true, block_urls: false }
         expect(response.status).to eq(200)
         expect(ScreenedUrl.exists?(url: @urls)).to eq(false)

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -814,6 +814,96 @@ RSpec.describe Admin::UsersController do
       end
     end
 
+    it "blocks the e-mail if block_email == true" do
+      user_emails = delete_me.user_emails.pluck(:email)
+
+      delete "/admin/users/#{delete_me.id}.json", params: { block_email: true }
+      expect(response.status).to eq(200)
+
+      expect(user_emails.size).to be >= 1
+      expect(ScreenedEmail.where(email: user_emails).count).to eq(user_emails.size)
+    end
+
+    it "don't block the e-mails if block_email == false" do
+      user_emails = delete_me.user_emails.pluck(:email)
+
+      delete "/admin/users/#{delete_me.id}.json", params: { block_email: false }
+      expect(response.status).to eq(200)
+
+      expect(user_emails.size).to be >= 1
+      expect(ScreenedEmail.where(email: user_emails).count).to eq(0)
+    end
+
+    it "don't block the e-mails by default" do
+      user_emails = delete_me.user_emails.pluck(:email)
+
+      delete "/admin/users/#{delete_me.id}.json"
+      expect(response.status).to eq(200)
+
+      expect(user_emails.size).to be >= 1
+      expect(ScreenedEmail.where(email: user_emails).count).to eq(0)
+    end
+
+    it "blocks the ip address if block_ip == true" do
+      ip_address = delete_me.ip_address
+
+      delete "/admin/users/#{delete_me.id}.json", params: { block_ip: true }
+      expect(response.status).to eq(200)
+
+      expect(ScreenedIpAddress.where(ip_address: ip_address).count).to eq(1)
+    end
+
+    it "don't block the ip address if block_ip == false" do
+      ip_address = delete_me.ip_address
+
+      delete "/admin/users/#{delete_me.id}.json", params: { block_ip: false }
+      expect(response.status).to eq(200)
+
+      expect(ScreenedIpAddress.where(ip_address: ip_address).count).to eq(0)
+    end
+
+    it "don't block the ip address by default" do
+      ip_address = delete_me.ip_address
+
+      delete "/admin/users/#{delete_me.id}.json"
+      expect(response.status).to eq(200)
+
+      expect(ScreenedIpAddress.where(ip_address: ip_address).count).to eq(0)
+    end
+
+    context "block_email, block_ip and block_url" do
+      before do
+        @post = Fabricate(:post_with_external_links, user: delete_me)
+        TopicLink.extract_from(@post)
+
+        @urls = TopicLink.where(user: delete_me, internal: false).pluck(:url).map { |url| ScreenedUrl.normalize_url(url) }
+      end
+
+      it "blocks the urls if block_url == true" do
+        delete "/admin/users/#{delete_me.id}.json", params: { delete_posts: true, block_urls: true }
+        expect(response.status).to eq(200)
+
+        expect(@urls.size).to be >= 1
+        expect(ScreenedUrl.where(url: @urls).count).to be >= 1
+      end
+
+      it "don't block the urls if block_url == false" do
+        delete "/admin/users/#{delete_me.id}.json", params: { delete_posts: true, block_urls: false }
+        expect(response.status).to eq(200)
+
+        expect(@urls.size).to be >= 1
+        expect(ScreenedUrl.where(url: @urls).count).to eq(0)
+      end
+
+      it "don't block the urls by default" do
+        delete "/admin/users/#{delete_me.id}.json", params: { delete_posts: true, block_urls: false }
+        expect(response.status).to eq(200)
+
+        expect(@urls.size).to be >= 1
+        expect(ScreenedUrl.where(url: @urls).count).to eq(0)
+      end
+    end
+
     it "deletes the user record" do
       delete "/admin/users/#{delete_me.id}.json"
       expect(response.status).to eq(200)


### PR DESCRIPTION
When calling the API to delete a user:

```
curl -X DELETE "https://discourse.example.com/admin/users/159.json" \
-H "Content-Type: multipart/form-data;" \
-H "Api-Key: ***" \
-H "Api-Username: ***" \
-F "delete_posts=true" \
-F "block_email=false" \
-F "block_urls=false" \
-F "block_ip=false"
```

Setting the parameters `block_email`, `block_urls` and `block_ip`explicitly to `false` did not work because the values weren't being parsed to boolean. 