### PR TITLE
DEV: Revert topic loading async changes

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -71,7 +71,6 @@ export default Controller.extend(bufferedProperty("model"), {
   currentPostId: null,
   userLastReadPostNumber: null,
   highestPostNumber: null,
-  controllerReady: false,
 
   init() {
     this._super(...arguments);

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -24,7 +24,7 @@ import DiscourseURL, { userPath } from "discourse/lib/url";
 import deprecated from "discourse-common/lib/deprecated";
 import { applyModelTransformations } from "discourse/lib/model-transformers";
 
-export async function loadTopicView(topic, args) {
+export function loadTopicView(topic, args) {
   const data = deepMerge({}, args);
   const url = `${getURL("/t/")}${topic.id}`;
   const jsonUrl = (data.nearPost ? `${url}/${data.nearPost}` : url) + ".json";
@@ -33,12 +33,12 @@ export async function loadTopicView(topic, args) {
   delete data.__type;
   delete data.store;
 
-  const json = await PreloadStore.getAndRemove(`topic_${topic.id}`, () =>
+  return PreloadStore.getAndRemove(`topic_${topic.id}`, () =>
     ajax(jsonUrl, { data })
-  );
-
-  topic.updateFromJson(json);
-  return json;
+  ).then((json) => {
+    topic.updateFromJson(json);
+    return json;
+  });
 }
 
 export const ID_CONSTRAINT = /^\d+$/;

--- a/app/assets/javascripts/discourse/app/routes/topic-from-params.js
+++ b/app/assets/javascripts/discourse/app/routes/topic-from-params.js
@@ -80,7 +80,6 @@ export default DiscourseRoute.extend({
       enteredAt: Date.now().toString(),
       userLastReadPostNumber: topic.last_read_post_number,
       highestPostNumber: topic.highest_post_number,
-      controllerReady: true,
     });
 
     this.appEvents.trigger("page:topic-loaded", topic);

--- a/app/assets/javascripts/discourse/app/routes/topic.js
+++ b/app/assets/javascripts/discourse/app/routes/topic.js
@@ -352,7 +352,6 @@ const TopicRoute = DiscourseRoute.extend({
       model,
       editingTopic: false,
       firstPostExpanded: false,
-      controllerReady: false,
     });
 
     this.searchService.set("searchContext", model.get("searchContext"));

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -13,7 +13,7 @@
 
   <PluginOutlet @name="topic-above-post-stream" @tagName="span" @connectorTagName="div" @args={{hash model=this.model editFirstPost=(action "editFirstPost")}} />
 
-  {{#if (and this.controllerReady this.model.postStream.loaded)}}
+  {{#if this.model.postStream.loaded}}
     {{#if this.model.postStream.firstPostPresent}}
       <TopicTitle @cancelled={{action "cancelEditingTopic"}} @save={{action "finishedEditingTopic"}} @model={{this.model}}>
         {{#if this.editingTopic}}


### PR DESCRIPTION
This reverts commits 2c5e8f17635fd4e6d280a3dc794335711e19970e (#18585) and 589a249a6539f74c31c2a4f50c7249628c8b72b0 (#18727)

Those changes caused race conditions with scroll-to-post/lockOn code.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
