### PR TITLE
Disallow access to raw email for non-staff users

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -127,8 +127,7 @@ export default function transformPost(
     postType === postTypes.small_action || post.action_code === "split_topic";
   postAtts.canBookmark = !!currentUser;
   postAtts.canManage = currentUser && currentUser.get("canManageTopic");
-  postAtts.canViewRawEmail =
-    currentUser && (currentUser.id === post.user_id || currentUser.staff);
+  postAtts.canViewRawEmail = currentUser && currentUser.staff;
   postAtts.canArchiveTopic = !!details.can_archive_topic;
   postAtts.canCloseTopic = !!details.can_close_topic;
   postAtts.canSplitMergeTopic = !!details.can_split_merge_topic;

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -296,7 +296,7 @@ module PostGuardian
   end
 
   def can_view_raw_email?(post)
-    post && (is_staff? || post.user_id == @user.id)
+    post && is_staff?
   end
 
   def can_unhide?(post)


### PR DESCRIPTION
As discussed in this topic on meta: https://meta.discourse.org/t/clicking-the-envelope-does-not-work-for-non-staff-users/232242