### PR TITLE
FIX: improves handling of filter with invalid tag chars

### DIFF
--- a/app/assets/javascripts/select-kit/addon/mixins/tags.js
+++ b/app/assets/javascripts/select-kit/addon/mixins/tags.js
@@ -25,6 +25,10 @@ export default Mixin.create({
   allowAnyTag: reads("site.can_create_tag"),
 
   validateCreate(filter, content) {
+    if (!filter.length) {
+      return;
+    }
+
     const maximum = this.selectKit.options.maximum;
     if (maximum && makeArray(this.value).length >= parseInt(maximum, 10)) {
       this.addError(
@@ -39,18 +43,6 @@ export default Mixin.create({
     filter = filter.replace(filterRegexp, "").trim().toLowerCase();
 
     if (this.termMatchesForbidden) {
-      return false;
-    }
-
-    if (
-      !filter.length ||
-      this.get("siteSettings.max_tag_length") < filter.length
-    ) {
-      this.addError(
-        I18n.t("select_kit.invalid_selection_length", {
-          count: `[1 - ${this.get("siteSettings.max_tag_length")}]`,
-        })
-      );
       return false;
     }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2106,9 +2106,6 @@ en:
       min_content_not_reached:
         one: "Select at least %{count} item."
         other: "Select at least %{count} items."
-      invalid_selection_length:
-        one: "Selection must be at least %{count} character."
-        other: "Selection must be at least %{count} characters."
       components:
         tag_drop:
           filter_for_more: Filter for more...


### PR DESCRIPTION
Tags mixin is already filtering a lot of data from the user submitted filter in `createContentFromInput()` which can lead to sk receiving an empty filter while the input actually has a value.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
