### PR TITLE
FIX: Change UserCommScreener to use user_ids

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1040,8 +1040,8 @@ class Topic < ActiveRecord::Base
         raise UserExists.new(I18n.t("topic_invite.user_exists"))
       end
 
-      comm_screener = UserCommScreener.new(acting_user: invited_by, target_usernames: target_user.username)
-      if comm_screener.ignoring_or_muting_actor?(target_user.username)
+      comm_screener = UserCommScreener.new(acting_user: invited_by, target_user_ids: target_user.id)
+      if comm_screener.ignoring_or_muting_actor?(target_user.id)
         raise NotAllowed.new(I18n.t("not_accepting_pms", username: target_user.username))
       end
 
@@ -1053,11 +1053,11 @@ class Topic < ActiveRecord::Base
         raise NotAllowed.new(I18n.t("topic_invite.muted_topic"))
       end
 
-      if comm_screener.disallowing_pms_from_actor?(target_user.username)
+      if comm_screener.disallowing_pms_from_actor?(target_user.id)
         raise NotAllowed.new(I18n.t("topic_invite.receiver_does_not_allow_pm"))
       end
 
-      if UserCommScreener.new(acting_user: target_user, target_usernames: invited_by.username).disallowing_pms_from_actor?(invited_by.username)
+      if UserCommScreener.new(acting_user: target_user, target_user_ids: invited_by.id).disallowing_pms_from_actor?(invited_by.id)
         raise NotAllowed.new(I18n.t("topic_invite.sender_does_not_allow_pm"))
       end
 
@@ -1759,7 +1759,7 @@ class Topic < ActiveRecord::Base
   end
 
   def create_invite_notification!(target_user, notification_type, invited_by, post_number: 1)
-    if UserCommScreener.new(acting_user: invited_by, target_usernames: target_user.username).ignoring_or_muting_actor?(target_user.username)
+    if UserCommScreener.new(acting_user: invited_by, target_user_ids: target_user.id).ignoring_or_muting_actor?(target_user.id)
       raise NotAllowed.new(I18n.t("not_accepting_pms", username: target_user.username))
     end
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -394,8 +394,8 @@ class PostAlerter
 
     notifier_id = opts[:user_id] || post.user_id # xxxxx look at revision history
     return if notifier_id && UserCommScreener.new(
-      acting_user_id: notifier_id, target_usernames: user.username
-    ).ignoring_or_muting_actor?(user.username)
+      acting_user_id: notifier_id, target_user_ids: user.id
+    ).ignoring_or_muting_actor?(user.id)
 
     # skip if muted on the topic
     return if TopicUser.where(

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -113,8 +113,9 @@ class PostCreator
 
       # Make sure none of the users have muted or ignored the creator or prevented
       # PMs from being sent to them
-      UserCommScreener.new(acting_user: @user, target_usernames: names).preventing_actor_communication.each do |username|
-        errors.add(:base, I18n.t(:not_accepting_pms, username: username))
+      target_users = User.where(username_lower: names.map(&:downcase)).pluck(:id, :username).to_h
+      UserCommScreener.new(acting_user: @user, target_user_ids: target_users.keys).preventing_actor_communication.each do |user_id|
+        errors.add(:base, I18n.t(:not_accepting_pms, username: target_users[user_id]))
       end
 
       return false if errors[:base].present?

--- a/spec/lib/user_comm_screener_spec.rb
+++ b/spec/lib/user_comm_screener_spec.rb
@@ -13,22 +13,22 @@ describe UserCommScreener do
 
   subject do
     described_class.new(
-      acting_user: acting_user, target_usernames: ["bobscreen", "hughscreen", "alicescreen", "janescreen", "maryscreen"]
+      acting_user: acting_user, target_user_ids: [
+        target_user1.id,
+        target_user2.id,
+        target_user3.id,
+        target_user4.id,
+        target_user5.id
+      ]
     )
   end
 
   it "allows initializing the class with both an acting_user_id and an acting_user" do
     acting_user = Fabricate(:user)
-    screener = described_class.new(acting_user: acting_user, target_usernames: ["bobscreen"])
-    expect(screener.allowing_actor_communication).to eq(["bobscreen"])
-    screener = described_class.new(acting_user_id: acting_user.id, target_usernames: ["bobscreen"])
-    expect(screener.allowing_actor_communication).to eq(["bobscreen"])
-  end
-
-  it "makes sure to lowercase target usernames" do
-    acting_user = Fabricate(:user)
-    screener = described_class.new(acting_user: acting_user, target_usernames: ["BoBscrEEN", "HUghSCreen"])
-    expect(screener.allowing_actor_communication).to eq(["bobscreen", "hughscreen"])
+    screener = described_class.new(acting_user: acting_user, target_user_ids: [target_user1.id])
+    expect(screener.allowing_actor_communication).to eq([target_user1.id])
+    screener = described_class.new(acting_user_id: acting_user.id, target_user_ids: [target_user1.id])
+    expect(screener.allowing_actor_communication).to eq([target_user1.id])
   end
 
   context "when the actor is not staff" do
@@ -38,60 +38,60 @@ describe UserCommScreener do
 
     describe "#allowing_actor_communication" do
       it "returns the usernames of people not ignoring, muting, or disallowing PMs from the actor" do
-        expect(subject.allowing_actor_communication).to match_array(["janescreen", "maryscreen"])
+        expect(subject.allowing_actor_communication).to match_array([target_user4.id, target_user5.id])
       end
     end
 
     describe "#preventing_actor_communication" do
       it "returns the usernames of people ignoring, muting, or disallowing PMs from the actor" do
-        expect(subject.preventing_actor_communication).to match_array(["bobscreen", "hughscreen", "alicescreen"])
+        expect(subject.preventing_actor_communication).to match_array([target_user1.id, target_user2.id, target_user3.id])
       end
     end
 
     describe "#ignoring_or_muting_actor?" do
       it "does not raise an error when looking for a user who has no communication preferences" do
-        expect { subject.ignoring_or_muting_actor?(target_user5.username) }.not_to raise_error
+        expect { subject.ignoring_or_muting_actor?(target_user5.id) }.not_to raise_error
       end
 
       it "returns true for a user muting the actor" do
-        expect(subject.ignoring_or_muting_actor?(target_user1.username)).to eq(true)
+        expect(subject.ignoring_or_muting_actor?(target_user1.id)).to eq(true)
       end
 
       it "returns true for a user ignoring the actor" do
-        expect(subject.ignoring_or_muting_actor?(target_user2.username)).to eq(true)
+        expect(subject.ignoring_or_muting_actor?(target_user2.id)).to eq(true)
       end
 
       it "returns false for a user neither ignoring or muting the actor" do
-        expect(subject.ignoring_or_muting_actor?(target_user3.username)).to eq(false)
+        expect(subject.ignoring_or_muting_actor?(target_user3.id)).to eq(false)
       end
     end
 
     describe "#disallowing_pms_from_actor?" do
       it "returns true for a user disallowing all PMs" do
-        expect(subject.disallowing_pms_from_actor?(target_user3.username)).to eq(true)
+        expect(subject.disallowing_pms_from_actor?(target_user3.id)).to eq(true)
       end
 
       it "returns true for a user allowing only PMs for certain users but not the actor" do
         target_user4.user_option.update!(enable_allowed_pm_users: true)
-        expect(subject.disallowing_pms_from_actor?(target_user4.username)).to eq(true)
+        expect(subject.disallowing_pms_from_actor?(target_user4.id)).to eq(true)
       end
 
       it "returns false for a user allowing only PMs for certain users which the actor allowed" do
         target_user4.user_option.update!(enable_allowed_pm_users: true)
         AllowedPmUser.create!(user: target_user4, allowed_pm_user: acting_user)
-        expect(subject.disallowing_pms_from_actor?(target_user4.username)).to eq(false)
+        expect(subject.disallowing_pms_from_actor?(target_user4.id)).to eq(false)
       end
 
       it "returns false for a user not disallowing PMs or muting or ignoring" do
-        expect(subject.disallowing_pms_from_actor?(target_user5.username)).to eq(false)
+        expect(subject.disallowing_pms_from_actor?(target_user5.id)).to eq(false)
       end
 
       it "returns true for a user not disallowing PMs but still ignoring" do
-        expect(subject.disallowing_pms_from_actor?(target_user1.username)).to eq(true)
+        expect(subject.disallowing_pms_from_actor?(target_user1.id)).to eq(true)
       end
 
       it "returns true for a user not disallowing PMs but still muting" do
-        expect(subject.disallowing_pms_from_actor?(target_user2.username)).to eq(true)
+        expect(subject.disallowing_pms_from_actor?(target_user2.id)).to eq(true)
       end
     end
   end
@@ -103,7 +103,13 @@ describe UserCommScreener do
 
     describe "#allowing_actor_communication" do
       it "returns all usernames since staff can communicate with anyone" do
-        expect(subject.allowing_actor_communication).to match_array(["bobscreen", "hughscreen", "alicescreen", "janescreen", "maryscreen"])
+        expect(subject.allowing_actor_communication).to match_array([
+          target_user1.id,
+          target_user2.id,
+          target_user3.id,
+          target_user4.id,
+          target_user5.id
+        ])
       end
     end
 
@@ -115,38 +121,38 @@ describe UserCommScreener do
 
     describe "#ignoring_or_muting_actor?" do
       it "returns false for a user muting the staff" do
-        expect(subject.ignoring_or_muting_actor?(target_user1.username)).to eq(false)
+        expect(subject.ignoring_or_muting_actor?(target_user1.id)).to eq(false)
       end
 
       it "returns false for a user ignoring the staff actor" do
-        expect(subject.ignoring_or_muting_actor?(target_user2.username)).to eq(false)
+        expect(subject.ignoring_or_muting_actor?(target_user2.id)).to eq(false)
       end
 
       it "returns false for a user neither ignoring or muting the actor" do
-        expect(subject.ignoring_or_muting_actor?(target_user3.username)).to eq(false)
+        expect(subject.ignoring_or_muting_actor?(target_user3.id)).to eq(false)
       end
     end
 
     describe "#disallowing_pms_from_actor?" do
       it "returns false for a user disallowing all PMs" do
-        expect(subject.disallowing_pms_from_actor?(target_user3.username)).to eq(false)
+        expect(subject.disallowing_pms_from_actor?(target_user3.id)).to eq(false)
       end
 
       it "returns false for a user allowing only PMs for certain users but not the actor" do
         target_user4.user_option.update!(enable_allowed_pm_users: true)
-        expect(subject.disallowing_pms_from_actor?(target_user4.username)).to eq(false)
+        expect(subject.disallowing_pms_from_actor?(target_user4.id)).to eq(false)
       end
 
       it "returns false for a user not disallowing PMs or muting or ignoring" do
-        expect(subject.disallowing_pms_from_actor?(target_user5.username)).to eq(false)
+        expect(subject.disallowing_pms_from_actor?(target_user5.id)).to eq(false)
       end
 
       it "returns false for a user not disallowing PMs but still ignoring" do
-        expect(subject.disallowing_pms_from_actor?(target_user1.username)).to eq(false)
+        expect(subject.disallowing_pms_from_actor?(target_user1.id)).to eq(false)
       end
 
       it "returns false for a user not disallowing PMs but still muting" do
-        expect(subject.disallowing_pms_from_actor?(target_user2.username)).to eq(false)
+        expect(subject.disallowing_pms_from_actor?(target_user2.id)).to eq(false)
       end
     end
   end


### PR DESCRIPTION
It makes more sense to use user_ids for the UserCommScreener
introduced in fa5f3e228c102d4b9f7c6dde6eb07ef1f5880bbd since
in most cases the ID will be available, not the username. This
was discovered while starting work on a plugin that will
use this. In the cases where only usernames are available
the extra query is negligble.

