### PR TITLE
FIX: header offset position was not correct in some cases

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -177,6 +177,19 @@ const SiteHeaderComponent = MountWidget.extend(
         this.docAt = header.offsetTop;
       }
 
+      const headerRect = header.getBoundingClientRect();
+      let headerOffsetCalc = headerRect.top + headerRect.height;
+
+      if (window.scrollY < 0) {
+        headerOffsetCalc += window.scrollY;
+      }
+
+      const newValue = `${headerOffsetCalc}px`;
+      if (newValue !== this.currentHeaderOffsetValue) {
+        this.currentHeaderOffsetValue = newValue;
+        document.documentElement.style.setProperty("--header-offset", newValue);
+      }
+
       const main = document.querySelector(".ember-application");
       const offsetTop = main ? main.offsetTop : 0;
       const offset = window.pageYOffset - offsetTop;


### PR DESCRIPTION
When a topic is opened in a new tab and is fully loaded the scroll
position is a bit off.

This commit partially reverts 9a55c9c4339214ea18a73e71ab2506e4ad2967aa.
