### PR TITLE
FIX: do not overwrite top_menu site setting in wizard styling step

### DIFF
--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -144,13 +144,16 @@ class Wizard
           updater.update_setting(:base_font, updater.fields[:body_font])
           updater.update_setting(:heading_font, updater.fields[:heading_font])
 
-          if updater.fields[:homepage_style] == 'latest'
-            top_menu = "latest|new|unread|top|categories"
-          else
-            top_menu = "categories|latest|new|unread|top"
+          top_menu = SiteSetting.top_menu.split("|")
+          if updater.fields[:homepage_style] == 'latest' && top_menu[0] != "latest"
+            top_menu.delete("latest")
+            top_menu.insert(0, "latest")
+          elsif updater.fields[:homepage_style] != 'latest' && top_menu[0] != "categories"
+            top_menu.delete("categories")
+            top_menu.insert(0, "categories")
             updater.update_setting(:desktop_category_page_style, updater.fields[:homepage_style])
           end
-          updater.update_setting(:top_menu, top_menu)
+          updater.update_setting(:top_menu, top_menu.join("|"))
 
           scheme_name = (
             (updater.fields[:color_scheme] || "") ||

--- a/spec/lib/wizard/step_updater_spec.rb
+++ b/spec/lib/wizard/step_updater_spec.rb
@@ -217,6 +217,7 @@ RSpec.describe Wizard::StepUpdater do
 
     context "homepage style" do
       it "updates the fields correctly" do
+        SiteSetting.top_menu = "latest|categories|unread|top"
         updater = wizard.create_updater('styling',
           body_font: 'arial',
           heading_font: 'arial',
@@ -226,9 +227,10 @@ RSpec.describe Wizard::StepUpdater do
 
         expect(updater).to be_success
         expect(wizard.completed_steps?('styling')).to eq(true)
-        expect(SiteSetting.top_menu).to eq('categories|latest|new|unread|top')
+        expect(SiteSetting.top_menu).to eq('categories|latest|unread|top')
         expect(SiteSetting.desktop_category_page_style).to eq('categories_and_top_topics')
 
+        SiteSetting.top_menu = "categories|latest|new|top"
         updater = wizard.create_updater('styling',
           body_font: 'arial',
           heading_font: 'arial',
@@ -236,7 +238,29 @@ RSpec.describe Wizard::StepUpdater do
         )
         updater.update
         expect(updater).to be_success
-        expect(SiteSetting.top_menu).to eq('latest|new|unread|top|categories')
+        expect(SiteSetting.top_menu).to eq('latest|categories|new|top')
+      end
+
+      it "does not overwrite top_menu site setting" do
+        SiteSetting.top_menu = "latest|unread|unseen|categories"
+        updater = wizard.create_updater('styling',
+          body_font: 'arial',
+          heading_font: 'arial',
+          homepage_style: "latest"
+        )
+        updater.update
+        expect(updater).to be_success
+        expect(SiteSetting.top_menu).to eq('latest|unread|unseen|categories')
+
+        SiteSetting.top_menu = "categories|new|latest"
+        updater = wizard.create_updater('styling',
+          body_font: 'arial',
+          heading_font: 'arial',
+          homepage_style: "categories_and_top_topics"
+        )
+        updater.update
+        expect(updater).to be_success
+        expect(SiteSetting.top_menu).to eq('categories|new|latest')
       end
     end
   end


### PR DESCRIPTION
On the wizard styling step we're overwriting top_menu site setting to
match default value. This commit adds a check before update and only
updates the top_menu site setting if it's required.
