### PR TITLE
UX: improve group page grid scaling

### DIFF
--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -29,17 +29,9 @@
 .groups-boxes {
   display: grid;
   grid-gap: 1em;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(16em, 1fr));
   margin: 1em 0;
   width: 100%;
-
-  @include breakpoint("medium") {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  @include breakpoint("mobile-extra-large") {
-    grid-template-columns: repeat(2, 1fr);
-  }
 
   .group-box {
     display: flex;


### PR DESCRIPTION
This uses auto-fit combined with minmax to determine the number of columns and content width automagically. :sparkles: 


`auto-fit` says "fit as many columns as possible" 

`minmax` says "columns can't be less than 16em wide, or more than 1fr wide" 

This allows us to drop the media queries and prevents columns getting too narrow at various points like this: 

<img width="169" alt="Screen Shot 2022-06-22 at 4 53 52 PM" src="https://user-images.githubusercontent.com/1681963/175134245-7a3ab01e-0fd3-46e7-bbbb-99f79f1944f2.png">

