### PR TITLE
UX: Truncate long category names in sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/sidebar/section-link.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar/section-link.hbs
@@ -7,7 +7,9 @@
     @current-when={{@currentWhen}}
     @title={{@title}}
   >
-    {{@content}}
+    <span class="sidebar-section-link-content-text">
+      {{@content}}
+    </span>
 
     {{#if @badgeText}}
       <span class="sidebar-section-link-content-badge">

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -84,13 +84,11 @@
 
   .sidebar-section-link-wrapper {
     margin-left: 1.5em;
-    display: flex;
-    align-items: center;
   }
 
   .sidebar-section-link {
-    flex: 1 1 0;
     display: flex;
+    align-items: center;
     padding: 0.25em 0.5em;
     color: var(--primary-high);
     font-size: var(--font-down-1);
@@ -104,8 +102,24 @@
       font-weight: bold;
     }
 
-    .badge-wrapper {
-      font-size: 100%;
+    .sidebar-section-link-content-badge {
+      width: 30%;
+      text-align: right;
+    }
+
+    .sidebar-section-link-content-text {
+      width: 70%;
+
+      .badge-wrapper {
+        font-size: 100%;
+        width: 100%;
+
+        .category-name {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Before 

![Screenshot from 2022-06-22 15-23-55](https://user-images.githubusercontent.com/4335742/174968920-05db1ff5-20a1-42f6-8aa8-e0972001a28a.png)


### After

![Screenshot from 2022-06-22 15-23-46](https://user-images.githubusercontent.com/4335742/174968941-2a3a9ecc-f775-493f-85f6-e2a598f16b81.png)
