### PR TITLE
FEATURE: Make General the default category

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1077,6 +1077,14 @@ export default Controller.extend({
 
     let composerModel = this.model;
 
+    //const category = this.site.categories.findBy("slug", "general");
+    const general_category_id = this.siteSettings.general_category_id;
+
+    if (general_category_id) {
+      opts.categoryId = general_category_id;
+      //console.log(this.siteSettings.general_category_id)
+    }
+
     if (
       opts.ignoreIfChanged &&
       composerModel &&
@@ -1112,6 +1120,17 @@ export default Controller.extend({
         this.set("prioritizedCategoryId", opts.prioritizedCategoryId);
       }
     }
+
+    // Default Category
+    //if (!opts.categoryId && !opts.prioritizedCategoryId) {
+    //  console.log(this.site.categories);
+    //  const category = this.site.categories.findBy("slug", "general");
+    //  if (category) {
+    //    console.log(category.id);
+    //    //this.set("scopedCategoryId", category.id);
+    //    opts.categoryId = category.id;
+    //  }
+    //}
 
     // If we want a different draft than the current composer, close it and clear our model.
     if (

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1077,14 +1077,6 @@ export default Controller.extend({
 
     let composerModel = this.model;
 
-    //const category = this.site.categories.findBy("slug", "general");
-    const general_category_id = this.siteSettings.general_category_id;
-
-    if (general_category_id) {
-      opts.categoryId = general_category_id;
-      //console.log(this.siteSettings.general_category_id)
-    }
-
     if (
       opts.ignoreIfChanged &&
       composerModel &&
@@ -1120,17 +1112,6 @@ export default Controller.extend({
         this.set("prioritizedCategoryId", opts.prioritizedCategoryId);
       }
     }
-
-    // Default Category
-    //if (!opts.categoryId && !opts.prioritizedCategoryId) {
-    //  console.log(this.site.categories);
-    //  const category = this.site.categories.findBy("slug", "general");
-    //  if (category) {
-    //    console.log(category.id);
-    //    //this.set("scopedCategoryId", category.id);
-    //    opts.categoryId = category.id;
-    //  }
-    //}
 
     // If we want a different draft than the current composer, close it and clear our model.
     if (

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -143,7 +143,9 @@ const Composer = RestModel.extend({
       const oldCategoryId = this._categoryId;
 
       if (isEmpty(categoryId)) {
-        categoryId = null;
+        // Set General as the default category
+        const generalCategoryId = this.siteSettings.general_category_id;
+        categoryId = generalCategoryId ? generalCategoryId : null
       }
       this._categoryId = categoryId;
 

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -145,7 +145,7 @@ const Composer = RestModel.extend({
       if (isEmpty(categoryId)) {
         // Set General as the default category
         const generalCategoryId = this.siteSettings.general_category_id;
-        categoryId = generalCategoryId ? generalCategoryId : null
+        categoryId = generalCategoryId ? generalCategoryId : null;
       }
       this._categoryId = categoryId;
 

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -32,8 +32,27 @@ acceptance("Composer", function (needs) {
   });
   needs.settings({
     enable_whispers: true,
+    general_category_id: 1,
   });
-  needs.site({ can_tag_topics: true });
+  needs.site({
+    can_tag_topics: true,
+    categories: [
+      {
+        id: 1,
+        name: "General",
+        slug: "general",
+        permission: 1,
+        topic_template: null,
+      },
+      {
+        id: 2,
+        name: "test too",
+        slug: "test-too",
+        permission: 1,
+        topic_template: "",
+      },
+    ],
+  });
   needs.pretender((server, helper) => {
     server.post("/uploads/lookup-urls", () => {
       return helper.response([]);
@@ -62,6 +81,8 @@ acceptance("Composer", function (needs) {
   test("Composer is opened", async function (assert) {
     await visit("/");
     await click("#create-topic");
+    // Check that General category is selected
+    assert.strictEqual(selectKit(".category-chooser").header().value(), "1");
 
     assert.strictEqual(
       document.documentElement.style.getPropertyValue("--composer-height"),

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -126,6 +126,23 @@ module(
       assert.strictEqual(this.subject.header().label(), "category…");
     });
 
+    test("with allowUncategorized=null and generalCategoryId present", async function (assert) {
+      this.siteSettings.allow_uncategorized_topics = false;
+      this.siteSettings.general_category_id = 4;
+
+      await render(hbs`
+        <CategoryChooser
+          @value={{this.value}}
+          @options={{hash
+            allowUncategorized=null
+          }}
+        />
+      `);
+
+      assert.strictEqual(this.subject.header().value(), null);
+      assert.strictEqual(this.subject.header().label(), "");
+    });
+
     test("with allowUncategorized=null none=true", async function (assert) {
       this.siteSettings.allow_uncategorized_topics = false;
 

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -44,7 +44,10 @@ export default ComboBoxComponent.extend({
     ) {
       return Category.findUncategorized();
     } else {
-      //return this.defaultItem(null, htmlSafe(I18n.t("category.choose")));
+      const generalCategoryId = this.siteSettings.general_category_id;
+      if (!generalCategoryId) {
+        return this.defaultItem(null, htmlSafe(I18n.t("category.choose")));
+      }
     }
   },
 

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -44,7 +44,7 @@ export default ComboBoxComponent.extend({
     ) {
       return Category.findUncategorized();
     } else {
-      return this.defaultItem(null, htmlSafe(I18n.t("category.choose")));
+      //return this.defaultItem(null, htmlSafe(I18n.t("category.choose")));
     }
   },
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -68,6 +68,11 @@ Discourse::Application.configure do
       s.set_regardless_of_locale(:download_remote_images_to_local, false)
       s.set_regardless_of_locale(:unique_posts_mins, 0)
       s.set_regardless_of_locale(:max_consecutive_replies, 0)
+
+      # Most existing tests were written assuming allow_uncategorized_topics
+      # was enabled, so we should set it to true.
+      s.set_regardless_of_locale(:allow_uncategorized_topics, true)
+
       # disable plugins
       if ENV['LOAD_PLUGINS'] == '1'
         s.set_regardless_of_locale(:discourse_narrative_bot_enabled, false)

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -806,7 +806,7 @@ posting:
   max_emojis_in_title: 1
   allow_uncategorized_topics:
     client: true
-    default: true
+    default: false
     refresh: true
   allow_duplicate_topic_titles: false
   allow_duplicate_topic_titles_category: false
@@ -2291,6 +2291,7 @@ uncategorized:
   general_category_id:
     default: -1
     hidden: true
+    client: true
   meta_category_id:
     default: -1
     hidden: true

--- a/db/migrate/20220927171707_disable_allow_uncategorized_new_sites.rb
+++ b/db/migrate/20220927171707_disable_allow_uncategorized_new_sites.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class DisableAllowUncategorizedNewSites < ActiveRecord::Migration[7.0]
+  def up
+    result = execute <<~SQL
+      SELECT created_at
+      FROM schema_migration_details
+      ORDER BY created_at
+      LIMIT 1
+    SQL
+
+    # keep allow uncategorized for existing sites
+    if result.first['created_at'].to_datetime < 1.hour.ago
+      execute <<~SQL
+        INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+        VALUES('allow_uncategorized_topics', 5, 't', NOW(), NOW())
+        ON CONFLICT (name) DO NOTHING
+      SQL
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TopicConverter do
     fab!(:author) { Fabricate(:user) }
     fab!(:category) { Fabricate(:category, topic_count: 1) }
     fab!(:private_message) { Fabricate(:private_message_topic, user: author) } # creates a topic without a first post
-    let(:first_post) { create_post(user: author, topic: private_message) }
+    let(:first_post) { create_post(user: author, topic: private_message, allow_uncategorized_topics: false) }
     let(:other_user) { private_message.topic_allowed_users.find { |u| u.user != author }.user }
 
     let(:uncategorized_category) do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -47,7 +47,9 @@ module Helpers
   def create_post(args = {})
     # Pretty much all the tests with `create_post` will fail without this
     # since allow_uncategorized_topics is now false by default
-    SiteSetting.allow_uncategorized_topics = true
+    unless args[:allow_uncategorized_topics] == false
+      SiteSetting.allow_uncategorized_topics = true
+    end
 
     args[:title] ||= "This is my title #{Helpers.next_seq}"
     args[:raw] ||= "This is the raw body of my post, it is cool #{Helpers.next_seq}"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -45,6 +45,10 @@ module Helpers
   end
 
   def create_post(args = {})
+    # Pretty much all the tests with `create_post` will fail without this
+    # since allow_uncategorized_topics is now false by default
+    SiteSetting.allow_uncategorized_topics = true
+
     args[:title] ||= "This is my title #{Helpers.next_seq}"
     args[:raw] ||= "This is the raw body of my post, it is cool #{Helpers.next_seq}"
     args[:topic_id] = args[:topic].id if args[:topic]


### PR DESCRIPTION
This change will auto select the General category in the composer when a new topic is created. As part of this change it will remove the option to de-select the category from the composer when the allow uncategorized site setting is disabled (you can still switch categories in the composer, but will not be allowed to leave the category field blank). This means that a user will no-longer receive the "you must select a category" message when submitting a topic because they will always have one selected.

There is a migration that will only trigger for *new* sites for setting the `allow_uncategorized_topics` site setting to false so that it is now disabled by default. This change initially broke many tests because we don't currently seed the general category and most of the tests were written assuming that uncategorized topics were allowed. I made the necessary changes to get the tests to pass, but I think there will be a refactoring that will need to take place in the future where we seed the General category in the test env so that helpers like `create_post` use the General category instead of falling back to uncategorized.