### PR TITLE
DEV: Fix `InstallTrigger` deprecation warnings on Firefox

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
@@ -22,7 +22,7 @@ export default {
     caps.isAndroid = ua.includes("Android");
     caps.isWinphone = ua.includes("Windows Phone");
     caps.isOpera = !!window.opera || ua.includes(" OPR/");
-    caps.isFirefox = typeof InstallTrigger !== "undefined";
+    caps.isFirefox = "InstallTrigger" in window || ua.includes("Firefox");
     caps.isChrome = !!window.chrome && !caps.isOpera;
     caps.isSafari =
       /Constructor/.test(window.HTMLElement) ||

--- a/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/sniff-capabilities.js
@@ -22,7 +22,7 @@ export default {
     caps.isAndroid = ua.includes("Android");
     caps.isWinphone = ua.includes("Windows Phone");
     caps.isOpera = !!window.opera || ua.includes(" OPR/");
-    caps.isFirefox = "InstallTrigger" in window || ua.includes("Firefox");
+    caps.isFirefox = ua.includes("Firefox");
     caps.isChrome = !!window.chrome && !caps.isOpera;
     caps.isSafari =
       /Constructor/.test(window.HTMLElement) ||


### PR DESCRIPTION
"InstallTrigger is deprecated and will be removed in the future."

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
