### PR TITLE
FIX: raw translation string in user status tooltip

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/user-status-bubble.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-status-bubble.js
@@ -10,7 +10,7 @@ export default createWidget("user-status-bubble", {
       const until = moment
         .tz(attrs.ends_at, this.currentUser.timezone)
         .format(I18n.t("dates.long_date_without_year"));
-      title += `\n${I18n.t("user_status.until")} ${until}`;
+      title += `\n${I18n.t("until")} ${until}`;
     }
 
     return this.attach("emoji", { name: attrs.emoji, title });


### PR DESCRIPTION
It looked like this:
<img width="175" alt="Screenshot 2022-09-02 at 21 23 43" src="https://user-images.githubusercontent.com/1274517/188206545-b58fd36c-f678-4d60-846e-8366c030f529.png">

after the fix:
<img width="175" alt="Screenshot 2022-09-02 at 21 20 29" src="https://user-images.githubusercontent.com/1274517/188206561-7a9c652e-1edc-4898-a897-9f23fd29d77a.png">


