### PR TITLE
FIX: Stop falling back to topic image on embeds

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -301,8 +301,8 @@ class TopicView
   end
 
   def image_url
-    url = desired_post&.image_url if @post_number > 1
-    url || @topic.image_url
+    return @topic.image_url if @post_number == 1
+    desired_post&.image_url
   end
 
   def filter_posts(opts = {})

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -895,9 +895,9 @@ RSpec.describe TopicView do
         post1.update_column(:image_upload_id, op_upload.id)
       end
 
-      it "uses the topic image as a fallback when posts have no image" do
+      it "uses the topic image for op and posts image when they have one" do
         expect(topic_view_for_post(1).image_url).to end_with(op_upload.url)
-        expect(topic_view_for_post(2).image_url).to end_with(op_upload.url)
+        expect(topic_view_for_post(2).image_url).to eq(nil)
         expect(topic_view_for_post(3).image_url).to end_with(post3_upload.url)
       end
     end


### PR DESCRIPTION
If linked post (not OP) has no image, it won't fall back to the topic image anymore.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
