### PR TITLE
FIX: Theme components should work with empty locale files

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require 'json_schemer'
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 61
+  BASE_COMPILER_VERSION = 62
 
   attr_accessor :child_components
 

--- a/lib/theme_translation_parser.rb
+++ b/lib/theme_translation_parser.rb
@@ -10,7 +10,7 @@ class ThemeTranslationParser
   end
 
   def self.check_contains_hashes(hash)
-    hash.all? { |key, value| value.is_a?(String) || (value.is_a?(Hash) && self.check_contains_hashes(value)) }
+    hash.all? { |_key, value| value.is_a?(String) || (value.is_a?(Hash) && self.check_contains_hashes(value)) }
   end
 
   def load
@@ -21,13 +21,18 @@ class ThemeTranslationParser
     rescue Psych::SyntaxError, Psych::DisallowedClass => e
       raise InvalidYaml.new(e.message)
     end
-    raise InvalidYaml.new(I18n.t("themes.locale_errors.invalid_yaml")) unless parsed.is_a?(Hash) && ThemeTranslationParser.check_contains_hashes(parsed)
-    raise InvalidYaml.new(I18n.t("themes.locale_errors.top_level_locale")) unless parsed.keys.length == 1 && parsed.keys[0] == @setting_field.name
 
+    raise InvalidYaml.new(I18n.t("themes.locale_errors.invalid_yaml")) if !parsed.is_a?(Hash)
+    raise InvalidYaml.new(I18n.t("themes.locale_errors.top_level_locale")) if parsed.keys.length != 1 || parsed.keys.first != @setting_field.name
+
+    key = @setting_field.name.to_sym
     parsed.deep_symbolize_keys!
+    parsed[key] ||= {}
 
-    parsed[@setting_field.name.to_sym].slice!(*INTERNAL_KEYS) if @internal
-    parsed[@setting_field.name.to_sym].except!(*INTERNAL_KEYS) if !@internal
+    raise InvalidYaml.new(I18n.t("themes.locale_errors.invalid_yaml")) if !ThemeTranslationParser.check_contains_hashes(parsed)
+
+    parsed[key].slice!(*INTERNAL_KEYS) if @internal
+    parsed[key].except!(*INTERNAL_KEYS) if !@internal
 
     parsed
   end

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -342,6 +342,14 @@ HTML
         fr1.update(value: "fr: 'valuewithoutclosequote")
         expect { fr1.raw_translation_data }.to raise_error(ThemeTranslationParser::InvalidYaml)
       end
+
+      it "works when locale file doesn't contain translations" do
+        fr1.update(value: "fr:")
+        expect(fr1.translation_data).to eq(
+          fr: {},
+          en: { somestring1: "helloworld", group: { key1: "enval1" } }
+        )
+      end
     end
 
     describe "#translation_data" do


### PR DESCRIPTION
Theme components didn't work with empty locale files (just the locale key without any translations) that are created by translator-bot.

Currently only the https://github.com/discourse/discourse-table-builder and https://github.com/discourse/discourse-right-sidebar-blocks theme components are affected by this bug.