### PR TITLE
FIX: Should be UploadReference instead of UploadReferences

### DIFF
--- a/lib/shrink_uploaded_image.rb
+++ b/lib/shrink_uploaded_image.rb
@@ -134,7 +134,7 @@ class ShrinkUploadedImage
 
     if existing_upload
       begin
-        UploadReferences
+        UploadReference
           .where(target_type: 'Post')
           .where(upload_id: original_upload.id)
           .update_all(upload_id: upload.id)

--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -1029,7 +1029,7 @@ def fix_missing_s3
           puts "Failed to save upload #{save_error}"
         else
           OptimizedImage.where(upload_id: upload.id).destroy_all
-          rebake_ids = UploadReferences.where(upload_id: upload.id).where(target_type: 'Post').pluck(:target_id)
+          rebake_ids = UploadReference.where(upload_id: upload.id).where(target_type: 'Post').pluck(:target_id)
 
           if rebake_ids.present?
             Post.where(id: rebake_ids).each do |post|


### PR DESCRIPTION
This fixes a couple of typos that were introduced in https://github.com/discourse/discourse/commit/9db8f00b3dd6f2881adf1b786e29426889225e7a