### PR TITLE
DEV: Mark `bootbox` as deprecated

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/jquery-plugins.js
+++ b/app/assets/javascripts/discourse/app/initializers/jquery-plugins.js
@@ -19,7 +19,7 @@ export default {
           deprecated(
             "`bootbox.alert` is deprecated, please use the dialog service instead.",
             {
-              dropFrom: "3.0.0.beta1",
+              dropFrom: "3.1.0.beta5",
             }
           );
           return dialog.alert(arguments[0]);
@@ -34,7 +34,7 @@ export default {
       deprecated(
         "`bootbox` is now deprecated, please use the dialog service instead.",
         {
-          dropFrom: "3.0.0.beta1",
+          dropFrom: "3.1.0.beta5",
         }
       );
       return originalDialog(...arguments);

--- a/app/assets/javascripts/discourse/app/initializers/jquery-plugins.js
+++ b/app/assets/javascripts/discourse/app/initializers/jquery-plugins.js
@@ -1,5 +1,7 @@
 import autocomplete from "discourse/lib/autocomplete";
 import bootbox from "bootbox";
+import { getOwner } from "discourse-common/lib/get-owner";
+import deprecated from "discourse-common/lib/deprecated";
 
 export default {
   name: "jquery-plugins",
@@ -7,6 +9,36 @@ export default {
     // Settings for bootbox
     bootbox.animate(false);
     bootbox.backdrop(true);
+
+    // Monkey-patching simple alerts
+    const originalAlert = bootbox.alert;
+    bootbox.alert = function () {
+      if (arguments.length === 1) {
+        const dialog = getOwner(this).lookup("service:dialog");
+        if (dialog) {
+          deprecated(
+            "`bootbox.alert` is deprecated, please use the dialog service instead.",
+            {
+              dropFrom: "3.0.0.beta1",
+            }
+          );
+          return dialog.alert(arguments[0]);
+        }
+      }
+      return originalAlert(...arguments);
+    };
+
+    // adding deprecation notice for all other dialogs
+    const originalDialog = bootbox.dialog;
+    bootbox.dialog = function () {
+      deprecated(
+        "`bootbox` is now deprecated, please use the dialog service instead.",
+        {
+          dropFrom: "3.0.0.beta1",
+        }
+      );
+      return originalDialog(...arguments);
+    };
 
     // Initialize the autocomplete tool
     $.fn.autocomplete = autocomplete;


### PR DESCRIPTION
This does two things: it marks the bootbox library as deprecated and it replaces single-argument calls to `bootbox.alert` with the dialog service. 