### PR TITLE
FIX: properly log all internal job failures

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -177,11 +177,17 @@ module Discourse
 
     job = context[:job]
 
+    # mini_scheduler direct reporting
     if Hash === job
       job_class = job["class"]
       if job_class
         job_exception_stats[job_class] += 1
       end
+    end
+
+    # internal reporting
+    if job.class == Class && ::Jobs::Base > job
+      job_exception_stats[job] += 1
     end
 
     cm = RailsMultisite::ConnectionManagement

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -186,7 +186,7 @@ module Discourse
     end
 
     # internal reporting
-    if job.class == Class && job.is_a?(::Jobs::Base)
+    if job.class == Class && ::Jobs::Base > job
       job_exception_stats[job] += 1
     end
 

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -186,7 +186,7 @@ module Discourse
     end
 
     # internal reporting
-    if job.class == Class && ::Jobs::Base > job
+    if job.class == Class && job.is_a?(::Jobs::Base)
       job_exception_stats[job] += 1
     end
 

--- a/spec/jobs/jobs_base_spec.rb
+++ b/spec/jobs/jobs_base_spec.rb
@@ -38,23 +38,26 @@ RSpec.describe ::Jobs::Base do
     expect(bad.fail_count).to eq(3)
   end
 
-  context 'when looking at Discourse.job_exception_stats' do
-    before do
-      Discourse.reset_job_exception_stats!
-    end
-    after do
-      Discourse.reset_job_exception_stats!
-    end
-
-    it 'collects stats for failing jobs' do
-      bad = BadJob.new
-      3.times do
-        # During test env handle_job_exception errors out
-        # in production this is suppressed
-        expect { bad.perform({}) }.to raise_error(BadJob::BadJobError)
+  describe '#perform' do
+    context 'when a job raises an error' do
+      before do
+        Discourse.reset_job_exception_stats!
       end
 
-      expect(Discourse.job_exception_stats).to eq({ BadJob => 3 })
+      after do
+        Discourse.reset_job_exception_stats!
+      end
+
+      it 'collects stats for failing jobs in Discourse.job_exception_stats' do
+        bad = BadJob.new
+        3.times do
+          # During test env handle_job_exception errors out
+          # in production this is suppressed
+          expect { bad.perform({}) }.to raise_error(BadJob::BadJobError)
+        end
+
+        expect(Discourse.job_exception_stats).to eq({ BadJob => 3 })
+      end
     end
   end
 

--- a/spec/jobs/jobs_base_spec.rb
+++ b/spec/jobs/jobs_base_spec.rb
@@ -10,12 +10,15 @@ RSpec.describe ::Jobs::Base do
   end
 
   class BadJob < ::Jobs::Base
+    class BadJobError < StandardError
+    end
+
     attr_accessor :fail_count
 
     def execute(args)
       @fail_count ||= 0
       @fail_count += 1
-      raise StandardError
+      raise BadJobError
     end
   end
 
@@ -33,6 +36,26 @@ RSpec.describe ::Jobs::Base do
     bad = BadJob.new
     expect { bad.perform({}) }.to raise_error(Jobs::HandledExceptionWrapper)
     expect(bad.fail_count).to eq(3)
+  end
+
+  context 'Discourse.job_exception_stats' do
+    before do
+      Discourse.reset_job_exception_stats!
+    end
+    after do
+      Discourse.reset_job_exception_stats!
+    end
+
+    it 'collects stats for failing jobs' do
+      bad = BadJob.new
+      3.times do
+        # During test env handle_job_exception errors out
+        # in production this is suppressed
+        expect { bad.perform({}) }.to raise_error(BadJob::BadJobError)
+      end
+
+      expect(Discourse.job_exception_stats).to eq({ BadJob => 3 })
+    end
   end
 
   it 'delegates the process call to execute' do

--- a/spec/jobs/jobs_base_spec.rb
+++ b/spec/jobs/jobs_base_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ::Jobs::Base do
     expect(bad.fail_count).to eq(3)
   end
 
-  context 'Discourse.job_exception_stats' do
+  context 'when looking at Discourse.job_exception_stats' do
     before do
       Discourse.reset_job_exception_stats!
     end


### PR DESCRIPTION
Our internal implementation of #perform on jobs performs remapping.

This happens cause we do "exception aggregation".

Scheduled jobs run on every site in the multisite cluster, and we report
one error per site that failed. During this aggregation we reshape the
context from the original object shape returned by mini_scheduler

The new integration test ensures this interface will remain stable even if
decoupled parts of the code change shapes.
