### PR TITLE
FEATURE: Add contentCSSClass for sidebar section-link

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
@@ -33,7 +33,7 @@
           @prefixBadge={{@prefixBadge}}
         />
 
-        <span class="sidebar-section-link-content-text">
+        <span class={{concat-class "sidebar-section-link-content-text" @contentCSSClass}}>
           {{@content}}
         </span>
 

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/sections.hbs
@@ -28,6 +28,7 @@
           @model={{link.model}}
           @models={{link.models}}
           @title={{link.title}}
+          @contentCSSClass={{link.contentCSSClass}}
           @prefixColor={{link.prefixColor}}
           @prefixBadge={{link.prefixBadge}}
           @prefixType={{link.prefixType}}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/base-custom-sidebar-section-link.js
@@ -46,6 +46,11 @@ export default class BaseCustomSidebarSectionLink {
   }
 
   /**
+   * @returns {string} CSS class for the content text
+   */
+  get contentCSSClass() {}
+
+  /**
    * @returns {string} Prefix type for the link. Accepted value: icon, image, text
    */
   get prefixType() {}
@@ -68,22 +73,22 @@ export default class BaseCustomSidebarSectionLink {
   /**
    * @returns {string} CSS class for prefix
    */
-  get PrefixCSSClass() {}
+  get prefixCSSClass() {}
 
   /**
    * @returns {string} Suffix type for the link. Accepted value: icon
    */
-  get SuffixType() {}
+  get suffixType() {}
 
   /**
    * @returns {string} Suffix value for the link. Accepted value: icon name
    */
-  get SuffixValue() {}
+  get suffixValue() {}
 
   /**
    * @returns {string} CSS class for suffix
    */
-  get SuffixCSSClass() {}
+  get suffixCSSClass() {}
 
   /**
    * @returns {string} Type of the hover button. Accepted value: icon


### PR DESCRIPTION
In some cases, like in the chat plugin for muted channels,
we want to change the style of the sidebar content text.
This adds a new contentCSSClass function to the
BaseCustomSidebarSectionLink class and uses it in both
sections and section-link to add the CSS class if it is
provided.