### PR TITLE
DEV: Switch back to mainline `licensed` gem

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -48,10 +48,7 @@ jobs:
 
       - name: Setup licensed
         run: |
-          # gem install licensed
-          # Workaround for https://github.com/github/licensed/issues/521
-          gem install specific_install
-          gem specific_install https://github.com/CvX/licensed.git -b bundler-compat
+          gem install licensed
 
       - name: Get yarn cache directory
         id: yarn-cache-dir


### PR DESCRIPTION
The bundler issue has been fixed

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
