### PR TITLE
A11Y: Improve user card appearance in WHCM

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -39,6 +39,7 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
   background-size: cover;
   transition: opacity 0.2s, transform 0.2s;
   opacity: 0;
+  outline: 2px solid transparent;
   @include transform(scale(0.9));
   &.show {
     opacity: 1;


### PR DESCRIPTION
This PR improves the appearance of the user card in Windows High Contrast Mode:

|Before|After|
|---|---|
|<img width="590" alt="Screen Shot 2022-10-18 at 10 37 50 AM" src="https://user-images.githubusercontent.com/30090424/196504668-ddba426e-9f82-42c3-8350-47723e44900d.png">|<img width="605" alt="Screen Shot 2022-10-18 at 10 37 24 AM" src="https://user-images.githubusercontent.com/30090424/196504662-5118b2d6-c85a-40f8-a579-3488ac20ca4e.png">|
