### PR TITLE
DEV: Replace `current-user:main` with `service:current-user`

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -68,6 +68,11 @@ const DEPRECATED_MODULES = new Map(
       since: "2.9.0.beta7",
       dropFrom: "3.0.0",
     },
+    "current-user:main": {
+      newName: "service:current-user",
+      since: "2.9.0.beta7",
+      dropFrom: "3.0.0",
+    },
   })
 );
 

--- a/app/assets/javascripts/discourse/app/components/glimmer.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer.js
@@ -18,12 +18,7 @@ export default class DiscourseGlimmerComponent extends GlimmerComponent {
   @service keyValueStore;
   @service pmTopicTrackingState;
   @service siteSettings;
-
-  @cached
-  get currentUser() {
-    const applicationInstance = getOwner(this);
-    return applicationInstance.lookup("current-user:main");
-  }
+  @service currentUser;
 
   @cached
   get messageBus() {

--- a/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
+++ b/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
@@ -21,7 +21,7 @@ export function autoLoadModules(container, registry) {
     siteSettings: container.lookup("service:site-settings"),
     keyValueStore: container.lookup("service:key-value-store"),
     capabilities: container.lookup("capabilities:main"),
-    currentUser: container.lookup("current-user:main"),
+    currentUser: container.lookup("service:current-user"),
     site: container.lookup("site:main"),
     session: container.lookup("session:main"),
     topicTrackingState: container.lookup("topic-tracking-state:main"),

--- a/app/assets/javascripts/discourse/app/initializers/badging.js
+++ b/app/assets/javascripts/discourse/app/initializers/badging.js
@@ -8,7 +8,7 @@ export default {
       return;
     } // must have the Badging API
 
-    const user = container.lookup("current-user:main");
+    const user = container.lookup("service:current-user");
     if (!user) {
       return;
     } // must be logged in

--- a/app/assets/javascripts/discourse/app/initializers/logs-notice.js
+++ b/app/assets/javascripts/discourse/app/initializers/logs-notice.js
@@ -14,7 +14,7 @@ export default {
     const siteSettings = container.lookup("service:site-settings");
     const messageBus = container.lookup("service:message-bus");
     const keyValueStore = container.lookup("service:key-value-store");
-    const currentUser = container.lookup("current-user:main");
+    const currentUser = container.lookup("service:current-user");
     LogsNotice.reopenClass(Singleton, {
       createCurrent() {
         return this.create({

--- a/app/assets/javascripts/discourse/app/initializers/message-bus.js
+++ b/app/assets/javascripts/discourse/app/initializers/message-bus.js
@@ -41,7 +41,7 @@ export default {
     }
 
     const messageBus = container.lookup("service:message-bus"),
-      user = container.lookup("current-user:main"),
+      user = container.lookup("service:current-user"),
       siteSettings = container.lookup("service:site-settings");
 
     messageBus.alwaysLongPoll = !isProduction();

--- a/app/assets/javascripts/discourse/app/initializers/signup-cta.js
+++ b/app/assets/javascripts/discourse/app/initializers/signup-cta.js
@@ -13,7 +13,7 @@ export default {
     const session = Session.current();
     const siteSettings = container.lookup("service:site-settings");
     const keyValueStore = container.lookup("service:key-value-store");
-    const user = container.lookup("current-user:main");
+    const user = container.lookup("service:current-user");
     const appEvents = container.lookup("service:app-events");
 
     // Preconditions

--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -19,7 +19,7 @@ export default {
   after: "message-bus",
 
   initialize(container) {
-    const user = container.lookup("current-user:main");
+    const user = container.lookup("service:current-user");
     const bus = container.lookup("service:message-bus");
     const appEvents = container.lookup("service:app-events");
 

--- a/app/assets/javascripts/discourse/app/initializers/url-redirects.js
+++ b/app/assets/javascripts/discourse/app/initializers/url-redirects.js
@@ -7,7 +7,7 @@ export default {
   after: "inject-objects",
 
   initialize(container) {
-    const currentUser = container.lookup("current-user:main");
+    const currentUser = container.lookup("service:current-user");
     if (currentUser) {
       const username = currentUser.get("username");
       const escapedUsername = escapeRegExp(username);

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -135,7 +135,7 @@ export default {
 
     this.searchService = this.container.lookup("service:search");
     this.appEvents = this.container.lookup("service:app-events");
-    this.currentUser = this.container.lookup("current-user:main");
+    this.currentUser = this.container.lookup("service:current-user");
     this.siteSettings = this.container.lookup("service:site-settings");
 
     // Disable the shortcut if private messages are disabled

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -152,7 +152,7 @@ class PluginApi {
    * If the user is not logged in, it will be `null`.
    **/
   getCurrentUser() {
-    return this._lookupContainer("current-user:main");
+    return this._lookupContainer("service:current-user");
   }
 
   _lookupContainer(path) {

--- a/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
@@ -8,12 +8,18 @@ import User from "discourse/models/user";
 
 const ALL_TARGETS = ["controller", "component", "route", "model", "adapter"];
 
-function injectServiceIntoService({ container, app, property, specifier }) {
+function injectServiceIntoService({ app, property, specifier }) {
   // app.inject doesn't allow implicit injection of services into services.
   // However, we need to do it in order to convert our old service-like objects
   // into true services, without breaking existing implicit injections.
   // This hack will be removed when we remove implicit injections for the Ember 4.0 update.
-  container.lookup(specifier);
+
+  // Supplying a specific injection with the same property name prevents the infinite
+  // which would be caused by injecting a service into itself
+  app.register("discourse:null", null, { instantiate: false });
+  app.inject(specifier, property, "discourse:null");
+
+  // Bypass the validation in `app.inject` by adding directly to the array
   app.__registry__._typeInjections["service"].push({
     property,
     specifier,
@@ -64,20 +70,17 @@ export default {
 
     app.inject("service", "session", "session:main");
     injectServiceIntoService({
-      container,
       app,
       property: "messageBus",
       specifier: "service:message-bus",
     });
     injectServiceIntoService({
-      container,
       app,
       property: "siteSettings",
       specifier: "service:site-settings",
     });
     app.inject("service", "topicTrackingState", "topic-tracking-state:main");
     injectServiceIntoService({
-      container,
       app,
       property: "keyValueStore",
       specifier: "service:key-value-store",

--- a/app/assets/javascripts/discourse/app/pre-initializers/theme-errors-handler.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/theme-errors-handler.js
@@ -20,7 +20,7 @@ export default {
       return;
     }
 
-    this.currentUser = container.lookup("current-user:main");
+    this.currentUser = container.lookup("service:current-user");
 
     getAndClearUnhandledThemeErrors().forEach((e) => {
       reportThemeError(this.currentUser, e);

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -142,7 +142,7 @@ export default class Widget {
     this.key = this.buildKey ? this.buildKey(attrs) : null;
     this.site = register.lookup("site:main");
     this.siteSettings = register.lookup("service:site-settings");
-    this.currentUser = register.lookup("current-user:main");
+    this.currentUser = register.lookup("service:current-user");
     this.capabilities = register.lookup("capabilities:main");
     this.store = register.lookup("service:store");
     this.appEvents = register.lookup("service:app-events");

--- a/app/assets/javascripts/discourse/tests/helpers/component-test.js
+++ b/app/assets/javascripts/discourse/tests/helpers/component-test.js
@@ -8,6 +8,7 @@ import QUnit, { test } from "qunit";
 import { setupRenderingTest as emberSetupRenderingTest } from "ember-qunit";
 import { currentSettings } from "discourse/tests/helpers/site-settings";
 import { testCleanup } from "discourse/tests/helpers/qunit-helpers";
+import { injectServiceIntoService } from "discourse/pre-initializers/inject-discourse-objects";
 
 export function setupRenderingTest(hooks) {
   emberSetupRenderingTest(hooks);
@@ -31,12 +32,16 @@ export function setupRenderingTest(hooks) {
       timezone: "Australia/Brisbane",
     });
     this.currentUser = currentUser;
-    this.owner.unregister("current-user:main");
-    this.owner.register("current-user:main", currentUser, {
+    this.owner.unregister("service:current-user");
+    this.owner.register("service:current-user", currentUser, {
       instantiate: false,
     });
-    this.owner.inject("component", "currentUser", "current-user:main");
-    this.owner.inject("service", "currentUser", "current-user:main");
+    this.owner.inject("component", "currentUser", "service:current-user");
+    injectServiceIntoService({
+      app: this.owner.application,
+      property: "currentUser",
+      specifier: "service:current-user",
+    });
 
     this.owner.unregister("topic-tracking-state:main");
     this.owner.register(
@@ -85,7 +90,7 @@ export default function (name, hooks, opts) {
 
   test(name, async function (assert) {
     if (opts.anonymous) {
-      this.owner.unregister("current-user:main");
+      this.owner.unregister("service:current-user");
     }
 
     if (opts.beforeEach) {

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -32,7 +32,7 @@ module("Integration | Component | site-header", function (hooks) {
   });
 
   test("do not call authenticated endpoints as anonymous", async function (assert) {
-    this.owner.unregister("current-user:main");
+    this.owner.unregister("service:current-user");
 
     await render(hbs`<SiteHeader />`);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/hamburger-menu-test.js
@@ -68,7 +68,7 @@ module("Integration | Component | Widget | hamburger-menu", function (hooks) {
   });
 
   test("general links", async function (assert) {
-    this.owner.unregister("current-user:main");
+    this.owner.unregister("service:current-user");
 
     await render(hbs`<MountWidget @widget="hamburger-menu" />`);
 
@@ -86,7 +86,7 @@ module("Integration | Component | Widget | hamburger-menu", function (hooks) {
   let maxCategoriesToDisplay;
 
   test("top categories - anonymous", async function (assert) {
-    this.owner.unregister("current-user:main");
+    this.owner.unregister("service:current-user");
     this.siteSettings.header_dropdown_category_count = 8;
 
     await render(hbs`<MountWidget @widget="hamburger-menu" />`);
@@ -102,7 +102,7 @@ module("Integration | Component | Widget | hamburger-menu", function (hooks) {
   });
 
   test("top categories - allow_uncategorized_topics", async function (assert) {
-    this.owner.unregister("current-user:main");
+    this.owner.unregister("service:current-user");
     this.siteSettings.allow_uncategorized_topics = false;
     this.siteSettings.header_dropdown_category_count = 8;
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/header-test.js
@@ -15,7 +15,7 @@ module("Integration | Component | Widget | header", function (hooks) {
   });
 
   test("sign up / login buttons", async function (assert) {
-    this.owner.unregister("current-user:main");
+    this.owner.unregister("service:current-user");
     this.set("args", { canSignUp: true });
     this.set("showCreateAccount", () => (this.signupShown = true));
     this.set("showLogin", () => (this.loginShown = true));
@@ -40,7 +40,7 @@ module("Integration | Component | Widget | header", function (hooks) {
   });
 
   test("anon when login required", async function (assert) {
-    this.owner.unregister("current-user:main");
+    this.owner.unregister("service:current-user");
     this.set("args", { canSignUp: true });
     this.set("showCreateAccount", () => (this.signupShown = true));
     this.set("showLogin", () => (this.loginShown = true));

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.js
@@ -237,7 +237,7 @@ module("Integration | Component | Widget | post", function (hooks) {
   });
 
   test("anon liking", async function (assert) {
-    this.owner.unregister("current-user:main");
+    this.owner.unregister("service:current-user");
     const args = { showLike: true };
     this.set("args", args);
     this.set("showLogin", () => (this.loginShown = true));

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -21,7 +21,7 @@ discourseModule("Unit | Controller | topic", function (hooks) {
   });
 
   hooks.afterEach(function () {
-    this.registry.unregister("current-user:main");
+    this.registry.unregister("service:current-user");
     let topic = this.container.lookup("controller:topic");
     topic.setProperties({
       selectedPostIds: [],
@@ -264,10 +264,14 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
   test("canDeleteSelected", function (assert) {
     const currentUser = User.create({ admin: false });
-    this.registry.register("current-user:main", currentUser, {
+    this.registry.register("service:current-user", currentUser, {
       instantiate: false,
     });
-    this.registry.injection("controller", "currentUser", "current-user:main");
+    this.registry.injection(
+      "controller",
+      "currentUser",
+      "service:current-user"
+    );
     let model = topicWithStream({
       posts: [
         { id: 1, can_delete: false },
@@ -362,10 +366,14 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
   test("canChangeOwner", function (assert) {
     const currentUser = User.create({ admin: false });
-    this.registry.register("current-user:main", currentUser, {
+    this.registry.register("service:current-user", currentUser, {
       instantiate: false,
     });
-    this.registry.injection("controller", "currentUser", "current-user:main");
+    this.registry.injection(
+      "controller",
+      "currentUser",
+      "service:current-user"
+    );
 
     let model = topicWithStream({
       posts: [
@@ -405,10 +413,14 @@ discourseModule("Unit | Controller | topic", function (hooks) {
 
   test("modCanChangeOwner", function (assert) {
     const currentUser = User.create({ moderator: false });
-    this.registry.register("current-user:main", currentUser, {
+    this.registry.register("service:current-user", currentUser, {
       instantiate: false,
     });
-    this.registry.injection("controller", "currentUser", "current-user:main");
+    this.registry.injection(
+      "controller",
+      "currentUser",
+      "service:current-user"
+    );
 
     let model = topicWithStream({
       posts: [
@@ -667,10 +679,14 @@ discourseModule("Unit | Controller | topic", function (hooks) {
     });
 
     const currentUser = EmberObject.create({ moderator: true });
-    this.registry.register("current-user:main", currentUser, {
+    this.registry.register("service:current-user", currentUser, {
       instantiate: false,
     });
-    this.registry.injection("controller", "currentUser", "current-user:main");
+    this.registry.injection(
+      "controller",
+      "currentUser",
+      "service:current-user"
+    );
 
     let model = topicWithStream({
       stream: [2, 3, 4],

--- a/app/assets/javascripts/discourse/tests/unit/services/current-user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/current-user-test.js
@@ -5,7 +5,7 @@ acceptance("current-user", function (needs) {
   needs.user();
 
   test("currentUser has appEvents", function (assert) {
-    let currentUser = this.container.lookup("current-user:main");
+    let currentUser = this.container.lookup("service:current-user");
     assert.ok(currentUser.appEvents);
   });
 });


### PR DESCRIPTION
This will allow consumers to inject it using `currentUser: service()` in preparation for the removal of implicit injections in Ember 4.0. `current-user:main` is still available and will print a deprecation notice.