### PR TITLE
DEV: Introduce flag for compiling Plugin JS with Ember CLI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    name: ${{ matrix.target }} ${{ matrix.build_type }}
+    name: ${{ matrix.target }} ${{ matrix.build_type }} ${{ ((matrix.ember_cli_plugin_assets == '1') && '(ember-cli-compiled plugin js)') || ''}}
     runs-on: ubuntu-latest
     container: discourse/discourse_test:slim${{ startsWith(matrix.build_type, 'frontend') && '-browsers' || '' }}
     timeout-minutes: 60
@@ -29,6 +29,7 @@ jobs:
       PGUSER: discourse
       PGPASSWORD: discourse
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' && matrix.target == 'core' }}
+      EMBER_CLI_PLUGIN_ASSETS: ${{ matrix.ember_cli_plugin_assets }}
 
     strategy:
       fail-fast: false
@@ -36,11 +37,17 @@ jobs:
       matrix:
         build_type: [backend, frontend, annotations]
         target: [core, plugins]
+        ember_cli_plugin_assets: ['1', '0']
         exclude:
           - build_type: annotations
             target: plugins
           - build_type: frontend
             target: core # Handled by core_frontend_tests job (below)
+          - target: core
+            ember_cli_plugin_assets: '1'
+          - target: plugins
+            build_type: backend
+            ember_cli_plugin_assets: '1'
 
     steps:
       - uses: actions/checkout@v3

--- a/app/assets/javascripts/discourse-hbr/raw-handlebars-compiler.js
+++ b/app/assets/javascripts/discourse-hbr/raw-handlebars-compiler.js
@@ -134,7 +134,19 @@ TemplateCompiler.prototype.initializeFeatures =
   function initializeFeatures() {};
 
 TemplateCompiler.prototype.processString = function (string, relativePath) {
-  let filename = relativePath.replace(/^templates\//, "").replace(/\.hbr$/, "");
+  let filename;
+
+  const pluginName = relativePath.match(/^discourse\/plugins\/([^\/]+)\//)?.[1];
+
+  if (pluginName) {
+    filename = relativePath
+      .replace(`discourse/plugins/${pluginName}/`, "")
+      .replace(/^(discourse\/)?templates\//, "javascripts/");
+  } else {
+    filename = relativePath.replace(/^templates\//, "");
+  }
+
+  filename = filename.replace(/\.hbr$/, "");
 
   return (
     'import { template as compiler } from "discourse-common/lib/raw-handlebars";\n' +

--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -1,0 +1,120 @@
+"use strict";
+
+const path = require("path");
+const WatchedDir = require("broccoli-source").WatchedDir;
+const Funnel = require("broccoli-funnel");
+const mergeTrees = require("broccoli-merge-trees");
+const fs = require("fs");
+const concat = require("broccoli-concat");
+const RawHandlebarsCompiler = require("discourse-hbr/raw-handlebars-compiler");
+
+function fixLegacyExtensions(tree) {
+  return new Funnel(tree, {
+    getDestinationPath: function (relativePath) {
+      if (relativePath.endsWith(".es6")) {
+        return relativePath.slice(0, -4);
+      } else if (relativePath.endsWith(".raw.hbs")) {
+        return relativePath.replace(".raw.hbs", ".hbr");
+      }
+      return relativePath;
+    },
+  });
+}
+
+const COLOCATED_CONNECTOR_REGEX =
+  /^(?<prefix>.*)\/connectors\/(?<outlet>[^\/]+)\/(?<name>[^\/\.]+)\.(?<extension>.+)$/;
+
+// Having connector templates and js in the same directory causes a clash
+// when outputting es6 modules. This shim separates colocated connectors
+// into separate js / template locations.
+function unColocateConnectors(tree) {
+  return new Funnel(tree, {
+    getDestinationPath: function (relativePath) {
+      const match = relativePath.match(COLOCATED_CONNECTOR_REGEX);
+      if (
+        match &&
+        match.groups.extension === "hbs" &&
+        !match.groups.prefix.endsWith("/templates")
+      ) {
+        const { prefix, outlet, name } = match.groups;
+        return `${prefix}/templates/connectors/${outlet}/${name}.hbs`;
+      }
+      if (
+        match &&
+        match.groups.extension === "js" &&
+        match.groups.prefix.endsWith("/templates")
+      ) {
+        // Some plugins are colocating connector JS under `/templates`
+        const { prefix, outlet, name } = match.groups;
+        const newPrefix = prefix.slice(0, -"/templates".length);
+        return `${newPrefix}/connectors/${outlet}/${name}.js`;
+      }
+      return relativePath;
+    },
+  });
+}
+
+function namespaceModules(tree, pluginDirectoryName) {
+  return new Funnel(tree, {
+    getDestinationPath: function (relativePath) {
+      return `discourse/plugins/${pluginDirectoryName}/${relativePath}`;
+    },
+  });
+}
+
+module.exports = {
+  name: require("./package").name,
+
+  pluginInfos() {
+    const root = path.resolve("../../../../plugins");
+    const pluginDirectories = fs
+      .readdirSync(root, { withFileTypes: true })
+      .filter(
+        (dirent) =>
+          (dirent.isDirectory() || dirent.isSymbolicLink()) &&
+          !dirent.name.startsWith(".")
+      );
+
+    return pluginDirectories.map((directory) => {
+      const name = directory.name;
+      const jsDirectory = path.resolve(root, name, "assets/javascripts");
+      const hasJs = fs.existsSync(jsDirectory);
+      return { name, jsDirectory, hasJs };
+    });
+  },
+
+  generatePluginsTree() {
+    const trees = this.pluginInfos()
+      .filter((p) => p.hasJs)
+      .map(({ name, jsDirectory }) => {
+        let tree = new WatchedDir(jsDirectory);
+
+        tree = fixLegacyExtensions(tree);
+        tree = unColocateConnectors(tree);
+        tree = namespaceModules(tree, name);
+
+        tree = RawHandlebarsCompiler(tree);
+        tree = this.compileTemplates(tree);
+
+        tree = this.processedAddonJsFiles(tree);
+
+        return concat(mergeTrees([tree]), {
+          inputFiles: ["**/*.js"],
+          outputFile: `assets/plugins/${name}.js`,
+        });
+      });
+    return mergeTrees(trees);
+  },
+
+  shouldCompileTemplates() {
+    // The base Addon implementation checks for template
+    // files in the addon directories. We need to override that
+    // check so that the template compiler always runs.
+    return true;
+  },
+
+  treeFor() {
+    // This addon doesn't contribute any 'real' trees to the app
+    return;
+  },
+};

--- a/app/assets/javascripts/discourse-plugins/package.json
+++ b/app/assets/javascripts/discourse-plugins/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "discourse-plugins",
+  "version": "1.0.0",
+  "description": "A dummy addon which provides a broccoli tree for each Discourse plugin",
+  "author": "Discourse",
+  "license": "GPL-2.0-only",
+  "keywords": [
+    "ember-addon"
+  ],
+  "repository": "",
+  "dependencies": {
+    "ember-auto-import": "^2.4.2",
+    "ember-cli-babel": "^7.26.10",
+    "ember-cli-htmlbars": "^6.1.0",
+    "discourse-widget-hbs": "1.0"
+  },
+  "engines": {
+    "node": "16.* || >= 18",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.21.1"
+  },
+  "ember": {
+    "edition": "default"
+  }
+}

--- a/app/assets/javascripts/discourse-plugins/package.json
+++ b/app/assets/javascripts/discourse-plugins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "discourse-plugins",
   "version": "1.0.0",
-  "description": "A dummy addon which provides a broccoli tree for each Discourse plugin",
+  "description": "An addon providing a broccoli tree for each Discourse plugin",
   "author": "Discourse",
   "license": "GPL-2.0-only",
   "keywords": [

--- a/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
@@ -45,7 +45,12 @@ function findClass(outletName, uniqueName) {
   if (!_classPaths) {
     _classPaths = {};
     findOutlets(require._eak_seen, (outlet, res, un) => {
-      _classPaths[`${outlet}/${un}`] = requirejs(res).default;
+      const possibleConnectorClass = requirejs(res).default;
+      if (possibleConnectorClass.__id) {
+        // This is the template, not the connector class
+        return;
+      }
+      _classPaths[`${outlet}/${un}`] = possibleConnectorClass;
     });
   }
 

--- a/app/assets/javascripts/discourse/app/lib/source-identifier.js
+++ b/app/assets/javascripts/discourse/app/lib/source-identifier.js
@@ -30,10 +30,10 @@ export default function identifySource(error) {
 
   let plugin;
 
-  if (isDevelopment()) {
-    // Source-mapped:
-    plugin = plugin || error.stack.match(/plugins\/([\w-]+)\//)?.[1];
+  // Source-mapped:
+  plugin = plugin || error.stack.match(/plugins\/([\w-]+)\//)?.[1];
 
+  if (isDevelopment()) {
     // Un-source-mapped:
     plugin = plugin || error.stack.match(/assets\/plugins\/([\w-]+)\.js/)?.[1];
   }

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -33,6 +33,7 @@
     "@uppy/utils": "^4.1.0",
     "@uppy/xhr-upload": "^2.1.2",
     "admin": "^1.0.0",
+    "discourse-plugins": "^1.0.0",
     "bootstrap": "3.4.1",
     "broccoli-asset-rev": "^3.0.0",
     "deepmerge": "^4.2.2",

--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -95,6 +95,9 @@ if (process.argv.includes("-t")) {
 } else if (shouldLoadPluginTestJs()) {
   // Running with ember cli, but we want to pass through plugin request to Rails
   module.exports.proxies = {
+    "/assets/plugins/*_extra.js": {
+      target,
+    },
     "/assets/discourse/tests/active-plugins.js": {
       target,
     },

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -9,7 +9,7 @@ setEnvironment("testing");
 
 document.addEventListener("discourse-booted", () => {
   const script = document.getElementById("plugin-test-script");
-  if (script && !requirejs.entries["discourse/tests/active-plugins"]) {
+  if (script && !requirejs.entries["discourse/tests/plugin-tests"]) {
     throw new Error(
       `Plugin JS payload failed to load from ${script.src}. Is the Rails server running?`
     );

--- a/app/assets/javascripts/package.json
+++ b/app/assets/javascripts/package.json
@@ -3,6 +3,7 @@
   "workspaces": [
     "discourse",
     "admin",
+    "discourse-plugins",
     "discourse-common",
     "discourse-ensure-deprecation-order",
     "discourse-hbr",

--- a/app/views/qunit/theme.html.erb
+++ b/app/views/qunit/theme.html.erb
@@ -8,7 +8,9 @@
       <%= preload_script "vendor" %>
       <%= preload_script "discourse" %>
       <%= preload_script "admin" %>
-      <%= preload_script "discourse/tests/active-plugins" %>
+      <%- Discourse.find_plugin_js_assets(include_disabled: true).each do |file| %>
+        <%= preload_script file %>
+      <%- end %>
       <%= preload_script "admin-plugins" %>
       <%= preload_script "test-support" %>
       <%= preload_script "test-helpers" %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -53,7 +53,7 @@ Rails.application.config.assets.precompile += %w{
   scripts/discourse-boot
 }
 
-Rails.application.config.assets.precompile += EmberCli::ASSETS.map { |name| name.sub('.js', '.map') }
+Rails.application.config.assets.precompile += EmberCli.assets.map { |name| name.sub('.js', '.map') }
 
 # Precompile all available locales
 unless GlobalSetting.try(:omit_base_locales)

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -382,12 +382,17 @@ module Discourse
 
   def self.find_plugin_js_assets(args)
     plugins = self.find_plugins(args).select do |plugin|
-      plugin.js_asset_exists?
+      plugin.js_asset_exists? || plugin.extra_js_asset_exists?
     end
 
     plugins = apply_asset_filters(plugins, :js, args[:request])
 
-    plugins.map { |plugin| "plugins/#{plugin.directory_name}" }
+    plugins.flat_map do |plugin|
+      assets = []
+      assets << "plugins/#{plugin.directory_name}" if plugin.js_asset_exists?
+      assets << "plugins/#{plugin.directory_name}_extra" if plugin.extra_js_asset_exists?
+      assets
+    end
   end
 
   def self.assets_digest

--- a/lib/discourse_sourcemapping_url_processor.rb
+++ b/lib/discourse_sourcemapping_url_processor.rb
@@ -6,7 +6,7 @@
 class DiscourseSourcemappingUrlProcessor < Sprockets::Rails::SourcemappingUrlProcessor
   def self.sourcemap_asset_path(sourcemap_logical_path, context:)
     result = super(sourcemap_logical_path, context: context)
-    if File.basename(sourcemap_logical_path) === sourcemap_logical_path
+    if (File.basename(sourcemap_logical_path) === sourcemap_logical_path) || sourcemap_logical_path.start_with?("plugins/")
       # If the original sourcemap reference is relative, keep it relative
       result = File.basename(result)
     end


### PR DESCRIPTION
When `EMBER_CLI_PLUGIN_ASSETS=1`, plugin application JS will be compiled via Ember CLI. In this mode, the existing `register_asset` API will cause any registered JS files to be made available in `/plugins/{plugin-name}_extra.js`. These 'extra' files will be loaded immediately after the plugin app JS file, so this should not affect functionality.

Plugin compilation in Ember CLI is implemented as an addon, similar to the existing 'admin' addon. We bypass the normal Ember CLI compilation process (which would add the JS to the main app bundle), and reroute the addon Broccoli tree into a separate JS file per-plugin.

This change has been designed to be a like-for-like replacement of the old plugin compilation system, so we do not expect any breakage. Even so, the environment variable flag will allow us to test this in a range of environments before enabling it by default.

A manual silence implementation is added for the build-time `ember-glimmer.link-to.positional-arguments` deprecation while we work on a better story for plugins.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
