### PR TITLE
DEV: prevent class clash with user-field names

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -215,7 +215,7 @@
           <div class="public-user-fields">
             {{#each this.publicUserFields as |uf|}}
               {{#if uf.value}}
-                <div class="public-user-field {{uf.field.dasherized_name}}">
+                <div class="public-user-field public-user-field-{{uf.field.dasherized_name}}">
                   <span class="user-field-name">{{uf.field.name}}:</span>
                   <span class="user-field-value">
                     {{#each uf.value as |v|}} {{! some values are arrays }}

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -215,7 +215,7 @@
           <div class="public-user-fields">
             {{#each this.publicUserFields as |uf|}}
               {{#if uf.value}}
-                <div class="public-user-field public-user-field-{{uf.field.dasherized_name}}">
+                <div class="public-user-field public-user-field__{{uf.field.dasherized_name}}">
                   <span class="user-field-name">{{uf.field.name}}:</span>
                   <span class="user-field-value">
                     {{#each uf.value as |v|}} {{! some values are arrays }}


### PR DESCRIPTION
User field names can be named anything an admin sets, so we should prefix them to avoid class collisions. 

Reported here: https://meta.discourse.org/t/about-the-user-fields-arrangement-problem/236935