### PR TITLE
FEATURE: show status in search results when mentioning user in composers

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/emoji.js
+++ b/app/assets/javascripts/discourse/app/helpers/emoji.js
@@ -1,11 +1,9 @@
 import { emojiUnescape } from "discourse/lib/text";
 import { escapeExpression } from "discourse/lib/utilities";
 import { htmlSafe } from "@ember/template";
-import { helper } from "@ember/component/helper";
+import { registerUnbound } from "discourse-common/lib/helpers";
 
-function emoji(code, options) {
+registerUnbound("emoji", function (code, options) {
   const escaped = escapeExpression(`:${code}:`);
   return htmlSafe(emojiUnescape(escaped, options));
-}
-
-export default helper(emoji);
+});

--- a/app/assets/javascripts/discourse/app/templates/user-selector-autocomplete.hbr
+++ b/app/assets/javascripts/discourse/app/templates/user-selector-autocomplete.hbr
@@ -5,8 +5,9 @@
         <a href title="{{user.name}}">
           {{avatar user imageSize="tiny"}}
           <span class='username'>{{format-username user.username}}</span>
-          <span class='name'>{{user.name}}</span>
-          {{decorate-username-selector user.username}}
+          {{#if user.status}}
+            {{emoji user.status.emoji title=user.status.description}}
+          {{/if}}
         </a>
       </li>
     {{/each}}

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-editor-mentions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-editor-mentions-test.js
@@ -1,6 +1,10 @@
 import { test } from "qunit";
 import { click, fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
-import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
 import { setCaretPosition } from "discourse/lib/utilities";
 
 acceptance("Composer - editor mentions", function (needs) {
@@ -16,6 +20,10 @@ acceptance("Composer - editor mentions", function (needs) {
             name: "Some User",
             avatar_template:
               "https://avatars.discourse.org/v3/letter/t/41988e/{size}.png",
+            status: {
+              emoji: "tooth",
+              description: "off to dentist",
+            },
           },
           {
             username: "user2",
@@ -103,5 +111,21 @@ acceptance("Composer - editor mentions", function (needs) {
       "abc @user 123",
       "should replace mention correctly"
     );
+  });
+
+  test("shows status on search results when mentioning a user", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+
+    // emulate typing in "abc @u"
+    const editor = query(".d-editor-input");
+    await fillIn(".d-editor-input", "@");
+    await setCaretPosition(editor, 5);
+    await triggerKeyEvent(".d-editor-input", "keyup", "@");
+    await fillIn(".d-editor-input", "@u");
+    await setCaretPosition(editor, 6);
+    await triggerKeyEvent(".d-editor-input", "keyup", "U");
+
+    assert.ok(exists(".autocomplete .emoji[title='off to dentist']"));
   });
 });


### PR DESCRIPTION
This adds status to search results when mentioning a user in composer:

<img width="906" alt="Screenshot 2022-08-05 at 20 36 05" src="https://user-images.githubusercontent.com/1274517/183129379-6bae7f59-2221-469d-8437-decdda98a478.png">

and in chat-composer:
<img width="423" alt="Screenshot 2022-08-05 at 20 34 52" src="https://user-images.githubusercontent.com/1274517/183129470-13e92022-af3f-4a79-86b3-c0eecfedf3b8.png">

