### PR TITLE
DEV: Fix flaky admin badges.json api docs spec

### DIFF
--- a/spec/requests/api/badges_spec.rb
+++ b/spec/requests/api/badges_spec.rb
@@ -3,8 +3,8 @@ require 'swagger_helper'
 
 describe 'badges' do
 
-  let(:admin) { Fabricate(:admin) }
-  let(:badge) { Fabricate(:badge) }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:badge) { Fabricate(:badge) }
 
   before do
     Jobs.run_immediately!

--- a/spec/requests/api/schemas/json/badge_list_response.json
+++ b/spec/requests/api/schemas/json/badge_list_response.json
@@ -78,7 +78,10 @@
               "type": "boolean"
             },
             "i18n_name": {
-              "type": "string"
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "badge_type_id": {
               "type": "integer"
@@ -105,7 +108,6 @@
             "target_posts",
             "auto_revoke",
             "show_posts",
-            "i18n_name",
             "badge_type_id"
           ]
         }


### PR DESCRIPTION
This commit is to fix this incredibly vague error message:

```
Failure/Error: expect(valid).to eq(true)

  expected: true
       got: false
```

From this test:

> Assertion: badges /admin/badges.json get success response behaves like
> a JSON endpoint response body matches the documented response schema

I was finally able to repro locally using parallel tests:

```
RAILS_ENV=test bundle exec ./bin/turbo_rspec
```

I *think* the parallel tests might be swallowing the `puts` output, but
when I also specified the individual spec file

```
RAILS_ENV=test bundle exec ./bin/turbo_rspec spec/requests/api/badges_spec.rb
```

It revealed the issue:

```
VALIDATION DETAILS: {"missing_keys"=>["i18n_name"]}
```

``` ruby
# admin_badge_serializer.rb
...
  def include_i18n_name?
    object.system?
  end
```

Looks like if the "system" user isn't being used the `i18n_name` won't
be returned in the json response so we shouldn't mark it as a required
attribute.
