### PR TITLE
UX: Make popup menu options scroll on limited screen height

### DIFF
--- a/app/assets/stylesheets/common/select-kit/toolbar-popup-menu-options.scss
+++ b/app/assets/stylesheets/common/select-kit/toolbar-popup-menu-options.scss
@@ -1,6 +1,10 @@
 .select-kit {
   &.dropdown-select-box {
     &.toolbar-popup-menu-options {
+      .select-kit-collection {
+        max-height: 50vh;
+      }
+
       .select-kit-body {
         box-shadow: none;
         width: 230px;


### PR DESCRIPTION
When the viewport height is smaller such as when developer tools are open, items in the Toolbar Popup Menu options cannot be accessed as there is no ability to scroll:

![Screen Shot 2022-08-17 at 11 34 45 AM](https://user-images.githubusercontent.com/30090424/185217765-c3cc5fee-34b6-44b1-99ba-22754566a857.png)

This PR resolves that issues by ensuring a scroll behaviour is present by limiting the height.

![Screen Shot 2022-08-17 at 11 34 54 AM](https://user-images.githubusercontent.com/30090424/185217914-efa5008e-77e2-4809-8131-ebbee748be6b.png)

