### PR TITLE
UX: Set theme color on splash a bit earlier

### DIFF
--- a/app/views/common/_discourse_splash.html.erb
+++ b/app/views/common/_discourse_splash.html.erb
@@ -114,13 +114,14 @@
   <style>
     html {
       overflow-y: hidden !important;
+      background-color: #<%= ColorScheme.hex_for_name("secondary", scheme_id) %>;
     }
 
     #d-splash {
       display: grid;
       place-items: center;
       backface-visibility: hidden;
-      background: #<%= ColorScheme.hex_for_name("secondary", scheme_id) %>;
+      background-color: #<%= ColorScheme.hex_for_name("secondary", scheme_id) %>;
       position: absolute;
       left: 0;
       top: 0;
@@ -183,8 +184,11 @@
     }
 
     @media (prefers-color-scheme: dark) {
+      html {
+        background-color: #<%= ColorScheme.hex_for_name("secondary", dark_scheme_id) %>;
+      }
       #d-splash {
-        background: #<%= ColorScheme.hex_for_name("secondary", dark_scheme_id) %>;
+        background-color: #<%= ColorScheme.hex_for_name("secondary", dark_scheme_id) %>;
       }
       #d-splash .preloader-text-wrapper {
         color: #<%= ColorScheme.hex_for_name("primary", dark_scheme_id) %>;

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -6,7 +6,8 @@
 <%- if site_apple_touch_icon_url.present? %>
 <link rel="apple-touch-icon" type="image/png" href="<%= ::UrlHelper.absolute(site_apple_touch_icon_url) %>">
 <%- end %>
-<meta name="theme-color" content="#<%= ColorScheme.hex_for_name('header_background', scheme_id) %>">
+<meta name="theme-color" content="#<%= ColorScheme.hex_for_name('header_background', scheme_id) %>" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#<%= ColorScheme.hex_for_name('header_background', dark_scheme_id) %>" media="(prefers-color-scheme: dark)">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=yes, viewport-fit=cover">
 <%- if Discourse.base_path.present? %>
 <meta name="discourse-base-uri" content="<%= Discourse.base_path %>">


### PR DESCRIPTION
Context: https://meta.discourse.org/t/introducing-discourse-splash-a-visual-preloader-displayed-while-site-assets-load/232003/17

We currently set the theme `secondary` color as the background for the splash, and this works and respects light/dark modes. 

The issue is that we set it on the `#d-splash` div. That div doesn't have a specified height and only gets its height when the splash image loads. 

This can cause a flicker effect where the `<HTML>` background shows for a fraction of a second while the splash image loads. 

This PR sets the theme color on the `<HTML>` tag to alleviate this. This allows us to set the theme color a little bit sooner and should hopefully prevent the flicker effect from happening.

This PR also adds the `theme-color` `<meta>` tag for dark mode. Browsers that don't support multiple `theme-color` tags will ignore the second tag and fall back to the first one. 