### PR TITLE
DEV: Avoid cloning site settings in QUnit tests

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -127,11 +127,10 @@ export function withFrozenTime(timeString, timezone, callback) {
 
 let _pretenderCallbacks = {};
 
-export function resetSite(siteSettings, extras = {}) {
+export function resetSite(extras = {}) {
   const siteAttrs = {
     ...siteFixtures["site.json"].site,
     ...extras,
-    siteSettings,
   };
 
   PreloadStore.store("site", cloneJSON(siteAttrs));
@@ -311,9 +310,10 @@ export function acceptance(name, optionsOrCallback) {
       if (settingChanges) {
         mergeSettings(settingChanges);
       }
+
       this.siteSettings = currentSettings();
 
-      resetSite(currentSettings(), siteChanges);
+      resetSite(siteChanges);
 
       this.container = getOwner(this);
 

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -313,7 +313,7 @@ export default function setupTests(config) {
     });
 
     PreloadStore.reset();
-    resetSite(settings);
+    resetSite();
 
     sinon.stub(ScrollingDOMMethods, "screenNotFull");
     sinon.stub(ScrollingDOMMethods, "bindOnScroll");


### PR DESCRIPTION
`siteSettings` is now a service which means there should only be one
state for `siteSettings` during the life time of the application. This
also helps to maintain parity with production where the `site` model
relies on the `siteSettings` service and not a clone of the attributes.