### PR TITLE
PERF: Do not double bundle common langs in hljs bundle

### DIFF
--- a/lib/highlight_js.rb
+++ b/lib/highlight_js.rb
@@ -2,6 +2,7 @@
 
 module HighlightJs
   HIGHLIGHTJS_DIR ||= "#{Rails.root}/vendor/assets/javascripts/highlightjs/"
+  BUNDLED_LANGS = %w(bash c cpp csharp css diff go graphql ini java javascript json kotlin less lua makefile xml markdown objectivec perl php php-template plaintext python python-repl r ruby rust scss shell sql swift typescript vbnet wasm yaml)
 
   def self.languages
     langs = Dir.glob(HIGHLIGHTJS_DIR + "languages/*.js").map do |path|
@@ -13,7 +14,7 @@ module HighlightJs
 
   def self.bundle(langs)
     result = File.read(HIGHLIGHTJS_DIR + "highlight.min.js")
-    langs.each do |lang|
+    (langs - BUNDLED_LANGS).each do |lang|
       begin
         result << "\n" << File.read(HIGHLIGHTJS_DIR + "languages/#{lang}.min.js")
       rescue Errno::ENOENT


### PR DESCRIPTION
At some point moved from hljs pure source to their CDN assets, but we
did not change the way we created the HLJS bundle. The CDN asset comes
with their "common" languages already included, so we were duplicating
around 35 languagues in the bundle we create.

This patch includes a list of their current common langs so we never
double bundle those.

Changes in size are significant. Numbers before minimization/compression
are 747.53 KB before and 117.57 KB after.

This double bundle bug was added in #12441, so 18 months now.
