### PR TITLE
FIX: warning about sidebar prefix style

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link-prefix.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link-prefix.hbs
@@ -15,7 +15,7 @@
     {{/if}}
 
     {{#if (eq @prefixType "span")}}
-      <span style={{@prefixCSS}} class="prefix-span"></span>
+      <span style={{html-safe @prefixCSS}} class="prefix-span"></span>
     {{/if}}
 
     {{#if @prefixBadge}}


### PR DESCRIPTION
New double color feature introduced warning about CSS. 

Related PR https://github.com/discourse/discourse/pull/18525

<img width="491" alt="Screen Shot 2022-10-12 at 8 53 10 am" src="https://user-images.githubusercontent.com/72780/195205920-9f527ce4-dbfd-4203-bb7c-b60c966ef9b7.png">


