### PR TITLE
UX: Hide chat image overflow

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -218,6 +218,7 @@ aside.onebox {
           max-width: initial;
           max-height: initial;
           float: none;
+          overflow: hidden;
         }
       }
 


### PR DESCRIPTION
When there was a problem with an image the built-in frame would expand way outside the message.

Before/After
<img width="86" alt="Screenshot 2022-08-19 at 09 31 35" src="https://user-images.githubusercontent.com/66961/185638137-cc8b3ae2-2ed6-4bbd-a713-af2356025d69.png"> <img width="86" alt="Screenshot 2022-08-19 at 09 31 41" src="https://user-images.githubusercontent.com/66961/185638171-0b649538-fbc4-467a-9807-235172666111.png">

If anyone has a better solution, please come forward 😄 