### PR TITLE
FIX: Ensure moderators_manage_categories_and_groups is respected

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -111,7 +111,7 @@ class Admin::GroupsController < Admin::StaffController
     raise Discourse::NotFound unless group
 
     users = User.where(username: group_params[:usernames].split(","))
-    users.each { |user| guardian.ensure_can_change_primary_group!(user) }
+    users.each { |user| guardian.ensure_can_change_primary_group!(user, group) }
     users.update_all(primary_group_id: params[:primary] == "true" ? group.id : nil)
 
     render json: success_json

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -241,11 +241,11 @@ class Admin::UsersController < Admin::StaffController
   end
 
   def primary_group
-    guardian.ensure_can_change_primary_group!(@user)
-
     if params[:primary_group_id].present?
       primary_group_id = params[:primary_group_id].to_i
       if group = Group.find(primary_group_id)
+        guardian.ensure_can_change_primary_group!(@user, group)
+
         if group.user_ids.include?(@user.id)
           @user.primary_group_id = primary_group_id
         end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -359,8 +359,8 @@ class Guardian
     flair_icon.present? || flair_upload_id.present?
   end
 
-  def can_change_primary_group?(user)
-    user && is_staff?
+  def can_change_primary_group?(user, group)
+    user && can_edit_group?(group)
   end
 
   def can_change_trust_level?(user)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -2728,6 +2728,40 @@ RSpec.describe Guardian do
     end
   end
 
+  describe "#can_change_primary_group?" do
+    it "returns false without a logged in user" do
+      expect(Guardian.new(nil).can_change_primary_group?(user, group)).to eq(false)
+    end
+
+    it "returns false for regular users" do
+      expect(Guardian.new(user).can_change_primary_group?(user, group)).to eq(false)
+    end
+
+    it "returns true for admins" do
+      expect(Guardian.new(admin).can_change_primary_group?(user, group)).to eq(true)
+    end
+
+    context "when moderators_manage_categories_and_groups site setting is enabled" do
+      before do
+        SiteSetting.moderators_manage_categories_and_groups = true
+      end
+
+      it "returns true for moderators" do
+        expect(Guardian.new(moderator).can_change_primary_group?(user, group)).to eq(true)
+      end
+    end
+
+    context "when moderators_manage_categories_and_groups site setting is disabled" do
+      before do
+        SiteSetting.moderators_manage_categories_and_groups = false
+      end
+
+      it "returns false for moderators" do
+        expect(Guardian.new(moderator).can_change_primary_group?(user, group)).to eq(false)
+      end
+    end
+  end
+
   describe 'can_change_trust_level?' do
 
     it 'is false without a logged in user' do

--- a/spec/requests/admin/groups_controller_spec.rb
+++ b/spec/requests/admin/groups_controller_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe Admin::GroupsController do
           SiteSetting.moderators_manage_categories_and_groups = false
         end
 
-        it "sets multiple primary users" do
+        it "prevents setting of primary group with a 403 response" do
           user2.update!(primary_group_id: group.id)
 
           put "/admin/groups/#{group.id}/primary.json", params: {
@@ -480,8 +480,9 @@ RSpec.describe Admin::GroupsController do
             primary: "true"
           }
 
-          expect(response.status).to eq(200)
-          expect(User.where(primary_group_id: group.id).size).to eq(3)
+          expect(response.status).to eq(403)
+          expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+          expect(User.where(primary_group_id: group.id).size).to eq(1)
         end
       end
     end


### PR DESCRIPTION
Currently, moderators are able to set primary group for users irrespective of the of the `moderators_manage_categories_and_groups` site setting value.

This change updates Guardian implementation to honour it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
