### PR TITLE
DEV: Allow use of qunit notrycatch mode

### DIFF
--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -117,14 +117,9 @@ function createApplication(config, settings) {
 function setupToolbar() {
   // Most default toolbar items aren't useful for Discourse
   QUnit.config.urlConfig = QUnit.config.urlConfig.reject((c) =>
-    [
-      "noglobals",
-      "notrycatch",
-      "nolint",
-      "devmode",
-      "dockcontainer",
-      "nocontainer",
-    ].includes(c.id)
+    ["noglobals", "nolint", "devmode", "dockcontainer", "nocontainer"].includes(
+      c.id
+    )
   );
 
   QUnit.config.urlConfig.push({


### PR DESCRIPTION
This is useful when debugging exceptions - when the box is checked, exceptions will be thrown and handled by the browser rather than being absorbed by qunit. This allows developers to intercept the exception and inspect the stack.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
