### PR TITLE
FIX: Remove splash screen in no-js view take 2

### DIFF
--- a/app/views/common/_discourse_splash.html.erb
+++ b/app/views/common/_discourse_splash.html.erb
@@ -3,7 +3,6 @@
   <style>
     html {
       background: var(--secondary);
-      overflow: hidden !important;
     }
 
     #d-splash {
@@ -29,6 +28,7 @@
       animation: fade-in 0.5s ease-in-out;
       animation-delay: 2.5s;
       animation-fill-mode: forwards;
+      color: var(--primary);
     }
 
     #d-splash .preloader-text:after {
@@ -79,5 +79,17 @@
   <div class="preloader-text">
     <span> <%= I18n.t("js.preloader_text") %> </span>
   </div>
+
+  <noscript>
+    <style>
+      html {
+        background: revert;
+      }
+
+      #d-splash {
+        display: none;
+      }
+    </style>
+  </noscript>
 </section>
 <%- end %>


### PR DESCRIPTION
Take 2 of this one #17223

Posting the same message here

We use javascript to remove the splash screen when the site boots up. If the user has js disabled, they get stuck on the splash screen.

If the user has js disabled. We don't show the splash screen at all.
