### PR TITLE
DEV: Use toggle event for sidebar more-section-links component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
@@ -41,8 +41,6 @@ export default class SidebarMoreSectionLinks extends GlimmerComponent {
         document
           .querySelector(".sidebar-more-section-links-details")
           ?.removeAttribute("open");
-
-        this.toggleSectionLinks();
       }
     }
   }

--- a/app/assets/javascripts/discourse/app/templates/components/sidebar/more-section-links.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar/more-section-links.hbs
@@ -10,7 +10,7 @@
     @model={{this.activeSectionLink.model}} />
 {{/if}}
 
-<details class="sidebar-more-section-links-details" {{on "click" this.toggleSectionLinks}}>
+<details class="sidebar-more-section-links-details" {{on "toggle" this.toggleSectionLinks}}>
   <summary class="sidebar-more-section-links-details-summary" >
     {{i18n "sidebar.more_count" (hash count=this.sectionLinks.length)}}
   </summary>


### PR DESCRIPTION
A click event is trigger on a link click as well which is not what we
want. This caused the links to trigger a full reload instead of an Ember
transition for some reason.

### Final behaviour

![Peek 2022-07-29 11-38](https://user-images.githubusercontent.com/4335742/181677909-77cc5d90-2e53-4aca-947f-6dad3c0b6dab.gif)
