### PR TITLE
FEATURE: Replace the Lounge with the General category

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -648,8 +648,8 @@ en:
 
   uncategorized_category_name: "Uncategorized"
 
-  vip_category_name: "Lounge"
-  vip_category_description: "A category exclusive to members with trust level 3 and higher."
+  general_category_name: "General"
+  general_category_description: "Create topics here that don’t fit into any other existing category."
 
   meta_category_name: "Site Feedback"
   meta_category_description: "Discussion about this site, its organization, how it works, and how we can improve it."
@@ -673,30 +673,6 @@ en:
       <img src="%{base_path}/images/welcome/discourse-edit-post-animated.gif" width="508" height="106">
 
       You may want to close this topic via the admin :wrench: (at the upper right and bottom), so that replies don't pile up on an announcement.
-
-  lounge_welcome:
-    title: "Welcome to the Lounge"
-    body: |
-
-      Congratulations! :confetti_ball:
-
-      If you can see this topic, you were recently promoted to **regular** (trust level 3).
-
-      You can now &hellip;
-
-      * Edit the title of any topic
-      * Change the category of any topic
-      * Have all your links followed ([automatic nofollow](https://en.wikipedia.org/wiki/Nofollow) is removed)
-      * Access a private Lounge category only visible to users at trust level 3 and higher
-      * Hide spam with a single flag
-
-      Here's the [current list of fellow regulars](%{base_path}/badges/3/regular). Be sure to say hi.
-
-      Thanks for being an important part of this community!
-
-      (For more information on trust levels, [see this topic][trust]. Please note that only members who continue to meet the requirements over time will remain regulars.)
-
-      [trust]: https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/
 
   admin_quick_start_title: "READ ME FIRST: Admin Quick Start Guide"
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2263,7 +2263,7 @@ uncategorized:
     hidden: true
 
   # Category IDs
-  lounge_category_id:
+  general_category_id:
     default: -1
     hidden: true
   meta_category_id:
@@ -2335,9 +2335,6 @@ uncategorized:
     default: -1
     hidden: true
     client: true
-  lounge_welcome_topic_id:
-    default: -1
-    hidden: true
   admin_quick_start_topic_id:
     default: -1
     hidden: true

--- a/lib/seed_data/categories.rb
+++ b/lib/seed_data/categories.rb
@@ -77,14 +77,14 @@ module SeedData
           force_permissions: true
         },
         {
-          site_setting_name: 'lounge_category_id',
-          name: I18n.t('vip_category_name'),
-          description: I18n.t('vip_category_description'),
+          site_setting_name: 'general_category_id',
+          name: I18n.t('general_category_name'),
+          description: I18n.t('general_category_description'),
           position: 3,
-          color: 'A461EF',
-          text_color: '652D90',
-          permissions: { trust_level_3: :full },
-          force_permissions: false
+          color: '25AAE2',
+          text_color: 'FFFFFF',
+          permissions: { everyone: :full },
+          force_permissions: true
         }
       ]
 

--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -85,24 +85,14 @@ module SeedData
 
       if include_welcome_topics
         # Welcome Topic
-        topics << {
-          site_setting_name: 'welcome_topic_id',
-          title: I18n.t('discourse_welcome_topic.title'),
-          raw: I18n.t('discourse_welcome_topic.body', base_path: Discourse.base_path),
-          after_create: proc do |post|
-            post.topic.update_pinned(true, true)
-          end
-        }
-
-        # Lounge Welcome Topic
-        if lounge_category = Category.find_by(id: SiteSetting.lounge_category_id)
+        if general_category = Category.find_by(id: SiteSetting.general_category_id)
           topics << {
-            site_setting_name: 'lounge_welcome_topic_id',
-            title: I18n.t('lounge_welcome.title'),
-            raw: I18n.t('lounge_welcome.body', base_path: Discourse.base_path),
-            category: lounge_category,
+            site_setting_name: 'welcome_topic_id',
+            title: I18n.t('discourse_welcome_topic.title'),
+            raw: I18n.t('discourse_welcome_topic.body', base_path: Discourse.base_path),
+            category: general_category,
             after_create: proc do |post|
-              post.topic.update_pinned(true)
+              post.topic.update_pinned(true, true)
             end
           }
         end

--- a/spec/lib/seed_data/categories_spec.rb
+++ b/spec/lib/seed_data/categories_spec.rb
@@ -158,13 +158,13 @@ RSpec.describe SeedData::Categories do
   describe "#reseed_options" do
     it "returns only existing categories as options" do
       create_category("meta_category_id")
-      create_category("lounge_category_id")
+      create_category("general_category_id")
       Post.last.revise(Fabricate(:admin), raw: "Hello world")
 
       expected_options = [
         { id: "uncategorized_category_id", name: I18n.t("uncategorized_category_name"), selected: true },
         { id: "meta_category_id", name: I18n.t("meta_category_name"), selected: true },
-        { id: "lounge_category_id", name: I18n.t("vip_category_name"), selected: false }
+        { id: "general_category_id", name: I18n.t("general_category_name"), selected: false }
       ]
 
       expect(subject.reseed_options).to eq(expected_options)

--- a/spec/lib/seed_data/topics_spec.rb
+++ b/spec/lib/seed_data/topics_spec.rb
@@ -5,6 +5,11 @@ require 'seed_data/topics'
 RSpec.describe SeedData::Topics do
   subject { SeedData::Topics.with_default_locale }
 
+  before do
+    general_category = Fabricate(:category, name: "General")
+    SiteSetting.general_category_id = general_category.id
+  end
+
   def create_topic(name = "welcome_topic_id")
     subject.create(site_setting_names: [name])
   end
@@ -18,7 +23,7 @@ RSpec.describe SeedData::Topics do
       topic = Topic.last
       expect(topic.title).to eq(I18n.t("discourse_welcome_topic.title"))
       expect(topic.first_post.raw).to eq(I18n.t('discourse_welcome_topic.body', base_path: Discourse.base_path).rstrip)
-      expect(topic.category_id).to eq(SiteSetting.uncategorized_category_id)
+      expect(topic.category_id).to eq(SiteSetting.general_category_id)
       expect(topic.user_id).to eq(Discourse::SYSTEM_USER_ID)
       expect(topic.pinned_globally).to eq(true)
       expect(topic.pinned_at).to be_present


### PR DESCRIPTION
The first of a few PRs that will...

> provide new users (and new admins!) with defaults that provide a simplified, human-readable, straightforward experience. They are able to understand how the site is structured, where users go to join forum discussions, and have an example to follow when customizing the structure by adding more categories and tags. Any of these default categories can be deleted by the admin should they so desire. We also have a category to put the general chat channel that is accessible to all users on the site by default.

This PR:
- Seeds the General category so that the general chat channel will have
  a home
- Does not seed the Lounge category anymore
- Moves the "Welcome to Site" topic to the General category