### PR TITLE
DEV: Extensively use `includes()`

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
+++ b/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
@@ -41,7 +41,7 @@ export default Component.extend({
     if (["color_definitions"].includes(fieldName)) {
       return "scss";
     }
-    return fieldName && fieldName.indexOf("scss") > -1 ? "scss" : "html";
+    return fieldName && fieldName.includes("scss") ? "scss" : "html";
   },
 
   @discourseComputed("currentTargetName", "fieldName")

--- a/app/assets/javascripts/admin/addon/components/site-settings/color.js
+++ b/app/assets/javascripts/admin/addon/components/site-settings/color.js
@@ -3,7 +3,7 @@ import Component from "@ember/component";
 
 function RGBToHex(rgb) {
   // Choose correct separator
-  let sep = rgb.indexOf(",") > -1 ? "," : " ";
+  let sep = rgb.includes(",") ? "," : " ";
   // Turn "rgb(r,g,b)" into [r,g,b]
   rgb = rgb.slice(4).split(")")[0].split(sep);
 

--- a/app/assets/javascripts/admin/addon/components/value-list.js
+++ b/app/assets/javascripts/admin/addon/components/value-list.js
@@ -29,7 +29,7 @@ export default Component.extend({
 
   @discourseComputed("choices.[]", "collection.[]")
   filteredChoices(choices, collection) {
-    return makeArray(choices).filter((i) => collection.indexOf(i) < 0);
+    return makeArray(choices).filter((i) => !collection.includes(i));
   },
 
   keyDown(event) {

--- a/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-customize-themes-show.js
@@ -69,7 +69,7 @@ export default Controller.extend({
     if (available) {
       const themes = !childThemes
         ? available
-        : available.filter((theme) => childThemes.indexOf(theme) === -1);
+        : available.filter((theme) => !childThemes.includes(theme));
       return themes.length === 0 ? null : themes;
     }
   },

--- a/app/assets/javascripts/admin/addon/controllers/admin-dashboard-reports.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-dashboard-reports.js
@@ -17,8 +17,8 @@ export default Controller.extend({
       filter = filter.toLowerCase();
       reports = reports.filter((report) => {
         return (
-          (get(report, "title") || "").toLowerCase().indexOf(filter) > -1 ||
-          (get(report, "description") || "").toLowerCase().indexOf(filter) > -1
+          (get(report, "title") || "").toLowerCase().includes(filter) ||
+          (get(report, "description") || "").toLowerCase().includes(filter)
         );
       });
     }

--- a/app/assets/javascripts/admin/addon/controllers/admin-watched-words.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-watched-words.js
@@ -24,7 +24,7 @@ export default Controller.extend({
 
     this.allWatchedWords.forEach((wordsForAction) => {
       const wordRecords = wordsForAction.words.filter((wordRecord) => {
-        return wordRecord.word.indexOf(filter) > -1;
+        return wordRecord.word.includes(filter);
       });
 
       model.pushObject(

--- a/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-show-events.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-show-events.js
@@ -38,7 +38,7 @@ export default Controller.extend({
   _addIncoming(eventId) {
     const incomingEventIds = this.incomingEventIds;
 
-    if (incomingEventIds.indexOf(eventId) === -1) {
+    if (!incomingEventIds.includes(eventId)) {
       incomingEventIds.pushObject(eventId);
     }
   },

--- a/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-web-hooks-show.js
@@ -42,7 +42,7 @@ export default Controller.extend({
   @discourseComputed("model.secret")
   secretValidation(secret) {
     if (!isEmpty(secret)) {
-      if (secret.indexOf(" ") !== -1) {
+      if (secret.includes(" ")) {
         return EmberObject.create({
           failed: true,
           reason: I18n.t("admin.web_hooks.secret_invalid"),

--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -86,7 +86,7 @@ export default Mixin.create({
 
   @discourseComputed("type")
   componentType(type) {
-    return CUSTOM_TYPES.indexOf(type) !== -1 ? type : "string";
+    return CUSTOM_TYPES.includes(type) ? type : "string";
   },
 
   @discourseComputed("setting")

--- a/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
@@ -103,7 +103,7 @@ export function registerIconRenderer(renderer) {
 function iconClasses(icon, params) {
   // "notification." is invalid syntax for classes, use replacement instead
   const dClass =
-    icon.replacementId && icon.id.indexOf("notification.") > -1
+    icon.replacementId && icon.id.includes("notification.")
       ? icon.replacementId
       : icon.id;
 

--- a/app/assets/javascripts/discourse-common/addon/utils/handle-descriptor.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/handle-descriptor.js
@@ -50,11 +50,7 @@ function niceAttr(attr) {
   let i;
 
   for (i = 0; i < parts.length; i++) {
-    if (
-      parts[i] === "@each" ||
-      parts[i] === "[]" ||
-      parts[i].indexOf("{") !== -1
-    ) {
+    if (parts[i] === "@each" || parts[i] === "[]" || parts[i].includes("{")) {
       break;
     }
   }

--- a/app/assets/javascripts/discourse/app/adapters/rest.js
+++ b/app/assets/javascripts/discourse/app/adapters/rest.js
@@ -38,7 +38,7 @@ export default EmberObject.extend({
   },
 
   basePath(store, type) {
-    if (ADMIN_MODELS.indexOf(type.replace("_", "-")) !== -1) {
+    if (ADMIN_MODELS.includes(type.replace("_", "-"))) {
       return "/admin/";
     }
     return "/";

--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -488,7 +488,7 @@ export default Component.extend(ComposerUploadUppy, {
         }
 
         let name = mention.dataset.name;
-        if (found.indexOf(name) === -1) {
+        if (!found.includes(name)) {
           this.groupsMentioned([
             {
               name,
@@ -517,7 +517,7 @@ export default Component.extend(ComposerUploadUppy, {
       preview?.querySelectorAll(".mention.cannot-see")?.forEach((mention) => {
         let name = mention.dataset.name;
 
-        if (found.indexOf(name) === -1) {
+        if (!found.includes(name)) {
           // add a delay to allow for typing, so you don't open the warning right away
           // previously we would warn after @bob even if you were about to mention @bob2
           discourseLater(

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -602,7 +602,7 @@ export default Component.extend(TextareaTextManipulation, {
   },
 
   _applyList(sel, head, exampleKey, opts) {
-    if (sel.value.indexOf("\n") !== -1) {
+    if (sel.value.includes("\n")) {
       this.applySurround(sel, head, "", exampleKey, opts);
     } else {
       const [hval, hlen] = getHead(head);
@@ -740,7 +740,7 @@ export default Component.extend(TextareaTextManipulation, {
 
       const sel = this.getSelected("", { lineVal: true });
       const selValue = sel.value;
-      const hasNewLine = selValue.indexOf("\n") !== -1;
+      const hasNewLine = selValue.includes("\n");
       const isBlankLine = sel.lineVal.trim().length === 0;
       const isFourSpacesIndent =
         this.siteSettings.code_formatting_style === FOUR_SPACES_INDENT;

--- a/app/assets/javascripts/discourse/app/components/honeypot-input.js
+++ b/app/assets/javascripts/discourse/app/components/honeypot-input.js
@@ -8,7 +8,7 @@ export default TextField.extend({
     // https://bugs.chromium.org/p/chromium/issues/detail?id=987293
     // work around issue while leaving a semi useable honeypot for
     // bots that are running full Chrome
-    if (navigator.userAgent.indexOf("Chrome") > -1) {
+    if (navigator.userAgent.includes("Chrome")) {
       this.set("type", "text");
     } else {
       this.set("type", "password");

--- a/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
+++ b/app/assets/javascripts/discourse/app/components/scrolling-post-stream.js
@@ -251,7 +251,7 @@ export default MountWidget.extend({
 
       delete prev[postNumber];
 
-      if (onscreen.indexOf(idx) !== -1) {
+      if (onscreen.includes(idx)) {
         onscreenPostNumbers.push(postNumber);
         if (post.read) {
           readPostNumbers.push(postNumber);

--- a/app/assets/javascripts/discourse/app/components/user-selector.js
+++ b/app/assets/javascripts/discourse/app/components/user-selector.js
@@ -121,7 +121,7 @@ export default TextField.extend({
             return v.username || v.name;
           } else {
             const excludes = allExcludedUsernames();
-            return v.usernames.filter((item) => excludes.indexOf(item) === -1);
+            return v.usernames.filter((item) => !excludes.includes(item));
           }
         },
 

--- a/app/assets/javascripts/discourse/app/components/user-selector.js
+++ b/app/assets/javascripts/discourse/app/components/user-selector.js
@@ -128,7 +128,7 @@ export default TextField.extend({
         onChangeItems(items) {
           let hasGroups = false;
           items = items.map((i) => {
-            if (groups.indexOf(i) > -1) {
+            if (groups.includes(i)) {
               hasGroups = true;
             }
             return i.username ? i.username : i;

--- a/app/assets/javascripts/discourse/app/controllers/forgot-password.js
+++ b/app/assets/javascripts/discourse/app/controllers/forgot-password.js
@@ -20,7 +20,7 @@ export default Controller.extend(ModalFunctionality, {
     }
 
     if (this.siteSettings.hide_email_address_taken) {
-      return (accountEmailOrUsername || "").indexOf("@") === -1;
+      return !(accountEmailOrUsername || "").includes("@");
     } else {
       return isEmpty((accountEmailOrUsername || "").trim());
     }

--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -194,7 +194,7 @@ export default Controller.extend({
 
   @discourseComputed("q")
   showLikeCount(q) {
-    return q && q.indexOf("order:likes") > -1;
+    return q?.includes("order:likes");
   },
 
   @observes("q")
@@ -211,11 +211,11 @@ export default Controller.extend({
     return (
       q &&
       this.currentUser &&
-      (q.indexOf("in:messages") > -1 ||
-        q.indexOf("in:personal") > -1 ||
-        q.indexOf(
+      (q.includes("in:messages") ||
+        q.includes("in:personal") ||
+        q.includes(
           `personal_messages:${this.currentUser.get("username_lower")}`
-        ) > -1)
+        ))
     );
   },
 
@@ -394,7 +394,7 @@ export default Controller.extend({
   actions: {
     createTopic(searchTerm) {
       let topicCategory;
-      if (searchTerm.indexOf("category:") !== -1) {
+      if (searchTerm.includes("category:")) {
         const match = searchTerm.match(/category:(\S*)/);
         if (match && match[1]) {
           topicCategory = match[1];

--- a/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
+++ b/app/assets/javascripts/discourse/app/controllers/insert-hyperlink.js
@@ -102,7 +102,7 @@ export default Controller.extend(ModalFunctionality, {
   },
 
   triggerSearch() {
-    if (this.linkUrl.length > 3 && this.linkUrl.indexOf("http") === -1) {
+    if (this.linkUrl.length > 3 && !this.linkUrl.startsWith("http")) {
       this.set("searchLoading", true);
       this._activeSearch = searchForTerm(this.linkUrl, {
         typeFilter: "topic",

--- a/app/assets/javascripts/discourse/app/controllers/review-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/review-index.js
@@ -106,7 +106,7 @@ export default Controller.extend({
       }
 
       let newList = this.reviewables.reject((reviewable) => {
-        return ids.indexOf(reviewable.id) !== -1;
+        return ids.includes(reviewable.id);
       });
 
       if (newList.length === 0) {

--- a/app/assets/javascripts/discourse/app/initializers/strip-mobile-app-url-params.js
+++ b/app/assets/javascripts/discourse/app/initializers/strip-mobile-app-url-params.js
@@ -4,7 +4,7 @@ export default {
   initialize() {
     let queryStrings = window.location.search;
 
-    if (queryStrings.indexOf("user_api_public_key") !== -1) {
+    if (queryStrings.includes("user_api_public_key")) {
       let params = queryStrings.startsWith("?")
         ? queryStrings.slice(1).split("&")
         : [];

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -483,7 +483,7 @@ export default function (options) {
   }
 
   function performAutocomplete(e) {
-    if ([keys.esc, keys.enter].indexOf(e.which) !== -1) {
+    if ([keys.esc, keys.enter].includes(e.which)) {
       return true;
     }
 

--- a/app/assets/javascripts/discourse/app/lib/autosize.js
+++ b/app/assets/javascripts/discourse/app/lib/autosize.js
@@ -6,7 +6,7 @@ const set =
 
         return {
           has(key) {
-            return Boolean(list.indexOf(key) > -1);
+            return Boolean(list.includes(key));
           },
           add(key) {
             list.push(key);

--- a/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
@@ -26,7 +26,7 @@ const DefaultConnectorClass = {
 
 function findOutlets(collection, callback) {
   Object.keys(collection).forEach(function (res) {
-    if (res.indexOf("/connectors/") !== -1) {
+    if (res.includes("/connectors/")) {
       const segments = res.split("/");
       let outletName = segments[segments.length - 2];
       const uniqueName = segments[segments.length - 1];

--- a/app/assets/javascripts/discourse/app/lib/topic-list-tracked-filter.js
+++ b/app/assets/javascripts/discourse/app/lib/topic-list-tracked-filter.js
@@ -53,7 +53,7 @@ export function isTrackedTopic(topic) {
     const tags = User.current().trackedTags;
 
     for (const tag of tags) {
-      if (topic.tags.indexOf(tag) > -1) {
+      if (topic.tags.includes(tag)) {
         return true;
       }
     }

--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -178,7 +178,7 @@ export default function transformPost(
   }
 
   const showTopicMap =
-    _additionalAttributes.indexOf("topicMap") !== -1 ||
+    _additionalAttributes.includes("topicMap") ||
     showPMMap ||
     (post.post_number === 1 &&
       topic.archetype === "regular" &&

--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -135,7 +135,7 @@ function extensionsToArray(exts) {
     .toLowerCase()
     .replace(/[\s\.]+/g, "")
     .split("|")
-    .filter((ext) => ext.indexOf("*") === -1);
+    .filter((ext) => !ext.includes("*"));
 }
 
 function extensions(siteSettings) {

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -490,7 +490,7 @@ export function setURLContainer(container) {
 }
 
 export function prefixProtocol(url) {
-  return url.indexOf("://") === -1 && url.indexOf("mailto:") !== 0
+  return !url.includes("://") && url.indexOf("mailto:") !== 0
     ? "https://" + url
     : url;
 }

--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -207,7 +207,7 @@ export function skipSearch(term, allowEmails, lastSeenUsers = false) {
   if (lastSeenUsers) {
     return false;
   }
-  if (term.indexOf("@") > -1 && !allowEmails) {
+  if (term.includes("@") && !allowEmails) {
     return true;
   }
 

--- a/app/assets/javascripts/discourse/app/lib/user-search.js
+++ b/app/assets/javascripts/discourse/app/lib/user-search.js
@@ -159,7 +159,7 @@ function organizeResults(r, options) {
 
   if (r.users) {
     r.users.every(function (u) {
-      if (exclude.indexOf(u.username) === -1) {
+      if (!exclude.includes(u.username)) {
         users.push(u);
         results.push(u);
       }
@@ -179,7 +179,7 @@ function organizeResults(r, options) {
         options.term.toLowerCase() === g.name.toLowerCase() ||
         results.length < limit
       ) {
-        if (exclude.indexOf(g.name) === -1) {
+        if (!exclude.includes(g.name)) {
           groups.push(g);
           results.push(g);
         }

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -152,7 +152,7 @@ export function hostnameValid(hostname) {
 }
 
 export function extractDomainFromUrl(url) {
-  if (url.indexOf("://") > -1) {
+  if (url.includes("://")) {
     url = url.split("/")[2];
   } else {
     url = url.split("/")[0];
@@ -441,7 +441,7 @@ export function areCookiesEnabled() {
   // see: https://github.com/Modernizr/Modernizr/blob/400db4043c22af98d46e1d2b9cbc5cb062791192/feature-detects/cookies.js
   try {
     document.cookie = "cookietest=1";
-    let ret = document.cookie.indexOf("cookietest=") !== -1;
+    let ret = document.cookie.includes("cookietest=");
     document.cookie = "cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT";
     return ret;
   } catch (e) {

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -116,7 +116,7 @@ const Bookmark = RestModel.extend({
     const newTags = [];
 
     tags.forEach(function (tag) {
-      if (title.toLowerCase().indexOf(tag) === -1) {
+      if (!title.toLowerCase().includes(tag)) {
         newTags.push(tag);
       }
     });

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -602,7 +602,7 @@ Category.reopenClass({
             category.get("slug").toLowerCase().indexOf(slugTerm) > 0) &&
           validCategoryParent(category)
         ) {
-          if (data.indexOf(category) === -1) {
+          if (!data.includes(category)) {
             data.push(category);
           }
         }

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -303,7 +303,7 @@ const Composer = RestModel.extend({
     if (
       !categoryId &&
       categoryIds &&
-      (categoryIds.indexOf(this.site.uncategorized_category_id) !== -1 ||
+      (categoryIds.includes(this.site.uncategorized_category_id) ||
         !this.siteSettings.allow_uncategorized_topics)
     ) {
       return true;
@@ -311,7 +311,7 @@ const Composer = RestModel.extend({
     return (
       categoryIds === undefined ||
       !categoryIds.length ||
-      categoryIds.indexOf(categoryId) !== -1
+      categoryIds.includes(categoryId)
     );
   },
 

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -714,7 +714,7 @@ export default RestModel.extend({
     let missingIds = [];
 
     postIds.forEach((postId) => {
-      if (postId && this.stream.indexOf(postId) === -1) {
+      if (postId && !this.stream.includes(postId)) {
         missingIds.push(postId);
       }
     });
@@ -725,7 +725,7 @@ export default RestModel.extend({
 
     if (loadedAllPosts) {
       missingIds.forEach((postId) => {
-        if (this._loadingPostIds.indexOf(postId) === -1) {
+        if (!this._loadingPostIds.includes(postId)) {
           this._loadingPostIds.push(postId);
         }
       });

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -940,7 +940,7 @@ const TopicTrackingState = EmberObject.extend({
   },
 
   _addIncoming(topicId) {
-    if (this.newIncoming.indexOf(topicId) === -1) {
+    if (!this.newIncoming.includes(topicId)) {
       this.newIncoming.push(topicId);
     }
   },

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -500,15 +500,11 @@ const TopicTrackingState = EmberObject.extend({
         return false;
       }
 
-      if (tagId && !(topic.tags && topic.tags.indexOf(tagId) > -1)) {
+      if (tagId && !topic.tags?.includes(tagId)) {
         return false;
       }
 
-      if (
-        type === "new" &&
-        mutedCategoryIds &&
-        mutedCategoryIds.indexOf(topic.category_id) !== -1
-      ) {
+      if (type === "new" && mutedCategoryIds?.includes(topic.category_id)) {
         return false;
       }
 
@@ -588,7 +584,7 @@ const TopicTrackingState = EmberObject.extend({
       (topic, newTopic, unreadTopic) => {
         if (topic.tags && topic.tags.length > 0) {
           tags.forEach((tag) => {
-            if (topic.tags.indexOf(tag) > -1) {
+            if (topic.tags.includes(tag)) {
               if (unreadTopic) {
                 counts[tag].unreadCount++;
               }
@@ -615,7 +611,7 @@ const TopicTrackingState = EmberObject.extend({
       if (
         topic.category_id === category_id &&
         !topic.deleted &&
-        (!tagId || (topic.tags && topic.tags.indexOf(tagId) > -1))
+        (!tagId || topic.tags?.includes(tagId))
       ) {
         sum +=
           topic.last_read_post_number === null ||
@@ -960,7 +956,7 @@ const TopicTrackingState = EmberObject.extend({
   _stateKey(topicOrId) {
     if (typeof topicOrId === "number") {
       return `t${topicOrId}`;
-    } else if (typeof topicOrId === "string" && topicOrId.indexOf("t") > -1) {
+    } else if (typeof topicOrId === "string" && topicOrId.includes("t")) {
       return topicOrId;
     } else {
       return `t${topicOrId.topic_id}`;

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -164,7 +164,7 @@ const Topic = RestModel.extend({
     const newTags = [];
 
     tags.forEach(function (tag) {
-      if (title.indexOf(tag.toLowerCase()) === -1) {
+      if (!title.includes(tag.toLowerCase())) {
         newTags.push(tag);
       }
     });

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -369,13 +369,13 @@ const User = RestModel.extend({
 
   save(fields) {
     const data = this.getProperties(
-      userFields.filter((uf) => !fields || fields.indexOf(uf) !== -1)
+      userFields.filter((uf) => !fields || fields.includes(uf))
     );
 
     let filteredUserOptionFields = [];
     if (fields) {
-      filteredUserOptionFields = userOptionFields.filter(
-        (uo) => fields.indexOf(uo) !== -1
+      filteredUserOptionFields = userOptionFields.filter((uo) =>
+        fields.includes(uo)
       );
     } else {
       filteredUserOptionFields = userOptionFields;

--- a/app/assets/javascripts/discourse/app/routes/discovery.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery.js
@@ -24,7 +24,7 @@ export default DiscourseRoute.extend(OpenComposer, {
     let matches;
     if (
       (url === "/" || url === "/latest" || url === "/categories") &&
-      transition.targetName.indexOf("discovery.top") === -1 &&
+      !transition.targetName.includes("discovery.top") &&
       User.currentProp("should_be_redirected_to_top")
     ) {
       User.currentProp("should_be_redirected_to_top", false);

--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -204,7 +204,7 @@ export default class ScreenTrack extends Service {
         this.appEvents.trigger("topic:timings-sent", data);
       })
       .catch((e) => {
-        if (e.jqXHR && ALLOWED_AJAX_FAILURES.indexOf(e.jqXHR.status) > -1) {
+        if (e.jqXHR && ALLOWED_AJAX_FAILURES.includes(e.jqXHR.status)) {
           const delay = AJAX_FAILURE_DELAYS[this._ajaxFailures];
           this._ajaxFailures += 1;
 

--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -305,7 +305,7 @@ export default class ScreenTrack extends Service {
         }
 
         if (
-          topicIds.indexOf(topicId) === -1 &&
+          !topicIds.includes(topicId) &&
           topicIds.length < ANON_MAX_TOPIC_IDS
         ) {
           topicIds.push(topicId);

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -509,7 +509,7 @@ export default createWidget("post-menu", {
         if (
           (attrs.yours && button.attrs && button.attrs.alwaysShowYours) ||
           (attrs.reviewableId && i === "flag") ||
-          hiddenButtons.indexOf(i) === -1
+          !hiddenButtons.includes(i)
         ) {
           visibleButtons.push(button);
         }

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -58,13 +58,13 @@ const DEFAULT_QUICK_TIPS = [
 let QUICK_TIPS = [];
 
 export function addSearchSuggestion(value) {
-  if (suggestionShortcuts.indexOf(value) === -1) {
+  if (!suggestionShortcuts.includes(value)) {
     suggestionShortcuts.push(value);
   }
 }
 
 export function addQuickSearchRandomTip(tip) {
-  if (QUICK_TIPS.indexOf(tip) === -1) {
+  if (!QUICK_TIPS.includes(tip)) {
     QUICK_TIPS.push(tip);
   }
 }

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -902,7 +902,7 @@ export function applyDefaultHandlers(pretender) {
       ];
     }
 
-    if (request.queryParams.url.indexOf("/internal-page.html") > -1) {
+    if (request.queryParams.url.includes("/internal-page.html")) {
       return [
         200,
         { "Content-Type": "application/html" },

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -828,7 +828,7 @@ module("Unit | Model | post-stream", function () {
 
     const found = postStream.findLoadedPost(stagedPost.get("id"));
     assert.present(found, "the post is in the identity map");
-    assert.ok(postStream.indexOf(stagedPost) > -1, "the post is in the stream");
+    assert.ok(postStream.includes(stagedPost), "the post is in the stream");
     assert.strictEqual(
       found.get("raw"),
       "different raw value",

--- a/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/post-stream-test.js
@@ -11,7 +11,7 @@ import sinon from "sinon";
 function buildStream(id, stream) {
   const store = createStore();
   const topic = store.createRecord("topic", { id, chunk_size: 5 });
-  const ps = topic.get("postStream");
+  const ps = topic.postStream;
   if (stream) {
     ps.set("stream", stream);
   }
@@ -32,10 +32,7 @@ module("Unit | Model | post-stream", function () {
 
   test("defaults", function (assert) {
     const postStream = buildStream(1234);
-    assert.blank(
-      postStream.get("posts"),
-      "there are no posts in a stream by default"
-    );
+    assert.blank(postStream.posts, "there are no posts in a stream by default");
     assert.ok(!postStream.get("loaded"), "it has never loaded");
     assert.present(postStream.get("topic"));
   });
@@ -206,7 +203,7 @@ module("Unit | Model | post-stream", function () {
       1,
       "it loaded the posts"
     );
-    assert.containsInstance(postStream.get("posts"), Post);
+    assert.containsInstance(postStream.posts, Post);
 
     assert.strictEqual(postStream.get("extra_property"), 12);
   });
@@ -617,7 +614,7 @@ module("Unit | Model | post-stream", function () {
     );
 
     assert.strictEqual(
-      postStream.get("posts").length,
+      postStream.posts.length,
       6,
       "it adds the right posts into the stream"
     );
@@ -640,7 +637,7 @@ module("Unit | Model | post-stream", function () {
     );
 
     assert.strictEqual(
-      postStream.get("posts").length,
+      postStream.posts.length,
       6,
       "it adds the right posts into the stream"
     );
@@ -723,7 +720,7 @@ module("Unit | Model | post-stream", function () {
       "it is assigned a created date"
     );
     assert.ok(
-      postStream.get("posts").includes(stagedPost),
+      postStream.posts.includes(stagedPost),
       "the post is added to the stream"
     );
     assert.strictEqual(
@@ -752,7 +749,7 @@ module("Unit | Model | post-stream", function () {
       "it retains the filteredPostsCount"
     );
     assert.ok(
-      !postStream.get("posts").includes(stagedPost),
+      !postStream.posts.includes(stagedPost),
       "the post is removed from the stream"
     );
     assert.strictEqual(
@@ -815,7 +812,7 @@ module("Unit | Model | post-stream", function () {
 
     postStream.commitPost(stagedPost);
     assert.ok(
-      postStream.get("posts").includes(stagedPost),
+      postStream.posts.includes(stagedPost),
       "the post is still in the stream"
     );
     assert.ok(!postStream.get("loading"), "it is no longer loading");
@@ -828,7 +825,10 @@ module("Unit | Model | post-stream", function () {
 
     const found = postStream.findLoadedPost(stagedPost.get("id"));
     assert.present(found, "the post is in the identity map");
-    assert.ok(postStream.includes(stagedPost), "the post is in the stream");
+    assert.ok(
+      postStream.posts.includes(stagedPost),
+      "the post is in the stream"
+    );
     assert.strictEqual(
       found.get("raw"),
       "different raw value",

--- a/app/assets/javascripts/pretty-text/addon/sanitizer.js
+++ b/app/assets/javascripts/pretty-text/addon/sanitizer.js
@@ -118,8 +118,7 @@ export function sanitize(text, allowLister) {
         const forAttr = forTag[name];
 
         if (
-          (forAttr &&
-            (forAttr.indexOf("*") !== -1 || forAttr.indexOf(value) !== -1)) ||
+          (forAttr && (forAttr.includes("*") || forAttr.includes(value))) ||
           (!name.includes("data-html-") &&
             name.indexOf("data-") === 0 &&
             (forTag["data-*"] || testDataAttribute(forTag, name, value))) ||
@@ -157,7 +156,7 @@ export function sanitize(text, allowLister) {
 
         // Heading ids must begin with `heading--`
         if (
-          ["h1", "h2", "h3", "h4", "h5", "h6"].indexOf(tag) !== -1 &&
+          ["h1", "h2", "h3", "h4", "h5", "h6"].includes(tag) &&
           value.match(/^heading\-\-[a-zA-Z0-9\-\_]+$/)
         ) {
           return attr(name, value);

--- a/app/assets/javascripts/pretty-text/addon/sanitizer.js
+++ b/app/assets/javascripts/pretty-text/addon/sanitizer.js
@@ -120,7 +120,7 @@ export function sanitize(text, allowLister) {
         if (
           (forAttr &&
             (forAttr.indexOf("*") !== -1 || forAttr.indexOf(value) !== -1)) ||
-          (name.indexOf("data-html-") === -1 &&
+          (!name.includes("data-html-") &&
             name.indexOf("data-") === 0 &&
             (forTag["data-*"] || testDataAttribute(forTag, name, value))) ||
           (tag === "a" &&

--- a/app/assets/javascripts/pretty-text/addon/upload-short-url.js
+++ b/app/assets/javascripts/pretty-text/addon/upload-short-url.js
@@ -116,7 +116,7 @@ function getAttributeBasedUrl(dataAttribute, cachedUpload, siteSettings) {
   // in this case for permission checks
   if (
     siteSettings.secure_media &&
-    cachedUpload.url.indexOf("secure-media-uploads") > -1
+    cachedUpload.url.includes("secure-media-uploads")
   ) {
     return cachedUpload.url;
   }

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/code.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/code.js
@@ -53,9 +53,9 @@ function render(tokens, idx, options, env, slf, md) {
   const acceptableCodeClasses =
     md.options.discourse.acceptableCodeClasses || [];
 
-  if (TEXT_CODE_CLASSES.indexOf(tag) > -1) {
+  if (TEXT_CODE_CLASSES.includes(tag)) {
     className = "lang-nohighlight";
-  } else if (acceptableCodeClasses.indexOf(tag) > -1) {
+  } else if (acceptableCodeClasses.includes(tag)) {
     className = `lang-${tag}`;
   } else {
     className = "lang-nohighlight";
@@ -91,7 +91,7 @@ export function setup(helper) {
       if (tag === "code" && name === "class") {
         const m = /^lang\-(.+)$/.exec(value);
         if (m) {
-          return helper.getOptions().acceptableCodeClasses.indexOf(m[1]) !== -1;
+          return helper.getOptions().acceptableCodeClasses.includes(m[1]);
         }
       }
     },

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/upload-protocol.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/upload-protocol.js
@@ -140,7 +140,7 @@ function rule(state) {
           // url to take advantage of access control security
           if (
             state.md.options.discourse.limitedSiteSettings.secureMedia &&
-            mapped.url.indexOf("secure-media-uploads") > -1
+            mapped.url.includes("secure-media-uploads")
           ) {
             token.attrs[srcIndex][1] = mapped.url;
           } else {

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -191,6 +191,6 @@ export default ComboBoxComponent.extend({
   },
 
   _matchCategory(filter, categoryName) {
-    return this._normalize(categoryName).indexOf(filter) > -1;
+    return this._normalize(categoryName).includes(filter);
   },
 });

--- a/app/assets/javascripts/select-kit/addon/components/list-setting.js
+++ b/app/assets/javascripts/select-kit/addon/components/list-setting.js
@@ -18,17 +18,13 @@ export default MultiSelectComponent.extend({
   },
 
   modifyComponentForRow(collection) {
-    if (
-      collection === MAIN_COLLECTION &&
-      this.settingName &&
-      this.settingName.indexOf("color") > -1
-    ) {
+    if (collection === MAIN_COLLECTION && this.settingName?.includes("color")) {
       return "create-color-row";
     }
   },
 
   selectedChoiceComponent: computed("settingName", function () {
-    if (this.settingName && this.settingName.indexOf("color") > -1) {
+    if (this.settingName?.includes("color")) {
       return "selected-choice-color";
     } else {
       return "selected-choice";

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -232,7 +232,7 @@ export default Component.extend(
 
         if (
           typeof value === "string" &&
-          value.indexOf(".") < 0 &&
+          !value.includes(".") &&
           value in this
         ) {
           const computedValue = get(this, value);

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -593,7 +593,7 @@ export default Component.extend(
         filter = this._normalize(filter);
         content = content.filter((c) => {
           const name = this._normalize(this.getName(c));
-          return name && name.indexOf(filter) > -1;
+          return name?.includes(filter);
         });
       }
       return content;

--- a/app/assets/javascripts/select-kit/addon/mixins/utils.js
+++ b/app/assets/javascripts/select-kit/addon/mixins/utils.js
@@ -77,7 +77,7 @@ export default Mixin.create({
     const property = get(this.selectKit, type);
 
     if (!property) {
-      if (content.indexOf(item) > -1) {
+      if (content.includes(item)) {
         return item;
       }
     } else if (typeof property === "string") {

--- a/lib/pretty_text/shims.js
+++ b/lib/pretty_text/shims.js
@@ -78,7 +78,7 @@ function __getURLNoCDN(url) {
     return url;
   }
 
-  if (url.indexOf(__paths.baseUri) !== -1) {
+  if (url.includes(__paths.baseUri)) {
     return url;
   }
   if (url[0] !== "/") {

--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -81,7 +81,7 @@
     if (!e) {
       return;
     }
-    if (normalizeUrl(DE.discourseUrl).indexOf(normalizeUrl(e.origin)) === -1) {
+    if (!normalizeUrl(DE.discourseUrl).includes(normalizeUrl(e.origin))) {
       return;
     }
 

--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -159,7 +159,7 @@ async function runAllTests() {
       expression: `(${qunit_script})();`,
     });
 
-    if (args[0].indexOf("report_requests=1") > -1) {
+    if (args[0].includes("report_requests=1")) {
       await Runtime.evaluate({
         expression: "QUnit.config.logAllRequests = true",
       });


### PR DESCRIPTION
Also, the change in insert-hyperlink (from `this.linkUrl.indexOf("http") === -1` to `!this.linkUrl.startsWith("http")`) is an intentional fix: we don't want to prevent users from looking up topics with http in their titles.

An eslint rule for both this and `startsWith` (https://github.com/discourse/discourse/pull/17540) will probably be added at some point.