### PR TITLE
FIX: Detect firefox < 89 as an unsupported browser

### DIFF
--- a/app/assets/javascripts/discourse/scripts/browser-detect.js
+++ b/app/assets/javascripts/discourse/scripts/browser-detect.js
@@ -1,12 +1,24 @@
-if (!window.WeakMap || !window.Promise || typeof globalThis === "undefined") {
-  window.unsupportedBrowser = true;
-} else {
-  // Some implementations of `WeakMap.prototype.has` do not accept false
-  // values and Ember's `isClassicDecorator` sometimes does that (it only
-  // checks for `null` and `undefined`).
-  try {
-    new WeakMap().has(0);
-  } catch (err) {
+/* eslint-disable no-var */ // `let` is not supported in very old browsers
+
+(function () {
+  if (!window.WeakMap || !window.Promise || typeof globalThis === "undefined") {
     window.unsupportedBrowser = true;
+  } else {
+    // Some implementations of `WeakMap.prototype.has` do not accept false
+    // values and Ember's `isClassicDecorator` sometimes does that (it only
+    // checks for `null` and `undefined`).
+    try {
+      new WeakMap().has(0);
+    } catch (err) {
+      window.unsupportedBrowser = true;
+    }
+
+    var match = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./);
+    var firefoxVersion = match ? parseInt(match[1], 10) : null;
+    if (firefoxVersion && firefoxVersion < 89) {
+      // prior to v89, Firefox has bugs with document.execCommand("insertText")
+      // https://bugzil.la/1220696
+      window.unsupportedBrowser = true;
+    }
   }
-}
+})();


### PR DESCRIPTION
Prior to v89, Firefox has bugs with document.execCommand("insertText"): https://bugzil.la/1220696

This commit introduces some variables to browser-detect, and therefore wraps the entire logic in an IIFE to avoid state leaking. (`let`/`const` are not supported on older browsers)

(best reviewed [with whitespace changes hidden](https://github.com/discourse/discourse/pull/17443/files?diff=split&w=1))
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
