### PR TITLE
DEV: `message-bus:main` -> `service:message-bus`

### DIFF
--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
@@ -7,7 +7,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 const PLUGIN_ID = "new-user-narrative";
 
 function initialize(api) {
-  const messageBus = api.container.lookup("message-bus:main");
+  const messageBus = api.container.lookup("service:message-bus");
   const currentUser = api.getCurrentUser();
   const appEvents = api.container.lookup("service:app-events");
 


### PR DESCRIPTION
The former has been deprecated