### PR TITLE
DEV: Enable ember-cli plugin assets by default

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -146,7 +146,7 @@ module.exports = function (defaults) {
   );
 
   let discoursePluginsTree;
-  if (process.env.EMBER_CLI_PLUGIN_ASSETS === "1") {
+  if (process.env.EMBER_CLI_PLUGIN_ASSETS !== "0") {
     discoursePluginsTree = app.project
       .findAddonByName("discourse-plugins")
       .generatePluginsTree();

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -381,7 +381,7 @@ module.exports = {
     if (shouldLoadPluginTestJs() && type === "test-plugin-js") {
       const scripts = [];
 
-      if (process.env.EMBER_CLI_PLUGIN_ASSETS === "1") {
+      if (process.env.EMBER_CLI_PLUGIN_ASSETS !== "0") {
         const pluginInfos = this.app.project
           .findAddonByName("discourse-plugins")
           .pluginInfos();

--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -2,7 +2,7 @@
 
 module EmberCli
   def self.plugin_assets?
-    ENV["EMBER_CLI_PLUGIN_ASSETS"] == "1"
+    ENV["EMBER_CLI_PLUGIN_ASSETS"] != "0"
   end
 
   def self.assets


### PR DESCRIPTION
For now, `EMBER_CLI_PLUGIN_ASSETS` can be set to 0 to restore the old behavior. This option will be removed very soon.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
