### PR TITLE
FEATURE: Add sidebar link for admin to configure default categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
@@ -31,5 +31,16 @@
     {{/if}}
 
     <Sidebar::Common::AllCategoriesSectionLink />
+
+    {{#if (and this.currentUser.admin (not this.hasDefaultSidebarCategories))}}
+      <Sidebar::SectionLink
+        @linkName="configure-default-sidebar-categories"
+        @content={{i18n "sidebar.sections.categories.configure_defaults"}}
+        @prefixType="icon"
+        @prefixValue="wrench"
+        @route="adminSiteSettingsCategory"
+        @model="sidebar"
+        @query={{hash filter="default_sidebar_categories"}} />
+    {{/if}}
   </Sidebar::Section>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.js
@@ -49,11 +49,15 @@ export default class SidebarUserCategoriesSection extends SidebarCommonCategorie
    * If a site has default sidebar categories configured, always show categories section for the user.
    */
   get shouldDisplay() {
-    if (this.siteSettings.default_sidebar_categories.length > 0) {
+    if (this.hasDefaultSidebarCategories) {
       return true;
     } else {
       return this.categories.length > 0;
     }
+  }
+
+  get hasDefaultSidebarCategories() {
+    return this.siteSettings.default_sidebar_categories.length > 0;
   }
 
   @action

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -25,7 +25,7 @@ acceptance(
       enable_sidebar: true,
     });
 
-    needs.user();
+    needs.user({ admin: false });
 
     test("uncategorized category is not shown", async function (assert) {
       const categories = Site.current().categories;
@@ -61,6 +61,7 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
   needs.user({
     sidebar_category_ids: [],
     sidebar_tags: [],
+    admin: false,
   });
 
   needs.settings({
@@ -542,6 +543,26 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
     assert.ok(
       Object.keys(topicTrackingState.stateChangeCallbacks).length <
         initialCallbackCount
+    );
+  });
+
+  test("section link to admin site settings page when default sidebar categories have not been configured", async function (assert) {
+    setupUserSidebarCategories();
+    updateCurrentUser({ admin: true });
+
+    await visit("/");
+
+    assert.ok(
+      exists(".sidebar-section-link-configure-default-sidebar-categories"),
+      "section link to configure default sidebar categories is shown"
+    );
+
+    await click(".sidebar-section-link-configure-default-sidebar-categories");
+
+    assert.strictEqual(
+      currentURL(),
+      "/admin/site_settings/category/all_results?filter=default_sidebar_categories",
+      "it links to the admin site settings page correctly"
     );
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4194,6 +4194,7 @@ en:
           click_to_get_started: "Click here to get started."
           header_link_text: "Categories"
           header_action_title: "edit your sidebar categories"
+          configure_defaults: "Configure defaults"
         community:
           header_link_text: "Community"
           header_action_title: "create a new topic"


### PR DESCRIPTION
Displays a sidebar section link to admin users when
`default_sidebar_categories` site setting has not been configured for the
site.

Internal Ref: /t/73500