### PR TITLE
DEV: Make admin-start-backup template extendable

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-start-backup.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-start-backup.js
@@ -1,8 +1,21 @@
 import Controller, { inject as controller } from "@ember/controller";
+import discourseComputed from "discourse-common/utils/decorators";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 
 export default Controller.extend(ModalFunctionality, {
   adminBackupsLogs: controller(),
+
+  @discourseComputed
+  warningMessage() {
+    // this is never shown here, but we may want to show different
+    // messages in plugins
+    return "";
+  },
+
+  @discourseComputed
+  yesLabel() {
+    return "yes_value";
+  },
 
   actions: {
     startBackupWithUploads() {

--- a/app/assets/javascripts/admin/addon/templates/modal/admin-start-backup.hbs
+++ b/app/assets/javascripts/admin/addon/templates/modal/admin-start-backup.hbs
@@ -1,5 +1,8 @@
 <DModalBody @title="admin.backups.operations.backup.confirm">
-  <DButton @class="btn-primary backup-with-uploads" @action={{action "startBackupWithUploads"}} @label="yes_value" />
+  {{#if this.warningMessage}}
+    <div class="alert alert-warning">{{html-safe this.warningMessage}}</div>
+  {{/if}}
+  <DButton @class="btn-primary backup-with-uploads" @action={{action "startBackupWithUploads"}} @label={{this.yesLabel}} />
   <DButton @class="backup-no-uploads" @action={{action "startBackupWithoutUploads"}} @label="admin.backups.operations.backup.without_uploads" />
   <DButton @class="btn-default" @action={{action "cancel"}} @label="no_value" />
 </DModalBody>

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2136,6 +2136,7 @@ backups:
   include_s3_uploads_in_backups:
     default: false
     hidden: true
+    client: true
 
 search:
   use_pg_headlines_for_excerpt:


### PR DESCRIPTION
We need to change the content of this modal in different plugins based on context, so move some parts of it into the JS file. Also makes `include_s3_uploads_in_backups`, again so plugins can access this boolean on the clientside.