### PR TITLE
FIX: New general category changes preventing topic create

### DIFF
--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -145,7 +145,8 @@ const Composer = RestModel.extend({
       if (isEmpty(categoryId)) {
         // Set General as the default category
         const generalCategoryId = this.siteSettings.general_category_id;
-        categoryId = generalCategoryId ? generalCategoryId : null;
+        categoryId =
+          generalCategoryId && generalCategoryId > 0 ? generalCategoryId : null;
       }
       this._categoryId = categoryId;
 

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -143,6 +143,23 @@ module(
       assert.strictEqual(this.subject.header().label(), "");
     });
 
+    test("with allowUncategorized=null and generalCategoryId present, but not set", async function (assert) {
+      this.siteSettings.allow_uncategorized_topics = false;
+      this.siteSettings.general_category_id = -1;
+
+      await render(hbs`
+        <CategoryChooser
+          @value={{this.value}}
+          @options={{hash
+            allowUncategorized=null
+          }}
+        />
+      `);
+
+      assert.strictEqual(this.subject.header().value(), null);
+      assert.strictEqual(this.subject.header().label(), "category…");
+    });
+
     test("with allowUncategorized=null none=true", async function (assert) {
       this.siteSettings.allow_uncategorized_topics = false;
 

--- a/app/assets/javascripts/select-kit/addon/components/category-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/category-chooser.js
@@ -45,7 +45,7 @@ export default ComboBoxComponent.extend({
       return Category.findUncategorized();
     } else {
       const generalCategoryId = this.siteSettings.general_category_id;
-      if (!generalCategoryId) {
+      if (!generalCategoryId || generalCategoryId < 0) {
         return this.defaultItem(null, htmlSafe(I18n.t("category.choose")));
       }
     }


### PR DESCRIPTION
Follow up to: #18383

The logic in the previous commit was checking for null, but we are
seeding the SiteSetting.general_category_id with an id of -1 so we need
to check for a positive value as well as checking for null.

See: https://meta.discourse.org/t/240661
