### PR TITLE
DEV: Proxy `mobile_view` param to /bootstrap.json

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -241,13 +241,21 @@ async function buildFromBootstrap(proxy, baseURL, req, response, preload) {
 
     const forUrlSearchParams = new URL(req.url, "https://dummy-origin.invalid")
       .searchParams;
+
+    const mobileView = forUrlSearchParams.get("mobile_view");
+    if (mobileView) {
+      url.searchParams.append("mobile_view", mobileView);
+    }
+
     const reqUrlSafeMode = forUrlSearchParams.get("safe_mode");
     if (reqUrlSafeMode) {
       url.searchParams.append("safe_mode", reqUrlSafeMode);
     }
 
     const reqUrlPreviewThemeId = forUrlSearchParams.get("preview_theme_id");
-    url.searchParams.append("preview_theme_id", reqUrlPreviewThemeId);
+    if (reqUrlPreviewThemeId) {
+      url.searchParams.append("preview_theme_id", reqUrlPreviewThemeId);
+    }
 
     const res = await fetch(url, { headers: req.headers });
     const json = await res.json();


### PR DESCRIPTION
Without this it took an extra request for the setting to take in dev mode.

Also, append `preview_theme_id` only when present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
