### PR TITLE
UX: Hide tags section from anonymous user when site has no tags

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.hbs
@@ -1,18 +1,20 @@
-<Sidebar::Section
-  @sectionName="tags"
-  @headerLinkText={{i18n "sidebar.sections.tags.header_link_text"}}
-  @collapsable={{@collapsable}} >
+{{#if this.displaySection}}
+  <Sidebar::Section
+    @sectionName="tags"
+    @headerLinkText={{i18n "sidebar.sections.tags.header_link_text"}}
+    @collapsable={{@collapsable}} >
 
-  {{#each this.sectionLinks as |sectionLink|}}
-    <Sidebar::SectionLink
-      @route={{sectionLink.route}}
-      @content={{sectionLink.text}}
-      @currentWhen={{sectionLink.currentWhen}}
-      @prefixType={{sectionLink.prefixType}}
-      @prefixValue={{sectionLink.prefixValue}}
-      @models={{sectionLink.models}} >
-    </Sidebar::SectionLink>
-  {{/each}}
+    {{#each this.sectionLinks as |sectionLink|}}
+      <Sidebar::SectionLink
+        @route={{sectionLink.route}}
+        @content={{sectionLink.text}}
+        @currentWhen={{sectionLink.currentWhen}}
+        @prefixType={{sectionLink.prefixType}}
+        @prefixValue={{sectionLink.prefixValue}}
+        @models={{sectionLink.models}} >
+      </Sidebar::SectionLink>
+    {{/each}}
 
-  <Sidebar::Common::AllTagsSectionLink />
-</Sidebar::Section>
+    <Sidebar::Common::AllTagsSectionLink />
+  </Sidebar::Section>
+{{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/anonymous/tags-section.js
@@ -8,6 +8,13 @@ export default class SidebarAnonymousTagsSection extends Component {
   @service topicTrackingState;
   @service site;
 
+  get displaySection() {
+    return (
+      this.site.anonymous_default_sidebar_tags?.length > 0 ||
+      this.site.top_tags?.length > 0
+    );
+  }
+
   @cached
   get sectionLinks() {
     let tags;


### PR DESCRIPTION
If there are no top tags that an anonymous user can see and the site do
not have default sidebar tags configured for anonymous users, hide the
tag section entirely.