### PR TITLE
DEV: Clear tagsHtmlCallbacks after each test

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/render-tags.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tags.js
@@ -17,6 +17,11 @@ export function addTagsHtmlCallback(callback, options) {
   callbacks.splice(i, 0, callback);
 }
 
+export function clearTagsHtmlCallbacks() {
+  callbacks = null;
+  priorities = null;
+}
+
 export default function (topic, params) {
   let tags = topic.tags;
   let buffer = "";

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -69,6 +69,7 @@ import {
   clearTagDecorateCallbacks,
   clearTextDecorateCallbacks,
 } from "discourse/lib/to-markdown";
+import { clearTagsHtmlCallbacks } from "discourse/lib/render-tags";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -193,6 +194,7 @@ export function testCleanup(container, app) {
   clearTextDecorateCallbacks();
   clearResolverOptions();
   clearLegacyResolverOptions();
+  clearTagsHtmlCallbacks();
 }
 
 export function discourseModule(name, options) {


### PR DESCRIPTION
Fixes leakage between tests

From discourse-assign:
<img width="480" alt="image" src="https://user-images.githubusercontent.com/66961/179360131-ad3b5f8a-e8be-4ed7-a7bc-d61ff9672928.png">
