### PR TITLE
DEV: Fallback to `bookmarkable_url` if bookmark reminder notification has no topic info

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-items/bookmark-reminder.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-items/bookmark-reminder.js
@@ -1,5 +1,6 @@
 import NotificationItemBase from "discourse/lib/notification-items/base";
 import I18n from "I18n";
+import getUrl from "discourse-common/lib/get-url";
 
 export default class extends NotificationItemBase {
   get linkTitle() {
@@ -13,5 +14,15 @@ export default class extends NotificationItemBase {
 
   get description() {
     return super.description || this.notification.data.title;
+  }
+
+  get linkHref() {
+    let linkHref = super.linkHref;
+    if (linkHref) {
+      return linkHref;
+    }
+    if (this.notification.data.bookmarkable_url) {
+      return getUrl(this.notification.data.bookmarkable_url);
+    }
   }
 }

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-items/bookmark-reminder-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-items/bookmark-reminder-test.js
@@ -82,4 +82,42 @@ discourseModule("Unit | Notification Items | bookmark-reminder", function () {
       "description falls back to the bookmark title if there's no fancy title"
     );
   });
+
+  test("linkHref", function (assert) {
+    let notification = getNotification();
+    let director = createRenderDirector(
+      notification,
+      "bookmark_reminder",
+      this.siteSettings
+    );
+    assert.strictEqual(
+      director.linkHref,
+      "/t/this-is-fancy-title/449/113",
+      "is a link to the topic that the bookmark belongs to"
+    );
+
+    notification = getNotification({
+      post_number: null,
+      topic_id: null,
+      fancy_title: null,
+      slug: null,
+      data: {
+        title: "bookmark from some plugin",
+        display_username: "osama",
+        bookmark_name: "",
+        bookmarkable_url: "/link/to/somewhere",
+        bookmarkable_id: 4324,
+      },
+    });
+    director = createRenderDirector(
+      notification,
+      "bookmark_reminder",
+      this.siteSettings
+    );
+    assert.strictEqual(
+      director.linkHref,
+      "/link/to/somewhere",
+      "falls back to bookmarkable_url"
+    );
+  });
 });


### PR DESCRIPTION
This fix is for the experimental user menu. Some `bookmark_reminder` notifications may not be associated with a topic/post (e.g. bookmark reminder for a chat message) in which case the default notification renderer cannot figure out the `href` for those `bookmark_reminder` notifications. This PR teaches the `bookmark_reminder` notification type renderer to fallback to `bookmarkable_url` that's present in the notification data if the default notification renderer doesn't return a `href` for the notification.