### PR TITLE
DEV: Modernise rest adapter query parameter construction

### DIFF
--- a/app/assets/javascripts/discourse/app/adapters/rest.js
+++ b/app/assets/javascripts/discourse/app/adapters/rest.js
@@ -47,20 +47,22 @@ export default EmberObject.extend({
   appendQueryParams(path, findArgs, extension) {
     if (findArgs) {
       if (typeof findArgs === "object") {
-        const queryString = Object.keys(findArgs)
-          .reject((k) => !findArgs[k])
-          .map((k) => k + "=" + encodeURIComponent(findArgs[k]));
+        const urlSearchParams = new URLSearchParams();
 
-        if (queryString.length) {
-          return `${path}${extension ? extension : ""}?${queryString.join(
-            "&"
-          )}`;
+        for (const [key, value] of Object.entries(findArgs)) {
+          if (typeof value !== "undefined") {
+            urlSearchParams.set(key, value);
+          }
+        }
+
+        const queryString = urlSearchParams.toString();
+
+        if (queryString) {
+          return `${path}${extension || ""}?${queryString}`;
         }
       } else {
         // It's serializable as a string if not an object
-        return `${path}/${encodeURIComponent(findArgs)}${
-          extension ? extension : ""
-        }`;
+        return `${path}/${encodeURIComponent(findArgs)}${extension || ""}`;
       }
     }
     return path;

--- a/app/assets/javascripts/discourse/app/adapters/rest.js
+++ b/app/assets/javascripts/discourse/app/adapters/rest.js
@@ -50,7 +50,7 @@ export default EmberObject.extend({
         const urlSearchParams = new URLSearchParams();
 
         for (const [key, value] of Object.entries(findArgs)) {
-          if (typeof value !== "undefined") {
+          if (value) {
             urlSearchParams.set(key, value);
           }
         }


### PR DESCRIPTION
Using `URLSearchParams` means that we don't have to manually encode/join strings

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
