### PR TITLE
DEV: Include quote notifications in the replies tab in the user menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -45,11 +45,14 @@ const CORE_TOP_TABS = [
     }
 
     get count() {
-      return this.getUnreadCountForType("replied");
+      return (
+        this.getUnreadCountForType("replied") +
+        this.getUnreadCountForType("quoted")
+      );
     }
 
     get notificationTypes() {
-      return ["replied"];
+      return ["replied", "quoted"];
     }
 
     get linkWhenActive() {

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
@@ -239,6 +239,8 @@ module("Integration | Component | user-menu", function (hooks) {
             },
           },
         ];
+      } else if (queryParams.filter_by_types === "replied,quoted") {
+        data = [];
       } else {
         throw new Error(
           `unexpected notification type ${queryParams.filter_by_types}`
@@ -285,6 +287,22 @@ module("Integration | Component | user-menu", function (hooks) {
       "active tab is now the likes tab"
     );
     assert.strictEqual(queryAll("#quick-access-likes ul li").length, 3);
+
+    await click("#user-menu-button-replies");
+    assert.ok(exists("#quick-access-replies.quick-access-panel"));
+    assert.strictEqual(
+      queryParams.filter_by_types,
+      "replied,quoted",
+      "request params has filter_by_types set to `replied` and `quoted`"
+    );
+    assert.strictEqual(queryParams.silent, "true");
+    activeTabs = queryAll(".top-tabs .btn.active");
+    assert.strictEqual(activeTabs.length, 1);
+    assert.strictEqual(
+      activeTabs[0].id,
+      "user-menu-button-replies",
+      "active tab is now the replies tab"
+    );
 
     await click("#user-menu-button-review-queue");
     assert.ok(exists("#quick-access-review-queue.quick-access-panel"));


### PR DESCRIPTION
The rationale behind this change is that quote notifications are almost always as important as replies notifications so it makes sense for them to be included in the replies tab instead of the "other" tab. Internal topic: t/74748.