### PR TITLE
DEV: Add select-kit option to hide values from preview

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -128,10 +128,10 @@ module(
 
     test("values in hiddenFromPreview will not display in preview", async function (assert) {
       this.set("value", ["foo", "bar"]);
-      this.set("hiddenFromPreview", ["foo"]);
+      this.set("hiddenValues", ["foo"]);
 
       await render(
-        hbs`<MiniTagChooser @options={{hash allowAny=true}} @value={{this.value}} @hiddenFromPreview={{hiddenFromPreview}}/>`
+        hbs`<MiniTagChooser @options={{hash allowAny=true hiddenValues=hiddenValues}} @value={{this.value}} />`
       );
       assert.strictEqual(
         query(".formatted-selection").textContent.trim(),

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -131,7 +131,7 @@ module(
       this.set("hiddenValues", ["foo"]);
 
       await render(
-        hbs`<MiniTagChooser @options={{hash allowAny=true hiddenValues=hiddenValues}} @value={{this.value}} />`
+        hbs`<MiniTagChooser @options={{hash allowAny=true hiddenValues=this.hiddenValues}} @value={{this.value}} />`
       );
       assert.strictEqual(
         query(".formatted-selection").textContent.trim(),

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -125,5 +125,26 @@ module(
         "it forces the max length of the tag"
       );
     });
+
+    test("values in hiddenFromPreview will not display in preview", async function (assert) {
+      this.set("value", ["foo", "bar"]);
+      this.set("hiddenFromPreview", ["foo"]);
+
+      await render(
+        hbs`<MiniTagChooser @options={{hash allowAny=true}} @value={{this.value}} @hiddenFromPreview={{hiddenFromPreview}}/>`
+      );
+      assert.strictEqual(
+        query(".formatted-selection").textContent.trim(),
+        "bar"
+      );
+
+      await this.subject.expand();
+      assert.deepEqual(
+        [...queryAll(".selected-content .selected-choice")].map((el) =>
+          el.textContent.trim()
+        ),
+        ["bar"]
+      );
+    });
   }
 );

--- a/app/assets/javascripts/select-kit/addon/components/mini-tag-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/mini-tag-chooser.js
@@ -26,6 +26,7 @@ export default MultiSelectComponent.extend(TagsMixin, {
     closeOnChange: false,
     maximum: "maxTagsPerTopic",
     autoInsertNoneItem: false,
+    hiddenFromPreview: null,
   },
 
   modifyComponentForRow(collection, item) {
@@ -59,7 +60,11 @@ export default MultiSelectComponent.extend(TagsMixin, {
   }),
 
   content: computed("value.[]", function () {
-    return makeArray(this.value).map((x) => this.defaultItem(x, x));
+    let values = makeArray(this.value);
+    if (this.hiddenFromPreview) {
+      values = values.filter((val) => !this.hiddenFromPreview.includes(val));
+    }
+    return values.map((x) => this.defaultItem(x, x));
   }),
 
   search(filter) {

--- a/app/assets/javascripts/select-kit/addon/components/mini-tag-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/mini-tag-chooser.js
@@ -26,7 +26,6 @@ export default MultiSelectComponent.extend(TagsMixin, {
     closeOnChange: false,
     maximum: "maxTagsPerTopic",
     autoInsertNoneItem: false,
-    hiddenFromPreview: null,
   },
 
   modifyComponentForRow(collection, item) {
@@ -61,8 +60,10 @@ export default MultiSelectComponent.extend(TagsMixin, {
 
   content: computed("value.[]", function () {
     let values = makeArray(this.value);
-    if (this.hiddenFromPreview) {
-      values = values.filter((val) => !this.hiddenFromPreview.includes(val));
+    if (this.selectKit.options.hiddenValues) {
+      values = values.filter(
+        (val) => !this.selectKit.options.hiddenValues.includes(val)
+      );
     }
     return values.map((x) => this.defaultItem(x, x));
   }),

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -293,6 +293,7 @@ export default Component.extend(
       placementStrategy: null,
       mobilePlacementStrategy: null,
       desktopPlacementStrategy: null,
+      hiddenValues: null,
     },
 
     autoFilterable: computed("content.[]", "selectKit.filter", function () {


### PR DESCRIPTION
Add `hiddenFromPreview` option to `MiniTagChooser` manipulate the values displayed in the select-kit preview without actually changing the `selected` value. 
 
 eg.
 ```
  <MiniTagChooser
    @value={{@value}}
    @onChange={{@onChange}}
    @options={{hash hiddenValues=this.hiddenValues}} <- array of values
  />
```

In https://github.com/discourse/discourse-global-filter we have a custom row of `tags` that can be selected and added to a topic. While we want those selected tags to persist on topic creation, we don't want them to be displayed in the select-kit preview.

<img width="782" alt="Screen Shot 2022-08-18 at 4 56 56 PM" src="https://user-images.githubusercontent.com/50783505/185502353-8b3ab4a9-f8b0-4216-8160-4edd79f7115c.png">
