### PR TITLE
DEV: Move sidebar site settings to the sidebar category

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2033,6 +2033,18 @@ developer:
     default: false
     client: true
     hidden: true
+  enable_new_user_profile_nav_groups:
+    client: true
+    type: group_list
+    list_type: compact
+    default: ""
+    allow_any: false
+    refresh: true
+  include_associated_account_ids:
+    default: false
+    hidden: true
+
+sidebar:
   enable_sidebar:
     default: true
     client: true
@@ -2044,16 +2056,6 @@ developer:
     type: tag_list
     default: ""
     client: true
-  enable_new_user_profile_nav_groups:
-    client: true
-    type: group_list
-    list_type: compact
-    default: ""
-    allow_any: false
-    refresh: true
-  include_associated_account_ids:
-    default: false
-    hidden: true
 
 embedding:
   embed_by_username:

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -832,4 +832,24 @@ RSpec.describe SiteSettingExtension do
       end
     end
   end
+
+  describe 'sidebar category site settings' do
+    describe '.all_settings' do
+      before do
+        settings.setting(:test_setting, 88, category: :sidebar)
+      end
+
+      it 'does not include the sidebar category setting when enable_experimental_sidebar_hamburger site setting is disabled' do
+        SiteSetting.enable_experimental_sidebar_hamburger = false
+
+        expect(settings.all_settings.detect { |s| s[:setting] == :test_setting }).to eq(nil)
+      end
+
+      it 'includes the sidebar category setting when enable_experimental_sidebar_hamburger site setting is enabled' do
+        SiteSetting.enable_experimental_sidebar_hamburger = true
+
+        expect(settings.all_settings.detect { |s| s[:setting] == :test_setting }[:setting]).to eq(:test_setting)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sidebar category is only shown in the admin panel when `enable_experimental_sidebar_hamburger` site setting is enabled

This is to support the two related PRs below. Instead of linking to the `developer` site setting category, it is better UX wise to link directly to a sidebar category.