### PR TITLE
DEV: Remove testem `parallel` limit

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -44,7 +44,7 @@ module.exports = {
   launch_in_ci: ["Chrome"],
   // launch_in_dev: ["Chrome"] // Ember-CLI always launches testem in 'CI' mode
   tap_failed_tests_only: false,
-  parallel: 1, // disable parallel tests for stability
+  parallel: -1,
   browser_start_timeout: 120,
   browser_args: {
     Chrome: [


### PR DESCRIPTION
In itself, this change will not cause tests to run in parallel. It just unlocks the ability to use tools like `ember exam` to run tests in parallel. For example:

```
yarn ember exam --load-balance --parallel=3 --random
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
