### PR TITLE
FIX: Unsubscribe from `/reviewable_counts` message bus channel when leaving the review-index route

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -82,6 +82,10 @@ export default DiscourseRoute.extend({
 
   deactivate() {
     this.messageBus.unsubscribe("/reviewable_claimed");
+    const channel = this.currentUser.enable_redesigned_user_menu
+      ? `/reviewable_counts/${this.currentUser.id}`
+      : "/reviewable_counts";
+    this.messageBus.unsubscribe(channel);
   },
 
   @action


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/ce9eec8606e6c55ef6fa09b630464067fcea7b43.

When the review-index route is entered, we listen to the `/reviewable_counts` (or `/reviewable_counts/<user_id>` when the new user menu is enabled) channel so we can listen for changes to reviewables and update the UI accordingly. However, we currently don't unsubscribe when leaving the route which means each time the route is entered, we setup a new listener causing the browser to do unnecessary work and potentially state leakage.