### PR TITLE
UX: Hide welcome topic from admins as well if not edited

### DIFF
--- a/lib/topic_query_params.rb
+++ b/lib/topic_query_params.rb
@@ -30,7 +30,6 @@ module TopicQueryParams
 
   def hide_welcome_topic?
     return false if !SiteSetting.bootstrap_mode_enabled
-    return false if @guardian.is_admin?
     Site.welcome_topic_exists_and_is_not_edited?
   end
 end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1003,14 +1003,14 @@ RSpec.describe ListController do
       expect(parsed["topic_list"]["topics"].first["id"]).to eq(welcome_topic.id)
     end
 
-    it "is shown to admins" do
+    it "is hidden to admins" do
       sign_in(admin)
 
       get "/latest.json"
       expect(response.status).to eq(200)
       parsed = response.parsed_body
-      expect(parsed["topic_list"]["topics"].length).to eq(2)
-      expect(parsed["topic_list"]["topics"].first["id"]).to eq(welcome_topic.id)
+      expect(parsed["topic_list"]["topics"].length).to eq(1)
+      expect(parsed["topic_list"]["topics"].first["id"]).not_to eq(welcome_topic.id)
     end
 
     it "is shown to users when bootstrap mode is disabled" do


### PR DESCRIPTION
Depends on: #18806

We have a banner that prompts to edit the welcome topic, so let's not
show it in the topic list until it has been edited. Previously this
banner covered the welcome topic, now the banner will be above the topic
list, so we need to hide the welcome topic.
