### PR TITLE
UX: Add icons to all navigation link on user page

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -228,8 +228,19 @@
       <section class="user-primary-navigation">
         <MobileNav @class="main-nav" @desktopClass="nav nav-pills user-nav">
           {{#unless this.model.profile_hidden}}
-            <li class="summary"><LinkTo @route="user.summary">{{i18n 'user.summary.title'}}</LinkTo></li>
-            <li class="activity"><LinkTo @route="userActivity">{{i18n 'user.activity_stream'}}</LinkTo></li>
+            <li class="summary">
+              <LinkTo @route="user.summary">
+                {{d-icon "user"}}
+                {{i18n 'user.summary.title'}}
+              </LinkTo>
+            </li>
+
+            <li class="activity">
+              <LinkTo @route="userActivity">
+                {{d-icon "stream"}}
+                {{i18n 'user.activity_stream'}}
+              </LinkTo>
+            </li>
           {{/unless}}
           {{#if this.showNotificationsTab}}
             <li class="user-notifications">


### PR DESCRIPTION
The PR is a small step towards our efforts in rebuilding the navigation links on the user pages to work well with Sidebar.

### Before

![Screenshot from 2022-09-20 12-32-04](https://user-images.githubusercontent.com/4335742/191169208-0bfb5e7b-49ab-49a6-9335-f820c9b70ad0.png)

### After

![Screenshot from 2022-09-20 12-31-52](https://user-images.githubusercontent.com/4335742/191169223-f3dd9169-e743-4d0b-97ec-5fc05d71da65.png)

No tests as I don't think the tests will provide any substantial value.