### PR TITLE
DEV: Prioritize unread notifications in the experimental user menu

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2955,4 +2955,22 @@ RSpec.describe User do
       )
     end
   end
+
+  describe "#bump_last_seen_notification!" do
+    it "doesn't error if there are no notifications" do
+      Notification.destroy_all
+      expect(user.bump_last_seen_notification!).to eq(false)
+      expect(user.reload.seen_notification_id).to eq(0)
+    end
+
+    it "updates seen_notification_id to the last notification that the user can see" do
+      last_notification = Fabricate(:notification, user: user)
+      deleted_notification = Fabricate(:notification, user: user)
+      deleted_notification.topic.trash!
+      someone_else_notification = Fabricate(:notification, user: Fabricate(:user))
+
+      expect(user.bump_last_seen_notification!).to eq(true)
+      expect(user.reload.seen_notification_id).to eq(last_notification.id)
+    end
+  end
 end


### PR DESCRIPTION
Right now the experimental user menu sorts notifications the same way that the old menu does: unread high-priority notifications are shown first in reverse-chronological order followed by everything else also in reverse-chronological order. However, since the experimental user menu has dedicated tabs for some notification types and each tab displays a badge with the count of unread notifications in the tab, we feel like it makes sense to change how notifications are sorted in the experimental user menu to this:

1. unread high-priority notifications
2. unread regular notifications
3. all read notifications (both high-priority and regular)
4. within each group, notifications are sorted in reverse-chronological order (i.e. newest is shown first).

This new sorting logic applies to all tabs in the experimental user menu, however it doesn't change anything in the old menu. With this change, if a tab in the experimental user menu shows an unread notification badge for a really old notification, it will be surfaced to the top and prevents confusing scenarios where a user sees an unread notification badge on a tab, but the tab doesn't show the unread notification because it's too old to make it to the list.

Internal topic: t72199.