### PR TITLE
DEV: Ensure getter can always return without error

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -52,6 +52,10 @@ export default class SectionLink extends Component {
   }
 
   get prefixElementColors() {
+    if (!this.args.prefixElementColors) {
+      return;
+    }
+
     const prefixElementColors = this.args.prefixElementColors.filter((color) =>
       color?.slice(0, 6)
     );


### PR DESCRIPTION
Normally, arguments passed to components are lazily evaluated. `get prefixElementColors` will only be evaluated for `@prefixType="span"`. However, when using the Ember Inspector in development, arguments are eagerly evaluated and their values displayed in the inspector. Therefore we need to make sure that getters can always be evaluated without exceptions being thrown.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
