### PR TITLE
FIX: Disable Twitter onebox without API support

### DIFF
--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -27,7 +27,38 @@ module Onebox
             twitter_data[m_property.to_sym] = m_content
           end
         end
+
+        begin
+          extract_twitter_data!(html, twitter_data)
+        rescue => e
+          Rails.logger.warn("Failed to extract Twitter data: #{e.message}\n#{e.backtrace.join("\n")}")
+        end
+
         twitter_data
+      end
+
+      def extract_twitter_data!(html, twitter_data)
+        tweet_html = html.css('[itemtype="https://schema.org/SocialMediaPosting"]')[0]
+        author_html = tweet_html.css('[itemprop="author"]')[0]
+        twitter_data[:title] = author_html.css('[itemprop="givenName"]')[0]['content']
+        twitter_data[:screen_name] = author_html.css('[itemprop="additionalName"]')[0]['content']
+        twitter_data[:timestamp] = tweet_html.css('[itemprop="datePublished"]')[0]['content']
+        tweet_html.children.each do |child|
+          if child['itemprop'] == 'interactionStatistic'
+            key = child.css('[itemprop="name"]')[0]['content']
+            value = child.css('[itemprop="userInteractionCount"]')[0]['content']
+
+            case key
+            when 'Likes'
+              twitter_data[:likes] = value
+            when 'Retweets'
+              twitter_data[:retweets] = value
+            end
+          end
+        end
+
+        tweet_html = tweet_html.css('[data-testid="tweet"]')[0]
+        twitter_data[:image] = tweet_html.css('[data-testid="Tweet-User-Avatar"] img')[0]['src']
       end
 
       def match
@@ -76,7 +107,7 @@ module Onebox
           offset = (user_offset >= 0 ? "+" : "-") + Time.at(user_offset.abs).gmtime.strftime("%H%M")
           date.new_offset(offset).strftime("%-l:%M %p - %-d %b %Y")
         else
-          attr_at_css(".tweet-timestamp", 'title')
+          twitter_data[:timestamp]&.to_datetime&.strftime("%-l:%M %p - %-d %b %Y")
         end
       end
 
@@ -84,7 +115,7 @@ module Onebox
         if twitter_api_credentials_present?
           access(:user, :name)
         else
-          attr_at_css('.tweet.permalink-tweet', 'data-name')
+          twitter_data[:title]
         end
       end
 
@@ -92,7 +123,7 @@ module Onebox
         if twitter_api_credentials_present?
           access(:user, :screen_name)
         else
-          attr_at_css('.tweet.permalink-tweet', 'data-screen-name')
+          twitter_data[:screen_name]
         end
       end
 
@@ -108,7 +139,7 @@ module Onebox
         if twitter_api_credentials_present?
           prettify_number(access(:favorite_count).to_i)
         else
-          attr_at_css(".request-favorited-popup", 'data-compact-localized-count')
+          prettify_number(twitter_data[:likes].to_i)
         end
       end
 
@@ -116,7 +147,7 @@ module Onebox
         if twitter_api_credentials_present?
           prettify_number(access(:retweet_count).to_i)
         else
-          attr_at_css(".request-retweeted-popup", 'data-compact-localized-count')
+          prettify_number(twitter_data[:retweets].to_i)
         end
       end
 
@@ -124,7 +155,7 @@ module Onebox
         if twitter_api_credentials_present?
           access(:quoted_status, :user, :name)
         else
-          raw.css('.QuoteTweet-fullname')[0]&.text
+          twitter_data[:quoted_full_name]
         end
       end
 
@@ -132,7 +163,7 @@ module Onebox
         if twitter_api_credentials_present?
           access(:quoted_status, :user, :screen_name)
         else
-          attr_at_css(".QuoteTweet-innerContainer", "data-screen-name")
+          twitter_data[:quoted_screen_name]
         end
       end
 
@@ -140,7 +171,7 @@ module Onebox
         if twitter_api_credentials_present?
           access(:quoted_status, :full_text)
         else
-          raw.css('.QuoteTweet-text')[0]&.text
+          twitter_data[:quote_text]
         end
       end
 
@@ -148,16 +179,12 @@ module Onebox
         if twitter_api_credentials_present?
           "https://twitter.com/#{quoted_screen_name}/status/#{access(:quoted_status, :id)}"
         else
-          "https://twitter.com#{attr_at_css(".QuoteTweet-innerContainer", "href")}"
+          "https://twitter.com#{twitter_data[:quote_url]}"
         end
       end
 
       def prettify_number(count)
         count > 0 ? client.prettify_number(count) : nil
-      end
-
-      def attr_at_css(css_property, attribute_name)
-        raw.at_css(css_property)&.attr(attribute_name)
       end
 
       def data

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -18,6 +18,10 @@ module Onebox
         { 'User-Agent' => 'DiscourseBot/1.0' }
       end
 
+      def to_html
+        raw.present? ? super : ''
+      end
+
       private
 
       def match
@@ -34,7 +38,7 @@ module Onebox
 
       def raw
         if twitter_api_credentials_present?
-          @raw ||= OpenStruct.new(client.status(match[:id]).to_hash)
+          @raw ||= client.status(match[:id]).to_hash
         end
       end
 

--- a/lib/twitter_api.rb
+++ b/lib/twitter_api.rb
@@ -125,7 +125,13 @@ class TwitterApi
     def twitter_get(uri)
       request = Net::HTTP::Get.new(uri)
       request.add_field 'Authorization', "Bearer #{bearer_token}"
-      http(uri).request(request).body
+      response = http(uri).request(request)
+
+      if response.kind_of?(Net::HTTPTooManyRequests)
+        Rails.logger.warn("Twitter API rate limit has been reached")
+      end
+
+      response.body
     end
 
     def authorization

--- a/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
@@ -107,40 +107,12 @@ RSpec.describe Onebox::Engine::TwitterStatusOnebox do
     end
   end
 
-  context "with html" do
-    context "with a standard tweet" do
-      let(:tweet_content) { "I'm a sucker for pledges." }
+  context "without twitter client" do
+    let(:link) { "https://twitter.com/discourse/status/1428031057186627589" }
 
-      include_context "with standard tweet info"
-      include_context "with engines"
-
-      it_behaves_like "an engine"
-      it_behaves_like "#to_html"
-    end
-
-    context "with a quoted tweet" do
-      let(:tweet_content) do
-        "Thank you to everyone who came out for #MetInParis last night for helping us support @EMMAUSolidarite &amp;"
-      end
-
-      include_context "with quoted tweet info"
-      include_context "with engines"
-
-      it_behaves_like "an engine"
-      it_behaves_like '#to_html'
-      it_behaves_like "includes quoted tweet data"
-    end
-
-    context "with a featured image tweet" do
-      let(:tweet_content) do
-        "My first text message from my child! A moment that shall live on in infamy!"
-      end
-
-      include_context "with featured image info"
-      include_context "with engines"
-
-      it_behaves_like "an engine"
-      it_behaves_like '#to_html'
+    it "does not match the url" do
+      onebox = Onebox::Matcher.new(link, { allowed_iframe_regexes: [/.*/] }).oneboxed
+      expect(onebox).not_to be(described_class)
     end
   end
 

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -508,6 +508,29 @@ RSpec.describe Oneboxer do
     end
   end
 
+  context 'Twitter' do
+    let(:url) { 'https://twitter.com/discourse/status/1428031057186627589' }
+
+    before do
+      SiteSetting.twitter_consumer_key = 'twitter_consumer_key'
+      SiteSetting.twitter_consumer_secret = 'twitter_consumer_secret'
+    end
+
+    it 'works with rate limit' do
+      stub_request(:head, "https://twitter.com/discourse/status/1428031057186627589")
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://twitter.com/discourse/status/1428031057186627589")
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:post, "https://api.twitter.com/oauth2/token")
+        .to_return(status: 200, body: "{access_token: 'token'}", headers: {})
+
+      expect(Oneboxer.preview(url, invalidate_oneboxes: true)).to eq('')
+      expect(Oneboxer.onebox(url, invalidate_oneboxes: true)).to eq('')
+    end
+  end
+
   describe '#apply' do
     it 'generates valid HTML' do
       raw = "Before Onebox\nhttps://example.com\nAfter Onebox"

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe Oneboxer do
     end
   end
 
-  context 'Twitter' do
+  describe 'Twitter' do
     let(:url) { 'https://twitter.com/discourse/status/1428031057186627589' }
 
     before do


### PR DESCRIPTION
Twitter removed OpenGraph tags from their pages. We can no longer
extract all the information (for example, the quoted tweet) we need
to render Oneboxes without using their API.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
