### PR TITLE
FIX: Handle actor not having preferences in UserCommScreener

### DIFF
--- a/lib/user_comm_screener.rb
+++ b/lib/user_comm_screener.rb
@@ -172,6 +172,7 @@ class UserCommScreener
 
   def actor_disallowing_pms?(user_id)
     validate_user_id!(user_id)
+    return true if actor_disallowing_all_pms?
     return false if !acting_user.user_option.enable_allowed_pm_users
     actor_preferences[:disallowed_pms_from].include?(user_id)
   end
@@ -244,10 +245,16 @@ class UserCommScreener
         hash[pref.preference_type] << pref.target_user_id
         hash
       end
+      disallowed_pms_from = \
+        if acting_user.user_option.enable_allowed_pm_users
+          (user_ids_by_preference_type["disallowed_pm"] || [])
+        else
+          []
+        end
       {
-        muting: user_ids_by_preference_type["muted"],
-        ignoring: user_ids_by_preference_type["ignored"],
-        disallowed_pms_from: user_ids_by_preference_type["disallowed_pm"]
+        muting: user_ids_by_preference_type["muted"] || [],
+        ignoring: user_ids_by_preference_type["ignored"] || [],
+        disallowed_pms_from: disallowed_pms_from
       }
     end
   end


### PR DESCRIPTION
Followup to d66115d9187624f0f74a59c3e6fc6d91ff6323ca

* Makes sure the `actor_preferences` all initialize with an empty array instead of nil if there are no preferences e.g. the actor is not ignoring anyone
* If the actor has disabled all PMs make `actor_disallowing_pms?` always return true