### PR TITLE
DEV: Remove no-op autocomplete disabler

### DIFF
--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -295,9 +295,6 @@ export default function setupTests(config) {
     sinon.stub(ScrollingDOMMethods, "screenNotFull");
     sinon.stub(ScrollingDOMMethods, "bindOnScroll");
     sinon.stub(ScrollingDOMMethods, "unbindOnScroll");
-
-    // Unless we ever need to test this, let's leave it off.
-    $.fn.autocomplete = function () {};
   });
 
   QUnit.testDone(function () {


### PR DESCRIPTION
It was done before the autocomplete initializer, so had no effect.