### PR TITLE
UX: mobile experimental sidebar improvement

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar.js
@@ -1,3 +1,41 @@
 import GlimmerComponent from "discourse/components/glimmer";
+import { bind } from "discourse-common/utils/decorators";
 
-export default class Sidebar extends GlimmerComponent {}
+export default class Sidebar extends GlimmerComponent {
+  constructor() {
+    super(...arguments);
+    if (this.site.mobileView) {
+      document.addEventListener("click", this.mobileOutsideClick);
+    }
+  }
+
+  _cleanUp() {
+    this.args.applicationController.set("showSidebar", false);
+
+    if (this.site.mobileView) {
+      document.removeEventListener("click", this.mobileOutsideClick);
+      this.appEvents.off("page:changed", this, this._cleanUp);
+    }
+  }
+
+  @bind
+  mobileOutsideClick(event) {
+    this.appEvents.on("page:changed", this, this._cleanUp);
+
+    let sidebarParentContainer = event
+      .composedPath()
+      .filter(
+        (element) =>
+          element.className && element.className === "sidebar-wrapper"
+      );
+
+    if (!sidebarParentContainer.length) {
+      this.args.applicationController.set("showSidebar", false);
+      document.removeEventListener("click", this.mobileOutsideClick);
+    }
+  }
+
+  willDestroy() {
+    this._cleanUp;
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/sidebar.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar.js
@@ -36,6 +36,6 @@ export default class Sidebar extends GlimmerComponent {
   }
 
   willDestroy() {
-    this._cleanUp;
+    this._cleanUp();
   }
 }

--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -6,7 +6,16 @@ export default Controller.extend({
   showTop: true,
   showFooter: false,
   router: service(),
-  showSidebar: true,
+
+  @discourseComputed
+  showSidebar() {
+    if (this.site.mobileView) {
+      // never remember state on mobile
+      this.keyValueStore.removeItem("showSidebar");
+    }
+
+    return this.keyValueStore.getItem("showSidebar");
+  },
 
   @discourseComputed
   canSignUp() {

--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -1,20 +1,22 @@
 import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
+import discourseDebounce from "discourse-common/lib/debounce";
 import { inject as service } from "@ember/service";
+import { action } from "@ember/object";
 
 export default Controller.extend({
   showTop: true,
   showFooter: false,
   router: service(),
+  showSidebar: null,
+  hideSidebarKey: "sidebar-hidden",
 
-  @discourseComputed
-  showSidebar() {
-    if (this.site.mobileView) {
-      // never remember state on mobile
-      this.keyValueStore.removeItem("showSidebar");
-    }
+  init() {
+    this._super(...arguments);
 
-    return this.keyValueStore.getItem("showSidebar");
+    this.showSidebar = this.site.mobileView
+      ? false
+      : this.currentUser && !this.keyValueStore.getItem(this.hideSidebarKey);
   },
 
   @discourseComputed
@@ -34,5 +36,32 @@ export default Controller.extend({
   @discourseComputed
   showFooterNav() {
     return this.capabilities.isAppWebview || this.capabilities.isiOSPWA;
+  },
+
+  _mainOutletAnimate() {
+    document
+      .querySelector("#main-outlet")
+      .classList.remove("main-outlet-animate");
+  },
+
+  @action
+  toggleSidebar() {
+    // enables CSS transitions, but not on did-insert
+    document.querySelector("body").classList.add("sidebar-animate");
+
+    // reduces CSS transition jank
+    document.querySelector("#main-outlet").classList.add("main-outlet-animate");
+
+    discourseDebounce(this, this._mainOutletAnimate, 250);
+
+    this.toggleProperty("showSidebar");
+
+    if (!this.site.mobileView) {
+      if (this.showSidebar) {
+        this.keyValueStore.removeItem(this.hideSidebarKey);
+      } else {
+        this.keyValueStore.setItem(this.hideSidebarKey);
+      }
+    }
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -1,6 +1,7 @@
 import DiscourseURL, { userPath } from "discourse/lib/url";
 import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
+import discourseDebounce from "discourse-common/lib/debounce";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import OpenComposer from "discourse/mixins/open-composer";
@@ -40,6 +41,12 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
   shortSiteDescription: setting("short_site_description"),
   documentTitle: service(),
 
+  _mainOutletAnimate() {
+    document
+      .querySelector("#main-outlet")
+      .classList.remove("main-outlet-animate");
+  },
+
   actions: {
     toggleAnonymous() {
       ajax(userPath("toggle-anon"), { type: "POST" }).then(() => {
@@ -50,6 +57,19 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
     toggleSidebar() {
       // enables CSS transitions, but not on did-insert
       document.querySelector("body").classList.add("sidebar-animate");
+
+      if (!this.keyValueStore.getItem("showSidebar")) {
+        this.keyValueStore.setItem("showSidebar");
+      } else {
+        this.keyValueStore.removeItem("showSidebar");
+      }
+
+      // reduces CSS transition jank
+      document
+        .querySelector("#main-outlet")
+        .classList.add("main-outlet-animate");
+
+      discourseDebounce(this, this._mainOutletAnimate, 250);
 
       this.controllerFor("application").toggleProperty("showSidebar");
     },

--- a/app/assets/javascripts/discourse/app/routes/application.js
+++ b/app/assets/javascripts/discourse/app/routes/application.js
@@ -1,7 +1,6 @@
 import DiscourseURL, { userPath } from "discourse/lib/url";
 import Category from "discourse/models/category";
 import Composer from "discourse/models/composer";
-import discourseDebounce from "discourse-common/lib/debounce";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import OpenComposer from "discourse/mixins/open-composer";
@@ -41,37 +40,11 @@ const ApplicationRoute = DiscourseRoute.extend(OpenComposer, {
   shortSiteDescription: setting("short_site_description"),
   documentTitle: service(),
 
-  _mainOutletAnimate() {
-    document
-      .querySelector("#main-outlet")
-      .classList.remove("main-outlet-animate");
-  },
-
   actions: {
     toggleAnonymous() {
       ajax(userPath("toggle-anon"), { type: "POST" }).then(() => {
         window.location.reload();
       });
-    },
-
-    toggleSidebar() {
-      // enables CSS transitions, but not on did-insert
-      document.querySelector("body").classList.add("sidebar-animate");
-
-      if (!this.keyValueStore.getItem("showSidebar")) {
-        this.keyValueStore.setItem("showSidebar");
-      } else {
-        this.keyValueStore.removeItem("showSidebar");
-      }
-
-      // reduces CSS transition jank
-      document
-        .querySelector("#main-outlet")
-        .classList.add("main-outlet-animate");
-
-      discourseDebounce(this, this._mainOutletAnimate, 250);
-
-      this.controllerFor("application").toggleProperty("showSidebar");
     },
 
     toggleMobileView() {

--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -2,7 +2,7 @@
   <a href="#main-container" id="skip-link">{{i18n "skip_to_main_content"}}</a>
   <DDocument />
   <PluginOutlet @name="above-site-header" @connectorTagName="div" />
-  <SiteHeader @canSignUp={{canSignUp}} @showCreateAccount={{route-action "showCreateAccount"}} @showLogin={{route-action "showLogin"}} @showKeyboard={{route-action "showKeyboardShortcutsHelp"}} @toggleMobileView={{route-action "toggleMobileView"}} @toggleAnonymous={{route-action "toggleAnonymous"}} @logout={{route-action "logout"}} @toggleSidebar={{route-action "toggleSidebar"}} />
+  <SiteHeader @canSignUp={{canSignUp}} @showCreateAccount={{route-action "showCreateAccount"}} @showLogin={{route-action "showLogin"}} @showKeyboard={{route-action "showKeyboardShortcutsHelp"}} @toggleMobileView={{route-action "toggleMobileView"}} @toggleAnonymous={{route-action "toggleAnonymous"}} @logout={{route-action "logout"}} @toggleSidebar={{action "toggleSidebar"}} />
   <SoftwareUpdatePrompt />
 
   <PluginOutlet @name="below-site-header" @connectorTagName="div" @args={{hash currentPath=router._router.currentPath}} />
@@ -12,7 +12,7 @@
     <div class="sidebar-wrapper">
       {{!-- empty div allows for animation --}}
       {{#if (and currentUser.experimental_sidebar_enabled showSidebar)}}
-        <Sidebar @applicationController={{this}}/>
+        <Sidebar @toggleSidebar={{action "toggleSidebar"}}/>
       {{/if}}
     </div>
 

--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -8,9 +8,13 @@
   <PluginOutlet @name="below-site-header" @connectorTagName="div" @args={{hash currentPath=router._router.currentPath}} />
 
   <div id="main-outlet-wrapper" class="wrap" role="main">
-    {{#if (and currentUser.experimental_sidebar_enabled showSidebar)}}
-      <Sidebar />
-    {{/if}}
+
+    <div class="sidebar-wrapper">
+      {{!-- empty div allows for animation --}}
+      {{#if (and currentUser.experimental_sidebar_enabled showSidebar)}}
+        <Sidebar @applicationController={{this}}/>
+      {{/if}}
+    </div>
 
     <div id="main-outlet">
       <PluginOutlet @name="above-main-container" @connectorTagName="div" />

--- a/app/assets/javascripts/discourse/app/templates/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar.hbs
@@ -1,16 +1,14 @@
-<DSection @pageClass="has-sidebar" @class="sidebar-wrapper">
-  <div class="sidebar-container">
-    <div class="sidebar-scroll-wrap">
-      <Sidebar::TopicsSection />
-      <Sidebar::CategoriesSection />
+<DSection @pageClass="has-sidebar" @class="sidebar-container">
+  <div class="sidebar-scroll-wrap">
+    <Sidebar::TopicsSection />
+    <Sidebar::CategoriesSection />
 
-      {{#if this.siteSettings.tagging_enabled}}
-        <Sidebar::TagsSection />
-      {{/if}}
+    {{#if this.siteSettings.tagging_enabled}}
+      <Sidebar::TagsSection />
+    {{/if}}
 
-      {{#if this.siteSettings.enable_personal_messages}}
-        <Sidebar::MessagesSection />
-      {{/if}}
-    </div>
+    {{#if this.siteSettings.enable_personal_messages}}
+      <Sidebar::MessagesSection />
+    {{/if}}
   </div>
 </DSection>

--- a/app/assets/javascripts/discourse/app/widgets/sidebar-toggle.js
+++ b/app/assets/javascripts/discourse/app/widgets/sidebar-toggle.js
@@ -9,7 +9,7 @@ export default createWidget("sidebar-toggle", {
         title: "",
         icon: "bars",
         action: "toggleSidebar",
-        className: "btn btn-flat",
+        className: "btn btn-flat btn-sidebar-toggle",
       }),
     ];
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-mobile-test.js
@@ -1,0 +1,64 @@
+import { test } from "qunit";
+
+import { click, pauseTest, visit } from "@ember/test-helpers";
+import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Sidebar - Mobile - User with sidebar enabled", function (needs) {
+  needs.user({ experimental_sidebar_enabled: true });
+  needs.mobileView();
+
+  test("hidden by default", async function (assert) {
+    await visit("/");
+
+    assert.ok(!exists(".sidebar-container"), "sidebar is not displayed");
+  });
+
+  test("clicking outside sidebar collapses it", async function (assert) {
+    await visit("/");
+
+    await click(".btn-sidebar-toggle");
+
+    assert.ok(exists(".sidebar-container"), "sidebar is displayed");
+
+    await click("#main-outlet");
+
+    assert.ok(!exists(".sidebar-container"), "sidebar is collapsed");
+  });
+
+  test("clicking on a link or button in sidebar collapses it", async function (assert) {
+    await visit("/");
+
+    await click(".btn-sidebar-toggle");
+    await click(".sidebar-section-link-tracked");
+
+    assert.ok(
+      !exists(".sidebar-container"),
+      "sidebar is collapsed when a button in sidebar is clicked"
+    );
+
+    await click(".btn-sidebar-toggle");
+    await click(".sidebar-section-header-link");
+
+    assert.ok(
+      !exists(".sidebar-container"),
+      "sidebar is collapsed when a link in sidebar is clicked"
+    );
+  });
+
+  test("collpasing sidebar sections does not collapse sidebar", async function (assert) {
+    await visit("/");
+
+    await click(".btn-sidebar-toggle");
+    await click(".sidebar-section-header-caret");
+
+    assert.ok(
+      !exists(".sidebar-section-topics .sidebar-section-content"),
+      "topics section is collapsed"
+    );
+
+    assert.ok(
+      exists(".sidebar-container"),
+      "sidebar is not collapsed when clicking on caret to collapse a section in sidebar"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-mobile-test.js
@@ -1,6 +1,6 @@
 import { test } from "qunit";
 
-import { click, pauseTest, visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Sidebar - Mobile - User with sidebar enabled", function (needs) {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-test.js
@@ -14,7 +14,7 @@ acceptance("Sidebar - Anon User", function () {
       "does not add sidebar utility class to body"
     );
 
-    assert.ok(!exists(".sidebar-wrapper"));
+    assert.ok(!exists(".sidebar-container"));
   });
 });
 
@@ -30,7 +30,7 @@ acceptance("Sidebar - User with sidebar disabled", function (needs) {
       "does not add sidebar utility class to body"
     );
 
-    assert.ok(!exists(".sidebar-wrapper"));
+    assert.ok(!exists(".sidebar-container"));
   });
 });
 
@@ -46,7 +46,7 @@ acceptance("Sidebar - User with sidebar enabled", function (needs) {
       "adds sidebar utility class to body"
     );
 
-    assert.ok(exists(".sidebar-wrapper"), "displays the sidebar by default");
+    assert.ok(exists(".sidebar-container"), "displays the sidebar by default");
 
     await click(".header-sidebar-toggle .btn");
 
@@ -56,10 +56,10 @@ acceptance("Sidebar - User with sidebar enabled", function (needs) {
       "removes sidebar utility class to body"
     );
 
-    assert.ok(!exists(".sidebar-wrapper"), "hides the sidebar");
+    assert.ok(!exists(".sidebar-container"), "hides the sidebar");
 
     await click(".header-sidebar-toggle .btn");
 
-    assert.ok(exists(".sidebar-wrapper"), "displays the sidebar");
+    assert.ok(exists(".sidebar-container"), "displays the sidebar");
   });
 });

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -671,6 +671,22 @@ table {
 
 // Special elements
 
+#main-outlet-wrapper {
+  box-sizing: border-box;
+  width: 100%;
+  display: grid;
+  // we can CSS transition the sidebar grid width change
+  // as long as we keep the column count consistent
+  // grid transitions are only supported in Firefox at the moment, but coming summer 2022 to Chrome
+  grid-template-areas: "sidebar content";
+  grid-template-columns: min-content minmax(0, 1fr);
+  gap: 0;
+
+  #main-outlet {
+    grid-area: content;
+  }
+}
+
 #main-outlet {
   padding-top: 2.5em;
 }

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -131,7 +131,7 @@
   .sidebar-section-link {
     display: flex;
     align-items: center;
-    padding: 0.25em 0.5em;
+    padding: 0.35em 0.5em;
     color: var(--primary-high);
     font-size: var(--font-down-1);
 

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -187,22 +187,6 @@ input {
   }
 }
 
-#main-outlet-wrapper {
-  box-sizing: border-box;
-  width: 100%;
-  display: grid;
-  // we can CSS transition the sidebar grid width change
-  // as long as we keep the column count consistent
-  // grid transitions are only supported in Firefox at the moment, but coming summer 2022 to Chrome
-  grid-template-areas: "sidebar content";
-  grid-template-columns: 0 minmax(0, 1fr);
-  gap: 0;
-
-  #main-outlet {
-    grid-area: content;
-  }
-}
-
 body.has-sidebar-page {
   .wrap {
     // increase page max-width to accommodate sidebar width

--- a/app/assets/stylesheets/mobile/discourse.scss
+++ b/app/assets/stylesheets/mobile/discourse.scss
@@ -134,3 +134,57 @@ blockquote {
 #simple-container {
   width: 90%;
 }
+
+#main-outlet-wrapper {
+  width: 100%;
+
+  #main-outlet {
+    &.main-outlet-animate {
+      width: 95vw; // prevents content width shift during animation
+    }
+  }
+}
+
+.sidebar-wrapper {
+  width: 0;
+  transition: width 0.25s ease-in-out;
+}
+
+body.has-sidebar-page {
+  position: fixed;
+  height: calc(100vh - var(--header-offset));
+
+  #main {
+    overflow: hidden;
+  }
+
+  .sidebar-wrapper {
+    width: var(--d-sidebar-width);
+  }
+
+  #main-outlet {
+    position: relative;
+    width: 95vw; // prevents content width shift during animation
+    &:after {
+      content: "";
+      background: rgba(0, 0, 0, 0.5);
+      position: absolute;
+      top: 0;
+      left: -2em; // compensate for gap
+      right: 0;
+      bottom: 0;
+      z-index: z("dropdown");
+    }
+  }
+
+  #main-outlet-wrapper {
+    grid-template-columns: min-content minmax(0, 100vw);
+    gap: 0 2em;
+    padding-left: 0;
+
+    .sidebar-container {
+      padding-bottom: 6.6em;
+      transition: width 0.25s;
+    }
+  }
+}


### PR DESCRIPTION
To test: `SiteSetting.enable_experimental_sidebar=true`

Glimmer component can use a good review... 

* First pass of getting the sidebar workable on mobile + animation
* Added saving sidebar state to localstorage on desktop
* A little more padding for sidebar items
* Moved some styles from desktop to common

![Kapture 2022-07-01 at 22 39 16](https://user-images.githubusercontent.com/1681963/176983758-02e3cb3f-c8fa-4df5-a5f0-ee15565e2b55.gif)

