### PR TITLE
A11Y: add keyboard support to youtube embeds

### DIFF
--- a/plugins/lazy-yt/assets/javascripts/lib/lazyYT.js
+++ b/plugins/lazy-yt/assets/javascripts/lib/lazyYT.js
@@ -51,7 +51,7 @@ export default function initLazyYt($) {
     //
     // This HTML will be placed inside 'lazyYT' container
 
-    innerHtml.push('<div class="ytp-thumbnail">');
+    innerHtml.push('<div class="ytp-thumbnail" tabIndex="0">');
 
     // Play button from YouTube (exactly as it is in YouTube)
     innerHtml.push('<div class="ytp-large-play-button"');
@@ -135,7 +135,11 @@ export default function initLazyYt($) {
     $thumb = $el
       .find(".ytp-thumbnail")
       .addClass("lazyYT-image-loaded")
-      .on("click", function (e) {
+      .on("keypress click", function (e) {
+        // Only support Enter for keypress
+        if (e.type === "keypress" && e.keyCode !== 13) {
+          return;
+        }
         e.preventDefault();
 
         if (

--- a/plugins/lazy-yt/assets/stylesheets/lazyYT.css
+++ b/plugins/lazy-yt/assets/stylesheets/lazyYT.css
@@ -113,6 +113,7 @@
 }
 
 .lazyYT-image-loaded:hover .ytp-large-play-button-svg,
+.lazyYT-image-loaded:focus .ytp-large-play-button-svg,
 .ytp-large-play-button:focus .ytp-large-play-button-svg {
   opacity: 1;
   fill: #cc181e;


### PR DESCRIPTION
The lazyYT mini-plugin could certainly use a refresher, but this PR isn't that. It simply adds keyboard support so that screen reader users can focus on the video and trigger launching it via keyboard. 