### PR TITLE
FIX: Do not attempt to serialize Tag objects when tagging disabled

### DIFF
--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -208,6 +208,7 @@ class PostRevisionSerializer < ApplicationSerializer
 
     # Retrieve any `tracked_topic_fields`
     PostRevisor.tracked_topic_fields.each_key do |field|
+      next if field == :tags # Special handling below
       if topic.respond_to?(field)
         latest_modifications[field.to_s] = [topic.public_send(field)]
       end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1750,6 +1750,23 @@ RSpec.describe PostsController do
         expect(response.status).to eq(200)
       end
     end
+
+    context "with a tagged topic" do
+      let(:tag) { Fabricate(:tag) }
+      it "works" do
+        SiteSetting.tagging_enabled = true
+
+        post_revision.post.topic.update(tags: [tag])
+
+        get "/posts/#{post_revision.post_id}/revisions/latest.json"
+        expect(response.status).to eq(200)
+
+        SiteSetting.tagging_enabled = false
+
+        get "/posts/#{post_revision.post_id}/revisions/latest.json"
+        expect(response.status).to eq(200)
+      end
+    end
   end
 
   describe '#revert' do


### PR DESCRIPTION
When tagging is enabled, we were correctly serializing tags by their name. However, when tagging was disabled we were attempting to serialize an entire Tag object which raises an error since ee07f6da7d.

https://meta.discourse.org/t/232885

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
