### PR TITLE
UX: Tweak user menu padding

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -61,7 +61,7 @@
   .panel-body-bottom {
     display: flex;
     flex: 1 0 0%; // safari height fix
-    margin-top: 0.5em;
+    margin: 0.5rem 0.5rem 0;
     flex-wrap: wrap;
 
     .show-all {
@@ -104,7 +104,7 @@
     flex-direction: column;
     justify-content: space-between;
     border-left: 1px solid var(--primary-low);
-    padding: 0.75em 0;
+    padding: 0.5rem 0;
   }
 
   .tabs-list {
@@ -144,7 +144,7 @@
 
   .quick-access-panel {
     width: 320px;
-    padding: 0.75em;
+    padding: 0.5rem 0;
     justify-content: space-between;
     box-sizing: border-box;
 
@@ -401,8 +401,7 @@
 
       a {
         display: flex;
-        margin: 0.25em;
-        padding: 0em 0.25em;
+        padding: 0.25rem 0.75rem;
       }
 
       button {


### PR DESCRIPTION
Smaller padding + the background (and clickable space) expanded to fill the horizontal space

Before / After

<img width="374" alt="Screenshot 2022-08-10 at 20 49 29" src="https://user-images.githubusercontent.com/66961/183996083-97105a3d-801f-4d0d-95c0-edcd7e3140bc.png"> <img width="374" alt="Screenshot 2022-08-10 at 20 49 38" src="https://user-images.githubusercontent.com/66961/183996099-76c9140c-928b-4c30-a037-bf82b2449694.png">

Btw. now that I'm looking at it, I'm not a fan of unread elements and active tab sharing the same background color. Should the tabs perhaps use the same colors as top nav?

<img width="667" alt="Screenshot 2022-08-10 at 21 06 14" src="https://user-images.githubusercontent.com/66961/183997024-88911bb4-6288-425d-a4eb-39d78d1489c5.png">
