### PR TITLE
FIX: Inject appEvents in ScreenTrack

### DIFF
--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -1,4 +1,4 @@
-import Service from "@ember/service";
+import Service, { inject as service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse-common/utils/decorators";
 import { isTesting } from "discourse-common/config/environment";
@@ -18,6 +18,8 @@ const AJAX_FAILURE_DELAYS = [5000, 10000, 20000, 40000];
 const ALLOWED_AJAX_FAILURES = [405, 429, 500, 501, 502, 503, 504];
 
 export default class ScreenTrack extends Service {
+  @service appEvents;
+
   _consolidatedTimings = [];
   _lastTick = null;
   _lastScrolled = null;

--- a/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
@@ -26,4 +26,25 @@ discourseModule("Unit | Service | screen-track", function () {
       "caches highest read post number for second topic"
     );
   });
+
+  test("ScreenTrack has appEvents", async function (assert) {
+    const tracker = this.container.lookup("service:screen-track");
+    assert.ok(tracker.appEvents);
+  });
+
+  test("appEvent topic:timings-sent is triggered", async function (assert) {
+    assert.timeout(1000);
+
+    const tracker = this.container.lookup("service:screen-track");
+    const appEvents = this.container.lookup("service:app-events");
+
+    const done = assert.async();
+
+    appEvents.on("topic:timings-sent", () => {
+      assert.ok(true);
+      done();
+    });
+
+    await tracker.sendNextConsolidatedTiming();
+  });
 });

--- a/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
@@ -1,3 +1,5 @@
+import AppEvents from "discourse/services/app-events";
+import ScreenTrack from "discourse/services/screen-track";
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
@@ -27,22 +29,15 @@ discourseModule("Unit | Service | screen-track", function () {
     );
   });
 
-  test("ScreenTrack has appEvents", async function (assert) {
-    const tracker = this.container.lookup("service:screen-track");
-    assert.ok(tracker.appEvents);
-  });
-
-  test("appEvent topic:timings-sent is triggered", async function (assert) {
-    assert.timeout(1000);
-
-    const tracker = this.container.lookup("service:screen-track");
-    const appEvents = this.container.lookup("service:app-events");
-
-    const done = assert.async();
+  test("appEvent topic:timings-sent is triggered when ..........", async function (assert) {
+    const appEvents = AppEvents.create();
+    const tracker = ScreenTrack.create({
+      appEvents,
+      _consolidatedTimings: [""],
+    });
 
     appEvents.on("topic:timings-sent", () => {
       assert.ok(true);
-      done();
     });
 
     await tracker.sendNextConsolidatedTiming();

--- a/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/screen-track-test.js
@@ -29,7 +29,7 @@ discourseModule("Unit | Service | screen-track", function () {
     );
   });
 
-  test("appEvent topic:timings-sent is triggered when ..........", async function (assert) {
+  test("appEvent topic:timings-sent is triggered after posting consolidated timings", async function (assert) {
     const appEvents = AppEvents.create();
     const tracker = ScreenTrack.create({
       appEvents,


### PR DESCRIPTION
This commits reverts partially https://github.com/discourse/discourse/pull/17543.

Service appEvents was not being injected in ScreenTrack. This causes
`this.appEvents.trigger("topic:timings-sent", data);` to fail and the error is
swallowed by the `catch` on the promise.

This caused a regression on plugins that rely on this event to implement other
behaviors.
