### PR TITLE
FIX: Secondary more section links not marked as active

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
@@ -11,6 +11,8 @@ export default class SidebarMoreSectionLinks extends GlimmerComponent {
   @tracked activeSectionLink;
   @service router;
 
+  #allLinks = [...this.args.sectionLinks, ...this.args.secondarySectionLinks];
+
   constructor() {
     super(...arguments);
     this.#setActiveSectionLink();
@@ -89,7 +91,7 @@ export default class SidebarMoreSectionLinks extends GlimmerComponent {
   }
 
   #setActiveSectionLink() {
-    const activeSectionLink = this.args.sectionLinks.find((sectionLink) => {
+    const activeSectionLink = this.#allLinks.find((sectionLink) => {
       const args = [sectionLink.route];
 
       if (sectionLink.model) {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-community-section-test.js
@@ -313,6 +313,11 @@ acceptance("Sidebar - Community Section", function (needs) {
       "/about",
       "navigates to about route correctly"
     );
+
+    assert.ok(
+      exists(".sidebar-section-community .sidebar-section-link-about.active"),
+      "about section link link is displayed in the main section and marked as active"
+    );
   });
 
   test("navigating to FAQ from sidebar", async function (assert) {


### PR DESCRIPTION
When the route of the link is equal to the active route, we promote it
out of the "more..." links drawer and display it directly under the
community section. This commit fixes a bug where the secondary links in
the "more..." links drawer was not being marked as active.

Follow-up to e09fd7cde2d7162d55511ba40b59150ab03c7419


## Recording 

![Peek 2022-08-04 16-13](https://user-images.githubusercontent.com/4335742/182798215-c8025a06-8ff3-4b82-89d1-5a5dcd68c6bb.gif)
