### PR TITLE
DEV: Improve setting of raw-view owner

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/raw.js
+++ b/app/assets/javascripts/discourse/app/helpers/raw.js
@@ -13,8 +13,8 @@ function renderRaw(ctx, template, templateName, params) {
     const viewClass = context.registry.resolve(`raw-view:${templateName}`);
 
     if (viewClass) {
+      setOwner(params, getOwner(context));
       params.view = viewClass.create(params, context);
-      setOwner(params.view, getOwner(context.site));
     }
 
     if (!params.view) {


### PR DESCRIPTION
Using the owner of `site` is not perfectly reliable, especially given that `site` is stubbed in tests. Instead, we can fetch the owner of the `context` object itself.

Also, Ember sets the owner of an EmberObject based on the first parameter to `create`. This is preferable to a separate `setOwner` call because it means the owner is available during initialization.

Unfortunately we don't have any way to compile raw templates inline during tests, so testing this behavior in core is very difficult. Given that we aim to remove the raw handlebars system in the not-too-distant future, it doesn't make sense to invest lots of time on tooling here. Regressions of this behavior will be detected by theme CI tests [like this](https://github.com/discourse/discourse-topic-thumbnails/pull/21).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
