### PR TITLE
UX: Fixes navigation 1px jitter

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-list.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.js
@@ -31,7 +31,7 @@ export default Component.extend(Scrolling, {
     if (scrollTo >= 0) {
       schedule("afterRender", () => {
         if (this.element && !this.isDestroying && !this.isDestroyed) {
-          next(() => window.scrollTo(0, scrollTo + 1));
+          next(() => window.scrollTo(0, scrollTo));
         }
       });
     }

--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
@@ -17,7 +17,7 @@ export default Component.extend(UrlRefresh, LoadMore, {
     if (scrollTo >= 0) {
       schedule("afterRender", () => {
         if (this.element && !this.isDestroying && !this.isDestroyed) {
-          next(() => window.scrollTo(0, scrollTo + 1));
+          next(() => window.scrollTo(0, scrollTo));
         }
       });
     } else {

--- a/app/assets/javascripts/discourse/app/components/topic-list.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list.js
@@ -78,7 +78,7 @@ export default Component.extend(LoadMore, {
     if (scrollTo >= 0) {
       schedule("afterRender", () => {
         if (this.element && !this.isDestroying && !this.isDestroyed) {
-          next(() => window.scrollTo(0, scrollTo + 1));
+          next(() => window.scrollTo(0, scrollTo));
         }
       });
     }

--- a/app/assets/javascripts/discourse/app/components/user-stream.js
+++ b/app/assets/javascripts/discourse/app/components/user-stream.js
@@ -77,7 +77,7 @@ export default Component.extend(LoadMore, {
     if (scrollTo >= 0) {
       schedule("afterRender", () => {
         if (this.element && !this.isDestroying && !this.isDestroyed) {
-          next(() => window.scrollTo(0, scrollTo + 1));
+          next(() => window.scrollTo(0, scrollTo));
         }
       });
     }


### PR DESCRIPTION
Context: https://meta.discourse.org/t/pixel-jump-whenever-page-refreshes-mobile-desktop/231053

We currently add 1 extra pixel when we try to restore the last scroll position on a few routes. 

This is causing a bit of jumpiness, as described in the linked topic above. 

<img height="300" src="https://d11a6trkgmumsb.cloudfront.net/original/4X/a/e/9/ae9e69f7fd40daba8bc0b41fec9cafbf0d4b3830.gif">

Notice how the content shifts by 1px while stuff loads.

I believe this 1px that we add is an artifact from the days when we used to set the header to `fixed` but I'm not sure. Either way, the header now uses `position: sticky;` so we shouldn't need that 1px adjustment.

This PR introduced no visual changes except that it fixes the jitter mentioned above.