### PR TITLE
UX: make user status emoji on post stream smaller

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -234,6 +234,11 @@ $quote-share-maxwidth: 150px;
     flex: 0 0 auto;
     align-items: center;
   }
+
+  img.emoji {
+    width: 1em;
+    height: 1em;
+  }
 }
 
 nav.post-controls {


### PR DESCRIPTION
Before:

<img width="300" alt="Screenshot 2022-09-02 at 20 39 29" src="https://user-images.githubusercontent.com/1274517/188200470-52cd8e05-d90e-499d-a0ab-657a1aef02e0.png">

after:

<img width="300" alt="Screenshot 2022-09-02 at 20 42 30" src="https://user-images.githubusercontent.com/1274517/188200477-028f08b3-bf61-4ffa-acf0-91f9f38fba8a.png">



