### PR TITLE
DEV: Don't interpret user field names as HTML

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/user-fields/confirm.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-fields/confirm.hbs
@@ -1,6 +1,6 @@
 {{#if this.field.name}}
   <label class="control-label">
-    {{html-safe this.field.name}} {{#if this.field.required}}<span class="required">*</span>{{/if}}
+    {{this.field.name}} {{#if this.field.required}}<span class="required">*</span>{{/if}}
   </label>
 {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/components/user-fields/dropdown.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-fields/dropdown.hbs
@@ -1,5 +1,5 @@
 <label class="control-label" for={{concat "user-" this.elementId}}>
-  {{html-safe this.field.name}}
+  {{this.field.name}}
   {{#if this.field.required}}
     <span class="required">*</span>
   {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/user-fields/multiselect.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-fields/multiselect.hbs
@@ -1,5 +1,5 @@
 <label class="control-label" for={{concat "user-" this.elementId}}>
-  {{html-safe this.field.name}}
+  {{this.field.name}}
   {{#if this.field.required}}
     <span class="required">*</span>
   {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/user-fields/text.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-fields/text.hbs
@@ -1,5 +1,5 @@
 <label class="control-label" for={{concat "user-" this.elementId}}>
-  {{html-safe this.field.name}}
+  {{this.field.name}}
   {{#if this.field.required}}<span class="required">*</span>{{/if}}
 </label>
 <div class="controls">


### PR DESCRIPTION
This isn't a security bug, because only admins can create user fields and we have to trust admins, because they can change themes, which are shown site-wide and can contain unrestricted JS.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
