### PR TITLE
UX: Prevent reply to name from being longer than 400px

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1350,6 +1350,7 @@ a.mention-group {
   align-items: center;
   margin-right: 2em;
   max-width:400px;
+  overflow:hidden;
 
   img {
     margin: 0 0.25em;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1349,8 +1349,8 @@ a.mention-group {
   display: flex;
   align-items: center;
   margin-right: 2em;
-  max-width:400px;
-  overflow:hidden;
+  max-width: 400px;
+  overflow: hidden;
 
   img {
     margin: 0 0.25em;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1349,6 +1349,7 @@ a.mention-group {
   display: flex;
   align-items: center;
   margin-right: 2em;
+  max-width:400px;
 
   img {
     margin: 0 0.25em;


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
This will prevent large names from breaking the window.

Before:
![image](https://user-images.githubusercontent.com/91509874/196242121-51a8bdcf-bc96-4a86-aa0a-7ec5154491ed.png)
![image](https://user-images.githubusercontent.com/91509874/196242174-12f8f145-d9b6-4773-aef1-4b9282e8e900.png)


After:
![image](https://user-images.githubusercontent.com/91509874/196242046-ab4c3c1b-b540-4976-b988-85ca362fa840.png)
![image](https://user-images.githubusercontent.com/91509874/196242312-d0b910bb-fc07-45ca-9a76-4edf74bec14b.png)
