### PR TITLE
FIX: Allow users to quote in closed topics

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -417,12 +417,14 @@ export default Component.extend(KeyEnterEscape, {
     return getAbsoluteURL(postUrl(topic.slug, topic.id, postNumber));
   },
 
-  @discourseComputed("topic.details.can_create_post", "composerVisible")
-  embedQuoteButton(canCreatePost, composerOpened) {
+  @discourseComputed(
+    "topic.details.can_create_post",
+    "topic.details.can_reply_as_new_topic"
+  )
+  embedQuoteButton(canCreatePost, canReplyAsNewTopic) {
     return (
-      (canCreatePost || composerOpened) &&
-      this.currentUser &&
-      this.currentUser.get("enable_quoting")
+      (canCreatePost || canReplyAsNewTopic) &&
+      this.currentUser?.get("enable_quoting")
     );
   },
 


### PR DESCRIPTION
Previously, non-staff users could only quote if they had an open composer.

This change shows the quote control when selecting text in closed topics
at all times and if the composer isn't already open, it will default to
creating a linked topic.

See https://meta.discourse.org/t/it-is-not-possible-to-quote-closed-topics-solved/167402/11 