### PR TITLE
UX: Prevent overlap between splash loader and splash text on some browsers take 2

### DIFF
--- a/app/views/common/_discourse_splash.html.erb
+++ b/app/views/common/_discourse_splash.html.erb
@@ -11,9 +11,6 @@
       backface-visibility: hidden;
       background: var(--secondary);
       position: absolute;
-      left: 0;
-      top: 0;
-      height: 100%;
       width: 100%;
       z-index: 1001;
       --animation-state: paused;
@@ -32,10 +29,7 @@
       animation-fill-mode: forwards;
       animation-play-state: var(--animation-state);
       color: var(--primary);
-    }
-
-    #d-splash .preloader-text {
-      padding-top: 4em;
+      margin-bottom: -4em;
     }
 
     #d-splash .preloader-text:after {


### PR DESCRIPTION
Same as https://github.com/discourse/discourse/pull/17340

context: https://meta.discourse.org/t/show-a-loader-starting-page-for-slow-connections/42981/23?u=johani

No visual changes, just a fix for more situations where the overlap happens.