### PR TITLE
FIX: Missing sidebar section link icon for PM tags

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/messages-section/message-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/messages-section/message-section-link.js
@@ -73,14 +73,10 @@ export default class MessageSectionLink {
   }
 
   get prefixType() {
-    if (this._isInbox) {
-      return "icon";
-    }
+    return "icon";
   }
 
   get prefixValue() {
-    if (this._isInbox) {
-      return "inbox";
-    }
+    return "inbox";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/base-tag-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/base-tag-section-link.js
@@ -1,0 +1,21 @@
+export default class BaseTagSectionLink {
+  constructor({ tagName }) {
+    this.tagName = tagName;
+  }
+
+  get name() {
+    return this.tagName;
+  }
+
+  get text() {
+    return this.tagName;
+  }
+
+  get prefixType() {
+    return "icon";
+  }
+
+  get prefixValue() {
+    return "tag";
+  }
+}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/pm-tag-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/pm-tag-section-link.js
@@ -1,11 +1,9 @@
-export default class PMTagSectionLink {
-  constructor({ tagName, currentUser }) {
-    this.tagName = tagName;
-    this.currentUser = currentUser;
-  }
+import BaseTagSectionLink from "discourse/lib/sidebar/user/tags-section/base-tag-section-link";
 
-  get name() {
-    return this.tagName;
+export default class PMTagSectionLink extends BaseTagSectionLink {
+  constructor({ currentUser }) {
+    super(...arguments);
+    this.currentUser = currentUser;
   }
 
   get models() {
@@ -14,9 +12,5 @@ export default class PMTagSectionLink {
 
   get route() {
     return "userPrivateMessages.tagsShow";
-  }
-
-  get text() {
-    return this.tagName;
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
@@ -3,13 +3,14 @@ import I18n from "I18n";
 import { tracked } from "@glimmer/tracking";
 
 import { bind } from "discourse-common/utils/decorators";
+import BaseTagSectionLink from "discourse/lib/sidebar/user/tags-section/base-tag-section-link";
 
-export default class TagSectionLink {
+export default class TagSectionLink extends BaseTagSectionLink {
   @tracked totalUnread = 0;
   @tracked totalNew = 0;
 
-  constructor({ tagName, topicTrackingState }) {
-    this.tagName = tagName;
+  constructor({ topicTrackingState }) {
+    super(...arguments);
     this.topicTrackingState = topicTrackingState;
     this.refreshCounts();
   }
@@ -25,10 +26,6 @@ export default class TagSectionLink {
         tagId: this.tagName,
       });
     }
-  }
-
-  get name() {
-    return this.tagName;
   }
 
   get models() {
@@ -49,10 +46,6 @@ export default class TagSectionLink {
     return "tag.show tag.showNew tag.showUnread tag.showTop";
   }
 
-  get text() {
-    return this.tagName;
-  }
-
   get badgeText() {
     if (this.totalUnread > 0) {
       return I18n.t("sidebar.unread_count", {
@@ -63,13 +56,5 @@ export default class TagSectionLink {
         count: this.totalNew,
       });
     }
-  }
-
-  get prefixType() {
-    return "icon";
-  }
-
-  get prefixValue() {
-    return "tag";
   }
 }


### PR DESCRIPTION
No tests cause a missing icon regression is not the end of the world and
I don't feel like it will provide enough value as a regression test long
term.