### PR TITLE
FIX: UserCommScreener filter acting user ID from target user IDs

### DIFF
--- a/lib/user_comm_screener.rb
+++ b/lib/user_comm_screener.rb
@@ -99,7 +99,7 @@ class UserCommScreener
   def initialize(acting_user: nil, acting_user_id: nil, target_user_ids:)
     raise ArgumentError if acting_user.blank? && acting_user_id.blank?
     @acting_user = acting_user.present? ? acting_user : User.find(acting_user_id)
-    @target_users = User.where(id: target_user_ids).pluck(:id, :username).to_h
+    @target_users = User.where(id: target_user_ids).where.not(id: @acting_user.id).pluck(:id, :username).to_h
     @preferences = load_preference_map
   end
 

--- a/lib/user_comm_screener.rb
+++ b/lib/user_comm_screener.rb
@@ -99,7 +99,8 @@ class UserCommScreener
   def initialize(acting_user: nil, acting_user_id: nil, target_user_ids:)
     raise ArgumentError if acting_user.blank? && acting_user_id.blank?
     @acting_user = acting_user.present? ? acting_user : User.find(acting_user_id)
-    @target_users = User.where(id: target_user_ids).where.not(id: @acting_user.id).pluck(:id, :username).to_h
+    target_user_ids = Array.wrap(target_user_ids) - [@acting_user.id]
+    @target_users = User.where(id: target_user_ids).pluck(:id, :username).to_h
     @preferences = load_preference_map
   end
 

--- a/spec/lib/user_comm_screener_spec.rb
+++ b/spec/lib/user_comm_screener_spec.rb
@@ -31,6 +31,12 @@ describe UserCommScreener do
     expect(screener.allowing_actor_communication).to eq([target_user1.id])
   end
 
+  it "filters out the acting user from target_user_ids" do
+    acting_user = Fabricate(:user)
+    screener = described_class.new(acting_user: acting_user, target_user_ids: [target_user1.id, acting_user.id])
+    expect(screener.allowing_actor_communication).to eq([target_user1.id])
+  end
+
   context "when the actor is not staff" do
     fab!(:acting_user) { Fabricate(:user) }
     fab!(:muted_user) { Fabricate(:muted_user, user: target_user1, muted_user: acting_user) }


### PR DESCRIPTION
Fixes edge case from fa5f3e228c102d4b9f7c6dde6eb07ef1f5880bbd.
In case the acting user is sent in with the target_user_ids,
we do not need to load those preferences, because even if the
acting user is preventing PMs or muting etc they need to always be able to
send themselves messages.
