### PR TITLE
FIX: Allow .git end to miss from Git repo URL

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
@@ -24,10 +24,7 @@ export default Controller.extend(ModalFunctionality, {
   keyGenUrl: "/admin/themes/generate_key_pair",
   importUrl: "/admin/themes/import",
   recordType: "theme",
-  checkPrivate: match(
-    "uploadUrl",
-    /^ssh\:\/\/.*\@.*(?:\.git)?$|.*\@.*\:.*(?:\.git)?$/
-  ),
+  checkPrivate: match("uploadUrl", /^ssh:\/\/.+@.+$|.+@.+:.+$/),
   localFile: null,
   uploadUrl: null,
   uploadName: null,

--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
@@ -24,7 +24,10 @@ export default Controller.extend(ModalFunctionality, {
   keyGenUrl: "/admin/themes/generate_key_pair",
   importUrl: "/admin/themes/import",
   recordType: "theme",
-  checkPrivate: match("uploadUrl", /^ssh\:\/\/.*\@.*\.git$|.*\@.*\:.*\.git$/),
+  checkPrivate: match(
+    "uploadUrl",
+    /^ssh\:\/\/.*\@.*(?:\.git)?$|.*\@.*\:.*(?:\.git)?$/
+  ),
   localFile: null,
   uploadUrl: null,
   uploadName: null,

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
@@ -79,6 +79,15 @@ acceptance("Admin - Themes - Install modal", function (needs) {
 
     await fillIn(urlInput, "git@github.com:discourse/discourse.git");
     assert.ok(query(publicKey), "shows public key for valid github repo url");
+
+    await fillIn(urlInput, "git@github.com:discourse/discourse");
+    assert.ok(query(publicKey), "shows public key for valid github repo url");
+
+    await fillIn(urlInput, "git@github.com/discourse/discourse");
+    assert.notOk(
+      query(publicKey),
+      "does not shows public key for valid github repo url"
+    );
   });
 
   test("modal can be auto-opened with the right query params", async function (assert) {


### PR DESCRIPTION
When installing private themes and theme components, the public key does
not show until the administrator types a valid Git repo URL. The regular
expression that checked the URL was too strict and it required the URL
to end with ".git".

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
