### PR TITLE
DEV: Remove contact username dropdown from wizard

### DIFF
--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -207,15 +207,6 @@ class Wizard
         step.add_field(id: 'contact_url', type: 'text', value: SiteSetting.contact_url)
         step.add_field(id: 'city_for_disputes', type: 'text', value: SiteSetting.city_for_disputes)
 
-        username = SiteSetting.site_contact_username
-        username = Discourse.system_user.username if username.blank?
-        contact = step.add_field(id: 'site_contact', type: 'dropdown', value: username)
-
-        User.human_users.where(admin: true).pluck(:username).each do |c|
-          contact.add_choice(c) unless reserved_usernames.include?(c.downcase)
-        end
-        contact.add_choice(Discourse.system_user.username)
-
         step.on_update do |updater|
           update_tos do |raw|
             replace_setting_value(updater, raw, 'company_name')
@@ -224,7 +215,6 @@ class Wizard
           end
 
           updater.apply_settings(:company_name, :governing_law, :city_for_disputes, :contact_url)
-          updater.update_setting(:site_contact_username, updater.fields[:site_contact])
         end
       end
 


### PR DESCRIPTION
To simplify the wizard, we are removing the site contract username dropdown as an option to edit on the "Your Org" wizard step.

