### PR TITLE
A11Y: Improve group box hover highlight

### DIFF
--- a/app/assets/stylesheets/common/base/groups.scss
+++ b/app/assets/stylesheets/common/base/groups.scss
@@ -45,6 +45,7 @@
 
       &:hover {
         box-shadow: shadow("card");
+        border-color: var(--primary-low-mid-or-secondary-high);
       }
     }
 


### PR DESCRIPTION
Most noticeable on dark themes (light themes already had a shadow effect). 

Cursor for each screenshot is over the "admin" group box. 

Before (squint!)
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/184447314-d65c9dc1-f8d5-4139-b711-491b72858ee5.png">

After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/184447282-f77f877d-ab00-49be-b459-08ca52d5ffca.png">

Before
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/184447548-8a634172-2beb-4e84-80fa-b27957e60c6d.png">

After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/184447586-ac0fbd8d-829a-4f6f-95cc-d2c331054b7b.png">

