### PR TITLE
FIX: Don't raise on deleted topic in UpdateHotlinkedRaw

### DIFF
--- a/app/jobs/regular/update_hotlinked_raw.rb
+++ b/app/jobs/regular/update_hotlinked_raw.rb
@@ -11,6 +11,7 @@ module Jobs
       post = Post.find_by(id: @post_id)
       return if post.nil?
       return if post.cook_method == Post.cook_methods[:raw_html]
+      return if post.topic.nil?
 
       hotlinked_map = post.post_hotlinked_media.preload(:upload).map { |r| [r.url, r] }.to_h
 


### PR DESCRIPTION
Fixes:

```
Job exception: undefined method `acting_user=' for nil:NilClass
```

in
```
/var/www/discourse/lib/post_revisor.rb:181:in `revise!'
/var/www/discourse/app/models/post.rb:646:in `revise'
/var/www/discourse/app/jobs/regular/update_hotlinked_raw.rb:24:in `execute'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
