### PR TITLE
FIX: Ensure low-resolution placeholders are used while loading images

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -25,7 +25,7 @@ export function nativeLazyLoading(api) {
 
             img.style.setProperty(
               "background-image",
-              `url(${img.dataset.smallUpload});`
+              `url(${img.dataset.smallUpload})`
             );
             img.style.setProperty("background-size", "cover");
           }


### PR DESCRIPTION
This regressed in 32346f4ba5. Unfortunately this behaviour is very difficult to test because it involves onload callbacks and scrolling-triggered lazy-loading

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
