### PR TITLE
DEV: Custom section in Sidebar should implement own willDestory hook

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar.js
@@ -37,7 +37,6 @@ export default class Sidebar extends GlimmerComponent {
     if (this.site.mobileView) {
       document.removeEventListener("click", this.collapseSidebar);
     }
-    this.customSections.forEach((customSection) => customSection.teardown());
   }
 
   @cached

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-section.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-section.js
@@ -7,11 +7,6 @@ export default class BaseCustomSidebarSection {
   }
 
   /**
-   * Called when sidebar component is torn down.
-   */
-  teardown() {}
-
-  /**
    * @returns {string} The name of the section header. Needs to be dasherized and lowercase.
    */
   get name() {


### PR DESCRIPTION
No need for us to specify our custom teardown hook when Sidebar
component is destroyed when each custom section link is expected to be
its own component and can implement its own `willDestory` hook.