### PR TITLE
FIX: Show timelines dates as clickable

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -212,7 +212,6 @@
     }
 
     .start-date {
-      @include unselectable;
       color: var(--primary-med-or-secondary-med);
     }
 
@@ -296,7 +295,6 @@
     }
 
     .now-date {
-      @include unselectable;
       display: inline-block;
       color: var(--primary-med-or-secondary-med);
       margin-top: 0.5em;


### PR DESCRIPTION
These two dates used to have the default cursor when hovering. This
commit removes the 'cursor: default' CSS property.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
