### PR TITLE
DEV: move BasicUserWithStatusSerializer from Discourse Chat to Core

### DIFF
--- a/app/serializers/basic_user_with_status_serializer.rb
+++ b/app/serializers/basic_user_with_status_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class BasicUserWithStatusSerializer < BasicUserSerializer
+  attributes :status
+
+  def include_status?
+    SiteSetting.enable_user_status && user.has_status?
+  end
+
+  def status
+    UserStatusSerializer.new(user.user_status, root: false)
+  end
+end

--- a/spec/serializers/basic_user_with_status_serializer_spec.rb
+++ b/spec/serializers/basic_user_with_status_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe BasicUserWithStatusSerializer do
+  fab!(:user_status) { Fabricate(:user_status) }
+  fab!(:user) { Fabricate(:user, user_status: user_status) }
+  let(:serializer) { described_class.new(user, scope: Guardian.new(user), root: false) }
+
+  it "adds user status when enabled" do
+    SiteSetting.enable_user_status = true
+
+    json = serializer.as_json
+
+    expect(json[:status]).to_not be_nil do |status|
+      expect(status.description).to eq(user_status.description)
+      expect(status.emoji).to eq(user_status.emoji)
+    end
+  end
+
+  it "doesn't add user status when status is disabled in site settings" do
+    SiteSetting.enable_user_status = false
+    json = serializer.as_json
+    expect(json.keys).not_to include :status
+  end
+
+  it "doesn't add expired user status" do
+    SiteSetting.enable_user_status = true
+
+    user.user_status.ends_at = 1.minutes.ago
+    serializer = described_class.new(user, scope: Guardian.new(user), root: false)
+    json = serializer.as_json
+
+    expect(json.keys).not_to include :status
+  end
+
+  it "doesn't return status if user doesn't have it set" do
+    SiteSetting.enable_user_status = true
+
+    user.clear_status!
+    user.reload
+    json = serializer.as_json
+
+    expect(json.keys).not_to include :status
+  end
+end


### PR DESCRIPTION
We're going to need this serializer to show user status on inline mentions on posts (https://github.com/discourse/discourse/pull/18683).

Note that this serializer still [exists](https://github.com/discourse/discourse-chat/blob/main/app/serializers/basic_user_with_status_serializer.rb) in Discourse Chat, but I tested it to make sure that merging it won't provoke an error because of loading a class with the same name twice.

So we're safe to merge it, and after that I'll [drop](https://github.com/discourse/discourse-chat/pull/1328) `BasicUserWithStatusSerializer` in Discourse Chat.
