### PR TITLE
UX: Skip length check on reply drafts

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -1211,11 +1211,6 @@ const Composer = RestModel.extend({
       if (isEmpty(this.reply)) {
         return false;
       }
-
-      // Do not save when the reply's length is too small
-      if (this.replyLength < this.minimumPostLength) {
-        return false;
-      }
     }
 
     return true;

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -912,6 +912,16 @@ acceptance("Composer", function (needs) {
     await click(".save-or-cancel .cancel");
     assert.notOk(exists(".discard-draft-modal .save-draft"));
   });
+
+  test("Saves drafts that only contain quotes", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-footer-buttons .create");
+
+    await fillIn(".d-editor-input", "[quote]some quote[/quote]");
+
+    await click(".save-or-cancel .cancel");
+    assert.ok(exists(".discard-draft-modal .save-draft"));
+  });
 });
 
 acceptance("Composer - Customizations", function (needs) {


### PR DESCRIPTION
We don't count quote characters as part of the reply length. 

We don't save drafts if the reply length is less than the `min_post_length` site setting.

If you start a reply that only contains a bunch of quotes with the intent to continue later, you get no draft. 

This PR fixes that. 

Note that we still don't save drafts if the composer is completely empty or if you're composing a new topic. This only affects replies.

This PR only changes the behavior if the **reply** composer contains _something_ regardless of whether that something is a quote or not and ignores the `min_post_length` site setting.