### PR TITLE
FIX: Bug with permanent delete modal

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -564,8 +564,8 @@ export default Controller.extend(bufferedProperty("model"), {
       return this.get("model.details").removeAllowedGroup(group);
     },
 
-    deleteTopic() {
-      this.deleteTopic();
+    deleteTopic(opts = {}) {
+      this.deleteTopic(opts);
     },
 
     // Archive a PM (as opposed to archiving a topic)
@@ -1522,7 +1522,11 @@ export default Controller.extend(bufferedProperty("model"), {
     this.model.recover();
   },
 
-  deleteTopic(opts) {
+  deleteTopic(opts = {}) {
+    if (opts.force_destroy) {
+      return this.model.destroy(this.currentUser, opts);
+    }
+
     if (
       this.model.views > this.siteSettings.min_topic_views_for_delete_confirm
     ) {

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -83,12 +83,10 @@ module("Unit | Controller | topic", function (hooks) {
     const opts = { force_destroy: true };
     const model = Topic.create();
     const siteSettings = this.owner.lookup("service:site-settings");
-
     siteSettings.min_topic_views_for_delete_confirm = 5;
 
     const controller = this.owner.lookup("controller:topic");
     controller.setProperties({ model });
-
     model.set("views", 100);
 
     const stub = sinon.stub(model, "destroy");

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -78,6 +78,29 @@ module("Unit | Controller | topic", function (hooks) {
     assert.ok(destroyed, "destroy not popular topic");
   });
 
+  test("deleteTopic permanentDelete", function (assert) {
+    const model = Topic.create();
+    let destroyed = false;
+    model.destroy = async () => (destroyed = true);
+
+    const siteSettings = this.owner.lookup("service:site-settings");
+    siteSettings.min_topic_views_for_delete_confirm = 5;
+
+    const controller = this.owner.lookup("controller:topic");
+    controller.setProperties({
+      model,
+    });
+
+    model.set("views", 100);
+    controller.send("deleteTopic", { force_destroy: true });
+
+    assert.ok(
+      destroyed,
+      "do not show delete confirm when permanently deleting topic"
+      // permanent delete happens after first delete, no need to show modal again
+    );
+  });
+
   test("toggleMultiSelect", async function (assert) {
     const model = this.store.createRecord("topic");
     const controller = getOwner(this).lookup("controller:topic");

--- a/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/topic-test.js
@@ -81,7 +81,7 @@ module("Unit | Controller | topic", function (hooks) {
 
   test("deleteTopic permanentDelete", function (assert) {
     const opts = { force_destroy: true };
-    const model = Topic.create();
+    const model = this.store.createRecord("topic");
     const siteSettings = this.owner.lookup("service:site-settings");
     siteSettings.min_topic_views_for_delete_confirm = 5;
 


### PR DESCRIPTION
Repro steps:
- enable permanent deletes (via hidden site setting)
- set `min_topic_views_for_delete_confirm` to 0

When permanently deleting, the delete confirm modal is shown (for a second time) and it doesn't pass the `force_destroy` parameter to the request and the action results in a 422 error (i.e. can't perma-delete).

This change skips showing the confirm modal when perma-deleting given that it has already been show on the first delete action.
