### PR TITLE
DEV: Improve multisite db scripts in dev

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -45,7 +45,7 @@ if ENV['RAILS_ENV'] == "test" && ENV['TEST_ENV_NUMBER']
   pid = Process.spawn("redis-server --dir tmp/test_data_#{n}/redis --port #{port}", out: "/dev/null")
 
   ENV["DISCOURSE_REDIS_PORT"] = port.to_s
-  ENV["RAILS_DB"] = "discourse_test_#{n}"
+  ENV["RAILS_TEST_DB"] = "discourse_test_#{n}"
 
   at_exit do
     Process.kill("SIGTERM", pid)

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,7 +22,7 @@ development:
 # Do not set this db to the same as development or production.
 
 <%
-  test_db = ENV["RAILS_DB"]
+  test_db = ENV["RAILS_TEST_DB"]
   if !test_db.present?
     test_db = "discourse_test"
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -11,17 +11,17 @@ end
 
 module MultisiteTestHelpers
   def self.load_multisite?
-    Rails.env.test? && !ENV["RAILS_DB"] && !ENV["SKIP_MULTISITE"]
+    Rails.env.test? && !ENV["RAILS_TEST_DB"] && !ENV["SKIP_MULTISITE"]
   end
 
   def self.create_multisite?
-    (Rails.env.test? || Rails.env.development?) && !ENV["RAILS_DB"] && !ENV["DATABASE_URL"] && !ENV["SKIP_MULTISITE"]
+    (Rails.env.test? || Rails.env.development?) && !ENV["RAILS_TEST_DB"] && !ENV["DATABASE_URL"] && !ENV["SKIP_MULTISITE"]
   end
 end
 
 task 'db:environment:set' => [:load_config]  do |_, args|
   if MultisiteTestHelpers.load_multisite?
-    system("RAILS_ENV=test RAILS_DB=discourse_test_multisite rake db:environment:set")
+    system("RAILS_ENV=test RAILS_TEST_DB=discourse_test_multisite rake db:environment:set")
   end
 end
 
@@ -50,7 +50,7 @@ end
 
 task 'db:create' => [:load_config] do |_, args|
   if MultisiteTestHelpers.create_multisite?
-    unless system("RAILS_ENV=test RAILS_DB=discourse_test_multisite rake db:create")
+    unless system("RAILS_ENV=test RAILS_TEST_DB=discourse_test_multisite rake db:create")
 
       STDERR.puts "-" * 80
       STDERR.puts "ERROR: Could not create multisite DB. A common cause of this is a plugin"
@@ -77,7 +77,7 @@ end
 
 task 'db:drop' => [:load_config] do |_, args|
   if MultisiteTestHelpers.create_multisite?
-    system("RAILS_DB=discourse_test_multisite RAILS_ENV=test rake db:drop")
+    system("RAILS_TEST_DB=discourse_test_multisite RAILS_ENV=test rake db:drop")
 
     RailsMultisite::ConnectionManagement.all_dbs.each do |db|
       spec = RailsMultisite::ConnectionManagement.connection_spec(db: db)
@@ -269,7 +269,7 @@ task 'db:migrate' => ['load_config', 'environment', 'set_locale'] do |_, args|
     SeedFu.quiet = true
     SeedFu.seed(SeedHelper.paths, SeedHelper.filter)
 
-    if Rails.env.development? && !ENV["RAILS_DB"]
+    if Rails.env.development? && !ENV["RAILS_TEST_DB"]
       Rake::Task['db:schema:cache:dump'].invoke
     end
 
@@ -279,7 +279,7 @@ task 'db:migrate' => ['load_config', 'environment', 'set_locale'] do |_, args|
   end
 
   if !Discourse.is_parallel_test? && MultisiteTestHelpers.load_multisite?
-    system("RAILS_DB=discourse_test_multisite rake db:migrate")
+    system("RAILS_TEST_DB=discourse_test_multisite rake db:migrate")
   end
 end
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -84,9 +84,9 @@ task "db:create" => :load_config do
 end
 
 begin
-  reqs = Rake::Task['db:create'].prerequisites.map(&:to_sym)
+  prerequisites = Rake::Task['db:create'].prerequisites.map(&:to_sym)
   Rake::Task['db:create'].clear_prerequisites
-  Rake::Task['db:create'].enhance(["db:force_skip_persist", "multisite:create"] + reqs)
+  Rake::Task['db:create'].enhance(["db:force_skip_persist", "multisite:create"] + prerequisites)
 end
 
 # db:drop and related tasks
@@ -119,9 +119,9 @@ task "db:drop" => :load_config do
 end
 
 begin
-  reqs = Rake::Task['db:drop'].prerequisites.map(&:to_sym)
+  prerequisites = Rake::Task['db:drop'].prerequisites.map(&:to_sym)
   Rake::Task['db:drop'].clear_prerequisites
-  Rake::Task['db:drop'].enhance(["db:force_skip_persist", "multisite:drop"] + reqs)
+  Rake::Task['db:drop'].enhance(["db:force_skip_persist", "multisite:drop"] + prerequisites)
 end
 
 # db:migrate and related tasks

--- a/lib/temporary_db.rb
+++ b/lib/temporary_db.rb
@@ -104,13 +104,13 @@ class TemporaryDb
     old_user = ENV["PGUSER"]
     old_port = ENV["PGPORT"]
     old_dev_db = ENV["DISCOURSE_DEV_DB"]
-    old_rails_db = ENV["RAILS_DB"]
+    old_rails_test_db = ENV["RAILS_TEST_DB"]
 
     ENV["PGHOST"] = "localhost"
     ENV["PGUSER"] = "discourse"
     ENV["PGPORT"] = pg_port.to_s
     ENV["DISCOURSE_DEV_DB"] = "discourse"
-    ENV["RAILS_DB"] = "discourse"
+    ENV["RAILS_TEST_DB"] = "discourse"
 
     yield
   ensure
@@ -118,7 +118,7 @@ class TemporaryDb
     ENV["PGUSER"] = old_user
     ENV["PGPORT"] = old_port
     ENV["DISCOURSE_DEV_DB"] = old_dev_db
-    ENV["RAILS_DB"] = old_rails_db
+    ENV["RAILS_TEST_DB"] = old_rails_test_db
   end
 
   def remove


### PR DESCRIPTION
## Without multisite.yml config

No change. `bin/rails db:create` / `db:migrate` / `db:drop` should work the same.

## With multisite.yml config

### db:create

`bin/rails db:create` creates development, test, and all databases from the multisite config

`RAILS_DB=[site] bin/rails db:create` creates the database for the specified site from the multisite config

### db:migrate

`bin/rails db:migrate` migrates the development database and all databases from the multisite config

`RAILS_ENV=test bin/rails db:migrate` migrates the test database and `discourse_test_multisite`

`RAILS_DB=[site] bin/rails db:migrate` migrates the database for the specified site from the multisite config

### db:drop

`bin/rails db:drop` drops development, test, and all databases from the multisite config

`RAILS_DB=[site] bin/rails db:create` drops the database for the specified site from the multisite config