### PR TITLE
FIX: do not show welcome CTA banner if the welcome topic is deleted

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -215,7 +215,12 @@ class Site
     return show_welcome_topic_banner unless show_welcome_topic_banner.nil?
 
     show_welcome_topic_banner = if (user_id == User.first_login_admin_id)
-      Post.find_by("topic_id = :topic_id AND post_number = 1 AND version = 1 AND created_at > :created_at", topic_id: SiteSetting.welcome_topic_id, created_at: 1.month.ago).present?
+      Post.joins(:topic)
+        .find_by(
+          "topics.id = :topic_id AND topics.deleted_at IS NULL AND posts.post_number = 1 AND posts.version = 1 AND posts.created_at > :created_at",
+          topic_id: SiteSetting.welcome_topic_id,
+          created_at: 1.month.ago
+        ).present?
     else
       false
     end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -232,6 +232,18 @@ RSpec.describe Site do
       expect(Site.show_welcome_topic_banner?(Guardian.new(admin))).to eq(false)
       expect(Discourse.cache.read(Site.welcome_topic_banner_cache_key(admin.id))).to eq(false)
     end
+
+    it "returns false when welcome topic has been deleted" do
+      admin = Fabricate(:admin)
+      UserAuthToken.generate!(user_id: admin.id)
+
+      topic = Fabricate(:topic, deleted_at: 1.minute.ago)
+      first_post = Fabricate(:post, topic: topic, created_at: 25.days.ago)
+      SiteSetting.welcome_topic_id = topic.id
+
+      expect(Site.show_welcome_topic_banner?(Guardian.new(admin))).to eq(false)
+      expect(Discourse.cache.read(Site.welcome_topic_banner_cache_key(admin.id))).to eq(false)
+    end
   end
 
 end


### PR DESCRIPTION
Internal topic: `/t/-/71275/29`