### PR TITLE
DEV: implements parseAsync in discourse/lib/text

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/text.js
+++ b/app/assets/javascripts/discourse/app/lib/text.js
@@ -68,6 +68,12 @@ export function sanitizeAsync(text, options) {
   });
 }
 
+export function parseAsync(md, options) {
+  return loadMarkdownIt().then(() => {
+    return createPrettyText(options).opts.engine.parse(md);
+  });
+}
+
 function loadMarkdownIt() {
   return new Promise((resolve) => {
     let markdownItURL = Session.currentProp("markdownItURL");

--- a/app/assets/javascripts/discourse/tests/unit/lib/text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/text-test.js
@@ -1,0 +1,14 @@
+import { module, test } from "qunit";
+import { parseAsync } from "discourse/lib/text";
+
+module("Unit | Utility | text", function () {
+  test("parseAsync", async function (assert) {
+    await parseAsync("**test**").then((tokens) => {
+      assert.strictEqual(
+        tokens[1].children[1].type,
+        "strong_open",
+        "it parses the raw markdown"
+      );
+    });
+  });
+});


### PR DESCRIPTION
`parseAsync` allows to parse a block of markdown into tokens.

Usage:

```javascript
import { parseAsync } from "discourse/lib/text";

// ...

await parseAsync("**test**").then((tokens) => {
 console.log(tokens);
})
```
