### PR TITLE
FIX: Allow Time objects to be deserialized in PostRevision

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -102,7 +102,7 @@ module Discourse
     config.action_controller.forgery_protection_origin_check = false
     config.active_record.belongs_to_required_by_default = false
     config.active_record.legacy_connection_handling = true
-    config.active_record.yaml_column_permitted_classes = [Hash, HashWithIndifferentAccess]
+    config.active_record.yaml_column_permitted_classes = [Hash, HashWithIndifferentAccess, Time]
 
     # we skip it cause we configure it in the initializer
     # the railtie for message_bus would insert it in the

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe PostRevision do
+  it "can deserialize old YAML" do
+    # Date objects are stored in core post_revisions prior
+    # to https://github.com/discourse/discourse/commit/e7f251c105
+    # and are also stored by some plugins
+
+    pr = Fabricate(:post_revision)
+    DB.exec("UPDATE post_revisions SET modifications = ?", <<~YAML)
+      ---
+      last_version_at:
+      - 2013-12-12 21:40:13.225239000 Z
+      - 2013-12-12 22:10:51.433689320 Z
+    YAML
+    pr.reload
+    expect(pr.modifications).to eq(
+      {
+        "last_version_at" => [
+          Time.parse("2013-12-12 21:40:13.225239000 Z"),
+          Time.parse("2013-12-12 22:10:51.433689320 Z")
+        ]
+      }
+    )
+  end
+end


### PR DESCRIPTION
Followup to ee07f6da7d111e46ca79454320d027c1aca7e157

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
