### PR TITLE
COPY: Change "old" to "unsupported" browser

### DIFF
--- a/app/assets/javascripts/discourse/scripts/browser-update.js
+++ b/app/assets/javascripts/discourse/scripts/browser-update.js
@@ -49,7 +49,7 @@
     if (t.indexOf(".browser_update]") !== -1) {
       // very old browsers might fail to load even translations
       t =
-        'Unfortunately, <a href="https://www.discourse.org/faq/#browser">your browser is too old to work on this site</a>. Please <a href="https://browsehappy.com">upgrade your browser</a> to view rich content, log in and reply.';
+        'Unfortunately, <a href="https://www.discourse.org/faq/#browser">your browser is unsupported</a>. Please <a href="https://browsehappy.com">switch to a supported browser</a> to view rich content, log in and reply.';
     }
 
     // create the notification div HTML

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3696,7 +3696,7 @@ en:
         today: "Today"
         other_periods: "see top:"
 
-    browser_update: 'Unfortunately, <a href="https://www.discourse.org/faq/#browser">your browser is too old to work on this site</a>. Please <a href="https://browsehappy.com">upgrade your browser</a> to view rich content, log in and reply.'
+    browser_update: 'Unfortunately, <a href="https://www.discourse.org/faq/#browser">your browser is unsupported</a>. Please <a href="https://browsehappy.com">switch to a supported browser</a> to view rich content, log in and reply.'
 
     permission_types:
       full: "Create / Reply / See"


### PR DESCRIPTION
The word choice was inaccurate because new browsers may still not work
well with Discourse because not all required browser features are
present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
