### PR TITLE
FIX: Correctly reset `controllerReady` prop

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -71,6 +71,7 @@ export default Controller.extend(bufferedProperty("model"), {
   currentPostId: null,
   userLastReadPostNumber: null,
   highestPostNumber: null,
+  controllerReady: false,
 
   init() {
     this._super(...arguments);

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -16,16 +16,9 @@ const SCROLL_DELAY = 500;
 const TopicRoute = DiscourseRoute.extend({
   screenTrack: service(),
 
-  init() {
-    this._super(...arguments);
-
-    this.setProperties({
-      isTransitioning: false,
-      scheduledReplace: null,
-      lastScrollPos: null,
-      controllerReady: true,
-    });
-  },
+  scheduledReplace: null,
+  lastScrollPos: null,
+  isTransitioning: false,
 
   redirect() {
     return this.redirectIfLoginRequired();
@@ -359,6 +352,7 @@ const TopicRoute = DiscourseRoute.extend({
       model,
       editingTopic: false,
       firstPostExpanded: false,
+      controllerReady: false,
     });
 
     this.searchService.set("searchContext", model.get("searchContext"));


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
