### PR TITLE
FIX: remove `nil` items before sorting the sha1 string array.

### DIFF
--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -225,7 +225,7 @@ class Stylesheet::Manager::Builder
       sha1s << upload_field.upload&.sha1
     end
 
-    Digest::SHA1.hexdigest(sha1s.sort!.join("\n"))
+    Digest::SHA1.hexdigest(sha1s.compact.sort!.join("\n"))
   end
 
   def default_digest

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -374,6 +374,16 @@ RSpec.describe Stylesheet::Manager do
         type_id: ThemeField.types[:theme_upload_var]
       )
 
+      upload2 = UploadCreator.new(image2, "icon.png").create_for(-1)
+      field = ThemeField.create!(
+        theme_id: theme.id,
+        target_id: Theme.targets[:common],
+        name: "icon",
+        value: "",
+        upload_id: upload2.id,
+        type_id: ThemeField.types[:theme_upload_var]
+      )
+
       manager = manager(theme.id)
 
       builder = Stylesheet::Manager::Builder.new(


### PR DESCRIPTION
Previously, when the array had both nil and string values it returned the error "comparison of NilClass with String failed". Now I added the `.compact` method to prevent this issue as per @martin-brennan's suggestion https://github.com/discourse/discourse/pull/18431#discussion_r984204788

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
