### PR TITLE
DEV: Preload CSS in the `<head>`

### DIFF
--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -11,7 +11,6 @@
     <bootstrap-content key="before-script-load">
     {{content-for "before-script-load"}}
 
-
     <bootstrap-content key="discourse-preload-stylesheets">
     {{content-for "discourse-preload-stylesheets"}}
 

--- a/app/assets/javascripts/discourse/app/index.html
+++ b/app/assets/javascripts/discourse/app/index.html
@@ -11,6 +11,10 @@
     <bootstrap-content key="before-script-load">
     {{content-for "before-script-load"}}
 
+
+    <bootstrap-content key="discourse-preload-stylesheets">
+    {{content-for "discourse-preload-stylesheets"}}
+
     <script defer src="{{rootURL}}assets/vendor.js"></script>
     <script defer src="{{rootURL}}assets/discourse.js"></script>
 

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -101,6 +101,26 @@ function beforeScriptLoad(buffer, bootstrap) {
   );
 }
 
+function discoursePreloadStylesheets(buffer, bootstrap) {
+  (bootstrap.stylesheets || []).forEach((s) => {
+    let attrs = [];
+    if (s.media) {
+      attrs.push(`media="${s.media}"`);
+    }
+    if (s.target) {
+      attrs.push(`data-target="${s.target}"`);
+    }
+    if (s.theme_id) {
+      attrs.push(`data-theme-id="${s.theme_id}"`);
+    }
+    if (s.class) {
+      attrs.push(`class="${s.class}"`);
+    }
+    let link = `<link rel="preload" as="style" href="${s.href}">`;
+    buffer.push(link);
+  });
+}
+
 function discourseStylesheets(buffer, bootstrap) {
   (bootstrap.stylesheets || []).forEach((s) => {
     let attrs = [];
@@ -164,6 +184,7 @@ function preloaded(buffer, bootstrap) {
 const BUILDERS = {
   "html-tag": htmlTag,
   "before-script-load": beforeScriptLoad,
+  "discourse-preload-stylesheets": discoursePreloadStylesheets,
   head,
   body,
   "discourse-stylesheets": discourseStylesheets,

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -103,19 +103,6 @@ function beforeScriptLoad(buffer, bootstrap) {
 
 function discoursePreloadStylesheets(buffer, bootstrap) {
   (bootstrap.stylesheets || []).forEach((s) => {
-    let attrs = [];
-    if (s.media) {
-      attrs.push(`media="${s.media}"`);
-    }
-    if (s.target) {
-      attrs.push(`data-target="${s.target}"`);
-    }
-    if (s.theme_id) {
-      attrs.push(`data-theme-id="${s.theme_id}"`);
-    }
-    if (s.class) {
-      attrs.push(`class="${s.class}"`);
-    }
     let link = `<link rel="preload" as="style" href="${s.href}">`;
     buffer.push(link);
   });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -570,6 +570,19 @@ module ApplicationHelper
     )
   end
 
+  def discourse_stylesheet_preload_tag(name, opts = {})
+    manager =
+      if opts.key?(:theme_id)
+        Stylesheet::Manager.new(
+          theme_id: customization_disabled? ? nil : opts[:theme_id]
+        )
+      else
+        stylesheet_manager
+      end
+
+    manager.stylesheet_preload_tag(name, 'all')
+  end
+
   def discourse_stylesheet_link_tag(name, opts = {})
     manager =
       if opts.key?(:theme_id)
@@ -581,6 +594,17 @@ module ApplicationHelper
       end
 
     manager.stylesheet_link_tag(name, 'all')
+  end
+
+  def discourse_preload_color_scheme_stylesheets
+    result = +""
+    result << stylesheet_manager.color_scheme_stylesheet_preload_tag(scheme_id, 'all')
+
+    if dark_scheme_id != -1
+      result << stylesheet_manager.color_scheme_stylesheet_preload_tag(dark_scheme_id, '(prefers-color-scheme: dark)')
+    end
+
+    result.html_safe
   end
 
   def discourse_color_scheme_stylesheets

--- a/app/views/common/_discourse_preload_stylesheet.html.erb
+++ b/app/views/common/_discourse_preload_stylesheet.html.erb
@@ -1,0 +1,23 @@
+<%= discourse_preload_color_scheme_stylesheets %>
+
+<%- if rtl? %>
+  <%= discourse_stylesheet_preload_tag(mobile_view? ? :mobile_rtl : :desktop_rtl) %>
+<%- else %>
+  <%= discourse_stylesheet_preload_tag(mobile_view? ? :mobile : :desktop) %>
+<%- end %>
+
+<%- if staff? %>
+  <%= discourse_stylesheet_preload_tag(:admin) %>
+<%- end %>
+
+<%- if admin? %>
+  <%= discourse_stylesheet_preload_tag(:wizard) %>
+<%- end %>
+
+<%- Discourse.find_plugin_css_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, mobile_view: mobile_view?, desktop_view: !mobile_view?, request: request).each do |file| %>
+  <%= discourse_stylesheet_preload_tag(file) %>
+<%- end %>
+
+<%- if theme_id.present? %>
+  <%= discourse_stylesheet_preload_tag(mobile_view? ? :mobile_theme : :desktop_theme) %>
+<%- end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,8 @@
     <meta name="description" content="<%= @description_meta || SiteSetting.site_description %>">
     <meta name="discourse_theme_id" content="<%= theme_id %>">
     <meta name="discourse_current_homepage" content="<%= current_homepage %>">
+
+    <%= render partial: "common/discourse_preload_stylesheet" %>
     <%= render partial: "layouts/head" %>
     <%= discourse_csrf_tags %>
 

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -188,6 +188,18 @@ class Stylesheet::Manager
     stylesheet_details(target, "all")
   end
 
+  def stylesheet_preload_tag(target = :desktop, media = 'all')
+    stylesheets = stylesheet_details(target, media)
+    stylesheets.map do |stylesheet|
+      href = stylesheet[:new_href]
+      theme_id = stylesheet[:theme_id]
+      data_theme_id = theme_id ? "data-theme-id=\"#{theme_id}\"" : ""
+      theme_name = stylesheet[:theme_name]
+      data_theme_name = theme_name ? "data-theme-name=\"#{CGI.escapeHTML(theme_name)}\"" : ""
+      %[<link href="#{href}" rel="preload" as="style"/>]
+    end.join("\n").html_safe
+  end
+
   def stylesheet_link_tag(target = :desktop, media = 'all')
     stylesheets = stylesheet_details(target, media)
     stylesheets.map do |stylesheet|
@@ -291,6 +303,18 @@ class Stylesheet::Manager
     stylesheet[:new_href] = href
     cache.defer_set(cache_key, stylesheet.freeze)
     stylesheet
+  end
+
+  def color_scheme_stylesheet_preload_tag(color_scheme_id = nil, media = 'all')
+    stylesheet = color_scheme_stylesheet_details(color_scheme_id, media)
+
+    return '' if !stylesheet
+
+    href = stylesheet[:new_href]
+
+    css_class = media == 'all' ? "light-scheme" : "dark-scheme"
+
+    %[<link href="#{href}" rel="preload" as="style"/>].html_safe
   end
 
   def color_scheme_stylesheet_link_tag(color_scheme_id = nil, media = 'all')

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -192,10 +192,6 @@ class Stylesheet::Manager
     stylesheets = stylesheet_details(target, media)
     stylesheets.map do |stylesheet|
       href = stylesheet[:new_href]
-      theme_id = stylesheet[:theme_id]
-      data_theme_id = theme_id ? "data-theme-id=\"#{theme_id}\"" : ""
-      theme_name = stylesheet[:theme_name]
-      data_theme_name = theme_name ? "data-theme-name=\"#{CGI.escapeHTML(theme_name)}\"" : ""
       %[<link href="#{href}" rel="preload" as="style"/>]
     end.join("\n").html_safe
   end
@@ -311,8 +307,6 @@ class Stylesheet::Manager
     return '' if !stylesheet
 
     href = stylesheet[:new_href]
-
-    css_class = media == 'all' ? "light-scheme" : "dark-scheme"
 
     %[<link href="#{href}" rel="preload" as="style"/>].html_safe
   end


### PR DESCRIPTION
This commit adds preload links for core/plugin/theme CSS stylesheets in the head. 

Preload links are non-blocking and run in parallel. This means that they should have already been downloaded by the time we use the actual stylesheets (in the `<body>` tag). 

Google is currently complaining about this here.

<img height=300 src="https://user-images.githubusercontent.com/33972521/177163991-f0b082fc-a248-45ef-af8d-2b60f282e091.png">

and this PR will address that warning. 

This PR will also fix an issue in the splash screen where it sometimes doesn't respect the theme colors - causing a slightly jarring experience on dark themes.

Note that I opted not to add new specs because the underlying work required already has a lot of coverage. The new methods only change the output `HTML` so we can chuck that in the document `<head>` 

This change also means that we can make all the stylesheets non-render blocking, but that will follow in a separate PR.