### PR TITLE
DEV: includes search_aliases in emoji object

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -10,7 +10,7 @@ class Emoji
 
   include ActiveModel::SerializerSupport
 
-  attr_accessor :name, :url, :tonable, :group
+  attr_accessor :name, :url, :tonable, :group, :search_aliases
 
   def self.global_emoji_cache
     @global_emoji_cache ||= DistributedCache.new("global_emoji_cache", namespace: false)
@@ -95,6 +95,7 @@ class Emoji
       e.tonable = Emoji.tonable_emojis.include?(name)
       e.url = Emoji.url_for(filename)
       e.group = groups[name] || DEFAULT_GROUP
+      e.search_aliases = search_aliases[name] || []
     end
   end
 

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -148,5 +148,10 @@ RSpec.describe Emoji do
       emoji = Emoji.create_from_db_item("name" => "scotland")
       expect(emoji.group).to eq("flags")
     end
+
+    it "sets the search aliases of the emoji" do
+      emoji = Emoji.create_from_db_item("name" => "sad")
+      expect(emoji.search_aliases).to contain_exactly("frowning_face", "slightly_frowning_face", "sob", "crying_cat_face", "cry", "face_holding_back_tears")
+    end
   end
 end


### PR DESCRIPTION
This is an information we need on client side for example when filtering emojis.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
