### PR TITLE
FIX: Defer removing the splash screen until the window load event fires take 3

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -82,8 +82,14 @@ const Discourse = Application.extend({
       });
     });
 
-    // The app booted. Remove the splash screen
-    document.querySelector("#d-splash")?.remove();
+    window.addEventListener(
+      "load",
+      () => {
+        // The app booted. Remove the splash screen
+        document.querySelector("#d-splash")?.remove();
+      },
+      { once: true }
+    );
   },
 
   _registerPluginCode(version, code) {

--- a/app/views/common/_discourse_splash.html.erb
+++ b/app/views/common/_discourse_splash.html.erb
@@ -2,15 +2,20 @@
 <section id="d-splash">
   <style>
     html {
-      background: var(--secondary);
+      overflow-y: hidden !important;
     }
 
     #d-splash {
       display: grid;
       place-items: center;
-      position: relative;
       backface-visibility: hidden;
-      will-change: transform;
+      position: absolute;
+      left: 0;
+      top: 0;
+      height: 100%;
+      width: 100%;
+      z-index: 1001; /* above the header */
+      background: var(--secondary);
     }
 
     #d-splash .preloader-image {
@@ -20,28 +25,22 @@
 
     #d-splash .preloader-text {
       padding-top: 4em;
-      position: absolute;
-      display: grid;
-      grid-auto-flow: column;
-      place-items: center;
-      opacity: 0;
-      animation: fade-in 0.5s ease-in-out;
-      animation-delay: 2.5s;
-      animation-fill-mode: forwards;
-      color: var(--primary);
+          position: absolute;
+          opacity: 0;
+          animation: fade-in 0.5s ease-in-out;
+          animation-delay: 2.5s;
+          animation-fill-mode: forwards;
+          color: var(--primary);
     }
 
     #d-splash .preloader-text:after {
       animation: loading-text 3s infinite;
       content: "";
       position: absolute;
-      top: 4em;
       margin: 0 0.1em;
-      left: 100%;
     }
 
     .rtl #d-splash .preloader-text:after {
-      left: 0;
       right: 100%;
     }
 
@@ -72,7 +71,7 @@
 
   <img
     class="preloader-image"
-    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.1' data-ember-extension='1'%0A%3E%3Cstyle%3E :root %7B /* these need to be injected dynamicly to match theme colors */ --primary: %23222222; --secondary: %23ffffff; --tertiary: %23f15c21; --highlight: %23f0ea88; --quaternary: %2365ccff; --success: %23009900; %7D /* these styles need to live here because the SVG has a different scope */ .dots %7B animation-name: loader; animation-timing-function: ease-in-out; animation-duration: 3s; animation-iteration-count: infinite; animation-delay: 1.5s; stroke: %23fff; stroke-width: 0.5px; transform-origin: center; opacity: 0; r: max(1vw, 11px); cy: 50%25; %7D .dots:first-child %7B fill: var(--tertiary); animation-delay: 1s; %7D .dots:nth-child(2) %7B fill: var(--tertiary); animation-delay: 1.1s; %7D .dots:nth-child(3) %7B fill: var(--highlight); animation-delay: 1.2s; %7D .dots:nth-child(4) %7B fill: var(--quaternary); animation-delay: 1.3s; %7D .dots:nth-child(5) %7B fill: var(--quaternary); animation-delay: 1.4s; %7D @keyframes loader %7B 15%25 %7B opacity: 0; transform: scale(1); %7D 45%25 %7B opacity: 1; transform: scale(0.7); %7D 65%25 %7B opacity: 1; transform: scale(0.7); %7D 95%25 %7B opacity: 0; transform: scale(1); %7D %7D %3C/style%3E%3Cg class='container'%3E%3Ccircle class='dots' cx='30vw' /%3E%3Ccircle class='dots' cx='40vw' /%3E%3Ccircle class='dots' cx='50vw' /%3E%3Ccircle class='dots' cx='60vw' /%3E%3Ccircle class='dots' cx='70vw' /%3E%3C/g%3E%3C/svg%3E%0A"
+    src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.1' data-ember-extension='1'%3E%3Cstyle%3E /* these need to be injected dynamicly to match theme colors */ :root %7B --primary: %23222222; --secondary: %23ffffff; --tertiary: %23f15c21; --highlight: %23f0ea88; --quaternary: %2365ccff; --success: %23009900; %7D /* these styles need to live here because the SVG has a different scope */ .dots %7B animation-name: loader; animation-timing-function: ease-in-out; animation-duration: 3s; animation-iteration-count: infinite; animation-delay: 1.5s; stroke: %23fff; stroke-width: 0.5px; transform-origin: center; opacity: 0; r: max(1vw, 11px); cy: 50%25; %7D .dots:first-child %7B fill: var(--tertiary); animation-delay: 1.25s; %7D .dots:nth-child(2) %7B fill: var(--tertiary); animation-delay: 1.35s; %7D .dots:nth-child(3) %7B fill: var(--highlight); animation-delay: 1.45s; %7D .dots:nth-child(4) %7B fill: var(--quaternary); animation-delay: 1.55s; %7D .dots:nth-child(5) %7B fill: var(--quaternary); animation-delay: 1.65s; %7D @keyframes loader %7B 0%25 %7B opacity: 0; transform: scale(1); %7D 45%25 %7B opacity: 1; transform: scale(0.7); %7D 65%25 %7B opacity: 1; transform: scale(0.7); %7D 100%25 %7B opacity: 0; transform: scale(1); %7D %7D %3C/style%3E%3Cg class='container'%3E%3Ccircle class='dots' cx='30vw'/%3E%3Ccircle class='dots' cx='40vw'/%3E%3Ccircle class='dots' cx='50vw'/%3E%3Ccircle class='dots' cx='60vw'/%3E%3Ccircle class='dots' cx='70vw'/%3E%3C/g%3E%3C/svg%3E%0A"
     alt="<%=SiteSetting.title%>"
   />
 
@@ -83,7 +82,7 @@
   <noscript>
     <style>
       html {
-        background: revert;
+        overflow-y: revert !important;
       }
 
       #d-splash {

--- a/public/images/preloader.svg
+++ b/public/images/preloader.svg
@@ -1,12 +1,8 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
-  version="1.1"
-  data-ember-extension="1"
->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" data-ember-extension="1">
   <style>
+
+    /* these need to be injected dynamicly to match theme colors */
     :root {
-      /* these need to be injected dynamicly to match theme colors */
       --primary: #222222;
       --secondary: #ffffff;
       --tertiary: #f15c21;
@@ -32,46 +28,43 @@
 
     .dots:first-child {
       fill: var(--tertiary);
-      animation-delay: 1s;
+      animation-delay: 1.25s;
     }
 
     .dots:nth-child(2) {
       fill: var(--tertiary);
-      animation-delay: 1.1s;
+      animation-delay: 1.35s;
     }
 
     .dots:nth-child(3) {
       fill: var(--highlight);
-      animation-delay: 1.2s;
+      animation-delay: 1.45s;
     }
 
     .dots:nth-child(4) {
       fill: var(--quaternary);
-      animation-delay: 1.3s;
+      animation-delay: 1.55s;
     }
 
     .dots:nth-child(5) {
       fill: var(--quaternary);
-      animation-delay: 1.4s;
+      animation-delay: 1.65s;
     }
 
     @keyframes loader {
-      15% {
+      0% {
         opacity: 0;
         transform: scale(1);
       }
-
       45% {
         opacity: 1;
         transform: scale(0.7);
       }
-
       65% {
         opacity: 1;
         transform: scale(0.7);
       }
-
-      95% {
+      100% {
         opacity: 0;
         transform: scale(1);
       }
@@ -79,10 +72,10 @@
   </style>
 
   <g class="container">
-    <circle class="dots" cx="30vw" />
-    <circle class="dots" cx="40vw" />
-    <circle class="dots" cx="50vw" />
-    <circle class="dots" cx="60vw" />
-    <circle class="dots" cx="70vw" />
+    <circle class="dots" cx="30vw"/>
+    <circle class="dots" cx="40vw"/>
+    <circle class="dots" cx="50vw"/>
+    <circle class="dots" cx="60vw"/>
+    <circle class="dots" cx="70vw"/>
   </g>
 </svg>


### PR DESCRIPTION
We currently remove the splash screen once Discourse starts booting. 

This can be an issue on very slow devices, which can take up to 6 seconds. This PR ensures that we don't remove the splash until the browser has finished parsing all of the site's assets. It won't impact fast devices.

Internal topic /t/65378/60