### PR TITLE
FIX: Padding on User Profile Groups

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -171,7 +171,7 @@
       }
 
       .groups {
-        margin-left: 10px;
+        margin-left: 0px;
         display: inline;
       }
 


### PR DESCRIPTION
Currently the Groups text with more than 2 groups uselessly spans 2 lines, this will make it all fit into one line correctly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
BEFORE:
![image](https://user-images.githubusercontent.com/91509874/180630862-84dfbb86-9a30-413e-8839-efc5dfb6f8bb.png)

AFTER:
![image](https://user-images.githubusercontent.com/91509874/180630851-291ac96b-8657-4b1e-9c61-81687aa4db17.png)
