### PR TITLE
FIX: variable name typo

### DIFF
--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -505,7 +505,7 @@ blockquote {
 .topic-area > .loading-container {
   // loader needs to be same width as posts
   width: calc(
-    var(--topic-body-width) + var(--topic-avatar) +
+    var(--topic-body-width) + var(--topic-avatar-width) +
       (var(--topic-body-width-padding) * 2)
   );
   max-width: 100%;


### PR DESCRIPTION
Follow-up to d0f88da, this was causing an issue when loading posts