### PR TITLE
FIX: Vimeo regex pattern

### DIFF
--- a/lib/onebox/engine/vimeo_onebox.rb
+++ b/lib/onebox/engine/vimeo_onebox.rb
@@ -6,7 +6,7 @@ module Onebox
       include Engine
       include StandardEmbed
 
-      matches_regexp(/^https?:\/\/(www\.)?vimeo\.com\/\d+/)
+      matches_regexp(/^https?:\/\/(www\.)?vimeo\.com\/\d+(\/\w+)?\/?/)
       requires_iframe_origins "https://player.vimeo.com"
       always_https
 


### PR DESCRIPTION
Vimeo has two url structure:

- Normal /video_id

- Private/Unlisted /video_id/hash_string

This changes change the regex pattern thus it would be able to

catch both. Also it tolerate trailing slash.

This shall fixes:

https://meta.discourse.org/t/vimeo-embed-urls-parsed-incorrectly-in-email/231042

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
