### PR TITLE
DEV: Update `backburner.js` to include bugfix and dev improvements

### DIFF
--- a/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/discourse-bootstrap.js
@@ -12,12 +12,18 @@ import Session from "discourse/models/session";
 import { setDefaultOwner } from "discourse-common/lib/get-owner";
 import { setIconList } from "discourse-common/lib/icon-library";
 import { setURLContainer } from "discourse/lib/url";
+import runloop from "@ember/runloop";
+import { DEBUG } from "@glimmer/env";
 
 export default {
   name: "discourse-bootstrap",
 
   // The very first initializer to run
   initialize(container) {
+    if (DEBUG) {
+      runloop._backburner.ASYNC_STACKS = true;
+    }
+
     setURLContainer(container);
     setDefaultOwner(container);
 

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -79,6 +79,12 @@ module.exports = function (defaults) {
 
     // We need to build tests in prod for theme tests
     tests: true,
+
+    vendorFiles: {
+      // Freedom patch - includes bug fix and async stack support
+      // https://github.com/discourse/backburner.js/commits/discourse-patches
+      backburner: "node_modules/backburner.js/dist/named-amd/backburner.js",
+    },
   });
 
   // Patching a private method is not great, but there's no other way for us to tell

--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -37,6 +37,7 @@
     "admin": "^1.0.0",
     "discourse-plugins": "^1.0.0",
     "babel-plugin-ember-template-compilation": "^1.0.2",
+    "backburner.js": "https://github.com/discourse/backburner.js#discourse-patches",
     "bootstrap": "3.4.1",
     "broccoli-asset-rev": "^3.0.0",
     "deepmerge": "^4.2.2",

--- a/app/assets/javascripts/yarn.lock
+++ b/app/assets/javascripts/yarn.lock
@@ -2581,6 +2581,10 @@ backbone@^1.1.2:
   dependencies:
     underscore ">=1.8.3"
 
+"backburner.js@https://github.com/discourse/backburner.js#discourse-patches":
+  version "2.7.0"
+  resolved "https://github.com/discourse/backburner.js#4b227c302c8a2bfa604dcdcca3802ed018423683"
+
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"


### PR DESCRIPTION
This version of backburner is patched to include
- Fix for scheduleOnce/cancel bug: https://github.com/BackburnerJS/backburner.js/pull/402
- Async stack debugging in Chrome: https://github.com/BackburnerJS/backburner.js/pull/404

The async debugging feature is enabled only in debug builds of Discourse to ensure production performance is unaffected.

Adding to `vendorFiles` causes the JS to be inserted directly after the `ember-source` bundle. That means that the `backburner` module defined by ember-source will be replaced with the patched version. Compression means that the output bundle size is barely affected by the almost-duplicate code.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
