### PR TITLE
DEV: removes legacy sanitizer helper from topic

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -3,7 +3,6 @@
 class Topic < ActiveRecord::Base
   class UserExists < StandardError; end
   class NotAllowed < StandardError; end
-  include ActionView::Helpers::SanitizeHelper
   include RateLimiter::OnCreateRecord
   include HasCustomFields
   include Trashable


### PR DESCRIPTION
No methods from https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html seem to be used in models/topic.rb
