### PR TITLE
UX: don't animate experimental sidebar on reload

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -187,15 +187,6 @@ input {
   }
 }
 
-#main-outlet-wrapper {
-  //  grid-template-columns transition supported in Firefox, Chrome support coming summer 2022
-  transition: grid-template-columns var(--d-sidebar-animation-time);
-}
-
-.d-header-wrap .wrap {
-  transition: max-width var(--d-sidebar-animation-time);
-}
-
 body.has-sidebar-page {
   .wrap {
     // increase page max-width to accommodate sidebar width
@@ -213,6 +204,11 @@ body.has-sidebar-page {
 
 body.sidebar-animate {
   #main-outlet-wrapper {
-    transition: all var(--d-sidebar-animation-time);
+    //  grid-template-columns transition supported in Firefox, Chrome support coming summer 2022
+    transition: grid-template-columns var(--d-sidebar-animation-time);
+  }
+
+  .d-header-wrap .wrap {
+    transition: max-width var(--d-sidebar-animation-time);
   }
 }


### PR DESCRIPTION
Just needed to scope the transitions to the `sidebar-animate` class