### PR TITLE
UX: improve experimental sidebar scrollbar

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar.hbs
@@ -1,14 +1,16 @@
 {{#d-section pageClass="has-sidebar" class="sidebar-wrapper"}}
   <div class="sidebar-container">
-    <Sidebar::TopicsSection />
-    <Sidebar::CategoriesSection />
+    <div class="sidebar-scroll-wrap">
+      <Sidebar::TopicsSection />
+      <Sidebar::CategoriesSection />
 
-    {{#if this.siteSettings.tagging_enabled}}
-      <Sidebar::TagsSection />
-    {{/if}}
+      {{#if this.siteSettings.tagging_enabled}}
+        <Sidebar::TagsSection />
+      {{/if}}
 
-    {{#if this.siteSettings.enable_personal_messages}}
-      <Sidebar::MessagesSection />
-    {{/if}}
+      {{#if this.siteSettings.enable_personal_messages}}
+        <Sidebar::MessagesSection />
+      {{/if}}
+    </div>
   </div>
 {{/d-section}}

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -36,7 +36,36 @@
     box-sizing: border-box;
     height: 100%;
     width: 240px;
-    padding: 1em 0.5em 1em 0;
+    padding: 1em 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    // custom scrollbar styling
+    --scrollbarBg: transparent;
+    --scrollbarThumbBg: var(--primary-low);
+    --scrollbarWidth: 1em;
+
+    scrollbar-color: transparent var(--scrollbarBg);
+    transition: scrollbar-color 0.2s ease-in-out;
+    &::-webkit-scrollbar-thumb {
+      background-color: transparent;
+      border-radius: calc(var(--scrollbarWidth) / 2);
+      border: calc(var(--scrollbarWidth) / 4) solid var(--primary-very-low);
+    }
+    &:hover {
+      scrollbar-color: var(--scrollbarThumbBg) var(--scrollbarBg);
+      &::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbarThumbBg);
+      }
+    }
+    &::-webkit-scrollbar {
+      width: var(--scrollbarWidth);
+    }
+  }
+
+  .sidebar-scroll-wrap {
+    // limit the wrapper width, so when the scrollbar is added the content doesn't shift
+    max-width: calc(var(--d-sidebar-width) - var(--scrollbarWidth));
   }
 
   .sidebar-toggle {


### PR DESCRIPTION
This hides the sidebar scrollbar until hover, and makes it more subtle in appearance 

![Screen Shot 2022-06-30 at 4 07 37 PM](https://user-images.githubusercontent.com/1681963/176768551-6dc6265f-513f-4eff-b9e4-0cf006e14281.png)

