### PR TITLE
DEV: Fix /logs in dev env

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -329,7 +329,7 @@ async function handleRequest(proxy, baseURL, req, res) {
 
     const newCSP = csp
       .replaceAll(proxy, `http://${originalHost}`)
-      .replaceAll("script-src ", `script-src ${emberCliAdditions}`);
+      .replaceAll("script-src ", `script-src ${emberCliAdditions} `);
 
     res.set("content-security-policy", newCSP);
   }


### PR DESCRIPTION
The space character was missing in CSP between `_lr` and `logs` urls.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
