### PR TITLE
UX: less link-like unread/new color in sidebar

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -25,6 +25,10 @@
       color: var(--primary);
       background: var(--d-sidebar-highlight-color);
 
+      .sidebar-section-link-content-badge {
+        color: var(--primary-high);
+      }
+
       .sidebar-section-link-prefix {
         &.icon {
           color: var(--primary-high);
@@ -36,7 +40,7 @@
       @include ellipsis;
       padding-left: 0.5em;
       text-align: right;
-      color: var(--tertiary);
+      color: var(--primary-medium);
       font-size: var(--font-down-1);
       font-weight: normal;
       margin-left: auto;


### PR DESCRIPTION
Some of the feedback on Meta has indicated that people expect the blue unread/new link to be separate from the category/tag link... adjusting the color to see if it has any impact. 


![Screen Shot 2022-11-03 at 2 44 09 PM](https://user-images.githubusercontent.com/1681963/199807874-feb7f1e2-6f90-456f-9f5f-4a01fd38c352.png)
