### PR TITLE
FIX: Prevent layout shift while traversing dropdown

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-filter.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-filter.js
@@ -83,11 +83,13 @@ export default Component.extend(UtilsMixin, {
 
     if (event.key === "ArrowUp") {
       this.selectKit.highlightLast();
+      event.preventDefault();
       return false;
     }
 
     if (event.key === "ArrowDown") {
       this.selectKit.highlightFirst();
+      event.preventDefault();
       return false;
     }
 


### PR DESCRIPTION
Currently when pressing the <kbd>↑</kbd> or <kbd>↓</kbd> keys to traverse the dropdown when selecting tags in the composer, the page scrolls up/down along with the keypress.

This PR prevents the page from moving up/down while traversing the dropdown. Tests omitted as its difficult to test page shifts and this is a minor non-critical issue.