### PR TITLE
DEV: Enforce dominant_color length in validation

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -37,6 +37,7 @@ class Upload < ActiveRecord::Base
 
   validates_presence_of :filesize
   validates_presence_of :original_filename
+  validates :dominant_color, length: { is: 6 }, allow_blank: true, allow_nil: true
 
   validates_with UploadValidator
 

--- a/db/migrate/20220915132547_add_dominant_color_to_uploads.rb
+++ b/db/migrate/20220915132547_add_dominant_color_to_uploads.rb
@@ -2,7 +2,7 @@
 
 class AddDominantColorToUploads < ActiveRecord::Migration[7.0]
   def change
-    add_column :uploads, :dominant_color, :text, limit: 6, null: true
+    add_column :uploads, :dominant_color, :text, null: true
     add_index :uploads, :id, where: "dominant_color IS NULL"
   end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -689,5 +689,22 @@ RSpec.describe Upload do
 
       expect(invalid_image.dominant_color).to eq(nil)
     end
+
+    it "is validated for length" do
+      u = Fabricate(:upload)
+
+      # Acceptable values
+      u.update!(dominant_color: nil)
+      u.update!(dominant_color: "")
+      u.update!(dominant_color: "abcdef")
+
+      expect {
+        u.update!(dominant_color: "toomanycharacters")
+      }.to raise_error(ActiveRecord::RecordInvalid)
+
+      expect {
+        u.update!(dominant_color: "abcd")
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
   end
 end


### PR DESCRIPTION
The `add_column` `limit` parameter has no effect on a postgres `text` column. Instead we can perform the check in ActiveRecord.

We never expect this condition to be hit - users cannot control this value. It's just a safety net.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
