### PR TITLE
DEV: Update eslint-config-discourse to introduce `sort-class-members`

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
@@ -17,8 +17,8 @@ const ICON = "icon";
 export default class AdminBadgesShowController extends Controller.extend(
   bufferedProperty("model")
 ) {
-  @controller adminBadges;
   @service router;
+  @controller adminBadges;
 
   @tracked saving = false;
   @tracked savingStatus = "";

--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.js
@@ -7,9 +7,10 @@ import { bind } from "discourse-common/utils/decorators";
 import Component from "@glimmer/component";
 
 export default class SidebarMoreSectionLinks extends Component {
+  @service router;
+
   @tracked shouldDisplaySectionLinks = false;
   @tracked activeSectionLink;
-  @service router;
 
   #allLinks = [...this.args.sectionLinks, ...this.args.secondarySectionLinks];
 

--- a/app/assets/javascripts/discourse/app/lib/sticky-avatars.js
+++ b/app/assets/javascripts/discourse/app/lib/sticky-avatars.js
@@ -5,15 +5,15 @@ import { headerOffset } from "discourse/lib/offset-calculator";
 import { schedule } from "@ember/runloop";
 
 export default class StickyAvatars {
+  static init(container) {
+    return new this(container).init();
+  }
+
   stickyClass = "sticky-avatar";
   topicPostSelector = "#topic .post-stream .topic-post";
   intersectionObserver = null;
   direction = "⬇️";
   prevOffset = -1;
-
-  static init(container) {
-    return new this(container).init();
-  }
 
   constructor(container) {
     this.container = container;

--- a/app/assets/javascripts/discourse/app/lib/to-markdown.js
+++ b/app/assets/javascripts/discourse/app/lib/to-markdown.js
@@ -82,50 +82,6 @@ export class Tag {
     return klass;
   }
 
-  constructor(prefix = "", suffix = "", inline = false) {
-    this.prefix = prefix;
-    this.suffix = suffix;
-    this.inline = inline;
-  }
-
-  decorate(text) {
-    for (const callback of tagDecorateCallbacks) {
-      const result = callback.call(this, text);
-
-      if (typeof result !== "undefined") {
-        text = result;
-      }
-    }
-
-    if (this.prefix || this.suffix) {
-      text = [this.prefix, text, this.suffix].join("");
-    }
-
-    if (this.inline) {
-      const { prev, next } = this.element;
-
-      if (prev && prev.name !== "#text") {
-        text = " " + text;
-      }
-
-      if (next && next.name !== "#text") {
-        text = text + " ";
-      }
-    }
-
-    return text;
-  }
-
-  toMarkdown() {
-    const text = this.element.innerMarkdown();
-
-    if (text?.trim()) {
-      return this.decorate(text);
-    }
-
-    return text;
-  }
-
   static blocks() {
     return [
       "address",
@@ -643,6 +599,50 @@ export class Tag {
       }
     };
   }
+
+  constructor(prefix = "", suffix = "", inline = false) {
+    this.prefix = prefix;
+    this.suffix = suffix;
+    this.inline = inline;
+  }
+
+  decorate(text) {
+    for (const callback of tagDecorateCallbacks) {
+      const result = callback.call(this, text);
+
+      if (typeof result !== "undefined") {
+        text = result;
+      }
+    }
+
+    if (this.prefix || this.suffix) {
+      text = [this.prefix, text, this.suffix].join("");
+    }
+
+    if (this.inline) {
+      const { prev, next } = this.element;
+
+      if (prev && prev.name !== "#text") {
+        text = " " + text;
+      }
+
+      if (next && next.name !== "#text") {
+        text = text + " ";
+      }
+    }
+
+    return text;
+  }
+
+  toMarkdown() {
+    const text = this.element.innerMarkdown();
+
+    if (text?.trim()) {
+      return this.decorate(text);
+    }
+
+    return text;
+  }
 }
 
 let tagsMap;
@@ -684,6 +684,34 @@ function tagByName(name) {
 }
 
 class Element {
+  static toMarkdown(element, parent, prev, next, metadata) {
+    return new Element(element, parent, prev, next, metadata).toMarkdown();
+  }
+
+  static parseChildren(parent) {
+    return Element.parse(parent.children, parent);
+  }
+
+  static parse(elements, parent = null) {
+    if (elements) {
+      let result = [];
+      let metadata = {};
+
+      for (let i = 0; i < elements.length; i++) {
+        const prev = i === 0 ? null : elements[i - 1];
+        const next = i === elements.length ? null : elements[i + 1];
+
+        result.push(
+          Element.toMarkdown(elements[i], parent, prev, next, metadata)
+        );
+      }
+
+      return result.join("");
+    }
+
+    return "";
+  }
+
   constructor(element, parent, previous, next, metadata) {
     this.name = element.name;
     this.data = element.data;
@@ -761,34 +789,6 @@ class Element {
 
   filterParentNames(names) {
     return this.parentNames.filter((p) => names.includes(p));
-  }
-
-  static toMarkdown(element, parent, prev, next, metadata) {
-    return new Element(element, parent, prev, next, metadata).toMarkdown();
-  }
-
-  static parseChildren(parent) {
-    return Element.parse(parent.children, parent);
-  }
-
-  static parse(elements, parent = null) {
-    if (elements) {
-      let result = [];
-      let metadata = {};
-
-      for (let i = 0; i < elements.length; i++) {
-        const prev = i === 0 ? null : elements[i - 1];
-        const next = i === elements.length ? null : elements[i + 1];
-
-        result.push(
-          Element.toMarkdown(elements[i], parent, prev, next, metadata)
-        );
-      }
-
-      return result.join("");
-    }
-
-    return "";
   }
 }
 

--- a/app/assets/javascripts/discourse/app/routes/groups-index.js
+++ b/app/assets/javascripts/discourse/app/routes/groups-index.js
@@ -2,10 +2,6 @@ import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 
 export default class GroupsIndexRoute extends DiscourseRoute {
-  titleToken() {
-    return I18n.t("groups.index.title");
-  }
-
   queryParams = {
     order: { refreshModel: true, replace: true },
     asc: { refreshModel: true, replace: true },
@@ -13,6 +9,10 @@ export default class GroupsIndexRoute extends DiscourseRoute {
     type: { refreshModel: true, replace: true },
     username: { refreshModel: true },
   };
+
+  titleToken() {
+    return I18n.t("groups.index.title");
+  }
 
   model(params) {
     return params;

--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -2,11 +2,11 @@ const TapReporter = require("testem/lib/reporters/tap_reporter");
 const { shouldLoadPluginTestJs } = require("discourse/lib/plugin-js");
 
 class Reporter {
+  failReports = [];
+
   constructor() {
     this._tapReporter = new TapReporter(...arguments);
   }
-
-  failReports = [];
 
   reportMetadata(tag, metadata) {
     if (tag === "summary-line") {

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/render-glimmer-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/render-glimmer-test.js
@@ -42,6 +42,7 @@ class DemoWidget extends Widget {
 class DemoComponent extends ClassicComponent {
   static eventLog = [];
   classNames = ["demo-component"];
+  layout = hbs`<DButton class="component-action-button" @label="component_action" @action={{@action}} />`;
 
   init() {
     DemoComponent.eventLog.push("init");
@@ -63,8 +64,6 @@ class DemoComponent extends ClassicComponent {
   willDestroy() {
     DemoComponent.eventLog.push("willDestroy");
   }
-
-  layout = hbs`<DButton class="component-action-button" @label="component_action" @action={{@action}} />`;
 }
 
 module("Integration | Component | Widget | render-glimmer", function (hooks) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "chart.js": "3.5.1",
     "chartjs-plugin-datalabels": "^2.0.0",
     "diffhtml": "^1.0.0-beta.20",
-    "eslint-config-discourse": "^3.2.0",
+    "eslint-config-discourse": "^3.3.0",
     "magnific-popup": "1.1.0",
     "markdown-it": "13.0.1",
     "moment": "2.29.2",

--- a/plugins/discourse-local-dates/assets/javascripts/lib/date-with-zone-helper.js
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/date-with-zone-helper.js
@@ -14,6 +14,19 @@ import { getProperties } from "@ember/object";
   duration between two dates, eg for duration: "1.weeks", "2.months"...
 */
 export default class DateWithZoneHelper {
+  static fromDatetime(datetime, timezone, localTimezone) {
+    return new DateWithZoneHelper({
+      year: datetime.year(),
+      month: datetime.month(),
+      day: datetime.date(),
+      hour: datetime.hour(),
+      minute: datetime.minute(),
+      second: datetime.second(),
+      timezone,
+      localTimezone,
+    });
+  }
+
   constructor(params = {}) {
     this.timezone = params.timezone || "UTC";
     this.localTimezone = params.localTimezone || moment.tz.guess();
@@ -75,19 +88,6 @@ export default class DateWithZoneHelper {
     }
 
     return this.datetime.tz(this.localTimezone).toISOString(true);
-  }
-
-  static fromDatetime(datetime, timezone, localTimezone) {
-    return new DateWithZoneHelper({
-      year: datetime.year(),
-      month: datetime.month(),
-      day: datetime.date(),
-      hour: datetime.hour(),
-      minute: datetime.minute(),
-      second: datetime.second(),
-      timezone,
-      localTimezone,
-    });
   }
 
   _fromDatetime(datetime, timezone, localTimezone) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -999,10 +999,10 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-config-discourse@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-discourse/-/eslint-config-discourse-3.2.0.tgz#e48dfe9881845400d7acb7f4b8b867da8698254a"
-  integrity sha512-ckfLjFMfzzxN3VX7nB0DKPAOycVM7mbkAsytaU7rGJnlsMh1SQPBUUfIronQvAR9+f3Q6FQ3VA4T9DZYfWgyIw==
+eslint-config-discourse@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-discourse/-/eslint-config-discourse-3.3.0.tgz#e521620b5dfbd53bbd8bf0413319b3c41cc52944"
+  integrity sha512-s+N5j8DNxAsr+9czYDA7CvVVi3vsMrPgokbHwDnlLug8RJ35f47B09cHNNiREwx1ITj2epPhMbzH52wc78UPMg==
   dependencies:
     "@babel/core" "^7.18.5"
     "@babel/eslint-parser" "^7.18.2"
@@ -1014,6 +1014,7 @@ eslint-config-discourse@^3.2.0:
     eslint-plugin-ember "^10.6.1"
     eslint-plugin-lodash "^7.1.0"
     eslint-plugin-node "^11.1.0"
+    eslint-plugin-sort-class-members "^1.14.1"
     prettier "2.7.1"
 
 eslint-plugin-discourse-ember@latest:
@@ -1061,6 +1062,11 @@ eslint-plugin-node@^11.1.0:
     minimatch "^3.0.4"
     resolve "^1.10.1"
     semver "^6.1.0"
+
+eslint-plugin-sort-class-members@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.14.1.tgz#e701d6341e267ed0d0bf44c8293ff1e15b324e3c"
+  integrity sha512-/Q/cm3h4N9DBNYvJMQMhluucSmr3Yydr9U0BgGcXUQe/rgWdXKSymZ5Ewcf4vmAG0bbTmAYmekuMnYYrqlu9Rg==
 
 eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
This enforces some ordering rules for properties/methods in native JS classes. Having enforced structure across our codebase will help developers to quickly get their bearings when reading different classes.

The eslint-config-discourse update introduces an enforced ordering of:

```javascript
"order": [
  "[static-properties]",
  "[static-methods]",
  "[injected-services]",
  "[injected-controllers]",
  "[tracked-properties]",
  "[properties]",
  "[private-properties]",
  "constructor",
  "[everything-else]"
]
```

We may wish to introduce more strict ordering of getters/setters/methods in future.