### PR TITLE
UX: Remove toggle from sidebar, improve styles

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -23,7 +23,7 @@
     <div class="sidebar-wrapper">
       {{!-- empty div allows for animation --}}
       {{#if (and this.currentUser.experimental_sidebar_enabled this.showSidebar)}}
-        <Sidebar/>
+        <Sidebar @toggleSidebar={{action "toggleSidebar"}}/>
       {{/if}}
     </div>
 

--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -23,7 +23,7 @@
     <div class="sidebar-wrapper">
       {{!-- empty div allows for animation --}}
       {{#if (and this.currentUser.experimental_sidebar_enabled this.showSidebar)}}
-        <Sidebar @toggleSidebar={{action "toggleSidebar"}}/>
+        <Sidebar/>
       {{/if}}
     </div>
 

--- a/app/assets/javascripts/discourse/app/templates/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar.hbs
@@ -1,6 +1,6 @@
 <DSection @pageClass="has-sidebar" @class="sidebar-container" @scrollTop={{false}}>
   <div class="sidebar-scroll-wrap">
     <Sidebar::Sections @collapsableSections={{true}}/>
-    <Sidebar::Footer @toggleSidebar={{@toggleSidebar}} @tagName=""/>
+    <Sidebar::Footer @tagName=""/>
   </div>
 </DSection>

--- a/app/assets/javascripts/discourse/app/templates/components/sidebar/footer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar/footer.hbs
@@ -6,6 +6,7 @@
       </LinkTo>
 
       {{#if this.currentUser.staff}}
+        <span class="sidebar-footer-links-separator">&bull;</span>
         <LinkTo @route="admin" title={{i18n "admin_title"}} class="sidebar-footer-link sidebar-footer-link-admin">
           {{i18n "admin_title"}}
         </LinkTo>
@@ -18,13 +19,6 @@
         @title="keyboard_shortcuts_help.title"
         @icon="keyboard"
         @class="sidebar-footer-actions-button sidebar-footer-actions-keyboard-shortcuts" />
-
-      {{#if (and this.site.desktopView (not @sidebarDocked))}}
-        <DButton
-          @action={{@toggleSidebar}}
-          @icon="thumbtack"
-          @class="sidebar-footer-actions-button sidebar-footer-actions-dock-toggle"/>
-      {{/if}}
     </div>
   </div>
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-categories-section-test.js
@@ -10,8 +10,6 @@ import {
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
-import { undockSidebar } from "discourse/tests/helpers/sidebar-helpers";
-
 import Site from "discourse/models/site";
 import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
 import categoryFixture from "discourse/tests/fixtures/category-fixtures";
@@ -396,8 +394,6 @@ acceptance("Sidebar - Categories Section", function (needs) {
     const initialCallbackCount = Object.keys(
       topicTrackingState.stateChangeCallbacks
     ).length;
-
-    await undockSidebar();
 
     assert.strictEqual(
       Object.keys(topicTrackingState.stateChangeCallbacks).length,

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-community-section-test.js
@@ -9,7 +9,6 @@ import {
   publishToMessageBus,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import { undockSidebar } from "discourse/tests/helpers/sidebar-helpers";
 import topicFixtures from "discourse/tests/fixtures/discovery-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -752,8 +751,6 @@ acceptance("Sidebar - Community Section", function (needs) {
     const initialCallbackCount = Object.keys(
       topicTrackingState.stateChangeCallbacks
     ).length;
-
-    await undockSidebar();
 
     assert.strictEqual(
       Object.keys(topicTrackingState.stateChangeCallbacks).length,

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -10,7 +10,6 @@ import {
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { resetSidebarSection } from "discourse/lib/sidebar/custom-sections";
 import { bind } from "discourse-common/utils/decorators";
-import { undockSidebar } from "discourse/tests/helpers/sidebar-helpers";
 
 acceptance("Sidebar - Plugin API", function (needs) {
   needs.user({ experimental_sidebar_enabled: true });
@@ -338,8 +337,6 @@ acceptance("Sidebar - Plugin API", function (needs) {
       "hover button title attribute",
       "displays hover button with correct title"
     );
-
-    await undockSidebar();
 
     assert.strictEqual(
       linkDestroy,

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-tags-section-test.js
@@ -9,7 +9,6 @@ import {
   query,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
-import { undockSidebar } from "discourse/tests/helpers/sidebar-helpers";
 import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
 
@@ -323,8 +322,6 @@ acceptance("Sidebar - Tags section", function (needs) {
     const initialCallbackCount = Object.keys(
       topicTrackingState.stateChangeCallbacks
     ).length;
-
-    await undockSidebar();
 
     assert.strictEqual(
       Object.keys(topicTrackingState.stateChangeCallbacks).length,

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-test.js
@@ -7,7 +7,6 @@ import {
   exists,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
-import { undockSidebar } from "discourse/tests/helpers/sidebar-helpers";
 
 acceptance("Sidebar - Anon User", function () {
   // Don't show sidebar for anon user until we know what we want to display
@@ -75,54 +74,5 @@ acceptance("Sidebar - User with sidebar enabled", function (needs) {
     await visit("/");
 
     assert.notOk(exists(".sidebar-footer-link-admin"));
-  });
-
-  test("undocking and docking sidebar", async function (assert) {
-    await visit("/");
-
-    assert.ok(
-      document.body.classList.contains("has-sidebar-page"),
-      "adds sidebar utility class to body"
-    );
-
-    assert.ok(exists(".sidebar-container"), "displays the sidebar by default");
-
-    await undockSidebar();
-
-    assert.ok(
-      !document.body.classList.contains("has-sidebar-page"),
-      "removes sidebar utility class from body"
-    );
-
-    assert.ok(!exists(".sidebar-container"), "hides the sidebar");
-
-    assert.ok(
-      exists(".sidebar-hamburger-dropdown"),
-      "displays the sidebar in hamburger dropdown automatically after undocking"
-    );
-
-    await click("button.sidebar-footer-actions-dock-toggle");
-
-    assert.ok(
-      exists(".sidebar-container"),
-      "displays the sidebar after docking"
-    );
-
-    assert.notOk(
-      exists(".sidebar-hamburger-dropdown"),
-      "hides the sidebar in hamburger dropdown automatically after docking"
-    );
-
-    await click(".hamburger-dropdown");
-
-    assert.ok(
-      exists(".sidebar-hamburger-dropdown"),
-      "displays the sidebar in hamburger dropdown even when sidebar is docked"
-    );
-
-    assert.notOk(
-      exists(".sidebar-hamburger-dropdown .sidebar-footer-actions-dock-toggle"),
-      "does not display sidebar dock toggle in hamburger dropdown when sidebar is docked"
-    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/helpers/sidebar-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/sidebar-helpers.js
@@ -1,5 +1,0 @@
-import { click } from "@ember/test-helpers";
-
-export async function undockSidebar() {
-  await click("button.sidebar-footer-actions-dock-toggle");
-}

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -572,6 +572,7 @@ div.menu-links-header {
 // Sidebar-hamburger hybrid
 
 .hamburger-menu.revamped {
+  --d-sidebar-highlight-color: var(--highlight-medium);
   width: var(--d-sidebar-width);
 
   .panel-body-content {
@@ -589,19 +590,9 @@ div.menu-links-header {
       color: var(--primary-high);
       background: var(--tertiary-low);
     }
-
-    .sidebar-section-header-link,
-    .sidebar-section-header-button,
-    .sidebar-section-link {
-      &:hover {
-        background: var(--highlight-medium);
-      }
-    }
   }
 
-  .sidebar-footer-actions-button.btn {
-    &:hover {
-      background: var(--highlight-medium);
-    }
+  .sidebar-footer-wrapper {
+    padding: 0.5em 0 0;
   }
 }

--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -1,8 +1,8 @@
 .sidebar-wrapper {
   .sidebar-footer-wrapper {
     .sidebar-footer-container {
-      margin-left: 1.5em;
       margin-right: 0.15em;
+      margin-left: 1em;
     }
   }
 }
@@ -13,19 +13,24 @@
 
   .sidebar-footer-container {
     display: flex;
+    align-items: stretch;
   }
 
   .sidebar-footer-link {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    height: 100%;
     font-size: var(--font-down-1);
     color: var(--primary-high);
-    padding: 0.25em 0;
-    height: 100%;
-
-    &:not(:first-child):before {
-      content: "•";
-      padding: 0 0.25em;
+    padding: 0 0.5em;
+    &:hover,
+    &:focus {
+      background: var(--d-sidebar-highlight-color);
     }
+  }
+
+  .sidebar-footer-links-separator {
+    color: var(--primary-low-mid);
   }
 
   .sidebar-footer-actions {
@@ -41,9 +46,9 @@
       font-size: var(--font-down-1);
       color: var(--primary-medium);
     }
-
+    &:focus,
     &:hover {
-      background: var(--primary-low);
+      background: var(--d-sidebar-highlight-color);
     }
   }
 }

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -12,8 +12,9 @@
     font-size: var(--font-down-1);
     transition: background-color 0.25s;
 
+    &:focus,
     &:hover {
-      background: var(--primary-low);
+      background: var(--d-sidebar-highlight-color);
     }
 
     &.active {

--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -11,8 +11,9 @@
     .select-kit {
       .btn {
         background: transparent;
+        &:focus,
         &:hover {
-          background: var(--primary-low);
+          background: var(--d-sidebar-highlight-color);
         }
       }
       .d-icon {
@@ -39,9 +40,9 @@
     &:visited {
       color: var(--primary);
     }
-
+    &:focus,
     &:hover {
-      background: var(--primary-low);
+      background: var(--d-sidebar-highlight-color);
     }
   }
 
@@ -55,8 +56,9 @@
       color: var(--primary-medium);
     }
 
+    &:focus,
     &:hover {
-      background: var(--primary-low);
+      background: var(--d-sidebar-highlight-color);
     }
   }
   .select-kit-collection {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -6,6 +6,8 @@
 
 #main-outlet-wrapper {
   .sidebar-wrapper {
+    --d-sidebar-highlight-color: var(--primary-low);
+
     grid-area: sidebar;
     position: sticky;
     top: var(--header-offset);


### PR DESCRIPTION
* removed the pin toggle from the sidebar footer 
* added a `--d-sidebar-highlight-color` variable to make this easier to change
* improved focus and hover styles
* minor spacing adjustments 