### PR TITLE
UX: sidebar appearance shouldn't shrink fonts

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -196,25 +196,10 @@
 
 /* Tablet (portrait) ----------- */
 
-@include breakpoint(medium, $sidebar: true) {
-  // slightly smaller font, tighten spacing on nav pills
-  .nav-pills {
-    > li > a {
-      font-size: $font-0;
-      padding: 7px 10px;
-    }
-  }
+// These styles kick in a little earlier when the sidebar appears
 
+@include breakpoint(medium, $sidebar: true) {
   .topic-list {
-    // tighter table header spacing
-    .topic-list-item .topic-list-data:first-of-type {
-      padding: 12px 5px;
-    }
-    // smaller table cell spacing
-    .topic-list-data {
-      padding: 10px;
-      font-size: $font-0;
-    }
     // suppress views column
     .views {
       display: none;
@@ -242,6 +227,28 @@
           margin: 0 auto;
         }
       }
+    }
+  }
+}
+
+@include breakpoint(medium) {
+  // slightly smaller font, tighten spacing on nav pills
+  .nav-pills {
+    > li > a {
+      font-size: $font-0;
+      padding: 7px 10px;
+    }
+  }
+
+  .topic-list {
+    // tighter table header spacing
+    .topic-list-item .topic-list-data:first-of-type {
+      padding: 12px 5px;
+    }
+    // smaller table cell spacing
+    .topic-list-data {
+      padding: 10px;
+      font-size: $font-0;
     }
   }
 }


### PR DESCRIPTION
Previously when the sidebar appeared it would shrink the width of the topic list and reduce the font size of topic titles. This change will mean that the font size won't be impacted by the appearance of the sidebar. 