### PR TITLE
UX: Ability to scroll menu tabs when height is limited

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -104,6 +104,7 @@
     flex-direction: column;
     border-left: 1px solid var(--primary-low);
     padding: 0.75em 0 0;
+    overflow-y: auto;
   }
 
   .tabs-list {


### PR DESCRIPTION
This PR allows you to scroll through the user menu tab items when there is a limited height.

<img width="373" alt="Screen Shot 2022-09-20 at 12 12 24 PM" src="https://user-images.githubusercontent.com/30090424/191344481-0c2316f1-09e3-4b99-a1cc-e059472842e1.png">
