### PR TITLE
DEV: Clear clearToolbarCallbacks after each test

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -69,6 +69,7 @@ import {
   clearTagDecorateCallbacks,
   clearTextDecorateCallbacks,
 } from "discourse/lib/to-markdown";
+import { clearToolbarCallbacks } from "discourse/components/d-editor";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -193,6 +194,7 @@ export function testCleanup(container, app) {
   clearTextDecorateCallbacks();
   clearResolverOptions();
   clearLegacyResolverOptions();
+  clearToolbarCallbacks();
 }
 
 export function discourseModule(name, options) {

--- a/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/d-editor-test.js
@@ -13,17 +13,12 @@ import {
 } from "discourse/tests/helpers/textarea-selection-helper";
 import { hbs } from "ember-cli-htmlbars";
 import I18n from "I18n";
-import { clearToolbarCallbacks } from "discourse/components/d-editor";
 import formatTextWithSelection from "discourse/tests/helpers/d-editor-helper";
 import { next } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 module("Integration | Component | d-editor", function (hooks) {
   setupRenderingTest(hooks);
-
-  hooks.afterEach(function () {
-    clearToolbarCallbacks();
-  });
 
   test("preview updates with markdown", async function (assert) {
     await render(hbs`<DEditor @value={{this.value}} />`);


### PR DESCRIPTION
Fixes leakage between tests. Have a composer toolbar with a 100 "Add emoji" buttons? I gotchu.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
