### PR TITLE
FIX: Use plugin's defined name for es6 module path

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -386,17 +386,31 @@ module.exports = {
           .findAddonByName("discourse-plugins")
           .pluginInfos();
 
-        for (const { name, hasJs, hasAdminJs } of pluginInfos) {
+        for (const {
+          pluginName,
+          directoryName,
+          hasJs,
+          hasAdminJs,
+        } of pluginInfos) {
           if (hasJs) {
-            scripts.push({ src: `plugins/${name}.js`, name });
+            scripts.push({
+              src: `plugins/${directoryName}.js`,
+              name: pluginName,
+            });
           }
 
-          if (fs.existsSync(`../plugins/${name}_extras.js.erb`)) {
-            scripts.push({ src: `plugins/${name}_extras.js`, name });
+          if (fs.existsSync(`../plugins/${directoryName}_extras.js.erb`)) {
+            scripts.push({
+              src: `plugins/${directoryName}_extras.js`,
+              name: pluginName,
+            });
           }
 
           if (hasAdminJs) {
-            scripts.push({ src: `plugins/${name}_admin.js`, name });
+            scripts.push({
+              src: `plugins/${directoryName}_admin.js`,
+              name: pluginName,
+            });
           }
         }
       } else {
@@ -420,8 +434,8 @@ module.exports = {
           .pluginInfos()
           .filter(({ hasTests }) => hasTests)
           .map(
-            ({ name }) =>
-              `<script src="${config.rootURL}assets/plugins/test/${name}_tests.js" data-discourse-plugin="${name}"></script>`
+            ({ directoryName, pluginName }) =>
+              `<script src="${config.rootURL}assets/plugins/test/${directoryName}_tests.js" data-discourse-plugin="${pluginName}"></script>`
           )
           .join("\n");
       } else {


### PR DESCRIPTION
We were using the directory name rather than the plugin's defined `name`. This was an unintended change in behaviour from the old sprockets implementation. This commit makes the ember-cli naming logic match the old sprockets logic.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
