### PR TITLE
UX: Enforce bullet category style in sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/categories-section/category-section-link.js
@@ -49,7 +49,9 @@ export default class CategorySectionLink {
   }
 
   get text() {
-    return htmlSafe(categoryBadgeHTML(this.category, { link: false }));
+    return htmlSafe(
+      categoryBadgeHTML(this.category, { link: false, categoryStyle: "bullet" })
+    );
   }
 
   get badgeCount() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-categories-section-test.js
@@ -141,6 +141,20 @@ acceptance("Sidebar - Categories Section", function (needs) {
     );
   });
 
+  test("category section links uses the bullet style even when category_style site setting has been configured", async function (assert) {
+    this.siteSettings.category_style = "box";
+    const { category1 } = setupUserSidebarCategories();
+
+    await visit("/");
+
+    assert.ok(
+      exists(
+        `.sidebar-section-categories .sidebar-section-link-${category1.slug} .badge-wrapper.bullet`
+      ),
+      "category badge uses the bullet style"
+    );
+  });
+
   test("category section links", async function (assert) {
     const { category1, category2 } = setupUserSidebarCategories();
 


### PR DESCRIPTION
The other category styles do not fit into how we want the sidebar to
look.