### PR TITLE
DEV: Randomize tests order in more cases

### DIFF
--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -38,7 +38,7 @@ document.addEventListener("discourse-booted", () => {
   setupTests(config.APP);
   let loader = loadEmberExam();
 
-  if (loader.urlParams.size === 0 && !QUnit.config.seed) {
+  if (QUnit.config.seed === undefined) {
     // If we're running in browser, default to random order. Otherwise, let Ember Exam
     // handle randomization.
     QUnit.config.seed = true;


### PR DESCRIPTION
Previously it would randomize the order only when running tests:

1. through ember-exam
2. in browser, with no params

Running just core tests, or just plugins, or a single plugin, or with filter, etc. disabled randomization.

Now all those cases are covered.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
