### PR TITLE
FIX: Return next bookmarks page only if it exists

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-activity-bookmarks.js
@@ -96,6 +96,7 @@ export default Controller.extend({
 
   _processLoadResponse(searchTerm, response) {
     if (!response || !response.user_bookmark_list) {
+      this.model.loadMoreUrl = null;
       return;
     }
 

--- a/app/models/user_bookmark_list.rb
+++ b/app/models/user_bookmark_list.rb
@@ -5,7 +5,7 @@ class UserBookmarkList
 
   PER_PAGE = 20
 
-  attr_reader :bookmarks, :per_page
+  attr_reader :bookmarks, :per_page, :has_more
   attr_accessor :more_bookmarks_url, :bookmark_serializer_opts
 
   def initialize(user:, guardian:, params:)
@@ -21,7 +21,9 @@ class UserBookmarkList
   end
 
   def load(&blk)
-    @bookmarks = BookmarkQuery.new(user: @user, guardian: @guardian, params: @params).list_all(&blk)
+    query = BookmarkQuery.new(user: @user, guardian: @guardian, params: @params)
+    @bookmarks = query.list_all(&blk)
+    @has_more = (@params[:page].to_i + 1) * @params[:per_page] < query.count
     @bookmarks
   end
 

--- a/app/serializers/user_bookmark_list_serializer.rb
+++ b/app/serializers/user_bookmark_list_serializer.rb
@@ -15,6 +15,6 @@ class UserBookmarkListSerializer < ApplicationSerializer
   end
 
   def include_more_bookmarks_url?
-    @include_more_bookmarks_url ||= object.bookmarks.size == object.per_page
+    @include_more_bookmarks_url ||= object.has_more
   end
 end

--- a/lib/bookmark_query.rb
+++ b/lib/bookmark_query.rb
@@ -26,7 +26,7 @@ class BookmarkQuery
     end
   end
 
-  attr_reader :guardian
+  attr_reader :guardian, :count
 
   def initialize(user:, guardian: nil, params: {})
     @user = user
@@ -34,6 +34,7 @@ class BookmarkQuery
     @guardian = guardian || Guardian.new(@user)
     @page = @params[:page].to_i
     @limit = @params[:limit].present? ? @params[:limit].to_i : @params[:per_page]
+    @count = 0
   end
 
   def list_all(&blk)
@@ -72,6 +73,8 @@ class BookmarkQuery
         bookmarks.reminder_at ASC,
         bookmarks.updated_at DESC"
     )
+
+    @count = results.count
 
     if @page.positive?
       results = results.offset(@page * @params[:per_page])

--- a/spec/models/user_bookmark_list_spec.rb
+++ b/spec/models/user_bookmark_list_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe UserBookmarkList do
   it "returns all types of bookmarks" do
     list.load
     expect(list.bookmarks.map(&:id)).to match_array([post_bookmark.id, topic_bookmark.id, user_bookmark.id])
+    expect(list.has_more).to eq(false)
   end
 
   it "defaults to 20 per page" do


### PR DESCRIPTION
It used to return the next URL anyway which lead to an additional
request. On the frontend, if the result set was empty, it kept retrying
until at least one result was returned. This bug is fixed in this commit
too.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
