### PR TITLE
A11Y: Listen for escape key on hamburger & user menu

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
@@ -400,4 +400,12 @@ export default createWidget("hamburger-menu", {
       this.sendWidgetAction("toggleHamburger");
     }
   },
+
+  keyDown(e) {
+    if (e.key === "Escape") {
+      this.sendWidgetAction("toggleHamburger");
+      e.preventDefault();
+      return false;
+    }
+  },
 });

--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -313,6 +313,14 @@ export default createWidget("user-menu", {
     }
   },
 
+  keyDown(e) {
+    if (e.key === "Escape") {
+      this.sendWidgetAction("toggleUserMenu");
+      e.preventDefault();
+      return false;
+    }
+  },
+
   quickAccess(type) {
     if (this.state.currentQuickAccess !== type) {
       this.state.currentQuickAccess = type;

--- a/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/hamburger-menu-test.js
@@ -1,9 +1,10 @@
 import {
   acceptance,
+  exists,
   query,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
-import { click, visit } from "@ember/test-helpers";
+import { click, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 
 acceptance(
@@ -26,3 +27,12 @@ acceptance(
     });
   }
 );
+
+acceptance("Hamburger Menu accessibility", function () {
+  test("Escape key closes hamburger menu", async function (assert) {
+    await visit("/");
+    await click("#toggle-hamburger-menu");
+    await triggerKeyEvent(".hamburger-panel", "keydown", "Escape");
+    assert.ok(!exists(".hamburger-panel"), "Esc closes the hamburger panel");
+  });
+});


### PR DESCRIPTION
This PR adds accessibility to hamburger and user menu, allowing the hamburger and user menu (old) to be closed on escape key press. Test for user menu is omitted as will soon be replaced by revamped menu.