### PR TITLE
FIX: Skip job if tag edit notification is disabled

### DIFF
--- a/app/jobs/regular/notify_tag_change.rb
+++ b/app/jobs/regular/notify_tag_change.rb
@@ -3,6 +3,8 @@
 module Jobs
   class NotifyTagChange < ::Jobs::Base
     def execute(args)
+      return if SiteSetting.disable_tags_edit_notifications
+
       post = Post.find_by(id: args[:post_id])
 
       if post&.topic&.visible?

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -113,7 +113,14 @@ class PostRevisor
         DB.after_commit do
           post = tc.topic.ordered_posts.first
           notified_user_ids = [post.user_id, post.last_editor_id].uniq
-          Jobs.enqueue(:notify_tag_change, post_id: post.id, notified_user_ids: notified_user_ids, diff_tags: ((tags - prev_tags) | (prev_tags - tags))) if !SiteSetting.disable_tags_edit_notifications
+          if !SiteSetting.disable_tags_edit_notifications
+            Jobs.enqueue(
+              :notify_tag_change,
+              post_id: post.id,
+              notified_user_ids: notified_user_ids,
+              diff_tags: ((tags - prev_tags) | (prev_tags - tags))
+            )
+          end
         end
       end
     end

--- a/spec/jobs/notify_tag_change_spec.rb
+++ b/spec/jobs/notify_tag_change_spec.rb
@@ -25,6 +25,22 @@ describe ::Jobs::NotifyTagChange do
     expect(notification.notification_type).to eq(Notification.types[:posted])
   end
 
+  it "doesn't create notifications if tags edit notifications are disabled" do
+    SiteSetting.disable_tags_edit_notifications = true
+
+    TagUser.create!(
+      user_id: user.id,
+      tag_id: tag.id,
+      notification_level: NotificationLevels.topic_levels[:watching]
+    )
+    TopicTag.create!(
+      topic_id: post.topic.id,
+      tag_id: tag.id
+    )
+
+    expect { described_class.new.execute(post_id: post.id, notified_user_ids: [regular_user.id]) }.not_to change { Notification.count }
+  end
+
   it 'doesnt create notification for user watching category' do
     CategoryUser.create!(
       user_id: user.id,


### PR DESCRIPTION
Previous commit did not schedule any more new jobs, but the jobs in
queue could still create notifications.

Follow up to commit e8d802eb86bb4c9fda140422325e80b21541e33e.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
