### PR TITLE
DEV: Fix flaky tests caused by timezone updates

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -3,6 +3,7 @@ import Group from "discourse/models/group";
 import User from "discourse/models/user";
 import PreloadStore from "discourse/lib/preload-store";
 import sinon from "sinon";
+import { settled } from "@ember/test-helpers";
 
 module("Unit | Model | user", function () {
   test("staff", function (assert) {
@@ -77,7 +78,7 @@ module("Unit | Model | user", function () {
     assert.deepEqual(user.calculateMutedIds(1, 1, "muted_category_ids"), []);
   });
 
-  test("createCurrent() guesses timezone if user doesn't have it set", function (assert) {
+  test("createCurrent() guesses timezone if user doesn't have it set", async function (assert) {
     PreloadStore.store("currentUser", {
       username: "eviltrout",
       timezone: null,
@@ -88,6 +89,8 @@ module("Unit | Model | user", function () {
     const currentUser = User.createCurrent();
 
     assert.deepEqual(currentUser.timezone, expectedTimezone);
+
+    await settled(); // `User` sends a request to save the timezone
   });
 
   test("createCurrent() doesn't guess timezone if user has it already set", function (assert) {


### PR DESCRIPTION
Hopefully fixes flakes like:

```
not ok 1123 Chrome 102.0 - [undefined ms] - Global error: Uncaught Error: Unhandled request in test environment: /forum/u/eviltrout.json (PUT) at http://localhost:7357/assets/vendor.js, line 38378
 While executing test: Unit | Utility | click-track: routes to absolute internal urls
    ---
        browser log: |
            {"type":"error","text":"Unhandled request in test environment: /forum/u/eviltrout.json (PUT)"}
            {"type":"error","text":"Uncaught Error: Unhandled request in test environment: /forum/u/eviltrout.json (PUT) at http://localhost:7357/assets/vendor.js, line 38378\n","testContext":{"id":1123,"name":"Unit | Utility | click-track: routes to absolute internal urls","items":[],"state":"executing"}}
    ...
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
