### PR TITLE
UX: account for iPad hub nav when calculating top

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -11,6 +11,9 @@
     grid-area: sidebar;
     position: sticky;
     top: var(--header-offset);
+    .footer-nav-ipad & {
+      top: calc(var(--header-offset) + var(--footer-nav-height));
+    }
     height: calc(100vh - var(--header-offset));
     align-self: start;
     overflow-y: auto;

--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -50,6 +50,9 @@ $topic-progress-height: 42px;
       align-self: start;
       @include sticky;
       top: calc(var(--header-offset, 60px) + 2em);
+      .footer-nav-ipad & {
+        top: calc(var(--header-offset, 60px) + var(--footer-nav-height) + 2em);
+      }
       margin-left: 1em;
       z-index: z("timeline");
 


### PR DESCRIPTION
This fixes the sidebar and the timeline. The top position wasn't including the iPad "footer" nav, so the tops of these elements are covered by the header. 

![Screen Shot 2022-08-03 at 11 39 49 AM](https://user-images.githubusercontent.com/1681963/182650701-e038f3d3-1432-48ba-a462-43dea067d8af.png)

