### PR TITLE
FIX: Ensure error handlers render correctly without preload_json

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -38,7 +38,12 @@ export default {
       preloaded = JSON.parse(preloadedDataElement.dataset.preloaded);
     }
 
-    Object.keys(preloaded).forEach(function (key) {
+    const keys = Object.keys(preloaded);
+    if (keys.length === 0) {
+      throw "No preload data found in #data-preloaded. Unable to boot Discourse.";
+    }
+
+    keys.forEach(function (key) {
       PreloadStore.store(key, JSON.parse(preloaded[key]));
 
       if (setupData.debugPreloadedAppData === "true") {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -339,7 +339,7 @@ class ApplicationController < ActionController::Base
         return render plain: message, status: status_code
       end
       with_resolved_locale do
-        error_page_opts[:layout] = opts[:include_ember] ? 'application' : 'no_ember'
+        error_page_opts[:layout] = (opts[:include_ember] && @preloaded) ? 'application' : 'no_ember'
         render html: build_not_found_page(error_page_opts)
       end
     end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -2000,10 +2000,17 @@ describe PostsController do
       expect(response).to be_redirect
     end
 
-    it "returns a 403 when access is denied" do
+    it "returns a 403 when access is denied for JSON format" do
       post = Fabricate(:private_message_post)
       get "/p/#{post.id}.json"
       expect(response).to be_forbidden
+    end
+
+    it "returns a 403 when access is denied for HTML format" do
+      post = Fabricate(:private_message_post)
+      get "/p/#{post.id}"
+      expect(response).to be_forbidden
+      expect(response.body).to have_tag("body.no-ember")
     end
 
     it "renders a 404 page" do


### PR DESCRIPTION
Some errors (e.g. InvalidAccess) are rendered with `include_ember: true`. Booting the ember app requires that the 'preload' data is rendered in the HTML.

If a particular route was configured to `skip_before_action :preload_json`, and then went on to raise an InvalidAccess error, then we'd attempt to render the Ember app without the preload json. This led to a blank screen and a client-side error.

This commit ensures that error pages will fallback to the no_ember view if there is no preload data. It also adds a sanity check in `discourse-bootstrap` so that it's easier for us to identify similar errors in future.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
