### PR TITLE
PHPBB 3.3 support

### DIFF
--- a/script/import_scripts/phpbb3/database/database.rb
+++ b/script/import_scripts/phpbb3/database/database.rb
@@ -22,13 +22,13 @@ module ImportScripts::PhpBB3
       if version.start_with?('3.0')
         require_relative 'database_3_0'
         Database_3_0.new(@database_client, @database_settings)
-      elsif version.start_with?('3.1') || version.start_with?('3.2')
+      elsif version.start_with?('3.1') || version.start_with?('3.2') || version.start_with?('3.3')
         require_relative 'database_3_1'
         Database_3_1.new(@database_client, @database_settings)
       else
         raise UnsupportedVersionError, <<~TEXT
           Unsupported version (#{version}) of phpBB detected.
-          Currently only version 3.0, 3.1 and 3.2 are supported by this importer.
+          Currently only version 3.0, 3.1, 3.2 and 3.3 are supported by this importer.
         TEXT
       end
     end

--- a/script/import_scripts/phpbb3/database/database_3_0.rb
+++ b/script/import_scripts/phpbb3/database/database_3_0.rb
@@ -115,13 +115,13 @@ module ImportScripts::PhpBB3
     def fetch_poll_options(topic_id)
       query(<<-SQL)
         SELECT o.poll_option_id, o.poll_option_text, o.poll_option_total AS total_votes,
-          o.poll_option_total - (
+          GREATEST(CAST(o.poll_option_total AS SIGNED) - (
             SELECT COUNT(DISTINCT v.vote_user_id)
               FROM #{@table_prefix}poll_votes v
                 JOIN #{@table_prefix}users u ON (v.vote_user_id = u.user_id)
                 JOIN #{@table_prefix}topics t ON (v.topic_id = t.topic_id)
               WHERE v.poll_option_id = o.poll_option_id AND v.topic_id = o.topic_id
-          ) AS anonymous_votes
+          ),0) AS anonymous_votes
         FROM #{@table_prefix}poll_options o
         WHERE o.topic_id = #{topic_id}
         ORDER BY o.poll_option_id

--- a/script/import_scripts/phpbb3/importers/message_importer.rb
+++ b/script/import_scripts/phpbb3/importers/message_importer.rb
@@ -77,9 +77,9 @@ module ImportScripts::PhpBB3
       # If there is a "u_" prefix, the prefix is discarded and the rest is a user_id
       user_ids = to_address.split(':')
       user_ids.uniq!
-      user_ids.map! { |u| u[2..-1].to_i if u[0..1] == 'u_'}.compact
+      user_ids.map! { |u| u[2..-1].to_i if u[0..1] == 'u_' }.compact
     end
-    
+
     def get_recipient_group_ids(to_address)
       return [] if to_address.blank?
 
@@ -87,23 +87,22 @@ module ImportScripts::PhpBB3
       # If there is a "g_" prefix, the prefix is discarded and the rest is a group_id
       group_ids = to_address.split(':')
       group_ids.uniq!
-      group_ids.map! { |g| g[2..-1].to_i if g[0..1] == 'g_'}.compact
+      group_ids.map! { |g| g[2..-1].to_i if g[0..1] == 'g_' }.compact
     end
-        
 
     def get_recipient_usernames(row)
       import_user_ids = get_recipient_user_ids(row[:to_address])
       usernames = import_user_ids.map do |import_user_id|
         @lookup.find_user_by_import_id(@settings.prefix(import_user_id)).try(:username)
       end.compact
-      
+
       import_group_ids = get_recipient_group_ids(row[:to_address])
       import_group_ids.each do |import_group_id|
         group = @lookup.find_group_by_import_id(@settings.prefix(import_group_id))
         next unless group
         usernames = usernames + group.users.pluck(:username)
       end
-      
+
       usernames.uniq
     end
 

--- a/script/import_scripts/phpbb3/importers/message_importer.rb
+++ b/script/import_scripts/phpbb3/importers/message_importer.rb
@@ -73,19 +73,38 @@ module ImportScripts::PhpBB3
     def get_recipient_user_ids(to_address)
       return [] if to_address.blank?
 
-      # to_address looks like this: "u_91:u_1234:u_200"
-      # The "u_" prefix is discarded and the rest is a user_id.
+      # to_address looks like this: "u_91:u_1234:g_200"
+      # If there is a "u_" prefix, the prefix is discarded and the rest is a user_id
       user_ids = to_address.split(':')
       user_ids.uniq!
-      user_ids.map! { |u| u[2..-1].to_i }
+      user_ids.map! { |u| u[2..-1].to_i if u[0..1] == 'u_'}.compact
     end
+    
+    def get_recipient_group_ids(to_address)
+      return [] if to_address.blank?
+
+      # to_address looks like this: "u_91:u_1234:g_200"
+      # If there is a "g_" prefix, the prefix is discarded and the rest is a group_id
+      group_ids = to_address.split(':')
+      group_ids.uniq!
+      group_ids.map! { |g| g[2..-1].to_i if g[0..1] == 'g_'}.compact
+    end
+        
 
     def get_recipient_usernames(row)
       import_user_ids = get_recipient_user_ids(row[:to_address])
-
-      import_user_ids.map! do |import_user_id|
+      usernames = import_user_ids.map do |import_user_id|
         @lookup.find_user_by_import_id(@settings.prefix(import_user_id)).try(:username)
       end.compact
+      
+      import_group_ids = get_recipient_group_ids(row[:to_address])
+      import_group_ids.each do |import_group_id|
+        group = @lookup.find_group_by_import_id(@settings.prefix(import_group_id))
+        next unless group
+        usernames = usernames + group.users.pluck(:username)
+      end
+      
+      usernames.uniq
     end
 
     def get_topic_title(row)

--- a/script/import_scripts/phpbb3/importers/poll_importer.rb
+++ b/script/import_scripts/phpbb3/importers/poll_importer.rb
@@ -64,7 +64,7 @@ module ImportScripts::PhpBB3
       arguments << "close=#{poll_data.close_time.iso8601}" if poll_data.close_time
 
       if poll_data.max_options > 1
-        arguments << "type=multiple" << "max=#{poll_data.max_options}"
+        arguments << "type=multiple" << "max=#{[poll_data.max_options, poll_data.options.count].min}"
       else
         arguments << "type=regular"
       end

--- a/script/import_scripts/phpbb3/support/text_processor.rb
+++ b/script/import_scripts/phpbb3/support/text_processor.rb
@@ -14,7 +14,7 @@ module ImportScripts::PhpBB3
       @database = database
       @smiley_processor = smiley_processor
       @he = HTMLEntities.new
-      @use_xml_to_markdown = phpbb_config[:phpbb_version].start_with?('3.2')
+      @use_xml_to_markdown = phpbb_config[:phpbb_version].start_with?('3.2') || phpbb_config[:phpbb_version].start_with?('3.3')
 
       @settings = settings
       @new_site_prefix = settings.new_site_prefix


### PR DESCRIPTION
- Fix: handle polls with incorrect poll_option_total values (see https://meta.discourse.org/t/importing-migrating-from-phpbb3/30810/679)
- Fix: handle polls with duplicate items
- Feature: handle PM's which have group ID's as recipient. Because groups and users can be mixed we have chosen to implement this by expanding the groups to users instead of using group inboxes.
- update version checks