### PR TITLE
DEV: Remove harded id when fabricating in tests (#18729)

### DIFF
--- a/spec/components/topic_view_spec.rb
+++ b/spec/components/topic_view_spec.rb
@@ -996,7 +996,7 @@ RSpec.describe TopicView do
     subject(:topic_view) { described_class.new(topic, user) }
 
     let(:topic) { Fabricate(:topic) }
-    let(:user) { Fabricate(:user, id: 1) }
+    let(:user) { Fabricate(:user) }
     let(:category) { topic.category }
 
     before do

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -107,7 +107,7 @@ describe PostSerializer do
   end
 
   context "with a hidden post with add_raw enabled" do
-    let(:user) { Fabricate(:user, id: -99999) }
+    let(:user) { Fabricate(:user) }
     let(:raw)  { "Raw contents of the post." }
 
     context "with a public post" do


### PR DESCRIPTION
Hardcoding ids always lead to sadness for our test suite

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
