### PR TITLE
PERF: Correct should_skip? logic in `s3:upload`

### DIFF
--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -13,6 +13,7 @@ end
 def should_skip?(path)
   return false if ENV['FORCE_S3_UPLOADS']
   @existing_assets ||= Set.new(helper.list("assets/").map(&:key))
+  path = File.join(helper.s3_bucket_folder_path, path) if helper.s3_bucket_folder_path
   @existing_assets.include?(path)
 end
 


### PR DESCRIPTION
This task is supposed to skip uploading if the asset is already present in S3. However, when a bucket 'folder path' was configured, this logic was broken and so the assets would be re-uploaded every time.

This commit fixes that logic to include the bucket 'folder path' in the check

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
