### PR TITLE
DEV: Version bump to v2.9.0.beta6

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -10,7 +10,7 @@ module Discourse
       MAJOR = 2
       MINOR = 9
       TINY  = 0
-      PRE   = 'beta5'
+      PRE   = 'beta6'
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
     end


### PR DESCRIPTION
Needed for https://meta.discourse.org/t/unable-to-find-discourse-version-2-9-0-beta6/231511 :(