### PR TITLE
UX: Change unrelated icon in the CTA Signup prompt

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/signup-cta.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/signup-cta.hbs
@@ -8,7 +8,7 @@
     <p>{{replace-emoji (i18n "signup_cta.value_prop")}}</p>
 
     <div class="buttons">
-      <DButton @action={{route-action "showCreateAccount"}} @label="signup_cta.sign_up" @icon="check" @class="btn-primary" />
+      <DButton @action={{route-action "showCreateAccount"}} @label="signup_cta.sign_up" @icon="user" @class="btn-primary" />
       <DButton @action={{action "hideForSession"}} @label="signup_cta.hide_session" @class="no-icon" />
       <a href {{action "neverShow"}}>{{i18n "signup_cta.hide_forever"}}</a>
     </div>


### PR DESCRIPTION
The CTA Signup icon is misleading (a check), so this makes it a person to be consistent with the real sign up button
Before:
![image](https://user-images.githubusercontent.com/91509874/181860595-6658d5cf-a1ac-47d9-90a5-188fd9338c16.png)
After:
![image](https://user-images.githubusercontent.com/91509874/181860687-d433742c-00c9-4f28-9a37-2f5b51d0f949.png)
