### PR TITLE
UX: Retain category badge style on categories select kit.

### DIFF
--- a/app/assets/stylesheets/common/select-kit/category-row.scss
+++ b/app/assets/stylesheets/common/select-kit/category-row.scss
@@ -10,10 +10,6 @@
       -webkit-box-flex: 0;
       -ms-flex: 1 1 auto;
       flex: 1 1 auto;
-
-      .category-name {
-        color: var(--primary);
-      }
     }
     .category-desc p {
       margin: 0;


### PR DESCRIPTION
Category badge changes based on the `category style` site setting so we
do not want to forcing all category names to the same color.

Follow-up to 3266350e80da4508243f667a39fd9d07e031adf1

### Before 

![Screenshot from 2022-07-05 09-55-39](https://user-images.githubusercontent.com/4335742/177234402-8aacbebd-f209-4380-bf1b-546b8c492278.png)

 
### After 

![Screenshot from 2022-07-05 09-55-47](https://user-images.githubusercontent.com/4335742/177234411-33f100fd-a5d1-430c-bca0-8d3ff1d46b74.png)
