### PR TITLE
FIX: Show bookmarks loading spinner correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -15,7 +15,7 @@ export default Controller.extend({
 
   application: controller(),
   user: controller(),
-  loading: false,
+  loading: true,
   loadingMore: false,
   permissionDenied: false,
   inSearchMode: notEmpty("q"),

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -9,6 +9,11 @@ export default DiscourseRoute.extend({
     q: { refreshModel: true },
   },
 
+  setupController(controller) {
+    this._super(...arguments);
+    controller.set("loading", false);
+  },
+
   model(params, transition) {
     const controller = this.controllerFor("user-activity-bookmarks");
 
@@ -51,15 +56,6 @@ export default DiscourseRoute.extend({
   didTransition() {
     this.controllerFor("user-activity")._showFooter();
     return true;
-  },
-
-  @action
-  loading(transition) {
-    let controller = this.controllerFor("user-activity-bookmarks");
-    controller.set("loading", true);
-    transition.promise.finally(function () {
-      controller.set("loading", false);
-    });
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -9,11 +9,6 @@ export default DiscourseRoute.extend({
     q: { refreshModel: true },
   },
 
-  setupController(controller) {
-    this._super(...arguments);
-    controller.set("loading", false);
-  },
-
   model(params, transition) {
     const controller = this.controllerFor("user-activity-bookmarks");
 
@@ -43,6 +38,7 @@ export default DiscourseRoute.extend({
 
         const model = { bookmarks, loadMoreUrl };
         this.session.set("bookmarksModel", model);
+        controller.set("loading", false);
         return model;
       })
       .catch(() => controller.set("permissionDenied", true));

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -38,10 +38,10 @@ export default DiscourseRoute.extend({
 
         const model = { bookmarks, loadMoreUrl };
         this.session.set("bookmarksModel", model);
-        controller.set("loading", false);
         return model;
       })
-      .catch(() => controller.set("permissionDenied", true));
+      .catch(() => controller.set("permissionDenied", true))
+      .finally(() => controller.set("loading", false));
   },
 
   renderTemplate() {


### PR DESCRIPTION
There was a minor issue where the bookmark loading
spinner would not show correctly because of how
the route was handling the setting of loading,
this fixes the issue.