### PR TITLE
FIX: markdown-it parse fn requires an env arg with {} as default

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/text.js
+++ b/app/assets/javascripts/discourse/app/lib/text.js
@@ -68,9 +68,9 @@ export function sanitizeAsync(text, options) {
   });
 }
 
-export function parseAsync(md, options) {
+export function parseAsync(md, options = {}, env = {}) {
   return loadMarkdownIt().then(() => {
-    return createPrettyText(options).opts.engine.parse(md);
+    return createPrettyText(options).opts.engine.parse(md, env);
   });
 }
 


### PR DESCRIPTION
See https://markdown-it.github.io/markdown-it/#MarkdownIt.parse for more details