### PR TITLE
DEV: Switch from htmlbars-inline-precompile to ember-cli-htmlbars

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -1,5 +1,5 @@
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/modal-test.js
@@ -8,7 +8,7 @@ import {
 import { click, settled, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import showModal from "discourse/lib/show-modal";
 
 acceptance("Modal", function (needs) {

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -7,7 +7,7 @@ import {
 import { click, visit } from "@ember/test-helpers";
 import { action } from "@ember/object";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { test } from "qunit";
 
 const PREFIX = "javascripts/single-test/connectors";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-decorator-test.js
@@ -3,7 +3,7 @@ import {
   exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-multi-template-test.js
@@ -4,7 +4,7 @@ import {
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { clearCache } from "discourse/lib/plugin-connectors";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-single-template-test.js
@@ -3,7 +3,7 @@ import {
   count,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/ace-editor-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | ace-editor", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/activation-controls-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/activation-controls-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | activation-controls", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-report-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender from "discourse/tests/helpers/create-pretender";
 
 module("Integration | Component | admin-report", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/admin-user-field-item-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import I18n from "I18n";
 
 module("Integration | Component | admin-user-field-item", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/avatar-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/avatar-uploader-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { createFile } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender from "discourse/tests/helpers/create-pretender";
 
 module("Integration | Component | avatar-uploader", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-button-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | badge-button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/badge-title-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import EmberObject from "@ember/object";

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-icon-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-icon-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import Bookmark from "discourse/models/bookmark";
 import I18n from "I18n";
 import { formattedReminderTime } from "discourse/lib/bookmark";

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | bookmark", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/category-badge-helper-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/category-badge-helper-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import Category from "discourse/models/category";
 
 module("Integration | Component | category-badge helper", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/cook-text-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { resetCache } from "pretty-text/upload-short-url";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-button-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render, triggerKeyEvent } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | d-button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -11,7 +11,7 @@ import {
   getTextareaSelection,
   setTextareaSelection,
 } from "discourse/tests/helpers/textarea-selection-helper";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import I18n from "I18n";
 import { clearToolbarCallbacks } from "discourse/components/d-editor";
 import formatTextWithSelection from "discourse/tests/helpers/d-editor-helper";

--- a/app/assets/javascripts/discourse/tests/integration/components/d-icon-helper-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-icon-helper-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | d-icon helper", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/d-navigation-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-navigation-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { count, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | d-navigation", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/d-popover-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-popover-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render, triggerKeyEvent } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { showPopover } from "discourse/lib/d-popover";
 
 module("Integration | Component | d-popover", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-input-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 function dateInput() {
   return query(".date-picker");

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 function fromDateInput() {
   return query(".from.d-date-time-input .date-picker");

--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 function dateInput() {
   return query(".date-picker");

--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-picker-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | emoji-picker", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/emoji-uploader-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { fillIn, render } from "@ember/test-helpers";
 import { createFile } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/empty-state-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/empty-state-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | empty-state", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/flat-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/flat-button-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render, triggerKeyEvent } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | flat-button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-list-setting-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import EmberObject from "@ember/object";
 
 module("Integration | Component | group-list site-setting", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/group-membership-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/group-membership-button-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | group-membership-button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/hidden-details-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/hidden-details-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import I18n from "I18n";
 
 module("Integration | Component | hidden-details", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/highlighted-code-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 const LONG_CODE_BLOCK = "puts a\n".repeat(15000);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/html-safe-helper-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/html-safe-helper-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | html-safe-helper", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/iframed-html-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | iframed-html", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/input-size-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/input-size-test.js
@@ -2,7 +2,7 @@ import { module } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { chromeTest, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module(
   "Integration | Component | consistent input/dropdown/button sizes",

--- a/app/assets/javascripts/discourse/tests/integration/components/invite-panel-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/invite-panel-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import User from "discourse/models/user";

--- a/app/assets/javascripts/discourse/tests/integration/components/load-more-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/load-more-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { configureEyeline } from "discourse/lib/eyeline";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | load-more", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/pending-post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/pending-post-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import createStore from "discourse/tests/helpers/create-store";
 
 module("Integration | Component | pending-post", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/relative-time-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/relative-time-picker-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module("Integration | Component | relative-time-picker", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/secret-value-list-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { blur, click, fillIn, render } from "@ember/test-helpers";
 import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | secret-value-list", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/api-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/api-test.js
@@ -7,7 +7,7 @@ import selectKit, {
   setDefaultState,
 } from "discourse/tests/helpers/select-kit-helper";
 import { clearCallbacks } from "select-kit/mixins/plugin-api";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 module("Integration | Component | select-kit/api", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import I18n from "I18n";
 import createStore from "discourse/tests/helpers/create-store";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-drop-test.js
@@ -8,7 +8,7 @@ import {
 import Category from "discourse/models/category";
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { set } from "@ember/object";
 import sinon from "sinon";

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/combo-box-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const DEFAULT_CONTENT = [

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/dropdown-select-box-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/dropdown-select-box-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const DEFAULT_CONTENT = [

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/future-date-input-test.js
@@ -6,7 +6,7 @@ import {
   fakeTime,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import I18n from "I18n";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/list-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/list-setting-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module("Integration | Component | select-kit/list-setting", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const DEFAULT_CONTENT = [

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/notifications-button-test.js
@@ -4,7 +4,7 @@ import { render } from "@ember/test-helpers";
 import selectKit, {
   setDefaultState,
 } from "discourse/tests/helpers/select-kit-helper";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module(
   "Integration | Component | select-kit/notifications-button",

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/pinned-options-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import Topic from "discourse/models/topic";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const buildTopic = function (pinned = true) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const DEFAULT_CONTENT = [

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-button-test.js
@@ -4,7 +4,7 @@ import { render } from "@ember/test-helpers";
 import I18n from "I18n";
 import Topic from "discourse/models/topic";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const buildTopic = function (opts) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/topic-notifications-options-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import I18n from "I18n";
 import Topic from "discourse/models/topic";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 const buildTopic = function (archetype) {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/user-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/user-chooser-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module("Integration | Component | select-kit/user-chooser", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/simple-list-test.js
@@ -8,7 +8,7 @@ import {
   triggerKeyEvent,
 } from "@ember/test-helpers";
 import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | simple-list", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
 import pretender from "discourse/tests/helpers/create-pretender";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | site-header", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-setting-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | site-setting", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/slow-mode-info-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/slow-mode-info-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | slow-mode-info", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/software-update-prompt-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/software-update-prompt-test.js
@@ -6,7 +6,7 @@ import {
   exists,
   publishToMessageBus,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { later } from "@ember/runloop";
 
 module("Integration | Component | software-update-prompt", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/text-field-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { fillIn, render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import sinon from "sinon";
 import I18n from "I18n";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/themes-list-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/themes-list-item-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import I18n from "I18n";
 import Theme from "admin/models/theme";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/themes-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/themes-list-test.js
@@ -7,7 +7,7 @@ import {
   query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import Theme, { COMPONENTS, THEMES } from "admin/models/theme";
 import I18n from "I18n";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-input-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 function setTime(time) {

--- a/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/time-shortcut-picker-test.js
@@ -8,7 +8,7 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | time-shortcut-picker", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-list-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-list-item-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import Topic from "discourse/models/topic";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | topic-list-item", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/topic-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/topic-list-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import Topic from "discourse/models/topic";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | topic-list", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/uppy-image-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/uppy-image-uploader-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | uppy-image-uploader", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/user-avatar-flair-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-avatar-flair-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { resetFlair } from "discourse/lib/avatar-flair";
 
 function setupSiteGroups(that) {

--- a/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-info-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
 
 module("Integration | Component | user-info", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 function paste(element, text) {
   let e = new Event("paste");

--- a/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/value-list-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { blur, click, fillIn, render } from "@ember/test-helpers";
 import { count, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module("Integration | Component | value-list", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/watched-word-uploader-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render, waitFor } from "@ember/test-helpers";
 import { createFile } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 module("Integration | Component | watched-word-uploader", function (hooks) {

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/actions-summary-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/actions-summary-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | Widget | actions-summary", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/avatar-flair-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/avatar-flair-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | Widget | avatar-flair", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/button-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/button-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | Widget | button", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/default-notification-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/default-notification-item-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render, triggerEvent } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import EmberObject from "@ember/object";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/hamburger-menu-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count, exists, queryAll } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 
 const topCategoryIds = [2, 3, 1];

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/header-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | Widget | header", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/home-logo-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/home-logo-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import Session from "discourse/models/session";
 
 const bigLogo = "/images/d-logo-sketch.png?test";

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-links-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-links-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { count } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | Widget | post-links", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-menu-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import { resetPostMenuExtraButtons } from "discourse/widgets/post-menu";
 import { withPluginApi } from "discourse/lib/plugin-api";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-small-action-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-small-action-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module(
   "Integration | Component | Widget | post-small-action",

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-stream-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import Post from "discourse/models/post";
 import Topic from "discourse/models/topic";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.js
@@ -7,7 +7,7 @@ import {
   query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import EmberObject from "@ember/object";
 import I18n from "I18n";
 import createStore from "discourse/tests/helpers/create-store";

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/poster-name-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/poster-name-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | Widget | poster-name", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/quick-access-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/quick-access-item-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 const CONTENT_DIV_SELECTOR = "li > a > div";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/small-user-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/small-user-list-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | Widget | small-user-list", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-admin-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-admin-menu-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import Category from "discourse/models/category";
 import Topic from "discourse/models/topic";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-participant-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-participant-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module(
   "Integration | Component | Widget | topic-participant",

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-status-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-status-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import TopicStatusIcons from "discourse/helpers/topic-status-icons";
 import createStore from "discourse/tests/helpers/create-store";
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/user-menu-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { exists, query, queryAll } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import sinon from "sinon";
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/widget-dropdown-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/widget-dropdown-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 const DEFAULT_CONTENT = {
   content: [

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/widget-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { count, exists, query } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import widgetHbs from "discourse/widgets/hbs-compiler";
 import I18n from "I18n";
 import { Promise } from "rsvp";

--- a/app/assets/javascripts/discourse/tests/integration/components/wizard-invite-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/wizard-invite-list-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, fillIn, render } from "@ember/test-helpers";
 import { count, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 module("Integration | Component | Wizard | invite-list", function (hooks) {
   setupRenderingTest(hooks);

--- a/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
@@ -7,7 +7,7 @@ import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 
 const fooComponent = Component.extend({
   classNames: ["foo-component"],

--- a/app/assets/javascripts/discourse/tests/unit/utils/dom-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/dom-utils-test.js
@@ -2,7 +2,7 @@ import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import hbs from "htmlbars-inline-precompile";
+import { hbs } from "ember-cli-htmlbars";
 import domUtils from "discourse-common/utils/dom-utils";
 
 discourseModule("utils:dom-utils", function (hooks) {


### PR DESCRIPTION
See https://github.com/ember-cli/ember-cli-htmlbars#tagged-template-usage--migrating-from-htmlbars-inline-precompile

Re-hash of #17220
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
