### PR TITLE
Ux sidebar muted icon

### DIFF
--- a/plugins/chat/assets/stylesheets/sidebar-extensions.scss
+++ b/plugins/chat/assets/stylesheets/sidebar-extensions.scss
@@ -165,13 +165,13 @@
   .sidebar-section-link--muted {
     opacity: 0.5;
 
-    .sidebar-section-link-prefix.icon {
-      color: var(--primary-medium) !important;
+    .sidebar-section-link-prefix.icon .d-icon {
+      color: var(--primary-medium);
     }
 
     &.active {
-      .sidebar-section-link-prefix.icon {
-        color: var(--primary-high) !important;
+      .sidebar-section-link-prefix.icon .d-icon {
+        color: var(--primary-high);
       }
     }
   }

--- a/plugins/chat/assets/stylesheets/sidebar-extensions.scss
+++ b/plugins/chat/assets/stylesheets/sidebar-extensions.scss
@@ -163,6 +163,10 @@
   }
 
   .sidebar-section-link--muted {
-    opacity: 0.3;
+    opacity: 0.5;
+
+    .sidebar-section-link-prefix.icon {
+      color: var(--primary-medium) !important;
+    }
   }
 }

--- a/plugins/chat/assets/stylesheets/sidebar-extensions.scss
+++ b/plugins/chat/assets/stylesheets/sidebar-extensions.scss
@@ -165,12 +165,14 @@
   .sidebar-section-link--muted {
     opacity: 0.5;
 
-    &.active {
-      opacity: 0.7;
-    }
-
     .sidebar-section-link-prefix.icon {
       color: var(--primary-medium) !important;
+    }
+
+    &.active {
+      .sidebar-section-link-prefix.icon {
+        color: var(--primary-high) !important;
+      }
     }
   }
 }

--- a/plugins/chat/assets/stylesheets/sidebar-extensions.scss
+++ b/plugins/chat/assets/stylesheets/sidebar-extensions.scss
@@ -165,6 +165,10 @@
   .sidebar-section-link--muted {
     opacity: 0.5;
 
+    &.active {
+      opacity: 0.7;
+    }
+
     .sidebar-section-link-prefix.icon {
       color: var(--primary-medium) !important;
     }


### PR DESCRIPTION
The contrast on a muted channel was getting a little low:

<img width="246" alt="image" src="https://user-images.githubusercontent.com/101828855/199688196-9ee26623-35fe-4c13-9899-7644b5723266.png">

So upped it a little bit:
<img width="463" alt="image" src="https://user-images.githubusercontent.com/101828855/199690249-021abede-8130-413a-98ea-2980357a20d5.png">


And slightly higher when the channel is active:
<img width="468" alt="image" src="https://user-images.githubusercontent.com/101828855/199690134-e387fdd2-4fe8-4a8a-b13f-4e4e39105b29.png">

And greyed out the icon when muted too.