### PR TITLE
FIX: prevents multi-select to use noneItem for its list

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/multi-select-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { paste, query } from "discourse/tests/helpers/qunit-helpers";
+import { exists, paste, query } from "discourse/tests/helpers/qunit-helpers";
 
 const DEFAULT_CONTENT = [
   { id: 1, name: "foo" },
@@ -117,5 +117,19 @@ module("Integration | Component | select-kit/multi-select", function (hooks) {
     await paste(query(".filter-input"), "foo|bar");
 
     assert.equal(this.subject.header().value(), "1,2");
+  });
+
+  test("no value property with no content", async function (assert) {
+    setDefaultState(this);
+
+    await render(hbs`
+      <MultiSelect @valueProperty={{null}} />
+    `);
+    await this.subject.expand();
+
+    assert.notOk(
+      exists(".selected-content"),
+      "it doesn’t render an empty content div"
+    );
   });
 });

--- a/app/assets/javascripts/select-kit/addon/components/multi-select.js
+++ b/app/assets/javascripts/select-kit/addon/components/multi-select.js
@@ -156,7 +156,7 @@ export default SelectKitComponent.extend({
         return this.selectKit.modifySelection(content);
       }
 
-      return this.selectKit.noneItem;
+      return null;
     }
   ),
 

--- a/app/assets/javascripts/select-kit/addon/templates/components/multi-select/multi-select-header.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/multi-select/multi-select-header.hbs
@@ -3,7 +3,7 @@
     {{d-icon icon}}
   {{/each}}
 
-  <MultiSelect::FormatSelectedContent @content={{this.selectedContent}} @selectKit={{this.selectKit}} />
+  <MultiSelect::FormatSelectedContent @content={{or this.selectedContent this.selectKit.noneItem}} @selectKit={{this.selectKit}} />
 
   {{d-icon this.caretIcon class="caret-icon"}}
 </div>


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
