### PR TITLE
FIX: fix circle indicator on "my posts", color

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
@@ -79,7 +79,7 @@ export default class MyPostsSectionLink extends BaseSectionLink {
   }
 
   get suffixValue() {
-    if (this.hideCount) {
+    if (this._hasDraft && this.hideCount) {
       return "circle";
     }
   }

--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -45,6 +45,7 @@
     .sidebar-section-link-suffix {
       margin-left: 0.25rem;
       font-size: var(--font-down-4);
+      color: var(--tertiary-medium);
     }
 
     .sidebar-section-link-content-text {


### PR DESCRIPTION
Left off a check for drafts. Also need to add the color here for when chat is disabled. Follow-up to 2531828