### PR TITLE
DEV: Update `rake qunit:test` to support filtering

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 desc "Runs the qunit test suite"
-task "qunit:test", [:timeout, :qunit_path] do |_, args|
+task "qunit:test", [:timeout, :qunit_path, :filter] do |_, args|
   require "socket"
   require "chrome_installed_checker"
 
@@ -65,6 +65,7 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
     success = true
     test_path = "#{Rails.root}/test"
     qunit_path = args[:qunit_path]
+    filter = args[:filter]
 
     options = { seed: (ENV["QUNIT_SEED"] || Random.new.seed), hidepassed: 1 }
 
@@ -107,6 +108,8 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
       system("yarn", "ember", "build", chdir: "#{Rails.root}/app/assets/javascripts/discourse")
       test_page = "#{qunit_path}?#{query}&testem=1"
       cmd += ["yarn", "testem", "ci", "-f", "testem.js", "-t", test_page]
+    elsif filter
+      cmd += ["yarn", "ember", "test", "--query", query, "--filter", filter]
     else
       cmd += ["yarn", "ember", "test", "--query", query]
     end


### PR DESCRIPTION
When doing local dev running `rake qunit:test` can take a long time to get to your test(s). This change makes it so you can filter which tests will run via https://guides.emberjs.com/v3.12.0/testing/#toc_choosing-the-tests-to-run.

#### Example:

Arbitrary code change: 
![image](https://user-images.githubusercontent.com/6325318/190177325-4e566730-dd76-41b6-be3c-55c0a1e67e0e.png)

```
$ rake qunit:test[,,"Sidebar - Anonymous Categories Section"]
.
.
.
```

Tests ran:
![image](https://user-images.githubusercontent.com/6325318/190178060-bc5a3afc-497a-4c7f-b22f-5bcb5fec88e3.png)


`Sidebar - Anonymous Categories Section` fuzzy matches 2 tests found in `/discourse/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js`