### PR TITLE
UX: Improve empty state copy on the activity/replies page

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
@@ -2,6 +2,8 @@ import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
 import I18n from "I18n";
 import { action } from "@ember/object";
+import { htmlSafe } from "@ember/template";
+import getURL from "discourse-common/lib/get-url";
 
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["posts"],
@@ -12,7 +14,11 @@ export default UserActivityStreamRoute.extend({
     let title, body;
     if (this.isCurrentUser(user)) {
       title = I18n.t("user_activity.no_replies_title");
-      body = "";
+      body = htmlSafe(
+        I18n.t("user_activity.no_replies_body", {
+          searchUrl: getURL("/search"),
+        })
+      );
     } else {
       title = I18n.t("user_activity.no_replies_title_others", {
         username: user.username,

--- a/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
@@ -9,12 +9,17 @@ export default UserActivityStreamRoute.extend({
   emptyState() {
     const user = this.modelFor("user");
 
-    const title = this.isCurrentUser(user)
-      ? I18n.t("user_activity.no_replies_title")
-      : I18n.t("user_activity.no_replies_title_others", {
-          username: user.username,
-        });
-    const body = "";
+    let title, body;
+    if (this.isCurrentUser(user)) {
+      title = I18n.t("user_activity.no_replies_title");
+      body = "";
+    } else {
+      title = I18n.t("user_activity.no_replies_title_others", {
+        username: user.username,
+      });
+      body = "";
+    }
+
     return { title, body };
   },
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4062,6 +4062,7 @@ en:
       no_activity_body: "Welcome to our community! You are brand new here and have not yet contributed to discussions. As a first step, visit <a href='%{topUrl}'>Top</a> or <a href='%{categoriesUrl}'>Categories</a> and just start reading! Select %{heartIcon} on posts that you like or want to learn more about. As you participate, your activity will be listed here."
       no_replies_title: "You have not replied to any topics yet"
       no_replies_title_others: "%{username} has not replied to any topics yet"
+      no_replies_body: "When you <a href='%{searchUrl}'>discover</a> an interesting conversation that you wish to contribute to, press the <kbd>Reply</kbd> button directly under any post to begin repying to that specific post. Or, if you’d prefer to reply to the general topic rather than any individual post or person, look for the <kbd>Reply</kbd> button at the very bottom of the topic, or under the topic timeline."
       no_drafts_title: "You haven’t started any drafts"
       no_drafts_body: "Not quite ready to post? We’ll automatically save a new draft and list it here whenever you start composing a topic, reply, or personal message. Select the cancel button to discard or save your draft to continue later."
       no_likes_title: "You haven’t liked any topics yet"


### PR DESCRIPTION
Before:

<img width="805" alt="Screenshot 2022-08-03 at 23 39 36" src="https://user-images.githubusercontent.com/1274517/182694932-cb632aff-3477-4b9f-8085-29e54a34d2b1.png">

After:

<img width="802" alt="Screenshot 2022-08-03 at 23 39 06" src="https://user-images.githubusercontent.com/1274517/182694965-30d367f7-5fb6-41b3-87b2-476764179d59.png">


