### PR TITLE
FIX: sidebar_list_destination in CurrentUserSerializer

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/sidebar.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/sidebar.js
@@ -46,6 +46,10 @@ export default class extends Controller {
         if (result.user.sidebar_tags) {
           this.model.set("sidebar_tags", result.user.sidebar_tags);
         }
+        this.model.set(
+          "sidebar_list_destination",
+          this.newSidebarListDestination
+        );
 
         this.saved = true;
       })

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -350,7 +350,7 @@ const User = RestModel.extend({
     );
   },
 
-  sidebarListDestination: readOnly("user_option.sidebar_list_destination"),
+  sidebarListDestination: readOnly("sidebar_list_destination"),
 
   changeUsername(new_username) {
     return ajax(userPath(`${this.username_lower}/preferences/username`), {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -295,9 +295,7 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
   test("clicking section links - sidebar_list_destination set to unread/new and no unread or new topics", async function (assert) {
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
     const { category1 } = setupUserSidebarCategories();
 
@@ -336,9 +334,7 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
       created_in_new_period: true,
     });
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
 
     await visit("/");
@@ -384,9 +380,7 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
       created_in_new_period: true,
     });
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
 
     await visit("/");

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -162,9 +162,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
   test("clicking on everything link - sidebar_list_destination set to unread/new and no unread or new topics", async function (assert) {
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
 
     await visit("/t/280");
@@ -201,9 +199,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       created_in_new_period: true,
     });
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
     await visit("/t/280");
     await click(".sidebar-section-community .sidebar-section-link-everything");
@@ -248,9 +244,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       created_in_new_period: true,
     });
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
     await visit("/t/280");
     await click(".sidebar-section-community .sidebar-section-link-everything");
@@ -299,9 +293,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
 
   test("clicking on tracked link - sidebar_list_destination set to unread/new and no unread or new topics", async function (assert) {
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
 
     await visit("/t/280");
@@ -340,9 +332,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       created_in_new_period: true,
     });
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
     await visit("/t/280");
     await click(".sidebar-section-community .sidebar-section-link-tracked");
@@ -389,9 +379,7 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
       created_in_new_period: true,
     });
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
     await visit("/t/280");
     await click(".sidebar-section-community .sidebar-section-link-tracked");

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -238,9 +238,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
 
   test("clicking tag section links - sidebar_list_destination set to unread/new and no unread or new topics", async function (assert) {
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
 
     await visit("/");
@@ -266,9 +264,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
 
   test("clicking tag section links - sidebar_list_destination set to unread/new with new topics", async function (assert) {
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
 
     this.container.lookup("service:topic-tracking-state").loadStates([
@@ -308,9 +304,7 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
 
   test("clicking tag section links - sidebar_list_destination set to unread/new with unread topics", async function (assert) {
     updateCurrentUser({
-      user_option: {
-        sidebar_list_destination: "unread_new",
-      },
+      sidebar_list_destination: "unread_new",
     });
 
     this.container.lookup("service:topic-tracking-state").loadStates([

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-sidebar-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-sidebar-test.js
@@ -46,9 +46,7 @@ acceptance("User Preferences - Sidebar", function (needs) {
               { name: "monkey", pm_only: false },
               { name: "gazelle", pm_only: false },
             ],
-            user_option: {
-              sidebar_list_destination: "unread_new",
-            },
+            sidebar_list_destination: "unread_new",
           },
         });
       }

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -81,7 +81,8 @@ class CurrentUserSerializer < BasicUserSerializer
              :likes_notifications_disabled,
              :grouped_unread_notifications,
              :redesigned_user_menu_enabled,
-             :redesigned_user_page_nav_enabled
+             :redesigned_user_page_nav_enabled,
+             :sidebar_list_destination
 
   delegate :user_stat, to: :object, private: true
   delegate :any_posts, :draft_count, :pending_posts_count, :read_faq?, to: :user_stat
@@ -158,6 +159,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def bookmark_auto_delete_preference
     object.user_option.bookmark_auto_delete_preference
+  end
+
+  def sidebar_list_destination
+    object.user_option.sidebar_list_none_selected? ? SiteSetting.default_sidebar_list_destination : object.user_option.sidebar_list_destination
   end
 
   def can_send_private_email_messages

--- a/app/serializers/user_option_serializer.rb
+++ b/app/serializers/user_option_serializer.rb
@@ -34,8 +34,7 @@ class UserOptionSerializer < ApplicationSerializer
              :timezone,
              :skip_new_user_tips,
              :default_calendar,
-             :oldest_search_log_date,
-             :sidebar_list_destination
+             :oldest_search_log_date
 
   def auto_track_topics_after_msecs
     object.auto_track_topics_after_msecs || SiteSetting.default_other_auto_track_topics_after_msecs
@@ -51,9 +50,5 @@ class UserOptionSerializer < ApplicationSerializer
 
   def theme_ids
     object.theme_ids.presence || [SiteSetting.default_theme_id]
-  end
-
-  def sidebar_list_destination
-    object.sidebar_list_none_selected? ? SiteSetting.default_sidebar_list_destination : object.sidebar_list_destination
   end
 end

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -388,5 +388,14 @@ RSpec.describe CurrentUserSerializer do
     end
   end
 
+  describe "#sidebar_list_destination" do
+    it "returns choosen value or default" do
+      expect(serializer.as_json[:sidebar_list_destination]).to eq(SiteSetting.default_sidebar_list_destination)
+
+      user.user_option.update!(sidebar_list_destination: "unread_new")
+      expect(serializer.as_json[:sidebar_list_destination]).to eq("unread_new")
+    end
+  end
+
   include_examples "#display_sidebar_tags", described_class
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -426,13 +426,4 @@ RSpec.describe UserSerializer do
   end
 
   include_examples "#display_sidebar_tags", UserSerializer
-
-  describe "#sidebar_list_destination" do
-    it "returns choosen value or default" do
-      expect(serializer.as_json[:user_option][:sidebar_list_destination]).to eq(SiteSetting.default_sidebar_list_destination)
-
-      user.user_option.update!(sidebar_list_destination: "unread_new")
-      expect(serializer.as_json[:user_option][:sidebar_list_destination]).to eq("unread_new")
-    end
-  end
 end


### PR DESCRIPTION
Before, `sidebar_list_destination` was an attribute on UserOptionSerializer. The problem was that this attribute was added to user model only when the user entered the preferences panel. We want that attribute to be available all the time, therefore it was moved to CurrentUserSerializer.
