### PR TITLE
DEV: Replace `session:main` with `service:session`

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -73,6 +73,11 @@ const DEPRECATED_MODULES = new Map(
       since: "2.9.0.beta7",
       dropFrom: "3.0.0",
     },
+    "session:main": {
+      newName: "service:session",
+      since: "2.9.0.beta7",
+      dropFrom: "3.0.0",
+    },
   })
 );
 

--- a/app/assets/javascripts/discourse/app/components/glimmer.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer.js
@@ -20,6 +20,7 @@ export default class DiscourseGlimmerComponent extends GlimmerComponent {
   @service siteSettings;
   @service messageBus;
   @service currentUser;
+  @service session;
 
   @cached
   get topicTrackingState() {
@@ -31,11 +32,5 @@ export default class DiscourseGlimmerComponent extends GlimmerComponent {
   get site() {
     const applicationInstance = getOwner(this);
     return applicationInstance.lookup("site:main");
-  }
-
-  @cached
-  get session() {
-    const applicationInstance = getOwner(this);
-    return applicationInstance.lookup("session:main");
   }
 }

--- a/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
+++ b/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
@@ -23,7 +23,7 @@ export function autoLoadModules(container, registry) {
     capabilities: container.lookup("capabilities:main"),
     currentUser: container.lookup("service:current-user"),
     site: container.lookup("site:main"),
-    session: container.lookup("session:main"),
+    session: container.lookup("service:session"),
     topicTrackingState: container.lookup("topic-tracking-state:main"),
     registry,
   };

--- a/app/assets/javascripts/discourse/app/initializers/csrf-token.js
+++ b/app/assets/javascripts/discourse/app/initializers/csrf-token.js
@@ -7,7 +7,7 @@ export default {
   name: "csrf-token",
   initialize(container) {
     // Add a CSRF token to all AJAX requests
-    let session = container.lookup("session:main");
+    let session = container.lookup("service:session");
     session.set(
       "csrfToken",
       document.head.querySelector("meta[name=csrf-token]")?.content

--- a/app/assets/javascripts/discourse/app/initializers/live-development.js
+++ b/app/assets/javascripts/discourse/app/initializers/live-development.js
@@ -8,7 +8,7 @@ export default {
 
   initialize(container) {
     const messageBus = container.lookup("service:message-bus");
-    const session = container.lookup("session:main");
+    const session = container.lookup("service:session");
 
     // Preserve preview_theme_id=## and pp=async-flamegraph parameters across pages
     const params = new URLSearchParams(window.location.search);

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -15,7 +15,7 @@ export default {
   initialize(container) {
     withPluginApi("0.1", (api) => {
       const siteSettings = container.lookup("service:site-settings");
-      const session = container.lookup("session:main");
+      const session = container.lookup("service:session");
       const site = container.lookup("site:main");
       api.decorateCookedElement(
         (elem) => {

--- a/app/assets/javascripts/discourse/app/initializers/register-service-worker.js
+++ b/app/assets/javascripts/discourse/app/initializers/register-service-worker.js
@@ -4,7 +4,7 @@ export default {
   name: "register-service-worker",
 
   initialize(container) {
-    let { serviceWorkerURL } = container.lookup("session:main");
+    let { serviceWorkerURL } = container.lookup("service:session");
     registerServiceWorker(container, serviceWorkerURL);
   },
 };

--- a/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
@@ -20,6 +20,7 @@ export function injectServiceIntoService({ app, property, specifier }) {
   app.inject(specifier, property, "discourse:null");
 
   // Bypass the validation in `app.inject` by adding directly to the array
+  app.__registry__._typeInjections["service"] ??= [];
   app.__registry__._typeInjections["service"].push({
     property,
     specifier,
@@ -53,7 +54,7 @@ export default {
     app.register("site:main", site, { instantiate: false });
 
     const session = Session.current();
-    app.register("session:main", session, { instantiate: false });
+    app.register("service:session", session, { instantiate: false });
 
     app.register("location:discourse-location", DiscourseLocation);
 
@@ -63,14 +64,18 @@ export default {
       app.inject(t, "store", "service:store");
       app.inject(t, "site", "site:main");
       app.inject(t, "searchService", "service:search");
-      app.inject(t, "session", "session:main");
+      app.inject(t, "session", "service:session");
       app.inject(t, "messageBus", "service:message-bus");
       app.inject(t, "siteSettings", "service:site-settings");
       app.inject(t, "topicTrackingState", "topic-tracking-state:main");
       app.inject(t, "keyValueStore", "service:key-value-store");
     });
 
-    app.inject("service", "session", "session:main");
+    injectServiceIntoService({
+      app,
+      property: "session",
+      specifier: "service:session",
+    });
     injectServiceIntoService({
       app,
       property: "messageBus",

--- a/app/assets/javascripts/discourse/app/pre-initializers/svg-sprite-fontawesome.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/svg-sprite-fontawesome.js
@@ -5,7 +5,7 @@ export default {
   after: "discourse-bootstrap",
 
   initialize(container) {
-    let session = container.lookup("session:main");
+    let session = container.lookup("service:session");
     if (session.svgSpritePath) {
       loadSprites(session.svgSpritePath, "fontawesome");
     }


### PR DESCRIPTION
This will allow consumers to inject it using `session: service()` in preparation for the removal of implicit injections in Ember 4.0. `session:main` is still available and will print a deprecation notice.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
