### PR TITLE
DEV: Rename notification enums for 'q&a' to 'upvotes'

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/concerns/notification-types.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/concerns/notification-types.js
@@ -36,5 +36,5 @@ export const NOTIFICATION_TYPES = {
   chat_group_mention: 32,
   chat_quoted: 33,
   assigned: 34,
-  question_answer_user_commented: 35,
+  upvotes_user_commented: 35,
 };

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -121,7 +121,7 @@ class Notification < ActiveRecord::Base
                         chat_group_mention: 32, # March 2022 - This is obsolete, as all chat_mentions use `chat_mention` type
                         chat_quoted: 33,
                         assigned: 34,
-                        question_answer_user_commented: 35, # Used by https://github.com/discourse/discourse-question-answer
+                        upvotes_user_commented: 35, # Used by https://github.com/discourse/discourse-upvotes
                        )
   end
 

--- a/lib/plugin/metadata.rb
+++ b/lib/plugin/metadata.rb
@@ -64,7 +64,7 @@ class Plugin::Metadata
     "discourse-prometheus",
     "discourse-prometheus-alert-receiver",
     "discourse-push-notifications",
-    "discourse-question-answer",
+    "discourse-upvotes",
     "discourse-reactions",
     "discourse-restricted-replies",
     "discourse-rss-polling",


### PR DESCRIPTION
Dependent on https://github.com/discourse/discourse-upvotes/pull/100 being merged.

Reason from https://github.com/discourse/discourse-upvotes/pull/99:
> A functional name change. The "Q&A" name carries a lot of meaning which this plugin is not intended for. Part 1 is just plugin name change, part 2 will include filenames and symbols.
> 
> t/52356/146