### PR TITLE
DEV: Upgrade "lefthook" and skip hooks during merge/rebase

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,10 +1,8 @@
-app/assets/javascripts/browser-update.js
 app/assets/javascripts/locales/i18n.js
 app/assets/javascripts/ember-addons/
-app/assets/javascripts/discourse/lib/autosize.js
 lib/javascripts/locale/
 lib/javascripts/messageformat.js
-lib/highlight_js/
+lib/javascripts/messageformat-lookup.js
 lib/pretty_text/
 plugins/**/lib/javascripts/locale
 public/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,9 @@ skip_output:
 
 pre-commit:
   parallel: true
+  skip:
+    - merge
+    - rebase
   commands:
     rubocop:
       glob: "*.rb"

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "workbox-sw": "^4.3.1"
   },
   "devDependencies": {
-    "@arkweid/lefthook": "^0.7.7",
     "@mixer/parallel-prettier": "^2.0.1",
     "chrome-launcher": "^0.15.0",
     "chrome-remote-interface": "^0.31.2",
+    "lefthook": "^1.2.0",
     "puppeteer-core": "^13.7.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,11 +10,6 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@arkweid/lefthook@^0.7.7":
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/@arkweid/lefthook/-/lefthook-0.7.7.tgz#12951b09b955d8054885ffe929aa07a49f39027c"
-  integrity sha512-Eq30OXKmjxIAIsTtbX2fcF3SNZIXS8yry1u8yty7PQFYRctx04rVlhOJCEB2UmfTh8T2vrOMC9IHHUvvo5zbaQ==
-
 "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1655,6 +1650,48 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "~0.3.2"
 
+lefthook-darwin-arm64@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.2.0.tgz#148e89174a3cc9795bea22ab472649efae0352b8"
+  integrity sha512-jOyt6HxCRPr2LYkze0vpazp2rqKHsnDz6OVFu8fwIafP92cf9lhu9aAbCSIsbnT0wrHWEYi+t9a5n8Xm05BlFw==
+
+lefthook-darwin-x64@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lefthook-darwin-x64/-/lefthook-darwin-x64-1.2.0.tgz#1cbeee6aabc05055bc0ab452f1c9032a1d2077cf"
+  integrity sha512-G9bFTPvZBanfXS+MIm0hMwUWdkmvL26SCh7d3P6P5bnXNnp+2hx+V1ulDy4iGb9My5P9ORNF3tLLGq+qvXRp0w==
+
+lefthook-linux-arm64@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lefthook-linux-arm64/-/lefthook-linux-arm64-1.2.0.tgz#f36886a04e0074d4a52f93418891b42762628fe7"
+  integrity sha512-aoBXGJtGkzkHDVIYZrSUbG/8+J8gkrtTt1y6KE5/l1uY/xH9JSh2igttYvWaKd9KNbYUjsrEnff+25uzluwOEA==
+
+lefthook-linux-x64@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lefthook-linux-x64/-/lefthook-linux-x64-1.2.0.tgz#4d35f5bcdf0a866680008f307137fdffb75aea25"
+  integrity sha512-FxdtAIQianqVNSpU0Hqj5Qb3ALKR4YjNqk9IUfGbFFnVnp7qnPgtitrh0WkcFu6T7KoCo6YEu3dZl+8y7JP9dQ==
+
+lefthook-windows-arm64@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lefthook-windows-arm64/-/lefthook-windows-arm64-1.2.0.tgz#8f4a213ee71e95f4b617811932d99f1fff5df5d2"
+  integrity sha512-ZhItQksNHvvzTitlnmWmZhnAKhoXjStSJwdGYIMMG8g7GOFZRIG3CmTrtSoWPncpZX+xRlJHd2KeEFYTcB+uzA==
+
+lefthook-windows-x64@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lefthook-windows-x64/-/lefthook-windows-x64-1.2.0.tgz#473048cdf42c761b031912196e3b840c3b263d68"
+  integrity sha512-UZQb/+o2AfcaMPzP8Y8JmWirEC5inMTzZPStAuG8pBe8Lv6IhC7EFdfDSkn2bdBvxWooBEFKf/a5EdlQ/f5/bQ==
+
+lefthook@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/lefthook/-/lefthook-1.2.0.tgz#c31e30688df10f205b223f6d612ba14ffe118885"
+  integrity sha512-FLw0YDTDJGleWDLSVVAMJtGIQ0Kh5wX4JJJHTNQtjzT0CZOAXSBjTP87loubg6S2QOuvmspvhSc62NkW6Jn82w==
+  optionalDependencies:
+    lefthook-darwin-arm64 "1.2.0"
+    lefthook-darwin-x64 "1.2.0"
+    lefthook-linux-arm64 "1.2.0"
+    lefthook-linux-x64 "1.2.0"
+    lefthook-windows-arm64 "1.2.0"
+    lefthook-windows-x64 "1.2.0"
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -2222,7 +2259,7 @@ squoosh@discourse/squoosh#dc9649d:
   version "2.0.0"
   resolved "https://codeload.github.com/discourse/squoosh/tar.gz/dc9649d0a4d396d1251c22291b17d99f1716da44"
   dependencies:
-    wasm-feature-detect "^1.2.9"
+    wasm-feature-detect "^1.2.11"
 
 stream-shift@^1.0.0:
   version "1.0.1"
@@ -2440,10 +2477,10 @@ v8-compile-cache@^2.0.3, v8-compile-cache@^2.3.0:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-wasm-feature-detect@^1.2.9:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/wasm-feature-detect/-/wasm-feature-detect-1.2.11.tgz#e21992fd1f1d41a47490e392a5893cb39d81e29e"
-  integrity sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w==
+wasm-feature-detect@^1.2.11:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/wasm-feature-detect/-/wasm-feature-detect-1.3.0.tgz#fb3fc5dd4a1ba950a429be843daad67fe048bc42"
+  integrity sha512-w9datO3OReMouWgKOelvu1CozmLK/VbkXOtlzNTanBJpR0uBHyUwS3EYdXf5vBPoHKYS0lpuYo91rpqMNIZM9g==
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The old lefthook package was deprecated a long time ago and skipping hooks during merge/rebase makes those git commands a lot faster.