### PR TITLE
UX: Add classes to create-account modal for easier customization

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -2,7 +2,7 @@
   {{#unless this.complete}}
     <PluginOutlet @name="create-account-before-modal-body" @tagName="span" @connectorTagName="div" />
     <DModalBody @class={{this.modalBodyClasses}} @preventModalAlertHiding={{true}}>
-      <div class="create-account-form">
+      <div class="create-account-form {{this.authOptions.auth_provider}}">
         <div class="login-welcome-header" id="create-account-title">
           <h1 class="login-title">{{i18n "create_account.header_title"}}</h1> <img src={{this.wavingHandURL}} alt="" class="waving-hand">
           <p class="login-subheader">{{i18n "create_account.subheader_title"}}</p>
@@ -28,7 +28,7 @@
                 <span class="more-info">{{i18n "user.email.instructions"}}</span>
               </div>
 
-              <div class="input-group">
+              <div class="input-group create-account-username">
                 <Input @value={{this.accountUsername}} disabled={{this.usernameDisabled}} class={{value-entered this.accountUsername}} id="new-account-username" name="username" maxlength={{this.maxUsernameLength}} aria-describedby="username-validation" aria-invalid={{this.usernameValidation.failed}} autocomplete="off" />
                 <label class="alt-placeholder" for="new-account-username">
                   {{i18n "user.username.title"}}
@@ -41,7 +41,7 @@
                 <span class="more-info">{{i18n "user.username.instructions"}}</span>
               </div>
 
-              <div class="input-group">
+              <div class="input-group create-account-fullname">
                 {{#if this.fullnameRequired}}
                   <TextField @disabled={{this.nameDisabled}} @value={{this.accountName}} @id="new-account-name" @class={{value-entered this.accountName}} @aria-describedby="fullname-validation" @aria-invalid={{this.nameValidation.failed}} />
                   <label class="alt-placeholder" for="new-account-name">
@@ -66,7 +66,7 @@
                     authOptions=this.authOptions
                   }} />
 
-              <div class="input-group">
+              <div class="input-group create-account-password">
                 {{#if this.passwordRequired}}
                   <PasswordField @value={{this.accountPassword}} @class={{value-entered this.accountPassword}} @type="password" @id="new-account-password" @autocomplete="current-password" @capsLockOn={{this.capsLockOn}} @aria-describedby="password-validation" @aria-invalid={{this.passwordValidation.failed}} />
                   <label class="alt-placeholder" for="new-account-password">
@@ -91,7 +91,7 @@
               </div>
 
               {{#if this.requireInviteCode }}
-                <div class="input-group">
+                <div class="input-group create-account-invite-code">
                   <Input @value={{this.inviteCode}} class={{value-entered this.inviteCode}} id="inviteCode" />
                   <label class="alt-placeholder" for="invite-code">{{i18n "user.invite_code.title"}}</label>
                   <span class="more-info">{{i18n "user.invite_code.instructions"}}</span>

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -12,11 +12,11 @@
           <div class="login-form">
             <form>
               {{#if this.associateHtml}}
-                <div class="input-group create-account-associate-link">
+                <div class="input-group create-account__associate-link">
                   <span>{{html-safe this.associateHtml}}</span>
                 </div>
               {{/if}}
-              <div class="input-group create-account-email">
+              <div class="input-group create-account__email">
                 <Input @type="email" disabled={{this.emailDisabled}} @value={{this.accountEmail}} id="new-account-email" name="email" class={{value-entered this.accountEmail}} autofocus="autofocus" {{on "focusout" (action "checkEmailAvailability")}} aria-describedby="account-email-validation" aria-invalid={{this.emailValidation.failed}} />
                 <label class="alt-placeholder" for="new-account-email">
                   {{i18n "user.email.title"}}
@@ -28,7 +28,7 @@
                 <span class="more-info">{{i18n "user.email.instructions"}}</span>
               </div>
 
-              <div class="input-group create-account-username">
+              <div class="input-group create-account__username">
                 <Input @value={{this.accountUsername}} disabled={{this.usernameDisabled}} class={{value-entered this.accountUsername}} id="new-account-username" name="username" maxlength={{this.maxUsernameLength}} aria-describedby="username-validation" aria-invalid={{this.usernameValidation.failed}} autocomplete="off" />
                 <label class="alt-placeholder" for="new-account-username">
                   {{i18n "user.username.title"}}
@@ -41,7 +41,7 @@
                 <span class="more-info">{{i18n "user.username.instructions"}}</span>
               </div>
 
-              <div class="input-group create-account-fullname">
+              <div class="input-group create-account__fullname">
                 {{#if this.fullnameRequired}}
                   <TextField @disabled={{this.nameDisabled}} @value={{this.accountName}} @id="new-account-name" @class={{value-entered this.accountName}} @aria-describedby="fullname-validation" @aria-invalid={{this.nameValidation.failed}} />
                   <label class="alt-placeholder" for="new-account-name">
@@ -66,7 +66,7 @@
                     authOptions=this.authOptions
                   }} />
 
-              <div class="input-group create-account-password">
+              <div class="input-group create-account__password">
                 {{#if this.passwordRequired}}
                   <PasswordField @value={{this.accountPassword}} @class={{value-entered this.accountPassword}} @type="password" @id="new-account-password" @autocomplete="current-password" @capsLockOn={{this.capsLockOn}} @aria-describedby="password-validation" @aria-invalid={{this.passwordValidation.failed}} />
                   <label class="alt-placeholder" for="new-account-password">
@@ -91,7 +91,7 @@
               </div>
 
               {{#if this.requireInviteCode }}
-                <div class="input-group create-account-invite-code">
+                <div class="input-group create-account__invite-code">
                   <Input @value={{this.inviteCode}} class={{value-entered this.inviteCode}} id="inviteCode" />
                   <label class="alt-placeholder" for="invite-code">{{i18n "user.invite_code.title"}}</label>
                   <span class="more-info">{{i18n "user.invite_code.instructions"}}</span>

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -12,11 +12,11 @@
           <div class="login-form">
             <form>
               {{#if this.associateHtml}}
-                <div class="input-group create-account__associate-link">
+                <div class="input-group create-account-associate-link">
                   <span>{{html-safe this.associateHtml}}</span>
                 </div>
               {{/if}}
-              <div class="input-group create-account__email">
+              <div class="input-group create-account-email">
                 <Input @type="email" disabled={{this.emailDisabled}} @value={{this.accountEmail}} id="new-account-email" name="email" class={{value-entered this.accountEmail}} autofocus="autofocus" {{on "focusout" (action "checkEmailAvailability")}} aria-describedby="account-email-validation" aria-invalid={{this.emailValidation.failed}} />
                 <label class="alt-placeholder" for="new-account-email">
                   {{i18n "user.email.title"}}


### PR DESCRIPTION
This will follow the same pattern that was used for the associate-link and email input-group elements.

It also adds a class to the create-account-form element that highlights which auth provider is used if any.

<img width="912" alt="Screen Shot 2022-07-11 at 3 02 46 PM" src="https://user-images.githubusercontent.com/22733864/178367393-69fe97e3-b772-44e2-8c2d-2243881da685.png">

If no auth provider is used, no class is added.