### PR TITLE
Add sd_notify gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -214,6 +214,7 @@ gem 'rack-mini-profiler', require: ['enable_rails_patches']
 
 gem 'unicorn', require: false, platform: :ruby
 gem 'puma', require: false
+gem 'sd_notify', require: false
 gem 'rbtrace', require: false, platform: :mri
 gem 'gc_tracer', require: false, platform: :mri
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,6 +442,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sd_notify (0.1.1)
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -635,6 +636,7 @@ DEPENDENCIES
   sanitize
   sassc (= 2.0.1)
   sassc-rails
+  sd_notify
   selenium-webdriver
   shoulda-matchers
   sidekiq


### PR DESCRIPTION
Enables systemd to run Puma as a Type=notify and watchdog [service](https://github.com/puma/puma/blob/master/docs/systemd.md).
One benefit is that systemd can restart Puma if it hangs.