### PR TITLE
DEV: Add before-composer-fields plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -45,6 +45,7 @@
 
         <ComposerEditor @topic={{this.topic}} @composer={{this.model}} @lastValidatedAt={{this.lastValidatedAt}} @canWhisper={{this.canWhisper}} @storeToolbarState={{action "storeToolbarState"}} @onPopupMenuAction={{action "onPopupMenuAction"}} @showUploadModal={{route-action "showUploadSelector"}} @popupMenuOptions={{this.popupMenuOptions}} @draftStatus={{this.model.draftStatus}} @isUploading={{this.isUploading}} @isProcessingUpload={{this.isProcessingUpload}} @allowUpload={{this.allowUpload}} @uploadIcon={{this.uploadIcon}} @isCancellable={{this.isCancellable}} @uploadProgress={{this.uploadProgress}} @groupsMentioned={{action "groupsMentioned"}} @cannotSeeMention={{action "cannotSeeMention"}} @hereMention={{action "hereMention"}} @importQuote={{action "importQuote"}} @togglePreview={{action "togglePreview"}} @processPreview={{this.showPreview}} @showToolbar={{this.showToolbar}} @afterRefresh={{action "afterRefresh"}} @focusTarget={{this.focusTarget}} @disableTextarea={{this.disableTextarea}}>
           <div class="composer-fields">
+            <PluginOutlet @name="before-composer-fields" @args={{hash model=this.model}} />
             {{#unless this.model.viewFullscreen}}
               {{#if this.model.canEditTitle}}
                 {{#if this.model.creatingPrivateMessage}}


### PR DESCRIPTION
Add ability to insert content before `composer-fields`

<img width="929" alt="Screen Shot 2022-08-12 at 3 00 23 PM" src="https://user-images.githubusercontent.com/50783505/184433977-52e5261f-d55c-4424-8df5-5fb494e4d1ad.png">

