### PR TITLE
FIX: Replace onebox markdown when pulling hotlinked image

### DIFF
--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -245,6 +245,14 @@ class InlineUploads
     # Markdown inline - ![alt](http://... "image title")
     InlineUploads.match_md_inline_img(raw, external_src: true, &replace)
 
+    raw.gsub!(/^(https?:\/\/\S+)(\s?)$/) do |match|
+      if upload = blk.call(match)
+        "![](#{upload.short_url})"
+      else
+        match
+      end
+    end
+
     raw
   end
 

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -350,6 +350,7 @@ describe Jobs::PullHotlinkedImages do
       before do
         stub_request(:head, url)
         stub_request(:get, url).to_return(body: '')
+        stub_request(:head, image_url)
 
         stub_request(:get, api_url).to_return(body: "{
           \"query\": {
@@ -399,6 +400,7 @@ describe Jobs::PullHotlinkedImages do
         #{url}
         <img src='#{broken_image_url}'>
         <a href='#{url}'><img src='#{large_image_url}'></a>
+        #{image_url}
         MD
         stub_image_size
 
@@ -413,6 +415,7 @@ describe Jobs::PullHotlinkedImages do
         https://commons.wikimedia.org/wiki/File:Brisbane_May_2013201.jpg
         <img src='#{broken_image_url}'>
         <a href='#{url}'><img src='#{large_image_url}'></a>
+        ![](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
         MD
 
         expect(post.cooked).to match(/<p><img src=.*\/uploads/)


### PR DESCRIPTION
If an image is oneboxed directly, then we should replace the onebox URL with a markdown image tag. This ensures that the wrapper link points to the downloaded version rather than the original.

This regressed in bf6f8299

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
