### PR TITLE
FIX: Correctly handle HTTP errors during dominant color calculation

### DIFF
--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -704,21 +704,21 @@ RSpec.describe Upload do
     end
 
     it "correctly handles error when file is too large to download" do
-      white_image.stubs(:local?).returns(true)
-      Discourse.store.stubs(:download).returns(nil)
+      white_image.stubs(:local?).returns(false)
+      FileStore::LocalStore.any_instance.stubs(:download).returns(nil).once
 
-      expect(invalid_image.dominant_color).to eq(nil)
-      expect(invalid_image.dominant_color(calculate_if_missing: true)).to eq("")
-      expect(invalid_image.dominant_color).to eq("")
+      expect(white_image.dominant_color).to eq(nil)
+      expect(white_image.dominant_color(calculate_if_missing: true)).to eq("")
+      expect(white_image.dominant_color).to eq("")
     end
 
     it "correctly handles error when file has HTTP error" do
-      white_image.stubs(:local?).returns(true)
-      Discourse.store.stubs(:download).raises(OpenURI::HTTPError)
+      white_image.stubs(:local?).returns(false)
+      FileStore::LocalStore.any_instance.stubs(:download).raises(OpenURI::HTTPError.new("Error", nil)).once
 
-      expect(invalid_image.dominant_color).to eq(nil)
-      expect(invalid_image.dominant_color(calculate_if_missing: true)).to eq("")
-      expect(invalid_image.dominant_color).to eq("")
+      expect(white_image.dominant_color).to eq(nil)
+      expect(white_image.dominant_color(calculate_if_missing: true)).to eq("")
+      expect(white_image.dominant_color).to eq("")
     end
 
     it "is validated for length" do


### PR DESCRIPTION
The previous fix in e83d35d6 was incorrect, and the stub in the test was never actually hit. This commit moves the error handling to the right place and updates the specs to ensure the stub is always used.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
