### PR TITLE
FIX: Do not redeem invites if user resets password

### DIFF
--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -69,7 +69,7 @@ class EmailToken < ActiveRecord::Base
       user.create_reviewable if !skip_reviewable
       user.set_automatic_groups
       DiscourseEvent.trigger(:user_confirmed_email, user)
-      Invite.redeem_from_email(user.email) if scope != EmailToken.scopes[:password_reset]
+      Invite.redeem_from_email(user.email) if scope == EmailToken.scopes[:signup]
 
       user.reload
     end

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -69,7 +69,7 @@ class EmailToken < ActiveRecord::Base
       user.create_reviewable if !skip_reviewable
       user.set_automatic_groups
       DiscourseEvent.trigger(:user_confirmed_email, user)
-      Invite.redeem_from_email(user.email)
+      Invite.redeem_from_email(user.email) if scope != EmailToken.scopes[:password_reset]
 
       user.reload
     end

--- a/spec/models/email_token_spec.rb
+++ b/spec/models/email_token_spec.rb
@@ -139,5 +139,40 @@ describe EmailToken do
         expect(confirmed_invited_user).to be_approved
       end
     end
+
+    context 'does not redeem the invite if token is password_reset' do
+      before do
+        SiteSetting.must_approve_users = true
+        Jobs.run_immediately!
+      end
+
+      fab!(:invite) { Fabricate(:invite, email: 'test@example.com') }
+      fab!(:invited_user) { Fabricate(:user, active: false, email: invite.email) }
+      let!(:user_email_token) { Fabricate(:email_token, user: invited_user, scope: EmailToken.scopes[:password_reset]) }
+      let!(:confirmed_invited_user) { EmailToken.confirm(user_email_token.token, scope: EmailToken.scopes[:password_reset]) }
+
+      it "returns the correct user" do
+        expect(confirmed_invited_user).to eq invited_user
+      end
+
+      it 'marks the user as active' do
+        confirmed_invited_user.reload
+        expect(confirmed_invited_user).to be_active
+      end
+
+      it 'marks the token as confirmed' do
+        user_email_token.reload
+        expect(user_email_token).to be_confirmed
+      end
+
+      it 'does not redeem invite' do
+        invite.reload
+        expect(invite).not_to be_redeemed
+      end
+
+      it 'marks the user as approved' do
+        expect(confirmed_invited_user).to be_approved
+      end
+    end
   end
 end

--- a/spec/models/email_token_spec.rb
+++ b/spec/models/email_token_spec.rb
@@ -113,8 +113,8 @@ describe EmailToken do
 
       fab!(:invite) { Fabricate(:invite, email: 'test@example.com') }
       fab!(:invited_user) { Fabricate(:user, active: false, email: invite.email) }
-      let!(:user_email_token) { Fabricate(:email_token, user: invited_user) }
-      let!(:confirmed_invited_user) { EmailToken.confirm(user_email_token.token) }
+      let!(:user_email_token) { Fabricate(:email_token, user: invited_user, scope: EmailToken.scopes[:signup]) }
+      let!(:confirmed_invited_user) { EmailToken.confirm(user_email_token.token, scope: EmailToken.scopes[:signup]) }
 
       it "returns the correct user" do
         expect(confirmed_invited_user).to eq invited_user


### PR DESCRIPTION
The invites should be redeemed during the signup process. This was a
problem because when user tried to redeem an admin invite it tried to
authenticate the user using information from the session that was not
available.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
