### PR TITLE
DEV: Improve colocated component rootName logic

### DIFF
--- a/app/assets/javascripts/discourse-plugins/colocated-template-compiler.js
+++ b/app/assets/javascripts/discourse-plugins/colocated-template-compiler.js
@@ -3,17 +3,12 @@ const ColocatedTemplateProcessor = require("ember-cli-htmlbars/lib/colocated-bro
 module.exports = class DiscoursePluginColocatedTemplateProcessor extends (
   ColocatedTemplateProcessor
 ) {
+  constructor(tree, discoursePluginName) {
+    super(tree);
+    this.discoursePluginName = discoursePluginName;
+  }
+
   detectRootName() {
-    const entries = this.currentEntries().filter((e) => !e.isDirectory());
-
-    const path = entries[0]?.relativePath;
-
-    const match = path?.match(
-      /^discourse\/plugins\/(?<name>[^/]+)\/discourse\//
-    );
-
-    if (match) {
-      return `discourse/plugins/${match.groups.name}/discourse`;
-    }
+    return `discourse/plugins/${this.discoursePluginName}/discourse`;
   }
 };

--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -171,7 +171,7 @@ module.exports = {
 
     tree = RawHandlebarsCompiler(tree);
 
-    tree = new DiscoursePluginColocatedTemplateProcessor(tree);
+    tree = new DiscoursePluginColocatedTemplateProcessor(tree, pluginName);
     tree = this.compileTemplates(tree);
 
     tree = this.processedAddonJsFiles(tree);


### PR DESCRIPTION
The complex regex-based detection was based on Ember CLI's implementation, which is necessarily generic and needs to auto-detect the name. In our case, we know the name of the plugin so we can just pass it in - no need for dynamic detection. This resolves issues when there are other files in the `discourse/plugins/{name}` directory which are sorted before `discourse/`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
