### PR TITLE
Revert "DEV: Improve multisite db scripts in dev (#17337)"

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -45,7 +45,7 @@ if ENV['RAILS_ENV'] == "test" && ENV['TEST_ENV_NUMBER']
   pid = Process.spawn("redis-server --dir tmp/test_data_#{n}/redis --port #{port}", out: "/dev/null")
 
   ENV["DISCOURSE_REDIS_PORT"] = port.to_s
-  ENV["RAILS_TEST_DB"] = "discourse_test_#{n}"
+  ENV["RAILS_DB"] = "discourse_test_#{n}"
 
   at_exit do
     Process.kill("SIGTERM", pid)

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,7 @@ development:
 # Do not set this db to the same as development or production.
 
 <%
-  test_db = ENV["RAILS_TEST_DB"]
+  test_db = ENV["RAILS_DB"]
   if !test_db.present?
     test_db = "discourse_test"
 

--- a/lib/temporary_db.rb
+++ b/lib/temporary_db.rb
@@ -104,13 +104,13 @@ class TemporaryDb
     old_user = ENV["PGUSER"]
     old_port = ENV["PGPORT"]
     old_dev_db = ENV["DISCOURSE_DEV_DB"]
-    old_rails_test_db = ENV["RAILS_TEST_DB"]
+    old_rails_db = ENV["RAILS_DB"]
 
     ENV["PGHOST"] = "localhost"
     ENV["PGUSER"] = "discourse"
     ENV["PGPORT"] = pg_port.to_s
     ENV["DISCOURSE_DEV_DB"] = "discourse"
-    ENV["RAILS_TEST_DB"] = "discourse"
+    ENV["RAILS_DB"] = "discourse"
 
     yield
   ensure
@@ -118,7 +118,7 @@ class TemporaryDb
     ENV["PGUSER"] = old_user
     ENV["PGPORT"] = old_port
     ENV["DISCOURSE_DEV_DB"] = old_dev_db
-    ENV["RAILS_TEST_DB"] = old_rails_test_db
+    ENV["RAILS_DB"] = old_rails_db
   end
 
   def remove


### PR DESCRIPTION
This reverts commit 2e4056d18532435e6e68d79cceca5b8b280c6948.

Unfortunately, this broke db:create and db:drop when multisite config
wasn't present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
