### PR TITLE
FIX: use --aspect-ratio on category logo, not on container

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -108,14 +108,12 @@
   .category-logo.aspect-image {
     --max-height: 150px;
     max-height: var(--max-height);
-    width: calc(var(--max-height) * var(--aspect-ratio));
     max-width: 100%;
     height: auto;
 
     img {
-      width: 100%;
+      width: calc(var(--max-height) * var(--aspect-ratio));
       height: inherit;
-      max-width: initial;
       max-height: var(--max-height);
     }
   }


### PR DESCRIPTION
The `--aspect-ratio` of the image is set on the image tag, but was being calculated in the parent element's CSS...

![Screen Shot 2022-10-20 at 1 01 54 PM](https://user-images.githubusercontent.com/1681963/197012663-e80d8889-1a4e-428a-bf2a-f9e3d8f9b8c8.png)

![Screen Shot 2022-10-20 at 1 01 34 PM](https://user-images.githubusercontent.com/1681963/197012603-8888acd1-3217-4d2f-b21a-4baa635449e2.png)

This issue only seems apparent in Safari... I think perhaps the other browsers are more strictly obeying the intrinsic aspect ratio calculated by height and width? 


Before:

![Screen Shot 2022-10-20 at 12 57 33 PM](https://user-images.githubusercontent.com/1681963/197013019-876a0288-571b-420f-9fe7-9675c5a4d01d.png)
![Screen Shot 2022-10-20 at 12 57 36 PM](https://user-images.githubusercontent.com/1681963/197013022-9c120c77-3fe4-4e0c-a66c-91a868d5abd2.png)

After: 
![Screen Shot 2022-10-20 at 12 57 25 PM](https://user-images.githubusercontent.com/1681963/197013859-6e4a741b-1f1c-43c3-9466-b835c6878616.png)

![Screen Shot 2022-10-20 at 12 57 17 PM](https://user-images.githubusercontent.com/1681963/197013856-e28de308-3c41-4d15-9b99-5d0fff22c0e0.png)
