### PR TITLE
UX: minor experimental sidebar alignment changes

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -4,11 +4,19 @@
 
 .header-sidebar-toggle {
   margin-right: 1em;
-  margin-left: -10px;
+
+  @media screen and (min-width: 1300px) {
+    // extending the toggle beyond the page when space allows
+    // for better logo alignment with content
+    body:not(.has-sidebar-page) & {
+      margin-left: -3.7em;
+    }
+  }
 
   button {
     position: relative;
     font-size: var(--font-up-2);
+    padding: 0.5em;
 
     .discourse-no-touch & {
       &:hover {

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -216,6 +216,10 @@ body.has-sidebar-page {
     gap: 0 2em;
     padding-left: 0;
   }
+  .extra-info-wrapper {
+    // align docked header title with post content
+    margin-left: 7.7em;
+  }
 }
 
 body.sidebar-animate {

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -209,7 +209,7 @@ body.has-sidebar-page {
     max-width: calc(var(--d-sidebar-width) + var(--d-max-width));
   }
   .d-header .wrap {
-    padding-left: 1.75em;
+    padding-left: 0;
   }
   #main-outlet-wrapper {
     grid-template-columns: var(--d-sidebar-width) minmax(0, 1fr);


### PR DESCRIPTION
1. Trying out hanging the toggle off the left of the page when space allows, for better logo alignment with content. 

    ![Screen Shot 2022-06-30 at 2 29 17 PM](https://user-images.githubusercontent.com/1681963/176768003-05130346-f097-4260-923a-8bdbb648d49d.png)



2. Shifting the alignment of docked topic titles so they align with the content of the topic when the sidebar is present. 
