### PR TITLE
UX: Fix width of preview pane to fix scroll

### DIFF
--- a/app/assets/javascripts/wizard/addon/components/homepage-preview.js
+++ b/app/assets/javascripts/wizard/addon/components/homepage-preview.js
@@ -4,7 +4,7 @@ import {
   darkLightDiff,
 } from "wizard/lib/preview";
 
-export default createPreviewComponent(342, 322, {
+export default createPreviewComponent(628, 322, {
   logo: null,
   avatar: null,
 

--- a/app/assets/javascripts/wizard/addon/components/styling-preview.js
+++ b/app/assets/javascripts/wizard/addon/components/styling-preview.js
@@ -13,7 +13,7 @@ Nullam eget sem non elit tincidunt rhoncus. Fusce
 velit nisl, porttitor sed nisl ac, consectetur interdum
 metus. Fusce in consequat augue, vel facilisis felis.`;
 
-export default createPreviewComponent(642, 322, {
+export default createPreviewComponent(628, 322, {
   logo: null,
   avatar: null,
   previewTopic: true,


### PR DESCRIPTION
This adjustment fixes with theme & styling preview from being cut off on click of `homepage preview` or `topic preview

### After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/30537603/188176401-82e31d13-9861-45e9-b7c9-bc47ff9ad642.png">

### Before
<img width="600" alt="image" src="https://user-images.githubusercontent.com/30537603/188176258-56c2a5ea-8922-420d-879b-b4230a6bf8f7.png">

