### PR TITLE
FIX: Use only first line from commit message

### DIFF
--- a/lib/onebox/engine/github_pull_request_onebox.rb
+++ b/lib/onebox/engine/github_pull_request_onebox.rb
@@ -40,7 +40,7 @@ module Onebox
         result['body'], result['excerpt'] = compute_body(result['body'])
 
         if result['commit'] = load_commit(link)
-          result['body'], result['excerpt'] = compute_body(result['commit']['body'])
+          result['body'], result['excerpt'] = compute_body(result['commit']['commit']['message'].lines[1..].join)
         elsif result['comment'] = load_comment(link)
           result['body'], result['excerpt'] = compute_body(result['comment']['body'])
         elsif result['discussion'] = load_review(link)

--- a/lib/onebox/templates/githubpullrequest.mustache
+++ b/lib/onebox/templates/githubpullrequest.mustache
@@ -26,7 +26,7 @@
   <div class="github-info-container">
     {{#commit}}
       <h4>
-        <a href="{{link}}" target="_blank" rel="noopener">{{commit.message}}</a>
+        <a href="{{link}}" target="_blank" rel="noopener">{{commit.message.lines.first}}</a>
       </h4>
 
       <span>

--- a/spec/lib/onebox/engine/github_pull_request_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_pull_request_onebox_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Onebox::Engine::GithubPullRequestOnebox do
 
     it "includes commit name" do
       expect(html).to include("Add audio onebox")
+      expect(html).not_to include("http://meta.discourse.org/t/audio-html5-tag/8168")
     end
   end
 

--- a/spec/lib/onebox/engine/github_pull_request_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_pull_request_onebox_spec.rb
@@ -59,8 +59,9 @@ RSpec.describe Onebox::Engine::GithubPullRequestOnebox do
     end
 
     it "includes commit name" do
-      expect(html).to include("Add audio onebox")
-      expect(html).not_to include("http://meta.discourse.org/t/audio-html5-tag/8168")
+      doc = Nokogiri::HTML5(html)
+      expect(doc.css('h4').text.strip).to eq("Add audio onebox")
+      expect(doc.css('.github-body-container').text).to include("http://meta.discourse.org/t/audio-html5-tag/8168")
     end
   end
 


### PR DESCRIPTION
Linking a commit from a GitHub pull request included the complete commit message, instead of just the first line.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
