### PR TITLE
FIX: Don't crash on incomplete/invalid quotes

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -283,8 +283,9 @@ export default class PostCooked {
         const $title = $(".title", $aside);
 
         // If post/topic is not found then display username, skip controls
-        if (e.classList.contains("quote-post-not-found")) {
-          return (e.querySelector(".title").innerHTML = e.dataset.username);
+        if (e.classList.contains("quote-post-not-found") && $title.length) {
+          e.querySelector(".title").innerHTML = e.dataset.username;
+          return;
         }
 
         // Unless it's a full quote, allow click to expand

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-cooked-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-cooked-test.js
@@ -1,0 +1,21 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { render } from "@ember/test-helpers";
+import { query } from "discourse/tests/helpers/qunit-helpers";
+import { hbs } from "ember-cli-htmlbars";
+
+module("Integration | Component | Widget | post-cooked", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("quotes with no username and no valid topic", async function (assert) {
+    this.set("args", {
+      cooked: `<aside class=\"quote no-group quote-post-not-found\" data-post=\"1\" data-topic=\"123456\">\n<blockquote>\n<p>abcd</p>\n</blockquote>\n</aside>\n<p>Testing the issue</p>`,
+    });
+
+    await render(
+      hbs`<MountWidget @widget="post-cooked" @args={{this.args}} />`
+    );
+
+    assert.strictEqual(query("blockquote").innerText, "abcd");
+  });
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -442,6 +442,19 @@ eviltrout</p>
     );
   });
 
+  test("Incomplete quotes", function (assert) {
+    assert.cookedOptions(
+      '[quote=", post: 1"]\na quote\n[/quote]',
+      { topicId: 2 },
+      `<aside class=\"quote no-group\" data-post=\"1\">
+<blockquote>
+<p>a quote</p>
+</blockquote>
+</aside>`,
+      "works with missing username"
+    );
+  });
+
   test("Mentions", function (assert) {
     assert.cooked(
       "Hello @sam",


### PR DESCRIPTION
Previously it would throw if a quote had no username and an invalid post/topic id.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
