### PR TITLE
Revert "UX: Hide chat image overflow (#18000)"

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -218,7 +218,6 @@ aside.onebox {
           max-width: initial;
           max-height: initial;
           float: none;
-          overflow: hidden;
         }
       }
 


### PR DESCRIPTION
This reverts commit e3108ded110336822a8726bda91ead13e3fb7c29.

Wrong selector, wrong repo 😆 Resubmitted as https://github.com/discourse/discourse-chat/pull/1196

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
