### PR TITLE
DEV: Add `normal` as an alias for `regular` in `NotificationLevels.topic_levels`

### DIFF
--- a/lib/notification_levels.rb
+++ b/lib/notification_levels.rb
@@ -13,6 +13,7 @@ module NotificationLevels
   def self.topic_levels
     @topic_levels ||= Enum.new(muted: 0,
                                regular: 1,
+                               normal: 1, # alias for regular
                                tracking: 2,
                                watching: 3)
   end


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/5176c689e953f3c91abf97ec45cd528ef36cdee1