### PR TITLE
Revert "UX: Hide user menu bookmark link when experimental sidebar is enabled (#17336)"

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -153,9 +153,7 @@ createWidget("user-menu-links", {
       });
     }
 
-    if (!this.currentUser.experimental_sidebar_enabled) {
-      glyphs.push(this.bookmarksGlyph());
-    }
+    glyphs.push(this.bookmarksGlyph());
 
     if (this.siteSettings.enable_personal_messages || this.currentUser.staff) {
       glyphs.push(this.messagesGlyph());

--- a/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/widgets/user-menu-test.js
@@ -154,21 +154,6 @@ discourseModule(
       },
     });
 
-    componentTest("bookmarks - experimental sidebar enabled", {
-      template: hbs`{{mount-widget widget="user-menu"}}`,
-
-      beforeEach() {
-        this.currentUser.setProperties({ experimental_sidebar_enabled: true });
-      },
-
-      async test(assert) {
-        assert.notOk(
-          exists(".user-bookmarks-link"),
-          "user bookmark link is not displayed"
-        );
-      },
-    });
-
     componentTest("bookmarks", {
       template: hbs`{{mount-widget widget="user-menu"}}`,
 


### PR DESCRIPTION
This reverts commit 526e6e7a3b1a6edb35dcb124ef642ea23a756eef.

Link in dropdown user menu is kept in favor of link in experimental sidebar