### PR TITLE
FIX: Clarify security key copy

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/second-factor-add-security-key.js
+++ b/app/assets/javascripts/discourse/app/controllers/second-factor-add-security-key.js
@@ -13,11 +13,23 @@ export default Controller.extend(ModalFunctionality, {
   errorMessage: null,
 
   onShow() {
+    let securityKeyName;
+    if (this.capabilities.isIOS && !this.capabilities.isIpadOS) {
+      securityKeyName = I18n.t(
+        "user.second_factor.security_key.iphone_default_name"
+      );
+    } else if (this.capabilities.isAndroid) {
+      securityKeyName = I18n.t(
+        "user.second_factor.security_key.android_default_name"
+      );
+    } else {
+      securityKeyName = I18n.t("user.second_factor.security_key.default_name");
+    }
     // clear properties every time because the controller is a singleton
     this.setProperties({
       errorMessage: null,
       loading: true,
-      securityKeyName: I18n.t("user.second_factor.security_key.default_name"),
+      securityKeyName,
       webauthnUnsupported: !isWebauthnSupported(),
     });
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1389,7 +1389,7 @@ en:
         edit_title: "Edit Authenticator"
         edit_description: "Authenticator Name"
         enable_security_key_description: |
-          When you have your <a href="https://www.google.com/search?q=hardware+security+key" target="_blank">hardware security key</a> prepared, press the Register button below.
+          When you have your <a href="https://www.google.com/search?q=hardware+security+key" target="_blank">hardware security key</a> or compatible mobile device prepared, press the Register button below.
         totp:
           title: "Token-Based Authenticators"
           add: "Add Authenticator"
@@ -1397,14 +1397,16 @@ en:
           name_and_code_required_error: "You must provide a name and the code from your authenticator app."
         security_key:
           register: "Register"
-          title: "Security Keys"
-          add: "Add Security Key"
+          title: "Physical Security Keys"
+          add: "Add Physical Security Key"
           default_name: "Main Security Key"
+          iphone_default_name: "iPhone"
+          android_default_name: "Android"
           not_allowed_error: "The security key registration process either timed out or was cancelled."
           already_added_error: "You have already registered this security key. You don’t have to register it again."
-          edit: "Edit Security Key"
+          edit: "Edit Physical Security Key"
           save: "Save"
-          edit_description: "Security Key Name"
+          edit_description: "Physical Security Key Name"
           name_required_error: "You must provide a name for your security key."
 
       change_about:
@@ -2004,7 +2006,7 @@ en:
       second_factor_backup_title: "Two-Factor Backup"
       second_factor_backup_description: "Please enter one of your backup codes:"
       second_factor: "Log in using Authenticator app"
-      security_key_description: "When you have your physical security key prepared press the Authenticate with Security Key button below."
+      security_key_description: "When you have your physical security key or compatible mobile device prepared press the Authenticate with Security Key button below."
       security_key_alternative: "Try another way"
       security_key_authenticate: "Authenticate with Security Key"
       security_key_not_allowed_error: "The security key authentication process either timed out or was cancelled."


### PR DESCRIPTION
In user preferences, we want to make it more obvious that a security key is a physical device, and also you can use your phone.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/920448/196316021-ec9b1699-a677-4e23-b4ac-5eca3ac69ddf.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/920448/196316062-a48096ba-b29a-4751-9ee6-327257de278c.png">
