### PR TITLE
FIX: use padding for sidebar counts, not margin

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -202,7 +202,7 @@
 
     .sidebar-section-link-content-badge {
       @include ellipsis;
-      margin-left: 0.5em;
+      padding-left: 0.5em;
       text-align: right;
     }
 


### PR DESCRIPTION
accidentally overrode the left margin

before:

![Screen Shot 2022-07-18 at 12 56 15 PM](https://user-images.githubusercontent.com/1681963/179563364-2616b9bc-0319-4e19-b59c-236620ad9e8c.png)

after:

![Screen Shot 2022-07-18 at 12 56 55 PM](https://user-images.githubusercontent.com/1681963/179563436-a677d6fa-8e30-4e49-9d60-f9c781ffeb8d.png)

