### PR TITLE
FEATURE: Implement new onboarding popups

### DIFF
--- a/app/assets/javascripts/discourse/app/components/mount-widget.js
+++ b/app/assets/javascripts/discourse/app/components/mount-widget.js
@@ -71,6 +71,7 @@ export default Component.extend({
     this._connected.forEach((v) => v.destroy());
     this._connected.length = 0;
 
+    traverseCustomWidgets(this._tree, (w) => w.destroy());
     this._rootNode = patch(this._rootNode, diff(this._tree, null));
     this._tree = null;
   },

--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -251,39 +251,41 @@ const SiteHeaderComponent = MountWidget.extend(
         this.currentUser.on("status-changed", this, "queueRerender");
       }
 
-      if (
-        this.currentUser &&
-        !this.get("currentUser.read_first_notification")
-      ) {
-        document.body.classList.add("unread-first-notification");
-      }
+      if (!this.siteSettings.enable_onboarding_popups) {
+        if (
+          this.currentUser &&
+          !this.get("currentUser.read_first_notification")
+        ) {
+          document.body.classList.add("unread-first-notification");
+        }
 
-      // Allow first notification to be dismissed on a click anywhere
-      if (
-        this.currentUser &&
-        !this.get("currentUser.read_first_notification") &&
-        !this.get("currentUser.enforcedSecondFactor")
-      ) {
-        this._dismissFirstNotification = (e) => {
-          if (document.body.classList.contains("unread-first-notification")) {
-            document.body.classList.remove("unread-first-notification");
-          }
-          if (
-            !e.target.closest("#current-user") &&
-            !e.target.closest(".ring-backdrop") &&
-            this.currentUser &&
-            !this.get("currentUser.read_first_notification") &&
-            !this.get("currentUser.enforcedSecondFactor")
-          ) {
-            this.eventDispatched(
-              "header:dismiss-first-notification-mask",
-              "header"
-            );
-          }
-        };
-        document.addEventListener("click", this._dismissFirstNotification, {
-          once: true,
-        });
+        // Allow first notification to be dismissed on a click anywhere
+        if (
+          this.currentUser &&
+          !this.get("currentUser.read_first_notification") &&
+          !this.get("currentUser.enforcedSecondFactor")
+        ) {
+          this._dismissFirstNotification = (e) => {
+            if (document.body.classList.contains("unread-first-notification")) {
+              document.body.classList.remove("unread-first-notification");
+            }
+            if (
+              !e.target.closest("#current-user") &&
+              !e.target.closest(".ring-backdrop") &&
+              this.currentUser &&
+              !this.get("currentUser.read_first_notification") &&
+              !this.get("currentUser.enforcedSecondFactor")
+            ) {
+              this.eventDispatched(
+                "header:dismiss-first-notification-mask",
+                "header"
+              );
+            }
+          };
+          document.addEventListener("click", this._dismissFirstNotification, {
+            once: true,
+          });
+        }
       }
 
       const header = document.querySelector("header.d-header");

--- a/app/assets/javascripts/discourse/app/lib/popup.js
+++ b/app/assets/javascripts/discourse/app/lib/popup.js
@@ -1,0 +1,158 @@
+import { iconHTML } from "discourse-common/lib/icon-library";
+import I18n from "I18n";
+import tippy from "tippy.js";
+
+const GLOBAL_POPUPS_KEY = "new_user_tips";
+const POPUP_KEYS = ["first-notification", "topic-timeline"];
+
+const instances = {};
+const queue = [];
+
+// Plugin used to implement actions of the two buttons
+const PopupPlugin = {
+  name: "popup",
+
+  fn(instance) {
+    return {
+      onCreate() {
+        instance.popper
+          .querySelector(".btn-primary")
+          .addEventListener("click", (event) => {
+            const { currentUser, id } = instance.props;
+            hidePopupForever(currentUser, id);
+            event.preventDefault();
+          });
+
+        instance.popper
+          .querySelector(".btn-flat")
+          .addEventListener("click", (event) => {
+            const { currentUser } = instance.props;
+            hidePopupForever(currentUser, GLOBAL_POPUPS_KEY);
+            event.preventDefault();
+          });
+      },
+    };
+  },
+};
+
+function getUserOptionKey(popupId) {
+  return `skip_${popupId.replaceAll("-", "_")}_tips`;
+}
+
+export function showPopup(options) {
+  hidePopup(options.id);
+
+  if (
+    !options.reference ||
+    !options.currentUser ||
+    options.currentUser.get(getUserOptionKey(options.id))
+  ) {
+    return;
+  }
+
+  if (Object.keys(instances).length > 0) {
+    return addToQueue(options);
+  }
+
+  instances[options.id] = tippy(options.reference, {
+    id: options.id,
+    plugins: [PopupPlugin],
+
+    // Current user is used to keep track of popups.
+    currentUser: options.currentUser,
+
+    // Tippy must be displayed as soon as possible and not be hidden unless
+    // the user clicks on one of the two buttons.
+    showOnCreate: true,
+    hideOnClick: false,
+    trigger: "manual",
+
+    // It must be interactive to make buttons work.
+    interactive: true,
+
+    arrow: iconHTML("tippy-rounded-arrow"),
+    placement: options.placement,
+
+    // It often happens for the reference element to be rerendered. In this
+    // case, tippy must be rerendered too. Having an animation means that the
+    // animation will replay over and over again.
+    animation: false,
+
+    // The `content` property below is HTML.
+    allowHTML: true,
+
+    content: `
+      <div class='onboarding-popup-container'>
+        <div class='onboarding-popup-title'>${options.titleText}</div>
+        <div class='onboarding-popup-content'>${options.contentText}</div>
+        <div class='onboarding-popup-buttons'>
+          <button class="btn btn-primary">${
+            options.primaryBtnText || I18n.t("popup.primary")
+          }</button>
+          <button class="btn btn-flat btn-text">${
+            options.secondaryBtnText || I18n.t("popup.secondary")
+          }</button>
+        </div>
+      </div>`,
+  });
+}
+
+export function hidePopup(popupId) {
+  const instance = instances[popupId];
+  if (instance && !instance.state.isDestroyed) {
+    instance.destroy();
+  }
+  delete instances[popupId];
+}
+
+export function hidePopupForever(user, popupId) {
+  if (!user) {
+    return;
+  }
+
+  const popupIds =
+    popupId === GLOBAL_POPUPS_KEY
+      ? [GLOBAL_POPUPS_KEY, ...POPUP_KEYS]
+      : [popupId];
+
+  // Destroy tippy instances
+  popupIds.forEach(hidePopup);
+
+  // Update user options
+  if (!user.user_option) {
+    user.set("user_option", {});
+  }
+
+  const userOptionKeys = popupIds.map(getUserOptionKey);
+  let updates = false;
+  userOptionKeys.forEach((key) => {
+    if (!user.get(key)) {
+      user.set(key, true);
+      user.set(`user_option.${key}`, true);
+      updates = true;
+    }
+  });
+
+  // Show next popup in queue
+  showNextPopup();
+
+  return updates ? user.save(userOptionKeys) : Promise.resolve();
+}
+
+function addToQueue(options) {
+  for (let i = 0; i < queue.size; ++i) {
+    if (queue[i].id === options.id) {
+      queue[i] = options;
+      return;
+    }
+  }
+
+  queue.push(options);
+}
+
+function showNextPopup() {
+  const options = queue.shift();
+  if (options) {
+    showPopup(options);
+  }
+}

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -104,6 +104,7 @@ let userOptionFields = [
   "title_count_mode",
   "timezone",
   "skip_new_user_tips",
+  "skip_first_notification_tips",
   "default_calendar",
   "bookmark_auto_delete_preference",
 ];
@@ -441,7 +442,7 @@ const User = RestModel.extend({
           "external_links_in_new_tab",
           "dynamic_favicon"
         );
-        User.current().setProperties(userProps);
+        User.current()?.setProperties(userProps);
         this.setProperties(updatedState);
         return result;
       })

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -105,6 +105,7 @@ let userOptionFields = [
   "timezone",
   "skip_new_user_tips",
   "skip_first_notification_tips",
+  "skip_topic_timeline_tips",
   "default_calendar",
   "bookmark_auto_delete_preference",
 ];

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -35,6 +35,7 @@ import Evented from "@ember/object/evented";
 import { cancel } from "@ember/runloop";
 import discourseLater from "discourse-common/lib/later";
 import { isTesting } from "discourse-common/config/environment";
+import { hidePopup, showNextPopup, showPopup } from "discourse/lib/popup";
 
 export const SECOND_FACTOR_METHODS = {
   TOTP: 1,
@@ -104,8 +105,7 @@ let userOptionFields = [
   "title_count_mode",
   "timezone",
   "skip_new_user_tips",
-  "skip_first_notification_tips",
-  "skip_topic_timeline_tips",
+  "seen_popups",
   "default_calendar",
   "bookmark_auto_delete_preference",
 ];
@@ -1092,6 +1092,65 @@ const User = RestModel.extend({
           .map((groupId) => parseInt(groupId, 10))
       )
     );
+  },
+
+  showPopup(options) {
+    const popupTypes = Site.currentProp("onboarding_popup_types");
+    if (!popupTypes[options.id]) {
+      // eslint-disable-next-line no-console
+      console.warn("Cannot display popup with type =", options.id);
+      return;
+    }
+
+    const seenPopups = this.seen_popups || [];
+    if (seenPopups.includes(popupTypes[options.id])) {
+      return;
+    }
+
+    showPopup({
+      ...options,
+      onDismiss: () => this.hidePopupForever(options.id),
+      onDismissAll: () => this.hidePopupForever(),
+    });
+  },
+
+  hidePopupForever(popupId) {
+    // Empty popupId means all popups.
+    const popupTypes = Site.currentProp("onboarding_popup_types");
+    if (popupId && !popupTypes[popupId]) {
+      // eslint-disable-next-line no-console
+      console.warn("Cannot hide popup with type =", popupId);
+      return;
+    }
+
+    // Hide any shown popups.
+    let seenPopups = this.seen_popups || [];
+    if (popupId) {
+      hidePopup(popupId);
+      if (!seenPopups.includes(popupTypes[popupId])) {
+        seenPopups.push(popupTypes[popupId]);
+      }
+    } else {
+      Object.keys(popupTypes).forEach(hidePopup);
+      seenPopups = Object.values(popupTypes);
+    }
+
+    // Show next popup in queue.
+    showNextPopup();
+
+    // Save seen popups on the server.
+    if (!this.user_option) {
+      this.set("user_option", {});
+    }
+    this.set("seen_popups", seenPopups);
+    this.set("user_option.seen_popups", seenPopups);
+    if (popupId) {
+      return this.save(["seen_popups"]);
+    } else {
+      this.set("skip_new_user_tips", true);
+      this.set("user_option.skip_new_user_tips", true);
+      return this.save(["seen_popups", "skip_new_user_tips"]);
+    }
   },
 });
 

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -13,7 +13,7 @@ import { wantsNewWindow } from "discourse/lib/intercept-click";
 import { logSearchLinkClick } from "discourse/lib/search";
 import RenderGlimmer from "discourse/widgets/render-glimmer";
 import { hbs } from "ember-cli-htmlbars";
-import { hidePopup, showPopup } from "discourse/lib/popup";
+import { hidePopup } from "discourse/lib/popup";
 
 let _extraHeaderIcons = [];
 
@@ -161,10 +161,6 @@ createWidget("header-notifications", {
   },
 
   _addAvatarHighlight(contents) {
-    if (this.siteSettings.enable_onboarding_popups) {
-      return;
-    }
-
     contents.push(h("span.ring"));
     contents.push(h("span.ring-backdrop-spotlight"));
     contents.push(
@@ -201,15 +197,15 @@ createWidget("header-notifications", {
 
   didRenderWidget() {
     if (
+      !this.currentUser ||
       !this.siteSettings.enable_onboarding_popups ||
       !this._shouldHighlightAvatar()
     ) {
       return;
     }
 
-    showPopup({
-      id: "first-notification",
-      currentUser: this.currentUser,
+    this.currentUser.showPopup({
+      id: "first_notification",
 
       titleText: I18n.t("popup.first_notification.title"),
       contentText: I18n.t("popup.first_notification.content"),
@@ -223,19 +219,11 @@ createWidget("header-notifications", {
   },
 
   destroy() {
-    if (!this.siteSettings.enable_onboarding_popups) {
-      return;
-    }
-
-    hidePopup("first-notification");
+    hidePopup("first_notification");
   },
 
   willRerenderWidget() {
-    if (!this.siteSettings.enable_onboarding_popups) {
-      return;
-    }
-
-    hidePopup("first-notification");
+    hidePopup("first_notification");
   },
 });
 

--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -607,7 +607,6 @@ export default createWidget("topic-timeline", {
 
     this.currentUser.showPopup({
       id: "topic_timeline",
-      currentUser: this.currentUser,
 
       titleText: I18n.t("popup.topic_timeline.title"),
       contentText: I18n.t("popup.topic_timeline.content"),

--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -9,6 +9,7 @@ import discourseLater from "discourse-common/lib/later";
 import { relativeAge } from "discourse/lib/formatter";
 import renderTags from "discourse/lib/render-tags";
 import renderTopicFeaturedLink from "discourse/lib/render-topic-featured-link";
+import { hidePopup, showPopup } from "discourse/lib/popup";
 
 const SCROLLER_HEIGHT = 50;
 const LAST_READ_HEIGHT = 20;
@@ -597,5 +598,27 @@ export default createWidget("topic-timeline", {
     }
 
     return result;
+  },
+
+  didRenderWidget() {
+    showPopup({
+      id: "topic-timeline",
+      currentUser: this.currentUser,
+
+      titleText: I18n.t("popup.topic_timeline.title"),
+      contentText: I18n.t("popup.topic_timeline.content"),
+
+      reference: document.querySelector("div.timeline-scrollarea-wrapper"),
+
+      placement: "left",
+    });
+  },
+
+  destroy() {
+    hidePopup("topic-timeline");
+  },
+
+  willRerenderWidget() {
+    hidePopup("topic-timeline");
   },
 });

--- a/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-timeline.js
@@ -9,7 +9,7 @@ import discourseLater from "discourse-common/lib/later";
 import { relativeAge } from "discourse/lib/formatter";
 import renderTags from "discourse/lib/render-tags";
 import renderTopicFeaturedLink from "discourse/lib/render-topic-featured-link";
-import { hidePopup, showPopup } from "discourse/lib/popup";
+import { hidePopup } from "discourse/lib/popup";
 
 const SCROLLER_HEIGHT = 50;
 const LAST_READ_HEIGHT = 20;
@@ -601,8 +601,12 @@ export default createWidget("topic-timeline", {
   },
 
   didRenderWidget() {
-    showPopup({
-      id: "topic-timeline",
+    if (!this.currentUser || !this.siteSettings.enable_onboarding_popups) {
+      return;
+    }
+
+    this.currentUser.showPopup({
+      id: "topic_timeline",
       currentUser: this.currentUser,
 
       titleText: I18n.t("popup.topic_timeline.title"),
@@ -615,10 +619,10 @@ export default createWidget("topic-timeline", {
   },
 
   destroy() {
-    hidePopup("topic-timeline");
+    hidePopup("topic_timeline");
   },
 
   willRerenderWidget() {
-    hidePopup("topic-timeline");
+    hidePopup("topic_timeline");
   },
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-actions-test.js
@@ -29,6 +29,7 @@ acceptance("Composer Actions", function (needs) {
   });
   needs.site({ can_tag_topics: true });
   needs.pretender((server, helper) => {
+    server.put("/u/kris.json", () => helper.response({ user: {} }));
     const cardResponse = cloneJSON(userFixtures["/u/shade/card.json"]);
     server.get("/u/shade/card.json", () => helper.response(cardResponse));
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -61,6 +61,7 @@ acceptance("Composer", function (needs) {
     ],
   });
   needs.pretender((server, helper) => {
+    server.put("/u/kris.json", () => helper.response({ user: {} }));
     server.post("/uploads/lookup-urls", () => {
       return helper.response([]);
     });

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -570,6 +570,25 @@ table {
   animation-name: ping;
 }
 
+.onboarding-popup-container {
+  min-width: 300px;
+  padding: 0.5em;
+  text-align: left;
+
+  .onboarding-popup-title {
+    font-size: $font-up-2;
+    font-weight: bold;
+  }
+
+  .onboarding-popup-content {
+    margin-top: 0.25em;
+  }
+
+  .onboarding-popup-buttons {
+    margin-top: 1em;
+  }
+}
+
 .fade {
   opacity: 0;
   transition: opacity 0.15s linear;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1966,7 +1966,7 @@ class UsersController < ApplicationController
     end
 
     result = params
-      .permit(permitted, theme_ids: [])
+      .permit(permitted, theme_ids: [], seen_popups: [])
       .reverse_merge(
         ip_address: request.remote_ip,
         registration_ip_address: request.remote_ip

--- a/app/models/onboarding_popup.rb
+++ b/app/models/onboarding_popup.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OnboardingPopup
+  def self.types
+    @types ||= Enum.new(
+      first_notification: 1,
+      topic_timeline: 2,
+    )
+  end
+end

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -268,8 +268,7 @@ end
 #  oldest_search_log_date           :datetime
 #  bookmark_auto_delete_preference  :integer          default(3), not null
 #  enable_experimental_sidebar      :boolean          default(FALSE)
-#  skip_first_notification_tips     :boolean          default(FALSE)
-#  skip_topic_timeline_tips         :boolean          default(FALSE)
+#  seen_popups                      :integer          is an Array
 #
 # Indexes
 #

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -268,6 +268,7 @@ end
 #  oldest_search_log_date           :datetime
 #  bookmark_auto_delete_preference  :integer          default(3), not null
 #  enable_experimental_sidebar      :boolean          default(FALSE)
+#  skip_first_notification_tips     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -269,6 +269,7 @@ end
 #  bookmark_auto_delete_preference  :integer          default(3), not null
 #  enable_experimental_sidebar      :boolean          default(FALSE)
 #  skip_first_notification_tips     :boolean          default(FALSE)
+#  skip_topic_timeline_tips         :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -68,6 +68,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :timezone,
              :featured_topic,
              :skip_new_user_tips,
+             :skip_first_notification_tips,
              :do_not_disturb_until,
              :has_topic_draft,
              :can_review,
@@ -280,6 +281,12 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def skip_new_user_tips
     object.user_option.skip_new_user_tips
+  end
+
+  def skip_first_notification_tips
+    !SiteSetting.enable_onboarding_popups ||
+      object.user_option.skip_new_user_tips ||
+      object.user_option.skip_first_notification_tips
   end
 
   def include_primary_group_id?

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -68,8 +68,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :timezone,
              :featured_topic,
              :skip_new_user_tips,
-             :skip_first_notification_tips,
-             :skip_topic_timeline_tips,
+             :seen_popups,
              :do_not_disturb_until,
              :has_topic_draft,
              :can_review,
@@ -284,16 +283,12 @@ class CurrentUserSerializer < BasicUserSerializer
     object.user_option.skip_new_user_tips
   end
 
-  def skip_first_notification_tips
-    !SiteSetting.enable_onboarding_popups ||
-      object.user_option.skip_new_user_tips ||
-      object.user_option.skip_first_notification_tips
+  def seen_popups
+    object.user_option.seen_popups
   end
 
-  def skip_topic_timeline_tips
-    !SiteSetting.enable_onboarding_popups ||
-      object.user_option.skip_new_user_tips ||
-      object.user_option.skip_topic_timeline_tips
+  def include_seen_popups?
+    SiteSetting.enable_onboarding_popups
   end
 
   def include_primary_group_id?

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -69,6 +69,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :featured_topic,
              :skip_new_user_tips,
              :skip_first_notification_tips,
+             :skip_topic_timeline_tips,
              :do_not_disturb_until,
              :has_topic_draft,
              :can_review,
@@ -287,6 +288,12 @@ class CurrentUserSerializer < BasicUserSerializer
     !SiteSetting.enable_onboarding_popups ||
       object.user_option.skip_new_user_tips ||
       object.user_option.skip_first_notification_tips
+  end
+
+  def skip_topic_timeline_tips
+    !SiteSetting.enable_onboarding_popups ||
+      object.user_option.skip_new_user_tips ||
+      object.user_option.skip_topic_timeline_tips
   end
 
   def include_primary_group_id?

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -6,6 +6,7 @@ class SiteSerializer < ApplicationSerializer
     :default_archetype,
     :notification_types,
     :post_types,
+    :onboarding_popup_types,
     :trust_levels,
     :groups,
     :filters,
@@ -101,6 +102,14 @@ class SiteSerializer < ApplicationSerializer
 
   def post_types
     Post.types
+  end
+
+  def onboarding_popup_types
+    OnboardingPopup.types
+  end
+
+  def include_onboarding_popup_types?
+    SiteSetting.enable_onboarding_popups
   end
 
   def filters

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -17,6 +17,10 @@ class UserUpdater
     muted_tags: :muted
   }
 
+  POPUP_OPTION_ATTR = [
+    :skip_first_notification_tips,
+  ]
+
   OPTION_ATTR = [
     :mailing_list_mode,
     :mailing_list_mode_frequency,
@@ -48,7 +52,7 @@ class UserUpdater
     :timezone,
     :skip_new_user_tips,
     :default_calendar
-  ]
+  ] + POPUP_OPTION_ATTR
 
   NOTIFICATION_SCHEDULE_ATTRS = -> {
     attrs = [:enabled]

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -19,6 +19,7 @@ class UserUpdater
 
   POPUP_OPTION_ATTR = [
     :skip_first_notification_tips,
+    :skip_topic_timeline_tips,
   ]
 
   OPTION_ATTR = [

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -178,6 +178,12 @@ class UserUpdater
       end
     end
 
+    if attributes.key?(:skip_new_user_tips)
+      POPUP_OPTION_ATTR.each do |attribute|
+        user.user_option.public_send("#{attribute}=", user.user_option.skip_new_user_tips)
+      end
+    end
+
     # automatically disable digests when mailing_list_mode is enabled
     user.user_option.email_digests = false if user.user_option.mailing_list_mode
 

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -17,11 +17,6 @@ class UserUpdater
     muted_tags: :muted
   }
 
-  POPUP_OPTION_ATTR = [
-    :skip_first_notification_tips,
-    :skip_topic_timeline_tips,
-  ]
-
   OPTION_ATTR = [
     :mailing_list_mode,
     :mailing_list_mode_frequency,
@@ -52,8 +47,9 @@ class UserUpdater
     :title_count_mode,
     :timezone,
     :skip_new_user_tips,
+    :seen_popups,
     :default_calendar
-  ] + POPUP_OPTION_ATTR
+  ]
 
   NOTIFICATION_SCHEDULE_ATTRS = -> {
     attrs = [:enabled]
@@ -184,8 +180,10 @@ class UserUpdater
     end
 
     if attributes.key?(:skip_new_user_tips)
-      POPUP_OPTION_ATTR.each do |attribute|
-        user.user_option.public_send("#{attribute}=", user.user_option.skip_new_user_tips)
+      user.user_option.seen_popups = if user.user_option.skip_new_user_tips
+        OnboardingPopup.types.values
+      else
+        nil
       end
     end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1820,6 +1820,10 @@ en:
         title: "Your first notification!"
         content: "Notifications are used to keep you up-to-date with what is happening in community."
 
+      topic_timeline:
+        title: "Topic timeline"
+        content: "Scroll quickly through a post using the topic timeline."
+
     loading: "Loading..."
     errors:
       prev_page: "while trying to load"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1816,6 +1816,10 @@ en:
       primary: "Got it!"
       secondary: "don't show me these tips"
 
+      first_notification:
+        title: "Your first notification!"
+        content: "Notifications are used to keep you up-to-date with what is happening in community."
+
     loading: "Loading..."
     errors:
       prev_page: "while trying to load"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1812,6 +1812,10 @@ en:
       what_are_you_doing: "What are you doing?"
       remove_status: "Remove status"
 
+    popup:
+      primary: "Got it!"
+      secondary: "don't show me these tips"
+
     loading: "Loading..."
     errors:
       prev_page: "while trying to load"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1818,7 +1818,7 @@ en:
 
       first_notification:
         title: "Your first notification!"
-        content: "Notifications are used to keep you up-to-date with what is happening in community."
+        content: "Notifications are used to keep you up to date with what is happening in the community."
 
       topic_timeline:
         title: "Topic timeline"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2349,7 +2349,7 @@ en:
     sitemap_page_size: "Number of URLs to include in each sitemap page. Max 50.000"
 
     enable_user_status: "(experimental) Allow users to set custom status message (emoji + description)."
-    enable_onboarding_popups: "(experimental) Enable detailed just-in-time popups that describe popular features"
+    enable_onboarding_popups: "(experimental) Enable educational popups that describe key features to users"
 
     short_title: "The short title will be used on the user's home screen, launcher, or other places where space may be limited. It should be limited to 12 characters."
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2349,6 +2349,7 @@ en:
     sitemap_page_size: "Number of URLs to include in each sitemap page. Max 50.000"
 
     enable_user_status: "(experimental) Allow users to set custom status message (emoji + description)."
+    enable_onboarding_popups: "(experimental) Enable detailed just-in-time popups that describe popular features"
 
     short_title: "The short title will be used on the user's home screen, launcher, or other places where space may be limited. It should be limited to 12 characters."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -379,6 +379,9 @@ basic:
   enable_user_status:
     client: true
     default: false
+  enable_onboarding_popups:
+    client: true
+    default: false
 
 login:
   invite_only:

--- a/db/migrate/20220923212549_add_popup_to_user_option.rb
+++ b/db/migrate/20220923212549_add_popup_to_user_option.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPopupToUserOption < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_options, :skip_first_notification_tips, :boolean, default: false
+  end
+end

--- a/db/migrate/20220923212549_add_popup_to_user_option.rb
+++ b/db/migrate/20220923212549_add_popup_to_user_option.rb
@@ -3,5 +3,6 @@
 class AddPopupToUserOption < ActiveRecord::Migration[7.0]
   def change
     add_column :user_options, :skip_first_notification_tips, :boolean, default: false
+    add_column :user_options, :skip_topic_timeline_tips, :boolean, default: false
   end
 end

--- a/db/migrate/20220923212549_add_popup_to_user_option.rb
+++ b/db/migrate/20220923212549_add_popup_to_user_option.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class AddPopupToUserOption < ActiveRecord::Migration[7.0]
-  def change
-    add_column :user_options, :skip_first_notification_tips, :boolean, default: false
-    add_column :user_options, :skip_topic_timeline_tips, :boolean, default: false
-  end
-end

--- a/db/migrate/20220923212549_add_seen_popups_to_user_options.rb
+++ b/db/migrate/20220923212549_add_seen_popups_to_user_options.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSeenPopupsToUserOptions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_options, :seen_popups, :integer, array: true
+  end
+end

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe SiteSerializer do
     Site.clear_cache
   end
 
+  describe '#onboarding_popup_types' do
+    it 'is included if enable_onboarding_popups' do
+      SiteSetting.enable_onboarding_popups = true
+
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+      expect(serialized[:onboarding_popup_types]).to eq(OnboardingPopup.types)
+    end
+
+    it 'is not included if enable_onboarding_popups is disabled' do
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+      expect(serialized[:onboarding_popup_types]).to eq(nil)
+    end
+  end
+
   it "includes category custom fields only if its preloaded" do
     category.custom_fields["enable_marketplace"] = true
     category.save_custom_fields

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -530,14 +530,12 @@ RSpec.describe UserUpdater do
         UserUpdater.new(Discourse.system_user, user).update(skip_new_user_tips: true)
 
         expect(user.user_option.skip_new_user_tips).to eq(true)
-        expect(user.user_option.skip_first_notification_tips).to eq(true)
-        expect(user.user_option.skip_topic_timeline_tips).to eq(true)
+        expect(user.user_option.seen_popups).to eq(OnboardingPopup.types.values)
 
         UserUpdater.new(Discourse.system_user, user).update(skip_new_user_tips: false)
 
         expect(user.user_option.skip_new_user_tips).to eq(false)
-        expect(user.user_option.skip_first_notification_tips).to eq(false)
-        expect(user.user_option.skip_topic_timeline_tips).to eq(false)
+        expect(user.user_option.seen_popups).to eq(nil)
       end
     end
 

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -531,11 +531,13 @@ RSpec.describe UserUpdater do
 
         expect(user.user_option.skip_new_user_tips).to eq(true)
         expect(user.user_option.skip_first_notification_tips).to eq(true)
+        expect(user.user_option.skip_topic_timeline_tips).to eq(true)
 
         UserUpdater.new(Discourse.system_user, user).update(skip_new_user_tips: false)
 
         expect(user.user_option.skip_new_user_tips).to eq(false)
         expect(user.user_option.skip_first_notification_tips).to eq(false)
+        expect(user.user_option.skip_topic_timeline_tips).to eq(false)
       end
     end
 

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -525,6 +525,20 @@ RSpec.describe UserUpdater do
       end
     end
 
+    context 'when skip_new_user_tips is edited' do
+      it 'updates all fields' do
+        UserUpdater.new(Discourse.system_user, user).update(skip_new_user_tips: true)
+
+        expect(user.user_option.skip_new_user_tips).to eq(true)
+        expect(user.user_option.skip_first_notification_tips).to eq(true)
+
+        UserUpdater.new(Discourse.system_user, user).update(skip_new_user_tips: false)
+
+        expect(user.user_option.skip_new_user_tips).to eq(false)
+        expect(user.user_option.skip_first_notification_tips).to eq(false)
+      end
+    end
+
     it "logs the action" do
       user = Fabricate(:user, name: 'Billy Bob')
 


### PR DESCRIPTION
This commit introduces a new framework for building user tutorials as
tips using the Tippy JS library. Currently, the new framework is used
to replace the old notification spotlight and tips and show a new one
related to the topic timeline.

Each new tip has a key that is used to store its state (active or
dismissed) in the database, in the user_options table. The existent
skip_new_user_tips key continues to exist as a key to store the global
state of all tips.

All tips follow the same structure and have a title, a description, an
optional image and two buttons for either dismissing just the current
tip or all of them at once. The first button simply updates the skip
key associated to the tip to "false" and the other button updates the
skip_new_user_tips user option to "true" and then all user tips are
marked as skipped.

<img width="345" alt="Screenshot 2022-09-26 at 13 53 18" src="https://user-images.githubusercontent.com/23153890/192259432-7df4b420-732b-4f43-b9ca-8d2c8f6a8b69.png">

<img width="598" alt="Screenshot 2022-09-26 at 13 54 52" src="https://user-images.githubusercontent.com/23153890/192259436-69ff8980-6a75-4f89-98e4-7cb2e21053d9.png">



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
