### PR TITLE
FIX: Incorrect `currentUser` could be cached for requests with API key

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -412,6 +412,14 @@ class Auth::DefaultCurrentUserProvider
   # However, in some scenarios it is essential to send them via url parameters
   # so we need to add some exceptions
   def api_parameter_allowed?
+    if @env[ActionDispatch::Http::Parameters::PARAMETERS_KEY].nil? && @request.path_info.present?
+      @env[ActionDispatch::Http::Parameters::PARAMETERS_KEY] = begin
+        Rails.application.routes.recognize_path(@request.path_info)
+      rescue ActionController::RoutingError
+        {}
+      end
+    end
+
     parameter_api_patterns.any? { |p| p.match?(env: @env) }
   end
 

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -41,7 +41,6 @@ class Auth::DefaultCurrentUserProvider
   COOKIE_ATTEMPTS_PER_MIN ||= 10
   BAD_TOKEN ||= "_DISCOURSE_BAD_TOKEN"
   DECRYPTED_AUTH_COOKIE = "_DISCOURSE_DECRYPTED_AUTH_COOKIE"
-  PATH_PARAMETERS ||= "_DISCOURSE_REQUEST_PATH_PARAMETERS"
 
   TOKEN_SIZE = 32
 
@@ -413,19 +412,6 @@ class Auth::DefaultCurrentUserProvider
   # However, in some scenarios it is essential to send them via url parameters
   # so we need to add some exceptions
   def api_parameter_allowed?
-    if @env[ActionDispatch::Http::Parameters::PARAMETERS_KEY].nil? && @request.path_info.present?
-      # We need to manually recognize the path when Rails hasn't done that yet. That can happen when
-      # `currentUser` gets called in a Middleware before the controller did its work.
-      # We store the result of `recognize_path` in a custom env key, so that we don't change
-      # some Rails behavior by accident. The matchers from `parameter_api_patterns` will fall back
-      # to the custom env key if the `path_parameters` from Rails are missing.
-      @env[PATH_PARAMETERS] ||= begin
-        Rails.application.routes.recognize_path(@request.path_info)
-      rescue ActionController::RoutingError
-        {}
-      end
-    end
-
     parameter_api_patterns.any? { |p| p.match?(env: @env) }
   end
 

--- a/lib/route_matcher.rb
+++ b/lib/route_matcher.rb
@@ -41,7 +41,7 @@ class RouteMatcher
     # message_bus is not a rails route, special handling
     return true if actions.include?("message_bus") && request.fullpath =~ /^\/message-bus\/.*\/poll/
 
-    path_params = request.path_parameters
+    path_params = request.path_parameters.presence || request.env[Auth::DefaultCurrentUserProvider::PATH_PARAMETERS] || {}
     actions.include? "#{path_params[:controller]}##{path_params[:action]}"
   end
 

--- a/lib/route_matcher.rb
+++ b/lib/route_matcher.rb
@@ -37,11 +37,11 @@ class RouteMatcher
 
   def action_allowed?(request)
     return true if actions.nil? # actions are unrestricted
-    path_params = request.path_parameters
 
     # message_bus is not a rails route, special handling
     return true if actions.include?("message_bus") && request.fullpath =~ /^\/message-bus\/.*\/poll/
 
+    path_params = request.path_parameters
     actions.include? "#{path_params[:controller]}##{path_params[:action]}"
   end
 

--- a/lib/route_matcher.rb
+++ b/lib/route_matcher.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RouteMatcher
+  PATH_PARAMETERS ||= "_DISCOURSE_REQUEST_PATH_PARAMETERS"
+
   attr_reader :actions, :params, :methods, :aliases, :formats, :allowed_param_values
 
   def initialize(actions: nil, params: nil, methods: nil, formats: nil, aliases: nil, allowed_param_values: nil)
@@ -41,7 +43,7 @@ class RouteMatcher
     # message_bus is not a rails route, special handling
     return true if actions.include?("message_bus") && request.fullpath =~ /^\/message-bus\/.*\/poll/
 
-    path_params = request.path_parameters.presence || request.env[Auth::DefaultCurrentUserProvider::PATH_PARAMETERS] || {}
+    path_params = path_params_from_request(request)
     actions.include? "#{path_params[:controller]}##{path_params[:action]}"
   end
 
@@ -81,5 +83,21 @@ class RouteMatcher
     return true if formats.nil?
     request_format = request.formats&.first&.symbol
     formats.include?(request_format)
+  end
+
+  def path_params_from_request(request)
+    if request.env[ActionDispatch::Http::Parameters::PARAMETERS_KEY].nil?
+      # We need to manually recognize the path when Rails hasn't done that yet. That can happen when
+      # the matcher gets called in a Middleware before the controller did its work.
+      # We store the result of `recognize_path` in a custom env key, so that we don't change
+      # some Rails behavior by accident.
+      request.env[PATH_PARAMETERS] ||= begin
+        Rails.application.routes.recognize_path(request.path_info)
+      rescue ActionController::RoutingError
+        {}
+      end
+    end
+
+    request.path_parameters.presence || request.env[PATH_PARAMETERS] || {}
   end
 end

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -310,6 +310,28 @@ describe Auth::DefaultCurrentUserProvider do
         expect(u.last_seen_at).to eq(nil)
       end
     end
+
+    it "should not cache an invalid user when Rails hasn't set `path_parameters` on the request yet" do
+      SiteSetting.login_required = true
+      user = Fabricate(:user)
+      api_key = ApiKey.create!(user_id: user.id, created_by_id: Discourse.system_user)
+      url = "/latest.rss?api_key=#{api_key.key}&api_username=#{user.username_lower}"
+      env = { ActionDispatch::Http::Parameters::PARAMETERS_KEY => nil }
+
+      provider = provider(url, env)
+      env = provider.env
+
+      expect(env[Auth::DefaultCurrentUserProvider::PATH_PARAMETERS]).to be_nil
+      expect(env[ActionDispatch::Http::Parameters::PARAMETERS_KEY]).to be_nil
+      expect(provider.env[Auth::DefaultCurrentUserProvider::CURRENT_USER_KEY]).to be_nil
+
+      u = provider.current_user
+
+      expect(u).to eq(user)
+      expect(env[Auth::DefaultCurrentUserProvider::PATH_PARAMETERS]).to be_present
+      expect(env[ActionDispatch::Http::Parameters::PARAMETERS_KEY]).to be_blank
+      expect(provider.env[Auth::DefaultCurrentUserProvider::CURRENT_USER_KEY]).to eq(u)
+    end
   end
 
   it "should update last seen for non ajax" do

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -321,14 +321,12 @@ describe Auth::DefaultCurrentUserProvider do
       provider = provider(url, env)
       env = provider.env
 
-      expect(env[Auth::DefaultCurrentUserProvider::PATH_PARAMETERS]).to be_nil
       expect(env[ActionDispatch::Http::Parameters::PARAMETERS_KEY]).to be_nil
       expect(provider.env[Auth::DefaultCurrentUserProvider::CURRENT_USER_KEY]).to be_nil
 
       u = provider.current_user
 
       expect(u).to eq(user)
-      expect(env[Auth::DefaultCurrentUserProvider::PATH_PARAMETERS]).to be_present
       expect(env[ActionDispatch::Http::Parameters::PARAMETERS_KEY]).to be_blank
       expect(provider.env[Auth::DefaultCurrentUserProvider::CURRENT_USER_KEY]).to eq(u)
     end


### PR DESCRIPTION
This happened when a middleware accessed the `currentUser` before a controller had a chance to populate the `action_dispatch.request.path_parameters` env variable. In that case Discourse would always cache `nil` as `currentUser`.

This solution tries to recognize the path before the relevant code (check if API call is allowed) is run.