### PR TITLE
FIX: Linear gradient with stops makes R2 confused

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -76,8 +76,8 @@
         pointer-events: none;
         background: linear-gradient(
           to bottom,
-          transparent 0%,
-          rgba(var(--primary-very-low-rgb), 100%)
+          transparent,
+          rgba(var(--primary-very-low-rgb), 1)
         );
       }
     }
@@ -92,8 +92,8 @@
         // fade to make scroll more apparent
         background: linear-gradient(
           to bottom,
-          transparent 0%,
-          rgba(var(--secondary-rgb), 100%)
+          transparent,
+          rgba(var(--secondary-rgb), 1)
         );
       }
     }


### PR DESCRIPTION
Context: https://meta.discourse.org/t/the-theme-is-broken-in-right-to-left-languages-even-in-meta/233908

We use the R2 gem to do the magic RTL CSS conversion. There are cases where we feed it too much, and it gets confused. The issue here is that we use a linear gradient with CSS variables, an RGBA function, and we set the stops. 

This makes R2 choke and causes it to return jumbled CSS, which means that any CSS that comes after that rule is junk and doesn't apply.

This PR removes the stops from the gradient. This shouldn't cause any visual changes since these are the default stops.

More explanation of the issue here: https://meta.discourse.org/t/user-card-will-not-open-on-the-mobile/171268/6?u=johani