### PR TITLE
FIX: Add missing string for reviewables in user menu when reviewable post is deleted

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/reviewable-types/flagged-post.js
+++ b/app/assets/javascripts/discourse/app/lib/reviewable-types/flagged-post.js
@@ -1,6 +1,7 @@
 import ReviewableTypeBase from "discourse/lib/reviewable-types/base";
 import { htmlSafe } from "@ember/template";
 import I18n from "I18n";
+import { emojiUnescape } from "discourse/lib/text";
 
 export default class extends ReviewableTypeBase {
   get description() {
@@ -10,11 +11,11 @@ export default class extends ReviewableTypeBase {
       return htmlSafe(
         I18n.t("user_menu.reviewable.post_number_with_topic_title", {
           post_number: postNumber,
-          title,
+          title: emojiUnescape(title),
         })
       );
     } else {
-      return I18n.t("user_menu.reviewable.delete_post");
+      return I18n.t("user_menu.reviewable.deleted_post");
     }
   }
 }

--- a/app/assets/javascripts/discourse/tests/unit/lib/reviewable-types/flagged-post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/reviewable-types/flagged-post-test.js
@@ -1,0 +1,54 @@
+import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { createRenderDirector } from "discourse/tests/helpers/reviewable-types-helper";
+import { htmlSafe } from "@ember/template";
+import { emojiUnescape } from "discourse/lib/text";
+import UserMenuReviewable from "discourse/models/user-menu-reviewable";
+import I18n from "I18n";
+
+function getReviewable(overrides = {}) {
+  return UserMenuReviewable.create(
+    Object.assign(
+      {
+        flagger_username: "sayo2",
+        id: 17,
+        pending: false,
+        type: "ReviewableFlaggedPost",
+        topic_fancy_title: "anything hello world",
+        post_number: 1,
+      },
+      overrides
+    )
+  );
+}
+
+discourseModule("Unit | Reviewable Items | flagged-post", function () {
+  test("description", function (assert) {
+    const reviewable = getReviewable({
+      topic_fancy_title: "This is safe title &lt;a&gt; :heart:",
+    });
+    const director = createRenderDirector(
+      reviewable,
+      "ReviewableFlaggedPost",
+      this.siteSettings
+    );
+    assert.deepEqual(
+      director.description,
+      htmlSafe(
+        I18n.t("user_menu.reviewable.post_number_with_topic_title", {
+          title: `This is safe title &lt;a&gt; ${emojiUnescape(":heart:")}`,
+          post_number: 1,
+        })
+      ),
+      "contains the fancy title without escaping because it's already safe"
+    );
+
+    delete reviewable.topic_fancy_title;
+    delete reviewable.post_number;
+    assert.deepEqual(
+      director.description,
+      I18n.t("user_menu.reviewable.deleted_post"),
+      "falls back to generic string when the post/topic is deleted"
+    );
+  });
+});

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2610,6 +2610,7 @@ en:
         view_all: "view all review items"
         queue: "Queue"
         deleted_user: "(deleted user)"
+        deleted_post: "(deleted post)"
         post_number_with_topic_title: "post #%{post_number} - %{title}"
         new_post_in_topic: "new post in %{title}"
         user_requires_approval: "%{username} requires approval"


### PR DESCRIPTION
This PR add a missing translation string that's meant to appear as a generic placeholder in the reviewables tab in the user menu when a flagged post/topic is deleted.

Before:

<img src="https://user-images.githubusercontent.com/17474474/191328944-5039b79b-6561-4bfa-a0b6-84c6d6929dee.png" width=400>

After:

<img src="https://user-images.githubusercontent.com/17474474/191328771-a85ed344-e243-4a33-9872-a0052779ade0.png" width=400>
