### PR TITLE
DEV: Ensure experimental user menu tabs don't go off screen

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -150,6 +150,7 @@
     padding: 0.75em;
     justify-content: space-between;
     box-sizing: border-box;
+    min-width: 0; // makes sure menu tabs don't go off screen
 
     .double-user,
     .multi-user {


### PR DESCRIPTION
In the experimental user menu, when there's a notification with a very long word in its title, the menu tabs go off-screen:

<img src="https://user-images.githubusercontent.com/17474474/187108200-9911c6b9-e193-44e3-80d0-8634b16de7d4.png" width=350>

This fix ensures that the tabs are always on-screen regardless of the menu content is:

<img src="https://user-images.githubusercontent.com/17474474/187108227-cb8ada03-a38a-41ab-b7b1-ed8d4a25d366.png" width=350>
