### PR TITLE
DEV: Remove development cache-buster query parameter

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -125,13 +125,6 @@ module ApplicationHelper
       path = path.gsub("#{GlobalSetting.cdn_url}/assets/", "#{GlobalSetting.cdn_url}/brotli_asset/")
     end
 
-    if Rails.env == "development"
-      if !path.include?("?")
-        # cache breaker for mobile iOS
-        path = path + "?#{Time.now.to_f}"
-      end
-    end
-
     path
   end
 


### PR DESCRIPTION
All our development-mode assets serve a `Cache-Control: no-cache` header, so a query parameter shouldn't be needed. Ember CLI does not include cache-busting parameters, so this change will move the development rails app to the same behaviour.

This will fix adding persistent breakpoints in the dev tools. Previously, the browser would think that the assets have been replaced and throw away the breakpoints.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
