### PR TITLE
DEV: Clean up pre-initializers

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/svg-sprite-fontawesome.js
+++ b/app/assets/javascripts/discourse/app/initializers/svg-sprite-fontawesome.js
@@ -2,10 +2,11 @@ import { loadSprites } from "discourse/lib/svg-sprite-loader";
 
 export default {
   name: "svg-sprite-fontawesome",
-  after: "discourse-bootstrap",
+  after: "export-application-global",
 
   initialize(container) {
-    let session = container.lookup("service:session");
+    const session = container.lookup("service:session");
+
     if (session.svgSpritePath) {
       loadSprites(session.svgSpritePath, "fontawesome");
     }

--- a/app/assets/javascripts/discourse/app/initializers/theme-errors-handler.js
+++ b/app/assets/javascripts/discourse/app/initializers/theme-errors-handler.js
@@ -14,7 +14,7 @@ const showingErrors = new Set();
 
 export default {
   name: "theme-errors-handler",
-  after: "inject-discourse-objects",
+  after: "export-application-global",
 
   initialize(container) {
     if (isTesting()) {
@@ -23,9 +23,7 @@ export default {
 
     this.currentUser = container.lookup("service:current-user");
 
-    getAndClearUnhandledThemeErrors().forEach((e) => {
-      reportThemeError(this.currentUser, e);
-    });
+    getAndClearUnhandledThemeErrors().forEach((e) => this.reportThemeError(e));
 
     document.addEventListener("discourse-error", this.handleDiscourseError);
   },
@@ -38,11 +36,64 @@ export default {
   @bind
   handleDiscourseError(e) {
     if (e.detail?.themeId) {
-      reportThemeError(this.currentUser, e);
+      this.reportThemeError(e);
     } else {
-      reportGenericError(this.currentUser, e);
+      this.reportGenericError(e);
     }
+
     e.preventDefault(); // Mark as handled
+  },
+
+  reportThemeError(e) {
+    const { themeId, error } = e.detail;
+    const source = {
+      type: "theme",
+      ...getThemeInfo(themeId),
+    };
+
+    reportToConsole(error, source);
+    reportToLogster(source.name, error);
+
+    const message = I18n.t("themes.broken_theme_alert");
+    this.displayErrorNotice(this.currentUser, message, source);
+  },
+
+  reportGenericError(e) {
+    const { messageKey, error } = e.detail;
+
+    const message = I18n.t(messageKey);
+    const source = identifySource(error);
+
+    reportToConsole(error, source);
+
+    if (messageKey && !showingErrors.has(messageKey)) {
+      showingErrors.add(messageKey);
+      this.displayErrorNotice(message, source);
+    }
+  },
+
+  displayErrorNotice(message, source) {
+    if (!this.currentUser?.admin) {
+      return;
+    }
+
+    let html = `⚠️ ${message}`;
+
+    if (source && source.type === "theme") {
+      html += `<br/>${I18n.t("themes.error_caused_by", {
+        name: escape(source.name),
+        path: source.path,
+      })}`;
+    }
+
+    html += `<br/><span class='theme-error-suffix'>${I18n.t(
+      "themes.only_admins"
+    )}</span>`;
+
+    const alertDiv = document.createElement("div");
+    alertDiv.classList.add("broken-theme-alert");
+    alertDiv.innerHTML = html;
+    document.body.prepend(alertDiv);
   },
 };
 
@@ -59,36 +110,6 @@ function reportToLogster(name, error) {
   });
 }
 
-function reportThemeError(currentUser, e) {
-  const { themeId, error } = e.detail;
-
-  const source = {
-    type: "theme",
-    ...getThemeInfo(themeId),
-  };
-
-  reportToConsole(error, source);
-  reportToLogster(source.name, error);
-
-  const message = I18n.t("themes.broken_theme_alert");
-  displayErrorNotice(currentUser, message, source);
-}
-
-function reportGenericError(currentUser, e) {
-  const { messageKey, error } = e.detail;
-
-  let message = I18n.t(messageKey);
-
-  const source = identifySource(error);
-
-  reportToConsole(error, source);
-
-  if (messageKey && !showingErrors.has(messageKey)) {
-    showingErrors.add(messageKey);
-    displayErrorNotice(currentUser, message, source);
-  }
-}
-
 function reportToConsole(error, source) {
   const prefix = consolePrefix(error, source);
   if (prefix) {
@@ -98,28 +119,4 @@ function reportToConsole(error, source) {
     /* eslint-disable-next-line no-console */
     console.error(error);
   }
-}
-
-function displayErrorNotice(currentUser, message, source) {
-  if (!currentUser?.admin) {
-    return;
-  }
-
-  let html = `⚠️ ${message}`;
-
-  if (source && source.type === "theme") {
-    html += `<br/>${I18n.t("themes.error_caused_by", {
-      name: escape(source.name),
-      path: source.path,
-    })}`;
-  }
-
-  html += `<br/><span class='theme-error-suffix'>${I18n.t(
-    "themes.only_admins"
-  )}</span>`;
-
-  const alertDiv = document.createElement("div");
-  alertDiv.classList.add("broken-theme-alert");
-  alertDiv.innerHTML = html;
-  document.body.prepend(alertDiv);
 }

--- a/app/assets/javascripts/discourse/app/mapping-router.js
+++ b/app/assets/javascripts/discourse/app/mapping-router.js
@@ -141,14 +141,3 @@ export function mapRoutes() {
     this.route("unknown", { path: "*path" });
   });
 }
-export function teardownRouter(routerClass) {
-  routerClass.dslCallbacks.splice(0, routerClass.dslCallbacks.length);
-}
-
-export function registerRouter(registry) {
-  registry.unregister("router:main");
-  let router = mapRoutes();
-
-  registry.register("router:main", router);
-  return router;
-}

--- a/app/assets/javascripts/discourse/app/pre-initializers/map-routes.js
+++ b/app/assets/javascripts/discourse/app/pre-initializers/map-routes.js
@@ -1,16 +1,15 @@
-import { registerRouter, teardownRouter } from "discourse/mapping-router";
+import { mapRoutes } from "discourse/mapping-router";
 
 export default {
   name: "map-routes",
   after: "inject-discourse-objects",
 
-  initialize(container, app) {
-    let routerClass = registerRouter(app);
-    container.registry.register("router:main", routerClass);
-    this.routerClass = routerClass;
+  initialize(_, app) {
+    this.routerClass = mapRoutes();
+    app.register("router:main", this.routerClass);
   },
 
   teardown() {
-    teardownRouter(this.routerClass);
+    this.routerClass.dslCallbacks.length = 0;
   },
 };


### PR DESCRIPTION
Convert two of them (`svg-sprite-fontawesome` and `theme-errors-handler`) into instance initializers, and remove unused code from `map-routes`.