### PR TITLE
DEV: Fix flaky spec due to ordering of Array intersection

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1662,9 +1662,11 @@ class User < ActiveRecord::Base
 
   def sidebar_categories_ids
     categories_ids = category_sidebar_section_links.pluck(:linkable_id)
+
     if categories_ids.blank? && SiteSetting.default_sidebar_categories.present?
-      return guardian.allowed_category_ids & SiteSetting.default_sidebar_categories.split("|").map(&:to_i)
+      return SiteSetting.default_sidebar_categories.split("|").map(&:to_i) & guardian.allowed_category_ids
     end
+
     categories_ids
   end
 


### PR DESCRIPTION
```
  1) CurrentUserSerializer#sidebar_category_ids includes visible default sidebar categories
     Failure/Error: expect(json[:sidebar_category_ids]).to eq([category.id, category_2.id])

       expected: [378, 379]
            got: [379, 378]
```

Note that in the Ruby doc it says "The order is preserved from the original array". In this case, we want to preserve the order of the site setting.