### PR TITLE
UX: trigger tooltips on click for touch devices

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-tooltip.js
+++ b/app/assets/javascripts/discourse/app/components/d-tooltip.js
@@ -26,6 +26,7 @@ export default class DiscourseTooltip extends Component {
       const parent = viewBounds.parentElement;
       this._tippyInstance = tippy(parent, {
         content: element,
+        trigger: this.capabilities.touch ? "click" : "mouseenter",
         theme: "d-tooltip",
         arrow: false,
         placement: "bottom-start",


### PR DESCRIPTION
This allows tooltips to appear on touch-based devices