### PR TITLE
DEV: Remove workaround for advisory lock

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,6 @@ development:
   pool: 5
   timeout: 5000
   checkout_timeout: <%= ENV['CHECKOUT_TIMEOUT'] || 5 %>
-  advisory_locks: false # Disable until https://github.com/rails/rails/issues/40029 has been resolved.
   host_names:
     ### Don't include the port number here. Change the "port" site setting instead, at /admin/site_settings.
     ### If you change this setting you will need to
@@ -40,7 +39,6 @@ test:
   min_messages: warning
   pool: 5
   timeout: 5000
-  advisory_locks: false # Disable until https://github.com/rails/rails/issues/40029 has been resolved.
   host_names:
     - test.localhost
 


### PR DESCRIPTION
This reverts f08d440ea0c375e506d4db69d4f8b4db78ade910 because the issue has been resolved in Rails 6.1.0 and later.