### PR TITLE
UX: make whole category box clickable

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
@@ -2,7 +2,7 @@
   <div data-notification-level={{c.notificationLevelString}} style={{unless this.noCategoryStyle (html-safe (concat (border-color c.color) (category-color-variable c.color)))}} class="category category-box category-box-{{c.slug}} {{if c.isMuted "muted"}} {{if this.noCategoryStyle "no-category-boxes-style"}}">
     <div class="category-box-inner">
       <div class="category-box-heading">
-        <a href={{c.url}}>
+        <a class="parent-box-link" href={{c.url}}>
           {{#unless c.isMuted}}
             {{#if c.uploaded_logo.url}}
               <CategoryLogo @category={{c}} />

--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -275,6 +275,9 @@
 
   .featured-topics {
     margin-bottom: 1em;
+    // we absolutely position the parent category's link so the whole box is clickable
+    // to prevent this covering topic links, we need to raise the z-index
+    z-index: 1;
     ul {
       color: var(--primary-medium);
       list-style: none;


### PR DESCRIPTION
This was already done for other category boxes here: https://github.com/discourse/discourse/commit/ef9828b25dbe046c098de358523d8afd31c07c61

So now I'm just extending this behavior to the categories boxes with topics.

This makes the whole category box clickable by absolutely positioning the parent link, and then uses z-index to layer the featured topics on top so they're not obscured by the parent link. 

Doing it this way avoids nesting links within each other. 


Screenshot just to reference the category layout I'm talking about: 

![Screen Shot 2022-10-27 at 3 14 43 PM](https://user-images.githubusercontent.com/1681963/198378651-bc88b9f3-da6e-4c04-870d-1324d73490c2.png)
