### PR TITLE
UX: Use dominant color as image loading placeholder

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
+++ b/app/assets/javascripts/discourse/app/lib/lazy-load-images.js
@@ -1,14 +1,3 @@
-// Min size in pixels for consideration for lazy loading
-const MINIMUM_SIZE = 150;
-
-function forEachImage(post, callback) {
-  post.querySelectorAll("img").forEach((img) => {
-    if (img.width >= MINIMUM_SIZE && img.height >= MINIMUM_SIZE) {
-      callback(img);
-    }
-  });
-}
-
 function isLoaded(img) {
   // In Safari, img.complete sometimes returns true even when the image is not loaded.
   // naturalHeight seems to be a more reliable check
@@ -17,39 +6,47 @@ function isLoaded(img) {
 
 export function nativeLazyLoading(api) {
   api.decorateCookedElement(
+    (post) =>
+      post.querySelectorAll("img").forEach((img) => (img.loading = "lazy")),
+    {
+      id: "discourse-lazy-load",
+    }
+  );
+
+  api.decorateCookedElement(
     (post) => {
       const siteSettings = api.container.lookup("service:site-settings");
 
-      forEachImage(post, (img) => {
-        img.loading = "lazy";
+      post.querySelectorAll("img").forEach((img) => {
+        // Support for smallUpload should be maintained until Post::BAKED_VERSION is bumped higher than 2
+        const { smallUpload, dominantColor } = img.dataset;
 
-        if (siteSettings.secure_media) {
+        if (siteSettings.secure_media && smallUpload) {
           // Secure media requests go through the app. In topics with many images,
           // this makes it very easy to hit rate limiters. Skipping the low-res
           // placeholders reduces the chance of this problem occuring.
           return;
         }
 
-        if (img.dataset.smallUpload) {
-          if (!isLoaded(img)) {
-            if (!img.onload) {
-              img.onload = () => {
-                img.style.removeProperty("background-image");
-                img.style.removeProperty("background-size");
-              };
-            }
+        if ((smallUpload || dominantColor) && !isLoaded(img)) {
+          if (!img.onload) {
+            img.onload = () => {
+              img.style.removeProperty("background-image");
+              img.style.removeProperty("background-size");
+              img.style.removeProperty("background-color");
+            };
+          }
 
-            img.style.setProperty(
-              "background-image",
-              `url(${img.dataset.smallUpload})`
-            );
+          if (smallUpload) {
+            img.style.setProperty("background-image", `url(${smallUpload})`);
             img.style.setProperty("background-size", "cover");
+          } else {
+            img.style.setProperty("background-color", `#${dominantColor}`);
           }
         }
       });
     },
     {
-      onlyStream: true,
       id: "discourse-lazy-load-after-adopt",
       afterAdopt: true,
     }

--- a/app/jobs/scheduled/periodical_updates.rb
+++ b/app/jobs/scheduled/periodical_updates.rb
@@ -48,7 +48,7 @@ module Jobs
 
       Category.auto_bump_topic!
 
-      Upload.backfill_dominant_colors!(100)
+      Upload.backfill_dominant_colors!(25)
 
       nil
     end

--- a/app/jobs/scheduled/periodical_updates.rb
+++ b/app/jobs/scheduled/periodical_updates.rb
@@ -48,6 +48,8 @@ module Jobs
 
       Category.auto_bump_topic!
 
+      Upload.backfill_dominant_colors!(100)
+
       nil
     end
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -628,9 +628,9 @@ end
 #
 #  idx_uploads_on_verification_status       (verification_status)
 #  index_uploads_on_access_control_post_id  (access_control_post_id)
-#  index_uploads_on_dominant_color          (dominant_color) WHERE (dominant_color IS NULL)
 #  index_uploads_on_etag                    (etag)
 #  index_uploads_on_extension               (lower((extension)::text))
+#  index_uploads_on_id                      (id) WHERE (dominant_color IS NULL)
 #  index_uploads_on_id_and_url              (id,url)
 #  index_uploads_on_original_sha1           (original_sha1)
 #  index_uploads_on_sha1                    (sha1) UNIQUE

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -10,7 +10,7 @@ class Upload < ActiveRecord::Base
   SEEDED_ID_THRESHOLD = 0
   URL_REGEX ||= /(\/original\/\dX[\/\.\w]*\/(\h+)[\.\w]*)/
   MAX_IDENTIFY_SECONDS = 5
-  MAX_DOMINANT_COLOR_SECONDS = 5
+  DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS = 5
 
   belongs_to :user
   belongs_to :access_control_post, class_name: 'Post'
@@ -356,7 +356,7 @@ class Upload < ActiveRecord::Base
           "-format",
           "%c",
           "histogram:info:",
-          timeout: MAX_DOMINANT_COLOR_SECONDS
+          timeout: DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS
         )
 
         color = data[/#([0-9A-F]{6})/, 1]

--- a/app/serializers/upload_serializer.rb
+++ b/app/serializers/upload_serializer.rb
@@ -13,7 +13,8 @@ class UploadSerializer < ApplicationSerializer
              :short_url,
              :short_path,
              :retain_hours,
-             :human_filesize
+             :human_filesize,
+             :dominant_color
 
   def url
     object.for_site_setting ? object.url : UrlHelper.cook_url(object.url, secure: SiteSetting.secure_media? && object.secure)

--- a/db/migrate/20220915132547_add_dominant_color_to_uploads.rb
+++ b/db/migrate/20220915132547_add_dominant_color_to_uploads.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDominantColorToUploads < ActiveRecord::Migration[7.0]
+  def change
+    add_column :uploads, :dominant_color, :text, limit: 6, null: true
+    add_index :uploads, :dominant_color, where: "dominant_color IS NULL"
+  end
+end

--- a/db/migrate/20220915132547_add_dominant_color_to_uploads.rb
+++ b/db/migrate/20220915132547_add_dominant_color_to_uploads.rb
@@ -3,6 +3,6 @@
 class AddDominantColorToUploads < ActiveRecord::Migration[7.0]
   def change
     add_column :uploads, :dominant_color, :text, limit: 6, null: true
-    add_index :uploads, :dominant_color, where: "dominant_color IS NULL"
+    add_index :uploads, :id, where: "dominant_color IS NULL"
   end
 end

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -109,6 +109,16 @@ module Discourse
       nil
     end
 
+    class CommandError < RuntimeError
+      attr_reader :status, :stdout, :stderr
+      def initialize(message, status: nil, stdout: nil, stderr: nil)
+        super(message)
+        @status = status
+        @stdout = stdout
+        @stderr = stderr
+      end
+    end
+
     private
 
     class CommandRunner
@@ -145,7 +155,12 @@ module Discourse
 
         if !status.exited? || !success_status_codes.include?(status.exitstatus)
           failure_message = "#{failure_message}\n" if !failure_message.blank?
-          raise "#{caller[0]}: #{failure_message}#{stderr}"
+          raise CommandError.new(
+            "#{caller[0]}: #{failure_message}#{stderr}",
+            stdout: stdout,
+            stderr: stderr,
+            status: status
+          )
         end
 
         stdout

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -168,6 +168,7 @@ class UploadCreator
         @upload.thumbnail_width, @upload.thumbnail_height = ImageSizer.resize(w, h)
         @upload.width, @upload.height = w, h
         @upload.animated = animated?
+        @upload.calculate_dominant_color!(@file.path)
       end
 
       add_metadata!

--- a/spec/fabricators/upload_fabricator.rb
+++ b/spec/fabricators/upload_fabricator.rb
@@ -22,9 +22,11 @@ Fabricator(:upload) do
 end
 
 Fabricator(:image_upload, from: :upload) do
-  after_create do |upload|
+  transient color: "white"
+
+  after_create do |upload, transients|
     file = Tempfile.new(['fabricated', '.png'])
-    `convert -size #{upload.width}x#{upload.height} xc:white "#{file.path}"`
+    `convert -size #{upload.width}x#{upload.height} xc:#{transients[:color]} "#{file.path}"`
 
     upload.url = Discourse.store.store_upload(file, upload)
     upload.sha1 = Upload.generate_digest(file.path)

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -619,12 +619,12 @@ RSpec.describe Upload do
     end
   end
 
-  describe "dominant_color" do
+  describe "#dominant_color" do
     let(:white_image) { Fabricate(:image_upload, color: "white") }
     let(:red_image) { Fabricate(:image_upload, color: "red") }
     let(:not_an_image) { Fabricate(:upload) }
 
-    it "works" do
+    it "correctly identifies and stores an image's dominant color" do
       expect(white_image.dominant_color).to eq(nil)
       expect(white_image.dominant_color(calculate_if_missing: true)).to eq("FFFFFF")
       expect(white_image.dominant_color).to eq("FFFFFF")
@@ -650,6 +650,7 @@ RSpec.describe Upload do
     it "stores an empty string for non-image uploads" do
       expect(not_an_image.dominant_color).to eq(nil)
       expect(not_an_image.dominant_color(calculate_if_missing: true)).to eq("")
+      expect(not_an_image.dominant_color).to eq("")
     end
   end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -618,4 +618,38 @@ RSpec.describe Upload do
       expect(Upload.secure_media_url?(url)).to eq(false)
     end
   end
+
+  describe "dominant_color" do
+    let(:white_image) { Fabricate(:image_upload, color: "white") }
+    let(:red_image) { Fabricate(:image_upload, color: "red") }
+    let(:not_an_image) { Fabricate(:upload) }
+
+    it "works" do
+      expect(white_image.dominant_color).to eq(nil)
+      expect(white_image.dominant_color(calculate_if_missing: true)).to eq("FFFFFF")
+      expect(white_image.dominant_color).to eq("FFFFFF")
+
+      expect(red_image.dominant_color).to eq(nil)
+      expect(red_image.dominant_color(calculate_if_missing: true)).to eq("FF0000")
+      expect(red_image.dominant_color).to eq("FF0000")
+    end
+
+    it "can be backfilled" do
+      expect(white_image.dominant_color).to eq(nil)
+      expect(red_image.dominant_color).to eq(nil)
+
+      Upload.backfill_dominant_colors!(5)
+
+      white_image.reload
+      red_image.reload
+
+      expect(white_image.dominant_color).to eq("FFFFFF")
+      expect(red_image.dominant_color).to eq("FF0000")
+    end
+
+    it "stores an empty string for non-image uploads" do
+      expect(not_an_image.dominant_color).to eq(nil)
+      expect(not_an_image.dominant_color(calculate_if_missing: true)).to eq("")
+    end
+  end
 end

--- a/spec/requests/api/schemas/json/upload_create_response.json
+++ b/spec/requests/api/schemas/json/upload_create_response.json
@@ -39,6 +39,9 @@
     },
     "human_filesize": {
       "type": "string"
+    },
+    "dominant_color": {
+      "type": ["string", "null"]
     }
   },
   "required": [


### PR DESCRIPTION
We previously had a system which would generate a 10x10px preview of images and add their URLs in a data-small-upload attribute. The client would then use that as the background-image of the `<img>` element. This works reasonably well on fast connections, but on slower connections it can take a few seconds for the placeholders to appear. The act of loading the placeholders can also break or delay the loading of the 'real' images.

This commit replaces the placeholder logic with a new approach. Instead of a 10x10px preview, we use imagemagick to calculate the average color of an image and store it in the database. The hex color value then added as a `data-dominant-color` attribute on the `<img>` element, and the client can use this as a `background-color` on the element while the real image is loading. That means no extra HTTP request is required, and so the placeholder color can appear instantly.

Dominant color will be calculated:
1. When a new upload is created
2. During a post rebake, if the dominant color is missing from an upload, it will be calculated and stored
3. Every 15 minutes, 100 old upload records are fetched and their dominant color calculated and stored. (part of the existing PeriodicalUpdates job)

Existing posts will continue to use the old 10x10px placeholder system until they are next rebaked