### PR TITLE
DEV: add `emoji` handlebars helper

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/emoji.js
+++ b/app/assets/javascripts/discourse/app/helpers/emoji.js
@@ -1,0 +1,11 @@
+import { emojiUnescape } from "discourse/lib/text";
+import { escapeExpression } from "discourse/lib/utilities";
+import { htmlSafe } from "@ember/template";
+import { helper } from "@ember/component/helper";
+
+function emoji(code, options) {
+  const escaped = escapeExpression(`:${code}:`);
+  return htmlSafe(emojiUnescape(escaped, options));
+}
+
+export default helper(emoji);

--- a/app/assets/javascripts/discourse/tests/integration/helpers/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/emoji-test.js
@@ -1,0 +1,14 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { render } from "@ember/test-helpers";
+import { exists } from "discourse/tests/helpers/qunit-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+module("Integration | Helper | emoji", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it renders", async function (assert) {
+    await render(hbs`{{emoji "tada"}}`);
+    assert.ok(exists(`.emoji[title="tada"]`));
+  });
+});


### PR DESCRIPTION
A simple handlebars helper built on top of helper functions we already have. If you need to add an emoji to a template, do just this:
```hbs
{{emoji "mega"}}
```
