### PR TITLE
FIX: hide sidebar toggle button when no sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -18,7 +18,7 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
     this.showSidebar =
-      this.sidebarAvailable && !this.keyValueStore.getItem(HIDE_SIDEBAR_KEY);
+      this.canDisplaySidebar && !this.keyValueStore.getItem(HIDE_SIDEBAR_KEY);
   },
 
   @discourseComputed
@@ -31,7 +31,7 @@ export default Controller.extend({
   },
 
   @discourseComputed
-  sidebarAvailable() {
+  canDisplaySidebar() {
     return this.currentUser || !this.siteSettings.login_required;
   },
 
@@ -65,15 +65,15 @@ export default Controller.extend({
     "enable_sidebar",
     "siteSettings.enable_sidebar",
     "router.currentRouteName",
-    "sidebarAvailable"
+    "canDisplaySidebar"
   )
   sidebarEnabled(
     sidebarQueryParamOverride,
     enableSidebar,
     currentRouteName,
-    sidebarAvailable
+    canDisplaySidebar
   ) {
-    if (!sidebarAvailable) {
+    if (!canDisplaySidebar) {
       return false;
     }
     if (sidebarQueryParamOverride === "1") {

--- a/app/assets/javascripts/discourse/app/controllers/application.js
+++ b/app/assets/javascripts/discourse/app/controllers/application.js
@@ -18,8 +18,7 @@ export default Controller.extend({
   init() {
     this._super(...arguments);
     this.showSidebar =
-      (this.currentUser || !this.siteSettings.login_required) &&
-      !this.keyValueStore.getItem(HIDE_SIDEBAR_KEY);
+      this.sidebarAvailable && !this.keyValueStore.getItem(HIDE_SIDEBAR_KEY);
   },
 
   @discourseComputed
@@ -29,6 +28,11 @@ export default Controller.extend({
       this.siteSettings.allow_new_registrations &&
       !this.siteSettings.enable_discourse_connect
     );
+  },
+
+  @discourseComputed
+  sidebarAvailable() {
+    return this.currentUser || !this.siteSettings.login_required;
   },
 
   @discourseComputed
@@ -60,9 +64,18 @@ export default Controller.extend({
   @discourseComputed(
     "enable_sidebar",
     "siteSettings.enable_sidebar",
-    "router.currentRouteName"
+    "router.currentRouteName",
+    "sidebarAvailable"
   )
-  sidebarEnabled(sidebarQueryParamOverride, enableSidebar, currentRouteName) {
+  sidebarEnabled(
+    sidebarQueryParamOverride,
+    enableSidebar,
+    currentRouteName,
+    sidebarAvailable
+  ) {
+    if (!sidebarAvailable) {
+      return false;
+    }
     if (sidebarQueryParamOverride === "1") {
       return true;
     }

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-user-test.js
@@ -22,6 +22,11 @@ acceptance("Sidebar - Anonymous User", function (needs) {
       exists(".sidebar-container"),
       "sidebar exists for anonymous user"
     );
+
+    assert.ok(
+      exists(".header-sidebar-toggle"),
+      "toggle button for anonymous user"
+    );
   });
 });
 
@@ -32,12 +37,17 @@ acceptance("Sidebar - Anonymous User - Login Required", function (needs) {
     login_required: true,
   });
 
-  test("sidebar is hidden", async function (assert) {
+  test("sidebar and toggle button is hidden", async function (assert) {
     await visit("/");
 
     assert.ok(
       !exists(".sidebar-container"),
       "sidebar is hidden for anonymous user"
+    );
+
+    assert.ok(
+      !exists(".header-sidebar-toggle"),
+      "toggle button is hidden for anonymous user"
     );
   });
 });


### PR DESCRIPTION
When sidebar is not available (for example for anonymous user for sites which requires log in), toggle button should be hidden as well.

<img width="651" alt="Screen Shot 2022-08-24 at 12 40 01 pm" src="https://user-images.githubusercontent.com/72780/186306893-32e2db59-c8e9-4793-be6a-cf61f9ee7891.png">

