### PR TITLE
Update client.es.yml

### DIFF
--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -4811,7 +4811,7 @@ es:
         nav:
           new: "Nuevos"
           active: "Activos"
-          staff: "Personal"
+          staff: "STAFF"
           suspended: "Suspendidos"
           silenced: "Silenciados"
           staged: "Temporal"
@@ -4825,7 +4825,7 @@ es:
           member: "Usuarios con nivel de confianza 2 (Miembro)"
           regular: "Usuarios con nivel de confianza 3 (Habitual)"
           leader: "Usuarios con nivel de confianza 4 (Líder)"
-          staff: "Personal"
+          staff: "STAFF"
           admins: "Administradores"
           moderators: "Moderadores"
           silenced: "Usuarios silenciados"


### PR DESCRIPTION
Change in the translation, "STAFF" would be left as such "STAFF" since the translation "PERSONAL" (work team), is identical to the term "PERSONAL" (which is typical or characteristic of a certain person).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
