### PR TITLE
DEV: Remove asset precompilation hack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -243,18 +243,6 @@ module Discourse
 
       # we got to clear the pool in case plugins connect
       ActiveRecord::Base.connection_handler.clear_active_connections!
-
-      # This nasty hack is required for not precompiling QUnit assets
-      # in test mode. see: https://github.com/rails/sprockets-rails/issues/299#issuecomment-167701012
-      ActiveSupport.on_load(:action_view) do
-        default_checker = ActionView::Base.precompiled_asset_checker
-
-        ActionView::Base.precompiled_asset_checker = -> logical_path do
-          default_checker[logical_path] ||
-            logical_path =~ /\/node_modules/ ||
-            logical_path =~ /\/dist/
-        end
-      end
     end
 
     if ENV['RBTRACE'] == "1"


### PR DESCRIPTION
I don't think it's needed anymore?

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
