### PR TITLE
DEV: Use json schema file to describe update group endpoint

### DIFF
--- a/spec/requests/api/groups_spec.rb
+++ b/spec/requests/api/groups_spec.rb
@@ -60,17 +60,9 @@ RSpec.describe 'groups' do
       operationId 'updateGroup'
       consumes 'application/json'
       parameter name: :id, in: :path, type: :integer
-      parameter name: :group, in: :body, schema: {
-        type: :object,
-        properties: {
-          group: {
-            type: :object,
-            properties: {
-              name: { type: :string },
-            }, required: ['name']
-          }
-        }, required: ['group']
-      }
+
+      expected_request_schema = load_spec_schema('group_create_request')
+      parameter name: :params, in: :body, schema: expected_request_schema
 
       produces 'application/json'
       response '200', 'success response' do
@@ -79,7 +71,7 @@ RSpec.describe 'groups' do
         }
 
         let(:id) { Fabricate(:group).id }
-        let(:group) { { name: 'awesome' } }
+        let(:params) { { 'group' => { 'name' => 'awesome' } } }
 
         run_test!
       end


### PR DESCRIPTION
Updating another endpoint in our api docs to use json schema files for
describing the request/response bodies.
