### PR TITLE
A11Y: Sortable header elements should have pointer

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -297,7 +297,6 @@ table {
   .d-icon {
     margin-left: 0.25em;
   }
-  @include unselectable;
 }
 
 .radio,


### PR DESCRIPTION
This PR fixes a regression where sortable table elements in the header should have a `cursor: pointer` to indicate it is selectable.