### PR TITLE
SECURITY: Limit user profile field length

### DIFF
--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -8,7 +8,8 @@ class UserProfile < ActiveRecord::Base
   belongs_to :featured_topic, class_name: 'Topic'
 
   validates :bio_raw, length: { maximum: 3000 }
-  validates :website, url: true, allow_blank: true, if: Proc.new { |c| c.new_record? || c.website_changed? }
+  validates :website, url: true, length: { maximum: 3000 }, allow_blank: true, if: Proc.new { |c| c.new_record? || c.website_changed? }
+  validates :location, length: { maximum: 3000 }
   validates :user, presence: true
   before_save :cook
   after_save :trigger_badges
@@ -168,8 +169,8 @@ end
 # Table name: user_profiles
 #
 #  user_id                      :integer          not null, primary key
-#  location                     :string
-#  website                      :string
+#  location                     :string(3000)
+#  website                      :string(3000)
 #  bio_raw                      :text
 #  bio_cooked                   :text
 #  dismissed_banner_key         :integer

--- a/db/migrate/20220920044310_enforce_user_profile_max_limits.rb
+++ b/db/migrate/20220920044310_enforce_user_profile_max_limits.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EnforceUserProfileMaxLimits < ActiveRecord::Migration[6.1]
+  def change
+    execute "UPDATE user_profiles SET location = LEFT(location, 3000) WHERE location IS NOT NULL"
+    execute "UPDATE user_profiles SET website = LEFT(website, 3000) WHERE website IS NOT NULL"
+
+    change_column :user_profiles, :location, :string, limit: 3000
+    change_column :user_profiles, :website, :string, limit: 3000
+  end
+end


### PR DESCRIPTION
Adds limits to location and website fields at model and DB level to match the bio_raw field limits. A limit cannot be added at the DB level for bio_raw because it is a postgres text field.

Co-authored-by: Alan Guo Xiang Tan gxtan1990@gmail.com

