### PR TITLE
UX: hide sidebar li overflow, remove title margin

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -145,7 +145,7 @@
     }
 
     .sidebar-section-link-content-text {
-      width: 70%;
+      @include ellipsis;
 
       .badge-wrapper {
         font-size: 100%;

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -216,10 +216,6 @@ body.has-sidebar-page {
     gap: 0 2em;
     padding-left: 0;
   }
-  .extra-info-wrapper {
-    // align docked header title with post content
-    margin-left: 7.7em;
-  }
 }
 
 body.sidebar-animate {


### PR DESCRIPTION
Truncates sidebar overflow for long text:  

![Screen Shot 2022-06-30 at 5 23 27 PM](https://user-images.githubusercontent.com/1681963/176780643-9303cf06-541e-4c12-af28-fb430bafe624.png)
 
Also removes some header margin, need a better solution for that to account for logo width