### PR TITLE
FIX: Support for group everyone in tag setting

### DIFF
--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -11,8 +11,12 @@ module TagGuardian
   end
 
   def can_tag_pms?
+    return false if !SiteSetting.tagging_enabled
     return false if @user.blank?
-    SiteSetting.tagging_enabled && @user == Discourse.system_user || @user.group_users.exists?(group_id: SiteSetting.pm_tags_allowed_for_groups.to_s.split("|").map(&:to_i))
+    return true if @user == Discourse.system_user
+
+    group_ids = SiteSetting.pm_tags_allowed_for_groups.to_s.split("|").map(&:to_i)
+    group_ids.include?(Group::AUTO_GROUPS[:everyone]) || @user.group_users.exists?(group_id: group_ids)
   end
 
   def can_admin_tags?

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3379,6 +3379,22 @@ describe Guardian do
         end
       end
     end
+
+    context "tagging PMs" do
+      it "pm_tags_allowed_for_groups contains everyone" do
+        SiteSetting.pm_tags_allowed_for_groups = "#{Group::AUTO_GROUPS[:everyone]}"
+
+        expect(Guardian.new(user).can_tag_pms?).to be_truthy
+      end
+
+      it "pm_tags_allowed_for_groups contains a group" do
+        SiteSetting.pm_tags_allowed_for_groups = "#{group.id}"
+        group.add(member)
+
+        expect(Guardian.new(user).can_tag_pms?).to be_falsey
+        expect(Guardian.new(member).can_tag_pms?).to be_truthy
+      end
+    end
   end
 
   describe(:can_see_group) do


### PR DESCRIPTION
The "everyone" group is an automatic group and GroupUser records do not
exist for it. This commit allows all users if the group everyone is one
of the groups in the setting "pm_tags_allowed_for_groups".

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
