### PR TITLE
UX: Fix alt text cancel button in dark mode

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/image-controls.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/image-controls.js
@@ -85,10 +85,10 @@ function buildImageEditAltTextControls(altText) {
   return `
   <span class="alt-text-edit-container" hidden="true">
     <input class="alt-text-input" type="text" value="${altText}" />
-    <button class="alt-text-edit-ok btn-primary">
+    <button class="alt-text-edit-ok btn btn-primary">
         <svg class="fa d-icon d-icon-check svg-icon svg-string"><use href="#check"></use></svg>
     </button>
-    <button class="alt-text-edit-cancel btn-default">
+    <button class="alt-text-edit-cancel btn btn-default">
         <svg class="fa d-icon d-icon-times svg-icon svg-string"><use href="#times"></use></svg>
     </button>
   </span>
@@ -174,10 +174,10 @@ export function setup(helper) {
       "span[hidden=true]",
       "input[type=text]",
       "input[class=alt-text-input]",
-      "button[class=alt-text-edit-ok btn-primary]",
+      "button[class=alt-text-edit-ok btn btn-primary]",
       "svg[class=fa d-icon d-icon-check svg-icon svg-string]",
       "use[href=#check]",
-      "button[class=alt-text-edit-cancel btn-default]",
+      "button[class=alt-text-edit-cancel btn btn-default]",
       "svg[class=fa d-icon d-icon-times svg-icon svg-string]",
       "svg[class=fa d-icon d-icon-trash-alt svg-icon svg-string]",
       "use[href=#times]",


### PR DESCRIPTION
This PR fixes a small design issue where the `alt-text-edit-cancel` button's icon shows the wrong color.

**Mode**|**Before**|**After**|
|---|---|---|
|Light| <img width="289" alt="Screen Shot 2022-10-18 at 7 03 29 AM" src="https://user-images.githubusercontent.com/30090424/196454632-cd0f2c31-078f-4a3d-ab3c-1f3c748731c7.png"> | <img width="280" alt="Screen Shot 2022-10-18 at 7 07 09 AM" src="https://user-images.githubusercontent.com/30090424/196454970-5f59ad41-c9f9-4251-a4a6-b326bd1abd15.png"> |
|Dark | <img width="292" alt="Screen Shot 2022-10-18 at 7 03 20 AM" src="https://user-images.githubusercontent.com/30090424/196454795-2765351c-1f7c-47bc-88f9-a85e43e66d60.png"> | <img width="281" alt="Screen Shot 2022-10-18 at 7 12 39 AM" src="https://user-images.githubusercontent.com/30090424/196455172-a5eb9e40-9f6c-400b-bfc2-75ebd9c537eb.png"> |







