### PR TITLE
DEV: Do the full cleanup after **every** test

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/component-test.js
+++ b/app/assets/javascripts/discourse/tests/helpers/component-test.js
@@ -7,7 +7,6 @@ import { autoLoadModules } from "discourse/initializers/auto-load-modules";
 import QUnit, { test } from "qunit";
 import { setupRenderingTest as emberSetupRenderingTest } from "ember-qunit";
 import { currentSettings } from "discourse/tests/helpers/site-settings";
-import { testCleanup } from "discourse/tests/helpers/qunit-helpers";
 import { injectServiceIntoService } from "discourse/pre-initializers/inject-discourse-objects";
 
 export function setupRenderingTest(hooks) {
@@ -16,11 +15,7 @@ export function setupRenderingTest(hooks) {
   hooks.beforeEach(function () {
     if (!hooks.usingDiscourseModule) {
       this.siteSettings = currentSettings();
-
-      if (!this.registry) {
-        this.registry = this.owner.__registry__;
-      }
-
+      this.registry ||= this.owner.__registry__;
       this.container = this.owner;
     }
 
@@ -60,12 +55,6 @@ export function setupRenderingTest(hooks) {
 
     $.fn.autocomplete = function () {};
   });
-
-  if (!hooks.usingDiscourseModule) {
-    hooks.afterEach(function () {
-      testCleanup(this.container);
-    });
-  }
 }
 
 export default function (name, hooks, opts) {

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -222,8 +222,6 @@ export function discourseModule(name, options) {
         this.siteSettings = currentSettings();
       });
 
-      hooks.afterEach(() => testCleanup(this.container));
-
       this.getController = function (controllerName, properties) {
         let controller = this.container.lookup(`controller:${controllerName}`);
         controller.application = {};
@@ -251,7 +249,6 @@ export function discourseModule(name, options) {
     },
     afterEach() {
       options?.afterEach?.call(this);
-      testCleanup(this.container);
     },
   });
 }

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -2,6 +2,7 @@ import {
   applyPretender,
   exists,
   resetSite,
+  testCleanup,
   testsInitialized,
   testsTornDown,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -11,7 +12,7 @@ import pretender, {
   resetPretender,
 } from "discourse/tests/helpers/create-pretender";
 import { resetSettings } from "discourse/tests/helpers/site-settings";
-import { setDefaultOwner } from "discourse-common/lib/get-owner";
+import { getOwner, setDefaultOwner } from "discourse-common/lib/get-owner";
 import { setApplication, setResolver } from "@ember/test-helpers";
 import { setupS3CDN, setupURL } from "discourse-common/lib/get-url";
 import Application from "../app";
@@ -217,12 +218,13 @@ export default function setupTests(config) {
     setupDataElement.remove();
   }
 
+  let app;
   QUnit.testStart(function (ctx) {
     bootbox.$body = $("#ember-testing");
     let settings = resetSettings();
     resetThemeSettings();
 
-    const app = createApplication(config, settings);
+    app = createApplication(config, settings);
 
     const cdn = setupData ? setupData.cdn : null;
     const baseUri = setupData ? setupData.baseUri : "";
@@ -296,6 +298,8 @@ export default function setupTests(config) {
   });
 
   QUnit.testDone(function () {
+    testCleanup(getOwner(app), app);
+
     sinon.restore();
     resetPretender();
     clearPresenceState();


### PR DESCRIPTION
Previously the global state wasn't cleared in some cases leading to widespread test failures.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
