### PR TITLE
FIX: Clientside checks for personal_message_enabled_groups

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/sections.js
@@ -24,6 +24,6 @@ export default class SidebarUserSections extends Component {
   }
 
   get enableMessagesSection() {
-    return this.currentUser?.allowPersonalMessages;
+    return this.currentUser?.can_send_private_messages;
   }
 }

--- a/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
+++ b/app/assets/javascripts/discourse/app/components/topic-footer-buttons.js
@@ -46,10 +46,7 @@ export default Component.extend({
     return !isPM || this.canSendPms;
   },
 
-  @discourseComputed("currentUser.allowPersonalMessages")
-  canSendPms() {
-    return this.currentUser?.allowPersonalMessages;
-  },
+  canSendPms: alias("currentUser.can_send_private_messages"),
 
   canInviteTo: alias("topic.details.can_invite_to"),
 

--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -120,7 +120,7 @@ const CORE_TOP_TABS = [
     }
 
     get shouldDisplay() {
-      return this.currentUser?.allowPersonalMessages;
+      return this.currentUser?.can_send_private_messages;
     }
 
     get notificationTypes() {

--- a/app/assets/javascripts/discourse/app/controllers/group.js
+++ b/app/assets/javascripts/discourse/app/controllers/group.js
@@ -91,10 +91,10 @@ export default Controller.extend({
   @discourseComputed(
     "model.has_messages",
     "model.is_group_user",
-    "currentUser.allowPersonalMessages"
+    "currentUser.can_send_private_messages"
   )
   showMessages(hasMessages, isGroupUser) {
-    if (!this.currentUser?.allowPersonalMessages) {
+    if (!this.currentUser?.can_send_private_messages) {
       return false;
     }
 

--- a/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
+++ b/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
@@ -326,7 +326,7 @@ export default Controller.extend(ModalFunctionality, {
       bookmarks: buildShortcut("jump_to.bookmarks", { keys1: ["g", "b"] }),
       profile: buildShortcut("jump_to.profile", { keys1: ["g", "p"] }),
     };
-    if (this.currentUser?.allowPersonalMessages) {
+    if (this.currentUser?.can_send_private_messages) {
       shortcuts.messages = buildShortcut("jump_to.messages", {
         keys1: ["g", "m"],
       });

--- a/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
@@ -90,9 +90,9 @@ export default Controller.extend({
     ];
   },
 
-  @discourseComputed("currentUser.allowPersonalMessages")
+  @discourseComputed("currentUser.can_send_private_messages")
   showMessageSettings() {
-    return this.currentUser?.allowPersonalMessages;
+    return this.currentUser?.can_send_private_messages;
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/controllers/preferences/users.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/users.js
@@ -72,9 +72,9 @@ export default Controller.extend({
     return !allowPrivateMessages;
   },
 
-  @discourseComputed("currentUser.allowPersonalMessages")
+  @discourseComputed("currentUser.can_send_private_messages")
   showMessageSettings() {
-    return this.currentUser?.allowPersonalMessages;
+    return this.currentUser?.can_send_private_messages;
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -212,9 +212,9 @@ export default Controller.extend(bufferedProperty("model"), {
     );
   },
 
-  @discourseComputed("currentUser.allowPersonalMessages")
+  @discourseComputed("currentUser.can_send_private_messages")
   canSendPms() {
-    return this.currentUser?.allowPersonalMessages;
+    return this.currentUser?.can_send_private_messages;
   },
 
   @discourseComputed("buffered.category_id")

--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -112,10 +112,12 @@ export default Controller.extend(CanCheckEmails, {
   @discourseComputed(
     "viewingSelf",
     "currentUser.admin",
-    "currentUser.allowPersonalMessages"
+    "currentUser.can_send_private_messages"
   )
   showPrivateMessages(viewingSelf, isAdmin) {
-    return this.currentUser?.allowPersonalMessages && (viewingSelf || isAdmin);
+    return (
+      this.currentUser?.can_send_private_messages && (viewingSelf || isAdmin)
+    );
   },
 
   @discourseComputed("viewingSelf", "currentUser.admin")

--- a/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
+++ b/app/assets/javascripts/discourse/app/lib/keyboard-shortcuts.js
@@ -140,7 +140,7 @@ export default {
     this.site = this.container.lookup("service:site");
 
     // Disable the shortcut if private messages are disabled
-    if (!this.currentUser?.allowPersonalMessages) {
+    if (!this.currentUser?.can_send_private_messages) {
       delete DEFAULT_BINDINGS["g m"];
     }
   },

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -640,6 +640,8 @@ const User = RestModel.extend({
     return filteredGroups.length > numGroupsToDisplay;
   },
 
+  // NOTE: This only includes groups *visible* to the user via the serializer,
+  // so be wary when using this.
   isInAnyGroups(groupIds) {
     if (!this.groups) {
       return;
@@ -1092,18 +1094,6 @@ const User = RestModel.extend({
   )
   trackedTags(trackedTags, watchedTags, watchingFirstPostTags) {
     return [...trackedTags, ...watchedTags, ...watchingFirstPostTags];
-  },
-
-  @discourseComputed("staff", "groups.[]")
-  allowPersonalMessages() {
-    return (
-      this.staff ||
-      this.isInAnyGroups(
-        this.siteSettings.personal_message_enabled_groups
-          .split("|")
-          .map((groupId) => parseInt(groupId, 10))
-      )
-    );
   },
 
   showPopup(options) {

--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -156,7 +156,7 @@ createWidget("user-menu-links", {
 
     glyphs.push(this.bookmarksGlyph());
 
-    if (this.currentUser?.allowPersonalMessages) {
+    if (this.currentUser?.can_send_private_messages) {
       glyphs.push(this.messagesGlyph());
     }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-messages-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-messages-section-test.js
@@ -13,14 +13,17 @@ import {
 import { NotificationLevels } from "discourse/lib/notification-levels";
 
 acceptance(
-  "Sidebar - Logged on user - Messages Section - user not in personal_message_enabled_groups",
+  "Sidebar - Logged on user - Messages Section - user does not have can_send_private_messages permission",
   function (needs) {
-    needs.user({ moderator: false, admin: false });
+    needs.user({
+      moderator: false,
+      admin: false,
+      can_send_private_messages: false,
+    });
 
     needs.settings({
       enable_experimental_sidebar_hamburger: true,
       enable_sidebar: true,
-      personal_message_enabled_groups: "13", // trust_level_3 auto group ID;
     });
 
     test("clicking on section header button", async function (assert) {
@@ -35,9 +38,9 @@ acceptance(
 );
 
 acceptance(
-  "Sidebar - Logged on user - Messages Section - user in personal_message_enabled_groups",
+  "Sidebar - Logged on user - Messages Section - user does have can_send_private_messages permission",
   function (needs) {
-    needs.user();
+    needs.user({ can_send_private_messages: true });
 
     needs.settings({
       enable_experimental_sidebar_hamburger: true,

--- a/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/session-fixtures.js
@@ -24,6 +24,7 @@ export default {
       trust_level: 4,
       can_edit: true,
       can_invite_to_forum: true,
+      can_send_private_messages: true,
       should_be_redirected_to_top: false,
       custom_fields: {},
       muted_category_ids: [],

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -144,6 +144,7 @@ module("Integration | Component | site-header", function (hooks) {
 
   test("arrow up/down keys move focus between the tabs", async function (assert) {
     this.currentUser.set("redesigned_user_menu_enabled", true);
+    this.currentUser.set("can_send_private_messages", true);
     await render(hbs`<SiteHeader />`);
     await click(".header-dropdown-toggle.current-user");
     let activeTab = query(".menu-tabs-container .btn.active");

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
@@ -100,11 +100,11 @@ module("Integration | Component | user-menu", function (hooks) {
     assert.notOk(exists("#user-menu-button-review-queue"));
   });
 
-  test("messages tab isn't shown if current user isn't staff and user does not belong to personal_message_enabled_groups", async function (assert) {
+  test("messages tab isn't shown if current user does not have can_send_private_messages permission", async function (assert) {
     this.currentUser.set("moderator", false);
     this.currentUser.set("admin", false);
     this.currentUser.set("groups", []);
-    this.siteSettings.personal_message_enabled_groups = "13"; // trust_level_3 auto group ID;
+    this.currentUser.set("can_send_private_messages", false);
 
     await render(template);
 
@@ -120,11 +120,11 @@ module("Integration | Component | user-menu", function (hooks) {
     );
   });
 
-  test("messages tab is shown if current user is staff even if they do not belong to personal_message_enabled_groups", async function (assert) {
+  test("messages tab is shown if user has can_send_private_messages permission", async function (assert) {
     this.currentUser.set("moderator", true);
     this.currentUser.set("admin", false);
     this.currentUser.set("groups", []);
-    this.siteSettings.personal_message_enabled_groups = "999";
+    this.currentUser.set("can_send_private_messages", true);
 
     await render(template);
 

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
@@ -36,6 +36,7 @@ module("Integration | Component | user-menu", function (hooks) {
   });
 
   test("the menu has a group of tabs at the top", async function (assert) {
+    this.currentUser.set("can_send_private_messages", true);
     await render(template);
     const tabs = queryAll(".top-tabs.tabs-list .btn");
     assert.strictEqual(tabs.length, 6);
@@ -52,6 +53,7 @@ module("Integration | Component | user-menu", function (hooks) {
   });
 
   test("the menu has a group of tabs at the bottom", async function (assert) {
+    this.currentUser.set("can_send_private_messages", true);
     await render(template);
     const tabs = queryAll(".bottom-tabs.tabs-list .btn");
     assert.strictEqual(tabs.length, 1);
@@ -63,6 +65,7 @@ module("Integration | Component | user-menu", function (hooks) {
 
   test("likes tab is hidden if current user's like notifications frequency is 'never'", async function (assert) {
     this.currentUser.set("likes_notifications_disabled", true);
+    this.currentUser.set("can_send_private_messages", true);
     await render(template);
     assert.ok(!exists("#user-menu-button-likes"));
 
@@ -79,6 +82,7 @@ module("Integration | Component | user-menu", function (hooks) {
   test("reviewables tab is shown if current user can review and there are pending reviewables", async function (assert) {
     this.currentUser.set("can_review", true);
     this.currentUser.set("reviewable_count", 1);
+    this.currentUser.set("can_send_private_messages", true);
     await render(template);
     const tab = query("#user-menu-button-review-queue");
     assert.strictEqual(tab.dataset.tabNumber, "5");

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/user-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/user-menu-test.js
@@ -92,8 +92,11 @@ module("Integration | Component | Widget | user-menu", function (hooks) {
   });
 
   test("private messages - disabled", async function (assert) {
-    this.currentUser.setProperties({ admin: false, moderator: false });
-    this.siteSettings.personal_message_enabled_groups = "13"; // trust_level_3 auto group ID;
+    this.currentUser.setProperties({
+      admin: false,
+      moderator: false,
+      can_send_private_messages: false,
+    });
 
     await render(hbs`<MountWidget @widget="user-menu" />`);
 
@@ -101,7 +104,11 @@ module("Integration | Component | Widget | user-menu", function (hooks) {
   });
 
   test("private messages - enabled", async function (assert) {
-    this.siteSettings.personal_message_enabled_groups = "11"; // trust_level_1 auto group ID;
+    this.currentUser.setProperties({
+      admin: false,
+      moderator: false,
+      can_send_private_messages: true,
+    });
 
     await render(hbs`<MountWidget @widget="user-menu" />`);
 


### PR DESCRIPTION
The clientside `allowPersonalMessages` function introduced in e62e93f83a77adfa80b38fbfecf82bbee14e12fe sometimes did not work correctly, because the `currentUser.groups` property only contained **visible** groups for the current user, which could exclude auto groups that had their permissions set to be owner-only visible.

It was unnecessary to add this anyway since we already have `can_send_private_messages` on the `CurrentUserSerializer`. It's better the backend does this calculation anyway. Use that in the clientside code instead and get rid of `allowPersonalMessages`

