### PR TITLE
DEV: Include reaction notifications in the likes tab

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/likes-notifications-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/likes-notifications-list.js
@@ -2,7 +2,10 @@ import UserMenuNotificationsList from "discourse/components/user-menu/notificati
 
 export default class UserMenuLikesNotificationsList extends UserMenuNotificationsList {
   get filterByTypes() {
-    return ["liked", "liked_consolidated"];
+    // TODO(osama): reaction is a type used by the reactions plugin, but it's
+    // added here temporarily unitl we add a plugin API for extending
+    // filterByTypes in lists
+    return ["liked", "liked_consolidated", "reaction"];
   }
 
   get dismissTypes() {

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
@@ -181,7 +181,9 @@ module("Integration | Component | user-menu", function (hooks) {
             },
           },
         ];
-      } else if (queryParams.filter_by_types === "liked,liked_consolidated") {
+      } else if (
+        queryParams.filter_by_types === "liked,liked_consolidated,reaction"
+      ) {
         data = [
           {
             id: 60,
@@ -278,8 +280,8 @@ module("Integration | Component | user-menu", function (hooks) {
     assert.ok(exists("#quick-access-likes.quick-access-panel"));
     assert.strictEqual(
       queryParams.filter_by_types,
-      "liked,liked_consolidated",
-      "request params has filter_by_types set to `liked` and `liked_consolidated"
+      "liked,liked_consolidated,reaction",
+      "request params has filter_by_types set to `liked`, `liked_consolidated` and `reaction`"
     );
     assert.strictEqual(queryParams.silent, "true");
     activeTabs = queryAll(".top-tabs .btn.active");


### PR DESCRIPTION
This is a temporary workaround for the experimental user menu to make the likes tab display reaction notifications. We'll remove the `reaction` type reference from the `likes-notifications-list.js` file when we have a plugin API that the reactions plugin can use to add its type to the likes tab.