### PR TITLE
UX: Fix cut-off accents in sidebar headings

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -62,6 +62,7 @@
 
   .sidebar-section-header-text {
     font-weight: bold;
+    line-height: normal;
     margin-right: 0.25em;
     @include ellipsis;
   }


### PR DESCRIPTION
This PR fixes a small UI bug where accented characters are cut off in sidebar heading. 

Identified by user on Meta (https://meta.discourse.org/t/dots-above-umlauts-are-cut-in-sidebar-headlines/239900)

Before:
<img width="700" alt="before" src="https://user-images.githubusercontent.com/30090424/192061103-bb5aef37-1766-4641-b8a6-edae5ff943fd.png">

After:
<img width="696" alt="after" src="https://user-images.githubusercontent.com/30090424/192061111-8e2c80d6-d728-405b-87e5-0c4e1ba88891.png">
