### PR TITLE
DEV: Passing symbols to jobs was deprecated, use a string instead

### DIFF
--- a/app/jobs/regular/publish_group_membership_updates.rb
+++ b/app/jobs/regular/publish_group_membership_updates.rb
@@ -3,12 +3,13 @@
 module Jobs
   class PublishGroupMembershipUpdates < ::Jobs::Base
     def execute(args)
-      raise Discourse::InvalidParameters.new(:type) if !%w[add remove].include?(args[:type])
+      available_types = [Group::AUTO_GROUPS_ADD, Group::AUTO_GROUPS_REMOVE]
+      raise Discourse::InvalidParameters.new(:type) if !available_types.include?(args[:type])
 
       group = Group.find_by(id: args[:group_id])
       return if !group
 
-      added_members = args[:type] == 'add'
+      added_members = args[:type] == Group::AUTO_GROUPS_ADD
 
       User.human_users.where(id: args[:user_ids]).each do |user|
         if added_members

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -103,6 +103,9 @@ class Group < ActiveRecord::Base
   AUTO_GROUP_IDS = Hash[*AUTO_GROUPS.to_a.flatten.reverse]
   STAFF_GROUPS = [:admins, :moderators, :staff]
 
+  AUTO_GROUPS_ADD = "add"
+  AUTO_GROUPS_REMOVE = "remove"
+
   IMAP_SETTING_ATTRIBUTES = [
     "imap_server",
     "imap_port",
@@ -493,7 +496,7 @@ class Group < ActiveRecord::Base
     if removed_user_ids.present?
       Jobs.enqueue(
         :publish_group_membership_updates,
-        user_ids: removed_user_ids, group_id: group.id, type: :remove
+        user_ids: removed_user_ids, group_id: group.id, type: AUTO_GROUPS_REMOVE
       )
     end
 
@@ -526,7 +529,7 @@ class Group < ActiveRecord::Base
     if added_user_ids.present?
       Jobs.enqueue(
         :publish_group_membership_updates,
-        user_ids: added_user_ids, group_id: group.id, type: :add
+        user_ids: added_user_ids, group_id: group.id, type: AUTO_GROUPS_ADD
       )
     end
 


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
