### PR TITLE
FEATURE: add user status to user preferences

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/account.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/account.js
@@ -11,6 +11,7 @@ import getURL from "discourse-common/lib/get-url";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { inject as service } from "@ember/service";
 import { next } from "@ember/runloop";
+import showModal from "discourse/lib/show-modal";
 
 export default Controller.extend(CanCheckEmails, {
   dialog: service(),
@@ -22,16 +23,19 @@ export default Controller.extend(CanCheckEmails, {
       "title",
       "primary_group_id",
       "flair_group_id",
+      "status",
     ];
     this.set("revoking", {});
   },
 
   canEditName: setting("enable_names"),
+  canSelectUserStatus: setting("enable_user_status"),
   canSaveUser: true,
 
   newNameInput: null,
   newTitleInput: null,
   newPrimaryGroupInput: null,
+  newStatus: null,
 
   revoking: null,
 
@@ -146,6 +150,18 @@ export default Controller.extend(CanCheckEmails, {
       });
   },
 
+  @action
+  showUserStatusModal(status) {
+    showModal("user-status", {
+      title: "user_status.set_custom_status",
+      modalClass: "user-status",
+      model: {
+        status,
+        saveAction: async (s) => this.set("newStatus", s),
+      },
+    });
+  },
+
   actions: {
     save() {
       this.set("saved", false);
@@ -155,6 +171,7 @@ export default Controller.extend(CanCheckEmails, {
         title: this.newTitleInput,
         primary_group_id: this.newPrimaryGroupInput,
         flair_group_id: this.newFlairGroupId,
+        status: this.newStatus,
       });
 
       return this.model

--- a/app/assets/javascripts/discourse/app/controllers/preferences/account.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/account.js
@@ -158,6 +158,7 @@ export default Controller.extend(CanCheckEmails, {
       model: {
         status,
         saveAction: async (s) => this.set("newStatus", s),
+        deleteAction: async () => this.set("newStatus", null),
       },
     });
   },

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -68,6 +68,7 @@ let userFields = [
   "user_notification_schedule",
   "sidebar_category_ids",
   "sidebar_tag_names",
+  "status",
 ];
 
 export function addSaveableUserField(fieldName) {

--- a/app/assets/javascripts/discourse/app/routes/preferences-account.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-account.js
@@ -31,6 +31,7 @@ export default RestrictedUserRoute.extend({
       newTitleInput: user.get("title"),
       newPrimaryGroupInput: user.get("primary_group_id"),
       newFlairGroupId: user.get("flair_group_id"),
+      newStatus: user.status,
     });
   },
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
@@ -173,6 +173,24 @@
   </div>
 {{/if}}
 
+{{#if this.canSelectUserStatus}}
+  <div class="control-group pref-user-status">
+    <label class="control-label">{{i18n "user.status.title"}}</label>
+    <div class="controls">
+      {{#if this.newStatus}}
+        <UserStatusMessage @status={{this.newStatus}} @showDescription={{true}} />
+      {{else}}
+        <span class="static">{{i18n "user.status.not_set"}}</span>
+      {{/if}}
+      <DButton
+        @action={{action "showUserStatusModal"}}
+        @actionParam={{this.newStatus}}
+        @class="btn-default btn-small pad-left"
+        @icon="pencil-alt"/>
+    </div>
+  </div>
+{{/if}}
+
 {{#if this.canSelectPrimaryGroup}}
   <div class="control-group pref-primary-group">
     <label class="control-label">{{i18n "user.primary_group.title"}}</label>

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-account-user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-account-user-status-test.js
@@ -1,0 +1,128 @@
+import {
+  acceptance,
+  query,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+
+async function openUserStatusModal() {
+  await click(".pref-user-status .btn-default");
+}
+
+async function pickEmoji(emoji) {
+  await click(".btn-emoji");
+  await fillIn(".emoji-picker-content .filter", emoji);
+  await click(".results .emoji");
+}
+
+async function setStatus(status) {
+  await openUserStatusModal();
+  await pickEmoji(status.emoji);
+  await fillIn(".user-status-description", status.description);
+  await click(".modal-footer .btn-primary"); // save and close modal
+}
+
+acceptance("User Profile - Account - User Status", function (needs) {
+  const username = "eviltrout";
+  const status = {
+    emoji: "tooth",
+    description: "off to dentist",
+  };
+
+  needs.user({ username, status });
+
+  test("doesn't render status block if status is disabled in site settings", async function (assert) {
+    this.siteSettings.enable_user_status = false;
+    await visit(`/u/${username}/preferences/account`);
+    assert.notOk(query(".pref-user-status"));
+  });
+
+  test("renders status block if status is enabled in site settings", async function (assert) {
+    this.siteSettings.enable_user_status = true;
+
+    await visit(`/u/${username}/preferences/account`);
+
+    assert.ok(
+      query(".pref-user-status .user-status-message"),
+      "status is shown"
+    );
+    assert.ok(
+      query(`.pref-user-status .emoji[alt='${status.emoji}`),
+      "status emoji is correct"
+    );
+    assert.equal(
+      query(
+        `.pref-user-status .user-status-message-description`
+      ).innerText.trim(),
+      status.description,
+      "status description is correct"
+    );
+  });
+
+  test("the status modal sets status", async function (assert) {
+    this.siteSettings.enable_user_status = true;
+    updateCurrentUser({ status: null });
+
+    await visit(`/u/${username}/preferences/account`);
+    assert.notOk(
+      query(".pref-user-status .user-status-message"),
+      "status isn't shown"
+    );
+
+    await setStatus(status);
+
+    assert.ok(
+      query(".pref-user-status .user-status-message"),
+      "status is shown"
+    );
+    assert.ok(
+      query(`.pref-user-status .emoji[alt='${status.emoji}`),
+      "status emoji is correct"
+    );
+    assert.equal(
+      query(
+        `.pref-user-status .user-status-message-description`
+      ).innerText.trim(),
+      status.description,
+      "status description is correct"
+    );
+  });
+
+  test("the status modal updates status", async function (assert) {
+    this.siteSettings.enable_user_status = true;
+
+    await visit(`/u/${username}/preferences/account`);
+    const newStatus = { emoji: "surfing_man", description: "surfing" };
+    await setStatus(newStatus);
+
+    assert.ok(
+      query(".pref-user-status .user-status-message"),
+      "status is shown"
+    );
+    assert.ok(
+      query(`.pref-user-status .emoji[alt='${newStatus.emoji}`),
+      "status emoji is correct"
+    );
+    assert.equal(
+      query(
+        `.pref-user-status .user-status-message-description`
+      ).innerText.trim(),
+      newStatus.description,
+      "status description is correct"
+    );
+  });
+
+  test("the status modal clears status", async function (assert) {
+    this.siteSettings.enable_user_status = true;
+
+    await visit(`/u/${username}/preferences/account`);
+    await openUserStatusModal();
+    await click(".btn.delete-status");
+
+    assert.notOk(
+      query(".pref-user-status .user-status-message"),
+      "status isn't shown"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-account-user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-account-user-status-test.js
@@ -1,5 +1,6 @@
 import {
   acceptance,
+  exists,
   query,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -35,7 +36,7 @@ acceptance("User Profile - Account - User Status", function (needs) {
   test("doesn't render status block if status is disabled in site settings", async function (assert) {
     this.siteSettings.enable_user_status = false;
     await visit(`/u/${username}/preferences/account`);
-    assert.notOk(query(".pref-user-status"));
+    assert.notOk(exists(".pref-user-status"));
   });
 
   test("renders status block if status is enabled in site settings", async function (assert) {
@@ -44,11 +45,11 @@ acceptance("User Profile - Account - User Status", function (needs) {
     await visit(`/u/${username}/preferences/account`);
 
     assert.ok(
-      query(".pref-user-status .user-status-message"),
+      exists(".pref-user-status .user-status-message"),
       "status is shown"
     );
     assert.ok(
-      query(`.pref-user-status .emoji[alt='${status.emoji}`),
+      exists(`.pref-user-status .emoji[alt='${status.emoji}']`),
       "status emoji is correct"
     );
     assert.equal(
@@ -66,18 +67,18 @@ acceptance("User Profile - Account - User Status", function (needs) {
 
     await visit(`/u/${username}/preferences/account`);
     assert.notOk(
-      query(".pref-user-status .user-status-message"),
+      exists(".pref-user-status .user-status-message"),
       "status isn't shown"
     );
 
     await setStatus(status);
 
     assert.ok(
-      query(".pref-user-status .user-status-message"),
+      exists(".pref-user-status .user-status-message"),
       "status is shown"
     );
     assert.ok(
-      query(`.pref-user-status .emoji[alt='${status.emoji}`),
+      exists(`.pref-user-status .emoji[alt='${status.emoji}']`),
       "status emoji is correct"
     );
     assert.equal(
@@ -97,11 +98,11 @@ acceptance("User Profile - Account - User Status", function (needs) {
     await setStatus(newStatus);
 
     assert.ok(
-      query(".pref-user-status .user-status-message"),
+      exists(".pref-user-status .user-status-message"),
       "status is shown"
     );
     assert.ok(
-      query(`.pref-user-status .emoji[alt='${newStatus.emoji}`),
+      exists(`.pref-user-status .emoji[alt='${newStatus.emoji}']`),
       "status emoji is correct"
     );
     assert.equal(
@@ -121,7 +122,7 @@ acceptance("User Profile - Account - User Status", function (needs) {
     await click(".btn.delete-status");
 
     assert.notOk(
-      query(".pref-user-status .user-status-message"),
+      exists(".pref-user-status .user-status-message"),
       "status isn't shown"
     );
   });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1966,7 +1966,7 @@ class UsersController < ApplicationController
     end
 
     if SiteSetting.enable_user_status
-      permitted << { status: [:emoji, :description] }
+      permitted << { status: [:emoji, :description, :ends_at] }
     end
 
     result = params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1965,6 +1965,10 @@ class UsersController < ApplicationController
       end
     end
 
+    if SiteSetting.enable_user_status
+      permitted << { status: [:emoji, :description] }
+    end
+
     result = params
       .permit(permitted, theme_ids: [])
       .reverse_merge(

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -209,9 +209,17 @@ class UserUpdater
         update_sidebar_tag_section_links(attributes[:sidebar_tag_names])
       end
 
+      if attributes.key?(:status)
+        update_user_status(attributes[:status])
+      end
+
       name_changed = user.name_changed?
-      if (saved = (!save_options || user.user_option.save) && (user_notification_schedule.nil? || user_notification_schedule.save) && user_profile.save && user.save) &&
-         (name_changed && old_user_name.casecmp(attributes.fetch(:name)) != 0)
+      saved = (!save_options || user.user_option.save) &&
+        (user_notification_schedule.nil? || user_notification_schedule.save) &&
+        user_profile.save &&
+        user.save
+
+      if saved && (name_changed && old_user_name.casecmp(attributes.fetch(:name)) != 0)
 
         StaffActionLogger.new(@actor).log_name_change(
           user.id,
@@ -329,6 +337,14 @@ class UserUpdater
       delete_all_sidebar_section_links('Category')
     else
       update_sidebar_section_links('Category', Category.secured(guardian).where(id: category_ids).pluck(:id))
+    end
+  end
+
+  def update_user_status(status)
+    if status.blank?
+      @user.clear_status!
+    else
+      @user.set_status!(status[:description], status[:emoji])
     end
   end
 

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -209,7 +209,7 @@ class UserUpdater
         update_sidebar_tag_section_links(attributes[:sidebar_tag_names])
       end
 
-      if attributes.key?(:status)
+      if SiteSetting.enable_user_status?
         update_user_status(attributes[:status])
       end
 

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -344,7 +344,7 @@ class UserUpdater
     if status.blank?
       @user.clear_status!
     else
-      @user.set_status!(status[:description], status[:emoji])
+      @user.set_status!(status[:description], status[:emoji], status[:ends_at])
     end
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1789,6 +1789,9 @@ en:
         title: "Flair"
         none: "(none)"
         instructions: "icon displayed next to your profile picture"
+      status:
+        title: "Custom Status"
+        not_set: "Not set"
       primary_group:
         title: "Primary Group"
         none: "(none)"


### PR DESCRIPTION
This PR adds user status to the `preferences/account` page. The ability to edit status from that page will enable admins to edit status of other users.

<img width="550" alt="Screenshot 2022-10-10 at 23 38 10" src="https://user-images.githubusercontent.com/1274517/194940860-a0fe0c63-fc79-4dfc-85ee-6616507f5d85.png">

<img width="550" alt="Screenshot 2022-10-10 at 23 39 28" src="https://user-images.githubusercontent.com/1274517/194940872-69349ea0-5c83-4612-83c8-e7d20ae1bb87.png">

<img width="550" alt="Screenshot 2022-10-10 at 23 38 52" src="https://user-images.githubusercontent.com/1274517/194940884-41c6e748-27c6-48ba-9e9d-31fd9015383b.png">




