### PR TITLE
DEV: Update commit hash for .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -57,4 +57,4 @@ ce3fe2f4c4ddf166949ee3cec3d9ecbf9108ab52
 bbe5d8d5cf1220165842985c0e2cd4c454d501cd
 
 # DEV: Template colocation for sidebar files
-60c2df925394114dd8f92e0e0cee7146ff709aee
+95c7cdab941a56686ac5831d2a5c5eca38d780c5


### PR DESCRIPTION
I merged the commits the wrong way and it changed the commit sha for the
commit we wanted to ignore

Follow-up to 84464a2898fa180ddcce356f34ca287a732be363