### PR TITLE
DEV: Compile plugin tests using ember-cli

### DIFF
--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -78,12 +78,20 @@ module.exports = {
     return pluginDirectories.map((directory) => {
       const name = directory.name;
       const jsDirectory = path.resolve(root, name, "assets/javascripts");
+      const testDirectory = path.resolve(root, name, "test/javascripts");
       const hasJs = fs.existsSync(jsDirectory);
-      return { name, jsDirectory, hasJs };
+      const hasTests = fs.existsSync(testDirectory);
+      return { name, jsDirectory, testDirectory, hasJs, hasTests };
     });
   },
 
   generatePluginsTree() {
+    const appTree = this._generatePluginAppTree();
+    const testTree = this._generatePluginTestTree();
+    return mergeTrees([appTree, testTree]);
+  },
+
+  _generatePluginAppTree() {
     const trees = this.pluginInfos()
       .filter((p) => p.hasJs)
       .map(({ name, jsDirectory }) => {
@@ -101,6 +109,24 @@ module.exports = {
         return concat(mergeTrees([tree]), {
           inputFiles: ["**/*.js"],
           outputFile: `assets/plugins/${name}.js`,
+        });
+      });
+    return mergeTrees(trees);
+  },
+
+  _generatePluginTestTree() {
+    const trees = this.pluginInfos()
+      .filter((p) => p.hasTests)
+      .map(({ name, testDirectory }) => {
+        let tree = new WatchedDir(testDirectory);
+
+        tree = fixLegacyExtensions(tree);
+        tree = namespaceModules(tree, name);
+        tree = this.processedAddonJsFiles(tree);
+
+        return concat(mergeTrees([tree]), {
+          inputFiles: ["**/*.js"],
+          outputFile: `assets/plugins/test/${name}_tests.js`,
         });
       });
     return mergeTrees(trees);

--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -109,6 +109,7 @@ module.exports = {
         return concat(mergeTrees([tree]), {
           inputFiles: ["**/*.js"],
           outputFile: `assets/plugins/${name}.js`,
+          allowNone: true,
         });
       });
     return mergeTrees(trees);
@@ -127,6 +128,7 @@ module.exports = {
         return concat(mergeTrees([tree]), {
           inputFiles: ["**/*.js"],
           outputFile: `assets/plugins/test/${name}_tests.js`,
+          allowNone: true,
         });
       });
     return mergeTrees(trees);

--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -411,7 +411,19 @@ module.exports = {
         )
         .join("\n");
     } else if (shouldLoadPluginTestJs() && type === "test-plugin-tests-js") {
-      return `<script id="plugin-test-script" src="${config.rootURL}assets/discourse/tests/plugin-tests.js" data-discourse-plugin="_all"></script>`;
+      if (process.env.EMBER_CLI_PLUGIN_ASSETS !== "0") {
+        return this.app.project
+          .findAddonByName("discourse-plugins")
+          .pluginInfos()
+          .filter(({ hasTests }) => hasTests)
+          .map(
+            ({ name }) =>
+              `<script src="${config.rootURL}assets/plugins/test/${name}_tests.js" data-discourse-plugin="${name}"></script>`
+          )
+          .join("\n");
+      } else {
+        return `<script id="plugin-test-script" src="${config.rootURL}assets/discourse/tests/plugin-tests.js" data-discourse-plugin="_all"></script>`;
+      }
     }
   },
 


### PR DESCRIPTION
For now, `EMBER_CLI_PLUGIN_ASSETS` can be set to 0 to restore the old behavior. This option will be removed very soon.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
