### PR TITLE
UX: Prevent long toolbars from resizing the column

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -15,6 +15,7 @@
   flex: 1;
   flex-direction: column;
   max-width: 100%;
+  min-width: 0;
 }
 
 .d-editor-textarea-wrapper {
@@ -298,6 +299,8 @@
   border-bottom: 1px solid var(--primary-low);
   width: 100%;
   box-sizing: border-box;
+  overflow-x: auto;
+  flex-shrink: 0;
 
   .d-editor-spacer {
     height: 1em;


### PR DESCRIPTION
Before / After

<img width="1512" alt="Screenshot 2022-07-17 at 11 56 27" src="https://user-images.githubusercontent.com/66961/179393384-c015170b-fda4-46d5-8074-c3cc26db549b.png">

<img width="1511" alt="Screenshot 2022-07-17 at 11 58 24" src="https://user-images.githubusercontent.com/66961/179393381-a9e52ad3-8f04-47ec-91b5-82dcf1b548f4.png">
