### PR TITLE
FEATURE: Adds seeded default categories to the sidebar

### DIFF
--- a/lib/seed_data/categories.rb
+++ b/lib/seed_data/categories.rb
@@ -64,7 +64,8 @@ module SeedData
           color: '808281',
           text_color: 'FFFFFF',
           permissions: { everyone: :full },
-          force_permissions: true
+          force_permissions: true,
+          sidebar: true
         },
         {
           site_setting_name: 'staff_category_id',
@@ -74,7 +75,8 @@ module SeedData
           color: 'E45735',
           text_color: 'FFFFFF',
           permissions: { staff: :full },
-          force_permissions: true
+          force_permissions: true,
+          sidebar: true
         },
         {
           site_setting_name: 'general_category_id',
@@ -84,7 +86,8 @@ module SeedData
           color: '25AAE2',
           text_color: 'FFFFFF',
           permissions: { everyone: :full },
-          force_permissions: true
+          force_permissions: true,
+          sidebar: true
         }
       ]
 
@@ -96,7 +99,7 @@ module SeedData
     end
 
     def create_category(site_setting_name:, name:, description:, position:, color:, text_color:,
-                        permissions:, force_permissions:, force_existence: false)
+                        permissions:, force_permissions:, force_existence: false, sidebar: false)
       category_id = SiteSetting.get(site_setting_name)
 
       if should_create_category?(category_id, force_existence)
@@ -114,6 +117,12 @@ module SeedData
         category.save!
 
         SiteSetting.set(site_setting_name, category.id)
+
+        if sidebar
+          sidebar_categories = SiteSetting.default_sidebar_categories.split('|')
+          sidebar_categories << category.id
+          SiteSetting.set('default_sidebar_categories', sidebar_categories.join('|'))
+        end
       elsif category = Category.find_by(id: category_id)
         if description.present? && (category.topic_id.blank? || !Topic.exists?(category.topic_id))
           category.description = description

--- a/spec/lib/seed_data/categories_spec.rb
+++ b/spec/lib/seed_data/categories_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe SeedData::Categories do
       expect(Category.last.name).to eq("General")
     end
 
+    it "adds default categories SiteSetting.default_sidebar_categories" do
+      create_category("staff_category_id")
+      staff_category = Category.last
+      create_category("meta_category_id")
+      site_feedback_category = Category.last
+      create_category("general_category_id")
+      general_category = Category.last
+      site_setting_ids = SiteSetting.default_sidebar_categories.split('|')
+      create_category("uncategorized_category_id")
+
+      expect(site_setting_ids[0].to_i).to eq(staff_category.id)
+      expect(site_setting_ids[1].to_i).to eq(site_feedback_category.id)
+      expect(site_setting_ids[2].to_i).to eq(general_category.id)
+      expect(site_setting_ids.count).to eq(3)
+    end
+
     it "does not override permissions of existing category when not forced" do
       create_category("lounge_category_id")
 


### PR DESCRIPTION
This change adds some of the seeded categories to the
SiteSetting.default_sidebar_categories setting so that new sites will
not have an empty categories section in their sidebar.

Adds the General, Side Feedback, and Staff categories. Uncategorized is
not included.
