### PR TITLE
DEV: Try to kickstart npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,7 @@ updates:
     directory: "/app/assets/javascripts/"
     schedule:
       interval: daily
-      time: "08:00"
-      timezone: Australia/Sydney
+      time: "12:00"
+      timezone: Europe/Warsaw
     open-pull-requests-limit: 10
     versioning-strategy: increase


### PR DESCRIPTION
Dependabot hasn't picked up the previous config change. Let's see if it picks up this one.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
