### PR TITLE
DEV: Replace `site-settings:main` with `service:site-settings`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer.js
@@ -17,12 +17,7 @@ export default class DiscourseGlimmerComponent extends GlimmerComponent {
   @service("search") searchService;
   @service keyValueStore;
   @service pmTopicTrackingState;
-
-  @cached
-  get siteSettings() {
-    const applicationInstance = getOwner(this);
-    return applicationInstance.lookup("site-settings:main");
-  }
+  @service siteSettings;
 
   @cached
   get currentUser() {

--- a/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
+++ b/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
@@ -18,7 +18,7 @@ export function autoLoadModules(container, registry) {
   });
 
   let context = {
-    siteSettings: container.lookup("site-settings:main"),
+    siteSettings: container.lookup("service:site-settings"),
     keyValueStore: container.lookup("service:key-value-store"),
     capabilities: container.lookup("capabilities:main"),
     currentUser: container.lookup("current-user:main"),

--- a/app/assets/javascripts/discourse/app/initializers/codeblock-buttons.js
+++ b/app/assets/javascripts/discourse/app/initializers/codeblock-buttons.js
@@ -8,7 +8,7 @@ export default {
   name: "codeblock-buttons",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
 
     withPluginApi("0.8.7", (api) => {
       function _cleanUp() {

--- a/app/assets/javascripts/discourse/app/initializers/enable-emoji.js
+++ b/app/assets/javascripts/discourse/app/initializers/enable-emoji.js
@@ -6,7 +6,7 @@ export default {
   name: "enable-emoji",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (!siteSettings.enable_emoji) {
       return;
     }

--- a/app/assets/javascripts/discourse/app/initializers/inject-objects.js
+++ b/app/assets/javascripts/discourse/app/initializers/inject-objects.js
@@ -19,7 +19,7 @@ export default {
             dropFrom: "2.9",
           }
         );
-        return container.lookup("site-settings:main");
+        return container.lookup("service:site-settings");
       },
     });
     Object.defineProperty(app, "User", {

--- a/app/assets/javascripts/discourse/app/initializers/localization.js
+++ b/app/assets/javascripts/discourse/app/initializers/localization.js
@@ -6,7 +6,7 @@ export default {
   after: "inject-objects",
 
   isVerboseLocalizationEnabled(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (siteSettings.verbose_localization) {
       return true;
     }

--- a/app/assets/javascripts/discourse/app/initializers/logs-notice.js
+++ b/app/assets/javascripts/discourse/app/initializers/logs-notice.js
@@ -11,7 +11,7 @@ export default {
       return;
     }
 
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     const messageBus = container.lookup("service:message-bus");
     const keyValueStore = container.lookup("service:key-value-store");
     const currentUser = container.lookup("current-user:main");

--- a/app/assets/javascripts/discourse/app/initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/initializers/message-bus.js
@@ -42,7 +42,7 @@ export default {
 
     const messageBus = container.lookup("service:message-bus"),
       user = container.lookup("current-user:main"),
-      siteSettings = container.lookup("site-settings:main");
+      siteSettings = container.lookup("service:site-settings");
 
     messageBus.alwaysLongPoll = !isProduction();
     messageBus.shouldLongPollCallback = () =>

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -14,7 +14,7 @@ export default {
   name: "post-decorations",
   initialize(container) {
     withPluginApi("0.1", (api) => {
-      const siteSettings = container.lookup("site-settings:main");
+      const siteSettings = container.lookup("service:site-settings");
       const session = container.lookup("session:main");
       const site = container.lookup("site:main");
       api.decorateCookedElement(

--- a/app/assets/javascripts/discourse/app/initializers/register-media-optimization-upload-processor.js
+++ b/app/assets/javascripts/discourse/app/initializers/register-media-optimization-upload-processor.js
@@ -5,7 +5,7 @@ export default {
   name: "register-media-optimization-upload-processor",
 
   initialize(container) {
-    let siteSettings = container.lookup("site-settings:main");
+    let siteSettings = container.lookup("service:site-settings");
     if (siteSettings.composer_media_optimization_image_enabled) {
       addComposerUploadPreProcessor(
         UppyMediaOptimization,

--- a/app/assets/javascripts/discourse/app/initializers/sharing-sources.js
+++ b/app/assets/javascripts/discourse/app/initializers/sharing-sources.js
@@ -5,7 +5,7 @@ export default {
   name: "sharing-sources",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
 
     Sharing.addSource({
       id: "twitter",

--- a/app/assets/javascripts/discourse/app/initializers/signup-cta.js
+++ b/app/assets/javascripts/discourse/app/initializers/signup-cta.js
@@ -11,7 +11,7 @@ export default {
   initialize(container) {
     const screenTrack = container.lookup("service:screen-track");
     const session = Session.current();
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     const keyValueStore = container.lookup("service:key-value-store");
     const user = container.lookup("current-user:main");
     const appEvents = container.lookup("service:app-events");

--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -122,7 +122,7 @@ export default {
       });
 
       const site = container.lookup("site:main");
-      const siteSettings = container.lookup("site-settings:main");
+      const siteSettings = container.lookup("service:site-settings");
       const router = container.lookup("router:main");
 
       bus.subscribe("/categories", (data) => {

--- a/app/assets/javascripts/discourse/app/initializers/url-redirects.js
+++ b/app/assets/javascripts/discourse/app/initializers/url-redirects.js
@@ -23,7 +23,7 @@ export default {
     DiscourseURL.rewrite(/^\/groups\//, "/g/");
 
     // Initialize default homepage
-    let siteSettings = container.lookup("site-settings:main");
+    let siteSettings = container.lookup("service:site-settings");
     initializeDefaultHomepage(siteSettings);
 
     DiscourseURL.rewrite(/^\/u\/([^\/]+)\/?$/, "/u/$1/summary", {

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -136,7 +136,7 @@ export default {
     this.searchService = this.container.lookup("service:search");
     this.appEvents = this.container.lookup("service:app-events");
     this.currentUser = this.container.lookup("current-user:main");
-    this.siteSettings = this.container.lookup("site-settings:main");
+    this.siteSettings = this.container.lookup("service:site-settings");
 
     // Disable the shortcut if private messages are disabled
     if (!this.siteSettings.enable_personal_messages) {

--- a/app/assets/javascripts/discourse/app/models/category.js
+++ b/app/assets/javascripts/discourse/app/models/category.js
@@ -344,7 +344,7 @@ let _uncategorized;
 
 Category.reopenClass({
   slugEncoded() {
-    let siteSettings = getOwner(this).lookup("site-settings:main");
+    let siteSettings = getOwner(this).lookup("service:site-settings");
     return siteSettings.slug_generation_method === "encoded";
   },
 

--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -244,7 +244,7 @@ NavItem.reopenClass({
         since: "2.6.0",
         dropFrom: "2.7.0",
       });
-      args.siteSettings = getOwner(this).lookup("site-settings:main");
+      args.siteSettings = getOwner(this).lookup("service:site-settings");
     }
     let items = args.siteSettings.top_menu.split("|");
 

--- a/app/assets/javascripts/discourse/app/models/rest.js
+++ b/app/assets/javascripts/discourse/app/models/rest.js
@@ -110,7 +110,7 @@ RestModel.reopenClass({
       args.store = owner.lookup("service:store");
     }
     if (!args.siteSettings) {
-      args.siteSettings = owner.lookup("site-settings:main");
+      args.siteSettings = owner.lookup("service:site-settings");
     }
     if (!args.appEvents) {
       args.appEvents = owner.lookup("service:appEvents");

--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -17,7 +17,7 @@ export default {
   name: "discourse-bootstrap",
 
   // The very first initializer to run
-  initialize(container, app) {
+  initialize(container) {
     setURLContainer(container);
     setDefaultOwner(container);
 
@@ -54,7 +54,6 @@ export default {
 
     setupURL(setupData.cdn, setupData.baseUrl, setupData.baseUri);
     setEnvironment(setupData.environment);
-    app.SiteSettings = PreloadStore.get("siteSettings");
     I18n.defaultLocale = setupData.defaultLocale;
 
     window.Logster = window.Logster || {};

--- a/app/assets/javascripts/discourse/app/services/site-settings.js
+++ b/app/assets/javascripts/discourse/app/services/site-settings.js
@@ -1,0 +1,9 @@
+import PreloadStore from "discourse/lib/preload-store";
+
+export default class SiteSettingsService {
+  static isServiceFactory = true;
+
+  static create() {
+    return PreloadStore.get("siteSettings");
+  }
+}

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -141,7 +141,7 @@ export default class Widget {
 
     this.key = this.buildKey ? this.buildKey(attrs) : null;
     this.site = register.lookup("site:main");
-    this.siteSettings = register.lookup("site-settings:main");
+    this.siteSettings = register.lookup("service:site-settings");
     this.currentUser = register.lookup("current-user:main");
     this.capabilities = register.lookup("capabilities:main");
     this.store = register.lookup("service:store");

--- a/app/assets/javascripts/discourse/tests/helpers/create-store.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-store.js
@@ -73,7 +73,7 @@ export default function (customLookup = () => {}) {
           this._tracker = this._tracker || TopicTrackingState.create();
           return this._tracker;
         }
-        if (type === "site-settings:main") {
+        if (type === "service:site-settings") {
           this._settings = this._settings || currentSettings();
           return this._settings;
         }

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -28,11 +28,11 @@ import { buildResolver } from "discourse-common/resolver";
 import { createHelperContext } from "discourse-common/lib/helpers";
 import deprecated from "discourse-common/lib/deprecated";
 import { flushMap } from "discourse/services/store";
-import { registerObjects } from "discourse/pre-initializers/inject-discourse-objects";
 import sinon from "sinon";
 import { disableCloaking } from "discourse/widgets/post-stream";
 import { clearState as clearPresenceState } from "discourse/tests/helpers/presence-pretender";
 import { addModuleExcludeMatcher } from "ember-cli-test-loader/test-support/index";
+import SiteSettingService from "discourse/services/site-settings";
 
 const Plugin = $.fn.modal;
 const Modal = Plugin.Constructor;
@@ -94,6 +94,8 @@ function createApplication(config, settings) {
       return container;
     });
 
+  SiteSettingService.create = () => settings;
+
   if (!started) {
     app.instanceInitializer({
       name: "test-helper",
@@ -105,8 +107,6 @@ function createApplication(config, settings) {
     started = true;
   }
 
-  app.SiteSettings = settings;
-  registerObjects(app);
   return app;
 }
 
@@ -278,7 +278,7 @@ export default function setupTests(config) {
 
     createHelperContext({
       get siteSettings() {
-        return app.__container__.lookup("site-settings:main");
+        return app.__container__.lookup("service:site-settings");
       },
       capabilities: {},
       get site() {

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -109,7 +109,7 @@ function _rangeElements(element) {
 }
 
 function initializeDiscourseLocalDates(api) {
-  const siteSettings = api.container.lookup("site-settings:main");
+  const siteSettings = api.container.lookup("service:site-settings");
   const defaultTitle = I18n.t("discourse_local_dates.default_title", {
     site_name: siteSettings.title,
   });
@@ -336,7 +336,7 @@ export default {
       return;
     }
 
-    const siteSettings = owner.lookup("site-settings:main");
+    const siteSettings = owner.lookup("service:site-settings");
 
     showPopover(event, {
       trigger: "click",
@@ -357,7 +357,7 @@ export default {
   initialize(container) {
     window.addEventListener("click", this.showDatePopover);
 
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (siteSettings.discourse_local_dates_enabled) {
       $.fn.applyLocalDates = function () {
         deprecated(

--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
@@ -119,7 +119,7 @@ export default {
   name: "new-user-narratve",
 
   initialize(container) {
-    const siteSettings = container.lookup("site-settings:main");
+    const siteSettings = container.lookup("service:site-settings");
     if (siteSettings.discourse_narrative_bot_enabled) {
       withPluginApi("0.8.7", initialize);
     }

--- a/plugins/poll/assets/javascripts/initializers/extend-for-poll.js
+++ b/plugins/poll/assets/javascripts/initializers/extend-for-poll.js
@@ -24,8 +24,9 @@ function cleanUpPolls() {
 
 function initializePolls(api) {
   const register = getRegister(api),
-    pollGroupableUserFields =
-      api.container.lookup("site-settings:main").poll_groupable_user_fields;
+    pollGroupableUserFields = api.container.lookup(
+      "service:site-settings"
+    ).poll_groupable_user_fields;
   cleanUpPolls();
 
   api.modifyClass("controller:topic", {


### PR DESCRIPTION
This will allow consumers to inject it using `siteSettings: service()` in preparation for the removal of implicit injections in Ember 4.0. `site-settings:main` is still available and will print a deprecation notice.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
