### PR TITLE
Allow configuration of smtp timeout settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,9 @@ Discourse::Application.configure do
       user_name: GlobalSetting.smtp_user_name,
       password: GlobalSetting.smtp_password,
       authentication: GlobalSetting.smtp_authentication,
-      enable_starttls_auto: GlobalSetting.smtp_enable_start_tls
+      enable_starttls_auto: GlobalSetting.smtp_enable_start_tls,
+      open_timeout: GlobalSetting.smtp_open_timeout,
+      read_timeout: GlobalSetting.smtp_read_timeout
     }
 
     settings[:openssl_verify_mode] = GlobalSetting.smtp_openssl_verify_mode if GlobalSetting.smtp_openssl_verify_mode


### PR DESCRIPTION
Allow configuration of smtp timeout settings for slower SMTP servers. 

- DISCOURSE_SMTP_OPEN_TIMEOUT 
- DISCOURSE_SMTP_READ_TIMEOUT

After patching `production.rb` according to @xfalcox [reply](https://meta.discourse.org/t/smtp-net-readtimeout-without-relation-to-net-or-login-problems-smtp-host-is-just-slow/235727/2?u=rfk) the two settings are being utilized as expected. This is in the admin test page (`admin/email`) and on the production background jobs. 