### PR TITLE
FIX: Backup/Restore didn't use correct Redis namespace in multisite

### DIFF
--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -98,9 +98,13 @@ module BackupRestore
       BackupRestore.clear_shutdown_signal!
 
       Thread.new do
-        while BackupRestore.is_operation_running?
-          exit if BackupRestore.should_shutdown?
-          sleep 0.1
+        Thread.current.name = "shutdown_wait"
+
+        RailsMultisite::ConnectionManagement.with_connection(@current_db) do
+          while BackupRestore.is_operation_running?
+            exit if BackupRestore.should_shutdown?
+            sleep 0.1
+          end
         end
       end
     end

--- a/lib/backup_restore/system_interface.rb
+++ b/lib/backup_restore/system_interface.rb
@@ -47,9 +47,13 @@ module BackupRestore
       BackupRestore.clear_shutdown_signal!
 
       Thread.new do
-        while BackupRestore.is_operation_running?
-          exit if BackupRestore.should_shutdown?
-          sleep 0.1
+        Thread.current.name = "shutdown_wait"
+
+        RailsMultisite::ConnectionManagement.with_connection(@current_db) do
+          while BackupRestore.is_operation_running?
+            exit if BackupRestore.should_shutdown?
+            sleep 0.1
+          end
         end
       end
     end

--- a/spec/lib/backup_restore/system_interface_multisite_spec.rb
+++ b/spec/lib/backup_restore/system_interface_multisite_spec.rb
@@ -36,4 +36,21 @@ RSpec.describe BackupRestore::SystemInterface, type: :multisite do
       end
     end
   end
+
+  describe "#listen_for_shutdown_signal" do
+    it "uses the correct Redis namespace" do
+      test_multisite_connection("second") do
+        BackupRestore.mark_as_running!
+
+        expect do
+          thread = subject.listen_for_shutdown_signal
+          BackupRestore.set_shutdown_signal!
+          thread.join
+        end.to raise_error(SystemExit)
+
+        BackupRestore.clear_shutdown_signal!
+        BackupRestore.mark_as_not_running!
+      end
+    end
+  end
 end


### PR DESCRIPTION
In a multisite Discourse reported that no backup is running after 60 seconds because the Redis key expired. Also, the thread that listens for a shutdown signal stopped running immediately because it didn't detect a running operation.