### PR TITLE
FIX: Use default locale for footer of embedded topics

### DIFF
--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -23,7 +23,9 @@ class TopicEmbed < ActiveRecord::Base
   end
 
   def self.imported_from_html(url)
-    "\n<hr>\n<small>#{I18n.t('embed.imported_from', link: "<a href='#{url}'>#{url}</a>")}</small>\n"
+    I18n.with_locale(SiteSetting.default_locale) do
+      "\n<hr>\n<small>#{I18n.t('embed.imported_from', link: "<a href='#{url}'>#{url}</a>")}</small>\n"
+    end
   end
 
   # Import an article from a source (RSS/Atom/Other)

--- a/spec/models/topic_embed_spec.rb
+++ b/spec/models/topic_embed_spec.rb
@@ -399,4 +399,18 @@ RSpec.describe TopicEmbed do
     end
   end
 
+  describe ".imported_from_html" do
+    after { I18n.reload! }
+
+    it "uses the default site locale for the 'imported_from' footer" do
+      TranslationOverride.upsert!("en", "embed.imported_from", "English translation of embed.imported_from with %{link}")
+      TranslationOverride.upsert!("de", "embed.imported_from", "German translation of embed.imported_from with %{link}")
+
+      I18n.locale = :en
+      expected_html = TopicEmbed.imported_from_html("some_url")
+
+      I18n.locale = :de
+      expect(TopicEmbed.imported_from_html("some_url")).to eq(expected_html)
+    end
+  end
 end


### PR DESCRIPTION
The content from the remote site and the footer get cached for 10 minutes, so Discourse should use the default locale instead of the user locale for the footer. Otherwise Discourse might cache the message in a different language.