### PR TITLE
UX: staff notice should utilize full post width

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1437,6 +1437,7 @@ a.mention-group {
   background-color: var(--tertiary-low);
   border-top: 1px solid var(--primary-low);
   display: flex;
+  width: 100%;
   max-width: calc(
     #{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} -
       (0.8em * 2)


### PR DESCRIPTION
Before:
![Screen Shot 2022-07-05 at 3 45 06 PM](https://user-images.githubusercontent.com/1681963/177403970-fdcebd6c-b7da-48d0-951e-4d94958d1f2a.png)

After:
![Screen Shot 2022-07-05 at 3 45 12 PM](https://user-images.githubusercontent.com/1681963/177403973-064b5bf7-9642-4077-a18a-c9ab5e2a7af6.png)

