### PR TITLE
DEV: Add `rake plugins:turbo_spec` task

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       RAILS_ENV: test
       PGUSER: discourse
       PGPASSWORD: discourse
-      USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' && matrix.target == 'core' }}
+      USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' }}
       EMBER_CLI_PLUGIN_ASSETS: ${{ matrix.ember_cli_plugin_assets }}
 
     strategy:
@@ -158,7 +158,7 @@ jobs:
 
       - name: Plugin RSpec
         if: matrix.build_type == 'backend' && matrix.target == 'plugins'
-        run: bin/rake plugin:spec
+        run: bin/rake plugin:turbo_spec
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'

--- a/bin/rake
+++ b/bin/rake
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 if ENV['RAILS_ENV'] == 'test' && ENV['LOAD_PLUGINS'].nil?
-  if ARGV.include?('db:migrate')
+  if ARGV.include?('db:migrate') || ARGV.include?('parallel:migrate')
     STDERR.puts "You are attempting to run migrations in your test environment and are not loading plugins, setting LOAD_PLUGINS to 1"
     ENV['LOAD_PLUGINS'] = '1'
   end


### PR DESCRIPTION
This leans on our existing `turbo_rspec` implementation to run plugin specs in parallel on all available cores

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
