### PR TITLE
DEV: Check if screen-track was destroyed

### DIFF
--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -183,6 +183,10 @@ export default class ScreenTrack extends Service {
       },
     })
       .then(() => {
+        if (this.isDestroying || this.isDestroyed) {
+          return;
+        }
+
         this._ajaxFailures = 0;
         const topicController = this._topicController;
         if (topicController) {


### PR DESCRIPTION
This error is swallowed by `.catch()` but it's an error nonetheless.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
