### PR TITLE
UX: Display gap between tag sort options on PMs

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user-private-messages-tags.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-private-messages-tags.hbs
@@ -6,16 +6,8 @@
 
 <div class="tag-sort-options">
   {{i18n "tagging.sort_by"}}
-  <span class="tag-sort-count {{if sortedByCount "active"}}">
-    <a href {{action "sortByCount"}}>
-      {{i18n "tagging.sort_by_count"}}
-    </a>
-  </span>
-  <span class="tag-sort-name {{if sortedByName "active"}}">
-    <a href {{action "sortById"}}>
-      {{i18n "tagging.sort_by_name"}}
-    </a>
-  </span>
+  <span class="tag-sort-count {{if sortedByCount "active"}}"><a href {{action "sortByCount"}}>{{i18n "tagging.sort_by_count"}}</a></span>
+  <span class="tag-sort-name {{if sortedByName "active"}}"><a href {{action "sortById"}}>{{i18n "tagging.sort_by_name"}}</a></span>
 </div>
 
 <hr>

--- a/app/assets/javascripts/discourse/app/templates/user-private-messages-tags.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-private-messages-tags.hbs
@@ -6,8 +6,16 @@
 
 <div class="tag-sort-options">
   {{i18n "tagging.sort_by"}}
-  <span class="tag-sort-count {{if sortedByCount "active"}}"><a href {{action "sortByCount"}}>{{i18n "tagging.sort_by_count"}}</a></span>
-  <span class="tag-sort-name {{if sortedByName "active"}}"><a href {{action "sortById"}}>{{i18n "tagging.sort_by_name"}}</a></span>
+  <span class="tag-sort-count {{if sortedByCount "active"}}">
+    <a href {{action "sortByCount"}}>
+      {{i18n "tagging.sort_by_count"}}
+    </a>
+  </span>
+  <span class="tag-sort-name {{if sortedByName "active"}}">
+    <a href {{action "sortById"}}>
+      {{i18n "tagging.sort_by_name"}}
+    </a>
+  </span>
 </div>
 
 <hr>

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -185,6 +185,7 @@ header .discourse-tag {
   margin-bottom: 20px;
   a {
     text-decoration: underline;
+    display: inline-flex;
   }
   span.active a {
     font-weight: bold;


### PR DESCRIPTION
Adjust whitespace on private message tag sorting options so that the two links are rendered with a gap between them.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
