### PR TITLE
FIX: Remove last_unread_post excerpt logic for bookmarks

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -240,7 +240,10 @@ export default Controller.extend(bufferedProperty("model"), {
           this.model.removeBookmark(post.bookmark_id);
         });
     }
-    const forTopicBookmark = this.model.bookmarks.findBy("for_topic", true);
+    const forTopicBookmark = this.model.bookmarks.findBy(
+      "bookmarkable_type",
+      "Topic"
+    );
     if (
       forTopicBookmark?.auto_delete_preference ===
       AUTO_DELETE_PREFERENCES.ON_OWNER_REPLY

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -143,7 +143,8 @@ const Bookmark = RestModel.extend({
     // for topic level bookmarks we want to jump to the last unread post URL,
     // which the topic-link helper does by default if no linked post number is
     // provided
-    const linkedPostNumber = this.for_topic ? null : this.linked_post_number;
+    const linkedPostNumber =
+      this.bookmarkable_type === "Topic" ? null : this.linked_post_number;
 
     return Topic.create({
       id: this.topic_id,

--- a/app/assets/javascripts/discourse/tests/unit/models/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/bookmark-test.js
@@ -1,0 +1,42 @@
+import { module, test } from "qunit";
+import Bookmark from "discourse/models/bookmark";
+
+module("Unit | Model | bookmark", function () {
+  test("topicForList - Topic bookmarkable", function (assert) {
+    let bookmark = Bookmark.create({
+      id: 1,
+      bookmarkable_type: "Topic",
+      bookmarkable_id: 999,
+      linked_post_number: null,
+      topic_id: 999,
+      fancy_title: "Some test topic",
+      last_read_post_number: 23,
+      highest_post_number: 30,
+    });
+
+    assert.strictEqual(
+      bookmark.topicForList.linked_post_number,
+      null,
+      "linked_post_number is null"
+    );
+  });
+
+  test("topicForList - Post bookmarkable", function (assert) {
+    let bookmark = Bookmark.create({
+      id: 1,
+      bookmarkable_type: "Post",
+      bookmarkable_id: 999,
+      linked_post_number: 787,
+      topic_id: 999,
+      fancy_title: "Some test topic",
+      last_read_post_number: 23,
+      highest_post_number: 30,
+    });
+
+    assert.strictEqual(
+      bookmark.topicForList.linked_post_number,
+      787,
+      "linked_post_number is correct"
+    );
+  });
+});

--- a/app/serializers/user_topic_bookmark_serializer.rb
+++ b/app/serializers/user_topic_bookmark_serializer.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class UserTopicBookmarkSerializer < UserPostTopicBookmarkBaseSerializer
-  # it does not matter what the linked post number is for topic bookmarks,
-  # on the client we always take the user to the last unread post in the
-  # topic when the bookmark URL is clicked
-
   attributes :last_read_post_number
 
+  # NOTE: It does not matter what the linked post number is for topic bookmarks,
+  # on the client we always take the user to the last unread post in the
+  # topic when the bookmark URL is clicked
   def linked_post_number
     1
   end
@@ -28,28 +27,7 @@ class UserTopicBookmarkSerializer < UserPostTopicBookmarkBaseSerializer
   end
 
   def cooked
-    @cooked ||= \
-      if last_read_post_number.present?
-        for_topic_cooked_post
-      else
-        first_post.cooked
-      end
-  end
-
-  def for_topic_cooked_post
-    post_number = [last_read_post_number + 1, highest_post_number].min
-    sorted_regular_posts = topic.posts.sort_by(&:post_number).select do |post|
-      post.post_type == Post.types[:regular]
-    end
-    first_unread_post = sorted_regular_posts.find do |post|
-      post.post_number >= post_number
-    end
-
-    # if first_unread_cooked is blank this likely means that the last
-    # read post was either deleted or is a small action post.
-    # in this case we should just get the last regular post and
-    # use that for the cooked value so we have something to show
-    (first_unread_post || sorted_regular_posts.last).cooked
+    first_post.cooked
   end
 
   def bookmarkable_user

--- a/app/services/topic_bookmarkable.rb
+++ b/app/services/topic_bookmarkable.rb
@@ -12,7 +12,7 @@ class TopicBookmarkable < BaseBookmarkable
   end
 
   def self.preload_associations
-    [:tags, { posts: :user }]
+    [:tags, { first_post: :user }]
   end
 
   def self.perform_custom_preload!(topic_bookmarks, guardian)


### PR DESCRIPTION
The logic to determine what post excerpt to show for
a topic-level bookmark based on the last unread post
was complex and slow, so we decided to remove it and
always just use the first post excerpt.

This commit also fixes an issue where a couple of
instances of for_topic were missed when doing the
Bookmarkable refactors, so:

1. Clicking the topic bookmark link was not taking
   the user to the last unread post
2. When replying to a topic where there was a topic
   level bookmark with the auto delete preference
   of "on owner reply", we were not removing the
   bookmark from the UI correctly.

A test has been added for the former, the latter would
be quite time-consuming to test and not really worth
it considering it's quite an edge case UI bug.

