### PR TITLE
FEATURE: new site setting to hide user profiles by default.

### DIFF
--- a/app/assets/javascripts/admin/addon/mixins/setting-component.js
+++ b/app/assets/javascripts/admin/addon/mixins/setting-component.js
@@ -136,6 +136,7 @@ export default Mixin.create({
       "default_email_mailing_list_mode_frequency",
       "default_email_previous_replies",
       "default_email_in_reply_to",
+      "default_hide_profile_and_presence",
       "default_other_new_topic_duration_minutes",
       "default_other_auto_track_topics_after_msecs",
       "default_other_notification_level_when_replying",

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -187,7 +187,8 @@ class Admin::SiteSettingsController < Admin::AdminController
       default_email_digest_frequency: "digest_after_minutes",
       default_include_tl0_in_digests: "include_tl0_in_digests",
       default_text_size: "text_size_key",
-      default_title_count_mode: "title_count_mode_key"
+      default_title_count_mode: "title_count_mode_key",
+      default_hide_profile_and_presence: "hide_profile_and_presence"
     }
   end
 

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -87,6 +87,8 @@ class UserOption < ActiveRecord::Base
 
     self.title_count_mode = SiteSetting.default_title_count_mode
 
+    self.hide_profile_and_presence = SiteSetting.default_hide_profile_and_presence
+
     true
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2279,6 +2279,8 @@ en:
 
     default_email_in_reply_to: "Include excerpt of replied to post in emails by default."
 
+    default_hide_profile_and_presence: "Hide user public profile and presence features by default."
+
     default_other_new_topic_duration_minutes: "Global default condition for which a topic is considered new."
     default_other_auto_track_topics_after_msecs: "Global default time before a topic is automatically tracked."
     default_other_notification_level_when_replying: "Global default notification level when the user replies to a topic."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2523,6 +2523,8 @@ user_preferences:
     default: 2
   default_email_in_reply_to:
     default: false
+  default_hide_profile_and_presence:
+    default: false
 
   default_other_new_topic_duration_minutes:
     enum: "NewTopicDurationSiteSetting"

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -160,7 +160,8 @@ def insert_user_options
                   auto_track_topics_after_msecs,
                   notification_level_when_replying,
                   like_notification_frequency,
-                  skip_new_user_tips
+                  skip_new_user_tips,
+                  hide_profile_and_presence
                 )
              SELECT u.id
                   , #{SiteSetting.default_email_mailing_list_mode}
@@ -181,6 +182,7 @@ def insert_user_options
                   , #{SiteSetting.default_other_notification_level_when_replying}
                   , #{SiteSetting.default_other_like_notification_frequency}
                   , #{SiteSetting.default_other_skip_new_user_tips}
+                  , #{SiteSetting.default_hide_profile_and_presence}
                FROM users u
           LEFT JOIN user_options uo ON uo.user_id = u.id
               WHERE uo.user_id IS NULL

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1833,6 +1833,7 @@ RSpec.describe User do
       SiteSetting.default_other_dynamic_favicon = true
       SiteSetting.default_other_skip_new_user_tips = true
 
+      SiteSetting.default_hide_profile_and_presence = true
       SiteSetting.default_topics_automatic_unpin = false
 
       SiteSetting.default_categories_watching = category0.id.to_s
@@ -1853,6 +1854,7 @@ RSpec.describe User do
       expect(options.enable_quoting).to eq(false)
       expect(options.dynamic_favicon).to eq(true)
       expect(options.skip_new_user_tips).to eq(true)
+      expect(options.hide_profile_and_presence).to eq(true)
       expect(options.automatically_unpin_topics).to eq(false)
       expect(options.new_topic_duration_minutes).to eq(-1)
       expect(options.auto_track_topics_after_msecs).to eq(0)


### PR DESCRIPTION
Previously, we didn't have a site-wide setting to set the default behavior for user profile visibility and user presence features. But we already have a user preference for that.
