### PR TITLE
UX: Close the revamped user menu when opening modals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.hbs
@@ -6,7 +6,7 @@
         class="quick-access-panel"
         tabindex="-1"
         aria-labelledby={{concat "user-menu-button-" this.currentTabId}}>
-        {{component this.currentPanelComponent}}
+        {{component this.currentPanelComponent closeUserMenu=@closeUserMenu}}
       </div>
       <div class="menu-tabs-container" role="tablist" aria-orientation="vertical" aria-label={{i18n "user_menu.sr_menu_tabs"}}>
         <div class="top-tabs tabs-list">

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
@@ -48,12 +48,14 @@ export default class UserMenuProfileTabContent extends Component {
       });
     } else {
       this.saving = false;
+      this.args.closeUserMenu();
       showModal("do-not-disturb");
     }
   }
 
   @action
   setUserStatusClick() {
+    this.args.closeUserMenu();
     showModal("user-status", {
       title: "user_status.set_custom_status",
       modalClass: "user-status",

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -407,9 +407,16 @@ createWidget("revamped-user-menu-wrapper", {
       new RenderGlimmer(
         this,
         "div.widget-component-connector",
-        hbs`<UserMenu::Menu />`
+        hbs`<UserMenu::Menu @closeUserMenu={{@data.closeUserMenu}} />`,
+        {
+          closeUserMenu: this.closeUserMenu.bind(this),
+        }
       ),
     ];
+  },
+
+  closeUserMenu() {
+    this.sendWidgetAction("toggleUserMenu");
   },
 
   clickOutside() {

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -420,7 +420,7 @@ createWidget("revamped-user-menu-wrapper", {
   },
 
   clickOutside() {
-    this.sendWidgetAction("toggleUserMenu");
+    this.closeUserMenu();
   },
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/do-not-disturb-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/do-not-disturb-test.js
@@ -209,4 +209,15 @@ acceptance("Do not disturb - new user menu", function (needs) {
       "the Do Not Disturb button has the toggle-off icon"
     );
   });
+
+  test("user menu gets closed when the DnD modal is opened", async function (assert) {
+    this.siteSettings.enable_user_status = true;
+
+    await visit("/");
+    await click(".header-dropdown-toggle.current-user");
+    await click("#user-menu-button-profile");
+    await click("#quick-access-profile .do-not-disturb .btn");
+
+    assert.notOk(exists(".user-menu"));
+  });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
@@ -423,4 +423,15 @@ acceptance("User Status - new user menu", function (needs) {
       "shows user status emoji on the user avatar in the header"
     );
   });
+
+  test("user menu gets closed when the user status modal is opened", async function (assert) {
+    this.siteSettings.enable_user_status = true;
+
+    await visit("/");
+    await click(".header-dropdown-toggle.current-user");
+    await click("#user-menu-button-profile");
+    await click(".set-user-status button");
+
+    assert.notOk(exists(".user-menu"));
+  });
 });


### PR DESCRIPTION
When opening the DnD modal and the User Status modal, user menu remained open, this PR fixes it

![522d8b666c1e46db1b54980077947e20ed471d89_2_1034x700](https://user-images.githubusercontent.com/1274517/187748386-2ff694f5-d2f3-4320-b0bf-7534cf6ffe9c.png)


