### PR TITLE
FIX: Preload topic_list correctly for categories+latest

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-categories.js
@@ -77,7 +77,7 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
   _findCategoriesAndTopics(filter) {
     return hash({
       wrappedCategoriesList: PreloadStore.getAndRemove("categories_list"),
-      topicsList: PreloadStore.getAndRemove(`topic_list_${filter}`),
+      topicsList: PreloadStore.getAndRemove("topic_list"),
     }).then((response) => {
       let { wrappedCategoriesList, topicsList } = response;
       let categoriesList =


### PR DESCRIPTION
The preload key was changed in e7a84948b9 but this location was missed. This caused an extra AJAX request and left the cached topic list in the PreloadStore, which would then be accidentally used when navigating to the next topic-list route.

Reported at https://meta.discourse.org/t/237126

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
