### PR TITLE
UX: scope chat-channel-title hover effect

### DIFF
--- a/plugins/chat/assets/stylesheets/desktop/chat-channel-title.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-channel-title.scss
@@ -1,8 +1,12 @@
-.chat-channel-title {
-  max-width: 96%;
+.channels-list .direct-message-channels {
+  .chat-channel-title {
+    max-width: 100%;
+    box-sizing: border-box;
+  }
 
-  .direct-message-channels .chat-channel-row:hover & {
-    overflow: hidden;
-    max-width: unset;
+  .chat-channel-row:hover {
+    .chat-channel-title {
+      overflow: hidden;
+    }
   }
 }


### PR DESCRIPTION
Making sure the styling-with-hover-effect-for-x of a direct chat-channel-title only applies in channels-list:

- in drawer mode
<img width="402" alt="image" src="https://user-images.githubusercontent.com/101828855/199671555-04cbb102-0dc8-4afe-9664-3ded2262a787.png">

- in full page chat
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/101828855/199671689-aba3eb4a-a282-4e05-8111-0048ceb5db50.png">

but not for example in the title of the chat pane
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/101828855/199671798-1ee93d45-214e-4c8a-a1f9-9710d586fc57.png">



