### PR TITLE
UX: Make Post Notices consistent

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1432,6 +1432,8 @@ a.mention-group {
   }
 }
 
+}
+
 .post-notice {
   align-items: center;
   background-color: var(--tertiary-low);
@@ -1439,6 +1441,17 @@ a.mention-group {
   display: flex;
   width: 100%;
   max-width: calc(
+    align-items: center;
+    display: flex;
+    margin-bottom: 1em;
+    border: none;
+    background: var(--primary-very-low);
+    border-radius: var(--border-radius);
+    margin-left: 1.5em;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 1.5em 2em;
+    max-width: calc(
     #{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} -
       (0.8em * 2)
   );

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1468,9 +1468,6 @@ a.mention-group {
   }
 }
 
-
-
-
 #topic-footer-buttons {
   margin: var(--below-topic-margin) 0;
   padding: 0;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1446,7 +1446,7 @@ a.mention-group {
     #{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} -
       (0.8em * 2)
   );
-  border-radius: 20px;
+  border-radius: 18px;
 
   &.old {
     background-color: unset;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1433,47 +1433,39 @@ a.mention-group {
 }
 
 .post-notice {
-  align-items: center;
-  background-color: var(--tertiary-low);
-  border-top: 1px solid var(--primary-low);
-  display: flex;
-  width: 100%;
-  max-width: calc(
-    align-items: center;
-    display: flex;
     margin-bottom: 1em;
     border: none;
     background: var(--primary-very-low);
     border-radius: var(--border-radius);
     margin-left: 1.5em;
-    width: 100%;
     box-sizing: border-box;
     padding: 1.5em 2em;
-    max-width: calc(
-    #{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} -
-      (0.8em * 2)
-  );
-  padding: 0.8em;
+    align-items: center;
+    display: flex;
+    width: 100%;
+    max-width: calc(#{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} - (0.8em * 2));
+    border-radius:20px;
+    
+    &.old {
+        background-color: unset;
+        color: var(--primary-medium);
 
-  &.old {
-    background-color: unset;
-    color: var(--primary-medium);
+        .d-icon {
+            color: var(--primary-medium);
+        }
+    }
+
+    p {
+        margin: 0;
+    }
 
     .d-icon {
-      color: var(--primary-medium);
+        font-size: 2em;
+        color: var(--primary-high);
+        margin-right: 0.65em;
     }
-  }
-
-  p {
-    margin: 0;
-  }
-
-  .d-icon {
-    font-size: 2em;
-    color: var(--primary-high);
-    margin-right: 0.65em;
-  }
 }
+
 
 #topic-footer-buttons {
   margin: var(--below-topic-margin) 0;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1436,7 +1436,6 @@ a.mention-group {
     margin-bottom: 1em;
     border: none;
     background: var(--primary-very-low);
-    border-radius: var(--border-radius);
     margin-left: 1.5em;
     box-sizing: border-box;
     padding: 1.5em 2em;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1432,8 +1432,6 @@ a.mention-group {
   }
 }
 
-}
-
 .post-notice {
   align-items: center;
   background-color: var(--tertiary-low);

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1433,16 +1433,20 @@ a.mention-group {
 }
 
 .post-notice {
+  margin-bottom: 1em;
+  border: none;
+  background: var(--primary-very-low);
+  margin-left: 1.5em;
+  box-sizing: border-box;
+  padding: 1.5em 2em;
   align-items: center;
-  background-color: var(--tertiary-low);
-  border-top: 1px solid var(--primary-low);
   display: flex;
   width: 100%;
   max-width: calc(
     #{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} -
       (0.8em * 2)
   );
-  padding: 0.8em;
+  border-radius: 20px;
 
   &.old {
     background-color: unset;
@@ -1463,6 +1467,7 @@ a.mention-group {
     margin-right: 0.65em;
   }
 }
+
 
 
 

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1433,12 +1433,11 @@ a.mention-group {
 }
 
 .post-notice {
-  margin-bottom: 1em;
-  border: none;
+  border: 1px solid var(--primary-low);
   background: var(--primary-very-low);
   margin-left: 1.5em;
   box-sizing: border-box;
-  padding: 1.5em 2em;
+  padding: 1em 1.5em;
   align-items: center;
   display: flex;
   width: 100%;
@@ -1446,7 +1445,7 @@ a.mention-group {
     #{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} -
       (0.8em * 2)
   );
-  border-radius: 18px;
+  border-radius: 12px;
 
   &.old {
     background-color: unset;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1433,37 +1433,37 @@ a.mention-group {
 }
 
 .post-notice {
-    margin-bottom: 1em;
-    border: none;
-    background: var(--primary-very-low);
-    margin-left: 1.5em;
-    box-sizing: border-box;
-    padding: 1.5em 2em;
-    align-items: center;
-    display: flex;
-    width: 100%;
-    max-width: calc(#{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} - (0.8em * 2));
-    border-radius:20px;
-    
-    &.old {
-        background-color: unset;
-        color: var(--primary-medium);
+  align-items: center;
+  background-color: var(--tertiary-low);
+  border-top: 1px solid var(--primary-low);
+  display: flex;
+  width: 100%;
+  max-width: calc(
+    #{$topic-body-width} + (#{$topic-body-width-padding} * 2) + #{$topic-avatar-width} -
+      (0.8em * 2)
+  );
+  padding: 0.8em;
 
-        .d-icon {
-            color: var(--primary-medium);
-        }
-    }
-
-    p {
-        margin: 0;
-    }
+  &.old {
+    background-color: unset;
+    color: var(--primary-medium);
 
     .d-icon {
-        font-size: 2em;
-        color: var(--primary-high);
-        margin-right: 0.65em;
+      color: var(--primary-medium);
     }
+  }
+
+  p {
+    margin: 0;
+  }
+
+  .d-icon {
+    font-size: 2em;
+    color: var(--primary-high);
+    margin-right: 0.65em;
+  }
 }
+
 
 
 #topic-footer-buttons {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
I deleted the repository that had the original PR, sorry! This is a duplicate of it, nothing has changed.

Notices look like this in DMs:
![image](https://user-images.githubusercontent.com/91509874/181137215-98c3e9da-f95a-4a8b-9224-3b27122c2d19.png)

But they look like this in posts:
![image](https://user-images.githubusercontent.com/91509874/181137229-511d32b1-672b-4fc0-ada2-fc6aadc1bd99.png)

So, in this PR I made them both look the same.
![image](https://user-images.githubusercontent.com/91509874/181137258-2597b1ae-b6d9-4b9d-994b-31edf0d40164.png)


All old discussion is here, I just deleted `darkpixlz/discourse` stupidly, so it closed all of the PRs that were merged from my repository.
https://github.com/discourse/discourse/pull/17635