### PR TITLE
UX: Remove extraneous margins in profile pic modal

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -388,6 +388,9 @@
     button {
       margin-left: auto;
     }
+    label a {
+      margin: 0;
+    }
   }
   $label-max-width: 300px;
   label.radio {


### PR DESCRIPTION
Before / After (notice horizontal margins around "Gravatar")

<img width="340" alt="Screenshot 2022-08-12 at 23 59 39" src="https://user-images.githubusercontent.com/66961/184474744-680a80b9-e2cf-4313-a93b-5306817b6cd5.png"> <img width="340" alt="Screenshot 2022-08-12 at 23 59 27" src="https://user-images.githubusercontent.com/66961/184474747-a5ea469b-72c1-4b82-af64-b828f86f7c55.png">

