### PR TITLE
UX: Add back button in chat browse screen on mobile

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-browse-view.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-browse-view.js
@@ -87,6 +87,11 @@ export default class ChatBrowseView extends Component {
     showModal("create-channel");
   }
 
+  @action
+  returnToChannelsList() {
+    return this.router.transitionTo("chat.index");
+  }
+
   @bind
   filterChannels(filter) {
     this.canLoadMore = true;

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-browse-view.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-browse-view.hbs
@@ -6,6 +6,14 @@
 
 <div class="chat-browse-view">
   <div class="chat-browse-view__header">
+    {{#if this.site.mobileView}}
+      <DButton
+        @action={{action "returnToChannelsList"}}
+        @icon="chevron-left"
+        @class="chat-browse-view__back"
+        @title="chat.browse.back"
+      />
+    {{/if}}
     <h1 class="chat-browse-view__title">{{i18n "chat.browse.title"}}</h1>
     {{#if this.currentUser.staff}}
       <DButton

--- a/plugins/chat/assets/stylesheets/common/chat-browse.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-browse.scss
@@ -10,13 +10,14 @@
 
   &__header {
     display: flex;
-    justify-content: space-between;
+    gap: 1rem;
     align-items: center;
     margin: 1rem 0 1rem 1rem;
   }
 
   &__title {
     box-sizing: border-box;
+    margin-bottom: 0;
   }
 
   &__content_wrapper {
@@ -26,6 +27,10 @@
     @include breakpoint(tablet) {
       margin-top: 1rem;
     }
+  }
+
+  .new-channel-btn {
+    margin-left: auto;
   }
 
   &__cards {

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -176,6 +176,7 @@ en:
         open: "Open"
 
       browse:
+        back: "Back"
         title: Channels
         filter_all: All
         filter_open: Opened

--- a/plugins/chat/test/javascripts/acceptance/mobile-chat-test.js
+++ b/plugins/chat/test/javascripts/acceptance/mobile-chat-test.js
@@ -23,6 +23,11 @@ acceptance("Discourse Chat - Mobile test", function (needs) {
     server.get("/u/search/users", () => {
       return helper.response([]);
     });
+
+    server.get("/chat/api/chat_channels.json", () => {
+      const channels = [];
+      return helper.response(channels);
+    });
   });
 
   needs.settings({
@@ -52,6 +57,16 @@ acceptance("Discourse Chat - Mobile test", function (needs) {
       currentURL(),
       "/chat",
       "Clicking the left arrow button returns to the channels list"
+    );
+  });
+
+  test("Chat browse screen back button", async function (assert) {
+    await visit("/chat/browse");
+    await click(".chat-browse-view__back");
+    assert.strictEqual(
+      currentURL(),
+      "/chat",
+      "Clicking the back button returns to the channels list"
     );
   });
 });


### PR DESCRIPTION
This PR adds a <kbd>←</kbd> (back) button to the chat browse screen on mobile to easily return to the channels list.
|Light|Dark|
|---|---|
|<img width="319" alt="Screenshot 2022-11-02 at 2 33 55 PM" src="https://user-images.githubusercontent.com/30090424/199606959-ef026b00-63bc-43fd-9463-32dd3d88cfc6.png">|<img width="319" alt="Screenshot 2022-11-02 at 2 34 05 PM" src="https://user-images.githubusercontent.com/30090424/199606960-19cb980b-ee12-47b1-9b89-f78bfcfc84bd.png">|
