### PR TITLE
UX: add ellipsis for long category names in category chooser dropdown

### DIFF
--- a/app/assets/stylesheets/common/select-kit/category-drop.scss
+++ b/app/assets/stylesheets/common/select-kit/category-drop.scss
@@ -6,6 +6,7 @@
       .badge-wrapper {
         font-size: $font-0;
         font-weight: normal;
+        max-width: 260px;
 
         &.box {
           margin: 0;


### PR DESCRIPTION
Before:

<img width="318" alt="Screenshot 2022-08-02 at 9 32 34 PM" src="https://user-images.githubusercontent.com/11170663/182420589-596e348f-d1e1-4483-92f7-b31f72327356.png">

After:

<img width="306" alt="Screenshot 2022-08-02 at 9 33 00 PM" src="https://user-images.githubusercontent.com/11170663/182420608-b4d7680f-9bff-4442-b67b-fe535d2fa428.png">
