### PR TITLE
Add support for toggling between mobile and desktop view on sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/sidebar/footer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/sidebar/footer.hbs
@@ -1,6 +1,14 @@
 <div class="sidebar-footer-wrapper">
   <div class="sidebar-footer-container">
     <div class="sidebar-footer-actions">
+      {{#if (or this.site.mobileView (and this.siteSettings.enable_mobile_theme this.capabilities.touch))}}
+        <DButton
+          @action={{route-action "toggleMobileView"}}
+          @title={{if this.site.mobileView "desktop_view" "mobile_view"}}
+          @icon={{if this.site.mobileView "desktop" "mobile-alt"}}
+          @class="sidebar-footer-actions-button sidebar-footer-actions-toggle-mobile-view" />
+      {{/if}}
+
       <DButton
         @action={{route-action "showKeyboardShortcutsHelp"}}
         @title="keyboard_shortcuts_help.title"

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-mobile-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-mobile-test.js
@@ -1,5 +1,8 @@
+import I18n from "I18n";
 import { test } from "qunit";
+
 import { click, visit } from "@ember/test-helpers";
+
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Sidebar - Mobile - User with sidebar enabled", function (needs) {
@@ -64,6 +67,25 @@ acceptance("Sidebar - Mobile - User with sidebar enabled", function (needs) {
     assert.ok(
       exists(".sidebar-container"),
       "sidebar is not collapsed when clicking on caret to collapse a section in sidebar"
+    );
+  });
+
+  test("button to toggle between mobile and desktop view", async function (assert) {
+    await visit("/");
+    await click(".hamburger-dropdown");
+
+    assert.ok(
+      exists(
+        `.sidebar-footer-actions-toggle-mobile-view[title="${I18n.t(
+          "desktop_view"
+        )}"]`
+      ),
+      "displays the right title for the button"
+    );
+
+    assert.ok(
+      exists(".sidebar-footer-actions-toggle-mobile-view .d-icon-desktop"),
+      "displays the desktop icon for the button"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-test.js
@@ -170,5 +170,26 @@ acceptance(
         "hides the sidebar dropdown"
       );
     });
+
+    test("button to toggle between mobile and desktop view on touch devices ", async function (assert) {
+      const capabilities = this.container.lookup("capabilities:main");
+      capabilities.touch = true;
+
+      await visit("/");
+
+      assert.ok(
+        exists(
+          `.sidebar-footer-actions-toggle-mobile-view[title="${I18n.t(
+            "mobile_view"
+          )}"]`
+        ),
+        "displays the right title for the button"
+      );
+
+      assert.ok(
+        exists(".sidebar-footer-actions-toggle-mobile-view .d-icon-mobile-alt"),
+        "displays the mobile icon for the button"
+      );
+    });
   }
 );


### PR DESCRIPTION
In the current hamburger menu dropdown, we have a link which allows users to toggle between mobile and desktop view on mobile and touch devices. This commit brings the same behaviour to sidebar. 

See https://github.com/discourse/discourse/blob/e09fd7cde2d7162d55511ba40b59150ab03c7419/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js#L268-L274

## Recording

![Peek 2022-08-04 13-43](https://user-images.githubusercontent.com/4335742/182771729-675fb6b3-7dc3-4cdc-85a2-fe83ee667964.gif)
