### PR TITLE
DEV: Increase timeout when pulling hotlinked image

### DIFF
--- a/app/jobs/regular/pull_hotlinked_images.rb
+++ b/app/jobs/regular/pull_hotlinked_images.rb
@@ -86,7 +86,8 @@ module Jobs
           max_file_size: @max_size,
           retain_on_max_file_size_exceeded: true,
           tmp_file_name: "discourse-hotlinked",
-          follow_redirect: true
+          follow_redirect: true,
+          read_timeout: 15
         )
       rescue => e
         if SiteSetting.verbose_upload_logging


### PR DESCRIPTION
We observed that some sites seemingly put us in a tarpit when we attempt to pull hotlinked images. Increasing the timeout will help in these situations.
