### PR TITLE
UX: Onboarding edits

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/popup.js
+++ b/app/assets/javascripts/discourse/app/lib/popup.js
@@ -23,6 +23,7 @@ export function showPopup(options) {
     showOnCreate: true,
     hideOnClick: false,
     trigger: "manual",
+    theme: "d-onboarding",
 
     // It must be interactive to make buttons work.
     interactive: true,

--- a/app/assets/stylesheets/common/base/_index.scss
+++ b/app/assets/stylesheets/common/base/_index.scss
@@ -12,6 +12,7 @@
 @import "crawler_layout";
 @import "d-icon";
 @import "d-popover";
+@import "d-onboarding";
 @import "dialog";
 @import "directory";
 @import "discourse";

--- a/app/assets/stylesheets/common/base/d-onboarding.scss
+++ b/app/assets/stylesheets/common/base/d-onboarding.scss
@@ -1,0 +1,37 @@
+.onboarding-popup-container {
+  min-width: 300px;
+  padding: 0.5em;
+  text-align: left;
+
+  .onboarding-popup-title {
+    font-size: $font-up-2;
+    font-weight: bold;
+  }
+
+  .onboarding-popup-content {
+    margin-top: 0.25em;
+  }
+
+  .onboarding-popup-buttons {
+    margin-top: 1em;
+  }
+}
+
+.tippy-box[data-theme~="d-onboarding"][data-placement^="left"]
+  > .tippy-svg-arrow
+  > svg {
+  left: 11px;
+}
+
+.tippy-box[data-theme~="d-onboarding"][data-placement^="bottom"]
+  > .tippy-svg-arrow
+  > svg {
+  top: -13px;
+  left: -1px;
+}
+
+.tippy-box[data-theme~="d-onboarding"] > .tippy-svg-arrow:after,
+.tippy-box[data-theme~="d-onboarding"] > .tippy-svg-arrow > svg {
+  width: 18px;
+  height: 18px;
+}

--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -8,12 +8,23 @@ $d-popover-border: var(--primary-low);
   box-shadow: shadow("menu-panel");
 }
 
+.tippy-box > .tippy-svg-arrow:after,
+.tippy-box > .tippy-svg-arrow > svg {
+  width: 1.5em;
+  height: 1.5em;
+}
+
 .tippy-box[data-placement^="top"] .tippy-svg-arrow > svg {
   top: 12px;
 }
 .tippy-box[data-placement^="bottom"] .tippy-svg-arrow > svg {
   top: -10px;
 }
+
+.tippy-box[data-placement^="left"] > .tippy-svg-arrow > svg {
+  left: 10px;
+}
+
 .tippy-rounded-arrow {
   fill: $d-popover-background;
   .svg-arrow {

--- a/app/assets/stylesheets/common/base/d-popover.scss
+++ b/app/assets/stylesheets/common/base/d-popover.scss
@@ -8,21 +8,11 @@ $d-popover-border: var(--primary-low);
   box-shadow: shadow("menu-panel");
 }
 
-.tippy-box > .tippy-svg-arrow:after,
-.tippy-box > .tippy-svg-arrow > svg {
-  width: 1.5em;
-  height: 1.5em;
-}
-
 .tippy-box[data-placement^="top"] .tippy-svg-arrow > svg {
   top: 12px;
 }
 .tippy-box[data-placement^="bottom"] .tippy-svg-arrow > svg {
   top: -10px;
-}
-
-.tippy-box[data-placement^="left"] > .tippy-svg-arrow > svg {
-  left: 10px;
 }
 
 .tippy-rounded-arrow {

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -570,25 +570,6 @@ table {
   animation-name: ping;
 }
 
-.onboarding-popup-container {
-  min-width: 300px;
-  padding: 0.5em;
-  text-align: left;
-
-  .onboarding-popup-title {
-    font-size: $font-up-2;
-    font-weight: bold;
-  }
-
-  .onboarding-popup-content {
-    margin-top: 0.25em;
-  }
-
-  .onboarding-popup-buttons {
-    margin-top: 1em;
-  }
-}
-
 .fade {
   opacity: 0;
   transition: opacity 0.15s linear;


### PR DESCRIPTION
Minimal refactor & moving css into its own stylesheet. I adjusted the size of the svg triangle & added a data-theme attribute for easier targeting of the triangle within the onboarding tippy popup.

## After

### Topic Timeline
<img width="550" alt="image" src="https://user-images.githubusercontent.com/30537603/195608902-74c023e4-00cc-4375-8ab6-8828080b1653.png">

### First Notification
<img width="550" alt="image" src="https://user-images.githubusercontent.com/30537603/195608829-d88fee72-bfab-4c17-a851-b7cef3f4fb28.png">

## Before

### Topic Timeline
<img width="550" alt="image" src="https://user-images.githubusercontent.com/30537603/195609136-aa6c9ba6-2bd6-41d4-bbca-8185eb9d774d.png">

### First Notification
<img width="550" alt="image" src="https://user-images.githubusercontent.com/30537603/195609204-edf032b8-e0f1-4ec2-a24e-cb9328b93cc0.png">



