### PR TITLE
Reduce theme/color-scheme cookie cookie duration

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/handle-cookies.js
+++ b/app/assets/javascripts/discourse/app/initializers/handle-cookies.js
@@ -1,6 +1,9 @@
 import { extendThemeCookie } from "discourse/lib/theme-selector";
 import { extendColorSchemeCookies } from "discourse/lib/color-scheme-picker";
 import { later } from "@ember/runloop";
+import { isTesting } from "discourse-common/config/environment";
+
+const DELAY = isTesting() ? 0 : 5000;
 
 export default {
   name: "handle-cookies",
@@ -10,6 +13,6 @@ export default {
     later(() => {
       extendThemeCookie();
       extendColorSchemeCookies();
-    }, 5000);
+    }, DELAY);
   },
 };

--- a/app/assets/javascripts/discourse/app/initializers/handle-cookies.js
+++ b/app/assets/javascripts/discourse/app/initializers/handle-cookies.js
@@ -1,0 +1,15 @@
+import { extendThemeCookie } from "discourse/lib/theme-selector";
+import { extendColorSchemeCookies } from "discourse/lib/color-scheme-picker";
+import { later } from "@ember/runloop";
+
+export default {
+  name: "handle-cookies",
+
+  initialize() {
+    // No need to block boot for this housekeeping - we can defer it a few seconds
+    later(() => {
+      extendThemeCookie();
+      extendColorSchemeCookies();
+    }, 5000);
+  },
+};

--- a/app/assets/javascripts/discourse/app/lib/color-scheme-picker.js
+++ b/app/assets/javascripts/discourse/app/lib/color-scheme-picker.js
@@ -89,14 +89,35 @@ export function loadColorSchemeStylesheet(
   );
 }
 
+const COLOR_SCHEME_COOKIE_NAME = "color_scheme_id";
+const DARK_SCHEME_COOKIE_NAME = "dark_scheme_id";
+const COOKIE_EXPIRY_DAYS = 365;
+
 export function updateColorSchemeCookie(id, options = {}) {
-  const cookieName = options.dark ? "dark_scheme_id" : "color_scheme_id";
+  const cookieName = options.dark
+    ? DARK_SCHEME_COOKIE_NAME
+    : COLOR_SCHEME_COOKIE_NAME;
   if (id) {
     cookie(cookieName, id, {
       path: "/",
-      expires: 9999,
+      expires: COOKIE_EXPIRY_DAYS,
     });
   } else {
-    removeCookie(cookieName, { path: "/", expires: 1 });
+    removeCookie(cookieName, { path: "/" });
+  }
+}
+
+export function extendColorSchemeCookies() {
+  for (const cookieName of [
+    COLOR_SCHEME_COOKIE_NAME,
+    DARK_SCHEME_COOKIE_NAME,
+  ]) {
+    const currentValue = cookie(cookieName);
+    if (currentValue) {
+      cookie(cookieName, currentValue, {
+        path: "/",
+        expires: COOKIE_EXPIRY_DAYS,
+      });
+    }
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/theme-selector.js
+++ b/app/assets/javascripts/discourse/app/lib/theme-selector.js
@@ -3,6 +3,8 @@ import I18n from "I18n";
 import deprecated from "discourse-common/lib/deprecated";
 
 const keySelector = "meta[name=discourse_theme_id]";
+const COOKIE_NAME = "theme_ids";
+const COOKIE_EXPIRY_DAYS = 365;
 
 export function currentThemeKey() {
   // eslint-disable-next-line no-console
@@ -35,12 +37,22 @@ export function currentThemeId() {
 export function setLocalTheme(ids, themeSeq) {
   ids = ids.reject((id) => !id);
   if (ids && ids.length > 0) {
-    cookie("theme_ids", `${ids.join(",")}|${themeSeq}`, {
+    cookie(COOKIE_NAME, `${ids.join(",")}|${themeSeq}`, {
       path: "/",
-      expires: 9999,
+      expires: COOKIE_EXPIRY_DAYS,
     });
   } else {
-    removeCookie("theme_ids", { path: "/", expires: 1 });
+    removeCookie(COOKIE_NAME, { path: "/" });
+  }
+}
+
+export function extendThemeCookie() {
+  const currentValue = cookie(COOKIE_NAME);
+  if (currentValue) {
+    cookie(COOKIE_NAME, currentValue, {
+      path: "/",
+      expires: COOKIE_EXPIRY_DAYS,
+    });
   }
 }
 


### PR DESCRIPTION
Previously these were set to expire after 9999 days (27 years). This commit updates them to last 1 year, and to automatically be extended on every user visit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
