### PR TITLE
DEV: Ensure custom ember-cli addons only output JS files

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -143,9 +143,11 @@ module.exports = function (defaults) {
       destDir: "assets/highlightjs",
     }),
     concat(mergeTrees([app.options.adminTree]), {
+      inputFiles: ["**/*.js"],
       outputFile: `assets/admin.js`,
     }),
     concat(mergeTrees([app.options.wizardTree]), {
+      inputFiles: ["**/*.js"],
       outputFile: `assets/wizard.js`,
     }),
     prettyTextEngine(vendorJs, "discourse-markdown"),


### PR DESCRIPTION
Without this filter, a binary file (e.g. `.DS_Store`) in one of these addon directories will be concatenated into the output JS. Note that this filter is applied at the end of the build pipeline, so any hbs files have already been transpiled into `.js`.

This mirrors the filtering performed on the main application bundle by Ember CLI: https://github.com/ember-cli/ember-cli/blob/04a38fda2c/lib/broccoli/default-packager.js#L1255

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
