### PR TITLE
FIX: Evaluate all callbacks rather than override them

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-menu-test.js
@@ -75,4 +75,17 @@ module("Integration | Component | Widget | post-menu", function (hooks) {
 
     assert.ok(!exists(".actions .reply"), "it removes reply button");
   });
+
+  test("removes button when any callback evaluates to true", async function (assert) {
+    this.set("args", {});
+
+    withPluginApi("0.14.0", (api) => {
+      api.removePostMenuButton("reply", () => true);
+      api.removePostMenuButton("reply", () => false);
+    });
+
+    await render(hbs`<MountWidget @widget="post-menu" @args={{this.args}} />`);
+
+    assert.ok(!exists(".actions .reply"), "it removes reply button");
+  });
 });


### PR DESCRIPTION
When we have multiple plugins triggering

```
api.removePostMenuButton("like", () => x);
```

the last plugin that makes the call gets to decide if the post menu button is removed or not. This change makes it such that we will evaluate all callbacks rather than just rely on the last one.

Essentially, we ended up with duplicate like buttons when the discourse-upvotes plugin evaluates after discourse-reactions.

<img width="354" alt="Screenshot 2022-10-28 at 7 33 19 PM" src="https://user-images.githubusercontent.com/1555215/198577684-add9e90d-7523-4595-8680-216add1cfe84.png">


Related: https://meta.discourse.org/t/thumbs-up-twice/240867/
