### PR TITLE
DEV: Fabricate instead of just building topic, post and user in tests

### DIFF
--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -995,8 +995,8 @@ RSpec.describe TopicView do
   describe "#queued_posts_enabled?" do
     subject(:topic_view) { described_class.new(topic, user) }
 
-    let(:topic) { Fabricate.build(:topic) }
-    let(:user) { Fabricate.build(:user, id: 1) }
+    let(:topic) { Fabricate(:topic) }
+    let(:user) { Fabricate(:user, id: 1) }
     let(:category) { topic.category }
 
     before do

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -106,12 +106,12 @@ describe PostSerializer do
     end
   end
 
-  context "a hidden post with add_raw enabled" do
-    let(:user) { Fabricate.build(:user, id: -99999) }
+  context "with a hidden post with add_raw enabled" do
+    let(:user) { Fabricate(:user, id: -99999) }
     let(:raw)  { "Raw contents of the post." }
 
-    context "a public post" do
-      let(:post) { Fabricate.build(:post, raw: raw, user: user) }
+    context "with a public post" do
+      let(:post) { Fabricate(:post, raw: raw, user: user) }
 
       it "includes the raw post for everyone" do
         [nil, user, Fabricate(:user), Fabricate(:moderator), Fabricate(:admin)].each do |user|
@@ -120,8 +120,8 @@ describe PostSerializer do
       end
     end
 
-    context "a hidden post" do
-      let(:post) { Fabricate.build(:post, raw: raw, user: user, hidden: true, hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached]) }
+    context "with a hidden post" do
+      let(:post) { Fabricate(:post, raw: raw, user: user, hidden: true, hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached]) }
 
       it "shows the raw post only if authorized to see it" do
         expect(serialized_post_for_user(nil)[:raw]).to eq(nil)
@@ -163,8 +163,8 @@ describe PostSerializer do
       end
     end
 
-    context "a public wiki post" do
-      let(:post) { Fabricate.build(:post, raw: raw, user: user, wiki: true) }
+    context "with a public wiki post" do
+      let(:post) { Fabricate(:post, raw: raw, user: user, wiki: true) }
 
       it "can view edit history" do
         [nil, user, Fabricate(:user), Fabricate(:moderator), Fabricate(:admin)].each do |user|
@@ -175,7 +175,7 @@ describe PostSerializer do
 
     context "a hidden wiki post" do
       let(:post) {
-        Fabricate.build(
+        Fabricate(
           :post,
           raw: raw,
           user: user,


### PR DESCRIPTION
Building does not persist the object in the database which is
unrealistic since we're mostly dealing with persisted objects in
production.

In theory, this will result our test suite taking longer to run since we
now have to write to the database. However, I don't expect the increase
to be significant and it is actually no different than us adding new
tests which fabricates more objects.