### PR TITLE
fix: wording for visible topic

### DIFF
--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -2726,7 +2726,7 @@ fr:
         unarchive: "Désarchiver le sujet"
         archive: "Archiver le sujet"
         invisible: "Rendre le sujet invisible"
-        visible: "Lister le sujet"
+        visible: "Rendre le sujet visible"
         reset_read: "Réinitialiser les données de lecture"
         make_public: "Rendre le sujet public…"
         make_private: "Transformer en message direct"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

It is just a translation issue, it is pretty unclear how to make visible a topic for a french user. Here the translation is closer to a "hide"/"show" logic. I do not think there are tests for translations.
