### PR TITLE
DEV: Fix `fabricator` deprecations

### DIFF
--- a/spec/fabricators/category_fabricator.rb
+++ b/spec/fabricators/category_fabricator.rb
@@ -28,7 +28,7 @@ Fabricator(:private_category_with_definition, from: :private_category) do
 end
 
 Fabricator(:link_category, from: :category) do
-  before_validation { |category, transients| category.topic_featured_link_allowed = true }
+  before_create { |category, transients| category.topic_featured_link_allowed = true }
 end
 
 Fabricator(:mailinglist_mirror_category, from: :category) do

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -7,7 +7,7 @@ Fabricator(:post) do
   post_type Post.types[:regular]
 
   # Fabrication bypasses PostCreator, for performance reasons, where the counts are updated so we have to handle this manually here.
-  after_save do |post, _transients|
+  after_create do |post, _transients|
     UserStatCountUpdater.increment!(post)
   end
 end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
