### PR TITLE
FEATURE: when entering a topic scroll to last visited line marker

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -117,6 +117,15 @@ const DiscourseURL = EmberObject.extend({
 
       if (!holder) {
         selector = holderId;
+
+        if (
+          document.getElementsByClassName(
+            `topic-post-visited-line post-${postNumber - 1}`
+          )?.length === 1
+        ) {
+          selector = ".small-action.topic-post-visited";
+        }
+
         holder = document.querySelector(selector);
       }
 


### PR DESCRIPTION
When a user enters a topic they have already visited they are navigated to that post that is newest for them (post_number_last_read + 1). Above that post, there is a "last visited" line marker which is visible when the user scrolls a bit above the post they landed on. This commit makes sure that the "last visited" line marker is visible as soon as the user lands on the topic.

![SCR-20220930-lt9](https://user-images.githubusercontent.com/5732281/193248196-69f9ffbf-9de3-4aee-bbb1-abfc9eaf0180.png)

I tried to add client-side tests for this feature but I don't think the scrolling behavior is replicated in the tests because the `window.scrollY` is always `0` even if the post_number in the topic URL is `11`. I also didn't see any existing test case for all the scroll magic we're doing in [`lock-on.js`](https://github.com/discourse/discourse/blob/0760b249ffe39a9ff57b7e36b6304e63a5082d7e/app/assets/javascripts/discourse/app/lib/lock-on.js), [`url.js`](https://github.com/discourse/discourse/blob/8ebd5edd1e02e6fafe7732515edefec5a5dfc3f7/app/assets/javascripts/discourse/app/lib/url.js), etc.
