### PR TITLE
UX: improve composer toolbar flexibility

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -50,7 +50,7 @@ let _createCallbacks = [];
 
 class Toolbar {
   constructor(opts) {
-    const { site, siteSettings } = opts;
+    const { siteSettings, capabilities } = opts;
     this.shortcuts = {};
     this.context = null;
 
@@ -106,16 +106,16 @@ class Toolbar {
         }),
     });
 
-    this.addButton({
-      id: "code",
-      group: "insertions",
-      shortcut: "E",
-      preventFocus: true,
-      trimLeading: true,
-      action: (...args) => this.context.send("formatCode", args),
-    });
+    if (!capabilities.touch) {
+      this.addButton({
+        id: "code",
+        group: "insertions",
+        shortcut: "E",
+        preventFocus: true,
+        trimLeading: true,
+        action: (...args) => this.context.send("formatCode", args),
+      });
 
-    if (!site.mobileView) {
       this.addButton({
         id: "bullet",
         group: "extras",
@@ -354,7 +354,7 @@ export default Component.extend(TextareaTextManipulation, {
   @discourseComputed()
   toolbar() {
     const toolbar = new Toolbar(
-      this.getProperties("site", "siteSettings", "showLink")
+      this.getProperties("site", "siteSettings", "showLink", "capabilities")
     );
     toolbar.context = this;
 
@@ -708,6 +708,7 @@ export default Component.extend(TextareaTextManipulation, {
           this.applySurround(selected, head, tail, exampleKey, opts),
         applyList: (head, exampleKey, opts) =>
           this._applyList(selected, head, exampleKey, opts),
+        formatCode: (...args) => this.send("formatCode", args),
         addText: (text) => this.addText(selected, text),
         getText: () => this.value,
         toggleDirection: () => this._toggleDirection(),

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -337,7 +337,7 @@ export default Controller.extend({
         options.push(
           this._setupPopupMenuOption(() => {
             return {
-              action: "applyformatCode",
+              action: "applyFormatCode",
               icon: "code",
               label: "composer.code_title",
             };

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -808,7 +808,7 @@ export default Controller.extend({
       });
     },
 
-    applyformatCode() {
+    applyFormatCode() {
       this.toolbarEvent.formatCode();
     },
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -333,7 +333,17 @@ export default Controller.extend({
         })
       );
 
-      if (this.site.mobileView) {
+      if (this.capabilities.touch) {
+        options.push(
+          this._setupPopupMenuOption(() => {
+            return {
+              action: "applyformatCode",
+              icon: "code",
+              label: "composer.code_title",
+            };
+          })
+        );
+
         options.push(
           this._setupPopupMenuOption(() => {
             return {
@@ -796,6 +806,10 @@ export default Controller.extend({
           count,
         }),
       });
+    },
+
+    applyformatCode() {
+      this.toolbarEvent.formatCode();
     },
 
     applyUnorderedList() {

--- a/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
@@ -15,10 +15,6 @@
               <DButton @action={{b.action}} @type="button" @actionParam={{b}} @translatedTitle={{b.title}} @label={{b.label}} @icon={{b.icon}} @class={{b.className}} @preventFocus={{b.preventFocus}} @tabindex={{b.tabindex}} @onKeyDown={{this.rovingButtonBar}} />
             {{/if}}
           {{/each}}
-
-          {{#unless group.lastGroup}}
-            <div class="d-editor-spacer"></div>
-          {{/unless}}
         {{/each}}
       </div>
 

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -546,14 +546,6 @@ body:not(.ios-safari-composer-hacks) {
   }
 }
 
-.show-preview {
-  @media screen and (max-width: 850px) {
-    .d-editor-button-bar {
-      font-size: $font-down-1;
-    }
-  }
-}
-
 .toggle-preview {
   margin-left: 8px;
   transition: all 0.33s ease-out;

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -305,28 +305,13 @@
 
 // d-editor bar button sizing
 .d-editor-button-bar {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(2rem, 1fr));
   align-items: center;
   border-bottom: 1px solid var(--primary-low);
   width: 100%;
   box-sizing: border-box;
-
-  html:not(.keyboard-visible) & {
-    overflow-x: auto; // hiding overflow breaks the cog menu on iPad and mobile
-  }
-
   flex-shrink: 0;
-
-  .d-editor-spacer {
-    height: 1em;
-    display: inline-block;
-    border-left: 1px solid var(--primary-low);
-    margin: 0 0.25em;
-
-    .mobile-view & {
-      display: none;
-    }
-  }
 
   .btn:focus {
     @include default-focus;
@@ -340,27 +325,14 @@
     .d-icon {
       color: currentColor;
     }
-    &:hover {
-      color: var(--primary-low);
+    .discourse-no-touch & {
+      &:hover {
+        color: var(--primary-low);
+      }
     }
   }
 
-  // ensures items grow/shrink on mobile to fit available space
-  @include breakpoint(mobile-large) {
-    .btn {
-      flex-grow: 1;
-      flex-shrink: 1;
-      flex-basis: auto;
-      padding-left: 0.25em;
-      padding-right: 0.25em;
-    }
-
-    .select-kit.toolbar-popup-menu-options {
-      flex-grow: 1;
-      flex-basis: auto;
-      .select-kit-header .select-kit-header-wrapper {
-        justify-content: center;
-      }
-    }
+  .select-kit-header-wrapper {
+    justify-content: center;
   }
 }

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -307,6 +307,13 @@
 .d-editor-button-bar {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(2.35em, 1fr));
+  @include breakpoint(tablet) {
+    // occupy available space on narrower screens
+    grid-template-columns: repeat(auto-fit, minmax(2em, 1fr));
+  }
+  @include breakpoint(mobile-medium) {
+    font-size: var(--font-down-1);
+  }
   align-items: center;
   border-bottom: 1px solid var(--primary-low);
   width: 100%;

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -306,7 +306,7 @@
 // d-editor bar button sizing
 .d-editor-button-bar {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(2rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(2.35em, 1fr));
   align-items: center;
   border-bottom: 1px solid var(--primary-low);
   width: 100%;

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -161,12 +161,10 @@
     }
   }
 
-  .d-editor-button-bar {
-    display: none;
-  }
-
-  .toolbar-visible .d-editor-button-bar {
-    display: flex;
+  .wmd-controls:not(.toolbar-visible) {
+    .d-editor-button-bar {
+      display: none;
+    }
   }
 
   .d-editor-button-bar .btn {


### PR DESCRIPTION
We've been having some problems with toolbar overflow when there are many buttons present, so I did some refactoring in an attempt to avoid the issue and simplify... 

Relevant topic (there are a couple customer reports as well): https://meta.discourse.org/t/toolbar-of-composer-is-too-wide-at-least-on-ipad/234743/14

Part of the issue is that we use different positioning for the cog dropdown on iOS and desktop, so we can't hide overflow without also hiding/breaking the dropdown menu on iOS. (We use different positioning on iOS because it has trouble with fixed position elements) 

In this PR I've approached the "too many buttons" issue and the "can't hide overflow" issue in a few different ways: 

1. I updated the way we hide menu items from `site.mobileView` to `capabilities.touch` — this means that iPads are now included in the mobile behavior of showing fewer icons. They were previously left out and had some issues due to narrower widths. 

    It's possible some large touch devices get caught up in this, but showing too many icons on iPad (and causing overflow issues) seems more problematic than hiding some options within the cog dropdown. (Alternatively we could check viewport width instead of relying on mobileView.)
  
2. I moved the preformatted text button to be hidden within the cog menu on mobile. This is most often used for code, and it seems less likely that someone's sharing code on a mobile device. 

3. I'm allowing the buttons to wrap. This isn't ideal, but better than breaking the cog menu and might make admins think twice about how many buttons they have here

4. I updated the layout of the button bar from flex to grid. This allows us to use auto-fill/fit, simplify our CSS, and allow for easier equal spacing when wrapping. I also removed the dividers because grid containers want all children to be in an equal-width column. I don't think these were doing much for us other than occupying more space, but if we want to add them back I can use CSS psuedo selectors. 

Default:

![Screen Shot 2022-09-07 at 6 37 11 PM](https://user-images.githubusercontent.com/1681963/188995720-f442c08b-4534-418e-9191-33a0bf82b576.png)

Too many buttons wrap:

![Screen Shot 2022-09-07 at 6 37 32 PM](https://user-images.githubusercontent.com/1681963/188995740-45702ddd-b801-4739-b370-9df360b5559f.png)

Mobile default:

![Screen Shot 2022-09-07 at 6 37 49 PM](https://user-images.githubusercontent.com/1681963/188995751-00ff6d5e-c38a-4ce1-b16f-8ac48de1b25d.png)

More mobile buttons can fill the space: 

![Screen Shot 2022-09-07 at 6 39 27 PM](https://user-images.githubusercontent.com/1681963/188995834-be83880a-86a4-4b66-bf9f-7639da54f645.png)

Too many mobile buttons: 

![Screen Shot 2022-09-07 at 6 40 02 PM](https://user-images.githubusercontent.com/1681963/188995886-ce5d06bf-2a7b-42f7-9327-7cf0fb0c65d7.png)


iPad default: 
![Screen Shot 2022-09-07 at 6 38 16 PM](https://user-images.githubusercontent.com/1681963/188995764-f66445a8-ef12-430e-ab0f-db5ad1aedfa4.png)


