### PR TITLE
DEV: Remove `adminjs` and `jsapp` symlinks

### DIFF
--- a/adminjs
+++ b/adminjs
@@ -1,1 +1,0 @@
-app/assets/javascripts/admin

--- a/jsapp
+++ b/jsapp
@@ -1,1 +1,0 @@
-app/assets/javascripts/discourse


### PR DESCRIPTION
These only existed for developer convenience, but have proven to cause confusion. In the future we may move the JS app into a higher-level directory, but for now it can be found under app/assets/javascripts/discourse

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
