### PR TITLE
FIX: Recursively tag topics with missing ancestor tags

### DIFF
--- a/spec/lib/discourse_tagging_spec.rb
+++ b/spec/lib/discourse_tagging_spec.rb
@@ -562,6 +562,15 @@ RSpec.describe DiscourseTagging do
           expect(valid).to eq(true)
           expect(topic.reload.tags.map(&:name)).to contain_exactly(*[foo, bar, baz].map(&:name))
         end
+
+        it "adds missing tags even with cycles" do
+          tag_group4 = Fabricate(:tag_group, parent_tag_id: baz.id)
+          tag_group4.tags = [foo]
+
+          valid = DiscourseTagging.tag_topic_by_names(topic, Guardian.new(user), [baz.name])
+          expect(valid).to eq(true)
+          expect(topic.reload.tags.map(&:name)).to contain_exactly(*[foo, bar, baz].map(&:name))
+        end
       end
     end
 

--- a/spec/lib/discourse_tagging_spec.rb
+++ b/spec/lib/discourse_tagging_spec.rb
@@ -497,9 +497,19 @@ RSpec.describe DiscourseTagging do
       end
 
       it "adds all parent tags that are missing" do
+        parent_tag_group = Fabricate(:tag_group)
         parent_tag = Fabricate(:tag, name: 'parent')
+        parent_tag_group.tags = [parent_tag]
+
         tag_group2 = Fabricate(:tag_group, parent_tag_id: parent_tag.id)
         tag_group2.tags = [tag2]
+
+        tag_group1 = Fabricate(:tag_group)
+        tag_group1.tags = [tag1]
+
+        tag_group3 = Fabricate(:tag_group, parent_tag_id: tag1.id)
+        tag_group3.tags = [tag3]
+
         valid = DiscourseTagging.tag_topic_by_names(topic, Guardian.new(user), [tag3.name, tag2.name])
         expect(valid).to eq(true)
         expect(topic.reload.tags.map(&:name)).to contain_exactly(
@@ -518,6 +528,24 @@ RSpec.describe DiscourseTagging do
         valid = DiscourseTagging.tag_topic_by_names(topic, Guardian.new(user), [parent_tag.name, common.name])
         expect(valid).to eq(true)
         expect(topic.reload.tags.map(&:name)).to contain_exactly(*[parent_tag, common].map(&:name))
+      end
+
+      it "recursively adds all ancestors" do
+        tag_group1 = Fabricate(:tag_group)
+        foo = Fabricate(:tag, name: 'foo')
+        tag_group1.tags = [foo]
+
+        tag_group2 = Fabricate(:tag_group, parent_tag_id: foo.id)
+        bar = Fabricate(:tag, name: 'bar')
+        tag_group2.tags = [bar]
+
+        tag_group3 = Fabricate(:tag_group, parent_tag_id: bar.id)
+        baz = Fabricate(:tag, name: 'baz')
+        tag_group3.tags = [baz]
+
+        valid = DiscourseTagging.tag_topic_by_names(topic, Guardian.new(user), [baz.name])
+        expect(valid).to eq(true)
+        expect(topic.reload.tags.map(&:name)).to contain_exactly(*[foo, bar, baz].map(&:name))
       end
     end
 


### PR DESCRIPTION
Currently, only immediate parents of  tags are derived for use in tagging topics.

This change walks up the ancestry chain, gets all ancestors for use in tagging a topic. For tags with multiple parents, it maintains compatibility with the current implementation by traversing and returning just the first parent.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
