### PR TITLE
FIX: Regression with admin user delete dialog buttons

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -378,6 +378,7 @@ export default Controller.extend(CanCheckEmails, {
       };
 
       this.dialog.alert({
+        title: I18n.t("admin.user.delete_confirm_title"),
         message: I18n.t("admin.user.delete_confirm"),
         class: "delete-user-modal",
         buttons: [

--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -385,7 +385,7 @@ export default Controller.extend(CanCheckEmails, {
             label: I18n.t("admin.user.delete_dont_block"),
             class: "btn-primary",
             action: () => {
-              return performDestroy(true);
+              return performDestroy(false);
             },
           },
           {
@@ -393,7 +393,7 @@ export default Controller.extend(CanCheckEmails, {
             label: I18n.t("admin.user.delete_and_block"),
             class: "btn-danger",
             action: () => {
-              return performDestroy(false);
+              return performDestroy(true);
             },
           },
           {

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -216,7 +216,7 @@
               {{/if}}
 
               {{#if this.canDeleteUser}}
-                <div class='pull-right'><DButton @action={{action "adminDelete"}} @icon="exclamation-triangle" @label="user.admin_delete" @class="btn-danger" /></div>
+                <div class='pull-right'><DButton @action={{action "adminDelete"}} @icon="exclamation-triangle" @label="user.admin_delete" @class="btn-danger btn-delete-user" /></div>
               {{/if}}
             </dl>
             <PluginOutlet @name="user-profile-secondary" @tagName="span" @connectorTagName="div" @args={{hash model=this.model}} />

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -247,6 +247,13 @@ acceptance("Admin - User Index", function (needs) {
   test("delete user - delete without blocking works as expected", async function (assert) {
     await visit("/admin/users/5/user5");
     await click(".btn-user-delete");
+
+    assert.equal(
+      query("#dialog-title").textContent,
+      I18n.t("admin.user.delete_confirm_title"),
+      "dialog has a title"
+    );
+
     await click(".dialog-footer .btn-primary");
 
     assert.notOk(deleteAndBlock, "user does not get blocked");

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-user-index-test.js
@@ -10,6 +10,8 @@ import I18n from "I18n";
 import { SECOND_FACTOR_METHODS } from "discourse/models/user";
 
 const { TOTP, BACKUP_CODE, SECURITY_KEY } = SECOND_FACTOR_METHODS;
+let deleteAndBlock = null;
+
 acceptance("Admin - User Index", function (needs) {
   needs.user();
   needs.pretender((server, helper) => {
@@ -97,6 +99,34 @@ acceptance("Admin - User Index", function (needs) {
         allowed_methods: [TOTP, BACKUP_CODE, SECURITY_KEY],
       });
     });
+
+    server.get("/admin/users/5.json", () => {
+      return helper.response({
+        id: 5,
+        username: "user5",
+        name: null,
+        avatar_template: "/letter_avatar_proxy/v4/letter/b/f0a364/{size}.png",
+        active: true,
+        can_be_deleted: true,
+        post_count: 0,
+      });
+    });
+
+    server.delete("/admin/users/5.json", (request) => {
+      const data = helper.parsePostData(request.requestBody);
+
+      if (data.block_email || data.block_ip || data.block_urls) {
+        deleteAndBlock = true;
+      } else {
+        deleteAndBlock = false;
+      }
+
+      return helper.response({});
+    });
+  });
+
+  needs.hooks.beforeEach(() => {
+    deleteAndBlock = null;
   });
 
   test("can edit username", async function (assert) {
@@ -212,5 +242,21 @@ acceptance("Admin - User Index", function (needs) {
       "/session/2fa?nonce=some-nonce",
       "user is redirected to the 2FA page"
     );
+  });
+
+  test("delete user - delete without blocking works as expected", async function (assert) {
+    await visit("/admin/users/5/user5");
+    await click(".btn-user-delete");
+    await click(".dialog-footer .btn-primary");
+
+    assert.notOk(deleteAndBlock, "user does not get blocked");
+  });
+
+  test("delete user - delete and block works as expected", async function (assert) {
+    await visit("/admin/users/5/user5");
+    await click(".btn-user-delete");
+    await click(".dialog-footer .btn-danger");
+
+    assert.ok(deleteAndBlock, "user does not get blocked");
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5390,7 +5390,8 @@ en:
         cant_delete_all_too_many_posts:
           one: "Can't delete all posts because the user has more than %{count} post. (delete_all_posts_max)"
           other: "Can't delete all posts because the user has more than %{count} posts. (delete_all_posts_max)"
-        delete_confirm: "It is generally preferable to anonymize users rather than deleting them, to avoid removing content from existing discussions.<br><br>Are you SURE you want to delete this user? This is permanent!"
+        delete_confirm_title: "Are you SURE you want to delete this user? This is permanent!"
+        delete_confirm: "It is generally preferable to anonymize users rather than deleting them, to avoid removing content from existing discussions."
         delete_and_block: "Delete and <b>block</b> this email and IP address"
         delete_dont_block: "Delete only"
         deleting_user: "Deleting user..."


### PR DESCRIPTION
The dialog buttons were flipped: "delete and block" was only deleting, "delete but don't block" was deleting and blocking the user.

This also 
- updates the same dialog in the user summary screen
- makes a copy change to use a title and a message in both dialogs

Screenshot: 

<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/188314988-9d130f73-51d8-4061-8f48-1283f0844fa7.png">
