### PR TITLE
DEV: allow custom composer heights in CSS

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1236,7 +1236,9 @@ export default Controller.extend({
     }
 
     const defaultComposerHeight =
-      this.model.action === "reply" ? "300px" : "400px";
+      this.model.action === "reply"
+        ? "var(--reply-composer-height, 300px)"
+        : "var(--new-topic-composer-height, 400px)";
 
     this.set("model.composerHeight", defaultComposerHeight);
     document.documentElement.style.setProperty(

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1235,6 +1235,7 @@ export default Controller.extend({
       this.model.set("reply", opts.topicBody);
     }
 
+    // The two custom properties below can be overriden by themes/plugins to set different default composer heights.
     const defaultComposerHeight =
       this.model.action === "reply"
         ? "var(--reply-composer-height, 300px)"

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -65,7 +65,7 @@ acceptance("Composer", function (needs) {
 
     assert.strictEqual(
       document.documentElement.style.getPropertyValue("--composer-height"),
-      "400px",
+      "var(--new-topic-composer-height, 400px)",
       "sets --composer-height to 400px when creating topic"
     );
 
@@ -83,7 +83,7 @@ acceptance("Composer", function (needs) {
     await click(".toggle-fullscreen");
     assert.strictEqual(
       document.documentElement.style.getPropertyValue("--composer-height"),
-      "400px",
+      "var(--new-topic-composer-height, 400px)",
       "sets --composer-height back to 400px when composer is opened from draft mode"
     );
 


### PR DESCRIPTION
This sets the default composer heights as CSS custom property fallbacks. This means that if someone doesn't set a CSS custom property for these, we fallback to the same old values... but if a theme sets the properties, those will be used as the defaults instead. 