### PR TITLE
DEV: Drop the deprecated `themeSettings.blah` syntax

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/theme-helpers.js
+++ b/app/assets/javascripts/discourse/app/helpers/theme-helpers.js
@@ -1,6 +1,5 @@
 import { registerUnbound } from "discourse-common/lib/helpers";
 import I18n from "I18n";
-import deprecated from "discourse-common/lib/deprecated";
 import { getSetting as getThemeSetting } from "discourse/lib/theme-settings-store";
 
 registerUnbound("theme-i18n", (themeId, key, params) => {
@@ -12,13 +11,6 @@ registerUnbound(
   (themeId, key) => `theme_translations.${themeId}.${key}`
 );
 
-registerUnbound("theme-setting", (themeId, key, hash) => {
-  if (hash.deprecated) {
-    deprecated(
-      "The `{{themeSetting.setting_name}}` syntax is deprecated. Use `{{theme-setting 'setting_name'}}` instead",
-      { since: "v2.2.0.beta8" }
-    );
-  }
-
+registerUnbound("theme-setting", (themeId, key) => {
   return getThemeSetting(themeId, key);
 });

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require 'json_schemer'
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 56
+  BASE_COMPILER_VERSION = 57
 
   attr_accessor :child_components
 

--- a/spec/lib/theme_javascript_compiler_spec.rb
+++ b/spec/lib/theme_javascript_compiler_spec.rb
@@ -52,15 +52,6 @@ describe ThemeJavascriptCompiler do
         to eq('dummy(theme_translations.22.translation_key)')
     end
 
-    it 'works with the old settings syntax' do
-      expect(render("{{themeSettings.setting_key}}")).
-        to eq('setting(22:setting_key)')
-
-      # Works when used inside other statements
-      expect(render("{{dummy-helper themeSettings.setting_key}}")).
-        to eq('dummy(setting(22:setting_key))')
-    end
-
     it "doesn't duplicate number parameter inside {{each}}" do
       expect(compiler.compile("{{#each item as |test test2|}}{{theme-setting 'setting_key'}}{{/each}}")).
         to include('{"name":"theme-setting","hash":{},"hashTypes":{},"hashContexts":{},"types":["NumberLiteral","StringLiteral"]')
@@ -110,21 +101,6 @@ describe ThemeJavascriptCompiler do
         theme_compile "{{dummy-helper (theme-prefix 'translation_key')}}"
       ).to eq(
         standard_compile "{{dummy-helper (theme-prefix #{theme_id} 'translation_key')}}"
-      )
-    end
-
-    it 'works with the old settings syntax' do
-      expect(
-        theme_compile "{{themeSettings.setting_key}}"
-      ).to eq(
-        standard_compile "{{theme-setting #{theme_id} 'setting_key' deprecated=true}}"
-      )
-
-      # Works when used inside other statements
-      expect(
-        theme_compile "{{dummy-helper themeSettings.setting_key}}"
-      ).to eq(
-        standard_compile "{{dummy-helper (theme-setting #{theme_id} 'setting_key' deprecated=true)}}"
       )
     end
   end


### PR DESCRIPTION
This syntax has been printing deprecation messages since 880311dd4d2b367e54cc8244fba60fce69e121c3

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
