### PR TITLE
FIX: Ensure theme_uploads_local only has one `/` at beginning

### DIFF
--- a/app/models/javascript_cache.rb
+++ b/app/models/javascript_cache.rb
@@ -12,7 +12,7 @@ class JavascriptCache < ActiveRecord::Base
   end
 
   def local_url
-    "#{Discourse.base_path}/#{path}"
+    "#{Discourse.base_path}#{path}"
   end
 
   private

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -504,6 +504,7 @@ HTML
 
         expect(val["theme_uploads"]["test_js"]).to eq(js_field.upload.url)
         expect(val["theme_uploads_local"]["test_js"]).to eq(js_field.javascript_cache.local_url)
+        expect(val["theme_uploads_local"]["test_js"]).to start_with("/theme-javascripts/")
 
       end
 


### PR DESCRIPTION
Followup to c7dfb1c549c29e560ea24558bc1a32d8991625c2

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
