### PR TITLE
FIX: Staff action log 'show details' links

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-logs-staff-action-logs.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-logs-staff-action-logs.js
@@ -5,6 +5,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { exportEntity } from "discourse/lib/export-csv";
 import { outputExportResult } from "discourse/lib/export-result";
 import { scheduleOnce } from "@ember/runloop";
+import showModal from "discourse/lib/show-modal";
 
 export default Controller.extend({
   queryParams: ["filters"],
@@ -146,5 +147,26 @@ export default Controller.extend({
   @action
   loadMore() {
     this.model.loadMore();
+  },
+
+  @action
+  showDetailsModal(model, event) {
+    event?.preventDefault();
+    showModal("admin-staff-action-log-details", {
+      model,
+      admin: true,
+      modalClass: "log-details-modal",
+    });
+  },
+
+  @action
+  showCustomDetailsModal(model, event) {
+    event?.preventDefault();
+    let modal = showModal("admin-theme-change", {
+      model,
+      admin: true,
+      modalClass: "history-modal",
+    });
+    modal.loadDiff();
   },
 });

--- a/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
@@ -1,6 +1,5 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import EmberObject from "@ember/object";
-import showModal from "discourse/lib/show-modal";
 
 export default DiscourseRoute.extend({
   queryParams: {
@@ -43,17 +42,6 @@ export default DiscourseRoute.extend({
   },
 
   actions: {
-    showDetailsModal(model) {
-      showModal("admin-staff-action-log-details", { model, admin: true });
-      this.controllerFor("modal").set("modalClass", "log-details-modal");
-    },
-
-    showCustomDetailsModal(model) {
-      let modal = showModal("admin-theme-change", { model, admin: true });
-      this.controllerFor("modal").set("modalClass", "history-modal");
-      modal.loadDiff();
-    },
-
     onFiltersChange(filters) {
       if (filters && Object.keys(filters) === 0) {
         this.transitionTo("adminLogs.staffActionLogs");


### PR DESCRIPTION
Followup to 03b7b7d1bc7c978c280e441a610a5ef5c049c60c

The template was inadvertently updated to assume the actions were in the controller rather than the route. The controller is probably a better place for them anyway, so this commit moves them there.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
