### PR TITLE
DEV: Ensure GitHub workflows cancel cleanly

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -67,7 +67,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Check RubyGems Licenses
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
           licensed cache
           licensed status
@@ -76,14 +76,14 @@ jobs:
         run: yarn install
 
       - name: Check Yarn Licenses
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
           yarn global add licensee
           yarn global upgrade licensee
           licensee --errors-only
 
       - name: Check Ember CLI Workspace Licenses
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         working-directory: ./app/assets/javascripts
         run: |
           licensee --errors-only

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -64,19 +64,19 @@ jobs:
         run: yarn install
 
       - name: Rubocop
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: bundle exec rubocop --parallel .
 
       - name: ESLint (core)
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: yarn eslint app/assets/javascripts
 
       - name: ESLint (core plugins)
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: yarn eslint plugins
 
       - name: Prettier
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
           yarn prettier -v
           yarn pprettier --list-different \
@@ -86,7 +86,7 @@ jobs:
             "plugins/**/assets/javascripts/**/*.js"
 
       - name: Ember template lint
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
           yarn ember-template-lint \
             --no-error-on-unmatched-pattern \
@@ -94,9 +94,9 @@ jobs:
             "plugins/**/assets/javascripts/**/*.hbs"
 
       - name: English locale lint (core)
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: bundle exec ruby script/i18n_lint.rb "config/**/locales/{client,server}.en.yml"
 
       - name: English locale lint (core plugins)
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: bundle exec ruby script/i18n_lint.rb "plugins/**/locales/{client,server}.en.yml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -220,19 +220,19 @@ jobs:
           sudo -E -u discourse -H yarn ember build --environment=test  -o /tmp/emberbuild
 
       - name: Core QUnit 1
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=1 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 15
 
       - name: Core QUnit 2
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=2 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 15
 
       - name: Core QUnit 3
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         working-directory: ./app/assets/javascripts/discourse
         run: sudo -E -u discourse -H yarn ember exam --path /tmp/emberbuild --split=3 --partition=3 --launch "${{ matrix.browser }}" --random
         timeout-minutes: 15


### PR DESCRIPTION
We added `always()` on some steps so that they run even if previous steps fail. That helps give us a picture of all failures in one run, rather than having to re-run the workflow after fixing the first failure.

However, when we explicitly cancel a job, we should skip running these steps. `!cancelled()` is a better substitute for `always()` in this case.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
