### PR TITLE
FIX: Unread count badge shown for topics that user is not tracking

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
+++ b/app/assets/javascripts/discourse/app/lib/topic-list-tracker.js
@@ -1,4 +1,6 @@
 import { Promise } from "rsvp";
+import { NotificationLevels } from "discourse/lib/notification-levels";
+
 let model, currentTopicId;
 
 let lastTopicId, lastHighestRead;
@@ -7,14 +9,21 @@ export function setTopicList(incomingModel) {
   model = incomingModel;
 
   model?.topics?.forEach((topic) => {
-    let highestRead = getHighestReadCache(topic.id);
-    if (highestRead && highestRead >= topic.last_read_post_number) {
-      let count = Math.max(topic.highest_post_number - highestRead, 0);
-      topic.setProperties({
-        unread_posts: count,
-        new_posts: count,
-      });
-      resetHighestReadCache();
+    // Only update unread counts for tracked topics
+
+    if (topic.notification_level >= NotificationLevels.TRACKING) {
+      const highestRead = getHighestReadCache(topic.id);
+
+      if (highestRead && highestRead >= topic.last_read_post_number) {
+        const count = Math.max(topic.highest_post_number - highestRead, 0);
+
+        topic.setProperties({
+          unread_posts: count,
+          new_posts: count,
+        });
+
+        resetHighestReadCache();
+      }
     }
   });
   currentTopicId = null;

--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -38,6 +38,7 @@ export default class ScreenTrack extends Service {
 
   start(topicId, topicController) {
     const currentTopicId = this._topicId;
+
     if (currentTopicId && currentTopicId !== topicId) {
       this.tick();
       this.flush();
@@ -277,9 +278,12 @@ export default class ScreenTrack extends Service {
     this.topicTrackingState.updateSeen(topicId, highestSeen);
 
     if (newTimingsKeys.length > 0) {
-      if (this.currentUser && !isTesting()) {
+      if (this.currentUser) {
         this.consolidateTimings(newTimings, this._topicTime, topicId);
-        this.sendNextConsolidatedTiming();
+
+        if (!isTesting()) {
+          this.sendNextConsolidatedTiming();
+        }
       } else if (this._anonCallback) {
         // Anonymous viewer - save to localStorage
         const storage = this.keyValueStore;


### PR DESCRIPTION
When navigating to a topic and directly back to a topic list, an unread count may be shown for the topic even if the user is not tracking it.
