### PR TITLE
FIX: ensure dropdown is above sibling labels

### DIFF
--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -197,6 +197,9 @@ body.invite-page {
         padding: 0 0.25em 0 0.25em;
         font-size: $font-down-1;
       }
+      .user-field.dropdown:focus-within {
+        z-index: 1000; // this ensures the active dropdown is always on top of sibling dropdown labels
+      }
       input:focus + label.alt-placeholder,
       input.value-entered + label.alt-placeholder {
         top: -8px;


### PR DESCRIPTION
This ensures that the currently active dropdown is always above the sibling dropdowns in the z-index by using `focus-within` to increase the z-index by 1. 

Before (the "what do you like" label from the next custom field is above the dropdown):

![Screen Shot 2022-10-18 at 5 52 34 PM](https://user-images.githubusercontent.com/1681963/196551916-b65abdf4-e542-4f29-b403-d9acd0caf15b.png)


After:

![Screen Shot 2022-10-18 at 5 52 22 PM](https://user-images.githubusercontent.com/1681963/196551937-1f8d0c95-c4f3-4eae-a144-0eec44dbdbaf.png)
