### PR TITLE
DEV: Remove 'legacy ember' logic from discourse-root component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discourse-root.js
+++ b/app/assets/javascripts/discourse/app/components/discourse-root.js
@@ -2,10 +2,4 @@ import Component from "@ember/component";
 
 let componentArgs = { tagName: "div", classNames: ["discourse-root"] };
 
-// TODO: Once we've moved to Ember CLI completely we can remove this block
-// eslint-disable-next-line no-undef
-if (!Ember.FEATURES.EMBER_GLIMMER_SET_COMPONENT_TEMPLATE) {
-  componentArgs = { tagName: "" };
-}
-
 export default Component.extend(componentArgs);


### PR DESCRIPTION
This logic should no longer be triggered. The EMBER_GLIMMER_SET_COMPONENT_TEMPLATE gets removed in recent versions of Ember, which can cause it to accidently trigger and cause layout issues with some plugins/themes.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
