### PR TITLE
DEV: discourse-root should be targetable

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discourse-root.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-root.js
@@ -1,6 +1,6 @@
 import Component from "@ember/component";
 
-let componentArgs = { tagName: "div" };
+let componentArgs = { tagName: "div", classNames: ["discourse-root"] };
 
 // TODO: Once we've moved to Ember CLI completely we can remove this block
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
We can't remove it for now as themes rely on it, so we should at least be able to target it in the DOM

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
