### PR TITLE
DEV: Remove `before(:all)` from RSpec suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,7 +170,7 @@ group :test, :development do
   gem 'shoulda-matchers', require: false
   gem 'rspec-html-matchers'
   gem 'byebug', require: ENV['RM_INFO'].nil?, platform: :mri
-  gem "rubocop-discourse", require: false
+  gem 'rubocop-discourse', require: false, github: 'discourse/rubocop-discourse'
   gem 'parallel_tests'
 
   gem 'rswag-specs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,14 @@ GIT
     mail (2.8.0.edge)
       mini_mime (>= 0.1.1)
 
+GIT
+  remote: https://github.com/discourse/rubocop-discourse.git
+  revision: 0de6d72891fea488cae22332505e4e3f26b4e157
+  specs:
+    rubocop-discourse (2.5.0)
+      rubocop (>= 1.1.0)
+      rubocop-rspec (>= 2.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -422,9 +430,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.19.1)
       parser (>= 3.1.1.0)
-    rubocop-discourse (2.5.0)
-      rubocop (>= 1.1.0)
-      rubocop-rspec (>= 2.0.0)
     rubocop-rspec (2.12.1)
       rubocop (~> 1.31)
     ruby-prof (1.4.3)
@@ -612,7 +617,7 @@ DEPENDENCIES
   rspec-rails
   rss
   rswag-specs
-  rubocop-discourse
+  rubocop-discourse!
   ruby-prof
   ruby-readability
   rubyzip

--- a/spec/helpers/redis_snapshot_helper.rb
+++ b/spec/helpers/redis_snapshot_helper.rb
@@ -2,14 +2,6 @@
 
 module RedisSnapshotHelper
   def use_redis_snapshotting
-    before(:all) do
-      RedisSnapshot.begin_faux_transaction
-    end
-
-    after(:all) do
-      RedisSnapshot.end_faux_transaction
-    end
-
     before(:each) do
       RedisSnapshot.begin_faux_transaction
     end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
