### PR TITLE
DEV: Update user-menu components to use `@glimmer/component`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/bookmark-notification-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/bookmark-notification-item.js
@@ -1,7 +1,7 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import Notification from "discourse/models/notification";
 
-export default class UserMenuBookmarkNotificationItem extends GlimmerComponent {
+export default class UserMenuBookmarkNotificationItem extends Component {
   get component() {
     if (this.args.item.constructor === Notification) {
       return "user-menu/notification-item";

--- a/app/assets/javascripts/discourse/app/components/user-menu/items-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/items-list.js
@@ -1,9 +1,9 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import Session from "discourse/models/session";
 
-export default class UserMenuItemsList extends GlimmerComponent {
+export default class UserMenuItemsList extends Component {
   @tracked loading = false;
   @tracked items = [];
 

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu-item.js
@@ -1,7 +1,7 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { action } from "@ember/object";
 
-export default class UserMenuItem extends GlimmerComponent {
+export default class UserMenuItem extends Component {
   get className() {}
 
   get linkHref() {

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -1,8 +1,9 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { NO_REMINDER_ICON } from "discourse/models/bookmark";
 import UserMenuTab, { CUSTOM_TABS_CLASSES } from "discourse/lib/user-menu/tab";
+import { inject as service } from "@ember/service";
 
 const DEFAULT_TAB_ID = "all-notifications";
 const DEFAULT_PANEL_COMPONENT = "user-menu/notifications-list";
@@ -135,7 +136,12 @@ const CORE_TOP_TABS = [
   },
 ];
 
-export default class UserMenu extends GlimmerComponent {
+export default class UserMenu extends Component {
+  @service currentUser;
+  @service siteSettings;
+  @service site;
+  @service appEvents;
+
   @tracked currentTabId = DEFAULT_TAB_ID;
   @tracked currentPanelComponent = DEFAULT_PANEL_COMPONENT;
 

--- a/app/assets/javascripts/discourse/app/components/user-menu/message-notification-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/message-notification-item.js
@@ -1,7 +1,7 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import Notification from "discourse/models/notification";
 
-export default class UserMenuMessageNotificationItem extends GlimmerComponent {
+export default class UserMenuMessageNotificationItem extends Component {
   get component() {
     if (this.args.item.constructor === Notification) {
       return "user-menu/notification-item";

--- a/app/assets/javascripts/discourse/app/components/user-menu/notification-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/notification-item.js
@@ -4,8 +4,13 @@ import { action } from "@ember/object";
 import { getRenderDirector } from "discourse/lib/notification-item";
 import getURL from "discourse-common/lib/get-url";
 import cookie from "discourse/lib/cookie";
+import { inject as service } from "@ember/service";
 
 export default class UserMenuNotificationItem extends UserMenuItem {
+  @service currentUser;
+  @service siteSettings;
+  @service site;
+
   constructor() {
     super(...arguments);
     this.renderDirector = getRenderDirector(

--- a/app/assets/javascripts/discourse/app/components/user-menu/notifications-list-empty-state.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/notifications-list-empty-state.js
@@ -1,3 +1,3 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import templateOnly from "@ember/component/template-only";
 
-export default class UserMenuNotificationsListEmptyState extends GlimmerComponent {}
+export default templateOnly();

--- a/app/assets/javascripts/discourse/app/components/user-menu/notifications-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/notifications-list.js
@@ -4,8 +4,13 @@ import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { postRNWebviewMessage } from "discourse/lib/utilities";
 import showModal from "discourse/lib/show-modal";
+import { inject as service } from "@ember/service";
 
 export default class UserMenuNotificationsList extends UserMenuItemsList {
+  @service currentUser;
+  @service site;
+  @service store;
+
   get filterByTypes() {
     return null;
   }

--- a/app/assets/javascripts/discourse/app/components/user-menu/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/reviewable-item.js
@@ -1,8 +1,13 @@
 import UserMenuItem from "discourse/components/user-menu/menu-item";
 import getURL from "discourse-common/lib/get-url";
 import { getRenderDirector } from "discourse/lib/reviewable-item";
+import { inject as service } from "@ember/service";
 
 export default class UserMenuReviewableItem extends UserMenuItem {
+  @service currentUser;
+  @service siteSettings;
+  @service site;
+
   constructor() {
     super(...arguments);
     this.reviewable = this.args.item;


### PR DESCRIPTION
Now that all of our singletons have been converted to true Ember Services, we can remove our custom `discourse/component/glimmer` superclass and use explicit injection

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
