### PR TITLE
DEV: Set owner of sidebar section objects

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/sections.js
@@ -1,5 +1,6 @@
 import GlimmerComponent from "discourse/components/glimmer";
 import { customSections as sidebarCustomSections } from "discourse/lib/sidebar/custom-sections";
+import { getOwner, setOwner } from "@ember/application";
 
 export default class SidebarSections extends GlimmerComponent {
   customSections;
@@ -11,7 +12,9 @@ export default class SidebarSections extends GlimmerComponent {
 
   get _customSections() {
     return sidebarCustomSections.map((customSection) => {
-      return new customSection({ sidebar: this });
+      const section = new customSection({ sidebar: this });
+      setOwner(section, getOwner(this));
+      return section;
     });
   }
 }


### PR DESCRIPTION
Allows e.g. `@service` usage in their implementation

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
