### PR TITLE
UX: Default to dark category logo on dark schemes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/category-logo.js
+++ b/app/assets/javascripts/discourse/app/components/category-logo.js
@@ -1,3 +1,23 @@
-import templateOnly from "@ember/component/template-only";
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
 
-export default templateOnly();
+export default class CategoryLogo extends Component {
+  @service session;
+
+  constructor() {
+    super(...arguments);
+  }
+
+  get defaultCategoryLogo() {
+    // use dark logo by default in edge case
+    // when scheme is dark and dark logo is present
+    if (
+      this.session.defaultColorSchemeIsDark &&
+      this.args.category.uploaded_logo_dark
+    ) {
+      return this.args.category.uploaded_logo_dark;
+    }
+
+    return this.args.category.uploaded_logo;
+  }
+}

--- a/app/assets/javascripts/discourse/app/components/category-logo.js
+++ b/app/assets/javascripts/discourse/app/components/category-logo.js
@@ -4,10 +4,6 @@ import { inject as service } from "@ember/service";
 export default class CategoryLogo extends Component {
   @service session;
 
-  constructor() {
-    super(...arguments);
-  }
-
   get defaultCategoryLogo() {
     // use dark logo by default in edge case
     // when scheme is dark and dark logo is present

--- a/app/assets/javascripts/discourse/app/templates/components/category-logo.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/category-logo.hbs
@@ -2,7 +2,7 @@
   {{#if (and @category.uploaded_logo.url @category.uploaded_logo_dark.url)}}
     <picture>
       <source srcset={{@category.uploaded_logo_dark.url}} width={{@category.uploaded_logo_dark.width}} height={{@category.uploaded_logo_dark.height}} media="(prefers-color-scheme: dark)">
-      <CdnImg @src={{@category.uploaded_logo.url}} @width={{@category.uploaded_logo.width}} @height={{@category.uploaded_logo.height}}/>
+      <CdnImg @src={{this.defaultCategoryLogo.url}} @width={{this.defaultCategoryLogo.width}} @height={{this.defaultCategoryLogo.height}}/>
     </picture>
   {{else if @category.uploaded_logo.url}}
     <CdnImg @src={{@category.uploaded_logo.url}} @width={{@category.uploaded_logo.width}} @height={{@category.uploaded_logo.height}}/>


### PR DESCRIPTION
Fixes an edge case for when a category has a dark logo and the loaded color scheme is dark. Followup to https://github.com/discourse/discourse/pull/18460. 
