### PR TITLE
DEV: Remove 6-yrs old deprecated loadScript opt

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/load-script.js
+++ b/app/assets/javascripts/discourse/app/lib/load-script.js
@@ -48,11 +48,6 @@ export function loadCSS(url) {
 }
 
 export default function loadScript(url, opts = {}) {
-  // TODO: Remove this once plugins have been updated not to use it:
-  if (url === "defer/html-sanitizer-bundle") {
-    return Promise.resolve();
-  }
-
   if (_loaded[url]) {
     return Promise.resolve();
   }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
