### PR TITLE
FIX: Uninitialized class variable error in sidekiq

### DIFF
--- a/app/jobs/base.rb
+++ b/app/jobs/base.rb
@@ -100,7 +100,7 @@ module Jobs
 
         @@log_queue ||= Queue.new
 
-        if !@@log_thread || !@@log_thread.alive?
+        if !defined?(@@log_thread) || !@@log_thread.alive?
           @@log_thread = Thread.new do
             loop do
               @@logger << @@log_queue.pop


### PR DESCRIPTION
Follow-up to 4199ada1ce341212e3d2d4890074db9de018d7a4