### PR TITLE
DEV: Ensure `censorFn` copes with null `regexpList`

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/censored-words.js
+++ b/app/assets/javascripts/pretty-text/addon/censored-words.js
@@ -4,7 +4,7 @@ import {
 } from "discourse-common/utils/watched-words";
 
 export function censorFn(regexpList, replacementLetter) {
-  if (regexpList.length) {
+  if (regexpList?.length) {
     replacementLetter = replacementLetter || "&#9632;";
     let censorRegexps = regexpList.map((regexp) => {
       return createWatchedWordRegExp(toWatchedWord(regexp));


### PR DESCRIPTION
This fixes the test suite failures introduced by 862007fb181b3165a855a55757608a98bc189e29

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
