### PR TITLE
FIX: Sidebar scroll fade on older iOS

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -24,7 +24,7 @@
       pointer-events: none;
       background: linear-gradient(
         to bottom,
-        rgba(0, 0, 0, 0),
+        rgba(var(--primary-very-low-rgb), 0),
         rgba(var(--primary-very-low-rgb), 1)
       );
     }

--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -24,7 +24,7 @@
       pointer-events: none;
       background: linear-gradient(
         to bottom,
-        transparent,
+        rgba(0, 0, 0, 0),
         rgba(var(--primary-very-low-rgb), 1)
       );
     }

--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -97,6 +97,16 @@
     margin-top: 0;
   }
 
+  .sidebar-footer-container {
+    &:before {
+      background: linear-gradient(
+        to bottom,
+        rgba(var(--primary-very-low-rgb), 0),
+        rgba(var(--primary-very-low-rgb), 1)
+      );
+    }
+  }
+
   .sidebar-sections {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
The sidebar's scroll fade uses a `linear-gradient()` which in older versions of iOS, such as `15.0` only has **partial support**:

>Partial support in Safari and Older Firefox versions refers to not using premultiplied colors which results in unexpected behavior when using the transparent keyword as advised by the [spec 1](https://www.w3.org/TR/2012/CR-css3-images-20120417/#color-stop-syntax).

Since the linear-gradient() has the usage of the `transparent` keyword, the gradient appears broken on older iOS versions:
<details>
<summary>See screenshot</summary>

![image](https://user-images.githubusercontent.com/30090424/191365107-4589d0c2-4993-4777-8969-1be03c74c028.png)

</details>

**This PR resolves this issue by** removing the usage of the `transparent` keyword and instead using a CSS variable with a `0` alpha value.

<img width="378" alt="iOS-15-simulator-screenshot" src="https://user-images.githubusercontent.com/30090424/191365524-d6dbbaba-9ec6-45f1-ab37-a9430b8c5571.png">

