### PR TITLE
DEV: Enable jquery-integration runtime deprecation

### DIFF
--- a/app/assets/javascripts/discourse/config/optional-features.json
+++ b/app/assets/javascripts/discourse/config/optional-features.json
@@ -1,5 +1,4 @@
 {
   "application-template-wrapper": false,
-  "default-async-observers": true,
-  "jquery-integration": true
+  "default-async-observers": true
 }

--- a/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
@@ -18,3 +18,16 @@ define("ember-addons/ember-computed-decorators", [
   );
   return decorators;
 });
+
+// Based on https://github.com/emberjs/ember-jquery-legacy
+// The addon has out-of-date dependences, but it's super simple so we can reproduce here instead:
+define("ember-jquery-legacy", ["exports"], function (exports) {
+  exports.normalizeEvent = function (e) {
+    if (e instanceof Event) {
+      return e;
+    }
+    // __originalEvent is a private escape hatch of Ember's EventDispatcher to allow accessing `originalEvent` without
+    // triggering a deprecation message.
+    return e.__originalEvent || e.originalEvent;
+  };
+});


### PR DESCRIPTION
Omitting the flag from optional-features enables the runtime deprecation notice.

Also introduces `ember-jquery-legacy` which can be used to migrate to the new behaviour early. Details at https://deprecations.emberjs.com/v3.x/#toc_jquery-event

Core does not appear to make use of `originalEvent` in Ember event handlers. When searching for `originalEvent` there are some matches which relate to our pan-events mixin, but this is our own implementation and not affected by this deprecation.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
