### PR TITLE
FIX: Do not show a 404 page when visiting messages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -475,7 +475,7 @@ Discourse::Application.routes.draw do
       get "#{root_path}/:username/messages/:filter" => "user_actions#private_messages", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/messages/group/:group_name" => "user_actions#private_messages", constraints: { username: RouteFormat.username, group_name: RouteFormat.username }
       get "#{root_path}/:username/messages/group/:group_name/:filter" => "user_actions#private_messages", constraints: { username: RouteFormat.username, group_name: RouteFormat.username }
-      get "#{root_path}/:username/messages/tags/:tag_id" => "user_actions#private_messages", constraints: { username: RouteFormat.username }
+      get "#{root_path}/:username/messages/tags/:tag_id" => "list#private_messages_tag", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username.json" => "users#show", constraints: { username: RouteFormat.username }, defaults: { format: :json }
       get({ "#{root_path}/:username" => "users#show", constraints: { username: RouteFormat.username } }.merge(index == 1 ? { as: 'user' } : {}))
       put "#{root_path}/:username" => "users#update", constraints: { username: RouteFormat.username }, defaults: { format: :json }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -475,7 +475,7 @@ Discourse::Application.routes.draw do
       get "#{root_path}/:username/messages/:filter" => "user_actions#private_messages", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username/messages/group/:group_name" => "user_actions#private_messages", constraints: { username: RouteFormat.username, group_name: RouteFormat.username }
       get "#{root_path}/:username/messages/group/:group_name/:filter" => "user_actions#private_messages", constraints: { username: RouteFormat.username, group_name: RouteFormat.username }
-      get "#{root_path}/:username/messages/tags/:tag_id" => "user_actions#private_messages", constraints: StaffConstraint.new
+      get "#{root_path}/:username/messages/tags/:tag_id" => "user_actions#private_messages", constraints: { username: RouteFormat.username }
       get "#{root_path}/:username.json" => "users#show", constraints: { username: RouteFormat.username }, defaults: { format: :json }
       get({ "#{root_path}/:username" => "users#show", constraints: { username: RouteFormat.username } }.merge(index == 1 ? { as: 'user' } : {}))
       put "#{root_path}/:username" => "users#update", constraints: { username: RouteFormat.username }, defaults: { format: :json }

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -186,6 +186,16 @@ RSpec.describe ListController do
       expect(response.parsed_body["topic_list"]["topics"].first["id"])
         .to eq(private_message.id)
     end
+
+    it 'should work for users who are allowed and direct links' do
+      SiteSetting.pm_tags_allowed_for_groups = group.name
+      group.add(user)
+      sign_in(user)
+
+      get "/u/#{user.username}/messages/tags/#{tag.name}"
+
+      expect(response.status).to eq(200)
+    end
   end
 
   describe '#private_messages_group' do

--- a/spec/requests/user_actions_controller_spec.rb
+++ b/spec/requests/user_actions_controller_spec.rb
@@ -169,15 +169,4 @@ RSpec.describe UserActionsController do
       end
     end
   end
-
-  describe '#private_messages' do
-    fab!(:user) { Fabricate(:user) }
-    fab!(:tag) { Fabricate(:tag) }
-
-    it 'returns 200 if tag exists' do
-      get "/u/#{user.username}/messages/tags/#{tag.name}"
-
-      expect(response.status).to eq(200)
-    end
-  end
 end

--- a/spec/requests/user_actions_controller_spec.rb
+++ b/spec/requests/user_actions_controller_spec.rb
@@ -169,4 +169,15 @@ RSpec.describe UserActionsController do
       end
     end
   end
+
+  describe '#private_messages' do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:tag) { Fabricate(:tag) }
+
+    it 'returns 200 if tag exists' do
+      get "/u/#{user.username}/messages/tags/#{tag.name}"
+
+      expect(response.status).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
Visiting tagged messages directly by using a bookmarked URL or typing the URL in the browser's address bar resulted in a 404 error being displayed because non-staff members were not allowed.

This PR contains one more improvements which uses the correct list controller and action to make use of preload store and get rid of the request that fetched the topic list.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
