### PR TITLE
DEV: Remove frontend/core-plugins job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,6 @@ jobs:
             target: plugins
           - build_type: frontend
             target: core # Handled by core_frontend_tests job (below)
-        include:
-          - build_type: frontend
-            target: core-plugins
 
     steps:
       - uses: actions/checkout@v3
@@ -154,7 +151,7 @@ jobs:
         run: bin/rake plugin:spec
 
       - name: Plugin QUnit
-        if: matrix.build_type == 'frontend' && (matrix.target == 'plugins' || matrix.target == 'core-plugins')
+        if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
         run: bin/rake plugin:qunit['*','1200000']
         timeout-minutes: 30
 


### PR DESCRIPTION
Frontend tests for core plugins already run in frontend/plugins job

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
