### PR TITLE
FIX: Regression with Categories nav item

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/navigation/default.js
+++ b/app/assets/javascripts/discourse/app/controllers/navigation/default.js
@@ -10,6 +10,6 @@ export default Controller.extend(FilterModeMixin, {
 
   @discourseComputed("router.currentRoute.queryParams.f")
   skipCategoriesNavItem(filterParamValue) {
-    return !filterParamValue || filterParamValue !== TRACKED_QUERY_PARAM_VALUE;
+    return filterParamValue === TRACKED_QUERY_PARAM_VALUE;
   },
 });

--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -262,7 +262,7 @@ NavItem.reopenClass({
         }
 
         if (
-          (category || !args.skipCategoriesNavItem) &&
+          (category || args.skipCategoriesNavItem) &&
           i.name.startsWith("categor")
         ) {
           return false;

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-tracked-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-tracked-test.js
@@ -69,6 +69,13 @@ acceptance("Topic Discovery Tracked", function (needs) {
       "the categories nav item is displayed when tracked filter is not present"
     );
 
+    await visit("/categories");
+
+    assert.ok(
+      exists("#navigation-bar li.categories"),
+      "the categories nav item is displayed on categories route when tracked filter is not present"
+    );
+
     await visit("/?f=tracked");
 
     assert.ok(


### PR DESCRIPTION
Since https://github.com/discourse/discourse/pull/16714 the categories nav item was hidden in the `/categories` route. This was not the intention of the original PR, the goal there was to hide the button only when URLs contain the `f=tracked` query parameter. 