### PR TITLE
FEATURE: Export locale overrides for default client/server files

### DIFF
--- a/app/services/locale_overrides_task.rb
+++ b/app/services/locale_overrides_task.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class LocaleOverridesTask
+  SUPPORTED_TYPES = ["client","server"]
+  def self.export_to_hash(type)
+    if !type.in?(SUPPORTED_TYPES)
+      raise Discourse::InvalidParameters,  "Unsupported type provided, must be one of #{SUPPORTED_TYPES}"
+    end
+    locale_file = LocaleFileChecker.new.load_default_locale_files(I18n.locale)[type.to_sym]
+    overrides = TranslationOverride.where(locale: I18n.locale)
+    locale_hash = Hash.new { |h,k| h[k] = h.dup.clear }
+    overrides.each{|t|
+      # Check if this override is in the specified hash
+      # If it is go ahead and store it
+
+      this_override_key = t.translation_key.to_s
+      this_override_key_path = this_override_key.split(".")
+      if (!locale_file.dig(I18n.locale.to_s, *this_override_key_path).nil?)
+        # Value exists for this type, let's create the correct path for the export
+
+        # First, use dig to create the path if it isn't already present
+        locale_hash.dig(*this_override_key_path)
+
+        # Now, use inject to set the value
+        this_override_key_path[0...-1].inject(locale_hash, :fetch)[this_override_key_path.last] = t.value
+      end
+    }
+
+    override_hash = {}
+    override_hash[I18n.locale.to_s] = locale_hash
+
+    override_hash
+  end
+end

--- a/lib/i18n/locale_file_checker.rb
+++ b/lib/i18n/locale_file_checker.rb
@@ -32,6 +32,21 @@ class LocaleFileChecker
     @errors
   end
 
+  def load_default_locale_files(locale)
+    @locale = locale.to_s
+    locale_files.each do |locale_path|
+      if locale_path.match(Regexp.new "#{Rails.root}/#{YML_DIRS[0]}/server")
+        @locale_server_yaml = YAML.load_file(locale_path)
+      end
+
+      if locale_path.match(Regexp.new "#{Rails.root}/#{YML_DIRS[0]}/client")
+        @locale_client_yaml = YAML.load_file(locale_path)
+      end
+    end
+
+    {server: @locale_server_yaml, client: @locale_client_yaml}
+  end
+
   private
 
   YML_DIRS = ["config/locales", "plugins/**/locales"]

--- a/lib/tasks/locale_overrides.rake
+++ b/lib/tasks/locale_overrides.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+desc 'Exports locale overrides'
+task 'locale_overrides:export', [:type] => [:environment] do |_, args|
+  begin
+    h = LocaleOverridesTask.export_to_hash(args[:type])
+    puts h.to_yaml
+  rescue => e
+    STDERR.puts e
+  end
+end


### PR DESCRIPTION
This commit creates a rake task to export a yml file of overridden client/server translations. In order to do this, I've created a second accessible function in the LocaleFileChecker, load_default_locale_files, that will return the contents of the server and client locale files located at config/locales/*.XX.yml, where the locale XX is the default for the Discourse configuration.

We then loop through all values configured in that TranslationOverride table and use the defaults above to determine if the overridden value is from the client.yml file or the server.yml file. Values for the specified type are then output by the rake task created here.

To call the rake task, use

  rake locale_overrides: export[client]
  rake locale_overrides: export[server]

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
