### PR TITLE
DEV: Stick to ipv4 when proxying testem requests

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -68,7 +68,7 @@ module.exports = {
   reporter: Reporter,
 };
 
-const target = `http://localhost:${process.env.UNICORN_PORT || "3000"}`;
+const target = `http://127.0.0.1:${process.env.UNICORN_PORT || "3000"}`;
 
 if (process.argv.includes("-t")) {
   // Running testem without ember cli. Probably for theme-qunit


### PR DESCRIPTION
`localhost` made it use ipv6, which didn't work (on macOS 13)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
