### PR TITLE
FIX: Ensure topic-list adapter never serializes `undefined`

### DIFF
--- a/app/assets/javascripts/discourse/app/adapters/topic-list.js
+++ b/app/assets/javascripts/discourse/app/adapters/topic-list.js
@@ -8,18 +8,18 @@ export function finderFor(filter, params) {
     let url = getURL("/") + filter + ".json";
 
     if (params) {
-      const keys = Object.keys(params),
-        encoded = [];
+      const urlSearchParams = new URLSearchParams();
 
-      keys.forEach(function (p) {
-        const value = encodeURI(params[p]);
+      for (const [key, value] of Object.entries(params)) {
         if (typeof value !== "undefined") {
-          encoded.push(p + "=" + value);
+          urlSearchParams.set(key, value);
         }
-      });
+      }
 
-      if (encoded.length > 0) {
-        url += "?" + encoded.join("&");
+      const queryString = urlSearchParams.toString();
+
+      if (queryString) {
+        url = `${url}?${queryString}`;
       }
     }
     return ajax(url);

--- a/app/assets/javascripts/discourse/app/adapters/topic-list.js
+++ b/app/assets/javascripts/discourse/app/adapters/topic-list.js
@@ -5,24 +5,16 @@ import getURL from "discourse-common/lib/get-url";
 
 export function finderFor(filter, params) {
   return function () {
-    let url = getURL("/") + filter + ".json";
+    let url = new URL(getURL("/") + filter + ".json");
 
     if (params) {
-      const urlSearchParams = new URLSearchParams();
-
       for (const [key, value] of Object.entries(params)) {
         if (typeof value !== "undefined") {
-          urlSearchParams.set(key, value);
+          url.searchParams.set(key, value);
         }
       }
-
-      const queryString = urlSearchParams.toString();
-
-      if (queryString) {
-        url = `${url}?${queryString}`;
-      }
     }
-    return ajax(url);
+    return ajax(url.toString());
   };
 }
 

--- a/app/assets/javascripts/discourse/app/adapters/topic-list.js
+++ b/app/assets/javascripts/discourse/app/adapters/topic-list.js
@@ -5,16 +5,24 @@ import getURL from "discourse-common/lib/get-url";
 
 export function finderFor(filter, params) {
   return function () {
-    let url = new URL(getURL("/") + filter + ".json");
+    let url = getURL("/") + filter + ".json";
 
     if (params) {
+      const urlSearchParams = new URLSearchParams();
+
       for (const [key, value] of Object.entries(params)) {
         if (typeof value !== "undefined") {
-          url.searchParams.set(key, value);
+          urlSearchParams.set(key, value);
         }
       }
+
+      const queryString = urlSearchParams.toString();
+
+      if (queryString) {
+        url = `${url}?${queryString}`;
+      }
     }
-    return ajax(url.toString());
+    return ajax(url);
   };
 }
 

--- a/app/assets/javascripts/discourse/app/adapters/topic-list.js
+++ b/app/assets/javascripts/discourse/app/adapters/topic-list.js
@@ -19,7 +19,7 @@ export function finderFor(filter, params) {
       const queryString = urlSearchParams.toString();
 
       if (queryString) {
-        url = `${url}?${queryString}`;
+        url += `?${queryString}`;
       }
     }
     return ajax(url);


### PR DESCRIPTION
There was existing logic for this, but it was broken because the values were being run through `encodeURI` before checking its type. This commit takes the opportunity to modernise the function to use `URLSearchParams`, which means we no longer need to handle encoding/joining strings manually.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
