### PR TITLE
FEATURE: users with no posts shouldn't able to edit username after the allowed period.

### DIFF
--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -27,7 +27,7 @@ module UserGuardian
     return true if is_staff?
     return false if SiteSetting.username_change_period <= 0
     return false if is_anonymous?
-    is_me?(user) && ((user.post_count + user.topic_count) == 0 || user.created_at > SiteSetting.username_change_period.days.ago)
+    is_me?(user) && user.created_at > SiteSetting.username_change_period.days.ago
   end
 
   def can_edit_email?(user)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -2789,8 +2789,8 @@ describe Guardian do
 
       context 'with no posts' do
         include_examples "staff can always change usernames"
-        it "is true for the user to change their own username" do
-          expect(Guardian.new(target_user).can_edit_username?(target_user)).to be_truthy
+        it "is false for the user to change their own username" do
+          expect(Guardian.new(target_user).can_edit_username?(target_user)).to be_falsey
         end
       end
 

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -42,7 +42,8 @@ describe UserSerializer do
                              id: 1,
                              user_profile: Fabricate.build(:user_profile),
                              user_option: UserOption.new(dynamic_favicon: true, skip_new_user_tips: true),
-                             user_stat: UserStat.new
+                             user_stat: UserStat.new,
+                             created_at: Time.zone.now
                             )
 
       json = UserSerializer.new(user, scope: Guardian.new(user), root: false).as_json


### PR DESCRIPTION
We no longer going to let users to change their username after the allowed `username_change_period` when there are no posts created by the user.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
