### PR TITLE
FIX: Bugs with year selector and erase button

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/discourse/components/discourse-local-dates-create-form.js
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/components/discourse-local-dates-create-form.js
@@ -401,22 +401,22 @@ export default Component.extend({
   },
 
   _setPickerMinDate(date) {
-    if (date && !moment(date, this.dateFormat).isValid()) {
-      date = null;
-    }
-
     schedule("afterRender", () => {
-      this._picker.setMinDate(moment(date, this.dateFormat).toDate());
+      if (moment(date, this.dateFormat).isValid()) {
+        this._picker.setMinDate(moment(date, this.dateFormat).toDate());
+      } else {
+        this._picker.setMinDate(null);
+      }
     });
   },
 
   _setPickerDate(date) {
-    if (date && !moment(date, this.dateFormat).isValid()) {
-      date = null;
-    }
-
     schedule("afterRender", () => {
-      this._picker.setDate(moment.utc(date), true);
+      if (moment(date, this.dateFormat).isValid()) {
+        this._picker.setDate(moment.utc(date), true);
+      } else {
+        this._picker.setDate(null);
+      }
     });
   },
 

--- a/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
@@ -34,7 +34,7 @@
             @translatedLabel={{this.formattedTo}}
             @class="date-time" />
           {{#if this.toFilled}}
-            <DButton @icon="times" action={{action "eraseToDateTime"}} @class="delete-to-date" />
+            <DButton @icon="times" @action={{action "eraseToDateTime"}} @class="delete-to-date" />
           {{/if}}
         </div>
 

--- a/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js
@@ -1,4 +1,8 @@
-import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  query,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { click, fillIn, visit } from "@ember/test-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -75,6 +79,47 @@ acceptance("Local Dates - composer", function (needs) {
     assert.ok(
       query(".preview .discourse-local-date").textContent.includes("Macau"),
       "it outputs a preview date in selected timezone"
+    );
+  });
+
+  test("date modal - controls", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    await click(".d-editor-button-bar .local-dates");
+
+    await click('.pika-table td[data-day="5"] > .pika-button');
+
+    assert.ok(
+      query("#from-date-time").textContent.includes("5,"),
+      "selected FROM date works"
+    );
+
+    await click(".date-time-control.to .date-time");
+
+    assert.strictEqual(
+      queryAll(".pika-table .is-disabled").length,
+      4,
+      "date just before selected FROM date is disabled"
+    );
+
+    await click('.pika-table td[data-day="10"] > .pika-button');
+
+    assert.ok(
+      query(".date-time-control.to button").textContent.includes("10,"),
+      "selected TO date works"
+    );
+
+    assert.strictEqual(
+      query(".pika-table .is-selected").textContent,
+      "10",
+      "selected date is the 10th"
+    );
+
+    await click(".delete-to-date");
+
+    assert.notOk(
+      query(".pika-table .is-selected"),
+      "deleting selected TO date works"
     );
   });
 });


### PR DESCRIPTION
Fixes two issues: 
- year picker selection was not working due to an invalid date object being passed to pikaday
- the To date erase button was also not working, due to a typo