### PR TITLE
UX: allow mobile topic-list date to be tapped

### DIFF
--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -161,8 +161,11 @@
   }
 
   .topic-item-stats {
-    // disabling clicks because these targets are too small on mobile
-    pointer-events: none;
+    .category,
+    .discourse-tags {
+      // disabling clicks because these targets are too small on mobile
+      pointer-events: none;
+    }
     position: relative;
     display: flex;
     align-items: baseline;


### PR DESCRIPTION
Previously this prevented the date in the mobile topic list from being tappable because it's a small tap target like the category and tags... 

But after reviewing a customer complaint about the change, the date has much more space around it than categories and tags, so I think it's ok to make it tappable... it's much less likely to be mis-tapped. 