### PR TITLE
DEV: Add description for active param on create user api docs

### DIFF
--- a/spec/requests/api/schemas/json/user_create_request.json
+++ b/spec/requests/api/schemas/json/user_create_request.json
@@ -14,7 +14,8 @@
       "type": "string"
     },
     "active": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "This param requires an api key in the request header or it will be ignored"
     },
     "approved": {
       "type": "boolean"


### PR DESCRIPTION
The `active` param on the create user endpoint requires that an api key
is used in the request header otherwise it is ignored, so adding this
distinction to the api docs.
