### PR TITLE
FIX: simplify display of multiple AJAX errors  

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/ajax-error.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax-error.js
@@ -33,8 +33,12 @@ export function extractError(error, defaultMessage) {
   }
 
   if (parsedJSON) {
-    if (parsedJSON.errors && parsedJSON.errors.length > 0) {
-      parsedError = parsedJSON.errors.join("<br>");
+    if (parsedJSON.errors?.length > 1) {
+      parsedError = I18n.t("multiple_errors", {
+        errors: parsedJSON.errors.map((e, i) => `${i + 1}) ${e}`).join(" "),
+      });
+    } else if (parsedJSON.errors?.length > 0) {
+      parsedError = parsedJSON.errors[0];
     } else if (parsedJSON.error) {
       parsedError = parsedJSON.error;
     } else if (parsedJSON.message) {

--- a/app/assets/javascripts/discourse/app/lib/ajax-error.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax-error.js
@@ -38,7 +38,9 @@ export function extractError(error, defaultMessage) {
         errors: parsedJSON.errors.map((e, i) => `${i + 1}) ${e}`).join(" "),
       });
     } else if (parsedJSON.errors?.length > 0) {
-      parsedError = parsedJSON.errors[0];
+      parsedError = I18n.t("generic_error_with_reason", {
+        error: parsedJSON.errors[0],
+      });
     } else if (parsedJSON.error) {
       parsedError = parsedJSON.error;
     } else if (parsedJSON.message) {

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -1,3 +1,4 @@
+import I18n from "I18n";
 import {
   acceptance,
   count,
@@ -166,7 +167,9 @@ acceptance("Category Edit", function (needs) {
 
     assert.strictEqual(
       query(".dialog-body").textContent.trim(),
-      "duplicate email"
+      I18n.t("generic_error_with_reason", {
+        error: "duplicate email",
+      })
     );
 
     await click(".dialog-footer .btn-primary");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-email-settings-test.js
@@ -363,8 +363,10 @@ acceptance(
 
       assert.strictEqual(
         query(".dialog-body").innerText.trim(),
-        "There was an issue with the SMTP credentials provided, check the username and password and try again.",
-        "shows a dialogue with the error message from the server"
+        I18n.t("generic_error_with_reason", {
+          error:
+            "There was an issue with the SMTP credentials provided, check the username and password and try again.",
+        })
       );
       await click(".dialog-footer .btn-primary");
     });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -257,6 +257,7 @@ en:
     delete: "Delete"
     generic_error: "Sorry, an error has occurred."
     generic_error_with_reason: "An error occurred: %{error}"
+    multiple_errors: "Multiple errors: %{errors}"
     sign_up: "Sign Up"
     log_in: "Log In"
     age: "Age"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -257,7 +257,7 @@ en:
     delete: "Delete"
     generic_error: "Sorry, an error has occurred."
     generic_error_with_reason: "An error occurred: %{error}"
-    multiple_errors: "Multiple errors: %{errors}"
+    multiple_errors: "Multiple errors occurred: %{errors}"
     sign_up: "Sign Up"
     log_in: "Log In"
     age: "Age"


### PR DESCRIPTION
Our dialog service doesn't accept HTML by default and we shouldn't include HTML in the error message string. And given that the Ajax error handler is called in multiple contexts, it's tricky to properly support line breaks via either HTML or `\n` so we are opting for plain text in AJAX error messages. 

Before: 
<img width="1466" alt="image" src="https://user-images.githubusercontent.com/368961/198142005-9e14c328-f8f3-44a8-83bf-0fbd3b85f043.png">


After: 
<img width="993" alt="image" src="https://user-images.githubusercontent.com/368961/198141949-9d1a44a3-5d99-4bee-8051-2a7da2fd9ee1.png">
