### PR TITLE
DEV: Disable RAISE_ON_DEPRECATION

### DIFF
--- a/app/assets/javascripts/discourse/config/environment.js
+++ b/app/assets/javascripts/discourse/config/environment.js
@@ -33,7 +33,7 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    ENV.EmberENV.RAISE_ON_DEPRECATION = true;
+    ENV.EmberENV.RAISE_ON_DEPRECATION = false;
   }
 
   if (environment === "test") {
@@ -47,7 +47,7 @@ module.exports = function (environment) {
     ENV.APP.rootElement = "#ember-testing";
     ENV.APP.autoboot = false;
 
-    ENV.EmberENV.RAISE_ON_DEPRECATION = true;
+    ENV.EmberENV.RAISE_ON_DEPRECATION = false;
   }
 
   if (environment === "production") {


### PR DESCRIPTION
Some plugins/themes are still awaiting updates for some deprecations, and they started raising errors in development. It's not clear that the errors are development-only, so it can be quite confusing for developers.

Disabling this flag for now until we can make the messages clearer and fix up existing deprecation issues in themes/plugins.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
