### PR TITLE
UX: a save should always have a cancel action

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/preferences-username.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences-username.hbs
@@ -26,6 +26,9 @@
       <div class="control-group">
         <div class="controls">
           <DButton @class="btn-primary" @action={{action "changeUsername"}} @type="submit" @disabled={{this.saveDisabled}} @translatedLabel={{this.saveButtonText}} />
+          <LinkTo @route="preferences" @model={{this.currentUser}} class="btn btn-flat -cancel">
+            {{i18n "cancel"}}
+          </LinkTo>
           {{#if this.saved}}{{i18n "saved"}}{{/if}}
         </div>
       </div>


### PR DESCRIPTION
Added a cancel button to username change action (screenshot from a theme, ignore styling)

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/101828855/177938778-27e43ebb-789c-4560-a07e-fdab305e4d6d.png">
