### PR TITLE
FIX: Allow `match_all_tags` to be passed as a URL param

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -479,7 +479,7 @@ class TagsController < ::ApplicationController
       options[:no_tags] = true
     else
       options[:tags] = tag_params
-      options[:match_all_tags] = true
+      options[:match_all_tags] ||= true
     end
 
     options

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -680,7 +680,7 @@ class TopicQuery
         tags_query = tags_arg[0].is_a?(String) ? Tag.where_name(tags_arg) : Tag.where(id: tags_arg)
         tags = tags_query.select(:id, :target_tag_id).map { |t| t.target_tag_id || t.id }.uniq
 
-        if @options[:match_all_tags]
+        if ActiveModel::Type::Boolean.new.cast(@options[:match_all_tags])
           # ALL of the given tags:
           if tags_arg.length == tags.length
             tags.each_with_index do |tag, index|

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe TopicQuery do
       end
 
       it "can return topics with tag intersections using truthy values" do
-        expect(TopicQuery.new(moderator, tags: [tag.name, other_tag.name], match_all_tags: "false").list_latest.topics.map(&:id)).sort.to eq([tagged_topic1.id, tagged_topic2.id, tagged_topic3.id].sort)
+        expect(TopicQuery.new(moderator, tags: [tag.name, other_tag.name], match_all_tags: "false").list_latest.topics.map(&:id).sort).to eq([tagged_topic1.id, tagged_topic2.id, tagged_topic3.id].sort)
       end
 
       it "returns an empty relation when an invalid tag is passed" do

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -427,6 +427,10 @@ RSpec.describe TopicQuery do
         expect(TopicQuery.new(moderator, tags: [tag.name, other_tag.name], match_all_tags: true).list_latest.topics.map(&:id)).to eq([tagged_topic3.id])
       end
 
+      it "can return topics with tag intersections using truthy values" do
+        expect(TopicQuery.new(moderator, tags: [tag.name, other_tag.name], match_all_tags: "false").list_latest.topics.map(&:id)).sort.to eq([tagged_topic1.id, tagged_topic2.id, tagged_topic3.id].sort)
+      end
+
       it "returns an empty relation when an invalid tag is passed" do
         expect(TopicQuery.new(moderator, tags: [tag.name, 'notatag'], match_all_tags: true).list_latest.topics).to be_empty
       end

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe TopicQuery do
         expect(TopicQuery.new(moderator, tags: [tag.name, other_tag.name], match_all_tags: true).list_latest.topics.map(&:id)).to eq([tagged_topic3.id])
       end
 
-      it "can return topics with tag intersections using truthy values" do
+      it "can return topics with tag intersections using truthy/falsey values" do
         expect(TopicQuery.new(moderator, tags: [tag.name, other_tag.name], match_all_tags: "false").list_latest.topics.map(&:id).sort).to eq([tagged_topic1.id, tagged_topic2.id, tagged_topic3.id].sort)
       end
 


### PR DESCRIPTION
`TopicQueryParams` allows for `match_all_tags` to be passed as a query parameter. `TagsController` forces the value to be true.

This change allows a value to be passed, and only sets it to true if no value has been set. It then uses `ActiveModel::Type::Boolean.new.cast` to compare the value.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
