### PR TITLE
FIX: Move `ember-cli-deprecation-workflow` to runtime deps

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -44,6 +44,7 @@
     "ember-cli-app-version": "^5.0.0",
     "ember-cli-babel": "^7.23.1",
     "ember-cli-dependency-checker": "^3.3.1",
+    "ember-cli-deprecation-workflow": "^2.1.0",
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
@@ -91,7 +92,6 @@
   },
   "devDependencies": {
     "ember-cached-decorator-polyfill": "^0.1.4",
-    "ember-cli-deprecation-workflow": "^2.1.0",
     "ember-exam": "^7.0.1"
   }
 }


### PR DESCRIPTION
We have a weird setup where almost all deps need to be runtime…

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
