### PR TITLE
DEV: remove sidebar outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/sidebar/sections.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar/sections.hbs
@@ -46,8 +46,4 @@
       {{/each}}
     </Sidebar::Section>
   {{/each}}
-
-  {{!-- DO NOT USE, this outlet is temporary and will be removed. --}}
-  {{!-- Outlet will be replaced with sidebar API. --}}
-  <PluginOutlet @name="after-sidebar" />
 </div>


### PR DESCRIPTION
That outlet was a temporary solution and is not used anymore

