### PR TITLE
PERF: Make stylesheet hashes consistent between deploys

### DIFF
--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -13,7 +13,7 @@ class Stylesheet::Manager::Builder
   def compile(opts = {})
     if !opts[:force]
       if File.exist?(stylesheet_fullpath)
-        unless StylesheetCache.where(target: qualified_target, digest: digest).exists?
+        if !StylesheetCache.where(target: qualified_target, digest: digest).exists?
           begin
             source_map = begin
               File.read(source_map_fullpath)
@@ -229,7 +229,7 @@ class Stylesheet::Manager::Builder
   end
 
   def default_digest
-    Digest::SHA1.hexdigest "default-#{Stylesheet::Manager.last_file_updated}-#{plugins_digest}-#{current_hostname}"
+    Digest::SHA1.hexdigest "default-#{Stylesheet::Manager.fs_asset_cachebuster}-#{plugins_digest}-#{current_hostname}"
   end
 
   def color_scheme_digest
@@ -248,9 +248,9 @@ class Stylesheet::Manager::Builder
     digest_string = "#{current_hostname}-"
     if cs || categories_updated > 0
       theme_color_defs = resolve_baked_field(:common, :color_definitions)
-      digest_string += "#{RailsMultisite::ConnectionManagement.current_db}-#{cs&.id}-#{cs&.version}-#{theme_color_defs}-#{Stylesheet::Manager.last_file_updated}-#{categories_updated}-#{fonts}"
+      digest_string += "#{RailsMultisite::ConnectionManagement.current_db}-#{cs&.id}-#{cs&.version}-#{theme_color_defs}-#{Stylesheet::Manager.fs_asset_cachebuster}-#{categories_updated}-#{fonts}"
     else
-      digest_string += "defaults-#{Stylesheet::Manager.last_file_updated}-#{fonts}"
+      digest_string += "defaults-#{Stylesheet::Manager.fs_asset_cachebuster}-#{fonts}"
 
       if cdn_url = GlobalSetting.cdn_url
         digest_string += "-#{cdn_url}"

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -64,6 +64,7 @@ task 'assets:precompile:css' => 'environment' do
         STDERR.puts "-------------"
         STDERR.puts "Compiling CSS for #{db} #{Time.zone.now}"
         begin
+          Stylesheet::Manager.recalculate_fs_asset_cachebuster!
           Stylesheet::Manager.precompile_css if db == "default"
           Stylesheet::Manager.precompile_theme_css
         rescue PG::UndefinedColumn, ActiveModel::MissingAttributeError, NoMethodError => e


### PR DESCRIPTION
Previously the stylesheet cachebusting hash was based on the maximum mtime of files. This works well in development and during in-container updates (e.g. via docker_manager). However, when a fresh docker image is created for each deploy, the file mtimes will change even if the contents has not.

This commit changes the production logic to calculate the cachebuster from the filenames and contents of the relevant assets. This should be consistent across deploys, thereby improving cache hits and improving page load times.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
