### PR TITLE
FIX: show button bar overflow on iPad & mobile

### DIFF
--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -299,7 +299,11 @@
   border-bottom: 1px solid var(--primary-low);
   width: 100%;
   box-sizing: border-box;
-  overflow-x: auto;
+
+  html:not(.keyboard-visible) & {
+    overflow-x: auto; // hiding overflow breaks the cog menu on iPad and mobile
+  }
+
   flex-shrink: 0;
 
   .d-editor-spacer {

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -235,8 +235,3 @@
     margin-right: 6px;
   }
 }
-
-.d-editor-button-bar {
-  // can't hide overflow here because it hides the cog menu dropdown
-  overflow: unset;
-}


### PR DESCRIPTION
The exception needs to work for iPads and mobile; the keyboard visible class seems to do the trick. 

We'll need to come up with a different way to handle overflow here in general. 

Issue reported here: https://meta.discourse.org/t/no-gear-icon-menu-for-moderator/234167