### PR TITLE
DEV: Update welcome-topic-banner to use `@glimmer/component`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/welcome-topic-banner.js
+++ b/app/assets/javascripts/discourse/app/components/welcome-topic-banner.js
@@ -1,10 +1,14 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { getOwner } from "discourse-common/lib/get-owner";
 import Topic from "discourse/models/topic";
 import Composer from "discourse/models/composer";
+import { inject as service } from "@ember/service";
 
-export default class WelcomeTopicBanner extends GlimmerComponent {
+export default class WelcomeTopicBanner extends Component {
+  @service siteSettings;
+  @service store;
+
   @action
   editWelcomeTopic() {
     const topicController = getOwner(this).lookup("controller:topic");


### PR DESCRIPTION
Now that all of our singletons have been converted to true Ember Services, we can remove our custom `discourse/component/glimmer` superclass and use explicit injection


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
