### PR TITLE
FEATURE: add site setting to include user associated account ids.

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -58,6 +58,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :can_create_group,
              :link_posting_access,
              :external_id,
+             :associated_account_ids,
              :top_category_ids,
              :hide_profile_and_presence,
              :groups,
@@ -291,6 +292,20 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def include_external_id?
     SiteSetting.enable_discourse_connect
+  end
+
+  def associated_account_ids
+    values = {}
+
+    object.user_associated_accounts.map do |user_associated_account|
+      values[user_associated_account.provider_name] = user_associated_account.provider_uid
+    end
+
+    values
+  end
+
+  def include_associated_account_ids?
+    SiteSetting.include_associated_account_ids
   end
 
   def second_factor_enabled

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2018,6 +2018,9 @@ developer:
     default: ""
     allow_any: false
     refresh: true
+  include_associated_account_ids:
+    default: false
+    hidden: true
 
 embedding:
   embed_by_username:

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -372,4 +372,19 @@ RSpec.describe CurrentUserSerializer do
       expect(serializer.as_json[:redesigned_user_page_nav_enabled]).to eq(true)
     end
   end
+
+  describe '#associated_account_ids' do
+    before do
+      UserAssociatedAccount.create(user_id: user.id, provider_name: "twitter", provider_uid: "1", info: { nickname: "sam" })
+    end
+
+    it 'should not include associated account ids by default' do
+      expect(serializer.as_json[:associated_account_ids]).to be_nil
+    end
+
+    it 'should include associated account ids when site setting enabled' do
+      SiteSetting.include_associated_account_ids = true
+      expect(serializer.as_json[:associated_account_ids]).to eq({ "twitter" => "1" })
+    end
+  end
 end


### PR DESCRIPTION
By default, we won't include associated account ids in current user serializer. If the new hidden site setting `include_associated_account_ids` is enabled then we will add it in the serializer.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
