### PR TITLE
DEV: Make sure testing-container fits in the viewport

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-listen-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-test-listen-boot.js
@@ -1,9 +1,30 @@
 document.body.insertAdjacentHTML(
   "afterbegin",
   `
-  <style>#ember-testing-container { position: fixed; background: white; bottom: 0; right: 0; width: 640px; height: 384px; overflow: auto; z-index: 9999; border: 1px solid #ccc; transform: translateZ(0)} #ember-testing { width: 200%; height: 200%; transform: scale(0.5); transform-origin: top left; }</style>
+  <style>
+    #ember-testing-container {
+      position: fixed;
+      background: white;
+      bottom: 0;
+      right: 0;
+      width: 640px;
+      height: 384px;
+      overflow: auto;
+      z-index: 9999;
+      border: 1px solid #ccc;
+      transform: translateZ(0);
+      box-sizing: border-box;
+      max-height: 100vh;
+    }
+
+    #ember-testing {
+      width: 200%;
+      height: 200%;
+      transform: scale(0.5);
+      transform-origin: top left;
+    }
+  </style>
   `
 );
-
 
 require('discourse/tests/test-boot-ember-cli');

--- a/app/assets/stylesheets/testem.scss
+++ b/app/assets/stylesheets/testem.scss
@@ -19,3 +19,8 @@ $love: #fa6c8d !default;
 @import "common/foundation/mixins";
 @import "desktop";
 @import "color_definitions";
+
+#ember-testing-container {
+  box-sizing: border-box;
+  max-height: 100vh;
+}


### PR DESCRIPTION
This prevents tests failures when the browser viewport is too small.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
