### PR TITLE
UX: ensures we don't focus invisible button in sidebar

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -32,6 +32,10 @@
       .discourse-no-touch & {
         transition: all 0.25s;
         opacity: 0;
+
+        &:focus {
+          opacity: 1;
+        }
       }
 
       background: transparent;
@@ -74,6 +78,10 @@
 
     &.sidebar-section-header-collapsable {
       justify-content: flex-start;
+
+      &:focus {
+        background: transparent;
+      }
     }
   }
 


### PR DESCRIPTION
Before this fix, pressing the tab multiple times in the sidebar, you would focus on the invisible "sidebar-section-header-button." This change ensures the button will become visible when tabbing, even if not hovering over this section.

The `background: transparent change` is to avoid a flashing background due to different transition timing on the collapsable button.
