### PR TITLE
Introduce warning message for Safari 13 and below

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/safari-13-deprecation.js
+++ b/app/assets/javascripts/discourse/app/initializers/safari-13-deprecation.js
@@ -1,0 +1,30 @@
+import I18n from "I18n";
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+function setupMessage(api) {
+  const isSafari = navigator.vendor === "Apple Computer, Inc.";
+  if (!isSafari) {
+    return;
+  }
+
+  let safariMajorVersion = navigator.userAgent.match(/Version\/(\d+)\./)?.[1];
+  safariMajorVersion = safariMajorVersion
+    ? parseInt(safariMajorVersion, 10)
+    : null;
+
+  if (safariMajorVersion && safariMajorVersion <= 13) {
+    api.addGlobalNotice(
+      I18n.t("safari_13_warning"),
+      "browser-deprecation-warning",
+      { dismissable: true, dismissDuration: moment.duration(1, "week") }
+    );
+  }
+}
+
+export default {
+  name: "safari-13-deprecation",
+
+  initialize() {
+    withPluginApi("0.8.37", setupMessage);
+  },
+};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3731,6 +3731,8 @@ en:
 
     browser_update: 'Unfortunately, <a href="https://www.discourse.org/faq/#browser">your browser is unsupported</a>. Please <a href="https://browsehappy.com">switch to a supported browser</a> to view rich content, log in and reply.'
 
+    safari_13_warning: This site will soon remove support for iOS and Safari versions 13 and below - please update your browser
+
     permission_types:
       full: "Create / Reply / See"
       create_post: "Reply / See"


### PR DESCRIPTION
Discourse will be dropping support for these browsers in early 2023. https://meta.discourse.org/t/224747

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

<img width="394" alt="Screenshot 2022-09-15 at 11 26 48" src="https://user-images.githubusercontent.com/6270921/190382098-6654999e-259e-43fe-a050-55a56c1e8975.png">
