### PR TITLE
UX: Make post notices in topics consistent with DMs

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1433,16 +1433,20 @@ a.mention-group {
 }
 
 .post-notice {
-  align-items: center;
-  background-color: var(--tertiary-low);
-  border-top: 1px solid var(--primary-low);
-  display: flex;
-  width: 100%;
-  max-width: calc(
+    align-items: center;
+    display: flex;
+    margin-bottom: 1em;
+    border: none;
+    background: var(--primary-very-low);
+    border-radius: var(--border-radius);
+    margin-left: 1.5em;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 1.5em 2em;
+    max-width: calc(
     #{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} -
       (0.8em * 2)
   );
-  padding: 0.8em;
 
   &.old {
     background-color: unset;


### PR DESCRIPTION
Notices look like this in DMs
![image](https://user-images.githubusercontent.com/91509874/180701693-fcc6dd31-3ea8-4b99-b900-c903a41fadfe.png)

I made it so they look the same in topics.
Before:
![image](https://user-images.githubusercontent.com/91509874/180701594-0c3b7ea4-a5fb-45dd-aca3-9de37d35d3c5.png)
After:
![image](https://user-images.githubusercontent.com/91509874/180701535-f5385d01-a81b-4bf3-ab8c-ee5821321a8c.png)
