### PR TITLE
FEATURE: Add metadata to chat channel list

### DIFF
--- a/plugins/chat/app/serializers/chat_channel_serializer.rb
+++ b/plugins/chat/app/serializers/chat_channel_serializer.rb
@@ -17,7 +17,8 @@ class ChatChannelSerializer < ApplicationSerializer
              :total_messages,
              :archive_topic_id,
              :memberships_count,
-             :current_user_membership
+             :current_user_membership,
+             :last_message
 
   def initialize(object, opts)
     super(object, opts)
@@ -91,6 +92,10 @@ class ChatChannelSerializer < ApplicationSerializer
       scope: scope,
       root: false,
     ).as_json
+  end
+
+  def last_message
+    ChatMessage.where('chat_channel_id': object.id).last
   end
 
   alias_method :include_archive_topic_id?, :include_archive_status?

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-metadata.js
@@ -1,0 +1,8 @@
+import Component from "@ember/component";
+
+export default class ChatChannelMetadata extends Component {
+  tagName = "div";
+  classNames = ["chat-channel-metadata"];
+  channel = null;
+  unreadIndicator = false;
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.js
@@ -59,20 +59,10 @@ export default Component.extend({
     if (channel.current_user_membership.muted) {
       classes.push("muted");
     }
+    if (this.options.leaveButton) {
+      classes.push("can-leave");
+    }
     return classes.join(" ");
-  },
-
-  @discourseComputed(
-    "isDirectMessageRow",
-    "channel.chatable.users.[]",
-    "channel.chatable.users.@each.status"
-  )
-  showUserStatus(isDirectMessageRow) {
-    return !!(
-      isDirectMessageRow &&
-      this.channel.chatable.users.length === 1 &&
-      this.channel.chatable.users[0].status
-    );
   },
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-title.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-title.js
@@ -20,4 +20,12 @@ export default class ChatChannelTitle extends Component {
   get channelColorStyle() {
     return htmlSafe(`color: #${this.channel.chatable.color}`);
   }
+
+  @computed("channel.chatable.users.[]", "channel.chatable.users.@each.status")
+  get showUserStatus() {
+    return !!(
+      this.channel.chatable.users.length === 1 &&
+      this.channel.chatable.users[0].status
+    );
+  }
 }

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-metadata.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-metadata.hbs
@@ -1,0 +1,3 @@
+<span class="chat-channel-metadata__date">
+  {{format-date this.channel.last_message_sent_at format="tiny"}}
+</span>

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-metadata.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-metadata.hbs
@@ -1,3 +1,9 @@
-<span class="chat-channel-metadata__date">
+<div class="chat-channel-metadata__date">
   {{format-date this.channel.last_message_sent_at format="tiny"}}
-</span>
+</div>
+
+{{#if this.unreadIndicator}}
+  <div class="chat-channel-metadata__unread-count">
+    <ChatChannelUnreadIndicator @channel={{this.channel}} />
+  </div>
+{{/if}}

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -8,12 +8,7 @@
   tabindex="0"
   data-chat-channel-id={{this.channel.id}}
 >
-  <ChatChannelTitle @channel={{this.channel}} @unreadIndicator={{true}} />
-
-  {{#if this.showUserStatus}}
-    <UserStatusMessage @status={{this.channel.chatable.users.firstObject.status}} />
-  {{/if}}
-
+  <ChatChannelTitle @channel={{this.channel}} />
   <ChatChannelMetadata @channel={{this.channel}} @unreadIndicator={{true}} />
 
   {{#if (and this.options.leaveButton this.channel.isFollowing (not this.site.mobileView))}}

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -14,6 +14,8 @@
     <UserStatusMessage @status={{this.channel.chatable.users.firstObject.status}} />
   {{/if}}
 
+  <ChatChannelMetadata @channel={{this.channel}} @unreadIndicator={{true}} />
+
   {{#if (and this.options.leaveButton this.channel.isFollowing (not this.site.mobileView))}}
     <ToggleChannelMembershipButton
       @channel={{this.channel}}

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -34,7 +34,12 @@
           {{/if}}
         </div>
         <div class="chat-channel-title__last-message">
-          <span>YOU: </span>This is an example last message todo.
+          {{#if (eq this.channel.last_message.user_id this.currentUser.id)}}
+            <span class="chat-channel-title__last-message-prefix">
+              {{i18n "chat.direct_messages.you_last_messaged"}}
+            </span>
+          {{/if}}
+          {{this.channel.last_message.message}}
         </div>
       </div>
 

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -8,20 +8,35 @@
 {{else}}
   {{#if this.channel.isDirectMessageChannel}}
     <div class="chat-channel-title is-dm">
-      {{#if this.multiDm}}
-        <span class="chat-channel-title__users-count">
-          {{this.channel.chatable.users.length}}
-        </span>
-        <span class="chat-channel-title__name">{{this.usernames}}</span>
-      {{else}}
-        <ChatUserAvatar @user={{this.channel.chatable.users.firstObject}} />
-        <span class="chat-channel-title__usernames">
-          {{#let this.channel.chatable.users.firstObject as |user|}}
-            <span class="chat-channel-title__name">{{user.username}}</span>
-            <PluginOutlet @name="after-chat-channel-username" @args={{hash user=user}} @tagName="" @connectorTagName="" />
-          {{/let}}
-        </span>
-      {{/if}}
+
+      <div class="chat-channel-title__avatar">
+        {{#if this.multiDm}}
+          <span class="chat-channel-title__users-count">
+            {{this.channel.chatable.users.length}}
+          </span>
+        {{else}}
+          <ChatUserAvatar @user={{this.channel.chatable.users.firstObject}} />
+        {{/if}}
+      </div>
+
+      <div class="chat-channel-title__user-info">
+        <div class="chat-channel-title__usernames">
+          {{#if this.multiDm}}
+            <span class="chat-channel-title__name">{{this.usernames}}</span>
+          {{else}}
+            {{#let this.channel.chatable.users.firstObject as |user|}}
+              <span class="chat-channel-title__name">{{user.username}}</span>
+              {{#if this.showUserStatus}}
+                <UserStatusMessage @status={{this.channel.chatable.users.firstObject.status}} @showDescription={{if this.site.mobileView "true"}} />
+              {{/if}}
+              <PluginOutlet @name="after-chat-channel-username" @args={{hash user=user}} @tagName="" @connectorTagName="" />
+            {{/let}}
+          {{/if}}
+        </div>
+        <div class="chat-channel-title__last-message">
+          <span>YOU: </span>This is an example last message todo.
+        </div>
+      </div>
 
       {{#if (has-block)}}
         {{yield}}
@@ -46,9 +61,5 @@
         {{yield}}
       {{/if}}
     </div>
-  {{/if}}
-
-  {{#if this.unreadIndicator}}
-    <ChatChannelUnreadIndicator @channel={{this.channel}} />
   {{/if}}
 {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-unread-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-channel-unread-indicator.hbs
@@ -1,3 +1,7 @@
 {{#if this.hasUnread}}
-  <span class="chat-channel-unread-indicator {{if this.isUrgent "urgent"}}"></span>
+  <div class="chat-channel-unread-indicator {{if this.isUrgent "urgent"}}">
+    <div class="number-wrap">
+      <div class="number">{{this.unreadCount}}</div>
+    </div>
+  </div>
 {{/if}}

--- a/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
@@ -1,6 +1,7 @@
 .chat-channel-title {
   display: flex;
   align-items: center;
+  @include ellipsis;
 
   .category-chat-private .d-icon {
     background-color: var(--secondary);
@@ -12,6 +13,14 @@
     width: 0.5em;
     left: calc(0.6125em + 3px);
     top: -4px;
+  }
+
+  &__avatar {
+    margin-right: 1rem;
+  }
+
+  .user-status-message {
+    display: none; // we only show when in channels list
   }
 
   .chat-name,
@@ -29,6 +38,10 @@
       vertical-align: text-bottom;
       width: 1.2em;
     }
+  }
+
+  &__last-message {
+    display: none; // we only show when in channels list
   }
 
   .d-icon-lock {

--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -44,11 +44,11 @@ body.composer-open .topic-chat-float-container {
     }
 
     .chat-channel-unread-indicator {
+      padding: 5px;
       left: 3px;
       min-width: 8px;
       width: 8px;
       height: 8px;
-      border-radius: 7px;
       top: calc(50% - 5px);
     }
 

--- a/plugins/chat/assets/stylesheets/common/common.scss
+++ b/plugins/chat/assets/stylesheets/common/common.scss
@@ -79,7 +79,9 @@ $float-height: 530px;
   border: 2px solid var(--secondary);
   -webkit-touch-callout: none;
   background: var(--tertiary-med-or-tertiary);
+  color: var(--secondary);
   font-size: var(--font-down-2);
+  text-align: center;
 
   &.urgent {
     background: var(--success);
@@ -136,17 +138,7 @@ $float-height: 530px;
   }
 
   .chat-channel-unread-indicator {
-    flex-shrink: 0;
-    width: 10px;
-    height: 10px;
-    border-radius: 10px;
-    border: 0;
-    right: 7px;
-    top: calc(50% - 5px);
-
-    &.urgent .number-wrap {
-      display: none;
-    }
+    font-size: var(--font-down-1);
   }
 
   .edit-channel-membership-btn,
@@ -408,18 +400,58 @@ $float-height: 530px;
   }
 }
 
+.public-channels .chat-channel-row {
+  .chat-channel-metadata {
+    flex-direction: row-reverse;
+    gap: 0.25rem;
+  }
+}
+
 .chat-channel-row {
   align-items: center;
   box-sizing: border-box;
   display: flex;
+  justify-content: space-between;
   position: relative;
   cursor: pointer;
   color: var(--primary-high);
   transition: opacity 50ms ease-in;
   opacity: 1;
 
-  .chat-channel-unread-indicator {
-    margin-left: 0.5rem;
+  .chat-channel-title {
+    &__user-info {
+      @include ellipsis;
+    }
+
+    &__last-message {
+      display: block;
+      font-size: var(--font-down-1);
+      @include ellipsis;
+    }
+
+    &__usernames {
+      display: block;
+    }
+
+    .user-status-message {
+      display: inline-block;
+      color: var(--primary-medium);
+      font-size: var(--font-down-2);
+    }
+  }
+
+  .chat-channel-metadata {
+    margin-right: 1rem;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+
+    .chat-channel-unread-indicator {
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
 
   &.unfollowing {
@@ -427,17 +459,22 @@ $float-height: 530px;
   }
 
   .toggle-channel-membership-button.-leave {
-    visibility: hidden;
+    display: none;
     margin-left: auto;
+    margin-right: 1rem;
   }
 
-  &:hover {
+  &.can-leave:hover {
     .toggle-channel-membership-button.-leave {
-      visibility: visible;
+      display: block;
 
       > * {
         pointer-events: auto;
       }
+    }
+
+    .chat-channel-metadata {
+      display: none;
     }
   }
 

--- a/plugins/chat/assets/stylesheets/common/common.scss
+++ b/plugins/chat/assets/stylesheets/common/common.scss
@@ -427,6 +427,11 @@ $float-height: 530px;
       display: block;
       font-size: var(--font-down-1);
       @include ellipsis;
+
+      &-prefix {
+        font-weight: bold;
+        color: var(--primary-very-high);
+      }
     }
 
     &__usernames {

--- a/plugins/chat/assets/stylesheets/mobile/mobile.scss
+++ b/plugins/chat/assets/stylesheets/mobile/mobile.scss
@@ -70,10 +70,8 @@ body.has-full-page-chat {
   }
 
   .chat-channel-unread-indicator {
-    width: 6px;
-    height: 6px;
-    left: 5px;
-    top: calc(50% - 3px);
+    padding: 5px;
+    font-size: var(--font-0);
   }
 }
 

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -307,7 +307,8 @@ en:
         create: "Go"
         leave: "Leave this personal chat"
         cannot_create: "Sorry, you cannot send direct messages."
-
+        you_last_messaged: "You:"
+        
       incoming_webhooks:
         back: "Back"
         channel_placeholder: "Select a channel"


### PR DESCRIPTION
⚠️ This PR is still a WIP.

**To Do:**
- [ ] Ensure last message is updated without page refresh (currently last message is only updated on page refresh)
- [ ] Add relevant tests
- [ ] Minor UX/UI tweaks
- [ ] Test for issues

This PR adds some meta data to the channel list. In particular:
- unread indicator now includes a count of the number of unread messages
- a timestamp indicating the date the last message was sent is now present
- an excerpt of the last message sent in the chat (for DM's)

Type|Light|Dark|
|---|---|---|
|Mobile| <img width="318" alt="mobile-light" src="https://user-images.githubusercontent.com/30090424/200085647-ccc7f8d6-8f72-41d9-a2a9-38ecfdb5eaf9.png">|<img width="316" alt="mobile-dark" src="https://user-images.githubusercontent.com/30090424/200085645-5b62f7cd-4daa-4ad1-96cd-0d6879e81fbf.png">|
|Drawer|<img width="408" alt="drawer-light" src="https://user-images.githubusercontent.com/30090424/200085649-89cd2b9f-bec6-480a-98ce-a9cce95e93c0.png">|<img width="405" alt="drawer-dark" src="https://user-images.githubusercontent.com/30090424/200085648-ad5d97e4-587f-4d9e-8b63-fc11fae19849.png">|
|Full Page Chat|<img width="276" alt="fullpage-light" src="https://user-images.githubusercontent.com/30090424/200085652-cb9492df-25d4-40ac-951f-f3f0bfa3f21d.png">|<img width="278" alt="fullpage-dark" src="https://user-images.githubusercontent.com/30090424/200085650-825ff3e7-d2a4-4b39-9b51-e27d322abb15.png">|

