### PR TITLE
FIX: Defer removing the splash screen until the window load event fires

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -82,8 +82,14 @@ const Discourse = Application.extend({
       });
     });
 
-    // The app booted. Remove the splash screen
-    document.querySelector("#d-splash")?.remove();
+    window.addEventListener(
+      "load",
+      (event) => {
+        // The app booted. Remove the splash screen
+        document.querySelector("#d-splash")?.remove();
+      },
+      { once: true }
+    );
   },
 
   _registerPluginCode(version, code) {

--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -84,7 +84,7 @@ const Discourse = Application.extend({
 
     window.addEventListener(
       "load",
-      (event) => {
+      () => {
         // The app booted. Remove the splash screen
         document.querySelector("#d-splash")?.remove();
       },


### PR DESCRIPTION
There's an obscure bug where really slow devices end up removing the splash screen before they're finished parsing all of the Discourse assets. 

This PR won't impact fast devices but should hopefully prevent the premature removal of the splash on super slow devices.