### PR TITLE
A11Y: Add `aria-label` to topic post badges

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic-post-badges.hbr
+++ b/app/assets/javascripts/discourse/app/templates/topic-post-badges.hbr
@@ -1,11 +1,26 @@
-<span class='topic-post-badges'>
-  {{~#if newPosts ~}}
-    &nbsp;<a href='{{url}}' class='badge badge-notification unread-posts' title='{{i18n "topic.unread_posts" count=newPosts}}'>{{newPosts}}</a>
+<span class="topic-post-badges">
+  {{~#if newPosts~}}
+    &nbsp;<a
+      href="{{url}}"
+      class="badge badge-notification unread-posts"
+      title="{{i18n 'topic.unread_posts' count=newPosts}}"
+      aria-label="{{i18n 'topic.unread_posts' count=newPosts}}"
+    >{{newPosts}}</a>
   {{~/if}}
-  {{~#if unreadPosts ~}}
-    &nbsp;<a href='{{url}}' class='badge badge-notification unread-posts' title='{{i18n "topic.unread_posts" count=unreadPosts}}'>{{unreadPosts}}</a>
+  {{~#if unreadPosts~}}
+    &nbsp;<a
+      href="{{url}}"
+      class="badge badge-notification unread-posts"
+      title="{{i18n 'topic.unread_posts' count=unreadPosts}}"
+      aria-label="{{i18n 'topic.unread_posts' count=unreadPosts}}"
+    >{{unreadPosts}}</a>
   {{~/if}}
-  {{~#if unseen ~}}
-    &nbsp;<a href='{{url}}' class='badge badge-notification new-topic' title='{{i18n "topic.new"}}'>{{newDotText}}</a>
+  {{~#if unseen~}}
+    &nbsp;<a
+      href="{{url}}"
+      class="badge badge-notification new-topic"
+      title="{{i18n 'topic.new'}}"
+      aria-label="{{i18n 'topic.new'}}"
+    >{{newDotText}}</a>
   {{~/if}}
 </span>


### PR DESCRIPTION
This PR adds the `aria-label` attribute to topic post badges to improve accessibility.

<img width="77" alt="Screen Shot 2022-10-18 at 2 53 37 PM" src="https://user-images.githubusercontent.com/30090424/196552059-69ff8d25-d2ed-4d3d-b3d5-09aee2dad723.png">
<img width="223" alt="Screen Shot 2022-10-18 at 2 53 32 PM" src="https://user-images.githubusercontent.com/30090424/196552094-518b23ee-2f2e-4699-b1d8-7d6292636d24.png">
