### PR TITLE
DEV: Use auto-injected `keyValueStore` for `screenTrack` service

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/signup-cta.js
+++ b/app/assets/javascripts/discourse/app/initializers/signup-cta.js
@@ -16,8 +16,6 @@ export default {
     const user = container.lookup("current-user:main");
     const appEvents = container.lookup("service:app-events");
 
-    screenTrack.keyValueStore = keyValueStore;
-
     // Preconditions
     if (user) {
       return;


### PR DESCRIPTION
This manual assignment was added before the keyValueStore was refactored into a service. Now that it's a service, it gets all our standard auto-injections, including the keyValueStore.

Overwriting an automatic injection like this raises an error in future Ember versions.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
