### PR TITLE
DEV: Declare new SMTP settings from 3a37a7f

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -95,6 +95,12 @@ smtp_openssl_verify_mode =
 # force implicit TLS as per RFC 8314 3.3
 smtp_force_tls = false
 
+# number of seconds to wait while attempting to open a SMTP connection
+smtp_open_timeout = 5
+
+# Number of seconds to wait until timing-out a SMTP read(2) call
+smtp_read_timeout = 5
+
 # load MiniProfiler in production, to be used by developers
 load_mini_profiler = true
 


### PR DESCRIPTION
Follow up to 3a37a7f where adding those new SMTP settings forgot to
declare it in our defaults file.
