### PR TITLE
DEV: Make it possible to hide tooltip on the user status

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-status-message.js
+++ b/app/assets/javascripts/discourse/app/components/user-status-message.js
@@ -2,8 +2,9 @@ import Component from "@ember/component";
 import { computed } from "@ember/object";
 import I18n from "I18n";
 
-export default class extends Component {
+export default class UserStatusMessage extends Component {
   tagName = "";
+  showTooltip = true;
 
   @computed("status.ends_at")
   get until() {

--- a/app/assets/javascripts/discourse/app/templates/components/user-status-message.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-status-message.hbs
@@ -5,17 +5,19 @@
       {{@status.description}}
     </span>
   {{/if}}
-  <DTooltip>
-    <div class="user-status-message-tooltip">
-      {{emoji @status.emoji skipTitle=true}}
-      <span class="user-status-tooltip-description">
-        {{@status.description}}
-      </span>
-      {{#if this.until}}
-        <div class="user-status-tooltip-until">
-          {{this.until}}
-        </div>
-      {{/if}}
-    </div>
-  </DTooltip>
+  {{#if this.showTooltip}}
+    <DTooltip>
+      <div class="user-status-message-tooltip">
+        {{emoji @status.emoji skipTitle=true}}
+        <span class="user-status-tooltip-description">
+          {{@status.description}}
+        </span>
+        {{#if this.until}}
+          <div class="user-status-tooltip-until">
+            {{this.until}}
+          </div>
+        {{/if}}
+      </div>
+    </DTooltip>
+  {{/if}}
 </span>

--- a/app/assets/javascripts/discourse/tests/integration/components/user-status-message-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-status-message-test.js
@@ -111,4 +111,34 @@ module("Integration | Component | user-status-message", function (hooks) {
       document.querySelector("[data-tippy-root] .user-status-tooltip-until")
     );
   });
+
+  test("it shows tooltip by default", async function (assert) {
+    this.set("status", {
+      emoji: "tooth",
+      description: "off to dentist",
+    });
+
+    await render(hbs`<UserStatusMessage @status={{this.status}} />`);
+    await mouseenter();
+
+    assert.ok(
+      document.querySelector("[data-tippy-root] .user-status-message-tooltip")
+    );
+  });
+
+  test("it doesn't show tooltip if disabled", async function (assert) {
+    this.set("status", {
+      emoji: "tooth",
+      description: "off to dentist",
+    });
+
+    await render(
+      hbs`<UserStatusMessage @status={{this.status}} @showTooltip={{false}} />`
+    );
+    await mouseenter();
+
+    assert.notOk(
+      document.querySelector("[data-tippy-root] .user-status-message-tooltip")
+    );
+  });
 });


### PR DESCRIPTION
Sometimes status appears on popovers, and we may not want to show a tooltip in that case. But by default, tooltip is enabled.
