### PR TITLE
FIX: retention reminder is absolute and needs relative parent

### DIFF
--- a/plugins/chat/assets/stylesheets/common/common.scss
+++ b/plugins/chat/assets/stylesheets/common/common.scss
@@ -316,6 +316,7 @@ $float-height: 530px;
   flex-direction: column;
   width: 100%;
   min-height: 1px;
+  position: relative;
 
   .chat-messages-scroll {
     flex-grow: 1;


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
