### PR TITLE
UX: Remove focus on hamburger icon after toggle

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -596,9 +596,14 @@ export default createWidget("header", {
       this.state.hamburgerVisible = !this.state.hamburgerVisible;
       this.toggleBodyScrolling(this.state.hamburgerVisible);
 
-      // auto focus on first link in dropdown
       schedule("afterRender", () => {
-        document.querySelector(".hamburger-panel .menu-links a")?.focus();
+        if (this.siteSettings.enable_experimental_sidebar_hamburger) {
+          // Remove focus from hamburger toggle button
+          document.querySelector("#toggle-hamburger-menu").blur();
+        } else {
+          // auto focus on first link in dropdown
+          document.querySelector(".hamburger-panel .menu-links a")?.focus();
+        }
       });
     }
   },


### PR DESCRIPTION
No tests here because I can't seem to detect the `activeElement` in the acceptance test correctly. Even if this regressed, it isn't the end of the world so I'm just accepting risk here.

### Before

![Peek 2022-08-26 15-19](https://user-images.githubusercontent.com/4335742/186845543-6234b565-83b2-475b-b1b7-40e104150cc9.gif)

### After

![Peek 2022-08-26 15-20](https://user-images.githubusercontent.com/4335742/186845555-781389cf-bb8b-4e1e-9eea-80dbee569ccf.gif)
