### PR TITLE
FIX: Allow Symbol objects to be deserialized in PostRevision (stable)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -246,7 +246,7 @@ module Discourse
     # see: http://stackoverflow.com/questions/11894180/how-does-one-correctly-add-custom-sql-dml-in-migrations/11894420#11894420
     config.active_record.schema_format = :sql
 
-    config.active_record.yaml_column_permitted_classes = [Hash, HashWithIndifferentAccess, Time]
+    config.active_record.yaml_column_permitted_classes = [Hash, HashWithIndifferentAccess, Time, Symbol]
 
     # We use this in development-mode only (see development.rb)
     config.active_record.use_schema_cache_dump = false

--- a/spec/models/post_revision_spec.rb
+++ b/spec/models/post_revision_spec.rb
@@ -23,4 +23,15 @@ describe PostRevision do
       }
     )
   end
+
+  it "can serialize and deserialize symbols" do
+    # Plugins may store symbolized values in this column
+    pr = Fabricate(:post_revision, modifications: { key: :value })
+    pr.reload
+    expect(pr.modifications).to eq(
+      {
+        key: :value
+      }
+    )
+  end
 end


### PR DESCRIPTION
Followup to bb287c6c74aed9c9ccd36f6270c219f806bb84f3

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
