### PR TITLE
Add matching by username to the associated auth

### DIFF
--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -140,7 +140,7 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
   def find_user_by_username(auth_token)
     username = auth_token.dig(:info, :nickname)
     if username
-      User.find_by_username_lower(username.downcase)
+      User.find_by_username(username)
     end
   end
 

--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -140,7 +140,7 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
   def find_user_by_username(auth_token)
     username = auth_token.dig(:info, :nickname)
     if username
-      User.find_by_username(username)
+      User.find_by_username_lower(username.downcase)
     end
   end
 

--- a/spec/lib/auth/managed_authenticator_spec.rb
+++ b/spec/lib/auth/managed_authenticator_spec.rb
@@ -254,6 +254,48 @@ RSpec.describe Auth::ManagedAuthenticator do
         expect(user.user_profile.location).to eq("DiscourseVille")
       end
     end
+
+    describe 'match by username' do
+      SiteSetting.username_change_period = 0
+      authenticator = Class.new(described_class) do
+        def name
+          "myauth"
+        end
+        def match_by_email
+          false
+        end
+        def match_by_username
+          true
+        end
+      end.new
+
+      it 'works normally' do
+        user = Fabricate(:user)
+        result = authenticator.after_authenticate(hash.deep_merge(info: { nickname: user.username }))
+        expect(result.user.id).to eq(user.id)
+        expect(UserAssociatedAccount.find_by(provider_name: 'myauth', provider_uid: "1234").user_id).to eq(user.id)
+      end
+
+      it 'works if there is already an association with the target account' do
+        user = Fabricate(:user, username: "IAmGroot")
+        result = authenticator.after_authenticate(hash)
+        expect(result.user.id).to eq(user.id)
+      end
+
+      it 'does not match if match_by_username is false' do
+        authenticator = Class.new(described_class) do
+          def name
+            "myauth"
+          end
+          def match_by_username
+            false
+          end
+        end.new
+        user = Fabricate(:user, username: "coolguy")
+        result = authenticator.after_authenticate(hash)
+        expect(result.user).to eq(nil)
+      end
+    end
   end
 
   describe 'description_for_user' do

--- a/spec/lib/auth/managed_authenticator_spec.rb
+++ b/spec/lib/auth/managed_authenticator_spec.rb
@@ -285,6 +285,13 @@ RSpec.describe Auth::ManagedAuthenticator do
         expect(result.user.id).to eq(user.id)
       end
 
+      it 'works if the username is different case' do
+        SiteSetting.username_change_period = 0
+        user = Fabricate(:user, username: "IAMGROOT")
+        result = user_match_authenticator.after_authenticate(hash)
+        expect(result.user.id).to eq(user.id)
+      end
+
       it 'does not match if username_change_period isn\'t 0' do
         SiteSetting.username_change_period = 3
         user = Fabricate(:user, username: "IAmGroot")

--- a/spec/lib/auth/managed_authenticator_spec.rb
+++ b/spec/lib/auth/managed_authenticator_spec.rb
@@ -299,6 +299,18 @@ RSpec.describe Auth::ManagedAuthenticator do
         expect(result.user).to eq(nil)
       end
 
+      it 'does not match if default match_by_username not overriden' do
+        SiteSetting.username_change_period = 0
+        authenticator = Class.new(described_class) do
+          def name
+            "myauth"
+          end
+        end.new
+        user = Fabricate(:user, username: "IAmGroot")
+        result = authenticator.after_authenticate(hash)
+        expect(result.user).to eq(nil)
+      end
+
       it 'does not match if match_by_username is false' do
         SiteSetting.username_change_period = 0
         authenticator = Class.new(described_class) do

--- a/spec/lib/auth/managed_authenticator_spec.rb
+++ b/spec/lib/auth/managed_authenticator_spec.rb
@@ -256,33 +256,44 @@ RSpec.describe Auth::ManagedAuthenticator do
     end
 
     describe 'match by username' do
-      SiteSetting.username_change_period = 0
-      authenticator = Class.new(described_class) do
-        def name
-          "myauth"
-        end
-        def match_by_email
-          false
-        end
-        def match_by_username
-          true
-        end
-      end.new
+      let(:user_match_authenticator) {
+        Class.new(described_class) do
+          def name
+            "myauth"
+          end
+          def match_by_email
+            false
+          end
+          def match_by_username
+            true
+          end
+        end.new
+      }
 
       it 'works normally' do
+        SiteSetting.username_change_period = 0
         user = Fabricate(:user)
-        result = authenticator.after_authenticate(hash.deep_merge(info: { nickname: user.username }))
+        result = user_match_authenticator.after_authenticate(hash.deep_merge(info: { nickname: user.username }))
         expect(result.user.id).to eq(user.id)
         expect(UserAssociatedAccount.find_by(provider_name: 'myauth', provider_uid: "1234").user_id).to eq(user.id)
       end
 
       it 'works if there is already an association with the target account' do
+        SiteSetting.username_change_period = 0
         user = Fabricate(:user, username: "IAmGroot")
-        result = authenticator.after_authenticate(hash)
+        result = user_match_authenticator.after_authenticate(hash)
         expect(result.user.id).to eq(user.id)
       end
 
+      it 'does not match if username_change_period isn\'t 0' do
+        SiteSetting.username_change_period = 3
+        user = Fabricate(:user, username: "IAmGroot")
+        result = user_match_authenticator.after_authenticate(hash)
+        expect(result.user).to eq(nil)
+      end
+
       it 'does not match if match_by_username is false' do
+        SiteSetting.username_change_period = 0
         authenticator = Class.new(described_class) do
           def name
             "myauth"
@@ -291,7 +302,7 @@ RSpec.describe Auth::ManagedAuthenticator do
             false
           end
         end.new
-        user = Fabricate(:user, username: "coolguy")
+        user = Fabricate(:user, username: "IAmGroot")
         result = authenticator.after_authenticate(hash)
         expect(result.user).to eq(nil)
       end


### PR DESCRIPTION
This is mostly for cases where SSOs map by username rather than email, providing an option to authenticators to map that way.