### PR TITLE
UX: Prevent pre tag from making posts too wide

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -470,6 +470,7 @@ blockquote {
 .topic-body {
   width: calc(#{$topic-body-width} + (#{$topic-body-width-padding} * 2));
   float: left;
+  min-width: 0; // prevents some elements, like <pre>, from blowing out the width
   position: relative;
   border-top: 1px solid var(--primary-low);
   padding: 12px 0 0 0;


### PR DESCRIPTION
fixes this issue here:

![Screen Shot 2022-07-15 at 3 40 09 PM](https://user-images.githubusercontent.com/1681963/179299197-11c83516-20ae-417c-9aa6-29cbaff95a26.png)

