### PR TITLE
UX: Show category edit button when in tag intersection

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -16,13 +16,8 @@
       }} />
   {{/if}}
 
-  {{#if this.category}}
-    {{#unless this.tag}}
-      {{!-- don't show category edit button on tag pages --}}
-      {{#if this.showCategoryEdit}}
-        <DButton @class="btn-default edit-category" @action={{this.editCategory}} @icon="wrench" @ariaLabel="category.edit" />
-      {{/if}}
-    {{/unless}}
+  {{#if (and this.category this.showCategoryEdit)}}
+    <DButton @class="btn-default edit-category" @action={{this.editCategory}} @icon="wrench" @ariaLabel="category.edit" />
   {{/if}}
 
   {{#if this.tag}}

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -17,7 +17,7 @@
   {{/if}}
 
   {{#if (and this.category this.showCategoryEdit)}}
-    <DButton @class="btn-default edit-category" @action={{this.editCategory}} @icon="wrench" @ariaLabel="category.edit" />
+    <DButton @class="btn-default edit-category" @action={{this.editCategory}} @icon="wrench" @title="category.edit_title" />
   {{/if}}
 
   {{#if this.tag}}

--- a/app/assets/javascripts/discourse/app/templates/tag/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag/show.hbs
@@ -9,7 +9,7 @@
     <PluginOutlet @name="discovery-navigation-bar-above" @connectorTagName="div" />
     <div class="container">
       <section class="navigation-container tag-navigation">
-        <DNavigation @filterMode={{this.filterMode}} @canCreateTopic={{this.canCreateTopic}} @hasDraft={{this.currentUser.has_topic_draft}} @createTopic={{route-action "createTopic"}} @category={{this.category}} @tag={{this.tag}} @noSubcategories={{this.noSubcategories}} @tagNotification={{this.tagNotification}} @additionalTags={{this.additionalTags}} @showInfo={{this.showInfo}} @canCreateTopicOnTag={{this.canCreateTopicOnTag}} @changeTagNotificationLevel={{action "changeTagNotificationLevel"}} @toggleInfo={{action "toggleInfo"}} />
+        <DNavigation @filterMode={{this.filterMode}} @canCreateTopic={{this.canCreateTopic}} @hasDraft={{this.currentUser.has_topic_draft}} @createTopic={{route-action "createTopic"}} @category={{this.category}} @editCategory={{route-action "editCategory" this.category}} @tag={{this.tag}} @noSubcategories={{this.noSubcategories}} @tagNotification={{this.tagNotification}} @additionalTags={{this.additionalTags}} @showInfo={{this.showInfo}} @canCreateTopicOnTag={{this.canCreateTopicOnTag}} @changeTagNotificationLevel={{action "changeTagNotificationLevel"}} @toggleInfo={{action "toggleInfo"}} />
 
         <PluginOutlet @name="tag-navigation" @connectorTagName="div" @args={{hash category=this.category tag=this.tag}} />
       </section>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3455,6 +3455,7 @@ en:
       all: "All categories"
       choose: "category&hellip;"
       edit: "Edit"
+      edit_title: "Edit this category"
       edit_dialog_title: "Edit: %{categoryName}"
       view: "View Topics in Category"
       back: "Back to category"


### PR DESCRIPTION
Given that the category structure is generally speaking the backbone of most Discourse instances, it makes sense to show the edit button for the category even when the user is in a category/tag intersection. This PR also adds a more descriptive title attribute, so that it's clear to users that they are editing the current category (even if the view is a tag intersection). 

(The immediate need for this change is to allow categories to be edited when using the global filters plugin. But I do think it makes sense as default core behaviour.) 