### PR TITLE
DEV: Add user status to basic user serializer

### DIFF
--- a/app/serializers/basic_user_serializer.rb
+++ b/app/serializers/basic_user_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BasicUserSerializer < ApplicationSerializer
-  attributes :id, :username, :name, :avatar_template
+  attributes :id, :username, :name, :avatar_template, :status
 
   def name
     Hash === user ? user[:name] : user.try(:name)
@@ -35,5 +35,13 @@ class BasicUserSerializer < ApplicationSerializer
 
   def category_user_notification_levels
     @category_user_notification_levels ||= CategoryUser.notification_levels_for(user)
+  end
+
+  def include_status?
+    SiteSetting.enable_user_status && object.has_status?
+  end
+
+  def status
+    UserStatusSerializer.new(object.user_status, root: false)
   end
 end

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -72,7 +72,6 @@ class CurrentUserSerializer < BasicUserSerializer
              :bookmark_auto_delete_preference,
              :pending_posts_count,
              :experimental_sidebar_enabled,
-             :status,
              :sidebar_category_ids,
              :sidebar_tag_names
 
@@ -329,13 +328,5 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def include_sidebar_tag_names?
     include_sidebar_category_ids? && SiteSetting.tagging_enabled
-  end
-
-  def include_status?
-    SiteSetting.enable_user_status && object.has_status?
-  end
-
-  def status
-    UserStatusSerializer.new(object.user_status, root: false)
   end
 end

--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -66,8 +66,7 @@ class UserCardSerializer < BasicUserSerializer
              :flair_color,
              :featured_topic,
              :timezone,
-             :pending_posts_count,
-             :status
+             :pending_posts_count
 
   untrusted_attributes :bio_excerpt,
                        :website,
@@ -221,14 +220,6 @@ class UserCardSerializer < BasicUserSerializer
 
   def card_background_upload_url
     object.card_background_upload&.url
-  end
-
-  def include_status?
-    SiteSetting.enable_user_status && user.has_status?
-  end
-
-  def status
-    UserStatusSerializer.new(user.user_status, root: false)
   end
 
   private

--- a/spec/serializers/basic_user_serializer_spec.rb
+++ b/spec/serializers/basic_user_serializer_spec.rb
@@ -25,4 +25,47 @@ describe BasicUserSerializer do
       expect(json[:name]).to eq(nil)
     end
   end
+
+  describe "#status" do
+    fab!(:user_status) { Fabricate(:user_status) }
+    fab!(:user) { Fabricate(:user, user_status: user_status) }
+    let(:serializer) { described_class.new(user, scope: Guardian.new(user), root: false) }
+
+    it "adds user status when enabled" do
+      SiteSetting.enable_user_status = true
+
+      json = serializer.as_json
+
+      expect(json[:status]).to_not be_nil do |status|
+        expect(status.description).to eq(user_status.description)
+        expect(status.emoji).to eq(user_status.emoji)
+      end
+    end
+
+    it "doesn't add user status when disabled" do
+      SiteSetting.enable_user_status = false
+      json = serializer.as_json
+      expect(json.keys).not_to include :status
+    end
+
+    it "doesn't add expired user status" do
+      SiteSetting.enable_user_status = true
+
+      user.user_status.ends_at = 1.minutes.ago
+      serializer = described_class.new(user, scope: Guardian.new(user), root: false)
+      json = serializer.as_json
+
+      expect(json.keys).not_to include :status
+    end
+
+    it "doesn't return status if user doesn't have it set" do
+      SiteSetting.enable_user_status = true
+
+      user.clear_status!
+      user.reload
+      json = serializer.as_json
+
+      expect(json.keys).not_to include :status
+    end
+  end
 end

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -177,49 +177,6 @@ RSpec.describe CurrentUserSerializer do
     end
   end
 
-  describe "#status" do
-    fab!(:user_status) { Fabricate(:user_status) }
-    fab!(:user) { Fabricate(:user, user_status: user_status) }
-    let(:serializer) { described_class.new(user, scope: Guardian.new(user), root: false) }
-
-    it "adds user status when enabled" do
-      SiteSetting.enable_user_status = true
-
-      json = serializer.as_json
-
-      expect(json[:status]).to_not be_nil do |status|
-        expect(status.description).to eq(user_status.description)
-        expect(status.emoji).to eq(user_status.emoji)
-      end
-    end
-
-    it "doesn't add user status when disabled" do
-      SiteSetting.enable_user_status = false
-      json = serializer.as_json
-      expect(json.keys).not_to include :status
-    end
-
-    it "doesn't add expired user status" do
-      SiteSetting.enable_user_status = true
-
-      user.user_status.ends_at = 1.minutes.ago
-      serializer = described_class.new(user, scope: Guardian.new(user), root: false)
-      json = serializer.as_json
-
-      expect(json.keys).not_to include :status
-    end
-
-    it "doesn't return status if user doesn't have it set" do
-      SiteSetting.enable_user_status = true
-
-      user.clear_status!
-      user.reload
-      json = serializer.as_json
-
-      expect(json.keys).not_to include :status
-    end
-  end
-
   describe '#sidebar_tag_names' do
     fab!(:tag_sidebar_section_link) { Fabricate(:tag_sidebar_section_link, user: user) }
     fab!(:tag_sidebar_section_link_2) { Fabricate(:tag_sidebar_section_link, user: user) }

--- a/spec/serializers/user_card_serializer_spec.rb
+++ b/spec/serializers/user_card_serializer_spec.rb
@@ -70,47 +70,4 @@ describe UserCardSerializer do
     end
 
   end
-
-  describe "#status" do
-    fab!(:user_status) { Fabricate(:user_status) }
-    fab!(:user) { Fabricate(:user, user_status: user_status) }
-    let(:serializer) { described_class.new(user, scope: Guardian.new(user), root: false) }
-
-    it "adds user status when enabled" do
-      SiteSetting.enable_user_status = true
-
-      json = serializer.as_json
-
-      expect(json[:status]).to_not be_nil do |status|
-        expect(status.description).to eq(user_status.description)
-        expect(status.emoji).to eq(user_status.emoji)
-      end
-    end
-
-    it "doesn't add user status when disabled" do
-      SiteSetting.enable_user_status = false
-      json = serializer.as_json
-      expect(json.keys).not_to include :status
-    end
-
-    it "doesn't add expired user status" do
-      SiteSetting.enable_user_status = true
-
-      user.user_status.ends_at = 1.minutes.ago
-      serializer = described_class.new(user, scope: Guardian.new(user), root: false)
-      json = serializer.as_json
-
-      expect(json.keys).not_to include :status
-    end
-
-    it "doesn't return status if user doesn't have it set" do
-      SiteSetting.enable_user_status = true
-
-      user.clear_status!
-      user.reload
-      json = serializer.as_json
-
-      expect(json.keys).not_to include :status
-    end
-  end
 end


### PR DESCRIPTION
Before, I  was avoiding adding user status to [BasicUserSerializer](https://github.com/discourse/discourse/blob/main/app/serializers/basic_user_serializer.rb). So far I added status to [CurrentUserSerializer](https://github.com/discourse/discourse/blob/main/app/serializers/current_user_serializer.rb) and [UserCardSerializer](https://github.com/discourse/discourse/blob/main/app/serializers/user_card_serializer.rb).

Now I'm about to add user status to the chat and that makes me think of the best serializer for user status. We use [UserWithCustomFieldsSerializer](https://github.com/discourse/discourse/blob/main/app/serializers/user_with_custom_fields_serializer.rb) for the DM message list on the sidebar and in order to add status there I probably need to create a new _UserWithCustomFields**WithStatus**Serializer_, then switch the plugin to using the new serializer (and take care of compatibility along the way). Not the best solution, IMO.

Now, I think that the best solution would be adding user status to _BasicUserSerializer_. This will make everything so much simper and actually should be fine because:
1. We strip off status completely on the sites with disabled user status
2. If user status enabled, we'll be showing it in many places
3. The status in the payload is not too big:
    ```json
    {
        "description": "off to dentist",
        "emoji": "tooth",
        "ends_at": "2022-07-05T18:15:46.681Z"
    }
    ```
