### PR TITLE
DEV: Allow `rake qunit` filter to be used alongside parallel option

### DIFF
--- a/lib/tasks/qunit.rake
+++ b/lib/tasks/qunit.rake
@@ -108,13 +108,12 @@ task "qunit:test", [:timeout, :qunit_path, :filter] do |_, args|
       system("yarn", "ember", "build", chdir: "#{Rails.root}/app/assets/javascripts/discourse")
       test_page = "#{qunit_path}?#{query}&testem=1"
       cmd += ["yarn", "testem", "ci", "-f", "testem.js", "-t", test_page]
-    elsif filter
-      cmd += ["yarn", "ember", "test", "--query", query, "--filter", filter]
     else
       cmd += ["yarn", "ember", "exam", "--query", query]
       if parallel = ENV["QUNIT_PARALLEL"]
         cmd += ["--load-balance", "--parallel", parallel]
       end
+      cmd += ["--filter", filter] if filter
     end
 
     system(*cmd, chdir: "#{Rails.root}/app/assets/javascripts/discourse")


### PR DESCRIPTION
Followup to 61f5c8716d2b7cfe229a49b7653c255916ee7f02

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
