### PR TITLE
FIX: Ensure splash screen `<noscript>` is loaded for legacy browsers

### DIFF
--- a/app/assets/javascripts/discourse/scripts/browser-update.js
+++ b/app/assets/javascripts/discourse/scripts/browser-update.js
@@ -24,21 +24,23 @@
     }
 
     document.getElementsByTagName("body")[0].className += " crawler";
-    var mainElement = document.getElementById("main");
     var noscriptElements = document.getElementsByTagName("noscript");
     // find the element with the "data-path" attribute set
-    for (var i = 0; i < noscriptElements.length; ++i) {
-      if (noscriptElements[i].getAttribute("data-path")) {
-        // noscriptElements[i].innerHTML contains encoded HTML, so we need to access
-        // the childNodes instead. Browsers seem to split very long content into multiple
-        // text childNodes.
-        var result = "";
-        for (var j = 0; j < noscriptElements[i].childNodes.length; j++) {
-          result += noscriptElements[i].childNodes[j].nodeValue;
-        }
+    for (var i = noscriptElements.length - 1; i >= 0; i--) {
+      var element = noscriptElements[i];
 
-        mainElement.outerHTML = result;
-        break;
+      // noscriptElements[i].innerHTML contains encoded HTML, so we need to access
+      // the childNodes instead. Browsers seem to split very long content into multiple
+      // text childNodes.
+      var result = "";
+      for (var j = 0; j < element.childNodes.length; j++) {
+        result += element.childNodes[j].nodeValue;
+      }
+
+      if (element.getAttribute("data-path")) {
+        document.getElementById("main").outerHTML = result;
+      } else {
+        element.outerHTML = result;
       }
     }
 


### PR DESCRIPTION
Previously we would only expand the main `<noscript>` element for older browsers. This commit ensures that we expand all noscript elements on the page, including the one used by the splashscreen to hide itself on the no-js view.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
