### PR TITLE
FIX: remove unexpected scrollbar from the new user menu

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -94,28 +94,6 @@
   right: 0;
   width: 320px;
   padding: 0;
-  #quick-access-profile {
-    ul {
-      flex-wrap: nowrap;
-      height: 100%;
-      align-items: center;
-      overflow-y: auto; // really short viewports
-    }
-    li {
-      flex: 1 1 auto;
-      max-height: 3em; // prevent buttons from getting too tall
-      > * {
-        // button, a, and everything else
-        height: 100%;
-        align-items: center;
-        margin: 0;
-        padding: 0 0.5em;
-      }
-      .d-icon {
-        padding-top: 0;
-      }
-    }
-  }
 
   .panel-body-bottom {
     flex: 0;
@@ -207,6 +185,28 @@
 
   #quick-access-profile {
     display: inline;
+    max-height: 99%; //  macOS Chrome sometimes adds an unneeded scrollbar at 100%
+
+    ul {
+      flex-wrap: nowrap;
+      height: 100%;
+      align-items: center;
+      overflow-y: auto; // really short viewports
+    }
+    li {
+      flex: 1 1 auto;
+      max-height: 3em; // prevent buttons from getting too tall
+      > * {
+        // button, a, and everything else
+        height: 100%;
+        align-items: center;
+        margin: 0;
+        padding: 0 0.5em;
+      }
+      .d-icon {
+        padding-top: 0;
+      }
+    }
 
     .set-user-status {
       .emoji {
@@ -361,7 +361,7 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
-    max-height: 99%;
+    max-height: 100%;
     border-top: 1px solid var(--primary-low);
     padding-top: 0.75em;
     margin-top: -1px;

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -361,7 +361,7 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
-    max-height: 100%;
+    max-height: 99%;
     border-top: 1px solid var(--primary-low);
     padding-top: 0.75em;
     margin-top: -1px;


### PR DESCRIPTION
Looks like we have a rounding issue that provokes appearing a scrollbar on the new user menu:

![7ad02c6108d7911fdd0506b8070d8a88dc53ff54](https://user-images.githubusercontent.com/1274517/186746328-d9e5a60b-81ad-47cd-9a96-c063113918c2.png)

The problem seems to arose after merging #18079.

