### PR TITLE
UX: Fix topic admin menu hidden on narrow screens

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -79,7 +79,7 @@ createWidget("topic-admin-menu-button", {
     let button;
 
     if (e === undefined) {
-      button = document.getElementsByClassName(".keyboard-target-admin-menu");
+      button = document.querySelector(".keyboard-target-admin-menu");
     } else {
       button = e.target.closest("button");
     }
@@ -88,7 +88,7 @@ createWidget("topic-admin-menu-button", {
     const spacing = 3;
     const menuWidth = 212;
 
-    const rtl = document.querySelectorAll("html.rtl")[0];
+    const rtl = document.documentElement.classList.contains("html.rtl");
     const buttonDOMRect = button.getBoundingClientRect();
     position.outerHeight = buttonDOMRect.height;
 

--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -76,33 +76,44 @@ createWidget("topic-admin-menu-button", {
 
   showAdminMenu(e) {
     this.state.expanded = true;
-    let $button;
+    let button;
 
     if (e === undefined) {
-      $button = $(".keyboard-target-admin-menu");
+      button = document.getElementsByClassName(".keyboard-target-admin-menu");
     } else {
-      $button = $(e.target.closest("button"));
+      button = e.target.closest("button");
     }
 
-    const position = $button.position(),
-      SPACING = 3,
-      MENU_WIDTH = 217;
+    const position = { top: button.offsetTop, left: button.offsetLeft };
+    const spacing = 3;
+    const menuWidth = 212;
 
-    const rtl = $("html").hasClass("rtl");
-    position.outerHeight = $button.outerHeight();
-
-    if (rtl) {
-      position.left -= MENU_WIDTH - $button.outerWidth();
-    }
+    const rtl = document.querySelectorAll("html.rtl")[0];
+    const buttonDOMRect = button.getBoundingClientRect();
+    position.outerHeight = buttonDOMRect.height;
 
     if (this.attrs.openUpwards) {
       if (rtl) {
-        position.left -= $button[0].offsetWidth + SPACING;
+        position.left -= buttonDOMRect.width + spacing;
       } else {
-        position.left += $button[0].offsetWidth + SPACING;
+        position.left += buttonDOMRect.width + spacing;
       }
     } else {
-      position.top += $button[0].offsetHeight + SPACING;
+      if (rtl) {
+        if (buttonDOMRect.left < menuWidth) {
+          position.left += 0;
+        } else {
+          position.left -= menuWidth - buttonDOMRect.width;
+        }
+      } else {
+        const offsetRight = window.innerWidth - buttonDOMRect.right;
+
+        if (offsetRight < menuWidth) {
+          position.left -= menuWidth - buttonDOMRect.width;
+        }
+      }
+
+      position.top += buttonDOMRect.height + spacing;
     }
 
     this.state.position = position;


### PR DESCRIPTION
When there is not enough window width to display the admin menu on the
right, we display it on the left instead. Behavior is reversed on RTL
layout.

This commit removes jQuery usage. 

No tests here because testing code that is dependent on browser width is very complex. Instead, I've manually tested the changes locally with the recordings below and I recommend that the reviewer do the same. 

### Narrow screen layout
![Peek 2022-08-19 15-49](https://user-images.githubusercontent.com/4335742/185571000-e9e36baf-cf70-4012-9a65-97ce1e72d03b.gif)

### Normal layout
![Peek 2022-08-19 15-48](https://user-images.githubusercontent.com/4335742/185571011-162b23c0-6e54-44dc-b205-b71665c4dafe.gif)

### RTL layout
![Peek 2022-08-19 15-47](https://user-images.githubusercontent.com/4335742/185571014-98bc0a5f-b7e6-4f08-903d-ea1831231616.gif)
