### PR TITLE
FIX: Ensure uploads work when the user's browser rewrites ellipsis

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -453,6 +453,15 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
         placeholderData.uploadPlaceholder,
         placeholderData.processingPlaceholder
       );
+
+      // Safari applies user-defined replacements to text inserted programatically.
+      // One of the most common replacements is ... -> …, so we take care of the case
+      // where that transformation has been applied to the original placeholder
+      this.appEvents.trigger(
+        `${this.composerEventPrefix}:replace-text`,
+        placeholderData.uploadPlaceholder.replace("...", "…"),
+        placeholderData.processingPlaceholder
+      );
     });
 
     this._onPreProcessComplete(


### PR DESCRIPTION
https://meta.discourse.org/t/cannot-upload-images-with-safari/232563

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
