### PR TITLE
FIX: Ensure `<script>` handlebars templates are namespaced correctly

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require 'json_schemer'
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 62
+  BASE_COMPILER_VERSION = 63
 
   attr_accessor :child_components
 

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -92,7 +92,7 @@ class ThemeField < ActiveRecord::Base
         if is_raw
           js_compiler.append_raw_template(name, hbs_template)
         else
-          js_compiler.append_ember_template(name, hbs_template)
+          js_compiler.append_ember_template("discourse/templates/#{name}", hbs_template)
         end
       rescue ThemeJavascriptCompiler::CompileError => ex
         errors << ex.message

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -134,6 +134,7 @@ HTML
     expect(javascript_cache.content).to include("testing-div")
     expect(javascript_cache.content).to include("string_setting")
     expect(javascript_cache.content).to include("test text \\\" 123!")
+    expect(javascript_cache.content).to include("define(\"discourse/theme-#{theme_field.theme_id}/discourse/templates/my-template\"")
   end
 
   it "correctly generates errors for transpiled css" do


### PR DESCRIPTION
This regressed in 7e74dd0afe

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
