### PR TITLE
UX: Improve empty state copy on the activity/topics page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
@@ -1,6 +1,8 @@
 import UserAction from "discourse/models/user-action";
 import UserTopicListRoute from "discourse/routes/user-topic-list";
 import { action } from "@ember/object";
+import { htmlSafe } from "@ember/template";
+import getURL from "discourse-common/lib/get-url";
 import I18n from "I18n";
 
 export default UserTopicListRoute.extend({
@@ -30,16 +32,22 @@ export default UserTopicListRoute.extend({
 
   emptyState() {
     const user = this.modelFor("user");
-    const title = this.isCurrentUser(user)
-      ? I18n.t("user_activity.no_topics_title")
-      : I18n.t("user_activity.no_topics_title_others", {
-          username: user.username,
-        });
+    let title, body;
+    if (this.isCurrentUser(user)) {
+      title = I18n.t("user_activity.no_topics_title");
+      body = htmlSafe(
+        I18n.t("user_activity.no_topics_body", {
+          searchUrl: getURL("/search"),
+        })
+      );
+    } else {
+      title = I18n.t("user_activity.no_topics_title_others", {
+        username: user.username,
+      });
+      body = "";
+    }
 
-    return {
-      title,
-      body: "",
-    };
+    return { title, body };
   },
 
   @action

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4054,6 +4054,7 @@ en:
       no_likes_body: "A great way to jump in and start contributing is to start reading conversations that have already taken place, and select the %{heartIcon} on posts that you like!"
       no_likes_others: "No liked posts."
       no_topics_title: "You have not started any topics yet"
+      no_topics_body: "It’s always best to <a href='%{searchUrl}'>search</a> for existing topics of conversation before starting a new one, but if you’re confident the topic you want isn’t out there already, go ahead and start a new topic of your very own. Look for the <kbd>+ New Topic</kbd> button at the top right of the topic list, category, or tag to begin creating a new topic in that area."
       no_topics_title_others: "%{username} has not started any topics yet"
       no_read_topics_title: "You haven’t read any topics yet"
       no_read_topics_body: "Once you start reading discussions, you’ll see a list here. To start reading, look for topics that interest you in <a href='%{topUrl}'>Top</a> or <a href='%{categoriesUrl}'>Categories</a> or search by keyword %{searchIcon}"


### PR DESCRIPTION
Before:
<img width="450" alt="Screenshot 2022-08-01 at 23 55 14" src="https://user-images.githubusercontent.com/1274517/182234000-de2d0220-99ac-4d7d-9564-e4a3b8dba54b.png">

After:
<img width="450" alt="Screenshot 2022-08-01 at 23 44 54" src="https://user-images.githubusercontent.com/1274517/182234014-3cec3c8c-47e6-405d-a1dd-36b1d8a7df29.png">

I'm not adding tests because it's already covered with tests ([here](https://github.com/discourse/discourse/blob/cfd0a04965fc058012b02d40da05384f61f951a7/app/assets/javascripts/discourse/tests/acceptance/user-activity-topic-test.js#L40)), and this PR changes copy only.
