### PR TITLE
DEV: Add a rake task to export/import translation overrides

### DIFF
--- a/lib/import_export.rb
+++ b/lib/import_export.rb
@@ -6,6 +6,7 @@ require "import_export/category_structure_exporter"
 require "import_export/category_exporter"
 require "import_export/topic_exporter"
 require "import_export/group_exporter"
+require "import_export/translation_overrides_exporter"
 require "json"
 
 module ImportExport
@@ -31,4 +32,7 @@ module ImportExport
     ImportExport::GroupExporter.new(include_users).perform.save_to_file(filename)
   end
 
+  def self.export_translation_overrides(filename = nil)
+    ImportExport::TranslationOverridesExporter.new.perform.save_to_file(filename)
+  end
 end

--- a/lib/import_export/base_exporter.rb
+++ b/lib/import_export/base_exporter.rb
@@ -178,6 +178,12 @@ module ImportExport
       data
     end
 
+    def export_translation_overrides
+      @export_data[:translation_overrides] = TranslationOverride.all.select(:locale, :translation_key, :value)
+
+      self
+    end
+
     def default_filename_prefix
       raise "Overwrite me!"
     end

--- a/lib/import_export/importer.rb
+++ b/lib/import_export/importer.rb
@@ -10,6 +10,7 @@ module ImportExport
       @groups = data[:groups]
       @categories = data[:categories]
       @topics = data[:topics]
+      @translation_overrides = data[:translation_overrides]
 
       # To support legacy `category_export` script
       if data[:category].present?
@@ -25,6 +26,7 @@ module ImportExport
       import_groups
       import_categories
       import_topics
+      import_translation_overrides
 
       self
     ensure
@@ -165,6 +167,16 @@ module ImportExport
       puts ""
 
       self
+    end
+
+    def import_translation_overrides
+      puts "Importing translation overrides..."
+
+      @translation_overrides.each do |tu|
+        TranslationOverride.upsert!(tu[:locale], tu[:translation_key], tu[:value])
+      end
+
+      TranslationOverride.reload_all_overrides!
     end
 
     def new_user_id(external_user_id)

--- a/lib/import_export/importer.rb
+++ b/lib/import_export/importer.rb
@@ -170,6 +170,8 @@ module ImportExport
     end
 
     def import_translation_overrides
+      return if @translation_overrides.blank?
+
       puts "Importing translation overrides..."
 
       @translation_overrides.each do |tu|

--- a/lib/import_export/translation_overrides_exporter.rb
+++ b/lib/import_export/translation_overrides_exporter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ImportExport
+  class TranslationOverridesExporter < BaseExporter
+
+    def initialize()
+      @export_data = {
+        translation_overrides: []
+      }
+    end
+
+    def perform
+      puts "Exporting all translation overrides...", ""
+      export_translation_overrides
+
+      self
+    end
+
+    def default_filename_prefix
+      "translation-overrides"
+    end
+
+  end
+end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -24,3 +24,11 @@ task 'export:groups', [:include_group_users, :file_name] => [:environment] do |_
   ImportExport.export_groups(args[:include_group_users], args[:file_name])
   puts "", "Done", ""
 end
+
+desc 'Export all translation overrides'
+task 'export:translation_overrides' => [:environment] do |_, args|
+  require "import_export"
+
+  ImportExport.export_translation_overrides
+  puts "", "Done", ""
+end

--- a/spec/fixtures/json/import-export.json
+++ b/spec/fixtures/json/import-export.json
@@ -27,5 +27,8 @@
         {"id":7,"user_id":-1,"post_number":2,"raw":"Edit the first post in this topic to change the contents of the FAQ/Guidelines page.","created_at":"2017-10-26T17:15:03.822Z","reply_to_post_number":null,"hidden":false,"hidden_reason_id":null,"wiki":false}
       ]
     }
+  ],
+  "translation_overrides":[
+    {"locale":"en","translation_key":"login_required.welcome_message","value":"## [Dude, Welcome to %{title}](#welcome)\nAn account is required. Please create an account or log in to continue again!\n"}
   ]
 }

--- a/spec/import_export/importer_spec.rb
+++ b/spec/import_export/importer_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe ImportExport::Importer do
         .and change { Group.count }.by(2)
         .and change { Topic.count }.by(8)
         .and change { User.count }.by(2)
+        .and change { TranslationOverride.count }.by(1)
     end
   end
 end


### PR DESCRIPTION
Use `bin/rake export:translation_overrides` to export to a file. Then, copy that file to a new site and run `bin/rake import:file["filename"].
