### PR TITLE
UX: Add badges section link to community section.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/community-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/community-section.js
@@ -14,6 +14,7 @@ import UsersSectionLink from "discourse/lib/sidebar/user/community-section/users
 import AboutSectionLink from "discourse/lib/sidebar/user/community-section/about-section-link";
 import FAQSectionLink from "discourse/lib/sidebar/user/community-section/faq-section-link";
 import AdminSectionLink from "discourse/lib/sidebar/user/community-section/admin-section-link";
+import BadgesSectionLink from "discourse/lib/sidebar/user/community-section/badges-section-link";
 
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
@@ -27,7 +28,11 @@ const MAIN_SECTION_LINKS = [
 
 const ADMIN_MAIN_SECTION_LINKS = [AdminSectionLink];
 
-const MORE_SECTION_LINKS = [GroupsSectionLink, UsersSectionLink];
+const MORE_SECTION_LINKS = [
+  GroupsSectionLink,
+  UsersSectionLink,
+  BadgesSectionLink,
+];
 const MORE_SECONDARY_SECTION_LINKS = [AboutSectionLink, FAQSectionLink];
 
 export default class SidebarUserCommunitySection extends Component {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/badges-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/badges-section-link.js
@@ -1,0 +1,21 @@
+import I18n from "I18n";
+
+import BaseSectionLink from "discourse/lib/sidebar/user/community-section/base-section-link";
+
+export default class BadgesSectionLink extends BaseSectionLink {
+  get name() {
+    return "badges";
+  }
+
+  get route() {
+    return "badges";
+  }
+
+  get title() {
+    return I18n.t("badges.title");
+  }
+
+  get text() {
+    return I18n.t("badges.title");
+  }
+}

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -229,6 +229,22 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     );
   });
 
+  test("clicking on badges link", async function (assert) {
+    await visit("/");
+
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    await click(".sidebar-section-community .sidebar-section-link-badges");
+
+    assert.strictEqual(
+      currentURL(),
+      "/badges",
+      "it should transition to the badges url"
+    );
+  });
+
   test("clicking on groups link", async function (assert) {
     await visit("/t/280");
 


### PR DESCRIPTION
We have a link to /badges in the old hamburger dropdown so maintaining
parity here.

![Peek 2022-08-23 15-27](https://user-images.githubusercontent.com/4335742/186097649-9473d249-39cb-45bd-8ba6-e66d2b5229bf.gif)
