### PR TITLE
PERF: Rely on preload for first_post for TopicBookmarkable

### DIFF
--- a/app/serializers/user_topic_bookmark_serializer.rb
+++ b/app/serializers/user_topic_bookmark_serializer.rb
@@ -11,7 +11,7 @@ class UserTopicBookmarkSerializer < UserPostTopicBookmarkBaseSerializer
   end
 
   def first_post
-    @first_post ||= topic.posts.find { |post| post.post_number == 1 }
+    @first_post ||= topic.first_post
   end
 
   def deleted


### PR DESCRIPTION
In 49a70a37f10edb05fd98ac9935f72aeb00a842d2 I removed the
topic: :posts preload for TopicBookmarkable, but did not
update the UserTopicBookmarkSerializer to reflect this,
which was causing up to multi-hundred millisecond queries to
be made for each topic bookmark based on the size of the
topic.
