### PR TITLE
DEV: Clean up keyTrapper prototype override

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -151,6 +151,10 @@ export default {
   },
 
   teardown() {
+    const prototype = Object.getPrototypeOf(this.keyTrapper);
+    prototype.stopCallback = this.oldStopCallback;
+    this.oldStopCallback = null;
+
     this.keyTrapper?.destroy();
     this.keyTrapper = null;
     this.container = null;
@@ -819,7 +823,7 @@ export default {
 
   _stopCallback() {
     const prototype = Object.getPrototypeOf(this.keyTrapper);
-    const oldStopCallback = prototype.stopCallback;
+    const oldCallback = (this.oldStopCallback = prototype.stopCallback);
 
     prototype.stopCallback = function (e, element, combo, sequence) {
       if (this.paused) {
@@ -833,7 +837,7 @@ export default {
         return false;
       }
 
-      return oldStopCallback.call(this, e, element, combo, sequence);
+      return oldCallback.call(this, e, element, combo, sequence);
     };
   },
 


### PR DESCRIPTION
Fixes "Uncaught InternalError: too much recursion"

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
