### PR TITLE
Add discourse-chat to official plugins list

### DIFF
--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -26,6 +26,7 @@ class Plugin::Metadata
     "discourse-categories-suppressed",
     "discourse-category-experts",
     "discourse-characters-required",
+    "discourse-chat",
     "discourse-chat-integration",
     "discourse-checklist",
     "discourse-code-review",


### PR DESCRIPTION
It is now in open beta with an official post on meta so we should include it in the list here.
https://meta.discourse.org/t/discourse-chat-plugin/230881

