### PR TITLE
FIX: allow array values for custom fields in category params.

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -371,7 +371,7 @@ class CategoriesController < ApplicationController
         :read_only_banner,
         :default_list_filter,
         :reviewable_by_group_id,
-        custom_fields: [params[:custom_fields].try(:keys)],
+        custom_fields: [custom_field_params],
         permissions: [*p.try(:keys)],
         allowed_tags: [],
         allowed_tag_groups: [],
@@ -383,6 +383,15 @@ class CategoriesController < ApplicationController
       end
 
       result
+    end
+  end
+
+  def custom_field_params
+    keys = params[:custom_fields].try(:keys)
+    return if keys.blank?
+
+    keys.map do |key|
+      params[:custom_fields][key].is_a?(Array) ? { key => [] } : key
     end
   end
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -520,7 +520,8 @@ describe CategoriesController do
               "staff" => create_post
             },
             custom_fields: {
-              "dancing" => "frogs"
+              "dancing" => "frogs",
+              "running" => ["turtle", "salamander"]
             },
             minimum_required_tags: "",
             allow_global_tags: 'true',
@@ -539,7 +540,7 @@ describe CategoriesController do
           expect(category.slug).to eq("hello-category")
           expect(category.color).to eq("ff0")
           expect(category.auto_close_hours).to eq(72)
-          expect(category.custom_fields).to eq("dancing" => "frogs")
+          expect(category.custom_fields).to eq("dancing" => "frogs", "running" => ["turtle", "salamander"])
           expect(category.minimum_required_tags).to eq(0)
           expect(category.allow_global_tags).to eq(true)
           expect(category.category_required_tag_groups.count).to eq(1)


### PR DESCRIPTION
Previously, when we used `params[:custom_fields].try(:keys)` code it worked for all the custom fields unless it's an array. It created the problem in the discourse-restricted-replies plugin.

https://github.com/discourse/discourse-restricted-replies/pull/37#issuecomment-1194207693

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
