### PR TITLE
FIX: Don't notify editor when category or tag change

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -203,8 +203,8 @@ class PostAlerter
 
     warn_if_not_sidekiq
 
-    # Don't notify the OP
-    user_ids -= [post.user_id]
+    # Don't notify the OP and last editor
+    user_ids -= [post.user_id, post.last_editor_id]
     users = User.where(id: user_ids).includes(:do_not_disturb_timings)
 
     DiscourseEvent.trigger(:before_create_notifications_for_users, users, post)

--- a/spec/jobs/notify_category_change_spec.rb
+++ b/spec/jobs/notify_category_change_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe ::Jobs::NotifyCategoryChange do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:regular_user) { Fabricate(:trust_level_4) }
+  fab!(:post) { Fabricate(:post, user: regular_user) }
+  fab!(:category) { Fabricate(:category, name: 'test') }
+
+  it "doesn't create notification for the editor who watches new tag" do
+    CategoryUser.set_notification_level_for_category(user, CategoryUser.notification_levels[:watching_first_post], category.id)
+    post.topic.update!(category: category)
+    post.update!(last_editor_id: user.id)
+
+    expect { described_class.new.execute(post_id: post.id, notified_user_ids: []) }.not_to change { Notification.count }
+  end
+end

--- a/spec/jobs/notify_tag_change_spec.rb
+++ b/spec/jobs/notify_tag_change_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe ::Jobs::NotifyTagChange do
     expect { described_class.new.execute(post_id: post.id, notified_user_ids: [regular_user.id]) }.not_to change { Notification.count }
   end
 
+  it "doesn't create notification for the editor who watches new tag" do
+    TagUser.change(user.id, tag.id, TagUser.notification_levels[:watching_first_post])
+    TopicTag.create!(topic: post.topic, tag: tag)
+    post.update!(last_editor_id: user.id)
+
+    expect { described_class.new.execute(post_id: post.id, notified_user_ids: []) }.not_to change { Notification.count }
+  end
+
   it 'doesnt create notification for user watching category' do
     CategoryUser.create!(
       user_id: user.id,

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1194,24 +1194,6 @@ RSpec.describe PostAlerter do
       end
       expect(events).to include(event_name: :before_create_notifications_for_users, params: [[user], post])
     end
-
-    it "does not notify user who edits topic category" do
-      CategoryUser.set_notification_level_for_category(user, CategoryUser.notification_levels[:watching_first_post], category.id)
-      post.update!(last_editor_id: user.id)
-
-      post_alerter = PostAlerter.new
-      post_alerter.notify_first_post_watchers(post, post_alerter.category_watchers(post.topic))
-      expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
-    end
-
-    it "does not notify user who edits topic tag" do
-      TagUser.change(user.id, tag.id, TagUser.notification_levels[:watching_first_post])
-      post.update!(last_editor_id: user.id)
-
-      post_alerter = PostAlerter.new
-      post_alerter.notify_first_post_watchers(post, post_alerter.tag_watchers(post.topic))
-      expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
-    end
   end
 
   context "with replies" do

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1194,6 +1194,24 @@ RSpec.describe PostAlerter do
       end
       expect(events).to include(event_name: :before_create_notifications_for_users, params: [[user], post])
     end
+
+    it "does not notify user who edits topic category" do
+      CategoryUser.set_notification_level_for_category(user, CategoryUser.notification_levels[:watching_first_post], category.id)
+      post.update!(last_editor_id: user.id)
+
+      post_alerter = PostAlerter.new
+      post_alerter.notify_first_post_watchers(post, post_alerter.category_watchers(post.topic))
+      expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
+    end
+
+    it "does not notify user who edits topic tag" do
+      TagUser.change(user.id, tag.id, TagUser.notification_levels[:watching_first_post])
+      post.update!(last_editor_id: user.id)
+
+      post_alerter = PostAlerter.new
+      post_alerter.notify_first_post_watchers(post, post_alerter.tag_watchers(post.topic))
+      expect(user.notifications.where(notification_type: Notification.types[:watching_first_post]).count).to eq(0)
+    end
   end
 
   context "with replies" do


### PR DESCRIPTION
When a user was editing a topic they were also receiving a notification
if they were watching any of the new category or tags.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
