### PR TITLE
FIX: Respect site settings for sidebar users, groups and badges link

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/common/community-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/community-section.js
@@ -23,27 +23,19 @@ export default class SidebarCommunitySection extends Component {
   constructor() {
     super(...arguments);
 
-    this.moreSectionLinks = [
+    this.moreSectionLinks = this.#initializeSectionLinks([
       ...this.defaultMoreSectionLinks,
       ...customSectionLinks,
-    ].map((sectionLinkClass) => {
-      return this.#initializeSectionLink(sectionLinkClass);
-    });
+    ]);
 
-    this.moreSecondarySectionLinks = [
+    this.moreSecondarySectionLinks = this.#initializeSectionLinks([
       ...this.defaultMoreSecondarySectionLinks,
       ...secondaryCustomSectionLinks,
-    ].map((sectionLinkClass) => {
-      return this.#initializeSectionLink(sectionLinkClass);
-    });
+    ]);
 
-    const mainSectionLinks = this.currentUser?.staff
-      ? [...this.defaultMainSectionLinks, ...this.defaultAdminMainSectionLinks]
-      : [...this.defaultMainSectionLinks];
-
-    this.sectionLinks = mainSectionLinks.map((sectionLinkClass) => {
-      return this.#initializeSectionLink(sectionLinkClass);
-    });
+    this.sectionLinks = this.#initializeSectionLinks(
+      this.defaultMainSectionLinks
+    );
 
     this.callbackId = this.topicTrackingState.onStateChange(() => {
       this.sectionLinks.forEach((sectionLink) => {
@@ -63,11 +55,6 @@ export default class SidebarCommunitySection extends Component {
   }
 
   // Override in child
-  get defaultAdminMainSectionLinks() {
-    return [];
-  }
-
-  // Override in child
   get defaultMoreSectionLinks() {
     return [];
   }
@@ -75,6 +62,18 @@ export default class SidebarCommunitySection extends Component {
   // Override in child
   get defaultMoreSecondarySectionLinks() {
     return [];
+  }
+
+  #initializeSectionLinks(sectionLinkClasses) {
+    return sectionLinkClasses.reduce((links, sectionLinkClass) => {
+      const sectionLink = this.#initializeSectionLink(sectionLinkClass);
+
+      if (sectionLink.shouldDisplay) {
+        links.push(sectionLink);
+      }
+
+      return links;
+    }, []);
   }
 
   #initializeSectionLink(sectionLinkClass) {

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/community-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/community-section.js
@@ -32,11 +32,12 @@ export default class SidebarUserCommunitySection extends SidebarCommonCommunityS
   }
 
   get defaultMainSectionLinks() {
-    return [EverythingSectionLink, TrackedSectionLink, MyPostsSectionLink];
-  }
-
-  get defaultAdminMainSectionLinks() {
-    return [AdminSectionLink];
+    return [
+      EverythingSectionLink,
+      TrackedSectionLink,
+      MyPostsSectionLink,
+      AdminSectionLink,
+    ];
   }
 
   get defaultMoreSectionLinks() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-community-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-community-section-link.js
@@ -34,6 +34,13 @@ export default class BaseCommunitySectionLink {
   }
 
   /**
+   * @returns {boolean} Whether the section link should be displayed. Defaults to true.
+   */
+  get shouldDisplay() {
+    return true;
+  }
+
+  /**
    * @returns {string} Ember route
    */
   get route() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/badges-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/badges-section-link.js
@@ -18,4 +18,8 @@ export default class BadgesSectionLink extends BaseSectionLink {
   get text() {
     return I18n.t("sidebar.sections.community.links.badges.content");
   }
+
+  get shouldDisplay() {
+    return this.siteSettings.enable_badges;
+  }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/groups-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/groups-section-link.js
@@ -18,4 +18,8 @@ export default class GroupsSectionLink extends BaseSectionLink {
   get text() {
     return I18n.t("sidebar.sections.community.links.groups.content");
   }
+
+  get shouldDisplay() {
+    return this.siteSettings.enable_group_directory;
+  }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/users-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/users-section-link.js
@@ -18,4 +18,11 @@ export default class UsersSectionLink extends BaseSectionLink {
   get text() {
     return I18n.t("sidebar.sections.community.links.users.content");
   }
+
+  get shouldDisplay() {
+    return (
+      this.siteSettings.enable_user_directory &&
+      (this.currentUser || !this.siteSettings.hide_user_profiles_from_public)
+    );
+  }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/admin-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/admin-section-link.js
@@ -18,4 +18,8 @@ export default class AdminSectionLink extends BaseSectionLink {
   get text() {
     return I18n.t("sidebar.sections.community.links.admin.content");
   }
+
+  get shouldDisplay() {
+    return this.currentUser?.staff;
+  }
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
@@ -4,6 +4,7 @@ import { test } from "qunit";
 
 import {
   acceptance,
+  exists,
   query,
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -72,7 +73,18 @@ acceptance("Sidebar - Anonymous user - Community Section", function (needs) {
     );
   });
 
-  test("groups  and badges section links are shown in more...", async function (assert) {
+  test("users section link is not shown when hide_user_profiles_from_public site setting is enabled", async function (assert) {
+    this.siteSettings.hide_user_profiles_from_public = true;
+
+    await visit("/");
+
+    assert.notOk(
+      exists(".sidebar-section-community .sidebar-section-link-users"),
+      "users section link is not shown in sidebar"
+    );
+  });
+
+  test("groups and badges section links are shown in more...", async function (assert) {
     await visit("/");
 
     await click(

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -229,6 +229,21 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     );
   });
 
+  test("users section link is not shown when enable_user_directory site setting is disabled", async function (assert) {
+    this.siteSettings.enable_user_directory = false;
+
+    await visit("/");
+
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    assert.notOk(
+      exists(".sidebar-section-community .sidebar-section-link-users"),
+      "users section link is not displayed in sidebar"
+    );
+  });
+
   test("clicking on badges link", async function (assert) {
     await visit("/");
 
@@ -242,6 +257,21 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       currentURL(),
       "/badges",
       "it should transition to the badges url"
+    );
+  });
+
+  test("badges section link is not shown when badges has been disabled", async function (assert) {
+    this.siteSettings.enable_badges = false;
+
+    await visit("/");
+
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    assert.notOk(
+      exists(".sidebar-section-community .sidebar-section-link-badges"),
+      "badges section link is not shown in sidebar"
     );
   });
 
@@ -289,6 +319,21 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     assert.ok(
       exists(".sidebar-section-community .sidebar-section-link-groups.active"),
       "groups link is displayed in sidebar when it is the active route"
+    );
+  });
+
+  test("groups section link is not shown when enable_group_directory site setting has been disabled", async function (assert) {
+    this.siteSettings.enable_group_directory = false;
+
+    await visit("/");
+
+    await click(
+      ".sidebar-section-community .sidebar-more-section-links-details-summary"
+    );
+
+    assert.notOk(
+      exists(".sidebar-section-community .sidebar-section-link-groups"),
+      "groups section link is not shown in sidebar"
     );
   });
 

--- a/app/assets/javascripts/discourse/tests/helpers/site-settings.js
+++ b/app/assets/javascripts/discourse/tests/helpers/site-settings.js
@@ -98,6 +98,7 @@ const ORIGINAL_SETTINGS = {
   secure_media: false,
   external_emoji_url: "",
   remove_muted_tags_from_latest: "always",
+  enable_group_directory: true,
 };
 
 let siteSettings = Object.assign({}, ORIGINAL_SETTINGS);


### PR DESCRIPTION
The links should not be displayed when its associated site setting has
been disabled. This commit maintains parity with the old hamburger menu.