### PR TITLE
DEV: `list_type: simple` to allow for easy re-ordering

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -168,7 +168,7 @@ basic:
     client: true
     refresh: true
     type: list
-    list_type: compact
+    list_type: simple
     default: "latest|new|unread|top|categories"
     regex: "latest"
     regex_error: "site_settings.errors.must_include_latest"


### PR DESCRIPTION
Can we use `list_type: simple` for the `top_menu` setting?

Re-ordering is sometimes done in the `top_menu` to change which appears when first visiting the homepage. Putting categories first makes the site homepage have categories, while putting latest as first allows the site to open with the topic list.

With the current type being set as `list_type: compact`
<img width="439" alt="Screen Shot 2022-08-16 at 9 43 17 AM" src="https://user-images.githubusercontent.com/30090424/184933726-0b342351-2262-4884-94a5-140221eb88ce.png">

You will need to remove each element to change the order, as new items are appended to the end.

By changing to `list_type: simple`, we can easily re-order items with the built-in arrows.

<img width="436" alt="Screen Shot 2022-08-16 at 9 42 15 AM" src="https://user-images.githubusercontent.com/30090424/184934599-5f6126ef-8c17-4c73-8b33-caec1fc15557.png">

