### PR TITLE
remove focus from sidebar header toggle click

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section.js
@@ -39,6 +39,11 @@ export default class SidebarSection extends Component {
     } else {
       this.keyValueStore.setItem(this.collapsedSidebarSectionKey, true);
     }
+
+    // remove focus from the toggle, but only on click
+    if (!event.key) {
+      document.activeElement.blur();
+    }
   }
 
   @action


### PR DESCRIPTION
Removing focus after click so that the related focus highlight doesn't stick around. For keyboard users the focus should stay so they can toggle again and retain focus position. 