### PR TITLE
DEV: Fix fake-timer issues

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -107,6 +107,7 @@ export function fakeTime(timeString, timezone = null, advanceTime = false) {
   return sinon.useFakeTimers({
     now: now.valueOf(),
     shouldAdvanceTime: advanceTime,
+    shouldClearNativeTimers: true,
   });
 }
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -11,7 +11,6 @@ import {
   discourseModule,
   fakeTime,
 } from "discourse/tests/helpers/qunit-helpers";
-import sinon from "sinon";
 import { test } from "qunit";
 import domFromString from "discourse-common/lib/dom-from-string";
 

--- a/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/formatter-test.js
@@ -7,7 +7,10 @@ import {
   relativeAge,
   updateRelativeAge,
 } from "discourse/lib/formatter";
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
+import {
+  discourseModule,
+  fakeTime,
+} from "discourse/tests/helpers/qunit-helpers";
 import sinon from "sinon";
 import { test } from "qunit";
 import domFromString from "discourse-common/lib/dom-from-string";
@@ -44,14 +47,14 @@ function strip(html) {
 
 discourseModule("Unit | Utility | formatter", function (hooks) {
   hooks.beforeEach(function () {
-    this.clock = sinon.useFakeTimers(new Date(2012, 11, 31, 12, 0).getTime());
+    this.clock = fakeTime("2012-12-31 12:00");
   });
 
   hooks.afterEach(function () {
     this.clock.restore();
   });
 
-  test("formating medium length dates", function (assert) {
+  test("formatting medium length dates", function (assert) {
     let shortDateYear = shortDateTester("MMM D, 'YY");
 
     assert.strictEqual(
@@ -133,7 +136,7 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
     );
 
     this.clock.restore();
-    this.clock = sinon.useFakeTimers(new Date(2012, 0, 9, 12, 0).getTime()); // Jan 9, 2012
+    this.clock = fakeTime("2012-01-09 12:00");
 
     assert.strictEqual(
       strip(formatDays(8, { format: "medium" })),
@@ -145,7 +148,7 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
     );
   });
 
-  test("formating tiny dates", function (assert) {
+  test("formatting tiny dates", function (assert) {
     let shortDateYear = shortDateTester("MMM 'YY");
 
     assert.strictEqual(formatMins(0), "1m");
@@ -207,7 +210,7 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
     this.siteSettings.relative_date_duration = 14;
 
     this.clock.restore();
-    this.clock = sinon.useFakeTimers(new Date(2012, 0, 12, 12, 0).getTime()); // Jan 12, 2012
+    this.clock = fakeTime("2012-01-12 12:00");
 
     assert.strictEqual(formatDays(11), "11d");
     assert.strictEqual(formatDays(14), "14d");
@@ -215,7 +218,7 @@ discourseModule("Unit | Utility | formatter", function (hooks) {
     assert.strictEqual(formatDays(366), shortDateYear(366));
 
     this.clock.restore();
-    this.clock = sinon.useFakeTimers(new Date(2012, 0, 20, 12, 0).getTime()); // Jan 20, 2012
+    this.clock = fakeTime("2012-01-20 12:00");
 
     assert.strictEqual(formatDays(14), "14d");
     assert.strictEqual(formatDays(15), shortDate(15));

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -5,6 +5,7 @@ import Category from "discourse/models/category";
 import MessageBus from "message-bus-client";
 import {
   discourseModule,
+  fakeTime,
   publishToMessageBus,
 } from "discourse/tests/helpers/qunit-helpers";
 import { NotificationLevels } from "discourse/lib/notification-levels";
@@ -16,7 +17,7 @@ import sinon from "sinon";
 
 discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
   hooks.beforeEach(function () {
-    this.clock = sinon.useFakeTimers(new Date(2012, 11, 31, 12, 0).getTime());
+    this.clock = fakeTime("2012-12-31 12:00");
   });
 
   hooks.afterEach(function () {


### PR DESCRIPTION
Occasionally some code (e.g. live-reload) would try to clear a timer that was set up before fake timers were installed. That would lead to issues and warnings. Enabling `shouldClearNativeTimers` option fixes it.