### PR TITLE
FIX: Skip uncategorized category in sidebar when disabled

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.hbs
@@ -5,6 +5,7 @@
 
   {{#each this.sectionLinks as |sectionLink|}}
     <Sidebar::SectionLink
+      @linkName={{sectionLink.name}}
       @route={{sectionLink.route}}
       @title={{sectionLink.title}}
       @content={{sectionLink.text}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.js
@@ -2,6 +2,7 @@ import { cached } from "@glimmer/tracking";
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 import CategorySectionLink from "discourse/lib/sidebar/user/categories-section/category-section-link";
+import { canDisplayCategory } from "discourse/lib/sidebar/helpers";
 
 export default class SidebarAnonymousCategoriesSection extends Component {
   @service topicTrackingState;
@@ -22,7 +23,11 @@ export default class SidebarAnonymousCategoriesSection extends Component {
       );
     } else {
       categories = categories
-        .filter((category) => !category.parent_category_id)
+        .filter(
+          (category) =>
+            canDisplayCategory(category, this.siteSettings) &&
+            !category.parent_category_id
+        )
         .slice(0, 5);
     }
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.js
@@ -6,11 +6,13 @@ import { action } from "@ember/object";
 
 import Component from "@glimmer/component";
 import CategorySectionLink from "discourse/lib/sidebar/user/categories-section/category-section-link";
+import { canDisplayCategory } from "discourse/lib/sidebar/helpers";
 
 export default class SidebarUserCategoriesSection extends Component {
   @service router;
   @service topicTrackingState;
   @service currentUser;
+  @service siteSettings;
 
   constructor() {
     super(...arguments);
@@ -30,7 +32,11 @@ export default class SidebarUserCategoriesSection extends Component {
   get sectionLinks() {
     const links = [];
 
-    for (const category of this.currentUser.sidebarCategories) {
+    const categories = this.currentUser.sidebarCategories.filter((category) => {
+      return canDisplayCategory(category, this.siteSettings);
+    });
+
+    for (const category of categories) {
       links.push(
         new CategorySectionLink({
           category,

--- a/app/assets/javascripts/discourse/app/lib/sidebar/helpers.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/helpers.js
@@ -1,0 +1,7 @@
+export function canDisplayCategory(category, siteSettings) {
+  if (siteSettings.allow_uncategorized_topics) {
+    return true;
+  }
+
+  return !category.isUncategorizedCategory;
+}

--- a/app/assets/javascripts/discourse/app/models/site.js
+++ b/app/assets/javascripts/discourse/app/models/site.js
@@ -90,8 +90,8 @@ const Site = RestModel.extend({
     for (const category of categories) {
       if (category.isTracked) {
         if (
-          !this.siteSettings.suppress_uncategorized_badge ||
-          category.id !== this.uncategorized_category_id
+          this.siteSettings.allow_uncategorized_topics ||
+          !category.isUncategorizedCategory
         ) {
           trackedCategories.push(category);
         }

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -334,16 +334,9 @@ const User = RestModel.extend({
     }
 
     return Site.current()
-      .categoriesList.filter((category) => {
-        if (
-          this.siteSettings.suppress_uncategorized_badge &&
-          category.isUncategorizedCategory
-        ) {
-          return false;
-        }
-
-        return sidebarCategoryIds.includes(category.id);
-      })
+      .categoriesList.filter((category) =>
+        sidebarCategoryIds.includes(category.id)
+      )
       .sort((a, b) => a.name.localeCompare(b.name));
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
@@ -32,7 +32,7 @@ acceptance("Sidebar - Anonymous Categories Section", function (needs) {
     );
   });
 
-  test("catgegory section links in sidebar when default_sidebar_categories site setting has been configured", async function (assert) {
+  test("category section links in sidebar when default_sidebar_categories site setting has been configured", async function (assert) {
     this.siteSettings.default_sidebar_categories = "3|13|1";
     await visit("/");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
@@ -5,12 +5,12 @@ import {
   exists,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
+import Site from "discourse/models/site";
 
 acceptance("Sidebar - Anonymous Categories Section", function (needs) {
   needs.settings({
     enable_experimental_sidebar_hamburger: true,
     enable_sidebar: true,
-    suppress_uncategorized_badge: false,
   });
 
   test("category section links", async function (assert) {
@@ -32,7 +32,7 @@ acceptance("Sidebar - Anonymous Categories Section", function (needs) {
     );
   });
 
-  test("default sidebar categories", async function (assert) {
+  test("catgegory section links in sidebar when default_sidebar_categories site setting has been configured", async function (assert) {
     this.siteSettings.default_sidebar_categories = "3|13|1";
     await visit("/");
 
@@ -48,6 +48,27 @@ acceptance("Sidebar - Anonymous Categories Section", function (needs) {
     assert.ok(
       exists("a.sidebar-section-link-all-categories"),
       "all categories link is visible"
+    );
+  });
+
+  test("default uncategorized category section links is not shown when allow_uncategorized_topics is disabled", async function (assert) {
+    this.siteSettings.allow_uncategorized_topics = false;
+    this.siteSettings.fixed_category_positions = true;
+    const site = Site.current();
+
+    const firstCategory = Site.current().categories.find((category) => {
+      return !category.parent_category_id;
+    });
+
+    site.set("uncategorized_category_id", firstCategory.id);
+
+    await visit("/");
+
+    assert.notOk(
+      exists(
+        `.sidebar-section-categories .sidebar-section-link-${firstCategory.slug}`
+      ),
+      "category section link is not shown in sidebar after being marked as uncategorized"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -17,10 +17,10 @@ import categoryFixture from "discourse/tests/fixtures/category-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
 
 acceptance(
-  "Sidebar - Logged on user - Categories Section - suppress_uncategorized_badge enabled",
+  "Sidebar - Logged on user - Categories Section - allow_uncategorized_topics disabled",
   function (needs) {
     needs.settings({
-      suppress_uncategorized_badge: true,
+      allow_uncategorized_topics: false,
       enable_experimental_sidebar_hamburger: true,
       enable_sidebar: true,
     });


### PR DESCRIPTION
When `allow_uncategorized_topics` is set to `false`, we do not want to
show the uncategorized in sidebar by default.

This commit updates a couple of places in the code related to sidebar
which was incorrectly using `suppress_uncategorized_badge` site setting
which is mainly used for hiding the category badge for uncategorized
category and should not be used to determine if uncategorized categories
should be allowed or not.