### PR TITLE
FIX: Ability to trigger emoji after indented code block 

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -461,15 +461,15 @@ export function postRNWebviewMessage(prop, value) {
 
 const CODE_BLOCKS_REGEX =
   /^(    |\t).*|`[^`]+`|^```[^]*?^```|\[code\][^]*?\[\/code\]/gm;
-//                        |      ^     |   ^   |      ^      |           ^           |
-//                               |         |          |                  |
-//                               |         |          |       code blocks between [code]
-//                               |         |          |
-//                               |         |          +--- code blocks between three backticks
-//                               |         |
-//                               |         +----- inline code between backticks
-//                               |
-//                               +------- paragraphs starting with 4 spaces or tab
+//|      ^     |   ^   |      ^      |           ^           |
+//       |         |          |                  |
+//       |         |          |       code blocks between [code]
+//       |         |          |
+//       |         |          +--- code blocks between three backticks
+//       |         |
+//       |         +----- inline code between backticks
+//       |
+//       +------- paragraphs starting with 4 spaces or tab
 
 const OPEN_CODE_BLOCKS_REGEX = /`[^`]+|^```[^]*?|\[code\][^]*?/gm;
 

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -471,7 +471,7 @@ const CODE_BLOCKS_REGEX =
 //       |
 //       +------- paragraphs starting with 4 spaces or tab
 
-const OPEN_CODE_BLOCKS_REGEX = /`[^`]+|^```[^]*?|\[code\][^]*?/gm;
+const OPEN_CODE_BLOCKS_REGEX = /^(  |\t).*|`[^`]+|^```[^]*?|\[code\][^]*?/gm;
 
 export function inCodeBlock(text, pos) {
   let end = 0;

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -469,7 +469,7 @@ const CODE_BLOCKS_REGEX =
 //       |         |
 //       |         +----- inline code between backticks
 //       |
-//       +------- paragraphs starting with 4 spaces or tab
+//       +------- paragraphs starting with 2 spaces or tab
 
 const OPEN_CODE_BLOCKS_REGEX = /^(  |\t).*|`[^`]+|^```[^]*?|\[code\][^]*?/gm;
 

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -461,15 +461,15 @@ export function postRNWebviewMessage(prop, value) {
 
 const CODE_BLOCKS_REGEX =
   /^(  |\t).*|`[^`]+`|^```[^]*?^```|\[code\][^]*?\[\/code\]/gm;
-//|      ^     |   ^   |      ^      |           ^           |
-//       |         |          |                  |
-//       |         |          |       code blocks between [code]
-//       |         |          |
-//       |         |          +--- code blocks between three backticks
-//       |         |
-//       |         +----- inline code between backticks
-//       |
-//       +------- paragraphs starting with 2 spaces or tab
+//|    ^     |   ^   |      ^      |           ^           |
+//     |         |          |                  |
+//     |         |          |       code blocks between [code]
+//     |         |          |
+//     |         |          +--- code blocks between three backticks
+//     |         |
+//     |         +----- inline code between backticks
+//     |
+//     +------- paragraphs starting with 2 spaces or tab
 
 const OPEN_CODE_BLOCKS_REGEX = /^(  |\t).*|`[^`]+|^```[^]*?|\[code\][^]*?/gm;
 

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -460,7 +460,7 @@ export function postRNWebviewMessage(prop, value) {
 }
 
 const CODE_BLOCKS_REGEX =
-  /^(    |\t).*|`[^`]+`|^```[^]*?^```|\[code\][^]*?\[\/code\]/gm;
+  /^(  |\t).*|`[^`]+`|^```[^]*?^```|\[code\][^]*?\[\/code\]/gm;
 //|      ^     |   ^   |      ^      |           ^           |
 //       |         |          |                  |
 //       |         |          |       code blocks between [code]

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -278,6 +278,8 @@ discourseModule("Unit | Utilities", function () {
       "000\n[code]111",
       // complex test
       "000\n\n```\n111\n```\n\n000\n\n`111 111`\n\n000\n\n[code]\n111\n[/code]\n\n    111\n\t111\n\n000`111",
+      // indented open code blocks
+      "000\n\t```111\n\t111\n\t111```\n000",
     ];
 
     texts.forEach((text) => {

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -266,20 +266,23 @@ discourseModule("Unit | Utilities", function () {
 
   test("inCodeBlock", function (assert) {
     const texts = [
-      // closed code blocks
+      // CLOSED CODE BLOCKS:
       "000\n\n    111\n\n000",
       "000 `111` 000",
       "000\n```\n111\n```\n000",
       "000\n[code]111[/code]\n000",
-      // open code blocks
+      // OPEN CODE BLOCKS:
       "000\n\n    111",
       "000 `111",
       "000\n```\n111",
       "000\n[code]111",
-      // complex test
+      // COMPLEX TEST:
       "000\n\n```\n111\n```\n\n000\n\n`111 111`\n\n000\n\n[code]\n111\n[/code]\n\n    111\n\t111\n\n000`111",
-      // indented open code blocks
+      // INDENTED OPEN CODE BLOCKS:
+      // - Using tab
       "000\n\t```111\n\t111\n\t111```\n000",
+      // - Using spaces
+      `000\n  \`\`\`111\n  111\n  111\`\`\`\n000`,
     ];
 
     texts.forEach((text) => {


### PR DESCRIPTION
This PR fixes the ability to trigger the emoji autocomplete after an indented code block. 

Previously a passage of text like this:

> - Item
> 
>   ```
>   This is an indented code block
>   ```
> :fireworks: 👈🏽 not triggered 

Now, the auto complete emoji picker should once again trigger after an indented code block.

<img width="284" alt="Screen Shot 2022-10-04 at 4 18 55 PM" src="https://user-images.githubusercontent.com/30090424/193948118-1f39dbda-9c1e-4044-885b-436400530efa.png">
