### PR TITLE
FIX: Determining if date ranges are the same day is erroring when there is no time

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -58,6 +58,12 @@ export function applyLocalDates(dates, siteSettings) {
 }
 
 function _rangeIsSameLocalDay(fromElement, toElement) {
+  if (
+    !fromElement.attributes["data-time"] ||
+    !toElement.attributes["data-time"]
+  ) {
+    return false;
+  }
   const timezone = fromElement.attributes["data-timezone"].value;
   const from = moment(_getDateFromElement(fromElement)).tz(timezone);
   const to = moment(_getDateFromElement(toElement)).tz(timezone);

--- a/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/lib/local-date-builder-test.js
@@ -11,7 +11,7 @@ const PARIS = "Europe/Paris";
 const LAGOS = "Africa/Lagos";
 const LONDON = "Europe/London";
 
-function freezeTime({ date, timezone }, cb) {
+export function freezeTime({ date, timezone }, cb) {
   date = date || "2020-01-22 10:34";
   const newTimezone = timezone || PARIS;
   const previousZone = moment.tz.guess();
@@ -89,11 +89,11 @@ module("lib:local-date-builder", function () {
   test("time", function (assert) {
     assert.buildsCorrectDate(
       {
-        "time": "12:22:00",
-        "date": "2022-10-07",
-        "timezone": "Asia/Singapore",
-        "localTimezone": "Asia/Singapore",
-        "sameLocalDayAsFrom": true
+        time: "12:22:00",
+        date: "2022-10-07",
+        timezone: "Asia/Singapore",
+        localTimezone: "Asia/Singapore",
+        sameLocalDayAsFrom: true,
       },
       { formatted: "12:22 PM (Singapore)" },
       "it displays the time only as the date is the same local day as 'from'"

--- a/plugins/discourse-local-dates/test/javascripts/unit/discourse-local-dates-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/unit/discourse-local-dates-test.js
@@ -1,0 +1,80 @@
+import { module, test } from "qunit";
+import { applyLocalDates } from "../initializers/discourse-local-dates";
+import { freezeTime } from "../lib/local-date-builder-test";
+
+module("Unit | Discourse Local Dates | discourse-local-dates", function () {
+  function createElementFromHTML(htmlString) {
+    const div = document.createElement("div");
+    div.innerHTML = htmlString.trim();
+    // we need "element", not "node", since `.dataset` isn't available on nodes
+    return div.firstElementChild;
+  }
+
+  const fromElement = () =>
+    createElementFromHTML(
+      "<span " +
+        'data-date="2022-10-06" ' +
+        'data-time="17:21:00" ' +
+        'class="discourse-local-date" ' +
+        'data-range="from" ' +
+        'data-timezone="Asia/Singapore" ' +
+        'data-title="Testing dates with the local date builder">' +
+        "</span>"
+    );
+  const toElement = () =>
+    createElementFromHTML(
+      "<span " +
+        'data-date="2022-10-06" ' +
+        'data-time="22:22:00" ' +
+        'class="discourse-local-date" ' +
+        'data-range="to" ' +
+        'data-timezone="Asia/Singapore" ' +
+        'data-title="Testing dates with the local date builder">' +
+        "</span>"
+    );
+
+  test("applyLocalDates sets formatted relative time", function (assert) {
+    const from = fromElement();
+    const to = toElement();
+    const dateElements = [from, to];
+
+    freezeTime(
+      { date: "2022-10-07T10:10:10", timezone: "Asia/Singapore" },
+      () => {
+        applyLocalDates(dateElements, { discourse_local_dates_enabled: true });
+
+        assert.equal(
+          from.querySelector(".relative-time").textContent,
+          "Yesterday 5:21 PM"
+        );
+        assert.equal(
+          to.querySelector(".relative-time").textContent,
+          "10:22 PM (Singapore)"
+        );
+      }
+    );
+  });
+
+  test("applyLocalDates does not fail when a date element has no time", function (assert) {
+    const from = fromElement();
+    const to = toElement();
+    delete to.dataset.time;
+    const dateElements = [from, to];
+
+    freezeTime(
+      { date: "2022-10-07T10:10:10", timezone: "Asia/Singapore" },
+      () => {
+        applyLocalDates(dateElements, { discourse_local_dates_enabled: true });
+
+        assert.equal(
+          from.querySelector(".relative-time").textContent,
+          "Yesterday 5:21 PM"
+        );
+        assert.equal(
+          to.querySelector(".relative-time").textContent,
+          "Thursday"
+        );
+      }
+    );
+  });
+});


### PR DESCRIPTION
Some date ranges have no "time" data attribute, e.g. `[date-range from=2021-10-08 to=2021-10-08 timezone="Asia/Singapore"]`. This covers for those cases.