### PR TITLE
SECURITY: Limit user profile field length

### DIFF
--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -13,9 +13,9 @@ class UserProfile < ActiveRecord::Base
   has_many :user_profile_views, dependent: :destroy
 
   validates :bio_raw, length: { maximum: 3000 }, watched_words: true
-  validates :website, url: true, allow_blank: true, if: :validate_website?
+  validates :website, url: true, length: { maximum: 3000 }, allow_blank: true, if: :validate_website?
+  validates :location, length: { maximum: 3000 }, watched_words: true
   validates :user, presence: true
-  validates :location, watched_words: true
 
   validate :website_domain_validator, if: :validate_website?
 
@@ -188,8 +188,8 @@ end
 # Table name: user_profiles
 #
 #  user_id                      :integer          not null, primary key
-#  location                     :string
-#  website                      :string
+#  location                     :string(3000)
+#  website                      :string(3000)
 #  bio_raw                      :text
 #  bio_cooked                   :text
 #  dismissed_banner_key         :integer

--- a/db/migrate/20220920044310_enforce_user_profile_max_limits.rb
+++ b/db/migrate/20220920044310_enforce_user_profile_max_limits.rb
@@ -2,8 +2,8 @@
 
 class EnforceUserProfileMaxLimits < ActiveRecord::Migration[7.0]
   def change
-    execute "UPDATE user_profiles SET location = LEFT(location, 3000)"
-    execute "UPDATE user_profiles SET website = LEFT(website, 3000)"
+    execute "UPDATE user_profiles SET location = LEFT(location, 3000) WHERE location IS NOT NULL"
+    execute "UPDATE user_profiles SET website = LEFT(website, 3000) WHERE website IS NOT NULL"
 
     change_column :user_profiles, :location, :string, limit: 3000
     change_column :user_profiles, :website, :string, limit: 3000

--- a/db/migrate/20220920044310_enforce_user_profile_max_limits.rb
+++ b/db/migrate/20220920044310_enforce_user_profile_max_limits.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EnforceUserProfileMaxLimits < ActiveRecord::Migration[7.0]
+  def change
+    execute "UPDATE user_profiles SET location = LEFT(location, 3000)"
+    execute "UPDATE user_profiles SET website = LEFT(website, 3000)"
+
+    change_column :user_profiles, :location, :string, limit: 3000
+    change_column :user_profiles, :website, :string, limit: 3000
+  end
+end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe UserProfile do
         before { profile.location = "a" * 3500 }
 
         it "is not valid" do
-          profile.valid?
+          expect(profile.valid?).to eq(false)
           expect(profile.errors.full_messages).to include(/Location is too long \(maximum is 3000 characters\)/)
         end
       end
@@ -76,7 +76,7 @@ RSpec.describe UserProfile do
         before { profile.bio_raw = "a" * 3500 }
 
         it "is not valid" do
-          profile.valid?
+          expect(profile.valid?).to eq(false)
           expect(profile.errors.full_messages).to include(/About Me is too long \(maximum is 3000 characters\)/)
         end
       end

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe UserProfile do
         end
       end
 
+      context "when it is > 3000 characters" do
+        before { profile.location = "a" * 3500 }
+
+        it "is not valid" do
+          profile.valid?
+          expect(profile.errors.full_messages).to include(/Location is too long \(maximum is 3000 characters\)/)
+        end
+      end
+
       context "when it does not contain watched words" do
         it { is_expected.to be_valid }
       end
@@ -60,6 +69,15 @@ RSpec.describe UserProfile do
           profile.valid?
           expect(profile.errors[:base].size).to eq(1)
           expect(profile.errors.messages[:base]).to include(/you can't post the word/)
+        end
+      end
+
+      context "when it is > 3000 characters" do
+        before { profile.bio_raw = "a" * 3500 }
+
+        it "is not valid" do
+          profile.valid?
+          expect(profile.errors.full_messages).to include(/About Me is too long \(maximum is 3000 characters\)/)
         end
       end
 
@@ -128,6 +146,11 @@ RSpec.describe UserProfile do
 
         user_profile.website = 'user - https://forum.example.com/user'
         expect { user_profile.save! }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it "does not allow > 3000 characters" do
+        user_profile.website = "a" * 3500
+        expect(user_profile).to_not be_valid
       end
     end
 


### PR DESCRIPTION
Adds limits to location and website fields at model and DB level to match the bio_raw field limits. A limit cannot be added at the DB level for bio_raw because it is a postgres text field.
