### PR TITLE
UX: Simplify bootstrap mode visuals

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.js
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.js
@@ -5,6 +5,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import { getOwner } from "discourse-common/lib/get-owner";
 import { inject as service } from "@ember/service";
+import showModal from "discourse/lib/show-modal";
 
 export default Component.extend(FilterModeMixin, {
   router: service(),
@@ -161,6 +162,10 @@ export default Component.extend(FilterModeMixin, {
       } else {
         this.createTopic();
       }
+    },
+
+    inviteUsers() {
+      showModal("create-invite");
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/templates/components/bootstrap-mode-notice.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bootstrap-mode-notice.hbs
@@ -1,13 +1,5 @@
 <div class="row bootstrap-mode-notice">
   <div class="alert alert-info alert-bootstrap-mode">
-    <div class="col-text">
-      {{this.message}}
-    </div>
-    <div class="col-button">
-      <div class="alert--button"><DButton @icon="user-plus" @action={{this.inviteUsers}} @class="btn-primary bootstrap-invite-button" @label="bootstrap_invite_button_title" /></div>
-      {{#if this.site.wizard_required}}
-        <div class="alert--link"><a class="bootstrap-wizard-link" href="/wizard">{{i18n "bootstrap_wizard_link_title"}}</a></div>
-      {{/if}}
-    </div>
+    {{this.message}}
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -39,6 +39,17 @@
       category=this.category
       tag=this.tag}} />
 
+  {{#if (or this.site.siteSettings.invite_only this.site.siteSettings.bootstrap_mode_enabled)}}
+    <DButton @icon="user-plus" @action={{action "inviteUsers"}} @class="btn-primary" @title="bootstrap_invite_button_title" />
+  {{/if}}
+  
+  {{#if this.site.siteSettings.wizard_required}}
+    <LinkTo @route="wizard.index" class="btn-primary">
+      {{d-icon "pencil-alt"}}
+      {{i18n "bootstrap_wizard_link_title"}}
+    </LinkTo>
+  {{/if}}
+
   <CreateTopicButton @canCreateTopic={{this.canCreateTopic}} @action={{action "clickCreateTopicButton"}} @disabled={{this.createTopicButtonDisabled}} @label={{this.createTopicLabel}} @btnClass={{this.createTopicClass}} @canCreateTopicOnTag={{this.canCreateTopicOnTag}} />
 
   <PluginOutlet @name="after-create-topic-button" @connectorTagName="div" @tagName="" @args={{hash

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -42,13 +42,13 @@
   {{#if (or this.site.siteSettings.invite_only this.site.siteSettings.bootstrap_mode_enabled)}}
     <DButton @icon="user-plus" @action={{action "inviteUsers"}} @class="btn-primary" @title="bootstrap_invite_button_title" />
   {{/if}}
-  
-  {{#if this.site.siteSettings.wizard_required}}
-    <LinkTo @route="wizard.index" class="btn-primary">
+
+  {{!-- {{#if this.site.siteSettings.wizard_required}} --}}
+    <LinkTo @route="wizard.index" class="btn-primary bootstrap-wizard-link">
       {{d-icon "pencil-alt"}}
       {{i18n "bootstrap_wizard_link_title"}}
     </LinkTo>
-  {{/if}}
+  {{!-- {{/if}} --}}
 
   <CreateTopicButton @canCreateTopic={{this.canCreateTopic}} @action={{action "clickCreateTopicButton"}} @disabled={{this.createTopicButtonDisabled}} @label={{this.createTopicLabel}} @btnClass={{this.createTopicClass}} @canCreateTopicOnTag={{this.canCreateTopicOnTag}} />
 

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -39,16 +39,18 @@
       category=this.category
       tag=this.tag}} />
 
-  {{#if (or this.site.siteSettings.invite_only this.site.siteSettings.bootstrap_mode_enabled)}}
+  {{#if (and (or this.site.siteSettings.invite_only this.site.siteSettings.bootstrap_mode_enabled) this.currentUser.admin)}}
     <DButton @icon="user-plus" @action={{action "inviteUsers"}} @class="btn-primary" @title="bootstrap_invite_button_title" />
   {{/if}}
 
-  {{!-- {{#if this.site.siteSettings.wizard_required}} --}}
-    <LinkTo @route="wizard.index" class="btn-primary bootstrap-wizard-link">
-      {{d-icon "pencil-alt"}}
-      {{i18n "bootstrap_wizard_link_title"}}
-    </LinkTo>
-  {{!-- {{/if}} --}}
+  {{#if (and this.site.siteSettings.wizard_required this.currentUser.admin)}}
+    {{#unless this.site.mobileView}}
+      <LinkTo @route="wizard.index" class="btn-primary bootstrap-wizard-link">
+        {{d-icon "pencil-alt"}}
+        {{i18n "bootstrap_wizard_link_title"}}
+      </LinkTo>
+    {{/unless}}
+  {{/if}}
 
   <CreateTopicButton @canCreateTopic={{this.canCreateTopic}} @action={{action "clickCreateTopicButton"}} @disabled={{this.createTopicButtonDisabled}} @label={{this.createTopicLabel}} @btnClass={{this.createTopicClass}} @canCreateTopicOnTag={{this.canCreateTopicOnTag}} />
 

--- a/app/assets/javascripts/discourse/tests/acceptance/bootstrap-mode-notice-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bootstrap-mode-notice-test.js
@@ -1,6 +1,6 @@
 import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
-import { click, currentURL, settled, visit } from "@ember/test-helpers";
+import { settled, visit } from "@ember/test-helpers";
 import { set } from "@ember/object";
 
 acceptance("Bootstrap Mode Notice", function (needs) {

--- a/app/assets/javascripts/discourse/tests/acceptance/bootstrap-mode-notice-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/bootstrap-mode-notice-test.js
@@ -17,24 +17,6 @@ acceptance("Bootstrap Mode Notice", function (needs) {
       exists(".bootstrap-mode-notice"),
       "has the bootstrap mode notice"
     );
-    assert.ok(
-      exists(".bootstrap-invite-button"),
-      "bootstrap notice has invite button"
-    );
-    assert.ok(
-      exists(".bootstrap-wizard-link"),
-      "bootstrap notice has wizard link"
-    );
-
-    await click(".bootstrap-invite-button");
-    assert.ok(exists(".create-invite-modal"), "opens create invite modal");
-
-    await click(".bootstrap-wizard-link");
-    assert.strictEqual(
-      currentURL(),
-      "/wizard/steps/hello-world",
-      "it transitions to the wizard page"
-    );
 
     await visit("/");
     set(this.siteSettings, "bootstrap_mode_enabled", false);


### PR DESCRIPTION
This PR:

- removes the invite button from the bootstrap mode banner.
- adds an invite next to `+ New Topic` button IF site is `invite_only` OR site is in bootstrap mode
- adds a `Finish Wizard Setup` button next to `+ New Topic` when wizard has not been finished

## After

### Bootstrap mode disabled + site is invite only
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/196269951-05141754-5fc1-4e5e-b610-93520a37655d.png">

### Bootstrap mode enabled
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/196270054-ce5f711a-15f9-477d-8bfb-4fa1afe37faf.png">

### Wizard complete + site invite only
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/196270396-2accf443-a5b4-4b8f-bdf3-ae06441bf812.png">



