### PR TITLE
FEATURE: make user status a public experimental feature

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2336,6 +2336,8 @@ en:
     enable_sitemap: "Generate a sitemap for your site and include it in the robots.txt file."
     sitemap_page_size: "Number of URLs to include in each sitemap page. Max 50.000"
 
+    enable_user_status: "(experimental) Allow users to set custom status message (emoji + description)."
+
     short_title: "The short title will be used on the user's home screen, launcher, or other places where space may be limited. It should be limited to 12 characters."
 
     dashboard_hidden_reports: "Allow to hide the specified reports from the dashboard."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -372,7 +372,6 @@ basic:
   sitemap_page_size:
     default: 10000
   enable_user_status:
-    hidden: true
     client: true
     default: false
 


### PR DESCRIPTION
Now the `enable_user_status` setting will be visible:

<img width="700" alt="Screenshot 2022-09-25 at 22 15 12" src="https://user-images.githubusercontent.com/1274517/192159007-e6a3f8ca-6f4d-40c8-89ba-76651859bcd0.png">
