### PR TITLE
FIX: User card focus state appearing on click

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -71,7 +71,7 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
         display: flex;
         align-items: center;
 
-        &:focus {
+        &:focus-visible {
           border: 1px solid;
           @include default-focus;
         }


### PR DESCRIPTION
This PR fixes an issue that was brought up on [Meta](https://meta.discourse.org/t/user-card-huge-avatar-outline-appears-on-plugins-and-components/240454/4) where a focus ring appears on the user card (for themes/plugins) when clicking. This PR ensures the focus ring only appears when the user card is selected via <kbd>Tab</kbd> only rather than by click.

**After clicking on avatar:**

|Before|After|
|---|---
|<img width="707" alt="Screen Shot 2022-10-18 at 11 03 47 AM" src="https://user-images.githubusercontent.com/30090424/196509502-69c8b086-8b76-4267-ae5c-14fa5e2c065c.png">|<img width="706" alt="Screen Shot 2022-10-18 at 11 03 40 AM" src="https://user-images.githubusercontent.com/30090424/196509591-183cfb91-1729-4d41-8535-8b890e74da30.png">|



