### PR TITLE
DEV: Add support for running plugin qunit in parallel

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -108,7 +108,10 @@ task "qunit:test", [:timeout, :qunit_path] do |_, args|
       test_page = "#{qunit_path}?#{query}&testem=1"
       cmd += ["yarn", "testem", "ci", "-f", "testem.js", "-t", test_page]
     else
-      cmd += ["yarn", "ember", "test", "--query", query]
+      cmd += ["yarn", "ember", "exam", "--query", query]
+      if parallel = ENV["QUNIT_PARALLEL"]
+        cmd += ["--load-balance", "--parallel", parallel]
+      end
     end
 
     system(*cmd, chdir: "#{Rails.root}/app/assets/javascripts/discourse")


### PR DESCRIPTION
For example, to run in three concurrent browsers and assemble the results:

```
QUNIT_PARALLEL=3 bin/rake "plugin:qunit[discourse-chat]"
```

(requires https://github.com/discourse/discourse/pull/18290)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
