### PR TITLE
UX: Send notification of type `replied` to topic author if they're watching the topic

### DIFF
--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1333,9 +1333,9 @@ RSpec.describe PostAlerter do
 
       u1.notifications.destroy_all
 
-      expect {
+      expect do
         create_post(topic: topic, user: u2)
-      }.to change { u1.reload.notifications.count }.by(1)
+      end.to change { u1.reload.notifications.count }.by(1)
       expect(u1.notifications.exists?(
         topic_id: topic.id,
         notification_type: Notification.types[:replied],

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1322,6 +1322,27 @@ RSpec.describe PostAlerter do
       NotificationEmailer.expects(:process_notification).once
       expect { PostAlerter.post_created(reply) }.to change(user.notifications, :count).by(1)
     end
+
+    it "creates a notification of type `replied` instead of `posted` for the topic author if they're watching the topic" do
+      Jobs.run_immediately!
+
+      u1 = Fabricate(:admin)
+      u2 = Fabricate(:admin)
+
+      topic = create_topic(user: u1)
+
+      u1.notifications.destroy_all
+
+      expect {
+        create_post(topic: topic, user: u2)
+      }.to change { u1.reload.notifications.count }.by(1)
+      expect(u1.notifications.exists?(
+        topic_id: topic.id,
+        notification_type: Notification.types[:replied],
+        post_number: 1,
+        read: false
+      )).to eq(true)
+    end
   end
 
   context "with category" do


### PR DESCRIPTION
Related to #18217.

Before the change in #18217, notifications for direct replies to your posts and notifications for replies in watched topics looked the same in the notifications menu -- they both used the arrow icon:

<img src="https://user-images.githubusercontent.com/17474474/197065009-847c118d-c91b-4b93-8b7c-80e0aa8118ab.png" width=300>

And we decided in #18217 to distinguish them by changing "watched topics" notifications to use the bell icon because it was confusing for users who watch topics. However, that change also means that non-power/new users who receive replies to topics _they create_ will get notifications with the bell icon because technically they're watching the topic, but the arrow icon is more appropriate for this case because we use it throughout the app to indicate "replies".

This PR adds a special-case so that if a user is watching a topic AND the topic is created by them, they receive notifications with the arrow icon (type `replied`) instead of the bell icon (type `posted`) for new posts in the topic.

Internal topic: t/79051.