### PR TITLE
DEV: Add profile tab to the experimental user menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.hbs
@@ -11,37 +11,24 @@
       <div class="menu-tabs-container" role="tablist" aria-orientation="vertical" aria-label={{i18n "user_menu.sr_menu_tabs"}}>
         <div class="top-tabs tabs-list">
           {{#each this.topTabs as |tab|}}
-            <button
-              class={{concat "btn btn-flat btn-icon no-text" (if (eq tab.id this.currentTabId) " active")}}
-              type="button"
-              role="tab"
-              id={{concat "user-menu-button-" tab.id}}
-              tabindex={{if (eq tab.id this.currentTabId) "0" "-1"}}
-              aria-selected={{if (eq tab.id this.currentTabId) "true" "false"}}
-              aria-controls={{concat "quick-access-" tab.id}}
-              data-tab-number={{tab.position}}
-              {{on "click" (fn this.changeTab tab)}}
-              {{!-- template-lint-disable require-context-role --}}
+            <UserMenu::TabButton
+              @tab={{tab}}
+              @currentTabId={{this.currentTabId}}
+              @changeTabFunction={{fn this.changeTab tab}}
             >
-              {{d-icon tab.icon}}
               {{#if tab.count}}
                 <span class="badge-notification">{{tab.count}}</span>
               {{/if}}
-            </button>
+            </UserMenu::TabButton>
           {{/each}}
         </div>
         <div class="bottom-tabs tabs-list">
           {{#each this.bottomTabs as |tab|}}
-            <a
-              class="btn btn-flat btn-icon no-text"
-              role="tab"
-              tabindex="-1"
-              href={{tab.href}}
-              data-tab-number={{tab.position}}
-              {{!-- template-lint-disable require-context-role --}}
-            >
-              {{d-icon tab.icon}}
-            </a>
+            <UserMenu::TabButton
+              @tab={{tab}}
+              @currentTabId={{this.currentTabId}}
+              @changeTabFunction={{fn this.changeTab tab}}
+            />
           {{/each}}
         </div>
       </div>

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -136,6 +136,22 @@ const CORE_TOP_TABS = [
   },
 ];
 
+const CORE_BOTTOM_TABS = [
+  class extends UserMenuTab {
+    get id() {
+      return "profile";
+    }
+
+    get icon() {
+      return "user";
+    }
+
+    get panelComponent() {
+      return "user-menu/profile-tab-content";
+    }
+  },
+];
+
 export default class UserMenu extends Component {
   @service currentUser;
   @service siteSettings;
@@ -185,8 +201,17 @@ export default class UserMenu extends Component {
   }
 
   get _bottomTabs() {
+    const tabs = [];
+
+    CORE_BOTTOM_TABS.forEach((tabClass) => {
+      const tab = new tabClass(this.currentUser, this.siteSettings, this.site);
+      if (tab.shouldDisplay) {
+        tabs.push(tab);
+      }
+    });
+
     const topTabsLength = this.topTabs.length;
-    return this._coreBottomTabs.map((tab, index) => {
+    return tabs.map((tab, index) => {
       tab.position = index + topTabsLength;
       return tab;
     });

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.hbs
@@ -57,12 +57,12 @@
         {{#if this.isInDoNotDisturb}}
           <span>{{i18n "do_not_disturb.label"}}</span>
           <span
-            title={{this.dateTitle}}
-            data-time={{this.dateTime}}
+            title={{this.doNotDisturbDateTitle}}
+            data-time={{this.doNotDisturbDateTime}}
             data-format="tiny"
             class="relative-date"
           >
-            {{this.dateContent}}
+            {{this.doNotDisturbDateContent}}
           </span>
         {{else}}
           {{i18n "do_not_disturb.label"}}

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.hbs
@@ -51,7 +51,7 @@
   </li>
 
   <li class="do-not-disturb">
-    <DButton @class="btn-flat profile-tab-btn" @action={{action "doNotDisturbClick"}}>
+    <DButton @class="btn-flat profile-tab-btn" @action={{this.doNotDisturbClick}}>
       {{d-icon (if this.isInDoNotDisturb "toggle-on" "toggle-off")}}
       <span class="item-label">
         {{#if this.isInDoNotDisturb}}

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.hbs
@@ -1,0 +1,100 @@
+<ul>
+  <li class="summary">
+    <LinkTo @route="user.summary" @model={{this.currentUser}}>
+      {{d-icon "user"}}
+      <span class="item-label">
+        {{i18n "user.summary.title"}}
+      </span>
+    </LinkTo>
+  </li>
+
+  <li class="activity">
+    <LinkTo @route="userActivity" @model={{this.currentUser}}>
+      {{d-icon "stream"}}
+      <span class="item-label">
+        {{i18n "user.activity_stream"}}
+      </span>
+    </LinkTo>
+  </li>
+
+  {{#if this.currentUser.can_invite_to_forum}}
+    <li class="invites">
+      <LinkTo @route="userInvited" @model={{this.currentUser}}>
+        {{d-icon "user-plus"}}
+        <span class="item-label">
+          {{i18n "user.invited.title"}}
+        </span>
+      </LinkTo>
+    </li>
+  {{/if}}
+
+  <li class="drafts">
+    <LinkTo @route="userActivity.drafts" @model={{this.currentUser}}>
+      {{d-icon "pencil-alt"}}
+      <span class="item-label">
+        {{#if this.currentUser.draft_count}}
+          {{i18n "drafts.label_with_count" count=this.currentUser.draft_count}}
+        {{else}}
+          {{i18n "drafts.label"}}
+        {{/if}}
+      </span>
+    </LinkTo>
+  </li>
+
+  <li class="preferences">
+    <LinkTo @route="preferences" @model={{this.currentUser}}>
+      {{d-icon "cog"}}
+      <span class="item-label">
+        {{i18n "user.preferences"}}
+      </span>
+    </LinkTo>
+  </li>
+
+  <li class="do-not-disturb">
+    <DButton @class="btn-flat profile-tab-btn" @action={{action "doNotDisturbClick"}}>
+      {{d-icon (if this.isInDoNotDisturb "toggle-on" "toggle-off")}}
+      <span class="item-label">
+        {{#if this.isInDoNotDisturb}}
+          <span>{{i18n "do_not_disturb.label"}}</span>
+          <span
+            title={{this.dateTitle}}
+            data-time={{this.dateTime}}
+            data-format="tiny"
+            class="relative-date"
+          >
+            {{this.dateContent}}
+          </span>
+        {{else}}
+          {{i18n "do_not_disturb.label"}}
+        {{/if}}
+      </span>
+    </DButton>
+  </li>
+
+  {{#if this.showToggleAnonymousButton}}
+    <li class={{if this.currentUser.is_anonymous "disable-anonymous" "enable-anonymous"}}>
+      <DButton @class="btn-flat profile-tab-btn" @action={{route-action "toggleAnonymous"}}>
+        {{#if this.currentUser.is_anonymous}}
+          {{d-icon "ban"}}
+          <span class="item-label">
+            {{i18n "switch_from_anon"}}
+          </span>
+        {{else}}
+          {{d-icon "user-secret"}}
+          <span class="item-label">
+            {{i18n "switch_to_anon"}}
+          </span>
+        {{/if}}
+      </DButton>
+    </li>
+  {{/if}}
+
+  <li class="logout">
+    <DButton @class="btn-flat profile-tab-btn" @action={{route-action "logout"}}>
+      {{d-icon "sign-out-alt"}}
+      <span class="item-label">
+        {{i18n "user.log_out"}}
+      </span>
+    </DButton>
+  </li>
+</ul>

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
@@ -22,15 +22,15 @@ export default class UserMenuProfileTabContent extends Component {
     return !!this.#doNotDisturbUntilDate;
   }
 
-  get dateTitle() {
+  get doNotDisturbDateTitle() {
     return longDate(this.#doNotDisturbUntilDate);
   }
 
-  get dateContent() {
+  get doNotDisturbDateContent() {
     return relativeAge(this.#doNotDisturbUntilDate);
   }
 
-  get dateTime() {
+  get doNotDisturbDateTime() {
     return this.#doNotDisturbUntilDate.getTime();
   }
 

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
@@ -1,0 +1,63 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+import { action } from "@ember/object";
+import showModal from "discourse/lib/show-modal";
+import { longDate, relativeAge } from "discourse/lib/formatter";
+
+export default class UserMenuProfileTabContent extends Component {
+  @service currentUser;
+  @service siteSettings;
+  saving = false;
+
+  get showToggleAnonymousButton() {
+    return (
+      (this.siteSettings.allow_anonymous_posting &&
+        this.currentUser.trust_level >=
+          this.siteSettings.anonymous_posting_min_trust_level) ||
+      this.currentUser.is_anonymous
+    );
+  }
+
+  get isInDoNotDisturb() {
+    return !!this.#doNotDisturbUntilDate;
+  }
+
+  get dateTitle() {
+    return longDate(this.#doNotDisturbUntilDate);
+  }
+
+  get dateContent() {
+    return relativeAge(this.#doNotDisturbUntilDate);
+  }
+
+  get dateTime() {
+    return this.#doNotDisturbUntilDate.getTime();
+  }
+
+  get #doNotDisturbUntilDate() {
+    if (!this.currentUser.get("do_not_disturb_until")) {
+      return;
+    }
+    const date = new Date(this.currentUser.get("do_not_disturb_until"));
+    if (date < new Date()) {
+      return;
+    }
+    return date;
+  }
+
+  @action
+  doNotDisturbClick() {
+    if (this.saving) {
+      return;
+    }
+    this.saving = true;
+    if (this.currentUser.do_not_disturb_until) {
+      return this.currentUser.leaveDoNotDisturb().finally(() => {
+        this.saving = false;
+      });
+    } else {
+      this.saving = false;
+      showModal("do-not-disturb");
+    }
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/user-menu/tab-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/tab-button.hbs
@@ -1,0 +1,15 @@
+<button
+  class={{concat "btn btn-flat btn-icon no-text" (if (eq @tab.id @currentTabId) " active")}}
+  type="button"
+  role="tab"
+  id={{concat "user-menu-button-" @tab.id}}
+  tabindex={{if (eq @tab.id @currentTabId) "0" "-1"}}
+  aria-selected={{if (eq @tab.id @currentTabId) "true" "false"}}
+  aria-controls={{concat "quick-access-" @tab.id}}
+  data-tab-number={{@tab.position}}
+  {{on "click" @changeTabFunction}}
+  {{!-- template-lint-disable require-context-role --}}
+>
+  {{d-icon @tab.icon}}
+  {{yield}}
+</button>

--- a/app/assets/javascripts/discourse/app/components/user-menu/tab-button.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/tab-button.js
@@ -1,0 +1,3 @@
+import templateOnly from "@ember/component/template-only";
+
+export default templateOnly();

--- a/app/assets/javascripts/discourse/tests/acceptance/do-not-disturb-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/do-not-disturb-test.js
@@ -105,7 +105,7 @@ acceptance("Do not disturb - new user menu", function (needs) {
   needs.user({ redesigned_user_menu_enabled: true });
   needs.pretender((server, helper) => {
     server.post("/do-not-disturb.json", () => {
-      let now = new Date();
+      const now = new Date();
       now.setHours(now.getHours() + 1);
       return helper.response({ ends_at: now });
     });
@@ -171,7 +171,7 @@ acceptance("Do not disturb - new user menu", function (needs) {
   });
 
   test("when turned on, it can be turned off", async function (assert) {
-    let now = new Date();
+    const now = new Date();
     now.setHours(now.getHours() + 1);
     updateCurrentUser({ do_not_disturb_until: now });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/do-not-disturb-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/do-not-disturb-test.js
@@ -100,3 +100,113 @@ acceptance("Do not disturb", function (needs) {
     );
   });
 });
+
+acceptance("Do not disturb - new user menu", function (needs) {
+  needs.user({ redesigned_user_menu_enabled: true });
+  needs.pretender((server, helper) => {
+    server.post("/do-not-disturb.json", () => {
+      let now = new Date();
+      now.setHours(now.getHours() + 1);
+      return helper.response({ ends_at: now });
+    });
+    server.delete("/do-not-disturb.json", () =>
+      helper.response({ success: true })
+    );
+  });
+
+  test("when turned off, it is turned on from modal", async function (assert) {
+    updateCurrentUser({ do_not_disturb_until: null });
+
+    await visit("/");
+    await click(".header-dropdown-toggle.current-user");
+    await click("#user-menu-button-profile");
+    await click("#quick-access-profile .do-not-disturb .btn");
+
+    assert.ok(exists(".do-not-disturb-modal"), "modal to choose time appears");
+
+    let tiles = queryAll(".do-not-disturb-tile");
+    assert.ok(tiles.length === 4, "There are 4 duration choices");
+
+    await click(tiles[0]);
+
+    assert.ok(query(".do-not-disturb-modal.hidden"), "modal is hidden");
+
+    assert.ok(
+      exists(".header-dropdown-toggle .do-not-disturb-background .d-icon-moon"),
+      "moon icon is present in header"
+    );
+  });
+
+  test("Can be invoked via keyboard", async function (assert) {
+    updateCurrentUser({ do_not_disturb_until: null });
+
+    await visit("/");
+    await click(".header-dropdown-toggle.current-user");
+    await click("#user-menu-button-profile");
+    await click("#quick-access-profile .do-not-disturb .btn");
+
+    assert.ok(exists(".do-not-disturb-modal"), "DND modal is displayed");
+
+    assert.strictEqual(
+      count(".do-not-disturb-tile"),
+      4,
+      "There are 4 duration choices"
+    );
+
+    await triggerKeyEvent(
+      ".do-not-disturb-tile:nth-child(1)",
+      "keydown",
+      "Enter"
+    );
+
+    assert.ok(
+      query(".do-not-disturb-modal.hidden"),
+      "DND modal is hidden after making a choice"
+    );
+
+    assert.ok(
+      exists(".header-dropdown-toggle .do-not-disturb-background .d-icon-moon"),
+      "moon icon is shown in header avatar"
+    );
+  });
+
+  test("when turned on, it can be turned off", async function (assert) {
+    let now = new Date();
+    now.setHours(now.getHours() + 1);
+    updateCurrentUser({ do_not_disturb_until: now });
+
+    await visit("/");
+
+    assert.ok(
+      exists(".do-not-disturb-background"),
+      "The active moon icon is shown"
+    );
+
+    await click(".header-dropdown-toggle.current-user");
+    await click("#user-menu-button-profile");
+    assert.strictEqual(
+      query(".do-not-disturb .relative-date").textContent.trim(),
+      "1h",
+      "the Do Not Disturb button shows how much time is left for DND mode"
+    );
+    assert.ok(
+      exists(".do-not-disturb .d-icon-toggle-on"),
+      "the Do Not Disturb button has the toggle-on icon"
+    );
+
+    await click("#quick-access-profile .do-not-disturb .btn");
+
+    assert.notOk(
+      exists(".do-not-disturb-background"),
+      "The active moon icons are removed"
+    );
+    assert.notOk(
+      exists(".do-not-disturb .relative-date"),
+      "the text showing how much time is left for DND mode is gone"
+    );
+    assert.ok(
+      exists(".do-not-disturb .d-icon-toggle-off"),
+      "the Do Not Disturb button has the toggle-off icon"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -238,6 +238,16 @@ acceptance("User menu", function (needs) {
       "invites link has the right icon"
     );
 
+    await click("header.d-header"); // close the menu
+    updateCurrentUser({ can_invite_to_forum: false });
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-profile");
+
+    assert.notOk(
+      exists("#quick-access-profile ul li.invites"),
+      "invites link not shown when the user can't invite"
+    );
+
     const dratsLink = query("#quick-access-profile ul li.drafts a");
     assert.ok(
       dratsLink.href.endsWith("/u/eviltrout/activity/drafts"),

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -361,11 +361,11 @@ acceptance("User menu", function (needs) {
 
     assert.notOk(
       exists("#quick-access-profile ul li.enable-anonymous"),
-      "toggle anon button isn't shown the user can't use it"
+      "toggle anon button isn't shown when the user can't use it"
     );
     assert.notOk(
       exists("#quick-access-profile ul li.disable-anonymous"),
-      "toggle anon button isn't shown the user can't use it"
+      "toggle anon button isn't shown when the user can't use it"
     );
 
     await click("header.d-header"); // close the menu

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -6,6 +6,7 @@ import {
   publishToMessageBus,
   query,
   queryAll,
+  updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse-common/lib/object";
@@ -19,7 +20,14 @@ acceptance("User menu", function (needs) {
   needs.user({
     redesigned_user_menu_enabled: true,
     unread_high_priority_notifications: 73,
+    trust_level: 3,
   });
+
+  needs.settings({
+    allow_anonymous_posting: true,
+    anonymous_posting_min_trust_level: 3,
+  });
+
   let requestHeaders = {};
 
   needs.pretender((server, helper) => {
@@ -176,6 +184,190 @@ acceptance("User menu", function (needs) {
     assert.ok(
       exists("#quick-access-custom-tab-1 button.btn"),
       "the tab's content is now displayed in the panel"
+    );
+  });
+
+  test("the profile tab", async function (assert) {
+    updateCurrentUser({ draft_count: 13 });
+    await visit("/");
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-profile");
+
+    const summaryLink = query("#quick-access-profile ul li.summary a");
+    assert.ok(
+      summaryLink.href.endsWith("/u/eviltrout/summary"),
+      "has a link to the summary page of the user"
+    );
+    assert.strictEqual(
+      summaryLink.textContent.trim(),
+      I18n.t("user.summary.title"),
+      "summary link has the right label"
+    );
+    assert.ok(
+      summaryLink.querySelector(".d-icon-user"),
+      "summary link has the right icon"
+    );
+
+    const activityLink = query("#quick-access-profile ul li.activity a");
+    assert.ok(
+      activityLink.href.endsWith("/u/eviltrout/activity"),
+      "has a link to the activity page of the user"
+    );
+    assert.strictEqual(
+      activityLink.textContent.trim(),
+      I18n.t("user.activity_stream"),
+      "activity link has the right label"
+    );
+    assert.ok(
+      activityLink.querySelector(".d-icon-stream"),
+      "activity link has the right icon"
+    );
+
+    const invitesLink = query("#quick-access-profile ul li.invites a");
+    assert.ok(
+      invitesLink.href.endsWith("/u/eviltrout/invited"),
+      "has a link to the invites page of the user"
+    );
+    assert.strictEqual(
+      invitesLink.textContent.trim(),
+      I18n.t("user.invited.title"),
+      "invites link has the right label"
+    );
+    assert.ok(
+      invitesLink.querySelector(".d-icon-user-plus"),
+      "invites link has the right icon"
+    );
+
+    const dratsLink = query("#quick-access-profile ul li.drafts a");
+    assert.ok(
+      dratsLink.href.endsWith("/u/eviltrout/activity/drafts"),
+      "has a link to the drafts page of the user"
+    );
+    assert.strictEqual(
+      dratsLink.textContent.trim(),
+      I18n.t("drafts.label_with_count", { count: 13 }),
+      "drafts link has the right label with count of the user's drafts"
+    );
+    assert.ok(
+      dratsLink.querySelector(".d-icon-pencil-alt"),
+      "drafts link has the right icon"
+    );
+
+    const preferencesLink = query("#quick-access-profile ul li.preferences a");
+    assert.ok(
+      preferencesLink.href.endsWith("/u/eviltrout/preferences"),
+      "has a link to the preferences page of the user"
+    );
+    assert.strictEqual(
+      preferencesLink.textContent.trim(),
+      I18n.t("user.preferences"),
+      "preferences link has the right label"
+    );
+    assert.ok(
+      preferencesLink.querySelector(".d-icon-cog"),
+      "preferences link has the right icon"
+    );
+
+    let doNotDisturbButton = query(
+      "#quick-access-profile ul li.do-not-disturb .btn"
+    );
+    assert.strictEqual(
+      doNotDisturbButton.textContent
+        .replaceAll(/\s+/g, " ")
+        .replaceAll(/\u200B/g, "")
+        .trim(),
+      I18n.t("do_not_disturb.label"),
+      "Do Not Disturb button has the right label"
+    );
+    assert.ok(
+      doNotDisturbButton.querySelector(".d-icon-toggle-off"),
+      "Do Not Disturb button has the right icon"
+    );
+
+    await click("header.d-header"); // close the menu
+    const date = new Date();
+    date.setHours(date.getHours() + 2);
+    updateCurrentUser({ do_not_disturb_until: date.toISOString() });
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-profile");
+
+    doNotDisturbButton = query(
+      "#quick-access-profile ul li.do-not-disturb .btn"
+    );
+    assert.strictEqual(
+      doNotDisturbButton.textContent
+        .replaceAll(/\s+/g, " ")
+        .replaceAll(/\u200B/g, "")
+        .trim(),
+      `${I18n.t("do_not_disturb.label")} 2h`,
+      "Do Not Disturb button has the right label when Do Not Disturb is enabled"
+    );
+    assert.ok(
+      doNotDisturbButton.querySelector(".d-icon-toggle-on"),
+      "Do Not Disturb button has the right icon when Do Not Disturb is enabled"
+    );
+
+    let toggleAnonButton = query(
+      "#quick-access-profile ul li.enable-anonymous"
+    );
+    assert.strictEqual(
+      toggleAnonButton.textContent
+        .replaceAll(/\s+/g, " ")
+        .replaceAll(/\u200B/g, "")
+        .trim(),
+      I18n.t("switch_to_anon"),
+      "toggle anonymous button has the right label when the user isn't anonymous"
+    );
+    assert.ok(
+      toggleAnonButton.querySelector(".d-icon-user-secret"),
+      "toggle anonymous button has the right icon when the user isn't anonymous"
+    );
+
+    await click("header.d-header"); // close the menu
+    updateCurrentUser({ is_anonymous: true });
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-profile");
+
+    toggleAnonButton = query("#quick-access-profile ul li.disable-anonymous");
+    assert.strictEqual(
+      toggleAnonButton.textContent
+        .replaceAll(/\s+/g, " ")
+        .replaceAll(/\u200B/g, "")
+        .trim(),
+      I18n.t("switch_from_anon"),
+      "toggle anonymous button has the right label when the user is anonymous"
+    );
+    assert.ok(
+      toggleAnonButton.querySelector(".d-icon-ban"),
+      "toggle anonymous button has the right icon when the user is anonymous"
+    );
+
+    await click("header.d-header"); // close the menu
+    updateCurrentUser({ is_anonymous: false, trust_level: 2 });
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-profile");
+
+    assert.notOk(
+      exists("#quick-access-profile ul li.enable-anonymous"),
+      "toggle anon button isn't shown the user can't use it"
+    );
+    assert.notOk(
+      exists("#quick-access-profile ul li.disable-anonymous"),
+      "toggle anon button isn't shown the user can't use it"
+    );
+
+    const logoutButton = query("#quick-access-profile ul li.logout");
+    assert.strictEqual(
+      logoutButton.textContent
+        .replaceAll(/\s+/g, " ")
+        .replaceAll(/\u200B/g, "")
+        .trim(),
+      I18n.t("user.log_out"),
+      "logout button has the right label"
+    );
+    assert.ok(
+      logoutButton.querySelector(".d-icon-sign-out-alt"),
+      "logout button has the right icon"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -368,6 +368,42 @@ acceptance("User menu", function (needs) {
       "toggle anon button isn't shown the user can't use it"
     );
 
+    await click("header.d-header"); // close the menu
+    updateCurrentUser({ is_anonymous: true, trust_level: 2 });
+    this.siteSettings.allow_anonymous_posting = false;
+    this.siteSettings.anonymous_posting_min_trust_level = 3;
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-profile");
+
+    assert.ok(
+      exists("#quick-access-profile ul li.disable-anonymous"),
+      "toggle anon button is always shown if the user is anonymous"
+    );
+
+    await click("header.d-header"); // close the menu
+    updateCurrentUser({ is_anonymous: false, trust_level: 4 });
+    this.siteSettings.allow_anonymous_posting = false;
+    this.siteSettings.anonymous_posting_min_trust_level = 3;
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-profile");
+
+    assert.notOk(
+      exists("#quick-access-profile ul li.enable-anonymous"),
+      "toggle anon button is not shown if the allow_anonymous_posting setting is false"
+    );
+
+    await click("header.d-header"); // close the menu
+    updateCurrentUser({ is_anonymous: false, trust_level: 2 });
+    this.siteSettings.allow_anonymous_posting = true;
+    this.siteSettings.anonymous_posting_min_trust_level = 3;
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-profile");
+
+    assert.notOk(
+      exists("#quick-access-profile ul li.enable-anonymous"),
+      "toggle anon button is not shown if the user doesn't have a high enough trust level"
+    );
+
     const logoutButton = query("#quick-access-profile ul li.logout .btn");
     assert.strictEqual(
       logoutButton.textContent

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -318,7 +318,7 @@ acceptance("User menu", function (needs) {
     );
 
     let toggleAnonButton = query(
-      "#quick-access-profile ul li.enable-anonymous"
+      "#quick-access-profile ul li.enable-anonymous .btn"
     );
     assert.strictEqual(
       toggleAnonButton.textContent
@@ -338,7 +338,9 @@ acceptance("User menu", function (needs) {
     await click(".d-header-icons .current-user");
     await click("#user-menu-button-profile");
 
-    toggleAnonButton = query("#quick-access-profile ul li.disable-anonymous");
+    toggleAnonButton = query(
+      "#quick-access-profile ul li.disable-anonymous .btn"
+    );
     assert.strictEqual(
       toggleAnonButton.textContent
         .replaceAll(/\s+/g, " ")
@@ -366,7 +368,7 @@ acceptance("User menu", function (needs) {
       "toggle anon button isn't shown the user can't use it"
     );
 
-    const logoutButton = query("#quick-access-profile ul li.logout");
+    const logoutButton = query("#quick-access-profile ul li.logout .btn");
     assert.strictEqual(
       logoutButton.textContent
         .replaceAll(/\s+/g, " ")

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -164,8 +164,9 @@ module("Integration | Component | site-header", function (hooks) {
     await triggerKeyEvent(document, "keydown", "ArrowDown");
 
     focusedTab = document.activeElement;
-    assert.ok(
-      focusedTab.href.endsWith("/u/eviltrout/preferences"),
+    assert.strictEqual(
+      focusedTab.id,
+      "user-menu-button-profile",
       "the down arrow key can move the focus to the bottom tabs"
     );
 
@@ -179,8 +180,9 @@ module("Integration | Component | site-header", function (hooks) {
 
     await triggerKeyEvent(document, "keydown", "ArrowUp");
     focusedTab = document.activeElement;
-    assert.ok(
-      focusedTab.href.endsWith("/u/eviltrout/preferences"),
+    assert.strictEqual(
+      focusedTab.id,
+      "user-menu-button-profile",
       "the up arrow key moves the focus in the opposite direction"
     );
   });

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
@@ -70,10 +70,10 @@ module("Integration | Component | user-menu", function (hooks) {
     await render(template);
     const tabs = queryAll(".bottom-tabs.tabs-list .btn");
     assert.strictEqual(tabs.length, 1);
-    const preferencesTab = tabs[0];
-    assert.ok(preferencesTab.href.endsWith("/u/eviltrout/preferences"));
-    assert.strictEqual(preferencesTab.dataset.tabNumber, "6");
-    assert.strictEqual(preferencesTab.getAttribute("tabindex"), "-1");
+    const profileTab = tabs[0];
+    assert.strictEqual(profileTab.id, "user-menu-button-profile");
+    assert.strictEqual(profileTab.dataset.tabNumber, "6");
+    assert.strictEqual(profileTab.getAttribute("tabindex"), "-1");
   });
 
   test("likes tab is hidden if current user's like notifications frequency is 'never'", async function (assert) {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -99,11 +99,11 @@
       flex-wrap: nowrap;
       height: 100%;
       align-items: center;
-      max-height: 20em; // really tall viewports
       overflow-y: auto; // really short viewports
     }
     li {
       flex: 1 1 auto;
+      max-height: 3em; // prevent buttons from getting too tall
       > * {
         // button, a, and everything else
         height: 100%;

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -102,7 +102,6 @@
   .menu-tabs-container {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     border-left: 1px solid var(--primary-low);
     padding: 0.75em 0;
   }
@@ -135,6 +134,10 @@
         background-color: var(--highlight-medium);
       }
     }
+  }
+
+  .bottom-tabs {
+    border-top: 1px solid var(--primary-low);
   }
 
   .panel-body-contents {
@@ -176,6 +179,31 @@
           // we don't need the link focus because we're styling the parent
           outline: 0;
         }
+      }
+    }
+  }
+
+  #quick-access-profile {
+    display: inline;
+
+    .profile-tab-btn {
+      justify-content: unset;
+      line-height: $line-height-large;
+      width: 100%;
+
+      .d-icon {
+        padding: 0;
+      }
+    }
+
+    .do-not-disturb {
+      .relative-date {
+        font-size: $font-down-3;
+        color: var(--primary-medium);
+      }
+
+      .d-icon-toggle-on {
+        color: var(--tertiary);
       }
     }
   }
@@ -399,7 +427,8 @@
         }
       }
 
-      a {
+      a,
+      .profile-tab-btn {
         display: flex;
         margin: 0.25em;
         padding: 0em 0.25em;

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -94,6 +94,28 @@
   right: 0;
   width: 320px;
   padding: 0;
+  #quick-access-profile {
+    ul {
+      flex-wrap: nowrap;
+      height: 100%;
+      align-items: center;
+      max-height: 20em; // really tall viewports
+      overflow-y: auto; // really short viewports
+    }
+    li {
+      flex: 1 1 auto;
+      > * {
+        // button, a, and everything else
+        height: 100%;
+        align-items: center;
+        margin: 0;
+        padding: 0 0.5em;
+      }
+      .d-icon {
+        padding-top: 0;
+      }
+    }
+  }
 
   .panel-body-bottom {
     flex: 0;
@@ -103,7 +125,7 @@
     display: flex;
     flex-direction: column;
     border-left: 1px solid var(--primary-low);
-    padding: 0.75em 0;
+    padding: 0.75em 0 0;
   }
 
   .tabs-list {


### PR DESCRIPTION
This PR adds the profile tab to the experimental user menu. Screenshot:

<img src="https://user-images.githubusercontent.com/17474474/185360345-593d7e54-60e1-4d2c-b9ab-be57337512c5.png" width=400>

We're adding the profile tab to the user menu because it contains links/buttons that are not available anywhere else. We may remove the tab again if we find better places for those links/buttons, but for now it'll stay.