### PR TITLE
PERF: Skip image placeholders when secure_media is enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -17,9 +17,19 @@ function isLoaded(img) {
 
 export function nativeLazyLoading(api) {
   api.decorateCookedElement(
-    (post) =>
+    (post) => {
+      const siteSettings = api.container.lookup("service:site-settings");
+
       forEachImage(post, (img) => {
         img.loading = "lazy";
+
+        if (siteSettings.secure_media) {
+          // Secure media requests go through the app. In topics with many images,
+          // this makes it very easy to hit rate limiters. Skipping the low-res
+          // placeholders reduces the chance of this problem occuring.
+          return;
+        }
+
         if (img.dataset.smallUpload) {
           if (!isLoaded(img)) {
             if (!img.onload) {
@@ -36,7 +46,8 @@ export function nativeLazyLoading(api) {
             img.style.setProperty("background-size", "cover");
           }
         }
-      }),
+      });
+    },
     {
       onlyStream: true,
       id: "discourse-lazy-load-after-adopt",


### PR DESCRIPTION
Secure media requests go through the app. In topics with many images, this makes it very easy to hit rate limiters. Skipping the low-res placeholders reduces the chance of this problem occuring.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
