### PR TITLE
FIX: darkMode availiability detection was broken

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -70,9 +70,8 @@ export default {
     }
 
     session.darkModeAvailable =
-      document.head.querySelectorAll(
-        'link[media="(prefers-color-scheme: dark)"]'
-      ).length > 0;
+      document.querySelectorAll('link[media="(prefers-color-scheme: dark)"]')
+        .length > 0;
 
     session.defaultColorSchemeIsDark = setupData.colorSchemeIsDark === "true";
 


### PR DESCRIPTION
This regressed on 2f66eb5 where CSS was moved from the HTML document
head to the body.

Bug report at https://meta.discourse.org/t/-/230656?u=falco
