### PR TITLE
DEV: updates popper to 2.11.5

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -24,7 +24,7 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/syntax": "^0.84.2",
     "@glimmer/tracking": "^1.1.2",
-    "@popperjs/core": "2.10.2",
+    "@popperjs/core": "^2.11.5",
     "@uppy/aws-s3": "^2.0.8",
     "@uppy/aws-s3-multipart": "^2.2.1",
     "@uppy/core": "^2.1.6",

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -887,14 +887,6 @@ export default Component.extend(
               },
             },
             {
-              name: "preventOverflow",
-              options: {
-                altAxis: !this?.site?.mobileView,
-                tetherOffset: ({ reference }) =>
-                  Math.max(reference.y, document.documentElement.scrollTop),
-              },
-            },
-            {
               name: "offset",
               options: {
                 offset: [0, 3],

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -1278,10 +1278,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@popperjs/core@2.10.2":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
-  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
+"@popperjs/core@^2.11.5":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
+  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
 "@popperjs/core@^2.9.0":
   version "2.11.0"


### PR DESCRIPTION
This commit also removes a modifier used in select-kit which was causing issues with this update and doesn’t appear to be needed anymore.
