### PR TITLE
FIX: Use `Category#category_text` for sidebar title

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
@@ -41,7 +41,7 @@ export default class CategorySectionLink {
   }
 
   get title() {
-    return this.category.description_excerpt;
+    return this.category.description_text;
   }
 
   get text() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -254,6 +254,25 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
     );
   });
 
+  test("category section link have the right title", async function (assert) {
+    const categories = Site.current().categories;
+
+    // Category with link HTML tag in description
+    const category = categories.find((c) => c.id === 28);
+
+    updateCurrentUser({
+      sidebar_category_ids: [category.id],
+    });
+
+    await visit("/");
+
+    assert.strictEqual(
+      query(`.sidebar-section-link-${category.slug}`).title,
+      category.description_text,
+      "category description without HTML entity is used as the link's title"
+    );
+  });
+
   test("visiting category discovery new route", async function (assert) {
     const { category1 } = setupUserSidebarCategories();
 


### PR DESCRIPTION
Previously we used `Category#category_excerpt` but the excerpt keeps the
HTML entities around if present and we can't really display HTML in the
title of a link.