### PR TITLE
FEATURE: show status in the tooltip on the status bubble on the user menu

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -69,11 +69,7 @@ createWidget("header-notifications", {
     ];
 
     if (this.currentUser.status) {
-      contents.push(
-        this.attach("user-status-bubble", {
-          emoji: this.currentUser.status.emoji,
-        })
-      );
+      contents.push(this.attach("user-status-bubble", this.currentUser.status));
     }
 
     if (user.isInDoNotDisturb()) {

--- a/app/assets/javascripts/discourse/app/widgets/user-status-bubble.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-status-bubble.js
@@ -1,9 +1,18 @@
 import { createWidget } from "discourse/widgets/widget";
+import I18n from "I18n";
 
 export default createWidget("user-status-bubble", {
   tagName: "div.user-status-background",
 
   html(attrs) {
-    return this.attach("emoji", { name: attrs.emoji });
+    let title = attrs.description;
+    if (attrs.ends_at) {
+      const until = moment
+        .tz(attrs.ends_at, this.currentUser.timezone)
+        .format(I18n.t("dates.long_date_without_year"));
+      title += `\n${I18n.t("user_status.until")} ${until}`;
+    }
+
+    return this.attach("emoji", { name: attrs.emoji, title });
   },
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1800,6 +1800,7 @@ en:
       set_custom_status: "Set custom status"
       what_are_you_doing: "What are you doing?"
       remove_status: "Remove status"
+      until: "Until:"
 
     loading: "Loading..."
     errors:


### PR DESCRIPTION
This adds a tooltip to the status bubble:

<img width="200" alt="Screenshot 2022-07-12 at 21 09 54" src="https://user-images.githubusercontent.com/1274517/178552555-5e21371b-446b-424f-bf06-dc0fa921e13a.png">

Note that this is just a quick fix for the current status bubble, we're going to move status to the new place on the user menu soon and this code will be removed. That's why I haven't added a test.

But note that we're going to use string `user_status.until` in other places, so it's ok to add that string in this PR.
