### PR TITLE
A11Y: Bookmarks modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
@@ -42,7 +42,7 @@
     <DButton @id="save-bookmark" @label="bookmarks.save" @class="btn-primary" @action={{action "saveAndClose"}} />
     <DModalCancel @close={{action "closeWithoutSavingBookmark"}} />
     {{#if this.showDelete}}
-      <DButton @id="delete-bookmark" @icon="trash-alt" @class="delete-bookmark btn-danger" @action={{action "delete"}} />
+      <DButton @id="delete-bookmark" @icon="trash-alt" @class="delete-bookmark btn-danger" @action={{action "delete"}} @ariaLabel="post.bookmarks.actions.delete_bookmark.name" @title="post.bookmarks.actions.delete_bookmark.name" />
     {{/if}}
   </div>
 </ConditionalLoadingSpinner>

--- a/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
@@ -9,7 +9,7 @@
 
   <div class="control-group bookmark-name-wrap">
     <Input id="bookmark-name" @value={{this.model.name}} name="bookmark-name" class="bookmark-name" @enter={{action "saveAndClose"}} placeholder={{i18n "post.bookmarks.name_placeholder"}} maxlength="100" />
-    <DButton @icon="cog" @action={{action "toggleShowOptions"}} @class="bookmark-options-button" @ariaLabel="post.bookmarks.options" />
+    <DButton @icon="cog" @action={{action "toggleShowOptions"}} @class="bookmark-options-button" @ariaLabel="post.bookmarks.options" @title="post.bookmarks.options" />
   </div>
 
   {{#if this.showOptions}}


### PR DESCRIPTION
This PR improves the accessibility in the bookmarks modal by adding an `aria-label` and `title` to the delete icon as well as a `title` to the options icon.

<img width="452" alt="Screen Shot 2022-10-17 at 2 42 02 PM" src="https://user-images.githubusercontent.com/30090424/196289295-4b05ee56-90e5-4ffd-b795-f56d86dd9b9b.png">
