### PR TITLE
DEV: Bump Ember from 3.28.8 to 2.28.9

### DIFF
--- a/app/assets/javascripts/admin/package.json
+++ b/app/assets/javascripts/admin/package.json
@@ -34,7 +34,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-source-channel-url": "^3.0.0",
     "loader.js": "^4.7.0"
   },

--- a/app/assets/javascripts/discourse-common/package.json
+++ b/app/assets/javascripts/discourse-common/package.json
@@ -41,7 +41,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-source-channel-url": "^3.0.0",
     "loader.js": "^4.7.0"
   },

--- a/app/assets/javascripts/discourse-hbr/package.json
+++ b/app/assets/javascripts/discourse-hbr/package.json
@@ -34,7 +34,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-source-channel-url": "^3.0.0",
     "loader.js": "^4.7.0"
   },

--- a/app/assets/javascripts/discourse-widget-hbs/package.json
+++ b/app/assets/javascripts/discourse-widget-hbs/package.json
@@ -35,7 +35,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-source-channel-url": "^3.0.0",
     "loader.js": "^4.7.0"
   },

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -57,7 +57,7 @@
     "ember-load-initializers": "^2.1.1",
     "ember-qunit": "^5.1.5",
     "ember-rfc176-data": "^0.3.17",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-test-selectors": "^6.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-qunit": "^6.2.0",

--- a/app/assets/javascripts/pretty-text/package.json
+++ b/app/assets/javascripts/pretty-text/package.json
@@ -34,7 +34,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-source-channel-url": "^3.0.0",
     "loader.js": "^4.7.0"
   },

--- a/app/assets/javascripts/select-kit/package.json
+++ b/app/assets/javascripts/select-kit/package.json
@@ -33,7 +33,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-source-channel-url": "^3.0.0",
     "loader.js": "^4.7.0"
   },

--- a/app/assets/javascripts/truth-helpers/package.json
+++ b/app/assets/javascripts/truth-helpers/package.json
@@ -33,7 +33,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-source-channel-url": "^3.0.0",
     "loader.js": "^4.7.0"
   },

--- a/app/assets/javascripts/wizard/package.json
+++ b/app/assets/javascripts/wizard/package.json
@@ -34,7 +34,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-load-initializers": "^2.1.1",
     "ember-resolver": "^8.0.3",
-    "ember-source": "~3.28.8",
+    "ember-source": "~3.28.9",
     "ember-source-channel-url": "^3.0.0",
     "loader.js": "^4.7.0"
   },

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -5040,7 +5040,7 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.28.8:
+ember-source@~3.28.9:
   version "3.28.9"
   resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.9.tgz#804c56b2d71d3cc3decff15a3273bb35d668300a"
   integrity sha512-Fy7V3yvj+3oyo2+ke52aaihKMcFnnF7Oj9ixj547yzh2faqRfqouB5ZSiwXFH8rxw22rKaM8DiuQO4JN2Ay6xQ==


### PR DESCRIPTION
Includes a fix for a memory leak in the Router service class

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
