### PR TITLE
FIX: Skip all post validations if necessary

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -560,7 +560,7 @@ class PostRevisor
       @post.last_editor_id = PostRevision.where(post_id: @post.id).order(number: :desc).pluck_first(:user_id) || @post.user_id
       @post.version -= 1
       @post.public_version -= 1
-      @post.save
+      @post.save(validate: @validate_post)
     else
       revision.save
     end

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1303,6 +1303,20 @@ RSpec.describe PostRevisor do
           .and change { DraftSequence.where(user_id: user.id, draft_key: draft_key).first.sequence }.by(1)
       end
     end
+
+    context 'when skipping validations' do
+      fab!(:post) { Fabricate(:post, raw: 'aaa', skip_validation: true) }
+
+      it 'can revise multiple times and remove unnecessary revisions' do
+        subject.revise!(admin, { raw: 'bbb' }, skip_validations: true)
+        expect(post.errors).to be_empty
+
+        # Revert to old version which was invalid to destroy previously created
+        # post revision and trigger another post save.
+        subject.revise!(admin, { raw: 'aaa' }, skip_validations: true)
+        expect(post.errors).to be_empty
+      end
+    end
   end
 
   context 'when the review_every_post setting is enabled' do


### PR DESCRIPTION
When PostRevisor is called with 'skip_validations: true' it can save the post twice and one of the calls passes the correct 'validate: false' argument, but the other one does not.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
