### PR TITLE
UX: change wrap order of navbar elements based on width (with on-resize modifier)

### DIFF
--- a/app/assets/javascripts/discourse/app/components/navigation-bar.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-bar.js
@@ -9,10 +9,6 @@ export default Component.extend(FilterModeMixin, {
   classNameBindings: [":nav", ":nav-pills"],
   elementId: "navigation-bar",
 
-  init() {
-    this._super(...arguments);
-  },
-
   @discourseComputed("filterType", "navItems")
   selectedNavItem(filterType, navItems) {
     let item = navItems.find((i) => i.active === true);

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -1,11 +1,17 @@
-<BreadCrumbs @categories={{this.categories}} @category={{this.category}} @noSubcategories={{this.noSubcategories}} @tag={{this.tag}} @additionalTags={{this.additionalTags}} />
+<BreadCrumbs @categories={{this.categories}} @category={{this.category}} @noSubcategories={{this.noSubcategories}} @tag={{this.tag}} @additionalTags={{this.additionalTags}} {{on-resize this.childResized}}/>
 
 {{#unless this.additionalTags}}
   {{!-- nav bar doesn't work with tag intersections --}}
-  <NavigationBar @navItems={{this.navItems}} @filterMode={{this.filterMode}} @category={{this.category}} />
+  <NavigationBar
+    @navItems={{this.navItems}}
+    @filterMode={{this.filterMode}}
+    @category={{this.category}}
+    class={{if this.wrapNavigationBar "wrapped-navigation-bar"}}
+    {{on-resize this.childResized}}
+    />
 {{/unless}}
 
-<div class="navigation-controls">
+<div class="navigation-controls" {{on-resize this.childResized}}>
   {{#if (and this.notCategoriesRoute this.site.mobileView this.canBulk)}}
     <BulkSelectToggle @parentController={{"discovery/topics"}} @tagName=""/>
   {{/if}}

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -60,6 +60,7 @@
     "ember-source": "~3.28.8",
     "ember-test-selectors": "^6.0.0",
     "ember-modifier": "^3.2.7",
+    "ember-on-resize-modifier": "^1.1.0",
     "@ember/render-modifiers": "^2.0.4",
     "eslint": "^7.32.0",
     "eslint-plugin-qunit": "^6.2.0",

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -4813,6 +4813,16 @@ ember-modifier@^3.2.7:
     ember-cli-typescript "^5.0.0"
     ember-compatibility-helpers "^1.2.5"
 
+ember-on-resize-modifier@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-on-resize-modifier/-/ember-on-resize-modifier-1.1.0.tgz#96b92cb190a552a8e240a2077037b0b71facc54e"
+  integrity sha512-Pz7muUcwzgAVGQ3ZNCdY/KMKtmvtJk5DWetuvx2MVHZCRpVzSRvkVa2tKXcp4tmz/COYUysneJxAR4tmwAyH9Q==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^5.7.1"
+    ember-modifier "^3.2.7"
+    ember-resize-observer-service "^1.1.0"
+
 ember-qunit@^5.1.5:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-5.1.5.tgz#24a7850f052be24189ff597dfc31b923e684c444"
@@ -4827,6 +4837,14 @@ ember-qunit@^5.1.5:
     resolve-package-path "^3.1.0"
     silent-error "^1.1.1"
     validate-peer-dependencies "^1.2.0"
+
+ember-resize-observer-service@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-resize-observer-service/-/ember-resize-observer-service-1.1.0.tgz#62729a9de656e8eade4b3e65bd9999840dc44f65"
+  integrity sha512-/vbfxtHSyOGSNdjPKL8X3SyvUnYo3z88sJtD/bLJ0ZGhqVPaXCmtSkLyr/Fh75ckJDixRFxK4i4zEUSlrbk0PA==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+    ember-cli-htmlbars "^5.7.1"
 
 ember-resolver@^8.0.3:
   version "8.0.3"

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -51,7 +51,12 @@
   flex-wrap: wrap;
   margin: 0;
   margin-bottom: var(--nav-space);
-  margin-right: auto;
+
+  &.wrapped-navigation-bar {
+    // When the elements in .navigation-container start wrapping, this class is added to `#navigation-bar`.
+    // We use this to visually reorder the navigation bar after the `.navigation-controls`.
+    order: 3;
+  }
 }
 
 .navigation-controls {
@@ -59,6 +64,7 @@
   flex-wrap: wrap;
   align-items: stretch;
   margin-bottom: var(--nav-space);
+  margin-left: auto;
   gap: var(--nav-space) 0; // used if the buttons wrap
   > * {
     white-space: nowrap;


### PR DESCRIPTION
When the three children of .navigation-container start wrapping, a `.wrapped-navigation-bar` class will be added to the #navigation-bar, and then used to visually re-order it after the `.navigation-controls`.

This commit introduces a new `{{on-resize}}` modifier along with its companion `resize-observer` Service. These automatically take care of setting up the observer and handling cleanup. They will also translate well to Glimmer Components, which do not have an `didInsertElement()` method.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

(this is an experimental refactor of #17562. I'd like to add some tests, so this is a draft for now)