### PR TITLE
DEV: Be specific about time units

### DIFF
--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -361,7 +361,7 @@ describe PostRevisor do
 
       it "resets the edit_reason attribute in post model" do
         freeze_time
-        SiteSetting.editing_grace_period = 5
+        SiteSetting.editing_grace_period = 5.seconds
         post = Fabricate(:post, raw: 'hello world')
         revisor = PostRevisor.new(post)
         revisor.revise!(post.user, { raw: 'hello world123456789', edit_reason: 'this is my reason' }, revised_at: post.updated_at + 1.second)


### PR DESCRIPTION
All other tests that are setting grade_period use either unitless `0`, `1.minute` or `5.minutes` so it wasn't clear if `5` was meant to be seconds (it was)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
