### PR TITLE
FIX: don't memoize site setting in guardian

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -113,15 +113,17 @@ class Guardian
     return false if !SiteSetting.enable_category_group_moderation?
     return false if !category
     return false if !authenticated?
-    return false if !category.reviewable_by_group_id.present?
 
-    @is_category_group_moderator ||= {}
+    reviewable_by_group_id = category.reviewable_by_group_id
+    return false if reviewable_by_group_id.blank?
 
-    if @is_category_group_moderator.key?(category.id)
-      @is_category_group_moderator[category.id]
+    @is_group_member ||= {}
+
+    if @is_group_member.key?(reviewable_by_group_id)
+      @is_group_member[reviewable_by_group_id]
     else
-      @is_category_group_moderator[category.id] ||= begin
-        GroupUser.where(group_id: category.reviewable_by_group_id, user_id: @user.id).exists?
+      @is_group_member[reviewable_by_group_id] ||= begin
+        GroupUser.where(group_id: reviewable_by_group_id, user_id: @user.id).exists?
       end
     end
   end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -122,7 +122,7 @@ class Guardian
     if @is_group_member.key?(reviewable_by_group_id)
       @is_group_member[reviewable_by_group_id]
     else
-      @is_group_member[reviewable_by_group_id] ||= begin
+      @is_group_member[reviewable_by_group_id] = begin
         GroupUser.where(group_id: reviewable_by_group_id, user_id: @user.id).exists?
       end
     end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -110,14 +110,13 @@ class Guardian
   end
 
   def is_category_group_moderator?(category)
+    return false if !SiteSetting.enable_category_group_moderation?
     return false if !category
     return false if !authenticated?
-    return false if !SiteSetting.enable_category_group_moderation?
+    return false if !category.reviewable_by_group_id.present?
 
     @is_category_group_moderator ||= {}
     @is_category_group_moderator[category.id] ||= begin
-      category.present? &&
-      category.reviewable_by_group_id.present? &&
       GroupUser.where(group_id: category.reviewable_by_group_id, user_id: @user.id).exists?
     end
   end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -116,8 +116,13 @@ class Guardian
     return false if !category.reviewable_by_group_id.present?
 
     @is_category_group_moderator ||= {}
-    @is_category_group_moderator[category.id] ||= begin
-      GroupUser.where(group_id: category.reviewable_by_group_id, user_id: @user.id).exists?
+
+    if @is_category_group_moderator.key?(category.id)
+      @is_category_group_moderator[category.id]
+    else
+      @is_category_group_moderator[category.id] ||= begin
+        GroupUser.where(group_id: category.reviewable_by_group_id, user_id: @user.id).exists?
+      end
     end
   end
 

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -110,14 +110,15 @@ class Guardian
   end
 
   def is_category_group_moderator?(category)
-    return false unless category
-    return false unless authenticated?
+    return false if !category
+    return false if !authenticated?
+    return false if !SiteSetting.enable_category_group_moderation?
+
     @is_category_group_moderator ||= {}
     @is_category_group_moderator[category.id] ||= begin
-      SiteSetting.enable_category_group_moderation? &&
-        category.present? &&
-        category.reviewable_by_group_id.present? &&
-        GroupUser.where(group_id: category.reviewable_by_group_id, user_id: @user.id).exists?
+      category.present? &&
+      category.reviewable_by_group_id.present? &&
+      GroupUser.where(group_id: category.reviewable_by_group_id, user_id: @user.id).exists?
     end
   end
 

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3968,6 +3968,10 @@ RSpec.describe Guardian do
 
       expect(guardian.is_category_group_moderator?(category)).to eq(true)
       expect(guardian.is_category_group_moderator?(plain_category)).to eq(false)
+
+      # edge case ... site setting disabled while guardian instansiated (can help with test cases)
+      SiteSetting.enable_category_group_moderation = false
+      expect(guardian.is_category_group_moderator?(category)).to eq(false)
     end
   end
 end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3966,7 +3966,10 @@ RSpec.describe Guardian do
       category.reviewable_by_group_id = group.id
       guardian = Guardian.new(user)
 
+      # implementation detail, ensure memoization is good (hence testing twice)
       expect(guardian.is_category_group_moderator?(category)).to eq(true)
+      expect(guardian.is_category_group_moderator?(category)).to eq(true)
+      expect(guardian.is_category_group_moderator?(plain_category)).to eq(false)
       expect(guardian.is_category_group_moderator?(plain_category)).to eq(false)
 
       # edge case ... site setting disabled while guardian instansiated (can help with test cases)


### PR DESCRIPTION
Memoizing site settings can make tests more fragile and harder to debug
