### PR TITLE
FIX: simplfies previous route handling

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -20,7 +20,6 @@ import discourseLater from "discourse-common/lib/later";
 import { inject as service } from "@ember/service";
 import { Promise } from "rsvp";
 import { resetIdle } from "discourse/lib/desktop-notifications";
-import { defaultHomepage } from "discourse/lib/utilities";
 import { capitalize } from "@ember/string";
 import {
   onPresenceChange,
@@ -1266,14 +1265,15 @@ export default Component.extend({
   @action
   onCloseFullScreen(channel) {
     this.fullPageChat.isPreferred = false;
-    this.appEvents.trigger("chat:open-channel", channel);
 
-    const previousRouteInfo = this.fullPageChat.exit();
-    if (previousRouteInfo) {
-      this._transitionToRoute(previousRouteInfo);
-    } else {
-      this.router.transitionTo(`discovery.${defaultHomepage()}`);
+    let previousURL = this.fullPageChat.exit();
+    if (!previousURL || previousURL === "/") {
+      previousURL = `discovery`;
     }
+
+    this.router.replaceWith(previousURL).then(() => {
+      this.appEvents.trigger("chat:open-channel", channel);
+    });
   },
 
   @action
@@ -1430,18 +1430,6 @@ export default Component.extend({
         this.set("hasNewMessages", true);
       }
     });
-  },
-
-  _transitionToRoute(routeInfo) {
-    const routeName = routeInfo.name;
-    let params = [];
-
-    do {
-      params = Object.values(routeInfo.params).concat(params);
-      routeInfo = routeInfo.parent;
-    } while (routeInfo);
-
-    this.router.transitionTo(routeName, ...params);
   },
 
   @bind

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -14,12 +14,12 @@ export default class ChatRoute extends DiscourseRoute {
     return I18n.t("chat.title_capitalized");
   }
 
-  beforeModel(transition) {
+  beforeModel() {
     if (!this.chat.userCanChat) {
       return this.transitionTo(`discovery.${defaultHomepage()}`);
     }
 
-    this.fullPageChat.enter(transition?.from);
+    this.fullPageChat.enter(this.router.currentURL);
   }
 
   activate() {

--- a/plugins/chat/assets/javascripts/discourse/services/full-page-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/full-page-chat.js
@@ -6,17 +6,17 @@ const STORE_NAMESPACE_CHAT_WINDOW = "discourse_chat_window_";
 
 export default class FullPageChat extends Service {
   store = new KeyValueStore(STORE_NAMESPACE_CHAT_WINDOW);
-  _previousRouteInfo = null;
+  _previousURL = null;
   _isActive = false;
 
-  enter(previousRouteInfo) {
-    this._previousRouteInfo = previousRouteInfo;
+  enter(previousURL) {
+    this._previousURL = previousURL;
     this._isActive = true;
   }
 
   exit() {
     this._isActive = false;
-    return this._previousRouteInfo;
+    return this._previousURL;
   }
 
   get isActive() {


### PR DESCRIPTION
This commits makes sure we correctly wait for the end of the transition to reopen the drawer on the correct channel/view. Also fixes a bug when previous URL was `/` and causing a double transition.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
