### PR TITLE
A11Y: add focus state for advanced search toggles

### DIFF
--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -157,14 +157,21 @@
     details.advanced-filters,
     details.search-advanced-additional-options {
       margin-top: 1em;
-
       > summary {
         color: var(--tertiary);
         cursor: pointer;
+        padding-top: 0.25em;
+        padding-bottom: 0.25em;
+        &:focus-visible {
+          background-color: var(--tertiary-very-low);
+        }
       }
       &[open] > summary {
         color: var(--primary);
         margin-bottom: 1em;
+        &:focus-visible {
+          background-color: var(--tertiary-very-low);
+        }
       }
     }
 


### PR DESCRIPTION
Using `focus-visible` to ensure this only shows when navigating using a keyboard.

<img width="914" alt="image" src="https://user-images.githubusercontent.com/368961/184445134-8e7cee58-cc82-4475-b4e3-01b89d39b18c.png">