### PR TITLE
DEV: Remove invalid pretender calls

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/redirect-to-top-test.js
@@ -8,9 +8,6 @@ import { test } from "qunit";
 
 acceptance("Redirect to Top", function (needs) {
   needs.pretender((server, helper) => {
-    server.get("/top.json?period=weekly", () => {
-      return helper.response(DiscoveryFixtures["/latest.json"]);
-    });
     server.get("/top/monthly.json", () => {
       return helper.response(DiscoveryFixtures["/latest.json"]);
     });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-discovery-test.js
@@ -201,15 +201,11 @@ acceptance("Topic Discovery | Footer", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    server.get("/c/dev/7/l/latest.json", () => {
+    server.get("/c/dev/7/l/latest.json", (request) => {
       const json = cloneJSON(discoveryFixtures["/c/dev/7/l/latest.json"]);
-      json.topic_list.more_topics_url = "/c/dev/7/l/latest.json?page=2";
-      return helper.response(json);
-    });
-
-    server.get("/c/dev/7/l/latest.json?page=2", () => {
-      const json = cloneJSON(discoveryFixtures["/c/dev/7/l/latest.json"]);
-      json.topic_list.more_topics_url = null;
+      if (!request.queryParams.page) {
+        json.topic_list.more_topics_url = "/c/dev/7/l/latest.json?page=2";
+      }
       return helper.response(json);
     });
   });


### PR DESCRIPTION
Get parameters cannot be included in the URL of request stubs. Instead, the callback can check `request.queryParams` to modify behavior.

cc @techAPJ 

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
