### PR TITLE
FIX: Transpile start-discourse.js to fix iOS12 support

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -179,11 +179,6 @@ module.exports = function (defaults) {
       })
     ),
     applyTerser(prettyTextEngine(app)),
-    concat("public/assets/scripts", {
-      outputFile: `assets/start-discourse.js`,
-      headerFiles: [`start-app.js`],
-      inputFiles: [`discourse-boot.js`],
-    }),
     generateScriptsTree(app),
     applyTerser(discoursePluginsTree),
   ]);

--- a/app/assets/javascripts/discourse/lib/scripts.js
+++ b/app/assets/javascripts/discourse/lib/scripts.js
@@ -35,5 +35,21 @@ module.exports = function scriptsTree(app) {
     trees.push(transpiledWithDecodedSourcemap);
   }
 
+  // start-discourse.js is a combination of start-app and discourse-boot
+  let startDiscourseTree = funnel(`public/assets/scripts`, {
+    files: ["start-app.js", "discourse-boot.js"],
+    destDir: "scripts",
+  });
+  startDiscourseTree = babelAddon.transpileTree(
+    startDiscourseTree,
+    babelConfig
+  );
+  startDiscourseTree = concat(startDiscourseTree, {
+    outputFile: `assets/start-discourse.js`,
+    headerFiles: [`scripts/start-app.js`],
+    inputFiles: [`scripts/discourse-boot.js`],
+  });
+  trees.push(startDiscourseTree);
+
   return mergeTrees(trees);
 };


### PR DESCRIPTION
33a2624f09 introduced a JS safe-navigation operator in `discourse-boot.js`. This needs to be transpiled to maintain iOS 12 support.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
