### PR TITLE
DEV: Use `.ember-application` instead of `#main`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -177,7 +177,7 @@ const SiteHeaderComponent = MountWidget.extend(
         this.docAt = header.offsetTop;
       }
 
-      const main = document.querySelector("#main");
+      const main = document.querySelector(".ember-application");
       const offsetTop = main ? main.offsetTop : 0;
       const offset = window.pageYOffset - offsetTop;
       if (offset >= this.docAt) {

--- a/app/assets/javascripts/discourse/app/mixins/scrolling.js
+++ b/app/assets/javascripts/discourse/app/mixins/scrolling.js
@@ -19,7 +19,9 @@ const ScrollingDOMMethods = {
   },
 
   screenNotFull() {
-    return window.height > document.querySelector("#main").offsetHeight;
+    return (
+      window.height > document.querySelector(".ember-application").offsetHeight
+    );
   },
 };
 

--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -334,8 +334,9 @@ export default createWidget("topic-admin-menu", {
 
     if (attrs.openUpwards) {
       const documentHeight = $(document).height();
-      const mainHeight = $("#main").height();
-      let bottom = documentHeight - top - 70 - $("#main").offset().top;
+      const mainHeight = $(".ember-application").height();
+      let bottom =
+        documentHeight - top - 70 - $(".ember-application").offset().top;
 
       if (documentHeight > mainHeight) {
         bottom = bottom - (documentHeight - mainHeight) - outerHeight;


### PR DESCRIPTION
`#main` in the test environment is replaced with `#ember-testing`, so this code would break. It never did only because we don't test these code paths 👀

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
