### PR TITLE
FIX: action_code_path not being loaded for user-stream-item

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-stream-item.js
+++ b/app/assets/javascripts/discourse/app/components/user-stream-item.js
@@ -28,7 +28,8 @@ export default Component.extend({
   actionDescription: actionDescription(
     "item.action_code",
     "item.created_at",
-    "item.action_code_who"
+    "item.action_code_who",
+    "item.action_code_path"
   ),
 
   @discourseComputed("item.draft_username", "item.username")

--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -26,11 +26,21 @@ export function actionDescriptionHtml(actionCode, createdAt, username, path) {
   return htmlSafe(I18n.t(`action_codes.${actionCode}`, { who, when, path }));
 }
 
-export function actionDescription(actionCode, createdAt, username) {
+export function actionDescription(
+  actionCode,
+  createdAt,
+  username,
+  path = null
+) {
   return computed(actionCode, createdAt, function () {
     const ac = this.get(actionCode);
     if (ac) {
-      return actionDescriptionHtml(ac, this.get(createdAt), this.get(username));
+      return actionDescriptionHtml(
+        ac,
+        this.get(createdAt),
+        this.get(username),
+        path ? this.get(path) : null
+      );
     }
   });
 }

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -232,7 +232,7 @@ class UserAction < ActiveRecord::Base
       JOIN users au on au.id = a.user_id
       LEFT JOIN categories c on c.id = t.category_id
       LEFT JOIN post_custom_fields pc ON pc.post_id = a.target_post_id AND pc.name = 'action_code_who'
-      LEFT JOIN post_custom_fields pc2 ON pc2.post_id = a.target_post_id AND pc.name = 'action_code_path'
+      LEFT JOIN post_custom_fields pc2 ON pc2.post_id = a.target_post_id AND pc2.name = 'action_code_path'
       /*where*/
       /*order_by*/
       /*offset*/

--- a/spec/models/user_action_spec.rb
+++ b/spec/models/user_action_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe UserAction do
         log_test_action(action_type: UserAction::ASSIGNED)
         private_post.custom_fields ||= {}
         private_post.custom_fields["action_code_who"] = 'testing'
+        private_post.custom_fields["action_code_path"] = '/p/1234'
         private_post.custom_fields["random_field"] = 'random_value'
         private_post.save!
       end
@@ -133,6 +134,7 @@ RSpec.describe UserAction do
 
         expect(user_action_row.action_type).to eq(UserAction::ASSIGNED)
         expect(user_action_row.action_code_who).to eq('testing')
+        expect(user_action_row.action_code_path).to eq('/p/1234')
       end
     end
 


### PR DESCRIPTION
This commit fixes an issue where we had a typo in the UserAction.stream query which meant that action_code_path was not loaded correctly. Once that was fixed, we were also not actually using the action_code_path in the user-stream-item, so that has been fixed here too.

The bug this caused was that, when the link for the action was clicked within the user-stream-item, the user would be redirected to a URL ending with `[missing%20%%7Bpath%7D%20value]` because the I18n call did not have the path present.
