### PR TITLE
DEV: Don't double inject in `screen-track`

### DIFF
--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from "@ember/service";
+import Service from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse-common/utils/decorators";
 import { isTesting } from "discourse-common/config/environment";
@@ -17,8 +17,6 @@ const AJAX_FAILURE_DELAYS = [5000, 10000, 20000, 40000];
 const ALLOWED_AJAX_FAILURES = [405, 429, 500, 501, 502, 503, 504];
 
 export default class ScreenTrack extends Service {
-  @service appEvents;
-
   _consolidatedTimings = [];
   _lastTick = null;
   _lastScrolled = null;
@@ -174,7 +172,7 @@ export default class ScreenTrack extends Service {
 
     this._inProgress = true;
 
-    ajax("/topics/timings", {
+    return ajax("/topics/timings", {
       data,
       type: "POST",
       headers: {
@@ -201,6 +199,7 @@ export default class ScreenTrack extends Service {
             resetHighestReadCache(topicId);
           }
         }
+
         this.appEvents.trigger("topic:timings-sent", data);
       })
       .catch((e) => {

--- a/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
@@ -1,4 +1,3 @@
-import { settled } from "@ember/test-helpers";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
@@ -19,10 +18,7 @@ discourseModule("Unit | Service | screen-track", function () {
       "expecting consolidated timings to match correctly"
     );
 
-    tracker.sendNextConsolidatedTiming();
-
-    // Wait for the requests to finish
-    await settled();
+    await tracker.sendNextConsolidatedTiming();
 
     assert.equal(
       tracker.highestReadFromCache(2),


### PR DESCRIPTION
1. Injecting `appEvents` service into `screen-track` was unnecessary as it's already injected into all services (and was causing an assertion error)
2. Return a promise from `sendNextConsolidatedTiming()` (no need for `await settled()` then)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
