### PR TITLE
UX: correct colour to nav instead of danger

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/themes-list.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/themes-list.hbs
@@ -1,6 +1,6 @@
 <div class="themes-list-header">
-  <DButton @action={{action "changeView"}} @actionParam={{this.THEMES}} @class={{concat "themes-tab " "tab " (if this.themesTabActive "btn-danger active" "")}} @label="admin.customize.theme.title" />
-  <DButton @action={{action "changeView"}} @actionParam={{this.COMPONENTS}} @class={{concat "components-tab " "tab " (if this.componentsTabActive "btn-danger active" "")}} @label="admin.customize.theme.components" @icon="puzzle-piece" />
+  <DButton @action={{action "changeView"}} @actionParam={{this.THEMES}} @class={{concat "themes-tab " "tab " (if this.themesTabActive "active" "")}} @label="admin.customize.theme.title" />
+  <DButton @action={{action "changeView"}} @actionParam={{this.COMPONENTS}} @class={{concat "components-tab " "tab " (if this.componentsTabActive "active" "")}} @label="admin.customize.theme.components" @icon="puzzle-piece" />
 </div>
 
 <div class="themes-list-container">

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -189,6 +189,8 @@
       text-align: center;
 
       &.active {
+        background-color: var(--quaternary);
+        color: var(--secondary);
         font-weight: 700;
       }
     }


### PR DESCRIPTION
Fixed something minor that was bothering me:

These tab buttons using .btn-danger as active colour
<img width="332" alt="image" src="https://user-images.githubusercontent.com/101828855/194672309-ab581b85-32ba-4f95-8396-d58fdd64a01e.png">

Changed to what it should be: quaternary for nav
<img width="329" alt="image" src="https://user-images.githubusercontent.com/101828855/194672353-cbf79e55-f5ce-4a49-87d1-30b261cab812.png">

