### PR TITLE
DEV: Deprecate `DISCOURSE_DEV_HOSTS`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,6 +67,7 @@ Discourse::Application.configure do
   end
 
   if hosts = ENV['DISCOURSE_DEV_HOSTS']
+    Discourse.deprecate("DISCOURSE_DEV_HOSTS is deprecated. Use RAILS_DEVELOPMENT_HOSTS instead.")
     config.hosts.concat(hosts.split(","))
   end
 


### PR DESCRIPTION
`RAILS_DEVELOPMENT_HOSTS` is a Rails standard does exactly the same thing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
