### PR TITLE
Revert "Build(deps): Bump jwt from 2.4.1 to 2.5.0 (#18095)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       uri_template (~> 0.7)
-    jwt (2.5.0)
+    jwt (2.4.1)
     kgio (2.11.4)
     libv8-node (16.10.0.0)
     libv8-node (16.10.0.0-aarch64-linux)


### PR DESCRIPTION
This reverts commit 9c7274997fdb5a3571c57c72a932e9176847f98c.

THe upgrade broke the build. I thought it was a flaky test when I merged.