### PR TITLE
Adding 3.2 to the versions of phpbb supported by the migration script

### DIFF
--- a/script/import_scripts/phpbb3.rb
+++ b/script/import_scripts/phpbb3.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Importer for phpBB 3.0 and 3.1
+# Importer for phpBB 3.0, 3.1 and 3.2
 # Documentation: https://meta.discourse.org/t/importing-from-phpbb3/30810
 
 if ARGV.length != 1 || !File.exist?(ARGV[0])


### PR DESCRIPTION
So the versions in the comment match the docs, and what actual versions the script supports. When scoping a migration, sometimes we just look at the script, and the mismatched versions were causing confusion. 