### PR TITLE
DEV: Bump rubocop config and switch back to rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,7 +170,7 @@ group :test, :development do
   gem 'shoulda-matchers', require: false
   gem 'rspec-html-matchers'
   gem 'byebug', require: ENV['RM_INFO'].nil?, platform: :mri
-  gem 'rubocop-discourse', require: false, github: 'discourse/rubocop-discourse'
+  gem 'rubocop-discourse', require: false
   gem 'parallel_tests'
 
   gem 'rswag-specs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,14 +5,6 @@ GIT
     mail (2.8.0.edge)
       mini_mime (>= 0.1.1)
 
-GIT
-  remote: https://github.com/discourse/rubocop-discourse.git
-  revision: a5aea6e5f150b1eb7765a805bec0ff618cb718b3
-  specs:
-    rubocop-discourse (2.5.0)
-      rubocop (>= 1.1.0)
-      rubocop-rspec (>= 2.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -383,7 +375,7 @@ GEM
     redis (4.7.1)
     redis-namespace (1.9.0)
       redis (>= 4)
-    regexp_parser (2.5.0)
+    regexp_parser (2.6.0)
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.5)
@@ -435,6 +427,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
+    rubocop-discourse (3.0)
+      rubocop (>= 1.1.0)
+      rubocop-rspec (>= 2.0.0)
     rubocop-rspec (2.13.2)
       rubocop (~> 1.33)
     ruby-prof (1.4.3)
@@ -626,7 +621,7 @@ DEPENDENCIES
   rspec-rails
   rss
   rswag-specs
-  rubocop-discourse!
+  rubocop-discourse
   ruby-prof
   ruby-readability
   rubyzip


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
