### PR TITLE
PERF: Exclude anon sidebar tags in site serializer for logged in user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1682,10 +1682,12 @@ class User < ActiveRecord::Base
 
   def sidebar_tags
     return custom_sidebar_tags if custom_sidebar_tags.present?
+
     if SiteSetting.default_sidebar_tags.present?
       tag_names = SiteSetting.default_sidebar_tags.split("|") - DiscourseTagging.hidden_tag_names(guardian)
       return Tag.where(name: tag_names)
     end
+
     Tag.none
   end
 

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -224,7 +224,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def include_anonymous_default_sidebar_tags?
-    SiteSetting.default_sidebar_tags.present?
+    scope.anonymous? && SiteSetting.tagging_enabled && SiteSetting.default_sidebar_tags.present?
   end
 
   private

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -125,15 +125,45 @@ RSpec.describe SiteSerializer do
     expect(serialized[:show_welcome_topic_banner]).to eq(true)
   end
 
-  it 'includes anonymous_default_sidebar_tags' do
-    Fabricate(:tag, name: "dev")
-    Fabricate(:tag, name: "random")
-    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-    expect(serialized[:anonymous_default_sidebar_tags]).to eq(nil)
+  describe '#anonymous_default_sidebar_tags' do
+    fab!(:user) { Fabricate(:user) }
 
-    SiteSetting.default_sidebar_tags = "dev|random"
-    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-    expect(serialized[:anonymous_default_sidebar_tags]).to eq(["dev", "random"])
+    it 'is not included in the serialised object when tagging is not enabled' do
+      SiteSetting.tagging_enabled = false
+      guardian = Guardian.new(user)
+
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+      expect(serialized[:anonymous_default_sidebar_tags]).to eq(nil)
+    end
+
+    describe 'when tagging is enabled and default sidebar tags have been configured' do
+      fab!(:tag) { Fabricate(:tag, name: 'dev') }
+      fab!(:tag2) { Fabricate(:tag, name: 'random') }
+
+      before do
+        SiteSetting.tagging_enabled = true
+        SiteSetting.default_sidebar_tags = "#{tag.name}|#{tag2.name}"
+      end
+
+      it 'is not included in the serialised object when user is not anonymous' do
+        guardian = Guardian.new(user)
+
+        serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+        expect(serialized[:anonymous_default_sidebar_tags]).to eq(nil)
+      end
+
+      it 'is not included in the serialisd object when default sidebar tags have not been configured' do
+        SiteSetting.default_sidebar_tags = ""
+
+        serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+        expect(serialized[:anonymous_default_sidebar_tags]).to eq(nil)
+      end
+
+      it 'is included in the serialised object when user is anonymous' do
+        serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+        expect(serialized[:anonymous_default_sidebar_tags]).to eq(["dev", "random"])
+      end
+    end
   end
 
   describe '#top_tags' do


### PR DESCRIPTION
This commits excludes the `anonymous_default_sidebar_tags` property in `SiteSerializer` when user
is not anonymous and when tagging has been disabled.