### PR TITLE
FEATURE: Add sidebar link for admin to configure default tags

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.hbs
@@ -27,5 +27,16 @@
     {{/if}}
 
     <Sidebar::Common::AllTagsSectionLink />
+
+    {{#if (and this.currentUser.admin (not this.hasDefaultSidebarTags))}}
+      <Sidebar::SectionLink
+        @linkName="configure-default-sidebar-tags"
+        @content={{i18n "sidebar.sections.tags.configure_defaults"}}
+        @prefixType="icon"
+        @prefixValue="wrench"
+        @route="adminSiteSettingsCategory"
+        @model="sidebar"
+        @query={{hash filter="default_sidebar_tags"}} />
+    {{/if}}
   </Sidebar::Section>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.js
@@ -71,11 +71,15 @@ export default class SidebarUserTagsSection extends Component {
    * If a site has default sidebar tags configured, always display the tags section.
    */
   get shouldDisplay() {
-    if (this.siteSettings.default_sidebar_tags.length > 0) {
+    if (this.hasDefaultSidebarTags) {
       return true;
     } else {
       return this.currentUser.sidebarTags.length > 0;
     }
+  }
+
+  get hasDefaultSidebarTags() {
+    return this.siteSettings.default_sidebar_tags.length > 0;
   }
 
   @action

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -59,6 +59,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
       },
     ],
     display_sidebar_tags: true,
+    admin: false,
   });
 
   needs.pretender((server, helper) => {
@@ -421,6 +422,25 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
     assert.ok(
       Object.keys(topicTrackingState.stateChangeCallbacks).length <
         initialCallbackCount
+    );
+  });
+
+  test("section link to admin site settings page when default sidebar tags have not been configured", async function (assert) {
+    updateCurrentUser({ admin: true });
+
+    await visit("/");
+
+    assert.ok(
+      exists(".sidebar-section-link-configure-default-sidebar-tags"),
+      "section link to configure default sidebar tags is shown"
+    );
+
+    await click(".sidebar-section-link-configure-default-sidebar-tags");
+
+    assert.strictEqual(
+      currentURL(),
+      "/admin/site_settings/category/all_results?filter=default_sidebar_tags",
+      "it links to the admin site settings page correctly"
     );
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1177,7 +1177,7 @@ en:
       enable_quoting: "Enable quote reply for highlighted text"
       enable_defer: "Enable defer to mark topics unread"
       experimental_sidebar:
-        enable: "Enable experimental sidebar"
+        enable: "Enable sidebar"
         options: "Options"
         categories_section: "Categories Section"
         categories_section_instruction: "Selected categories will be displayed under Sidebar's categories section."
@@ -4189,6 +4189,7 @@ en:
           click_to_get_started: "Click here to get started."
           header_link_text: "Tags"
           header_action_title: "edit your sidebar tags"
+          configure_defaults: "Configure defaults"
         categories:
           none: "You have not added any categories."
           click_to_get_started: "Click here to get started."
@@ -5665,6 +5666,7 @@ en:
           search: "Search"
           groups: "Groups"
           dashboard: "Dashboard"
+          sidebar: "Sidebar"
         secret_list:
           invalid_input: "Input fields cannot be empty or contain vertical bar character."
         default_categories:


### PR DESCRIPTION
Displays a sidebar section link to admin users when
`default_sidebar_tags` site setting has not been configured for the
site.

Internal Ref: /t/73500

### Screenshots

![Screenshot from 2022-10-14 11-46-02](https://user-images.githubusercontent.com/4335742/195757859-56bf8278-9dc1-4897-aca3-98dc77a4708c.png)
