### PR TITLE
DEV: Replace `topic-tracking-state:main` with `service:topic-tracking-state`

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -83,6 +83,11 @@ const DEPRECATED_MODULES = new Map(
       since: "2.9.0.beta7",
       dropFrom: "3.0.0",
     },
+    "topic-tracking-state:main": {
+      newName: "service:topic-tracking-state",
+      since: "2.9.0.beta7",
+      dropFrom: "3.0.0",
+    },
   })
 );
 

--- a/app/assets/javascripts/discourse/app/components/glimmer.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer.js
@@ -1,6 +1,4 @@
 import GlimmerComponent from "@glimmer/component";
-import { cached } from "@glimmer/tracking";
-import { getOwner } from "@ember/application";
 import { inject as service } from "@ember/service";
 
 /*
@@ -22,10 +20,5 @@ export default class DiscourseGlimmerComponent extends GlimmerComponent {
   @service currentUser;
   @service session;
   @service site;
-
-  @cached
-  get topicTrackingState() {
-    const applicationInstance = getOwner(this);
-    return applicationInstance.lookup("topic-tracking-state:main");
-  }
+  @service topicTrackingState;
 }

--- a/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
+++ b/app/assets/javascripts/discourse/app/initializers/auto-load-modules.js
@@ -24,7 +24,7 @@ export function autoLoadModules(container, registry) {
     currentUser: container.lookup("service:current-user"),
     site: container.lookup("service:site"),
     session: container.lookup("service:session"),
-    topicTrackingState: container.lookup("topic-tracking-state:main"),
+    topicTrackingState: container.lookup("service:topic-tracking-state"),
     registry,
   };
   setOwner(context, container);

--- a/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/inject-discourse-objects.js
@@ -46,7 +46,7 @@ export default {
       currentUser,
     });
 
-    app.register("topic-tracking-state:main", topicTrackingState, {
+    app.register("service:topic-tracking-state", topicTrackingState, {
       instantiate: false,
     });
 
@@ -67,7 +67,7 @@ export default {
       app.inject(t, "session", "service:session");
       app.inject(t, "messageBus", "service:message-bus");
       app.inject(t, "siteSettings", "service:site-settings");
-      app.inject(t, "topicTrackingState", "topic-tracking-state:main");
+      app.inject(t, "topicTrackingState", "service:topic-tracking-state");
       app.inject(t, "keyValueStore", "service:key-value-store");
     });
 
@@ -86,7 +86,11 @@ export default {
       property: "siteSettings",
       specifier: "service:site-settings",
     });
-    app.inject("service", "topicTrackingState", "topic-tracking-state:main");
+    injectServiceIntoService({
+      app,
+      property: "topicTrackingState",
+      specifier: "service:topic-tracking-state",
+    });
     injectServiceIntoService({
       app,
       property: "keyValueStore",

--- a/app/assets/javascripts/discourse/app/services/store.js
+++ b/app/assets/javascripts/discourse/app/services/store.js
@@ -266,7 +266,9 @@ export default Service.extend({
     obj.__state = obj[adapter.primaryKey] ? "created" : "new";
 
     // TODO: Have injections be automatic
-    obj.topicTrackingState = this.register.lookup("topic-tracking-state:main");
+    obj.topicTrackingState = this.register.lookup(
+      "service:topic-tracking-state"
+    );
     obj.keyValueStore = this.register.lookup("service:key-value-store");
 
     const klass = this.register.lookupFactory("model:" + type) || RestModel;

--- a/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
@@ -95,7 +95,7 @@ export default createWidget("hamburger-menu", {
   },
 
   lookupCount(type) {
-    const tts = this.register.lookup("topic-tracking-state:main");
+    const tts = this.register.lookup("service:topic-tracking-state");
     return tts ? tts.lookupCount({ type }) : 0;
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-categories-section-test.js
@@ -273,7 +273,7 @@ acceptance("Sidebar - Categories Section", function (needs) {
   test("new and unread count for categories link", async function (assert) {
     const { category1, category2 } = setupUserSidebarCategories();
 
-    this.container.lookup("topic-tracking-state:main").loadStates([
+    this.container.lookup("service:topic-tracking-state").loadStates([
       {
         topic_id: 1,
         highest_post_number: 1,
@@ -391,7 +391,7 @@ acceptance("Sidebar - Categories Section", function (needs) {
     await visit("/");
 
     const topicTrackingState = this.container.lookup(
-      "topic-tracking-state:main"
+      "service:topic-tracking-state"
     );
 
     const initialCallbackCount = Object.keys(

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-community-section-test.js
@@ -487,7 +487,7 @@ acceptance("Sidebar - Community Section", function (needs) {
   });
 
   test("new and unread count for everything link", async function (assert) {
-    this.container.lookup("topic-tracking-state:main").loadStates([
+    this.container.lookup("service:topic-tracking-state").loadStates([
       {
         topic_id: 1,
         highest_post_number: 1,
@@ -674,7 +674,7 @@ acceptance("Sidebar - Community Section", function (needs) {
     const category = categories.find((c) => c.id === 1001);
     category.set("notification_level", NotificationLevels.TRACKING);
 
-    this.container.lookup("topic-tracking-state:main").loadStates([
+    this.container.lookup("service:topic-tracking-state").loadStates([
       {
         topic_id: 1,
         highest_post_number: 1,
@@ -918,7 +918,7 @@ acceptance("Sidebar - Community Section", function (needs) {
     await visit("/");
 
     const topicTrackingState = this.container.lookup(
-      "topic-tracking-state:main"
+      "service:topic-tracking-state"
     );
 
     const initialCallbackCount = Object.keys(

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-tags-section-test.js
@@ -213,7 +213,7 @@ acceptance("Sidebar - Tags section", function (needs) {
   });
 
   test("new and unread count for tag section links", async function (assert) {
-    this.container.lookup("topic-tracking-state:main").loadStates([
+    this.container.lookup("service:topic-tracking-state").loadStates([
       {
         topic_id: 1,
         highest_post_number: 1,
@@ -319,7 +319,7 @@ acceptance("Sidebar - Tags section", function (needs) {
     await visit("/");
 
     const topicTrackingState = this.container.lookup(
-      "topic-tracking-state:main"
+      "service:topic-tracking-state"
     );
 
     const initialCallbackCount = Object.keys(

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-tracked-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-tracked-test.js
@@ -39,7 +39,7 @@ acceptance("Topic Discovery Tracked", function (needs) {
   });
 
   test("navigation items with tracked filter", async function (assert) {
-    this.container.lookup("topic-tracking-state:main").loadStates([
+    this.container.lookup("service:topic-tracking-state").loadStates([
       {
         topic_id: 1,
         highest_post_number: 1,
@@ -104,7 +104,7 @@ acceptance("Topic Discovery Tracked", function (needs) {
     const category = categories.find((c) => c.id === 1001);
     category.set("notification_level", NotificationLevels.TRACKING);
 
-    this.container.lookup("topic-tracking-state:main").loadStates([
+    this.container.lookup("service:topic-tracking-state").loadStates([
       {
         topic_id: 1,
         highest_post_number: 1,
@@ -230,7 +230,7 @@ acceptance("Topic Discovery Tracked", function (needs) {
   });
 
   test("visit discovery page filtered by tag with tracked filter", async function (assert) {
-    this.container.lookup("topic-tracking-state:main").loadStates([
+    this.container.lookup("service:topic-tracking-state").loadStates([
       {
         topic_id: 1,
         highest_post_number: 1,
@@ -278,7 +278,7 @@ acceptance("Topic Discovery Tracked", function (needs) {
     const category = categories.at(-1);
     category.set("notification_level", NotificationLevels.TRACKING);
 
-    this.container.lookup("topic-tracking-state:main").loadStates([
+    this.container.lookup("service:topic-tracking-state").loadStates([
       {
         topic_id: 1,
         highest_post_number: 1,

--- a/app/assets/javascripts/discourse/tests/helpers/component-test.js
+++ b/app/assets/javascripts/discourse/tests/helpers/component-test.js
@@ -43,17 +43,17 @@ export function setupRenderingTest(hooks) {
       specifier: "service:current-user",
     });
 
-    this.owner.unregister("topic-tracking-state:main");
+    this.owner.unregister("service:topic-tracking-state");
     this.owner.register(
-      "topic-tracking-state:main",
+      "service:topic-tracking-state",
       TopicTrackingState.create({ currentUser }),
       { instantiate: false }
     );
-    this.owner.inject(
-      "service",
-      "topicTrackingState",
-      "topic-tracking-state:main"
-    );
+    injectServiceIntoService({
+      app: this.owner.application,
+      property: "topicTrackingState",
+      specifier: "service:topic-tracking-state",
+    });
 
     autoLoadModules(this.owner, this.registry);
     this.owner.lookup("service:store");

--- a/app/assets/javascripts/discourse/tests/helpers/create-store.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-store.js
@@ -69,7 +69,7 @@ export default function (customLookup = () => {}) {
           this._kvs = this._kvs || new KeyValueStore();
           return this._kvs;
         }
-        if (type === "topic-tracking-state:main") {
+        if (type === "service:topic-tracking-state") {
           this._tracker = this._tracker || TopicTrackingState.create();
           return this._tracker;
         }


### PR DESCRIPTION
This will allow consumers to inject it using `topicTrackingState: service()` in preparation for the removal of implicit injections in Ember 4.0. `topic-tracking-state:main` is still available and will print a deprecation notice.

Ideally we would convert topic-tracking-state into a true service, rather than registering a model instance into the registry. However, inter-dependencies between service injections make this very difficult to achieve. We don't want to block Glimmer Component work, so this commit does the minimum for now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
