### PR TITLE
FIX: Allow Symbol objects to be deserialized in PostRevision

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -102,7 +102,7 @@ module Discourse
     config.action_controller.forgery_protection_origin_check = false
     config.active_record.belongs_to_required_by_default = false
     config.active_record.legacy_connection_handling = true
-    config.active_record.yaml_column_permitted_classes = [Hash, HashWithIndifferentAccess, Time]
+    config.active_record.yaml_column_permitted_classes = [Hash, HashWithIndifferentAccess, Time, Symbol]
 
     # we skip it cause we configure it in the initializer
     # the railtie for message_bus would insert it in the

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -23,4 +23,15 @@ describe PostRevision do
       }
     )
   end
+
+  it "can serialize and deserialize symbols" do
+    # Plugins may store symbolized values in this column
+    pr = Fabricate(:post_revision, modifications: { key: :value })
+    pr.reload
+    expect(pr.modifications).to eq(
+      {
+        key: :value
+      }
+    )
+  end
 end


### PR DESCRIPTION
Followup to ee07f6da7d111e46ca79454320d027c1aca7e157

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
