### PR TITLE
UX: hide keyboard shortcuts on tablet and smaller

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -65,4 +65,10 @@
       background: var(--d-sidebar-highlight-color);
     }
   }
+
+  @include breakpoint("tablet") {
+    .sidebar-footer-actions-keyboard-shortcuts {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
No use in displaying keyboard shortcuts on devices without a keyboard + bug reported on https://meta.discourse.org/t/cant-see-rest-of-keyboard-shortcuts-on-mobile/241568