### PR TITLE
A11Y: Return focus to header search button upon escape of search

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -356,8 +356,9 @@ export default createWidget("search-menu", {
   },
 
   keyDown(e) {
-    if (e.which === 27 /* escape */) {
+    if (e.key === "Escape") {
       this.sendWidgetAction("toggleSearchMenu");
+      document.querySelector("#search-button").focus();
       e.preventDefault();
       return false;
     }

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -450,6 +450,11 @@ acceptance("Search - Authenticated", function (needs) {
     );
 
     await triggerKeyEvent(".search-menu", "keydown", "Escape");
+    assert.strictEqual(
+      document.activeElement,
+      query("#search-button"),
+      "Escaping search returns focus to search button"
+    );
     assert.ok(!exists(".search-menu:visible"), "Esc removes search dropdown");
 
     await click("#search-button");


### PR DESCRIPTION
This PR improves keyboard accessibility for search by ensuring the focus returns to the header search button <kbd>:mag:</kbd> after pressing <kbd>esc</kbd> in the search menu.