### PR TITLE
FIX: keep unique post checks separate for PMs vs topics

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -248,7 +248,7 @@ class Post < ActiveRecord::Base
 
   # The key we use in redis to ensure unique posts
   def unique_post_key
-    "unique-post-#{topic&.private_message? ? "pm" : "topic"}-#{user_id}:#{raw_hash}"
+    "unique#{topic&.private_message? ? "-pm" : ""}-post-#{user_id}:#{raw_hash}"
   end
 
   def store_unique_post_key

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -248,7 +248,7 @@ class Post < ActiveRecord::Base
 
   # The key we use in redis to ensure unique posts
   def unique_post_key
-    "unique-post-#{user_id}:#{raw_hash}"
+    "unique-post-#{topic&.private_message? ? "pm" : "topic"}-#{user_id}:#{raw_hash}"
   end
 
   def store_unique_post_key


### PR DESCRIPTION
This allows for people to use PMs for drafting and then post them on topics.
