### PR TITLE
DEV: Remove duplicate getter from category-section-link

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/categories-section/category-section-link.js
@@ -34,10 +34,6 @@ export default class CategorySectionLink {
     return this.category.slug;
   }
 
-  get route() {
-    return "discovery.latestCategory";
-  }
-
   get model() {
     return `${Category.slugFor(this.category)}/${this.category.id}`;
   }


### PR DESCRIPTION
It's redefined a few lines below
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
