### PR TITLE
FIX: Support unicode in search filter @username

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -646,7 +646,7 @@ class Search
     end
   end
 
-  advanced_filter(/^\@([a-zA-Z0-9_\-.]+)$/i) do |posts, match|
+  advanced_filter(/^\@(\S+)$/i) do |posts, match|
     username = match.downcase
 
     user_id = User.where(staged: false).where(username_lower: username).pluck_first(:id)

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -647,9 +647,9 @@ class Search
   end
 
   advanced_filter(/^\@(\S+)$/i) do |posts, match|
-    username = match.downcase
+    username = User.normalize_username(match)
 
-    user_id = User.where(staged: false).where(username_lower: username).pluck_first(:id)
+    user_id = User.not_staged.where(username_lower: username).pluck_first(:id)
 
     if !user_id && username == "me"
       user_id = @guardian.user&.id

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1597,6 +1597,12 @@ RSpec.describe Search do
       expect(Search.execute("user:#{post_1.user_id}").posts).to contain_exactly(post_1)
 
       expect(Search.execute("@#{post_1.user.username}").posts).to contain_exactly(post_1)
+
+      SiteSetting.unicode_usernames = true
+      unicode_user = Fabricate(:unicode_user)
+      post_3 = Fabricate(:post, user: unicode_user, raw: 'post by a unicode user', topic: topic)
+
+      expect(Search.execute("@#{post_3.user.username}").posts).to contain_exactly(post_3)
     end
 
     context "when searching for posts made by users of a group" do


### PR DESCRIPTION
Fix the bug mentioned in https://meta.discourse.org/t/no-search-result-if-filtered-by-unicode-username/243349