### PR TITLE
FIX: Notify tag watchers when publishing topic

### DIFF
--- a/app/jobs/regular/notify_tag_change.rb
+++ b/app/jobs/regular/notify_tag_change.rb
@@ -3,7 +3,7 @@
 module Jobs
   class NotifyTagChange < ::Jobs::Base
     def execute(args)
-      return if SiteSetting.disable_tags_edit_notifications
+      return if SiteSetting.disable_tags_edit_notifications && !args[:force]
 
       post = Post.find_by(id: args[:post_id])
 

--- a/lib/topic_publisher.rb
+++ b/lib/topic_publisher.rb
@@ -49,7 +49,7 @@ class TopicPublisher
     Jobs.enqueue(
       :notify_tag_change,
       post_id: @topic.first_post.id,
-      notified_user_ids: [@topic.first_post.user_id],
+      notified_user_ids: [@topic.first_post.user_id, @published_by.id].uniq,
       diff_tags: @topic.tags.map(&:name),
       force: true,
     )

--- a/lib/topic_publisher.rb
+++ b/lib/topic_publisher.rb
@@ -46,6 +46,14 @@ class TopicPublisher
       end
     end
 
+    Jobs.enqueue(
+      :notify_tag_change,
+      post_id: @topic.first_post.id,
+      notified_user_ids: [@topic.first_post.user_id],
+      diff_tags: @topic.tags.map(&:name),
+      force: true,
+    )
+
     MessageBus.publish("/topic/#{@topic.id}", reload_topic: true, refresh_stream: true)
 
     @topic


### PR DESCRIPTION
When a topic was published from a shared draft and it had tags, the
users watching the tags were not notified. The problem was that the
topics are usually created in a secret category and publishing it just
moves an existent topic to the target category, without making any
changes to the tags.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
