### PR TITLE
UX: Change `posted` notification icon to `discourse-bell-exclamation`

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
@@ -27,7 +27,7 @@ const REPLACEMENTS = {
   "notification.group_mentioned": "users",
   "notification.quoted": "quote-right",
   "notification.replied": "reply",
-  "notification.posted": "reply",
+  "notification.posted": "discourse-bell-exclamation",
   "notification.edited": "pencil-alt",
   "notification.bookmark_reminder": "discourse-bookmark-clock",
   "notification.liked": "heart",


### PR DESCRIPTION
This PR changes the icon for `posted` notification types (these are the notifications that you receive when someone posts in a topic you're watching) from:

<img src="https://user-images.githubusercontent.com/17474474/189545732-a32c55c5-0d15-42ed-8d57-83f64e9c965f.png" width=350>

to:

<img src="https://user-images.githubusercontent.com/17474474/189545756-76d3162d-843e-4c35-beb6-609eabc8bebe.png" width=350>

We're doing this to visually distinguish between the `posted` notifications and `replied` notifications which are the notifications that you receive when someone replies to you directly.

Internal topic: t72835.