### PR TITLE
FIX: Only seed general category on new sites

### DIFF
--- a/lib/seed_data/categories.rb
+++ b/lib/seed_data/categories.rb
@@ -128,6 +128,8 @@ module SeedData
     end
 
     def should_create_category?(category_id, force_existence)
+      return false if User.last.id > 0
+
       if category_id > 0
         force_existence ? !Category.exists?(category_id) : false
       else

--- a/lib/seed_data/categories.rb
+++ b/lib/seed_data/categories.rb
@@ -128,7 +128,7 @@ module SeedData
     end
 
     def should_create_category?(category_id, force_existence)
-      return false if User.last.id > 0
+      return false if User.human_users.any?
 
       if category_id > 0
         force_existence ? !Category.exists?(category_id) : false

--- a/spec/lib/seed_data/categories_spec.rb
+++ b/spec/lib/seed_data/categories_spec.rb
@@ -93,6 +93,22 @@ RSpec.describe SeedData::Categories do
       end
     end
 
+    it "does not seed the general category for non-new sites" do
+      Fabricate(:user) # If the site has human users don't seed
+
+      expect { create_category("general_category_id") }
+        .to not_change { Category.count }
+        .and not_change { Topic.count }
+    end
+
+    it "seeds the general category for new sites" do
+      expect { create_category("general_category_id") }
+        .to change { Category.count }
+        .and change { Topic.count }
+
+      expect(Category.last.name).to eq("General")
+    end
+
     it "does not override permissions of existing category when not forced" do
       create_category("lounge_category_id")
 


### PR DESCRIPTION
If the site already has human users (users with an id > 0) don't seed
the categories.

Follow up to: a6ad74c759f8e4f785dbcdb38c05f78d43c4128f
