### PR TITLE
FIX: Destroy all posts when hard deleting topic

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -626,18 +626,16 @@ class TopicsController < ApplicationController
       if !guardian.can_permanently_delete?(topic)
         return render_json_error topic.cannot_permanently_delete_reason(current_user), status: 403
       end
-
-      # can_permanently_delete? returns true even if there are still some
-      # small actions in the topic and these must be deleted too.
-      topic.posts.with_deleted.order(post_number: :desc).find_each do |post|
-        PostDestroyer.new(current_user, post, context: params[:context], force_destroy: true).destroy
-      end
     else
       guardian.ensure_can_delete!(topic)
-
-      first_post = topic.posts.with_deleted.order(:post_number).first
-      PostDestroyer.new(current_user, first_post, context: params[:context]).destroy
     end
+
+    PostDestroyer.new(
+      current_user,
+      topic.ordered_posts.with_deleted.first,
+      context: params[:context],
+      force_destroy: params[:force_destroy].present?
+    ).destroy
 
     render body: nil
   rescue Discourse::InvalidAccess

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -621,8 +621,9 @@ class TopicsController < ApplicationController
 
   def destroy
     topic = Topic.with_deleted.find_by(id: params[:id])
+    force_destroy = ActiveModel::Type::Boolean.new.cast(params[:force_destroy])
 
-    if params[:force_destroy].present?
+    if force_destroy
       if !guardian.can_permanently_delete?(topic)
         return render_json_error topic.cannot_permanently_delete_reason(current_user), status: 403
       end
@@ -634,7 +635,7 @@ class TopicsController < ApplicationController
       current_user,
       topic.ordered_posts.with_deleted.first,
       context: params[:context],
-      force_destroy: params[:force_destroy].present?
+      force_destroy: force_destroy
     ).destroy
 
     render body: nil

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1802,12 +1802,12 @@ class Topic < ActiveRecord::Base
   end
 
   def cannot_permanently_delete_reason(user)
-    deleted_posts_count = Post.with_deleted
+    all_posts_count = Post.with_deleted
       .where(topic_id: self.id)
       .where(post_type: [Post.types[:regular], Post.types[:moderator_action], Post.types[:whisper]])
       .count
 
-    if posts_count > 0 || deleted_posts_count > 1
+    if posts_count > 0 || all_posts_count > 1
       I18n.t('post.cannot_permanently_delete.many_posts')
     elsif self.deleted_by_id == user&.id && self.deleted_at >= Post::PERMANENT_DELETE_TIMER.ago
       time_left = RateLimiter.time_left(Post::PERMANENT_DELETE_TIMER.to_i - Time.zone.now.to_i + self.deleted_at.to_i)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1802,7 +1802,12 @@ class Topic < ActiveRecord::Base
   end
 
   def cannot_permanently_delete_reason(user)
-    if self.posts_count > 0
+    deleted_posts_count = Post.with_deleted
+      .where(topic_id: self.id)
+      .where(post_type: [Post.types[:regular], Post.types[:moderator_action], Post.types[:whisper]])
+      .count
+
+    if posts_count > 0 || deleted_posts_count > 1
       I18n.t('post.cannot_permanently_delete.many_posts')
     elsif self.deleted_by_id == user&.id && self.deleted_at >= Post::PERMANENT_DELETE_TIMER.ago
       time_left = RateLimiter.time_left(Post::PERMANENT_DELETE_TIMER.to_i - Time.zone.now.to_i + self.deleted_at.to_i)

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -158,7 +158,20 @@ module TopicGuardian
   def can_permanently_delete_topic?(topic)
     return false if !SiteSetting.can_permanently_delete
     return false if !topic
+
+    # Ensure that all posts (including small actions) are at least soft
+    # deleted.
     return false if topic.posts_count > 0
+
+    # All other posts that were deleted still must be permanently deleted
+    # before the topic can be deleted with the exception of small action
+    # posts that will be deleted right before the topic is.
+    posts_count = Post.with_deleted
+      .where(topic_id: topic.id)
+      .where(post_type: [Post.types[:regular], Post.types[:moderator_action], Post.types[:whisper]])
+      .count
+    return false if posts_count > 1
+
     return false if !is_admin? || !can_see_topic?(topic)
     return false if !topic.deleted_at
     return false if topic.deleted_by_id == @user.id && topic.deleted_at >= Post::PERMANENT_DELETE_TIMER.ago

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -166,11 +166,11 @@ module TopicGuardian
     # All other posts that were deleted still must be permanently deleted
     # before the topic can be deleted with the exception of small action
     # posts that will be deleted right before the topic is.
-    posts_count = Post.with_deleted
+    all_posts_count = Post.with_deleted
       .where(topic_id: topic.id)
       .where(post_type: [Post.types[:regular], Post.types[:moderator_action], Post.types[:whisper]])
       .count
-    return false if posts_count > 1
+    return false if all_posts_count > 1
 
     return false if !is_admin? || !can_see_topic?(topic)
     return false if !topic.deleted_at

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3053,6 +3053,9 @@ describe Topic do
       expect(topic.reload.cannot_permanently_delete_reason(Fabricate(:admin))).to eq(I18n.t('post.cannot_permanently_delete.many_posts'))
 
       PostDestroyer.new(admin, post_2.reload).destroy
+      expect(topic.reload.cannot_permanently_delete_reason(Fabricate(:admin))).to eq(I18n.t('post.cannot_permanently_delete.many_posts'))
+
+      PostDestroyer.new(admin, post_2.reload, force_destroy: true).destroy
       expect(topic.reload.cannot_permanently_delete_reason(Fabricate(:admin))).to eq(nil)
     end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1189,6 +1189,48 @@ RSpec.describe TopicsController do
         end
       end
     end
+
+    describe 'force destroy' do
+      fab!(:post) { Fabricate(:post, topic: topic, post_number: 1) }
+
+      before do
+        SiteSetting.can_permanently_delete = true
+
+        sign_in(admin)
+      end
+
+      it 'force destroys all deleted small actions in topic too' do
+        small_action_post = Fabricate(:small_action, topic: topic)
+        PostDestroyer.new(Discourse.system_user, post).destroy
+        PostDestroyer.new(Discourse.system_user, small_action_post).destroy
+
+        delete "/t/#{topic.id}.json", params: { force_destroy: true }
+
+        expect(response.status).to eq(200)
+
+        expect(Topic.find_by(id: topic.id)).to eq(nil)
+        expect(Post.find_by(id: post.id)).to eq(nil)
+        expect(Post.find_by(id: small_action_post.id)).to eq(nil)
+      end
+
+      it 'does not allow to destroy topic if not all posts were force destroyed' do
+        other_post = Fabricate(:post, topic: topic, post_number: 2)
+        PostDestroyer.new(Discourse.system_user, post).destroy
+
+        delete "/t/#{topic.id}.json", params: { force_destroy: true }
+
+        expect(response.status).to eq(403)
+      end
+
+      it 'does not allow to destroy topic if not all small action posts were deleted' do
+        small_action_post = Fabricate(:small_action, topic: topic)
+        PostDestroyer.new(Discourse.system_user, small_action_post).destroy
+
+        delete "/t/#{topic.id}.json", params: { force_destroy: true }
+
+        expect(response.status).to eq(403)
+      end
+    end
   end
 
   describe '#id_for_slug' do


### PR DESCRIPTION
Hard deleting topics that contained soft deleted posts or small actions
used to create orphan posts because only the first post was hard
deleted. This commit adds an error message if there are still posts left
in the topic that must be hard deleted first or hard deletes all small
actions too immediately (there is no other way of hard deleting a small
action because there is no wrench menu).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
