### PR TITLE
FEATURE: track stats around failing scheduled jobs

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -153,6 +153,16 @@ module Discourse
     end
   end
 
+  def self.job_exception_stats
+    @job_exception_stats
+  end
+
+  def self.reset_job_exception_stats!
+    @job_exception_stats = Hash.new(0)
+  end
+
+  reset_job_exception_stats!
+
   # Log an exception.
   #
   # If your code is in a scheduled job, it is recommended to use the
@@ -164,6 +174,11 @@ module Discourse
 
     context ||= {}
     parent_logger ||= Sidekiq
+
+    job = context.dig(:job, "class")
+    if job
+      job_exception_stats[job] += 1
+    end
 
     cm = RailsMultisite::ConnectionManagement
     parent_logger.handle_exception(ex, {

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -351,8 +351,9 @@ RSpec.describe Discourse do
       }
 
       # re-raised unconditionally in test env
-      Discourse.handle_job_exception(StandardError.new, exception_context) rescue nil
-      Discourse.handle_job_exception(StandardError.new, exception_context) rescue nil
+      2.times do
+        expect { Discourse.handle_job_exception(StandardError.new, exception_context) }.to raise_error(StandardError)
+      end
 
       exception_context = {
         message: "Running a scheduled job",

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -344,6 +344,7 @@ RSpec.describe Discourse do
       Discourse.reset_job_exception_stats!
 
       # see MiniScheduler Manager which reports it like this
+      # https://github.com/discourse/mini_scheduler/blob/2b2c1c56b6e76f51108c2a305775469e24cf2b65/lib/mini_scheduler/manager.rb#L95
       exception_context = {
         message: "Running a scheduled job",
         job: { "class" => Jobs::ReindexSearch }

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -340,32 +340,42 @@ RSpec.describe Discourse do
       Sidekiq.error_handlers.delete(logger)
     end
 
-    it "should collect job exception stats" do
-      Discourse.reset_job_exception_stats!
+    describe "#job_exception_stats" do
 
-      # see MiniScheduler Manager which reports it like this
-      # https://github.com/discourse/mini_scheduler/blob/2b2c1c56b6e76f51108c2a305775469e24cf2b65/lib/mini_scheduler/manager.rb#L95
-      exception_context = {
-        message: "Running a scheduled job",
-        job: { "class" => Jobs::ReindexSearch }
-      }
-
-      # re-raised unconditionally in test env
-      2.times do
-        expect { Discourse.handle_job_exception(StandardError.new, exception_context) }.to raise_error(StandardError)
+      before do
+        Discourse.reset_job_exception_stats!
       end
 
-      exception_context = {
-        message: "Running a scheduled job",
-        job: { "class" => Jobs::PollMailbox }
-      }
+      after do
+        Discourse.reset_job_exception_stats!
+      end
 
-      expect { Discourse.handle_job_exception(StandardError.new, exception_context) }.to raise_error(StandardError)
+      it "should collect job exception stats" do
 
-      expect(Discourse.job_exception_stats).to eq({
-        Jobs::PollMailbox => 1,
-        Jobs::ReindexSearch => 2,
-      })
+        # see MiniScheduler Manager which reports it like this
+        # https://github.com/discourse/mini_scheduler/blob/2b2c1c56b6e76f51108c2a305775469e24cf2b65/lib/mini_scheduler/manager.rb#L95
+        exception_context = {
+          message: "Running a scheduled job",
+          job: { "class" => Jobs::ReindexSearch }
+        }
+
+        # re-raised unconditionally in test env
+        2.times do
+          expect { Discourse.handle_job_exception(StandardError.new, exception_context) }.to raise_error(StandardError)
+        end
+
+        exception_context = {
+          message: "Running a scheduled job",
+          job: { "class" => Jobs::PollMailbox }
+        }
+
+        expect { Discourse.handle_job_exception(StandardError.new, exception_context) }.to raise_error(StandardError)
+
+        expect(Discourse.job_exception_stats).to eq({
+          Jobs::PollMailbox => 1,
+          Jobs::ReindexSearch => 2,
+        })
+      end
     end
 
     it "should not fail when called" do

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe Discourse do
         job: { "class" => Jobs::PollMailbox }
       }
 
-      Discourse.handle_job_exception(StandardError.new, exception_context) rescue nil
+      expect { Discourse.handle_job_exception(StandardError.new, exception_context) }.to raise_error(StandardError)
 
       expect(Discourse.job_exception_stats).to eq({
         Jobs::PollMailbox => 1,


### PR DESCRIPTION
Discourse.job_exception_stats can now be used to gather stats around how
many regular scheduled jobs failed in the current process.

This will be consumed by the Prometheus plugin and potentially other
monitoring plugins.
