### PR TITLE
A11Y: Improve accessibility in WHCM themes

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -4,6 +4,7 @@
 @import "vendor/pikaday";
 @import "vendor/tippy";
 @import "vendor/svg-arrow";
+@import "common/whcm";
 @import "common/foundation/helpers";
 @import "common/foundation/base";
 @import "common/select-kit/_index";

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -163,6 +163,7 @@
         padding-top: 0.25em;
         padding-bottom: 0.25em;
         &:focus-visible {
+          outline: 2px solid transparent;
           background-color: var(--tertiary-very-low);
         }
       }

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -163,7 +163,6 @@
         padding-top: 0.25em;
         padding-bottom: 0.25em;
         &:focus-visible {
-          outline: 2px solid transparent;
           background-color: var(--tertiary-very-low);
         }
       }

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -27,7 +27,9 @@
     color: $icon-color;
     margin-right: 0.45em;
     transition: color 0.25s;
-    @include whcm-button-text;
+    @media (forced-colors: active) {
+      color: ButtonText;
+    }
   }
   .d-button-label + .d-icon {
     margin-left: 0.45em;
@@ -43,7 +45,9 @@
     color: $hover-text-color;
     .d-icon {
       color: $hover-icon-color;
-      @include whcm-highlight-text;
+      @media (forced-colors: active) {
+        color: Highlight;
+      }
     }
   }
   &:focus {
@@ -52,7 +56,9 @@
     color: $hover-text-color;
     .d-icon {
       color: $hover-icon-color;
-      @include whcm-highlight-text;
+      @media (forced-colors: active) {
+        color: Highlight;
+      }
     }
   }
   &[href] {

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -27,10 +27,7 @@
     color: $icon-color;
     margin-right: 0.45em;
     transition: color 0.25s;
-
-    @media (forced-colors: active) {
-      color: ButtonText;
-    }
+    @include whcm-button-text;
   }
   .d-button-label + .d-icon {
     margin-left: 0.45em;
@@ -46,10 +43,7 @@
     color: $hover-text-color;
     .d-icon {
       color: $hover-icon-color;
-
-      @media (forced-colors: active) {
-        color: Highlight;
-      }
+      @include whcm-highlight-text;
     }
   }
   &:focus {
@@ -58,10 +52,7 @@
     color: $hover-text-color;
     .d-icon {
       color: $hover-icon-color;
-
-      @media (forced-colors: active) {
-        color: Highlight;
-      }
+      @include whcm-highlight-text;
     }
   }
   &[href] {

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -27,6 +27,10 @@
     color: $icon-color;
     margin-right: 0.45em;
     transition: color 0.25s;
+
+    @media (forced-colors: active) {
+      color: ButtonText;
+    }
   }
   .d-button-label + .d-icon {
     margin-left: 0.45em;
@@ -42,6 +46,10 @@
     color: $hover-text-color;
     .d-icon {
       color: $hover-icon-color;
+
+      @media (forced-colors: active) {
+        color: Highlight;
+      }
     }
   }
   &:focus {
@@ -50,6 +58,10 @@
     color: $hover-text-color;
     .d-icon {
       color: $hover-icon-color;
+
+      @media (forced-colors: active) {
+        color: Highlight;
+      }
     }
   }
   &[href] {

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -27,6 +27,7 @@
     color: $icon-color;
     margin-right: 0.45em;
     transition: color 0.25s;
+    // For Windows High Contrast (see whcm.scss for more)
     @media (forced-colors: active) {
       color: ButtonText;
     }
@@ -45,6 +46,7 @@
     color: $hover-text-color;
     .d-icon {
       color: $hover-icon-color;
+      // For Windows High Contrast (see whcm.scss for more)
       @media (forced-colors: active) {
         color: Highlight;
       }

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -223,13 +223,6 @@
       background: var(--highlight-medium);
     }
 
-    &:focus,
-    &:hover {
-      @media (forced-colors: active) {
-        outline: 2px auto transparent;
-      }
-    }
-
     .discourse-tag,
     .discourse-tag:visited,
     .discourse-tag:hover {

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -223,6 +223,13 @@
       background: var(--highlight-medium);
     }
 
+    &:focus,
+    &:hover {
+      @media (forced-colors: active) {
+        outline: 2px auto transparent;
+      }
+    }
+
     .discourse-tag,
     .discourse-tag:visited,
     .discourse-tag:hover {

--- a/app/assets/stylesheets/common/whcm.scss
+++ b/app/assets/stylesheets/common/whcm.scss
@@ -1,0 +1,38 @@
+// Overrides for Windows High Contrast Mode
+
+// Mixins:
+@mixin whcm-highlight-text {
+  @media (forced-colors: active) {
+    color: Highlight;
+  }
+}
+
+@mixin whcm-button-text {
+  @media (forced-colors: active) {
+    color: ButtonText;
+  }
+}
+
+// Select Kit
+.select-kit {
+  .select-kit-row {
+    &:hover,
+    &:focus {
+      @media (forced-colors: active) {
+        outline: 2px auto transparent;
+      }
+    }
+  }
+}
+
+// Search
+.search-container .search-filters {
+  details.advanced-filters,
+  details.search-advanced-additional-options {
+    > summary {
+      &:focus-visible {
+        outline: 2px solid transparent;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/common/whcm.scss
+++ b/app/assets/stylesheets/common/whcm.scss
@@ -19,15 +19,3 @@
     }
   }
 }
-
-// Search
-.search-container .search-filters {
-  details.advanced-filters,
-  details.search-advanced-additional-options {
-    > summary {
-      &:focus-visible {
-        outline: 2px solid transparent;
-      }
-    }
-  }
-}

--- a/app/assets/stylesheets/common/whcm.scss
+++ b/app/assets/stylesheets/common/whcm.scss
@@ -1,17 +1,12 @@
 // Overrides for Windows High Contrast Mode
 
-// Mixins:
-@mixin whcm-highlight-text {
-  @media (forced-colors: active) {
-    color: Highlight;
-  }
-}
+/*
+  Some @media (forced-colors: active) {} styles
+  have also been used inside mixins in:
+  - common/components/buttons.scss
 
-@mixin whcm-button-text {
-  @media (forced-colors: active) {
-    color: ButtonText;
-  }
-}
+  See file above for overrides.
+*/
 
 // Select Kit
 .select-kit {


### PR DESCRIPTION
Windows High Contrast Mode (WHCM) has some unique requirements for accessibility as it doesn't detect aria roles and relies on semantics, outlines, backgrounds, media queries, etc.

**This PR** addresses some accessibility issues present on WHCM themes:

**Night Sky Theme:**
|Before|After|
|---|---|
|<img width="250" alt="b1d" src="https://user-images.githubusercontent.com/30090424/195957620-c922d9f1-9f48-441f-b445-6d6aeeb19a02.png">|<img width="251" alt="b2d" src="https://user-images.githubusercontent.com/30090424/195957632-ddceaa09-189a-4309-99b7-40090838d030.png">|
|<img width="773" alt="b1" src="https://user-images.githubusercontent.com/30090424/195957579-e23048ec-e8d6-41d5-9bd7-5f9d38ad94eb.png">|<img width="771" alt="b2" src="https://user-images.githubusercontent.com/30090424/195957589-238c412d-4548-41cd-9332-781c088d7c64.png">|




**Dusk Theme:**
|Before|After|
|---|---|
|<img width="252" alt="Screen Shot 2022-10-14 at 2 46 10 PM" src="https://user-images.githubusercontent.com/30090424/195948785-74d30179-87b8-4e1c-80e7-2b6bd0d224b9.png"> |<img width="260" alt="Screen Shot 2022-10-14 at 2 45 23 PM" src="https://user-images.githubusercontent.com/30090424/195948788-0a876cb7-7a9e-4920-9ae4-896b09d6dbab.png">|
|<img width="801" alt="Screen Shot 2022-10-14 at 3 04 16 PM" src="https://user-images.githubusercontent.com/30090424/195952726-5b540fcc-86ca-4f05-9693-0ad8a2c22f8f.png">|<img width="774" alt="Screen Shot 2022-10-14 at 3 04 50 PM" src="https://user-images.githubusercontent.com/30090424/195952750-b1b4841a-1e7e-4ee1-ab88-b1a0c7769414.png">|
