### PR TITLE
FEATURE: Adds full screen composer submit button and prompt

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/composer-fullscreen-prompt.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/composer-fullscreen-prompt.hbs
@@ -1,0 +1,3 @@
+<div class="composer-fullscreen-prompt">
+  {{this.exitPrompt}}
+</div>

--- a/app/assets/javascripts/admin/addon/templates/components/composer-fullscreen-prompt.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/composer-fullscreen-prompt.hbs
@@ -1,3 +1,3 @@
-<div class="composer-fullscreen-prompt">
+<div class="composer-fullscreen-prompt" {{did-insert this.registerAnimationListener}}>
   {{html-safe this.exitPrompt}}
 </div>

--- a/app/assets/javascripts/admin/addon/templates/components/composer-fullscreen-prompt.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/composer-fullscreen-prompt.hbs
@@ -1,3 +1,3 @@
 <div class="composer-fullscreen-prompt">
-  {{this.exitPrompt}}
+  {{html-safe this.exitPrompt}}
 </div>

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -1,5 +1,4 @@
 import GlimmerComponent from "@glimmer/component";
-import { htmlSafe } from "@ember/template";
 import I18n from "I18n";
 import { next } from "@ember/runloop";
 

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -26,6 +26,6 @@ export default class ComposerFullscreenPrompt extends GlimmerComponent {
   }
 
   get exitPrompt() {
-    return htmlSafe(I18n.t("composer.exit_fullscreen_prompt"));
+    return I18n.t("composer.exit_fullscreen_prompt");
   }
 }

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -1,27 +1,21 @@
+import { action } from "@ember/object";
 import GlimmerComponent from "@glimmer/component";
 import I18n from "I18n";
-import { next } from "@ember/runloop";
 
 export default class ComposerFullscreenPrompt extends GlimmerComponent {
-  constructor() {
-    super(...arguments);
-    this.#setupFullscreenPrompt();
+  @action
+  registerAnimationListener(element) {
+    this.#addAnimationEventListener(element);
   }
 
-  #setupFullscreenPrompt() {
-    next(() => {
-      const promptElement = document.querySelector(
-        ".composer-fullscreen-prompt"
-      );
-
-      promptElement?.addEventListener(
-        "animationend",
-        () => {
-          this.args.removeFullScreenExitPrompt();
-        },
-        { once: true }
-      );
-    });
+  #addAnimationEventListener(element) {
+    element?.addEventListener(
+      "animationend",
+      () => {
+        this.args.removeFullScreenExitPrompt();
+      },
+      { once: true }
+    );
   }
 
   get exitPrompt() {

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -18,7 +18,7 @@ export default class ComposerFullscreenPrompt extends GlimmerComponent {
       promptElement?.addEventListener(
         "animationend",
         () => {
-          this.args.model.set("showFullScreenExitPrompt", false);
+          this.args.model.toggleProperty("showFullScreenExitPrompt");
         },
         { once: true }
       );

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -9,7 +9,7 @@ export default class ComposerFullscreenPrompt extends GlimmerComponent {
   }
 
   #addAnimationEventListener(element) {
-    element?.addEventListener(
+    element.addEventListener(
       "animationend",
       () => {
         this.args.removeFullScreenExitPrompt();

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -1,0 +1,31 @@
+import GlimmerComponent from "@glimmer/component";
+import I18n from "I18n";
+import { htmlSafe } from "@ember/template";
+import { next } from "@ember/runloop";
+
+export default class ComposerFullscreenPrompt extends GlimmerComponent {
+  constructor() {
+    super(...arguments);
+    this.#setupFullscreenPrompt();
+  }
+
+  #setupFullscreenPrompt() {
+    next(() => {
+      const promptElement = document.querySelector(
+        ".composer-fullscreen-prompt"
+      );
+
+      promptElement?.addEventListener(
+        "animationend",
+        () => {
+          this.args.model.set("showFullScreenExitPrompt", false);
+        },
+        { once: true }
+      );
+    });
+  }
+
+  get exitPrompt() {
+    return htmlSafe(I18n.t("composer.exit_fullscreen_prompt"));
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -1,6 +1,6 @@
 import GlimmerComponent from "@glimmer/component";
-import I18n from "I18n";
 import { htmlSafe } from "@ember/template";
+import I18n from "I18n";
 import { next } from "@ember/runloop";
 
 export default class ComposerFullscreenPrompt extends GlimmerComponent {

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -18,7 +18,7 @@ export default class ComposerFullscreenPrompt extends GlimmerComponent {
       promptElement?.addEventListener(
         "animationend",
         () => {
-          this.args.model.toggleProperty("showFullScreenExitPrompt");
+          this.args.removeFullScreenExitPrompt();
         },
         { once: true }
       );

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -840,6 +840,10 @@ export default Controller.extend({
     const composer = this.model;
 
     if (composer.cantSubmitPost) {
+      if (composer.composeState === Composer.FULLSCREEN) {
+        this.toggleFullscreen();
+      }
+
       this.set("lastValidatedAt", Date.now());
       return;
     }

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -747,8 +747,15 @@ export default Controller.extend({
         return;
       }
 
-      if (this.get("model.viewOpen") || this.get("model.viewFullscreen")) {
+      const composer = this.model;
+
+      if (composer.viewOpen) {
         this.shrink();
+      }
+
+      if (composer.viewFullscreen) {
+        this.toggleFullscreen();
+        this.focusComposer();
       }
     },
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1495,7 +1495,7 @@ export default Controller.extend({
       composer?.set("composeState", Composer.OPEN);
     } else {
       composer?.set("composeState", Composer.FULLSCREEN);
-      composer?.set("showFullScreenExitPrompt", true);
+      composer?.toggleProperty("showFullScreenExitPrompt");
     }
   },
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -502,6 +502,11 @@ export default Controller.extend({
     return false;
   },
 
+  @action
+  removeFullScreenExitPrompt() {
+    this.set("model.showFullScreenExitPrompt", false);
+  },
+
   actions: {
     togglePreview() {
       this.toggleProperty("showPreview");
@@ -1495,12 +1500,12 @@ export default Controller.extend({
       composer?.set("composeState", Composer.OPEN);
     } else {
       composer?.set("composeState", Composer.FULLSCREEN);
-      composer?.toggleProperty("showFullScreenExitPrompt");
+      composer?.set("showFullScreenExitPrompt", true);
     }
   },
 
   @discourseComputed("model.viewFullscreen", "model.showFullScreenExitPrompt")
-  fullScreenPrompt(isFullscreen, showExitPrompt) {
+  showFullScreenPrompt(isFullscreen, showExitPrompt) {
     return isFullscreen && showExitPrompt;
   },
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1496,7 +1496,13 @@ export default Controller.extend({
       this.set("model.composeState", Composer.OPEN);
     } else {
       this.set("model.composeState", Composer.FULLSCREEN);
+      this.set("model.showFullScreenExitPrompt", true);
     }
+  },
+
+  @discourseComputed("model.viewFullscreen", "model.showFullScreenExitPrompt")
+  fullScreenPrompt(isFullscreen, showExitPrompt) {
+    return isFullscreen && showExitPrompt;
   },
 
   close() {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1506,7 +1506,7 @@ export default Controller.extend({
 
   @discourseComputed("model.viewFullscreen", "model.showFullScreenExitPrompt")
   showFullScreenPrompt(isFullscreen, showExitPrompt) {
-    return isFullscreen && showExitPrompt;
+    return isFullscreen && showExitPrompt && !this.capabilities.touch;
   },
 
   close() {

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -655,16 +655,12 @@ export default Controller.extend({
     toggle() {
       this.closeAutocomplete();
 
-      if (
-        isEmpty(this.get("model.reply")) &&
-        isEmpty(this.get("model.title"))
-      ) {
+      const composer = this.model;
+
+      if (isEmpty(composer?.reply) && isEmpty(composer?.title)) {
         this.close();
       } else {
-        if (
-          this.get("model.composeState") === Composer.OPEN ||
-          this.get("model.composeState") === Composer.FULLSCREEN
-        ) {
+        if (composer?.viewOpenOrFullscreen) {
           this.shrink();
         } else {
           this.cancelComposer();
@@ -749,11 +745,11 @@ export default Controller.extend({
 
       const composer = this.model;
 
-      if (composer.viewOpen) {
+      if (composer?.viewOpen) {
         this.shrink();
       }
 
-      if (composer.viewFullscreen) {
+      if (composer?.viewFullscreen) {
         this.toggleFullscreen();
         this.focusComposer();
       }
@@ -846,8 +842,8 @@ export default Controller.extend({
 
     const composer = this.model;
 
-    if (composer.cantSubmitPost) {
-      if (composer.composeState === Composer.FULLSCREEN) {
+    if (composer?.cantSubmitPost) {
+      if (composer?.viewFullscreen) {
         this.toggleFullscreen();
       }
 
@@ -1492,11 +1488,14 @@ export default Controller.extend({
 
   toggleFullscreen() {
     this._saveDraft();
-    if (this.get("model.composeState") === Composer.FULLSCREEN) {
-      this.set("model.composeState", Composer.OPEN);
+
+    const composer = this.model;
+
+    if (composer?.viewFullscreen) {
+      composer?.set("composeState", Composer.OPEN);
     } else {
-      this.set("model.composeState", Composer.FULLSCREEN);
-      this.set("model.showFullScreenExitPrompt", true);
+      composer?.set("composeState", Composer.FULLSCREEN);
+      composer?.set("showFullScreenExitPrompt", true);
     }
   },
 

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -124,6 +124,7 @@ const Composer = RestModel.extend({
   noBump: false,
   draftSaving: false,
   draftForceSave: false,
+  showFullScreenExitPrompt: false,
 
   archetypes: reads("site.archetypes"),
 

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -105,7 +105,6 @@
               <a href {{action "cancel"}} class="cancel" >{{i18n "close"}}</a>
             {{/if}}
 
-
             {{#if this.site.mobileView}}
               {{#if this.whisperOrUnlistTopic}}
                 <span class="whisper">

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -4,8 +4,8 @@
   {{#if this.visible}}
     <ComposerMessages @composer={{this.model}} @messageCount={{this.messageCount}} @addLinkLookup={{action "addLinkLookup"}} />
 
-    {{#if this.fullScreenPrompt}}
-      <ComposerFullscreenPrompt @model={{this.model}}/>
+    {{#if this.showFullScreenPrompt}}
+      <ComposerFullscreenPrompt @removeFullScreenExitPrompt={{action "removeFullScreenExitPrompt"}}/>
     {{/if}}
 
     {{#if this.model.viewOpenOrFullscreen}}

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -4,6 +4,10 @@
   {{#if this.visible}}
     <ComposerMessages @composer={{this.model}} @messageCount={{this.messageCount}} @addLinkLookup={{action "addLinkLookup"}} />
 
+    {{#if this.fullScreenPrompt}}
+      <ComposerFullscreenPrompt @model={{this.model}}/>
+    {{/if}}
+
     {{#if this.model.viewOpenOrFullscreen}}
       <div role="form" aria-label={{I18n this.saveLabel}} class="reply-area {{if this.canEditTags "with-tags" "without-tags"}}">
         <PluginOutlet @name="composer-open" @tagName="span" @connectorTagName="div" @args={{hash model=this.model}} />

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -91,21 +91,20 @@
           <PluginOutlet @name="composer-fields-below" @tagName="span" @connectorTagName="div" @args={{hash model=this.model}} />
 
           <div class="save-or-cancel">
-            {{#unless this.model.viewFullscreen}}
-              <ComposerSaveButton @action={{action "save"}} @icon={{this.saveIcon}} @label={{this.saveLabel}} @forwardEvent={{true}} @disableSubmit={{this.disableSubmit}} />
+            <ComposerSaveButton @action={{action "save"}} @icon={{this.saveIcon}} @label={{this.saveLabel}} @forwardEvent={{true}} @disableSubmit={{this.disableSubmit}} />
 
-              {{#if this.site.mobileView}}
-                <a href {{action "cancel"}} title={{i18n "cancel"}} class="cancel">
-                  {{#if this.canEdit}}
-                    {{d-icon "times"}}
-                  {{else}}
-                    {{d-icon "far-trash-alt"}}
-                  {{/if}}
-                </a>
-              {{else}}
-                <a href {{action "cancel"}} class="cancel" >{{i18n "close"}}</a>
-              {{/if}}
-            {{/unless}}
+            {{#if this.site.mobileView}}
+              <a href {{action "cancel"}} title={{i18n "cancel"}} class="cancel">
+                {{#if this.canEdit}}
+                  {{d-icon "times"}}
+                {{else}}
+                  {{d-icon "far-trash-alt"}}
+                {{/if}}
+              </a>
+            {{else}}
+              <a href {{action "cancel"}} class="cancel" >{{i18n "close"}}</a>
+            {{/if}}
+
 
             {{#if this.site.mobileView}}
               {{#if this.whisperOrUnlistTopic}}

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -509,6 +509,11 @@ acceptance("Composer", function (needs) {
       "it expands composer to full screen"
     );
 
+    assert.ok(
+      exists(".composer-fullscreen-prompt"),
+      "the exit fullscreen prompt is visible"
+    );
+
     await click(".toggle-fullscreen");
 
     assert.strictEqual(
@@ -532,6 +537,34 @@ acceptance("Composer", function (needs) {
       count("#reply-control.open"),
       1,
       "from draft, it expands composer back to open state"
+    );
+  });
+
+  test("Composer fullscreen submit button", async function (assert) {
+    await visit("/t/this-is-a-test-topic/9");
+    await click(".topic-post:nth-of-type(1) button.reply");
+
+    assert.strictEqual(
+      count("#reply-control.open"),
+      1,
+      "it starts in open state by default"
+    );
+
+    await click(".toggle-fullscreen");
+
+    assert.strictEqual(
+      count("#reply-control button.create"),
+      1,
+      "it shows composer submit button in fullscreen"
+    );
+
+    await fillIn(".d-editor-input", "too short");
+    await click("#reply-control button.create");
+
+    assert.strictEqual(
+      count("#reply-control.open"),
+      1,
+      "it goes back to open state if there's errors"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -509,8 +509,9 @@ acceptance("Composer", function (needs) {
       "it expands composer to full screen"
     );
 
-    assert.ok(
-      exists(".composer-fullscreen-prompt"),
+    assert.strictEqual(
+      count(".composer-fullscreen-prompt"),
+      1,
       "the exit fullscreen prompt is visible"
     );
 

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -288,3 +288,24 @@ a.toggle-preview {
     }
   }
 }
+
+.composer-fullscreen-prompt {
+  animation: fadeIn 1s ease-in-out;
+  animation-delay: 1.5s;
+  animation-direction: reverse;
+  animation-fill-mode: forwards;
+  position: fixed;
+  left: 50%;
+  top: 10%;
+  transform: translate(-50%, 0);
+  .rtl & {
+    // R2 is not smart enough to support this swap
+    transform: translate(50%, 0);
+  }
+  z-index: z("header") + 1;
+  background: var(--primary-very-high);
+  color: var(--secondary);
+  padding: 0.5em 0.75em;
+  pointer-events: none;
+  border-radius: 2px;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2257,6 +2257,7 @@ en:
       abandon: "close composer and discard draft"
       enter_fullscreen: "enter fullscreen composer"
       exit_fullscreen: "exit fullscreen composer"
+      exit_fullscreen_prompt: "Press <kbd>ESC</kbd> to exit full screen"
       show_toolbar: "show composer toolbar"
       hide_toolbar: "hide composer toolbar"
       modal_ok: "OK"
@@ -2305,7 +2306,7 @@ en:
       image_alt_text:
         aria_label: Alt text for image
 
-      delete_image_button: Delete Image  
+      delete_image_button: Delete Image
 
     notifications:
       tooltip:


### PR DESCRIPTION
Context: https://meta.discourse.org/t/still-display-the-reply-create-topic-button-when-using-full-screen-composition/123597/6?u=johani

Right now, we don't show the submit buttons when you enter the full-screen composer. The reasons for that are described in the context link above.

This PR adds the improvements highlighted here: https://meta.discourse.org/t/still-display-the-reply-create-topic-button-when-using-full-screen-composition/123597/12?u=johani

Here's a list of the changes this PR introduces:

1. When you enter full-screen mode, we will now add a prompt that matches the browser fullscreen <kbd>F11</kbd> function. It looks like so

    <img width="500" src="https://user-images.githubusercontent.com/33972521/183529813-71a20167-a661-466c-b9ef-c4d34e231000.png">
    
    The prompt fades away after a couple of seconds.
    
2. This PR adds the submit buttons to the full-screen composer mode. The submit buttons should work like normal if the post has no errors. If the post has errors (title too short, body too short, required categories/tags), then the button will make the composer exit the full-screen mode so that users will see the errors and fix them. The error logic is based on what we currently have; this PR doesn't add any new validation. Here's a video of what that looks like:

    https://meta.discourse.org/t/-/127948/14?u=johani

 

