### PR TITLE
PERF: Add index for TopicTimer#topic_id

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1357,11 +1357,11 @@ class Topic < ActiveRecord::Base
   end
 
   def public_topic_timer
-    @public_topic_timer ||= topic_timers.find_by(deleted_at: nil, public_type: true)
+    @public_topic_timer ||= topic_timers.find_by(public_type: true)
   end
 
   def slow_mode_topic_timer
-    @slow_mode_topic_timer ||= topic_timers.find_by(deleted_at: nil, status_type: TopicTimer.types[:clear_slow_mode])
+    @slow_mode_topic_timer ||= topic_timers.find_by(status_type: TopicTimer.types[:clear_slow_mode])
   end
 
   def delete_topic_timer(status_type, by_user: Discourse.system_user)

--- a/app/models/topic_timer.rb
+++ b/app/models/topic_timer.rb
@@ -196,5 +196,6 @@ end
 # Indexes
 #
 #  idx_topic_id_public_type_deleted_at  (topic_id) UNIQUE WHERE ((public_type = true) AND (deleted_at IS NULL))
+#  index_topic_timers_on_topic_id       (topic_id) WHERE (deleted_at IS NULL)
 #  index_topic_timers_on_user_id        (user_id)
 #

--- a/db/migrate/20220727040437_add_topic_timers_index.rb
+++ b/db/migrate/20220727040437_add_topic_timers_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTopicTimersIndex < ActiveRecord::Migration[7.0]
+  def change
+    add_index :topic_timers, [:topic_id], where: "deleted_at IS NULL"
+  end
+end


### PR DESCRIPTION
Topic timers has a default scope which excludes records which have been
trashed.