### PR TITLE
DEV: Use DiscourseJsProcessor for theme template compilation

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/raw-handlebars.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/raw-handlebars.js
@@ -73,9 +73,10 @@ if (Handlebars.Compiler) {
     RawHandlebars.JavaScriptCompiler;
   RawHandlebars.JavaScriptCompiler.prototype.namespace = "RawHandlebars";
 
-  RawHandlebars.precompile = function (value, asObject) {
+  RawHandlebars.precompile = function (value, asObject, { plugins = [] } = {}) {
     let ast = Handlebars.parse(value);
     replaceGet(ast);
+    plugins.forEach((plugin) => plugin(ast));
 
     let options = {
       knownHelpers: {
@@ -96,9 +97,10 @@ if (Handlebars.Compiler) {
     );
   };
 
-  RawHandlebars.compile = function (string) {
+  RawHandlebars.compile = function (string, { plugins = [] } = {}) {
     let ast = Handlebars.parse(string);
     replaceGet(ast);
+    plugins.forEach((plugin) => plugin(ast));
 
     // this forces us to rewrite helpers
     let options = { data: true, stringParams: true };

--- a/app/assets/javascripts/discourse-js-processor.js
+++ b/app/assets/javascripts/discourse-js-processor.js
@@ -1,0 +1,110 @@
+/* global Babel:true */
+
+// This is executed in mini_racer to provide the JS logic for lib/discourse_js_processor.rb
+
+const makeEmberTemplateCompilerPlugin =
+  require("babel-plugin-ember-template-compilation").default;
+const precompile = require("ember-template-compiler").precompile;
+const Handlebars = require("handlebars").default;
+
+function manipulateAstNodeForTheme(node, themeId) {
+  // Magically add theme id as the first param for each of these helpers)
+  if (
+    node.path.parts &&
+    ["theme-i18n", "theme-prefix", "theme-setting"].includes(node.path.parts[0])
+  ) {
+    if (node.params.length === 1) {
+      node.params.unshift({
+        type: "NumberLiteral",
+        value: themeId,
+        original: themeId,
+        loc: { start: {}, end: {} },
+      });
+    }
+  }
+}
+
+function buildEmberTemplateManipulatorPlugin(themeId) {
+  return function () {
+    return {
+      name: "theme-template-manipulator",
+      visitor: {
+        SubExpression: (node) => manipulateAstNodeForTheme(node, themeId),
+        MustacheStatement: (node) => manipulateAstNodeForTheme(node, themeId),
+      },
+    };
+  };
+}
+
+function buildTemplateCompilerBabelPlugins({ themeId }) {
+  let compileFunction = precompile;
+  if (themeId) {
+    compileFunction = (src, opts) => {
+      return precompile(src, {
+        ...opts,
+        plugins: {
+          ast: [buildEmberTemplateManipulatorPlugin(themeId)],
+        },
+      });
+    };
+  }
+
+  return [
+    require("widget-hbs-compiler").WidgetHbsCompiler,
+    [
+      makeEmberTemplateCompilerPlugin(() => compileFunction),
+      { enableLegacyModules: ["ember-cli-htmlbars"] },
+    ],
+  ];
+}
+
+function buildThemeRawHbsTemplateManipulatorPlugin(themeId) {
+  return function (ast) {
+    ["SubExpression", "MustacheStatement"].forEach((pass) => {
+      let visitor = new Handlebars.Visitor();
+      visitor.mutating = true;
+      visitor[pass] = (node) => manipulateAstNodeForTheme(node, themeId);
+      visitor.accept(ast);
+    });
+  };
+}
+
+exports.compileRawTemplate = function (source, themeId) {
+  try {
+    const RawHandlebars = require("raw-handlebars").default;
+    const plugins = [];
+    if (themeId) {
+      plugins.push(buildThemeRawHbsTemplateManipulatorPlugin(themeId));
+    }
+    return RawHandlebars.precompile(source, false, { plugins }).toString();
+  } catch (error) {
+    // Workaround for https://github.com/rubyjs/mini_racer/issues/262
+    error.message = JSON.stringify(error.message);
+    throw error;
+  }
+};
+
+exports.transpile = function (
+  source,
+  { moduleId, filename, skipModule, themeId, commonPlugins } = {}
+) {
+  const plugins = [];
+  plugins.push(...buildTemplateCompilerBabelPlugins({ themeId }));
+  if (moduleId && !skipModule) {
+    plugins.push(["transform-modules-amd", { noInterop: true }]);
+  }
+  plugins.push(...commonPlugins);
+
+  try {
+    return Babel.transform(source, {
+      moduleId,
+      filename,
+      ast: false,
+      plugins,
+    }).code;
+  } catch (error) {
+    // Workaround for https://github.com/rubyjs/mini_racer/issues/262
+    error.message = JSON.stringify(error.message);
+    throw error;
+  }
+};

--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
@@ -10,10 +10,12 @@
   const discoursePrefixLength = discoursePrefix.length;
 
   const pluginRegex = /^discourse\/plugins\/([^\/]+)\//;
+  const themeRegex = /^discourse\/theme-([^\/]+)\//;
 
   Object.keys(requirejs.entries).forEach(function (key) {
     let templateKey;
     let pluginName;
+    let themeId;
     if (key.startsWith(discoursePrefix)) {
       templateKey = key.slice(discoursePrefixLength);
     } else if (key.startsWith(adminPrefix) || key.startsWith(wizardPrefix)) {
@@ -28,6 +30,16 @@
       templateKey = key.slice(`discourse/plugins/${pluginName}/`.length);
       templateKey = templateKey.replace("discourse/templates/", "");
       templateKey = `javascripts/${templateKey}`;
+    } else if (
+      (themeId = key.match(themeRegex)?.[1]) &&
+      key.includes("/templates/")
+    ) {
+      // And likewise for themes - this mimics the old logic
+      templateKey = key.slice(`discourse/theme-${themeId}/`.length);
+      templateKey = templateKey.replace("discourse/templates/", "");
+      if (!templateKey.startsWith("javascripts/")) {
+        templateKey = `javascripts/${templateKey}`;
+      }
     }
 
     if (templateKey) {

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require 'json_schemer'
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 60
+  BASE_COMPILER_VERSION = 61
 
   attr_accessor :child_components
 

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -164,7 +164,7 @@ class ThemeField < ActiveRecord::Base
       when "js.es6", "js"
         js_compiler.append_module(content, filename, include_variables: true)
       when "hbs"
-        js_compiler.append_ember_template(filename.sub("discourse/templates/", ""), content)
+        js_compiler.append_ember_template(filename, content)
       when "hbr", "raw.hbs"
         js_compiler.append_raw_template(filename.sub("discourse/templates/", ""), content)
       else

--- a/spec/lib/discourse_js_processor_spec.rb
+++ b/spec/lib/discourse_js_processor_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe DiscourseJsProcessor do
         standard_compile "{{theme-setting #{theme_id} 'setting_key'}}"
       )
 
-      # # Works when used inside other statements
+      # Works when used inside other statements
       expect(
         theme_compile "{{dummy-helper (theme-prefix 'translation_key')}}"
       ).to eq(

--- a/spec/lib/discourse_js_processor_spec.rb
+++ b/spec/lib/discourse_js_processor_spec.rb
@@ -78,4 +78,111 @@ RSpec.describe DiscourseJsProcessor do
       });
     JS
   end
+
+  describe "Raw template theme transformations" do
+    # For the raw templates, we can easily render them serverside, so let's do that
+
+    let(:compiler) { DiscourseJsProcessor::Transpiler.new }
+    let(:theme_id) { 22 }
+
+    let(:helpers) {
+      <<~JS
+      Handlebars.registerHelper('theme-prefix', function(themeId, string) {
+        return `theme_translations.${themeId}.${string}`
+      })
+      Handlebars.registerHelper('theme-i18n', function(themeId, string) {
+        return `translated(theme_translations.${themeId}.${string})`
+      })
+      Handlebars.registerHelper('theme-setting', function(themeId, string) {
+        return `setting(${themeId}:${string})`
+      })
+      Handlebars.registerHelper('dummy-helper', function(string) {
+        return `dummy(${string})`
+      })
+      JS
+    }
+
+    let(:mini_racer) {
+      ctx = MiniRacer::Context.new
+      ctx.eval(File.open("#{Rails.root}/app/assets/javascripts/node_modules/handlebars/dist/handlebars.js").read)
+      ctx.eval(helpers)
+      ctx
+    }
+
+    def render(template)
+      compiled = compiler.compile_raw_template(template, theme_id: theme_id)
+      mini_racer.eval "Handlebars.template(#{compiled.squish})({})"
+    end
+
+    it 'adds the theme id to the helpers' do
+      # Works normally
+      expect(render("{{theme-prefix 'translation_key'}}")).
+        to eq('theme_translations.22.translation_key')
+      expect(render("{{theme-i18n 'translation_key'}}")).
+        to eq('translated(theme_translations.22.translation_key)')
+      expect(render("{{theme-setting 'setting_key'}}")).
+        to eq('setting(22:setting_key)')
+
+      # Works when used inside other statements
+      expect(render("{{dummy-helper (theme-prefix 'translation_key')}}")).
+        to eq('dummy(theme_translations.22.translation_key)')
+    end
+
+    it "doesn't duplicate number parameter inside {{each}}" do
+      expect(compiler.compile_raw_template("{{#each item as |test test2|}}{{theme-setting 'setting_key'}}{{/each}}", theme_id: theme_id)).
+        to include('{"name":"theme-setting","hash":{},"hashTypes":{},"hashContexts":{},"types":["NumberLiteral","StringLiteral"]')
+      # Fail would be if theme-setting is defined with types:["NumberLiteral","NumberLiteral","StringLiteral"]
+    end
+  end
+
+  describe "Ember template transformations" do
+    # For the Ember (Glimmer) templates, serverside rendering is not trivial,
+    # so we compile the expected result with the standard compiler and compare to the theme compiler
+    let(:theme_id) { 22 }
+
+    def theme_compile(template)
+      script = <<~JS
+        import { hbs } from 'ember-cli-htmlbars';
+        export default hbs(#{template.to_json});
+      JS
+      result = DiscourseJsProcessor.transpile(script, "", "theme/blah", theme_id: theme_id)
+      result.gsub(/\/\*(.*)\*\//m, "/* (js comment stripped) */")
+    end
+
+    def standard_compile(template)
+      script = <<~JS
+        import { hbs } from 'ember-cli-htmlbars';
+        export default hbs(#{template.to_json});
+      JS
+      result = DiscourseJsProcessor.transpile(script, "", "theme/blah")
+      result.gsub(/\/\*(.*)\*\//m, "/* (js comment stripped) */")
+    end
+
+    it 'adds the theme id to the helpers' do
+      expect(
+        theme_compile "{{theme-prefix 'translation_key'}}"
+      ).to eq(
+        standard_compile "{{theme-prefix #{theme_id} 'translation_key'}}"
+      )
+
+      expect(
+        theme_compile "{{theme-i18n 'translation_key'}}"
+      ).to eq(
+        standard_compile "{{theme-i18n #{theme_id} 'translation_key'}}"
+      )
+
+      expect(
+        theme_compile "{{theme-setting 'setting_key'}}"
+      ).to eq(
+        standard_compile "{{theme-setting #{theme_id} 'setting_key'}}"
+      )
+
+      # # Works when used inside other statements
+      expect(
+        theme_compile "{{dummy-helper (theme-prefix 'translation_key')}}"
+      ).to eq(
+        standard_compile "{{dummy-helper (theme-prefix #{theme_id} 'translation_key')}}"
+      )
+    end
+  end
 end

--- a/spec/lib/theme_javascript_compiler_spec.rb
+++ b/spec/lib/theme_javascript_compiler_spec.rb
@@ -1,112 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe ThemeJavascriptCompiler do
-
+  let(:compiler) { ThemeJavascriptCompiler.new(1, 'marks') }
   let(:theme_id) { 22 }
 
-  describe ThemeJavascriptCompiler::RawTemplatePrecompiler do
-    # For the raw templates, we can easily render them serverside, so let's do that
-
-    let(:compiler) { described_class.new(theme_id) }
-
-    let(:helpers) {
-      <<~JS
-      Handlebars.registerHelper('theme-prefix', function(themeId, string) {
-        return `theme_translations.${themeId}.${string}`
-      })
-      Handlebars.registerHelper('theme-i18n', function(themeId, string) {
-        return `translated(theme_translations.${themeId}.${string})`
-      })
-      Handlebars.registerHelper('theme-setting', function(themeId, string) {
-        return `setting(${themeId}:${string})`
-      })
-      Handlebars.registerHelper('dummy-helper', function(string) {
-        return `dummy(${string})`
-      })
-      JS
-    }
-
-    let(:mini_racer) {
-      ctx = MiniRacer::Context.new
-      ctx.eval(File.open("#{Rails.root}/app/assets/javascripts/node_modules/handlebars/dist/handlebars.js").read)
-      ctx.eval(helpers)
-      ctx
-    }
-
-    def render(template)
-      compiled = compiler.compile(template)
-      mini_racer.eval "Handlebars.template(#{compiled.squish})({})"
-    end
-
-    it 'adds the theme id to the helpers' do
-      # Works normally
-      expect(render("{{theme-prefix 'translation_key'}}")).
-        to eq('theme_translations.22.translation_key')
-      expect(render("{{theme-i18n 'translation_key'}}")).
-        to eq('translated(theme_translations.22.translation_key)')
-      expect(render("{{theme-setting 'setting_key'}}")).
-        to eq('setting(22:setting_key)')
-
-      # Works when used inside other statements
-      expect(render("{{dummy-helper (theme-prefix 'translation_key')}}")).
-        to eq('dummy(theme_translations.22.translation_key)')
-    end
-
-    it "doesn't duplicate number parameter inside {{each}}" do
-      expect(compiler.compile("{{#each item as |test test2|}}{{theme-setting 'setting_key'}}{{/each}}")).
-        to include('{"name":"theme-setting","hash":{},"hashTypes":{},"hashContexts":{},"types":["NumberLiteral","StringLiteral"]')
-      # Fail would be if theme-setting is defined with types:["NumberLiteral","NumberLiteral","StringLiteral"]
-    end
-  end
-
-  describe ThemeJavascriptCompiler::EmberTemplatePrecompiler do
-    # For the Ember (Glimmer) templates, serverside rendering is not trivial,
-    # so we compile the expected result with the standard compiler and compare to the theme compiler
-    let(:standard_compiler) { Barber::Ember::Precompiler.new }
-    let(:theme_compiler) { described_class.new(theme_id) }
-
-    def theme_compile(template)
-      compiled = theme_compiler.compile(template)
-      data = JSON.parse(compiled)
-      JSON.parse(data["block"])
-    end
-
-    def standard_compile(template)
-      compiled = standard_compiler.compile(template)
-      data = JSON.parse(compiled)
-      JSON.parse(data["block"])
-    end
-
-    it 'adds the theme id to the helpers' do
-      expect(
-        theme_compile "{{theme-prefix 'translation_key'}}"
-      ).to eq(
-        standard_compile "{{theme-prefix #{theme_id} 'translation_key'}}"
-      )
-
-      expect(
-        theme_compile "{{theme-i18n 'translation_key'}}"
-      ).to eq(
-        standard_compile "{{theme-i18n #{theme_id} 'translation_key'}}"
-      )
-
-      expect(
-        theme_compile "{{theme-setting 'setting_key'}}"
-      ).to eq(
-        standard_compile "{{theme-setting #{theme_id} 'setting_key'}}"
-      )
-
-      # # Works when used inside other statements
-      expect(
-        theme_compile "{{dummy-helper (theme-prefix 'translation_key')}}"
-      ).to eq(
-        standard_compile "{{dummy-helper (theme-prefix #{theme_id} 'translation_key')}}"
-      )
-    end
-  end
-
   describe "#append_raw_template" do
-    let(:compiler) { ThemeJavascriptCompiler.new(1, 'marks') }
     it 'uses the correct template paths' do
       template = "<h1>hello</h1>"
       name = "/path/to/templates1"
@@ -124,16 +22,54 @@ RSpec.describe ThemeJavascriptCompiler do
   end
 
   describe "#append_ember_template" do
-    let(:compiler) { ThemeJavascriptCompiler.new(1, 'marks') }
-    it 'prepends `javascripts/` to template name if it is not prepended' do
+    it 'maintains module names so that discourse-boot.js can correct them' do
       compiler.append_ember_template("/connectors/blah-1", "{{var}}")
-      expect(compiler.content.to_s).to include('Ember.TEMPLATES["javascripts/connectors/blah-1"]')
+      expect(compiler.content.to_s).to include("define(\"discourse/theme-1/connectors/blah-1\", [\"exports\", \"@ember/template-factory\"]")
 
       compiler.append_ember_template("connectors/blah-2", "{{var}}")
-      expect(compiler.content.to_s).to include('Ember.TEMPLATES["javascripts/connectors/blah-2"]')
+      expect(compiler.content.to_s).to include("define(\"discourse/theme-1/connectors/blah-2\", [\"exports\", \"@ember/template-factory\"]")
 
       compiler.append_ember_template("javascripts/connectors/blah-3", "{{var}}")
-      expect(compiler.content.to_s).to include('Ember.TEMPLATES["javascripts/connectors/blah-3"]')
+      expect(compiler.content.to_s).to include("define(\"discourse/theme-1/javascripts/connectors/blah-3\", [\"exports\", \"@ember/template-factory\"]")
+    end
+  end
+
+  describe "connector module name handling" do
+    it 'separates colocated connectors to avoid module name clash' do
+      # Colocated under `/connectors`
+      compiler = ThemeJavascriptCompiler.new(1, 'marks')
+      compiler.append_ember_template("connectors/outlet/blah-1", "{{var}}")
+      compiler.append_module("console.log('test')", "connectors/outlet/blah-1")
+      expect(compiler.content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
+      expect(compiler.content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
+
+      # Colocated under `/templates/connectors`
+      compiler = ThemeJavascriptCompiler.new(1, 'marks')
+      compiler.append_ember_template("templates/connectors/outlet/blah-1", "{{var}}")
+      compiler.append_module("console.log('test')", "templates/connectors/outlet/blah-1")
+      expect(compiler.content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
+      expect(compiler.content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
+
+      # Not colocated
+      compiler = ThemeJavascriptCompiler.new(1, 'marks')
+      compiler.append_ember_template("templates/connectors/outlet/blah-1", "{{var}}")
+      compiler.append_module("console.log('test')", "connectors/outlet/blah-1")
+      expect(compiler.content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
+      expect(compiler.content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
+    end
+  end
+
+  describe "error handling" do
+    it "handles syntax errors in raw templates" do
+      expect do
+        compiler.append_raw_template("sometemplate.hbr", "{{invalidtemplate")
+      end.to raise_error(ThemeJavascriptCompiler::CompileError, /Parse error on line 1/)
+    end
+
+    it "handles syntax errors in ember templates" do
+      expect do
+        compiler.append_ember_template("sometemplate", "{{invalidtemplate")
+      end.to raise_error(ThemeJavascriptCompiler::CompileError, /Parse error on line 1/)
     end
   end
 end

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -186,14 +186,14 @@ HTML
     expect(js_field.value_baked).to include("define(\"discourse/theme-#{theme.id}/controllers/discovery\"")
     expect(js_field.value_baked).to include("console.log('hello from .js.es6');")
 
-    expect(hbs_field.reload.value_baked).to include('Ember.TEMPLATES["javascripts/discovery"]')
+    expect(hbs_field.reload.value_baked).to include("define(\"discourse/theme-#{theme.id}/discourse/templates/discovery\", [\"exports\", \"@ember/template-factory\"]")
     expect(raw_hbs_field.reload.value_baked).to include('addRawTemplate("discovery"')
     expect(hbr_field.reload.value_baked).to include('addRawTemplate("other_discovery"')
     expect(unknown_field.reload.value_baked).to eq("")
     expect(unknown_field.reload.error).to eq(I18n.t("themes.compile_error.unrecognized_extension", extension: "blah"))
 
     # All together
-    expect(theme.javascript_cache.content).to include('Ember.TEMPLATES["javascripts/discovery"]')
+    expect(theme.javascript_cache.content).to include("define(\"discourse/theme-#{theme.id}/discourse/templates/discovery\", [\"exports\", \"@ember/template-factory\"]")
     expect(theme.javascript_cache.content).to include('addRawTemplate("discovery"')
     expect(theme.javascript_cache.content).to include("define(\"discourse/theme-#{theme.id}/controllers/discovery\"")
     expect(theme.javascript_cache.content).to include("define(\"discourse/theme-#{theme.id}/controllers/discovery-2\"")

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -135,7 +135,7 @@ HTML
     baked = Theme.lookup_field(theme.id, :mobile, "header")
 
     expect(baked).to include(field.javascript_cache.url)
-    expect(field.javascript_cache.content).to include('HTMLBars')
+    expect(field.javascript_cache.content).to include('@ember/template-factory')
     expect(field.javascript_cache.content).to include('raw-handlebars')
   end
 


### PR DESCRIPTION
Previously we were relying on a highly-customized version of the unmaintained Barber gem for theme template compilation. This commit switches us to use our own DiscourseJsProcessor, which makes use of more modern patterns and will be easier to maintain going forward.

In summary:
- Refactors DiscourseJsProcessor to move multiline JS heredocs into a companion `discourse-js-processor.js` file
- Use MiniRacer's `.call` method to avoid manually escaping JS strings
- Move Theme template AST transformers into DiscourseJsProcessor, and formalise interface for extending RawHandlebars AST transformations
- Update Ember template compilation to use a babel-based approach, just like Ember CLI. This gives each template its own ES6 module rather than directly assigning `Ember.TEMPLATES` values
- Improve testing of template compilation (and move some tests from `theme_javascript_compiler_spec.rb` to `discourse_js_processor_spec.rb`)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
