### PR TITLE
FIX: Allow connector template names to be camelCase

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -80,7 +80,17 @@ export function buildResolver(baseName) {
         }
       }
 
-      let normalized = super._normalize(fullName);
+      const split = fullName.split(":");
+      const type = split[0];
+
+      let normalized;
+      if (type === "template" && split[1]?.includes("connectors/")) {
+        // The default normalize implementation will skip dasherizing component template names
+        // We need the same for our connector templates names
+        normalized = "template:" + split[1].replace(/_/g, "-");
+      } else {
+        normalized = super._normalize(fullName);
+      }
 
       // This is code that we don't really want to keep long term. The main situation where we need it is for
       // doing stuff like `controllerFor('adminWatchedWordsAction')` where the real route name
@@ -88,8 +98,6 @@ export function buildResolver(baseName) {
       // normalize to `adminWatchedWordsAction` where the latter becomes `adminWatchedWords.action`.
       // While these end up looking up the same file ultimately, they are treated as different
       // items and so we can end up with two distinct version of the controller!
-      const split = fullName.split(":");
-      const type = split[0];
       if (
         split.length > 1 &&
         (type === "controller" || type === "route" || type === "template")

--- a/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
@@ -480,7 +480,11 @@ module("Unit | Ember | resolver", function (hooks) {
   });
 
   test("resolves connector templates", function (assert) {
-    setTemplates(["javascripts/foo", "javascripts/connectors/foo-bar/baz_qux"]);
+    setTemplates([
+      "javascripts/foo",
+      "javascripts/connectors/foo-bar/baz_qux",
+      "javascripts/connectors/foo-bar/camelCase",
+    ]);
 
     lookupTemplate(
       assert,
@@ -501,6 +505,20 @@ module("Unit | Ember | resolver", function (hooks) {
       "template:connectors/foo-bar/baz-qux",
       "javascripts/connectors/foo-bar/baz_qux",
       "underscores last segment"
+    );
+
+    lookupTemplate(
+      assert,
+      "template:connectors/foo-bar/camelCase",
+      "javascripts/connectors/foo-bar/camelCase",
+      "handles camelcase file names"
+    );
+
+    lookupTemplate(
+      assert,
+      resolver.normalize("template:connectors/foo-bar/camelCase"),
+      "javascripts/connectors/foo-bar/camelCase",
+      "handles camelcase file names when normalized"
     );
   });
 


### PR DESCRIPTION
The default Ember resolver implementation allows this for components. We need the same for connectors (which are essentially components behind-the-scenes)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
