### PR TITLE
FIX: Reset flair group if user is removed from group

### DIFF
--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -8,7 +8,7 @@ class GroupUser < ActiveRecord::Base
   after_destroy :grant_other_available_title
 
   after_save :set_primary_group
-  after_destroy :remove_primary_group, :remove_flair_group, :recalculate_trust_level
+  after_destroy :remove_primary_and_flair_group, :recalculate_trust_level
 
   before_create :set_notification_level
   after_save :grant_trust_level
@@ -84,10 +84,14 @@ class GroupUser < ActiveRecord::Base
     user.update!(primary_group: group) if group.primary_group
   end
 
-  def remove_primary_group
-    return if user.primary_group_id != group_id
+  def remove_primary_and_flair_group
     return if self.destroyed_by_association&.active_record == User # User is being destroyed, so don't try to update
-    user.update_attribute(:primary_group_id, nil)
+
+    updates = {}
+    updates[:primary_group_id] = nil if user.primary_group_id == group_id
+    updates[:flair_group_id] = nil if user.flair_group_id == group_id
+
+    user.update(updates) if updates.present?
   end
 
   def remove_flair_group

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -8,7 +8,7 @@ class GroupUser < ActiveRecord::Base
   after_destroy :grant_other_available_title
 
   after_save :set_primary_group
-  after_destroy :remove_primary_group, :recalculate_trust_level
+  after_destroy :remove_primary_group, :remove_flair_group, :recalculate_trust_level
 
   before_create :set_notification_level
   after_save :grant_trust_level
@@ -88,6 +88,12 @@ class GroupUser < ActiveRecord::Base
     return if user.primary_group_id != group_id
     return if self.destroyed_by_association&.active_record == User # User is being destroyed, so don't try to update
     user.update_attribute(:primary_group_id, nil)
+  end
+
+  def remove_flair_group
+    return if user.flair_group_id != group_id
+    return if self.destroyed_by_association&.active_record == User # User is being destroyed, so don't try to update
+    user.update_attribute(:flair_group_id, nil)
   end
 
   def grant_other_available_title

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -94,12 +94,6 @@ class GroupUser < ActiveRecord::Base
     user.update(updates) if updates.present?
   end
 
-  def remove_flair_group
-    return if user.flair_group_id != group_id
-    return if self.destroyed_by_association&.active_record == User # User is being destroyed, so don't try to update
-    user.update_attribute(:flair_group_id, nil)
-  end
-
   def grant_other_available_title
     if group.title.present? && group.title == user.title
       user.update_attribute(:title, user.next_best_title)

--- a/db/migrate/20220811170600_reset_flair_group_id_if_not_group_member.rb
+++ b/db/migrate/20220811170600_reset_flair_group_id_if_not_group_member.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ResetFlairGroupIdIfNotGroupMember < ActiveRecord::Migration[7.0]
+  def change
+    execute <<~SQL
+      UPDATE users
+      SET flair_group_id = NULL
+      WHERE flair_group_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1
+        FROM group_users
+        WHERE group_users.user_id = users.id
+          AND group_users.group_id = users.flair_group_id
+      )
+    SQL
+  end
+end

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -226,8 +226,8 @@ RSpec.describe GroupUser do
   describe '#destroy!' do
     fab!(:group) { Fabricate(:group) }
 
-    it "removes `primary_group_id` and exec `match_primary_group_changes` method on user model" do
-      user = Fabricate(:user, primary_group: group)
+    it "removes `primary_group_id`, `flair_group_id` and exec `match_primary_group_changes` method on user model" do
+      user = Fabricate(:user, primary_group: group, flair_group: group)
       group_user = Fabricate(:group_user, group: group, user: user)
 
       user.expects(:match_primary_group_changes).once
@@ -235,15 +235,6 @@ RSpec.describe GroupUser do
 
       user.reload
       expect(user.primary_group_id).to be_nil
-    end
-
-    it "removes flair_group_id" do
-      user = Fabricate(:user, flair_group: group)
-      group_user = Fabricate(:group_user, group: group, user: user)
-
-      group_user.destroy!
-
-      user.reload
       expect(user.flair_group_id).to be_nil
     end
   end

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -236,5 +236,15 @@ RSpec.describe GroupUser do
       user.reload
       expect(user.primary_group_id).to be_nil
     end
+
+    it "removes flair_group_id" do
+      user = Fabricate(:user, flair_group: group)
+      group_user = Fabricate(:group_user, group: group, user: user)
+
+      group_user.destroy!
+
+      user.reload
+      expect(user.flair_group_id).to be_nil
+    end
   end
 end


### PR DESCRIPTION
The flair used to stay set even if the user was removed from the group.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
