### PR TITLE
FEATURE: Redesigned user/notifications menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/badges-notifications-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/badges-notifications-list.js
@@ -1,0 +1,11 @@
+import UserMenuNotificationsList from "discourse/components/user-menu/notifications-list";
+
+export default class UserMenuBadgesNotificationsList extends UserMenuNotificationsList {
+  get filterByTypes() {
+    return ["granted_badge"];
+  }
+
+  dismissWarningModal() {
+    return null;
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/user-menu/bookmarks-notifications-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/bookmarks-notifications-list.js
@@ -1,0 +1,26 @@
+import UserMenuNotificationsList from "discourse/components/user-menu/notifications-list";
+import showModal from "discourse/lib/show-modal";
+import I18n from "I18n";
+
+export default class UserMenuBookmarksNotificationsList extends UserMenuNotificationsList {
+  get filterByTypes() {
+    return ["bookmark_reminder"];
+  }
+
+  dismissWarningModal() {
+    const unreadCount =
+      this.currentUser.grouped_unread_high_priority_notifications[
+        this.site.notification_types.bookmark_reminder
+      ];
+    if (unreadCount && unreadCount > 0) {
+      const modalController = showModal("dismiss-notification-confirmation");
+      modalController.set(
+        "confirmationMessage",
+        I18n.t("notifications.dismiss_confirmation.body.bookmark_reminders", {
+          count: unreadCount,
+        })
+      );
+      return modalController;
+    }
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -1,7 +1,8 @@
 import GlimmerComponent from "discourse/components/glimmer";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import UserMenuTab from "discourse/lib/user-menu/tab";
+import { WITH_REMINDER_ICON } from "discourse/models/bookmark";
+import UserMenuTab, { customTabsClasses } from "discourse/lib/user-menu/tab";
 
 const DEFAULT_TAB_ID = "all-notifications";
 const DEFAULT_PANEL_COMPONENT = "user-menu/notifications-list";
@@ -71,6 +72,56 @@ const CORE_TOP_TABS = [
 
   class extends UserMenuTab {
     get id() {
+      return "pms";
+    }
+
+    get icon() {
+      return "far-envelope";
+    }
+
+    get panelComponent() {
+      return "user-menu/pms-notifications-list";
+    }
+
+    get count() {
+      return this.getUnreadCountForType("private_message");
+    }
+  },
+
+  class extends UserMenuTab {
+    get id() {
+      return "bookmarks";
+    }
+
+    get icon() {
+      return WITH_REMINDER_ICON;
+    }
+
+    get panelComponent() {
+      return "user-menu/bookmarks-notifications-list";
+    }
+
+    get count() {
+      return this.getUnreadCountForType("bookmark_reminder");
+    }
+  },
+
+  class extends UserMenuTab {
+    get id() {
+      return "badges";
+    }
+
+    get icon() {
+      return "certificate";
+    }
+
+    get panelComponent() {
+      return "user-menu/badges-notifications-list";
+    }
+  },
+
+  class extends UserMenuTab {
+    get id() {
       return REVIEW_QUEUE_TAB_ID;
     }
 
@@ -108,6 +159,21 @@ export default class UserMenu extends GlimmerComponent {
       const tab = new tabClass(this.currentUser, this.siteSettings, this.site);
       if (tab.shouldDisplay) {
         tabs.push(tab);
+      }
+    });
+    let reviewQueueTabIndex = tabs.findIndex(
+      (tab) => tab.id === REVIEW_QUEUE_TAB_ID
+    );
+    customTabsClasses.forEach((tabClass) => {
+      const tab = new tabClass(this.currentUser, this.siteSettings, this.site);
+      if (tab.shouldDisplay) {
+        // ensure the review queue tab is always last
+        if (reviewQueueTabIndex === -1) {
+          tabs.push(tab);
+        } else {
+          tabs.insertAt(reviewQueueTabIndex, tab);
+          reviewQueueTabIndex++;
+        }
       }
     });
     return tabs.map((tab, index) => {

--- a/app/assets/javascripts/discourse/app/components/user-menu/pms-notifications-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/pms-notifications-list.js
@@ -1,0 +1,26 @@
+import UserMenuNotificationsList from "discourse/components/user-menu/notifications-list";
+import showModal from "discourse/lib/show-modal";
+import I18n from "I18n";
+
+export default class UserMenuPmsNotificationsList extends UserMenuNotificationsList {
+  get filterByTypes() {
+    return ["private_message"];
+  }
+
+  dismissWarningModal() {
+    const unreadCount =
+      this.currentUser.grouped_unread_high_priority_notifications[
+        this.site.notification_types.private_message
+      ];
+    if (unreadCount && unreadCount > 0) {
+      const modalController = showModal("dismiss-notification-confirmation");
+      modalController.set(
+        "confirmationMessage",
+        I18n.t("notifications.dismiss_confirmation.body.pms", {
+          count: unreadCount,
+        })
+      );
+      return modalController;
+    }
+  }
+}

--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -51,6 +51,8 @@ export default {
               data.unread_high_priority_notifications,
             read_first_notification: data.read_first_notification,
             all_unread_notifications_count: data.all_unread_notifications_count,
+            grouped_unread_high_priority_notifications:
+              data.grouped_unread_high_priority_notifications,
           });
 
           if (

--- a/app/assets/javascripts/discourse/app/lib/user-menu/tab.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/tab.js
@@ -24,4 +24,22 @@ export default class UserMenuTab {
   get icon() {
     throw new Error("not implemented");
   }
+
+  getUnreadCountForType(type) {
+    let key = "grouped_unread_high_priority_notifications.";
+    key += `${this.site.notification_types[type]}`;
+    // we're retrieving the value with get() so that Ember tracks the property
+    // and re-renders the UI when it changes
+    return this.currentUser.get(key) || 0;
+  }
+}
+
+export const customTabsClasses = [];
+
+export function registerUserMenuTab(func) {
+  customTabsClasses.push(func(UserMenuTab));
+}
+
+export function resetUserMenuTabs() {
+  customTabsClasses.clear();
 }

--- a/app/assets/javascripts/discourse/app/models/notification.js
+++ b/app/assets/javascripts/discourse/app/models/notification.js
@@ -23,7 +23,17 @@ function defaultComponentForType() {
 }
 
 let _componentForType = defaultComponentForType();
-// TODO(osama): add plugin API
+
+export function registerUserMenuComponentForNotificationType(
+  notificationType,
+  component
+) {
+  _componentForType[notificationType] = component;
+}
+
+export function resetUserMenuCustomComponents() {
+  _componentForType = defaultComponentForType();
+}
 
 export default class Notification extends RestModel {
   @tracked read;

--- a/app/assets/javascripts/discourse/app/templates/modal/dismiss-notification-confirmation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/dismiss-notification-confirmation.hbs
@@ -1,5 +1,9 @@
 <DModalBody @headerClass="hidden" @class="dismiss-notification-confirmation">
-  {{i18n "notifications.dismiss_confirmation.body" count=this.count}}
+  {{#if this.confirmationMessage}}
+    {{this.confirmationMessage}}
+  {{else}}
+    {{i18n "notifications.dismiss_confirmation.body.default" count=this.count}}
+  {{/if}}
 </DModalBody>
 
 <div class="modal-footer">

--- a/app/assets/javascripts/discourse/tests/acceptance/dismiss-notification-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/dismiss-notification-modal-test.js
@@ -9,6 +9,8 @@ import I18n from "I18n";
 import { test } from "qunit";
 import pretender, { response } from "../helpers/create-pretender";
 
+// TODO: remove this file when redesigned_user_menu_enabled is removed
+
 acceptance("Dismiss notification confirmation", function (needs) {
   needs.user();
 
@@ -34,7 +36,7 @@ acceptance("Dismiss notification confirmation", function (needs) {
 
     assert.strictEqual(
       query(".dismiss-notification-confirmation-modal .modal-body").innerText,
-      I18n.t("notifications.dismiss_confirmation.body", { count: 2 })
+      I18n.t("notifications.dismiss_confirmation.body.default", { count: 2 })
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -72,6 +72,10 @@ import {
 import { clearTagsHtmlCallbacks } from "discourse/lib/render-tags";
 import { clearToolbarCallbacks } from "discourse/components/d-editor";
 import { resetSidebarSection } from "discourse/lib/sidebar/custom-sections";
+import { resetUserMenuNotificationsProcessors } from "discourse/components/user-menu/notifications-list";
+import { resetUserMenuTopicTitleDecorators } from "discourse/components/user-menu/notification-item";
+import { resetUserMenuCustomComponents } from "discourse/models/notification";
+import { resetUserMenuTabs } from "discourse/lib/user-menu/tab";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -200,6 +204,10 @@ export function testCleanup(container, app) {
   clearTagsHtmlCallbacks();
   clearToolbarCallbacks();
   resetSidebarSection();
+  resetUserMenuTopicTitleDecorators();
+  resetUserMenuNotificationsProcessors();
+  resetUserMenuCustomComponents();
+  resetUserMenuTabs();
 }
 
 export function discourseModule(name, options) {

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -1,6 +1,12 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { click, render, settled, waitUntil } from "@ember/test-helpers";
+import {
+  click,
+  render,
+  settled,
+  triggerKeyEvent,
+  waitUntil,
+} from "@ember/test-helpers";
 import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { hbs } from "ember-cli-htmlbars";
@@ -134,5 +140,49 @@ module("Integration | Component | site-header", function (hooks) {
     document.querySelector(".d-header").style.height = 60 + "px";
     await waitUntil(() => getProperty() === "60px", { timeout: 100 });
     assert.strictEqual(getProperty(), "60px");
+  });
+
+  test("arrow up/down keys move focus between the tabs", async function (assert) {
+    this.currentUser.set("redesigned_user_menu_enabled", true);
+    await render(hbs`<SiteHeader />`);
+    await click(".header-dropdown-toggle.current-user");
+    let activeTab = query(".menu-tabs-container .btn.active");
+    assert.strictEqual(activeTab.id, "user-menu-button-all-notifications");
+
+    await triggerKeyEvent(document, "keydown", "ArrowDown");
+    let focusedTab = document.activeElement;
+    assert.strictEqual(
+      focusedTab.id,
+      "user-menu-button-replies",
+      "pressing the down arrow key moves focus to the next tab towards the bottom"
+    );
+
+    await triggerKeyEvent(document, "keydown", "ArrowDown");
+    await triggerKeyEvent(document, "keydown", "ArrowDown");
+    await triggerKeyEvent(document, "keydown", "ArrowDown");
+    await triggerKeyEvent(document, "keydown", "ArrowDown");
+    await triggerKeyEvent(document, "keydown", "ArrowDown");
+    await triggerKeyEvent(document, "keydown", "ArrowDown");
+
+    focusedTab = document.activeElement;
+    assert.ok(
+      focusedTab.href.endsWith("/u/eviltrout/preferences"),
+      "the down arrow key can move the focus to the bottom tabs"
+    );
+
+    await triggerKeyEvent(document, "keydown", "ArrowDown");
+    focusedTab = document.activeElement;
+    assert.strictEqual(
+      focusedTab.id,
+      "user-menu-button-all-notifications",
+      "the focus moves back to the top after reaching the bottom"
+    );
+
+    await triggerKeyEvent(document, "keydown", "ArrowUp");
+    focusedTab = document.activeElement;
+    assert.ok(
+      focusedTab.href.endsWith("/u/eviltrout/preferences"),
+      "the up arrow key moves the focus in the opposite direction"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/notification-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/notification-item-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
 import { render, settled } from "@ember/test-helpers";
 import { deepMerge } from "discourse-common/lib/object";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import Notification from "discourse/models/notification";
 import { hbs } from "ember-cli-htmlbars";
@@ -157,6 +158,26 @@ module(
         description.textContent.trim(),
         "this is title before it becomes fancy <a>!",
         "topic_title from data is rendered safely"
+      );
+    });
+
+    test("fancy_title can be decorated via the plugin API", async function (assert) {
+      withPluginApi("0.1", (api) => {
+        api.registerUserMenuTopicTitleDecorator((fancy_title) => {
+          return fancy_title.replaceAll("fancy", "ycnaf");
+        });
+        api.registerUserMenuTopicTitleDecorator((fancy_title) => {
+          return fancy_title.replaceAll("title", "eltit");
+        });
+      });
+      this.set("notification", getNotification());
+      await render(template);
+      const description = query("li a .notification-description");
+
+      assert.strictEqual(
+        description.textContent.trim(),
+        "This is ycnaf eltit <a>!",
+        "fancy_title decorators registered via plugin API are applied"
       );
     });
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -236,8 +236,8 @@ class Notification < ActiveRecord::Base
 
     if notifications.present?
       builder = DB.build(<<~SQL)
-         SELECT n.id FROM notifications n
-         /*where*/
+        SELECT n.id FROM notifications n
+        /*where*/
         ORDER BY n.id ASC
         /*limit*/
       SQL

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -77,6 +77,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :sidebar_category_ids,
              :sidebar_tag_names,
              :likes_notifications_disabled,
+             :grouped_unread_high_priority_notifications,
              :redesigned_user_menu_enabled
 
   delegate :user_stat, to: :object, private: true
@@ -342,6 +343,10 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def include_all_unread_notifications_count?
+    redesigned_user_menu_enabled
+  end
+
+  def include_grouped_unread_high_priority_notifications?
     redesigned_user_menu_enabled
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2361,8 +2361,15 @@ en:
       votes_released: "%{description} - completed"
       dismiss_confirmation:
         body:
-          one: "Are you sure? You have %{count} important notification."
-          other: "Are you sure? You have %{count} important notifications."
+          default:
+            one: "Are you sure? You have %{count} important notification."
+            other: "Are you sure? You have %{count} important notifications."
+          pms:
+            one: "Are you sure? You have %{count} unread PM notification."
+            other: "Are you sure? You have %{count} unread PM notifications."
+          bookmark_reminders:
+            one: "Are you sure? You have %{count} unread bookmark reminder."
+            other: "Are you sure? You have %{count} unread bookmark reminders."
         dismiss: "Dismiss"
         cancel: "Cancel"
 

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,18 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2022-06-xy # TODO: fix date
+
+### Added
+
+- Adds `addUserMenuNotificationsProcessor`, which allows users to do additional
+  processing (e.g. decrypting notifications content) on a list of notifications
+  before they're rendered in the user (a.k.a the notifications/avatar) menu.
+- Adds `registerUserMenuTopicTitleDecorator`, which allows users to decorate
+  topic title before they're displayed in the user menu.
+- Adds `registerUserMenuComponentForNotificationType`, which allows users to
+  customize how notifications of a specific type are rendered in the user menu.
+
 ## [1.3.0] - 2022-05-29
 
 ### Added

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2059,7 +2059,7 @@ RSpec.describe User do
     end
 
     context "with redesigned_user_menu_enabled on" do
-      it "adds all_unread_notifications_count to the payload" do
+      it "adds all_unread_notifications and grouped_unread_high_priority_notifications to the payload" do
         user.update!(admin: true)
         user.enable_redesigned_user_menu
         Fabricate(:notification, user: user)
@@ -2071,6 +2071,7 @@ RSpec.describe User do
 
         message = messages.first
         expect(message.data[:all_unread_notifications_count]).to eq(2)
+        expect(message.data[:grouped_unread_high_priority_notifications]).to eq({ 15 => 1 })
       ensure
         user.disable_redesigned_user_menu
       end
@@ -2796,6 +2797,29 @@ RSpec.describe User do
 
       expect(whisperer.whisperer?).to eq(true)
       expect(user.whisperer?).to eq(false)
+    end
+  end
+
+  describe "#grouped_unread_high_priority_notifications" do
+    it "returns a map of high priority types to their unread count" do
+      Fabricate(:notification, user: user, notification_type: 1, high_priority: true, read: true)
+      Fabricate(:notification, user: user, notification_type: 1, high_priority: true, read: false)
+      Fabricate(:notification, user: user, notification_type: 1, high_priority: false, read: true)
+      Fabricate(:notification, user: user, notification_type: 1, high_priority: false, read: false)
+
+      Fabricate(:notification, user: user, notification_type: 2, high_priority: true, read: false, topic: nil)
+
+      Fabricate(:notification, user: user, notification_type: 3, high_priority: true, read: false).tap do |n|
+        n.topic.trash!(Fabricate(:admin))
+      end
+
+      Fabricate(:notification, user: user, notification_type: 3, high_priority: false, read: true)
+
+      Fabricate(:notification, notification_type: 4, high_priority: true, read: false)
+
+      expect(user.grouped_unread_high_priority_notifications).to contain_exactly(
+        *{ 1 => 1, 2 => 1 }.to_a
+      )
     end
   end
 


### PR DESCRIPTION
This PR introduces a new design for the user menu (a.k.a notifications menu):

<img width=300 src="https://user-images.githubusercontent.com/17474474/177854545-654579d1-1d88-44cf-bc79-d0c407acb047.png">

The new design is behind a feature flag and is off by default so that we can test, fix bugs and improve the new design internally before we roll out the change to more sites. Eventually, when we're done testing the new design, we'll roll it out to everyone and remove all the code of the current design.

There's no UI to enable the new design, it can only be enabled in the Rails console:

```
User.find_by_username("<username>").enable_redesigned_user_menu
```
Replace `<username>` with a username and the new design will be enabled for that user (they'll need to reload the page). There's no way to turn it on globally.

To disable it:

```
User.find_by_username("<username>").disable_redesigned_user_menu
```

From a technical point of view, perhaps the biggest difference between the new design and the current one is that the new design is built with Glimmer components which are far much easier to work with than the widgets system which is what the current design is built with. Historically, many parts of the UI in Discourse, including the current user menu, were built using the widgets system instead of 'classic' Ember components (Glimmer components didn't exist back then) for performance reasons.

Glimmer components are faster than classic components, but aren't quite as fast as the widgets system. Despite that, we're moving away from the widgets system to Glimmer components because devices have gotten fast enough that we no longer believe that the performance benefits of the widgets system outweigh the developer pain caused by it.

Given that the new design is built with an entirely different system, existing JavaScript customizations **will not** work with the new design and they'll need to be updated. However, if your customizations are pure CSS, then they should continue to work with the new design with little to no updates because the HTML structure and element classes of the menu remain mostly the same.

This PR is very big, so I've drawn a little graph that hopefully will make it a bit easier to follow how the new design is structured:

```
site-header widget
├─ component-connector <- rendered when the user clicks their avatar
|  ├─ user-menu-wrapper <- classic component, needed to bridge Glimmer with widgets
|  |  ├─ user-menu/menu <- root of the menu, glimmer (and everything below)
|  |  |  ├─ (panel component of active tab)
|  |  |  ├─ tab 1
|  |  |  ├─ tab 2
|  |  |  ├─ tab 3
|  |  |  ├─ ...
|  |  |  ├─ tab n
```

The `site-header` widget contains the logic for whether the menu is shown or not, which means the menu is a "child" of that widget and it needs to be able to render it which is tricky because the menu is built with Glimmer. We have `component-connector`, which is a class that looks like a widget that can render classic Ember components inside widgets. I couldn't figure out how to make `component-connector` render a Glimmer component, so I resorted to creating a classic component, `user-menu-wrapper`, whose only purpose is to wrap the actual root Glimmer component of the menu, and then I made `component-connector` render the wrapper class. If you know a better way to do this, please let me know!

The root component of the menu, `user-menu/menu`, is responsible for rendering the 2 main parts of the menu:

1. the main content of the menu (aka the panel)
2. the column of tabs on the right

Examples of a panel are the `user-menu/notifications-list` and `user-menu/reviewables-list` components which both inherit from an "abstract" component `user-menu/items-list` since they share a very similar structure (they're a list of items).

Each tab completely controls what the panel looks like because it can specify a component to be rendered when it's active. This allows plugins/themes to add tabs that have complete freedom as to what they show when they're active and not have to adhere to the "list of items" structure. However, it's also very easy to make it a custom tab show a list of notifications like the core tabs do by simply creating a component that inherits from the `user-menu/notifications-list` component in core, overriding a few properties and then configuring the tab to render that component when it's active (more details in the `plugin-api.js` file).

Internal ticket: t65045.