### PR TITLE
Plugin resolution rework

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/legacy-resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/legacy-resolver.js
@@ -280,13 +280,13 @@ export function buildResolver(baseName) {
         }
       }
 
-      if (decamelized === "javascripts/admin") {
+      if (decamelized === "enabled-plugins/admin") {
         return Ember.TEMPLATES["admin/templates/admin"];
       }
 
       if (
         decamelized.indexOf("admin") === 0 ||
-        decamelized.indexOf("javascripts/admin") === 0
+        decamelized.indexOf("enabled-plugins/admin") === 0
       ) {
         decamelized = decamelized.replace(/^admin\_/, "admin/templates/");
         decamelized = decamelized.replace(/^admin\./, "admin/templates/");
@@ -312,13 +312,13 @@ export function buildResolver(baseName) {
         }
       }
 
-      if (decamelized === "javascripts/wizard") {
+      if (decamelized === "enabled-plugins/wizard") {
         return Ember.TEMPLATES["wizard/templates/wizard"];
       }
 
       if (
         decamelized.startsWith("wizard") ||
-        decamelized.startsWith("javascripts/wizard")
+        decamelized.startsWith("enabled-plugins/wizard")
       ) {
         decamelized = decamelized.replace(/^wizard\_/, "wizard/templates/");
         decamelized = decamelized.replace(/^wizard\./, "wizard/templates/");

--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -25,7 +25,7 @@ function lookupModuleBySuffix(suffix) {
   if (!moduleSuffixTrie) {
     moduleSuffixTrie = new SuffixTrie("/");
     Object.keys(requirejs.entries).forEach((name) => {
-      if (!name.includes("/templates/")) {
+      if (!name.includes("/templates/") && !name.startsWith("plugins/")) {
         moduleSuffixTrie.add(name);
       }
     });
@@ -216,17 +216,17 @@ export function buildResolver(baseName) {
             .replace("template:connectors/", "template:")
             .replace("components/", "")
         );
-        return this.findTemplate(connectorParsedName, "javascripts/");
+        return this.findTemplate(connectorParsedName, "enabled-plugins/");
       }
     }
 
     findPluginTemplate(parsedName) {
-      return this.findTemplate(parsedName, "javascripts/");
+      return this.findTemplate(parsedName, "enabled-plugins/");
     }
 
     findPluginMobileTemplate(parsedName) {
       if (_options.mobileView) {
-        return this.findTemplate(parsedName, "javascripts/mobile/");
+        return this.findTemplate(parsedName, "enabled-plugins/mobile/");
       }
     }
 
@@ -291,14 +291,14 @@ export function buildResolver(baseName) {
           // Built-in
           this.findTemplate(adminParsedName, "admin/templates/") ||
           // Plugin
-          this.findTemplate(adminParsedName, "javascripts/admin/");
+          this.findTemplate(adminParsedName, "admin/");
       }
 
       resolved ??=
         // Built-in
         this.findTemplate(parsedName, "admin/templates/") ||
         // Plugin
-        this.findTemplate(parsedName, "javascripts/admin/");
+        this.findTemplate(parsedName, "enabled-plugins/admin/");
 
       return resolved;
     }

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -64,6 +64,9 @@ function head(buffer, bootstrap, headers, baseURL) {
       setupData += ` data-${sd.replace(/\_/g, "-")}="${encode(val)}"`;
     }
   });
+  setupData += ` data-enabled-plugins=${encode(
+    JSON.stringify(bootstrap.enabled_plugins)
+  )}`;
   buffer.push(`<meta id="data-discourse-setup"${setupData} />`);
 
   if (bootstrap.preloaded.currentUser) {

--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
@@ -3,6 +3,22 @@
     throw "Unsupported browser detected";
   }
 
+  const setupDataElement = document.getElementById("data-discourse-setup");
+  let setupData;
+  if (setupDataElement) {
+    setupData = setupDataElement.dataset;
+  }
+
+  let enabledPlugins = setupData && setupData.enabledPlugins && JSON.parse(setupData.enabledPlugins);
+
+  Object.keys(Ember.TEMPLATES).forEach(function (key) {
+    let match = key.match(/^(plugins\/[^\/]+)\//);
+    if (match && (!enabledPlugins || enabledPlugins.includes(match[1]))) {
+      console.log('enabled', key);
+      Ember.TEMPLATES[key.replace(match[0], 'enabled-plugins/')] = Ember.TEMPLATES[key];
+    }
+  });
+
   // TODO: Remove this and have resolver find the templates
   const prefix = "discourse/templates/";
   const adminPrefix = "admin/templates/";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -10,7 +10,7 @@ import { extraConnectorClass } from "discourse/lib/plugin-connectors";
 import hbs from "htmlbars-inline-precompile";
 import { test } from "qunit";
 
-const PREFIX = "javascripts/single-test/connectors";
+const PREFIX = "enabled-plugins/single-test/connectors";
 
 acceptance("Plugin Outlet - Connector Class", function (needs) {
   needs.hooks.beforeEach(() => {

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -8,7 +8,7 @@ import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
-const PREFIX = "javascripts/single-test/connectors";
+const PREFIX = "enabled-plugins/single-test/connectors";
 
 acceptance("Plugin Outlet - Decorator", function (needs) {
   needs.user();

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -8,9 +8,10 @@ import hbs from "htmlbars-inline-precompile";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 
-const HELLO = "javascripts/multi-test/connectors/user-profile-primary/hello";
+const HELLO =
+  "enabled-plugins/multi-test/connectors/user-profile-primary/hello";
 const GOODBYE =
-  "javascripts/multi-test/connectors/user-profile-primary/goodbye";
+  "enabled-plugins/multi-test/connectors/user-profile-primary/goodbye";
 
 acceptance("Plugin Outlet - Multi Template", function (needs) {
   needs.hooks.beforeEach(() => {

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -8,7 +8,7 @@ import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 
 const CONNECTOR =
-  "javascripts/single-test/connectors/user-profile-primary/hello";
+  "enabled-plugins/single-test/connectors/user-profile-primary/hello";
 
 acceptance("Plugin Outlet - Single Template", function (needs) {
   needs.hooks.beforeEach(() => {

--- a/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/raw-plugin-outlet-test.js
@@ -12,7 +12,7 @@ import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 
 const CONNECTOR =
-  "javascripts/raw-test/connectors/topic-list-before-status/lala";
+  "enabled-plugins/raw-test/connectors/topic-list-before-status/lala";
 
 acceptance("Raw Plugin Outlet", function (needs) {
   needs.hooks.beforeEach(() => {

--- a/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
@@ -243,26 +243,26 @@ module("Unit | Ember | resolver", function (hooks) {
     );
   });
 
-  test("resolves plugin templates to 'javascripts/' namespace", function (assert) {
-    setTemplates(["javascripts/foo", "bar", "javascripts/bar", "baz"]);
+  test("resolves plugin templates to 'enabled-plugins/' namespace", function (assert) {
+    setTemplates(["enabled-plugins/foo", "bar", "enabled-plugins/bar", "baz"]);
 
-    // Default with javascripts/ added
+    // Default with enabled-plugins/ added
     lookupTemplate(
       assert,
       "template:foo",
-      "javascripts/foo",
+      "enabled-plugins/foo",
       "finding plugin version even if normal one is not present"
     );
 
-    // Default with javascripts/ added, takes precedence
+    // Default with enabled-plugins/ added, takes precedence
     lookupTemplate(
       assert,
       "template:bar",
-      "javascripts/bar",
+      "enabled-plugins/bar",
       "preferring plugin version when both versions are present"
     );
 
-    // Default when javascripts version not present
+    // Default when enabled-plugins version not present
     lookupTemplate(
       assert,
       "template:baz",
@@ -271,38 +271,38 @@ module("Unit | Ember | resolver", function (hooks) {
     );
   });
 
-  test("resolves plugin mobile templates to 'javascripts/mobile/' namespace", function (assert) {
+  test("resolves plugin mobile templates to 'enabled-plugins/mobile/' namespace", function (assert) {
     setTemplates([
-      "javascripts/mobile/foo",
-      "javascripts/mobile/bar",
-      "javascripts/bar",
-      "javascripts/mobile/baz",
+      "enabled-plugins/mobile/foo",
+      "enabled-plugins/mobile/bar",
+      "enabled-plugins/bar",
+      "enabled-plugins/mobile/baz",
       "mobile/baz",
     ]);
 
     setResolverOption("mobileView", true);
 
-    // Default with javascripts/mobile/ added
+    // Default with enabled-plugins/mobile/ added
     lookupTemplate(
       assert,
       "template:foo",
-      "javascripts/mobile/foo",
+      "enabled-plugins/mobile/foo",
       "finding plugin version even if normal one is not present"
     );
 
-    // Default with javascripts/mobile added, takes precedence over non-mobile
+    // Default with enabled-plugins/mobile added, takes precedence over non-mobile
     lookupTemplate(
       assert,
       "template:bar",
-      "javascripts/mobile/bar",
+      "enabled-plugins/mobile/bar",
       "preferring plugin mobile version when both non-mobile plugin version is also present"
     );
 
-    // Default with javascripts/mobile when non-plugin mobile version is present
+    // Default with enabled-plugins/mobile when non-plugin mobile version is present
     lookupTemplate(
       assert,
       "template:baz",
-      "javascripts/mobile/baz",
+      "enabled-plugins/mobile/baz",
       "preferring plugin mobile version over non-plugin mobile version"
     );
   });
@@ -316,7 +316,7 @@ module("Unit | Ember | resolver", function (hooks) {
       "admin/templates/bar",
       "admin/templates/dashboard_general",
       "admin-baz-qux",
-      "javascripts/admin/plugin-template",
+      "enabled-plugins/admin/plugin-template",
     ]);
 
     // Switches prefix to admin/templates when camelized
@@ -392,7 +392,7 @@ module("Unit | Ember | resolver", function (hooks) {
     lookupTemplate(
       assert,
       "template:admin-plugin/template",
-      "javascripts/admin/plugin-template",
+      "enabled-plugins/admin/plugin-template",
       "looks up templates in plugins"
     );
   });
@@ -481,43 +481,43 @@ module("Unit | Ember | resolver", function (hooks) {
 
   test("resolves connector templates", function (assert) {
     setTemplates([
-      "javascripts/foo",
-      "javascripts/connectors/foo-bar/baz_qux",
-      "javascripts/connectors/foo-bar/camelCase",
+      "enabled-plugins/foo",
+      "enabled-plugins/connectors/foo-bar/baz_qux",
+      "enabled-plugins/connectors/foo-bar/camelCase",
     ]);
 
     lookupTemplate(
       assert,
       "template:connectors/foo",
-      "javascripts/foo",
-      "looks up in javascripts/ namespace"
+      "enabled-plugins/foo",
+      "looks up in enabled-plugins/ namespace"
     );
 
     lookupTemplate(
       assert,
       "template:connectors/components/foo",
-      "javascripts/foo",
+      "enabled-plugins/foo",
       "removes components segment"
     );
 
     lookupTemplate(
       assert,
       "template:connectors/foo-bar/baz-qux",
-      "javascripts/connectors/foo-bar/baz_qux",
+      "enabled-plugins/connectors/foo-bar/baz_qux",
       "underscores last segment"
     );
 
     lookupTemplate(
       assert,
       "template:connectors/foo-bar/camelCase",
-      "javascripts/connectors/foo-bar/camelCase",
+      "enabled-plugins/connectors/foo-bar/camelCase",
       "handles camelcase file names"
     );
 
     lookupTemplate(
       assert,
       resolver.normalize("template:connectors/foo-bar/camelCase"),
-      "javascripts/connectors/foo-bar/camelCase",
+      "enabled-plugins/connectors/foo-bar/camelCase",
       "handles camelcase file names when normalized"
     );
   });
@@ -536,7 +536,7 @@ module("Unit | Ember | resolver", function (hooks) {
       "wizard/templates/bar",
       "wizard/templates/dashboard_general",
       "wizard-baz-qux",
-      "javascripts/wizard/plugin-template",
+      "enabled-plugins/wizard/plugin-template",
     ]);
 
     // Switches prefix to wizard/templates when underscored

--- a/app/controllers/bootstrap_controller.rb
+++ b/app/controllers/bootstrap_controller.rb
@@ -61,9 +61,16 @@ class BootstrapController < ApplicationController
       extra_locales << ExtraLocalesController.url('wizard')
     end
 
+    enabled_plugins = Discourse.find_plugin_js_assets(
+      include_official: allow_plugins?,
+      include_unofficial: allow_third_party_plugins?,
+      request: assets_fake_request
+    )
+
     plugin_js = Discourse.find_plugin_js_assets(
       include_official: allow_plugins?,
       include_unofficial: allow_third_party_plugins?,
+      include_disabled: true,
       request: assets_fake_request
     ).map { |f| script_asset_path(f) }
 
@@ -90,7 +97,8 @@ class BootstrapController < ApplicationController
       html_classes: html_classes,
       html_lang: html_lang,
       login_path: main_app.login_path,
-      authentication_data: authentication_data
+      authentication_data: authentication_data,
+      enabled_plugins: enabled_plugins,
     }
     bootstrap[:extra_locales] = extra_locales if extra_locales.present?
     bootstrap[:csrf_token] = form_authenticity_token if current_user

--- a/lib/freedom_patches/raw_handlebars.rb
+++ b/lib/freedom_patches/raw_handlebars.rb
@@ -80,6 +80,11 @@ class Ember::Handlebars::Template
 
     template_name = input[:name]
 
+    relative = Pathname.new(filename).relative_path_from(Rails.root)
+    if (m = relative.to_s.match(%r{^plugins/[^/]+/}))
+      template_name = m[0] + template_name.sub(%r{^javascripts/}, '')
+    end
+
     module_name =
       case config.output_type
       when :amd


### PR DESCRIPTION
This builds the JS for all plugins, namespacing the templates in plugins/PLUGIN_NAME and then on boot, if they're enabled, aliasing the templates to the "enabled-plugins" path where the resolver will look for them. There is no special handling for non-templates, so probably some work needs to be done there. Also, it loads all the plugin JS files, and we probably should only load the enabled ones. This also probably does not handle themes correctly yet.