### PR TITLE
FEATURE: double color for subcategories prefix

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/categories-section.hbs
@@ -13,6 +13,7 @@
       @model={{sectionLink.model}}
       @prefixType={{sectionLink.prefixType}}
       @prefixValue={{sectionLink.prefixValue}}
+      @prefixCSS={{sectionLink.prefixCSS}}
       @prefixColor={{sectionLink.prefixColor}} >
     </Sidebar::SectionLink>
   {{/each}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link-prefix.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link-prefix.hbs
@@ -1,5 +1,5 @@
-{{#if @prefixValue}}
-  <span class={{concat-class "sidebar-section-link-prefix" @prefixType @prefixCSSClass}} style={{@prefixCSS}}>
+{{#if @prefixType}}
+  <span class={{concat-class "sidebar-section-link-prefix" @prefixType @prefixCSSClass}} style={{@prefixColorCSS}}>
     {{#if (eq @prefixType "image")}}
       <img src={{@prefixValue}} class="prefix-image">
     {{/if}}
@@ -12,6 +12,10 @@
 
     {{#if (eq @prefixType "icon")}}
       {{d-icon @prefixValue class="prefix-icon"}}
+    {{/if}}
+
+    {{#if (eq @prefixType "span")}}
+      <span style={{@prefixCSS}} class="prefix-span"></span>
     {{/if}}
 
     {{#if @prefixBadge}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link-prefix.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link-prefix.hbs
@@ -1,5 +1,5 @@
 {{#if @prefixType}}
-  <span class={{concat-class "sidebar-section-link-prefix" @prefixType @prefixCSSClass}} style={{@prefixColorCSS}}>
+  <span class={{concat-class "sidebar-section-link-prefix" @prefixType @prefixCSSClass}} style={{html-safe (concat "color: " @prefixColor)}}>
     {{#if (eq @prefixType "image")}}
       <img src={{@prefixValue}} class="prefix-image">
     {{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
@@ -29,6 +29,7 @@
           @prefixValue={{@prefixValue}}
           @prefixCSSClass={{@prefixCSSClass}}
           @prefixCSS={{this.prefixCSS}}
+          @prefixColorCSS={{this.prefixColorCSS}}
           @prefixBadge={{@prefixBadge}}
         />
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
@@ -29,7 +29,7 @@
           @prefixValue={{@prefixValue}}
           @prefixCSSClass={{@prefixCSSClass}}
           @prefixCSS={{this.prefixCSS}}
-          @prefixColorCSS={{this.prefixColorCSS}}
+          @prefixColor={{this.prefixColor}}
           @prefixBadge={{@prefixBadge}}
         />
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { htmlSafe } from "@ember/template";
 
 export default class SectionLink extends Component {
   willDestroy() {
@@ -42,14 +41,14 @@ export default class SectionLink extends Component {
     return [];
   }
 
-  get prefixColorCSS() {
+  get prefixColor() {
     const color = this.args.prefixColor;
 
     if (!color || !color.match(/^\w{6}$/)) {
-      return htmlSafe("");
+      return "";
     }
 
-    return htmlSafe("color: #" + color);
+    return "#" + color;
   }
 
   get prefixCSS() {

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -42,7 +42,7 @@ export default class SectionLink extends Component {
     return [];
   }
 
-  get prefixCSS() {
+  get prefixColorCSS() {
     const color = this.args.prefixColor;
 
     if (!color || !color.match(/^\w{6}$/)) {
@@ -50,5 +50,9 @@ export default class SectionLink extends Component {
     }
 
     return htmlSafe("color: #" + color);
+  }
+
+  get prefixCSS() {
+    return this.args.prefixCSS;
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
@@ -19,6 +19,7 @@
         @prefixBadge={{sectionLink.prefixBadge}}
         @prefixType={{sectionLink.prefixType}}
         @prefixValue={{sectionLink.prefixValue}}
+        @prefixCSS={{sectionLink.prefixCSS}}
         @prefixColor={{sectionLink.prefixColor}} >
       </Sidebar::SectionLink>
     {{/each}}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
@@ -49,11 +49,15 @@ export default class CategorySectionLink {
   }
 
   get prefixType() {
-    return "icon";
+    return "span";
   }
 
-  get prefixValue() {
-    return "square-full";
+  get prefixCSS() {
+    if (this.category.parentCategory) {
+      return `background: linear-gradient(90deg, #${this.category.parentCategory.color} 50%, #${this.category.color} 50%)`;
+    } else {
+      return `background: #${this.category.color}`;
+    }
   }
 
   get prefixColor() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -88,12 +88,18 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
     const category1 = categories[0];
     const category2 = categories[1];
     const category3 = categories[5];
+    const category4 = categories[24];
 
     updateCurrentUser({
-      sidebar_category_ids: [category1.id, category2.id, category3.id],
+      sidebar_category_ids: [
+        category1.id,
+        category2.id,
+        category3.id,
+        category4.id,
+      ],
     });
 
-    return { category1, category2, category3 };
+    return { category1, category2, category3, category4 };
   };
 
   test("clicking on section header link", async function (assert) {
@@ -170,13 +176,14 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
     assert.deepEqual(
       categoryNames,
-      ["abc", "aBC", "efg"],
+      ["abc", "aBC", "efg", "Sub Category"],
       "category section links are displayed in the right order"
     );
   });
 
   test("category section links", async function (assert) {
-    const { category1, category2, category3 } = setupUserSidebarCategories();
+    const { category1, category2, category3, category4 } =
+      setupUserSidebarCategories();
 
     await visit("/");
 
@@ -184,22 +191,15 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
       count(
         ".sidebar-section-categories .sidebar-section-link:not(.sidebar-section-link-all-categories)"
       ),
-      3,
-      "there should only be 3 section link under the section"
+      4,
+      "there should only be 4 section link under the section"
     );
 
     assert.ok(
       exists(
-        `.sidebar-section-link-${category1.slug} .prefix-icon.d-icon-square-full`
+        `.sidebar-section-link-${category1.slug} .sidebar-section-link-prefix .prefix-span[style="background: #${category1.color}"]`
       ),
-      "category1 section link is rendered with right prefix icon"
-    );
-
-    assert.ok(
-      exists(
-        `.sidebar-section-link-${category1.slug} .sidebar-section-link-prefix[style="color: #${category1.color}"]`
-      ),
-      "category1 section link is rendered with right prefix icon color"
+      "category1 section link is rendered with solid prefix icon color"
     );
 
     assert.strictEqual(
@@ -251,6 +251,13 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
         `.sidebar-section-link-${category3.slug} .sidebar-section-link-prefix .prefix-badge.d-icon-lock`
       ),
       "category3 section link is rendered with lock prefix badge icon as it is read restricted"
+    );
+
+    assert.ok(
+      exists(
+        `.sidebar-section-link-${category4.slug} .sidebar-section-link-prefix .prefix-span[style="background: linear-gradient(90deg, #${category4.parentCategory.color} 50%, #${category4.color} 50%)"]`
+      ),
+      "sub category section link is rendered with double prefix color"
     );
   });
 

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -121,7 +121,8 @@
       }
     }
 
-    &.icon {
+    &.icon,
+    &.span {
       position: relative;
       color: var(--primary-medium);
 
@@ -141,6 +142,10 @@
         right: 0;
         margin-right: -0.2em;
       }
+    }
+    .prefix-span {
+      width: 0.9em;
+      height: 0.9em;
     }
   }
 


### PR DESCRIPTION
Subcategories should display color from parent category and subcategory to clearly indicate that it is a subcategory.

`prefixCSS` was moved to `prefixColorCSS` which is a better description. 

<img width="213" alt="Screen Shot 2022-10-10 at 2 37 19 pm" src="https://user-images.githubusercontent.com/72780/194796450-1f041dc4-d10b-461e-a4aa-55491f6f8695.png">
