### PR TITLE
FIX: sidebar list destination for tracked and tags

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.js
@@ -48,6 +48,7 @@ export default class SidebarUserTagsSection extends Component {
           new TagSectionLink({
             tagName: tag.name,
             topicTrackingState: this.topicTrackingState,
+            currentUser: this.currentUser,
           })
         );
       }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/tracked-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/tracked-section-link.js
@@ -3,6 +3,7 @@ import I18n from "I18n";
 import { tracked } from "@glimmer/tracking";
 import BaseSectionLink from "discourse/lib/sidebar/base-community-section-link";
 import { isTrackedTopic } from "discourse/lib/topic-list-tracked-filter";
+import { UNREAD_LIST_DESTINATION } from "discourse/controllers/preferences/sidebar";
 
 export default class TrackedSectionLink extends BaseSectionLink {
   @tracked totalUnread = 0;
@@ -64,6 +65,14 @@ export default class TrackedSectionLink extends BaseSectionLink {
   }
 
   get route() {
+    if (this.currentUser?.sidebarListDestination === UNREAD_LIST_DESTINATION) {
+      if (this.totalUnread > 0) {
+        return "discovery.unread";
+      }
+      if (this.totalNew > 0) {
+        return "discovery.new";
+      }
+    }
     return "discovery.latest";
   }
 

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/tags-section/tag-section-link.js
@@ -4,14 +4,16 @@ import { tracked } from "@glimmer/tracking";
 
 import { bind } from "discourse-common/utils/decorators";
 import BaseTagSectionLink from "discourse/lib/sidebar/user/tags-section/base-tag-section-link";
+import { UNREAD_LIST_DESTINATION } from "discourse/controllers/preferences/sidebar";
 
 export default class TagSectionLink extends BaseTagSectionLink {
   @tracked totalUnread = 0;
   @tracked totalNew = 0;
 
-  constructor({ topicTrackingState }) {
+  constructor({ topicTrackingState, currentUser }) {
     super(...arguments);
     this.topicTrackingState = topicTrackingState;
+    this.currentUser = currentUser;
     this.refreshCounts();
   }
 
@@ -33,6 +35,14 @@ export default class TagSectionLink extends BaseTagSectionLink {
   }
 
   get route() {
+    if (this.currentUser?.sidebarListDestination === UNREAD_LIST_DESTINATION) {
+      if (this.totalUnread > 0) {
+        return "tag.showUnread";
+      }
+      if (this.totalNew > 0) {
+        return "tag.showNew";
+      }
+    }
     return "tag.show";
   }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -297,6 +297,123 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     );
   });
 
+  test("clicking on tracked link - sidebar_list_destination set to unread/new and no unread or new topics", async function (assert) {
+    updateCurrentUser({
+      user_option: {
+        sidebar_list_destination: "unread_new",
+      },
+    });
+
+    await visit("/t/280");
+    await click(".sidebar-section-community .sidebar-section-link-tracked");
+    assert.strictEqual(
+      currentURL(),
+      "/latest?f=tracked",
+      "it should transition to the latest tracked url"
+    );
+
+    assert.ok(
+      exists(".sidebar-section-community .sidebar-section-link-tracked.active"),
+      "the tracked link is marked as active"
+    );
+
+    assert.strictEqual(
+      count(".sidebar-section-community .sidebar-section-link.active"),
+      1,
+      "only one link is marked as active"
+    );
+  });
+
+  test("clicking on tracked link - sidebar_list_destination set to unread/new with new topics", async function (assert) {
+    const categories = Site.current().categories;
+    const category = categories.find((c) => c.id === 1001);
+    category.set("notification_level", NotificationLevels.TRACKING);
+
+    const topicTrackingState = this.container.lookup(
+      "service:topic-tracking-state"
+    );
+    topicTrackingState.states.set("t112", {
+      last_read_post_number: null,
+      id: 112,
+      notification_level: NotificationLevels.TRACKING,
+      category_id: 1001,
+      created_in_new_period: true,
+    });
+    updateCurrentUser({
+      user_option: {
+        sidebar_list_destination: "unread_new",
+      },
+    });
+    await visit("/t/280");
+    await click(".sidebar-section-community .sidebar-section-link-tracked");
+
+    assert.strictEqual(
+      currentURL(),
+      "/new?f=tracked",
+      "it should transition to the tracked new page"
+    );
+
+    assert.ok(
+      exists(".sidebar-section-community .sidebar-section-link-tracked.active"),
+      "the tracked link is marked as active"
+    );
+
+    assert.strictEqual(
+      count(".sidebar-section-community .sidebar-section-link.active"),
+      1,
+      "only one link is marked as active"
+    );
+  });
+
+  test("clicking on tracked link - sidebar_list_destination set to unread/new with new and unread topics", async function (assert) {
+    const categories = Site.current().categories;
+    const category = categories.find((c) => c.id === 1001);
+    category.set("notification_level", NotificationLevels.TRACKING);
+
+    const topicTrackingState = this.container.lookup(
+      "service:topic-tracking-state"
+    );
+    topicTrackingState.states.set("t112", {
+      last_read_post_number: null,
+      id: 112,
+      notification_level: NotificationLevels.TRACKING,
+      category_id: 1001,
+      created_in_new_period: true,
+    });
+    topicTrackingState.states.set("t113", {
+      last_read_post_number: 1,
+      highest_post_number: 2,
+      id: 113,
+      notification_level: NotificationLevels.TRACKING,
+      category_id: 1001,
+      created_in_new_period: true,
+    });
+    updateCurrentUser({
+      user_option: {
+        sidebar_list_destination: "unread_new",
+      },
+    });
+    await visit("/t/280");
+    await click(".sidebar-section-community .sidebar-section-link-tracked");
+
+    assert.strictEqual(
+      currentURL(),
+      "/unread?f=tracked",
+      "it should transition to the tracked unread page"
+    );
+
+    assert.ok(
+      exists(".sidebar-section-community .sidebar-section-link-tracked.active"),
+      "the tracked link is marked as active"
+    );
+
+    assert.strictEqual(
+      count(".sidebar-section-community .sidebar-section-link.active"),
+      1,
+      "only one link is marked as active"
+    );
+  });
+
   test("clicking on users link", async function (assert) {
     await visit("/t/280");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -12,6 +12,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
+import { NotificationLevels } from "discourse/lib/notification-levels";
 
 acceptance(
   "Sidebar - Logged on user - Tags section - tagging disabled",
@@ -232,6 +233,118 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
     assert.ok(
       exists(`.sidebar-section-link-tag2.active`),
       "the tag2 section link is marked as active"
+    );
+  });
+
+  test("clicking tag section links - sidebar_list_destination set to unread/new and no unread or new topics", async function (assert) {
+    updateCurrentUser({
+      user_option: {
+        sidebar_list_destination: "unread_new",
+      },
+    });
+
+    await visit("/");
+    await click(".sidebar-section-link-tag1");
+
+    assert.strictEqual(
+      currentURL(),
+      "/tag/tag1",
+      "it should transition to tag1's topics discovery page"
+    );
+
+    assert.strictEqual(
+      count(".sidebar-section-tags .sidebar-section-link.active"),
+      1,
+      "only one link is marked as active"
+    );
+
+    assert.ok(
+      exists(`.sidebar-section-link-tag1.active`),
+      "the tag1 section link is marked as active"
+    );
+  });
+
+  test("clicking tag section links - sidebar_list_destination set to unread/new with new topics", async function (assert) {
+    updateCurrentUser({
+      user_option: {
+        sidebar_list_destination: "unread_new",
+      },
+    });
+
+    this.container.lookup("service:topic-tracking-state").loadStates([
+      {
+        topic_id: 1,
+        highest_post_number: 1,
+        last_read_post_number: null,
+        created_at: "2022-05-11T03:09:31.959Z",
+        category_id: 1,
+        notification_level: null,
+        created_in_new_period: true,
+        treat_as_new_topic_start_date: "2022-05-09T03:17:34.286Z",
+        tags: ["tag1"],
+      },
+    ]);
+
+    await visit("/");
+    await click(".sidebar-section-link-tag1");
+
+    assert.strictEqual(
+      currentURL(),
+      "/tag/tag1/l/new",
+      "it should transition to tag1's topics new page"
+    );
+
+    assert.strictEqual(
+      count(".sidebar-section-tags .sidebar-section-link.active"),
+      1,
+      "only one link is marked as active"
+    );
+
+    assert.ok(
+      exists(`.sidebar-section-link-tag1.active`),
+      "the tag1 section link is marked as active"
+    );
+  });
+
+  test("clicking tag section links - sidebar_list_destination set to unread/new with unread topics", async function (assert) {
+    updateCurrentUser({
+      user_option: {
+        sidebar_list_destination: "unread_new",
+      },
+    });
+
+    this.container.lookup("service:topic-tracking-state").loadStates([
+      {
+        topic_id: 1,
+        highest_post_number: 2,
+        last_read_post_number: 1,
+        created_at: "2022-05-11T03:09:31.959Z",
+        category_id: 1,
+        notification_level: NotificationLevels.TRACKING,
+        created_in_new_period: true,
+        treat_as_new_topic_start_date: "2022-05-09T03:17:34.286Z",
+        tags: ["tag1"],
+      },
+    ]);
+
+    await visit("/");
+    await click(".sidebar-section-link-tag1");
+
+    assert.strictEqual(
+      currentURL(),
+      "/tag/tag1/l/unread",
+      "it should transition to tag1's topics unread page"
+    );
+
+    assert.strictEqual(
+      count(".sidebar-section-tags .sidebar-section-link.active"),
+      1,
+      "only one link is marked as active"
+    );
+
+    assert.ok(
+      exists(`.sidebar-section-link-tag1.active`),
+      "the tag1 section link is marked as active"
     );
   });
 


### PR DESCRIPTION
Follow up for https://github.com/discourse/discourse/pull/18594

Same solution for tracked and tag links.