### PR TITLE
FIX: Get rid of new line for group

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -171,7 +171,7 @@
       }
 
       .groups {
-        margin-left: 10px;
+        margin-left: 0px;
         display: inline;
       }
 

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -171,7 +171,6 @@
       }
 
       .groups {
-        margin-left: 0px;
         display: inline;
       }
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

The "Groups" text spans 2 lines, this will fix that.

Before:
![image](https://user-images.githubusercontent.com/91509874/181655988-c7ae3635-103e-4b52-884f-76583d67cbaa.png)
After:
![image](https://user-images.githubusercontent.com/91509874/181656099-05626e04-c772-442b-a7b7-d72e8c66984d.png)
