### PR TITLE
Increase NGINX request header buffer

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -16,8 +16,12 @@ proxy_cache_path /var/nginx/cache inactive=1440m levels=1:2 keys_zone=one:10m ma
 
 # Increased from the default value to acommodate large cookies during oAuth2 flows
 # like in https://meta.discourse.org/t/x/74060 and large CSP and Link (preload) headers
-proxy_buffer_size 16k;
-proxy_buffers 4 16k;
+proxy_buffer_size 32k;
+proxy_buffers 4 32k;
+
+# Increased from the default value to allow for a large volume of cookies in request headers
+# Discourse itself tries to minimise cookie size, but we cannot control other cookies set by other tools on the same domain.
+large_client_header_buffers 4 32k;
 
 # If you are going to use Puma, use these:
 #


### PR DESCRIPTION
This allows a large volume of cookies in request headers. Discourse itself tries to minimise cookie size, but we cannot control other cookies set by other tools on the same domain.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
