### PR TITLE
DEV: Update composer-fullscreen-prompt to template-only component

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/composer-fullscreen-prompt.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/composer-fullscreen-prompt.hbs
@@ -1,3 +1,3 @@
-<div class="composer-fullscreen-prompt" {{did-insert this.registerAnimationListener}}>
-  {{html-safe this.exitPrompt}}
+<div class="composer-fullscreen-prompt" {{on "animationend" @removeFullScreenExitPrompt}}>
+  {{html-safe (i18n "composer.exit_fullscreen_prompt")}}
 </div>

--- a/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
+++ b/app/assets/javascripts/discourse/app/components/composer-fullscreen-prompt.js
@@ -1,24 +1,3 @@
-import { action } from "@ember/object";
-import GlimmerComponent from "@glimmer/component";
-import I18n from "I18n";
+import templateOnly from "@ember/component/template-only";
 
-export default class ComposerFullscreenPrompt extends GlimmerComponent {
-  @action
-  registerAnimationListener(element) {
-    this.#addAnimationEventListener(element);
-  }
-
-  #addAnimationEventListener(element) {
-    element.addEventListener(
-      "animationend",
-      () => {
-        this.args.removeFullScreenExitPrompt();
-      },
-      { once: true }
-    );
-  }
-
-  get exitPrompt() {
-    return I18n.t("composer.exit_fullscreen_prompt");
-  }
-}
+export default templateOnly();


### PR DESCRIPTION
1. Replace `{{did-insert` -> `addEventListener` with the builtin `{{on` modifier
2. Move the i18n call into the template

With both of those changes, there is no logic left in the backing class, so we can switch to `templateOnly()` which is significantly faster. (granted, not a big deal for a component like this, but it makes for a good demonstration)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
