### PR TITLE
FIX: Do not notify admins watching PM tags

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -170,6 +170,8 @@ class PostAlerter
 
       if topic.present?
         watchers = category_watchers(topic) + tag_watchers(topic) + group_watchers(topic)
+        # Notify only users who can see the topic
+        watchers &= topic.all_allowed_users.pluck(:id) if post.topic.private_message?
         notify_first_post_watchers(post, watchers)
       end
     end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -2004,4 +2004,33 @@ RSpec.describe PostAlerter do
       expect(liked_notification.data_hash[:custom_key]).to eq(custom_data)
     end
   end
+
+  it "does not create notifications for PMs if not invited" do
+    SiteSetting.pm_tags_allowed_for_groups = "#{Group::AUTO_GROUPS[:everyone]}"
+    tag_1 = Fabricate(:tag)
+    TagUser.change(admin.id, tag_1.id, TagUser.notification_levels[:watching_first_post])
+    tag_2 = Fabricate(:tag)
+    TagUser.change(admin.id, tag_2.id, TagUser.notification_levels[:watching])
+
+    post = create_post(tags: [tag_1.name, tag_2.name], archetype: Archetype.private_message, target_usernames: "#{evil_trout.username}")
+    expect { PostAlerter.new.after_save_post(post, true) }.to change { Notification.count }.by(1)
+
+    expect(
+      Notification.exists?(
+        user: evil_trout,
+        notification_type: Notification.types[:private_message],
+        topic: post.topic,
+        post_number: 1,
+      ),
+    ).to eq(true)
+
+    expect(
+      Notification.exists?(
+        user: admin,
+        notification_type: Notification.types[:watching_first_post],
+        topic: post.topic,
+        post_number: 1,
+      ),
+    ).to eq(false)
+  end
 end


### PR DESCRIPTION
Admins received notifications if a PM was tagged with a tag they
watched even if they were not invited to the PM.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
