### PR TITLE
DEV: Ensure date-time-input-range-test works in all timezones

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/date-time-input-range-test.js
@@ -21,7 +21,8 @@ function toTimeInput() {
   return query(".to.d-date-time-input .d-time-input .combo-box-header");
 }
 
-const DEFAULT_DATE_TIME = moment("2019-01-29 14:45");
+const DEFAULT_DATE_TIME_STRING = "2019-01-29 14:45";
+const DEFAULT_DATE_TIME = moment(DEFAULT_DATE_TIME_STRING);
 
 module("Integration | Component | date-time-input-range", function (hooks) {
   setupRenderingTest(hooks);
@@ -56,7 +57,10 @@ module("Integration | Component | date-time-input-range", function (hooks) {
 
   test("timezone support", async function (assert) {
     this.setProperties({
-      state: { from: moment.tz(DEFAULT_DATE_TIME, "Europe/Paris"), to: null },
+      state: {
+        from: moment.tz(DEFAULT_DATE_TIME_STRING, "Europe/Paris"),
+        to: null,
+      },
     });
 
     await render(
@@ -64,7 +68,7 @@ module("Integration | Component | date-time-input-range", function (hooks) {
     );
 
     assert.strictEqual(fromDateInput().value, "2019-01-29");
-    assert.strictEqual(fromTimeInput().dataset.name, "15:45");
+    assert.strictEqual(fromTimeInput().dataset.name, "14:45");
     assert.strictEqual(toDateInput().value, "");
     assert.strictEqual(toTimeInput().dataset.name, "--:--");
 


### PR DESCRIPTION
The test was failing when run outside of the UTC timezone because `moment()` will return a datetime based on the current browser timezone. Use a string for the timezone-based test instead, so we can be explicit with timezone.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
