### PR TITLE
DEV: make `bin/ember-cli -u` terminate unicorn when ember-cli fails

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -15,6 +15,12 @@ PROXY =
     "http://#{HOSTNAME}:#{PORT}"
   end
 
+def process_running?(pid)
+  !!Process.kill(0, pid)
+rescue Errno::ESRCH
+  false
+end
+
 command =
   if ARGV.include?("--test")
     "test"
@@ -58,11 +64,13 @@ end
 if ARGV.include?("-u") || ARGV.include?("--unicorn")
   unicorn_env = { "DISCOURSE_PORT" => ENV["DISCOURSE_PORT"] || "4200" }
   unicorn_pid = spawn(unicorn_env, __dir__ + "/unicorn")
+  ember_cli_pid = nil
 
   Thread.new do
     require 'open3'
     Open3.popen2e(yarn_env, "yarn", *args.to_a.flatten) do |i, oe, t|
-      puts "Ember CLI running on PID: #{t.pid}"
+      ember_cli_pid = t.pid
+      puts "Ember CLI running on PID: #{ember_cli_pid}"
       oe.each do |line|
         if line.include?("\e[32m200\e") || line.include?("\e[36m304\e[0m") || line.include?("POST /message-bus")
           # skip 200s and 304s and message bus
@@ -70,6 +78,10 @@ if ARGV.include?("-u") || ARGV.include?("--unicorn")
           puts line
         end
       end
+    end
+    if process_running?(unicorn_pid)
+      puts "[bin/ember-cli] ember-cli process stopped. Terminating unicorn."
+      Process.kill("TERM", unicorn_pid)
     end
   end
 
@@ -79,6 +91,11 @@ if ARGV.include?("-u") || ARGV.include?("--unicorn")
   end
 
   Process.wait(unicorn_pid)
+
+  if ember_cli_pid && process_running?(ember_cli_pid)
+    puts "[bin/ember-cli] unicorn process stopped. Terminating ember-cli."
+    Process.kill("TERM", ember_cli_pid)
+  end
 else
   exec(yarn_env, "yarn", *args.to_a.flatten)
 end

--- a/bin/unicorn
+++ b/bin/unicorn
@@ -107,6 +107,10 @@ if dev_mode
       restart = true
     end
 
+    Signal.trap("TERM") do
+      Process.kill('TERM', pid)
+    end
+
     while !done
       sleep 1
       done = Process.waitpid(pid, Process::WNOHANG)


### PR DESCRIPTION
Previously it was difficult to notice when ember-cli fails to start up under `bin/ember-cli -u` because the unicorn process would keep running.

This commit also adds `SIGTERM` handling to the `bin/unicorn` dev-mode wrapper.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
