### PR TITLE
UX: hide background image in crawler view

### DIFF
--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -6,6 +6,7 @@ body.crawler,
 body > noscript {
   font-family: serif;
 
+  &:after,
   &:before {
     // common way to show fixed background images
     display: none;

--- a/app/assets/stylesheets/common/base/crawler_layout.scss
+++ b/app/assets/stylesheets/common/base/crawler_layout.scss
@@ -5,6 +5,12 @@
 body.crawler,
 body > noscript {
   font-family: serif;
+
+  &:before {
+    // common way to show fixed background images
+    display: none;
+  }
+
   a {
     // we want all links to look like links
     color: blue !important;


### PR DESCRIPTION
Background images added with the before psuedo selector can interfere with other elements, most seriously, links. For example: https://web.archive.org/web/20220731051419/https://forums.gearboxsoftware.com/c/homeworld/57

Images applied this way should just be hidden. 