### PR TITLE
UX: let hamburger-sidebar restrict child width

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -572,12 +572,10 @@ div.menu-links-header {
 // Sidebar-hamburger hybrid
 
 .hamburger-menu.revamped {
-  .panel-body {
-    width: 100%;
+  width: var(--d-sidebar-width);
 
-    .panel-body-content {
-      width: 100%;
-    }
+  .panel-body-content {
+    min-width: 0; // prevent content blowing out width
   }
 
   .sidebar-section-wrapper {


### PR DESCRIPTION
Prevents this kind of overflow issue:
 
![Screen Shot 2022-07-22 at 10 12 34 AM](https://user-images.githubusercontent.com/1681963/180457665-ffdfd8aa-5229-4c40-9c1b-1f63cac23b01.png)
 