### PR TITLE
FIX: support systems without SSE 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,8 @@ gem 'omniauth-oauth2', require: false
 
 gem 'omniauth-google-oauth2'
 
-gem 'oj'
+# pending: https://github.com/ohler55/oj/issues/789
+gem 'oj', '3.13.14'
 
 gem 'pg'
 gem 'mini_sql'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -638,4 +638,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.3.13
+   2.3.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (3.13.16)
+    oj (3.13.14)
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -579,7 +579,7 @@ DEPENDENCIES
   mustache
   net-http
   nokogiri
-  oj
+  oj (= 3.13.14)
   omniauth
   omniauth-facebook
   omniauth-github
@@ -638,4 +638,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.3.16
+   2.3.13


### PR DESCRIPTION
Older CPUs do not support the instruction set used internally by the oj gem
starting with version 3.13.15.

This pins the version to a working one while oj patch the project to support
CPUs without the instructions (eg: AMD Opteron 4180).

see:

https://meta.discourse.org/t/discourse-update-keeps-failing/231862
https://github.com/ohler55/oj/issues/789
https://github.com/ohler55/oj/commit/a455c389c0bd09cb591d1144e9366fc3f3280da0
