### PR TITLE
DEV: emoji helper: add the ability to set custom title

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/helpers/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/emoji-test.js
@@ -11,4 +11,13 @@ module("Integration | Helper | emoji", function (hooks) {
     await render(hbs`{{emoji "tada"}}`);
     assert.ok(exists(`.emoji[title="tada"]`));
   });
+
+  test("it renders custom title", async function (assert) {
+    const title = "custom title";
+    this.set("title", title);
+
+    await render(hbs`{{emoji "tada" title=title}}`);
+
+    assert.ok(exists(`.emoji[title="${title}"]`));
+  });
 });

--- a/app/assets/javascripts/discourse/tests/integration/helpers/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/helpers/emoji-test.js
@@ -16,7 +16,7 @@ module("Integration | Helper | emoji", function (hooks) {
     const title = "custom title";
     this.set("title", title);
 
-    await render(hbs`{{emoji "tada" title=title}}`);
+    await render(hbs`{{emoji "tada" title=this.title}}`);
 
     assert.ok(exists(`.emoji[title="${title}"]`));
   });

--- a/app/assets/javascripts/pretty-text/addon/emoji.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji.js
@@ -92,12 +92,13 @@ export function performEmojiUnescape(string, opts) {
       (isEmoticon || hasEndingColon || isUnicodeEmoticon) &&
       isReplacableInlineEmoji(string, index, opts.inlineEmoji);
 
+    const title = opts.title ?? emojiVal;
     return url && isReplacable
       ? `<img width="20" height="20" src='${url}' ${
-          opts.skipTitle ? "" : `title='${emojiVal}'`
+          opts.skipTitle ? "" : `title='${title}'`
         } ${
           opts.lazy ? "loading='lazy' " : ""
-        }alt='${emojiVal}' class='${classes}'>`
+        }alt='${title}' class='${classes}'>`
       : m;
   };
 


### PR DESCRIPTION
By default, the emoji helper uses the emoji name to set the `title` and `alt` attributes. This PR adds the ability to set a custom title:

<img width="124" alt="Screenshot 2022-07-15 at 22 54 09" src="https://user-images.githubusercontent.com/1274517/179292374-7efe444f-1ec4-4324-8b64-7dbe2df85ec7.png">

