### PR TITLE
UX: option to account for the sidebar in the breakpoint mixin

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -1,5 +1,5 @@
 :root {
-  --d-sidebar-width: 16em;
+  --d-sidebar-width: #{$d-sidebar-width};
   --d-sidebar-animation-time: 0.25s;
   --d-sidebar-animation-ease: ease-in-out;
 }

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -16,13 +16,14 @@ $breakpoints: (
   extra-large: 1140px,
 );
 
-@mixin breakpoint($bp, $rule: max-width, $type: screen, $sidebar: true) {
+@mixin breakpoint($bp, $rule: max-width, $type: screen, $sidebar: false) {
   @media #{$type} and (#{$rule}: map-get($breakpoints, $bp)) {
     @content;
   }
 
-  // if you don't want to consider the sidebar in your breakpoint
-  // you can pass in $sidebar: false
+  // if you want to consider the sidebar in your breakpoint
+  // you can pass in $sidebar: true
+  // note that your breakpoint will need to be at the root level
   @if $sidebar {
     // when the sidebar is shown, we want to increase the breakpoints by the width of the sidebar
     @media #{$type} and (#{$rule}: calc(#{map-get($breakpoints, $bp)} + #{$d-sidebar-width})) {

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -16,9 +16,20 @@ $breakpoints: (
   extra-large: 1140px,
 );
 
-@mixin breakpoint($bp, $rule: max-width, $type: screen) {
+@mixin breakpoint($bp, $rule: max-width, $type: screen, $sidebar: true) {
   @media #{$type} and (#{$rule}: map-get($breakpoints, $bp)) {
     @content;
+  }
+
+  // if you don't want to consider the sidebar in your breakpoint
+  // you can pass in $sidebar: false
+  @if $sidebar {
+    // when the sidebar is shown, we want to increase the breakpoints by the width of the sidebar
+    @media #{$type} and (#{$rule}: calc(#{map-get($breakpoints, $bp)} + #{$d-sidebar-width})) {
+      .has-sidebar-page {
+        @content;
+      }
+    }
   }
 }
 

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -14,6 +14,8 @@ $topic-body-width-padding: 11px;
 $topic-avatar-width: 45px;
 $reply-area-max-width: 1475px !default;
 
+$d-sidebar-width: 16em !default;
+
 // Brand color variables
 // --------------------------------------------------
 

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -196,7 +196,7 @@
 
 /* Tablet (portrait) ----------- */
 
-@include breakpoint(medium) {
+@include breakpoint(medium, $sidebar: true) {
   // slightly smaller font, tighten spacing on nav pills
   .nav-pills {
     > li > a {


### PR DESCRIPTION
The sidebar reduces the amount of space available for content when open, so I'm adding the option to consider the sidebar width in the breakpoint mixin.

Here you can see how when the sidebar is expanded, the topic list and nav pill font size adjusts:

![Kapture 2022-07-19 at 16 59 40](https://user-images.githubusercontent.com/1681963/179847587-b9a68b47-54be-4bdd-a3f2-c78f472a48eb.gif)

This defaults to `false`, so it can be enabled as needed on root-level breakpoints by passing `$sidebar: true` to the mixin. 

