### PR TITLE
FIX: Hide old PM settings

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -820,6 +820,7 @@ posting:
   enable_personal_messages:
     default: true
     client: true
+    hidden: true
   enable_system_message_replies:
     default: true
   personal_message_enabled_groups:
@@ -1558,6 +1559,7 @@ trust:
   min_trust_to_send_messages:
     default: 1
     enum: "TrustLevelSetting"
+    hidden: true
   min_trust_to_send_email_messages:
     default: "4"
     enum: "TrustLevelAndStaffSetting"


### PR DESCRIPTION
Follow up to e62e93f83a77adfa80b38fbfecf82bbee14e12fe. It's confusing and unexpected that deprecated settings unconditionally change the new setting's value via the `SiteSettingsController`, even if `override` was set to `false`, a follow-up PR will correct the issue in `SiteSettingsController`.

See https://meta.discourse.org/t/non-staff-users-are-missing-link-to-messages-in-ui/241109/18
