### PR TITLE
UX: Remove collapsible sidebar section on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar.hbs
@@ -1,6 +1,6 @@
 <DSection @pageClass="has-sidebar" @class="sidebar-container" @scrollTop={{false}}>
   <div class="sidebar-scroll-wrap">
-    <Sidebar::Sections @collapsableSections={{true}}/>
+    <Sidebar::Sections @collapsableSections={{this.site.desktopView}}/>
     <Sidebar::Footer @toggleSidebar={{@toggleSidebar}} @tagName=""/>
   </div>
 </DSection>

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-mobile-test.js
@@ -49,20 +49,10 @@ acceptance("Sidebar - Mobile - User with sidebar enabled", function (needs) {
     );
   });
 
-  test("collapsing sidebar sections does not collapse sidebar", async function (assert) {
+  test("sidebar sections are not collapsible on mobile", async function (assert) {
     await visit("/");
-
     await click(".hamburger-dropdown");
-    await click(".sidebar-section-header-caret");
 
-    assert.ok(
-      !exists(".sidebar-section-topics .sidebar-section-content"),
-      "topics section is collapsed"
-    );
-
-    assert.ok(
-      exists(".sidebar-container"),
-      "sidebar is not collapsed when clicking on caret to collapse a section in sidebar"
-    );
+    assert.notOk(exists(".sidebar-section-header-caret"));
   });
 });

--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -1,12 +1,3 @@
-.sidebar-wrapper {
-  .sidebar-footer-wrapper {
-    .sidebar-footer-container {
-      margin-left: 1.5em;
-      margin-right: 0.15em;
-    }
-  }
-}
-
 .sidebar-footer-wrapper {
   border-top: 1.5px solid var(--primary-low);
   padding: 0.5em 0 0.5em 0.33em;

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -127,7 +127,3 @@
     }
   }
 }
-
-#main-outlet-wrapper .sidebar-section-link-wrapper {
-  margin-left: 1.5em;
-}

--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -49,9 +49,6 @@
     background: none;
     border: none;
     padding: 0.25em 0.5em;
-    opacity: 0;
-    transition: opacity 0.25s;
-    transition-delay: 0.5s;
 
     .d-icon {
       font-size: var(--font-down-1);
@@ -62,6 +59,7 @@
       background: var(--primary-low);
     }
   }
+
   .select-kit-collection {
     .texts {
       font-size: var(--font-0);
@@ -122,11 +120,5 @@
     hr {
       margin: 0em 1.5em;
     }
-  }
-}
-
-#main-outlet-wrapper .sidebar-section-wrapper {
-  .sidebar-section-message-wrapper {
-    margin-left: 1.5em;
   }
 }

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -13,13 +13,6 @@
     align-self: start;
     overflow-y: auto;
     background-color: var(--primary-very-low);
-    &:hover {
-      .sidebar-section-header-button,
-      .sidebar-section-header-caret {
-        opacity: 1;
-        transition-delay: 0s;
-      }
-    }
   }
 
   .sidebar-container {

--- a/app/assets/stylesheets/desktop/_index.scss
+++ b/app/assets/stylesheets/desktop/_index.scss
@@ -10,6 +10,10 @@
 @import "login";
 @import "menu-panel";
 @import "modal";
+@import "sidebar";
+@import "sidebar-footer";
+@import "sidebar-section";
+@import "sidebar-section-link";
 @import "topic-list";
 @import "topic-post";
 @import "topic";

--- a/app/assets/stylesheets/desktop/sidebar-footer.scss
+++ b/app/assets/stylesheets/desktop/sidebar-footer.scss
@@ -1,0 +1,8 @@
+.sidebar-wrapper {
+  .sidebar-footer-wrapper {
+    .sidebar-footer-container {
+      margin-left: 1.5em;
+      margin-right: 0.15em;
+    }
+  }
+}

--- a/app/assets/stylesheets/desktop/sidebar-section-link.scss
+++ b/app/assets/stylesheets/desktop/sidebar-section-link.scss
@@ -1,0 +1,3 @@
+#main-outlet-wrapper .sidebar-section-link-wrapper {
+  margin-left: 1.5em;
+}

--- a/app/assets/stylesheets/desktop/sidebar-section.scss
+++ b/app/assets/stylesheets/desktop/sidebar-section.scss
@@ -1,0 +1,5 @@
+#main-outlet-wrapper .sidebar-section-wrapper {
+  .sidebar-section-message-wrapper {
+    margin-left: 1.5em;
+  }
+}

--- a/app/assets/stylesheets/desktop/sidebar.scss
+++ b/app/assets/stylesheets/desktop/sidebar.scss
@@ -1,0 +1,18 @@
+.sidebar-wrapper {
+  .sidebar-section-header-button,
+  .sidebar-section-header-caret,
+  .sidebar-section-header-dropdown {
+    opacity: 0;
+    transition: opacity 0.25s;
+    transition-delay: 0.5s;
+  }
+
+  &:hover {
+    .sidebar-section-header-button,
+    .sidebar-section-header-caret,
+    .sidebar-section-header-dropdown {
+      opacity: 1;
+      transition-delay: 0s;
+    }
+  }
+}


### PR DESCRIPTION
On mobile, the sidebar acts more like a navgiation menu so the ability
to collapse sections is not desired.

### Before 

![Screenshot from 2022-07-22 14-09-48](https://user-images.githubusercontent.com/4335742/180375385-b8beb04e-3b31-4caa-851e-cac6d85a62bf.png)


### After

![Screenshot from 2022-07-22 14-10-02](https://user-images.githubusercontent.com/4335742/180375403-b9441bf8-1f5e-4559-9cbf-2d5a8cb0148e.png)
