### PR TITLE
FIX: Add ember redirect for tags/:tag_id -> tag/:tag_id

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/app-route-map.js
+++ b/app/assets/javascripts/discourse/app/routes/app-route-map.js
@@ -248,6 +248,9 @@ export default function () {
     this.route("intersection", {
       path: "intersection/:tag_id/*additional_tags",
     });
+
+    // legacy route
+    this.route("legacyRedirect", { path: "/:tag_id" });
   });
 
   this.route(

--- a/app/assets/javascripts/discourse/app/routes/tags-legacy-redirect.js
+++ b/app/assets/javascripts/discourse/app/routes/tags-legacy-redirect.js
@@ -1,0 +1,7 @@
+import Route from "@ember/routing/route";
+
+export default Route.extend({
+  beforeModel() {
+    this.transitionTo("tag.show", this.paramsFor("tags.legacyRedirect").tag_id);
+  },
+});


### PR DESCRIPTION
/tags/:tag_id is deprecated, but links may exist in posts.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
