### PR TITLE
FIX: Don’t raise an error on onebox timeouts

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -518,6 +518,9 @@ class FinalDestination
     end
 
     result
+  rescue Timeout::Error
+    log(:warn, "FinalDestination could not resolve URL (timeout): #{@uri}") if @verbose
+    nil
   rescue StandardError
     unsafe_close ? [:ok, headers_subset] : raise
   end


### PR DESCRIPTION
Currently when generating oneboxes if the connection timeouts and we’re using the `FinalDestination#get` method, then it raises an exception.

We already catch this exception when using the `FinalDestination#resolve` method so this PR just applies the same logic to `FinalDestination#get`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
