### PR TITLE
DEV: Make group message summary notification link to the group inbox

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-items/group-message-summary.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-items/group-message-summary.js
@@ -1,4 +1,5 @@
 import NotificationItemBase from "discourse/lib/notification-items/base";
+import { userPath } from "discourse/lib/url";
 import I18n from "I18n";
 
 export default class extends NotificationItemBase {
@@ -11,5 +12,11 @@ export default class extends NotificationItemBase {
 
   get label() {
     return null;
+  }
+
+  get linkHref() {
+    return userPath(
+      `${this.notification.data.username}/messages/group/${this.notification.data.group_name}`
+    );
   }
 }

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-items/group-message-summary-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-items/group-message-summary-test.js
@@ -47,5 +47,19 @@ discourseModule(
         "displays the right content"
       );
     });
+
+    test("linkHref", function (assert) {
+      const notification = getNotification();
+      const director = createRenderDirector(
+        notification,
+        "group_message_summary",
+        this.siteSettings
+      );
+      assert.strictEqual(
+        director.linkHref,
+        "/u/drummers.boss/messages/group/drummers",
+        "links to the group inbox in the user profile"
+      );
+    });
   }
 );


### PR DESCRIPTION
This fix is for the experimental user menu. 