### PR TITLE
FEATURE: add composer warning when user haven't been seen in a long time

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -145,10 +145,14 @@ export default Component.extend({
           ) {
             this.set("userNotSeenMessage", response.warning_message);
             this.messagesByTemplate["custom-body"] = undefined;
+            let title_key = "composer.user_not_seen_in_a_while_title.single";
+            if (response.user_count > 1) {
+              title_key = "composer.user_not_seen_in_a_while_title.multiple";
+            }
             const message = composer.store.createRecord("composer-message", {
               id: "user-not-seen",
               templateName: "custom-body",
-              title: I18n.t("composer.user_not_seen_in_a_while_title"),
+              title: I18n.t(title_key),
               body: response.warning_message,
             });
             this.send("popup", message);

--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -133,7 +133,7 @@ export default Component.extend({
       ) {
         _recipient_names = recipient_names;
 
-        ajax(`/composer_messages/user_not_seen`, {
+        ajax(`/composer_messages/user_not_seen_in_a_while`, {
           type: "GET",
           data: {
             usernames: recipient_names,
@@ -148,7 +148,7 @@ export default Component.extend({
             const message = composer.store.createRecord("composer-message", {
               id: "user-not-seen",
               templateName: "custom-body",
-              title: I18n.t("composer.user_not_seen_title"),
+              title: I18n.t("composer.user_not_seen_in_a_while_title"),
               body: response.warning_message,
             });
             this.send("popup", message);

--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -20,7 +20,7 @@ export default Component.extend({
   _similarTopicsMessage: null,
   _yourselfConfirm: null,
   similarTopics: null,
-  userNotSeenMessage: null,
+  usersNotSeen: null,
 
   hidden: not("composer.viewOpenOrFullscreen"),
 
@@ -141,19 +141,24 @@ export default Component.extend({
         }).then((response) => {
           if (
             response.user_count > 0 &&
-            this.get("userNotSeenMessage") !== response.warning_message
+            this.get("usersNotSeen") !== response.usernames.join("-")
           ) {
-            this.set("userNotSeenMessage", response.warning_message);
-            this.messagesByTemplate["custom-body"] = undefined;
-            let title_key = "composer.user_not_seen_in_a_while_title.single";
+            this.set("usersNotSeen", response.usernames.join("-"));
+            this.messagesByTemplate["education"] = undefined;
+
+            let usernames = [];
+            response.usernames.forEach((username, index) => {
+              usernames[index] = `<a class='mention' href='/u/${username}'>@${username}</a>`;
+            });
+
+            let body_key = "composer.user_not_seen_in_a_while.single";
             if (response.user_count > 1) {
-              title_key = "composer.user_not_seen_in_a_while_title.multiple";
+              body_key = "composer.user_not_seen_in_a_while.multiple";
             }
             const message = composer.store.createRecord("composer-message", {
               id: "user-not-seen",
-              templateName: "custom-body",
-              title: I18n.t(title_key),
-              body: response.warning_message,
+              templateName: "education",
+              body: I18n.t(body_key, { usernames: usernames.join(", "), time_ago: response.time_ago }),
             });
             this.send("popup", message);
           }

--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -148,7 +148,9 @@ export default Component.extend({
 
             let usernames = [];
             response.usernames.forEach((username, index) => {
-              usernames[index] = `<a class='mention' href='/u/${username}'>@${username}</a>`;
+              usernames[
+                index
+              ] = `<a class='mention' href='/u/${username}'>@${username}</a>`;
             });
 
             let body_key = "composer.user_not_seen_in_a_while.single";
@@ -158,7 +160,10 @@ export default Component.extend({
             const message = composer.store.createRecord("composer-message", {
               id: "user-not-seen",
               templateName: "education",
-              body: I18n.t(body_key, { usernames: usernames.join(", "), time_ago: response.time_ago }),
+              body: I18n.t(body_key, {
+                usernames: usernames.join(", "),
+                time_ago: response.time_ago,
+              }),
             });
             this.send("popup", message);
           }

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
@@ -1,0 +1,41 @@
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import { click, triggerKeyEvent, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+
+acceptance("Composer - Messages", function (needs) {
+  needs.user();
+  needs.pretender((server, helper) => {
+    server.get("/composer_messages/user_not_seen", () => {
+      return helper.response({
+        user_count: 1,
+        warning_message:
+          "The person you are messaging, charlie, hasn’t been seen here in a very long time – about 1 year ago. They may not receive your message. You may wish to seek out alternate methods of contacting charlie.",
+      });
+    });
+  });
+
+  test("Shows warning in composer if user hasn't been seen in a long time.", async function (assert) {
+    await visit("/u/charlie");
+    await click("button.compose-pm");
+    assert.ok(
+      !exists(".composer-popup"),
+      "composer warning is not shown by default"
+    );
+    await triggerKeyEvent(".d-editor-input", "keyup", "Space");
+    assert.ok(exists(".composer-popup"), "shows composer warning message");
+    assert.strictEqual(
+      query(".composer-popup h3").innerHTML.trim(),
+      "User hasn't been seen in a long time",
+      "warning message has correct title"
+    );
+    assert.strictEqual(
+      query(".composer-popup p").innerHTML.trim(),
+      "The person you are messaging, charlie, hasn’t been seen here in a very long time – about 1 year ago. They may not receive your message. You may wish to seek out alternate methods of contacting charlie.",
+      "warning message has correct body"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
@@ -12,8 +12,8 @@ acceptance("Composer - Messages", function (needs) {
     server.get("/composer_messages/user_not_seen_in_a_while", () => {
       return helper.response({
         user_count: 1,
-        warning_message:
-          "The person you are messaging, charlie, hasn’t been seen here in a very long time – about 1 year ago. They may not receive your message. You may wish to seek out alternate methods of contacting charlie.",
+        usernames: ["charlie"],
+        time_ago: "1 year ago",
       });
     });
   });
@@ -27,14 +27,13 @@ acceptance("Composer - Messages", function (needs) {
     );
     await triggerKeyEvent(".d-editor-input", "keyup", "Space");
     assert.ok(exists(".composer-popup"), "shows composer warning message");
-    assert.strictEqual(
-      query(".composer-popup h3").innerHTML.trim(),
-      "User hasn't been seen in a long time",
-      "warning message has correct title"
-    );
-    assert.strictEqual(
-      query(".composer-popup p").innerHTML.trim(),
-      "The person you are messaging, charlie, hasn’t been seen here in a very long time – about 1 year ago. They may not receive your message. You may wish to seek out alternate methods of contacting charlie.",
+    assert.ok(
+      query(".composer-popup").innerHTML.includes(
+        I18n.t("composer.user_not_seen_in_a_while.single", {
+          usernames: ["charlie"],
+          time_ago: "1 day ago",
+        })
+      ),
       "warning message has correct body"
     );
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
@@ -5,6 +5,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import I18n from "I18n";
 
 acceptance("Composer - Messages", function (needs) {
   needs.user();
@@ -30,8 +31,8 @@ acceptance("Composer - Messages", function (needs) {
     assert.ok(
       query(".composer-popup").innerHTML.includes(
         I18n.t("composer.user_not_seen_in_a_while.single", {
-          usernames: ["charlie"],
-          time_ago: "1 day ago",
+          usernames: ['<a class="mention" href="/u/charlie">@charlie</a>'],
+          time_ago: "1 year ago",
         })
       ),
       "warning message has correct body"

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-messages-test.js
@@ -9,7 +9,7 @@ import { test } from "qunit";
 acceptance("Composer - Messages", function (needs) {
   needs.user();
   needs.pretender((server, helper) => {
-    server.get("/composer_messages/user_not_seen", () => {
+    server.get("/composer_messages/user_not_seen_in_a_while", () => {
       return helper.response({
         user_count: 1,
         warning_message:

--- a/app/controllers/composer_messages_controller.rb
+++ b/app/controllers/composer_messages_controller.rb
@@ -30,8 +30,8 @@ class ComposerMessagesController < ApplicationController
       else
         "education.user_not_seen_in_a_while.multiple"
       end
-      users.map! { |username| "@#{username}" }
-      warning_message = I18n.t(message_locale, username: users.join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose'))
+      users.map! { |username| "<a class='mention' href='/u/#{username}'>@#{username}</a>" }
+      warning_message = I18n.t(message_locale, usernames: users.join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose'))
     end
 
     json = { user_count: user_count, warning_message: warning_message }

--- a/app/controllers/composer_messages_controller.rb
+++ b/app/controllers/composer_messages_controller.rb
@@ -17,4 +17,23 @@ class ComposerMessagesController < ApplicationController
 
     render_json_dump(json, rest_serializer: true)
   end
+
+  def user_not_seen
+    usernames = params.require(:usernames)
+    users = ComposerMessagesFinder.user_not_seen(usernames)
+    user_count = users.count
+    warning_message = nil
+
+    if user_count > 0
+      message_locale = if user_count == 1
+        "education.user_not_seen.single"
+      else
+        "education.user_not_seen.multiple"
+      end
+      warning_message = I18n.t(message_locale, username: users.join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose'))
+    end
+
+    json = { user_count: user_count, warning_message: warning_message }
+    render_json_dump(json)
+  end
 end

--- a/app/controllers/composer_messages_controller.rb
+++ b/app/controllers/composer_messages_controller.rb
@@ -30,6 +30,7 @@ class ComposerMessagesController < ApplicationController
       else
         "education.user_not_seen.multiple"
       end
+      users.map! { |username| "@#{username}" }
       warning_message = I18n.t(message_locale, username: users.join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose'))
     end
 

--- a/app/controllers/composer_messages_controller.rb
+++ b/app/controllers/composer_messages_controller.rb
@@ -30,11 +30,9 @@ class ComposerMessagesController < ApplicationController
       else
         "education.user_not_seen_in_a_while.multiple"
       end
-      users.map! { |username| "<a class='mention' href='/u/#{username}'>@#{username}</a>" }
-      warning_message = I18n.t(message_locale, usernames: users.join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose'))
     end
 
-    json = { user_count: user_count, warning_message: warning_message }
+    json = { user_count: user_count, usernames: users, time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose') }
     render_json_dump(json)
   end
 end

--- a/app/controllers/composer_messages_controller.rb
+++ b/app/controllers/composer_messages_controller.rb
@@ -18,17 +18,17 @@ class ComposerMessagesController < ApplicationController
     render_json_dump(json, rest_serializer: true)
   end
 
-  def user_not_seen
+  def user_not_seen_in_a_while
     usernames = params.require(:usernames)
-    users = ComposerMessagesFinder.user_not_seen(usernames)
+    users = ComposerMessagesFinder.user_not_seen_in_a_while(usernames)
     user_count = users.count
     warning_message = nil
 
     if user_count > 0
       message_locale = if user_count == 1
-        "education.user_not_seen.single"
+        "education.user_not_seen_in_a_while.single"
       else
-        "education.user_not_seen.multiple"
+        "education.user_not_seen_in_a_while.multiple"
       end
       users.map! { |username| "@#{username}" }
       warning_message = I18n.t(message_locale, username: users.join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose'))

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2275,7 +2275,9 @@ en:
         body: "Right now this message is only being sent to yourself!"
       slow_mode:
         error: "This topic is in slow mode. You already posted recently; you can post again in %{timeLeft}."
-      user_not_seen_in_a_while_title: "User hasn't been seen in a long time"
+      user_not_seen_in_a_while_title:
+        single: "User hasn't been seen in a long time"
+        multiple: "Users haven't been seen in a long time"
 
       admin_options_title: "Optional staff settings for this topic"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2275,7 +2275,7 @@ en:
         body: "Right now this message is only being sent to yourself!"
       slow_mode:
         error: "This topic is in slow mode. You already posted recently; you can post again in %{timeLeft}."
-      user_not_seen_title: "User hasn't been seen in a long time"
+      user_not_seen_in_a_while_title: "User hasn't been seen in a long time"
 
       admin_options_title: "Optional staff settings for this topic"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2275,6 +2275,7 @@ en:
         body: "Right now this message is only being sent to yourself!"
       slow_mode:
         error: "This topic is in slow mode. You already posted recently; you can post again in %{timeLeft}."
+      user_not_seen_title: "User hasn't been seen in a long time"
 
       admin_options_title: "Optional staff settings for this topic"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2275,9 +2275,9 @@ en:
         body: "Right now this message is only being sent to yourself!"
       slow_mode:
         error: "This topic is in slow mode. You already posted recently; you can post again in %{timeLeft}."
-      user_not_seen_in_a_while_title:
-        single: "User hasn't been seen in a long time"
-        multiple: "Users haven't been seen in a long time"
+      user_not_seen_in_a_while:
+        single: "The person you are messaging, <b>%{usernames}</b>, hasn’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting %{usernames}."
+        multiple: "The following people you are messaging: <b>%{usernames}</b>, haven’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting them."
 
       admin_options_title: "Optional staff settings for this topic"
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -554,6 +554,10 @@ en:
 
       Are you sure you want to continue this old conversation?
 
+    user_not_seen:
+      single: "The person you are messaging, %{username}, hasn’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting %{username}."
+      multiple: "The following people you are messaging: %{username}, haven’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting them."
+
   activerecord:
     attributes:
       category:
@@ -2148,6 +2152,8 @@ en:
     dominating_topic_minimum_percent: "What percentage of posts a user has to make in a topic before being reminded about overly dominating a topic."
 
     disable_avatar_education_message: "Disable education message for changing avatar."
+
+    pm_warn_user_last_seen_months_ago: "When creating a new PM warn users when target recepient has not been seen more than n months ago."
 
     suppress_uncategorized_badge: "Don't show the badge for uncategorized topics in topic lists."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -554,10 +554,6 @@ en:
 
       Are you sure you want to continue this old conversation?
 
-    user_not_seen_in_a_while:
-      single: "The person you are messaging, <b>%{usernames}</b>, hasn’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting %{usernames}."
-      multiple: "The following people you are messaging: <b>%{usernames}</b>, haven’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting them."
-
   activerecord:
     attributes:
       category:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -555,8 +555,8 @@ en:
       Are you sure you want to continue this old conversation?
 
     user_not_seen:
-      single: "The person you are messaging, %{username}, hasn’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting %{username}."
-      multiple: "The following people you are messaging: %{username}, haven’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting them."
+      single: "The person you are messaging, <b>%{username}</b>, hasn’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting %{username}."
+      multiple: "The following people you are messaging: <b>%{username}</b>, haven’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting them."
 
   activerecord:
     attributes:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -554,7 +554,7 @@ en:
 
       Are you sure you want to continue this old conversation?
 
-    user_not_seen:
+    user_not_seen_in_a_while:
       single: "The person you are messaging, <b>%{username}</b>, hasn’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting %{username}."
       multiple: "The following people you are messaging: <b>%{username}</b>, haven’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting them."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -555,8 +555,8 @@ en:
       Are you sure you want to continue this old conversation?
 
     user_not_seen_in_a_while:
-      single: "The person you are messaging, <b>%{username}</b>, hasn’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting %{username}."
-      multiple: "The following people you are messaging: <b>%{username}</b>, haven’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting them."
+      single: "The person you are messaging, <b>%{usernames}</b>, hasn’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting %{usernames}."
+      multiple: "The following people you are messaging: <b>%{usernames}</b>, haven’t been seen here in a very long time – %{time_ago}. They may not receive your message. You may wish to seek out alternate methods of contacting them."
 
   activerecord:
     attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -387,7 +387,7 @@ Discourse::Application.routes.draw do
     end
     get "session/scopes" => "session#scopes"
     get "composer_messages" => "composer_messages#index"
-    get "composer_messages/user_not_seen" => "composer_messages#user_not_seen"
+    get "composer_messages/user_not_seen_in_a_while" => "composer_messages#user_not_seen_in_a_while"
 
     resources :static
     post "login" => "static#enter"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -387,6 +387,7 @@ Discourse::Application.routes.draw do
     end
     get "session/scopes" => "session#scopes"
     get "composer_messages" => "composer_messages#index"
+    get "composer_messages/user_not_seen" => "composer_messages#user_not_seen"
 
     resources :static
     post "login" => "static#enter"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2272,6 +2272,7 @@ uncategorized:
   get_a_room_threshold: 3
   dominating_topic_minimum_percent: 20
   disable_avatar_education_message: false
+  pm_warn_user_last_seen_months_ago: 24
 
   global_notice:
     default: ""

--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -212,6 +212,10 @@ class ComposerMessagesFinder
     }
   end
 
+  def self.user_not_seen(usernames)
+    User.where(username_lower: usernames).where("last_seen_at < ?", SiteSetting.pm_warn_user_last_seen_months_ago.months.ago).pluck(:username).sort
+  end
+
   private
 
   def educate_reply?(type)

--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -212,7 +212,7 @@ class ComposerMessagesFinder
     }
   end
 
-  def self.user_not_seen(usernames)
+  def self.user_not_seen_in_a_while(usernames)
     User.where(username_lower: usernames).where("last_seen_at < ?", SiteSetting.pm_warn_user_last_seen_months_ago.months.ago).pluck(:username).sort
   end
 

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe ComposerMessagesFinder do
     end
   end
 
-  describe '#user_not_seen' do
+  describe '#user_not_seen_in_a_while' do
     fab!(:user_1) { Fabricate(:user, last_seen_at: 3.years.ago) }
     fab!(:user_2) { Fabricate(:user, last_seen_at: 2.years.ago) }
     fab!(:user_3) { Fabricate(:user, last_seen_at: 6.months.ago) }
@@ -512,13 +512,13 @@ RSpec.describe ComposerMessagesFinder do
     end
 
     it 'returns users that have not been seen recently' do
-      users = ComposerMessagesFinder.user_not_seen([user_1.username, user_2.username, user_3.username])
+      users = ComposerMessagesFinder.user_not_seen_in_a_while([user_1.username, user_2.username, user_3.username])
       expect(users).to contain_exactly(user_1.username, user_2.username)
     end
 
     it 'accounts for pm_warn_user_last_seen_months_ago site setting' do
       SiteSetting.pm_warn_user_last_seen_months_ago = 30
-      users = ComposerMessagesFinder.user_not_seen([user_1.username, user_2.username, user_3.username])
+      users = ComposerMessagesFinder.user_not_seen_in_a_while([user_1.username, user_2.username, user_3.username])
       expect(users).to contain_exactly(user_1.username)
     end
   end

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -501,4 +501,26 @@ RSpec.describe ComposerMessagesFinder do
       expect(edit_post_finder.find).to eq(nil)
     end
   end
+
+  describe '#user_not_seen' do
+    fab!(:user_1) { Fabricate(:user, last_seen_at: 3.years.ago) }
+    fab!(:user_2) { Fabricate(:user, last_seen_at: 2.years.ago) }
+    fab!(:user_3) { Fabricate(:user, last_seen_at: 6.months.ago) }
+
+    before do
+      SiteSetting.pm_warn_user_last_seen_months_ago = 24
+    end
+
+    it 'returns users that have not been seen recently' do
+      users = ComposerMessagesFinder.user_not_seen([user_1.username, user_2.username, user_3.username])
+      expect(users).to contain_exactly(user_1.username, user_2.username)
+    end
+
+    it 'accounts for pm_warn_user_last_seen_months_ago site setting' do
+      SiteSetting.pm_warn_user_last_seen_months_ago = 30
+      users = ComposerMessagesFinder.user_not_seen([user_1.username, user_2.username, user_3.username])
+      expect(users).to contain_exactly(user_1.username)
+    end
+  end
+
 end

--- a/spec/requests/composer_messages_controller_spec.rb
+++ b/spec/requests/composer_messages_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ComposerMessagesController do
         expect(response.status).to eq(200)
         json = response.parsed_body
         expect(json["user_count"]).to eq(2)
-        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen_in_a_while.multiple", username: [user_1.username, user_2.username].join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
+        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen_in_a_while.multiple", usernames: ["<a class='mention' href='/u/#{user_1.username}'>@#{user_1.username}</a>", "<a class='mention' href='/u/#{user_2.username}'>@#{user_2.username}</a>"].join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
       end
 
       it 'accounts for pm_warn_user_last_seen_months_ago site setting' do
@@ -67,7 +67,7 @@ RSpec.describe ComposerMessagesController do
         expect(response.status).to eq(200)
         json = response.parsed_body
         expect(json["user_count"]).to eq(1)
-        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen_in_a_while.single", username: user_1.username, time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
+        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen_in_a_while.single", usernames: "<a class='mention' href='/u/#{user_1.username}'>@#{user_1.username}</a>", time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
       end
     end
   end

--- a/spec/requests/composer_messages_controller_spec.rb
+++ b/spec/requests/composer_messages_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ComposerMessagesController do
         expect(response.status).to eq(200)
         json = response.parsed_body
         expect(json["user_count"]).to eq(2)
-        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen_in_a_while.multiple", usernames: ["<a class='mention' href='/u/#{user_1.username}'>@#{user_1.username}</a>", "<a class='mention' href='/u/#{user_2.username}'>@#{user_2.username}</a>"].join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
+        expect(json["usernames"]).to contain_exactly(user_1.username, user_2.username)
       end
 
       it 'accounts for pm_warn_user_last_seen_months_ago site setting' do
@@ -67,7 +67,7 @@ RSpec.describe ComposerMessagesController do
         expect(response.status).to eq(200)
         json = response.parsed_body
         expect(json["user_count"]).to eq(1)
-        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen_in_a_while.single", usernames: "<a class='mention' href='/u/#{user_1.username}'>@#{user_1.username}</a>", time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
+        expect(json["usernames"]).to contain_exactly(user_1.username)
       end
     end
   end

--- a/spec/requests/composer_messages_controller_spec.rb
+++ b/spec/requests/composer_messages_controller_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe ComposerMessagesController do
     end
   end
 
-  describe '#user_not_seen' do
+  describe '#user_not_seen_in_a_while' do
     fab!(:user_1) { Fabricate(:user, last_seen_at: 3.years.ago) }
     fab!(:user_2) { Fabricate(:user, last_seen_at: 2.years.ago) }
     fab!(:user_3) { Fabricate(:user, last_seen_at: 6.months.ago) }
 
     it 'requires you to be logged in' do
-      get '/composer_messages/user_not_seen.json', params: { usernames: [user_1.username, user_2.username, user_3.username] }
+      get '/composer_messages/user_not_seen_in_a_while.json', params: { usernames: [user_1.username, user_2.username, user_3.username] }
       expect(response.status).to eq(403)
     end
 
@@ -49,25 +49,25 @@ RSpec.describe ComposerMessagesController do
       end
 
       it 'requires usernames parameter to be present' do
-        get '/composer_messages/user_not_seen.json'
+        get '/composer_messages/user_not_seen_in_a_while.json'
         expect(response.status).to eq(400)
       end
 
       it 'returns users that have not been seen recently' do
-        get '/composer_messages/user_not_seen.json', params: { usernames: [user_1.username, user_2.username, user_3.username] }
+        get '/composer_messages/user_not_seen_in_a_while.json', params: { usernames: [user_1.username, user_2.username, user_3.username] }
         expect(response.status).to eq(200)
         json = response.parsed_body
         expect(json["user_count"]).to eq(2)
-        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen.multiple", username: [user_1.username, user_2.username].join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
+        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen_in_a_while.multiple", username: [user_1.username, user_2.username].join(", "), time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
       end
 
       it 'accounts for pm_warn_user_last_seen_months_ago site setting' do
         SiteSetting.pm_warn_user_last_seen_months_ago = 30
-        get '/composer_messages/user_not_seen.json', params: { usernames: [user_1.username, user_2.username, user_3.username] }
+        get '/composer_messages/user_not_seen_in_a_while.json', params: { usernames: [user_1.username, user_2.username, user_3.username] }
         expect(response.status).to eq(200)
         json = response.parsed_body
         expect(json["user_count"]).to eq(1)
-        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen.single", username: user_1.username, time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
+        expect(json["warning_message"]).to eq(I18n.t("education.user_not_seen_in_a_while.single", username: user_1.username, time_ago: FreedomPatches::Rails4.time_ago_in_words(SiteSetting.pm_warn_user_last_seen_months_ago.month.ago, true, scope: :'datetime.distance_in_words_verbose')))
       end
     end
   end


### PR DESCRIPTION
When a user creates a PM and adds a recipient that hasn't been seen in a long time then we'll now show a warning in composer indicating that the user hasn't been seen in a long time.

![SCR-20220927-g6v](https://user-images.githubusercontent.com/5732281/192573197-4623106e-0464-4a88-a69b-759edb33ddc0.png)

