### PR TITLE
FIX: Ensure pull-hotlinked can rewrite lone oneboxes

### DIFF
--- a/app/services/inline_uploads.rb
+++ b/app/services/inline_uploads.rb
@@ -245,7 +245,7 @@ class InlineUploads
     # Markdown inline - ![alt](http://... "image title")
     InlineUploads.match_md_inline_img(raw, external_src: true, &replace)
 
-    raw.gsub!(/^(https?:\/\/\S+)(\s?)$/) do |match|
+    raw = raw.gsub(/^(https?:\/\/\S+)(\s?)$/) do |match|
       if upload = blk.call(match)
         "![](#{upload.short_url})"
       else

--- a/spec/jobs/pull_hotlinked_images_spec.rb
+++ b/spec/jobs/pull_hotlinked_images_spec.rb
@@ -423,6 +423,25 @@ describe Jobs::PullHotlinkedImages do
         expect(post.cooked).to match(/<span class="broken-image/)
         expect(post.cooked).to match(/<div class="large-image-placeholder">/)
       end
+
+      it 'rewrites a lone onebox' do
+        post = Fabricate(:post, raw: <<~MD)
+        Onebox here:
+        #{image_url}
+        MD
+        stub_image_size
+
+        post.rebake!
+
+        post.reload
+
+        expect(post.raw).to eq(<<~MD.chomp)
+        Onebox here:
+        ![](upload://z2QSs1KJWoj51uYhDjb6ifCzxH6.gif)
+        MD
+
+        expect(post.cooked).to match(/<img src=.*\/uploads/)
+      end
     end
   end
 


### PR DESCRIPTION
Mutating the `raw` variable like this would cause issues upstream, meaning that the modification is not persisted. Instead, we should allocate a new string like the other replacement methods.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
