### PR TITLE
FIX: Arrive at topic must be hidden when `must_approve_users`

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-invite.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-invite.js
@@ -182,6 +182,14 @@ export default Controller.extend(
       return staff || groups.any((g) => g.owner);
     },
 
+    @discourseComputed("currentUser.staff")
+    canArriveAtTopic(staff) {
+      if (staff && !this.siteSettings.must_approve_users) {
+        return true;
+      }
+      return false;
+    },
+
     @discourseComputed
     timeShortcuts() {
       const timezone = this.currentUser.timezone;

--- a/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-invite.hbs
@@ -59,7 +59,7 @@
       </div>
     {{/if}}
 
-    {{#if this.currentUser.staff}}
+    {{#if this.canArriveAtTopic}}
       <div class="input-group invite-to-topic">
         <label for="invite-topic">{{d-icon "hand-point-right"}}{{i18n "user.invited.invite.invite_to_topic"}}</label>
         <TopicChooser @value={{this.buffered.topicId}} @content={{this.topics}} @onChange={{action "onChangeTopic"}} @options={{hash

--- a/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
@@ -229,3 +229,17 @@ acceptance(
     });
   }
 );
+
+acceptance(
+  "Invites - Create Invite on Site with must_approve_users Setting",
+  function (needs) {
+    needs.user();
+    needs.settings({ must_approve_users: true });
+
+    test("hides `Arrive at Topic` field on sites with `must_approve_users`", async function (assert) {
+      await visit("/u/eviltrout/invited/pending");
+      await click(".user-invite-buttons .btn:first-child");
+      assert.ok(!exists(".invite-to-topic"));
+    });
+  }
+);


### PR DESCRIPTION
The "Arrive at Topic" field in the Create Invite modal must be hidden when a site has enabled the setting: `must_approve_users`