### PR TITLE
FIX: Update user results page when no users found

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-users-list-show.js
@@ -59,10 +59,10 @@ export default Controller.extend(CanCheckEmails, {
       page,
     })
       .then((result) => {
-        if (result && result.length > 0) {
-          this._results[page] = result;
-          this.set("model", this._results.flat());
-        } else {
+        this._results[page] = result;
+        this.set("model", this._results.flat());
+
+        if (result.length === 0) {
           this._canLoadMore = false;
         }
       })

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-users-list-test.js
@@ -3,7 +3,7 @@ import {
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import { click, visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import I18n from "I18n";
 import { test } from "qunit";
 
@@ -15,6 +15,17 @@ acceptance("Admin - Users List", function (needs) {
 
     assert.ok(exists(".users-list .user"));
     assert.ok(!exists(".user:nth-of-type(1) .email small"), "escapes email");
+  });
+
+  test("searching users with no matches", async function (assert) {
+    await visit("/admin/users/list/active");
+
+    await fillIn(".controls.username input", "doesntexist");
+
+    assert.equal(
+      query(".users-list-container").innerText,
+      I18n.t("search.no_results")
+    );
   });
 
   test("sorts users", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -670,6 +670,12 @@ export function applyDefaultHandlers(pretender) {
       },
     ];
 
+    if (request.queryParams.filter) {
+      store = store.filter((user) =>
+        user.username.includes(request.queryParams.filter)
+      );
+    }
+
     const showEmails = request.queryParams.show_emails;
 
     if (showEmails === "false") {


### PR DESCRIPTION
The page was not updated if the server did not return any results. This caused the page to be either empty or display the previous result set.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
