### PR TITLE
FIX: Reset error props on Topic model

### DIFF
--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -358,6 +358,15 @@ export default RestModel.extend({
           loaded: true,
         });
         this._checkIfShouldShowRevisions();
+
+        // Reset all error props
+        topic.setProperties({
+          errorLoading: false,
+          errorTitle: null,
+          errorHtml: null,
+          errorMessage: null,
+          noRetry: false,
+        });
       })
       .catch((result) => {
         this.errorLoading(result);


### PR DESCRIPTION
If there's an error loading a topic, and later you load it successfully - the the stale error message would still briefly show up every time you navigate to that topic

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
