### PR TITLE
FIX: show update banner only once on categories with subcategory lists

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
@@ -23,6 +23,15 @@ export default DiscoveryController.extend({
   category: null,
 
   canEdit: reads("currentUser.staff"),
+  // This makes sure that we don't display incoming banners on categories with subcategory lists twice
+  @discourseComputed
+  showIncomingInParentCategories() {
+    if (typeof this.router.currentRoute.attributes.category === "undefined") {
+      return true;
+    }
+
+    return !this.router.currentRoute.attributes.category.show_subcategory_list;
+  },
   @discourseComputed("model.parentCategory")
   categoryPageStyle(parentCategory) {
     let style = this.siteSettings.desktop_category_page_style;

--- a/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
@@ -25,12 +25,8 @@ export default DiscoveryController.extend({
   canEdit: reads("currentUser.staff"),
   // This makes sure that we don't display incoming banners on categories with subcategory lists twice
   @discourseComputed
-  showIncomingInParentCategories() {
-    if (typeof this.router.currentRoute.attributes.category === "undefined") {
-      return true;
-    }
-
-    return !this.router.currentRoute.attributes.category.show_subcategory_list;
+  isCategoriesRoute() {
+    return this.router.currentRouteName === "discovery.categories";
   },
   @discourseComputed("model.parentCategory")
   categoryPageStyle(parentCategory) {

--- a/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/categories.js
@@ -23,7 +23,6 @@ export default DiscoveryController.extend({
   category: null,
 
   canEdit: reads("currentUser.staff"),
-  // This makes sure that we don't display incoming banners on categories with subcategory lists twice
   @discourseComputed
   isCategoriesRoute() {
     return this.router.currentRouteName === "discovery.categories";

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
@@ -1,7 +1,7 @@
 <PluginOutlet @name="above-discovery-categories" @connectorTagName="div" @args={{hash categories=this.model.categories categoryPageStyle=this.categoryPageStyle topics=this.model.topics}} />
 
 <DiscoveryCategories @refresh={{action "refresh"}}>
-  {{#if this.topicTrackingState.hasIncoming}}
+  {{#if (and this.topicTrackingState.hasIncoming this.showIncomingInParentCategories)}}
     <div class="show-more {{if this.hasTopics "has-topics"}}">
       <div role="button" class="alert alert-info clickable" {{action "showInserted"}}>
         <CountI18n @key="topic_count_" @suffix={{this.topicTrackingState.filter}} @count={{this.topicTrackingState.incomingCount}} />

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
@@ -1,7 +1,7 @@
 <PluginOutlet @name="above-discovery-categories" @connectorTagName="div" @args={{hash categories=this.model.categories categoryPageStyle=this.categoryPageStyle topics=this.model.topics}} />
 
 <DiscoveryCategories @refresh={{action "refresh"}}>
-  {{#if (and this.topicTrackingState.hasIncoming this.showIncomingInParentCategories)}}
+  {{#if (and this.topicTrackingState.hasIncoming this.isCategoriesRoute)}}
     <div class="show-more {{if this.hasTopics "has-topics"}}">
       <div role="button" class="alert alert-info clickable" {{action "showInserted"}}>
         <CountI18n @key="topic_count_" @suffix={{this.topicTrackingState.filter}} @count={{this.topicTrackingState.incomingCount}} />

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -14,47 +14,6 @@ import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
 import { ScrollingDOMMethods } from "discourse/mixins/scrolling";
 import { configureEyeline } from "discourse/lib/eyeline";
 
-acceptance("Topic discovery - subcategory list", function (needs) {
-  needs.settings({
-    show_pinned_excerpt_desktop: false,
-    desktop_category_page_style: "categories_and_latest_topics",
-  });
-
-  test("Topic with subcategory list", async function (assert) {
-    let presenceService = this.container.lookup("service:presence");
-
-    let channel = presenceService.getChannel("/latest");
-    await channel.subscribe();
-
-    await visit("/c/dev");
-    publishToMessageBus("/latest", {
-      message_type: "latest",
-      topic_id: 3823,
-      payload: {
-        highest_post_number: 1,
-        last_read_post_number: 2,
-        notification_level: 1,
-        topic_id: 3823,
-      },
-    });
-    publishToMessageBus("/latest", {
-      topic_id: 3823,
-      message_type: "unread",
-      payload: {
-        category_id: 7,
-        topic_tag_ids: [44],
-        tags: ["pending"],
-        highest_post_number: 10,
-        created_at: "2012-11-31 12:00:00 UTC",
-        archetype: "regular",
-      },
-    });
-    await channel._presenceState._resubscribePromise;
-    await visit("/c/dev");
-    assert.ok(exists(".show-more"), `displays the topic incoming info`);
-  });
-});
-
 acceptance("Topic Discovery", function (needs) {
   needs.settings({
     show_pinned_excerpt_desktop: true,
@@ -151,7 +110,7 @@ acceptance("Topic Discovery", function (needs) {
       "shows the topic unread"
     );
 
-    publishToMessageBus("/latest", {
+    await publishToMessageBus("/latest", {
       message_type: "read",
       topic_id: 11995,
       payload: {
@@ -161,8 +120,6 @@ acceptance("Topic Discovery", function (needs) {
         topic_id: 11995,
       },
     });
-
-    await visit("/"); // We're already there, but use this to wait for re-render
 
     assert.ok(
       exists(".topic-list-item.visited a[data-topic-id='11995']"),

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -14,6 +14,47 @@ import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
 import { ScrollingDOMMethods } from "discourse/mixins/scrolling";
 import { configureEyeline } from "discourse/lib/eyeline";
 
+acceptance("Topic discovery - subcategory list", function (needs) {
+  needs.settings({
+    show_pinned_excerpt_desktop: false,
+    desktop_category_page_style: "categories_and_latest_topics",
+  });
+
+  test("Topic with subcategory list", async function (assert) {
+    let presenceService = this.container.lookup("service:presence");
+
+    let channel = presenceService.getChannel("/latest");
+    await channel.subscribe();
+
+    await visit("/c/dev");
+    publishToMessageBus("/latest", {
+      message_type: "latest",
+      topic_id: 3823,
+      payload: {
+        highest_post_number: 1,
+        last_read_post_number: 2,
+        notification_level: 1,
+        topic_id: 3823,
+      },
+    });
+    publishToMessageBus("/latest", {
+      topic_id: 3823,
+      message_type: "unread",
+      payload: {
+        category_id: 7,
+        topic_tag_ids: [44],
+        tags: ["pending"],
+        highest_post_number: 10,
+        created_at: "2012-11-31 12:00:00 UTC",
+        archetype: "regular",
+      },
+    });
+    await channel._presenceState._resubscribePromise;
+    await visit("/c/dev");
+    assert.ok(exists(".show-more"), `displays the topic incoming info`);
+  });
+});
+
 acceptance("Topic Discovery", function (needs) {
   needs.settings({
     show_pinned_excerpt_desktop: true,
@@ -110,7 +151,7 @@ acceptance("Topic Discovery", function (needs) {
       "shows the topic unread"
     );
 
-    await publishToMessageBus("/latest", {
+    publishToMessageBus("/latest", {
       message_type: "read",
       topic_id: 11995,
       payload: {
@@ -120,6 +161,8 @@ acceptance("Topic Discovery", function (needs) {
         topic_id: 11995,
       },
     });
+
+    await visit("/"); // We're already there, but use this to wait for re-render
 
     assert.ok(
       exists(".topic-list-item.visited a[data-topic-id='11995']"),


### PR DESCRIPTION
Fix the following issue where the update banner is displayed twice on categories with a subcategory lists.

![image](https://user-images.githubusercontent.com/3180866/182681090-6aa9eb94-2fe8-40e8-93ad-f51b9e6edc52.png)

The banner is now only displayed on the `discovery.categories` route and no `discovery.category`

No tests: It was quite challenging to replicate this issue in tests, the message bus sent the message, but the banner never rendered.