### PR TITLE
DEV: Remove bootbox from root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@highlightjs/cdn-assets": "^11.6.0",
     "@json-editor/json-editor": "^2.6.1",
     "ace-builds": "1.4.13",
-    "bootbox": "3.2.0",
     "chart.js": "3.5.1",
     "chartjs-plugin-datalabels": "^2.0.0",
     "diffhtml": "^1.0.0-beta.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,11 +616,6 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bootbox@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/bootbox/-/bootbox-3.2.0.tgz#00bf643fc9edefd9ae1e7c648c6b022db4be0aee"
-  integrity sha1-AL9kP8nt79muHnxkjGsCLbS+Cu4=
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2222,7 +2217,7 @@ squoosh@discourse/squoosh#dc9649d:
   version "2.0.0"
   resolved "https://codeload.github.com/discourse/squoosh/tar.gz/dc9649d0a4d396d1251c22291b17d99f1716da44"
   dependencies:
-    wasm-feature-detect "^1.2.9"
+    wasm-feature-detect "^1.2.11"
 
 stream-shift@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2217,7 +2217,7 @@ squoosh@discourse/squoosh#dc9649d:
   version "2.0.0"
   resolved "https://codeload.github.com/discourse/squoosh/tar.gz/dc9649d0a4d396d1251c22291b17d99f1716da44"
   dependencies:
-    wasm-feature-detect "^1.2.11"
+    wasm-feature-detect "^1.2.9"
 
 stream-shift@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
We have a vendored version of bootbox which has heavily diverged from the original. We do not fetch it from node_modules, and `javascript.rake` does not reference it. Therefore there is no benefit to having it in `package.json`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
