### PR TITLE
PERF: Move dominant color calculation to separate job

### DIFF
--- a/app/jobs/scheduled/backfill_dominant_colors.rb
+++ b/app/jobs/scheduled/backfill_dominant_colors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Jobs
+  class BackfillDominantColors < ::Jobs::Scheduled
+    every 15.minutes
+
+    def execute(args)
+      Upload.backfill_dominant_colors!(25)
+    end
+  end
+end

--- a/app/jobs/scheduled/periodical_updates.rb
+++ b/app/jobs/scheduled/periodical_updates.rb
@@ -48,8 +48,6 @@ module Jobs
 
       Category.auto_bump_topic!
 
-      Upload.backfill_dominant_colors!(25)
-
       nil
     end
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -666,6 +666,19 @@ RSpec.describe Upload do
       expect(red_image.dominant_color).to eq("FF0000")
     end
 
+    it "is backfilled by the job" do
+      expect(white_image.dominant_color).to eq(nil)
+      expect(red_image.dominant_color).to eq(nil)
+
+      Jobs::BackfillDominantColors.new.execute({})
+
+      white_image.reload
+      red_image.reload
+
+      expect(white_image.dominant_color).to eq("FFFFFF")
+      expect(red_image.dominant_color).to eq("FF0000")
+    end
+
     it "stores an empty string for non-image uploads" do
       expect(not_an_image.dominant_color).to eq(nil)
       expect(not_an_image.dominant_color(calculate_if_missing: true)).to eq("")


### PR DESCRIPTION
This will ensure that any potential problems with this process do not affect the performance or reliability of the PeriodicalUpdates job.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
