### PR TITLE
FEATURE: reduce suspicious distance logins warning to 100km

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -498,7 +498,7 @@ login:
     default: false
   max_suspicious_distance_km:
     hidden: true
-    default: 500
+    default: 100
   discourse_connect_url:
     default: ""
     regex: '^https?:\/\/.+[^\/]$'


### PR DESCRIPTION
Suspicious login emails are incredibly rare, we are concerned they are in
fact too rare. Attempt to reduce the distance down to 100km.
