### PR TITLE
UX: Ensure image size is maintained even after loading error

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -196,6 +196,7 @@ $quote-share-maxwidth: 150px;
   img:not(.thumbnail):not(.ytp-thumbnail-image):not(.emoji) {
     max-width: 100%;
     height: auto;
+    display: inline-block; // Ensure dimensions are maintained even after load error
 
     @supports not (aspect-ratio: 1) {
       // (see javascripts/discourse/app/initializers/image-aspect-ratio.js)


### PR DESCRIPTION
In Firefox and Chrome, an image failing to load causes the `img` to shrink to the intrinsic size of its alt text. This causes unwanted layout shift. Applying `display: inline-block` ensures that the aspect-ratio is always maintained.