### PR TITLE
FIX: add clearfix back for admin contents

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -81,6 +81,15 @@ $mobile-breakpoint: 700px;
       margin: 0 15px 0 -10px;
     }
   }
+
+  .row:before,
+  .row:after {
+    display: table;
+    content: "";
+  }
+  .row:after {
+    clear: both;
+  }
 }
 
 .admin-contents table {


### PR DESCRIPTION
Removed this global clearfix in f0005401b7e0b7856137cf14dd64a13863b799d4, but the admin panel still needs it for various settings 