### PR TITLE
FIX: Ensure discovery-categories always clears PreloadStore

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-categories.js
@@ -31,6 +31,10 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
       return this._findCategoriesAndTopics("latest");
     } else if (style === "categories_and_top_topics") {
       return this._findCategoriesAndTopics("top");
+    } else {
+      // The server may have serialized this. Based on the logic above, we don't need it
+      // so remove it to avoid it being used later by another TopicList route.
+      PreloadStore.remove("topic_list");
     }
 
     return CategoryList.list(this.store);

--- a/app/assets/javascripts/discourse/tests/acceptance/categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/categories-test.js
@@ -6,6 +6,10 @@ import {
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
+import PreloadStore from "discourse/lib/preload-store";
+import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
+import { cloneJSON } from "discourse-common/lib/object";
+
 acceptance("Categories - 'categories_only'", function (needs) {
   needs.settings({
     desktop_category_page_style: "categories_only",
@@ -99,3 +103,41 @@ acceptance(
     });
   }
 );
+
+acceptance("Categories - preloadStore handling", function () {
+  const styles = [
+    "categories_only",
+    "categories_with_featured_topics",
+    "categories_and_latest_topics_created_date",
+    "categories_and_latest_topics",
+    "categories_and_top_topics",
+    "categories_boxes",
+    "categories_boxes_with_topics",
+    "subcategories_with_featured_topics",
+  ];
+
+  for (const style of styles) {
+    test(`${style} deletes data from PreloadStore to ensure it isn't left for another route`, async function (assert) {
+      this.siteSettings.desktop_category_page_style = style;
+      PreloadStore.store(
+        "topic_list",
+        cloneJSON(discoveryFixtures["/latest.json"])
+      );
+      PreloadStore.store(
+        "categories_list",
+        cloneJSON(discoveryFixtures["/categories.json"])
+      );
+
+      await visit(`/categories`);
+
+      assert.true(
+        PreloadStore.get("topic_list") === undefined,
+        `topic_list is removed from preloadStore for ${style}`
+      );
+      assert.true(
+        PreloadStore.get("categories_list") === undefined,
+        `topic_list is removed from preloadStore for ${style}`
+      );
+    });
+  }
+});


### PR DESCRIPTION
If the server is configured to use a view like `categories_and_latest_topics`, it will preload data for the topic list. If the client doesn't actually use it (e.g. on mobile), then that preloaded data would remain cached and be used for the next loaded topic list. This commit ensures it's always removed, and adds a test for the behaviour.

https://meta.discourse.org/t/237126/35

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
