### PR TITLE
FIX: Correctly display `/admin/emails` errors

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-email-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-email-index.js
@@ -43,10 +43,10 @@ export default Controller.extend({
           this.set("sentTestEmailMessage", response.sent_test_email_message)
         )
         .catch((e) => {
-          if (e.responseJSON && e.responseJSON.errors) {
+          if (e.jqXHR.responseJSON?.errors) {
             bootbox.alert(
               I18n.t("admin.email.error", {
-                server_error: e.responseJSON.errors[0],
+                server_error: e.jqXHR.responseJSON.errors[0],
               })
             );
           } else {

--- a/app/assets/javascripts/admin/addon/routes/admin-badges-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-badges-show.js
@@ -33,16 +33,6 @@ export default Route.extend({
   },
 
   actions: {
-    saveError(e) {
-      let msg = I18n.t("generic_error");
-      if (e.responseJSON && e.responseJSON.errors) {
-        msg = I18n.t("generic_error_with_reason", {
-          error: e.responseJSON.errors.join(". "),
-        });
-      }
-      bootbox.alert(msg);
-    },
-
     editGroupings() {
       const model = this.controllerFor("admin-badges").get("badgeGroupings");
       showModal("admin-edit-badge-groupings", { model, admin: true });


### PR DESCRIPTION
Also removed unused codepath in `admin-badges-show`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
