### PR TITLE
DEV: Fix testem output

### DIFF
--- a/app/assets/javascripts/discourse/testem.js
+++ b/app/assets/javascripts/discourse/testem.js
@@ -18,7 +18,7 @@ class Reporter {
 
   report(prefix, data) {
     if (data.failed) {
-      this.failReports.push([prefix, data]);
+      this.failReports.push([prefix, data, this._tapReporter.id]);
     }
     this._tapReporter.report(prefix, data);
   }
@@ -28,11 +28,14 @@ class Reporter {
 
     if (this.failReports.length > 0) {
       process.stdout.write("\nFailures:\n\n");
-      this.failReports.forEach(([prefix, data]) => {
+
+      this.failReports.forEach(([prefix, data, id]) => {
         if (process.env.GITHUB_ACTIONS) {
           process.stdout.write(`::error ::QUnit Test Failure: ${data.name}\n`);
         }
-        this.report(prefix, data);
+
+        this._tapReporter.id = id;
+        this._tapReporter.report(prefix, data);
       });
     }
   }


### PR DESCRIPTION
Failed tests list we're displaying at the end had incorrect ids. e.g

```
(…)
ok 2160 Chrome 106.0 - [54 ms] - Integration | Component | select-kit/category-drop: caretUpIcon
ok 2161 Chrome 106.0 - [20 ms] - Unit | Service | store: find embedded

Used JS Heap Size: 7.304GB

1..2161
# tests 2161
# pass  2152
# skip  7
# todo  0
# fail  2

Failures:

not ok 2162 Chrome 106.0 - [36 ms] - Acceptance: Unknown: Permalink URL to a static page
    ---
        actual: >
            null
        message: >
            Promise rejected during "Permalink URL to a static page": no no
        negative: >
            false
        browser log: |
    ...
not ok 2163 Chrome 106.0 - [238 ms] - Unit | Utility | text: parseAsync
    ---
        actual: >
            null
        message: >
            Promise rejected during "parseAsync": nope
        negative: >
            false
        browser log: |
    ...
Testem finished with non-zero exit code. Tests failed.
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
