### PR TITLE
FIX: Ensure admin templates are not used for non-admin controllers

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -274,7 +274,12 @@ export function buildResolver(baseName) {
       let namespaced, match;
 
       if (parsedName.fullNameWithoutType.startsWith("components/")) {
-        // Look up components as-is
+        return (
+          // Built-in
+          this.findTemplate(parsedName, "admin/templates/") ||
+          // Plugin
+          this.findTemplate(parsedName, "javascripts/admin/")
+        );
       } else if (/^admin[_\.-]/.test(parsedName.fullNameWithoutType)) {
         namespaced = parsedName.fullNameWithoutType.slice(6);
       } else if (
@@ -293,12 +298,6 @@ export function buildResolver(baseName) {
           // Plugin
           this.findTemplate(adminParsedName, "javascripts/admin/");
       }
-
-      resolved ??=
-        // Built-in
-        this.findTemplate(parsedName, "admin/templates/") ||
-        // Plugin
-        this.findTemplate(parsedName, "javascripts/admin/");
 
       return resolved;
     }

--- a/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ember/resolver-test.js
@@ -317,6 +317,7 @@ module("Unit | Ember | resolver", function (hooks) {
       "admin/templates/dashboard_general",
       "admin-baz-qux",
       "javascripts/admin/plugin-template",
+      "admin/templates/components/my-admin-component",
     ]);
 
     // Switches prefix to admin/templates when camelized
@@ -394,6 +395,20 @@ module("Unit | Ember | resolver", function (hooks) {
       "template:admin-plugin/template",
       "javascripts/admin/plugin-template",
       "looks up templates in plugins"
+    );
+
+    lookupTemplate(
+      assert,
+      "template:foo",
+      undefined,
+      "doesn't return admin templates for regular controllers"
+    );
+
+    lookupTemplate(
+      assert,
+      "template:components/my-admin-component",
+      "admin/templates/components/my-admin-component",
+      "returns admin-defined component templates"
     );
   });
 


### PR DESCRIPTION
Previously, if a non-admin controller did not have a template defined, then the resolver would return an admin template with the same name. This is not the desired behavior, and regressed in fc36ac6cde2afaf8c5e9e6df22e71a7b3044c0a2. However, we *do* want this behavior for components defined in the admin bundle (because admin components are not namespaced).

This was noticed because the non-admin `badges` route was using the `admin/badges` template

This commit fixes the behavior, and adds a tests for these cases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
