### PR TITLE
FIX: Link to `discovery.category` in sidebar`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
@@ -37,7 +37,7 @@ export default class CategorySectionLink {
   }
 
   get currentWhen() {
-    return "discovery.unreadCategory discovery.topCategory discovery.newCategory discovery.latestCategory";
+    return "discovery.unreadCategory discovery.topCategory discovery.newCategory discovery.latestCategory discovery.category";
   }
 
   get title() {
@@ -84,7 +84,7 @@ export default class CategorySectionLink {
     } else if (this.totalNew > 0) {
       return "discovery.newCategory";
     } else {
-      return "discovery.latestCategory";
+      return "discovery.category";
     }
   }
 }

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -212,8 +212,8 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
     assert.strictEqual(
       currentURL(),
-      `/c/${category1.slug}/${category1.id}/l/latest`,
-      "it should transition to the category1's discovery page"
+      `/c/${category1.slug}/${category1.id}`,
+      "it should transition to the category1 page"
     );
 
     assert.strictEqual(
@@ -231,8 +231,8 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
     assert.strictEqual(
       currentURL(),
-      `/c/${category2.slug}/${category2.id}/l/latest`,
-      "it should transition to the category2's discovery page"
+      `/c/${category2.slug}/${category2.id}`,
+      "it should transition to the category2's page"
     );
 
     assert.strictEqual(


### PR DESCRIPTION
`discovery.category` route respects the default view of the category as
configured by `Category#default_view`. `discovery.latestCategory` forces
the latest filter when viewing the category which is not what we want.

https://meta.discourse.org/t/239999