### PR TITLE
DEV: Increase nginx proxy buffer size

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -17,6 +17,7 @@ proxy_cache_path /var/nginx/cache inactive=1440m levels=1:2 keys_zone=one:10m ma
 # Increased from the default value to acommodate large cookies during oAuth2 flows
 # like in https://meta.discourse.org/t/x/74060 and large CSP and Link (preload) headers
 proxy_buffer_size 16k;
+proxy_buffers 4 16k;
 
 # If you are going to use Puma, use these:
 #

--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -14,8 +14,9 @@ upstream discourse {
 # max_size limits the size of the cache
 proxy_cache_path /var/nginx/cache inactive=1440m levels=1:2 keys_zone=one:10m max_size=600m;
 
-# see: https://meta.discourse.org/t/x/74060
-proxy_buffer_size 8k;
+# Increased from the default value to acommodate large cookies during oAuth2 flows
+# like in https://meta.discourse.org/t/x/74060 and large CSP and Link (preload) headers
+proxy_buffer_size 16k;
 
 # If you are going to use Puma, use these:
 #


### PR DESCRIPTION
This is needed so we can reland the patch to move our asset preloading
from link tags in the response document to response headers.
