### PR TITLE
FIX: a couple of topic elements are too wide

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1221,8 +1221,10 @@ blockquote > *:last-child {
       border-bottom: 1px solid var(--danger-medium);
       line-height: 0.1em;
       margin: 1rem 0px;
-      width: 100%;
-
+      width: calc(
+        var(--topic-body-width) + var(--topic-avatar-width) +
+          (var(--topic-body-width-padding) * 2)
+      );
       .topic-post-visited-message {
         background-color: var(--secondary);
         color: var(--danger-medium);

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -509,10 +509,6 @@ blockquote {
       (var(--topic-body-width-padding) * 2)
   );
   max-width: 100%;
-  @media all and (max-width: 790px) {
-    // 32px is (left + right padding * 2) from .wrap in common/base/discourse.scss
-    max-width: calc(100vw - 32px);
-  }
 }
 
 /* hide the reply border above the time gap notices */


### PR DESCRIPTION
The "last read" indicator within topics is too wide, and there's some extra CSS causing issues with the loading container at narrow desktop viewport widths. 

Follow-up to d0f88da