### PR TITLE
PERF: Ensure JS chunk content and filenames are deterministic

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -57,6 +57,19 @@ module.exports = function (defaults) {
     autoImport: {
       forbidEval: true,
       insertScriptsAt: "ember-auto-import-scripts",
+      webpack: {
+        output: {
+          // Workaround for https://github.com/ef4/ember-auto-import/issues/519
+          // Upstreamed in https://github.com/ef4/ember-auto-import/pull/548
+          filename: `chunk.[id].[contenthash].js`,
+          chunkFilename: `chunk.[id].[contenthash].js`,
+        },
+        optimization: {
+          // Workaround to provide deterministic chunk output
+          // See https://github.com/ef4/ember-auto-import/issues/478#issuecomment-1000526638
+          moduleIds: "size",
+        },
+      },
     },
     fingerprint: {
       // Handled by Rails asset pipeline


### PR DESCRIPTION
This commit works around a couple of issues in `ember-auto-import` which were causing non-deterministic chunk filenames and content. Deterministic output should improve cache-reusability across deploys.

Refs:
https://github.com/ef4/ember-auto-import/issues/519
https://github.com/ef4/ember-auto-import/pull/548
https://github.com/ef4/ember-auto-import/issues/478

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
