### PR TITLE
FIX: hide sidebar for anonymous when login required

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -17,7 +17,9 @@ export default Controller.extend({
 
   init() {
     this._super(...arguments);
-    this.showSidebar = !this.keyValueStore.getItem(HIDE_SIDEBAR_KEY);
+    this.showSidebar =
+      (this.currentUser || !this.siteSettings.login_required) &&
+      !this.keyValueStore.getItem(HIDE_SIDEBAR_KEY);
   },
 
   @discourseComputed

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-user-test.js
@@ -20,7 +20,24 @@ acceptance("Sidebar - Anonymous User", function (needs) {
 
     assert.ok(
       exists(".sidebar-container"),
-      "sidebar exists for anonymouse user"
+      "sidebar exists for anonymous user"
+    );
+  });
+});
+
+acceptance("Sidebar - Anonymous User - Login Required", function (needs) {
+  needs.settings({
+    enable_experimental_sidebar_hamburger: true,
+    enable_sidebar: true,
+    login_required: true,
+  });
+
+  test("sidebar is hidden", async function (assert) {
+    await visit("/");
+
+    assert.ok(
+      !exists(".sidebar-container"),
+      "sidebar is hidden for anonymous user"
     );
   });
 });


### PR DESCRIPTION
Recently, anonymous sidebar was introduced, but it should be hidden when the site requires users to authenticate.

Related PR - https://github.com/discourse/discourse/pull/17962
