### PR TITLE
Add topic title icon outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -70,7 +70,7 @@
               <a href {{action "editTopic"}} class="edit-topic" title={{i18n "edit"}}>{{d-icon "pencil-alt"}}</a>
             {{/if}}
 
-            <PluginOutlet @name="topic-title-icon" @tagName="" @connectorTagName="span" @args={{hash model=this.model}} />
+            <PluginOutlet @name="topic-title-suffix" @tagName="" @args={{hash model=this.model}} />
           </h1>
 
           <TopicCategory @topic={{this.model}} @class="topic-category" />

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -69,6 +69,8 @@
             {{#if this.model.details.can_edit}}
               <a href {{action "editTopic"}} class="edit-topic" title={{i18n "edit"}}>{{d-icon "pencil-alt"}}</a>
             {{/if}}
+
+            <PluginOutlet @name="topic-title-icon" @tagName="span" @connectorTagName="div" @args={{hash model=this.model}} />
           </h1>
 
           <TopicCategory @topic={{this.model}} @class="topic-category" />

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -70,7 +70,7 @@
               <a href {{action "editTopic"}} class="edit-topic" title={{i18n "edit"}}>{{d-icon "pencil-alt"}}</a>
             {{/if}}
 
-            <PluginOutlet @name="topic-title-icon" @tagName="span" @connectorTagName="div" @args={{hash model=this.model}} />
+            <PluginOutlet @name="topic-title-icon" @tagName="" @connectorTagName="span" @args={{hash model=this.model}} />
           </h1>
 
           <TopicCategory @topic={{this.model}} @class="topic-category" />


### PR DESCRIPTION
There are various situations in which having an outlet within the topic `h1` tag would be advantageous. The current situation prompting this is the addition of an icon to indicate the title text is translated, which is being implemented as part of https://meta.discourse.org/t/feature-request-topic-title-translation/144714/10?u=angus

<img width="444" alt="Screenshot 2022-07-25 at 18 37 10" src="https://user-images.githubusercontent.com/5931623/180839990-766743e1-305b-47f5-a0b2-feb2754c72fc.png">

Other potential uses:

- indication that the title represents a location (locations plugin)
- indication that the title represents an object or product
- topic status indications
