### PR TITLE
DEV: Decouple the user status modal from current user's status

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
@@ -59,6 +59,7 @@ export default class UserMenuProfileTabContent extends Component {
     showModal("user-status", {
       title: "user_status.set_custom_status",
       modalClass: "user-status",
+      model: { status: this.currentUser.status },
     });
   }
 }

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
@@ -64,6 +64,7 @@ export default class UserMenuProfileTabContent extends Component {
       model: {
         status: this.currentUser.status,
         saveAction: (status) => this.userStatus.set(status),
+        deleteAction: () => this.userStatus.clear(),
       },
     });
   }

--- a/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/profile-tab-content.js
@@ -6,6 +6,8 @@ import showModal from "discourse/lib/show-modal";
 export default class UserMenuProfileTabContent extends Component {
   @service currentUser;
   @service siteSettings;
+  @service userStatus;
+
   saving = false;
 
   get showToggleAnonymousButton() {
@@ -59,7 +61,10 @@ export default class UserMenuProfileTabContent extends Component {
     showModal("user-status", {
       title: "user_status.set_custom_status",
       modalClass: "user-status",
-      model: { status: this.currentUser.status },
+      model: {
+        status: this.currentUser.status,
+        saveAction: (status) => this.userStatus.set(status),
+      },
     });
   }
 }

--- a/app/assets/javascripts/discourse/app/controllers/user-status.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-status.js
@@ -1,7 +1,6 @@
 import Controller from "@ember/controller";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { action } from "@ember/object";
-import { inject as service } from "@ember/service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseComputed from "discourse-common/utils/decorators";
 import ItsATrap from "@discourse/itsatrap";
@@ -11,7 +10,6 @@ import {
 } from "discourse/lib/time-shortcut";
 
 export default Controller.extend(ModalFunctionality, {
-  userStatusService: service("user-status"),
   showDeleteButton: false,
   prefilledDateTime: null,
   timeShortcuts: null,

--- a/app/assets/javascripts/discourse/app/controllers/user-status.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-status.js
@@ -18,10 +18,10 @@ export default Controller.extend(ModalFunctionality, {
   _itsatrap: null,
 
   onShow() {
-    const currentStatus = { ...this.currentUser.status };
+    const currentStatus = { ...this.model.status };
     this.setProperties({
       status: currentStatus,
-      showDeleteButton: !!this.currentUser.status,
+      showDeleteButton: !!this.model.status,
       timeShortcuts: this._buildTimeShortcuts(),
       prefilledDateTime: currentStatus?.ends_at,
     });

--- a/app/assets/javascripts/discourse/app/controllers/user-status.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-status.js
@@ -72,11 +72,10 @@ export default Controller.extend(ModalFunctionality, {
       emoji: this.status.emoji,
       ends_at: this.status.endsAt?.toISOString(),
     };
-    this.userStatusService
-      .set(newStatus)
-      .then(() => {
-        this.send("closeModal");
-      })
+
+    this.model
+      .saveAction(newStatus)
+      .then(() => this.send("closeModal"))
       .catch((e) => this._handleError(e));
   },
 

--- a/app/assets/javascripts/discourse/app/controllers/user-status.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-status.js
@@ -54,8 +54,8 @@ export default Controller.extend(ModalFunctionality, {
 
   @action
   delete() {
-    this.userStatusService
-      .clear()
+    this.model
+      .deleteAction()
       .then(() => this.send("closeModal"))
       .catch((e) => this._handleError(e));
   },

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
@@ -41,6 +41,9 @@ createWidgetFrom(QuickAccessItem, "user-status-item", {
     showModal("user-status", {
       title: "user_status.set_custom_status",
       modalClass: "user-status",
+      model: {
+        status: this.currentUser.status,
+      },
     });
   },
 

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
@@ -45,6 +45,7 @@ createWidgetFrom(QuickAccessItem, "user-status-item", {
       model: {
         status: this.currentUser.status,
         saveAction: (status) => this.userStatus.set(status),
+        deleteAction: () => this.userStatus.clear(),
       },
     });
   },

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
@@ -26,6 +26,7 @@ createWidgetFrom(QuickAccessItem, "logout-item", {
 
 createWidgetFrom(QuickAccessItem, "user-status-item", {
   tagName: "li.user-status",
+  services: ["userStatus"],
 
   html() {
     const status = this.currentUser.status;
@@ -43,6 +44,7 @@ createWidgetFrom(QuickAccessItem, "user-status-item", {
       modalClass: "user-status",
       model: {
         status: this.currentUser.status,
+        saveAction: (status) => this.userStatus.set(status),
       },
     });
   },


### PR DESCRIPTION
We have this modal for setting user status:

<img width="300" alt="Screenshot 2022-10-08 at 02 26 45" src="https://user-images.githubusercontent.com/1274517/194670953-37c4eccb-8e18-4686-8fa5-38ff75fc245b.png">

Up to this moment, we used it only for setting current user's status. Now we want to add status to the user preferences pages and admins will be able to go to those pages and change statuses of other users. To use the modal there, I had to decouple it from the current user.

I am not adding tests because this behavior is well covered in https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js.
