### PR TITLE
FIX: Don't notify topic author about small action posts

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -146,8 +146,8 @@ class PostAlerter
     # replies
     reply_to_user = post.reply_notification_target
 
-    if new_record
-      if reply_to_user && !notified.include?(reply_to_user) && notify_about_reply?(post)
+    if new_record && notify_about_reply?(post)
+      if reply_to_user && !notified.include?(reply_to_user)
         notified += notify_non_pm_users(reply_to_user, :replied, post)
       end
 

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1343,6 +1343,21 @@ RSpec.describe PostAlerter do
         read: false
       )).to eq(true)
     end
+
+    it "it doesn't notify about small action posts when the topic author is watching the topic " do
+      Jobs.run_immediately!
+
+      u1 = Fabricate(:admin)
+      u2 = Fabricate(:admin)
+
+      topic = create_topic(user: u1)
+
+      u1.notifications.destroy_all
+
+      expect do
+        topic.update_status("closed", true, u2, message: "hello world")
+      end.not_to change { u1.reload.notifications.count }
+    end
   end
 
   context "with category" do


### PR DESCRIPTION
https://github.com/discourse/discourse/pull/18684 introduced a small unintended side-effect where a topic author gets reply notifications about "small action" posts if the topic author is watching the topic and the small post contains some content. These small action posts aren't supposed to create any notifications for anyone, so this PR fixes that side-effect of the linked PR.