### PR TITLE
DEV: Rename variable in TagSectionLink JavaScript class

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/tags-section.js
@@ -22,7 +22,7 @@ export default class SidebarTagsSection extends GlimmerComponent {
   get sectionLinks() {
     return this.currentUser.trackedTags.map((trackedTag) => {
       return new TagSectionLink({
-        tag: trackedTag,
+        tagName: trackedTag,
         topicTrackingState: this.topicTrackingState,
       });
     });

--- a/app/assets/javascripts/discourse/app/lib/sidebar/tags-section/tag-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/tags-section/tag-section-link.js
@@ -8,8 +8,8 @@ export default class TagSectionLink {
   @tracked totalUnread = 0;
   @tracked totalNew = 0;
 
-  constructor({ tag, topicTrackingState }) {
-    this.tag = tag;
+  constructor({ tagName, topicTrackingState }) {
+    this.tagName = tagName;
     this.topicTrackingState = topicTrackingState;
     this.refreshCounts();
   }
@@ -17,22 +17,22 @@ export default class TagSectionLink {
   @bind
   refreshCounts() {
     this.totalUnread = this.topicTrackingState.countUnread({
-      tagId: this.tag,
+      tagId: this.tagName,
     });
 
     if (this.totalUnread === 0) {
       this.totalNew = this.topicTrackingState.countNew({
-        tagId: this.tag,
+        tagId: this.tagName,
       });
     }
   }
 
   get name() {
-    return this.tag;
+    return this.tagName;
   }
 
   get model() {
-    return this.tag;
+    return this.tagName;
   }
 
   get currentWhen() {
@@ -44,7 +44,7 @@ export default class TagSectionLink {
   }
 
   get text() {
-    return this.tag;
+    return this.tagName;
   }
 
   get badgeText() {


### PR DESCRIPTION
Tag is vague and is mostly used in our code base to represent a Tag
ember object.