### PR TITLE
DEV: Use action helper in `bulk-tag` modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/bulk-tag.hbs
+++ b/app/assets/javascripts/discourse/app/templates/bulk-tag.hbs
@@ -2,4 +2,4 @@
 
 <p><TagChooser @tags={{this.tags}} @categoryId={{this.categoryId}} /></p>
 
-<DButton @action={{this.action}} @disabled={{this.emptyTags}} @label={{concat "topics.bulk." this.label}} />
+<DButton @action={{action this.action}} @disabled={{this.emptyTags}} @label={{concat "topics.bulk." this.label}} />


### PR DESCRIPTION
Passing a string action name to `DButton` causes it to use `sendAction`, which is deprecated and will be removed in Ember 4.x. The action helper converts a string to a closure action.

This also fixes compatibility with https://github.com/discourse/discourse/pull/17767

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
