### PR TITLE
FEAT: Add login-buttons plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/login-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/login-buttons.hbs
@@ -10,3 +10,4 @@
     {{b.title}}
   </button>
 {{/each}}
+<PluginOutlet @name="after-login-buttons" @connectorTagName="div" />


### PR DESCRIPTION
This change make it doable to use a plugin-outlet to override login-buttons tempalte/componenet

The reason we need to do this, is because Google One Tap sign in doesn't allow to render normal buttons
For context check the plugin: https://github.com/ghassanmas/discourse-google-one-tap
Also meta topic: https://meta.discourse.org/t/implement-google-one-tap-sign-in/236375

This change is suggested By David Taylor @davidtaylorhq


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
