### PR TITLE
FIX: Write to group logs when a user is added to group by invite

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -209,6 +209,7 @@ class InviteRedeemer
       group = Group.find_by(id: id)
       if guardian.can_edit_group?(group)
         invited_user.group_users.create!(group_id: group.id)
+        GroupActionLogger.new(invite.invited_by, group).log_add_user_to_group(invited_user)
         DiscourseEvent.trigger(:user_added_to_group, invited_user, group, automatic: false)
       end
     end


### PR DESCRIPTION
Invites can be configured to add the invited user(s) to specific groups as soon as they accept the invite and create their account. However, currently when users are added to groups via invites, they're added silently and without any trace in the group logs. This PR makes sure that group logs are created when users are added to a group via invites.