### PR TITLE
FIX: Ignore unique conflicts when backfilling sidebar defaults

### DIFF
--- a/app/services/sidebar_site_settings_backfiller.rb
+++ b/app/services/sidebar_site_settings_backfiller.rb
@@ -48,7 +48,7 @@ class SidebarSiteSettingsBackfiller
           end
         end
 
-        SidebarSectionLink.insert_all!(rows) if rows.present?
+        SidebarSectionLink.insert_all(rows) if rows.present?
       end
     end
   end

--- a/spec/services/sidebar_site_settings_backfiller_spec.rb
+++ b/spec/services/sidebar_site_settings_backfiller_spec.rb
@@ -80,6 +80,36 @@ RSpec.describe SidebarSiteSettingsBackfiller do
         )
       end
 
+      it 'creates the right sidebar section link records when categories are added' do
+        backfiller = described_class.new(
+          "default_sidebar_categories",
+          previous_value: "",
+          new_value: "#{category.id}|#{category2.id}|#{category3.id}"
+        )
+
+        expect do
+          backfiller.backfill!
+        end.to change { SidebarSectionLink.count }.by(6)
+
+        expect(SidebarSectionLink.where(linkable_type: 'Category', linkable_id: category.id).pluck(:user_id)).to contain_exactly(
+          user.id,
+          user2.id,
+          user3.id
+        )
+
+        expect(SidebarSectionLink.where(linkable_type: 'Category', linkable_id: category2.id).pluck(:user_id)).to contain_exactly(
+          user.id,
+          user2.id,
+          user3.id
+        )
+
+        expect(SidebarSectionLink.where(linkable_type: 'Category', linkable_id: category3.id).pluck(:user_id)).to contain_exactly(
+          user.id,
+          user2.id,
+          user3.id
+        )
+      end
+
       it 'deletes and creates the right sidebar section link records when categories are added and removed' do
         backfiller = described_class.new(
           "default_sidebar_categories",


### PR DESCRIPTION
`insert_all!` raises an error when the insertion violates any unique
constraints which is not what we want here.

Follow-up to 1b56a55f5087091a8573849a42c78f63992e1142