### PR TITLE
FIX: the phpbbb import script was not parsing youtube tags

### DIFF
--- a/script/import_scripts/phpbb3/support/bbcode/xml_to_markdown.rb
+++ b/script/import_scripts/phpbb3/support/bbcode/xml_to_markdown.rb
@@ -185,6 +185,13 @@ module ImportScripts::PhpBB3::BBCode
       end
     end
 
+    def visit_YOUTUBE(xml_node, md_node)
+      youtube_id = xml_node.attr("content")
+      md_node.text = "https://www.youtube.com/watch?v=" + youtube_id
+      md_node.prefix_linebreaks = md_node.postfix_linebreaks = 1
+      md_node.skip_children
+    end
+
     def visit_QUOTE(xml_node, md_node)
       if post = quoted_post(xml_node)
         md_node.prefix = %Q{[quote="#{post[:username]}, post:#{post[:post_number]}, topic:#{post[:topic_id]}"]\n}

--- a/script/import_scripts/phpbb3/support/text_processor.rb
+++ b/script/import_scripts/phpbb3/support/text_processor.rb
@@ -59,7 +59,7 @@ module ImportScripts::PhpBB3
         process_code(text)
         fix_markdown(text)
         process_attachments(text, attachments) if attachments.present?
-
+        process_videos(text)
         text
       end
     end
@@ -195,6 +195,12 @@ module ImportScripts::PhpBB3
     def fix_markdown(text)
       text.gsub!(/(\n*\[\/?quote.*?\]\n*)/mi) { |q| "\n#{q.strip}\n" }
       text.gsub!(/^!\[[^\]]*\]\([^\]]*\)$/i) { |img| "\n#{img.strip}\n" } # space out images single on line
+      text
+    end
+
+    def process_videos(text)
+      # [YOUTUBE]<id>[/YOUTUBE]
+      text.gsub(/\[youtube\](.+?)\[\/youtube\]/i) { "\nhttps://www.youtube.com/watch?v=#{$1}\n" }
       text
     end
   end


### PR DESCRIPTION
In older versions of phpbb (3.2 and below), youtube videos are embedded with bbcode tags in this format:
`[youtube]IDENTIFIER[youtube]`

Which in XML looks like:
`<YOUTUBE content="IDENTIFIER"><s>[youtube]</s>IDENTIFIER<e>[/youtube]</e></YOUTUBE>`

This PR adds the parsing rules, so youtube URLs are imported correctly to Discourse.

Note: I saw some occurrences of  `[youtube]URL[youtube]`. Maybe this way of embedding videos was supported at some point, but doesn't seem to be very common, and it doesn't work. Checking old support forums, they suggest this way `[youtube]IDENTIFIER[youtube]`. 

Note 2: I saw multiple mentions of the `[media]` tag used to embed youtube videos. But this functionality comes from an extension and is not a default in phpbb (AFAIK), so it shouldn't be supported by our script anyway.