### PR TITLE
FIX: status emoji was shown on the left on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-user-status.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-user-status.js
@@ -3,6 +3,8 @@ import RenderGlimmer from "discourse/widgets/render-glimmer";
 import { hbs } from "ember-cli-htmlbars";
 
 createWidget("post-user-status", {
+  tagName: "span.user-status-message-wrap",
+
   html(attrs) {
     return [
       new RenderGlimmer(

--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -362,6 +362,10 @@ span.highlighted {
       order: 2;
     }
 
+    .user-status-message-wrap {
+      order: 2;
+    }
+
     .second {
       order: 3;
       flex-basis: 100%;


### PR DESCRIPTION
Before:

<img width="455" alt="Screenshot 2022-10-12 at 20 04 28" src="https://user-images.githubusercontent.com/1274517/195393305-e6d34d0a-b130-4a5f-86fc-11e413549cd1.png">

After:

<img width="456" alt="Screenshot 2022-10-12 at 20 04 11" src="https://user-images.githubusercontent.com/1274517/195393139-6549ef18-18eb-4221-a591-f41068a8f707.png">
