### PR TITLE
FIX: set max-width on category logo img

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -113,6 +113,7 @@
 
     img {
       width: calc(var(--max-height) * var(--aspect-ratio));
+      max-width: 100%;
       height: inherit;
       max-height: var(--max-height);
     }

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -417,9 +417,6 @@ tr.category-topic-link {
 .category-logo.aspect-image {
   display: block;
   margin: 1.5em 0 1em;
-  img {
-    max-width: 100%;
-  }
 }
 
 button.dismiss-read {


### PR DESCRIPTION
In some cases a large image would overflow the category container, this restricts the max-width. I also deleted a duplicate max-width downstream. 