### PR TITLE
UX: made "Dismiss New" button clickable by replacing `float` method.

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -176,10 +176,9 @@
   }
 }
 
-button.dismiss-read {
-  float: right;
-  margin-bottom: 5px;
-  margin-left: 10px;
+.dismiss-container-top {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .category-breadcrumb {


### PR DESCRIPTION
Since we removed the `row:after { clear: both }` CSS we no longer use `float` style here. Instead, we should use `flex` style to align the button in right side.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
