### PR TITLE
FIX: avoid usage of dig when looking for job class

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -175,9 +175,13 @@ module Discourse
     context ||= {}
     parent_logger ||= Sidekiq
 
-    job = context.dig(:job, "class")
-    if job
-      job_exception_stats[job] += 1
+    job = context[:job]
+
+    if Hash === job
+      job_class = job["class"]
+      if job_class
+        job_exception_stats[job_class] += 1
+      end
     end
 
     cm = RailsMultisite::ConnectionManagement

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -342,12 +342,21 @@ RSpec.describe Discourse do
 
     describe "#job_exception_stats" do
 
+      class FakeTestError < StandardError
+      end
+
       before do
         Discourse.reset_job_exception_stats!
       end
 
       after do
         Discourse.reset_job_exception_stats!
+      end
+
+      it "should not fail on incorrectly shaped hash" do
+        expect do
+          Discourse.handle_job_exception(FakeTestError.new, { job: "test" })
+        end.to raise_error(FakeTestError)
       end
 
       it "should collect job exception stats" do
@@ -361,7 +370,7 @@ RSpec.describe Discourse do
 
         # re-raised unconditionally in test env
         2.times do
-          expect { Discourse.handle_job_exception(StandardError.new, exception_context) }.to raise_error(StandardError)
+          expect { Discourse.handle_job_exception(FakeTestError.new, exception_context) }.to raise_error(FakeTestError)
         end
 
         exception_context = {
@@ -369,7 +378,7 @@ RSpec.describe Discourse do
           job: { "class" => Jobs::PollMailbox }
         }
 
-        expect { Discourse.handle_job_exception(StandardError.new, exception_context) }.to raise_error(StandardError)
+        expect { Discourse.handle_job_exception(FakeTestError.new, exception_context) }.to raise_error(FakeTestError)
 
         expect(Discourse.job_exception_stats).to eq({
           Jobs::PollMailbox => 1,


### PR DESCRIPTION
`{a: "a"}.dig(:a, :b)` will result in an exception, since ruby assumes that `"a"` will be another hash it can look up the `:b` key on.