### PR TITLE
DEV: Fix `sidebar-hidden` localStorage value

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -4,22 +4,24 @@ import discourseDebounce from "discourse-common/lib/debounce";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 
+const HIDE_SIDEBAR_KEY = "sidebar-hidden";
+
 export default Controller.extend({
   queryParams: ["enable_sidebar"],
 
   showTop: true,
   showFooter: false,
   router: service(),
-  showSidebar: null,
-  hideSidebarKey: "sidebar-hidden",
+  showSidebar: false,
   enable_sidebar: null,
 
   init() {
     this._super(...arguments);
 
-    this.showSidebar = this.site.mobileView
-      ? false
-      : this.currentUser && !this.keyValueStore.getItem(this.hideSidebarKey);
+    this.showSidebar =
+      this.currentUser &&
+      !this.site.mobileView &&
+      !this.keyValueStore.getItem(HIDE_SIDEBAR_KEY);
   },
 
   @discourseComputed
@@ -86,9 +88,9 @@ export default Controller.extend({
 
     if (this.site.desktopView) {
       if (this.showSidebar) {
-        this.keyValueStore.removeItem(this.hideSidebarKey);
+        this.keyValueStore.removeItem(HIDE_SIDEBAR_KEY);
       } else {
-        this.keyValueStore.setItem(this.hideSidebarKey);
+        this.keyValueStore.setItem(HIDE_SIDEBAR_KEY, "true");
       }
     }
   },


### PR DESCRIPTION
Previously ,`undefined` value for `sidebar-hidden` would mean "hide". Not it uses `true`.

Also, extract it into a const.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
