### PR TITLE
DEV: Remove noop CSS

### DIFF
--- a/app/assets/stylesheets/common/admin/admin_base.scss
+++ b/app/assets/stylesheets/common/admin/admin_base.scss
@@ -351,7 +351,7 @@ $mobile-breakpoint: 700px;
       width: 300px;
       margin-right: 15px;
       margin-bottom: 5px;
-      display: inline-block;
+
       .bar {
         margin-top: 5px;
         background-color: var(--tertiary);

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -832,7 +832,6 @@ table.permalinks {
     border-bottom: 1px solid var(--primary-low);
     .form-display {
       width: 25%;
-      display: inline-block;
       float: left;
     }
     .form-element,

--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -61,7 +61,6 @@ a.loading-onebox {
       clear: both;
       padding-bottom: 25px;
       .metric {
-        display: inline-block;
         padding-left: 33px;
         float: left;
       }
@@ -727,7 +726,6 @@ aside.onebox.xkcd .onebox-body img {
     float: left;
     background: absolute-image-url("/favicons/pdf_64px.png") no-repeat;
     background-size: 48px 48px;
-    display: inline-block;
   }
   .filesize {
     color: gray;

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -14,7 +14,6 @@
 }
 
 .tags-list .tag-box {
-  display: inline-block;
   width: 300px;
   margin-bottom: 1em;
   float: left;

--- a/app/assets/stylesheets/embed.scss
+++ b/app/assets/stylesheets/embed.scss
@@ -106,7 +106,6 @@ img.emoji {
   font-size: var(--font-down-1);
   text-align: center;
   margin: 10px 20px 6px 0;
-  display: inline-block;
   float: right;
   color: var(--tertiary);
 }


### PR DESCRIPTION
The lint warnings were:

```
inline-block is ignored due to the float. If 'float' has a value other than 'none', the box is floated and 'display' is treated as 'block'

scss(propertyIgnoredDueToDisplay)
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
