### PR TITLE
DEV: Convert pm-topic-tracking-state to Ember Service

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer.js
@@ -16,6 +16,7 @@ export default class DiscourseGlimmerComponent extends GlimmerComponent {
   @service store;
   @service("search") searchService;
   @service keyValueStore;
+  @service pmTopicTrackingState;
 
   @cached
   get siteSettings() {
@@ -39,12 +40,6 @@ export default class DiscourseGlimmerComponent extends GlimmerComponent {
   get topicTrackingState() {
     const applicationInstance = getOwner(this);
     return applicationInstance.lookup("topic-tracking-state:main");
-  }
-
-  @cached
-  get pmTopicTrackingState() {
-    const applicationInstance = getOwner(this);
-    return applicationInstance.lookup("pm-topic-tracking-state:main");
   }
 
   @cached

--- a/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
@@ -1,7 +1,6 @@
 import TopicTrackingState, {
   startTracking,
 } from "discourse/models/topic-tracking-state";
-import PrivateMessageTopicTrackingState from "discourse/models/private-message-topic-tracking-state";
 import DiscourseLocation from "discourse/lib/discourse-location";
 import MessageBus from "message-bus-client";
 import Session from "discourse/models/session";
@@ -90,6 +89,15 @@ export default {
       dropFrom: "3.0.0",
     });
 
+    deprecateRegistration({
+      app,
+      container,
+      oldName: "pm-topic-tracking-state:main",
+      newName: "service:pm-topic-tracking-state",
+      since: "2.9.0.beta7",
+      dropFrom: "3.0.0",
+    });
+
     let siteSettings = container.lookup("site-settings:main");
 
     const currentUser = User.current();
@@ -106,15 +114,6 @@ export default {
       instantiate: false,
     });
 
-    const pmTopicTrackingState = PrivateMessageTopicTrackingState.create({
-      messageBus: MessageBus,
-      currentUser,
-    });
-
-    app.register("pm-topic-tracking-state:main", pmTopicTrackingState, {
-      instantiate: false,
-    });
-
     const site = Site.current();
     app.register("site:main", site, { instantiate: false });
 
@@ -125,7 +124,7 @@ export default {
 
     ALL_TARGETS.forEach((t) => {
       app.inject(t, "appEvents", "service:app-events");
-      app.inject(t, "pmTopicTrackingState", "pm-topic-tracking-state:main");
+      app.inject(t, "pmTopicTrackingState", "service:pm-topic-tracking-state");
       app.inject(t, "store", "service:store");
       app.inject(t, "site", "site:main");
       app.inject(t, "searchService", "service:search");

--- a/app/assets/javascripts/discourse/app/services/pm-topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/services/pm-topic-tracking-state.js
@@ -1,6 +1,6 @@
 import { Promise } from "rsvp";
 
-import EmberObject from "@ember/object";
+import Service from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { bind, on } from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -14,7 +14,7 @@ import {
 import { NotificationLevels } from "discourse/lib/notification-levels";
 
 // See private_message_topic_tracking_state.rb for documentation
-const PrivateMessageTopicTrackingState = EmberObject.extend({
+const PrivateMessageTopicTrackingState = Service.extend({
   CHANNEL_PREFIX: "/private-message-topic-tracking-state",
 
   inbox: null,

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-messages-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-messages-section-test.js
@@ -367,7 +367,7 @@ acceptance(
       await visit("/");
 
       const pmTopicTrackingState = this.container.lookup(
-        "pm-topic-tracking-state:main"
+        "service:pm-topic-tracking-state"
       );
 
       await publishToMessageBus(pmTopicTrackingState.groupChannel(1), {
@@ -440,7 +440,7 @@ acceptance(
       await visit("/");
 
       const pmTopicTrackingState = this.container.lookup(
-        "pm-topic-tracking-state:main"
+        "service:pm-topic-tracking-state"
       );
 
       await publishToMessageBus(pmTopicTrackingState.userChannel(), {

--- a/app/assets/javascripts/discourse/tests/unit/models/private-message-topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/private-message-topic-tracking-state-test.js
@@ -5,7 +5,7 @@ import {
   publishToMessageBus,
 } from "discourse/tests/helpers/qunit-helpers";
 import MessageBus from "message-bus-client";
-import PrivateMessageTopicTrackingState from "discourse/models/private-message-topic-tracking-state";
+import PrivateMessageTopicTrackingState from "discourse/services/pm-topic-tracking-state";
 import User from "discourse/models/user";
 
 function setupPretender() {


### PR DESCRIPTION
This will allow consumers to inject it using `pmTopicTrackingState: service()` in preparation for the removal of implicit injections in Ember 4.0. `pm-topic-tracking-state:main` is still available and will print a deprecation notice.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
