### PR TITLE
FEATURE: log to STDOUT using Rails 5 env var

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,4 +70,8 @@ Discourse::Application.configure do
   end
 
   config.active_record.dump_schema_after_migration = false
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
 end


### PR DESCRIPTION
Rails introduced a environment variables `RAILS_LOG_TO_STDOUT` in the
template for new projects here: https://github.com/rails/rails/pull/23734

This commit adds the same code to the discourse production environment,
making it easy to configure logging to stdout in production for
environments which already support log collection via stdout.


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->