### PR TITLE
FIX: reload styling changes for wizard styling step

### DIFF
--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -183,6 +183,7 @@ class Wizard
           if scheme.is_dark?
             updater.update_setting(:default_dark_mode_color_scheme_id, -1)
           end
+          updater.refresh_required = true
         end
       end
 

--- a/spec/lib/wizard/step_updater_spec.rb
+++ b/spec/lib/wizard/step_updater_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe Wizard::StepUpdater do
           updater.update
           expect(updater.success?).to eq(true)
           expect(wizard.completed_steps?('styling')).to eq(true)
+          expect(updater.refresh_required?).to eq(true)
           theme = Theme.find_by(id: SiteSetting.default_theme_id)
           expect(theme.color_scheme.base_scheme_id).to eq('Dark')
         end
@@ -112,6 +113,7 @@ RSpec.describe Wizard::StepUpdater do
             homepage_style: 'latest'
           )
           expect { updater.update }.not_to change { Theme.count }
+          expect(updater.refresh_required?).to eq(true)
           theme.reload
           expect(theme.color_scheme.base_scheme_id).to eq('Neutral')
         end


### PR DESCRIPTION
Currently the theme styling changes in wizard are not getting reflected until the site is refreshed manually. This commit will trigger changes on client side to reflect the theme changes instantaneously.