### PR TITLE
FIX: do not include group less emojis in standard list

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -88,13 +88,14 @@ class Emoji
 
   def self.create_from_db_item(emoji)
     name = emoji["name"]
+    return unless group = groups[name]
     filename = emoji['filename'] || name
 
     Emoji.new.tap do |e|
       e.name = name
       e.tonable = Emoji.tonable_emojis.include?(name)
       e.url = Emoji.url_for(filename)
-      e.group = groups[name] || DEFAULT_GROUP
+      e.group = group
       e.search_aliases = search_aliases[name] || []
     end
   end
@@ -151,7 +152,7 @@ class Emoji
   end
 
   def self.load_standard
-    db['emojis'].map { |e| Emoji.create_from_db_item(e) }
+    db['emojis'].map { |e| Emoji.create_from_db_item(e) }.compact
   end
 
   def self.load_custom

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -143,15 +143,26 @@ RSpec.describe Emoji do
     end
   end
 
+  describe ".load_standard" do
+    it "removes nil emojis" do
+      expect(Emoji.load_standard.any? { |element| element.nil? }).to be false
+    end
+  end
+
   describe "#create_from_db_item" do
     it "sets the group of the emoji" do
       emoji = Emoji.create_from_db_item("name" => "scotland")
       expect(emoji.group).to eq("flags")
     end
 
-    it "sets the search aliases of the emoji" do
-      emoji = Emoji.create_from_db_item("name" => "sad")
-      expect(emoji.search_aliases).to contain_exactly("frowning_face", "slightly_frowning_face", "sob", "crying_cat_face", "cry", "face_holding_back_tears")
+    it "sets the group of the emoji" do
+      emoji = Emoji.create_from_db_item("name" => "scotland")
+      expect(emoji.group).to eq("flags")
+    end
+
+    it "doesn’t create emoji when group is unknown" do
+      emoji = Emoji.create_from_db_item("name" => "white_hair")
+      expect(emoji).to be_nil
     end
   end
 end


### PR DESCRIPTION
Some emojis as :white_hair: are only meant to be used as part of other emojis and are not in any official group, we shouldn't include them in our list.
