### PR TITLE
DEV: Replace `message-bus:main` with `service:message-bus`

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/banner.js
+++ b/app/assets/javascripts/discourse/app/initializers/banner.js
@@ -11,7 +11,7 @@ export default {
 
     site.set("banner", banner);
 
-    const messageBus = container.lookup("message-bus:main");
+    const messageBus = container.lookup("service:message-bus");
     if (!messageBus) {
       return;
     }

--- a/app/assets/javascripts/discourse/app/initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/initializers/live-development.js
@@ -7,7 +7,7 @@ export default {
   name: "live-development",
 
   initialize(container) {
-    const messageBus = container.lookup("message-bus:main");
+    const messageBus = container.lookup("service:message-bus");
     const session = container.lookup("session:main");
 
     // Preserve preview_theme_id=## and pp=async-flamegraph parameters across pages

--- a/app/assets/javascripts/discourse/app/initializers/logout.js
+++ b/app/assets/javascripts/discourse/app/initializers/logout.js
@@ -10,7 +10,7 @@ export default {
   after: "message-bus",
 
   initialize(container) {
-    const messageBus = container.lookup("message-bus:main");
+    const messageBus = container.lookup("service:message-bus");
 
     if (!messageBus) {
       return;

--- a/app/assets/javascripts/discourse/app/initializers/logs-notice.js
+++ b/app/assets/javascripts/discourse/app/initializers/logs-notice.js
@@ -12,7 +12,7 @@ export default {
     }
 
     const siteSettings = container.lookup("site-settings:main");
-    const messageBus = container.lookup("message-bus:main");
+    const messageBus = container.lookup("service:message-bus");
     const keyValueStore = container.lookup("service:key-value-store");
     const currentUser = container.lookup("current-user:main");
     LogsNotice.reopenClass(Singleton, {

--- a/app/assets/javascripts/discourse/app/initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/initializers/message-bus.js
@@ -40,7 +40,7 @@ export default {
       return;
     }
 
-    const messageBus = container.lookup("message-bus:main"),
+    const messageBus = container.lookup("service:message-bus"),
       user = container.lookup("current-user:main"),
       siteSettings = container.lookup("site-settings:main");
 

--- a/app/assets/javascripts/discourse/app/initializers/read-only.js
+++ b/app/assets/javascripts/discourse/app/initializers/read-only.js
@@ -4,7 +4,7 @@ export default {
   after: "message-bus",
 
   initialize(container) {
-    const messageBus = container.lookup("message-bus:main");
+    const messageBus = container.lookup("service:message-bus");
     if (!messageBus) {
       return;
     }

--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -20,7 +20,7 @@ export default {
 
   initialize(container) {
     const user = container.lookup("current-user:main");
-    const bus = container.lookup("message-bus:main");
+    const bus = container.lookup("service:message-bus");
     const appEvents = container.lookup("service:app-events");
 
     if (user) {

--- a/app/assets/javascripts/discourse/app/services/message-bus.js
+++ b/app/assets/javascripts/discourse/app/services/message-bus.js
@@ -1,0 +1,9 @@
+import MessageBus from "message-bus-client";
+
+export default class MessageBusService {
+  static isServiceFactory = true;
+
+  static create() {
+    return MessageBus;
+  }
+}


### PR DESCRIPTION
This will allow consumers to inject it using `messageBus: service()` in preparation for the removal of implicit injections in Ember 4.0. `message-bus:main` is still available and will print a deprecation notice.

The MessageBus library is not en ember object, and doesn't need access to any of our injections. Therefore, we can set up a simple class which defines itself as a 'Service Factory', and returns the MessageBus library in the `create` method. Using 'plain old javascript objects' (POJOs) for services is not unusual. [Here is](https://github.com/tildeio/ember-swappable-service/blob/main/addon/index.js#L10) one other example where this approach is taken.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
