### PR TITLE
FIX: Follow up fixes for password-reset error page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1895,7 +1895,7 @@ class UsersController < ApplicationController
       @user = User.find(user_id) if user_id > 0
     end
 
-    @error = I18n.t('password_reset.no_token') if !@user
+    @error = I18n.t('password_reset.no_token', base_url: Discourse.base_url) if !@user
   end
 
   def respond_to_suspicious_request

--- a/app/views/users/password_reset.html.erb
+++ b/app/views/users/password_reset.html.erb
@@ -1,7 +1,7 @@
 <div id="simple-container">
   <%if @error%>
     <div class='alert alert-error'>
-      <%= @error %>
+      <%= @error.html_safe %>
     </div>
   <%end%>
   <% if @user.present? and @user.errors.present? %>

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe UsersController do
         SiteSetting.login_required = true
         get "/u/password-reset/#{token}"
         expect(response.status).to eq(200)
-        expect(CGI.unescapeHTML(response.body)).to include(I18n.t('password_reset.no_token'))
+        expect(CGI.unescapeHTML(response.body)).to include(I18n.t('password_reset.no_token', base_url: Discourse.base_url))
       end
     end
 
@@ -189,7 +189,7 @@ RSpec.describe UsersController do
         expect(response.status).to eq(200)
 
         expect(CGI.unescapeHTML(response.body))
-          .to include(I18n.t('password_reset.no_token'))
+          .to include(I18n.t('password_reset.no_token', base_url: Discourse.base_url))
 
         expect(response.body).to_not have_tag(:script, with: {
           src: '/assets/application.js'
@@ -202,7 +202,7 @@ RSpec.describe UsersController do
         get "/u/password-reset/#{token}.json"
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["message"]).to eq(I18n.t('password_reset.no_token'))
+        expect(response.parsed_body["message"]).to eq(I18n.t('password_reset.no_token', base_url: Discourse.base_url))
         expect(session[:current_user_id]).to be_blank
       end
     end
@@ -214,7 +214,7 @@ RSpec.describe UsersController do
         expect(response.status).to eq(200)
 
         expect(CGI.unescapeHTML(response.body))
-          .to include(I18n.t('password_reset.no_token'))
+          .to include(I18n.t('password_reset.no_token', base_url: Discourse.base_url))
 
         expect(response.body).to_not have_tag(:script, with: {
           src: '/assets/application.js'
@@ -227,7 +227,7 @@ RSpec.describe UsersController do
         put "/u/password-reset/evil_trout!.json", params: { password: "awesomeSecretPassword" }
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["message"]).to eq(I18n.t('password_reset.no_token'))
+        expect(response.parsed_body["message"]).to eq(I18n.t('password_reset.no_token', base_url: Discourse.base_url))
         expect(session[:current_user_id]).to be_blank
       end
     end


### PR DESCRIPTION
Pass in `base_url` to the template
Use `.html_safe` since the message now contains html

Follow up to: 9b1536fb833f00a1625fe198964e90a32bb5bc71
