### PR TITLE
FIX: Make sure first admin users are added to auto groups

### DIFF
--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -308,6 +308,10 @@ class Auth::DefaultCurrentUserProvider
     }
   end
 
+  # This is also used to set the first admin of the site via
+  # the finish installation & register -> user account activation
+  # for signup flow, since all admin emails are stored in
+  # DISCOURSE_DEVELOPER_EMAILS for self-hosters.
   def make_developer_admin(user)
     if  user.active? &&
         !user.admin &&
@@ -315,6 +319,7 @@ class Auth::DefaultCurrentUserProvider
         Rails.configuration.developer_emails.include?(user.email)
       user.admin = true
       user.save
+      Group.refresh_automatic_groups!(:staff, :admins)
     end
   end
 


### PR DESCRIPTION
When a user with an email matching those inside the DISCOURSE_DEVELOPER_EMAILS env var log in, we make them into admin users if they are not already. This is used when setting up the first admin user for
self-hosters, since the discourse-setup script sets the provided admin emails into DISCOURSE_DEVELOPER_EMAILS.

The issue being fixed here is that the new admins were not being automatically added to the staff and admins automatic groups, which was causing issues with the site settings that are group_list based that don't have an explicit staff override. All we need to do is refresh the automatic staff, admin groups when admin is granted for the user.
