### PR TITLE
FIX: Improve mixcloud oneboxing

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -826,13 +826,15 @@ aside.onebox.mixcloud-preview {
   padding: 0;
   border: 0;
   height: 120px;
-  background-color: #1C1F21;
+  background-color: #1c1f21;
   article.onebox-body img {
     padding: 0;
     max-height: 120px;
   }
   .onebox-body {
-    a[href], a[href]:visited, a[href]:hover {
+    a[href],
+    a[href]:visited,
+    a[href]:hover {
       color: #d1d1d1;
     }
     .video-icon {
@@ -854,7 +856,7 @@ aside.onebox.mixcloud-preview {
       }
       h4 {
         font-size: 12px;
-        font-weight: 200;  
+        font-weight: 200;
       }
       color: gray;
     }
@@ -967,4 +969,3 @@ aside.onebox.preview-error .site-icon {
   height: 16px;
   margin-right: 0.5em;
 }
-

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -836,12 +836,14 @@ aside.onebox.mixcloud-preview {
       color: #d1d1d1;
     }
     .video-icon {
-      top: 32px;
-      right: unset;
-      height: 24px;
+      position: relative;
+      top: 17px;
+      height: 100%;
+      float: left;
+      padding-left: 6px;
     }
     .mixcloud-text {
-      padding-left: 180px;
+      padding-left: 170px;
       font-family: sans-serif;
       h3 {
         font-size: 13px;

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -822,6 +822,43 @@ aside.onebox.xkcd .onebox-body img {
   @extend .imgur-album;
 }
 
+aside.onebox.mixcloud-preview {
+  padding: 0;
+  border: 0;
+  height: 120px;
+  background-color: #1C1F21;
+  article.onebox-body img {
+    padding: 0;
+    max-height: 120px;
+  }
+  .onebox-body {
+    a[href], a[href]:visited, a[href]:hover {
+      color: #d1d1d1;
+    }
+    .video-icon {
+      top: 32px;
+      right: unset;
+      height: 24px;
+    }
+    .mixcloud-text {
+      padding-left: 180px;
+      font-family: sans-serif;
+      h3 {
+        font-size: 13px;
+        font-weight: 300;
+        margin: 0;
+        padding-top: 15px;
+        height: 20px;
+      }
+      h4 {
+        font-size: 12px;
+        font-weight: 200;  
+      }
+      color: gray;
+    }
+  }
+}
+
 @supports (aspect-ratio: 1) {
   // Not supported on iOS < 15. For those devices, we just
   // use the fixed width/height attributes on the iframe
@@ -928,3 +965,4 @@ aside.onebox.preview-error .site-icon {
   height: 16px;
   margin-right: 0.5em;
 }
+

--- a/lib/onebox/engine/mixcloud_onebox.rb
+++ b/lib/onebox/engine/mixcloud_onebox.rb
@@ -8,10 +8,23 @@ module Onebox
 
       matches_regexp(/^https?:\/\/www\.mixcloud\.com\//)
       always_https
+      requires_iframe_origins "https://www.mixcloud.com"
 
       def placeholder_html
         oembed = get_oembed
-        "<img src='#{oembed.image}' height='#{oembed.height}' #{oembed.title_attr}>"
+
+        <<-HTML
+          <aside class="onebox mixcloud-preview">
+            <article class="onebox-body">
+              <img src="#{oembed.image}">
+              <span class="video-icon"></span>
+              <div class="mixcloud-text">
+                <h3><a href="#{oembed.url}" target="_blank" rel="nofollow ugc noopener">#{oembed.title}</a></h3>
+                <h4>#{oembed.author_name}</h4>
+              </div>   
+            </article>
+          </aside>
+        HTML
       end
 
       def to_html

--- a/lib/onebox/engine/mixcloud_onebox.rb
+++ b/lib/onebox/engine/mixcloud_onebox.rb
@@ -19,10 +19,9 @@ module Onebox
               <img src="#{oembed.image}">
               <div class="video-icon"></div>
               <div class="mixcloud-text">
-                
                 <h3><a href="#{oembed.url}" target="_blank" rel="nofollow ugc noopener">#{oembed.title}</a></h3>
                 <h4>#{oembed.author_name}</h4>
-              </div>   
+              </div>
             </article>
           </aside>
         HTML

--- a/lib/onebox/engine/mixcloud_onebox.rb
+++ b/lib/onebox/engine/mixcloud_onebox.rb
@@ -17,8 +17,9 @@ module Onebox
           <aside class="onebox mixcloud-preview">
             <article class="onebox-body">
               <img src="#{oembed.image}">
-              <span class="video-icon"></span>
+              <div class="video-icon"></div>
               <div class="mixcloud-text">
+                
                 <h3><a href="#{oembed.url}" target="_blank" rel="nofollow ugc noopener">#{oembed.title}</a></h3>
                 <h4>#{oembed.author_name}</h4>
               </div>   


### PR DESCRIPTION

- Sets `https://www.mixcloud.com` as a `requires_iframe_origins` to allow the iframe content to be displayed
- Attempts to render something approximating the Mixcloud content in the preview pane of the Composer, rather than just displaying a large version of the artwork associated with the link