### PR TITLE
DEV: Run ember-htmlbars-inline-precompile-codemod

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -1,5 +1,5 @@
+import { hbs } from "ember-cli-htmlbars";
 import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import {
   acceptance,
   controllerFor,
@@ -8,7 +9,6 @@ import {
 import { click, settled, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
 import showModal from "discourse/lib/show-modal";
 
 acceptance("Modal", function (needs) {

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import {
   acceptance,
   count,
@@ -7,7 +8,6 @@ import {
 import { click, visit } from "@ember/test-helpers";
 import { action } from "@ember/object";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";
-import hbs from "htmlbars-inline-precompile";
 import { test } from "qunit";
 
 const PREFIX = "javascripts/single-test/connectors";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import {
   acceptance,
   exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -1,10 +1,10 @@
+import { hbs } from "ember-cli-htmlbars";
 import {
   acceptance,
   count,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import { clearCache } from "discourse/lib/plugin-connectors";
-import hbs from "htmlbars-inline-precompile";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import {
   acceptance,
   count,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | ace-editor", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/activation-controls-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/activation-controls-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | activation-controls",

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -8,7 +9,6 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 import pretender from "discourse/tests/helpers/create-pretender";
 
 discourseModule("Integration | Component | admin-report", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import I18n from "I18n";
 import { click } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/avatar-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/avatar-uploader-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   createFile,
   discourseModule,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | avatar-uploader", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-button-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | badge-button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
@@ -1,10 +1,10 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import EmberObject from "@ember/object";
 import { click } from "@ember/test-helpers";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import pretender from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-icon-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-icon-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import Bookmark from "discourse/models/bookmark";
 import I18n from "I18n";
 import { formattedReminderTime } from "discourse/lib/bookmark";
@@ -5,7 +6,6 @@ import { tomorrow } from "discourse/lib/time-utils";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-import hbs from "htmlbars-inline-precompile";
 import {
   discourseModule,
   exists,

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | bookmark", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/category-badge-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import Category from "discourse/models/category";
 
 discourseModule("Integration | Component | category-badge", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { resetCache } from "pretty-text/upload-short-url";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -9,7 +10,6 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { triggerKeyEvent } from "@ember/test-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | d-button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import { click, fillIn, settled } from "@ember/test-helpers";
 import componentTest, {
   setupRenderingTest,
@@ -16,7 +17,6 @@ import {
 import I18n from "I18n";
 import { clearToolbarCallbacks } from "discourse/components/d-editor";
 import formatTextWithSelection from "discourse/tests/helpers/d-editor-helper";
-import hbs from "htmlbars-inline-precompile";
 import { next } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-icon-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-icon-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -5,7 +6,6 @@ import {
   discourseModule,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | d-icon", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/d-navigation-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-navigation-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import { click } from "@ember/test-helpers";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | d-navigation", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/d-popover-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-popover-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { showPopover } from "discourse/lib/d-popover";
 import { click, triggerKeyEvent } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 function dateInput() {
   return query(".date-picker");

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 function fromDateInput() {
   return query(".from.d-date-time-input .date-picker");

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 function dateInput() {
   return query(".date-picker");

--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-picker-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { click } from "@ember/test-helpers";
 
 discourseModule("Integration | Component | emoji-picker", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   createFile,
   discourseModule,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { fillIn } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/empty-state-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/empty-state-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | empty-state", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/flat-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/flat-button-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { click, triggerKeyEvent } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | flat-button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/future-date-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/future-date-input-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import componentTest, {
   setupRenderingTest,
@@ -8,7 +9,6 @@ import {
   fakeTime,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import I18n from "I18n";
 import { fillIn } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
@@ -1,11 +1,11 @@
+import { hbs } from "ember-cli-htmlbars";
 import EmberObject from "@ember/object";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 
+import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | group-list site-setting",

--- a/app/assets/javascripts/discourse/tests/integration/components/group-membership-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-membership-button-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import {
   count,
   discourseModule,
@@ -6,7 +7,6 @@ import {
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | group-membership-button",

--- a/app/assets/javascripts/discourse/tests/integration/components/hidden-details-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/hidden-details-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import I18n from "I18n";
 import { click } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -5,7 +6,6 @@ import {
   discourseModule,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 const LONG_CODE_BLOCK = "puts a\n".repeat(15000);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/html-safe-helper-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/html-safe-helper-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | html-safe-helper", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -5,7 +6,6 @@ import {
   discourseModule,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | iframed-html", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/input-size-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/input-size-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
+
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | consistent input/dropdown/button sizes",

--- a/app/assets/javascripts/discourse/tests/integration/components/invite-panel-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/invite-panel-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import { set } from "@ember/object";
 import { click } from "@ember/test-helpers";
 import User from "discourse/models/user";
@@ -11,7 +12,6 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | invite-panel", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/load-more-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/load-more-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { configureEyeline } from "discourse/lib/eyeline";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | load-more", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/pending-post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/pending-post-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-import hbs from "htmlbars-inline-precompile";
 import createStore from "discourse/tests/helpers/create-store";
 
 discourseModule("Integration | Component | pending-post", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/relative-time-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/relative-time-picker-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 discourseModule(

--- a/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import { click, fillIn } from "@ember/test-helpers";
 import componentTest, {
   setupRenderingTest,
@@ -9,7 +10,6 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | secret-value-list",

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/api-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/api-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -10,7 +11,6 @@ import selectKit, {
   setDefaultState,
 } from "discourse/tests/helpers/select-kit-helper";
 import { clearCallbacks } from "select-kit/mixins/plugin-api";
-import hbs from "htmlbars-inline-precompile";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 discourseModule("Integration | Component | select-kit:api", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -1,10 +1,10 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import I18n from "I18n";
 import createStore from "discourse/tests/helpers/create-store";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 discourseModule(

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import {
   ALL_CATEGORIES_ID,
   NO_CATEGORIES_ID,
@@ -9,7 +10,6 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import Category from "discourse/models/category";
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { set } from "@ember/object";
 import sinon from "sinon";

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const DEFAULT_CONTENT = [

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/dropdown-select-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/dropdown-select-box-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const DEFAULT_CONTENT = [

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/host-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/host-list-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | site-setting | host-list",

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/list-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/list-setting-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 discourseModule(

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -7,7 +8,6 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 discourseModule(

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const DEFAULT_CONTENT = [

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/notifications-button-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -5,7 +6,6 @@ import selectKit, {
   setDefaultState,
 } from "discourse/tests/helpers/select-kit-helper";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | select-kit/notifications-button",

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import Topic from "discourse/models/topic";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const buildTopic = function (pinned = true) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import I18n from "I18n";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const DEFAULT_CONTENT = [

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
@@ -1,10 +1,10 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import I18n from "I18n";
 import Site from "discourse/models/site";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import pretender from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { set } from "@ember/object";

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -7,7 +8,6 @@ import {
   discourseModule,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const buildTopic = function (opts) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
@@ -1,10 +1,10 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import I18n from "I18n";
 import Topic from "discourse/models/topic";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const buildTopic = function (archetype) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/user-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/user-chooser-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 discourseModule(

--- a/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import { click, fillIn, triggerKeyEvent } from "@ember/test-helpers";
 import componentTest, {
   setupRenderingTest,
@@ -8,7 +9,6 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | simple-list", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -7,7 +8,6 @@ import {
   exists,
 } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
-import hbs from "htmlbars-inline-precompile";
 import { click } from "@ember/test-helpers";
 
 discourseModule("Integration | Component | site-header", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/slow-mode-info-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/slow-mode-info-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   discourseModule,
   exists,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | slow-mode-info", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -8,7 +9,6 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { fillIn } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 import sinon from "sinon";
 
 discourseModule("Integration | Component | text-field", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/themes-list-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/themes-list-item-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import I18n from "I18n";
 import Theme from "admin/models/theme";
 import componentTest, {
@@ -8,7 +9,6 @@ import {
   discourseModule,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | themes-list-item", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/themes-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/themes-list-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import Theme, { COMPONENTS, THEMES } from "admin/models/theme";
 import I18n from "I18n";
 import componentTest, {
@@ -10,7 +11,6 @@ import {
   query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { click, fillIn } from "@ember/test-helpers";
 
 function createThemes(itemsCount, customAttributesCallback) {

--- a/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 function setTime(time) {

--- a/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -9,7 +10,6 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
 import { click } from "@ember/test-helpers";
 
 discourseModule(

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-list-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-list-item-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import Topic from "discourse/models/topic";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | topic-list-item", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-list-test.js
@@ -1,10 +1,10 @@
+import { hbs } from "ember-cli-htmlbars";
 import { click } from "@ember/test-helpers";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import Topic from "discourse/models/topic";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | topic-list", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/uppy-image-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/uppy-image-uploader-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -7,7 +8,6 @@ import {
   exists,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | uppy-image-uploader",

--- a/app/assets/javascripts/discourse/tests/integration/components/user-avatar-flair-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-avatar-flair-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { resetFlair } from "discourse/lib/avatar-flair";
 
 function setupSiteGroups(that) {

--- a/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
@@ -1,7 +1,7 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-import hbs from "htmlbars-inline-precompile";
 import {
   discourseModule,
   exists,

--- a/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 function paste(element, text) {
   let e = new Event("paste");

--- a/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -7,7 +8,6 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 discourseModule("Integration | Component | value-list", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -5,7 +6,6 @@ import {
   createFile,
   discourseModule,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { click, waitFor } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/wizard-invite-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/wizard-invite-list-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import {
   count,
   discourseModule,
@@ -7,7 +8,6 @@ import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { click, fillIn } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Wizard | invite-list",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/actions-summary-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/actions-summary-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { count, discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | actions-summary",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/avatar-flair-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/avatar-flair-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | avatar-flair",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/button-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | Widget | button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/default-notification-item-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -8,7 +9,6 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import EmberObject from "@ember/object";
-import hbs from "htmlbars-inline-precompile";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { settled } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/hamburger-menu-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -8,7 +9,6 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import { NotificationLevels } from "discourse/lib/notification-levels";
-import hbs from "htmlbars-inline-precompile";
 
 const topCategoryIds = [2, 3, 1];
 let mutedCategoryIds = [];

--- a/app/assets/javascripts/discourse/tests/integration/widgets/header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/header-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | Widget | header", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/widgets/home-logo-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/home-logo-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -8,7 +9,6 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import Session from "discourse/models/session";
-import hbs from "htmlbars-inline-precompile";
 
 const bigLogo = "/images/d-logo-sketch.png?test";
 const smallLogo = "/images/d-logo-sketch-small.png?test";

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-links-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-links-test.js
@@ -1,9 +1,9 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { count, discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | post-links",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-menu-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   discourseModule,
   exists,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { resetPostMenuExtraButtons } from "discourse/widgets/post-menu";
 import { withPluginApi } from "discourse/lib/plugin-api";
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-small-action-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-small-action-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | post-small-action",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-stream-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -8,7 +9,6 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import Post from "discourse/models/post";
 import Topic from "discourse/models/topic";
-import hbs from "htmlbars-inline-precompile";
 
 function postStreamTest(name, attrs) {
   componentTest(name, {

--- a/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/post-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -10,7 +11,6 @@ import {
 import EmberObject from "@ember/object";
 import I18n from "I18n";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule("Integration | Component | Widget | post", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/widgets/poster-name-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/poster-name-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | poster-name",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/quick-access-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/quick-access-item-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 const CONTENT_DIV_SELECTOR = "li > a > div";
 

--- a/app/assets/javascripts/discourse/tests/integration/widgets/small-user-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/small-user-list-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -6,7 +7,6 @@ import {
   discourseModule,
   exists,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | small-user-list",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/software-update-prompt-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/software-update-prompt-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -7,7 +8,6 @@ import {
   exists,
   publishToMessageBus,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import { later } from "@ember/runloop";
 
 discourseModule(

--- a/app/assets/javascripts/discourse/tests/integration/widgets/topic-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/topic-admin-menu-test.js
@@ -1,10 +1,10 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
 import Category from "discourse/models/category";
 import Topic from "discourse/models/topic";
-import hbs from "htmlbars-inline-precompile";
 
 const createArgs = (topic) => {
   return {

--- a/app/assets/javascripts/discourse/tests/integration/widgets/topic-participant-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/topic-participant-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | topic-participant",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/topic-status-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/topic-status-test.js
@@ -1,10 +1,10 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
 import { click } from "@ember/test-helpers";
 import TopicStatusIcons from "discourse/helpers/topic-status-icons";
-import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
   "Integration | Component | Widget | topic-status",

--- a/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -10,7 +11,6 @@ import {
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 import sinon from "sinon";
 
 discourseModule(

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-dropdown-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -9,7 +10,6 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { click } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 const DEFAULT_CONTENT = {
   content: [

--- a/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/widget-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -12,7 +13,6 @@ import I18n from "I18n";
 import { Promise } from "rsvp";
 import { click } from "@ember/test-helpers";
 import { createWidget } from "discourse/widgets/widget";
-import hbs from "htmlbars-inline-precompile";
 import widgetHbs from "discourse/widgets/hbs-compiler";
 import { next } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
@@ -1,3 +1,4 @@
+import { hbs } from "ember-cli-htmlbars";
 import Component from "@ember/component";
 import { clearRender } from "@ember/test-helpers";
 import discourseComputed, {
@@ -7,7 +8,6 @@ import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 
 const fooComponent = Component.extend({
   classNames: ["foo-component"],

--- a/app/assets/javascripts/discourse/tests/unit/utils/dom-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/dom-utils-test.js
@@ -1,8 +1,8 @@
+import { hbs } from "ember-cli-htmlbars";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
 import domUtils from "discourse-common/utils/dom-utils";
 
 discourseModule("utils:dom-utils", function (hooks) {


### PR DESCRIPTION
See https://github.com/ember-cli/ember-cli-htmlbars#tagged-template-usage--migrating-from-htmlbars-inline-precompile

The one remaining place using htmlbars-inline-precompile is the poll plugin. For reasons I haven't yet determined it cannot access ember-cli-htmlbars.