### PR TITLE
FIX: Move show like logic to client side

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -255,9 +255,12 @@ export default function transformPost(
   if (likeAction) {
     postAtts.liked = likeAction.acted;
     postAtts.canToggleLike = likeAction.get("canToggle");
-    postAtts.showLike = true;
+    postAtts.showLike = postAtts.liked || postAtts.canToggleLike;
     postAtts.likeCount = likeAction.count;
-  } else if (!currentUser) {
+  } else if (
+    !currentUser ||
+    (topic.archived && topic.user_id !== currentUser.id)
+  ) {
     postAtts.showLike = true;
   }
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -315,8 +315,7 @@ class PostSerializer < BasicPostSerializer
       summary.delete(:count) if summary[:count] == 0
 
       # Only include it if the user can do it or it has a count
-      # If it is a like, we want to show it always (even for archived topic)
-      if summary[:can_act] || summary[:count] || (sym == :like && object.user_id != scope.user&.id)
+      if summary[:can_act] || summary[:count]
         result << summary
       end
     end


### PR DESCRIPTION
The logic was added in commit ec8306835dcadf24a0d0ff83767016bbaefa8fa4,
to show the like action even if the user could not like the post. It is
not necessary for this logic to be implemented on the server side.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
