### PR TITLE
UX: Use the same text for linking to more categories and tags in sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.hbs
@@ -14,9 +14,6 @@
       @prefixColor={{sectionLink.prefixColor}} >
     </Sidebar::SectionLink>
   {{/each}}
-  <Sidebar::SectionLink
-    @linkName="more-categories"
-    @content={{i18n "sidebar.more"}}
-    @route="discovery.categories"
-  />
+
+  <Sidebar::Common::AllCategoriesSectionLink />
 </Sidebar::Section>

--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.hbs
@@ -10,9 +10,6 @@
       @models={{sectionLink.models}} >
     </Sidebar::SectionLink>
   {{/each}}
-  <Sidebar::SectionLink
-    @linkName="more-tags"
-    @content={{i18n "sidebar.more"}}
-    @route="tags"
-  />
+
+  <Sidebar::Common::AllTagsSectionLink />
 </Sidebar::Section>

--- a/app/assets/javascripts/discourse/app/components/sidebar/common/all-categories-section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/all-categories-section-link.hbs
@@ -1,0 +1,5 @@
+<Sidebar::SectionLink
+  @linkName="all-categories"
+  @content={{i18n "sidebar.all_categories"}}
+  @route="discovery.categories"
+/>

--- a/app/assets/javascripts/discourse/app/components/sidebar/common/all-categories-section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/all-categories-section-link.js
@@ -1,0 +1,3 @@
+import templateOnly from "@ember/component/template-only";
+
+export default templateOnly();

--- a/app/assets/javascripts/discourse/app/components/sidebar/common/all-tags-section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/all-tags-section-link.hbs
@@ -1,0 +1,5 @@
+<Sidebar::SectionLink
+  @linkName="all-tags"
+  @content={{i18n "sidebar.all_tags"}}
+  @route="tags"
+/>

--- a/app/assets/javascripts/discourse/app/components/sidebar/common/all-tags-section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/all-tags-section-link.js
@@ -1,0 +1,3 @@
+import templateOnly from "@ember/component/template-only";
+
+export default templateOnly();

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
@@ -27,10 +27,6 @@
       {{html-safe this.noCategoriesText}}
     </Sidebar::SectionMessage>
   {{/if}}
-  <Sidebar::SectionLink
-    @linkName="more-categories"
-    @content={{i18n "category.all"}}
-    @route="discovery.categories"
-    @class="sidebar-more-link"
-  />
+
+  <Sidebar::Common::AllCategoriesSectionLink />
 </Sidebar::Section>

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.hbs
@@ -22,10 +22,6 @@
       {{html-safe this.noTagsText}}
     </Sidebar::SectionMessage>
   {{/if}}
-  <Sidebar::SectionLink
-    @linkName="more-tags"
-    @content={{i18n "tagging.all_tags"}}
-    @route="tags"
-    @class="sidebar-more-link"
-  />
+
+  <Sidebar::Common::AllTagsSectionLink />
 </Sidebar::Section>

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
@@ -27,8 +27,8 @@ acceptance("Sidebar - Anonymous Categories Section", function (needs) {
     assert.strictEqual(categories[4].textContent.trim(), "ux");
 
     assert.ok(
-      exists("a.sidebar-section-link-more-categories"),
-      "more link is visible"
+      exists("a.sidebar-section-link-all-categories"),
+      "all categories link is visible"
     );
   });
 
@@ -46,8 +46,8 @@ acceptance("Sidebar - Anonymous Categories Section", function (needs) {
     assert.strictEqual(categories[2].textContent.trim(), "blog");
 
     assert.ok(
-      exists("a.sidebar-section-link-more-categories"),
-      "more link is visible"
+      exists("a.sidebar-section-link-all-categories"),
+      "all categories link is visible"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-tags-section-test.js
@@ -30,8 +30,8 @@ acceptance("Sidebar - Anonymous Tags Section", function (needs) {
     assert.strictEqual(categories[2].textContent.trim(), "fun");
 
     assert.ok(
-      exists("a.sidebar-section-link-more-tags"),
-      "more link is visible"
+      exists("a.sidebar-section-link-all-tags"),
+      "all tags link is visible"
     );
   });
 });
@@ -60,8 +60,8 @@ acceptance("Sidebar - Anonymous Tags Section - default tags", function (needs) {
     assert.strictEqual(categories[1].textContent.trim(), "meta");
 
     assert.ok(
-      exists("a.sidebar-section-link-more-tags"),
-      "more link is visible"
+      exists("a.sidebar-section-link-all-tags"),
+      "all tags link is visible"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -43,7 +43,7 @@ acceptance(
 
       assert.strictEqual(
         count(
-          ".sidebar-section-categories .sidebar-section-link:not(.sidebar-more-link)"
+          ".sidebar-section-categories .sidebar-section-link:not(.sidebar-section-link-all-categories)"
         ),
         1,
         "there should only be one section link under the section"
@@ -161,7 +161,7 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
     await visit("/");
 
     const categorySectionLinks = queryAll(
-      ".sidebar-section-categories .sidebar-section-link:not(.sidebar-more-link)"
+      ".sidebar-section-categories .sidebar-section-link:not(.sidebar-section-link-all-categories)"
     );
 
     const categoryNames = [...categorySectionLinks].map((categorySectionLink) =>
@@ -182,7 +182,7 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
     assert.strictEqual(
       count(
-        ".sidebar-section-categories .sidebar-section-link:not(.sidebar-more-link)"
+        ".sidebar-section-categories .sidebar-section-link:not(.sidebar-section-link-all-categories)"
       ),
       3,
       "there should only be 3 section link under the section"

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -123,7 +123,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
     await visit("/");
 
     const tagSectionLinks = queryAll(
-      ".sidebar-section-tags .sidebar-section-link:not(.sidebar-more-link)"
+      ".sidebar-section-tags .sidebar-section-link:not(.sidebar-section-link-all-tags)"
     );
 
     const tagNames = [...tagSectionLinks].map((tagSectionLink) =>
@@ -142,7 +142,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
 
     assert.strictEqual(
       count(
-        ".sidebar-section-tags .sidebar-section-link:not(.sidebar-more-link)"
+        ".sidebar-section-tags .sidebar-section-link:not(.sidebar-section-link-all-tags)"
       ),
       4,
       "4 section links under the section"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4097,6 +4097,8 @@ en:
         other: "%{count} new"
       toggle_section: "toggle section"
       more: "More..."
+      all_categories: "All categories"
+      all_tags: "All tags"
       sections:
         messages:
           header_link_text: "Messages"


### PR DESCRIPTION
Before this change, anonymous user and a logged in user used different
text for the links to the categories and tags routes.

Follow-up to 321aa4b4b45eacfb61ee887edf6315aae18f3efc