### PR TITLE
DEV: `zoom` isn't used anymore

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/mobile-pan-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/mobile-pan-test.js
@@ -7,15 +7,6 @@ import {
 import { click, triggerEvent, visit } from "@ember/test-helpers";
 
 async function triggerSwipeStart(touchTarget) {
-  // some tests are shown in a zoom viewport.
-  // boundingClientRect is affected by the zoom and need to be multiplied by the zoom effect.
-  // EG: if the element has a zoom of 50%, this DOUBLES the x and y positions and offsets.
-  // The numbers you get from getBoundingClientRect are seen as twice as large... however, the
-  // touch input still deals with the base inputs, not doubled. This allows us to convert for those environments.
-  let zoom = parseFloat(
-    window.getComputedStyle(document.querySelector("#ember-testing")).zoom || 1
-  );
-
   // Other tests are shown in a transformed viewport, and this is a multiple for the offsets
   let scale = parseFloat(
     window
@@ -26,13 +17,11 @@ async function triggerSwipeStart(touchTarget) {
   const touchStart = {
     touchTarget,
     x:
-      zoom *
-      (touchTarget.getBoundingClientRect().x +
-        (scale * touchTarget.offsetWidth) / 2),
+      touchTarget.getBoundingClientRect().x +
+      (scale * touchTarget.offsetWidth) / 2,
     y:
-      zoom *
-      (touchTarget.getBoundingClientRect().y +
-        (scale * touchTarget.offsetHeight) / 2),
+      touchTarget.getBoundingClientRect().y +
+      (scale * touchTarget.offsetHeight) / 2,
   };
   const touch = new Touch({
     identifier: "test",


### PR DESCRIPTION
As far I can tell no tests are being run "in a zoom viewport"?

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
