### PR TITLE
DEV: Move all resolver deprecations into `resolver.js`

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -9,6 +9,68 @@ import { buildResolver as buildLegacyResolver } from "discourse-common/lib/legac
 let _options = {};
 let moduleSuffixTrie = null;
 
+const DEPRECATED_MODULES = new Map(
+  Object.entries({
+    "controller:discovery.categoryWithID": {
+      newName: "controller:discovery.category",
+      since: "2.6.0",
+    },
+    "controller:discovery.parentCategory": {
+      newName: "controller:discovery.category",
+      since: "2.6.0",
+    },
+    "controller:tags-show": { newName: "controller:tag-show", since: "2.6.0" },
+    "controller:tags.show": { newName: "controller:tag.show", since: "2.6.0" },
+    "controller:tagsShow": { newName: "controller:tagShow", since: "2.6.0" },
+    "route:discovery.categoryWithID": {
+      newName: "route:discovery.category",
+      since: "2.6.0",
+    },
+    "route:discovery.parentCategory": {
+      newName: "route:discovery.category",
+      since: "2.6.0",
+    },
+    "route:tags-show": { newName: "route:tag-show", since: "2.6.0" },
+    "route:tags.show": { newName: "route:tag.show", since: "2.6.0" },
+    "route:tagsShow": { newName: "route:tagShow", since: "2.6.0" },
+    "app-events:main": {
+      newName: "service:app-events",
+      since: "2.4.0",
+      dropFrom: "2.9.0.beta1",
+    },
+    "store:main": {
+      newName: "service:store",
+      since: "2.8.0.beta8",
+      dropFrom: "2.9.0.beta1",
+    },
+    "search-service:main": {
+      newName: "service:search",
+      since: "2.8.0.beta8",
+      dropFrom: "2.9.0.beta1",
+    },
+    "key-value-store:main": {
+      newName: "service:key-value-store",
+      since: "2.9.0.beta7",
+      dropFrom: "3.0.0",
+    },
+    "pm-topic-tracking-state:main": {
+      newName: "service:pm-topic-tracking-state",
+      since: "2.9.0.beta7",
+      dropFrom: "3.0.0",
+    },
+    "message-bus:main": {
+      newName: "service:message-bus",
+      since: "2.9.0.beta7",
+      dropFrom: "3.0.0",
+    },
+    "site-settings:main": {
+      newName: "service:site-settings",
+      since: "2.9.0.beta7",
+      dropFrom: "3.0.0",
+    },
+  })
+);
+
 export function setResolverOption(name, value) {
   _options[name] = value;
 }
@@ -54,30 +116,16 @@ export function buildResolver(baseName) {
 
     // We overwrite this instead of `normalize` so we still get the benefits of the cache.
     _normalize(fullName) {
-      if (fullName === "app-events:main") {
+      const deprecationInfo = DEPRECATED_MODULES.get(fullName);
+      if (deprecationInfo) {
         deprecated(
-          "`app-events:main` has been replaced with `service:app-events`",
-          { since: "2.4.0", dropFrom: "2.9.0.beta1" }
+          `"${fullName}" is deprecated, use "${deprecationInfo.newName}" instead`,
+          {
+            since: deprecationInfo.since,
+            dropFrom: deprecationInfo.dropFrom,
+          }
         );
-        fullName = "service:app-events";
-      }
-
-      for (const [key, value] of Object.entries({
-        "controller:discovery.categoryWithID": "controller:discovery.category",
-        "controller:discovery.parentCategory": "controller:discovery.category",
-        "controller:tags-show": "controller:tag-show",
-        "controller:tags.show": "controller:tag.show",
-        "controller:tagsShow": "controller:tagShow",
-        "route:discovery.categoryWithID": "route:discovery.category",
-        "route:discovery.parentCategory": "route:discovery.category",
-        "route:tags-show": "route:tag-show",
-        "route:tags.show": "route:tag.show",
-        "route:tagsShow": "route:tagShow",
-      })) {
-        if (fullName === key) {
-          deprecated(`${key} was replaced with ${value}`, { since: "2.6.0" });
-          fullName = value;
-        }
+        fullName = deprecationInfo.newName;
       }
 
       const split = fullName.split(":");

--- a/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
@@ -5,7 +5,6 @@ import DiscourseLocation from "discourse/lib/discourse-location";
 import Session from "discourse/models/session";
 import Site from "discourse/models/site";
 import User from "discourse/models/user";
-import deprecated from "discourse-common/lib/deprecated";
 
 const ALL_TARGETS = ["controller", "component", "route", "model", "adapter"];
 
@@ -21,84 +20,11 @@ function injectServiceIntoService({ container, app, property, specifier }) {
   });
 }
 
-function deprecateRegistration({
-  app,
-  container,
-  oldName,
-  newName,
-  since,
-  dropFrom,
-}) {
-  app.register(oldName, {
-    create() {
-      deprecated(`"${oldName}" is deprecated, use "${newName}" instead`, {
-        since,
-        dropFrom,
-      });
-      return container.lookup(newName);
-    },
-  });
-}
-
 export default {
   name: "inject-discourse-objects",
   after: "discourse-bootstrap",
 
   initialize(container, app) {
-    deprecateRegistration({
-      app,
-      container,
-      oldName: "store:main",
-      newName: "service:store",
-      since: "2.8.0.beta8",
-      dropFrom: "2.9.0.beta1",
-    });
-
-    deprecateRegistration({
-      app,
-      container,
-      oldName: "search-service:main",
-      newName: "service:search",
-      since: "2.8.0.beta8",
-      dropFrom: "2.9.0.beta1",
-    });
-
-    deprecateRegistration({
-      app,
-      container,
-      oldName: "key-value-store:main",
-      newName: "service:key-value-store",
-      since: "2.9.0.beta7",
-      dropFrom: "3.0.0",
-    });
-
-    deprecateRegistration({
-      app,
-      container,
-      oldName: "pm-topic-tracking-state:main",
-      newName: "service:pm-topic-tracking-state",
-      since: "2.9.0.beta7",
-      dropFrom: "3.0.0",
-    });
-
-    deprecateRegistration({
-      app,
-      container,
-      oldName: "message-bus:main",
-      newName: "service:message-bus",
-      since: "2.9.0.beta7",
-      dropFrom: "3.0.0",
-    });
-
-    deprecateRegistration({
-      app,
-      container,
-      oldName: "site-settings:main",
-      newName: "service:site-settings",
-      since: "2.9.0.beta7",
-      dropFrom: "3.0.0",
-    });
-
     const siteSettings = container.lookup("service:site-settings");
 
     const currentUser = User.current();


### PR DESCRIPTION
Having them all in one place is much easier to reason with. It also means we can handle them without needing 'fake' registrations (which can sometimes cause odd behavior). This commit just moves the deprecation logic - it does not introduce any new deprecations.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
