### PR TITLE
UX: Hide tags section in sidebar when user has no visible tags

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/sections.hbs
@@ -2,7 +2,7 @@
   <Sidebar::User::CommunitySection @collapsable={{@collapsableSections}}/>
   <Sidebar::User::CategoriesSection @collapsable={{@collapsableSections}}/>
 
-  {{#if this.siteSettings.tagging_enabled}}
+  {{#if this.currentUser.display_sidebar_tags}}
     <Sidebar::User::TagsSection @collapsable={{@collapsableSections}}/>
   {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/sidebar.hbs
@@ -15,7 +15,7 @@
   <div class="instructions">{{i18n "user.experimental_sidebar.categories_section_instruction"}}</div>
 </div>
 
-{{#if this.siteSettings.tagging_enabled}}
+{{#if this.model.display_sidebar_tags}}
   <div class="control-group preferences-sidebar-tags">
     <legend class="control-label">{{i18n "user.experimental_sidebar.tags_section"}}</legend>
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -58,6 +58,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
         pm_only: false,
       },
     ],
+    display_sidebar_tags: true,
   });
 
   needs.pretender((server, helper) => {
@@ -88,6 +89,17 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
         );
       });
     });
+  });
+
+  test("section is not displayed when display_sidebar_tags property is false", async function (assert) {
+    updateCurrentUser({ display_sidebar_tags: false });
+
+    await visit("/");
+
+    assert.notOk(
+      exists(".sidebar-section-tags"),
+      "tags section is not displayed"
+    );
   });
 
   test("clicking on section header button", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
@@ -1,7 +1,11 @@
 import I18n from "I18n";
 import { test } from "qunit";
 import { click, visit } from "@ember/test-helpers";
-import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  exists,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
 
 acceptance(
   "Sidebar - Logged on user - Experimental sidebar and hamburger setting disabled",
@@ -171,7 +175,7 @@ acceptance(
     });
 
     test("clean up topic tracking state state changed callbacks when sidebar is destroyed", async function (assert) {
-      this.siteSettings.tagging_enabled = true;
+      updateCurrentUser({ display_sidebar_tags: true });
 
       await visit("/");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-sidebar-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-sidebar-test.js
@@ -13,6 +13,7 @@ acceptance("User Preferences - Sidebar", function (needs) {
   needs.user({
     sidebar_category_ids: [],
     sidebar_tags: [],
+    display_sidebar_tags: true,
   });
 
   needs.settings({
@@ -51,8 +52,8 @@ acceptance("User Preferences - Sidebar", function (needs) {
     });
   });
 
-  test("user should not see tag chooser when tagging is disabled", async function (assert) {
-    this.siteSettings.tagging_enabled = false;
+  test("user should not see tag chooser when display_sidebar_tags property is false", async function (assert) {
+    updateCurrentUser({ display_sidebar_tags: false });
 
     await visit("/u/eviltrout/preferences/sidebar");
 

--- a/app/serializers/concerns/user_sidebar_tags_mixin.rb
+++ b/app/serializers/concerns/user_sidebar_tags_mixin.rb
@@ -2,10 +2,20 @@
 
 module UserSidebarTagsMixin
   def self.included(base)
+    base.attributes :display_sidebar_tags
+
     base.has_many :sidebar_tags, serializer: Sidebar::TagSerializer, embed: :objects
   end
 
   def include_sidebar_tags?
-    SiteSetting.enable_experimental_sidebar_hamburger && SiteSetting.tagging_enabled
+    include_display_sidebar_tags?
+  end
+
+  def display_sidebar_tags
+    DiscourseTagging.filter_visible(Tag, scope).exists?
+  end
+
+  def include_display_sidebar_tags?
+    SiteSetting.tagging_enabled && SiteSetting.enable_experimental_sidebar_hamburger
   end
 end

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -387,4 +387,6 @@ RSpec.describe CurrentUserSerializer do
       expect(serializer.as_json[:associated_account_ids]).to eq({ "twitter" => "1" })
     end
   end
+
+  include_examples "#display_sidebar_tags", described_class
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -424,4 +424,6 @@ RSpec.describe UserSerializer do
       end
     end
   end
+
+  include_examples "#display_sidebar_tags", UserSerializer
 end

--- a/spec/support/user_sidebar_tags_mixin.rb
+++ b/spec/support/user_sidebar_tags_mixin.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "#display_sidebar_tags" do |serializer_klass|
+  fab!(:tag) { Fabricate(:tag) }
+  fab!(:user) { Fabricate(:user) }
+  let(:serializer) { serializer_klass.new(user, scope: Guardian.new(user), root: false) }
+
+  before do
+    SiteSetting.enable_experimental_sidebar_hamburger = true
+  end
+
+  it 'should not be included in serialised object when experimental hamburger and sidebar has been disabled' do
+    SiteSetting.tagging_enabled = true
+    SiteSetting.enable_experimental_sidebar_hamburger = false
+
+    expect(serializer.as_json[:display_sidebar_tags]).to eq(nil)
+  end
+
+  it 'should not be included in serialised object when tagging has been disabled' do
+    SiteSetting.tagging_enabled = false
+
+    expect(serializer.as_json[:display_sidebar_tags]).to eq(nil)
+  end
+
+  it 'should be true when user has visible tags' do
+    SiteSetting.tagging_enabled = true
+
+    Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [tag.name])
+    user.update!(admin: true)
+
+    expect(serializer.as_json[:display_sidebar_tags]).to eq(true)
+  end
+
+  it 'should be false when user has no visible tags' do
+    SiteSetting.tagging_enabled = true
+
+    Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [tag.name])
+
+    expect(serializer.as_json[:display_sidebar_tags]).to eq(false)
+  end
+end


### PR DESCRIPTION
Also hides the tags configuration for sidebar under user preferences

Internal ref: /t/73500