### PR TITLE
UX: Replace site-settings link with "Admin" link in sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/sidebar/footer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar/footer.hbs
@@ -5,9 +5,9 @@
         {{i18n "about.simple_title"}}
       </LinkTo>
 
-      {{#if this.currentUser.admin}}
-        <LinkTo @route="adminSiteSettings" title={{i18n "admin.site_settings.title"}} class="sidebar-footer-link sidebar-footer-link-site-settings">
-          {{i18n "admin.site_settings.title"}}
+      {{#if this.currentUser.staff}}
+        <LinkTo @route="admin" title={{i18n "admin_title"}} class="sidebar-footer-link sidebar-footer-link-admin">
+          {{i18n "admin_title"}}
         </LinkTo>
       {{/if}}
     </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-test.js
@@ -62,19 +62,19 @@ acceptance("Sidebar - User with sidebar enabled", function (needs) {
     );
   });
 
-  test("navigating to site setting route using sidebar", async function (assert) {
+  test("navigating to admin route using sidebar", async function (assert) {
     await visit("/");
-    await click(".sidebar-footer-link-site-settings");
+    await click(".sidebar-footer-link-admin");
 
-    assert.strictEqual(currentRouteName(), "adminSiteSettingsCategory");
+    assert.strictEqual(currentRouteName(), "admin.dashboard.general");
   });
 
-  test("site setting link is not shown in sidebar for non-admin user", async function (assert) {
-    updateCurrentUser({ admin: false });
+  test("admin link is not shown in sidebar for non-admin user", async function (assert) {
+    updateCurrentUser({ admin: false, moderator: false });
 
     await visit("/");
 
-    assert.notOk(exists(".sidebar-footer-link-site-settings"));
+    assert.notOk(exists(".sidebar-footer-link-admin"));
   });
 
   test("undocking and docking sidebar", async function (assert) {


### PR DESCRIPTION
The main landing page for admins/mods should be the admin Dashboard, not the site settings. Having a "Settings" link can be confused with user settings.

This commit also displays the button for moderators, who are also allowed access to parts of the admin dashboard

<img width="274" alt="Screenshot 2022-07-26 at 14 13 24" src="https://user-images.githubusercontent.com/6270921/181014449-c5dad82e-59ad-4c5c-b1c2-6c7af6479aa0.png">




<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
