### PR TITLE
DEV: Key the Theme `DistributedCache` on `BASE_COMPILER_VERSION`

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,9 +6,11 @@ require 'json_schemer'
 class Theme < ActiveRecord::Base
   include GlobalPath
 
+  BASE_COMPILER_VERSION = 56
+
   attr_accessor :child_components
 
-  @cache = DistributedCache.new('theme')
+  @cache = DistributedCache.new("theme:compiler#{BASE_COMPILER_VERSION}")
 
   belongs_to :user
   belongs_to :color_scheme
@@ -154,7 +156,6 @@ class Theme < ActiveRecord::Base
     SvgSprite.expire_cache
   end
 
-  BASE_COMPILER_VERSION = 56
   def self.compiler_version
     get_set_cache "compiler_version" do
       dependencies = [


### PR DESCRIPTION
All `DistributedCache` instances in Discourse are automatically keyed on the `Discourse.git_version`. Normally the theme compiler version is updated via a commit, and therefore a compiler version change will always happen at the same time as a git_version change.

However, in some situations, it's possible for the BASE_COMPILER_VERSION to change without a change to the git_version (e.g. when applying patches directly to the codebase).

This commit adds the `BASE_COMPILER_VERSION` to the DistributedCache key to ensure that content from different compiler versions does not leak into other processes.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
