### PR TITLE
A11Y: Don't include aria on reply count `span` element

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/list/posts-count-column.hbr
+++ b/app/assets/javascripts/discourse/app/templates/list/posts-count-column.hbr
@@ -1,6 +1,6 @@
 <{{view.tagName}} class='num posts-map posts {{view.likesHeat}} topic-list-data' title='{{view.title}}'>
   <button class="btn-link posts-map badge-posts {{view.likesHeat}}" aria-label="{{view.title}}">
     {{raw-plugin-outlet name="topic-list-before-reply-count"}}
-    {{number topic.replyCount noTitle="true" ariaLabel=view.title}}
+    {{number topic.replyCount noTitle="true"}}
   </button>
 </{{view.tagName}}>


### PR DESCRIPTION
The view's title is already included as a title attribute for the parent `td` and as an aria label for the button. The `span` element is invalid for an aria label anyway. 