### PR TITLE
FIX: Correctly pass `invite_to_topic` param to invites

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -140,6 +140,7 @@ class InvitesController < ApplicationController
       topic_id: topic&.id,
       group_ids: groups&.map(&:id),
       expires_at: params[:expires_at],
+      invite_to_topic: params[:invite_to_topic]
     )
 
     if invite.present?

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -203,9 +203,9 @@ RSpec.describe InvitesController do
       it 'works' do
         sign_in(user)
 
-        post '/invites.json', params: { email: 'test@example.com', topic_id: topic.id }
+        post '/invites.json', params: { email: 'test@example.com', topic_id: topic.id, invite_to_topic: true }
         expect(response.status).to eq(200)
-        expect(Jobs::InviteEmail.jobs.first['args'].first['invite_to_topic']).to be_falsey
+        expect(Jobs::InviteEmail.jobs.first['args'].first['invite_to_topic']).to be_truthy
       end
 
       it 'fails when topic_id is invalid' do


### PR DESCRIPTION
Ensures the correct mailer template is used.