### PR TITLE
UX: Improve autocomplete styling

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -393,43 +393,54 @@ html.composer-open {
   width: 240px;
   background-color: var(--secondary);
   border: 1px solid var(--primary-low);
+
   ul {
     list-style: none;
     padding: 0;
     margin: 0;
 
     li {
-      .d-icon-users {
-        color: var(--primary-medium);
-        padding: 0 2px;
+      &:not(:last-child) {
+        border-bottom: 1px solid var(--primary-low);
       }
 
-      border-bottom: 1px solid var(--primary-low);
-
       a {
-        padding: 5px;
-        display: block;
         @include ellipsis;
+        color: var(--primary-high);
+        display: flex;
+        padding: 5px;
 
-        span.username {
-          color: var(--primary);
-        }
-        span.name {
-          font-size: var(--font-down-1);
-          vertical-align: middle;
-        }
-        &.selected {
-          background-color: var(--tertiary-low);
-        }
         @include hover {
           background-color: var(--highlight-low);
           text-decoration: none;
+        }
+
+        &.selected {
+          background-color: var(--tertiary-low);
+        }
+
+        span {
+          margin-left: 5px;
+
+          &.username {
+            color: var(--primary);
+          }
+
+          &.name {
+            font-size: var(--font-down-1);
+            vertical-align: middle;
+          }
         }
 
         .relative-date {
           font-size: var(--font-down-3);
           padding-top: 10em;
         }
+      }
+
+      .d-icon-users {
+        color: var(--primary-medium);
+        padding: 0 2px;
       }
     }
   }


### PR DESCRIPTION
1. Restore the original text color (`--primary-high`)
2. Fix the double bottom border
3. Make the padding around icons even

Before / After
<img width="275" alt="Screenshot 2022-10-24 at 18 48 14" src="https://user-images.githubusercontent.com/66961/197581118-ba1eecea-2fa0-47ce-9798-fae7f76384b3.png"> <img width="275" alt="Screenshot 2022-10-24 at 18 48 03" src="https://user-images.githubusercontent.com/66961/197581127-753c47b0-4552-4022-ba1f-7eb600405c03.png">
