### PR TITLE
UX: left-align title with content for sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -2,16 +2,18 @@ import { createWidget } from "discourse/widgets/widget";
 import hbs from "discourse/widgets/hbs-compiler";
 
 createWidget("header-contents", {
-  tagName: "div.contents.clearfix",
+  tagName: "div.contents",
   template: hbs`
-    {{#if this.site.desktopView}}
-      {{#if this.siteSettings.enable_experimental_sidebar_hamburger}}
-        {{#if attrs.sidebarEnabled}}
-          {{sidebar-toggle attrs=attrs}}
+    <div class="header-logo-wrapper">
+      {{#if this.site.desktopView}}
+        {{#if this.siteSettings.enable_experimental_sidebar_hamburger}}
+          {{#if attrs.sidebarEnabled}}
+            {{sidebar-toggle attrs=attrs}}
+          {{/if}}
         {{/if}}
       {{/if}}
-    {{/if}}
-    {{home-logo attrs=attrs}}
+      {{home-logo attrs=attrs}}
+    </div>
     {{#if attrs.topic}}
       {{header-topic-info attrs=attrs}}
     {{/if}}

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -19,7 +19,12 @@
     height: 100%;
 
     .contents {
-      display: flex;
+      display: grid;
+      grid-template-areas: "logo-wrapper extra-info panel";
+      grid-template-columns: auto 1fr auto;
+      .has-sidebar-page & {
+        grid-template-columns: minmax(var(--d-sidebar-width), auto) 1fr auto;
+      }
       align-items: center;
       height: 100%;
 
@@ -42,7 +47,14 @@
     }
   }
 
+  .header-logo-wrapper {
+    grid-area: logo-wrapper;
+    display: flex;
+    align-items: center;
+  }
+
   .title {
+    grid-area: logo;
     display: flex;
     align-items: center;
     height: 100%;
@@ -61,6 +73,7 @@
   }
 
   .panel {
+    grid-area: panel;
     position: relative;
     display: flex;
     flex: 0 0 auto;
@@ -212,6 +225,7 @@
 }
 
 .header-sidebar-toggle {
+  grid-area: hamburger;
   button {
     margin-right: 1em;
     box-sizing: content-box; // matches other header icons

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -199,19 +199,3 @@ body.has-sidebar-page {
     padding-left: 0;
   }
 }
-
-@media (prefers-reduced-motion: no-preference) {
-  body.sidebar-animate {
-    #main-outlet-wrapper {
-      //  grid-template-columns transition supported in Firefox, Chrome support coming summer 2022
-      transition-property: grid-template-columns, max-width;
-      transition-timing-function: var(--d-sidebar-animation-ease);
-      transition-duration: var(--d-sidebar-animation-time);
-    }
-
-    .d-header-wrap .wrap {
-      transition: max-width var(--d-sidebar-animation-time)
-        var(--d-sidebar-animation-ease);
-    }
-  }
-}


### PR DESCRIPTION
This change adds a new wrapper to the site header and updates the layout to grid, so it may affect some themes, but hopefully the impact is minimal. 

I also removed the sidebar transition animations in this PR because this new header change isn't animatable with CSS, and personally I find no animations at all less jarring than some elements animating and some not. 

This makes the title left-align with the topic content when the sidebar is present:

![Screen Shot 2022-09-09 at 3 05 26 PM](https://user-images.githubusercontent.com/1681963/189426770-3655814b-b46c-4c16-843e-a16851602db3.png)
![Screen Shot 2022-09-09 at 3 05 34 PM](https://user-images.githubusercontent.com/1681963/189426771-b776eba1-c5da-4539-9f8d-85d94f62e666.png)

Wide logos can still work, but forces the alignment to be off (this is also the case before this change)

![Screen Shot 2022-09-09 at 3 06 14 PM](https://user-images.githubusercontent.com/1681963/189426773-bafc7df4-ff79-4fab-824b-a36fc95fa00a.png)

