### PR TITLE
FEATURE: Publish everyone's status to everyone

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -116,8 +116,8 @@ export default {
         user.updateDoNotDisturbStatus(data.ends_at);
       });
 
-      bus.subscribe(`/user-status/${user.id}`, (data) => {
-        appEvents.trigger("current-user-status:changed", data);
+      bus.subscribe(`/user-status`, (data) => {
+        appEvents.trigger("user-status:changed", data);
       });
 
       const site = container.lookup("site:main");

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1185,13 +1185,7 @@ User.reopen(Evented, {
   trackStatus() {
     this.addObserver("status", this, "_statusChanged");
 
-    if (this.isCurrent) {
-      this.appEvents.on(
-        "current-user-status:changed",
-        this,
-        this._updateStatus
-      );
-    }
+    this.appEvents.on("user-status:changed", this, this._updateStatus);
 
     if (this.status && this.status.ends_at) {
       this._scheduleStatusClearing(this.status.ends_at);
@@ -1200,13 +1194,7 @@ User.reopen(Evented, {
 
   stopTrackingStatus() {
     this.removeObserver("status", this, "_statusChanged");
-    if (this.isCurrent) {
-      this.appEvents.off(
-        "current-user-status:changed",
-        this,
-        this._updateStatus
-      );
-    }
+    this.appEvents.off("user-status:changed", this, this._updateStatus);
     this._unscheduleStatusClearing();
   },
 
@@ -1244,8 +1232,8 @@ User.reopen(Evented, {
     this.set("status", null);
   },
 
-  _updateStatus(status) {
-    this.set("status", status);
+  _updateStatus(statuses) {
+    this.set("status", statuses[this.id]);
   },
 });
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -676,7 +676,7 @@ class User < ActiveRecord::Base
       payload = nil
     end
 
-    MessageBus.publish("/user-status/#{id}", payload, user_ids: [id])
+    MessageBus.publish("/user-status", { id => payload })
   end
 
   def password=(password)

--- a/spec/requests/user_status_controller_spec.rb
+++ b/spec/requests/user_status_controller_spec.rb
@@ -98,12 +98,11 @@ describe UserStatusController do
         end
 
         expect(messages.size).to eq(1)
-        expect(messages[0].channel).to eq("/user-status/#{user.id}")
-        expect(messages[0].user_ids).to eq([user.id])
+        expect(messages[0].channel).to eq("/user-status")
 
-        expect(messages[0].data[:description]).to eq(status)
-        expect(messages[0].data[:emoji]).to eq(emoji)
-        expect(messages[0].data[:ends_at]).to eq(ends_at)
+        expect(messages[0].data[user.id][:description]).to eq(status)
+        expect(messages[0].data[user.id][:emoji]).to eq(emoji)
+        expect(messages[0].data[user.id][:ends_at]).to eq(ends_at)
       end
     end
   end
@@ -145,9 +144,8 @@ describe UserStatusController do
         messages = MessageBus.track_publish { delete "/user-status.json" }
 
         expect(messages.size).to eq(1)
-        expect(messages[0].channel).to eq("/user-status/#{user.id}")
-        expect(messages[0].data).to eq(nil)
-        expect(messages[0].user_ids).to eq([user.id])
+        expect(messages[0].channel).to eq("/user-status")
+        expect(messages[0].data[user.id]).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
Before, we were delivering only current user's status to the user themselves. This PR adds delivering everyone statuses to everyone. We will be delivering all statuses using the only message bus channel. Performance wise, we discussed this internally, and we don't expect that user statuses are going to be changing very often and likely this should work fine. But we may optimize this in the future.

For now, there is the only place in UI where this change makes a visible difference (there'll be more places soon). If a user would update status while you're looking at their user card, you'll see that immediately:

<img width="400" alt="Screenshot 2022-07-05 at 21 16 11" src="https://user-images.githubusercontent.com/1274517/177382423-f3571291-1d12-4089-8d7a-9bb191dca1b6.png">

This isn't the most desirable place where we want to have "live" status, this will be much more important on the chat. At the same time, with the current implementation, we'll likely be able to implement live statuses easily pretty much everywhere.
