### PR TITLE
FIX: In-page anchor links were broken in subfolder setups

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/intercept-click.js
+++ b/app/assets/javascripts/discourse/app/lib/intercept-click.js
@@ -27,7 +27,7 @@ export default function interceptClick(e) {
 
   if (
     !href ||
-    href === "#" ||
+    href.startsWith("#") ||
     currentTarget.getAttribute("target") ||
     currentTarget.dataset.emberAction ||
     currentTarget.dataset.autoRoute ||

--- a/app/assets/javascripts/discourse/app/lib/static-route-builder.js
+++ b/app/assets/javascripts/discourse/app/lib/static-route-builder.js
@@ -1,4 +1,4 @@
-import DiscourseURL, { jumpToElement } from "discourse/lib/url";
+import DiscourseURL from "discourse/lib/url";
 import DiscourseRoute from "discourse/routes/discourse";
 import I18n from "I18n";
 import StaticPage from "discourse/models/static-page";
@@ -25,7 +25,7 @@ export default function (page) {
 
     activate() {
       this._super(...arguments);
-      jumpToElement(document.location.hash.slice(1));
+      DiscourseURL.jumpToElement(document.location.hash.slice(1));
     },
 
     model() {

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -238,7 +238,7 @@ const DiscourseURL = EmberObject.extend({
     const m = /^#(.+)$/.exec(path);
     if (m) {
       jumpToElement(m[1]);
-      return this.replaceState(path);
+      return this.replaceState(`${this.router.currentURL}${path}`);
     }
 
     const oldPath = this.router.currentURL;

--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -73,29 +73,6 @@ let _jumpScheduled = false;
 let _transitioning = false;
 let lockOn = null;
 
-export function jumpToElement(elementId) {
-  if (_jumpScheduled || isEmpty(elementId)) {
-    return;
-  }
-
-  const selector = `#main #${elementId}, a[name=${elementId}]`;
-  _jumpScheduled = true;
-
-  schedule("afterRender", function () {
-    if (lockOn) {
-      lockOn.clearLock();
-    }
-
-    lockOn = new LockOn(selector, {
-      finished() {
-        _jumpScheduled = false;
-        lockOn = null;
-      },
-    });
-    lockOn.lock();
-  });
-}
-
 const DiscourseURL = EmberObject.extend({
   isJumpScheduled() {
     return _transitioning || _jumpScheduled;
@@ -237,8 +214,8 @@ const DiscourseURL = EmberObject.extend({
     // Scroll to the same page, different anchor
     const m = /^#(.+)$/.exec(path);
     if (m) {
-      jumpToElement(m[1]);
-      return this.replaceState(`${this.router.currentURL}${path}`);
+      this.jumpToElement(m[1]);
+      return;
     }
 
     const oldPath = this.router.currentURL;
@@ -479,9 +456,33 @@ const DiscourseURL = EmberObject.extend({
     transition._discourse_original_url = path;
 
     const promise = transition.promise || transition;
-    promise.then(() => jumpToElement(elementId));
+    promise.then(() => this.jumpToElement(elementId));
+  },
+
+  jumpToElement(elementId) {
+    if (_jumpScheduled || isEmpty(elementId)) {
+      return;
+    }
+
+    const selector = `#main #${elementId}, a[name=${elementId}]`;
+    _jumpScheduled = true;
+
+    schedule("afterRender", function () {
+      if (lockOn) {
+        lockOn.clearLock();
+      }
+
+      lockOn = new LockOn(selector, {
+        finished() {
+          _jumpScheduled = false;
+          lockOn = null;
+        },
+      });
+      lockOn.lock();
+    });
   },
 });
+
 let _urlInstance = DiscourseURL.create();
 
 export function setURLContainer(container) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -88,13 +88,6 @@ module("Unit | Utility | url", function () {
       DiscourseURL.handleURL.calledWith(`/u/${user.username}/messages`),
       "it should navigate to the messages page"
     );
-
-    sinon.stub(DiscourseURL, "replaceState");
-    DiscourseURL.routeTo("#heading1");
-    assert.ok(
-      DiscourseURL.replaceState.calledWith(`/forum#heading1`),
-      "it should keep subfolder when routing to in-page anchors"
-    );
   });
 
   test("prefixProtocol", async function (assert) {
@@ -158,6 +151,15 @@ module("Unit | Utility | url", function () {
       DiscourseURL.redirectTo.calledWith(
         "/secure-media-uploads/original/1X/test.pdf"
       )
+    );
+  });
+
+  test("anchor handling", async function (assert) {
+    sinon.stub(DiscourseURL, "jumpToElement");
+    DiscourseURL.routeTo("#heading1");
+    assert.ok(
+      DiscourseURL.jumpToElement.calledWith("heading1"),
+      "in-page anchors call jumpToElement"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -88,6 +88,13 @@ module("Unit | Utility | url", function () {
       DiscourseURL.handleURL.calledWith(`/u/${user.username}/messages`),
       "it should navigate to the messages page"
     );
+
+    sinon.stub(DiscourseURL, "replaceState");
+    DiscourseURL.routeTo("#heading1");
+    assert.ok(
+      DiscourseURL.replaceState.calledWith(`/forum#heading1`),
+      "it should keep subfolder when routing to in-page anchors"
+    );
   });
 
   test("prefixProtocol", async function (assert) {


### PR DESCRIPTION
A `#heading1` anchor in a topic would redirect users to `/subfolder#heading1`. Including the current URL when replacing state solves the issue.

On a more general note, I'm not sure we should be replacing state for anchor links. Just jumping to the element should be enough, it doesn't seem to help the browser history to replace the state. 

Thoughts @davidtaylorhq? 