### PR TITLE
DEV: Add faraday and faraday-retry as explicit dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -272,6 +272,9 @@ gem 'maxminddb'
 
 gem 'rails_failover', require: false
 
+gem 'faraday'
+gem 'faraday-retry'
+
 # workaround for faraday-net_http, see
 # https://github.com/ruby/net-imap/issues/16#issuecomment-803086765
 gem 'net-http'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.0)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     fast_blank (1.0.1)
     fast_xs (0.8.0)
     fastimage (2.2.6)
@@ -551,6 +553,8 @@ DEPENDENCIES
   fabrication
   faker (~> 2.16)
   fakeweb
+  faraday
+  faraday-retry
   fast_blank
   fast_xs
   fastimage
@@ -645,4 +649,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.3.18
+   2.3.22


### PR DESCRIPTION
`Faraday` is very commonly used in official and third-party plugins, and we will likely be increasing our use of it in core. This commit adds it as a direct dependency and adds the official faraday-retry gem which is very commonly used (e.g. by Octokit).

This will silence the _"To use retry middleware with Faraday v2.0+, install `faraday-retry` gem"_ warning from Octokit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
