### PR TITLE
UX: Makes splash screen site setting visible

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2426,7 +2426,6 @@ uncategorized:
 
   splash_screen:
     default: false
-    hidden: true
 
   suggest_weekends_in_date_pickers:
     client: true


### PR DESCRIPTION
The setting was previously hidden but we're now in a state where we want admins to see and experiment with it.