### PR TITLE
DEV: make ember-cli skip plugin directories without `plugin.rb`

### DIFF
--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -88,7 +88,8 @@ module.exports = {
       .filter(
         (dirent) =>
           (dirent.isDirectory() || dirent.isSymbolicLink()) &&
-          !dirent.name.startsWith(".")
+          !dirent.name.startsWith(".") &&
+          fs.existsSync(path.resolve(root, dirent.name, "plugin.rb"))
       );
 
     return pluginDirectories.map((directory) => {


### PR DESCRIPTION
This updates the ember-cli plugin detection logic to match the logic in `Plugin::Instance.find_all`. It will now ignore plugin directories which do not have a `plugin.rb` file.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
