### PR TITLE
FIX: don't raise an error if file not found in S3.

### DIFF
--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -98,6 +98,7 @@ class S3Helper
     s3_filename.prepend(multisite_upload_path) if Rails.configuration.multisite
     delete_object(get_path_for_s3_upload(s3_filename))
   rescue Aws::S3::Errors::NoSuchKey
+  rescue Aws::S3::Errors::NotFound
   end
 
   def delete_object(key)

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -102,8 +102,7 @@ class S3Helper
 
   def delete_object(key)
     s3_bucket.object(key).delete
-  rescue Aws::S3::Errors::NoSuchKey
-  rescue Aws::S3::Errors::NotFound
+  rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::NotFound
   end
 
   def copy(source, destination, options: {})

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -97,8 +97,7 @@ class S3Helper
     # delete the file
     s3_filename.prepend(multisite_upload_path) if Rails.configuration.multisite
     delete_object(get_path_for_s3_upload(s3_filename))
-  rescue Aws::S3::Errors::NoSuchKey
-  rescue Aws::S3::Errors::NotFound
+  rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::NotFound
   end
 
   def delete_object(key)

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -104,6 +104,7 @@ class S3Helper
   def delete_object(key)
     s3_bucket.object(key).delete
   rescue Aws::S3::Errors::NoSuchKey
+  rescue Aws::S3::Errors::NotFound
   end
 
   def copy(source, destination, options: {})


### PR DESCRIPTION
While deleting the object in S3, don't raise an error if the file is not available in S3.