### PR TITLE
FIX: Update word_watcher cache key following schema change

### DIFF
--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -2,6 +2,7 @@
 
 class WordWatcher
   REPLACEMENT_LETTER ||= CGI.unescape_html("&#9632;")
+  CACHE_VERSION = 2
 
   def initialize(raw)
     @raw = raw
@@ -105,7 +106,7 @@ class WordWatcher
   end
 
   def self.word_matcher_regexp_key(action)
-    "watched-words-list:#{action}"
+    "watched-words-list:v#{CACHE_VERSION}:#{action}"
   end
 
   def self.censor(html)


### PR DESCRIPTION
862007fb181b3165a855a55757608a98bc189e29 introduced a change to the format that watched words are cached in Redis. Newly-deployed versions of the app were attempting to load the old-format data from Redis, leading to a server error. This commit introduces a CACHE_VERSION constant which we can easily bump when making changes to the cache schema.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
