### PR TITLE
DEV: Fix mini profiler queries bg covering results

### DIFF
--- a/app/assets/stylesheets/common/admin/mini_profiler.scss
+++ b/app/assets/stylesheets/common/admin/mini_profiler.scss
@@ -1,6 +1,10 @@
 // Some basic overrides to https://github.com/MiniProfiler/rack-mini-profiler/blob/master/lib/html/includes.scss
 // which make the badge conform to the current site theme.
 
+.profiler-queries-bg {
+  z-index: z("header") - 2;
+}
+
 div.profiler-results.profiler-top {
   top: var(--header-offset);
   z-index: z("header") - 1;


### PR DESCRIPTION
![Screenshot from 2022-07-27 11-33-58](https://user-images.githubusercontent.com/4335742/181155344-af20d7de-8c2b-4320-84c1-65c9afe49601.png)

The background was covering the results making mini profiler unusable.