### PR TITLE
FIX: 404 sending beacon "leave all" on subfolder install

### DIFF
--- a/app/assets/javascripts/discourse/app/services/presence.js
+++ b/app/assets/javascripts/discourse/app/services/presence.js
@@ -13,6 +13,7 @@ import userPresent, {
 import { bind } from "discourse-common/utils/decorators";
 import Evented from "@ember/object/evented";
 import { isTesting } from "discourse-common/config/environment";
+import getURL from "discourse-common/lib/get-url";
 
 const PRESENCE_INTERVAL_S = 30;
 const PRESENCE_DEBOUNCE_MS = isTesting() ? 0 : 500;
@@ -472,7 +473,7 @@ export default class PresenceService extends Service {
     channelsToLeave.forEach((ch) => data.append("leave_channels[]", ch));
 
     data.append("authenticity_token", Session.currentProp("csrfToken"));
-    navigator.sendBeacon("/presence/update", data);
+    navigator.sendBeacon(getURL("/presence/update"), data);
   }
 
   _dedupQueue() {


### PR DESCRIPTION
Currently, on a subfolder install, there's always an unsuccessful `ping` response when reloading/leaving Discourse.

![image](https://user-images.githubusercontent.com/3530/192604382-132c5667-5b53-435c-8e10-36a06989cd91.png)

This PR uses `getURL` when calling `sendBeacon` to hit the correct subfolder endpoint, following what has been done before on `click-track`:
https://github.com/discourse/discourse/blob/5dea425ee92aed1b9349a2ecf123088453aaa0ca/app/assets/javascripts/discourse/app/lib/click-track.js#L167