### PR TITLE
UX: add border-box to stop padding from overflow

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -392,6 +392,7 @@ span.highlighted {
 }
 
 .post-notice {
+  box-sizing: border-box;
   margin-bottom: 1em;
   &.old {
     border-top: none;


### PR DESCRIPTION
This stops post notices from causing horizontal overflow on mobile

Reported here: https://meta.discourse.org/t/some-topics-allow-horizontal-scrolling-on-mobile/232275?u=jammydodger