### PR TITLE
FIX: Make ChatMessageUpdater check editing access for guardian

### DIFF
--- a/plugins/chat/app/controllers/chat_controller.rb
+++ b/plugins/chat/app/controllers/chat_controller.rb
@@ -144,7 +144,6 @@ class Chat::ChatController < Chat::ChatBaseController
   end
 
   def edit_message
-    guardian.ensure_can_edit_chat!(@message)
     chat_message_updater =
       Chat::ChatMessageUpdater.update(
         guardian: guardian,

--- a/plugins/chat/lib/chat_message_updater.rb
+++ b/plugins/chat/lib/chat_message_updater.rb
@@ -15,8 +15,6 @@ class Chat::ChatMessageUpdater
     @chat_message = chat_message
     @old_message_content = chat_message.message
     @chat_channel = @chat_message.chat_channel
-    @user = @chat_message.user
-    @guardian = Guardian.new(@user)
     @new_content = new_content
     @upload_ids = upload_ids
     @error = nil
@@ -25,6 +23,7 @@ class Chat::ChatMessageUpdater
   def update
     begin
       validate_channel_status!
+      @guardian.ensure_can_edit_chat!(@chat_message)
       @chat_message.message = @new_content
       @chat_message.last_editor_id = @user.id
       upload_info = get_upload_info
@@ -46,10 +45,6 @@ class Chat::ChatMessageUpdater
   end
 
   private
-
-  # TODO (martin) Since we have guardian here now we should move
-  # guardian.ensure_can_edit_chat!(@message) from the controller into
-  # this class.
 
   def validate_channel_status!
     return if @guardian.can_modify_channel_message?(@chat_channel)

--- a/plugins/chat/spec/requests/chat_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat_controller_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe Chat::ChatController do
 
       it "raises an invalid request" do
         put "/chat/#{chat_channel.id}/edit/#{chat_message.id}.json", params: { new_message: "Hi" }
-        expect(response.status).to eq(403)
+        expect(response.status).to eq(422)
       end
     end
 
@@ -540,7 +540,7 @@ RSpec.describe Chat::ChatController do
       sign_in(Fabricate(:user))
 
       put "/chat/#{chat_channel.id}/edit/#{chat_message.id}.json", params: { new_message: "edit!" }
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(422)
     end
 
     it "errors when staff tries to edit another user's message" do
@@ -551,7 +551,7 @@ RSpec.describe Chat::ChatController do
           params: {
             new_message: new_message,
           }
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(422)
     end
 
     it "allows a user to edit their own messages" do


### PR DESCRIPTION
Follow up to 766bcbc6840c9d665055441bcd77616b3a96e10e

This fixes a gaffe from that commit where I passed in the guardian to ChatMessageUpdater but then forgot to remove the old way of setting the guardian and user instance variables from the chat_message that was passed in.

Also, it moves the ensure_can_edit_message! check from the controller into ChatMessageUpdater so all the access checks are in the same place.
