### PR TITLE
FIX: Ensure local date format shortcuts work correctly

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/discourse/components/discourse-local-dates-create-form.js
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/components/discourse-local-dates-create-form.js
@@ -309,7 +309,7 @@ export default Component.extend({
   @action
   updateFormat(format, event) {
     event?.preventDefault();
-    this.format = format;
+    this.set("format", format);
   },
 
   actions: {

--- a/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/acceptance/local-dates-composer-test.js
@@ -9,7 +9,10 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Local Dates - composer", function (needs) {
   needs.user();
-  needs.settings({ discourse_local_dates_enabled: true });
+  needs.settings({
+    discourse_local_dates_enabled: true,
+    discourse_local_dates_default_formats: "LLL|LTS|LL|LLLL",
+  });
 
   test("composer bbcode", async function (assert) {
     const getAttr = (attr) => {
@@ -121,5 +124,11 @@ acceptance("Local Dates - composer", function (needs) {
       query(".pika-table .is-selected"),
       "deleting selected TO date works"
     );
+
+    await click(".advanced-mode-btn");
+
+    assert.strictEqual(query("input.format-input").value, "");
+    await click("ul.formats a.moment-format");
+    assert.strictEqual(query("input.format-input").value, "LLL");
   });
 });


### PR DESCRIPTION
Followup to 03b7b7d1bc7c978c280e441a610a5ef5c049c60c

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
