### PR TITLE
PERF: Minify admin and wizard JS bundles to match app

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -134,6 +134,9 @@ module.exports = function (defaults) {
       "/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js"
   );
 
+  const terserPlugin = app.project.findAddonByName("ember-cli-terser");
+  const applyTerser = (tree) => terserPlugin.postprocessTree("all", tree);
+
   return mergeTrees([
     createI18nTree(discourseRoot, vendorJs),
     app.toTree(),
@@ -142,14 +145,18 @@ module.exports = function (defaults) {
       files: ["highlight-test-bundle.min.js"],
       destDir: "assets/highlightjs",
     }),
-    concat(mergeTrees([app.options.adminTree]), {
-      inputFiles: ["**/*.js"],
-      outputFile: `assets/admin.js`,
-    }),
-    concat(mergeTrees([app.options.wizardTree]), {
-      inputFiles: ["**/*.js"],
-      outputFile: `assets/wizard.js`,
-    }),
+    applyTerser(
+      concat(mergeTrees([app.options.adminTree]), {
+        inputFiles: ["**/*.js"],
+        outputFile: `assets/admin.js`,
+      })
+    ),
+    applyTerser(
+      concat(mergeTrees([app.options.wizardTree]), {
+        inputFiles: ["**/*.js"],
+        outputFile: `assets/wizard.js`,
+      })
+    ),
     prettyTextEngine(vendorJs, "discourse-markdown"),
     concat("public/assets/scripts", {
       outputFile: `assets/start-discourse.js`,


### PR DESCRIPTION
This regressed when we switched these bundles to be compiled by ember-cli. Before/after sizes:

```
          before                  after
admin.js: 1370 KB (190 KB gz) --> 782 KB (125 KB gzipped)
wizard.js: 127 KB ( 22 KB gz) -->  68 KB ( 18 KB gzipped)
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
