### PR TITLE
FIX: Show tag chooser if can_tag_pms

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -204,14 +204,17 @@ export default Controller.extend({
 
   @discourseComputed("model.canEditTitle", "model.creatingPrivateMessage")
   canEditTags(canEditTitle, creatingPrivateMessage) {
-    if (creatingPrivateMessage && (this.site.mobileView || !this.isStaffUser)) {
+    if (creatingPrivateMessage && this.site.mobileView) {
       return false;
     }
 
+    const isPrivateMessage =
+      creatingPrivateMessage || this.get("model.topic.isPrivateMessage");
+
     return (
-      this.site.can_tag_topics &&
       canEditTitle &&
-      (!this.get("model.topic.isPrivateMessage") || this.site.can_tag_pms)
+      this.site.can_tag_topics &&
+      (!isPrivateMessage || this.site.can_tag_pms)
     );
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-tags-test.js
@@ -1,5 +1,6 @@
 import {
   acceptance,
+  exists,
   query,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -97,5 +98,29 @@ acceptance("Composer - Tags", function (needs) {
 
     await click("#reply-control button.create");
     assert.notStrictEqual(currentURL(), "/");
+  });
+
+  test("users who cannot tag PMs do not see the selector", async function (assert) {
+    await visit("/u/charlie");
+    await click("button.compose-pm");
+
+    assert.notOk(exists(".composer-fields .mini-tag-chooser"));
+  });
+});
+
+acceptance("Composer - Tags (PMs)", function (needs) {
+  needs.user();
+  needs.pretender((server, helper) => {
+    server.post("/uploads/lookup-urls", () => {
+      return helper.response([]);
+    });
+  });
+  needs.site({ can_tag_topics: true, can_tag_pms: true });
+
+  test("users who can tag PMs see the selector", async function (assert) {
+    await visit("/u/charlie");
+    await click("button.compose-pm");
+
+    assert.ok(exists(".composer-fields .mini-tag-chooser"));
   });
 });


### PR DESCRIPTION
The old logic did not make sense and hid the selector from regular users
even if they could tag PMs or showed selector for admins even if they
could not tag PMs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
