### PR TITLE
DEV: Improve UX for user menu tabs when they're empty

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/other-notifications-list-empty-state.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/other-notifications-list-empty-state.hbs
@@ -4,11 +4,7 @@
   </span>
   <div class="empty-state-body">
     <p>
-      {{html-safe (i18n
-        "user.no_other_notifications_body"
-        icon=(d-icon "bell")
-        badgesUrl=(get-url "/badges")
-      )}}
+      {{html-safe (i18n "user.no_other_notifications_body")}}
     </p>
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/components/user-menu/other-notifications-list-empty-state.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-menu/other-notifications-list-empty-state.hbs
@@ -1,0 +1,14 @@
+<div class="empty-state">
+  <span class="empty-state-title">
+    {{i18n "user.no_other_notifications_title"}}
+  </span>
+  <div class="empty-state-body">
+    <p>
+      {{html-safe (i18n
+        "user.no_other_notifications_body"
+        icon=(d-icon "bell")
+        badgesUrl=(get-url "/badges")
+      )}}
+    </p>
+  </div>
+</div>

--- a/app/assets/javascripts/discourse/app/components/user-menu/other-notifications-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/other-notifications-list.js
@@ -1,13 +1,12 @@
 import UserMenuNotificationsList from "discourse/components/user-menu/notifications-list";
-import { inject as service } from "@ember/service";
 
 export default class UserMenuOtherNotificationsList extends UserMenuNotificationsList {
-  @service currentUser;
-  @service siteSettings;
-  @service site;
-
   get dismissTypes() {
     return this.filterByTypes;
+  }
+
+  get emptyStateComponent() {
+    return "user-menu/other-notifications-list-empty-state";
   }
 
   dismissWarningModal() {

--- a/app/assets/javascripts/discourse/app/components/user-menu/replies-notifications-list.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/replies-notifications-list.js
@@ -8,4 +8,8 @@ export default class UserMenuRepliesNotificationsList extends UserMenuNotificati
   dismissWarningModal() {
     return null;
   }
+
+  get emptyStateComponent() {
+    return "user-menu/notifications-list-empty-state";
+  }
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/other-notifications-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/other-notifications-list-test.js
@@ -1,0 +1,31 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { exists, query } from "discourse/tests/helpers/qunit-helpers";
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import I18n from "I18n";
+
+module(
+  "Integration | Component | user-menu | other-notifications-list",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(() => {
+      pretender.get("/notifications", () => {
+        return response({ notifications: [] });
+      });
+    });
+
+    const template = hbs`<UserMenu::OtherNotificationsList/>`;
+
+    test("empty state when there are no notifications", async function (assert) {
+      await render(template);
+      assert.ok(exists(".empty-state .empty-state-body"));
+      assert.strictEqual(
+        query(".empty-state .empty-state-title").textContent.trim(),
+        I18n.t("user.no_other_notifications_title")
+      );
+    });
+  }
+);

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/replies-notifications-list-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/replies-notifications-list-test.js
@@ -1,0 +1,31 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { exists, query } from "discourse/tests/helpers/qunit-helpers";
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import I18n from "I18n";
+
+module(
+  "Integration | Component | user-menu | replies-notifications-list",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(() => {
+      pretender.get("/notifications", () => {
+        return response({ notifications: [] });
+      });
+    });
+
+    const template = hbs`<UserMenu::RepliesNotificationsList/>`;
+
+    test("empty state when there are no notifications", async function (assert) {
+      await render(template);
+      assert.ok(exists(".empty-state .empty-state-body"));
+      assert.strictEqual(
+        query(".empty-state .empty-state-title").textContent.trim(),
+        I18n.t("user.no_notifications_title")
+      );
+    });
+  }
+);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1140,6 +1140,9 @@ en:
         You will be notified in this panel about activity directly relevant to you, including replies to your topics and posts, when someone <b>@mentions</b> you or quotes you, and replies to topics you are watching. Notifications will also be sent to your email when you haven’t logged in for a while.
         <br><br>
         Look for the %{icon} to decide which specific topics, categories and tags you want to be notified about. For more, see your <a href='%{preferencesUrl}'>notification preferences</a>.
+      no_other_notifications_title: "You don’t have any other notifications yet"
+      no_other_notifications_body: >
+        You will be notified in this panel about other kinds of activity that may be relevant to you - for example, when you receive a <a href='%{badgesUrl}'>badge</a> or someone links to or edits one of your posts.
       no_notifications_page_title: "You don’t have any notifications yet"
       no_notifications_page_body: >
         You will be notified about activity directly relevant to you, including replies to your topics and posts, when someone <b>@mentions</b> you or quotes you, and replies to topics you are watching. Notifications will also be sent to your email when you haven’t logged in for a while.

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1142,7 +1142,7 @@ en:
         Look for the %{icon} to decide which specific topics, categories and tags you want to be notified about. For more, see your <a href='%{preferencesUrl}'>notification preferences</a>.
       no_other_notifications_title: "You don’t have any other notifications yet"
       no_other_notifications_body: >
-        You will be notified in this panel about other kinds of activity that may be relevant to you - for example, when you receive a <a href='%{badgesUrl}'>badge</a> or someone links to or edits one of your posts.
+        You will be notified in this panel about other kinds of activity that may be relevant to you - for example, when someone links to or edits one of your posts.
       no_notifications_page_title: "You don’t have any notifications yet"
       no_notifications_page_body: >
         You will be notified about activity directly relevant to you, including replies to your topics and posts, when someone <b>@mentions</b> you or quotes you, and replies to topics you are watching. Notifications will also be sent to your email when you haven’t logged in for a while.


### PR DESCRIPTION
This PR improves the UX for the replies and "other notifications" tabs when they're empty.

Replies and "other notifications" tabs (before):

<img src="https://user-images.githubusercontent.com/17474474/194772044-64a5e5a5-e8f1-43b9-bcc2-57001a8c43d8.png" width=300>

Replies tab (after):

<img src="https://user-images.githubusercontent.com/17474474/194771795-f61b87ff-5612-4a8d-9e00-eb9d2ac776ba.png" width=300>

"Other notifications" tab (after):

<img src="https://user-images.githubusercontent.com/17474474/194771919-2dc8e6a0-774b-496c-afd8-8da0aeca7e5e.png" width=300>

Internal topic: t/76879.