### PR TITLE
DEV: Remove old redis option

### DIFF
--- a/config/initializers/001-redis.rb
+++ b/config/initializers/001-redis.rb
@@ -5,10 +5,6 @@ if Rails.env.development? && ENV['DISCOURSE_FLUSH_REDIS']
   Discourse.redis.flushdb
 end
 
-# Pending https://github.com/MiniProfiler/rack-mini-profiler/pull/450 and
-# upgrade to Sidekiq 6.1
-Redis.exists_returns_integer = true
-
 begin
   if Gem::Version.new(Discourse.redis.info['redis_version']) < Gem::Version.new("6.2.0")
     STDERR.puts "Discourse requires Redis 6.2.0 or up"


### PR DESCRIPTION
`Redis.exists_returns_integer` is now true by default

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
