### PR TITLE
DEV: Remove flaky sidebar acceptance test.

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-community-section-test.js
@@ -148,15 +148,6 @@ acceptance("Sidebar - Community Section", function (needs) {
     await click(
       ".sidebar-section-community .sidebar-more-section-links-details-summary"
     );
-
-    await click("#main-outlet");
-
-    assert.notOk(
-      exists(
-        ".sidebar-section-community .sidebar-more-section-links-details-content"
-      ),
-      "additional section links are hidden when clicking outside"
-    );
   });
 
   test("clicking on everything link", async function (assert) {


### PR DESCRIPTION
At a certain point, the cost of debugging a flaky acceptance test is
just too high for what we're testing for here. I've decided to just
accept the risk of a minor UX feature.

Follow-up to 55fa94f75901fc95ac28e2fea8cc3813ab2750ab