### PR TITLE
A11Y: Make "Load parent post" element accessible

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -140,6 +140,12 @@ createWidget("reply-to-tab", {
     return { loading: false };
   },
 
+  buildAttributes() {
+    return {
+      tabindex: "0",
+    };
+  },
+
   html(attrs, state) {
     const icon = state.loading ? h("div.spinner.small") : iconNode("share");
     const name = prioritizeNameFallback(


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
