### PR TITLE
DEV: Fix Ember version lookup

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -157,7 +157,7 @@ class Theme < ActiveRecord::Base
     get_set_cache "compiler_version" do
       dependencies = [
         BASE_COMPILER_VERSION,
-        Ember::VERSION,
+        EmberCli.ember_version,
         GlobalSetting.cdn_url,
         GlobalSetting.s3_cdn_url,
         GlobalSetting.s3_endpoint,

--- a/lib/ember_cli.rb
+++ b/lib/ember_cli.rb
@@ -49,4 +49,11 @@ module EmberCli
   def self.is_ember_cli_asset?(name)
     assets.include?(name) || name.start_with?("chunk.")
   end
+
+  def self.ember_version
+    @version ||= begin
+      ember_source_package_raw = File.read("#{Rails.root}/app/assets/javascripts/node_modules/ember-source/package.json")
+      JSON.parse(ember_source_package_raw)["version"]
+    end
+  end
 end


### PR DESCRIPTION
The source-of-truth for our ember version is now the installed node_module. The `ember_source` gem carries an old version of Ember and so the constant is no longer useful. We'll be dropping the gem soon.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
