### PR TITLE
FIX: list_suggested_for conditional for personal_message_enabled_groups

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -205,7 +205,10 @@ class TopicQuery
     # Don't suggest messages unless we have a user, and private messages are
     # enabled.
     if topic.private_message? && (
-        @user.blank? || !@user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map || !SiteSetting.enable_personal_messages))
+        @user.blank? ||
+          !@user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map) ||
+          !SiteSetting.enable_personal_messages
+    )
       return
     end
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1157,7 +1157,7 @@ RSpec.describe TopicQuery do
 
     context 'when logged in' do
       def suggested_for(topic)
-        topic_query.list_suggested_for(topic).topics.map { |t| t.id }
+        topic_query.list_suggested_for(topic)&.topics&.map { |t| t.id }
       end
 
       let(:topic) { Fabricate(:topic) }
@@ -1259,6 +1259,16 @@ RSpec.describe TopicQuery do
 
           it 'should return the group topics' do
             expect(suggested_topics).to match_array([private_group_topic.id, private_message.id])
+          end
+
+          context "when enable_personal_messages is false" do
+            before do
+              SiteSetting.enable_personal_messages = false
+            end
+
+            it 'should not return topics by the group user' do
+              expect(suggested_topics).to eq(nil)
+            end
           end
         end
 

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -132,6 +132,11 @@ RSpec.describe TopicViewSerializer do
     end
 
     describe 'with private messages' do
+      before do
+        SiteSetting.enable_personal_messages = true
+        Group.refresh_automatic_groups!
+      end
+
       fab!(:topic) do
         Fabricate(:private_message_topic,
           highest_post_number: 1,


### PR DESCRIPTION
Follow-up to e62e93f83a77adfa80b38fbfecf82bbee14e12fe,
misplaced a bracket and changed the meaning of the conditional.