### PR TITLE
FIX: pass sidebar custom link willDestroy

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -2,6 +2,12 @@ import GlimmerComponent from "@glimmer/component";
 import { htmlSafe } from "@ember/template";
 
 export default class SectionLink extends GlimmerComponent {
+  willDestroy() {
+    if (this.args.willDestroy) {
+      this.args.willDestroy();
+    }
+  }
+
   get prefixCSS() {
     const color = this.args.prefixColor;
     if (!color || !color.match(/^\w{6}$/)) {

--- a/app/assets/javascripts/discourse/app/templates/components/sidebar/sections.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar/sections.hbs
@@ -39,6 +39,7 @@
           @hoverAction={{link.hoverAction}}
           @hoverTitle={{link.hoverTitle}}
           @currentWhen={{link.currentWhen}}
+          @willDestroy={{link.willDestroy}}
           @content={{link.text}} />
       {{/each}}
     </Sidebar::Section>

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -16,9 +16,8 @@ acceptance("Sidebar - section API", function (needs) {
 
   needs.hooks.afterEach(() => {
     resetSidebarSection();
-    delete window.link_destroy;
-    delete window.section_destroy;
   });
+  let linkDestroy, sectionDestroy;
 
   test("Multiple header actions and links", async function (assert) {
     withPluginApi("1.3.0", (api) => {
@@ -59,7 +58,7 @@ acceptance("Sidebar - section API", function (needs) {
             }
             @bind
             willDestroy() {
-              window.section_destroy = "section test";
+              sectionDestroy = "section test";
             }
             get links() {
               return [
@@ -102,7 +101,7 @@ acceptance("Sidebar - section API", function (needs) {
                   }
                   @bind
                   willDestroy() {
-                    window.link_destroy = "link test";
+                    linkDestroy = "link test";
                   }
                 })(),
                 new (class extends BaseCustomSidebarSectionLink {
@@ -288,12 +287,12 @@ acceptance("Sidebar - section API", function (needs) {
     );
     await click(".header-sidebar-toggle button");
     assert.strictEqual(
-      window.link_destroy,
+      linkDestroy,
       "link test",
       "calls link willDestroy function"
     );
     assert.strictEqual(
-      window.section_destroy,
+      sectionDestroy,
       "section test",
       "calls section willDestroy function"
     );

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -16,6 +16,8 @@ acceptance("Sidebar - section API", function (needs) {
 
   needs.hooks.afterEach(() => {
     resetSidebarSection();
+    linkDestroy = undefined;
+    sectionDestroy = undefined;
   });
   let linkDestroy, sectionDestroy;
 


### PR DESCRIPTION
Custom sidebar link willDestroy function has to be passed to SidebarLink component to call when component is removed.

Very similar to https://github.com/discourse/discourse/pull/17551

