### PR TITLE
UX: adjust sidebar margin to avoid composer height

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-body.js
+++ b/app/assets/javascripts/discourse/app/components/composer-body.js
@@ -107,8 +107,9 @@ export default Component.extend(KeyEnterEscape, {
     const minHeight = parseInt(getComputedStyle(this.element).minHeight, 10);
     size = Math.max(minHeight, size);
 
-    ["--reply-composer-height", "--new-topic-composer-height"].forEach((prop) =>
-      document.documentElement.style.setProperty(prop, size ? `${size}px` : "")
+    document.documentElement.style.setProperty(
+      "--composer-height",
+      size ? `${size}px` : ""
     );
 
     this._triggerComposerResized();

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1259,6 +1259,19 @@ export default Controller.extend({
       if (opts.topicBody) {
         this.model.set("reply", opts.topicBody);
       }
+
+      let defaultComposerHeight;
+
+      if (this.model.title == null) {
+        defaultComposerHeight = "300px";
+      } else {
+        defaultComposerHeight = "400px";
+      }
+
+      document.documentElement.style.setProperty(
+        "--composer-height",
+        defaultComposerHeight
+      );
     });
 
     return promise;

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1260,7 +1260,8 @@ export default Controller.extend({
         this.model.set("reply", opts.topicBody);
       }
 
-      const defaultComposerHeight = this.model.action === "reply" ? "300px" : "400px";
+      const defaultComposerHeight =
+        this.model.action === "reply" ? "300px" : "400px";
 
       document.documentElement.style.setProperty(
         "--composer-height",

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1260,13 +1260,7 @@ export default Controller.extend({
         this.model.set("reply", opts.topicBody);
       }
 
-      let defaultComposerHeight;
-
-      if (this.model.action === "reply") {
-        defaultComposerHeight = "300px";
-      } else {
-        defaultComposerHeight = "400px";
-      }
+      const defaultComposerHeight = this.model.action === "reply" ? "300px" : "400px";
 
       document.documentElement.style.setProperty(
         "--composer-height",

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1262,7 +1262,7 @@ export default Controller.extend({
 
       let defaultComposerHeight;
 
-      if (this.model.title == null) {
+      if (this.model.action === "reply") {
         defaultComposerHeight = "300px";
       } else {
         defaultComposerHeight = "400px";

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1,10 +1,6 @@
-:root {
-  --reply-composer-height: 300px;
-  --new-topic-composer-height: 400px;
-}
 html.composer-open {
   #main-outlet {
-    padding-bottom: var(--reply-composer-height);
+    padding-bottom: var(--composer-height);
     transition: padding-bottom 250ms ease;
   }
 }
@@ -53,11 +49,7 @@ html.composer-open {
   }
 
   &.open {
-    height: var(--reply-composer-height);
-    &.edit-title {
-      // more room when editing the title
-      height: var(--new-topic-composer-height);
-    }
+    height: var(--composer-height);
   }
 
   &.closed {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -63,7 +63,8 @@
 
     .composer-open & {
       // allows sidebar to scroll to the bottom when the composer is open
-      margin-bottom: calc(var(--composer-height));
+      margin-bottom: var(--composer-height);
+      padding-bottom: var(--composer-ipad-padding);
     }
   }
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -60,6 +60,11 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+
+    .composer-open & {
+      // allows sidebar to scroll to the bottom when the composer is open
+      margin-bottom: calc(var(--composer-height));
+    }
   }
 
   .sidebar-sections {


### PR DESCRIPTION
This adds some margin to the sidebar when the composer is open, so all the items within can be scrolled to. Similar to the behavior of the bottom of the topic page when the composer is open. 

![Screen Shot 2022-07-29 at 1 19 50 PM](https://user-images.githubusercontent.com/1681963/181811257-39c7c014-cc43-4b91-aba4-52605a3dc15b.png)

I moved the reply vs new-topic height logic to the controller and simplified to one `--composer-height` variable because I ran into trouble using either `--reply-composer-height` or `--new-topic-composer-height` in CSS, because they were both always set to their last value. So for example, I couldn't fallback to one or the other using `var(--new-topic-composer-height, var(--reply-composer-height));` because upon switch `--new-topic-composer-height` was still set. 



