### PR TITLE
UX: Hide user menu bookmark link when experimental sidebar is enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -153,7 +153,9 @@ createWidget("user-menu-links", {
       });
     }
 
-    glyphs.push(this.bookmarksGlyph());
+    if (!this.currentUser.experimental_sidebar_enabled) {
+      glyphs.push(this.bookmarksGlyph());
+    }
 
     if (this.siteSettings.enable_personal_messages || this.currentUser.staff) {
       glyphs.push(this.messagesGlyph());

--- a/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
@@ -154,6 +154,21 @@ discourseModule(
       },
     });
 
+    componentTest("bookmarks - experimental sidebar enabled", {
+      template: hbs`{{mount-widget widget="user-menu"}}`,
+
+      beforeEach() {
+        this.currentUser.setProperties({ experimental_sidebar_enabled: true });
+      },
+
+      async test(assert) {
+        assert.notOk(
+          exists(".user-bookmarks-link"),
+          "user bookmark link is not displayed"
+        );
+      },
+    });
+
     componentTest("bookmarks", {
       template: hbs`{{mount-widget widget="user-menu"}}`,
 


### PR DESCRIPTION
Sidebar has a link to bookmarks by default

### Before

![Screenshot from 2022-07-05 15-42-12](https://user-images.githubusercontent.com/4335742/177276153-dfed5746-d4bc-49ab-8b49-b0ded5b385a6.png)

### After

![Screenshot from 2022-07-05 15-42-19](https://user-images.githubusercontent.com/4335742/177276179-28522cfc-13ec-41f8-a2dd-1ec2201de639.png)
