### PR TITLE
FIX: Move group-box group name from class to data attribute

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.hbs
@@ -22,7 +22,7 @@
         <div class="container">
           <div class="groups-boxes">
             {{#each this.groups as |group|}}
-              <LinkTo @route="group.members" @model={{group.name}} class={{concat "group-box " group.name}}>
+              <LinkTo @route="group.members" @model={{group.name}} class="group-box" data-group-name={{group.name}}>
                 <div class="group-box-inner">
                   <div class="group-info-wrapper">
                     {{#if group.flair_url}}


### PR DESCRIPTION
Having the group name in the `class` attribute can cause a clash with 'real' CSS classes. Putting it in a data attribute is much safer, and can still be targetted via CSS if desired.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
