### PR TITLE
FIX: Recover from guardian check when deleting reviewable users.

### DIFF
--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -69,8 +69,8 @@ class ReviewableUser < Reviewable
         end
 
         destroyer.destroy(target, delete_args)
-      rescue UserDestroyer::PostsExistError
-        # If a user has posts, we won't delete them to preserve their content.
+      rescue UserDestroyer::PostsExistError, Discourse::InvalidAccess
+        # If a user has posts or user is an admin, we won't delete them to preserve their content.
         # However the reviewable record will be "rejected" and they will remain
         # unapproved in the database. A staff member can still approve them
         # via the admin.


### PR DESCRIPTION
Handles edge-case when a user is an admin and has an associated reviewable. Hitting this exception should be rare since we clear the reviewable when granting staff to the user.

