### PR TITLE
FIX: topic tracking stage error when no tags

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -207,7 +207,7 @@ const TopicTrackingState = EmberObject.extend({
       }
     }
 
-    if (filterTag && !data.payload.tags.includes(filterTag)) {
+    if (filterTag && !data.payload.tags?.includes(filterTag)) {
       return;
     }
 

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -104,6 +104,16 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
       0,
       "pending tag new counts"
     );
+
+    // Ensure it is not throwing an error when filterTag is set and message payload is missing tags
+    trackingState.trackIncoming("tag/test/l/latest");
+    trackingState.notifyIncoming({
+      message_type: "new_topic",
+      topic_id: 4,
+      payload: { category_id: 2 },
+    });
+    const testTagCount = trackingState.countTags(["test"]);
+    assert.strictEqual(testTagCount["test"].unreadCount, 0);
   });
 
   test("tag counts - with total", function (assert) {


### PR DESCRIPTION
When topic Tag is tracked and payload doesn't contain tags, it was throwing an error.

<img width="416" alt="Screenshot 2022-11-07 at 9 09 24 am" src="https://user-images.githubusercontent.com/72780/200202553-29aab3b7-ca36-43c9-82dc-308b20d21839.png">
