### PR TITLE
A11Y: Improve topic timeline in WHCM

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -243,6 +243,7 @@
       height: 100%;
       float: left;
       z-index: z("base") + 1;
+      outline: 1px solid transparent;
     }
 
     .timeline-scroller-content {
@@ -262,7 +263,7 @@
 
     .timeline-scroller {
       @include unselectable;
-      margin-left: -0.19em;
+      margin-left: -0.22em;
       cursor: ns-resize;
       display: flex;
       align-items: center;


### PR DESCRIPTION
**This PR improves the appearance of the topic timeline:**
- by better positioning it in the center
- improving its appearance in Windows High Contrast Mode


| Mode | Before | After |
|---|---|---|
|Normal|<img width="246" alt="Screen Shot 2022-10-18 at 10 13 15 AM" src="https://user-images.githubusercontent.com/30090424/196500198-3d33e1cd-d644-4cc4-a114-64dd02aa324f.png">|<img width="277" alt="Screen Shot 2022-10-18 at 10 12 26 AM" src="https://user-images.githubusercontent.com/30090424/196500256-81a91960-8d94-41a3-b217-8c5acd8d74cc.png">|
|WHCM|<img width="201" alt="Screen Shot 2022-10-18 at 10 13 10 AM" src="https://user-images.githubusercontent.com/30090424/196500251-f9ec1bd7-5d1a-478f-af24-6a062b709f3a.png">|<img width="206" alt="Screen Shot 2022-10-18 at 10 12 47 AM" src="https://user-images.githubusercontent.com/30090424/196500255-334e0552-b60e-41e7-af4c-477dd3423b1e.png">|






