### PR TITLE
DEV: Add plugin API to add to robots.txt

### DIFF
--- a/app/controllers/robots_txt_controller.rb
+++ b/app/controllers/robots_txt_controller.rb
@@ -84,6 +84,8 @@ class RobotsTxtController < ApplicationController
       result[:agents] << { name: 'Googlebot', disallow: deny_paths_googlebot }
     end
 
+    DiscourseEvent.trigger(:robots_info, result)
+
     result
   end
 end

--- a/spec/requests/robots_txt_controller_spec.rb
+++ b/spec/requests/robots_txt_controller_spec.rb
@@ -161,5 +161,25 @@ RSpec.describe RobotsTxtController do
         expect(response.body).not_to include(sitemap_line)
       end
     end
+
+    describe 'plugins' do
+      let(:event_handler) do
+        Proc.new { |robots_info| robots_info[:agents] << { name: 'Test', disallow: ['/test/'] } }
+      end
+
+      before do
+        DiscourseEvent.on(:robots_info, &event_handler)
+      end
+
+      after do
+        DiscourseEvent.off(:robots_info, &event_handler)
+      end
+
+      it 'can add to robots.txt' do
+        get '/robots.txt'
+
+        expect(response.parsed_body).to include("User-agent: Test\nDisallow: /test/")
+      end
+    end
   end
 end


### PR DESCRIPTION
This plugin API can be used to add to robots.txt. The event handler
receives the complete robots information before it is converted into
robots.txt.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
