### PR TITLE
FIX: do not prefill default site title value on wizard introduction step

### DIFF
--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -13,7 +13,7 @@ class Wizard
       @wizard.append_step('introduction') do |step|
         step.banner = "welcome-illustration"
 
-        step.add_field(id: 'title', type: 'text', required: true, value: SiteSetting.title)
+        step.add_field(id: 'title', type: 'text', required: true, value: SiteSetting.title == SiteSetting.defaults[:title] ? "" : SiteSetting.title)
         step.add_field(id: 'site_description', type: 'text', required: false, value: SiteSetting.site_description)
         step.add_field(id: 'contact_email', type: 'text', required: true, value: SiteSetting.contact_email)
 

--- a/spec/lib/wizard/wizard_builder_spec.rb
+++ b/spec/lib/wizard/wizard_builder_spec.rb
@@ -32,6 +32,42 @@ RSpec.describe Wizard::Builder do
     expect(wizard.steps).to be_blank
   end
 
+  describe 'introduction' do
+    let(:introduction_step) { wizard.steps.find { |s| s.id == 'introduction' } }
+
+    it 'should not prefill default site setting values' do
+      fields = introduction_step.fields
+      title_field = fields.first
+      description_field = fields.second
+      contact_email_field = fields.third
+
+      expect(title_field.id).to eq('title')
+      expect(title_field.value).to eq("")
+      expect(description_field.id).to eq('site_description')
+      expect(description_field.value).to eq("")
+      expect(contact_email_field.id).to eq('contact_email')
+      expect(contact_email_field.value).to eq("")
+    end
+
+    it 'should prefill overridden site setting values' do
+      SiteSetting.title = "foobar"
+      SiteSetting.site_description = "lorem ipsum"
+      SiteSetting.contact_email = "foobar@example.com"
+
+      fields = introduction_step.fields
+      title_field = fields.first
+      description_field = fields.second
+      contact_email_field = fields.third
+
+      expect(title_field.id).to eq('title')
+      expect(title_field.value).to eq("foobar")
+      expect(description_field.id).to eq('site_description')
+      expect(description_field.value).to eq("lorem ipsum")
+      expect(contact_email_field.id).to eq('contact_email')
+      expect(contact_email_field.value).to eq("foobar@example.com")
+    end
+  end
+
   describe 'privacy step' do
     let(:privacy_step) { wizard.steps.find { |s| s.id == 'privacy' } }
 


### PR DESCRIPTION
Internal topic: `/t/-/74660/12`