### PR TITLE
FEATURE: Add setting to always confirm old email

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2044,7 +2044,7 @@ en:
     raw_email_max_length: "How many characters should be stored for incoming email."
     raw_rejected_email_max_length: "How many characters should be stored for rejected incoming email."
     delete_rejected_email_after_days: "Delete rejected emails older than (n) days."
-    require_change_email_confirmation: "Require non-staff users to confirm their old email address before changing it. (Does not apply to staff users, they always need to confirm their old email address.")
+    require_change_email_confirmation: "Require non-staff users to confirm their old email address before changing it. Does not apply to staff users, they always need to confirm their old email address."
 
     manual_polling_enabled: "Push emails using the API for email replies."
     pop3_polling_enabled: "Poll via POP3 for email replies."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2044,7 +2044,7 @@ en:
     raw_email_max_length: "How many characters should be stored for incoming email."
     raw_rejected_email_max_length: "How many characters should be stored for rejected incoming email."
     delete_rejected_email_after_days: "Delete rejected emails older than (n) days."
-    require_change_email_confirmation: "Always confirm old email when changing it. When disabled, only staff members have to do it."
+    require_change_email_confirmation: "Require non-staff users to confirm their old email address before changing it. (Does not apply to staff users, they always need to confirm their old email address.")
 
     manual_polling_enabled: "Push emails using the API for email replies."
     pop3_polling_enabled: "Poll via POP3 for email replies."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2044,6 +2044,7 @@ en:
     raw_email_max_length: "How many characters should be stored for incoming email."
     raw_rejected_email_max_length: "How many characters should be stored for rejected incoming email."
     delete_rejected_email_after_days: "Delete rejected emails older than (n) days."
+    require_change_email_confirmation: "Always confirm old email when changing it. When disabled, only staff members have to do it."
 
     manual_polling_enabled: "Push emails using the API for email replies."
     pop3_polling_enabled: "Poll via POP3 for email replies."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1291,6 +1291,7 @@ email:
   max_participant_names:
     default: 10
     hidden: true
+  require_change_email_confirmation: false
 
 files:
   max_image_size_kb:

--- a/lib/email_updater.rb
+++ b/lib/email_updater.rb
@@ -58,8 +58,7 @@ class EmailUpdater
     end
 
     if @change_req.change_state.blank? || @change_req.change_state == EmailChangeRequest.states[:complete]
-      @change_req.change_state = if @user.staff?
-        # Staff users must confirm their old email address first.
+      @change_req.change_state = if SiteSetting.require_change_email_confirmation || @user.staff?
         EmailChangeRequest.states[:authorizing_old]
       else
         EmailChangeRequest.states[:authorizing_new]


### PR DESCRIPTION
By default, only staff members have to confirm their old email when changing it. This commit adds a site setting that when enabled will always ask the user to confirm old email.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
