### PR TITLE
DEV: Update `message-bus-client`

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -62,7 +62,7 @@
     "js-yaml": "^4.1.0",
     "jsdom": "^20.0.0",
     "loader.js": "^4.7.0",
-    "message-bus-client": "^3.3.0",
+    "message-bus-client": "^4.2.0",
     "messageformat": "0.1.5",
     "node-fetch": "^2.6.6",
     "pretender": "^3.4.7",

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -7932,10 +7932,10 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-message-bus-client@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/message-bus-client/-/message-bus-client-3.3.0.tgz#ee38ad26fa54f14dce17e65cc466be4e1aa7028b"
-  integrity sha512-dPfGLsxTkw1fNaQ+9nwbB1TXH5NnLXapjGkJtW9fZVsq7fNHaSomiTHZfXJHBibePZ10RH6AuHGemWKqgMtlIA==
+message-bus-client@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/message-bus-client/-/message-bus-client-4.2.0.tgz#1b994a1309eaa3d5b1ebe6d0b2f911e3355c2314"
+  integrity sha512-m0aOFoZybxNjrILZdG6tkawMHdwxi5AysUusZSkl5AYbcFwxHhHVlmyBILzuMKNcR1oET3d5eKpFlgPAc9IjOQ==
 
 messageformat@0.1.5:
   version "0.1.5"


### PR DESCRIPTION
This update covers commits:

* e309b6d [BREAKING Make JS client throw if lastId not number](https://github.com/discourse/message_bus/commit/e309b6d533dcc33cb9d3677c9b12a194f5f06990)
* f0bae69 [DEV: removes dead code](https://github.com/discourse/message_bus/commit/f0bae695b011bccc48ca001686114ff1de2f4588)
* a72b930 [FIX: force a poll more consistently when visibility changes](https://github.com/discourse/message_bus/commit/a72b9308b4b7edf273ec914f16be459e831bbd9e)
* 5c01715 [Permit CORS preflight caching](https://github.com/discourse/message_bus/commit/5c01715432c0fd34d7b2695cd3313dc670b9d61b)
* 1789784 [DEV: lint files](https://github.com/discourse/message_bus/commit/17897843b445ee21beba7787d3ef7a3e27079dde)
* b9cfb90 [FIX: do not leak visibility event subscriptions on stop/start](https://github.com/discourse/message_bus/commit/b9cfb90dd66eab522671aff5bc057e6c6559eb95)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
