### PR TITLE
DEV: Add secondary sort to `Group.visible_groups`

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -152,7 +152,7 @@ class Group < ActiveRecord::Base
   scope :visible_groups, Proc.new { |user, order, opts|
     groups = self
     groups = groups.order(order) if order
-    groups = groups.order("groups.name ASC") unless order.include?("name")
+    groups = groups.order("groups.name ASC") unless order&.include?("name")
 
     if !opts || !opts[:include_everyone]
       groups = groups.where("groups.id > 0")

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -150,7 +150,9 @@ class Group < ActiveRecord::Base
   scope :with_smtp_configured, -> { where(smtp_enabled: true) }
 
   scope :visible_groups, Proc.new { |user, order, opts|
-    groups = self.order(order || "groups.name ASC")
+    groups = self
+    groups = groups.order(order) if order
+    groups = groups.order("groups.name ASC") unless order.include?("name")
 
     if !opts || !opts[:include_everyone]
       groups = groups.where("groups.id > 0")


### PR DESCRIPTION
Fix a flaky group controller spec and makes the API responses more stable.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
