### PR TITLE
DEV: Don't publish to the `/reviewable_counts` channel

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -643,11 +643,6 @@ class User < ActiveRecord::Base
     if max_reviewable_id
       update!(last_seen_reviewable_id: max_reviewable_id)
       publish_reviewable_counts(unseen_reviewable_count: self.unseen_reviewable_count)
-      MessageBus.publish(
-        "/reviewable_counts",
-        { unseen_reviewable_count: self.unseen_reviewable_count },
-        user_ids: [self.id]
-      )
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2908,15 +2908,16 @@ RSpec.describe User do
 
     it "publishes a message to the user's /reviewable_counts message bus channel" do
       user.update!(admin: true)
-      reviewable = Fabricate(:reviewable)
+      Fabricate(:reviewable)
       messages = MessageBus.track_publish do
         user.bump_last_seen_reviewable!
       end
       expect(messages.size).to eq(1)
-      message = messages[0]
-      expect(message.channel).to eq("/reviewable_counts/#{user.id}")
-      expect(message.user_ids).to eq([user.id])
-      expect(message.data).to eq({ unseen_reviewable_count: 0 })
+      expect(messages.first).to have_attributes(
+        channel: "/reviewable_counts/#{user.id}",
+        user_ids: [user.id],
+        data: { unseen_reviewable_count: 1 }
+      )
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2916,7 +2916,7 @@ RSpec.describe User do
       expect(messages.first).to have_attributes(
         channel: "/reviewable_counts/#{user.id}",
         user_ids: [user.id],
-        data: { unseen_reviewable_count: 1 }
+        data: { unseen_reviewable_count: 0 }
       )
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/ce9eec8606e6c55ef6fa09b630464067fcea7b43.

I did a last-minute refactoring before merging my the commit above where I extracted the Message Bus publish call into a new method, but forgot to delete the publish call after adding a call to the new method.