### PR TITLE
DEV: Update sidebar components to use `@glimmer/component`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar.js
@@ -1,7 +1,11 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { bind } from "discourse-common/utils/decorators";
+import { inject as service } from "@ember/service";
 
-export default class Sidebar extends GlimmerComponent {
+export default class Sidebar extends Component {
+  @service appEvents;
+  @service site;
+
   constructor() {
     super(...arguments);
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/categories-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/categories-section.js
@@ -4,11 +4,13 @@ import { cached } from "@glimmer/tracking";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import CategorySectionLink from "discourse/lib/sidebar/categories-section/category-section-link";
 
-export default class SidebarCategoriesSection extends GlimmerComponent {
+export default class SidebarCategoriesSection extends Component {
   @service router;
+  @service topicTrackingState;
+  @service currentUser;
 
   constructor() {
     super(...arguments);

--- a/app/assets/javascripts/discourse/app/components/sidebar/community-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/community-section.js
@@ -1,4 +1,4 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import Composer from "discourse/models/composer";
 import { getOwner } from "discourse-common/lib/get-owner";
 import PermissionType from "discourse/models/permission-type";
@@ -30,8 +30,12 @@ const ADMIN_MAIN_SECTION_LINKS = [AdminSectionLink];
 const MORE_SECTION_LINKS = [GroupsSectionLink, UsersSectionLink];
 const MORE_SECONDARY_SECTION_LINKS = [AboutSectionLink, FAQSectionLink];
 
-export default class SidebarCommunitySection extends GlimmerComponent {
+export default class SidebarCommunitySection extends Component {
   @service router;
+  @service topicTrackingState;
+  @service currentUser;
+  @service appEvents;
+  @service siteSettings;
 
   moreSectionLinks = [...MORE_SECTION_LINKS, ...customSectionLinks].map(
     (sectionLinkClass) => {

--- a/app/assets/javascripts/discourse/app/components/sidebar/messages-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/messages-section.js
@@ -1,10 +1,11 @@
 import { cached } from "@glimmer/tracking";
 
 import { getOwner } from "discourse-common/lib/get-owner";
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { bind } from "discourse-common/utils/decorators";
 import GroupMessageSectionLink from "discourse/lib/sidebar/messages-section/group-message-section-link";
 import PersonalMessageSectionLink from "discourse/lib/sidebar/messages-section/personal-message-section-link";
+import { inject as service } from "@ember/service";
 
 export const INBOX = "inbox";
 export const UNREAD = "unread";
@@ -22,7 +23,11 @@ export const PERSONAL_MESSAGES_INBOX_FILTERS = [
 
 export const GROUP_MESSAGES_INBOX_FILTERS = [INBOX, NEW, UNREAD, ARCHIVE];
 
-export default class SidebarMessagesSection extends GlimmerComponent {
+export default class SidebarMessagesSection extends Component {
+  @service appEvents;
+  @service pmTopicTrackingState;
+  @service currentUser;
+
   constructor() {
     super(...arguments);
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
@@ -4,9 +4,9 @@ import { inject as service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 
 import { bind } from "discourse-common/utils/decorators";
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 
-export default class SidebarMoreSectionLinks extends GlimmerComponent {
+export default class SidebarMoreSectionLinks extends Component {
   @tracked shouldDisplaySectionLinks = false;
   @tracked activeSectionLink;
   @service router;

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -1,7 +1,7 @@
-import GlimmerComponent from "@glimmer/component";
+import Component from "@glimmer/component";
 import { htmlSafe } from "@ember/template";
 
-export default class SectionLink extends GlimmerComponent {
+export default class SectionLink extends Component {
   willDestroy() {
     if (this.args.willDestroy) {
       this.args.willDestroy();

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-message.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-message.js
@@ -1,3 +1,3 @@
-import Component from "@ember/component";
+import templateOnly from "@ember/component/template-only";
 
-export default Component.extend({});
+export default templateOnly();

--- a/app/assets/javascripts/discourse/app/components/sidebar/section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section.js
@@ -1,9 +1,12 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
 
 import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
 
-export default class SidebarSection extends GlimmerComponent {
+export default class SidebarSection extends Component {
+  @service keyValueStore;
+
   @tracked displaySection;
   collapsedSidebarSectionKey = `sidebar-section-${this.args.sectionName}-collapsed`;
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/sections.js
@@ -1,8 +1,12 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { customSections as sidebarCustomSections } from "discourse/lib/sidebar/custom-sections";
 import { getOwner, setOwner } from "@ember/application";
+import { inject as service } from "@ember/service";
 
-export default class SidebarSections extends GlimmerComponent {
+export default class SidebarSections extends Component {
+  @service siteSettings;
+  @service currentUser;
+
   customSections;
 
   constructor() {

--- a/app/assets/javascripts/discourse/app/components/sidebar/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/tags-section.js
@@ -4,11 +4,13 @@ import { cached } from "@glimmer/tracking";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import TagSectionLink from "discourse/lib/sidebar/tags-section/tag-section-link";
 
-export default class SidebarTagsSection extends GlimmerComponent {
+export default class SidebarTagsSection extends Component {
   @service router;
+  @service topicTrackingState;
+  @service currentUser;
 
   constructor() {
     super(...arguments);


### PR DESCRIPTION
Now that all of our singletons have been converted to true Ember Services, we can remove our custom `discourse/component/glimmer` superclass and use explicit injection

This also updates `section-message` to be a templateOnly glimmer component rather than a classic component.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
