### PR TITLE
UX: adjustments for exp user nav messages section

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-nav/messages-groups-dropdown.js
+++ b/app/assets/javascripts/discourse/app/components/user-nav/messages-groups-dropdown.js
@@ -25,27 +25,26 @@ export default ComboBoxComponent.extend({
     ];
 
     this.user.groupsWithMessages.forEach((group) => {
-      groups.push({ name: group.name, icon: "inbox" });
+      groups.push({
+        name: group.name,
+        icon: "inbox",
+        url: `/u/${this.user.username}/messages/group/${group.name}`,
+      });
     });
 
     if (this.pmTaggingEnabled) {
-      groups.push({ name: I18n.t("user.messages.tags") });
+      groups.push({
+        name: I18n.t("user.messages.tags"),
+        url: `/u/${this.user.username}/messages/tags`,
+      });
     }
 
     return groups;
   }),
 
   actions: {
-    onChange(item) {
-      let url;
-
-      if (this.user.groups.some((g) => g.name === item)) {
-        url = `/u/${this.user.username}/messages/group/${item}`;
-      } else if (item === I18n.t("user.messages.tags")) {
-        url = `/u/${this.user.username}/messages/tags`;
-      } else {
-        url = `/u/${this.user.username}/messages`;
-      }
+    onChange(name, object) {
+      let url = object.url ? object.url : `/u/${this.user.username}/messages`;
 
       DiscourseURL.routeToUrl(url);
     },

--- a/app/assets/javascripts/discourse/app/components/user-nav/messages-nav.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-nav/messages-nav.hbs
@@ -82,14 +82,14 @@
     {{/each}}
 
     {{#if this.displayTags}}
-      <li class="tags">
-        <LinkTo @route="userPrivateMessages.tags" @model={{@user}}>
-          {{d-icon "tag"}}
-          <span>{{i18n "user.messages.all_tags"}}</span>
-        </LinkTo>
-      </li>
-
       {{#if @tagId}}
+        <li class="tags">
+          <LinkTo @route="userPrivateMessages.tags" @model={{@user}}>
+            {{d-icon "tag"}}
+            <span>{{i18n "user.messages.all_tags"}}</span>
+          </LinkTo>
+        </li>
+
         <li class="archive">
           <LinkTo @route="userPrivateMessages.tagsShow" @model={{@tagId}}>
             {{@tagId}}
@@ -98,7 +98,6 @@
       {{/if}}
     {{/if}}
 
-    <PluginOutlet @name="user-messages-nav" @connectorTagName="li" @args={{hash model=@user}} />
   </HorizontalOverflowNav>
 
   {{#if this.site.desktopView}}

--- a/app/assets/javascripts/discourse/app/components/user-nav/messages-nav.js
+++ b/app/assets/javascripts/discourse/app/components/user-nav/messages-nav.js
@@ -12,6 +12,8 @@ export default class UserNavMessagesNav extends Component {
       default:
         if (this.args.groupFilter) {
           return this.args.groupFilter;
+        } else if (this.args.customFilter) {
+          return this.args.customFilter;
         } else {
           return "inbox";
         }

--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -18,6 +18,7 @@ export default Controller.extend({
   isPersonal: equal("pmView", "user"),
   group: null,
   groupFilter: alias("group.name"),
+  customFilter: null,
   currentRouteName: readOnly("router.currentRouteName"),
   pmTaggingEnabled: alias("site.can_tag_pms"),
   tagId: null,

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -7,6 +7,7 @@
     @viewingSelf={{this.viewingSelf}}
     @isGroup={{this.isGroup}}
     @groupFilter={{this.groupFilter}}
+    @customFilter={{this.customFilter}}
     @newLinkText={{this.newLinkText}}
     @unreadLinkText={{this.unreadLinkText}}
     @archiveLinkText={{this.archiveLinkText}}


### PR DESCRIPTION
I've made an attempt at making this user messages dropdown nav extendable from the Discourse Assign plugin. Adding `customFilter` to get the correct dropdown name in here feels like the most questionable part to me... 

The intention is to accomplish this: 

![Screen Shot 2022-11-04 at 11 37 32 AM](https://user-images.githubusercontent.com/1681963/200056238-2c787de7-480e-4b65-b313-cdc03672379a.png)

End result w/ plugin changes: 

![Screen Shot 2022-11-04 at 3 03 54 PM](https://user-images.githubusercontent.com/1681963/200056390-8e524a75-547f-4a2f-8f97-1aeb9716d568.png)

Plugin changes: https://github.com/discourse/discourse-assign/pull/392
