### PR TITLE
Revert "Build(deps-dev): Bump webmock from 3.16.0 to 3.17.0 (#17817)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -494,7 +494,7 @@ GEM
     uniform_notifier (1.16.0)
     uri (0.11.0)
     uri_template (0.7.0)
-    webmock (3.17.0)
+    webmock (3.16.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)


### PR DESCRIPTION
This reverts commit 41197edb515ab637c1c4e36a0dc0820bafd52b82.

Breaking out plugin test suite