### PR TITLE
FIX: Ensure injections are skipped when rehydrating stale models

### DIFF
--- a/app/assets/javascripts/discourse/app/services/store.js
+++ b/app/assets/javascripts/discourse/app/services/store.js
@@ -141,17 +141,13 @@ export default Service.extend({
       hydrated.get("content").map((item) => {
         let staleItem = stale.content.findBy(primaryKey, item.get(primaryKey));
         if (staleItem) {
-          const hydrateData = { ...item };
-
           for (const [key, value] of Object.entries(
             Object.getOwnPropertyDescriptors(staleItem)
           )) {
-            if (!value.writable) {
-              delete hydrateData[key];
+            if (value.writable && value.enumerable) {
+              staleItem.set(key, value.value);
             }
           }
-
-          staleItem.setProperties(hydrateData);
         } else {
           staleItem = item;
         }

--- a/app/assets/javascripts/discourse/app/services/store.js
+++ b/app/assets/javascripts/discourse/app/services/store.js
@@ -141,7 +141,17 @@ export default Service.extend({
       hydrated.get("content").map((item) => {
         let staleItem = stale.content.findBy(primaryKey, item.get(primaryKey));
         if (staleItem) {
-          staleItem.setProperties(item);
+          const hydrateData = { ...item };
+
+          for (const [key, value] of Object.entries(
+            Object.getOwnPropertyDescriptors(staleItem)
+          )) {
+            if (!value.writable) {
+              delete hydrateData[key];
+            }
+          }
+
+          staleItem.setProperties(hydrateData);
         } else {
           staleItem = item;
         }

--- a/app/assets/javascripts/discourse/tests/helpers/create-store.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-store.js
@@ -6,9 +6,30 @@ import TopicTrackingState from "discourse/models/topic-tracking-state";
 import { buildResolver } from "discourse-common/resolver";
 import { currentSettings } from "discourse/tests/helpers/site-settings";
 import Site from "discourse/models/site";
+import RestModel from "discourse/models/rest";
 
 const CatAdapter = RestAdapter.extend({
   primaryKey: "cat_id",
+});
+
+const CachedcatAdapter = RestAdapter.extend({
+  primaryKey: "cat_id",
+  cache: true,
+  apiNameFor() {
+    return "cat";
+  },
+});
+
+const Cachedcat = RestModel.extend({
+  init(...args) {
+    // Simulate an implicit injection
+    Object.defineProperty(this, "injectedProperty", {
+      writable: false,
+      enumerable: true,
+      value: "hello world",
+    });
+    this._super(...args);
+  },
 });
 
 export default function (customLookup = () => {}) {
@@ -27,6 +48,11 @@ export default function (customLookup = () => {}) {
           this._catAdapter =
             this._catAdapter || CatAdapter.create({ owner: this });
           return this._catAdapter;
+        }
+        if (type === "adapter:cachedcat") {
+          this._cachedcatAdapter =
+            this._cachedcatAdapter || CachedcatAdapter.create({ owner: this });
+          return this._cachedcatAdapter;
         }
         if (type === "adapter:rest") {
           if (!this._restAdapter) {
@@ -56,6 +82,9 @@ export default function (customLookup = () => {}) {
 
       lookupFactory(type) {
         const split = type.split(":");
+        if (type === "model:cachedcat") {
+          return Cachedcat;
+        }
         return resolver.resolveOther({
           type: split[0],
           fullNameWithoutType: split[1],

--- a/app/assets/javascripts/discourse/tests/helpers/create-store.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-store.js
@@ -12,7 +12,7 @@ const CatAdapter = RestAdapter.extend({
   primaryKey: "cat_id",
 });
 
-const CachedcatAdapter = RestAdapter.extend({
+const CachedCatAdapter = RestAdapter.extend({
   primaryKey: "cat_id",
   cache: true,
   apiNameFor() {
@@ -20,7 +20,7 @@ const CachedcatAdapter = RestAdapter.extend({
   },
 });
 
-const Cachedcat = RestModel.extend({
+const CachedCat = RestModel.extend({
   init(...args) {
     // Simulate an implicit injection
     Object.defineProperty(this, "injectedProperty", {
@@ -49,10 +49,10 @@ export default function (customLookup = () => {}) {
             this._catAdapter || CatAdapter.create({ owner: this });
           return this._catAdapter;
         }
-        if (type === "adapter:cachedcat") {
-          this._cachedcatAdapter =
-            this._cachedcatAdapter || CachedcatAdapter.create({ owner: this });
-          return this._cachedcatAdapter;
+        if (type === "adapter:cached-cat") {
+          this._cachedCatAdapter =
+            this._cachedCatAdapter || CachedCatAdapter.create({ owner: this });
+          return this._cachedCatAdapter;
         }
         if (type === "adapter:rest") {
           if (!this._restAdapter) {
@@ -82,8 +82,8 @@ export default function (customLookup = () => {}) {
 
       lookupFactory(type) {
         const split = type.split(":");
-        if (type === "model:cachedcat") {
-          return Cachedcat;
+        if (type === "model:cached-cat") {
+          return CachedCat;
         }
         return resolver.resolveOther({
           type: split[0],

--- a/app/assets/javascripts/discourse/tests/unit/services/store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/store-test.js
@@ -96,6 +96,19 @@ module("Unit | Service | store", function () {
     );
   });
 
+  test("rehydrating stale results with implicit injections", async function (assert) {
+    const store = createStore();
+
+    const cat = (await store.find("cachedcat", { name: "souna" })).content[0];
+
+    assert.strictEqual(cat.name, "souna");
+
+    const stale = store.findStale("cachedcat", { name: "souna" });
+    const refreshed = await stale.refresh();
+
+    assert.strictEqual(refreshed.content[0].name, "souna");
+  });
+
   test("update", async function (assert) {
     const store = createStore();
     const result = await store.update("widget", 123, { name: "hello" });

--- a/app/assets/javascripts/discourse/tests/unit/services/store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/store-test.js
@@ -99,11 +99,11 @@ module("Unit | Service | store", function () {
   test("rehydrating stale results with implicit injections", async function (assert) {
     const store = createStore();
 
-    const cat = (await store.find("cachedcat", { name: "souna" })).content[0];
+    const cat = (await store.find("cached-cat", { name: "souna" })).content[0];
 
     assert.strictEqual(cat.name, "souna");
 
-    const stale = store.findStale("cachedcat", { name: "souna" });
+    const stale = store.findStale("cached-cat", { name: "souna" });
     const refreshed = await stale.refresh();
 
     assert.strictEqual(refreshed.content[0].name, "souna");


### PR DESCRIPTION
This was causing an error when opening the experimental user menu for the second time in a session

> Cannot assign to read only property 'appEvents' of object '[object Object]'

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
