### PR TITLE
Refactor admin base controller

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::AdminController < ApplicationController
-
   requires_login
-  before_action :ensure_staff
+  before_action :ensure_admin
 
   def index
     render body: nil

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::DashboardController < Admin::AdminController
+class Admin::DashboardController < Admin::StaffController
   def index
     data = AdminDashboardIndexData.fetch_cached_stats
 

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::GroupsController < Admin::AdminController
+class Admin::GroupsController < Admin::StaffController
   def create
     guardian.ensure_can_create_group!
 

--- a/app/controllers/admin/plugins_controller.rb
+++ b/app/controllers/admin/plugins_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::PluginsController < Admin::AdminController
+class Admin::PluginsController < Admin::StaffController
 
   def index
     render_serialized(Discourse.visible_plugins, AdminPluginSerializer, root: 'plugins')

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::ReportsController < Admin::AdminController
+class Admin::ReportsController < Admin::StaffController
   def index
     reports_methods = ['page_view_total_reqs'] +
       ApplicationRequest.req_types.keys

--- a/app/controllers/admin/screened_emails_controller.rb
+++ b/app/controllers/admin/screened_emails_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::ScreenedEmailsController < Admin::AdminController
+class Admin::ScreenedEmailsController < Admin::StaffController
 
   def index
     screened_emails = ScreenedEmail.limit(200).order('last_match_at desc').to_a

--- a/app/controllers/admin/screened_ip_addresses_controller.rb
+++ b/app/controllers/admin/screened_ip_addresses_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::ScreenedIpAddressesController < Admin::AdminController
+class Admin::ScreenedIpAddressesController < Admin::StaffController
 
   before_action :fetch_screened_ip_address, only: [:update, :destroy]
 

--- a/app/controllers/admin/screened_urls_controller.rb
+++ b/app/controllers/admin/screened_urls_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::ScreenedUrlsController < Admin::AdminController
+class Admin::ScreenedUrlsController < Admin::StaffController
 
   def index
     screened_urls = ScreenedUrl.select("domain, sum(match_count) as match_count, max(last_match_at) as last_match_at, min(created_at) as created_at").group(:domain).order('last_match_at DESC').to_a

--- a/app/controllers/admin/search_logs_controller.rb
+++ b/app/controllers/admin/search_logs_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::SearchLogsController < Admin::AdminController
+class Admin::SearchLogsController < Admin::StaffController
 
   def index
     period = params[:period] || "all"

--- a/app/controllers/admin/staff_action_logs_controller.rb
+++ b/app/controllers/admin/staff_action_logs_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::StaffActionLogsController < Admin::AdminController
+class Admin::StaffActionLogsController < Admin::StaffController
 
   def index
     filters = params.slice(*UserHistory.staff_filters + [:page, :limit])

--- a/app/controllers/admin/staff_controller.rb
+++ b/app/controllers/admin/staff_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Admin::StaffController < ApplicationController
+  requires_login
+  before_action :ensure_staff
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::UsersController < Admin::AdminController
+class Admin::UsersController < Admin::StaffController
 
   before_action :fetch_user, only: [:suspend,
                                     :unsuspend,

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Admin::VersionsController < Admin::AdminController
+class Admin::VersionsController < Admin::StaffController
   def show
     render json: DiscourseUpdates.check_version
   end

--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -2,7 +2,7 @@
 
 require 'csv'
 
-class Admin::WatchedWordsController < Admin::AdminController
+class Admin::WatchedWordsController < Admin::StaffController
   skip_before_action :check_xhr, only: [:download]
 
   def index

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Admin::DashboardController do
     Jobs::VersionCheck.any_instance.stubs(:execute).returns(true)
   end
 
-  it "is a subclass of AdminController" do
-    expect(Admin::DashboardController < Admin::AdminController).to eq(true)
+  it "is a subclass of StaffController" do
+    expect(Admin::DashboardController < Admin::StaffController).to eq(true)
   end
 
   context 'while logged in as an admin' do

--- a/spec/requests/admin/email_styles_controller_spec.rb
+++ b/spec/requests/admin/email_styles_controller_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Admin::EmailStylesController do
     SiteSetting.remove_override!(:email_custom_css)
   end
 
+  it "is a subclass of AdminController" do
+    expect(Admin::EmailStylesController < Admin::AdminController).to eq(true)
+  end
+
   describe 'show' do
     it 'returns default values' do
       get '/admin/customize/email_style.json'

--- a/spec/requests/admin/email_templates_controller_spec.rb
+++ b/spec/requests/admin/email_templates_controller_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe Admin::EmailTemplatesController do
   fab!(:admin) { Fabricate(:admin) }
+  fab!(:moderator) { Fabricate(:moderator) }
   fab!(:user) { Fabricate(:user) }
 
   def original_text(key)
@@ -17,6 +18,10 @@ RSpec.describe Admin::EmailTemplatesController do
     I18n.reload!
   end
 
+  it "is a subclass of AdminController" do
+    expect(Admin::EmailTemplatesController < Admin::AdminController).to eq(true)
+  end
+
   describe "#index" do
     it "raises an error if you aren't logged in" do
       get '/admin/customize/email_templates.json'
@@ -26,6 +31,12 @@ RSpec.describe Admin::EmailTemplatesController do
     it "raises an error if you aren't an admin" do
       sign_in(user)
       get '/admin/customize/email_templates.json'
+      expect(response.status).to eq(404)
+    end
+
+    it "raises an error if you are a moderator" do
+      sign_in(moderator)
+      get "/admin/customize/email_templates.json"
       expect(response.status).to eq(404)
     end
 
@@ -75,6 +86,14 @@ RSpec.describe Admin::EmailTemplatesController do
       sign_in(user)
       put '/admin/customize/email_templates/some_id', params: {
         email_template: { subject: 'Subject', body: 'Body' }
+      }, headers: headers
+      expect(response.status).to eq(404)
+    end
+
+    it "raises an error if you are a moderator" do
+      sign_in(moderator)
+      put "/admin/customize/email_templates/some_id", params: {
+        email_template: { subject: "Subject", body: "Body" }
       }, headers: headers
       expect(response.status).to eq(404)
     end
@@ -265,6 +284,12 @@ RSpec.describe Admin::EmailTemplatesController do
     it "raises an error if you aren't an admin" do
       sign_in(user)
       delete '/admin/customize/email_templates/some_id', headers: headers
+      expect(response.status).to eq(404)
+    end
+
+    it "raises an error if you are a moderator" do
+      sign_in(moderator)
+      delete "/admin/customize/email_templates/some_id", headers: headers
       expect(response.status).to eq(404)
     end
 

--- a/spec/requests/admin/groups_controller_spec.rb
+++ b/spec/requests/admin/groups_controller_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Admin::GroupsController do
   fab!(:user) { Fabricate(:user) }
   fab!(:group) { Fabricate(:group) }
 
+  it 'is a subclass of StaffController' do
+    expect(Admin::UsersController < Admin::StaffController).to eq(true)
+  end
+
   before do
     sign_in(admin)
   end

--- a/spec/requests/admin/plugins_controller_spec.rb
+++ b/spec/requests/admin/plugins_controller_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe Admin::PluginsController do
 
-  it "is a subclass of AdminController" do
-    expect(Admin::PluginsController < Admin::AdminController).to eq(true)
+  it "is a subclass of StaffController" do
+    expect(Admin::PluginsController < Admin::StaffController).to eq(true)
   end
 
   context "while logged in as an admin" do

--- a/spec/requests/admin/reports_controller_spec.rb
+++ b/spec/requests/admin/reports_controller_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::ReportsController do
-  it "is a subclass of AdminController" do
-    expect(Admin::ReportsController < Admin::AdminController).to eq(true)
+  it "is a subclass of StaffController" do
+    expect(Admin::ReportsController < Admin::StaffController).to eq(true)
   end
 
   context 'while logged in as an admin' do

--- a/spec/requests/admin/screened_emails_controller_spec.rb
+++ b/spec/requests/admin/screened_emails_controller_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::ScreenedEmailsController do
-  it "is a subclass of AdminController" do
-    expect(Admin::ScreenedEmailsController < Admin::AdminController).to eq(true)
+  it "is a subclass of StaffController" do
+    expect(Admin::ScreenedEmailsController < Admin::StaffController).to eq(true)
   end
 
   describe '#index' do

--- a/spec/requests/admin/screened_ip_addresses_controller_spec.rb
+++ b/spec/requests/admin/screened_ip_addresses_controller_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe Admin::ScreenedIpAddressesController do
 
-  it "is a subclass of AdminController" do
-    expect(Admin::ScreenedIpAddressesController < Admin::AdminController).to eq(true)
+  it "is a subclass of StaffController" do
+    expect(Admin::ScreenedIpAddressesController < Admin::StaffController).to eq(true)
   end
 
   fab!(:admin) { Fabricate(:admin) }

--- a/spec/requests/admin/screened_urls_controller_spec.rb
+++ b/spec/requests/admin/screened_urls_controller_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::ScreenedUrlsController do
-  it "is a subclass of AdminController" do
-    expect(Admin::ScreenedUrlsController < Admin::AdminController).to eq(true)
+  it "is a subclass of StaffController" do
+    expect(Admin::ScreenedUrlsController < Admin::StaffController).to eq(true)
   end
 
   describe '#index' do

--- a/spec/requests/admin/staff_action_logs_controller_spec.rb
+++ b/spec/requests/admin/staff_action_logs_controller_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::StaffActionLogsController do
-  it "is a subclass of AdminController" do
-    expect(Admin::StaffActionLogsController < Admin::AdminController).to eq(true)
+  it "is a subclass of StaffController" do
+    expect(Admin::StaffActionLogsController < Admin::StaffController).to eq(true)
   end
 
   fab!(:admin) { Fabricate(:admin) }

--- a/spec/requests/admin/themes_controller_spec.rb
+++ b/spec/requests/admin/themes_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Admin::ThemesController do
   fab!(:admin) { Fabricate(:admin) }
 
   it "is a subclass of AdminController" do
-    expect(Admin::UsersController < Admin::AdminController).to eq(true)
+    expect(Admin::ThemesController < Admin::AdminController).to eq(true)
   end
 
   before do

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Admin::UsersController do
   fab!(:user) { Fabricate(:user) }
   fab!(:coding_horror) { Fabricate(:coding_horror) }
 
-  it 'is a subclass of AdminController' do
-    expect(Admin::UsersController < Admin::AdminController).to eq(true)
+  it 'is a subclass of StaffController' do
+    expect(Admin::UsersController < Admin::StaffController).to eq(true)
   end
 
   before do

--- a/spec/requests/admin/versions_controller_spec.rb
+++ b/spec/requests/admin/versions_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Admin::VersionsController do
     DiscourseUpdates.stubs(:critical_updates_available?).returns(false)
   end
 
-  it "is a subclass of AdminController" do
-    expect(Admin::VersionsController < Admin::AdminController).to eq(true)
+  it "is a subclass of StaffController" do
+    expect(Admin::VersionsController < Admin::StaffController).to eq(true)
   end
 
   context 'while logged in as an admin' do


### PR DESCRIPTION
The current parent(`Admin:AdminController`) for all admin-related controllers uses the `ensure_staff` before filter to allow staff-only(`admin` & `moderator`) access to endpoints. This works together with `StaffConstraint` and `AdminConstraint` route constraints to limit access when an endpoint really needs to be admin-only.

In the spirit of the Principle of Least Surprise, we  need  the `Admin:AdminController` base controller filtering for just admin users.

This  refactor introduces `Admin::StaffController` which filters for staff users and updates `Admin:AdminController` to filter for only admins.

