### PR TITLE
UX: Increase padding of back button in chat draft screen

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-draft-channel-screen.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-draft-channel-screen.hbs
@@ -2,7 +2,7 @@
   {{#if this.site.mobileView}}
     <header class="chat-draft-header">
       <FlatButton
-        @class="chat-draft-header__btn"
+        @class="chat-draft-header__btn btn"
         @icon="chevron-left"
         @title="chat.draft_channel_screen.cancel"
         @action={{action "onCancelChatDraft"}}


### PR DESCRIPTION
This PR increases the size of the <kbd>←</kbd> button's padding in the chat draft screen to imitate the same padding as the back button present in the live chat pane. This increased padding should make it the hit target area larger and easier to press on mobile devices.