### PR TITLE
FIX: Make sure user list is complete and sorted

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
@@ -17,7 +17,6 @@ export default Controller.extend(CanCheckEmails, {
   listFilter: null,
   selectAll: false,
   searchHint: i18n("search_hint"),
-  _searchIndex: 0,
 
   init() {
     this._super(...arguments);
@@ -49,8 +48,7 @@ export default Controller.extend(CanCheckEmails, {
       return;
     }
 
-    this._searchIndex++;
-    const searchIndex = this._searchIndex;
+    const page = this._page;
     this.set("refreshing", true);
 
     AdminUser.findAll(this.query, {
@@ -58,32 +56,19 @@ export default Controller.extend(CanCheckEmails, {
       show_emails: this.showEmails,
       order: this.order,
       asc: this.asc,
-      page: this._page,
+      page,
     })
       .then((result) => {
-        if (this.ignoreResponse(searchIndex)) {
-          return;
-        }
-
-        if (!result || result.length === 0) {
+        if (result && result.length > 0) {
+          this._results[page] = result;
+          this.set("model", this._results.flat());
+        } else {
           this._canLoadMore = false;
         }
-
-        this._results = this._results.concat(result);
-        this.set("model", this._results);
       })
       .finally(() => {
-        if (this.ignoreResponse(searchIndex)) {
-          return;
-        }
         this.set("refreshing", false);
       });
-  },
-
-  ignoreResponse(searchIndex) {
-    return (
-      searchIndex !== this._searchIndex || this.isDestroyed || this.isDestroying
-    );
   },
 
   actions: {


### PR DESCRIPTION
Sometimes the user list was incomplete when multiple requests were
created to fetch next pages. If the responses did not arrive in the
same order as the requests then only the last response was parsed.

This is a follow up commit to a0f4c7fe888af75424d5beaf4d17630e4d49f0fa.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
