### PR TITLE
FIX: In prod builds classes may not be "instancesof" EmberObject

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/utils/handle-descriptor.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/handle-descriptor.js
@@ -1,10 +1,11 @@
-import EmberObject, { computed, get } from "@ember/object";
+import CoreObject from "@ember/object/core";
+import { computed, get } from "@ember/object";
 import extractValue from "./extract-value";
 
 export default function handleDescriptor(target, key, desc, params = []) {
   const val = extractValue(desc);
 
-  if (typeof val === "function" && target instanceof EmberObject) {
+  if (typeof val === "function" && target instanceof CoreObject) {
     // We're in a native class, so convert the method to a getter first
     desc.writable = false;
     desc.initializer = undefined;


### PR DESCRIPTION
They do have CoreObject in their prototype chain.

Fixes the issue mentioned in https://github.com/discourse/discourse-chat/pull/1204