### PR TITLE
DEV: Run `yarn install` for all `rake docker:test` invocations

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -59,9 +59,9 @@ desc 'Run all tests (JS and code in a standalone environment)'
 task 'docker:test' do
   begin
     @good = true
+    @good &&= run_or_fail("yarn install")
 
     unless ENV['SKIP_LINT']
-      @good &&= run_or_fail("yarn install")
       puts "Running linters/prettyfiers"
       puts "eslint #{`yarn eslint -v`}"
       puts "prettier #{`yarn prettier -v`}"
@@ -206,7 +206,6 @@ task 'docker:test' do
 
       unless ENV["RUBY_ONLY"]
         js_timeout = ENV["JS_TIMEOUT"].presence || 900_000 # 15 minutes
-        @good &&= run_or_fail 'yarn install'
 
         unless ENV["SKIP_CORE"]
           @good &&= run_or_fail("cd app/assets/javascripts/discourse && CI=1 yarn ember exam --random")


### PR DESCRIPTION
Previously we were only `yarn install`ing for linting and qunit runs. The Rails app now relies on a number of `node_modules` dependencies (e.g. for pretty_text, and discourse_js_processor), so we need to make sure they're available.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
