### PR TITLE
FIX: Check if tags edit notifications are disabled

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -113,7 +113,7 @@ class PostRevisor
         DB.after_commit do
           post = tc.topic.ordered_posts.first
           notified_user_ids = [post.user_id, post.last_editor_id].uniq
-          Jobs.enqueue(:notify_tag_change, post_id: post.id, notified_user_ids: notified_user_ids, diff_tags: ((tags - prev_tags) | (prev_tags - tags)))
+          Jobs.enqueue(:notify_tag_change, post_id: post.id, notified_user_ids: notified_user_ids, diff_tags: ((tags - prev_tags) | (prev_tags - tags))) if !SiteSetting.disable_tags_edit_notifications
         end
       end
     end

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -124,6 +124,34 @@ describe PostRevisor do
     end
   end
 
+  context 'editing tags' do
+    fab!(:post) { Fabricate(:post) }
+
+    subject { PostRevisor.new(post) }
+
+    before do
+      Jobs.run_immediately!
+
+      TopicUser.change(
+        newuser.id,
+        post.topic_id,
+        notification_level: TopicUser.notification_levels[:watching]
+      )
+    end
+
+    it 'creates notifications' do
+      expect { subject.revise!(admin, tags: ['new-tag']) }
+        .to change { Notification.count }.by(1)
+    end
+
+    it 'skips notifications if disable_tags_edit_notifications' do
+      SiteSetting.disable_tags_edit_notifications = true
+
+      expect { subject.revise!(admin, tags: ['new-tag']) }
+        .to change { Notification.count }.by(0)
+    end
+  end
+
   context 'revise wiki' do
 
     before do


### PR DESCRIPTION
Tag edit notifications are either created by PostActionNotifier or
PostRevisor. PostActionNotifier already checks if the site setting is
enabled, but PostRevisor scheduled a NotifyTagChange job without
checking disable_tags_edit_notifications.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
