### PR TITLE
FIX: Ensure composer grippie stays visible

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -540,6 +540,7 @@ body:not(.ios-safari-composer-hacks) {
     }
     padding-bottom: var(--composer-ipad-padding);
     padding-bottom: calc(10px + env(keyboard-inset-height));
+    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
Fixes a small regression in ab58b0c.

Before, you could expand the composer too much (and would have no way to resize it again): 

<img width="1500" alt="image" src="https://user-images.githubusercontent.com/368961/192785949-e65f48ae-edde-439c-9973-b0d43a8a79ac.png">

After, composer doesn't go past header: 

<img width="1503" alt="image" src="https://user-images.githubusercontent.com/368961/192785799-67d4d0ea-15ef-4826-9bef-4a1a3a923ce8.png">
