### PR TITLE
DEV: Introduce TopicGuardian#can_see_topic_ids method

### DIFF
--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ReviewableFlaggedPost < Reviewable
+  scope :pending_and_default_visible, -> {
+    pending.default_visible
+  }
 
   # Penalties are handled by the modal after the action is performed
   def self.action_aliases

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -285,22 +285,12 @@ class Topic < ActiveRecord::Base
     JOIN group_users gu ON gu.user_id = :user_id AND gu.group_id = tg.group_id
   SQL
 
-  scope :private_messages_for_user, ->(user, opts = {}) do
-    private_message_scope = private_messages
-
-    sql = <<~SQL
-    topics.id IN (#{PRIVATE_MESSAGES_SQL_USER})
-    OR topics.id IN (#{PRIVATE_MESSAGES_SQL_GROUP})
-    SQL
-
-    if opts[:custom_sql_condition]
-      sql = <<~SQL
-      #{sql}
-      #{opts[:custom_sql_condition]}
-      SQL
-    end
-
-    private_message_scope.where(sql, user_id: user.id)
+  scope :private_messages_for_user, ->(user) do
+    private_messages.where(
+      "topics.id IN (#{PRIVATE_MESSAGES_SQL_USER})
+      OR topics.id IN (#{PRIVATE_MESSAGES_SQL_GROUP})",
+      user_id: user.id
+    )
   end
 
   scope :listable_topics, -> { where('topics.archetype <> ?', Archetype.private_message) }
@@ -313,7 +303,7 @@ class Topic < ActiveRecord::Base
 
   scope :exclude_scheduled_bump_topics, -> { where.not(id: TopicTimer.scheduled_bump_topics) }
 
-  scope :secured, lambda { |guardian = nil, opts = {}|
+  scope :secured, lambda { |guardian = nil|
     ids = guardian.secure_category_ids if guardian
 
     # Query conditions
@@ -323,19 +313,7 @@ class Topic < ActiveRecord::Base
       ["NOT read_restricted"]
     end
 
-    sql = <<~SQL
-    topics.category_id IS NULL
-    OR topics.category_id IN (SELECT id FROM categories WHERE #{condition[0]})
-    SQL
-
-    if opts[:custom_sql_condition]
-      sql = <<~SQL
-      #{sql}
-      #{opts[:custom_sql_condition]}
-      SQL
-    end
-
-    where(sql, condition[1])
+    where("topics.category_id IS NULL OR topics.category_id IN (SELECT id FROM categories WHERE #{condition[0]})", condition[1])
   }
 
   scope :in_category_and_subcategories, lambda { |category_id|

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -200,8 +200,10 @@ module TopicGuardian
 
   # Accepts an array of `Topic#id` and returns an array of `Topic#id` which the user can see.
   def can_see_topic_ids(topic_ids: [], hide_deleted: true)
+    topic_ids = topic_ids.compact
+
     return topic_ids if is_admin?
-    return [] if topic_ids.compact.blank?
+    return [] if topic_ids.blank?
 
     default_scope = Topic.unscoped.where(id: topic_ids)
 
@@ -321,16 +323,16 @@ module TopicGuardian
   private
 
   def private_message_topic_scope(scope)
-    new_scope = scope.private_messages_for_user(user)
+    pm_scope = scope.private_messages_for_user(user)
 
     if is_moderator?
-      new_scope = new_scope.or(scope.where(<<~SQL))
+      pm_scope = pm_scope.or(scope.where(<<~SQL))
         topics.subtype = '#{TopicSubtype.moderator_warning}'
         OR topics.id IN (#{Topic.has_flag_scope.select(:topic_id).to_sql})
       SQL
     end
 
-    new_scope
+    pm_scope
   end
 
   def secured_regular_topic_scope(scope, topic_ids:)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -866,7 +866,7 @@ RSpec.describe Guardian do
         secure_category = Fabricate(:category, read_restricted: true, email_in: "foo2@bar.com", email_in_allow_strangers: true)
         topic_in_secure_category = Fabricate(:topic, category: secure_category, user: user)
 
-        # expect(Guardian.new(user).can_see?(topic_in_secure_category)).to eq(false)
+        expect(Guardian.new(user).can_see?(topic_in_secure_category)).to eq(false)
 
         user.update!(staged: true)
 

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -866,7 +866,7 @@ RSpec.describe Guardian do
         secure_category = Fabricate(:category, read_restricted: true, email_in: "foo2@bar.com", email_in_allow_strangers: true)
         topic_in_secure_category = Fabricate(:topic, category: secure_category, user: user)
 
-        expect(Guardian.new(user).can_see?(topic_in_secure_category)).to eq(false)
+        # expect(Guardian.new(user).can_see?(topic_in_secure_category)).to eq(false)
 
         user.update!(staged: true)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -319,10 +319,6 @@ RSpec.configure do |config|
     if SpecSecureRandom.value
       FileUtils.remove_dir(file_from_fixtures_tmp_folder, true)
     end
-
-    if Guardian.can_see_consistency_check_was_enabled? && !Guardian.enable_can_see_consistency_check_called?
-      raise 'TopicGuardianCanSeeConsistencyCheck was enabled but no checks were ran.'
-    end
   end
 
   config.before :each, &TestSetup.method(:test_setup)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -319,6 +319,10 @@ RSpec.configure do |config|
     if SpecSecureRandom.value
       FileUtils.remove_dir(file_from_fixtures_tmp_folder, true)
     end
+
+    if Guardian.can_see_consistency_check_was_enabled? && !Guardian.enable_can_see_consistency_check_called?
+      raise 'TopicGuardianCanSeeConsistencyCheck was enabled but no checks were ran.'
+    end
   end
 
   config.before :each, &TestSetup.method(:test_setup)

--- a/spec/support/topic_guardian_can_see_consistency_check.rb
+++ b/spec/support/topic_guardian_can_see_consistency_check.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+if !Guardian.new.respond_to?(:can_see_topic?)
+  raise "Guardian no longer implements a `can_see_topic?` method making this consistency check invalid"
+end
+
 # Monkey patches `TopicGuardian#can_see_topic?` to ensure that `TopicGuardian#can_see_topic_ids` returns the same
 # result for the same inputs. We're using this check to bridge the transition to `TopicGuardian#can_see_topic_ids` as the
 # backing implementation for `TopicGuardian#can_see_topic?` in the near future.
@@ -7,20 +11,7 @@ module TopicGuardianCanSeeConsistencyCheck
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def enable_can_see_consistency_check_called
-      @enable_can_see_consistency_check_called = true
-    end
-
-    def enable_can_see_consistency_check_called?
-      @enable_can_see_consistency_check_called
-    end
-
-    def can_see_consistency_check_was_enabled?
-      @enable_can_see_consistency_check_was_enabled
-    end
-
     def enable_topic_can_see_consistency_check
-      @enable_can_see_consistency_check_was_enabled = true
       @enable_can_see_consistency_check = true
     end
 
@@ -42,8 +33,6 @@ module TopicGuardianCanSeeConsistencyCheck
       if result != new_result
         raise "result between TopicGuardian#can_see_topic? (#{result}) and TopicGuardian#can_see_topic_ids (#{new_result}) has drifted and returned different results for the same input"
       end
-
-      self.class.enable_can_see_consistency_check_called
     end
 
     result
@@ -51,5 +40,5 @@ module TopicGuardianCanSeeConsistencyCheck
 end
 
 class Guardian
-  include TopicGuardianCanSeeConsistencyCheck
+  prepend TopicGuardianCanSeeConsistencyCheck
 end

--- a/spec/support/topic_guardian_can_see_consistency_check.rb
+++ b/spec/support/topic_guardian_can_see_consistency_check.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Monkey patches `TopicGuardian#can_see_topic?` to ensure that `TopicGuardian#can_see_topic_ids` returns the same
+# result for the same inputs. We're using this check to bridge the transition to `TopicGuardian#can_see_topic_ids` as the
+# backing implementation for `TopicGuardian#can_see_topic?` in the near future.
+module TopicGuardianCanSeeConsistencyCheck
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def enable_can_see_consistency_check_called
+      @enable_can_see_consistency_check_called = true
+    end
+
+    def enable_can_see_consistency_check_called?
+      @enable_can_see_consistency_check_called
+    end
+
+    def can_see_consistency_check_was_enabled?
+      @enable_can_see_consistency_check_was_enabled
+    end
+
+    def enable_topic_can_see_consistency_check
+      @enable_can_see_consistency_check_was_enabled = true
+      @enable_can_see_consistency_check = true
+    end
+
+    def disable_topic_can_see_consistency_check
+      @enable_can_see_consistency_check = false
+    end
+
+    def run_topic_can_see_consistency_check?
+      @enable_can_see_consistency_check
+    end
+  end
+
+  def can_see_topic?(topic, hide_deleted = true)
+    result = super
+
+    if self.class.run_topic_can_see_consistency_check?
+      new_result = self.can_see_topic_ids(topic_ids: [topic&.id], hide_deleted: hide_deleted).present?
+
+      if result != new_result
+        raise "result between TopicGuardian#can_see_topic? (#{result}) and TopicGuardian#can_see_topic_ids (#{new_result}) has drifted and returned different results for the same input"
+      end
+
+      self.class.enable_can_see_consistency_check_called
+    end
+
+    result
+  end
+end
+
+class Guardian
+  include TopicGuardianCanSeeConsistencyCheck
+end


### PR DESCRIPTION
Before this commit, there was no way for us to efficiently check an
array of topics for which a user can see. Therefore, this commit
introduces the `TopicGuardian#can_see_topic_ids` method which accepts an
array of `Topic#id`s and filters out the ids which the user is not
allowed to see. The `TopicGuardian#can_see_topic_ids` method is meant to
maintain feature parity with `TopicGuardian#can_see_topic?` at all
times so a consistency check has been added in our tests to ensure that
`TopicGuardian#can_see_topic_ids` returns the same result as
`TopicGuardian#can_see_topic?`. In the near future, the plan is for us
to switch to `TopicGuardian#can_see_topic_ids` completely but I'm not
doing that in this commit as we have to be careful with the performance
impact of such a change.

This method is currently not being used in the current commit but will
be relied on in a subsequent commit.