### PR TITLE
DEV: Introduce a `@debounce(delay)` decorator

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/utils/decorators.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/decorators.js
@@ -91,15 +91,14 @@ export function readOnly(target, name, desc) {
 export function debounce(delay) {
   return function (target, name, descriptor) {
     return {
-      configurable: true,
-      get() {
-        const bound = emberBind(this, descriptor.value);
+      enumerable: descriptor.enumerable,
+      configurable: descriptor.configurable,
+      writable: descriptor.writable,
+      initializer() {
+        const originalFunction = descriptor.value;
         const debounced = function (...args) {
-          return discourseDebounce(this, bound, ...args, delay);
+          return discourseDebounce(this, originalFunction, ...args, delay);
         };
-
-        const attributes = { ...descriptor, value: debounced };
-        Object.defineProperty(this, name, attributes);
 
         return debounced;
       },

--- a/app/assets/javascripts/discourse-common/addon/utils/decorators.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/decorators.js
@@ -94,8 +94,8 @@ export function debounce(delay) {
       configurable: true,
       get() {
         const bound = emberBind(this, descriptor.value);
-        const debounced = function () {
-          return discourseDebounce(bound, delay);
+        const debounced = function (...args) {
+          return discourseDebounce(this, bound, ...args, delay);
         };
 
         const attributes = { ...descriptor, value: debounced };

--- a/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/decorators-test.js
@@ -56,8 +56,8 @@ class TestStub {
   counter = 0;
 
   @debounce(50)
-  increment() {
-    this.counter++;
+  increment(value) {
+    this.counter += value;
   }
 }
 
@@ -123,17 +123,18 @@ module("Unit | Utils | decorators", function (hooks) {
   test("debounce", async function (assert) {
     const stub = new TestStub();
 
-    stub.increment();
-    stub.increment();
-    stub.increment();
+    stub.increment(1);
+    stub.increment(1);
+    stub.increment(1);
     await settled();
 
     assert.strictEqual(stub.counter, 1);
 
-    stub.increment();
-    stub.increment();
+    stub.increment(500);
+    stub.increment(1000);
+    stub.increment(5);
     await settled();
 
-    assert.strictEqual(stub.counter, 2);
+    assert.strictEqual(stub.counter, 6);
   });
 });


### PR DESCRIPTION
An example from tests:

```js
class TestStub {
  counter = 0;

  @debounce(50)
  increment() {
    this.counter++;
  }
}

const stub = new TestStub();

stub.increment();
stub.increment();
stub.increment();
await settled();

assert.strictEqual(stub.counter, 1);
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
