### PR TITLE
DEV: Move mini profiler badge to the right

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -141,7 +141,7 @@ function bodyFooter(buffer, bootstrap, headers) {
 
   let v = generateUID();
   buffer.push(`
-		<script async type="text/javascript" id="mini-profiler" src="/mini-profiler-resources/includes.js?v=${v}" data-css-url="/mini-profiler-resources/includes.css?v=${v}" data-version="${v}" data-path="/mini-profiler-resources/" data-horizontal-position="left" data-vertical-position="top" data-trivial="false" data-children="false" data-max-traces="20" data-controls="false" data-total-sql-count="false" data-authorized="true" data-toggle-shortcut="alt+p" data-start-hidden="false" data-collapse-results="true" data-html-container="body" data-hidden-custom-fields="x" data-ids="${headers.get(
+		<script async type="text/javascript" id="mini-profiler" src="/mini-profiler-resources/includes.js?v=${v}" data-css-url="/mini-profiler-resources/includes.css?v=${v}" data-version="${v}" data-path="/mini-profiler-resources/" data-horizontal-position="right" data-vertical-position="top" data-trivial="false" data-children="false" data-max-traces="20" data-controls="false" data-total-sql-count="false" data-authorized="true" data-toggle-shortcut="alt+p" data-start-hidden="false" data-collapse-results="true" data-html-container="body" data-hidden-custom-fields="x" data-ids="${headers.get(
     "x-miniprofiler-ids"
   )}"></script>
 	`);

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -380,7 +380,7 @@ table {
   border-radius: 50%;
 }
 
-.profiler-results.profiler-left {
+.profiler-results.profiler-right {
   top: var(--header-offset) !important;
 }
 

--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -72,7 +72,6 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
   #  does not get clobbered.
   Rack::MiniProfiler.config.cookie_path = Discourse.base_path.presence || "/"
 
-  Rack::MiniProfiler.config.position = 'left'
   Rack::MiniProfiler.config.backtrace_ignores ||= []
   Rack::MiniProfiler.config.backtrace_ignores << /lib\/rack\/message_bus.rb/
   Rack::MiniProfiler.config.backtrace_ignores << /config\/initializers\/silence_logger/


### PR DESCRIPTION
In the era where we have left aligned sidebar, the mini profiler badge
gets in the way