### PR TITLE
UX: fix post placeholder on mobile

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -431,3 +431,7 @@ span.highlighted {
   opacity: 100%;
   margin-bottom: 1rem;
 }
+
+.placeholder .topic-body {
+  width: 100%;
+}


### PR DESCRIPTION
The placeholder body isn't full width on mobile, this fixes it. 

Issue reported here: https://meta.discourse.org/t/topic-placeholder-align-issue-while-scrolling-on-mobile/240457