### PR TITLE
FEATURE: site setting to disable usernames in share links.

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/share-url.js
+++ b/app/assets/javascripts/discourse/app/helpers/share-url.js
@@ -1,8 +1,11 @@
 import { helperContext } from "discourse-common/lib/helpers";
 
 export function resolveShareUrl(url, user) {
-  const badgesEnabled = helperContext().siteSettings.enable_badges;
-  const userSuffix = user && badgesEnabled ? `?u=${user.username_lower}` : "";
+  const siteSettings = helperContext().siteSettings;
+  const badgesEnabled = siteSettings.enable_badges;
+  const allowUsername = siteSettings.allow_username_in_share_links;
+  const userSuffix =
+    user && badgesEnabled && allowUsername ? `?u=${user.username_lower}` : "";
 
   return url + userSuffix;
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/share-topic-test.js
@@ -139,3 +139,24 @@ acceptance("Share url with badges disabled - desktop", function (needs) {
     );
   });
 });
+
+acceptance("With username in share links disabled - desktop", function (needs) {
+  needs.user();
+  needs.settings({ allow_username_in_share_links: false });
+
+  needs.pretender((server, helper) => {
+    server.get("/c/feature/find_by_slug.json", () =>
+      helper.response(200, CategoryFixtures["/c/1/show.json"])
+    );
+  });
+
+  test("topic footer button - username in share links disabled - desktop", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click("#topic-footer-button-share-and-invite");
+
+    assert.notOk(
+      query("input.invite-link").value.includes("?u=eviltrout"),
+      "it doesn't add the username param when username in share links are disabled"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/helpers/site-settings.js
+++ b/app/assets/javascripts/discourse/tests/helpers/site-settings.js
@@ -13,6 +13,7 @@ const ORIGINAL_SETTINGS = {
   post_menu: "like|share|flag|edit|bookmark|delete|admin|reply",
   post_menu_hidden_items: "flag|bookmark|edit|delete|admin",
   share_links: "twitter|facebook|email",
+  allow_username_in_share_links: true,
   category_colors:
     "BF1E2E|F1592A|F7941D|9EB83B|3AB54A|12A89D|25AAE2|0E76BD|652D90|92278F|ED207B|8C6238|231F20|27AA5B|B3B5B4|E45735",
   enable_mobile_theme: true,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1640,6 +1640,7 @@ en:
     post_menu: "Determine which items appear on the post menu, and in what order. Example like|edit|flag|delete|share|bookmark|reply"
     post_menu_hidden_items: "The menu items to hide by default in the post menu unless an expansion ellipsis is clicked on."
     share_links: "Determine which items appear on the share dialog, and in what order."
+    allow_username_in_share_links: "Allow usernames to be included in share links. This is useful to reward badges based on unique visitors."
     site_contact_username: "A valid staff username to send all automated messages from. If left blank the default System account will be used."
     site_contact_group_name: "A valid name of a group that gets invited to all automatically sent private messages."
     send_welcome_message: "Send all new users a welcome message with a quick start guide."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -222,6 +222,9 @@ basic:
       - twitter
       - facebook
       - email
+  allow_username_in_share_links:
+    client: true
+    default: true
   share_quote_visibility:
     client: true
     type: enum


### PR DESCRIPTION
Previously, it included the username if badges are enabled. It raised some privacy concerns in [meta.discourse](https://meta.discourse.org/t/share-a-link-for-a-post-should-not-leak-username/66489) couple of times.