### PR TITLE
A11Y: Add `href` to frequent poster avatars

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/topic-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-map.js
@@ -5,6 +5,7 @@ import { createWidget } from "discourse/widgets/widget";
 import { h } from "virtual-dom";
 import { replaceEmoji } from "discourse/widgets/emoji";
 import autoGroupFlairForUser from "discourse/lib/avatar-flair";
+import { userPath } from "discourse/lib/url";
 
 const LINKS_SHOWN = 5;
 
@@ -94,7 +95,7 @@ createWidget("topic-participant", {
         attributes: {
           title: attrs.username,
           "data-user-card": attrs.username,
-          href: `/u/${attrs.username}`,
+          href: userPath(attrs.username),
         },
       },
       linkContents

--- a/app/assets/javascripts/discourse/app/widgets/topic-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-map.js
@@ -87,12 +87,15 @@ createWidget("topic-participant", {
         linkContents.push(this.attach("avatar-flair", autoFlairAttrs));
       }
     }
-
     return h(
       "a.poster.trigger-user-card",
       {
         className: state.toggled ? "toggled" : null,
-        attributes: { title: attrs.username, "data-user-card": attrs.username },
+        attributes: {
+          title: attrs.username,
+          "data-user-card": attrs.username,
+          href: `/u/${attrs.username}`,
+        },
       },
       linkContents
     );


### PR DESCRIPTION
This PR adds the `href` attribute to the frequent poster avatars so that it is keyboard accessible.

## Before
<img width="719" alt="Screen Shot 2022-10-17 at 1 25 18 PM" src="https://user-images.githubusercontent.com/30090424/196276205-9d9fb9b0-ac61-443b-89c5-34cbe1e9c510.png">

## After
<img width="717" alt="Screen Shot 2022-10-17 at 1 24 51 PM" src="https://user-images.githubusercontent.com/30090424/196276109-07e308cd-05df-46a8-af17-71f6ebe79b94.png">
