### PR TITLE
DEV: Introduce minification and source maps for Theme JS

### DIFF
--- a/app/models/javascript_cache.rb
+++ b/app/models/javascript_cache.rb
@@ -41,6 +41,7 @@ end
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  theme_id       :bigint
+#  source_map     :text
 #
 # Indexes
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -561,6 +561,7 @@ Discourse::Application.routes.draw do
     get "stylesheets/:name.css" => "stylesheets#show", constraints: { name: /[-a-z0-9_]+/ }
     get "color-scheme-stylesheet/:id(/:theme_id)" => "stylesheets#color_scheme", constraints: { format: :json }
     get "theme-javascripts/:digest.js" => "theme_javascripts#show", constraints: { digest: /\h{40}/ }
+    get "theme-javascripts/:digest.map" => "theme_javascripts#show_map", constraints: { digest: /\h{40}/ }
     get "theme-javascripts/tests/:theme_id-:digest.js" => "theme_javascripts#show_tests"
 
     post "uploads/lookup-metadata" => "uploads#metadata"

--- a/db/migrate/20221018100550_add_source_map_to_javascript_cache.rb
+++ b/db/migrate/20221018100550_add_source_map_to_javascript_cache.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSourceMapToJavascriptCache < ActiveRecord::Migration[7.0]
+  def change
+    add_column :javascript_caches, :source_map, :text
+  end
+end

--- a/lib/discourse_js_processor.rb
+++ b/lib/discourse_js_processor.rb
@@ -152,6 +152,10 @@ class DiscourseJsProcessor
         }
       JS
 
+      # Terser
+      load_file_in_context(ctx, "node_modules/source-map/dist/source-map.js")
+      load_file_in_context(ctx, "node_modules/terser/dist/bundle.min.js")
+
       # Template Compiler
       load_file_in_context(ctx, "node_modules/ember-source/dist/ember-template-compiler.js")
       load_file_in_context(ctx, "node_modules/babel-plugin-ember-template-compilation/src/plugin.js", wrap_in_module: "babel-plugin-ember-template-compilation/index")
@@ -197,6 +201,8 @@ class DiscourseJsProcessor
       ctx.eval <<~JS
         globalThis.compileRawTemplate = require('discourse-js-processor').compileRawTemplate;
         globalThis.transpile = require('discourse-js-processor').transpile;
+        globalThis.minify = require('discourse-js-processor').minify;
+        globalThis.getMinifyResult = require('discourse-js-processor').getMinifyResult;
       JS
 
       ctx
@@ -219,9 +225,16 @@ class DiscourseJsProcessor
       @ctx
     end
 
+    # Call a method in the global scope of the v8 context.
+    # The `fetch_result_call` kwarg provides a workaround for the lack of mini_racer async
+    # result support. The first call can perform some async operation, and then `fetch_result_call`
+    # will be called to fetch the result.
     def self.v8_call(*args, **kwargs)
+      fetch_result_call = kwargs.delete(:fetch_result_call)
       mutex.synchronize do
-        v8.call(*args, **kwargs)
+        result = v8.call(*args, **kwargs)
+        result = v8.call(fetch_result_call) if fetch_result_call
+        result
       end
     rescue MiniRacer::RuntimeError => e
       message = e.message
@@ -276,5 +289,8 @@ class DiscourseJsProcessor
       self.class.v8_call("compileRawTemplate", source, theme_id)
     end
 
+    def terser(tree, opts)
+      self.class.v8_call("minify", tree, opts, fetch_result_call: "getMinifyResult")
+    end
   end
 end

--- a/spec/lib/discourse_js_processor_spec.rb
+++ b/spec/lib/discourse_js_processor_spec.rb
@@ -185,4 +185,30 @@ RSpec.describe DiscourseJsProcessor do
       )
     end
   end
+
+  describe "Transpiler#terser" do
+    it "can minify code and provide sourcemaps" do
+      sources = {
+        "multiply.js" => "let multiply = (firstValue, secondValue) => firstValue * secondValue;",
+        "add.js" => "let add = (firstValue, secondValue) => firstValue + secondValue;"
+      }
+
+      result = DiscourseJsProcessor::Transpiler.new.terser(sources, { sourceMap: { includeSources: true } })
+      expect(result.keys).to contain_exactly("code", "map")
+
+      begin
+        # Check the code still works
+        ctx = MiniRacer::Context.new
+        ctx.eval(result["code"])
+        expect(ctx.eval("multiply(2, 3)")).to eq(6)
+        expect(ctx.eval("add(2, 3)")).to eq(5)
+      ensure
+        ctx.dispose
+      end
+
+      map = JSON.parse(result["map"])
+      expect(map["sources"]).to contain_exactly(*sources.keys)
+      expect(map["sourcesContent"]).to contain_exactly(*sources.values)
+    end
+  end
 end

--- a/spec/lib/theme_javascript_compiler_spec.rb
+++ b/spec/lib/theme_javascript_compiler_spec.rb
@@ -8,28 +8,28 @@ RSpec.describe ThemeJavascriptCompiler do
       template = "<h1>hello</h1>"
       name = "/path/to/templates1"
       compiler.append_raw_template("#{name}.raw", template)
-      expect(compiler.content.to_s).to include("addRawTemplate(\"#{name}\"")
+      expect(compiler.raw_content.to_s).to include("addRawTemplate(\"#{name}\"")
 
       name = "/path/to/templates2"
       compiler.append_raw_template("#{name}.hbr", template)
-      expect(compiler.content.to_s).to include("addRawTemplate(\"#{name}\"")
+      expect(compiler.raw_content.to_s).to include("addRawTemplate(\"#{name}\"")
 
       name = "/path/to/templates3"
       compiler.append_raw_template("#{name}.hbs", template)
-      expect(compiler.content.to_s).to include("addRawTemplate(\"#{name}.hbs\"")
+      expect(compiler.raw_content.to_s).to include("addRawTemplate(\"#{name}.hbs\"")
     end
   end
 
   describe "#append_ember_template" do
     it 'maintains module names so that discourse-boot.js can correct them' do
       compiler.append_ember_template("/connectors/blah-1", "{{var}}")
-      expect(compiler.content.to_s).to include("define(\"discourse/theme-1/connectors/blah-1\", [\"exports\", \"@ember/template-factory\"]")
+      expect(compiler.raw_content.to_s).to include("define(\"discourse/theme-1/connectors/blah-1\", [\"exports\", \"@ember/template-factory\"]")
 
       compiler.append_ember_template("connectors/blah-2", "{{var}}")
-      expect(compiler.content.to_s).to include("define(\"discourse/theme-1/connectors/blah-2\", [\"exports\", \"@ember/template-factory\"]")
+      expect(compiler.raw_content.to_s).to include("define(\"discourse/theme-1/connectors/blah-2\", [\"exports\", \"@ember/template-factory\"]")
 
       compiler.append_ember_template("javascripts/connectors/blah-3", "{{var}}")
-      expect(compiler.content.to_s).to include("define(\"discourse/theme-1/javascripts/connectors/blah-3\", [\"exports\", \"@ember/template-factory\"]")
+      expect(compiler.raw_content.to_s).to include("define(\"discourse/theme-1/javascripts/connectors/blah-3\", [\"exports\", \"@ember/template-factory\"]")
     end
   end
 
@@ -39,22 +39,22 @@ RSpec.describe ThemeJavascriptCompiler do
       compiler = ThemeJavascriptCompiler.new(1, 'marks')
       compiler.append_ember_template("connectors/outlet/blah-1", "{{var}}")
       compiler.append_module("console.log('test')", "connectors/outlet/blah-1")
-      expect(compiler.content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
-      expect(compiler.content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
+      expect(compiler.raw_content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
+      expect(compiler.raw_content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
 
       # Colocated under `/templates/connectors`
       compiler = ThemeJavascriptCompiler.new(1, 'marks')
       compiler.append_ember_template("templates/connectors/outlet/blah-1", "{{var}}")
       compiler.append_module("console.log('test')", "templates/connectors/outlet/blah-1")
-      expect(compiler.content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
-      expect(compiler.content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
+      expect(compiler.raw_content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
+      expect(compiler.raw_content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
 
       # Not colocated
       compiler = ThemeJavascriptCompiler.new(1, 'marks')
       compiler.append_ember_template("templates/connectors/outlet/blah-1", "{{var}}")
       compiler.append_module("console.log('test')", "connectors/outlet/blah-1")
-      expect(compiler.content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
-      expect(compiler.content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
+      expect(compiler.raw_content.to_s).to include("discourse/theme-1/connectors/outlet/blah-1")
+      expect(compiler.raw_content.to_s).to include("discourse/theme-1/templates/connectors/outlet/blah-1")
     end
   end
 
@@ -83,8 +83,8 @@ RSpec.describe ThemeJavascriptCompiler do
           "discourse/templates/components/mycomponent.hbs" => "{{my-component-template}}"
         }
       )
-      expect(compiler.content).to include('define("discourse/theme-1/components/mycomponent"')
-      expect(compiler.content).to include('define("discourse/theme-1/discourse/templates/components/mycomponent"')
+      expect(compiler.raw_content).to include('define("discourse/theme-1/components/mycomponent"')
+      expect(compiler.raw_content).to include('define("discourse/theme-1/discourse/templates/components/mycomponent"')
     end
 
     it "handles colocated components" do
@@ -97,8 +97,8 @@ RSpec.describe ThemeJavascriptCompiler do
           "discourse/components/mycomponent.hbs" => "{{my-component-template}}"
         }
       )
-      expect(compiler.content).to include("__COLOCATED_TEMPLATE__ =")
-      expect(compiler.content).to include("setComponentTemplate")
+      expect(compiler.raw_content).to include("__COLOCATED_TEMPLATE__ =")
+      expect(compiler.raw_content).to include("setComponentTemplate")
     end
 
     it "prints error when default export missing" do
@@ -111,8 +111,8 @@ RSpec.describe ThemeJavascriptCompiler do
           "discourse/components/mycomponent.hbs" => "{{my-component-template}}"
         }
       )
-      expect(compiler.content).to include("__COLOCATED_TEMPLATE__ =")
-      expect(compiler.content).to include("throw new Error")
+      expect(compiler.raw_content).to include("__COLOCATED_TEMPLATE__ =")
+      expect(compiler.raw_content).to include("throw new Error")
     end
 
     it "handles template-only components" do
@@ -121,9 +121,35 @@ RSpec.describe ThemeJavascriptCompiler do
           "discourse/components/mycomponent.hbs" => "{{my-component-template}}"
         }
       )
-      expect(compiler.content).to include("__COLOCATED_TEMPLATE__ =")
-      expect(compiler.content).to include("setComponentTemplate")
-      expect(compiler.content).to include("@ember/component/template-only")
+      expect(compiler.raw_content).to include("__COLOCATED_TEMPLATE__ =")
+      expect(compiler.raw_content).to include("setComponentTemplate")
+      expect(compiler.raw_content).to include("@ember/component/template-only")
+    end
+  end
+
+  describe "terser compilation" do
+    it "applies terser and provides sourcemaps" do
+      sources = {
+        "multiply.js" => "let multiply = (firstValue, secondValue) => firstValue * secondValue;",
+        "add.js" => "let add = (firstValue, secondValue) => firstValue + secondValue;"
+      }
+
+      compiler.append_tree(sources)
+
+      expect(compiler.content).to include("multiply")
+      expect(compiler.content).to include("add")
+
+      map = JSON.parse(compiler.source_map)
+      expect(map["sources"]).to contain_exactly(*sources.keys)
+      expect(map["sourcesContent"].to_s).to include("let multiply")
+      expect(map["sourcesContent"].to_s).to include("let add")
+      expect(map["sourceRoot"]).to eq("theme-1/")
+    end
+
+    it "handles invalid JS" do
+      compiler.append_raw_script("filename.js", "if(someCondition")
+      expect(compiler.content).to include('console.error("[THEME 1')
+      expect(compiler.content).to include('Unexpected token')
     end
   end
 end

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Theme do
     Theme.clear_cache!
   end
 
+  before { ThemeJavascriptCompiler.disable_terser! }
+  after { ThemeJavascriptCompiler.enable_terser! }
+
   fab! :user do
     Fabricate(:user)
   end


### PR DESCRIPTION
Theme javascript is now minified using Terser, just like our core/plugin JS bundles. This reduces the amount of data sent over the network.

This commit also introduces sourcemaps for theme JS. Browser developer tools will now be able show each source file separately when browsing, and also in backtraces.

For theme test JS, the sourcemap is inlined for simplicity. Network load is not a concern for tests.

<img src="https://user-images.githubusercontent.com/6270921/196491113-7c2aded2-2384-490b-b706-9882b23c5d84.png" width=300/>

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
