### PR TITLE
Generate template backing classes

### DIFF
--- a/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.js
+++ b/app/assets/javascripts/admin/addon/components/dashboard-new-feature-item.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/dashboard-problems.js
+++ b/app/assets/javascripts/admin/addon/components/dashboard-problems.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/flag-user.js
+++ b/app/assets/javascripts/admin/addon/components/flag-user.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/resumable-upload.js
+++ b/app/assets/javascripts/admin/addon/components/resumable-upload.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/setting-validation-message.js
+++ b/app/assets/javascripts/admin/addon/components/setting-validation-message.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-customization-change-details.js
+++ b/app/assets/javascripts/admin/addon/components/site-customization-change-details.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-customization-change-field.js
+++ b/app/assets/javascripts/admin/addon/components/site-customization-change-field.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-settings/category.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/category.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-settings/emoji-list.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/emoji-list.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-settings/enum.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/enum.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-settings/list.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/list.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-settings/secret-list.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/secret-list.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-settings/upload.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/upload.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-settings/url-list.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/url-list.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/site-settings/value-list.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/value-list.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/admin/addon/components/version-checks.js
+++ b/app/assets/javascripts/admin/addon/components/version-checks.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/activation-email-form.js
+++ b/app/assets/javascripts/discourse/app/components/activation-email-form.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/cancel-link.js
+++ b/app/assets/javascripts/discourse/app/components/cancel-link.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/categories-with-featured-topics.js
+++ b/app/assets/javascripts/discourse/app/components/categories-with-featured-topics.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/category-name-fields.js
+++ b/app/assets/javascripts/discourse/app/components/category-name-fields.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/custom-html-container.js
+++ b/app/assets/javascripts/discourse/app/components/custom-html-container.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/emoji-group-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-group-buttons.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/emoji-group-sections.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-group-sections.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/empty-state.js
+++ b/app/assets/javascripts/discourse/app/components/empty-state.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/invite-link-panel.js
+++ b/app/assets/javascripts/discourse/app/components/invite-link-panel.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/ip-lookup.js
+++ b/app/assets/javascripts/discourse/app/components/ip-lookup.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/modal-footer-close.js
+++ b/app/assets/javascripts/discourse/app/components/modal-footer-close.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/popup-menu.js
+++ b/app/assets/javascripts/discourse/app/components/popup-menu.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-created-by-name.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-created-by-name.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-created-by.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-created-by.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-field-editor.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-field-editor.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-field-text.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-field-text.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-field-textarea.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-field-textarea.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-field.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-field.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-flagged-post.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-flagged-post.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-post-header.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-post-header.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-post.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-post.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-scores.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-scores.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-tags.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-tags.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/reviewable-topic-link.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-topic-link.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/score-value.js
+++ b/app/assets/javascripts/discourse/app/components/score-value.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/selected-posts.js
+++ b/app/assets/javascripts/discourse/app/components/selected-posts.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-message.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-message.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/subcategories-with-featured-topics.js
+++ b/app/assets/javascripts/discourse/app/components/subcategories-with-featured-topics.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/text-overflow.js
+++ b/app/assets/javascripts/discourse/app/components/text-overflow.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/user-fields/confirm.js
+++ b/app/assets/javascripts/discourse/app/components/user-fields/confirm.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/user-fields/dropdown.js
+++ b/app/assets/javascripts/discourse/app/components/user-fields/dropdown.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/user-fields/multiselect.js
+++ b/app/assets/javascripts/discourse/app/components/user-fields/multiselect.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/user-fields/text.js
+++ b/app/assets/javascripts/discourse/app/components/user-fields/text.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/user-profile-avatar.js
+++ b/app/assets/javascripts/discourse/app/components/user-profile-avatar.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/discourse/app/components/user-summary-users-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-summary-users-list.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options/toolbar-popup-menu-options-heading.js
+++ b/app/assets/javascripts/select-kit/addon/components/toolbar-popup-menu-options/toolbar-popup-menu-options-heading.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/wizard/addon/components/theme-preview.js
+++ b/app/assets/javascripts/wizard/addon/components/theme-preview.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/wizard/addon/components/wizard-field-checkbox.js
+++ b/app/assets/javascripts/wizard/addon/components/wizard-field-checkbox.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});

--- a/app/assets/javascripts/wizard/addon/components/wizard-field-text.js
+++ b/app/assets/javascripts/wizard/addon/components/wizard-field-text.js
@@ -1,0 +1,3 @@
+import Component from "@ember/component";
+
+export default Component.extend({});


### PR DESCRIPTION
```sh
npx ember-holy-futuristic-template-namespacing-batman-codemod ensure-template-only-has-backing-class
```

We would like to colocate templates but, when no backing class exists, colocated templates extend `templateOnly` instead of `Ember.Component`. Generating the backing class helps avoid any behavioral changes.

We can also run the `tagless-ember-components-codemod` to put the tags into the templates at which point we could convert these back to template-only components.