### PR TITLE
FIX: Ensure category-tag filter routes are functioning

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/dynamic-route-builders.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/dynamic-route-builders.js
@@ -107,15 +107,15 @@ export default {
         })
       );
       app.register(
-        `route:tag.show-${filterDasherized}-category`,
+        `route:tags.show-category-${filterDasherized}`,
         TagShowRoute.extend({ navMode: filter })
       );
       app.register(
-        `route:tag.show-${filterDasherized}-category-none`,
+        `route:tags.show-category-none-${filterDasherized}`,
         TagShowRoute.extend({ navMode: filter, noSubcategories: true })
       );
       app.register(
-        `route:tag.show-${filterDasherized}-category-all`,
+        `route:tags.show-category-all-${filterDasherized}`,
         TagShowRoute.extend({ navMode: filter, noSubcategories: false })
       );
     });

--- a/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/tags-test.js
@@ -284,6 +284,7 @@ acceptance("Tag info", function (needs) {
     [
       "/tags/c/faq/4/planters/l/latest.json",
       "/tags/c/feature/2/planters/l/latest.json",
+      "/tags/c/feature/2/planters/l/top.json",
       "/tags/c/feature/2/none/planters/l/latest.json",
     ].forEach((url) => {
       server.get(url, () => {
@@ -495,6 +496,17 @@ acceptance("Tag info", function (needs) {
       `.category-breadcrumb li:nth-of-type(2) .category-row[data-value="no-categories"]`
     );
     assert.strictEqual(currentURL(), "/tags/c/feature/2/none/planters");
+  });
+
+  test("can visit show-category-latest routes", async function (assert) {
+    await visit("/tags/c/feature/2/planters");
+
+    await click(".nav-item_latest a[href]");
+    // await pauseTest();
+    assert.strictEqual(currentURL(), "/tags/c/feature/2/planters/l/latest");
+
+    await click(".nav-item_top a[href]");
+    assert.strictEqual(currentURL(), "/tags/c/feature/2/planters/l/top");
   });
 
   test("admin can manage tags", async function (assert) {


### PR DESCRIPTION
This regressed as part of the changes in fc36ac6c.

This commit also introduces a test which would have caught the issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
