### PR TITLE
DEV: Add env to enable ActiveRecord query log tags

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -266,6 +266,10 @@ module Discourse
       require 'rbtrace'
     end
 
+    if ENV['RAILS_QUERY_LOG_TAGS'] == "1"
+      config.active_record.query_log_tags_enabled = true
+    end
+
     config.generators do |g|
       g.test_framework :rspec, fixture: false
     end


### PR DESCRIPTION
I can't seem to find any official docs for it but see https://blog.saeloun.com/2021/09/15/rails-maginalia-query-logs.html and https://github.com/rails/rails/pull/42240