### PR TITLE
DEV: Fix flaky twitter onebox behavior

### DIFF
--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -9,7 +9,7 @@ module Onebox
     def self.engines
       constants.select do |constant|
         constant.to_s =~ /Onebox$/
-      end.map(&method(:const_get))
+      end.sort.map(&method(:const_get))
     end
 
     def self.all_iframe_origins

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -11,7 +11,8 @@ module Onebox
       always_https
 
       def self.===(other)
-        !Onebox.options.twitter_client.twitter_credentials_missing? && super
+        client = Onebox.options.twitter_client
+        client && !client.twitter_credentials_missing? && super
       end
 
       def http_params


### PR DESCRIPTION
The order in which Onebox engines are loaded is not guaranteed. Occasionally during tests, the twitter engine would be loaded before the instagram engine, and cause the Instagram Onebox spec to fail due to the lack of `Onebox.options.twitter_client`.

This commit makes the load order of Onebox engines consistent, and fixes the issue in the twitter_status_onebox.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
