### PR TITLE
DEV: Fix missing optional site.json fields

### DIFF
--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -634,6 +634,16 @@
             },
             "can_edit": {
               "type": "boolean"
+            },
+            "custom_fields": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            },
+            "parent_category_id": {
+              "type": "integer"
             }
           },
           "required": [

--- a/spec/requests/api/site_spec.rb
+++ b/spec/requests/api/site_spec.rb
@@ -23,14 +23,18 @@ describe 'site' do
 
       produces 'application/json'
       response '200', 'success response' do
-        Site.preloaded_category_custom_fields << "no_oddjob"
+        begin
+          Site.preloaded_category_custom_fields << "no_oddjob"
 
-        expected_response_schema = load_spec_schema('site_response')
-        schema expected_response_schema
+          expected_response_schema = load_spec_schema('site_response')
+          schema expected_response_schema
 
-        it_behaves_like "a JSON endpoint", 200 do
-          let(:expected_response_schema) { expected_response_schema }
-          let(:expected_request_schema) { expected_request_schema }
+          it_behaves_like "a JSON endpoint", 200 do
+            let(:expected_response_schema) { expected_response_schema }
+            let(:expected_request_schema) { expected_request_schema }
+          end
+        ensure
+          Site.preloaded_category_custom_fields = Set.new
         end
       end
     end

--- a/spec/requests/api/site_spec.rb
+++ b/spec/requests/api/site_spec.rb
@@ -3,7 +3,9 @@ require 'swagger_helper'
 
 describe 'site' do
 
-  let(:admin) { Fabricate(:admin) }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:subcategory) { Fabricate(:category, parent_category: category) }
 
   before do
     Jobs.run_immediately!
@@ -21,6 +23,8 @@ describe 'site' do
 
       produces 'application/json'
       response '200', 'success response' do
+        Site.preloaded_category_custom_fields << "no_oddjob"
+
         expected_response_schema = load_spec_schema('site_response')
         schema expected_response_schema
 


### PR DESCRIPTION
The site.json endpoint was missing some optional fields on the
categories property that is returned. This commit documents the
`parent_category_id` which is present if there are subcategories and it
also documents the `custom_fields` property which the chat plugin is
using causing some flaky tests.
