### PR TITLE
DEV: Fix flaky uploads:disable_secure_uploads spec

### DIFF
--- a/spec/tasks/uploads_spec.rb
+++ b/spec/tasks/uploads_spec.rb
@@ -209,13 +209,11 @@ RSpec.describe "tasks/uploads" do
       expect(post2.reload.baked_at).not_to eq_time(1.week.ago)
     end
 
-    it "updates the affected ACLs" do
-      expect_enqueued_with(
-        job: :sync_acls_for_uploads,
-        args: { upload_ids: [upload1.id, upload2.id, upload3.id, upload4.id] },
-      ) do
-        invoke_task
-      end
+    it "updates the affected ACLs via the SyncAclsForUploads job" do
+      invoke_task
+      expect(Jobs::SyncAclsForUploads.jobs.last["args"][0]["upload_ids"]).to match_array(
+        [upload1.id, upload2.id, upload3.id, upload4.id]
+      )
     end
   end
 end


### PR DESCRIPTION
This test flakes occassionally, possibly because
of the arg ordering which we do not guarantee.
In future if this keeps occurring we may want to
try make expect_enqueued_with not care about
argument orders or the order of arrays etc within
those arguments.