### PR TITLE
DEV: Tweak core_frontend_tests timeouts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,7 @@ jobs:
     name: core frontend (${{ matrix.browser }})
     runs-on: ubuntu-latest
     container: discourse/discourse_test:slim-browsers
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     strategy:
       fail-fast: false
@@ -223,16 +223,16 @@ jobs:
         if: ${{ always() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=1 --launch "${{ matrix.browser }}" --random
-        timeout-minutes: 20
+        timeout-minutes: 15
 
       - name: Core QUnit 2
         if: ${{ always() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=2 --launch "${{ matrix.browser }}" --random
-        timeout-minutes: 20
+        timeout-minutes: 15
 
       - name: Core QUnit 3
         if: ${{ always() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=3 --launch "${{ matrix.browser }}" --random
-        timeout-minutes: 20
+        timeout-minutes: 15


### PR DESCRIPTION
Each test chunk takes about 10 minutes, so those timeouts can be decreased from 20 to 15.

And there are three of those chunks so total can be a bit over 30 minutes, hence the bump to 35.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
