### PR TITLE
FIX: Ensure that custom {{action}} modifier works with actions hash

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/ember-action-modifier.js
+++ b/app/assets/javascripts/discourse/app/lib/ember-action-modifier.js
@@ -18,7 +18,7 @@ export const actionModifier = modifier(
     const handler = (event) => {
       let fn;
       if (typeof callback === "string") {
-        fn = context[callback] ?? context.actions?.[callback];
+        fn = context.actions?.[callback] ?? context[callback];
       } else if (typeof callback === "function") {
         fn = callback;
       }

--- a/app/assets/javascripts/discourse/app/lib/ember-action-modifier.js
+++ b/app/assets/javascripts/discourse/app/lib/ember-action-modifier.js
@@ -16,7 +16,12 @@ export const actionModifier = modifier(
     { on, bubbles, preventDefault, allowedKeys }
   ) => {
     const handler = (event) => {
-      const fn = typeof callback === "string" ? context[callback] : callback;
+      let fn;
+      if (typeof callback === "string") {
+        fn = context[callback] ?? context.actions?.[callback];
+      } else if (typeof callback === "function") {
+        fn = callback;
+      }
       if (fn === undefined) {
         throw new Error(
           "Unexpected callback for `action` modifier. Please provide either a function or the name of a method on the current context."

--- a/app/assets/javascripts/discourse/tests/unit/lib/ember-action-modifer-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/ember-action-modifer-test.js
@@ -2,6 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { click, doubleClick, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { default as ClassicComponent } from "@ember/component";
 
 module("Unit | Lib | ember-action-modifer", function (hooks) {
   setupRenderingTest(hooks);
@@ -72,5 +73,58 @@ module("Unit | Lib | ember-action-modifer", function (hooks) {
     await doubleClick("#childButton");
 
     assert.strictEqual(this.dblClicked, 0);
+  });
+
+  module("used on a classic component with an actions hash", function () {
+    const ExampleClassicButton = ClassicComponent.extend({
+      tagName: "",
+      onDoSomething: null,
+
+      actions: {
+        doSomething(event) {
+          this.onDoSomething?.(event);
+        },
+      },
+    });
+    const exampleClassicButtonTemplate = hbs`
+      <a
+        href
+        class="btn btn-default no-text mobile-gif-insert"
+        aria-label={{i18n "gif.composer_title"}}
+        {{action "doSomething"}}
+      >
+        {{d-icon "discourse-gifs-gif"}}
+      </a>
+    `;
+
+    hooks.beforeEach(function () {
+      this.owner.register(
+        "component:example-classic-button",
+        ExampleClassicButton
+      );
+      this.owner.register(
+        "template:components/example-classic-button",
+        exampleClassicButtonTemplate
+      );
+    });
+
+    test("it can target listeners on the actions hash", async function (assert) {
+      let i = 0;
+
+      this.setProperties({
+        onOneClick: () => this.set("oneClicked", i++),
+        oneClicked: undefined,
+      });
+
+      await render(hbs`
+        <ExampleClassicButton @onDoSomething={{this.onOneClick}} />
+      `);
+
+      assert.strictEqual(this.oneClicked, undefined);
+
+      await click("a.btn");
+
+      assert.strictEqual(this.oneClicked, 0);
+    });
   });
 });


### PR DESCRIPTION
A callback that's provided as a string, such as `{{action "doSomething"}}`, may target the method `doSomething` on the context OR the context's `action` hash (if it exists).
