### PR TITLE
FIX: Remove zero-width space when not necessary

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/d-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-button.hbs
@@ -8,7 +8,8 @@
 
 {{~#if this.computedLabel~}}
   <span class="d-button-label">{{html-safe this.computedLabel}}{{#if this.ellipsis}}&hellip;{{/if}}</span>
-{{~else~}}
+  {{! template-lint-disable simple-unless }}
+{{~else unless (has-block)~}}
   &#8203;
   {{! Zero-width space character, so icon-only button height = regular button height }}
 {{~/if~}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-button.hbs
@@ -8,8 +8,7 @@
 
 {{~#if this.computedLabel~}}
   <span class="d-button-label">{{html-safe this.computedLabel}}{{#if this.ellipsis}}&hellip;{{/if}}</span>
-  {{! template-lint-disable simple-unless }}
-{{~else unless (has-block)~}}
+{{~else if (not (has-block))~}}
   &#8203;
   {{! Zero-width space character, so icon-only button height = regular button height }}
 {{~/if~}}


### PR DESCRIPTION
A zero-width space character is inserted for icon-only buttons, but that is unnecessary when the button has some rich-content and the block form is used and can be a problem for more complex designs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
