### PR TITLE
FEATURE: add hover tooltips to timeline start/end dates

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -579,6 +579,9 @@ export default createWidget("topic-timeline", {
             className: "start-date",
             rawLabel: timelineDate(createdAt),
             action: "jumpTop",
+            attributes: {
+              "data-tooltip": I18n.t("topic_entrance.sr_jump_top_button"),
+            },
           })
         ),
         this.attach("timeline-scrollarea", attrs),
@@ -588,6 +591,9 @@ export default createWidget("topic-timeline", {
             className: "now-date",
             rawLabel: bottomAge,
             action: "jumpBottom",
+            attributes: {
+              "data-tooltip": I18n.t("topic_entrance.sr_jump_bottom_button"),
+            },
           })
         ),
       ];

--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -214,6 +214,7 @@
     .start-date {
       @include unselectable;
       color: var(--primary-med-or-secondary-med);
+      cursor: pointer;
     }
 
     .timeline-scrollarea {
@@ -300,6 +301,7 @@
       display: inline-block;
       color: var(--primary-med-or-secondary-med);
       margin-top: 0.5em;
+      cursor: pointer;
     }
   }
 }


### PR DESCRIPTION
A customer requested this feature... but it seems like a simple and reasonable core addition. 

I could alternatively add a widget setting to make this optional. 

![Screen Shot 2022-09-20 at 1 24 46 PM](https://user-images.githubusercontent.com/1681963/191324911-b0430391-1225-4371-b102-de78b2cce859.png)
![Screen Shot 2022-09-20 at 1 24 51 PM](https://user-images.githubusercontent.com/1681963/191324913-a240c044-7f9d-43d5-82a7-45e5f468fd52.png)

