### PR TITLE
DEV: Clear custom sidebar sections after each test

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -71,6 +71,7 @@ import {
 } from "discourse/lib/to-markdown";
 import { clearTagsHtmlCallbacks } from "discourse/lib/render-tags";
 import { clearToolbarCallbacks } from "discourse/components/d-editor";
+import { resetSidebarSection } from "discourse/lib/sidebar/custom-sections";
 
 export function currentUser() {
   return User.create(sessionFixtures["/session/current.json"].current_user);
@@ -198,6 +199,7 @@ export function testCleanup(container, app) {
   clearLegacyResolverOptions();
   clearTagsHtmlCallbacks();
   clearToolbarCallbacks();
+  resetSidebarSection();
 }
 
 export function discourseModule(name, options) {


### PR DESCRIPTION
Initializers are re-run before each test, so we need to clear out the list to avoid duplicates building up over multiple tests.

(e.g. right now when running tests with chat installed)

<img width="193" alt="Screenshot 2022-08-03 at 09 13 56" src="https://user-images.githubusercontent.com/6270921/182560670-f165180f-bba7-4965-917d-03e38c30492d.png">

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
