### PR TITLE
DEV: Various A11Y improvements for the new user menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/items-list.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/items-list.hbs
@@ -3,7 +3,7 @@
     <div class="spinner"></div>
   </div>
 {{else if this.items.length}}
-  <ul>
+  <ul aria-labelledby={{@ariaLabelledby}}>
     {{#each this.items as |item|}}
       <UserMenu::MenuItem @item={{item}} @closeUserMenu={{@closeUserMenu}}/>
     {{/each}}

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu-tab.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu-tab.hbs
@@ -4,6 +4,7 @@
   class={{this.classNames}}
   id={{this.id}}
   tabindex={{this.tabIndex}}
+  title={{@tab.title}}
   aria-selected={{if this.isActive "true" "false"}}
   aria-controls={{this.ariaControls}}
   data-tab-number={{@tab.position}}
@@ -11,5 +12,8 @@
   {{!-- template-lint-disable require-context-role --}}
 >
   {{d-icon @tab.icon}}
+  {{#if @tab.count}}
+    <span aria-hidden="true" class="badge-notification">{{@tab.count}}</span>
+  {{/if}}
   {{yield}}
 </button>

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.hbs
@@ -1,25 +1,14 @@
 <div class="user-menu revamped menu-panel drop-down" data-max-width="320" {{did-insert this.triggerRenderedAppEvent}}>
   <div class="panel-body">
     <div class="panel-body-contents">
-      <div
-        id={{concat "quick-access-" this.currentTabId}}
-        class="quick-access-panel"
-        tabindex="-1"
-        aria-labelledby={{concat "user-menu-button-" this.currentTabId}}>
-        {{component this.currentPanelComponent closeUserMenu=@closeUserMenu filterByTypes=this.currentNotificationTypes}}
-      </div>
       <div class="menu-tabs-container" role="tablist" aria-orientation="vertical" aria-label={{i18n "user_menu.sr_menu_tabs"}}>
-        <div class="top-tabs tabs-list">
+        <div class="top-tabs tabs-list" {{did-insert this.focusFirstTab}}>
           {{#each this.topTabs as |tab|}}
             <UserMenu::MenuTab
               @tab={{tab}}
               @currentTabId={{this.currentTabId}}
               @onTabClick={{fn this.handleTabClick tab}}
-            >
-              {{#if tab.count}}
-                <span class="badge-notification">{{tab.count}}</span>
-              {{/if}}
-            </UserMenu::MenuTab>
+            />
           {{/each}}
         </div>
         <div class="bottom-tabs tabs-list">
@@ -31,6 +20,17 @@
             />
           {{/each}}
         </div>
+      </div>
+      <div
+        id={{concat "quick-access-" this.currentTabId}}
+        class="quick-access-panel"
+        tabindex="-1">
+        {{component
+          this.currentPanelComponent
+          closeUserMenu=@closeUserMenu
+          filterByTypes=this.currentNotificationTypes
+          ariaLabelledby=(concat "user-menu-button-" this.currentTabId)
+        }}
       </div>
     </div>
   </div>

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -257,7 +257,7 @@ const CORE_OTHER_NOTIFICATIONS_TAB = class extends UserMenuTab {
   }
 
   get id() {
-    return "other";
+    return "other-notifications";
   }
 
   get icon() {
@@ -377,5 +377,10 @@ export default class UserMenu extends Component {
   @action
   triggerRenderedAppEvent() {
     this.appEvents.trigger("user-menu:rendered");
+  }
+
+  @action
+  focusFirstTab(topTabsContainerElement) {
+    topTabsContainerElement.querySelector(".btn.active")?.focus();
   }
 }

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.hbs
@@ -1,4 +1,4 @@
-<ul>
+<ul aria-labelledby={{@ariaLabelledby}}>
   {{#if this.siteSettings.enable_user_status}}
     <li class="set-user-status">
       <DButton @class="btn-flat profile-tab-btn" @action={{this.setUserStatusClick}}>

--- a/app/assets/javascripts/discourse/app/lib/user-menu/notification-item.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/notification-item.js
@@ -65,8 +65,9 @@ export default class UserMenuNotificationItem extends UserMenuBaseItem {
     if (!this.notification.read) {
       this.notification.set("read", true);
 
-      const groupedUnreadNotifications =
-        this.currentUser.grouped_unread_notifications;
+      const groupedUnreadNotifications = {
+        ...this.currentUser.grouped_unread_notifications,
+      };
       const unreadCount =
         groupedUnreadNotifications &&
         groupedUnreadNotifications[this.notification.notification_type];

--- a/app/assets/javascripts/discourse/app/lib/user-menu/tab.js
+++ b/app/assets/javascripts/discourse/app/lib/user-menu/tab.js
@@ -1,3 +1,5 @@
+import I18n from "I18n";
+
 /**
  * abstract class representing a tab in the user menu
  */
@@ -20,6 +22,26 @@ export default class UserMenuTab {
    */
   get count() {
     return 0;
+  }
+
+  /**
+   * @returns {string} title attribute for the tab element in the DOM
+   */
+  get title() {
+    const id = this.id.replaceAll(/-/g, "_");
+    const count = this.count;
+    let key;
+    if (this.count) {
+      key = `user_menu.tabs.${id}_with_unread`;
+    } else {
+      key = `user_menu.tabs.${id}`;
+    }
+    // the lookup method returns undefined if the key doesn't exist.
+    // this ensures that don't use the "missing translation" string as the
+    // title for tabs that don't define title in the yml files.
+    if (I18n.lookup(key)) {
+      return I18n.t(key, { count });
+    }
   }
 
   /**

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
@@ -21,16 +21,6 @@ module("Integration | Component | user-menu", function (hooks) {
     assert.ok(notifications[2].classList.contains("liked-consolidated"));
   });
 
-  test("notifications panel has a11y attributes", async function (assert) {
-    await render(template);
-    const panel = query("#quick-access-all-notifications");
-    assert.strictEqual(panel.getAttribute("tabindex"), "-1");
-    assert.strictEqual(
-      panel.getAttribute("aria-labelledby"),
-      "user-menu-button-all-notifications"
-    );
-  });
-
   test("active tab has a11y attributes that indicate it's active", async function (assert) {
     await render(template);
     const activeTab = query(".top-tabs.tabs-list .btn.active");

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -48,8 +48,7 @@ document.addEventListener("discourse-booted", () => {
   if (QUnit.config.seed === undefined) {
     // If we're running in browser, default to random order. Otherwise, let Ember Exam
     // handle randomization.
-    // QUnit.config.seed = Math.random().toString(36).slice(2);
-    QUnit.config.seed = "9atcpy4t344";
+    QUnit.config.seed = Math.random().toString(36).slice(2);
   } else {
     // Don't reorder when specifying a seed
     QUnit.config.reorder = false;

--- a/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
+++ b/app/assets/javascripts/discourse/tests/test-boot-ember-cli.js
@@ -48,7 +48,8 @@ document.addEventListener("discourse-booted", () => {
   if (QUnit.config.seed === undefined) {
     // If we're running in browser, default to random order. Otherwise, let Ember Exam
     // handle randomization.
-    QUnit.config.seed = Math.random().toString(36).slice(2);
+    // QUnit.config.seed = Math.random().toString(36).slice(2);
+    QUnit.config.seed = "9atcpy4t344";
   } else {
     // Don't reorder when specifying a seed
     QUnit.config.reorder = false;

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -142,7 +142,7 @@
 
   .panel-body-contents {
     display: flex;
-    flex-direction: row;
+    flex-direction: row-reverse;
   }
 
   .quick-access-panel {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2599,8 +2599,8 @@ en:
           other: "Bookmarks - %{count} unread bookmarks"
         review_queue: "Review queue"
         review_queue_with_unread:
-          one: "Review queue - %{count} needs review"
-          other: "Review queue - %{count} need review"
+          one: "Review queue - %{count} item needs review"
+          other: "Review queue - %{count} items need review"
         other_notifications: "Other notifications"
         other_notifications_with_unread:
           one: "Other notifications - %{count} unread notification"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2575,36 +2575,36 @@ en:
         all_notifications: "All notifications"
         replies: "Replies"
         replies_with_unread:
-          one: "Replies - %{count} unread"
-          other: "Replies - %{count} unread"
+          one: "Replies - %{count} unread reply"
+          other: "Replies - %{count} unread replies"
         mentions: "Mentions"
         mentions_with_unread:
-          one: "Mentions - %{count} unread"
-          other: "Mentions - %{count} unread"
+          one: "Mentions - %{count} unread mention"
+          other: "Mentions - %{count} unread mentions"
         likes: "Likes"
         likes_with_unread:
-          one: "Likes - %{count} unread"
-          other: "Likes - %{count} unread"
+          one: "Likes - %{count} unread like"
+          other: "Likes - %{count} unread likes"
         watching: "Watched topics"
         watching_with_unread:
-          one: "Watched topics - %{count} unread"
-          other: "Watched topics - %{count} unread"
+          one: "Watched topics - %{count} unread watched topic"
+          other: "Watched topics - %{count} unread watched topics"
         messages: "Personal messages"
         messages_with_unread:
-          one: "Personal messages - %{count} unread"
-          other: "Personal messages - %{count} unread"
+          one: "Personal messages - %{count} unread message"
+          other: "Personal messages - %{count} unread messages"
         bookmarks: "Bookmarks"
         bookmarks_with_unread:
-          one: "Bookmarks - %{count} unread"
-          other: "Bookmarks - %{count} unread"
+          one: "Bookmarks - %{count} unread bookmark"
+          other: "Bookmarks - %{count} unread bookmarks"
         review_queue: "Review queue"
         review_queue_with_unread:
           one: "Review queue - %{count} needs review"
           other: "Review queue - %{count} need review"
         other_notifications: "Other notifications"
         other_notifications_with_unread:
-          one: "Other notifications - %{count} unread"
-          other: "Other notifications - %{count} unread"
+          one: "Other notifications - %{count} unread notification"
+          other: "Other notifications - %{count} unread notifications"
         profile: "Profile"
       reviewable:
         view_all: "view all review items"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2567,10 +2567,45 @@ en:
     view_all: "view all %{tab}"
     user_menu:
       generic_no_items: "There are no items in this list."
-      sr_menu_tabs: "Menu tabs"
+      sr_menu_tabs: "User menu tabs"
       view_all_notifications: "view all notifications"
       view_all_bookmarks: "view all bookmarks"
       view_all_messages: "view all personal messages"
+      tabs:
+        all_notifications: "All notifications"
+        replies: "Replies"
+        replies_with_unread:
+          one: "Replies - %{count} unread"
+          other: "Replies - %{count} unread"
+        mentions: "Mentions"
+        mentions_with_unread:
+          one: "Mentions - %{count} unread"
+          other: "Mentions - %{count} unread"
+        likes: "Likes"
+        likes_with_unread:
+          one: "Likes - %{count} unread"
+          other: "Likes - %{count} unread"
+        watching: "Watched topics"
+        watching_with_unread:
+          one: "Watched topics - %{count} unread"
+          other: "Watched topics - %{count} unread"
+        messages: "Personal messages"
+        messages_with_unread:
+          one: "Personal messages - %{count} unread"
+          other: "Personal messages - %{count} unread"
+        bookmarks: "Bookmarks"
+        bookmarks_with_unread:
+          one: "Bookmarks - %{count} unread"
+          other: "Bookmarks - %{count} unread"
+        review_queue: "Review queue"
+        review_queue_with_unread:
+          one: "Review queue - %{count} needs review"
+          other: "Review queue - %{count} need review"
+        other_notifications: "Other notifications"
+        other_notifications_with_unread:
+          one: "Other notifications - %{count} unread"
+          other: "Other notifications - %{count} unread"
+        profile: "Profile"
       reviewable:
         view_all: "view all review items"
         queue: "Queue"


### PR DESCRIPTION
This PR includes various accessibility improvements for the new user menu:

* Add `title` attributes to the user menu tabs
* Properly label lists (by adding `aria-labelledby` to `<ul>` elements) for screen readers
* Change the user menu structure so that the tabs come before the content panel in the DOM, but use CSS to reverse them visually.
  Normally, changing the order of elements via CSS is bad for accessibility, but I believe this is one of the rare scenarios where it [makes sense](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items#use_cases_for_order). Prior to this change, if you want to reach the first notification item after you select a tab using the keyboard, you have to hit <kbd>ctrl</kbd>+<kbd>tab</kbd> because the notifications list is before the tabs list. However, with this change, <kbd>tab</kbd> will move you to the first item in the list after you select a tab using your keyboard.
* Aria-hide the unread notifications badge/count on the tabs because the `title` attribute on the tab indicates the unread count.
* Add some tests.