### PR TITLE
FIX: Make word watcher work with nil strings

### DIFF
--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -124,14 +124,16 @@ class WordWatcher
   end
 
   def self.censor_text(text)
+    return text if text.blank?
+
     regexps = word_matcher_regexp_list(:censor)
     return text if regexps.blank?
 
     regexps.inject(text) { |txt, regexp| censor_text_with_regexp(txt, regexp) }
   end
 
-  def self.apply_to_text(text)
-    text = censor_text(text)
+  def self.replace_text(text)
+    return text if text.blank?
 
     %i[replace link]
       .flat_map { |type| word_matcher_regexps(type).to_a }
@@ -139,6 +141,12 @@ class WordWatcher
         case_flag = attrs[:case_sensitive] ? nil : Regexp::IGNORECASE
         replace_text_with_regexp(t, Regexp.new(word_regexp, case_flag), attrs[:replacement])
       end
+  end
+
+  def self.apply_to_text(text)
+    text = censor_text(text)
+    text = replace_text(text)
+    text
   end
 
   def self.clear_cache!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -148,13 +148,12 @@ RSpec.describe User do
 
     describe "#user_fields" do
       fab!(:user_field) { Fabricate(:user_field, show_on_profile: true) }
+      let(:user_field_value) { user.reload.user_fields[user_field.id.to_s] }
       fab!(:watched_word) { Fabricate(:watched_word, word: "bad") }
 
       before { user.set_user_field(user_field.id, value) }
 
       context "when user fields contain watched words" do
-        let(:user_field_value) { user.reload.user_fields[user_field.id.to_s] }
-
         context "when watched words are of type 'Block'" do
           let(:value) { "bad user field value" }
 
@@ -226,7 +225,6 @@ RSpec.describe User do
 
       context "when user fields contain URL" do
         let(:value) { "https://discourse.org" }
-        let(:user_field_value) { user.reload.user_fields[user_field.id.to_s] }
 
         it "is not cooked" do
           user.save!
@@ -267,6 +265,16 @@ RSpec.describe User do
           end
         end
 
+      end
+
+      context "when reseting user fields" do
+        let!(:censored_word) { Fabricate(:watched_word, word: "censored", action: WatchedWord.actions[:censor]) }
+        let(:value) { nil }
+
+        it "works" do
+          user.save!
+          expect(user_field_value).to eq nil
+        end
       end
     end
   end


### PR DESCRIPTION
Censoring or replacing nil strings raised an error.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
