### PR TITLE
DEV: Stabilize watched words order

### DIFF
--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -21,6 +21,7 @@ class WordWatcher
     words = WatchedWord
       .where(action: WatchedWord.actions[action.to_sym])
       .limit(WatchedWord::MAX_WORDS_PER_ACTION)
+      .order(:id)
 
     if WatchedWord.has_replacement?(action.to_sym)
       words.pluck(:word, :replacement).to_h


### PR DESCRIPTION
Fixes a flaky spec:

```
  1) WordWatcher.word_matcher_regexp format of the result regexp is correct when watched_words_regular_expressions = true
     Failure/Error: expect(regexp.inspect).to eq("/(#{word1})|(#{word2})/i")

       expected: "/(word35)|(word36)/i"
            got: "/(word36)|(word35)/i"

       (compared using ==)
     # ./spec/services/word_watcher_spec.rb:19:in `block (4 levels) in <main>'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
