### PR TITLE
FIX: LocalJumpError : unexpected return

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -630,12 +630,13 @@ class GroupsController < ApplicationController
             .permit(:host, :port, :username, :password, :ssl, :debug)
           EmailSettingsValidator.validate_as_user(current_user, "imap", **final_settings.to_h.symbolize_keys)
         end
+
+        render json: success_json
       rescue *EmailSettingsExceptionHandler::EXPECTED_EXCEPTIONS, StandardError => err
-        return render_json_error(
+        render_json_error(
           EmailSettingsExceptionHandler.friendly_exception_message(err, email_host)
         )
       end
-      render json: success_json
     end
   end
 


### PR DESCRIPTION
Error:

```
Failed to process hijacked response correctly : LocalJumpError : unexpected return

/var/www/discourse/app/controllers/groups_controller.rb:634:in `rescue in block in test_email_settings'
/var/www/discourse/app/controllers/groups_controller.rb:619:in `block in test_email_settings'
/var/www/discourse/lib/hijack.rb:56:in `instance_eval'
/var/www/discourse/lib/hijack.rb:56:in `block in hijack'
/var/www/discourse/lib/scheduler/defer.rb:94:in `block in do_work'
rails_multisite-4.0.1/lib/rails_multisite/connection_management.rb:80:in `with_connection'
/var/www/discourse/lib/scheduler/defer.rb:89:in `do_work'
/var/www/discourse/lib/scheduler/defer.rb:79:in `block (2 levels) in start_thread'
```