### PR TITLE
FIX: Ensure there is no limit on tag list settings

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/site-settings/tag-list.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/site-settings/tag-list.hbs
@@ -1,6 +1,5 @@
-<TagChooser @tags={{this.selectedTags}} @onChange={{action "changeSelectedTags"}} @everyTag={{true}} @options={{hash
+<TagChooser @tags={{this.selectedTags}} @onChange={{action "changeSelectedTags"}} @everyTag={{true}} @unlimitedTagCount={{true}} @options={{hash
     allowAny=false
-    maximum=null
   }} />
 <div class="desc">{{html-safe this.setting.description}}</div>
 <SettingValidationMessage @message={{this.validationMessage}} />


### PR DESCRIPTION
`maximum=null` is not a supported configuration option. Instead, we need to pass the `@unlimitedTagCount` attribute

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
