### PR TITLE
DEV: add currentPath arg to above-site-header plugin outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -1,7 +1,7 @@
 <DiscourseRoot>
   <a href="#main-container" id="skip-link">{{i18n "skip_to_main_content"}}</a>
   <DDocument />
-  <PluginOutlet @name="above-site-header" @connectorTagName="div" />
+  <PluginOutlet @name="above-site-header" @connectorTagName="div" @args={{hash currentPath=this.router._router.currentPath}} />
 
   {{#if this.showSiteHeader}}
     <SiteHeader


### PR DESCRIPTION
Add an argument for current path for plugins, mirrors below-site-header argument