### PR TITLE
FIX: Migration typo for secure_uploads

### DIFF
--- a/db/migrate/20220927065328_set_secure_uploads_settings_based_on_secure_media_equivalent.rb
+++ b/db/migrate/20220927065328_set_secure_uploads_settings_based_on_secure_media_equivalent.rb
@@ -25,7 +25,7 @@ class SetSecureUploadsSettingsBasedOnSecureMediaEquivalent < ActiveRecord::Migra
     if secure_media_max_email_embed_image_size_kb.present?
       execute <<~SQL
       INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
-      VALUES ('secure_uploads_max_email_embed_image_size_kb', 3, '#{secure_uploads_max_email_embed_image_size_kb[0]}', now(), now())
+      VALUES ('secure_uploads_max_email_embed_image_size_kb', 3, '#{secure_media_max_email_embed_image_size_kb[0]}', now(), now())
       SQL
     end
   end


### PR DESCRIPTION
Fixes typo from 8ebd5edd1e02e6fafe7732515edefec5a5dfc3f7 causing deploy issues.