### PR TITLE
DEV: Allow additional TopicList preloaded associations

### DIFF
--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -38,10 +38,6 @@ class TopicList
     user_ids
   end
 
-  def self.topic_preloader_associations
-    @topic_preloader_associations ||= [:image_upload, { topic_thumbnails: :optimized_image }]
-  end
-
   attr_accessor(
     :more_topics_url,
     :prev_topics_url,

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -140,8 +140,11 @@ class TopicList
       ft.topic_list = self
     end
 
+    topic_preloader_associations = [:image_upload, { topic_thumbnails: :optimized_image }]
+    topic_preloader_associations.concat(DiscoursePluginRegistry.topic_preloader_associations.to_a)
+
     ActiveRecord::Associations::Preloader
-      .new(records: @topics, associations: self.class.topic_preloader_associations)
+      .new(records: @topics, associations: topic_preloader_associations)
       .call
 
     if preloaded_custom_fields.present?

--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -38,6 +38,10 @@ class TopicList
     user_ids
   end
 
+  def self.topic_preloader_associations
+    @topic_preloader_associations ||= [:image_upload, { topic_thumbnails: :optimized_image }]
+  end
+
   attr_accessor(
     :more_topics_url,
     :prev_topics_url,
@@ -137,7 +141,7 @@ class TopicList
     end
 
     ActiveRecord::Associations::Preloader
-      .new(records: @topics, associations: [:image_upload, topic_thumbnails: :optimized_image])
+      .new(records: @topics, associations: self.class.topic_preloader_associations)
       .call
 
     if preloaded_custom_fields.present?

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -80,6 +80,7 @@ class DiscoursePluginRegistry
   define_filtered_register :group_params
 
   define_filtered_register :topic_thumbnail_sizes
+  define_filtered_register :topic_preloader_associations
 
   define_filtered_register :api_parameter_routes
   define_filtered_register :api_key_scope_mappings

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1167,6 +1167,10 @@ class Plugin::Instance
     end
   end
 
+  def register_topic_preloader_associations(fields)
+    DiscoursePluginRegistry.register_topic_preloader_association(fields, self)
+  end
+
   private
 
   def validate_directory_column_name(column_name)

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -921,7 +921,7 @@ RSpec.describe TopicQuery do
 
     context 'when preloading associations' do
       it "preloads associations" do
-        TopicList.topic_preloader_associations << :first_post
+        DiscoursePluginRegistry.register_topic_preloader_association(:first_post, Plugin::Instance.new)
 
         topic = Fabricate(:topic)
         Fabricate(:post, topic: topic)
@@ -931,7 +931,7 @@ RSpec.describe TopicQuery do
         expect(new_topic.association(:first_post).loaded?).to eq(true)   # Testing a user-defined preloaded association
         expect(new_topic.association(:user).loaded?).to eq(false)        # Testing the negative
 
-        TopicList.topic_preloader_associations.clear
+        DiscoursePluginRegistry.reset_register!(:topic_preloader_associations)
       end
     end
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -919,6 +919,22 @@ RSpec.describe TopicQuery do
       end
     end
 
+    context 'when preloading associations' do
+      it "preloads associations" do
+        TopicList.topic_preloader_associations << :first_post
+
+        topic = Fabricate(:topic)
+        Fabricate(:post, topic: topic)
+
+        new_topic = topic_query.list_new.topics.first
+        expect(new_topic.association(:image_upload).loaded?).to eq(true) # Preloaded by default
+        expect(new_topic.association(:first_post).loaded?).to eq(true)   # Testing a user-defined preloaded association
+        expect(new_topic.association(:user).loaded?).to eq(false)        # Testing the negative
+
+        TopicList.topic_preloader_associations.clear
+      end
+    end
+
     context 'with a new topic' do
       let!(:new_topic) { Fabricate(:topic, user: creator, bumped_at: 10.minutes.ago) }
       let(:topics) { topic_query.list_new.topics }


### PR DESCRIPTION
This provides a means to allow additional associations to be preloaded when generating a TopicList.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
