### PR TITLE
UX: change wrap order of navbar elements based on width

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -34,28 +34,30 @@ export default Component.extend(FilterModeMixin, {
           );
 
           this._resizeObserver = new ResizeObserver((entries) => {
-            for (let entry of entries) {
-              if (entry.contentRect && entry.contentRect.width) {
-                for (const [key, value] of Object.entries(navElements)) {
-                  if (value === entry.target) {
-                    navElements[key]["width"] = entry.contentRect.width;
+            window.requestAnimationFrame(() => {
+              for (let entry of entries) {
+                if (entry.contentRect && entry.contentRect.width) {
+                  for (const [key, value] of Object.entries(navElements)) {
+                    if (value === entry.target) {
+                      navElements[key]["width"] = entry.contentRect.width;
+                    }
                   }
                 }
               }
-            }
 
-            let childrenWidth =
-              navElements["navPills"]["width"] +
-              navElements["navBread"]["width"] +
-              navElements["navControls"]["width"];
+              let childrenWidth =
+                navElements["navPills"]["width"] +
+                navElements["navBread"]["width"] +
+                navElements["navControls"]["width"];
 
-            let wrapWidth = navElements["navWrap"]["width"];
+              let wrapWidth = navElements["navWrap"]["width"];
 
-            if (wrapWidth < childrenWidth) {
-              navElements["navPills"].style.order = "3";
-            } else {
-              navElements["navPills"].style.order = "unset";
-            }
+              if (wrapWidth < childrenWidth) {
+                navElements["navPills"].style.order = "3";
+              } else {
+                navElements["navPills"].style.order = "unset";
+              }
+            });
           });
 
           Object.values(navElements).forEach((element) => {

--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -15,49 +15,52 @@ export default Component.extend(FilterModeMixin, {
   },
 
   didInsertElement() {
-    // we want to reorder these elements based on their width, which can change on resize
-    // can move to container queries instead once they have browser support
+    if (!this.site.mobileView) {
+      // we want to reorder these elements based on their width, which can vary based on settings and viewport
 
-    if ("ResizeObserver" in window) {
-      let navElements = {};
+      if ("ResizeObserver" in window) {
+        let navElements = {};
 
-      navElements["navWrap"] = document.querySelector(".navigation-container");
-      navElements["navBread"] = document.querySelector(".category-breadcrumb");
-      navElements["navPills"] = document.querySelector(".nav-pills");
-      navElements["navControls"] = document.querySelector(
-        ".navigation-controls"
-      );
+        navElements["navWrap"] = document.querySelector(
+          ".navigation-container"
+        );
+        navElements["navBread"] = document.querySelector(
+          ".category-breadcrumb"
+        );
+        navElements["navPills"] = document.querySelector(".nav-pills");
+        navElements["navControls"] = document.querySelector(
+          ".navigation-controls"
+        );
 
-      this._resizeObserver = new ResizeObserver((entries) => {
-        for (let entry of entries) {
-          if (entry.contentRect && entry.contentRect.width) {
-            for (const [key, value] of Object.entries(navElements)) {
-              if (value === entry.target) {
-                navElements[key]["width"] = entry.contentRect.width;
+        this._resizeObserver = new ResizeObserver((entries) => {
+          for (let entry of entries) {
+            if (entry.contentRect && entry.contentRect.width) {
+              for (const [key, value] of Object.entries(navElements)) {
+                if (value === entry.target) {
+                  navElements[key]["width"] = entry.contentRect.width;
+                }
               }
             }
           }
-        }
 
-        let childrenWidth =
-          navElements["navPills"]["width"] +
-          navElements["navBread"]["width"] +
-          navElements["navControls"]["width"];
+          let childrenWidth =
+            navElements["navPills"]["width"] +
+            navElements["navBread"]["width"] +
+            navElements["navControls"]["width"];
 
-        let wrapWidth = navElements["navWrap"]["width"];
+          let wrapWidth = navElements["navWrap"]["width"];
 
-        if (wrapWidth < childrenWidth) {
-          navElements["navPills"].style.order = "3";
-          navElements["navControls"].style.marginLeft = "auto";
-        } else {
-          navElements["navPills"].style.order = "unset";
-          navElements["navControls"].style.marginLeft = "auto";
-        }
-      });
+          if (wrapWidth < childrenWidth) {
+            navElements["navPills"].style.order = "3";
+          } else {
+            navElements["navPills"].style.order = "unset";
+          }
+        });
 
-      Object.values(navElements).forEach((element) => {
-        this._resizeObserver.observe(element);
-      });
+        Object.values(navElements).forEach((element) => {
+          this._resizeObserver.observe(element);
+        });
+      }
     }
   },
 

--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -18,48 +18,50 @@ export default Component.extend(FilterModeMixin, {
     if (!this.site.mobileView) {
       // we want to reorder these elements based on their width, which can vary based on settings and viewport
 
-      if ("ResizeObserver" in window) {
-        let navElements = {};
+      let navContainer = document.querySelector(".navigation-container");
 
-        navElements["navWrap"] = document.querySelector(
-          ".navigation-container"
-        );
-        navElements["navBread"] = document.querySelector(
-          ".category-breadcrumb"
-        );
-        navElements["navPills"] = document.querySelector(".nav-pills");
-        navElements["navControls"] = document.querySelector(
-          ".navigation-controls"
-        );
+      if (navContainer) {
+        if ("ResizeObserver" in window) {
+          let navElements = {};
 
-        this._resizeObserver = new ResizeObserver((entries) => {
-          for (let entry of entries) {
-            if (entry.contentRect && entry.contentRect.width) {
-              for (const [key, value] of Object.entries(navElements)) {
-                if (value === entry.target) {
-                  navElements[key]["width"] = entry.contentRect.width;
+          navElements["navWrap"] = navContainer;
+          navElements["navBread"] = document.querySelector(
+            ".category-breadcrumb"
+          );
+          navElements["navPills"] = document.querySelector(".nav-pills");
+          navElements["navControls"] = document.querySelector(
+            ".navigation-controls"
+          );
+
+          this._resizeObserver = new ResizeObserver((entries) => {
+            for (let entry of entries) {
+              if (entry.contentRect && entry.contentRect.width) {
+                for (const [key, value] of Object.entries(navElements)) {
+                  if (value === entry.target) {
+                    navElements[key]["width"] = entry.contentRect.width;
+                  }
                 }
               }
             }
-          }
 
-          let childrenWidth =
-            navElements["navPills"]["width"] +
-            navElements["navBread"]["width"] +
-            navElements["navControls"]["width"];
+            let childrenWidth =
+              navElements["navPills"]["width"] +
+              navElements["navBread"]["width"] +
+              navElements["navControls"]["width"];
 
-          let wrapWidth = navElements["navWrap"]["width"];
+            let wrapWidth = navElements["navWrap"]["width"];
 
-          if (wrapWidth < childrenWidth) {
-            navElements["navPills"].style.order = "3";
-          } else {
-            navElements["navPills"].style.order = "unset";
-          }
-        });
+            if (wrapWidth < childrenWidth) {
+              navElements["navPills"].style.order = "3";
+            } else {
+              navElements["navPills"].style.order = "unset";
+            }
+          });
 
-        Object.values(navElements).forEach((element) => {
-          this._resizeObserver.observe(element);
-        });
+          Object.values(navElements).forEach((element) => {
+            this._resizeObserver.observe(element);
+          });
+        }
       }
     }
   },

--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -59,7 +59,9 @@ export default Component.extend(FilterModeMixin, {
           });
 
           Object.values(navElements).forEach((element) => {
-            this._resizeObserver.observe(element);
+            window.requestAnimationFrame(() => {
+              this._resizeObserver.observe(element);
+            });
           });
         }
       }

--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -59,9 +59,7 @@ export default Component.extend(FilterModeMixin, {
           });
 
           Object.values(navElements).forEach((element) => {
-            window.requestAnimationFrame(() => {
-              this._resizeObserver.observe(element);
-            });
+            this._resizeObserver.observe(element);
           });
         }
       }

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -51,7 +51,6 @@
   flex-wrap: wrap;
   margin: 0;
   margin-bottom: var(--nav-space);
-  margin-right: auto;
 }
 
 .navigation-controls {
@@ -59,6 +58,7 @@
   flex-wrap: wrap;
   align-items: stretch;
   margin-bottom: var(--nav-space);
+  margin-left: auto;
   gap: var(--nav-space) 0; // used if the buttons wrap
   > * {
     white-space: nowrap;


### PR DESCRIPTION
This makes our nav wrap in a better way on mid-sized screens. This checks element widths, and wraps the nav-pills rather than the controls. Since this content is highly variable there's no way to make this change with CSS alone. 

Before:
![Screen Shot 2022-07-18 at 4 51 24 PM](https://user-images.githubusercontent.com/1681963/179615105-97367b15-9b1a-4b9b-ae75-2f9daf4f889a.png)


After
![Screen Shot 2022-07-18 at 4 52 15 PM](https://user-images.githubusercontent.com/1681963/179615246-ce7394da-0a95-4ad3-a6b4-af26c7bf7402.png)


related to t/70110
