### PR TITLE
UX: Welcome topic CTA adjustments

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/welcome-topic-banner.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/welcome-topic-banner.hbs
@@ -1,9 +1,7 @@
-<div class="welcome-topic-banner">
-  <div class="col-text">
-    <h1 class="title">{{i18n "welcome_topic_banner.title"}}</h1>
-    <p class="description">{{i18n "welcome_topic_banner.description"}}</p>
+<div class="welcome-cta">
+  <div class="welcome-cta__content">
+    <h1 class="welcome-cta__title">{{i18n "welcome_topic_banner.title"}}</h1>
+    <p class="welcome-cta__description">{{i18n "welcome_topic_banner.description"}}</p>
   </div>
-  <div class="col-button">
-    <DButton @class="btn-primary welcome-topic-cta" @action={{action "editWelcomeTopic"}} @label="welcome_topic_banner.button_title" />
-  </div>
+  <DButton @class="btn-primary welcome-cta__button" @action={{action "editWelcomeTopic"}} @label="welcome_topic_banner.button_title" />
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/welcome-topic-banner-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/welcome-topic-banner-test.js
@@ -8,9 +8,9 @@ acceptance("Welcome Topic Banner", function (needs) {
 
   test("Navigation", async function (assert) {
     await visit("/");
-    assert.ok(exists(".welcome-topic-banner"), "has the welcome topic banner");
+    assert.ok(exists(".welcome-cta"), "has the welcome topic banner");
     assert.ok(
-      exists("button.welcome-topic-cta"),
+      exists("button.welcome-cta__button"),
       "has the welcome topic edit button"
     );
   });

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -253,21 +253,26 @@
   }
 }
 
-.welcome-topic-banner {
-  border: 1px solid var(--primary-low);
+.container.list-container {
+  position: relative;
+}
+
+.welcome-cta {
+  background-color: var(--secondary);
+  border: 2px solid var(--tertiary);
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.12);
-  padding: 10px;
+  padding: 12px 20px;
   display: flex;
   flex-direction: row;
-
-  .col-text {
+  justify-content: space-between;
+  position: absolute;
+  top: 44px;
+  width: calc(100% - 40px);
+  z-index: z("usercard");
+  &__content {
     width: 70%;
   }
-  .col-button {
-    width: 30%;
-    display: flex;
+  &__button {
     align-self: center;
-    justify-content: flex-end;
-    padding-right: 30px;
   }
 }

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -259,7 +259,7 @@
 
 .welcome-cta {
   background-color: var(--secondary);
-  border: 2px solid var(--tertiary);
+  border: 1px solid var(--primary-low-mid);
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.12);
   padding: 12px 20px;
   display: flex;


### PR DESCRIPTION
Some styling & syntax adjustments to better position & style the new `Welcome Topic` CTA. It is now hovering above the `welcome topic` on the actual topic list.

### After

<img width="600" alt="image" src="https://user-images.githubusercontent.com/30537603/188197546-70a51a88-1858-4850-9996-d6bc9d8e61be.png">

### Before
<img width="600" alt="image" src="https://user-images.githubusercontent.com/30537603/188197685-49d657d9-71e5-4525-99c1-41d6acbcb032.png">

