### PR TITLE
Add a test for create_post in import scripts

### DIFF
--- a/spec/script/import_scripts/base_spec.rb
+++ b/spec/script/import_scripts/base_spec.rb
@@ -60,4 +60,34 @@ RSpec.describe ImportScripts::Base do
     MockSpecImporter.new(import_data).perform
     expect(SiteSetting.purge_unactivated_users_grace_period_days).to eq(0)
   end
+
+  describe "#create_post" do
+    let(:importer) { described_class.new }
+    fab!(:user) { Fabricate(:user) }
+    let(:post_params) {
+      {
+        user_id: user.id,
+        raw: "Test post [b]content[/b]",
+        title: "Test topic for post"
+      }
+    }
+
+    it "creates a Post" do
+      expect {
+        importer.create_post(post_params, 123)
+      }.to change { Post.count }.by(1)
+    end
+
+    if ENV["IMPORT"] == "1"
+      it "uses the ruby-bbcode-to-md gem (conditional Gemfile option)" do
+        expect(String.method_defined?(:bbcode_to_md)).to be true
+      end
+
+      it "converts bbcode to markdown when specified" do
+        importer.instance_variable_set(:@bbcode_to_md, true)
+        importer.create_post(post_params, 123)
+        expect(Post.first.raw).to eq "Test post **content**"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add some testing of the `create_post` method in ImportScripts::Base

Basic test of Post creation and (if enabled) the bbcode_to_md call.
