### PR TITLE
DEV: Use the correct property for checking if redesigned user menu is enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -25,7 +25,7 @@ export default {
     const siteSettings = container.lookup("service:site-settings");
 
     if (user) {
-      const channel = user.enable_redesigned_user_menu
+      const channel = user.redesigned_user_menu_enabled
         ? `/reviewable_counts/${user.id}`
         : "/reviewable_counts";
 

--- a/app/assets/javascripts/discourse/app/routes/review-index.js
+++ b/app/assets/javascripts/discourse/app/routes/review-index.js
@@ -65,7 +65,7 @@ export default DiscourseRoute.extend({
       }
     });
 
-    const channel = this.currentUser.enable_redesigned_user_menu
+    const channel = this.currentUser.redesigned_user_menu_enabled
       ? `/reviewable_counts/${this.currentUser.id}`
       : "/reviewable_counts";
 


### PR DESCRIPTION
Silly error, the correct attribute for the new user menu feature flag is `redesigned_user_menu_enabled` not `enable_redesigned_user_menu`.