### PR TITLE
FEATURE: Validate tags in WatchedWords

### DIFF
--- a/app/models/watched_word.rb
+++ b/app/models/watched_word.rb
@@ -28,6 +28,7 @@ class WatchedWord < ActiveRecord::Base
   validates :action, presence: true
 
   validate :replacement_is_url, if: -> { action == WatchedWord.actions[:link] }
+  validate :replacement_is_tag_list, if: -> { action == WatchedWord.actions[:tag] }
 
   validates_each :word do |record, attr, val|
     if WatchedWord.where(action: record.action).count >= MAX_WORDS_PER_ACTION
@@ -47,6 +48,14 @@ class WatchedWord < ActiveRecord::Base
   def replacement_is_url
     if !(replacement =~ URI::regexp)
       errors.add(:base, :invalid_url)
+    end
+  end
+
+  def replacement_is_tag_list
+    tag_list = replacement&.split(',')
+    tags = Tag.where(name: tag_list)
+    if (tag_list.blank? || tags.empty? || tag_list.size != tags.size)
+      errors.add(:base, :invalid_tag_list)
     end
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -639,6 +639,7 @@ en:
               too_many: "Too many words for that action"
             base:
               invalid_url: "Replacement URL is invalid"
+              invalid_tag_list: "Replacement tag list is invalid"
 
   uncategorized_category_name: "Uncategorized"
 

--- a/spec/models/watched_word_spec.rb
+++ b/spec/models/watched_word_spec.rb
@@ -89,6 +89,12 @@ describe WatchedWord do
       }.to_not change { described_class.count }
     end
 
+    it "error when an tag action is created without valid tags" do
+      expect {
+        described_class.create!(word: "ramones", action: described_class.actions[:tag])
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
     it "replaces link with absolute URL" do
       word = Fabricate(:watched_word, action: described_class.actions[:link], word: "meta1")
       expect(word.replacement).to eq("http://test.localhost/")


### PR DESCRIPTION
We didn't validate watched words automatic tagging, so it was possible
for an admin to created watched words with an empty tag list which would
result in an exception when users tried to create a new topic that
matched the misconfigured watched word.

Bug report: https://meta.discourse.org/t/lib-topic-creator-fails-when-the-word-math-appears-in-the-topic-title-or-text/231018?u=falco
