### PR TITLE
FIX: Keep private theme key secret from admins

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
@@ -93,10 +93,7 @@ export default Controller.extend(ModalFunctionality, {
       this._keyLoading = true;
       ajax(this.keyGenUrl, { type: "POST" })
         .then((pair) => {
-          this.setProperties({
-            privateKey: pair.private_key,
-            publicKey: pair.public_key,
-          });
+          this.set("publicKey", pair.public_key);
         })
         .catch(popupAjaxError)
         .finally(() => {
@@ -139,7 +136,6 @@ export default Controller.extend(ModalFunctionality, {
     this.setProperties({
       duplicateRemoteThemeWarning: null,
       privateChecked: false,
-      privateKey: null,
       localFile: null,
       uploadUrl: null,
       publicKey: null,
@@ -216,7 +212,7 @@ export default Controller.extend(ModalFunctionality, {
         };
 
         if (this.privateChecked) {
-          options.data.private_key = this.privateKey;
+          options.data.public_key = this.publicKey;
         }
       }
 
@@ -239,10 +235,10 @@ export default Controller.extend(ModalFunctionality, {
           this.send("closeModal");
         })
         .then(() => {
-          this.setProperties({ privateKey: null, publicKey: null });
+          this.set("publicKey", null);
         })
         .catch((error) => {
-          if (!this.privateKey || this.themeCannotBeInstalled) {
+          if (!this.publicKey || this.themeCannotBeInstalled) {
             return popupAjaxError(error);
           }
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -82,6 +82,7 @@ en:
       file_too_big: "The uncompressed file is too big."
       unknown_file_type: "The file you uploaded does not appear to be a valid Discourse theme."
       not_allowed_theme: "`%{repo}` is not in the list of allowed themes (check `allowed_theme_repos` global setting)."
+      ssh_key_gone: "You waited too long to install the theme and SSH key expired. Please try again."
     errors:
       component_no_user_selectable: "Theme components can't be user-selectable"
       component_no_default: "Theme components can't be default theme"


### PR DESCRIPTION
Installing private themes (from a private Git repository) needs a RSA
keypair. The public key is added to GitHub and the private key is kept
for authentication.

The generate RSA key and import theme routes worked separate from each
other. The RSA key returned both the public and private key and it was
the frontend which posted the private key back to the server. With this
commit, only the public key is necessary as the server keeps a map of
public and private keys that is used to get the private key back from
a public key.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
