### PR TITLE
FIX: alignment of user status emoji on posts

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -235,9 +235,12 @@ $quote-share-maxwidth: 150px;
     align-items: center;
   }
 
-  img.emoji {
-    width: 1em;
-    height: 1em;
+  .user-status-message {
+    display: flex;
+    img.emoji {
+      width: 1em;
+      height: 1em;
+    }
   }
 }
 


### PR DESCRIPTION
User status emojis on posts were misaligned, they were placed too low. This PR fixes it.

Before:

<img width="584" alt="Screenshot 2022-10-12 at 18 02 46" src="https://user-images.githubusercontent.com/1274517/195364032-621b1479-1847-44f6-a680-f42cbcb6fb50.png">

After:

<img width="589" alt="Screenshot 2022-10-12 at 18 02 33" src="https://user-images.githubusercontent.com/1274517/195364052-e5571966-9f99-4f24-9541-375eab4a3b39.png">



