### PR TITLE
FIX: Just inline the QUnit CSS in theme-test html

### DIFF
--- a/app/assets/stylesheets/test_helper.scss
+++ b/app/assets/stylesheets/test_helper.scss
@@ -1,9 +1,0 @@
-@import "../javascripts/node_modules/qunit/qunit/qunit";
-
-.modal-backdrop {
-  display: none;
-}
-
-#reply-control {
-  transition-property: none !important;
-}

--- a/app/views/qunit/theme.html.erb
+++ b/app/views/qunit/theme.html.erb
@@ -4,8 +4,6 @@
     <title>Theme QUnit Test Runner</title>
     <%= discourse_color_scheme_stylesheets %>
     <%- if !@suggested_themes %>
-      <%= discourse_stylesheet_link_tag(:desktop, theme_id: nil) %>
-      <%= discourse_stylesheet_link_tag(:test_helper, theme_id: nil) %>
       <%= preload_script "locales/#{I18n.locale}" %>
       <%= preload_script "vendor" %>
       <%= preload_script "discourse" %>
@@ -18,10 +16,16 @@
       <%= theme_js_lookup %>
       <%= theme_lookup("head_tag") %>
       <%= theme_tests %>
+
       <%= tag.meta id: 'data-discourse-setup', data: client_side_setup_data %>
       <meta property="og:title" content="">
       <meta property="og:url" content="">
       <meta name="discourse/config/environment" content="<%=u discourse_config_environment(testing: true) %>" />
+
+      <%= discourse_stylesheet_link_tag(:desktop, theme_id: nil) %>
+      <style>
+        <%= File.read("#{Rails.root}/app/assets/javascripts/node_modules/qunit/qunit/qunit.css") %>
+      </style>
     <%- else %>
       <style>
         html {
@@ -29,6 +33,7 @@
         }
       </style>
     <%- end %>
+
     <%- if params['testem'] %>
       <script defer src="/assets/testem.js"></script>
     <%- end %>
@@ -36,6 +41,7 @@
   <body>
     <%- if @suggested_themes %>
       <h2>Theme QUnit Test Runner</h2>
+
       <%- if @suggested_themes.size == 0 %>
         <p>Cannot find any theme tests.</p>
       <%- else %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -251,11 +251,6 @@ module Discourse
 
         ActionView::Base.precompiled_asset_checker = -> logical_path do
           default_checker[logical_path] ||
-            %w{qunit.js
-              qunit.css
-              test_helper.css
-              discourse/tests/test-boot-rails.js
-            }.include?(logical_path) ||
             logical_path =~ /\/node_modules/ ||
             logical_path =~ /\/dist/
         end

--- a/spec/requests/qunit_controller_spec.rb
+++ b/spec/requests/qunit_controller_spec.rb
@@ -94,7 +94,7 @@ describe QunitController do
         expect(response.status).to eq(200)
         expect(response.body).to include("/stylesheets/color_definitions_base_")
         expect(response.body).to include("/stylesheets/desktop_")
-        expect(response.body).to include("/stylesheets/test_helper_")
+        expect(response.body).to include("* https://qunitjs.com/") # inlined QUnit CSS
         expect(response.body).to include("/assets/locales/en.js")
         expect(response.body).to include("/test-support")
         expect(response.body).to include("/test-helpers")


### PR DESCRIPTION
Side-steps sassc compilation issues.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
