### PR TITLE
DEV: use sketchy favicon in dev ember proxy

### DIFF
--- a/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
+++ b/app/assets/javascripts/discourse/lib/bootstrap-json/index.js
@@ -464,7 +464,12 @@ to serve API requests. For example:
 
     app.use(
       "/favicon.ico",
-      express.static(path.join(__dirname, "../../../../images/favicon.ico"))
+      express.static(
+        path.join(
+          __dirname,
+          "../../../../../../public/images/discourse-logo-sketch-small.png"
+        )
+      )
     );
 
     app.use(rawMiddleware, async (req, res, next) => {


### PR DESCRIPTION
Recently, we started using the logo as a favicon when running Discourse locally (see https://github.com/discourse/discourse/pull/18228). Because of that, tabs with local Discourse started looking as opened tabs with Meta:

<img width="400" alt="Screenshot 2022-09-19 at 23 29 13" src="https://user-images.githubusercontent.com/1274517/191124731-f903438f-8610-44ad-b19f-c7d5ec7b3637.png">

This PR makes dev ember proxy use the sketchy log instead, this way tabs with local Discourse are easily distinguishing from tabs with Meta:

<img width="400" alt="Screenshot 2022-09-19 at 23 32 40" src="https://user-images.githubusercontent.com/1274517/191124751-bd938817-2684-4c9d-a994-6df1d081e42d.png">

Sketchy favicon also matches the default logo that we show on local instances:

<img width="400" alt="Screenshot 2022-09-19 at 23 32 45" src="https://user-images.githubusercontent.com/1274517/191124767-e830eddc-e825-468b-bb44-4d4fc1b7691e.png">

cc: @CvX



