### PR TITLE
FEATURE: Show relative time when date is omitted

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js
+++ b/plugins/discourse-local-dates/assets/javascripts/lib/local-date-builder.js
@@ -67,12 +67,12 @@ export default class LocalDateBuilder {
     }
 
     const previews = this._generatePreviews(localDate, displayedTimezone);
-
+    const hasTime = hour !== undefined;
     return {
       pastEvent:
         !this.recurring &&
         moment.tz(this.localTimezone).isAfter(localDate.datetime),
-      formatted: this._applyFormatting(localDate, displayedTimezone),
+      formatted: this._applyFormatting(localDate, displayedTimezone, hasTime),
       previews,
       textPreview: this._generateTextPreviews(previews),
     };
@@ -210,7 +210,7 @@ export default class LocalDateBuilder {
     return duration < 0 ? dates.reverse() : dates;
   }
 
-  _applyFormatting(localDate, displayedTimezone) {
+  _applyFormatting(localDate, displayedTimezone, hasTime) {
     if (this.countdown) {
       const diffTime = moment.tz(this.localTimezone).diff(localDate.datetime);
 
@@ -241,7 +241,7 @@ export default class LocalDateBuilder {
       if (inCalendarRange && sameTimezone) {
         const date = localDate.datetimeWithZone(this.localTimezone);
 
-        if (date.hours() === 0 && date.minutes() === 0) {
+        if (hasTime && date.hours() === 0 && date.minutes() === 0) {
           return date.format("dddd");
         }
 

--- a/plugins/discourse-local-dates/test/javascripts/unit/discourse-local-dates-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/unit/discourse-local-dates-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { applyLocalDates } from "../initializers/discourse-local-dates";
-import { freezeTime } from "../lib/local-date-builder-test";
+import { freezeTime } from "./local-date-builder-test";
 
 module("Unit | Discourse Local Dates | discourse-local-dates", function () {
   function createElementFromHTML(htmlString) {
@@ -72,7 +72,7 @@ module("Unit | Discourse Local Dates | discourse-local-dates", function () {
         );
         assert.equal(
           to.querySelector(".relative-time").textContent,
-          "Thursday"
+          "Yesterday"
         );
       }
     );

--- a/plugins/discourse-local-dates/test/javascripts/unit/local-date-builder-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/unit/local-date-builder-test.js
@@ -1,5 +1,5 @@
 import I18n from "I18n";
-import LocalDateBuilder from "./local-date-builder";
+import LocalDateBuilder from "../lib/local-date-builder";
 import sinon from "sinon";
 import QUnit, { module, test } from "qunit";
 
@@ -10,6 +10,7 @@ const NEW_YORK = "America/New_York";
 const PARIS = "Europe/Paris";
 const LAGOS = "Africa/Lagos";
 const LONDON = "Europe/London";
+const SINGAPORE = "Asia/Singapore";
 
 export function freezeTime({ date, timezone }, cb) {
   date = date || "2020-01-22 10:34";
@@ -61,13 +62,30 @@ QUnit.assert.buildsCorrectDate = function (options, expected, message) {
   }
 };
 
-module("lib:local-date-builder", function () {
+module("Unit | Library | local-date-builder", function () {
   test("date", function (assert) {
     freezeTime({ date: "2020-03-11" }, () => {
       assert.buildsCorrectDate(
         { date: "2020-03-22", timezone: PARIS },
         { formatted: "March 22, 2020" },
         "it displays the date without time"
+      );
+    });
+
+    freezeTime({ date: "2022-10-11", timezone: "Asia/Singapore" }, () => {
+      const localDateBuilder = new LocalDateBuilder(
+        {
+          date: "2022-10-12",
+          timezone: SINGAPORE,
+          localTimezone: SINGAPORE,
+        },
+        SINGAPORE
+      );
+
+      assert.strictEqual(
+        localDateBuilder.build().formatted,
+        "Tomorrow",
+        "Displays relative day"
       );
     });
   });
@@ -91,8 +109,8 @@ module("lib:local-date-builder", function () {
       {
         time: "12:22:00",
         date: "2022-10-07",
-        timezone: "Asia/Singapore",
-        localTimezone: "Asia/Singapore",
+        timezone: SINGAPORE,
+        localTimezone: SINGAPORE,
         sameLocalDayAsFrom: true,
       },
       { formatted: "12:22 PM (Singapore)" },


### PR DESCRIPTION
If today's date is 12 October and we use

```
[date=2022-10-12 timezone="Asia/Singapore"]
```

the date would be shown as "Wednesday" rather than "Today".

This change makes it such that standalone dates are shown in relative terms, similar to when there's a time component included.

Essentially, from this
<img width="609" alt="Screenshot 2022-10-12 at 12 48 03 AM" src="https://user-images.githubusercontent.com/1555215/195152004-e6364b8f-e369-40fa-83e3-848e1f85f391.png">

to this
<img width="623" alt="Screenshot 2022-10-12 at 12 48 21 AM" src="https://user-images.githubusercontent.com/1555215/195152024-61803a35-ecbc-4f0e-9650-62163079c9cc.png">
