### PR TITLE
DEV: We already restore sinon after each test

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -145,7 +145,6 @@ acceptance("Composer Actions", function (needs) {
       I18n.t("topic.create_long")
     );
     assert.ok(query(".d-editor-input").value.includes(quote));
-    sinon.restore();
   });
 
   test("reply_as_new_topic without a new_topic draft", async function (assert) {
@@ -471,7 +470,6 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
     } finally {
       toggleCheckDraftPopup(false);
     }
-    sinon.restore();
   });
 
   test("reply_as_new_topic with new_topic draft", async function (assert) {
@@ -486,7 +484,6 @@ acceptance("Composer Actions With New Topic Draft", function (needs) {
       I18n.t("composer.composer_actions.reply_as_new_topic.confirm")
     );
     await click(".modal-footer .btn.btn-default");
-    sinon.restore();
   });
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -754,7 +754,6 @@ acceptance("Composer", function (needs) {
     } finally {
       toggleCheckDraftPopup(false);
     }
-    sinon.restore();
   });
 
   test("Loading draft also replaces the recipients", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -128,8 +128,6 @@ module("Unit | Model | category", function () {
       bah,
       "we can find a category with english slug whose parent slug is CJK"
     );
-
-    sinon.restore();
   });
 
   test("findSingleBySlug", function (assert) {
@@ -368,8 +366,6 @@ module("Unit | Model | category", function () {
       [child_category1, category2, read_restricted_category],
       "prioritize non read_restricted with limit"
     );
-
-    sinon.restore();
   });
 
   test("search with category slug", function (assert) {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
