### PR TITLE
FIX: minor alignment fix for mobile small-actions

### DIFF
--- a/app/assets/stylesheets/mobile/topic-post.scss
+++ b/app/assets/stylesheets/mobile/topic-post.scss
@@ -342,6 +342,18 @@ span.highlighted {
   /* must render on top of topic-body + topic-meta-data, otherwise not tappable */
 }
 
+.small-action .topic-avatar {
+  display: flex;
+  align-self: stretch;
+  align-items: flex-start;
+  margin-right: 0;
+  float: unset;
+  height: auto;
+  .d-icon {
+    font-size: 1.8em;
+  }
+}
+
 .topic-meta-data {
   margin-left: 50px;
   font-size: var(--font-down-1);


### PR DESCRIPTION
Follow-up to d0f88da

Before:
<img width="150" alt="Screen Shot 2022-11-02 at 8 34 28 PM" src="https://user-images.githubusercontent.com/1681963/199627215-953518e4-6c36-4c31-84ae-f2c5e2111d52.png">


After:
![Screen Shot 2022-11-02 at 8 28 56 PM](https://user-images.githubusercontent.com/1681963/199627178-5a6c10e4-f158-4a97-853c-2e3bca481c36.png)
