### PR TITLE
DEV: Assign Mini Profiler badge a z-index below the notifications menu

### DIFF
--- a/app/assets/stylesheets/common/admin/mini_profiler.scss
+++ b/app/assets/stylesheets/common/admin/mini_profiler.scss
@@ -3,6 +3,7 @@
 
 div.profiler-results.profiler-top {
   top: var(--header-offset);
+  z-index: z("header") - 1;
 
   .profiler-button {
     background-color: var(--header_background);


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/17468.

The notifications menu has a z-index at the header level, so the badge should be below that.

https://github.com/discourse/discourse/blob/72889573e6c551dd2836cfb087cfebb326d08758/app/assets/stylesheets/common/base/menu-panel.scss#L26