### PR TITLE
PERF: Update `s3:expire_missing_assets` to delete in batches

### DIFF
--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -105,6 +105,15 @@ class S3Helper
   rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::NotFound
   end
 
+  def delete_objects(keys)
+    s3_bucket.delete_objects({
+      delete: {
+        objects: keys.map { |k| { key: k } },
+        quiet: true,
+      },
+    })
+  end
+
   def copy(source, destination, options: {})
     if options[:apply_metadata_to_destination]
       options = options.except(:apply_metadata_to_destination).merge(metadata_directive: "REPLACE")

--- a/spec/lib/s3_helper_spec.rb
+++ b/spec/lib/s3_helper_spec.rb
@@ -212,4 +212,14 @@ RSpec.describe "S3Helper" do
       expect(s3_helper.ensure_cors!([S3CorsRulesets::BACKUP_DIRECT_UPLOAD])).to eq(false)
     end
   end
+
+  describe "#delete_objects" do
+    let(:s3_helper) { S3Helper.new("test-bucket", "", client: client) }
+
+    it "works" do
+      # The S3::Client with `stub_responses: true` includes validation of requests.
+      # If the request were invalid, this spec would raise an error
+      s3_helper.delete_objects(["object/one.txt", "object/two.txt"])
+    end
+  end
 end


### PR DESCRIPTION
Some sites may have thousands of stale assets - deleting them one-by-one is very slow.

Followup to e8570b5cc92908b038bcc56ddd0af201c2bed46e

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
