### PR TITLE
UX: truncate site text titles in a cleaner way

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -56,6 +56,11 @@
     width: auto;
   }
 
+  #site-text-logo {
+    margin: 0;
+    @include ellipsis;
+  }
+
   .d-icon-home {
     font-size: $font-up-6;
   }

--- a/app/assets/stylesheets/desktop/header.scss
+++ b/app/assets/stylesheets/desktop/header.scss
@@ -10,7 +10,6 @@
   }
   #site-text-logo {
     font-size: $font-up-3;
-    margin: 0;
   }
   .extra-info {
     &:not(.two-rows) {

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -26,7 +26,6 @@
     max-width: 100%;
   }
   #site-text-logo {
-    margin: 0;
     font-size: $font-up-1;
   }
   .extra-info-wrapper {


### PR DESCRIPTION
We're already truncating, but this gives some visual indication when we do

Before (full name is "local development long name":

![Screen Shot 2022-09-22 at 2 31 06 PM](https://user-images.githubusercontent.com/1681963/191825211-81ba811c-f336-45c0-a352-dca1b0f2a3cf.png)

After:

![Screen Shot 2022-09-22 at 2 30 52 PM](https://user-images.githubusercontent.com/1681963/191825325-cff520f8-a38f-42c9-b5f4-11950c1e2a40.png)
