### PR TITLE
FIX: remove RS384 and RS512 cose ciphers

### DIFF
--- a/lib/freedom_patches/cose_rsapkcs1.rb
+++ b/lib/freedom_patches/cose_rsapkcs1.rb
@@ -44,7 +44,5 @@ module COSE
     end
 
     register(RSAPKCS1.new(-257, 'RS256', hash_function: 'SHA256'))
-    register(RSAPKCS1.new(-258, 'RS384', hash_function: 'SHA384'))
-    register(RSAPKCS1.new(-259, 'RS512', hash_function: 'SHA512'))
   end
 end


### PR DESCRIPTION
RS256 was added for Windows Hello and as a side effect we speculatively added
RS384 and RS512. These ciphers were not tested and are now failing on solo
keys. It may be the case that the ciphers are not configured correctly on
our side. It may be the case that this is a Solo key bug.

Regardless, we are removing the ciphers and will only consider adding them
again if absolutely needed.
