### PR TITLE
UX: Make space for scrollbar in mini-profiler

### DIFF
--- a/app/assets/stylesheets/common/admin/mini_profiler.scss
+++ b/app/assets/stylesheets/common/admin/mini_profiler.scss
@@ -25,5 +25,6 @@ div.profiler-results.profiler-top {
 
   &.profiler-right .profiler-button {
     border-left: 1px solid var(--header_primary-low);
+    padding-right: 10px; // Make space for scrollbar
   }
 }


### PR DESCRIPTION
The macOS-style overlay scroll element could cover the number on the profiler button.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
