### PR TITLE
DEV: Add `aria-label` option to the `d-icon` helper

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
@@ -150,6 +150,10 @@ registerIconRenderer({
 
     if (params.label) {
       html += " aria-hidden='true'";
+    } else if (params["aria-label"]) {
+      html += ` aria-hidden='false' aria-label='${escape(
+        params["aria-label"]
+      )}'`;
     }
     html += ` xmlns="${SVG_NAMESPACE}"><use href="#${id}" /></svg>`;
     if (params.label) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/icon-library-test.js
@@ -25,15 +25,21 @@ module("Unit | Utility | icon-library", function () {
     assert.ok(!iconHTML(iconC).includes("  "), "trims whitespace");
   });
 
-  test("escape icon names, classes and titles", function (assert) {
-    const html = iconHTML("'<img src='x'>", {
+  test("escape icon names, classes, titles and aria-label", function (assert) {
+    let html = iconHTML("'<img src='x'>", {
       translatedTitle: "'<script src='y'>",
       label: "<iframe src='z'>",
       class: "'<link href='w'>",
+      "aria-label": "<script>alert(1)",
     });
     assert.ok(html.includes("&#x27;&lt;img src=&#x27;x&#x27;&gt;"));
     assert.ok(html.includes("&#x27;&lt;script src=&#x27;y&#x27;&gt;"));
     assert.ok(html.includes("&lt;iframe src=&#x27;z&#x27;&gt;"));
     assert.ok(html.includes("&#x27;&lt;link href=&#x27;w&#x27;&gt;"));
+
+    html = iconHTML("'<img src='x'>", {
+      "aria-label": "<script>alert(1)",
+    });
+    assert.ok(html.includes("aria-label='&lt;script&gt;alert(1)'"));
   });
 });


### PR DESCRIPTION
Extracted from https://github.com/discourse/discourse/pull/17379.

Depends on https://github.com/discourse/discourse/pull/17718.