### PR TITLE
FEATURE: Hide Privacy Policy and TOS topics

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -438,6 +438,9 @@ class TopicQuery
 
     topics = topics.to_a
 
+    # These don't need to be shown in the topic list
+    topics = topics.reject { |t| [SiteSetting.privacy_topic_id, SiteSetting.tos_topic_id].include?(t[:id]) }
+
     if options[:preload_posters]
       user_ids = []
       topics.each do |ft|

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -79,6 +79,19 @@ RSpec.describe ListController do
       expect(parsed["topic_list"]["topics"].length).to eq(1)
     end
 
+    it 'filters out privacy policy and tos topics' do
+      tos_topic = create_topic
+      SiteSetting.tos_topic_id = tos_topic.id
+
+      pp_topic = create_topic
+      SiteSetting.privacy_topic_id = pp_topic.id
+
+      get "/latest.json"
+      expect(response.status).to eq(200)
+      parsed = response.parsed_body
+      expect(parsed["topic_list"]["topics"].length).to eq(1)
+    end
+
     it "shows correct title if topic list is set for homepage" do
       get "/latest"
 


### PR DESCRIPTION
As a way to simplify new sites this change will hide the privacy policy
and the TOS topics from the topic list. They can still be accessed and
edited though.
