### PR TITLE
DEV: ctrl+click on user menu items should open in new tab

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/user-menu/base-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/base-item.js
@@ -1,4 +1,5 @@
 import DiscourseURL from "discourse/lib/url";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 
 export default class UserMenuBaseItem {
   get className() {}
@@ -30,6 +31,9 @@ export default class UserMenuBaseItem {
   get topicId() {}
 
   onClick({ event, closeUserMenu }) {
+    if (wantsNewWindow(event)) {
+      return;
+    }
     closeUserMenu();
     const href = this.linkHref;
     if (href) {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-menu-test.js
@@ -112,6 +112,25 @@ acceptance("User menu", function (needs) {
       exists(".user-menu"),
       "clicking on the same item again closes the menu"
     );
+
+    await click(".d-header-icons .current-user");
+    await click("#user-menu-button-review-queue");
+    // this may not be ideal because it actually attempts to open a new tab
+    // which gets blocked by the browser, but otherwise it seems harmless and
+    // doesn't cause the test to fail. if it causes problems for you, feel free
+    // to remove the ctrl+click tests.
+    await click("#quick-access-review-queue li.reviewable.reviewed a", {
+      ctrlKey: true,
+    });
+    assert.strictEqual(
+      currentURL(),
+      "/review/17",
+      "ctrl-clicking on an item doesn't navigate to a new page"
+    );
+    assert.ok(
+      exists(".user-menu"),
+      "ctrl-clicking on an item doesn't close the menu"
+    );
   });
 
   test("tabs added via the plugin API", async function (assert) {


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/commit/8c2c96af2579ed943cf62aaa991748d155a7a011.

Mouse clicks on user menu items while holding a modifier key, like ctrl, shift, etc., should let the browser's default action take place instead of our custom action/handler which should only be triggered when the user clicks on an item without any modifier keys. This PR adds a missing check that skips our custom handler when it makes sense to skip it, such as when clicking with ctrl or shift is held down.