### PR TITLE
FIX: adjust the users per trust level cells in RTL mode

### DIFF
--- a/app/assets/stylesheets/common/admin/dashboard.scss
+++ b/app/assets/stylesheets/common/admin/dashboard.scss
@@ -440,6 +440,11 @@
         margin-left: 5px;
       }
     }
+
+    .value {
+      border-radius: 9px 0 0 9px;
+      padding: 0 5px 0 8px;
+    }
   }
 }
 


### PR DESCRIPTION
The commit contains a fix to the users per trust level cells in the dashboard when Discourse uses an RTL language as default locale. In the image below you can see the change:
 - On the left side, you can see the current status - the border of the left cell (number of users) does not match the background.
 - On the right side, you can see the fix - the border of the left cell (number of users) now matches the background.

![image](https://user-images.githubusercontent.com/35470921/195948394-c677eb3c-806d-4993-9598-e395d61a7a85.png)

Steps to reproduce the issue:
1. Setup a new and clean Discourse instance.
2. Create a few users and give them different trust levels.
3. In settings, under "default locale" choose some RTL language (for example Hebrew).
4. Go to the dashboard and see the trust levels.