### PR TITLE
UX: Change the background color of the user status bubble

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -437,7 +437,7 @@ table {
   justify-content: center;
   width: 1.25em;
   height: 1.25em;
-  background-color: var(--tertiary-low);
+  background-color: var(--secondary);
   border-radius: 50%;
 
   .emoji {


### PR DESCRIPTION
We have changed the default user status emoji from 📣 to 💬. Turned out that the new default emoji doesn't play well with the user status bubble on the avatar. This PR makes it a bit better. Note that this is a temporary fix, since we're going to move the status emoji to a new place and remove that bubble completely.

Before:

<img width="79" alt="Screenshot 2022-06-22 at 19 10 12" src="https://user-images.githubusercontent.com/1274517/175067151-fe485e6d-ed9f-4210-b424-0737243becff.png">

After:

<img width="74" alt="Screenshot 2022-06-22 at 19 09 56" src="https://user-images.githubusercontent.com/1274517/175067190-9e62efb9-bc65-4566-9755-d124d6d5f92c.png">

