### PR TITLE
FIX: watched topic overcome muted category

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -866,7 +866,8 @@ const TopicTrackingState = EmberObject.extend({
 
       if (
         mutedCategoryIds &&
-        mutedCategoryIds.includes(data.payload.category_id)
+        mutedCategoryIds.includes(data.payload.category_id) &&
+        !this.isUnmutedTopic(data.topic_id)
       ) {
         return;
       }

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -760,6 +760,33 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
         );
       });
 
+      test("watched topics in muted categories are added to the state", async function (assert) {
+        trackingState.currentUser.setProperties({
+          muted_category_ids: [123],
+        });
+
+        trackingState.trackMutedOrUnmutedTopic({
+          topic_id: 222,
+          message_type: "unmuted",
+        });
+
+        await publishToMessageBus("/new", newTopicPayload);
+
+        assert.deepEqual(
+          trackingState.findState(222),
+          {
+            category_id: 123,
+            topic_tag_ids: [44],
+            tags: ["pending"],
+            last_read_post_number: null,
+            highest_post_number: 1,
+            created_at: "2012-11-31 12:00:00 UTC",
+            archetype: "regular",
+          },
+          "topic state updated"
+        );
+      });
+
       test("topics in muted tags do not get added to the state", async function (assert) {
         trackingState.currentUser.set("muted_tags", ["pending"]);
 

--- a/app/jobs/regular/notify_mailing_list_subscribers.rb
+++ b/app/jobs/regular/notify_mailing_list_subscribers.rb
@@ -69,7 +69,7 @@ module Jobs
       end
 
       if SiteSetting.mute_all_categories_by_default
-        users = users.watching_topic_when_mute_categories_by_default(post.topic)
+        users = users.watching_topic(post.topic)
       end
 
       DiscourseEvent.trigger(:notify_mailing_list_subscribers, users, post)

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -118,8 +118,7 @@ class TopicTrackingState
   end
 
   def self.publish_unmuted(topic)
-    return if !SiteSetting.mute_all_categories_by_default
-    user_ids = User.watching_topic_when_mute_categories_by_default(topic)
+    user_ids = User.watching_topic(topic)
       .where("users.last_seen_at > ?", 7.days.ago)
       .order("users.last_seen_at DESC")
       .limit(100)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -265,7 +265,7 @@ class User < ActiveRecord::Base
     end
   end
 
-  scope :watching_topic_when_mute_categories_by_default, ->(topic) do
+  scope :watching_topic, ->(topic) do
     joins(DB.sql_fragment("LEFT JOIN category_users ON category_users.user_id = users.id AND category_users.category_id = :category_id", category_id: topic.category_id))
       .joins(DB.sql_fragment("LEFT JOIN topic_users ON topic_users.user_id = users.id AND topic_users.topic_id = :topic_id",  topic_id: topic.id))
       .joins("LEFT JOIN tag_users ON tag_users.user_id = users.id AND tag_users.tag_id IN (#{topic.tag_ids.join(",").presence || 'NULL'})")


### PR DESCRIPTION
Previously, when categories were not muted by default, we were sending message about unmuted topics (topics which user explicitly set notification level to watching)

The same mechanism can be used to fix a bug. When the user was explicitly watching topic, but category was muted, then the user was not informed about new reply.