### PR TITLE
FIX: Links incorrectly marked as active in Sidebar::MoreSectionLinks

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
@@ -1,6 +1,8 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import { isEmpty } from "@ember/utils";
+
 import { bind } from "discourse-common/utils/decorators";
 import GlimmerComponent from "discourse/components/glimmer";
 
@@ -80,6 +82,12 @@ export default class SidebarMoreSectionLinks extends GlimmerComponent {
 
       if (sectionLink.model) {
         args.push(sectionLink.model);
+      } else if (sectionLink.models) {
+        args.push(...sectionLink.models);
+      }
+
+      if (!isEmpty(sectionLink.query)) {
+        args.push({ queryParams: sectionLink.query });
       }
 
       return this.router.isActive(...args) && sectionLink;

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -451,6 +451,13 @@ acceptance("Sidebar - Plugin API", function (needs) {
           rawLabel: "open bugs",
         };
       });
+
+      api.decorateWidget("hamburger-menu:generalLinks", () => {
+        return {
+          href: "/t/internationalization-localization/280",
+          rawLabel: "my favourite topic",
+        };
+      });
     });
 
     await visit("/");
@@ -520,6 +527,29 @@ acceptance("Sidebar - Plugin API", function (needs) {
     assert.ok(
       openBugsSectionLink.href.endsWith("/c/bug?status=open"),
       "sets the right href attribute for the custom open bugs section link"
+    );
+
+    // close more links
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    await visit("/t/internationalization-localization/280");
+
+    assert.ok(
+      exists(
+        ".sidebar-section-community .sidebar-section-link-my-favourite-topic.active"
+      ),
+      "displays my favourite topic custom section link when current route matches the link's route"
+    );
+
+    await visit("/t/short-topic-with-two-posts/54077");
+
+    assert.notOk(
+      exists(
+        ".sidebar-section-community .sidebar-section-link-my-favourite-topic.active"
+      ),
+      "does not display my favourite topic custom section link when current route does not match the link's route"
     );
   });
 });


### PR DESCRIPTION
Before this commit, links with routes that require multiple models were
incorrectly displayed as the active link in the
Sidebar::MoreSectionLinks component because we were only checking if the
routeName was active.