### PR TITLE
UX: theme setting highlight update

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -282,6 +282,7 @@
     {{#if this.hasSettings}}
       <div class="control-unit">
         <div class="mini-title">{{i18n "admin.customize.theme.theme_settings"}}</div>
+        <p><i>{{i18n "admin.customize.theme.overriden_settings_explanation"}}</i></p>
         <DSection @class="form-horizontal theme settings control-unit">
           {{#each this.settings as |setting|}}
             <ThemeSettingEditor @setting={{setting}} @model={{this.model}} @class="theme-setting control-unit" />

--- a/app/assets/stylesheets/common/admin/settings.scss
+++ b/app/assets/stylesheets/common/admin/settings.scss
@@ -109,8 +109,21 @@
     }
   }
   .setting.overridden {
+    input {
+      background-color: var(--highlight-medium);
+    }
     h3 {
-      color: var(--highlight-high);
+      position: relative;
+      &:before {
+        content: "";
+        position: absolute;
+        top: 0.5rem;
+        left: -1rem;
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 100%;
+        background-color: var(--highlight-high);
+      }
     }
   }
   .setting.overridden.string {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1040,7 +1040,7 @@ en:
     user_fields:
       none: "(select an option)"
       required: 'Please enter a value for "%{name}"'
-      same_as_password: 'Your password should not be repeated in other fields.'
+      same_as_password: "Your password should not be repeated in other fields."
 
     user:
       said: "%{username}:"
@@ -4231,7 +4231,7 @@ en:
 
     welcome_topic_banner:
       title: "Create your Welcome Topic"
-      description: 'Your welcome topic is the first thing new members will read. Think of it as your “elevator pitch” or “mission statement.” Let everyone know who this community is for, what they can expect to find here, and what you’d like them to do first.'
+      description: "Your welcome topic is the first thing new members will read. Think of it as your “elevator pitch” or “mission statement.” Let everyone know who this community is for, what they can expect to find here, and what you’d like them to do first."
       button_title: "Start Editing"
 
     until: "Until:"
@@ -4844,6 +4844,7 @@ en:
           has_overwritten_history: "Current theme version no longer exists because the Git history has been overwritten by a force push."
           add: "Add"
           theme_settings: "Theme Settings"
+          overriden_settings_explanation: "Overridden settings are marked with a dot and have a highlighted color. To reset these settings to the default value, press the reset button next to them."
           no_settings: "This theme has no settings."
           theme_translations: "Theme Translations"
           empty: "No items"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4231,7 +4231,7 @@ en:
 
     welcome_topic_banner:
       title: "Create your Welcome Topic"
-      description: "Your welcome topic is the first thing new members will read. Think of it as your “elevator pitch” or “mission statement.” Let everyone know who this community is for, what they can expect to find here, and what you’d like them to do first."
+      description: 'Your welcome topic is the first thing new members will read. Think of it as your “elevator pitch” or “mission statement.” Let everyone know who this community is for, what they can expect to find here, and what you’d like them to do first.'
       button_title: "Start Editing"
 
     until: "Until:"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1040,7 +1040,7 @@ en:
     user_fields:
       none: "(select an option)"
       required: 'Please enter a value for "%{name}"'
-      same_as_password: "Your password should not be repeated in other fields."
+      same_as_password: 'Your password should not be repeated in other fields.'
 
     user:
       said: "%{username}:"


### PR DESCRIPTION
The theme settings text, when overridden, get highlighted. This isnt great because the highlight colours are usually pretty light, because they are used as background meaning the visibility as text is kinda awful

## Old
example: highlight as background = nice, highlight as text = awful :

![image](https://user-images.githubusercontent.com/101828855/195964931-0f11fe48-af47-4145-9f60-eb20711bb9ec.png)

## New
- leave text as primary color
- use a dot + bg on inputs to indicate any overrule
- add text to explain
- 
![image](https://user-images.githubusercontent.com/101828855/195964919-1809ce71-dafe-4adc-8510-ae17880c7bf6.png)
