### PR TITLE
A11Y: Fix tab order in "Feature topic" modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/choose-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/choose-topic.hbs
@@ -13,7 +13,7 @@
   {{#if this.noResults}}
     <p>{{i18n "choose_topic.none_found"}}</p>
   {{else}}
-    <div class="choose-topic-list">
+    <div class="choose-topic-list" role="radiogroup">
       {{#each this.topics as |t|}}
         <div class="controls existing-topic">
           <label class="radio">

--- a/app/assets/javascripts/discourse/app/templates/modal/feature-topic-on-profile.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/feature-topic-on-profile.hbs
@@ -4,4 +4,5 @@
 
 <div class="modal-footer">
   <DButton @action={{action "save"}} @class="btn-primary save-featured-topic-on-profile" @disabled={{this.noTopicSelected}} @label="user.feature_topic_on_profile.save" />
+  <DButton @action={{route-action "closeModal" }} @label="cancel" @class="btn-flat" />
 </div>


### PR DESCRIPTION
Tab order acts strangely in Chrome when the last focusable element in a modal is a radio group: it switches focus to the address bar. This is a problem, because for keyboard users, it becomes very hard to return to the previous context.

This PR adds a focusable "Cancel" button, whose mere presence fixes the issue.
