### PR TITLE
FIX: Do not invite whisper or small action posters

### DIFF
--- a/app/models/topic_converter.rb
+++ b/app/models/topic_converter.rb
@@ -63,7 +63,9 @@ class TopicConverter
   private
 
   def posters
-    @posters ||= @topic.posts.distinct.pluck(:user_id)
+    @posters ||= @topic.posts
+      .where.not(post_type: [Post.types[:small_action], Post.types[:whisper]])
+      .distinct.pluck(:user_id)
   end
 
   def increment_users_post_count

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -169,6 +169,17 @@ RSpec.describe TopicConverter do
         expect(topic_user.reload.notification_level).to eq(TopicUser.notification_levels[:watching])
       end
 
+      it "invites only users with regular posts" do
+        post2 = Fabricate(:post, topic: topic)
+        whipser_post = Fabricate(:post, topic: topic, post_type: Post.types[:whisper])
+        small_action_post = Fabricate(:post, topic: topic, post_type: Post.types[:small_action])
+
+        topic.convert_to_private_message(admin)
+
+        expect(topic.reload.topic_allowed_users.pluck(:user_id))
+          .to contain_exactly(admin.id, post.user_id, post2.user_id)
+      end
+
       it "changes user_action type" do
         Jobs.run_immediately!
         UserActionManager.enable


### PR DESCRIPTION
If a topic is converted to a private message, all posters were invited
to the new private message. This included users who only whispered or
posted small actions.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
