### PR TITLE
DEV: Modernise discovery controller query parameter construction

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/discovery.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery.js
@@ -47,8 +47,6 @@ export default Controller.extend({
 
     const urlSearchParams = new URLSearchParams();
 
-    urlSearchParams.set("period", period);
-
     for (const [key, value] of Object.entries(
       this.router.currentRoute.queryParams
     )) {
@@ -57,13 +55,9 @@ export default Controller.extend({
       }
     }
 
-    const queryString = urlSearchParams.toString();
+    urlSearchParams.set("period", period);
 
-    if (queryString) {
-      url += `?${queryString}`;
-    }
-
-    return url;
+    return `${url}?${urlSearchParams.toString()}`;
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/controllers/discovery.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery.js
@@ -45,14 +45,22 @@ export default Controller.extend({
 
     url += "/top";
 
-    let queryParams = this.router.currentRoute.queryParams;
-    queryParams.period = period;
-    if (Object.keys(queryParams).length) {
-      url =
-        `${url}?` +
-        Object.keys(queryParams)
-          .map((key) => `${key}=${queryParams[key]}`)
-          .join("&");
+    const urlSearchParams = new URLSearchParams();
+
+    urlSearchParams.set("period", period);
+
+    for (const [key, value] of Object.entries(
+      this.router.currentRoute.queryParams
+    )) {
+      if (typeof value !== "undefined") {
+        urlSearchParams.set(key, value);
+      }
+    }
+
+    const queryString = urlSearchParams.toString();
+
+    if (queryString) {
+      url += `?${queryString}`;
     }
 
     return url;


### PR DESCRIPTION
Using `URLSearchParams` means that we don't have to manually encode/join strings

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
