### PR TITLE
DEV: Attempt to fix flaky sidebar test

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
@@ -72,8 +72,8 @@ export default class SidebarMoreSectionLinks extends GlimmerComponent {
   }
 
   @action
-  toggleSectionLinks() {
-    this.shouldDisplaySectionLinks = !this.shouldDisplaySectionLinks;
+  toggleSectionLinks(element) {
+    this.shouldDisplaySectionLinks = element.target.hasAttribute("open");
   }
 
   #removeClickEventListener() {


### PR DESCRIPTION
Makes displaying and hiding the list more deterministic.

```
Error: QUnit Test Failure: Exam Partition 1 - Acceptance: Sidebar - Community Section: clicking on more... link
not ok 491 Firefox 91.0 - [722 ms] - Exam Partition 1 - Acceptance: Sidebar - Community Section: clicking on more... link
    ---
        actual: >
            true
        expected: >
            false
        stack: >
            @http://localhost:7357/assets/core-tests.js:9826:14

        message: >
            additional section links are hidden
        negative: >
            false
        browser log: |
```