### PR TITLE
FIX: hide welcome topic banner as soon as the welcome topic is edited

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
+++ b/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
@@ -5,7 +5,7 @@ export default {
   initialize(container) {
     const site = container.lookup("service:site");
 
-    if (site.get("show_welcome_topic_banner")) {
+    if (site.show_welcome_topic_banner) {
       const messageBus = container.lookup("service:message-bus");
       messageBus.subscribe("/site/welcome-topic-banner", function (disabled) {
         site.set("show_welcome_topic_banner", disabled);

--- a/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
+++ b/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
@@ -1,0 +1,16 @@
+export default {
+  name: "welcome-topic-banner",
+  after: "message-bus",
+
+  initialize(container) {
+    const messageBus = container.lookup("service:message-bus");
+    if (!messageBus) {
+      return;
+    }
+
+    const site = container.lookup("service:site");
+    messageBus.subscribe("/site/welcome-topic-banner", function (disabled) {
+      site.set("show_welcome_topic_banner", disabled);
+    });
+  },
+};

--- a/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
+++ b/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
@@ -3,13 +3,13 @@ export default {
   after: "message-bus",
 
   initialize(container) {
-    const messageBus = container.lookup("service:message-bus");
-    if (!messageBus) {
-      return;
-    }
-
     const site = container.lookup("service:site");
+
     if (site.get("show_welcome_topic_banner")) {
+      const messageBus = container.lookup("service:message-bus");
+      if (!messageBus) {
+        return;
+      }
       messageBus.subscribe("/site/welcome-topic-banner", function (disabled) {
         site.set("show_welcome_topic_banner", disabled);
       });

--- a/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
+++ b/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
@@ -7,9 +7,6 @@ export default {
 
     if (site.get("show_welcome_topic_banner")) {
       const messageBus = container.lookup("service:message-bus");
-      if (!messageBus) {
-        return;
-      }
       messageBus.subscribe("/site/welcome-topic-banner", function (disabled) {
         site.set("show_welcome_topic_banner", disabled);
       });

--- a/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
+++ b/app/assets/javascripts/discourse/app/initializers/welcome-topic-banner.js
@@ -9,8 +9,10 @@ export default {
     }
 
     const site = container.lookup("service:site");
-    messageBus.subscribe("/site/welcome-topic-banner", function (disabled) {
-      site.set("show_welcome_topic_banner", disabled);
-    });
+    if (site.get("show_welcome_topic_banner")) {
+      messageBus.subscribe("/site/welcome-topic-banner", function (disabled) {
+        site.set("show_welcome_topic_banner", disabled);
+      });
+    }
   },
 };

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -203,10 +203,24 @@ class Site
     MessageBus.publish(SITE_JSON_CHANNEL, '')
   end
 
+  def self.welcome_topic_banner_cache_key(user_id)
+    "show_welcome_topic_banner:#{user_id}"
+  end
+
   def self.show_welcome_topic_banner?(guardian)
     return false unless guardian.is_admin?
-    return false unless guardian.user.id == User.first_login_admin_id
+    user_id = guardian.user.id
 
-    Post.find_by("topic_id = :topic_id AND post_number = 1 AND version = 1 AND created_at > :created_at", topic_id: SiteSetting.welcome_topic_id, created_at: 1.month.ago).present?
+    show_welcome_topic_banner = Discourse.cache.read(welcome_topic_banner_cache_key(user_id))
+    return show_welcome_topic_banner unless show_welcome_topic_banner.nil?
+
+    show_welcome_topic_banner = if (user_id == User.first_login_admin_id)
+      Post.find_by("topic_id = :topic_id AND post_number = 1 AND version = 1 AND created_at > :created_at", topic_id: SiteSetting.welcome_topic_id, created_at: 1.month.ago).present?
+    else
+      false
+    end
+
+    Discourse.cache.write(welcome_topic_banner_cache_key(user_id), show_welcome_topic_banner)
+    show_welcome_topic_banner
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -208,7 +208,7 @@ class Site
   end
 
   def self.show_welcome_topic_banner?(guardian)
-    return false unless guardian.is_admin?
+    return false if !guardian.is_admin?
     user_id = guardian.user.id
 
     show_welcome_topic_banner = Discourse.cache.read(welcome_topic_banner_cache_key(user_id))

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -630,6 +630,7 @@ class PostRevisor
 
     update_topic_excerpt
     update_category_description
+    hide_welcome_topic_banner
   end
 
   def update_topic_excerpt
@@ -649,6 +650,14 @@ class PostRevisor
     else
       @post.errors.add(:base, I18n.t("category.errors.description_incomplete"))
     end
+  end
+
+  def hide_welcome_topic_banner
+    return false unless guardian.is_admin?
+    return false unless guardian.user.id == User.first_login_admin_id
+    return false unless @topic.id == SiteSetting.welcome_topic_id
+
+    MessageBus.publish("/site/welcome-topic-banner", false)
   end
 
   def advance_draft_sequence

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -653,10 +653,11 @@ class PostRevisor
   end
 
   def hide_welcome_topic_banner
-    return false unless guardian.is_admin?
-    return false unless guardian.user.id == User.first_login_admin_id
-    return false unless @topic.id == SiteSetting.welcome_topic_id
+    return unless guardian.is_admin?
+    return unless @topic.id == SiteSetting.welcome_topic_id
+    return unless Discourse.cache.read(Site.welcome_topic_banner_cache_key(@editor.id))
 
+    Discourse.cache.write(Site.welcome_topic_banner_cache_key(@editor.id), false)
     MessageBus.publish("/site/welcome-topic-banner", false)
   end
 

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -696,7 +696,7 @@ RSpec.describe PostRevisor do
     describe "topic excerpt" do
       it "topic excerpt is updated only if first post is revised" do
         revisor = PostRevisor.new(post)
-        first_post = topic.posts.by_post_number.first
+        first_post = topic.first_post
         expect {
           revisor.revise!(first_post.user, { raw: 'Edit the first post' }, revised_at: first_post.updated_at + 10.seconds)
           topic.reload
@@ -714,9 +714,9 @@ RSpec.describe PostRevisor do
         SiteSetting.welcome_topic_id = topic.id
       end
 
-      it "should publish welcome topic change to clients" do
+      it "should publish welcome topic edit message" do
         revisor = PostRevisor.new(post)
-        first_post = topic.posts.by_post_number.first
+        first_post = topic.first_post
         UserAuthToken.generate!(user_id: admin.id)
 
         messages = MessageBus.track_publish("/site/welcome-topic-banner") do
@@ -724,6 +724,7 @@ RSpec.describe PostRevisor do
         end
         welcome_topic_banner_message = messages.find { |message| message.channel == "/site/welcome-topic-banner" }
         expect(welcome_topic_banner_message).to be_present
+        expect(welcome_topic_banner_message.data).to eq(false)
       end
     end
 

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -718,6 +718,7 @@ RSpec.describe PostRevisor do
         revisor = PostRevisor.new(post)
         first_post = topic.first_post
         UserAuthToken.generate!(user_id: admin.id)
+        Discourse.cache.write(Site.welcome_topic_banner_cache_key(admin.id), true)
 
         messages = MessageBus.track_publish("/site/welcome-topic-banner") do
           revisor.revise!(admin, { raw: 'updated welcome topic body' })

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -192,10 +192,12 @@ RSpec.describe Site do
     end
 
     it "returns false when the user is not first admin who logs in" do
+      admin = Fabricate(:admin)
       first_post = Fabricate(:post, created_at: 25.days.ago)
       SiteSetting.welcome_topic_id = first_post.topic.id
 
-      expect(Site.show_welcome_topic_banner?(Guardian.new(Fabricate(:admin)))).to eq(false)
+      expect(Site.show_welcome_topic_banner?(Guardian.new(admin))).to eq(false)
+      expect(Discourse.cache.read(Site.welcome_topic_banner_cache_key(admin.id))).to eq(false)
     end
 
     it "returns true when welcome topic is less than month old" do
@@ -206,6 +208,7 @@ RSpec.describe Site do
       SiteSetting.welcome_topic_id = first_post.topic.id
 
       expect(Site.show_welcome_topic_banner?(Guardian.new(admin))).to eq(true)
+      expect(Discourse.cache.read(Site.welcome_topic_banner_cache_key(admin.id))).to eq(true)
     end
 
     it "returns false when welcome topic is more than month old" do
@@ -216,6 +219,7 @@ RSpec.describe Site do
       SiteSetting.welcome_topic_id = first_post.topic.id
 
       expect(Site.show_welcome_topic_banner?(Guardian.new(admin))).to eq(false)
+      expect(Discourse.cache.read(Site.welcome_topic_banner_cache_key(admin.id))).to eq(false)
     end
 
     it "returns false when welcome topic has been edited" do
@@ -226,6 +230,7 @@ RSpec.describe Site do
       SiteSetting.welcome_topic_id = first_post.topic.id
 
       expect(Site.show_welcome_topic_banner?(Guardian.new(admin))).to eq(false)
+      expect(Discourse.cache.read(Site.welcome_topic_banner_cache_key(admin.id))).to eq(false)
     end
   end
 


### PR DESCRIPTION
This commit adds a message bus listener on client to hide the welcome
topic banner as soon as the welcome topic is edited.