### PR TITLE
DEV: Delete old `buffered-render` attributes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/count-i18n.js
+++ b/app/assets/javascripts/discourse/app/components/count-i18n.js
@@ -4,7 +4,6 @@ import { htmlSafe } from "@ember/template";
 
 export default Component.extend({
   tagName: "span",
-  rerenderTriggers: ["count", "suffix"],
   i18nCount: null,
 
   didReceiveAttrs() {

--- a/app/assets/javascripts/discourse/app/components/navigation-item.js
+++ b/app/assets/javascripts/discourse/app/components/navigation-item.js
@@ -13,7 +13,6 @@ export default Component.extend(FilterModeMixin, {
   ],
   attributeBindings: ["content.title:title"],
   hidden: false,
-  rerenderTriggers: ["content.count"],
   activeClass: "",
   hrefLink: null,
 

--- a/app/assets/javascripts/discourse/app/components/popup-input-tip.js
+++ b/app/assets/javascripts/discourse/app/components/popup-input-tip.js
@@ -8,7 +8,6 @@ export default Component.extend({
   tagName: "a",
   classNameBindings: [":popup-tip", "good", "bad", "lastShownAt::hide"],
   attributeBindings: ["role", "ariaLabel", "tabindex"],
-  rerenderTriggers: ["validation.reason"],
   tipReason: null,
   lastShownAt: or("shownAt", "validation.lastShownAt"),
   bad: reads("validation.failed"),

--- a/app/assets/javascripts/discourse/app/components/topic-post-badges.js
+++ b/app/assets/javascripts/discourse/app/components/topic-post-badges.js
@@ -5,7 +5,6 @@ import { or } from "@ember/object/computed";
 export default Component.extend({
   tagName: "span",
   classNameBindings: [":topic-post-badges"],
-  rerenderTriggers: ["url", "unread", "newPosts", "unreadPosts", "unseen"],
   newDotText: null,
 
   init() {


### PR DESCRIPTION
That mixin was removed in 1a31a403cefda7ead706076cc0a0decdb38a80c8 (January 2020)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
