### PR TITLE
DEV: Use relative URLs for theme_uploads_local

### DIFF
--- a/app/models/javascript_cache.rb
+++ b/app/models/javascript_cache.rb
@@ -12,7 +12,7 @@ class JavascriptCache < ActiveRecord::Base
   end
 
   def local_url
-    "#{Discourse.base_url}#{path}"
+    "#{Discourse.base_path}/#{path}"
   end
 
   private


### PR DESCRIPTION
Relative URLs will work just fine for Web Workers, which were the original reason for introducing the `theme_uploads_local` feature

Making them relative will mean that `loadScript()` automatically uses the CDN (when enabled), which is doubly important because our CSP doesn't allow loading theme-javascripts from the host domain when the CDN is enabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
