### PR TITLE
FEATURE: Hide welcome topic if it hasn't been edited

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -439,7 +439,11 @@ class TopicQuery
     topics = topics.to_a
 
     # These don't need to be shown in the topic list
-    topics = topics.reject { |t| [SiteSetting.privacy_topic_id, SiteSetting.tos_topic_id].include?(t[:id]) }
+    if (topics.pluck(:id) & [SiteSetting.privacy_topic_id, SiteSetting.tos_topic_id, SiteSetting.welcome_topic_id]).any?
+      welcome_topic = Topic.find_by(id: SiteSetting.welcome_topic_id)
+      topics = topics.reject { |t| [SiteSetting.privacy_topic_id, SiteSetting.tos_topic_id].include?(t[:id]) ||
+        (t[:id] == welcome_topic&.id && welcome_topic&.first_post&.revisions&.count == 0) }
+    end
 
     if options[:preload_posters]
       user_ids = []

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -92,6 +92,30 @@ RSpec.describe ListController do
       expect(parsed["topic_list"]["topics"].length).to eq(1)
     end
 
+    it 'filters out the welcome topic if un-edited' do
+      welcome_topic = create_topic
+      create_post(topic_id: welcome_topic.id)
+      SiteSetting.welcome_topic_id = welcome_topic.id
+
+      get "/latest.json"
+      expect(response.status).to eq(200)
+      parsed = response.parsed_body
+      expect(parsed["topic_list"]["topics"].length).to eq(1)
+    end
+
+    it 'does not filter out the welcome topic if edited' do
+      welcome_topic = create_topic
+      SiteSetting.welcome_topic_id = welcome_topic.id
+      welcome_post = create_post(raw: "hello", topic_id: welcome_topic.id)
+
+      welcome_post.revisions.create!(user_id: welcome_post.user_id, post_id: welcome_post.id, number: 2)
+
+      get "/latest.json"
+      expect(response.status).to eq(200)
+      parsed = response.parsed_body
+      expect(parsed["topic_list"]["topics"].length).to eq(2)
+    end
+
     it "shows correct title if topic list is set for homepage" do
       get "/latest"
 


### PR DESCRIPTION
If the seeded welcome topic doesn't have a single edit let's not show
it. Once it has been edited it will show up in the topic list.

This change also includes a minor refactor so that we only try to filter
out these seeded topics if their ids are included in the current list of
topics.
