### PR TITLE
UX: core adjustments and styles for the experimental sidebar 

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -48,6 +48,9 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
     },
 
     toggleSidebar() {
+      // enables CSS transitions, but not on did-insert
+      document.querySelector("body").classList.add("sidebar-animate");
+
       this.controllerFor("application").toggleProperty("showSidebar");
     },
 

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -327,11 +327,10 @@ table {
 }
 
 .wrap {
-  @extend .clearfix;
+  max-width: var(--d-max-width);
   margin-right: auto;
   margin-left: auto;
   padding: 0 10px;
-
   .contents {
     position: relative;
   }

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -1,3 +1,7 @@
+:root {
+  --d-sidebar-width: 240px;
+}
+
 .header-sidebar-toggle {
   margin-right: 1em;
   margin-left: -10px;
@@ -49,10 +53,16 @@
     text-transform: uppercase;
     font-size: 1em;
     font-weight: bold;
-    align-items: center;
+    align-items: stretch;
   }
 
   .sidebar-section-header-link {
+    @include ellipsis;
+    flex: 1 1 auto;
+    color: var(--primary);
+    font-size: var(--font-down-1);
+    padding: 0.25em 0.5em;
+
     &:visited {
       color: var(--primary);
     }
@@ -60,11 +70,6 @@
     &:hover {
       background: var(--primary-low);
     }
-
-    flex: 1 1 auto;
-    color: var(--primary);
-    font-size: var(--font-down-1);
-    padding: 0.25em 0.5em;
   }
 
   .sidebar-section-header-button {
@@ -142,17 +147,25 @@
   }
 
   .sidebar-section-header-caret {
+    flex: 0 0 auto;
     width: 1.5em;
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
+    align-items: center;
     border: none;
-    background-color: transparent;
+    background: transparent;
+    padding: 0.25em 0;
+    opacity: 0;
+    transition: opacity 0.25s;
 
     &:hover {
       opacity: 100;
     }
 
-    opacity: 0;
+    svg {
+      display: block;
+      flex: 0 0 auto;
+    }
 
     .d-icon {
       font-size: $font-down-1;

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -32,6 +32,7 @@ $topic-progress-height: 42px;
     max-width: calc(
       100vw - 20px
     ); // 20px is the left + right padding on .wrap in common/base/discourse.scss
+    min-width: 0; // grid needs to be able to shrink
   }
 
   .timeline-container {

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -208,7 +208,7 @@
     align-self: flex-start;
 
     @media screen and (min-width: 767px) {
-      max-width: calc(#{$large-width} / 2);
+      max-width: calc(var(--d-max-width) / 2);
       margin-right: 1.5em;
     }
 

--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -116,16 +116,6 @@ pre code {
   }
 }
 
-// TODO figure out a clean place to put stuff like this
-.row:before,
-.row:after {
-  display: table;
-  content: "";
-}
-.row:after {
-  clear: both;
-}
-
 // Tables
 // --------------------------------------------------
 

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -212,7 +212,7 @@ body.has-sidebar-page {
     padding-left: 1.75em;
   }
   #main-outlet-wrapper {
-    grid-template-columns: 240px minmax(0, 1fr);
+    grid-template-columns: var(--d-sidebar-width) minmax(0, 1fr);
     gap: 0 2em;
     padding-left: 0;
   }

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -3,6 +3,10 @@
 // BEWARE: changing these styles implies they take effect anywhere they are seen
 // throughout the Discourse application
 
+:root {
+  --d-max-width: 1110px;
+}
+
 // Base Elements
 body.widget-dragging {
   cursor: ns-resize;
@@ -187,8 +191,11 @@ input {
   box-sizing: border-box;
   width: 100%;
   display: grid;
-  grid-template-areas: "content";
-  grid-template-columns: minmax(0, 1fr);
+  // we can CSS transition the sidebar grid width change
+  // as long as we keep the column count consistent
+  // grid transitions are only supported in Firefox at the moment, but coming summer 2022 to Chrome
+  grid-template-areas: "sidebar content";
+  grid-template-columns: 0 minmax(0, 1fr);
   gap: 0;
 
   #main-outlet {
@@ -196,8 +203,24 @@ input {
   }
 }
 
-body.has-sidebar-page #main-outlet-wrapper {
-  grid-template-areas: "sidebar content";
-  grid-template-columns: 240px 1fr;
-  gap: 0 2em;
+body.has-sidebar-page {
+  .wrap {
+    // increase page max-width to accommodate sidebar width
+    max-width: calc(var(--d-sidebar-width) + var(--d-max-width));
+  }
+  .d-header .wrap {
+    padding-left: 1.75em;
+  }
+  #main-outlet-wrapper {
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 0 2em;
+    padding-left: 0;
+  }
+}
+
+body.sidebar-animate {
+  .d-header .wrap,
+  #main-outlet-wrapper {
+    transition: ease-in-out 0.5s;
+  }
 }

--- a/app/assets/stylesheets/desktop/history.scss
+++ b/app/assets/stylesheets/desktop/history.scss
@@ -2,7 +2,7 @@
 
 .modal.history-modal {
   .modal-inner-container {
-    max-width: $large-width;
+    max-width: var(--d-max-width);
   }
   .modal-body {
     height: 70vh;

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -1,7 +1,3 @@
-.wrap {
-  max-width: $large-width;
-}
-
 .full-width {
   margin-left: 0;
 }

--- a/app/assets/stylesheets/desktop/topic.scss
+++ b/app/assets/stylesheets/desktop/topic.scss
@@ -120,6 +120,10 @@
   left: 0;
 }
 
+.onscreen-post .row {
+  display: flex; // children should never wrap
+}
+
 @media all and (min-width: 400px) {
   #topic-footer-main-buttons {
     max-width: 70%;


### PR DESCRIPTION
There are changes that impact core immediately but shouldn't break anything; some general cleanup and sidebar prep, and some better sidebar behavior on medium sized screens. 

General changes:

* new `var(--d-max-width)` variable
* new `var(--d-sidebar-width)` variable 
* removed a couple old clearfixes 
* set posts' `.row` to `display: flex;` (topic-avatar and topic-body should never wrap on desktop)
* adjusted the grid on `#main-outlet-wrapper` to collapse the sidebar column to 0 width, rather than remove it — this will allow for CSS transitions 
* added `min-width: 0` to `.container.posts` so the content can shrink in grid layouts 

Sidebar specific: 
* increased the page's `max-width` to accommodate the sidebar width 
* added a first pass at CSS transitions 
* minor padding/alignment adjustments 