### PR TITLE
DEV: Emoji picker keyboard accessibility updates

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -271,12 +271,13 @@ export default Component.extend({
 
     if (event.key === "Escape") {
       this.onClose(event);
+      const path = event.path || (event.composedPath && event.composedPath());
 
-      const fromChatComposer = event.path.find((e) =>
+      const fromChatComposer = path.find((e) =>
         e?.classList?.contains("chat-composer-container")
       );
 
-      const fromTopicComposer = event.path.find((e) =>
+      const fromTopicComposer = path.find((e) =>
         e?.classList?.contains("d-editor")
       );
 

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -273,6 +273,8 @@ export default Component.extend({
 
     if (event.key === "Escape") {
       this.onClose(event);
+      const nearestInput = document.querySelector("textarea");
+      nearestInput.focus();
       return false;
     }
 

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -44,6 +44,7 @@ export default Component.extend({
   elements: {
     searchInput: ".emoji-picker-search-container input",
     picker: ".emoji-picker-emoji-area",
+    allEmojis: ".emoji-picker-emoji-area .emoji",
   },
 
   init() {
@@ -101,6 +102,9 @@ export default Component.extend({
       if (!emojiPicker) {
         return;
       }
+
+      this._applyAccessibility();
+
       const popperAnchor = this._getPopperAnchor();
 
       if (!this.site.isMobileDevice && this.usePopper && popperAnchor) {
@@ -352,6 +356,13 @@ export default Component.extend({
   _focusedOn(item) {
     // returns the item currently being focused on
     return document.activeElement.closest(item) ? document.activeElement : null;
+  },
+
+  _applyAccessibility() {
+    const allEmojis = document.querySelectorAll(this.elements.allEmojis);
+    allEmojis.forEach((emoji) => {
+      emoji.tabIndex = 0;
+    });
   },
 
   _applyFilter(filter) {

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -273,8 +273,23 @@ export default Component.extend({
 
     if (event.key === "Escape") {
       this.onClose(event);
-      const nearestInput = document.querySelector("textarea");
-      nearestInput.focus();
+
+      const fromChatComposer = event.path.find((e) =>
+        e?.classList?.contains("chat-composer-container")
+      );
+
+      const fromTopicComposer = event.path.find((e) =>
+        e?.classList?.contains("d-editor")
+      );
+
+      if (fromTopicComposer) {
+        document.querySelector(".d-editor-input")?.focus();
+      } else if (fromChatComposer) {
+        document.querySelector(".chat-composer-input")?.focus();
+      } else {
+        document.querySelector("textarea")?.focus();
+      }
+
       return false;
     }
 

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -397,6 +397,7 @@ export default Component.extend({
   _replaceEmoji(code) {
     const escaped = emojiUnescape(`:${escapeExpression(code)}:`, {
       lazy: true,
+      tabIndex: 0,
     });
     return htmlSafe(escaped);
   },

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -44,7 +44,6 @@ export default Component.extend({
   elements: {
     searchInput: ".emoji-picker-search-container input",
     picker: ".emoji-picker-emoji-area",
-    allEmojis: ".emoji-picker-emoji-area .emoji",
   },
 
   init() {

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -103,8 +103,6 @@ export default Component.extend({
         return;
       }
 
-      this._applyAccessibility();
-
       const popperAnchor = this._getPopperAnchor();
 
       if (!this.site.isMobileDevice && this.usePopper && popperAnchor) {
@@ -373,13 +371,6 @@ export default Component.extend({
   _focusedOn(item) {
     // returns the item currently being focused on
     return document.activeElement.closest(item) ? document.activeElement : null;
-  },
-
-  _applyAccessibility() {
-    const allEmojis = document.querySelectorAll(this.elements.allEmojis);
-    allEmojis.forEach((emoji) => {
-      emoji.tabIndex = 0;
-    });
   },
 
   _applyFilter(filter) {

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -404,7 +404,7 @@ export default Component.extend({
   _replaceEmoji(code) {
     const escaped = emojiUnescape(`:${escapeExpression(code)}:`, {
       lazy: true,
-      tabIndex: 0,
+      tabIndex: "0",
     });
     return htmlSafe(escaped);
   },

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-group-sections.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-group-sections.hbs
@@ -6,169 +6,169 @@
     <span class="title">{{i18n "emoji_picker.smileys_&_emotion"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":grinning:" (hash lazy=true)}}
-    {{replace-emoji ":smiley:" (hash lazy=true)}}
-    {{replace-emoji ":smile:" (hash lazy=true)}}
-    {{replace-emoji ":grin:" (hash lazy=true)}}
-    {{replace-emoji ":laughing:" (hash lazy=true)}}
-    {{replace-emoji ":sweat_smile:" (hash lazy=true)}}
-    {{replace-emoji ":rofl:" (hash lazy=true)}}
-    {{replace-emoji ":joy:" (hash lazy=true)}}
-    {{replace-emoji ":slightly_smiling_face:" (hash lazy=true)}}
-    {{replace-emoji ":upside_down_face:" (hash lazy=true)}}
-    {{replace-emoji ":melting_face:" (hash lazy=true)}}
-    {{replace-emoji ":wink:" (hash lazy=true)}}
-    {{replace-emoji ":blush:" (hash lazy=true)}}
-    {{replace-emoji ":innocent:" (hash lazy=true)}}
-    {{replace-emoji ":smiling_face_with_three_hearts:" (hash lazy=true)}}
-    {{replace-emoji ":heart_eyes:" (hash lazy=true)}}
-    {{replace-emoji ":star_struck:" (hash lazy=true)}}
-    {{replace-emoji ":kissing_heart:" (hash lazy=true)}}
-    {{replace-emoji ":kissing:" (hash lazy=true)}}
-    {{replace-emoji ":smiling_face:" (hash lazy=true)}}
-    {{replace-emoji ":kissing_closed_eyes:" (hash lazy=true)}}
-    {{replace-emoji ":kissing_smiling_eyes:" (hash lazy=true)}}
-    {{replace-emoji ":smiling_face_with_tear:" (hash lazy=true)}}
-    {{replace-emoji ":yum:" (hash lazy=true)}}
-    {{replace-emoji ":stuck_out_tongue:" (hash lazy=true)}}
-    {{replace-emoji ":stuck_out_tongue_winking_eye:" (hash lazy=true)}}
-    {{replace-emoji ":crazy_face:" (hash lazy=true)}}
-    {{replace-emoji ":stuck_out_tongue_closed_eyes:" (hash lazy=true)}}
-    {{replace-emoji ":money_mouth_face:" (hash lazy=true)}}
-    {{replace-emoji ":hugs:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_hand_over_mouth:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_open_eyes_and_hand_over_mouth:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_peeking_eye:" (hash lazy=true)}}
-    {{replace-emoji ":shushing_face:" (hash lazy=true)}}
-    {{replace-emoji ":thinking:" (hash lazy=true)}}
-    {{replace-emoji ":saluting_face:" (hash lazy=true)}}
-    {{replace-emoji ":zipper_mouth_face:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_raised_eyebrow:" (hash lazy=true)}}
-    {{replace-emoji ":neutral_face:" (hash lazy=true)}}
-    {{replace-emoji ":expressionless:" (hash lazy=true)}}
-    {{replace-emoji ":no_mouth:" (hash lazy=true)}}
-    {{replace-emoji ":dotted_line_face:" (hash lazy=true)}}
-    {{replace-emoji ":face_in_clouds:" (hash lazy=true)}}
-    {{replace-emoji ":smirk:" (hash lazy=true)}}
-    {{replace-emoji ":unamused:" (hash lazy=true)}}
-    {{replace-emoji ":roll_eyes:" (hash lazy=true)}}
-    {{replace-emoji ":grimacing:" (hash lazy=true)}}
-    {{replace-emoji ":face_exhaling:" (hash lazy=true)}}
-    {{replace-emoji ":lying_face:" (hash lazy=true)}}
-    {{replace-emoji ":relieved:" (hash lazy=true)}}
-    {{replace-emoji ":pensive:" (hash lazy=true)}}
-    {{replace-emoji ":sleepy:" (hash lazy=true)}}
-    {{replace-emoji ":drooling_face:" (hash lazy=true)}}
-    {{replace-emoji ":sleeping:" (hash lazy=true)}}
-    {{replace-emoji ":mask:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_thermometer:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_head_bandage:" (hash lazy=true)}}
-    {{replace-emoji ":nauseated_face:" (hash lazy=true)}}
-    {{replace-emoji ":face_vomiting:" (hash lazy=true)}}
-    {{replace-emoji ":sneezing_face:" (hash lazy=true)}}
-    {{replace-emoji ":hot_face:" (hash lazy=true)}}
-    {{replace-emoji ":cold_face:" (hash lazy=true)}}
-    {{replace-emoji ":woozy_face:" (hash lazy=true)}}
-    {{replace-emoji ":dizzy_face:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_spiral_eyes:" (hash lazy=true)}}
-    {{replace-emoji ":exploding_head:" (hash lazy=true)}}
-    {{replace-emoji ":cowboy_hat_face:" (hash lazy=true)}}
-    {{replace-emoji ":partying_face:" (hash lazy=true)}}
-    {{replace-emoji ":disguised_face:" (hash lazy=true)}}
-    {{replace-emoji ":sunglasses:" (hash lazy=true)}}
-    {{replace-emoji ":nerd_face:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_monocle:" (hash lazy=true)}}
-    {{replace-emoji ":confused:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_diagonal_mouth:" (hash lazy=true)}}
-    {{replace-emoji ":worried:" (hash lazy=true)}}
-    {{replace-emoji ":slightly_frowning_face:" (hash lazy=true)}}
-    {{replace-emoji ":frowning_face:" (hash lazy=true)}}
-    {{replace-emoji ":open_mouth:" (hash lazy=true)}}
-    {{replace-emoji ":hushed:" (hash lazy=true)}}
-    {{replace-emoji ":astonished:" (hash lazy=true)}}
-    {{replace-emoji ":flushed:" (hash lazy=true)}}
-    {{replace-emoji ":pleading_face:" (hash lazy=true)}}
-    {{replace-emoji ":face_holding_back_tears:" (hash lazy=true)}}
-    {{replace-emoji ":frowning_with_open_mouth:" (hash lazy=true)}}
-    {{replace-emoji ":anguished:" (hash lazy=true)}}
-    {{replace-emoji ":fearful:" (hash lazy=true)}}
-    {{replace-emoji ":cold_sweat:" (hash lazy=true)}}
-    {{replace-emoji ":disappointed_relieved:" (hash lazy=true)}}
-    {{replace-emoji ":cry:" (hash lazy=true)}}
-    {{replace-emoji ":sob:" (hash lazy=true)}}
-    {{replace-emoji ":scream:" (hash lazy=true)}}
-    {{replace-emoji ":confounded:" (hash lazy=true)}}
-    {{replace-emoji ":persevere:" (hash lazy=true)}}
-    {{replace-emoji ":disappointed:" (hash lazy=true)}}
-    {{replace-emoji ":sweat:" (hash lazy=true)}}
-    {{replace-emoji ":weary:" (hash lazy=true)}}
-    {{replace-emoji ":tired_face:" (hash lazy=true)}}
-    {{replace-emoji ":yawning_face:" (hash lazy=true)}}
-    {{replace-emoji ":triumph:" (hash lazy=true)}}
-    {{replace-emoji ":rage:" (hash lazy=true)}}
-    {{replace-emoji ":angry:" (hash lazy=true)}}
-    {{replace-emoji ":face_with_symbols_over_mouth:" (hash lazy=true)}}
-    {{replace-emoji ":smiling_imp:" (hash lazy=true)}}
-    {{replace-emoji ":imp:" (hash lazy=true)}}
-    {{replace-emoji ":skull:" (hash lazy=true)}}
-    {{replace-emoji ":skull_and_crossbones:" (hash lazy=true)}}
-    {{replace-emoji ":poop:" (hash lazy=true)}}
-    {{replace-emoji ":clown_face:" (hash lazy=true)}}
-    {{replace-emoji ":japanese_ogre:" (hash lazy=true)}}
-    {{replace-emoji ":japanese_goblin:" (hash lazy=true)}}
-    {{replace-emoji ":ghost:" (hash lazy=true)}}
-    {{replace-emoji ":alien:" (hash lazy=true)}}
-    {{replace-emoji ":space_invader:" (hash lazy=true)}}
-    {{replace-emoji ":robot:" (hash lazy=true)}}
-    {{replace-emoji ":smiley_cat:" (hash lazy=true)}}
-    {{replace-emoji ":smile_cat:" (hash lazy=true)}}
-    {{replace-emoji ":joy_cat:" (hash lazy=true)}}
-    {{replace-emoji ":heart_eyes_cat:" (hash lazy=true)}}
-    {{replace-emoji ":smirk_cat:" (hash lazy=true)}}
-    {{replace-emoji ":kissing_cat:" (hash lazy=true)}}
-    {{replace-emoji ":scream_cat:" (hash lazy=true)}}
-    {{replace-emoji ":crying_cat_face:" (hash lazy=true)}}
-    {{replace-emoji ":pouting_cat:" (hash lazy=true)}}
-    {{replace-emoji ":see_no_evil:" (hash lazy=true)}}
-    {{replace-emoji ":hear_no_evil:" (hash lazy=true)}}
-    {{replace-emoji ":speak_no_evil:" (hash lazy=true)}}
-    {{replace-emoji ":kiss:" (hash lazy=true)}}
-    {{replace-emoji ":love_letter:" (hash lazy=true)}}
-    {{replace-emoji ":cupid:" (hash lazy=true)}}
-    {{replace-emoji ":gift_heart:" (hash lazy=true)}}
-    {{replace-emoji ":sparkling_heart:" (hash lazy=true)}}
-    {{replace-emoji ":heartpulse:" (hash lazy=true)}}
-    {{replace-emoji ":heartbeat:" (hash lazy=true)}}
-    {{replace-emoji ":revolving_hearts:" (hash lazy=true)}}
-    {{replace-emoji ":two_hearts:" (hash lazy=true)}}
-    {{replace-emoji ":heart_decoration:" (hash lazy=true)}}
-    {{replace-emoji ":heavy_heart_exclamation:" (hash lazy=true)}}
-    {{replace-emoji ":broken_heart:" (hash lazy=true)}}
-    {{replace-emoji ":heart_on_fire:" (hash lazy=true)}}
-    {{replace-emoji ":mending_heart:" (hash lazy=true)}}
-    {{replace-emoji ":heart:" (hash lazy=true)}}
-    {{replace-emoji ":orange_heart:" (hash lazy=true)}}
-    {{replace-emoji ":yellow_heart:" (hash lazy=true)}}
-    {{replace-emoji ":green_heart:" (hash lazy=true)}}
-    {{replace-emoji ":blue_heart:" (hash lazy=true)}}
-    {{replace-emoji ":purple_heart:" (hash lazy=true)}}
-    {{replace-emoji ":brown_heart:" (hash lazy=true)}}
-    {{replace-emoji ":black_heart:" (hash lazy=true)}}
-    {{replace-emoji ":white_heart:" (hash lazy=true)}}
-    {{replace-emoji ":100:" (hash lazy=true)}}
-    {{replace-emoji ":anger:" (hash lazy=true)}}
-    {{replace-emoji ":boom:" (hash lazy=true)}}
-    {{replace-emoji ":dizzy:" (hash lazy=true)}}
-    {{replace-emoji ":sweat_drops:" (hash lazy=true)}}
-    {{replace-emoji ":dash:" (hash lazy=true)}}
-    {{replace-emoji ":hole:" (hash lazy=true)}}
-    {{replace-emoji ":bomb:" (hash lazy=true)}}
-    {{replace-emoji ":speech_balloon:" (hash lazy=true)}}
-    {{replace-emoji ":eye_in_speech_bubble:" (hash lazy=true)}}
-    {{replace-emoji ":left_speech_bubble:" (hash lazy=true)}}
-    {{replace-emoji ":right_anger_bubble:" (hash lazy=true)}}
-    {{replace-emoji ":thought_balloon:" (hash lazy=true)}}
-    {{replace-emoji ":zzz:" (hash lazy=true)}}
+    {{replace-emoji ":grinning:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smiley:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smile:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":grin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":laughing:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sweat_smile:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rofl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":joy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":slightly_smiling_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":upside_down_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":melting_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wink:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":blush:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":innocent:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smiling_face_with_three_hearts:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heart_eyes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":star_struck:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kissing_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kissing:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smiling_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kissing_closed_eyes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kissing_smiling_eyes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smiling_face_with_tear:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yum:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stuck_out_tongue:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stuck_out_tongue_winking_eye:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crazy_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stuck_out_tongue_closed_eyes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":money_mouth_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hugs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_hand_over_mouth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_open_eyes_and_hand_over_mouth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_peeking_eye:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shushing_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":thinking:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":saluting_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":zipper_mouth_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_raised_eyebrow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":neutral_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":expressionless:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":no_mouth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dotted_line_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_in_clouds:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smirk:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":unamused:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":roll_eyes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":grimacing:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_exhaling:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lying_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":relieved:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pensive:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sleepy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":drooling_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sleeping:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mask:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_thermometer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_head_bandage:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nauseated_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_vomiting:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sneezing_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hot_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cold_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":woozy_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dizzy_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_spiral_eyes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":exploding_head:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cowboy_hat_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":partying_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":disguised_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sunglasses:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nerd_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_monocle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":confused:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_diagonal_mouth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":worried:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":slightly_frowning_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":frowning_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":open_mouth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hushed:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":astonished:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flushed:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pleading_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_holding_back_tears:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":frowning_with_open_mouth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":anguished:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fearful:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cold_sweat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":disappointed_relieved:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cry:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sob:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":scream:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":confounded:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":persevere:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":disappointed:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sweat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":weary:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tired_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yawning_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":triumph:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rage:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":angry:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":face_with_symbols_over_mouth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smiling_imp:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":imp:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":skull:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":skull_and_crossbones:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":poop:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clown_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":japanese_ogre:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":japanese_goblin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ghost:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":alien:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":space_invader:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":robot:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smiley_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smile_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":joy_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heart_eyes_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smirk_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kissing_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":scream_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crying_cat_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pouting_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":see_no_evil:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hear_no_evil:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":speak_no_evil:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kiss:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":love_letter:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cupid:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gift_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sparkling_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heartpulse:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heartbeat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":revolving_hearts:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":two_hearts:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heart_decoration:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heavy_heart_exclamation:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":broken_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heart_on_fire:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mending_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":orange_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yellow_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":green_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":blue_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":purple_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":brown_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":100:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":anger:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":boom:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dizzy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sweat_drops:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dash:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hole:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bomb:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":speech_balloon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eye_in_speech_bubble:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":left_speech_bubble:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":right_anger_bubble:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":thought_balloon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":zzz:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>
 <div class="section" data-section="people_&_body">
@@ -176,367 +176,367 @@
     <span class="title">{{i18n "emoji_picker.people_&_body"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":wave:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":raised_back_of_hand:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":raised_hand_with_fingers_splayed:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":raised_hand:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":vulcan_salute:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":rightwards_hand:" (hash lazy=true)}}
-    {{replace-emoji ":leftwards_hand:" (hash lazy=true)}}
-    {{replace-emoji ":palm_down_hand:" (hash lazy=true)}}
-    {{replace-emoji ":palm_up_hand:" (hash lazy=true)}}
-    {{replace-emoji ":ok_hand:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":pinched_fingers:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":pinching_hand:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":v:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":crossed_fingers:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":hand_with_index_finger_and_thumb_crossed:" (hash lazy=true)}}
-    {{replace-emoji ":love_you_gesture:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":metal:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":call_me_hand:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":point_left:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":point_right:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":point_up_2:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":fu:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":point_down:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":point_up:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":index_pointing_at_the_viewer:" (hash lazy=true)}}
-    {{replace-emoji ":+1:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":-1:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":fist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":facepunch:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":fist_left:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":fist_right:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":clap:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":raised_hands:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":heart_hands:" (hash lazy=true)}}
-    {{replace-emoji ":open_hands:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":palms_up_together:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":handshake:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":pray:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":writing_hand:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":nail_care:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":selfie:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":muscle:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":mechanical_arm:" (hash lazy=true)}}
-    {{replace-emoji ":mechanical_leg:" (hash lazy=true)}}
-    {{replace-emoji ":leg:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":foot:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":ear:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":hear_with_hearing_aid:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":nose:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":brain:" (hash lazy=true)}}
-    {{replace-emoji ":anatomical_heart:" (hash lazy=true)}}
-    {{replace-emoji ":lungs:" (hash lazy=true)}}
-    {{replace-emoji ":tooth:" (hash lazy=true)}}
-    {{replace-emoji ":bone:" (hash lazy=true)}}
-    {{replace-emoji ":eyes:" (hash lazy=true)}}
-    {{replace-emoji ":eye:" (hash lazy=true)}}
-    {{replace-emoji ":tongue:" (hash lazy=true)}}
-    {{replace-emoji ":lips:" (hash lazy=true)}}
-    {{replace-emoji ":biting_lip:" (hash lazy=true)}}
-    {{replace-emoji ":baby:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":child:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":boy:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":girl:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":adult:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":blonde_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":bearded_person:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_beard:" (hash lazy=true)}}
-    {{replace-emoji ":woman_beard:" (hash lazy=true)}}
-    {{replace-emoji ":man_red_haired:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_curly_haired:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_white_haired:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_bald:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_red_haired:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_red_hair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_curly_haired:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_curly_hair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_white_haired:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_white_hair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_bald:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_bald:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":blonde_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_blond_hair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":older_adult:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":older_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":older_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_frowning:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":frowning_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":frowning_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_pouting:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":pouting_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":pouting_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_gesturing_no:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":no_good_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":no_good_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_gesturing_ok:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":ok_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":ok_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_tipping_hand:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":tipping_hand_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":tipping_hand_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_raising_hand:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":raising_hand_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":raising_hand_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":deaf_person:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":deaf_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":deaf_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":bowing_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_bowing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":bowing_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_facepalming:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_facepalming:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_facepalming:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_shrugging:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_shrugging:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_shrugging:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":health_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_health_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_health_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":student:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_student:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_student:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":teacher:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_teacher:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_teacher:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":judge:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_judge:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_judge:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":farmer:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_farmer:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_farmer:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":cook:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_cook:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_cook:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":mechanic:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_mechanic:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_mechanic:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":factory_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_factory_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_factory_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":office_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_office_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_office_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":scientist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_scientist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_scientist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":technologist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_technologist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_technologist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":singer:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_singer:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_singer:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":artist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_artist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_artist:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":pilot:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_pilot:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_pilot:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":astronaut:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_astronaut:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_astronaut:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":firefighter:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_firefighter:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_firefighter:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":policeman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_police_officer:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":policewoman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":male_detective:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_detective:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":female_detective:" (hash lazy=true)}}
-    {{replace-emoji ":guardsman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_guard:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":guardswoman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":ninja:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":construction_worker_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_construction_worker:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":construction_worker_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_with_crown:" (hash lazy=true)}}
-    {{replace-emoji ":prince:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":princess:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_with_turban:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_wearing_turban:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_with_turban:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_with_gua_pi_mao:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_with_headscarf:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_in_tuxedo:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_in_tuxedo:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_in_tuxedo:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":bride_with_veil:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_with_veil:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_with_veil:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":pregnant_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":pregnant_man:" (hash lazy=true)}}
-    {{replace-emoji ":pregnant_person:" (hash lazy=true)}}
-    {{replace-emoji ":breast_feeding:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_feeding_baby:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_feeding_baby:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_feeding_baby:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":angel:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":santa:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":mrs_claus:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":mx_claus:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":superhero:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_superhero:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_superhero:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":supervillain:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_supervillain:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_supervillain:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":mage:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_mage:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_mage:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":fairy:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_fairy:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_fairy:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":vampire:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_vampire:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_vampire:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":merperson:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":merman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":mermaid:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":elf:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_elf:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_elf:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":genie:" (hash lazy=true)}}
-    {{replace-emoji ":man_genie:" (hash lazy=true)}}
-    {{replace-emoji ":woman_genie:" (hash lazy=true)}}
-    {{replace-emoji ":zombie:" (hash lazy=true)}}
-    {{replace-emoji ":man_zombie:" (hash lazy=true)}}
-    {{replace-emoji ":woman_zombie:" (hash lazy=true)}}
-    {{replace-emoji ":troll:" (hash lazy=true)}}
-    {{replace-emoji ":person_getting_massage:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":massage_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":massage_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_getting_haircut:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":haircut_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":haircut_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":walking_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_walking:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":walking_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_standing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_standing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_standing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_kneeling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_kneeling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_kneeling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_with_white_cane:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_with_probing_cane:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_with_probing_cane:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_in_motorized_wheelchair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_in_motorized_wheelchair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_in_motorized_wheelchair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_in_manual_wheelchair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_in_manual_wheelchair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_in_manual_wheelchair:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":running_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_running:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":running_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":dancer:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_dancing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":business_suit_levitating:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":dancing_women:" (hash lazy=true)}}
-    {{replace-emoji ":dancing_men:" (hash lazy=true)}}
-    {{replace-emoji ":women_with_bunny_ears:" (hash lazy=true)}}
-    {{replace-emoji ":person_in_steamy_room:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_in_steamy_room:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_in_steamy_room:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_climbing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_climbing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_climbing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_fencing:" (hash lazy=true)}}
-    {{replace-emoji ":horse_racing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":skier:" (hash lazy=true)}}
-    {{replace-emoji ":snowboarder:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":golfing_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_golfing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":golfing_woman:" (hash lazy=true)}}
-    {{replace-emoji ":surfing_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_surfing:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":surfing_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":rowing_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_rowing_boat:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":rowing_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":swimming_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_swimming:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":swimming_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":basketball_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_bouncing_ball:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":basketball_woman:" (hash lazy=true)}}
-    {{replace-emoji ":weight_lifting_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_lifting_weights:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":weight_lifting_woman:" (hash lazy=true)}}
-    {{replace-emoji ":biking_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_biking:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":biking_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":mountain_biking_man:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_mountain_biking:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":mountain_biking_woman:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_cartwheeling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_cartwheeling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_cartwheeling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":people_wrestling:" (hash lazy=true)}}
-    {{replace-emoji ":men_wrestling:" (hash lazy=true)}}
-    {{replace-emoji ":women_wrestling:" (hash lazy=true)}}
-    {{replace-emoji ":person_playing_water_polo:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_playing_water_polo:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_playing_water_polo:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_playing_handball:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_playing_handball:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_playing_handball:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_juggling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_juggling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_juggling:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":person_in_lotus_position:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":man_in_lotus_position:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":woman_in_lotus_position:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":bath:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":sleeping_bed:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":people_holding_hands:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":two_women_holding_hands:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":couple:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":two_men_holding_hands:" (hash lazy=true class="diversity")}}
-    {{replace-emoji ":couplekiss_man_woman:" (hash lazy=true)}}
-    {{replace-emoji ":kiss_woman_man:" (hash lazy=true)}}
-    {{replace-emoji ":couplekiss_man_man:" (hash lazy=true)}}
-    {{replace-emoji ":couplekiss_woman_woman:" (hash lazy=true)}}
-    {{replace-emoji ":couple_with_heart:" (hash lazy=true)}}
-    {{replace-emoji ":couple_with_heart_woman_man:" (hash lazy=true)}}
-    {{replace-emoji ":couple_with_heart_man_man:" (hash lazy=true)}}
-    {{replace-emoji ":couple_with_heart_woman_woman:" (hash lazy=true)}}
-    {{replace-emoji ":family:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_woman_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_woman_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_woman_girl_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_woman_boy_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_woman_girl_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_man_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_man_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_man_girl_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_man_boy_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_man_girl_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_woman_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_woman_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_woman_girl_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_woman_boy_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_woman_girl_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_boy_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_girl_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_man_girl_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_boy_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_girl:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_girl_boy:" (hash lazy=true)}}
-    {{replace-emoji ":family_woman_girl_girl:" (hash lazy=true)}}
-    {{replace-emoji ":speaking_head:" (hash lazy=true)}}
-    {{replace-emoji ":bust_in_silhouette:" (hash lazy=true)}}
-    {{replace-emoji ":busts_in_silhouette:" (hash lazy=true)}}
-    {{replace-emoji ":people_hugging:" (hash lazy=true)}}
-    {{replace-emoji ":footprints:" (hash lazy=true)}}
+    {{replace-emoji ":wave:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":raised_back_of_hand:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":raised_hand_with_fingers_splayed:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":raised_hand:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":vulcan_salute:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":rightwards_hand:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":leftwards_hand:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":palm_down_hand:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":palm_up_hand:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ok_hand:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":pinched_fingers:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":pinching_hand:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":v:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":crossed_fingers:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":hand_with_index_finger_and_thumb_crossed:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":love_you_gesture:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":metal:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":call_me_hand:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":point_left:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":point_right:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":point_up_2:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":fu:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":point_down:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":point_up:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":index_pointing_at_the_viewer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":+1:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":-1:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":fist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":facepunch:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":fist_left:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":fist_right:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":clap:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":raised_hands:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":heart_hands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":open_hands:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":palms_up_together:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":handshake:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":pray:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":writing_hand:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":nail_care:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":selfie:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":muscle:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":mechanical_arm:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mechanical_leg:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":leg:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":foot:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":ear:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":hear_with_hearing_aid:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":nose:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":brain:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":anatomical_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lungs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tooth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eyes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eye:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tongue:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lips:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":biting_lip:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":baby:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":child:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":boy:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":girl:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":adult:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":blonde_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":bearded_person:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_beard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":woman_beard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":man_red_haired:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_curly_haired:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_white_haired:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_bald:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_red_haired:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_red_hair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_curly_haired:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_curly_hair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_white_haired:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_white_hair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_bald:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_bald:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":blonde_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_blond_hair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":older_adult:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":older_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":older_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_frowning:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":frowning_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":frowning_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_pouting:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":pouting_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":pouting_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_gesturing_no:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":no_good_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":no_good_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_gesturing_ok:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":ok_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":ok_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_tipping_hand:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":tipping_hand_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":tipping_hand_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_raising_hand:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":raising_hand_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":raising_hand_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":deaf_person:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":deaf_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":deaf_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":bowing_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_bowing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":bowing_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_facepalming:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_facepalming:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_facepalming:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_shrugging:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_shrugging:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_shrugging:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":health_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_health_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_health_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":student:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_student:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_student:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":teacher:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_teacher:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_teacher:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":judge:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_judge:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_judge:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":farmer:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_farmer:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_farmer:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":cook:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_cook:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_cook:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":mechanic:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_mechanic:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_mechanic:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":factory_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_factory_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_factory_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":office_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_office_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_office_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":scientist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_scientist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_scientist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":technologist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_technologist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_technologist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":singer:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_singer:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_singer:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":artist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_artist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_artist:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":pilot:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_pilot:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_pilot:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":astronaut:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_astronaut:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_astronaut:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":firefighter:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_firefighter:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_firefighter:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":policeman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_police_officer:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":policewoman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":male_detective:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_detective:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":female_detective:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guardsman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_guard:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":guardswoman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":ninja:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":construction_worker_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_construction_worker:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":construction_worker_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_with_crown:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":prince:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":princess:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_with_turban:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_wearing_turban:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_with_turban:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_with_gua_pi_mao:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_with_headscarf:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_in_tuxedo:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_in_tuxedo:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_in_tuxedo:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":bride_with_veil:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_with_veil:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_with_veil:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":pregnant_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":pregnant_man:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pregnant_person:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":breast_feeding:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_feeding_baby:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_feeding_baby:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_feeding_baby:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":angel:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":santa:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":mrs_claus:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":mx_claus:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":superhero:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_superhero:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_superhero:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":supervillain:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_supervillain:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_supervillain:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":mage:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_mage:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_mage:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":fairy:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_fairy:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_fairy:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":vampire:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_vampire:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_vampire:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":merperson:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":merman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":mermaid:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":elf:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_elf:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_elf:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":genie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":man_genie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":woman_genie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":zombie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":man_zombie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":woman_zombie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":troll:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":person_getting_massage:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":massage_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":massage_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_getting_haircut:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":haircut_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":haircut_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":walking_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_walking:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":walking_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_standing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_standing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_standing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_kneeling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_kneeling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_kneeling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_with_white_cane:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_with_probing_cane:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_with_probing_cane:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_in_motorized_wheelchair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_in_motorized_wheelchair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_in_motorized_wheelchair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_in_manual_wheelchair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_in_manual_wheelchair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_in_manual_wheelchair:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":running_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_running:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":running_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":dancer:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_dancing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":business_suit_levitating:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":dancing_women:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dancing_men:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":women_with_bunny_ears:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":person_in_steamy_room:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_in_steamy_room:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_in_steamy_room:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_climbing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_climbing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_climbing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_fencing:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":horse_racing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":skier:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":snowboarder:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":golfing_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_golfing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":golfing_woman:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":surfing_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_surfing:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":surfing_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":rowing_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_rowing_boat:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":rowing_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":swimming_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_swimming:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":swimming_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":basketball_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_bouncing_ball:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":basketball_woman:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":weight_lifting_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_lifting_weights:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":weight_lifting_woman:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":biking_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_biking:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":biking_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":mountain_biking_man:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_mountain_biking:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":mountain_biking_woman:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_cartwheeling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_cartwheeling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_cartwheeling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":people_wrestling:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":men_wrestling:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":women_wrestling:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":person_playing_water_polo:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_playing_water_polo:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_playing_water_polo:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_playing_handball:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_playing_handball:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_playing_handball:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_juggling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_juggling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_juggling:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":person_in_lotus_position:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":man_in_lotus_position:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":woman_in_lotus_position:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":bath:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":sleeping_bed:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":people_holding_hands:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":two_women_holding_hands:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":couple:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":two_men_holding_hands:" (hash lazy=true class="diversity" tabIndex="0")}}
+    {{replace-emoji ":couplekiss_man_woman:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kiss_woman_man:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":couplekiss_man_man:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":couplekiss_woman_woman:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":couple_with_heart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":couple_with_heart_woman_man:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":couple_with_heart_man_man:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":couple_with_heart_woman_woman:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_woman_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_woman_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_woman_girl_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_woman_boy_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_woman_girl_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_man_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_man_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_man_girl_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_man_boy_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_man_girl_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_woman_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_woman_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_woman_girl_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_woman_boy_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_woman_girl_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_boy_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_girl_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_man_girl_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_boy_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_girl_boy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":family_woman_girl_girl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":speaking_head:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bust_in_silhouette:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":busts_in_silhouette:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":people_hugging:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":footprints:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>
 <div class="section" data-section="animals_&_nature">
@@ -544,150 +544,150 @@
     <span class="title">{{i18n "emoji_picker.animals_&_nature"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":monkey_face:" (hash lazy=true)}}
-    {{replace-emoji ":monkey:" (hash lazy=true)}}
-    {{replace-emoji ":gorilla:" (hash lazy=true)}}
-    {{replace-emoji ":orangutan:" (hash lazy=true)}}
-    {{replace-emoji ":dog:" (hash lazy=true)}}
-    {{replace-emoji ":dog2:" (hash lazy=true)}}
-    {{replace-emoji ":guide_dog:" (hash lazy=true)}}
-    {{replace-emoji ":service_dog:" (hash lazy=true)}}
-    {{replace-emoji ":poodle:" (hash lazy=true)}}
-    {{replace-emoji ":wolf:" (hash lazy=true)}}
-    {{replace-emoji ":fox_face:" (hash lazy=true)}}
-    {{replace-emoji ":raccoon:" (hash lazy=true)}}
-    {{replace-emoji ":cat:" (hash lazy=true)}}
-    {{replace-emoji ":cat2:" (hash lazy=true)}}
-    {{replace-emoji ":black_cat:" (hash lazy=true)}}
-    {{replace-emoji ":lion:" (hash lazy=true)}}
-    {{replace-emoji ":tiger:" (hash lazy=true)}}
-    {{replace-emoji ":tiger2:" (hash lazy=true)}}
-    {{replace-emoji ":leopard:" (hash lazy=true)}}
-    {{replace-emoji ":horse:" (hash lazy=true)}}
-    {{replace-emoji ":racehorse:" (hash lazy=true)}}
-    {{replace-emoji ":unicorn:" (hash lazy=true)}}
-    {{replace-emoji ":zebra:" (hash lazy=true)}}
-    {{replace-emoji ":deer:" (hash lazy=true)}}
-    {{replace-emoji ":bison:" (hash lazy=true)}}
-    {{replace-emoji ":cow:" (hash lazy=true)}}
-    {{replace-emoji ":ox:" (hash lazy=true)}}
-    {{replace-emoji ":water_buffalo:" (hash lazy=true)}}
-    {{replace-emoji ":cow2:" (hash lazy=true)}}
-    {{replace-emoji ":pig:" (hash lazy=true)}}
-    {{replace-emoji ":pig2:" (hash lazy=true)}}
-    {{replace-emoji ":boar:" (hash lazy=true)}}
-    {{replace-emoji ":pig_nose:" (hash lazy=true)}}
-    {{replace-emoji ":ram:" (hash lazy=true)}}
-    {{replace-emoji ":sheep:" (hash lazy=true)}}
-    {{replace-emoji ":goat:" (hash lazy=true)}}
-    {{replace-emoji ":dromedary_camel:" (hash lazy=true)}}
-    {{replace-emoji ":camel:" (hash lazy=true)}}
-    {{replace-emoji ":llama:" (hash lazy=true)}}
-    {{replace-emoji ":giraffe:" (hash lazy=true)}}
-    {{replace-emoji ":elephant:" (hash lazy=true)}}
-    {{replace-emoji ":mammoth:" (hash lazy=true)}}
-    {{replace-emoji ":rhinoceros:" (hash lazy=true)}}
-    {{replace-emoji ":hippopotamus:" (hash lazy=true)}}
-    {{replace-emoji ":mouse:" (hash lazy=true)}}
-    {{replace-emoji ":mouse2:" (hash lazy=true)}}
-    {{replace-emoji ":rat:" (hash lazy=true)}}
-    {{replace-emoji ":hamster:" (hash lazy=true)}}
-    {{replace-emoji ":rabbit:" (hash lazy=true)}}
-    {{replace-emoji ":rabbit2:" (hash lazy=true)}}
-    {{replace-emoji ":chipmunk:" (hash lazy=true)}}
-    {{replace-emoji ":beaver:" (hash lazy=true)}}
-    {{replace-emoji ":hedgehog:" (hash lazy=true)}}
-    {{replace-emoji ":bat:" (hash lazy=true)}}
-    {{replace-emoji ":bear:" (hash lazy=true)}}
-    {{replace-emoji ":polar_bear:" (hash lazy=true)}}
-    {{replace-emoji ":koala:" (hash lazy=true)}}
-    {{replace-emoji ":panda_face:" (hash lazy=true)}}
-    {{replace-emoji ":sloth:" (hash lazy=true)}}
-    {{replace-emoji ":otter:" (hash lazy=true)}}
-    {{replace-emoji ":skunk:" (hash lazy=true)}}
-    {{replace-emoji ":kangaroo:" (hash lazy=true)}}
-    {{replace-emoji ":badger:" (hash lazy=true)}}
-    {{replace-emoji ":paw_prints:" (hash lazy=true)}}
-    {{replace-emoji ":turkey:" (hash lazy=true)}}
-    {{replace-emoji ":chicken:" (hash lazy=true)}}
-    {{replace-emoji ":rooster:" (hash lazy=true)}}
-    {{replace-emoji ":hatching_chick:" (hash lazy=true)}}
-    {{replace-emoji ":baby_chick:" (hash lazy=true)}}
-    {{replace-emoji ":hatched_chick:" (hash lazy=true)}}
-    {{replace-emoji ":bird:" (hash lazy=true)}}
-    {{replace-emoji ":penguin:" (hash lazy=true)}}
-    {{replace-emoji ":dove:" (hash lazy=true)}}
-    {{replace-emoji ":eagle:" (hash lazy=true)}}
-    {{replace-emoji ":duck:" (hash lazy=true)}}
-    {{replace-emoji ":swan:" (hash lazy=true)}}
-    {{replace-emoji ":owl:" (hash lazy=true)}}
-    {{replace-emoji ":dodo:" (hash lazy=true)}}
-    {{replace-emoji ":feather:" (hash lazy=true)}}
-    {{replace-emoji ":flamingo:" (hash lazy=true)}}
-    {{replace-emoji ":peacock:" (hash lazy=true)}}
-    {{replace-emoji ":parrot:" (hash lazy=true)}}
-    {{replace-emoji ":frog:" (hash lazy=true)}}
-    {{replace-emoji ":crocodile:" (hash lazy=true)}}
-    {{replace-emoji ":turtle:" (hash lazy=true)}}
-    {{replace-emoji ":lizard:" (hash lazy=true)}}
-    {{replace-emoji ":snake:" (hash lazy=true)}}
-    {{replace-emoji ":dragon_face:" (hash lazy=true)}}
-    {{replace-emoji ":dragon:" (hash lazy=true)}}
-    {{replace-emoji ":sauropod:" (hash lazy=true)}}
-    {{replace-emoji ":t_rex:" (hash lazy=true)}}
-    {{replace-emoji ":whale:" (hash lazy=true)}}
-    {{replace-emoji ":whale2:" (hash lazy=true)}}
-    {{replace-emoji ":dolphin:" (hash lazy=true)}}
-    {{replace-emoji ":seal:" (hash lazy=true)}}
-    {{replace-emoji ":fish:" (hash lazy=true)}}
-    {{replace-emoji ":tropical_fish:" (hash lazy=true)}}
-    {{replace-emoji ":blowfish:" (hash lazy=true)}}
-    {{replace-emoji ":shark:" (hash lazy=true)}}
-    {{replace-emoji ":octopus:" (hash lazy=true)}}
-    {{replace-emoji ":shell:" (hash lazy=true)}}
-    {{replace-emoji ":coral:" (hash lazy=true)}}
-    {{replace-emoji ":snail:" (hash lazy=true)}}
-    {{replace-emoji ":butterfly:" (hash lazy=true)}}
-    {{replace-emoji ":bug:" (hash lazy=true)}}
-    {{replace-emoji ":ant:" (hash lazy=true)}}
-    {{replace-emoji ":honeybee:" (hash lazy=true)}}
-    {{replace-emoji ":beetle:" (hash lazy=true)}}
-    {{replace-emoji ":lady_beetle:" (hash lazy=true)}}
-    {{replace-emoji ":cricket:" (hash lazy=true)}}
-    {{replace-emoji ":cockroach:" (hash lazy=true)}}
-    {{replace-emoji ":spider:" (hash lazy=true)}}
-    {{replace-emoji ":spider_web:" (hash lazy=true)}}
-    {{replace-emoji ":scorpion:" (hash lazy=true)}}
-    {{replace-emoji ":mosquito:" (hash lazy=true)}}
-    {{replace-emoji ":fly:" (hash lazy=true)}}
-    {{replace-emoji ":worm:" (hash lazy=true)}}
-    {{replace-emoji ":microbe:" (hash lazy=true)}}
-    {{replace-emoji ":bouquet:" (hash lazy=true)}}
-    {{replace-emoji ":cherry_blossom:" (hash lazy=true)}}
-    {{replace-emoji ":white_flower:" (hash lazy=true)}}
-    {{replace-emoji ":lotus:" (hash lazy=true)}}
-    {{replace-emoji ":rosette:" (hash lazy=true)}}
-    {{replace-emoji ":rose:" (hash lazy=true)}}
-    {{replace-emoji ":wilted_flower:" (hash lazy=true)}}
-    {{replace-emoji ":hibiscus:" (hash lazy=true)}}
-    {{replace-emoji ":sunflower:" (hash lazy=true)}}
-    {{replace-emoji ":blossom:" (hash lazy=true)}}
-    {{replace-emoji ":tulip:" (hash lazy=true)}}
-    {{replace-emoji ":seedling:" (hash lazy=true)}}
-    {{replace-emoji ":potted_plant:" (hash lazy=true)}}
-    {{replace-emoji ":evergreen_tree:" (hash lazy=true)}}
-    {{replace-emoji ":deciduous_tree:" (hash lazy=true)}}
-    {{replace-emoji ":palm_tree:" (hash lazy=true)}}
-    {{replace-emoji ":cactus:" (hash lazy=true)}}
-    {{replace-emoji ":ear_of_rice:" (hash lazy=true)}}
-    {{replace-emoji ":herb:" (hash lazy=true)}}
-    {{replace-emoji ":shamrock:" (hash lazy=true)}}
-    {{replace-emoji ":four_leaf_clover:" (hash lazy=true)}}
-    {{replace-emoji ":maple_leaf:" (hash lazy=true)}}
-    {{replace-emoji ":fallen_leaf:" (hash lazy=true)}}
-    {{replace-emoji ":leaves:" (hash lazy=true)}}
-    {{replace-emoji ":empty_nest:" (hash lazy=true)}}
-    {{replace-emoji ":nest_with_eggs:" (hash lazy=true)}}
+    {{replace-emoji ":monkey_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":monkey:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gorilla:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":orangutan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dog:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dog2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guide_dog:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":service_dog:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":poodle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wolf:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fox_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":raccoon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cat2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_cat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lion:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tiger:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tiger2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":leopard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":horse:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":racehorse:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":unicorn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":zebra:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":deer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bison:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ox:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":water_buffalo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cow2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pig:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pig2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":boar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pig_nose:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ram:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sheep:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":goat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dromedary_camel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":camel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":llama:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":giraffe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":elephant:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mammoth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rhinoceros:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hippopotamus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mouse:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mouse2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hamster:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rabbit:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rabbit2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chipmunk:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":beaver:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hedgehog:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bear:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":polar_bear:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":koala:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":panda_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sloth:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":otter:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":skunk:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kangaroo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":badger:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":paw_prints:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":turkey:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chicken:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rooster:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hatching_chick:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":baby_chick:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hatched_chick:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bird:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":penguin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dove:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eagle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":duck:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":swan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":owl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dodo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":feather:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flamingo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":peacock:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":parrot:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":frog:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crocodile:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":turtle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lizard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":snake:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dragon_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dragon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sauropod:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":t_rex:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":whale:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":whale2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dolphin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":seal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fish:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tropical_fish:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":blowfish:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shark:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":octopus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shell:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":coral:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":snail:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":butterfly:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bug:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ant:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":honeybee:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":beetle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lady_beetle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cricket:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cockroach:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":spider:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":spider_web:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":scorpion:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mosquito:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fly:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":worm:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":microbe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bouquet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cherry_blossom:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_flower:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lotus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rosette:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rose:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wilted_flower:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hibiscus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sunflower:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":blossom:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tulip:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":seedling:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":potted_plant:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":evergreen_tree:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":deciduous_tree:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":palm_tree:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cactus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ear_of_rice:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":herb:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shamrock:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":four_leaf_clover:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":maple_leaf:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fallen_leaf:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":leaves:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":empty_nest:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nest_with_eggs:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>
 <div class="section" data-section="food_&_drink">
@@ -695,138 +695,138 @@
     <span class="title">{{i18n "emoji_picker.food_&_drink"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":grapes:" (hash lazy=true)}}
-    {{replace-emoji ":melon:" (hash lazy=true)}}
-    {{replace-emoji ":watermelon:" (hash lazy=true)}}
-    {{replace-emoji ":tangerine:" (hash lazy=true)}}
-    {{replace-emoji ":lemon:" (hash lazy=true)}}
-    {{replace-emoji ":banana:" (hash lazy=true)}}
-    {{replace-emoji ":pineapple:" (hash lazy=true)}}
-    {{replace-emoji ":mango:" (hash lazy=true)}}
-    {{replace-emoji ":apple:" (hash lazy=true)}}
-    {{replace-emoji ":green_apple:" (hash lazy=true)}}
-    {{replace-emoji ":pear:" (hash lazy=true)}}
-    {{replace-emoji ":peach:" (hash lazy=true)}}
-    {{replace-emoji ":cherries:" (hash lazy=true)}}
-    {{replace-emoji ":strawberry:" (hash lazy=true)}}
-    {{replace-emoji ":blueberries:" (hash lazy=true)}}
-    {{replace-emoji ":kiwi_fruit:" (hash lazy=true)}}
-    {{replace-emoji ":tomato:" (hash lazy=true)}}
-    {{replace-emoji ":olive:" (hash lazy=true)}}
-    {{replace-emoji ":coconut:" (hash lazy=true)}}
-    {{replace-emoji ":avocado:" (hash lazy=true)}}
-    {{replace-emoji ":eggplant:" (hash lazy=true)}}
-    {{replace-emoji ":potato:" (hash lazy=true)}}
-    {{replace-emoji ":carrot:" (hash lazy=true)}}
-    {{replace-emoji ":corn:" (hash lazy=true)}}
-    {{replace-emoji ":hot_pepper:" (hash lazy=true)}}
-    {{replace-emoji ":bell_pepper:" (hash lazy=true)}}
-    {{replace-emoji ":cucumber:" (hash lazy=true)}}
-    {{replace-emoji ":leafy_green:" (hash lazy=true)}}
-    {{replace-emoji ":broccoli:" (hash lazy=true)}}
-    {{replace-emoji ":garlic:" (hash lazy=true)}}
-    {{replace-emoji ":onion:" (hash lazy=true)}}
-    {{replace-emoji ":mushroom:" (hash lazy=true)}}
-    {{replace-emoji ":peanuts:" (hash lazy=true)}}
-    {{replace-emoji ":beans:" (hash lazy=true)}}
-    {{replace-emoji ":chestnut:" (hash lazy=true)}}
-    {{replace-emoji ":bread:" (hash lazy=true)}}
-    {{replace-emoji ":croissant:" (hash lazy=true)}}
-    {{replace-emoji ":baguette_bread:" (hash lazy=true)}}
-    {{replace-emoji ":flatbread:" (hash lazy=true)}}
-    {{replace-emoji ":pretzel:" (hash lazy=true)}}
-    {{replace-emoji ":bagel:" (hash lazy=true)}}
-    {{replace-emoji ":pancakes:" (hash lazy=true)}}
-    {{replace-emoji ":waffle:" (hash lazy=true)}}
-    {{replace-emoji ":cheese:" (hash lazy=true)}}
-    {{replace-emoji ":meat_on_bone:" (hash lazy=true)}}
-    {{replace-emoji ":poultry_leg:" (hash lazy=true)}}
-    {{replace-emoji ":cut_of_meat:" (hash lazy=true)}}
-    {{replace-emoji ":bacon:" (hash lazy=true)}}
-    {{replace-emoji ":hamburger:" (hash lazy=true)}}
-    {{replace-emoji ":fries:" (hash lazy=true)}}
-    {{replace-emoji ":pizza:" (hash lazy=true)}}
-    {{replace-emoji ":hotdog:" (hash lazy=true)}}
-    {{replace-emoji ":sandwich:" (hash lazy=true)}}
-    {{replace-emoji ":taco:" (hash lazy=true)}}
-    {{replace-emoji ":burrito:" (hash lazy=true)}}
-    {{replace-emoji ":tamale:" (hash lazy=true)}}
-    {{replace-emoji ":stuffed_flatbread:" (hash lazy=true)}}
-    {{replace-emoji ":falafel:" (hash lazy=true)}}
-    {{replace-emoji ":egg:" (hash lazy=true)}}
-    {{replace-emoji ":fried_egg:" (hash lazy=true)}}
-    {{replace-emoji ":shallow_pan_of_food:" (hash lazy=true)}}
-    {{replace-emoji ":stew:" (hash lazy=true)}}
-    {{replace-emoji ":fondue:" (hash lazy=true)}}
-    {{replace-emoji ":bowl_with_spoon:" (hash lazy=true)}}
-    {{replace-emoji ":green_salad:" (hash lazy=true)}}
-    {{replace-emoji ":popcorn:" (hash lazy=true)}}
-    {{replace-emoji ":butter:" (hash lazy=true)}}
-    {{replace-emoji ":salt:" (hash lazy=true)}}
-    {{replace-emoji ":canned_food:" (hash lazy=true)}}
-    {{replace-emoji ":bento:" (hash lazy=true)}}
-    {{replace-emoji ":rice_cracker:" (hash lazy=true)}}
-    {{replace-emoji ":rice_ball:" (hash lazy=true)}}
-    {{replace-emoji ":rice:" (hash lazy=true)}}
-    {{replace-emoji ":curry:" (hash lazy=true)}}
-    {{replace-emoji ":ramen:" (hash lazy=true)}}
-    {{replace-emoji ":spaghetti:" (hash lazy=true)}}
-    {{replace-emoji ":sweet_potato:" (hash lazy=true)}}
-    {{replace-emoji ":oden:" (hash lazy=true)}}
-    {{replace-emoji ":sushi:" (hash lazy=true)}}
-    {{replace-emoji ":fried_shrimp:" (hash lazy=true)}}
-    {{replace-emoji ":fish_cake:" (hash lazy=true)}}
-    {{replace-emoji ":moon_cake:" (hash lazy=true)}}
-    {{replace-emoji ":dango:" (hash lazy=true)}}
-    {{replace-emoji ":dumpling:" (hash lazy=true)}}
-    {{replace-emoji ":fortune_cookie:" (hash lazy=true)}}
-    {{replace-emoji ":takeout_box:" (hash lazy=true)}}
-    {{replace-emoji ":crab:" (hash lazy=true)}}
-    {{replace-emoji ":lobster:" (hash lazy=true)}}
-    {{replace-emoji ":shrimp:" (hash lazy=true)}}
-    {{replace-emoji ":squid:" (hash lazy=true)}}
-    {{replace-emoji ":oyster:" (hash lazy=true)}}
-    {{replace-emoji ":icecream:" (hash lazy=true)}}
-    {{replace-emoji ":shaved_ice:" (hash lazy=true)}}
-    {{replace-emoji ":ice_cream:" (hash lazy=true)}}
-    {{replace-emoji ":doughnut:" (hash lazy=true)}}
-    {{replace-emoji ":cookie:" (hash lazy=true)}}
-    {{replace-emoji ":birthday:" (hash lazy=true)}}
-    {{replace-emoji ":cake:" (hash lazy=true)}}
-    {{replace-emoji ":cupcake:" (hash lazy=true)}}
-    {{replace-emoji ":pie:" (hash lazy=true)}}
-    {{replace-emoji ":chocolate_bar:" (hash lazy=true)}}
-    {{replace-emoji ":candy:" (hash lazy=true)}}
-    {{replace-emoji ":lollipop:" (hash lazy=true)}}
-    {{replace-emoji ":custard:" (hash lazy=true)}}
-    {{replace-emoji ":honey_pot:" (hash lazy=true)}}
-    {{replace-emoji ":baby_bottle:" (hash lazy=true)}}
-    {{replace-emoji ":milk_glass:" (hash lazy=true)}}
-    {{replace-emoji ":coffee:" (hash lazy=true)}}
-    {{replace-emoji ":teapot:" (hash lazy=true)}}
-    {{replace-emoji ":tea:" (hash lazy=true)}}
-    {{replace-emoji ":sake:" (hash lazy=true)}}
-    {{replace-emoji ":champagne:" (hash lazy=true)}}
-    {{replace-emoji ":wine_glass:" (hash lazy=true)}}
-    {{replace-emoji ":cocktail:" (hash lazy=true)}}
-    {{replace-emoji ":tropical_drink:" (hash lazy=true)}}
-    {{replace-emoji ":beer:" (hash lazy=true)}}
-    {{replace-emoji ":beers:" (hash lazy=true)}}
-    {{replace-emoji ":clinking_glasses:" (hash lazy=true)}}
-    {{replace-emoji ":tumbler_glass:" (hash lazy=true)}}
-    {{replace-emoji ":pouring_liquid:" (hash lazy=true)}}
-    {{replace-emoji ":cup_with_straw:" (hash lazy=true)}}
-    {{replace-emoji ":bubble_tea:" (hash lazy=true)}}
-    {{replace-emoji ":beverage_box:" (hash lazy=true)}}
-    {{replace-emoji ":maté:" (hash lazy=true)}}
-    {{replace-emoji ":ice_cube:" (hash lazy=true)}}
-    {{replace-emoji ":chopsticks:" (hash lazy=true)}}
-    {{replace-emoji ":plate_with_cutlery:" (hash lazy=true)}}
-    {{replace-emoji ":fork_and_knife:" (hash lazy=true)}}
-    {{replace-emoji ":spoon:" (hash lazy=true)}}
-    {{replace-emoji ":hocho:" (hash lazy=true)}}
-    {{replace-emoji ":jar:" (hash lazy=true)}}
-    {{replace-emoji ":amphora:" (hash lazy=true)}}
+    {{replace-emoji ":grapes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":melon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":watermelon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tangerine:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lemon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":banana:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pineapple:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mango:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":apple:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":green_apple:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pear:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":peach:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cherries:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":strawberry:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":blueberries:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kiwi_fruit:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tomato:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":olive:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":coconut:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":avocado:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eggplant:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":potato:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":carrot:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":corn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hot_pepper:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bell_pepper:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cucumber:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":leafy_green:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":broccoli:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":garlic:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":onion:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mushroom:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":peanuts:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":beans:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chestnut:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bread:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":croissant:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":baguette_bread:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flatbread:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pretzel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bagel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pancakes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":waffle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cheese:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":meat_on_bone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":poultry_leg:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cut_of_meat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bacon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hamburger:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fries:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pizza:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hotdog:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sandwich:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":taco:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":burrito:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tamale:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stuffed_flatbread:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":falafel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":egg:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fried_egg:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shallow_pan_of_food:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stew:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fondue:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bowl_with_spoon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":green_salad:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":popcorn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":butter:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":salt:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":canned_food:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bento:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rice_cracker:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rice_ball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rice:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":curry:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ramen:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":spaghetti:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sweet_potato:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":oden:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sushi:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fried_shrimp:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fish_cake:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":moon_cake:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dango:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dumpling:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fortune_cookie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":takeout_box:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crab:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lobster:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shrimp:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":squid:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":oyster:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":icecream:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shaved_ice:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ice_cream:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":doughnut:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cookie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":birthday:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cake:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cupcake:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chocolate_bar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":candy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lollipop:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":custard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":honey_pot:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":baby_bottle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":milk_glass:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":coffee:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":teapot:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tea:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sake:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":champagne:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wine_glass:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cocktail:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tropical_drink:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":beer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":beers:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clinking_glasses:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tumbler_glass:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pouring_liquid:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cup_with_straw:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bubble_tea:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":beverage_box:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":maté:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ice_cube:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chopsticks:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":plate_with_cutlery:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fork_and_knife:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":spoon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hocho:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":jar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":amphora:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>
 <div class="section" data-section="travel_&_places">
@@ -834,224 +834,224 @@
     <span class="title">{{i18n "emoji_picker.travel_&_places"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":earth_africa:" (hash lazy=true)}}
-    {{replace-emoji ":earth_americas:" (hash lazy=true)}}
-    {{replace-emoji ":earth_asia:" (hash lazy=true)}}
-    {{replace-emoji ":globe_with_meridians:" (hash lazy=true)}}
-    {{replace-emoji ":world_map:" (hash lazy=true)}}
-    {{replace-emoji ":japan:" (hash lazy=true)}}
-    {{replace-emoji ":compass:" (hash lazy=true)}}
-    {{replace-emoji ":mountain_snow:" (hash lazy=true)}}
-    {{replace-emoji ":mountain:" (hash lazy=true)}}
-    {{replace-emoji ":volcano:" (hash lazy=true)}}
-    {{replace-emoji ":mount_fuji:" (hash lazy=true)}}
-    {{replace-emoji ":camping:" (hash lazy=true)}}
-    {{replace-emoji ":beach_umbrella:" (hash lazy=true)}}
-    {{replace-emoji ":desert:" (hash lazy=true)}}
-    {{replace-emoji ":desert_island:" (hash lazy=true)}}
-    {{replace-emoji ":national_park:" (hash lazy=true)}}
-    {{replace-emoji ":stadium:" (hash lazy=true)}}
-    {{replace-emoji ":classical_building:" (hash lazy=true)}}
-    {{replace-emoji ":building_construction:" (hash lazy=true)}}
-    {{replace-emoji ":brick:" (hash lazy=true)}}
-    {{replace-emoji ":rock:" (hash lazy=true)}}
-    {{replace-emoji ":wood:" (hash lazy=true)}}
-    {{replace-emoji ":hut:" (hash lazy=true)}}
-    {{replace-emoji ":houses:" (hash lazy=true)}}
-    {{replace-emoji ":derelict_house:" (hash lazy=true)}}
-    {{replace-emoji ":house:" (hash lazy=true)}}
-    {{replace-emoji ":house_with_garden:" (hash lazy=true)}}
-    {{replace-emoji ":office:" (hash lazy=true)}}
-    {{replace-emoji ":post_office:" (hash lazy=true)}}
-    {{replace-emoji ":european_post_office:" (hash lazy=true)}}
-    {{replace-emoji ":hospital:" (hash lazy=true)}}
-    {{replace-emoji ":bank:" (hash lazy=true)}}
-    {{replace-emoji ":hotel:" (hash lazy=true)}}
-    {{replace-emoji ":love_hotel:" (hash lazy=true)}}
-    {{replace-emoji ":convenience_store:" (hash lazy=true)}}
-    {{replace-emoji ":school:" (hash lazy=true)}}
-    {{replace-emoji ":department_store:" (hash lazy=true)}}
-    {{replace-emoji ":factory:" (hash lazy=true)}}
-    {{replace-emoji ":japanese_castle:" (hash lazy=true)}}
-    {{replace-emoji ":european_castle:" (hash lazy=true)}}
-    {{replace-emoji ":wedding:" (hash lazy=true)}}
-    {{replace-emoji ":tokyo_tower:" (hash lazy=true)}}
-    {{replace-emoji ":statue_of_liberty:" (hash lazy=true)}}
-    {{replace-emoji ":church:" (hash lazy=true)}}
-    {{replace-emoji ":mosque:" (hash lazy=true)}}
-    {{replace-emoji ":hindu_temple:" (hash lazy=true)}}
-    {{replace-emoji ":synagogue:" (hash lazy=true)}}
-    {{replace-emoji ":shinto_shrine:" (hash lazy=true)}}
-    {{replace-emoji ":kaaba:" (hash lazy=true)}}
-    {{replace-emoji ":fountain:" (hash lazy=true)}}
-    {{replace-emoji ":tent:" (hash lazy=true)}}
-    {{replace-emoji ":foggy:" (hash lazy=true)}}
-    {{replace-emoji ":night_with_stars:" (hash lazy=true)}}
-    {{replace-emoji ":cityscape:" (hash lazy=true)}}
-    {{replace-emoji ":sunrise_over_mountains:" (hash lazy=true)}}
-    {{replace-emoji ":sunrise:" (hash lazy=true)}}
-    {{replace-emoji ":city_sunset:" (hash lazy=true)}}
-    {{replace-emoji ":city_sunrise:" (hash lazy=true)}}
-    {{replace-emoji ":bridge_at_night:" (hash lazy=true)}}
-    {{replace-emoji ":hotsprings:" (hash lazy=true)}}
-    {{replace-emoji ":carousel_horse:" (hash lazy=true)}}
-    {{replace-emoji ":playground_slide:" (hash lazy=true)}}
-    {{replace-emoji ":ferris_wheel:" (hash lazy=true)}}
-    {{replace-emoji ":roller_coaster:" (hash lazy=true)}}
-    {{replace-emoji ":barber:" (hash lazy=true)}}
-    {{replace-emoji ":circus_tent:" (hash lazy=true)}}
-    {{replace-emoji ":steam_locomotive:" (hash lazy=true)}}
-    {{replace-emoji ":railway_car:" (hash lazy=true)}}
-    {{replace-emoji ":bullettrain_side:" (hash lazy=true)}}
-    {{replace-emoji ":bullettrain_front:" (hash lazy=true)}}
-    {{replace-emoji ":train2:" (hash lazy=true)}}
-    {{replace-emoji ":metro:" (hash lazy=true)}}
-    {{replace-emoji ":light_rail:" (hash lazy=true)}}
-    {{replace-emoji ":station:" (hash lazy=true)}}
-    {{replace-emoji ":tram:" (hash lazy=true)}}
-    {{replace-emoji ":monorail:" (hash lazy=true)}}
-    {{replace-emoji ":mountain_railway:" (hash lazy=true)}}
-    {{replace-emoji ":train:" (hash lazy=true)}}
-    {{replace-emoji ":bus:" (hash lazy=true)}}
-    {{replace-emoji ":oncoming_bus:" (hash lazy=true)}}
-    {{replace-emoji ":trolleybus:" (hash lazy=true)}}
-    {{replace-emoji ":minibus:" (hash lazy=true)}}
-    {{replace-emoji ":ambulance:" (hash lazy=true)}}
-    {{replace-emoji ":fire_engine:" (hash lazy=true)}}
-    {{replace-emoji ":police_car:" (hash lazy=true)}}
-    {{replace-emoji ":oncoming_police_car:" (hash lazy=true)}}
-    {{replace-emoji ":taxi:" (hash lazy=true)}}
-    {{replace-emoji ":oncoming_taxi:" (hash lazy=true)}}
-    {{replace-emoji ":red_car:" (hash lazy=true)}}
-    {{replace-emoji ":oncoming_automobile:" (hash lazy=true)}}
-    {{replace-emoji ":blue_car:" (hash lazy=true)}}
-    {{replace-emoji ":pickup_truck:" (hash lazy=true)}}
-    {{replace-emoji ":truck:" (hash lazy=true)}}
-    {{replace-emoji ":articulated_lorry:" (hash lazy=true)}}
-    {{replace-emoji ":tractor:" (hash lazy=true)}}
-    {{replace-emoji ":racing_car:" (hash lazy=true)}}
-    {{replace-emoji ":motorcycle:" (hash lazy=true)}}
-    {{replace-emoji ":motor_scooter:" (hash lazy=true)}}
-    {{replace-emoji ":manual_wheelchair:" (hash lazy=true)}}
-    {{replace-emoji ":motorized_wheelchair:" (hash lazy=true)}}
-    {{replace-emoji ":auto_rickshaw:" (hash lazy=true)}}
-    {{replace-emoji ":bike:" (hash lazy=true)}}
-    {{replace-emoji ":kick_scooter:" (hash lazy=true)}}
-    {{replace-emoji ":skateboard:" (hash lazy=true)}}
-    {{replace-emoji ":roller_skate:" (hash lazy=true)}}
-    {{replace-emoji ":busstop:" (hash lazy=true)}}
-    {{replace-emoji ":motorway:" (hash lazy=true)}}
-    {{replace-emoji ":railway_track:" (hash lazy=true)}}
-    {{replace-emoji ":oil_drum:" (hash lazy=true)}}
-    {{replace-emoji ":fuelpump:" (hash lazy=true)}}
-    {{replace-emoji ":wheel:" (hash lazy=true)}}
-    {{replace-emoji ":rotating_light:" (hash lazy=true)}}
-    {{replace-emoji ":traffic_light:" (hash lazy=true)}}
-    {{replace-emoji ":vertical_traffic_light:" (hash lazy=true)}}
-    {{replace-emoji ":stop_sign:" (hash lazy=true)}}
-    {{replace-emoji ":construction:" (hash lazy=true)}}
-    {{replace-emoji ":anchor:" (hash lazy=true)}}
-    {{replace-emoji ":ring_buoy:" (hash lazy=true)}}
-    {{replace-emoji ":sailboat:" (hash lazy=true)}}
-    {{replace-emoji ":canoe:" (hash lazy=true)}}
-    {{replace-emoji ":speedboat:" (hash lazy=true)}}
-    {{replace-emoji ":passenger_ship:" (hash lazy=true)}}
-    {{replace-emoji ":ferry:" (hash lazy=true)}}
-    {{replace-emoji ":motor_boat:" (hash lazy=true)}}
-    {{replace-emoji ":ship:" (hash lazy=true)}}
-    {{replace-emoji ":airplane:" (hash lazy=true)}}
-    {{replace-emoji ":small_airplane:" (hash lazy=true)}}
-    {{replace-emoji ":flight_departure:" (hash lazy=true)}}
-    {{replace-emoji ":flight_arrival:" (hash lazy=true)}}
-    {{replace-emoji ":parachute:" (hash lazy=true)}}
-    {{replace-emoji ":seat:" (hash lazy=true)}}
-    {{replace-emoji ":helicopter:" (hash lazy=true)}}
-    {{replace-emoji ":suspension_railway:" (hash lazy=true)}}
-    {{replace-emoji ":mountain_cableway:" (hash lazy=true)}}
-    {{replace-emoji ":aerial_tramway:" (hash lazy=true)}}
-    {{replace-emoji ":artificial_satellite:" (hash lazy=true)}}
-    {{replace-emoji ":rocket:" (hash lazy=true)}}
-    {{replace-emoji ":flying_saucer:" (hash lazy=true)}}
-    {{replace-emoji ":bellhop_bell:" (hash lazy=true)}}
-    {{replace-emoji ":luggage:" (hash lazy=true)}}
-    {{replace-emoji ":hourglass:" (hash lazy=true)}}
-    {{replace-emoji ":hourglass_flowing_sand:" (hash lazy=true)}}
-    {{replace-emoji ":watch:" (hash lazy=true)}}
-    {{replace-emoji ":alarm_clock:" (hash lazy=true)}}
-    {{replace-emoji ":stopwatch:" (hash lazy=true)}}
-    {{replace-emoji ":timer_clock:" (hash lazy=true)}}
-    {{replace-emoji ":mantelpiece_clock:" (hash lazy=true)}}
-    {{replace-emoji ":clock12:" (hash lazy=true)}}
-    {{replace-emoji ":clock1230:" (hash lazy=true)}}
-    {{replace-emoji ":clock1:" (hash lazy=true)}}
-    {{replace-emoji ":clock130:" (hash lazy=true)}}
-    {{replace-emoji ":clock2:" (hash lazy=true)}}
-    {{replace-emoji ":clock230:" (hash lazy=true)}}
-    {{replace-emoji ":clock3:" (hash lazy=true)}}
-    {{replace-emoji ":clock330:" (hash lazy=true)}}
-    {{replace-emoji ":clock4:" (hash lazy=true)}}
-    {{replace-emoji ":clock430:" (hash lazy=true)}}
-    {{replace-emoji ":clock5:" (hash lazy=true)}}
-    {{replace-emoji ":clock530:" (hash lazy=true)}}
-    {{replace-emoji ":clock6:" (hash lazy=true)}}
-    {{replace-emoji ":clock630:" (hash lazy=true)}}
-    {{replace-emoji ":clock7:" (hash lazy=true)}}
-    {{replace-emoji ":clock730:" (hash lazy=true)}}
-    {{replace-emoji ":clock8:" (hash lazy=true)}}
-    {{replace-emoji ":clock830:" (hash lazy=true)}}
-    {{replace-emoji ":clock9:" (hash lazy=true)}}
-    {{replace-emoji ":clock930:" (hash lazy=true)}}
-    {{replace-emoji ":clock10:" (hash lazy=true)}}
-    {{replace-emoji ":clock1030:" (hash lazy=true)}}
-    {{replace-emoji ":clock11:" (hash lazy=true)}}
-    {{replace-emoji ":clock1130:" (hash lazy=true)}}
-    {{replace-emoji ":new_moon:" (hash lazy=true)}}
-    {{replace-emoji ":waxing_crescent_moon:" (hash lazy=true)}}
-    {{replace-emoji ":first_quarter_moon:" (hash lazy=true)}}
-    {{replace-emoji ":waxing_gibbous_moon:" (hash lazy=true)}}
-    {{replace-emoji ":full_moon:" (hash lazy=true)}}
-    {{replace-emoji ":waning_gibbous_moon:" (hash lazy=true)}}
-    {{replace-emoji ":last_quarter_moon:" (hash lazy=true)}}
-    {{replace-emoji ":waning_crescent_moon:" (hash lazy=true)}}
-    {{replace-emoji ":crescent_moon:" (hash lazy=true)}}
-    {{replace-emoji ":new_moon_with_face:" (hash lazy=true)}}
-    {{replace-emoji ":first_quarter_moon_with_face:" (hash lazy=true)}}
-    {{replace-emoji ":last_quarter_moon_with_face:" (hash lazy=true)}}
-    {{replace-emoji ":thermometer:" (hash lazy=true)}}
-    {{replace-emoji ":sunny:" (hash lazy=true)}}
-    {{replace-emoji ":full_moon_with_face:" (hash lazy=true)}}
-    {{replace-emoji ":sun_with_face:" (hash lazy=true)}}
-    {{replace-emoji ":ringer_planet:" (hash lazy=true)}}
-    {{replace-emoji ":star:" (hash lazy=true)}}
-    {{replace-emoji ":star2:" (hash lazy=true)}}
-    {{replace-emoji ":stars:" (hash lazy=true)}}
-    {{replace-emoji ":milky_way:" (hash lazy=true)}}
-    {{replace-emoji ":cloud:" (hash lazy=true)}}
-    {{replace-emoji ":partly_sunny:" (hash lazy=true)}}
-    {{replace-emoji ":cloud_with_lightning_and_rain:" (hash lazy=true)}}
-    {{replace-emoji ":sun_behind_small_cloud:" (hash lazy=true)}}
-    {{replace-emoji ":sun_behind_large_cloud:" (hash lazy=true)}}
-    {{replace-emoji ":sun_behind_rain_cloud:" (hash lazy=true)}}
-    {{replace-emoji ":cloud_with_rain:" (hash lazy=true)}}
-    {{replace-emoji ":cloud_with_snow:" (hash lazy=true)}}
-    {{replace-emoji ":cloud_with_lightning:" (hash lazy=true)}}
-    {{replace-emoji ":tornado:" (hash lazy=true)}}
-    {{replace-emoji ":fog:" (hash lazy=true)}}
-    {{replace-emoji ":wind_face:" (hash lazy=true)}}
-    {{replace-emoji ":cyclone:" (hash lazy=true)}}
-    {{replace-emoji ":rainbow:" (hash lazy=true)}}
-    {{replace-emoji ":closed_umbrella:" (hash lazy=true)}}
-    {{replace-emoji ":open_umbrella:" (hash lazy=true)}}
-    {{replace-emoji ":umbrella:" (hash lazy=true)}}
-    {{replace-emoji ":parasol_on_ground:" (hash lazy=true)}}
-    {{replace-emoji ":zap:" (hash lazy=true)}}
-    {{replace-emoji ":snowflake:" (hash lazy=true)}}
-    {{replace-emoji ":snowman_with_snow:" (hash lazy=true)}}
-    {{replace-emoji ":snowman:" (hash lazy=true)}}
-    {{replace-emoji ":comet:" (hash lazy=true)}}
-    {{replace-emoji ":fire:" (hash lazy=true)}}
-    {{replace-emoji ":droplet:" (hash lazy=true)}}
-    {{replace-emoji ":ocean:" (hash lazy=true)}}
+    {{replace-emoji ":earth_africa:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":earth_americas:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":earth_asia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":globe_with_meridians:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":world_map:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":japan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":compass:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mountain_snow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mountain:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":volcano:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mount_fuji:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":camping:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":beach_umbrella:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":desert:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":desert_island:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":national_park:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stadium:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":classical_building:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":building_construction:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":brick:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rock:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wood:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hut:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":houses:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":derelict_house:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":house:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":house_with_garden:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":office:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":post_office:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":european_post_office:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hospital:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bank:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hotel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":love_hotel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":convenience_store:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":school:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":department_store:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":factory:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":japanese_castle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":european_castle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wedding:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tokyo_tower:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":statue_of_liberty:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":church:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mosque:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hindu_temple:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":synagogue:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shinto_shrine:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kaaba:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fountain:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tent:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":foggy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":night_with_stars:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cityscape:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sunrise_over_mountains:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sunrise:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":city_sunset:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":city_sunrise:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bridge_at_night:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hotsprings:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":carousel_horse:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":playground_slide:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ferris_wheel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":roller_coaster:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":barber:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":circus_tent:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":steam_locomotive:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":railway_car:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bullettrain_side:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bullettrain_front:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":train2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":metro:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":light_rail:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":station:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tram:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":monorail:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mountain_railway:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":train:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":oncoming_bus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":trolleybus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":minibus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ambulance:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fire_engine:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":police_car:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":oncoming_police_car:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":taxi:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":oncoming_taxi:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":red_car:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":oncoming_automobile:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":blue_car:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pickup_truck:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":truck:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":articulated_lorry:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tractor:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":racing_car:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":motorcycle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":motor_scooter:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":manual_wheelchair:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":motorized_wheelchair:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":auto_rickshaw:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bike:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kick_scooter:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":skateboard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":roller_skate:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":busstop:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":motorway:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":railway_track:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":oil_drum:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fuelpump:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wheel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rotating_light:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":traffic_light:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":vertical_traffic_light:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stop_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":construction:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":anchor:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ring_buoy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sailboat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":canoe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":speedboat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":passenger_ship:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ferry:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":motor_boat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ship:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":airplane:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":small_airplane:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flight_departure:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flight_arrival:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":parachute:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":seat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":helicopter:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":suspension_railway:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mountain_cableway:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":aerial_tramway:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":artificial_satellite:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rocket:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flying_saucer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bellhop_bell:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":luggage:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hourglass:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hourglass_flowing_sand:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":watch:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":alarm_clock:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stopwatch:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":timer_clock:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mantelpiece_clock:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock12:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock1230:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock1:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock130:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock230:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock3:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock330:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock4:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock430:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock5:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock530:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock6:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock630:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock7:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock730:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock8:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock830:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock9:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock930:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock10:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock1030:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock11:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clock1130:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":new_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":waxing_crescent_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":first_quarter_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":waxing_gibbous_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":full_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":waning_gibbous_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":last_quarter_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":waning_crescent_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crescent_moon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":new_moon_with_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":first_quarter_moon_with_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":last_quarter_moon_with_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":thermometer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sunny:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":full_moon_with_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sun_with_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ringer_planet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":star:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":star2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stars:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":milky_way:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cloud:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":partly_sunny:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cloud_with_lightning_and_rain:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sun_behind_small_cloud:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sun_behind_large_cloud:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sun_behind_rain_cloud:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cloud_with_rain:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cloud_with_snow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cloud_with_lightning:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tornado:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fog:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wind_face:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cyclone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rainbow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":closed_umbrella:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":open_umbrella:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":umbrella:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":parasol_on_ground:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":zap:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":snowflake:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":snowman_with_snow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":snowman:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":comet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fire:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":droplet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ocean:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>
 <div class="section" data-section="activities">
@@ -1059,92 +1059,92 @@
     <span class="title">{{i18n "emoji_picker.activities"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":jack_o_lantern:" (hash lazy=true)}}
-    {{replace-emoji ":christmas_tree:" (hash lazy=true)}}
-    {{replace-emoji ":fireworks:" (hash lazy=true)}}
-    {{replace-emoji ":sparkler:" (hash lazy=true)}}
-    {{replace-emoji ":firecracker:" (hash lazy=true)}}
-    {{replace-emoji ":sparkles:" (hash lazy=true)}}
-    {{replace-emoji ":balloon:" (hash lazy=true)}}
-    {{replace-emoji ":tada:" (hash lazy=true)}}
-    {{replace-emoji ":confetti_ball:" (hash lazy=true)}}
-    {{replace-emoji ":tanabata_tree:" (hash lazy=true)}}
-    {{replace-emoji ":bamboo:" (hash lazy=true)}}
-    {{replace-emoji ":dolls:" (hash lazy=true)}}
-    {{replace-emoji ":flags:" (hash lazy=true)}}
-    {{replace-emoji ":wind_chime:" (hash lazy=true)}}
-    {{replace-emoji ":rice_scene:" (hash lazy=true)}}
-    {{replace-emoji ":red_gift_envelope:" (hash lazy=true)}}
-    {{replace-emoji ":ribbon:" (hash lazy=true)}}
-    {{replace-emoji ":gift:" (hash lazy=true)}}
-    {{replace-emoji ":reminder_ribbon:" (hash lazy=true)}}
-    {{replace-emoji ":tickets:" (hash lazy=true)}}
-    {{replace-emoji ":ticket:" (hash lazy=true)}}
-    {{replace-emoji ":medal_military:" (hash lazy=true)}}
-    {{replace-emoji ":trophy:" (hash lazy=true)}}
-    {{replace-emoji ":medal_sports:" (hash lazy=true)}}
-    {{replace-emoji ":1st_place_medal:" (hash lazy=true)}}
-    {{replace-emoji ":2nd_place_medal:" (hash lazy=true)}}
-    {{replace-emoji ":3rd_place_medal:" (hash lazy=true)}}
-    {{replace-emoji ":soccer:" (hash lazy=true)}}
-    {{replace-emoji ":baseball:" (hash lazy=true)}}
-    {{replace-emoji ":softball:" (hash lazy=true)}}
-    {{replace-emoji ":basketball:" (hash lazy=true)}}
-    {{replace-emoji ":volleyball:" (hash lazy=true)}}
-    {{replace-emoji ":football:" (hash lazy=true)}}
-    {{replace-emoji ":rugby_football:" (hash lazy=true)}}
-    {{replace-emoji ":tennis:" (hash lazy=true)}}
-    {{replace-emoji ":flying_disc:" (hash lazy=true)}}
-    {{replace-emoji ":bowling:" (hash lazy=true)}}
-    {{replace-emoji ":cricket_bat_and_ball:" (hash lazy=true)}}
-    {{replace-emoji ":field_hockey:" (hash lazy=true)}}
-    {{replace-emoji ":ice_hockey:" (hash lazy=true)}}
-    {{replace-emoji ":lacrosse:" (hash lazy=true)}}
-    {{replace-emoji ":ping_pong:" (hash lazy=true)}}
-    {{replace-emoji ":badminton:" (hash lazy=true)}}
-    {{replace-emoji ":boxing_glove:" (hash lazy=true)}}
-    {{replace-emoji ":martial_arts_uniform:" (hash lazy=true)}}
-    {{replace-emoji ":goal_net:" (hash lazy=true)}}
-    {{replace-emoji ":golf:" (hash lazy=true)}}
-    {{replace-emoji ":ice_skate:" (hash lazy=true)}}
-    {{replace-emoji ":fishing_pole_and_fish:" (hash lazy=true)}}
-    {{replace-emoji ":diving_mask:" (hash lazy=true)}}
-    {{replace-emoji ":running_shirt_with_sash:" (hash lazy=true)}}
-    {{replace-emoji ":ski:" (hash lazy=true)}}
-    {{replace-emoji ":sled:" (hash lazy=true)}}
-    {{replace-emoji ":curling_stone:" (hash lazy=true)}}
-    {{replace-emoji ":dart:" (hash lazy=true)}}
-    {{replace-emoji ":yo-yo:" (hash lazy=true)}}
-    {{replace-emoji ":kite:" (hash lazy=true)}}
-    {{replace-emoji ":8ball:" (hash lazy=true)}}
-    {{replace-emoji ":crystal_ball:" (hash lazy=true)}}
-    {{replace-emoji ":magic_wand:" (hash lazy=true)}}
-    {{replace-emoji ":nazar_amulet:" (hash lazy=true)}}
-    {{replace-emoji ":hamsa:" (hash lazy=true)}}
-    {{replace-emoji ":video_game:" (hash lazy=true)}}
-    {{replace-emoji ":joystick:" (hash lazy=true)}}
-    {{replace-emoji ":slot_machine:" (hash lazy=true)}}
-    {{replace-emoji ":game_die:" (hash lazy=true)}}
-    {{replace-emoji ":jigsaw:" (hash lazy=true)}}
-    {{replace-emoji ":teddy_bear:" (hash lazy=true)}}
-    {{replace-emoji ":piñata:" (hash lazy=true)}}
-    {{replace-emoji ":mirror_ball:" (hash lazy=true)}}
-    {{replace-emoji ":nesting_dolls:" (hash lazy=true)}}
-    {{replace-emoji ":spades:" (hash lazy=true)}}
-    {{replace-emoji ":hearts:" (hash lazy=true)}}
-    {{replace-emoji ":diamonds:" (hash lazy=true)}}
-    {{replace-emoji ":clubs:" (hash lazy=true)}}
-    {{replace-emoji ":chess_pawn:" (hash lazy=true)}}
-    {{replace-emoji ":black_joker:" (hash lazy=true)}}
-    {{replace-emoji ":mahjong:" (hash lazy=true)}}
-    {{replace-emoji ":flower_playing_cards:" (hash lazy=true)}}
-    {{replace-emoji ":performing_arts:" (hash lazy=true)}}
-    {{replace-emoji ":framed_picture:" (hash lazy=true)}}
-    {{replace-emoji ":art:" (hash lazy=true)}}
-    {{replace-emoji ":thread:" (hash lazy=true)}}
-    {{replace-emoji ":sewing_needle:" (hash lazy=true)}}
-    {{replace-emoji ":yarn:" (hash lazy=true)}}
-    {{replace-emoji ":knot:" (hash lazy=true)}}
+    {{replace-emoji ":jack_o_lantern:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":christmas_tree:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fireworks:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sparkler:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":firecracker:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sparkles:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":balloon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tada:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":confetti_ball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tanabata_tree:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bamboo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dolls:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flags:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wind_chime:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rice_scene:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":red_gift_envelope:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ribbon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gift:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":reminder_ribbon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tickets:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ticket:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":medal_military:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":trophy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":medal_sports:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":1st_place_medal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":2nd_place_medal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":3rd_place_medal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":soccer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":baseball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":softball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":basketball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":volleyball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":football:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rugby_football:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tennis:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flying_disc:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bowling:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cricket_bat_and_ball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":field_hockey:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ice_hockey:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lacrosse:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ping_pong:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":badminton:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":boxing_glove:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":martial_arts_uniform:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":goal_net:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":golf:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ice_skate:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fishing_pole_and_fish:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":diving_mask:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":running_shirt_with_sash:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ski:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sled:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":curling_stone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yo-yo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kite:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":8ball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crystal_ball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":magic_wand:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nazar_amulet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hamsa:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":video_game:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":joystick:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":slot_machine:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":game_die:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":jigsaw:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":teddy_bear:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":piñata:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mirror_ball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nesting_dolls:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":spades:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hearts:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":diamonds:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clubs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chess_pawn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_joker:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mahjong:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flower_playing_cards:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":performing_arts:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":framed_picture:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":art:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":thread:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sewing_needle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yarn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":knot:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>
 <div class="section" data-section="objects">
@@ -1152,261 +1152,261 @@
     <span class="title">{{i18n "emoji_picker.objects"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":eyeglasses:" (hash lazy=true)}}
-    {{replace-emoji ":dark_sunglasses:" (hash lazy=true)}}
-    {{replace-emoji ":goggles:" (hash lazy=true)}}
-    {{replace-emoji ":lab_coat:" (hash lazy=true)}}
-    {{replace-emoji ":safety_vest:" (hash lazy=true)}}
-    {{replace-emoji ":necktie:" (hash lazy=true)}}
-    {{replace-emoji ":tshirt:" (hash lazy=true)}}
-    {{replace-emoji ":jeans:" (hash lazy=true)}}
-    {{replace-emoji ":scarf:" (hash lazy=true)}}
-    {{replace-emoji ":gloves:" (hash lazy=true)}}
-    {{replace-emoji ":coat:" (hash lazy=true)}}
-    {{replace-emoji ":socks:" (hash lazy=true)}}
-    {{replace-emoji ":dress:" (hash lazy=true)}}
-    {{replace-emoji ":kimono:" (hash lazy=true)}}
-    {{replace-emoji ":sari:" (hash lazy=true)}}
-    {{replace-emoji ":one_piece_swimsuit:" (hash lazy=true)}}
-    {{replace-emoji ":briefs:" (hash lazy=true)}}
-    {{replace-emoji ":shorts:" (hash lazy=true)}}
-    {{replace-emoji ":bikini:" (hash lazy=true)}}
-    {{replace-emoji ":womans_clothes:" (hash lazy=true)}}
-    {{replace-emoji ":purse:" (hash lazy=true)}}
-    {{replace-emoji ":handbag:" (hash lazy=true)}}
-    {{replace-emoji ":pouch:" (hash lazy=true)}}
-    {{replace-emoji ":shopping:" (hash lazy=true)}}
-    {{replace-emoji ":school_satchel:" (hash lazy=true)}}
-    {{replace-emoji ":thong_sandal:" (hash lazy=true)}}
-    {{replace-emoji ":mans_shoe:" (hash lazy=true)}}
-    {{replace-emoji ":athletic_shoe:" (hash lazy=true)}}
-    {{replace-emoji ":hiking_boot:" (hash lazy=true)}}
-    {{replace-emoji ":flat_shoe:" (hash lazy=true)}}
-    {{replace-emoji ":high_heel:" (hash lazy=true)}}
-    {{replace-emoji ":sandal:" (hash lazy=true)}}
-    {{replace-emoji ":ballet_shoes:" (hash lazy=true)}}
-    {{replace-emoji ":boot:" (hash lazy=true)}}
-    {{replace-emoji ":crown:" (hash lazy=true)}}
-    {{replace-emoji ":womans_hat:" (hash lazy=true)}}
-    {{replace-emoji ":tophat:" (hash lazy=true)}}
-    {{replace-emoji ":mortar_board:" (hash lazy=true)}}
-    {{replace-emoji ":billed_cap:" (hash lazy=true)}}
-    {{replace-emoji ":military_helmet:" (hash lazy=true)}}
-    {{replace-emoji ":rescue_worker_helmet:" (hash lazy=true)}}
-    {{replace-emoji ":prayer_beads:" (hash lazy=true)}}
-    {{replace-emoji ":lipstick:" (hash lazy=true)}}
-    {{replace-emoji ":ring:" (hash lazy=true)}}
-    {{replace-emoji ":gem:" (hash lazy=true)}}
-    {{replace-emoji ":mute:" (hash lazy=true)}}
-    {{replace-emoji ":speaker:" (hash lazy=true)}}
-    {{replace-emoji ":sound:" (hash lazy=true)}}
-    {{replace-emoji ":loud_sound:" (hash lazy=true)}}
-    {{replace-emoji ":loudspeaker:" (hash lazy=true)}}
-    {{replace-emoji ":mega:" (hash lazy=true)}}
-    {{replace-emoji ":postal_horn:" (hash lazy=true)}}
-    {{replace-emoji ":bell:" (hash lazy=true)}}
-    {{replace-emoji ":no_bell:" (hash lazy=true)}}
-    {{replace-emoji ":musical_score:" (hash lazy=true)}}
-    {{replace-emoji ":musical_note:" (hash lazy=true)}}
-    {{replace-emoji ":notes:" (hash lazy=true)}}
-    {{replace-emoji ":studio_microphone:" (hash lazy=true)}}
-    {{replace-emoji ":level_slider:" (hash lazy=true)}}
-    {{replace-emoji ":control_knobs:" (hash lazy=true)}}
-    {{replace-emoji ":microphone:" (hash lazy=true)}}
-    {{replace-emoji ":headphones:" (hash lazy=true)}}
-    {{replace-emoji ":radio:" (hash lazy=true)}}
-    {{replace-emoji ":saxophone:" (hash lazy=true)}}
-    {{replace-emoji ":accordion:" (hash lazy=true)}}
-    {{replace-emoji ":guitar:" (hash lazy=true)}}
-    {{replace-emoji ":musical_keyboard:" (hash lazy=true)}}
-    {{replace-emoji ":trumpet:" (hash lazy=true)}}
-    {{replace-emoji ":violin:" (hash lazy=true)}}
-    {{replace-emoji ":banjo:" (hash lazy=true)}}
-    {{replace-emoji ":drum:" (hash lazy=true)}}
-    {{replace-emoji ":long_drum:" (hash lazy=true)}}
-    {{replace-emoji ":iphone:" (hash lazy=true)}}
-    {{replace-emoji ":calling:" (hash lazy=true)}}
-    {{replace-emoji ":phone:" (hash lazy=true)}}
-    {{replace-emoji ":telephone_receiver:" (hash lazy=true)}}
-    {{replace-emoji ":pager:" (hash lazy=true)}}
-    {{replace-emoji ":fax:" (hash lazy=true)}}
-    {{replace-emoji ":battery:" (hash lazy=true)}}
-    {{replace-emoji ":low_battery:" (hash lazy=true)}}
-    {{replace-emoji ":electric_plug:" (hash lazy=true)}}
-    {{replace-emoji ":computer:" (hash lazy=true)}}
-    {{replace-emoji ":desktop_computer:" (hash lazy=true)}}
-    {{replace-emoji ":printer:" (hash lazy=true)}}
-    {{replace-emoji ":keyboard:" (hash lazy=true)}}
-    {{replace-emoji ":computer_mouse:" (hash lazy=true)}}
-    {{replace-emoji ":trackball:" (hash lazy=true)}}
-    {{replace-emoji ":minidisc:" (hash lazy=true)}}
-    {{replace-emoji ":floppy_disk:" (hash lazy=true)}}
-    {{replace-emoji ":cd:" (hash lazy=true)}}
-    {{replace-emoji ":dvd:" (hash lazy=true)}}
-    {{replace-emoji ":abacus:" (hash lazy=true)}}
-    {{replace-emoji ":movie_camera:" (hash lazy=true)}}
-    {{replace-emoji ":film_strip:" (hash lazy=true)}}
-    {{replace-emoji ":film_projector:" (hash lazy=true)}}
-    {{replace-emoji ":clapper:" (hash lazy=true)}}
-    {{replace-emoji ":tv:" (hash lazy=true)}}
-    {{replace-emoji ":camera:" (hash lazy=true)}}
-    {{replace-emoji ":camera_flash:" (hash lazy=true)}}
-    {{replace-emoji ":video_camera:" (hash lazy=true)}}
-    {{replace-emoji ":vhs:" (hash lazy=true)}}
-    {{replace-emoji ":mag:" (hash lazy=true)}}
-    {{replace-emoji ":mag_right:" (hash lazy=true)}}
-    {{replace-emoji ":candle:" (hash lazy=true)}}
-    {{replace-emoji ":bulb:" (hash lazy=true)}}
-    {{replace-emoji ":flashlight:" (hash lazy=true)}}
-    {{replace-emoji ":izakaya_lantern:" (hash lazy=true)}}
-    {{replace-emoji ":diya_lamp:" (hash lazy=true)}}
-    {{replace-emoji ":notebook_with_decorative_cover:" (hash lazy=true)}}
-    {{replace-emoji ":closed_book:" (hash lazy=true)}}
-    {{replace-emoji ":open_book:" (hash lazy=true)}}
-    {{replace-emoji ":green_book:" (hash lazy=true)}}
-    {{replace-emoji ":blue_book:" (hash lazy=true)}}
-    {{replace-emoji ":orange_book:" (hash lazy=true)}}
-    {{replace-emoji ":books:" (hash lazy=true)}}
-    {{replace-emoji ":notebook:" (hash lazy=true)}}
-    {{replace-emoji ":ledger:" (hash lazy=true)}}
-    {{replace-emoji ":page_with_curl:" (hash lazy=true)}}
-    {{replace-emoji ":scroll:" (hash lazy=true)}}
-    {{replace-emoji ":page_facing_up:" (hash lazy=true)}}
-    {{replace-emoji ":newspaper:" (hash lazy=true)}}
-    {{replace-emoji ":newspaper_roll:" (hash lazy=true)}}
-    {{replace-emoji ":bookmark_tabs:" (hash lazy=true)}}
-    {{replace-emoji ":bookmark:" (hash lazy=true)}}
-    {{replace-emoji ":label:" (hash lazy=true)}}
-    {{replace-emoji ":moneybag:" (hash lazy=true)}}
-    {{replace-emoji ":coin:" (hash lazy=true)}}
-    {{replace-emoji ":yen:" (hash lazy=true)}}
-    {{replace-emoji ":dollar:" (hash lazy=true)}}
-    {{replace-emoji ":euro:" (hash lazy=true)}}
-    {{replace-emoji ":pound:" (hash lazy=true)}}
-    {{replace-emoji ":money_with_wings:" (hash lazy=true)}}
-    {{replace-emoji ":credit_card:" (hash lazy=true)}}
-    {{replace-emoji ":receipt:" (hash lazy=true)}}
-    {{replace-emoji ":chart:" (hash lazy=true)}}
-    {{replace-emoji ":email:" (hash lazy=true)}}
-    {{replace-emoji ":e-mail:" (hash lazy=true)}}
-    {{replace-emoji ":incoming_envelope:" (hash lazy=true)}}
-    {{replace-emoji ":envelope_with_arrow:" (hash lazy=true)}}
-    {{replace-emoji ":outbox_tray:" (hash lazy=true)}}
-    {{replace-emoji ":inbox_tray:" (hash lazy=true)}}
-    {{replace-emoji ":package:" (hash lazy=true)}}
-    {{replace-emoji ":mailbox:" (hash lazy=true)}}
-    {{replace-emoji ":mailbox_closed:" (hash lazy=true)}}
-    {{replace-emoji ":mailbox_with_mail:" (hash lazy=true)}}
-    {{replace-emoji ":mailbox_with_no_mail:" (hash lazy=true)}}
-    {{replace-emoji ":postbox:" (hash lazy=true)}}
-    {{replace-emoji ":ballot_box:" (hash lazy=true)}}
-    {{replace-emoji ":pencil2:" (hash lazy=true)}}
-    {{replace-emoji ":black_nib:" (hash lazy=true)}}
-    {{replace-emoji ":fountain_pen:" (hash lazy=true)}}
-    {{replace-emoji ":pen:" (hash lazy=true)}}
-    {{replace-emoji ":paintbrush:" (hash lazy=true)}}
-    {{replace-emoji ":crayon:" (hash lazy=true)}}
-    {{replace-emoji ":memo:" (hash lazy=true)}}
-    {{replace-emoji ":briefcase:" (hash lazy=true)}}
-    {{replace-emoji ":file_folder:" (hash lazy=true)}}
-    {{replace-emoji ":open_file_folder:" (hash lazy=true)}}
-    {{replace-emoji ":card_index_dividers:" (hash lazy=true)}}
-    {{replace-emoji ":date:" (hash lazy=true)}}
-    {{replace-emoji ":calendar:" (hash lazy=true)}}
-    {{replace-emoji ":spiral_notepad:" (hash lazy=true)}}
-    {{replace-emoji ":spiral_calendar:" (hash lazy=true)}}
-    {{replace-emoji ":card_index:" (hash lazy=true)}}
-    {{replace-emoji ":chart_with_upwards_trend:" (hash lazy=true)}}
-    {{replace-emoji ":chart_with_downwards_trend:" (hash lazy=true)}}
-    {{replace-emoji ":bar_chart:" (hash lazy=true)}}
-    {{replace-emoji ":clipboard:" (hash lazy=true)}}
-    {{replace-emoji ":pushpin:" (hash lazy=true)}}
-    {{replace-emoji ":round_pushpin:" (hash lazy=true)}}
-    {{replace-emoji ":paperclip:" (hash lazy=true)}}
-    {{replace-emoji ":paperclips:" (hash lazy=true)}}
-    {{replace-emoji ":straight_ruler:" (hash lazy=true)}}
-    {{replace-emoji ":triangular_ruler:" (hash lazy=true)}}
-    {{replace-emoji ":scissors:" (hash lazy=true)}}
-    {{replace-emoji ":card_file_box:" (hash lazy=true)}}
-    {{replace-emoji ":file_cabinet:" (hash lazy=true)}}
-    {{replace-emoji ":wastebasket:" (hash lazy=true)}}
-    {{replace-emoji ":lock:" (hash lazy=true)}}
-    {{replace-emoji ":unlock:" (hash lazy=true)}}
-    {{replace-emoji ":lock_with_ink_pen:" (hash lazy=true)}}
-    {{replace-emoji ":closed_lock_with_key:" (hash lazy=true)}}
-    {{replace-emoji ":key:" (hash lazy=true)}}
-    {{replace-emoji ":old_key:" (hash lazy=true)}}
-    {{replace-emoji ":hammer:" (hash lazy=true)}}
-    {{replace-emoji ":axe:" (hash lazy=true)}}
-    {{replace-emoji ":pick:" (hash lazy=true)}}
-    {{replace-emoji ":hammer_and_pick:" (hash lazy=true)}}
-    {{replace-emoji ":hammer_and_wrench:" (hash lazy=true)}}
-    {{replace-emoji ":dagger:" (hash lazy=true)}}
-    {{replace-emoji ":crossed_swords:" (hash lazy=true)}}
-    {{replace-emoji ":gun:" (hash lazy=true)}}
-    {{replace-emoji ":boomerang:" (hash lazy=true)}}
-    {{replace-emoji ":bow_and_arrow:" (hash lazy=true)}}
-    {{replace-emoji ":shield:" (hash lazy=true)}}
-    {{replace-emoji ":carpentry_saw:" (hash lazy=true)}}
-    {{replace-emoji ":wrench:" (hash lazy=true)}}
-    {{replace-emoji ":screwdriver:" (hash lazy=true)}}
-    {{replace-emoji ":nut_and_bolt:" (hash lazy=true)}}
-    {{replace-emoji ":gear:" (hash lazy=true)}}
-    {{replace-emoji ":clamp:" (hash lazy=true)}}
-    {{replace-emoji ":balance_scale:" (hash lazy=true)}}
-    {{replace-emoji ":probing_cane:" (hash lazy=true)}}
-    {{replace-emoji ":link:" (hash lazy=true)}}
-    {{replace-emoji ":chains:" (hash lazy=true)}}
-    {{replace-emoji ":hook:" (hash lazy=true)}}
-    {{replace-emoji ":toolbox:" (hash lazy=true)}}
-    {{replace-emoji ":magnet:" (hash lazy=true)}}
-    {{replace-emoji ":ladder:" (hash lazy=true)}}
-    {{replace-emoji ":alembic:" (hash lazy=true)}}
-    {{replace-emoji ":test_tube:" (hash lazy=true)}}
-    {{replace-emoji ":petri_dish:" (hash lazy=true)}}
-    {{replace-emoji ":dna:" (hash lazy=true)}}
-    {{replace-emoji ":microscope:" (hash lazy=true)}}
-    {{replace-emoji ":telescope:" (hash lazy=true)}}
-    {{replace-emoji ":satellite:" (hash lazy=true)}}
-    {{replace-emoji ":syringe:" (hash lazy=true)}}
-    {{replace-emoji ":drop_of_blood:" (hash lazy=true)}}
-    {{replace-emoji ":pill:" (hash lazy=true)}}
-    {{replace-emoji ":adhesive_bandage:" (hash lazy=true)}}
-    {{replace-emoji ":crutch:" (hash lazy=true)}}
-    {{replace-emoji ":stethoscope:" (hash lazy=true)}}
-    {{replace-emoji ":xray:" (hash lazy=true)}}
-    {{replace-emoji ":door:" (hash lazy=true)}}
-    {{replace-emoji ":elevator:" (hash lazy=true)}}
-    {{replace-emoji ":mirror:" (hash lazy=true)}}
-    {{replace-emoji ":window:" (hash lazy=true)}}
-    {{replace-emoji ":bed:" (hash lazy=true)}}
-    {{replace-emoji ":couch_and_lamp:" (hash lazy=true)}}
-    {{replace-emoji ":chair:" (hash lazy=true)}}
-    {{replace-emoji ":toilet:" (hash lazy=true)}}
-    {{replace-emoji ":plunger:" (hash lazy=true)}}
-    {{replace-emoji ":shower:" (hash lazy=true)}}
-    {{replace-emoji ":bathtub:" (hash lazy=true)}}
-    {{replace-emoji ":mouse_trap:" (hash lazy=true)}}
-    {{replace-emoji ":razor:" (hash lazy=true)}}
-    {{replace-emoji ":lotion_bottle:" (hash lazy=true)}}
-    {{replace-emoji ":safety_pin:" (hash lazy=true)}}
-    {{replace-emoji ":broom:" (hash lazy=true)}}
-    {{replace-emoji ":basket:" (hash lazy=true)}}
-    {{replace-emoji ":roll_of_toilet_paper:" (hash lazy=true)}}
-    {{replace-emoji ":bucket:" (hash lazy=true)}}
-    {{replace-emoji ":soap:" (hash lazy=true)}}
-    {{replace-emoji ":bubbles:" (hash lazy=true)}}
-    {{replace-emoji ":toothbrush:" (hash lazy=true)}}
-    {{replace-emoji ":sponge:" (hash lazy=true)}}
-    {{replace-emoji ":fire_extinguisher:" (hash lazy=true)}}
-    {{replace-emoji ":shopping_cart:" (hash lazy=true)}}
-    {{replace-emoji ":smoking:" (hash lazy=true)}}
-    {{replace-emoji ":coffin:" (hash lazy=true)}}
-    {{replace-emoji ":headstone:" (hash lazy=true)}}
-    {{replace-emoji ":funeral_urn:" (hash lazy=true)}}
-    {{replace-emoji ":moyai:" (hash lazy=true)}}
-    {{replace-emoji ":placard:" (hash lazy=true)}}
-    {{replace-emoji ":identification_card:" (hash lazy=true)}}
+    {{replace-emoji ":eyeglasses:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dark_sunglasses:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":goggles:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lab_coat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":safety_vest:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":necktie:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tshirt:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":jeans:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":scarf:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gloves:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":coat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":socks:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dress:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kimono:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sari:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":one_piece_swimsuit:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":briefs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shorts:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bikini:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":womans_clothes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":purse:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":handbag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pouch:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shopping:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":school_satchel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":thong_sandal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mans_shoe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":athletic_shoe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hiking_boot:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flat_shoe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":high_heel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sandal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ballet_shoes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":boot:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crown:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":womans_hat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tophat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mortar_board:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":billed_cap:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":military_helmet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rescue_worker_helmet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":prayer_beads:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lipstick:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ring:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gem:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mute:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":speaker:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sound:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":loud_sound:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":loudspeaker:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mega:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":postal_horn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bell:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":no_bell:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":musical_score:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":musical_note:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":notes:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":studio_microphone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":level_slider:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":control_knobs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":microphone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":headphones:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":radio:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":saxophone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":accordion:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guitar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":musical_keyboard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":trumpet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":violin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":banjo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":drum:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":long_drum:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":iphone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":calling:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":phone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":telephone_receiver:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pager:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fax:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":battery:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":low_battery:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":electric_plug:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":computer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":desktop_computer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":printer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":keyboard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":computer_mouse:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":trackball:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":minidisc:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":floppy_disk:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cd:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dvd:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":abacus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":movie_camera:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":film_strip:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":film_projector:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clapper:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tv:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":camera:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":camera_flash:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":video_camera:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":vhs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mag_right:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":candle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bulb:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":flashlight:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":izakaya_lantern:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":diya_lamp:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":notebook_with_decorative_cover:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":closed_book:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":open_book:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":green_book:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":blue_book:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":orange_book:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":books:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":notebook:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ledger:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":page_with_curl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":scroll:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":page_facing_up:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":newspaper:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":newspaper_roll:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bookmark_tabs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bookmark:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":label:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":moneybag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":coin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yen:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dollar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":euro:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pound:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":money_with_wings:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":credit_card:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":receipt:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":email:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":e-mail:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":incoming_envelope:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":envelope_with_arrow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":outbox_tray:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":inbox_tray:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":package:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mailbox:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mailbox_closed:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mailbox_with_mail:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mailbox_with_no_mail:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":postbox:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ballot_box:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pencil2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_nib:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fountain_pen:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pen:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":paintbrush:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crayon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":memo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":briefcase:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":file_folder:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":open_file_folder:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":card_index_dividers:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":date:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":calendar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":spiral_notepad:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":spiral_calendar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":card_index:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chart_with_upwards_trend:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chart_with_downwards_trend:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bar_chart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clipboard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pushpin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":round_pushpin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":paperclip:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":paperclips:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":straight_ruler:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":triangular_ruler:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":scissors:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":card_file_box:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":file_cabinet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wastebasket:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lock:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":unlock:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lock_with_ink_pen:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":closed_lock_with_key:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":key:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":old_key:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hammer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":axe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pick:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hammer_and_pick:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hammer_and_wrench:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dagger:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crossed_swords:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gun:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":boomerang:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bow_and_arrow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shield:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":carpentry_saw:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wrench:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":screwdriver:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nut_and_bolt:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gear:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clamp:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":balance_scale:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":probing_cane:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":link:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chains:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hook:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":toolbox:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":magnet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ladder:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":alembic:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":test_tube:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":petri_dish:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dna:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":microscope:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":telescope:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":satellite:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":syringe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":drop_of_blood:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pill:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":adhesive_bandage:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crutch:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stethoscope:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":xray:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":door:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":elevator:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mirror:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":window:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bed:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":couch_and_lamp:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chair:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":toilet:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":plunger:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shower:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bathtub:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mouse_trap:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":razor:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lotion_bottle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":safety_pin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":broom:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":basket:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":roll_of_toilet_paper:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bucket:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":soap:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bubbles:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":toothbrush:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sponge:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fire_extinguisher:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":shopping_cart:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":smoking:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":coffin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":headstone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":funeral_urn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":moyai:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":placard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":identification_card:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>
 <div class="section" data-section="symbols">
@@ -1414,227 +1414,227 @@
     <span class="title">{{i18n "emoji_picker.symbols"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":atm:" (hash lazy=true)}}
-    {{replace-emoji ":put_litter_in_its_place:" (hash lazy=true)}}
-    {{replace-emoji ":potable_water:" (hash lazy=true)}}
-    {{replace-emoji ":wheelchair:" (hash lazy=true)}}
-    {{replace-emoji ":mens:" (hash lazy=true)}}
-    {{replace-emoji ":womens:" (hash lazy=true)}}
-    {{replace-emoji ":restroom:" (hash lazy=true)}}
-    {{replace-emoji ":baby_symbol:" (hash lazy=true)}}
-    {{replace-emoji ":wc:" (hash lazy=true)}}
-    {{replace-emoji ":passport_control:" (hash lazy=true)}}
-    {{replace-emoji ":customs:" (hash lazy=true)}}
-    {{replace-emoji ":baggage_claim:" (hash lazy=true)}}
-    {{replace-emoji ":left_luggage:" (hash lazy=true)}}
-    {{replace-emoji ":warning:" (hash lazy=true)}}
-    {{replace-emoji ":children_crossing:" (hash lazy=true)}}
-    {{replace-emoji ":no_entry:" (hash lazy=true)}}
-    {{replace-emoji ":no_entry_sign:" (hash lazy=true)}}
-    {{replace-emoji ":no_bicycles:" (hash lazy=true)}}
-    {{replace-emoji ":no_smoking:" (hash lazy=true)}}
-    {{replace-emoji ":do_not_litter:" (hash lazy=true)}}
-    {{replace-emoji ":non-potable_water:" (hash lazy=true)}}
-    {{replace-emoji ":no_pedestrians:" (hash lazy=true)}}
-    {{replace-emoji ":no_mobile_phones:" (hash lazy=true)}}
-    {{replace-emoji ":underage:" (hash lazy=true)}}
-    {{replace-emoji ":radioactive:" (hash lazy=true)}}
-    {{replace-emoji ":biohazard:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_up:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_upper_right:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_right:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_lower_right:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_down:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_lower_left:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_left:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_upper_left:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_up_down:" (hash lazy=true)}}
-    {{replace-emoji ":left_right_arrow:" (hash lazy=true)}}
-    {{replace-emoji ":leftwards_arrow_with_hook:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_right_hook:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_heading_up:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_heading_down:" (hash lazy=true)}}
-    {{replace-emoji ":arrows_clockwise:" (hash lazy=true)}}
-    {{replace-emoji ":arrows_counterclockwise:" (hash lazy=true)}}
-    {{replace-emoji ":back:" (hash lazy=true)}}
-    {{replace-emoji ":end:" (hash lazy=true)}}
-    {{replace-emoji ":on:" (hash lazy=true)}}
-    {{replace-emoji ":soon:" (hash lazy=true)}}
-    {{replace-emoji ":top:" (hash lazy=true)}}
-    {{replace-emoji ":place_of_worship:" (hash lazy=true)}}
-    {{replace-emoji ":atom_symbol:" (hash lazy=true)}}
-    {{replace-emoji ":om:" (hash lazy=true)}}
-    {{replace-emoji ":star_of_david:" (hash lazy=true)}}
-    {{replace-emoji ":wheel_of_dharma:" (hash lazy=true)}}
-    {{replace-emoji ":yin_yang:" (hash lazy=true)}}
-    {{replace-emoji ":latin_cross:" (hash lazy=true)}}
-    {{replace-emoji ":orthodox_cross:" (hash lazy=true)}}
-    {{replace-emoji ":star_and_crescent:" (hash lazy=true)}}
-    {{replace-emoji ":peace_symbol:" (hash lazy=true)}}
-    {{replace-emoji ":menorah:" (hash lazy=true)}}
-    {{replace-emoji ":six_pointed_star:" (hash lazy=true)}}
-    {{replace-emoji ":aries:" (hash lazy=true)}}
-    {{replace-emoji ":taurus:" (hash lazy=true)}}
-    {{replace-emoji ":gemini:" (hash lazy=true)}}
-    {{replace-emoji ":cancer:" (hash lazy=true)}}
-    {{replace-emoji ":leo:" (hash lazy=true)}}
-    {{replace-emoji ":virgo:" (hash lazy=true)}}
-    {{replace-emoji ":libra:" (hash lazy=true)}}
-    {{replace-emoji ":scorpius:" (hash lazy=true)}}
-    {{replace-emoji ":sagittarius:" (hash lazy=true)}}
-    {{replace-emoji ":capricorn:" (hash lazy=true)}}
-    {{replace-emoji ":aquarius:" (hash lazy=true)}}
-    {{replace-emoji ":pisces:" (hash lazy=true)}}
-    {{replace-emoji ":ophiuchus:" (hash lazy=true)}}
-    {{replace-emoji ":twisted_rightwards_arrows:" (hash lazy=true)}}
-    {{replace-emoji ":repeat:" (hash lazy=true)}}
-    {{replace-emoji ":repeat_one:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_forward:" (hash lazy=true)}}
-    {{replace-emoji ":fast_forward:" (hash lazy=true)}}
-    {{replace-emoji ":next_track_button:" (hash lazy=true)}}
-    {{replace-emoji ":play_or_pause_button:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_backward:" (hash lazy=true)}}
-    {{replace-emoji ":rewind:" (hash lazy=true)}}
-    {{replace-emoji ":previous_track_button:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_up_small:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_double_up:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_down_small:" (hash lazy=true)}}
-    {{replace-emoji ":arrow_double_down:" (hash lazy=true)}}
-    {{replace-emoji ":pause_button:" (hash lazy=true)}}
-    {{replace-emoji ":stop_button:" (hash lazy=true)}}
-    {{replace-emoji ":record_button:" (hash lazy=true)}}
-    {{replace-emoji ":eject_button:" (hash lazy=true)}}
-    {{replace-emoji ":cinema:" (hash lazy=true)}}
-    {{replace-emoji ":low_brightness:" (hash lazy=true)}}
-    {{replace-emoji ":high_brightness:" (hash lazy=true)}}
-    {{replace-emoji ":signal_strength:" (hash lazy=true)}}
-    {{replace-emoji ":vibration_mode:" (hash lazy=true)}}
-    {{replace-emoji ":mobile_phone_off:" (hash lazy=true)}}
-    {{replace-emoji ":female_sign:" (hash lazy=true)}}
-    {{replace-emoji ":male_sign:" (hash lazy=true)}}
-    {{replace-emoji ":transgender_symbol:" (hash lazy=true)}}
-    {{replace-emoji ":heavy_multiplication_x:" (hash lazy=true)}}
-    {{replace-emoji ":heavy_plus_sign:" (hash lazy=true)}}
-    {{replace-emoji ":heavy_minus_sign:" (hash lazy=true)}}
-    {{replace-emoji ":heavy_division_sign:" (hash lazy=true)}}
-    {{replace-emoji ":heavy_equals_sign:" (hash lazy=true)}}
-    {{replace-emoji ":infinity:" (hash lazy=true)}}
-    {{replace-emoji ":bangbang:" (hash lazy=true)}}
-    {{replace-emoji ":interrobang:" (hash lazy=true)}}
-    {{replace-emoji ":question:" (hash lazy=true)}}
-    {{replace-emoji ":grey_question:" (hash lazy=true)}}
-    {{replace-emoji ":grey_exclamation:" (hash lazy=true)}}
-    {{replace-emoji ":exclamation:" (hash lazy=true)}}
-    {{replace-emoji ":wavy_dash:" (hash lazy=true)}}
-    {{replace-emoji ":currency_exchange:" (hash lazy=true)}}
-    {{replace-emoji ":heavy_dollar_sign:" (hash lazy=true)}}
-    {{replace-emoji ":medical_symbol:" (hash lazy=true)}}
-    {{replace-emoji ":recycle:" (hash lazy=true)}}
-    {{replace-emoji ":fleur_de_lis:" (hash lazy=true)}}
-    {{replace-emoji ":trident:" (hash lazy=true)}}
-    {{replace-emoji ":name_badge:" (hash lazy=true)}}
-    {{replace-emoji ":beginner:" (hash lazy=true)}}
-    {{replace-emoji ":o:" (hash lazy=true)}}
-    {{replace-emoji ":white_check_mark:" (hash lazy=true)}}
-    {{replace-emoji ":ballot_box_with_check:" (hash lazy=true)}}
-    {{replace-emoji ":heavy_check_mark:" (hash lazy=true)}}
-    {{replace-emoji ":x:" (hash lazy=true)}}
-    {{replace-emoji ":negative_squared_cross_mark:" (hash lazy=true)}}
-    {{replace-emoji ":curly_loop:" (hash lazy=true)}}
-    {{replace-emoji ":loop:" (hash lazy=true)}}
-    {{replace-emoji ":part_alternation_mark:" (hash lazy=true)}}
-    {{replace-emoji ":eight_spoked_asterisk:" (hash lazy=true)}}
-    {{replace-emoji ":eight_pointed_black_star:" (hash lazy=true)}}
-    {{replace-emoji ":sparkle:" (hash lazy=true)}}
-    {{replace-emoji ":copyright:" (hash lazy=true)}}
-    {{replace-emoji ":registered:" (hash lazy=true)}}
-    {{replace-emoji ":tm:" (hash lazy=true)}}
-    {{replace-emoji ":hash:" (hash lazy=true)}}
-    {{replace-emoji ":asterisk:" (hash lazy=true)}}
-    {{replace-emoji ":zero:" (hash lazy=true)}}
-    {{replace-emoji ":one:" (hash lazy=true)}}
-    {{replace-emoji ":two:" (hash lazy=true)}}
-    {{replace-emoji ":three:" (hash lazy=true)}}
-    {{replace-emoji ":four:" (hash lazy=true)}}
-    {{replace-emoji ":five:" (hash lazy=true)}}
-    {{replace-emoji ":six:" (hash lazy=true)}}
-    {{replace-emoji ":seven:" (hash lazy=true)}}
-    {{replace-emoji ":eight:" (hash lazy=true)}}
-    {{replace-emoji ":nine:" (hash lazy=true)}}
-    {{replace-emoji ":keycap_ten:" (hash lazy=true)}}
-    {{replace-emoji ":capital_abcd:" (hash lazy=true)}}
-    {{replace-emoji ":abcd:" (hash lazy=true)}}
-    {{replace-emoji ":1234:" (hash lazy=true)}}
-    {{replace-emoji ":symbols:" (hash lazy=true)}}
-    {{replace-emoji ":abc:" (hash lazy=true)}}
-    {{replace-emoji ":a:" (hash lazy=true)}}
-    {{replace-emoji ":ab:" (hash lazy=true)}}
-    {{replace-emoji ":b:" (hash lazy=true)}}
-    {{replace-emoji ":cl:" (hash lazy=true)}}
-    {{replace-emoji ":cool:" (hash lazy=true)}}
-    {{replace-emoji ":free:" (hash lazy=true)}}
-    {{replace-emoji ":information_source:" (hash lazy=true)}}
-    {{replace-emoji ":id:" (hash lazy=true)}}
-    {{replace-emoji ":m:" (hash lazy=true)}}
-    {{replace-emoji ":new:" (hash lazy=true)}}
-    {{replace-emoji ":ng:" (hash lazy=true)}}
-    {{replace-emoji ":o2:" (hash lazy=true)}}
-    {{replace-emoji ":ok:" (hash lazy=true)}}
-    {{replace-emoji ":parking:" (hash lazy=true)}}
-    {{replace-emoji ":sos:" (hash lazy=true)}}
-    {{replace-emoji ":up:" (hash lazy=true)}}
-    {{replace-emoji ":vs:" (hash lazy=true)}}
-    {{replace-emoji ":koko:" (hash lazy=true)}}
-    {{replace-emoji ":sa:" (hash lazy=true)}}
-    {{replace-emoji ":u6708:" (hash lazy=true)}}
-    {{replace-emoji ":u6709:" (hash lazy=true)}}
-    {{replace-emoji ":u6307:" (hash lazy=true)}}
-    {{replace-emoji ":ideograph_advantage:" (hash lazy=true)}}
-    {{replace-emoji ":u5272:" (hash lazy=true)}}
-    {{replace-emoji ":u7121:" (hash lazy=true)}}
-    {{replace-emoji ":u7981:" (hash lazy=true)}}
-    {{replace-emoji ":accept:" (hash lazy=true)}}
-    {{replace-emoji ":u7533:" (hash lazy=true)}}
-    {{replace-emoji ":u5408:" (hash lazy=true)}}
-    {{replace-emoji ":u7a7a:" (hash lazy=true)}}
-    {{replace-emoji ":congratulations:" (hash lazy=true)}}
-    {{replace-emoji ":secret:" (hash lazy=true)}}
-    {{replace-emoji ":u55b6:" (hash lazy=true)}}
-    {{replace-emoji ":u6e80:" (hash lazy=true)}}
-    {{replace-emoji ":red_circle:" (hash lazy=true)}}
-    {{replace-emoji ":orange_circle:" (hash lazy=true)}}
-    {{replace-emoji ":yellow_circle:" (hash lazy=true)}}
-    {{replace-emoji ":green_circle:" (hash lazy=true)}}
-    {{replace-emoji ":large_blue_circle:" (hash lazy=true)}}
-    {{replace-emoji ":purple_circle:" (hash lazy=true)}}
-    {{replace-emoji ":brown_circle:" (hash lazy=true)}}
-    {{replace-emoji ":black_circle:" (hash lazy=true)}}
-    {{replace-emoji ":white_circle:" (hash lazy=true)}}
-    {{replace-emoji ":red_square:" (hash lazy=true)}}
-    {{replace-emoji ":orange_square:" (hash lazy=true)}}
-    {{replace-emoji ":yellow_square:" (hash lazy=true)}}
-    {{replace-emoji ":green_square:" (hash lazy=true)}}
-    {{replace-emoji ":blue_square:" (hash lazy=true)}}
-    {{replace-emoji ":purple_square:" (hash lazy=true)}}
-    {{replace-emoji ":brown_square:" (hash lazy=true)}}
-    {{replace-emoji ":black_large_square:" (hash lazy=true)}}
-    {{replace-emoji ":white_large_square:" (hash lazy=true)}}
-    {{replace-emoji ":black_medium_square:" (hash lazy=true)}}
-    {{replace-emoji ":white_medium_square:" (hash lazy=true)}}
-    {{replace-emoji ":black_medium_small_square:" (hash lazy=true)}}
-    {{replace-emoji ":white_medium_small_square:" (hash lazy=true)}}
-    {{replace-emoji ":black_small_square:" (hash lazy=true)}}
-    {{replace-emoji ":white_small_square:" (hash lazy=true)}}
-    {{replace-emoji ":large_orange_diamond:" (hash lazy=true)}}
-    {{replace-emoji ":large_blue_diamond:" (hash lazy=true)}}
-    {{replace-emoji ":small_orange_diamond:" (hash lazy=true)}}
-    {{replace-emoji ":small_blue_diamond:" (hash lazy=true)}}
-    {{replace-emoji ":small_red_triangle:" (hash lazy=true)}}
-    {{replace-emoji ":small_red_triangle_down:" (hash lazy=true)}}
-    {{replace-emoji ":diamond_shape_with_a_dot_inside:" (hash lazy=true)}}
-    {{replace-emoji ":radio_button:" (hash lazy=true)}}
-    {{replace-emoji ":white_square_button:" (hash lazy=true)}}
-    {{replace-emoji ":black_square_button:" (hash lazy=true)}}
+    {{replace-emoji ":atm:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":put_litter_in_its_place:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":potable_water:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wheelchair:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mens:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":womens:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":restroom:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":baby_symbol:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wc:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":passport_control:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":customs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":baggage_claim:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":left_luggage:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":warning:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":children_crossing:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":no_entry:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":no_entry_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":no_bicycles:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":no_smoking:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":do_not_litter:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":non-potable_water:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":no_pedestrians:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":no_mobile_phones:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":underage:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":radioactive:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":biohazard:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_up:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_upper_right:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_right:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_lower_right:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_down:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_lower_left:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_left:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_upper_left:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_up_down:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":left_right_arrow:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":leftwards_arrow_with_hook:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_right_hook:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_heading_up:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_heading_down:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrows_clockwise:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrows_counterclockwise:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":back:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":end:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":on:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":soon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":top:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":place_of_worship:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":atom_symbol:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":om:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":star_of_david:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wheel_of_dharma:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yin_yang:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":latin_cross:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":orthodox_cross:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":star_and_crescent:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":peace_symbol:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":menorah:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":six_pointed_star:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":aries:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":taurus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gemini:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cancer:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":leo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":virgo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":libra:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":scorpius:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sagittarius:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":capricorn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":aquarius:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pisces:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ophiuchus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":twisted_rightwards_arrows:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":repeat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":repeat_one:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_forward:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fast_forward:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":next_track_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":play_or_pause_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_backward:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rewind:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":previous_track_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_up_small:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_double_up:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_down_small:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":arrow_double_down:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pause_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":stop_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":record_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eject_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cinema:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":low_brightness:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":high_brightness:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":signal_strength:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":vibration_mode:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mobile_phone_off:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":female_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":male_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":transgender_symbol:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heavy_multiplication_x:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heavy_plus_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heavy_minus_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heavy_division_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heavy_equals_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":infinity:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bangbang:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":interrobang:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":question:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":grey_question:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":grey_exclamation:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":exclamation:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wavy_dash:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":currency_exchange:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heavy_dollar_sign:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":medical_symbol:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":recycle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fleur_de_lis:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":trident:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":name_badge:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":beginner:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":o:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_check_mark:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ballot_box_with_check:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heavy_check_mark:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":x:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":negative_squared_cross_mark:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":curly_loop:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":loop:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":part_alternation_mark:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eight_spoked_asterisk:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eight_pointed_black_star:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sparkle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":copyright:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":registered:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tm:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hash:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":asterisk:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":zero:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":one:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":two:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":three:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":four:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":five:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":six:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":seven:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eight:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nine:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":keycap_ten:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":capital_abcd:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":abcd:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":1234:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":symbols:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":abc:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":a:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ab:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":b:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cl:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cool:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":free:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":information_source:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":id:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":m:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":new:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ng:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":o2:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ok:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":parking:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sos:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":up:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":vs:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":koko:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sa:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u6708:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u6709:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u6307:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ideograph_advantage:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u5272:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u7121:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u7981:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":accept:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u7533:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u5408:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u7a7a:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":congratulations:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":secret:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u55b6:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":u6e80:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":red_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":orange_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yellow_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":green_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":large_blue_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":purple_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":brown_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_circle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":red_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":orange_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yellow_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":green_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":blue_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":purple_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":brown_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_large_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_large_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_medium_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_medium_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_medium_small_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_medium_small_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_small_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_small_square:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":large_orange_diamond:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":large_blue_diamond:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":small_orange_diamond:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":small_blue_diamond:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":small_red_triangle:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":small_red_triangle_down:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":diamond_shape_with_a_dot_inside:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":radio_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_square_button:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_square_button:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>
 <div class="section" data-section="flags">
@@ -1642,274 +1642,274 @@
     <span class="title">{{i18n "emoji_picker.flags"}}</span>
   </div>
   <div class="section-group">
-    {{replace-emoji ":checkered_flag:" (hash lazy=true)}}
-    {{replace-emoji ":triangular_flag_on_post:" (hash lazy=true)}}
-    {{replace-emoji ":crossed_flags:" (hash lazy=true)}}
-    {{replace-emoji ":black_flag:" (hash lazy=true)}}
-    {{replace-emoji ":white_flag:" (hash lazy=true)}}
-    {{replace-emoji ":rainbow_flag:" (hash lazy=true)}}
-    {{replace-emoji ":transgender_flag:" (hash lazy=true)}}
-    {{replace-emoji ":pirate_flag:" (hash lazy=true)}}
-    {{replace-emoji ":ascension_island:" (hash lazy=true)}}
-    {{replace-emoji ":andorra:" (hash lazy=true)}}
-    {{replace-emoji ":united_arab_emirates:" (hash lazy=true)}}
-    {{replace-emoji ":afghanistan:" (hash lazy=true)}}
-    {{replace-emoji ":antigua_barbuda:" (hash lazy=true)}}
-    {{replace-emoji ":anguilla:" (hash lazy=true)}}
-    {{replace-emoji ":albania:" (hash lazy=true)}}
-    {{replace-emoji ":armenia:" (hash lazy=true)}}
-    {{replace-emoji ":angola:" (hash lazy=true)}}
-    {{replace-emoji ":antarctica:" (hash lazy=true)}}
-    {{replace-emoji ":argentina:" (hash lazy=true)}}
-    {{replace-emoji ":american_samoa:" (hash lazy=true)}}
-    {{replace-emoji ":austria:" (hash lazy=true)}}
-    {{replace-emoji ":australia:" (hash lazy=true)}}
-    {{replace-emoji ":aruba:" (hash lazy=true)}}
-    {{replace-emoji ":aland_islands:" (hash lazy=true)}}
-    {{replace-emoji ":azerbaijan:" (hash lazy=true)}}
-    {{replace-emoji ":bosnia_herzegovina:" (hash lazy=true)}}
-    {{replace-emoji ":barbados:" (hash lazy=true)}}
-    {{replace-emoji ":bangladesh:" (hash lazy=true)}}
-    {{replace-emoji ":belgium:" (hash lazy=true)}}
-    {{replace-emoji ":burkina_faso:" (hash lazy=true)}}
-    {{replace-emoji ":bulgaria:" (hash lazy=true)}}
-    {{replace-emoji ":bahrain:" (hash lazy=true)}}
-    {{replace-emoji ":burundi:" (hash lazy=true)}}
-    {{replace-emoji ":benin:" (hash lazy=true)}}
-    {{replace-emoji ":st_barthelemy:" (hash lazy=true)}}
-    {{replace-emoji ":bermuda:" (hash lazy=true)}}
-    {{replace-emoji ":brunei:" (hash lazy=true)}}
-    {{replace-emoji ":bolivia:" (hash lazy=true)}}
-    {{replace-emoji ":caribbean_netherlands:" (hash lazy=true)}}
-    {{replace-emoji ":brazil:" (hash lazy=true)}}
-    {{replace-emoji ":bahamas:" (hash lazy=true)}}
-    {{replace-emoji ":bhutan:" (hash lazy=true)}}
-    {{replace-emoji ":bouvet_island:" (hash lazy=true)}}
-    {{replace-emoji ":botswana:" (hash lazy=true)}}
-    {{replace-emoji ":belarus:" (hash lazy=true)}}
-    {{replace-emoji ":belize:" (hash lazy=true)}}
-    {{replace-emoji ":canada:" (hash lazy=true)}}
-    {{replace-emoji ":cocos_islands:" (hash lazy=true)}}
-    {{replace-emoji ":congo_kinshasa:" (hash lazy=true)}}
-    {{replace-emoji ":central_african_republic:" (hash lazy=true)}}
-    {{replace-emoji ":congo_brazzaville:" (hash lazy=true)}}
-    {{replace-emoji ":switzerland:" (hash lazy=true)}}
-    {{replace-emoji ":cote_divoire:" (hash lazy=true)}}
-    {{replace-emoji ":cook_islands:" (hash lazy=true)}}
-    {{replace-emoji ":chile:" (hash lazy=true)}}
-    {{replace-emoji ":cameroon:" (hash lazy=true)}}
-    {{replace-emoji ":cn:" (hash lazy=true)}}
-    {{replace-emoji ":colombia:" (hash lazy=true)}}
-    {{replace-emoji ":clipperton_island:" (hash lazy=true)}}
-    {{replace-emoji ":costa_rica:" (hash lazy=true)}}
-    {{replace-emoji ":cuba:" (hash lazy=true)}}
-    {{replace-emoji ":cape_verde:" (hash lazy=true)}}
-    {{replace-emoji ":curacao:" (hash lazy=true)}}
-    {{replace-emoji ":christmas_island:" (hash lazy=true)}}
-    {{replace-emoji ":cyprus:" (hash lazy=true)}}
-    {{replace-emoji ":czech_republic:" (hash lazy=true)}}
-    {{replace-emoji ":de:" (hash lazy=true)}}
-    {{replace-emoji ":diego_garcia:" (hash lazy=true)}}
-    {{replace-emoji ":djibouti:" (hash lazy=true)}}
-    {{replace-emoji ":denmark:" (hash lazy=true)}}
-    {{replace-emoji ":dominica:" (hash lazy=true)}}
-    {{replace-emoji ":dominican_republic:" (hash lazy=true)}}
-    {{replace-emoji ":algeria:" (hash lazy=true)}}
-    {{replace-emoji ":ceuta_and_melilla:" (hash lazy=true)}}
-    {{replace-emoji ":ecuador:" (hash lazy=true)}}
-    {{replace-emoji ":estonia:" (hash lazy=true)}}
-    {{replace-emoji ":egypt:" (hash lazy=true)}}
-    {{replace-emoji ":western_sahara:" (hash lazy=true)}}
-    {{replace-emoji ":eritrea:" (hash lazy=true)}}
-    {{replace-emoji ":es:" (hash lazy=true)}}
-    {{replace-emoji ":ethiopia:" (hash lazy=true)}}
-    {{replace-emoji ":eu:" (hash lazy=true)}}
-    {{replace-emoji ":finland:" (hash lazy=true)}}
-    {{replace-emoji ":fiji:" (hash lazy=true)}}
-    {{replace-emoji ":falkland_islands:" (hash lazy=true)}}
-    {{replace-emoji ":micronesia:" (hash lazy=true)}}
-    {{replace-emoji ":faroe_islands:" (hash lazy=true)}}
-    {{replace-emoji ":fr:" (hash lazy=true)}}
-    {{replace-emoji ":gabon:" (hash lazy=true)}}
-    {{replace-emoji ":uk:" (hash lazy=true)}}
-    {{replace-emoji ":grenada:" (hash lazy=true)}}
-    {{replace-emoji ":georgia:" (hash lazy=true)}}
-    {{replace-emoji ":french_guiana:" (hash lazy=true)}}
-    {{replace-emoji ":guernsey:" (hash lazy=true)}}
-    {{replace-emoji ":ghana:" (hash lazy=true)}}
-    {{replace-emoji ":gibraltar:" (hash lazy=true)}}
-    {{replace-emoji ":greenland:" (hash lazy=true)}}
-    {{replace-emoji ":gambia:" (hash lazy=true)}}
-    {{replace-emoji ":guinea:" (hash lazy=true)}}
-    {{replace-emoji ":guadeloupe:" (hash lazy=true)}}
-    {{replace-emoji ":equatorial_guinea:" (hash lazy=true)}}
-    {{replace-emoji ":greece:" (hash lazy=true)}}
-    {{replace-emoji ":south_georgia_south_sandwich_islands:" (hash lazy=true)}}
-    {{replace-emoji ":guatemala:" (hash lazy=true)}}
-    {{replace-emoji ":guam:" (hash lazy=true)}}
-    {{replace-emoji ":guinea_bissau:" (hash lazy=true)}}
-    {{replace-emoji ":guyana:" (hash lazy=true)}}
-    {{replace-emoji ":hong_kong:" (hash lazy=true)}}
-    {{replace-emoji ":heard_and_mc_donald_islands:" (hash lazy=true)}}
-    {{replace-emoji ":honduras:" (hash lazy=true)}}
-    {{replace-emoji ":croatia:" (hash lazy=true)}}
-    {{replace-emoji ":haiti:" (hash lazy=true)}}
-    {{replace-emoji ":hungary:" (hash lazy=true)}}
-    {{replace-emoji ":canary_islands:" (hash lazy=true)}}
-    {{replace-emoji ":indonesia:" (hash lazy=true)}}
-    {{replace-emoji ":ireland:" (hash lazy=true)}}
-    {{replace-emoji ":israel:" (hash lazy=true)}}
-    {{replace-emoji ":isle_of_man:" (hash lazy=true)}}
-    {{replace-emoji ":india:" (hash lazy=true)}}
-    {{replace-emoji ":british_indian_ocean_territory:" (hash lazy=true)}}
-    {{replace-emoji ":iraq:" (hash lazy=true)}}
-    {{replace-emoji ":iran:" (hash lazy=true)}}
-    {{replace-emoji ":iceland:" (hash lazy=true)}}
-    {{replace-emoji ":it:" (hash lazy=true)}}
-    {{replace-emoji ":jersey:" (hash lazy=true)}}
-    {{replace-emoji ":jamaica:" (hash lazy=true)}}
-    {{replace-emoji ":jordan:" (hash lazy=true)}}
-    {{replace-emoji ":jp:" (hash lazy=true)}}
-    {{replace-emoji ":kenya:" (hash lazy=true)}}
-    {{replace-emoji ":kyrgyzstan:" (hash lazy=true)}}
-    {{replace-emoji ":cambodia:" (hash lazy=true)}}
-    {{replace-emoji ":kiribati:" (hash lazy=true)}}
-    {{replace-emoji ":comoros:" (hash lazy=true)}}
-    {{replace-emoji ":st_kitts_nevis:" (hash lazy=true)}}
-    {{replace-emoji ":north_korea:" (hash lazy=true)}}
-    {{replace-emoji ":kr:" (hash lazy=true)}}
-    {{replace-emoji ":kuwait:" (hash lazy=true)}}
-    {{replace-emoji ":cayman_islands:" (hash lazy=true)}}
-    {{replace-emoji ":kazakhstan:" (hash lazy=true)}}
-    {{replace-emoji ":laos:" (hash lazy=true)}}
-    {{replace-emoji ":lebanon:" (hash lazy=true)}}
-    {{replace-emoji ":st_lucia:" (hash lazy=true)}}
-    {{replace-emoji ":liechtenstein:" (hash lazy=true)}}
-    {{replace-emoji ":sri_lanka:" (hash lazy=true)}}
-    {{replace-emoji ":liberia:" (hash lazy=true)}}
-    {{replace-emoji ":lesotho:" (hash lazy=true)}}
-    {{replace-emoji ":lithuania:" (hash lazy=true)}}
-    {{replace-emoji ":luxembourg:" (hash lazy=true)}}
-    {{replace-emoji ":latvia:" (hash lazy=true)}}
-    {{replace-emoji ":libya:" (hash lazy=true)}}
-    {{replace-emoji ":morocco:" (hash lazy=true)}}
-    {{replace-emoji ":monaco:" (hash lazy=true)}}
-    {{replace-emoji ":moldova:" (hash lazy=true)}}
-    {{replace-emoji ":montenegro:" (hash lazy=true)}}
-    {{replace-emoji ":st_martin:" (hash lazy=true)}}
-    {{replace-emoji ":madagascar:" (hash lazy=true)}}
-    {{replace-emoji ":marshall_islands:" (hash lazy=true)}}
-    {{replace-emoji ":macedonia:" (hash lazy=true)}}
-    {{replace-emoji ":mali:" (hash lazy=true)}}
-    {{replace-emoji ":myanmar:" (hash lazy=true)}}
-    {{replace-emoji ":mongolia:" (hash lazy=true)}}
-    {{replace-emoji ":macau:" (hash lazy=true)}}
-    {{replace-emoji ":northern_mariana_islands:" (hash lazy=true)}}
-    {{replace-emoji ":martinique:" (hash lazy=true)}}
-    {{replace-emoji ":mauritania:" (hash lazy=true)}}
-    {{replace-emoji ":montserrat:" (hash lazy=true)}}
-    {{replace-emoji ":malta:" (hash lazy=true)}}
-    {{replace-emoji ":mauritius:" (hash lazy=true)}}
-    {{replace-emoji ":maldives:" (hash lazy=true)}}
-    {{replace-emoji ":malawi:" (hash lazy=true)}}
-    {{replace-emoji ":mexico:" (hash lazy=true)}}
-    {{replace-emoji ":malaysia:" (hash lazy=true)}}
-    {{replace-emoji ":mozambique:" (hash lazy=true)}}
-    {{replace-emoji ":namibia:" (hash lazy=true)}}
-    {{replace-emoji ":new_caledonia:" (hash lazy=true)}}
-    {{replace-emoji ":niger:" (hash lazy=true)}}
-    {{replace-emoji ":norfolk_island:" (hash lazy=true)}}
-    {{replace-emoji ":nigeria:" (hash lazy=true)}}
-    {{replace-emoji ":nicaragua:" (hash lazy=true)}}
-    {{replace-emoji ":netherlands:" (hash lazy=true)}}
-    {{replace-emoji ":norway:" (hash lazy=true)}}
-    {{replace-emoji ":nepal:" (hash lazy=true)}}
-    {{replace-emoji ":nauru:" (hash lazy=true)}}
-    {{replace-emoji ":niue:" (hash lazy=true)}}
-    {{replace-emoji ":new_zealand:" (hash lazy=true)}}
-    {{replace-emoji ":oman:" (hash lazy=true)}}
-    {{replace-emoji ":panama:" (hash lazy=true)}}
-    {{replace-emoji ":peru:" (hash lazy=true)}}
-    {{replace-emoji ":french_polynesia:" (hash lazy=true)}}
-    {{replace-emoji ":papua_new_guinea:" (hash lazy=true)}}
-    {{replace-emoji ":philippines:" (hash lazy=true)}}
-    {{replace-emoji ":pakistan:" (hash lazy=true)}}
-    {{replace-emoji ":poland:" (hash lazy=true)}}
-    {{replace-emoji ":st_pierre_miquelon:" (hash lazy=true)}}
-    {{replace-emoji ":pitcairn_islands:" (hash lazy=true)}}
-    {{replace-emoji ":puerto_rico:" (hash lazy=true)}}
-    {{replace-emoji ":palestinian_territories:" (hash lazy=true)}}
-    {{replace-emoji ":portugal:" (hash lazy=true)}}
-    {{replace-emoji ":palau:" (hash lazy=true)}}
-    {{replace-emoji ":paraguay:" (hash lazy=true)}}
-    {{replace-emoji ":qatar:" (hash lazy=true)}}
-    {{replace-emoji ":reunion:" (hash lazy=true)}}
-    {{replace-emoji ":romania:" (hash lazy=true)}}
-    {{replace-emoji ":serbia:" (hash lazy=true)}}
-    {{replace-emoji ":ru:" (hash lazy=true)}}
-    {{replace-emoji ":rwanda:" (hash lazy=true)}}
-    {{replace-emoji ":saudi_arabia:" (hash lazy=true)}}
-    {{replace-emoji ":solomon_islands:" (hash lazy=true)}}
-    {{replace-emoji ":seychelles:" (hash lazy=true)}}
-    {{replace-emoji ":sudan:" (hash lazy=true)}}
-    {{replace-emoji ":sweden:" (hash lazy=true)}}
-    {{replace-emoji ":singapore:" (hash lazy=true)}}
-    {{replace-emoji ":st_helena:" (hash lazy=true)}}
-    {{replace-emoji ":slovenia:" (hash lazy=true)}}
-    {{replace-emoji ":svalbard_and_jan_mayen:" (hash lazy=true)}}
-    {{replace-emoji ":slovakia:" (hash lazy=true)}}
-    {{replace-emoji ":sierra_leone:" (hash lazy=true)}}
-    {{replace-emoji ":san_marino:" (hash lazy=true)}}
-    {{replace-emoji ":senegal:" (hash lazy=true)}}
-    {{replace-emoji ":somalia:" (hash lazy=true)}}
-    {{replace-emoji ":suriname:" (hash lazy=true)}}
-    {{replace-emoji ":south_sudan:" (hash lazy=true)}}
-    {{replace-emoji ":sao_tome_principe:" (hash lazy=true)}}
-    {{replace-emoji ":el_salvador:" (hash lazy=true)}}
-    {{replace-emoji ":sint_maarten:" (hash lazy=true)}}
-    {{replace-emoji ":syria:" (hash lazy=true)}}
-    {{replace-emoji ":swaziland:" (hash lazy=true)}}
-    {{replace-emoji ":tristan_da_cunha:" (hash lazy=true)}}
-    {{replace-emoji ":turks_caicos_islands:" (hash lazy=true)}}
-    {{replace-emoji ":chad:" (hash lazy=true)}}
-    {{replace-emoji ":french_southern_territories:" (hash lazy=true)}}
-    {{replace-emoji ":togo:" (hash lazy=true)}}
-    {{replace-emoji ":thailand:" (hash lazy=true)}}
-    {{replace-emoji ":tajikistan:" (hash lazy=true)}}
-    {{replace-emoji ":tokelau:" (hash lazy=true)}}
-    {{replace-emoji ":timor_leste:" (hash lazy=true)}}
-    {{replace-emoji ":turkmenistan:" (hash lazy=true)}}
-    {{replace-emoji ":tunisia:" (hash lazy=true)}}
-    {{replace-emoji ":tonga:" (hash lazy=true)}}
-    {{replace-emoji ":tr:" (hash lazy=true)}}
-    {{replace-emoji ":trinidad_tobago:" (hash lazy=true)}}
-    {{replace-emoji ":tuvalu:" (hash lazy=true)}}
-    {{replace-emoji ":taiwan:" (hash lazy=true)}}
-    {{replace-emoji ":tanzania:" (hash lazy=true)}}
-    {{replace-emoji ":ukraine:" (hash lazy=true)}}
-    {{replace-emoji ":uganda:" (hash lazy=true)}}
-    {{replace-emoji ":us_outlying_islands:" (hash lazy=true)}}
-    {{replace-emoji ":united_nations:" (hash lazy=true)}}
-    {{replace-emoji ":us:" (hash lazy=true)}}
-    {{replace-emoji ":uruguay:" (hash lazy=true)}}
-    {{replace-emoji ":uzbekistan:" (hash lazy=true)}}
-    {{replace-emoji ":vatican_city:" (hash lazy=true)}}
-    {{replace-emoji ":st_vincent_grenadines:" (hash lazy=true)}}
-    {{replace-emoji ":venezuela:" (hash lazy=true)}}
-    {{replace-emoji ":british_virgin_islands:" (hash lazy=true)}}
-    {{replace-emoji ":us_virgin_islands:" (hash lazy=true)}}
-    {{replace-emoji ":vietnam:" (hash lazy=true)}}
-    {{replace-emoji ":vanuatu:" (hash lazy=true)}}
-    {{replace-emoji ":wallis_futuna:" (hash lazy=true)}}
-    {{replace-emoji ":samoa:" (hash lazy=true)}}
-    {{replace-emoji ":kosovo:" (hash lazy=true)}}
-    {{replace-emoji ":yemen:" (hash lazy=true)}}
-    {{replace-emoji ":mayotte:" (hash lazy=true)}}
-    {{replace-emoji ":south_africa:" (hash lazy=true)}}
-    {{replace-emoji ":zambia:" (hash lazy=true)}}
-    {{replace-emoji ":zimbabwe:" (hash lazy=true)}}
-    {{replace-emoji ":england:" (hash lazy=true)}}
-    {{replace-emoji ":scotland:" (hash lazy=true)}}
-    {{replace-emoji ":wales:" (hash lazy=true)}}
+    {{replace-emoji ":checkered_flag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":triangular_flag_on_post:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":crossed_flags:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":black_flag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":white_flag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rainbow_flag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":transgender_flag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pirate_flag:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ascension_island:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":andorra:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":united_arab_emirates:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":afghanistan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":antigua_barbuda:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":anguilla:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":albania:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":armenia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":angola:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":antarctica:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":argentina:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":american_samoa:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":austria:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":australia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":aruba:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":aland_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":azerbaijan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bosnia_herzegovina:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":barbados:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bangladesh:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":belgium:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":burkina_faso:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bulgaria:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bahrain:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":burundi:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":benin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":st_barthelemy:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bermuda:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":brunei:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bolivia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":caribbean_netherlands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":brazil:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bahamas:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bhutan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":bouvet_island:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":botswana:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":belarus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":belize:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":canada:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cocos_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":congo_kinshasa:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":central_african_republic:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":congo_brazzaville:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":switzerland:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cote_divoire:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cook_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chile:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cameroon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cn:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":colombia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":clipperton_island:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":costa_rica:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cuba:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cape_verde:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":curacao:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":christmas_island:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cyprus:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":czech_republic:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":de:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":diego_garcia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":djibouti:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":denmark:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dominica:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":dominican_republic:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":algeria:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ceuta_and_melilla:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ecuador:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":estonia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":egypt:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":western_sahara:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eritrea:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":es:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ethiopia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":eu:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":finland:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fiji:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":falkland_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":micronesia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":faroe_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":fr:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gabon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":uk:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":grenada:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":georgia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":french_guiana:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guernsey:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ghana:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gibraltar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":greenland:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":gambia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guinea:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guadeloupe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":equatorial_guinea:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":greece:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":south_georgia_south_sandwich_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guatemala:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guam:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guinea_bissau:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":guyana:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hong_kong:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":heard_and_mc_donald_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":honduras:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":croatia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":haiti:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":hungary:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":canary_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":indonesia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ireland:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":israel:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":isle_of_man:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":india:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":british_indian_ocean_territory:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":iraq:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":iran:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":iceland:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":it:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":jersey:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":jamaica:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":jordan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":jp:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kenya:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kyrgyzstan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cambodia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kiribati:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":comoros:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":st_kitts_nevis:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":north_korea:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kr:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kuwait:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":cayman_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kazakhstan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":laos:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lebanon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":st_lucia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":liechtenstein:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sri_lanka:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":liberia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lesotho:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":lithuania:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":luxembourg:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":latvia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":libya:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":morocco:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":monaco:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":moldova:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":montenegro:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":st_martin:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":madagascar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":marshall_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":macedonia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mali:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":myanmar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mongolia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":macau:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":northern_mariana_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":martinique:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mauritania:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":montserrat:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":malta:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mauritius:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":maldives:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":malawi:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mexico:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":malaysia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mozambique:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":namibia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":new_caledonia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":niger:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":norfolk_island:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nigeria:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nicaragua:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":netherlands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":norway:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nepal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":nauru:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":niue:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":new_zealand:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":oman:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":panama:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":peru:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":french_polynesia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":papua_new_guinea:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":philippines:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pakistan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":poland:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":st_pierre_miquelon:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":pitcairn_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":puerto_rico:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":palestinian_territories:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":portugal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":palau:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":paraguay:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":qatar:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":reunion:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":romania:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":serbia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ru:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":rwanda:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":saudi_arabia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":solomon_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":seychelles:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sudan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sweden:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":singapore:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":st_helena:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":slovenia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":svalbard_and_jan_mayen:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":slovakia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sierra_leone:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":san_marino:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":senegal:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":somalia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":suriname:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":south_sudan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sao_tome_principe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":el_salvador:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":sint_maarten:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":syria:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":swaziland:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tristan_da_cunha:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":turks_caicos_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":chad:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":french_southern_territories:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":togo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":thailand:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tajikistan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tokelau:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":timor_leste:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":turkmenistan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tunisia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tonga:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tr:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":trinidad_tobago:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tuvalu:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":taiwan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":tanzania:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":ukraine:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":uganda:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":us_outlying_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":united_nations:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":us:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":uruguay:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":uzbekistan:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":vatican_city:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":st_vincent_grenadines:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":venezuela:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":british_virgin_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":us_virgin_islands:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":vietnam:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":vanuatu:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wallis_futuna:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":samoa:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":kosovo:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":yemen:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":mayotte:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":south_africa:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":zambia:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":zimbabwe:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":england:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":scotland:" (hash lazy=true tabIndex="0")}}
+    {{replace-emoji ":wales:" (hash lazy=true tabIndex="0")}}
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/emoji-picker.hbs
@@ -37,7 +37,7 @@
               </div>
               <div class="section-group">
                 {{#each this.recentEmojis as |emoji|}}
-                  {{replace-emoji (concat ":" emoji ":") (hash lazy=true class="recent-emoji")}}
+                  {{replace-emoji (concat ":" emoji ":") (hash lazy=true tabIndex="0" class="recent-emoji")}}
                 {{/each}}
               </div>
             </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/emoji-picker-test.js
@@ -268,5 +268,10 @@ acceptance("EmojiPicker", function (needs) {
     await click("button.emoji.btn");
     await triggerKeyEvent(document.activeElement, "keydown", "Escape");
     assert.notOk(exists(".emoji-picker"));
+    assert.strictEqual(
+      document.activeElement,
+      document.querySelector("textarea"),
+      "escaping from emoji picker focuses back on input"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
@@ -128,6 +128,11 @@ discourseModule("Unit | Utility | emoji", function () {
       "emoji when inline translation enabled",
       { enable_inline_emoji_translation: true }
     );
+    assert.strictEqual(
+      emojiUnescape(":smile:", { tabIndex: "0" }),
+      `<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji' tabindex='0'>`,
+      "emoji when tabindex is enabled"
+    );
   });
 
   test("Emoji search", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/emoji-test.js
@@ -32,12 +32,12 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "emoticons :)",
-      `emoticons <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji' tabindex='0'>`,
+      `emoticons <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'>`,
       "emoticons are still supported"
     );
     testUnescape(
       "With emoji :O: :frog: :smile:",
-      `With emoji <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/o.png?v=${v}' title='O' alt='O' class='emoji' tabindex='0'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/frog.png?v=${v}' title='frog' alt='frog' class='emoji' tabindex='0'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji' tabindex='0'>`,
+      `With emoji <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/o.png?v=${v}' title='O' alt='O' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/frog.png?v=${v}' title='frog' alt='frog' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "title with emoji"
     );
     testUnescape(
@@ -47,27 +47,27 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "(:frog:) :)",
-      `(<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/frog.png?v=${v}' title='frog' alt='frog' class='emoji' tabindex='0'>) <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji' tabindex='0'>`,
+      `(<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/frog.png?v=${v}' title='frog' alt='frog' class='emoji'>) <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'>`,
       "non-word characters allowed next to emoji"
     );
     testUnescape(
       ":smile: hi",
-      `<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji' tabindex='0'> hi`,
+      `<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'> hi`,
       "start of line"
     );
     testUnescape(
       "hi :smile:",
-      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji' tabindex='0'>`,
+      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "end of line"
     );
     testUnescape(
       "hi :blonde_woman:t4:",
-      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_woman/4.png?v=${v}' title='blonde_woman:t4' alt='blonde_woman:t4' class='emoji' tabindex='0'>`,
+      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_woman/4.png?v=${v}' title='blonde_woman:t4' alt='blonde_woman:t4' class='emoji'>`,
       "support for skin tones"
     );
     testUnescape(
       "hi :blonde_woman:t4: :blonde_man:t6:",
-      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_woman/4.png?v=${v}' title='blonde_woman:t4' alt='blonde_woman:t4' class='emoji' tabindex='0'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_man/6.png?v=${v}' title='blonde_man:t6' alt='blonde_man:t6' class='emoji' tabindex='0'>`,
+      `hi <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_woman/4.png?v=${v}' title='blonde_woman:t4' alt='blonde_woman:t4' class='emoji'> <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blonde_man/6.png?v=${v}' title='blonde_man:t6' alt='blonde_man:t6' class='emoji'>`,
       "support for multiple skin tones"
     );
     testUnescape(
@@ -95,7 +95,7 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "Hello 😊 World",
-      `Hello <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blush.png?v=${v}' title='blush' alt='blush' class='emoji' tabindex='0'> World`,
+      `Hello <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blush.png?v=${v}' title='blush' alt='blush' class='emoji'> World`,
       "emoji from Unicode emoji"
     );
     testUnescape(
@@ -108,7 +108,7 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "Hello😊World",
-      `Hello<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blush.png?v=${v}' title='blush' alt='blush' class='emoji' tabindex='0'>World`,
+      `Hello<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/blush.png?v=${v}' title='blush' alt='blush' class='emoji'>World`,
       "emoji from Unicode emoji when inline translation enabled",
       {
         enable_inline_emoji_translation: true,
@@ -124,7 +124,7 @@ discourseModule("Unit | Utility | emoji", function () {
     );
     testUnescape(
       "hi:smile:",
-      `hi<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji' tabindex='0'>`,
+      `hi<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "emoji when inline translation enabled",
       { enable_inline_emoji_translation: true }
     );

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -143,7 +143,7 @@ discourseModule("Unit | Model | topic", function () {
 
     assert.strictEqual(
       topic.get("fancyTitle"),
-      `<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji' tabindex='0'> with all <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji' tabindex='0'> the emojis <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/pear.png?v=${v}' title='pear' alt='pear' class='emoji' tabindex='0'><img width=\"20\" height=\"20\" src='/images/emoji/google_classic/peach.png?v=${v}' title='peach' alt='peach' class='emoji' tabindex='0'>`,
+      `<img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'> with all <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/slight_smile.png?v=${v}' title='slight_smile' alt='slight_smile' class='emoji'> the emojis <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/pear.png?v=${v}' title='pear' alt='pear' class='emoji'><img width=\"20\" height=\"20\" src='/images/emoji/google_classic/peach.png?v=${v}' title='peach' alt='peach' class='emoji'>`,
       "supports emojis"
     );
   });
@@ -173,7 +173,7 @@ discourseModule("Unit | Model | topic", function () {
 
     assert.strictEqual(
       topic.get("escapedExcerpt"),
-      `This is a test topic <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji' tabindex='0'>`,
+      `This is a test topic <img width=\"20\" height=\"20\" src='/images/emoji/google_classic/smile.png?v=${v}' title='smile' alt='smile' class='emoji'>`,
       "supports emojis"
     );
   });

--- a/app/assets/javascripts/pretty-text/addon/emoji.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji.js
@@ -98,7 +98,7 @@ export function performEmojiUnescape(string, opts) {
           opts.skipTitle ? "" : `title='${title}'`
         } ${
           opts.lazy ? "loading='lazy' " : ""
-        }alt='${title}' class='${classes}' tabindex='0'>`
+        }alt='${title}' class='${classes}'>`
       : m;
   };
 

--- a/app/assets/javascripts/pretty-text/addon/emoji.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji.js
@@ -93,7 +93,7 @@ export function performEmojiUnescape(string, opts) {
       isReplacableInlineEmoji(string, index, opts.inlineEmoji);
 
     const title = opts.title ?? emojiVal;
-    const tabIndex = opts.tabIndex ? ` tabindex=${opts.tabIndex}` : "";
+    const tabIndex = opts.tabIndex ? ` tabindex='${opts.tabIndex}'` : "";
     return url && isReplacable
       ? `<img width="20" height="20" src='${url}' ${
           opts.skipTitle ? "" : `title='${title}'`

--- a/app/assets/javascripts/pretty-text/addon/emoji.js
+++ b/app/assets/javascripts/pretty-text/addon/emoji.js
@@ -93,12 +93,13 @@ export function performEmojiUnescape(string, opts) {
       isReplacableInlineEmoji(string, index, opts.inlineEmoji);
 
     const title = opts.title ?? emojiVal;
+    const tabIndex = opts.tabIndex ? ` tabindex=${opts.tabIndex}` : "";
     return url && isReplacable
       ? `<img width="20" height="20" src='${url}' ${
           opts.skipTitle ? "" : `title='${title}'`
         } ${
           opts.lazy ? "loading='lazy' " : ""
-        }alt='${title}' class='${classes}'>`
+        }alt='${title}' class='${classes}'${tabIndex}>`
       : m;
   };
 

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -19,7 +19,7 @@ end
 def html_for_section(group)
   icons = group["icons"].map do |icon|
     class_attr = icon["diversity"] ? " class=\"diversity\"" : ""
-    "    {{replace-emoji \":#{icon['name']}:\" (hash lazy=true#{class_attr})}}"
+    "    {{replace-emoji \":#{icon['name']}:\" (hash lazy=true#{class_attr} tabIndex=\"0\")}}"
   end
 
   <<~HTML
@@ -210,7 +210,7 @@ task 'javascript:update_constants' => :environment do
 
   emoji_buttons = groups_json.map do |group|
     <<~HTML
-			<button type="button" data-section="#{group["name"]}" {{action onCategorySelection "#{group["name"]}"}} class="btn btn-default category-button emoji">
+			<button type="button" data-section="#{group["name"]}" {{action this.onCategorySelection "#{group["name"]}"}} class="btn btn-default category-button emoji">
 				 {{replace-emoji ":#{group["tabicon"]}:"}}
 			</button>
     HTML


### PR DESCRIPTION
This PR makes some updates to the prior keyboard accessibility commit (https://github.com/discourse/discourse/commit/eb987460f243553c2e735708624b873925758169):
- Makes `tabindex` attribute only appear on emoji markup in the emoji picker.
- After pressing the <kbd>Esc</kbd> key, focus returns to the `<textarea/>` input (composer editor or chat input)