### PR TITLE
UX: prevent sidebar badge count from wrapping

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -201,7 +201,8 @@
     }
 
     .sidebar-section-link-content-badge {
-      width: 30%;
+      @include ellipsis;
+      margin-left: 0.5em;
       text-align: right;
     }
 


### PR DESCRIPTION
before: 

![Screen Shot 2022-07-18 at 11 54 56 AM](https://user-images.githubusercontent.com/1681963/179552222-48b42758-d7df-4aea-8d7c-0d220f39ca3b.png)


after:

![Screen Shot 2022-07-18 at 11 55 06 AM](https://user-images.githubusercontent.com/1681963/179552229-378849b5-2b5c-4d1d-acac-781176d12e65.png)
