### PR TITLE
A11Y: Improve user card accessibility

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -364,9 +364,10 @@ export default Mixin.create({
 
   @bind
   _escListener(event) {
+    const target = this.cardTarget;
     if (this.visible && event.key === "Escape") {
       this._close();
-      this.cardTarget?.focus();
+      target?.focus();
       return;
     }
   },

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -1,5 +1,5 @@
 import { alias, match } from "@ember/object/computed";
-import { next, schedule, throttle } from "@ember/runloop";
+import { schedule, throttle } from "@ember/runloop";
 import DiscourseURL from "discourse/lib/url";
 import Mixin from "@ember/object/mixin";
 import afterTransition from "discourse/lib/after-transition";
@@ -7,6 +7,7 @@ import { escapeExpression } from "discourse/lib/utilities";
 import { inject as service } from "@ember/service";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { bind } from "discourse-common/utils/decorators";
+import discourseLater from "discourse-common/lib/later";
 
 const DEFAULT_SELECTOR = "#main-outlet";
 
@@ -279,10 +280,10 @@ export default Mixin.create({
         // note: we DO NOT use afterRender here cause _positionCard may
         // run afterwards, if we allowed this to happen the usercard
         // may be offscreen and we may scroll all the way to it on focus
-        next(null, () => {
+        discourseLater(() => {
           const firstLink = this.element.querySelector("a");
           firstLink && firstLink.focus();
-        });
+        }, 150);
       }
     });
   },

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -1,12 +1,12 @@
 import { alias, match } from "@ember/object/computed";
-import { schedule, throttle } from "@ember/runloop";
+import { throttle } from "@ember/runloop";
 import DiscourseURL from "discourse/lib/url";
 import Mixin from "@ember/object/mixin";
 import afterTransition from "discourse/lib/after-transition";
 import { escapeExpression } from "discourse/lib/utilities";
 import { inject as service } from "@ember/service";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
-import { bind } from "discourse-common/utils/decorators";
+import { afterRender, bind } from "discourse-common/utils/decorators";
 import discourseLater from "discourse-common/lib/later";
 
 const DEFAULT_SELECTOR = "#main-outlet";
@@ -192,6 +192,7 @@ export default Mixin.create({
     return this._show($target.text().replace(/^@/, ""), $target);
   },
 
+  @afterRender
   _positionCard(target) {
     const rtl = $("html").css("direction") === "rtl";
     if (!target) {
@@ -204,88 +205,86 @@ export default Mixin.create({
 
     let verticalAdjustments = 0;
 
-    schedule("afterRender", () => {
-      if (target) {
-        if (!this.site.mobileView) {
-          let position = target.offset();
-          if (target.parents(".d-header").length > 0) {
-            position.top = target.position().top;
-          }
-
-          if (position) {
-            position.bottom = "unset";
-
-            if (rtl) {
-              // The site direction is rtl
-              position.right = $(window).width() - position.left + 10;
-              position.left = "auto";
-              let overage = $(window).width() - 50 - (position.right + width);
-              if (overage < 0) {
-                position.right += overage;
-                position.top += target.height() + 48;
-                verticalAdjustments += target.height() + 48;
-              }
-            } else {
-              // The site direction is ltr
-              position.left += target.width() + 10;
-
-              let overage = $(window).width() - 50 - (position.left + width);
-              if (overage < 0) {
-                position.left += overage;
-                position.top += target.height() + 48;
-                verticalAdjustments += target.height() + 48;
-              }
-            }
-
-            // It looks better to have the card aligned slightly higher
-            position.top -= 24;
-
-            if (isFixed) {
-              position.top -= $("html").scrollTop();
-              //if content is fixed and will be cut off on the bottom, display it above...
-              if (
-                position.top + height + verticalAdjustments >
-                $(window).height() - 50
-              ) {
-                position.bottom =
-                  $(window).height() -
-                  (target.offset().top - $("html").scrollTop());
-                if (verticalAdjustments > 0) {
-                  position.bottom += 48;
-                }
-                position.top = "unset";
-              }
-            }
-
-            const avatarOverflowSize = 44;
-            if (isDocked && position.top < avatarOverflowSize) {
-              position.top = avatarOverflowSize;
-            }
-
-            $(this.element).css(position);
-          }
+    if (target) {
+      if (!this.site.mobileView) {
+        let position = target.offset();
+        if (target.parents(".d-header").length > 0) {
+          position.top = target.position().top;
         }
 
-        if (this.site.mobileView) {
-          $(".card-cloak").removeClass("hidden");
-          let position = target.offset();
-          position.top = "10%"; // match modal behaviour
-          position.left = 0;
+        if (position) {
+          position.bottom = "unset";
+
+          if (rtl) {
+            // The site direction is rtl
+            position.right = $(window).width() - position.left + 10;
+            position.left = "auto";
+            let overage = $(window).width() - 50 - (position.right + width);
+            if (overage < 0) {
+              position.right += overage;
+              position.top += target.height() + 48;
+              verticalAdjustments += target.height() + 48;
+            }
+          } else {
+            // The site direction is ltr
+            position.left += target.width() + 10;
+
+            let overage = $(window).width() - 50 - (position.left + width);
+            if (overage < 0) {
+              position.left += overage;
+              position.top += target.height() + 48;
+              verticalAdjustments += target.height() + 48;
+            }
+          }
+
+          // It looks better to have the card aligned slightly higher
+          position.top -= 24;
+
+          if (isFixed) {
+            position.top -= $("html").scrollTop();
+            //if content is fixed and will be cut off on the bottom, display it above...
+            if (
+              position.top + height + verticalAdjustments >
+              $(window).height() - 50
+            ) {
+              position.bottom =
+                $(window).height() -
+                (target.offset().top - $("html").scrollTop());
+              if (verticalAdjustments > 0) {
+                position.bottom += 48;
+              }
+              position.top = "unset";
+            }
+          }
+
+          const avatarOverflowSize = 44;
+          if (isDocked && position.top < avatarOverflowSize) {
+            position.top = avatarOverflowSize;
+          }
+
           $(this.element).css(position);
         }
-        $(this.element).toggleClass("docked-card", isDocked);
-
-        // After the card is shown, focus on the first link
-        //
-        // note: we DO NOT use afterRender here cause _positionCard may
-        // run afterwards, if we allowed this to happen the usercard
-        // may be offscreen and we may scroll all the way to it on focus
-        discourseLater(() => {
-          const firstLink = this.element.querySelector("a");
-          firstLink && firstLink.focus();
-        }, 150);
       }
-    });
+
+      if (this.site.mobileView) {
+        $(".card-cloak").removeClass("hidden");
+        let position = target.offset();
+        position.top = "10%"; // match modal behaviour
+        position.left = 0;
+        $(this.element).css(position);
+      }
+      $(this.element).toggleClass("docked-card", isDocked);
+
+      // After the card is shown, focus on the first link
+      //
+      // note: we DO NOT use afterRender here cause _positionCard may
+      // run afterwards, if we allowed this to happen the usercard
+      // may be offscreen and we may scroll all the way to it on focus
+      discourseLater(() => {
+        const firstLink = this.element.querySelector("a");
+        firstLink && firstLink.focus();
+      }, 150);
+    }
   },
 
   @bind

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -283,7 +283,7 @@ export default Mixin.create({
         discourseLater(() => {
           const firstLink = this.element.querySelector("a");
           firstLink && firstLink.focus();
-        }, 150);
+        }, 350);
       }
     });
   },

--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -364,10 +364,9 @@ export default Mixin.create({
 
   @bind
   _escListener(event) {
-    const target = this.cardTarget;
     if (this.visible && event.key === "Escape") {
+      this.cardTarget?.focus();
       this._close();
-      target?.focus();
       return;
     }
   },

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -36,12 +36,12 @@
         <div class="names">
           <h1 class="{{this.staff}} {{this.newUser}} {{if this.nameFirst "full-name" "username"}}">
             {{#if this.user.profile_hidden}}
-              <span class="name-username-wrapper">
+              <span id="discourse-user-card-title" class="name-username-wrapper">
                 {{if this.nameFirst this.user.name (format-username this.user.username)}}
               </span>
             {{else}}
               <a href={{this.user.path}} {{action "showUser" this.user}} class="user-profile-link">
-                <span class="name-username-wrapper">
+                <span id="discourse-user-card-title" class="name-username-wrapper">
                   {{if this.nameFirst this.user.name (format-username this.user.username)}}
                 </span>
                 {{user-status this.user currentUser=this.currentUser}}

--- a/app/assets/javascripts/discourse/app/templates/user-card.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-card.hbs
@@ -2,6 +2,5 @@
   <div class="card-cloak hidden"></div>
 {{/if}}
 
-<UserCardContents @topic={{this.topic.model}} @showUser={{action "showUser"}} @filterPosts={{action "filterPosts"}} @composePrivateMessage={{route-action "composePrivateMessage"}} @createNewMessageViaParams={{route-action "createNewMessageViaParams"}} />
-
+<UserCardContents @topic={{this.topic.model}} @showUser={{action "showUser"}} @filterPosts={{action "filterPosts"}} @composePrivateMessage={{route-action "composePrivateMessage"}} @createNewMessageViaParams={{route-action "createNewMessageViaParams"}} role="dialog" aria-labelledby="discourse-user-card-title"/>
 <GroupCardContents @topic={{this.topic.model}} @showUser={{action "showUser"}} @showGroup={{action "showGroup"}} @createNewMessageViaParams={{route-action "createNewMessageViaParams"}} />

--- a/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-card-test.js
@@ -3,7 +3,7 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import { click, triggerKeyEvent, visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import User from "discourse/models/user";
 import { test } from "qunit";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
@@ -101,38 +101,5 @@ acceptance("User Card - User Status", function (needs) {
     await click('a[data-user-card="charlie"]');
 
     assert.notOk(exists(".user-card h3.user-status"));
-  });
-});
-
-acceptance("User card - Accessibility", function (needs) {
-  needs.user();
-  needs.pretender((server, helper) => {
-    const cardResponse = cloneJSON(userFixtures["/u/eviltrout/card.json"]);
-    server.get("/u/eviltrout/card.json", () => helper.response(cardResponse));
-  });
-
-  test("user card focuses correctly", async function (assert) {
-    await visit("/");
-    const userAvatar = document.querySelector('a[data-user-card="eviltrout"]');
-    userAvatar.focus();
-
-    await triggerKeyEvent(document.activeElement, "keydown", "Enter");
-
-    assert.ok(exists(".user-card-eviltrout"), "evil trout's user card exists");
-    assert.strictEqual(
-      document.activeElement,
-      document.querySelector(".card-huge-avatar"),
-      "first element inside user card is in focus"
-    );
-
-    await triggerKeyEvent(document.activeElement, "keydown", "Escape");
-    assert.ok(
-      !exists(document.querySelector("user-card.show"), "user card is hidden")
-    );
-    assert.strictEqual(
-      document.activeElement,
-      userAvatar,
-      "user avatar returns to focus"
-    );
   });
 });

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -53,7 +53,7 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
       clear: both;
     }
     a.card-huge-avatar {
-      outline: none;
+      display: block;
     }
     .bio {
       @include line-clamp(2);
@@ -70,6 +70,11 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
       .user-profile-link {
         display: flex;
         align-items: center;
+
+        &:focus {
+          border: 1px solid;
+          @include default-focus;
+        }
       }
 
       .d-icon {


### PR DESCRIPTION
This PR fixes accessibility issues in the user card:
- [X] Adds semantics to user card (`role="dialog"`, `aria-labelledby`)
- [X] Makes focus states more apparent for user profile icon and username
- [X] Ensures focus order is correct   
- [x] Fixes issue where focus to first item was only happening after pressing <kbd>Enter</kbd> twice
- [x] Returns focus to poster icon when <kbd>esc</kbd> from user card
- [x] ~~Adds tests to ensure focus is correct~~
     > `triggerKeyEvent` is not working correctly to open user card in testing environment, so this PR will be omitting the tests. The component will likely see a bigger refactor in the future anyway to replace the `card-contents-base.js` mixin with native class inheritance and Glimmer components, so we can live without the tests for now.