### PR TITLE
FIX: Handle failed download when calculating image dominant color

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -340,10 +340,15 @@ class Upload < ActiveRecord::Base
         if local?
           Discourse.store.path_for(self)
         else
-          Discourse.store.download(self).path
+          Discourse.store.download(self)&.path
         end
 
-      color = begin
+      if local_path.nil?
+        # Download failed. Could be too large to download, or file could be missing in s3
+        color = ""
+      end
+
+      color ||= begin
         data = Discourse::Utils.execute_command(
           "nice",
           "-n",

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -690,6 +690,15 @@ RSpec.describe Upload do
       expect(invalid_image.dominant_color).to eq(nil)
     end
 
+    it "correctly handles download failures" do
+      white_image.stubs(:local?).returns(true)
+      Discourse.store.stubs(:download).returns(nil)
+
+      expect(invalid_image.dominant_color).to eq(nil)
+      expect(invalid_image.dominant_color(calculate_if_missing: true)).to eq("")
+      expect(invalid_image.dominant_color).to eq("")
+    end
+
     it "is validated for length" do
       u = Fabricate(:upload)
 


### PR DESCRIPTION
This can happen when the upload size exceeds the maximum upload size, or there is a network issue during download

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
