### PR TITLE
FEATURE: Allow iframe `allow` attribute in posts

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/allow-lister.js
+++ b/app/assets/javascripts/pretty-text/addon/allow-lister.js
@@ -171,6 +171,7 @@ export const DEFAULT_LIST = [
   "iframe[marginwidth]",
   "iframe[width]",
   "iframe[allowfullscreen]",
+  "iframe[allow]",
   "img[alt]",
   "img[height]",
   "img[title]",


### PR DESCRIPTION
This is used so iframes can use mic, camera, EME, etc.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#directives
lists current possible values

Feature request https://meta.discourse.org/t/iframe-attributes-not-working/127383?u=falco
