### PR TITLE
UX: make hamburger-sidebar menu occupy full width

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -575,6 +575,7 @@ div.menu-links-header {
   width: var(--d-sidebar-width);
 
   .panel-body-content {
+    width: 100%;
     min-width: 0; // prevent content blowing out width
   }
 


### PR DESCRIPTION
Before:
![Screen Shot 2022-07-25 at 2 12 13 PM](https://user-images.githubusercontent.com/1681963/180845915-dca62271-001c-4517-97f9-b0fffd53f9c8.png)

After:
![Screen Shot 2022-07-25 at 2 12 18 PM](https://user-images.githubusercontent.com/1681963/180845922-1e4f1fdc-4f8f-4522-98ce-74b452d1a768.png)

