### PR TITLE
DEV: set CSS custom property for footer-nav-height

### DIFF
--- a/app/assets/stylesheets/common/components/footer-nav.scss
+++ b/app/assets/stylesheets/common/components/footer-nav.scss
@@ -14,7 +14,7 @@ body.footer-nav-visible {
   }
 
   #reply-control.draft {
-    bottom: $footer-nav-height;
+    bottom: var(--footer-nav-height);
     margin-bottom: env(safe-area-inset-bottom);
     padding-bottom: 0px;
   }

--- a/app/assets/stylesheets/common/components/footer-nav.scss
+++ b/app/assets/stylesheets/common/components/footer-nav.scss
@@ -4,9 +4,13 @@
 
 $footer-nav-height: 49px;
 
+:root {
+  --footer-nav-height: #{$footer-nav-height};
+}
+
 body.footer-nav-visible {
   #main-outlet {
-    padding-bottom: $footer-nav-height + 15;
+    padding-bottom: calc(var(--footer-nav-height) + 15px);
   }
 
   #reply-control.draft {
@@ -16,20 +20,20 @@ body.footer-nav-visible {
   }
 
   #topic-progress-wrapper:not(.docked) {
-    margin-bottom: calc(#{$footer-nav-height} + env(safe-area-inset-bottom));
+    margin-bottom: calc(var(--footer-nav-height) + env(safe-area-inset-bottom));
   }
   .posts-filtered-notice {
     transition: all linear 0.1s;
-    bottom: calc(#{$footer-nav-height} + env(safe-area-inset-bottom));
+    bottom: calc(var(--footer-nav-height) + env(safe-area-inset-bottom));
   }
 }
 
 .footer-nav {
   background-color: rgba(var(--header_background-rgb), 0.9);
   box-shadow: shadow("footer-nav");
-  height: $footer-nav-height;
+  height: var(--footer-nav-height);
   position: fixed;
-  bottom: -$footer-nav-height;
+  bottom: calc(var(--footer-nav-height) * -1);
   left: 0;
   width: 100%;
   z-index: z("footer-nav");
@@ -73,7 +77,7 @@ body.footer-nav-visible {
 }
 
 body.footer-nav-ipad {
-  padding-top: $footer-nav-height;
+  padding-top: var(--footer-nav-height);
   .footer-nav {
     bottom: auto;
     top: 0px;
@@ -88,6 +92,6 @@ body.footer-nav-ipad {
   }
 
   &.docked .d-header-wrap {
-    top: $footer-nav-height;
+    top: var(--footer-nav-height);
   }
 }


### PR DESCRIPTION
Using this in the chat plugin. 

I noticed this was attempted before, but was reverted due to some issues with SASS math. 

For example, in the previous attempt things like this wouldn't work: 
`var(--footer-nav-height) + 15;`
`-var(--footer-nav-height;`

So to avoid those I've updated to:
`calc(var(--footer-nav-height) + 15px);`
`calc(var(--footer-nav-height) * -1);` 
