### PR TITLE
DEV: Fix greyed text for dark mode emails

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -60,7 +60,7 @@ module EmailHelper
         p,
         span,
         td {
-          color: #dddddd !important;
+          color: inherit !important;
         }
 
         [data-stripped-secure-media] {


### PR DESCRIPTION
Maintain original dark mode styles for updated browsers / mail clients

### Gmail / apple mail / etc
<img width="599" alt="Screenshot 2022-11-04 at 3 07 09 PM" src="https://user-images.githubusercontent.com/50783505/200065283-41114952-c23c-4611-ac6a-ba4f7e9e36ff.png">

while being more lenient towards browsers / mail clients which don't have the logic to handle dark mode styles or `prefers-color-scheme: dark`

### Outlook
<img width="593" alt="Screenshot 2022-11-04 at 3 09 58 PM" src="https://user-images.githubusercontent.com/50783505/200065622-7e34d947-4fab-4c19-b404-8ef3b5ec20c4.png">

