### PR TITLE
DEV: Always use non-builtin net-* and digest gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,13 +134,10 @@ gem 'cose', require: false
 gem 'addressable'
 gem 'json_schemer'
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1")
-  # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1
-  gem "net-smtp", "~> 0.2.1", require: false
-  gem "net-imap", "~> 0.2.1", require: false
-  gem "net-pop", "~> 0.1.1", require: false
-  gem "digest", "3.0.0", require: false
-end
+gem "net-smtp", require: false
+gem "net-imap", require: false
+gem "net-pop", require: false
+gem "digest", require: false
 
 # Gems used only for assets and not required in production environments by default.
 # Allow everywhere for now cause we are allowing asset debugging in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     diffy (3.4.2)
+    digest (3.1.0)
     discourse-ember-rails (0.18.6)
       active_model_serializers
       ember-data-source (>= 1.0.0.beta.5)
@@ -542,6 +543,7 @@ DEPENDENCIES
   cppjieba_rb
   css_parser
   diffy
+  digest
   discourse-ember-rails (= 0.18.6)
   discourse-ember-source (~> 3.12.2)
   discourse-fonts
@@ -588,6 +590,9 @@ DEPENDENCIES
   multi_json
   mustache
   net-http
+  net-imap
+  net-pop
+  net-smtp
   nokogiri
   oj (= 3.13.14)
   omniauth


### PR DESCRIPTION
This will possibly fix the issue we're having with Dependabot. It seems it now uses a different ruby version (i.e. 3.1+)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
