### PR TITLE
FIX: Rejected emails should not be cleaned up before their logs

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2432,6 +2432,7 @@ en:
       search_tokenize_chinese_enabled: "You must disable 'search_tokenize_chinese' before enabling this setting."
       search_tokenize_japanese_enabled: "You must disable 'search_tokenize_japanese' before enabling this setting."
       discourse_connect_cannot_be_enabled_if_second_factor_enforced: "You cannot enable DiscourseConnect if 2FA is enforced."
+      delete_rejected_email_after_days: "This setting cannot be set lower than the delete_email_logs_after_days setting or greater than 36500."
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2432,7 +2432,7 @@ en:
       search_tokenize_chinese_enabled: "You must disable 'search_tokenize_chinese' before enabling this setting."
       search_tokenize_japanese_enabled: "You must disable 'search_tokenize_japanese' before enabling this setting."
       discourse_connect_cannot_be_enabled_if_second_factor_enforced: "You cannot enable DiscourseConnect if 2FA is enforced."
-      delete_rejected_email_after_days: "This setting cannot be set lower than the delete_email_logs_after_days setting or greater than 36500."
+      delete_rejected_email_after_days: "This setting cannot be set lower than the delete_email_logs_after_days setting or greater than %{max}"
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1266,7 +1266,7 @@ email:
   raw_rejected_email_max_length: 4000
   delete_rejected_email_after_days:
     default: 90
-    max: 36500
+    validator: "DeleteRejectedEmailAfterDaysValidator"
   enable_secondary_emails:
     client: true
     default: true

--- a/db/migrate/20220726164831_fix_delete_rejected_email_after_days_site_setting.rb
+++ b/db/migrate/20220726164831_fix_delete_rejected_email_after_days_site_setting.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+class FixDeleteRejectedEmailAfterDaysSiteSetting < ActiveRecord::Migration[6.1]
+  def up
+    delete_rejected_email_after_days = DB.query_single("SELECT value FROM site_settings WHERE name = 'delete_rejected_email_after_days'").first
+    delete_email_logs_after_days = DB.query_single("SELECT value FROM site_settings WHERE name = 'delete_email_logs_after_days'").first
+
+    # These settings via the sql query return nil if they are using their default values
+    unless delete_email_logs_after_days
+      delete_email_logs_after_days = DeleteRejectedEmailAfterDaysValidator::MAX
+    end
+
+    # Only update if the setting is not using the default and it is lower than 'delete_email_logs_after_days'
+    if delete_rejected_email_after_days != nil && delete_rejected_email_after_days.to_i < delete_email_logs_after_days.to_i
+      execute <<~SQL
+      UPDATE site_settings
+      SET value = #{delete_email_logs_after_days.to_i}
+      WHERE name = 'delete_rejected_email_after_days'
+      SQL
+    end
+
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/validators/delete_rejected_email_after_days_validator.rb
+++ b/lib/validators/delete_rejected_email_after_days_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class DeleteRejectedEmailAfterDaysValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(value)
+    @valid = value.to_i >= SiteSetting.delete_email_logs_after_days && value.to_i <= 36500
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.delete_rejected_email_after_days") if !@valid
+  end
+end

--- a/lib/validators/delete_rejected_email_after_days_validator.rb
+++ b/lib/validators/delete_rejected_email_after_days_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DeleteRejectedEmailAfterDaysValidator
-  MAX = 36500.freeze
+  MAX = 36500
 
   def initialize(opts = {})
     @opts = opts
@@ -12,6 +12,6 @@ class DeleteRejectedEmailAfterDaysValidator
   end
 
   def error_message
-    I18n.t("site_settings.errors.delete_rejected_email_after_days") if !@valid
+    I18n.t("site_settings.errors.delete_rejected_email_after_days", max: MAX) if !@valid
   end
 end

--- a/lib/validators/delete_rejected_email_after_days_validator.rb
+++ b/lib/validators/delete_rejected_email_after_days_validator.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class DeleteRejectedEmailAfterDaysValidator
+  MAX = 36500.freeze
+
   def initialize(opts = {})
     @opts = opts
   end
 
   def valid_value?(value)
-    @valid = value.to_i >= SiteSetting.delete_email_logs_after_days && value.to_i <= 36500
+    @valid = value.to_i >= SiteSetting.delete_email_logs_after_days && value.to_i <= MAX
   end
 
   def error_message

--- a/spec/lib/email/cleaner_spec.rb
+++ b/spec/lib/email/cleaner_spec.rb
@@ -25,4 +25,5 @@ describe Email::Cleaner do
     expected_message = "Return-Path: <discourse@bar.com>\r\nDate: Sat, 30 Jan 2016 01:10:11 +0100\r\nFrom: Foo Bar <discourse@bar.com>\r\nTo: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com\r\nMessage-ID: <38@foo.bar.mail>\r\nMime-Version: 1.0\r\nContent-Type: multipart/mixed;\r\n boundary=\"--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\";\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlease fin\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--\r\n"
     expect(described_class.new(email, rejected: true).execute).to eq(expected_message)
   end
+
 end

--- a/spec/lib/email/cleaner_spec.rb
+++ b/spec/lib/email/cleaner_spec.rb
@@ -25,5 +25,4 @@ describe Email::Cleaner do
     expected_message = "Return-Path: <discourse@bar.com>\r\nDate: Sat, 30 Jan 2016 01:10:11 +0100\r\nFrom: Foo Bar <discourse@bar.com>\r\nTo: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com\r\nMessage-ID: <38@foo.bar.mail>\r\nMime-Version: 1.0\r\nContent-Type: multipart/mixed;\r\n boundary=\"--==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\";\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nPlease fin\r\n----==_mimepart_56abff5d49749_ddf83fca6d033a28548ad--\r\n"
     expect(described_class.new(email, rejected: true).execute).to eq(expected_message)
   end
-
 end

--- a/spec/lib/validators/delete_rejected_email_after_days_spec.rb
+++ b/spec/lib/validators/delete_rejected_email_after_days_spec.rb
@@ -2,14 +2,14 @@
 
 describe DeleteRejectedEmailAfterDaysValidator do
 
-  it 'will not set delete rejected emails setting earlier than removing the email logs' do
+  it 'is not valid if value is smaller than the value of SiteSetting.delete_email_logs_after_days' do
     SiteSetting.delete_email_logs_after_days = 90
 
     expect { SiteSetting.delete_rejected_email_after_days = 89 }.to raise_error(Discourse::InvalidParameters)
   end
 
-  it 'cannot be too large' do
-    expect { SiteSetting.delete_rejected_email_after_days = DeleteRejectedEmailAfterDaysValidator::MAX + 1 }.to raise_error(Discourse::InvalidParameters)
+  it "is not valid if value is greater than #{DeleteRejectedEmailAfterDaysValidator::MAX}" do
+    expect { SiteSetting.delete_rejected_email_after_days = DeleteRejectedEmailAfterDaysValidator::MAX + 1 }.to raise_error(Discourse::InvalidParameters, I18n.t("site_settings.errors.delete_rejected_email_after_days"))
   end
 
 end

--- a/spec/lib/validators/delete_rejected_email_after_days_spec.rb
+++ b/spec/lib/validators/delete_rejected_email_after_days_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe DeleteRejectedEmailAfterDaysValidator do
+
+  it 'will not set delete rejected emails setting earlier than removing the email logs' do
+    SiteSetting.delete_email_logs_after_days = 90
+
+    expect { SiteSetting.delete_rejected_email_after_days = 89 }.to raise_error(Discourse::InvalidParameters)
+  end
+
+end

--- a/spec/lib/validators/delete_rejected_email_after_days_spec.rb
+++ b/spec/lib/validators/delete_rejected_email_after_days_spec.rb
@@ -8,4 +8,8 @@ describe DeleteRejectedEmailAfterDaysValidator do
     expect { SiteSetting.delete_rejected_email_after_days = 89 }.to raise_error(Discourse::InvalidParameters)
   end
 
+  it 'cannot be too large' do
+    expect { SiteSetting.delete_rejected_email_after_days = DeleteRejectedEmailAfterDaysValidator::MAX + 1 }.to raise_error(Discourse::InvalidParameters)
+  end
+
 end

--- a/spec/lib/validators/delete_rejected_email_after_days_spec.rb
+++ b/spec/lib/validators/delete_rejected_email_after_days_spec.rb
@@ -9,7 +9,7 @@ describe DeleteRejectedEmailAfterDaysValidator do
   end
 
   it "is not valid if value is greater than #{DeleteRejectedEmailAfterDaysValidator::MAX}" do
-    expect { SiteSetting.delete_rejected_email_after_days = DeleteRejectedEmailAfterDaysValidator::MAX + 1 }.to raise_error(Discourse::InvalidParameters, I18n.t("site_settings.errors.delete_rejected_email_after_days"))
+    expect { SiteSetting.delete_rejected_email_after_days = DeleteRejectedEmailAfterDaysValidator::MAX + 1 }.to raise_error(Discourse::InvalidParameters)
   end
 
 end


### PR DESCRIPTION
If we delete the rejected emails before we delete their associated logs
we will receive 404 errors trying to inspect an email message for that
log.
