### PR TITLE
UX: Restrict width of "reply where" modal

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -279,6 +279,10 @@
 }
 
 .reply-where-modal {
+  .dialog-footer {
+    display: block;
+  }
+
   .btn {
     display: block;
     text-align: left;


### PR DESCRIPTION
Flex styling was causing the buttons to be too wide in some browsers.
