### PR TITLE
DEV: Fabricate instead of just building topic, post and user in tests

### DIFF
--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Guardian do
   fab!(:another_admin) { Fabricate(:admin) }
   fab!(:coding_horror) { Fabricate(:coding_horror) }
 
-  let(:topic) { build(:topic, user: user) }
-  let(:post) { build(:post, topic: topic, user: topic.user) }
+  fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:post) { Fabricate(:post, topic: topic, user: topic.user) }
 
   before do
     Group.refresh_automatic_groups!
@@ -94,8 +94,8 @@ RSpec.describe Guardian do
   end
 
   describe '#post_can_act?' do
-    let(:post) { build(:post) }
-    let(:user) { build(:user) }
+    fab!(:user) { Fabricate(:user) }
+    fab!(:post) { Fabricate(:post) }
 
     it "returns false when the user is nil" do
       expect(Guardian.new(nil).post_can_act?(post, :like)).to be_falsey
@@ -119,6 +119,7 @@ RSpec.describe Guardian do
 
     it "works as expected for silenced users" do
       UserSilencer.silence(user, admin)
+
       expect(Guardian.new(user).post_can_act?(post, :spam)).to be_falsey
       expect(Guardian.new(user).post_can_act?(post, :like)).to be_truthy
       expect(Guardian.new(user).post_can_act?(post, :bookmark)).to be_truthy
@@ -221,8 +222,8 @@ RSpec.describe Guardian do
   end
 
   describe "can_enable_safe_mode" do
-    let(:user) { Fabricate.build(:user) }
-    let(:moderator) { Fabricate.build(:moderator) }
+    fab!(:user) { Fabricate(:user) }
+    fab!(:moderator) { Fabricate(:moderator) }
 
     context "when enabled" do
       before do
@@ -487,8 +488,8 @@ RSpec.describe Guardian do
   end
 
   describe 'can_invite_to_forum?' do
-    let(:user) { Fabricate.build(:user) }
-    let(:moderator) { Fabricate.build(:moderator) }
+    fab!(:user) { Fabricate(:user) }
+    fab!(:moderator) { Fabricate(:moderator) }
 
     it 'returns true if user has sufficient trust level' do
       SiteSetting.min_trust_level_to_allow_invite = 2
@@ -716,31 +717,31 @@ RSpec.describe Guardian do
     describe 'a Category' do
 
       it 'allows public categories' do
-        public_category = build(:category, read_restricted: false)
+        public_category = Fabricate(:category, read_restricted: false)
         expect(Guardian.new.can_see?(public_category)).to be_truthy
       end
 
       it 'correctly handles secure categories' do
-        normal_user = build(:user)
-        staged_user = build(:user, staged: true)
-        admin_user  = build(:user, admin: true)
+        normal_user = Fabricate(:user)
+        staged_user = Fabricate(:user, staged: true)
+        admin_user  = Fabricate(:user, admin: true)
 
-        secure_category = build(:category, read_restricted: true)
+        secure_category = Fabricate(:category, read_restricted: true)
         expect(Guardian.new(normal_user).can_see?(secure_category)).to be_falsey
         expect(Guardian.new(staged_user).can_see?(secure_category)).to be_falsey
         expect(Guardian.new(admin_user).can_see?(secure_category)).to be_truthy
 
-        secure_category = build(:category, read_restricted: true, email_in: "foo@bar.com")
+        secure_category = Fabricate(:category, read_restricted: true, email_in: "foo@bar.com")
         expect(Guardian.new(normal_user).can_see?(secure_category)).to be_falsey
         expect(Guardian.new(staged_user).can_see?(secure_category)).to be_falsey
         expect(Guardian.new(admin_user).can_see?(secure_category)).to be_truthy
 
-        secure_category = build(:category, read_restricted: true, email_in_allow_strangers: true)
+        secure_category = Fabricate(:category, read_restricted: true, email_in_allow_strangers: true)
         expect(Guardian.new(normal_user).can_see?(secure_category)).to be_falsey
         expect(Guardian.new(staged_user).can_see?(secure_category)).to be_falsey
         expect(Guardian.new(admin_user).can_see?(secure_category)).to be_truthy
 
-        secure_category = build(:category, read_restricted: true, email_in: "foo@bar.com", email_in_allow_strangers: true)
+        secure_category = Fabricate(:category, read_restricted: true, email_in: "foo2@bar.com", email_in_allow_strangers: true)
         expect(Guardian.new(normal_user).can_see?(secure_category)).to be_falsey
         expect(Guardian.new(staged_user).can_see?(secure_category)).to be_truthy
         expect(Guardian.new(admin_user).can_see?(secure_category)).to be_truthy
@@ -784,27 +785,27 @@ RSpec.describe Guardian do
         topic = Fabricate(:topic)
         topic.trash!(moderator)
 
-        expect(Guardian.new(build(:user)).can_see?(topic)).to be_falsey
+        expect(Guardian.new.can_see?(topic)).to be_falsey
+        expect(Guardian.new(user).can_see?(topic)).to be_falsey
         expect(Guardian.new(moderator).can_see?(topic)).to be_truthy
         expect(Guardian.new(admin).can_see?(topic)).to be_truthy
       end
 
       it "restricts private topics" do
-        user.save!
         private_topic = Fabricate(:private_message_topic, user: user)
+
         expect(Guardian.new(private_topic.user).can_see?(private_topic)).to be_truthy
-        expect(Guardian.new(build(:user)).can_see?(private_topic)).to be_falsey
+        expect(Guardian.new(Fabricate(:user)).can_see?(private_topic)).to be_falsey
         expect(Guardian.new(moderator).can_see?(private_topic)).to be_falsey
         expect(Guardian.new(admin).can_see?(private_topic)).to be_truthy
       end
 
       it "restricts private deleted topics" do
-        user.save!
         private_topic = Fabricate(:private_message_topic, user: user)
         private_topic.trash!(admin)
 
         expect(Guardian.new(private_topic.user).can_see?(private_topic)).to be_falsey
-        expect(Guardian.new(build(:user)).can_see?(private_topic)).to be_falsey
+        expect(Guardian.new(Fabricate(:user)).can_see?(private_topic)).to be_falsey
         expect(Guardian.new(moderator).can_see?(private_topic)).to be_falsey
         expect(Guardian.new(admin).can_see?(private_topic)).to be_truthy
       end
@@ -813,21 +814,19 @@ RSpec.describe Guardian do
         tos_topic = Fabricate(:topic, user: Discourse.system_user)
         SiteSetting.tos_topic_id = tos_topic.id
 
-        expect(Guardian.new(build(:user)).can_edit?(tos_topic)).to be_falsey
+        expect(Guardian.new(Fabricate(:user)).can_edit?(tos_topic)).to be_falsey
         expect(Guardian.new(moderator).can_edit?(tos_topic)).to be_falsey
         expect(Guardian.new(admin).can_edit?(tos_topic)).to be_truthy
       end
 
       it "allows moderators to see a flagged private message" do
-        moderator.save!
-        user.save!
-
         private_topic = Fabricate(:private_message_topic, user: user)
         first_post = Fabricate(:post, topic: private_topic, user: user)
 
         expect(Guardian.new(moderator).can_see?(private_topic)).to be_falsey
 
         PostActionCreator.create(user, first_post, :off_topic)
+
         expect(Guardian.new(moderator).can_see?(private_topic)).to be_truthy
       end
 
@@ -923,26 +922,26 @@ RSpec.describe Guardian do
         SiteSetting.enable_whispers = true
         SiteSetting.whispers_allowed_groups = "#{group.id}"
         regular_post = post
-        whisper_post = Fabricate.build(:post, post_type: Post.types[:whisper])
+        whisper_post = Fabricate(:post, post_type: Post.types[:whisper])
 
         anon_guardian = Guardian.new
         expect(anon_guardian.can_see?(regular_post)).to eq(true)
         expect(anon_guardian.can_see?(whisper_post)).to eq(false)
 
-        regular_user = Fabricate.build(:user)
+        regular_user = Fabricate(:user)
         regular_guardian = Guardian.new(regular_user)
         expect(regular_guardian.can_see?(regular_post)).to eq(true)
         expect(regular_guardian.can_see?(whisper_post)).to eq(false)
 
         # can see your own whispers
-        regular_whisper = Fabricate.build(:post, post_type: Post.types[:whisper], user: regular_user)
+        regular_whisper = Fabricate(:post, post_type: Post.types[:whisper], user: regular_user)
         expect(regular_guardian.can_see?(regular_whisper)).to eq(true)
 
-        mod_guardian = Guardian.new(Fabricate.build(:moderator))
+        mod_guardian = Guardian.new(Fabricate(:moderator))
         expect(mod_guardian.can_see?(regular_post)).to eq(true)
         expect(mod_guardian.can_see?(whisper_post)).to eq(true)
 
-        admin_guardian = Guardian.new(Fabricate.build(:admin))
+        admin_guardian = Guardian.new(Fabricate(:admin))
         expect(admin_guardian.can_see?(regular_post)).to eq(true)
         expect(admin_guardian.can_see?(whisper_post)).to eq(true)
 
@@ -1030,15 +1029,15 @@ RSpec.describe Guardian do
 
       it "is false if user has not met minimum trust level" do
         SiteSetting.min_trust_to_create_topic = 1
-        expect(Guardian.new(build(:user, trust_level: 0)).can_create?(Topic, plain_category)).to be_falsey
+        expect(Guardian.new(Fabricate(:user, trust_level: 0)).can_create?(Topic, plain_category)).to be_falsey
       end
 
       it "is true if user has met or exceeded the minimum trust level" do
         SiteSetting.min_trust_to_create_topic = 1
-        expect(Guardian.new(build(:user, trust_level: 1)).can_create?(Topic, plain_category)).to be_truthy
-        expect(Guardian.new(build(:user, trust_level: 2)).can_create?(Topic, plain_category)).to be_truthy
-        expect(Guardian.new(build(:admin, trust_level: 0)).can_create?(Topic, plain_category)).to be_truthy
-        expect(Guardian.new(build(:moderator, trust_level: 0)).can_create?(Topic, plain_category)).to be_truthy
+        expect(Guardian.new(Fabricate(:user, trust_level: 1)).can_create?(Topic, plain_category)).to be_truthy
+        expect(Guardian.new(Fabricate(:user, trust_level: 2)).can_create?(Topic, plain_category)).to be_truthy
+        expect(Guardian.new(Fabricate(:admin, trust_level: 0)).can_create?(Topic, plain_category)).to be_truthy
+        expect(Guardian.new(Fabricate(:moderator, trust_level: 0)).can_create?(Topic, plain_category)).to be_truthy
       end
     end
 
@@ -1611,7 +1610,7 @@ RSpec.describe Guardian do
         end
 
         context 'when post is older than tl2_post_edit_time_limit' do
-          let(:old_post) { build(:post, topic: topic, user: topic.user, created_at: 12.minutes.ago) }
+          let(:old_post) { Fabricate(:post, topic: topic, user: topic.user, created_at: 12.minutes.ago) }
 
           before do
             topic.user.update_columns(trust_level: 2)
@@ -1643,11 +1642,11 @@ RSpec.describe Guardian do
 
       context "with first post of a static page doc" do
         let!(:tos_topic) { Fabricate(:topic, user: Discourse.system_user) }
-        let!(:tos_first_post) { build(:post, topic: tos_topic, user: tos_topic.user) }
+        let!(:tos_first_post) { Fabricate(:post, topic: tos_topic, user: tos_topic.user) }
         before { SiteSetting.tos_topic_id = tos_topic.id }
 
         it "restricts static doc posts" do
-          expect(Guardian.new(build(:user)).can_edit?(tos_first_post)).to be_falsey
+          expect(Guardian.new(Fabricate(:user)).can_edit?(tos_first_post)).to be_falsey
           expect(Guardian.new(moderator).can_edit?(tos_first_post)).to be_falsey
           expect(Guardian.new(admin).can_edit?(tos_first_post)).to be_truthy
         end
@@ -1742,7 +1741,7 @@ RSpec.describe Guardian do
       end
 
       context 'when archived' do
-        let(:archived_topic) { build(:topic, user: user, archived: true) }
+        let(:archived_topic) { Fabricate(:topic, user: user, archived: true) }
 
         it 'returns true as a moderator' do
           expect(Guardian.new(moderator).can_edit?(archived_topic)).to be_truthy
@@ -1771,7 +1770,7 @@ RSpec.describe Guardian do
       end
 
       context 'when very old' do
-        let(:old_topic) { build(:topic, user: user, created_at: 6.minutes.ago) }
+        let(:old_topic) { Fabricate(:topic, user: user, created_at: 6.minutes.ago) }
 
         before { SiteSetting.post_edit_time_limit = 5 }
 
@@ -2042,17 +2041,12 @@ RSpec.describe Guardian do
     end
 
     context 'with a Topic' do
-      before do
-        # pretend we have a real topic
-        topic.id = 9999999
-      end
-
       it 'returns false when not logged in' do
         expect(Guardian.new.can_delete?(topic)).to be_falsey
       end
 
       it 'returns false when not a moderator' do
-        expect(Guardian.new(user).can_delete?(topic)).to be_falsey
+        expect(Guardian.new(Fabricate(:user)).can_delete?(topic)).to be_falsey
       end
 
       it 'returns true when a moderator' do
@@ -2186,7 +2180,7 @@ RSpec.describe Guardian do
     end
 
     context 'with a Category' do
-      let(:category) { build(:category, user: moderator) }
+      let(:category) { Fabricate(:category, user: moderator) }
 
       it 'returns false when not logged in' do
         expect(Guardian.new.can_delete?(category)).to be_falsey
@@ -2434,7 +2428,7 @@ RSpec.describe Guardian do
   end
 
   describe "#can_access_forum?" do
-    let(:unapproved_user) { Fabricate.build(:user) }
+    let(:unapproved_user) { Fabricate(:user) }
 
     context "when must_approve_users is false" do
       before do
@@ -2749,11 +2743,11 @@ RSpec.describe Guardian do
 
   describe "can_edit_username?" do
     it "is false without a logged in user" do
-      expect(Guardian.new(nil).can_edit_username?(build(:user, created_at: 1.minute.ago))).to be_falsey
+      expect(Guardian.new(nil).can_edit_username?(Fabricate(:user, created_at: 1.minute.ago))).to be_falsey
     end
 
     it "is false for regular users to edit another user's username" do
-      expect(Guardian.new(build(:user)).can_edit_username?(build(:user, created_at: 1.minute.ago))).to be_falsey
+      expect(Guardian.new(Fabricate(:user)).can_edit_username?(Fabricate(:user, created_at: 1.minute.ago))).to be_falsey
     end
 
     shared_examples "staff can always change usernames" do
@@ -2862,11 +2856,11 @@ RSpec.describe Guardian do
       end
 
       it "is false when not logged in" do
-        expect(Guardian.new(nil).can_edit_email?(build(:user, created_at: 1.minute.ago))).to be_falsey
+        expect(Guardian.new(nil).can_edit_email?(Fabricate(:user, created_at: 1.minute.ago))).to be_falsey
       end
 
       it "is false for regular users to edit another user's email" do
-        expect(Guardian.new(build(:user)).can_edit_email?(build(:user, created_at: 1.minute.ago))).to be_falsey
+        expect(Guardian.new(Fabricate(:user)).can_edit_email?(Fabricate(:user, created_at: 1.minute.ago))).to be_falsey
       end
 
       it "is true for a regular user to edit their own email" do
@@ -2888,11 +2882,11 @@ RSpec.describe Guardian do
       end
 
       it "is false when not logged in" do
-        expect(Guardian.new(nil).can_edit_email?(build(:user, created_at: 1.minute.ago))).to be_falsey
+        expect(Guardian.new(nil).can_edit_email?(Fabricate(:user, created_at: 1.minute.ago))).to be_falsey
       end
 
       it "is false for regular users to edit another user's email" do
-        expect(Guardian.new(build(:user)).can_edit_email?(build(:user, created_at: 1.minute.ago))).to be_falsey
+        expect(Guardian.new(Fabricate(:user)).can_edit_email?(Fabricate(:user, created_at: 1.minute.ago))).to be_falsey
       end
 
       it "is false for a regular user to edit their own email" do
@@ -2932,11 +2926,11 @@ RSpec.describe Guardian do
 
   describe 'can_edit_name?' do
     it 'is false without a logged in user' do
-      expect(Guardian.new(nil).can_edit_name?(build(:user, created_at: 1.minute.ago))).to be_falsey
+      expect(Guardian.new(nil).can_edit_name?(Fabricate(:user, created_at: 1.minute.ago))).to be_falsey
     end
 
     it "is false for regular users to edit another user's name" do
-      expect(Guardian.new(build(:user)).can_edit_name?(build(:user, created_at: 1.minute.ago))).to be_falsey
+      expect(Guardian.new(Fabricate(:user)).can_edit_name?(Fabricate(:user, created_at: 1.minute.ago))).to be_falsey
     end
 
     context "for anonymous user" do
@@ -2950,7 +2944,7 @@ RSpec.describe Guardian do
     end
 
     context 'for a new user' do
-      let(:target_user) { build(:user, created_at: 1.minute.ago) }
+      let(:target_user) { Fabricate(:user, created_at: 1.minute.ago) }
 
       it 'is true for the user to change their own name' do
         expect(Guardian.new(target_user).can_edit_name?(target_user)).to be_truthy
@@ -3157,7 +3151,7 @@ RSpec.describe Guardian do
 
     context "when muter's trust level is below tl1" do
       let(:guardian) { Guardian.new(trust_level_0) }
-      let!(:trust_level_0) { build(:user, trust_level: 0) }
+      let!(:trust_level_0) { Fabricate(:user, trust_level: 0) }
 
       it 'does not allow muting user' do
         expect(guardian.can_mute_user?(another_user)).to eq(false)
@@ -3246,7 +3240,7 @@ RSpec.describe Guardian do
   end
 
   describe 'can_wiki?' do
-    let(:post) { build(:post, created_at: 1.minute.ago) }
+    let(:post) { Fabricate(:post, created_at: 1.minute.ago) }
 
     it 'returns false for regular user' do
       expect(Guardian.new(coding_horror).can_wiki?(post)).to be_falsey
@@ -3277,7 +3271,7 @@ RSpec.describe Guardian do
     end
 
     context 'when post is older than post_edit_time_limit' do
-      let(:old_post) { build(:post, user: trust_level_2, created_at: 6.minutes.ago) }
+      let(:old_post) { Fabricate(:post, user: trust_level_2, created_at: 6.minutes.ago) }
       before do
         SiteSetting.min_trust_to_allow_self_wiki = 2
         SiteSetting.tl2_post_edit_time_limit = 5
@@ -3745,7 +3739,7 @@ RSpec.describe Guardian do
     end
 
     context 'with trust_level >= 2 user' do
-      fab!(:topic_creator) { build(:user, trust_level: 2) }
+      fab!(:topic_creator) { Fabricate(:user, trust_level: 2) }
       fab!(:topic) { Fabricate(:topic, user: topic_creator) }
 
       before do

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -1000,8 +1000,8 @@ RSpec.describe TopicView do
   describe "#queued_posts_enabled?" do
     subject(:topic_view) { described_class.new(topic, user) }
 
-    let(:topic) { Fabricate.build(:topic) }
-    let(:user) { Fabricate.build(:user, id: 1) }
+    let(:topic) { Fabricate(:topic) }
+    let(:user) { Fabricate(:user, id: 1) }
     let(:category) { topic.category }
 
     before do

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -129,11 +129,11 @@ RSpec.describe PostSerializer do
   end
 
   context "with a hidden post with add_raw enabled" do
-    let(:user) { Fabricate.build(:user, id: -99999) }
+    let(:user) { Fabricate(:user, id: -99999) }
     let(:raw)  { "Raw contents of the post." }
 
     context "with a public post" do
-      let(:post) { Fabricate.build(:post, raw: raw, user: user) }
+      let(:post) { Fabricate(:post, raw: raw, user: user) }
 
       it "includes the raw post for everyone" do
         [nil, user, Fabricate(:user), Fabricate(:moderator), Fabricate(:admin)].each do |user|
@@ -143,7 +143,7 @@ RSpec.describe PostSerializer do
     end
 
     context "with a hidden post" do
-      let(:post) { Fabricate.build(:post, raw: raw, user: user, hidden: true, hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached]) }
+      let(:post) { Fabricate(:post, raw: raw, user: user, hidden: true, hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached]) }
 
       it "shows the raw post only if authorized to see it" do
         expect(serialized_post_for_user(nil)[:raw]).to eq(nil)
@@ -186,7 +186,7 @@ RSpec.describe PostSerializer do
     end
 
     context "with a public wiki post" do
-      let(:post) { Fabricate.build(:post, raw: raw, user: user, wiki: true) }
+      let(:post) { Fabricate(:post, raw: raw, user: user, wiki: true) }
 
       it "can view edit history" do
         [nil, user, Fabricate(:user), Fabricate(:moderator), Fabricate(:admin)].each do |user|
@@ -197,7 +197,7 @@ RSpec.describe PostSerializer do
 
     context "with a hidden wiki post" do
       let(:post) {
-        Fabricate.build(
+        Fabricate(
           :post,
           raw: raw,
           user: user,


### PR DESCRIPTION
Building does not persist the object in the database which is
unrealistic since we're mostly dealing with persisted objects in
production.

In theory, this will result our test suite taking longer to run since we
now have to write to the database. However, I don't expect the increase
to be significant and it is actually no different than us adding new
tests which fabricates more objects.