### PR TITLE
DEV: Add empty array to ignored_users for currentUser fixture

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
@@ -33,6 +33,7 @@ export default {
       timezone: "Australia/Brisbane",
       skip_new_user_tips: false,
       can_review: true,
+      ignored_users: []
     },
   },
 };


### PR DESCRIPTION
Since this is `[]` by default via `CurrentUserSerializer`