### PR TITLE
UX: Allow linebreaks mid-word in github onebox file paths

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -376,6 +376,10 @@ pre.onebox code ol.lines li:before {
   counter-increment: li-counter;
 }
 
+.onebox.githubblob h4 {
+  word-break: break-all;
+}
+
 pre.onebox code ol {
   margin-left: 0;
   line-height: var(--line-height-large);


### PR DESCRIPTION
Previously it would break on `-` characters, which is kinda arbitrary in a file path. Much cleaner to `break-all`.

Before:

<img width="704" alt="Screenshot 2022-10-27 at 17 38 01" src="https://user-images.githubusercontent.com/6270921/198349107-3d13c1e7-9811-40a9-91df-63c190260fdb.png">


After:

<img width="717" alt="Screenshot 2022-10-27 at 17 37 51" src="https://user-images.githubusercontent.com/6270921/198349092-ab005789-ff80-403b-95d5-d7569d2bfa12.png">
