### PR TITLE
Show user already blocked for review topics by blocked users

### DIFF
--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -253,6 +253,10 @@ protected
   end
 
   def find_reviewable
+    unless Reviewable.exists?(params[:reviewable_id])
+      raise Discourse::NotFound.new(custom_message: "reviewables.user_does_not_exist")
+    end
+
     reviewable = Reviewable.viewable_by(current_user).where(id: params[:reviewable_id]).first
     raise Discourse::NotFound.new if reviewable.blank?
     reviewable

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5086,6 +5086,7 @@ en:
   reviewables:
     already_handled: "Thanks, but we've already reviewed that post and determined it does not need to be flagged again."
     already_handled_and_user_not_exist: "Thanks, but someone already reviewed and that user no longer exists."
+    user_does_not_exist: "User is already deleted and blocked."
     priorities:
       low: "Low"
       medium: "Medium"


### PR DESCRIPTION
This PR solves https://meta.discourse.org/t/deleting-subsequent-moderated-message-from-deleted-user-fails/232434.

When a user is deleted and blocked when reviewing the topic their Reviewable objects also gets deleted. So the only way to check is if the Reviewable object exists or not. I've added  `"User is already deleted and blocked."` message when the Reviewable object is not present. Let me know if this works as a solution.
