### PR TITLE
DEV: Use our `ajax` helper consistently

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/category-tag-search.js
+++ b/app/assets/javascripts/discourse/app/lib/category-tag-search.js
@@ -5,8 +5,8 @@ import { Promise } from "rsvp";
 import { SEPARATOR } from "discourse/lib/category-hashtags";
 import { TAG_HASHTAG_POSTFIX } from "discourse/lib/tag-hashtags";
 import discourseDebounce from "discourse-common/lib/debounce";
-import getURL from "discourse-common/lib/get-url";
 import { isTesting } from "discourse-common/config/environment";
+import { ajax } from "discourse/lib/ajax";
 
 let cache = {};
 let cacheTime;
@@ -30,8 +30,7 @@ function searchTags(term, categories, limit) {
       discourseDebounce(
         this,
         function () {
-          oldSearch = $.ajax(getURL("/tags/filter/search"), {
-            type: "GET",
+          oldSearch = ajax("/tags/filter/search", {
             data: { limit, q },
           });
 
@@ -50,7 +49,7 @@ function searchTags(term, categories, limit) {
 
               returnVal = cats.concat(tags);
             })
-            .always(() => {
+            .finally(() => {
               oldSearch = null;
               resultFunc(returnVal);
             });

--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -5,6 +5,7 @@ import discourseDebounce from "discourse-common/lib/debounce";
 import { emailValid } from "discourse/lib/utilities";
 import { isTesting } from "discourse-common/config/environment";
 import { userPath } from "discourse/lib/url";
+import { ajax } from "discourse/lib/ajax";
 
 let cache = {},
   cacheKey,
@@ -75,7 +76,7 @@ function performSearch(
   }
 
   // need to be able to cancel this
-  oldSearch = $.ajax(userPath("search/users"), {
+  oldSearch = ajax(userPath("search/users"), {
     data,
   });
 
@@ -102,7 +103,7 @@ function performSearch(
         returnVal = r;
       }
     })
-    .always(function () {
+    .finally(function () {
       oldSearch = null;
       resultsFn(returnVal);
     });


### PR DESCRIPTION
Possibly fixes some flakes, but regardless - we need to avoid using `$.ajax` directly in most cases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
