### PR TITLE
A11Y: Add aria label to composer messages `Esc` button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -128,7 +128,7 @@ export default Component.extend({
           this._yourselfConfirm ||
           composer.store.createRecord("composer-message", {
             id: "yourself_confirm",
-            templateName: "custom-body",
+            templateName: "education",
             title: I18n.t("composer.yourself_confirm.title"),
             body: I18n.t("composer.yourself_confirm.body"),
           });

--- a/app/assets/javascripts/discourse/app/templates/composer/custom-body.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/custom-body.hbs
@@ -1,3 +1,0 @@
-<a href {{action this.closeMessage this.message}} class="close">{{d-icon "times"}}</a>
-{{#if this.message.title}}<h3>{{this.message.title}}</h3>{{/if}}
-<p>{{html-safe this.message.body}}</p>

--- a/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/dominating-topic.hbs
@@ -1,4 +1,6 @@
-<a href {{action this.closeMessage this.message}} class="close">{{d-icon "times"}}</a>
+<a href {{action this.closeMessage this.message}} class="close" aria-label={{i18n "composer.esc_label"}}>
+  {{i18n "composer.esc"}} {{d-icon "times"}}
+</a>
 
 {{html-safe this.message.body}}
 

--- a/app/assets/javascripts/discourse/app/templates/composer/education.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/education.hbs
@@ -1,2 +1,9 @@
-<a href {{action this.closeMessage this.message}} class="close">{{d-icon "times"}}</a>
+<a href {{action this.closeMessage this.message}} class="close" aria-label={{i18n "composer.esc_label"}}>
+  {{i18n "composer.esc"}} {{d-icon "times"}}
+</a>
+
+{{#if this.message.title}}
+  <h3>{{this.message.title}}</h3>
+{{/if}}
+
 {{html-safe this.message.body}}

--- a/app/assets/javascripts/discourse/app/templates/composer/get-a-room.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/get-a-room.hbs
@@ -1,4 +1,6 @@
-<a href {{action this.closeMessage this.message}} class="close">{{d-icon "times"}}</a>
+<a href {{action this.closeMessage this.message}} class="close" aria-label={{i18n "composer.esc_label"}}>
+  {{i18n "composer.esc"}} {{d-icon "times"}}
+</a>
 
 {{html-safe this.message.body}}
 

--- a/app/assets/javascripts/discourse/app/templates/composer/group-mentioned.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/group-mentioned.hbs
@@ -1,2 +1,5 @@
-<a href {{action this.closeMessage this.message}} class="close">{{d-icon "times"}}</a>
+<a href {{action this.closeMessage this.message}} class="close" aria-label={{i18n "composer.esc_label"}}>
+  {{i18n "composer.esc"}} {{d-icon "times"}}
+</a>
+
 {{html-safe this.message.body}}

--- a/app/assets/javascripts/discourse/app/templates/composer/similar-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer/similar-topics.hbs
@@ -1,4 +1,7 @@
-<a href {{action this.closeMessage this.message}} class="close">{{d-icon "times"}}</a>
+<a href {{action this.closeMessage this.message}} class="close" aria-label={{i18n "composer.esc_label"}}>
+  {{i18n "composer.esc"}} {{d-icon "times"}}
+</a>
+
 <h3>{{i18n "composer.similar_topics"}}</h3>
 
 <ul class="topics">

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -126,16 +126,14 @@
     top: 10px;
     color: var(--primary);
     opacity: 0.5;
-    font-size: $font-up-1;
-    &:before {
-      content: "esc";
-      font-size: $font-down-1;
-      margin-right: 0.5em;
+    font-size: var(--font-0);
+    .d-icon {
+      font-size: var(--font-up-1);
+      margin-left: 0.25em;
     }
-  }
-
-  a.close:hover {
-    opacity: 1;
+    &:hover {
+      opacity: 1;
+    }
   }
 
   ul {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2166,6 +2166,8 @@ en:
       similar_topics: "Your topic is similar to..."
       drafts_offline: "drafts offline"
       edit_conflict: "edit conflict"
+      esc: "esc"
+      esc_label: "Click or press Esc to dismiss"
 
       group_mentioned_limit:
         one: "<b>Warning!</b> You mentioned <a href='%{group_link}'>%{group}</a>, however this group has more members than the administrator configured mention limit of %{count} user. Nobody will be notified."


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
