### PR TITLE
FIX: Swallow SSL errors when generating oneboxes

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -192,13 +192,13 @@ class FinalDestination
 
     if @limit < 0
       @status = :too_many_redirects
-      log(:warn, "FinalDestination could not resolve URL (too many redirects): #{@uri}") if @verbose
+      log(:warn, "FinalDestination could not resolve URL (too many redirects): #{@uri}")
       return
     end
 
     unless validate_uri
       @status = :invalid_address
-      log(:warn, "FinalDestination could not resolve URL (invalid URI): #{@uri}") if @verbose
+      log(:warn, "FinalDestination could not resolve URL (invalid URI): #{@uri}")
       return
     end
 
@@ -344,10 +344,10 @@ class FinalDestination
     @status = :failure
     @status_code = response.status
 
-    log(:warn, "FinalDestination could not resolve URL (status #{response.status}): #{@uri}") if @verbose
+    log(:warn, "FinalDestination could not resolve URL (status #{response.status}): #{@uri}")
     nil
   rescue Excon::Errors::Timeout
-    log(:warn, "FinalDestination could not resolve URL (timeout): #{@uri}") if @verbose
+    log(:warn, "FinalDestination could not resolve URL (timeout): #{@uri}")
     nil
   end
 
@@ -427,6 +427,7 @@ class FinalDestination
   end
 
   def log(log_level, message)
+    return unless @verbose
     return if @status_code == 404
 
     Rails.logger.public_send(
@@ -519,7 +520,10 @@ class FinalDestination
 
     result
   rescue Timeout::Error
-    log(:warn, "FinalDestination could not resolve URL (timeout): #{@uri}") if @verbose
+    log(:warn, "FinalDestination could not resolve URL (timeout): #{@uri}")
+    nil
+  rescue OpenSSL::SSL::SSLError => exception
+    log(:warn, "An error with SSL occurred: #{@uri} #{exception.message}")
     nil
   rescue StandardError
     unsafe_close ? [:ok, headers_subset] : raise

--- a/spec/lib/final_destination_spec.rb
+++ b/spec/lib/final_destination_spec.rb
@@ -470,6 +470,23 @@ RSpec.describe FinalDestination do
         expect(get).to be_blank
       end
     end
+
+    context "when there is an SSL error" do
+      subject(:get) { fd.get {} }
+
+      before do
+        fd.stubs(:safe_session).raises(OpenSSL::SSL::SSLError)
+      end
+
+      it "logs the exception" do
+        Rails.logger.expects(:warn).with(regexp_matches(/an error with ssl occurred/i))
+        get
+      end
+
+      it "returns nothing" do
+        expect(get).to be_blank
+      end
+    end
   end
 
   describe '.validate_uri' do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
