### PR TITLE
UX: add more spacing to tab btns

### DIFF
--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -69,6 +69,12 @@
   }
 }
 
+.tabs-list .btn {
+  .user-menu-revamped & {
+    padding: 1.2em 1.4em;
+  }
+}
+
 .hamburger-panel .revamped {
   --d-sidebar-row-horizontal-padding: 1rem;
   --d-sidebar-highlight-color: var(--primary-low);


### PR DESCRIPTION
Some css for this request:
<img width="1458" alt="image" src="https://user-images.githubusercontent.com/101828855/194423813-995f672b-9b4b-44d3-af7e-b5ee2c6d879c.png">

**before:**
<img width="402" alt="image" src="https://user-images.githubusercontent.com/101828855/194424064-cc29c271-e0e0-4bf4-9280-c6c5bed5c66b.png">

**new:**
<img width="452" alt="image" src="https://user-images.githubusercontent.com/101828855/194424008-24bbcdd9-48b9-4885-bbf5-d5f7d8cf16e3.png">
