### PR TITLE
DEV: Fix a flaky spec

### DIFF
--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1903,7 +1903,7 @@ RSpec.describe Search do
       results = Search.new('#9998').execute
       expect(results.posts.length).to eq(1)
 
-      results = Search.new('#777').execute
+      results = Search.new('#nonexistent').execute
       expect(results.posts.length).to eq(0)
 
       results = Search.new('xxx #:').execute


### PR DESCRIPTION
In some cases the topic of the fabricated post can be titled "This is a test topic 777" which matches the search query "#777"

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
