### PR TITLE
DEV: remove old CustomHTML outlet

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/navigation-bar.hbs
@@ -1,5 +1,4 @@
 {{#each this.navItems as |navItem|}}
   <NavigationItem @content={{navItem}} @filterMode={{this.filterMode}} @category={{this.category}} @class={{concat "nav-item_" navItem.name}} />
 {{/each}}
-<CustomHtml @name="extraNavItem" @tagName="li" />
 <PluginOutlet @name="extra-nav-item" @connectorTagName="li" @args={{hash category=this.category filterMode=this.filterMode}} />


### PR DESCRIPTION
This generates an empty `li` tag in the nav on all sites, which can get in the way if you're using flex, grid, or any sort of `nth` selector in CSS. This doesn't seem to be in use on any themes and plugins. 