### PR TITLE
UX: Splash should always stick to top left corner of the viewport

### DIFF
--- a/app/views/common/_discourse_splash.html.erb
+++ b/app/views/common/_discourse_splash.html.erb
@@ -11,6 +11,8 @@
       backface-visibility: hidden;
       background: var(--secondary);
       position: absolute;
+      left: 0;
+      top: 0;
       width: 100%;
       z-index: 1001;
       --animation-state: paused;


### PR DESCRIPTION
No visual changes.

This PR only fixes some display issues on some browsers that don't respect the defaults.