### PR TITLE
UX: Don't shrink avatar/number box

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -70,6 +70,8 @@
   }
 
   .sidebar-section-link-prefix {
+    flex-shrink: 0;
+
     &.image {
       img {
         border-radius: 50%;


### PR DESCRIPTION
Fixes an issue where longer sidebar item text would squeeze the prefix element

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
