### PR TITLE
DEV: Tone down copy in experimental user menu for pending users

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/reviewable-types/user.js
+++ b/app/assets/javascripts/discourse/app/lib/reviewable-types/user.js
@@ -3,7 +3,7 @@ import I18n from "I18n";
 
 export default class extends ReviewableTypeBase {
   get description() {
-    return I18n.t("user_menu.reviewable.suspicious_user", {
+    return I18n.t("user_menu.reviewable.user_requires_approval", {
       username: this.reviewable.username,
     });
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2577,7 +2577,7 @@ en:
         deleted_user: "(deleted user)"
         post_number_with_topic_title: "post #%{post_number} - %{title}"
         new_post_in_topic: "new post in %{title}"
-        suspicious_user: "suspicious user %{username}"
+        user_requires_approval: "%{username} requires approval"
         default_item: "reviewable item #%{reviewable_id}"
 
     topics:


### PR DESCRIPTION
The experimental user menu has a tab that displays recent reviewables and at the moment when a new signs up for the site and they need to be approved, admins see a very scary "suspicious user" copy in the reviewables tab in the user menu. We don't need the copy to be very scary because when a user needs to be approved, it's because the site operator has configured the site to force all new users to go through the review queue and it's not some kind of spam detector flagging the user.