### PR TITLE
DEV: Remove contextual topic list linking behaviour in sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/everything-section-link.js
@@ -63,13 +63,7 @@ export default class EverythingSectionLink extends BaseSectionLink {
   }
 
   get route() {
-    if (this.totalUnread > 0) {
-      return "discovery.unread";
-    } else if (this.totalNew > 0) {
-      return "discovery.new";
-    } else {
-      return "discovery.latest";
-    }
+    return "discovery.latest";
   }
 
   get prefixValue() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
@@ -79,12 +79,6 @@ export default class CategorySectionLink {
   }
 
   get route() {
-    if (this.totalUnread > 0) {
-      return "discovery.unreadCategory";
-    } else if (this.totalNew > 0) {
-      return "discovery.newCategory";
-    } else {
-      return "discovery.category";
-    }
+    return "discovery.category";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/tracked-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/tracked-section-link.js
@@ -64,13 +64,7 @@ export default class TrackedSectionLink extends BaseSectionLink {
   }
 
   get route() {
-    if (this.totalUnread > 0) {
-      return "discovery.unread";
-    } else if (this.totalNew > 0) {
-      return "discovery.new";
-    } else {
-      return "discovery.latest";
-    }
+    return "discovery.latest";
   }
 
   get prefixValue() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
@@ -33,13 +33,7 @@ export default class TagSectionLink extends BaseTagSectionLink {
   }
 
   get route() {
-    if (this.totalUnread > 0) {
-      return "tag.showUnread";
-    } else if (this.totalNew > 0) {
-      return "tag.showNew";
-    } else {
-      return "tag.show";
-    }
+    return "tag.show";
   }
 
   get currentWhen() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -583,11 +583,6 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       "it displays the right unread count"
     );
 
-    assert.ok(
-      query(".sidebar-section-link-everything").href.endsWith("/unread"),
-      "it links to unread filter"
-    );
-
     // simulate reading topic 2
     await publishToMessageBus("/unread", {
       topic_id: 2,
@@ -637,11 +632,6 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       "it displays the new count once there are no unread topics"
     );
 
-    assert.ok(
-      query(".sidebar-section-link-everything").href.endsWith("/new"),
-      "it links to new filter"
-    );
-
     await publishToMessageBus("/unread", {
       topic_id: 1,
       message_type: "read",
@@ -657,11 +647,6 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
         ".sidebar-section-link-everything .sidebar-section-link-content-badge"
       ),
       "it removes new count once there are no new topics"
-    );
-
-    assert.ok(
-      query(".sidebar-section-link-everything").href.endsWith("/latest"),
-      "it links to latest filter"
     );
   });
 
@@ -871,11 +856,6 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       "it displays the right unread count"
     );
 
-    assert.ok(
-      query(".sidebar-section-link-tracked").href.endsWith("/unread?f=tracked"),
-      "it links to unread url with tracked filter"
-    );
-
     // simulate reading topic id 2
     await publishToMessageBus("/unread", {
       topic_id: 2,
@@ -922,11 +902,6 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       "it displays the new count once there are no tracked unread topics"
     );
 
-    assert.ok(
-      query(".sidebar-section-link-tracked").href.endsWith("/new?f=tracked"),
-      "it links to new url with tracked filter"
-    );
-
     // simulate reading topic id 1
     await publishToMessageBus("/unread", {
       topic_id: 1,
@@ -942,11 +917,6 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
         ".sidebar-section-link-tracked .sidebar-section-link-content-badge"
       ),
       "it removes new count once there are no tracked new topics"
-    );
-
-    assert.ok(
-      query(".sidebar-section-link-tracked").href.endsWith("/latest?f=tracked"),
-      "it links to latest url with tracked filter"
     );
   });
 


### PR DESCRIPTION
The feedback we got here is that the contextual topic list link
behaviour is surprising and people prefer that the topic list sidebar
links always go to a consistent location.

Internal ref: /t/74666/16