### PR TITLE
DEV: Speed up composer autocomplete tests

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -10,6 +10,7 @@ import afterTransition from "discourse/lib/after-transition";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import positioningWorkaround from "discourse/lib/safari-hacks";
+import { isTesting } from "discourse-common/config/environment";
 
 const START_DRAG_EVENTS = ["touchstart", "mousedown"];
 const DRAG_EVENTS = ["touchmove", "mousemove"];
@@ -62,12 +63,15 @@ export default Component.extend(KeyEnterEscape, {
     // One second from now, check to see if the last key was hit when
     // we recorded it. If it was, the user paused typing.
     cancel(this._lastKeyTimeout);
-    this._lastKeyTimeout = later(() => {
-      if (lastKeyUp !== this._lastKeyUp) {
-        return;
-      }
-      this.appEvents.trigger("composer:find-similar");
-    }, 1000);
+    this._lastKeyTimeout = later(
+      () => {
+        if (lastKeyUp !== this._lastKeyUp) {
+          return;
+        }
+        this.appEvents.trigger("composer:find-similar");
+      },
+      isTesting() ? 50 : 1000
+    );
   },
 
   @observes("composeState")


### PR DESCRIPTION
It was pausing for 1s after each keyup event.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
