### PR TITLE
UX: more apparent focus styles for sidebar headers, group chat count alignment

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -90,12 +90,16 @@
     }
 
     &.text {
-      border-radius: 3px;
+      border-radius: 100%;
       background: rgba(var(--primary-rgb), 0.1);
       text-align: center;
       font-size: var(--font-down-1);
-      padding: 0.2em 0.5em;
+      padding: 0.2em 0.47em;
       margin-right: 0.25em;
+      position: absolute;
+      + .sidebar-section-link-content-text {
+        margin-left: calc(20px + 0.5em);
+      }
     }
 
     &.icon {

--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -7,13 +7,6 @@
     box-sizing: border-box;
     padding: 0;
 
-    .discourse-no-touch & {
-      &:hover,
-      &:focus-within {
-        background: var(--d-sidebar-highlight-color);
-      }
-    }
-
     .select-kit {
       .btn {
         background: transparent;
@@ -58,9 +51,13 @@
 
     &.sidebar-section-header-collapsable {
       justify-content: flex-start;
-
+      .discourse-no-touch & {
+        &:hover {
+          background: var(--primary-200);
+        }
+      }
       &:focus {
-        background: transparent;
+        background: var(--primary-200);
       }
     }
   }
@@ -80,11 +77,12 @@
   }
 
   .sidebar-section-header-button {
-    background: none;
+    background: transparent;
     border: none;
-    padding: 0 var(--d-sidebar-row-horizontal-padding) 0
+    padding: calc(var(--d-sidebar-row-horizontal-padding) / 4)
+      var(--d-sidebar-row-horizontal-padding)
+      calc(var(--d-sidebar-row-horizontal-padding) / 4)
       calc(var(--d-sidebar-row-horizontal-padding) / 2);
-
     .d-icon {
       font-size: var(--font-down-1);
       color: var(--primary-medium);
@@ -94,6 +92,7 @@
       &:hover,
       &:focus {
         outline: none;
+        background: var(--primary-200);
         .d-icon {
           color: var(--primary);
         }


### PR DESCRIPTION
Ensuring the background changes on focus: 

![Screen Shot 2022-08-24 at 1 40 45 PM](https://user-images.githubusercontent.com/1681963/186486933-a7c8e718-bfb8-4495-a56b-d36d362b0112.png)
![Screen Shot 2022-08-24 at 1 40 39 PM](https://user-images.githubusercontent.com/1681963/186486934-afb4e807-dc05-4600-9f9b-50d058498130.png)

Matching group chat count with avatar styling:

![Screen Shot 2022-08-24 at 1 41 44 PM](https://user-images.githubusercontent.com/1681963/186487115-d5871a9c-f0a2-4639-9bee-136d1627cb8a.png)


