### PR TITLE
FIX: Empty inline BBCodes were broken

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/bbcode-inline.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/bbcode-inline.js
@@ -61,6 +61,10 @@ function tokenizeBBCode(state, silent, ruler) {
   } else {
     tagInfo.rule = rule;
 
+    if (tagInfo.closing && state.tokens.at(-1)?.meta === "bbcode") {
+      state.push("text", "", 0);
+    }
+
     let token = state.push("text", "", 0);
     token.content = state.src.slice(pos, pos + tagInfo.length);
     token.meta = "bbcode";
@@ -73,7 +77,6 @@ function tokenizeBBCode(state, silent, ruler) {
       token: state.tokens.length - 1,
       level: state.level,
       end: -1,
-      jump: 0,
     });
 
     state.pos = pos + tagInfo.length;

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1714,6 +1714,10 @@ HTML
     expect(PrettyText.cook("a[i]b[/i]c")).to eq('<p>a<span class="bbcode-i">b</span>c</p>')
   end
 
+  it "supports empty inline BBCode" do
+    expect(PrettyText.cook("a[b][/b]c")).to eq('<p>a<span class="bbcode-b"></span>c</p>')
+  end
+
   it "can handle bbcode after a newline" do
     # this is not 100% ideal cause we get an extra p here, but this is pretty rare
     expect(PrettyText.cook("a\n[code]code[/code]")).to eq("<p>a</p>\n<pre><code class=\"lang-auto\">code</code></pre>")


### PR DESCRIPTION
Upgrading to Markdown.it v13 broke empty inline BBCodes. This works around the problem by adding an empty token before a closing token if the previous token was a BBCode token.

It also removes the unused `jump` attribute which was removed in Markdown.it v12.3