### PR TITLE
FIX: Remove dead images from oneboxes

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -378,7 +378,12 @@ class CookedPostProcessor
     still_an_image = true
 
     if info&.too_large?
-      add_large_image_placeholder!(img)
+      if img.ancestors('.onebox, .onebox-body').blank?
+        add_large_image_placeholder!(img)
+      else
+        img.remove
+      end
+
       still_an_image = false
     elsif info&.download_failed?
       if img.ancestors('.onebox, .onebox-body').blank?
@@ -386,6 +391,7 @@ class CookedPostProcessor
       else
         img.remove
       end
+
       still_an_image = false
     elsif info&.downloaded? && upload = info&.upload
       img["src"] = UrlHelper.cook_url(upload.url, secure: @with_secure_media)

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -381,7 +381,11 @@ class CookedPostProcessor
       add_large_image_placeholder!(img)
       still_an_image = false
     elsif info&.download_failed?
-      add_broken_image_placeholder!(img)
+      if img.ancestors('.onebox, .onebox-body').blank?
+        add_broken_image_placeholder!(img)
+      else
+        img.remove
+      end
       still_an_image = false
     elsif info&.downloaded? && upload = info&.upload
       img["src"] = UrlHelper.cook_url(upload.url, secure: @with_secure_media)

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -1132,6 +1132,44 @@ RSpec.describe CookedPostProcessor do
       expect(cpp.doc.to_s).to include(I18n.t("upload.placeholders.too_large_humanized", max_size: "4 MB"))
     end
 
+    it "removes large images from onebox" do
+      url = 'https://example.com/article'
+
+      Oneboxer.stubs(:onebox).with(url, anything).returns <<~HTML
+        <aside class="onebox allowlistedgeneric" data-onebox-src="https://example.com/article">
+          <header class="source">
+            <img src="https://example.com/favicon.ico" class="site-icon">
+            <a href="https://example.com/article" target="_blank" rel="nofollow ugc noopener">Example Site</a>
+          </header>
+          <article class="onebox-body">
+            <img src="https://example.com/article.jpeg" class="thumbnail">
+            <h3><a href="https://example.com/article" target="_blank" rel="nofollow ugc noopener">Lorem Ispum</a></h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer tellus neque, malesuada ac neque ac, tempus tincidunt lectus.</p>
+          </article>
+        </aside>
+      HTML
+
+      post = Fabricate(:post, raw: url)
+
+      PostHotlinkedMedia.create!(url: "//example.com/favicon.ico", post: post, status: 'too_large')
+      PostHotlinkedMedia.create!(url: "//example.com/article.jpeg", post: post, status: 'too_large')
+
+      cpp = CookedPostProcessor.new(post, invalidate_oneboxes: true)
+      cpp.post_process
+
+      expect(cpp.doc).to match_html <<~HTML
+        <aside class="onebox allowlistedgeneric" data-onebox-src="https://example.com/article">
+          <header class="source">
+            <a href="https://example.com/article" target="_blank" rel="noopener nofollow ugc">Example Site</a>
+          </header>
+          <article class="onebox-body">
+            <h3><a href="https://example.com/article" target="_blank" rel="noopener nofollow ugc">Lorem Ispum</a></h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer tellus neque, malesuada ac neque ac, tempus tincidunt lectus.</p>
+          </article>
+        </aside>
+      HTML
+    end
+
     it "replaces broken image placeholder" do
       url = 'https://image.com/my-avatar'
       image_url = 'https://image.com/avatar.png'


### PR DESCRIPTION
Dead images used to be replaced with a broken chain icon, but with this
commit they will be removed instead. This applies to oneboxes only.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
