### PR TITLE
FIX: missing theme upload should not break precompile process.

### DIFF
--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -222,7 +222,7 @@ class Stylesheet::Manager::Builder
     sha1s = []
 
     (theme&.upload_fields || []).map do |upload_field|
-      sha1s << upload_field.upload.sha1
+      sha1s << upload_field.upload&.sha1
     end
 
     Digest::SHA1.hexdigest(sha1s.sort!.join("\n"))

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -351,6 +351,37 @@ RSpec.describe Stylesheet::Manager do
       expect(digest1).not_to eq(digest2)
     end
 
+    it 'can generate digest with a missing upload record' do
+      theme = Fabricate(:theme)
+
+      upload = UploadCreator.new(image, "logo.png").create_for(-1)
+      field = ThemeField.create!(
+        theme_id: theme.id,
+        target_id: Theme.targets[:common],
+        name: "logo",
+        value: "",
+        upload_id: upload.id,
+        type_id: ThemeField.types[:theme_upload_var]
+      )
+
+      manager = manager(theme.id)
+
+      builder = Stylesheet::Manager::Builder.new(
+        target: :desktop_theme, theme: theme, manager: manager
+      )
+
+      digest1 = builder.digest
+      upload.delete
+
+      builder = Stylesheet::Manager::Builder.new(
+        target: :desktop_theme, theme: theme.reload, manager: manager
+      )
+
+      digest2 = builder.digest
+
+      expect(digest1).not_to eq(digest2)
+    end
+
     it 'returns different digest based on target' do
       theme = Fabricate(:theme)
       builder = Stylesheet::Manager::Builder.new(target: :desktop_theme, theme: theme, manager: manager)


### PR DESCRIPTION
Previously, if an active default theme's upload record went missing then it will break the site and cause downtime.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
