### PR TITLE
FIX: Experimental sidebar preferences link not shown for users

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/preferences.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences.hbs
@@ -49,7 +49,8 @@
         {{i18n "user.preferences_nav.interface"}}
       </LinkTo>
     </li>
-    {{#if this.currentUser.experimental_sidebar_enabled}}
+
+    {{#if this.siteSettings.enable_experimental_sidebar}}
       <li class="indent nav-sidebar">
         {{#link-to "preferences.sidebar"}}
           {{i18n "user.preferences_nav.sidebar"}}


### PR DESCRIPTION
Not writing any tests here because there is very little value to test
for an option that will eventually be removed