### PR TITLE
A11Y: Improve group search accessibility

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.hbs
@@ -7,7 +7,7 @@
     {{/if}}
 
     <div class="groups-header-filters">
-      <Input @value={{readonly this.filter}} placeholder={{i18n "groups.index.all"}} class="groups-header-filters-name no-blur" {{on "input" (action "onFilterChanged" value="target.value")}} />
+      <Input @value={{readonly this.filter}} placeholder={{i18n "groups.index.all"}} class="groups-header-filters-name no-blur" {{on "input" (action "onFilterChanged" value="target.value")}} @type="search" aria-description={{i18n "groups.index.search_results"}} />
 
       <ComboBox @value={{this.type}} @content={{this.types}} @class="groups-header-filters-type" @onChange={{action (mut this.type)}} @options={{hash
           clearable=true
@@ -77,7 +77,7 @@
 
       <ConditionalLoadingSpinner @condition={{this.groups.loadingMore}} />
     {{else}}
-      <p>{{i18n "groups.index.empty"}}</p>
+      <p role="status">{{i18n "groups.index.empty"}}</p>
     {{/if}}
   </ConditionalLoadingSpinner>
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -888,6 +888,7 @@ en:
         group_type: "Group type"
         is_group_user: "Member"
         is_group_owner: "Owner"
+        search_results: "Search results will appear below."
       title:
         one: "Group"
         other: "Groups"


### PR DESCRIPTION
This PR improves accessibility when searching in the `/groups` page by:

1. Adding a `@type="search"` to the search input field so that screen readers announce its a search box
2. Adding a `role="status"` attribute to the text that appears when no results are present so it is announced by screen readers.