### PR TITLE
FIX: prevents chat to enter in endless loop when getting 404

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -243,6 +243,12 @@ export default Component.extend({
             return;
           }
           this.setMessageProps(messages, fetchingFromLastRead);
+
+          if (this.targetMessageId) {
+            this.highlightOrFetchMessage(this.targetMessageId);
+          }
+
+          this.focusComposer();
         })
         .catch(this._handleErrors)
         .finally(() => {
@@ -252,12 +258,6 @@ export default Component.extend({
 
           this.chat.set("messageId", null);
           this.set("loading", false);
-
-          if (this.targetMessageId) {
-            this.highlightOrFetchMessage(this.targetMessageId);
-          }
-
-          this.focusComposer();
         });
     });
   },

--- a/plugins/chat/test/javascripts/acceptance/chat-live-pane-test.js
+++ b/plugins/chat/test/javascripts/acceptance/chat-live-pane-test.js
@@ -252,10 +252,21 @@ acceptance(
       server.get("/chat/chat_channels/:chatChannelId", () =>
         helper.response({ id: 1, title: "something" })
       );
+
+      server.get("/chat/lookup/:messageId.json", () => {
+        return helper.response(404);
+      });
     });
 
     test("Handles 404 errors by displaying an alert", async function (assert) {
       await visit("/chat/channel/1/cat");
+
+      assert.ok(exists(".dialog-content"), "it displays a 404 error");
+      await click(".dialog-footer .btn-primary");
+    });
+
+    test("Handles 404 errors with unexisting messageId", async function (assert) {
+      await visit("/chat/channel/1/cat?messageId=2");
 
       assert.ok(exists(".dialog-content"), "it displays a 404 error");
       await click(".dialog-footer .btn-primary");


### PR DESCRIPTION
Doing DOM operations in finally would cause them to happen even when the request was a failure. Consequence of these DOM operations would be new request, which would also end up in a 404, and so on.

This commit simply moves the DOM operations in the then block where it should be safe to make.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
