### PR TITLE
FIX: ensures results is presents in emoji picker

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -259,6 +259,11 @@ export default Component.extend({
   _applyFilter(filter) {
     const emojiPicker = document.querySelector(".emoji-picker");
     const results = document.querySelector(".emoji-picker-emoji-area .results");
+
+    if (!results) {
+      return;
+    }
+
     results.innerHTML = "";
 
     if (filter) {


### PR DESCRIPTION
When adding/removing the picker, it's possible results are not available at this point in time.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
