### PR TITLE
UX: fix topic stream placeholders

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -42,6 +42,10 @@ $quote-share-maxwidth: 150px;
   margin-bottom: 0.6em;
 }
 
+.post-stream .placeholder .row {
+  display: flex;
+}
+
 .names {
   flex: 1 1 auto;
   overflow: hidden;


### PR DESCRIPTION
These are currently displayed backwards, this fix will get them in the right direction again. 

![image](https://user-images.githubusercontent.com/1681963/191831751-15d2314d-b430-40f6-9ddf-6040e61b4cb0.png)
