### PR TITLE
FIX: welcome topic title was not editable

### DIFF
--- a/app/assets/javascripts/discourse/app/components/welcome-topic-banner.js
+++ b/app/assets/javascripts/discourse/app/components/welcome-topic-banner.js
@@ -21,7 +21,10 @@ export default class WelcomeTopicBanner extends Component {
         })
         .postStream.loadPostByPostNumber(1)
         .then((post) => {
-          post.topic.set("draft_key", Composer.EDIT);
+          post.topic.setProperties({
+            draft_key: Composer.EDIT,
+            "details.can_edit": true,
+          });
           topicController.send("editPost", post);
         });
     });


### PR DESCRIPTION
The topic title was not editable when composer was opened from the welcome topic banner.