### PR TITLE
FIX: can't hide overflow of d-editor-button-bar

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -294,12 +294,12 @@
 
 // d-editor bar button sizing
 .d-editor-button-bar {
+  // we can't hide the overflow of this element because it contains select-kit dropdowns
   display: flex;
   align-items: center;
   border-bottom: 1px solid var(--primary-low);
   width: 100%;
   box-sizing: border-box;
-  overflow-x: auto;
   flex-shrink: 0;
 
   .d-editor-spacer {


### PR DESCRIPTION
This was hiding the composer cog dropdown menu on mobile devices. 

https://meta.discourse.org/t/mobile-view-editor-cog-dropdown-issue/233215