### PR TITLE
FIX: follow up to #7fca078

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -27,6 +27,7 @@ import {
 } from "discourse/lib/user-presence";
 import isZoomed from "discourse/plugins/chat/discourse/lib/zoom-check";
 import { isTesting } from "discourse-common/config/environment";
+import { defaultHomepage } from "discourse/lib/utilities";
 
 const MAX_RECENT_MSGS = 100;
 const STICKY_SCROLL_LENIENCE = 50;
@@ -1266,11 +1267,10 @@ export default Component.extend({
   @action
   onCloseFullScreen(channel) {
     this.chatPreferredMode.setDrawer();
-    this.appEvents.trigger("chat:open-channel", channel);
 
     let previousURL = this.fullPageChat.exit();
     if (!previousURL || previousURL === "/") {
-      previousURL = "discovery";
+      previousURL = this.router.urlFor(`discovery.${defaultHomepage()}`);
     }
 
     this.router.replaceWith(previousURL).then(() => {

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Navigation", type: :system, js: true do
       chat_page.open_full_page
       chat_page.minimize_full_page
 
-      expect(page).to have_current_path("/")
+      expect(page).to have_current_path(latest_path)
     end
   end
 


### PR DESCRIPTION
- prevents triggering chat:open-channel two times
- builds a correct URL for home page

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
