### PR TITLE
DEV: Add hint when qunit assertion fails and app is unsettled

### DIFF
--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -414,7 +414,7 @@ function patchFailedAssertion() {
     if (!resultInfo.result && !isSettled()) {
       // eslint-disable-next-line no-console
       console.warn(
-        "ℹ️ Hint: when the assertion failed, the Ember runloop was not in a settled state. Maybe you need to add `await settled()` before your assertion?",
+        "ℹ️ Hint: when the assertion failed, the Ember runloop was not in a settled state. Maybe you missed an `await` further up the test? Or maybe you need to manually add `await settled()` before your assertion?",
         getSettledState()
       );
     }

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -13,7 +13,12 @@ import pretender, {
 } from "discourse/tests/helpers/create-pretender";
 import { resetSettings } from "discourse/tests/helpers/site-settings";
 import { getOwner, setDefaultOwner } from "discourse-common/lib/get-owner";
-import { setApplication, setResolver } from "@ember/test-helpers";
+import {
+  getSettledState,
+  isSettled,
+  setApplication,
+  setResolver,
+} from "@ember/test-helpers";
 import { setupS3CDN, setupURL } from "discourse-common/lib/get-url";
 import Application from "../app";
 import MessageBus from "message-bus-client";
@@ -372,6 +377,7 @@ export default function setupTests(config) {
 
   setupToolbar();
   reportMemoryUsageAfterTests();
+  patchFailedAssertion();
 }
 
 function getUrlParameter(name) {
@@ -399,4 +405,20 @@ function replaceUrlParameter(name, value) {
       formElement.value = value;
     }
   });
+}
+
+function patchFailedAssertion() {
+  const oldPushResult = QUnit.assert.pushResult;
+
+  QUnit.assert.pushResult = function (resultInfo) {
+    if (!resultInfo.result && !isSettled()) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "ℹ️ Hint: when the assertion failed, the Ember runloop was not in a settled state. Maybe you need to add `await settled()` before your assertion?",
+        getSettledState()
+      );
+    }
+
+    oldPushResult.call(this, resultInfo);
+  };
 }


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
