### PR TITLE
FIX: Log out user if IP is no longer allowed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
 
   before_action :rate_limit_crawlers
   before_action :check_readonly_mode
+  before_action :logout_if_should_block_ip
   before_action :handle_theme
   before_action :set_current_user_for_logs
   before_action :set_mp_snapshot_fields
@@ -459,6 +460,12 @@ class ApplicationController < ActionController::Base
       request.env[NO_THEMES] = safe_mode.include?(NO_THEMES) || safe_mode.include?(LEGACY_NO_THEMES)
       request.env[NO_PLUGINS] = safe_mode.include?(NO_PLUGINS)
       request.env[NO_UNOFFICIAL_PLUGINS] = safe_mode.include?(NO_UNOFFICIAL_PLUGINS) || safe_mode.include?(LEGACY_NO_UNOFFICIAL_PLUGINS)
+    end
+  end
+
+  def logout_if_should_block_ip
+    if has_auth_cookie? && ScreenedIpAddress.should_block?(request.remote_ip)
+      log_off_user
     end
   end
 

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -349,6 +349,7 @@ class Auth::DefaultCurrentUserProvider
 
     cookie_jar.delete('authentication_data')
     cookie_jar.delete(TOKEN_COOKIE)
+    @env[CURRENT_USER_KEY] = nil
   end
 
   # api has special rights return true if api was detected

--- a/lib/current_user.rb
+++ b/lib/current_user.rb
@@ -32,6 +32,10 @@ module CurrentUser
     current_user_provider.is_user_api?
   end
 
+  def has_auth_cookie?
+    current_user_provider.has_auth_cookie?
+  end
+
   def current_user
     current_user_provider.current_user
   end

--- a/spec/models/screened_ip_address_spec.rb
+++ b/spec/models/screened_ip_address_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe ScreenedIpAddress do
   let(:ip_address) { '99.232.23.124' }
   let(:valid_params) { { ip_address: ip_address } }
 
+  before do
+    ScreenedIpAddress.clear_cache
+  end
+
+  after do
+    ScreenedIpAddress.clear_cache
+  end
+
   describe 'new record' do
     it 'sets a default action_type' do
       expect(described_class.create(valid_params).action_type).to eq(described_class.actions[:block])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -117,6 +117,7 @@ module TestSetup
     UserActionManager.disable
     NotificationEmailer.disable
     SiteIconManager.disable
+    ScreenedIpAddress.clear_cache
     WordWatcher.disable_cache
 
     SiteSetting.provider.all.each do |setting|


### PR DESCRIPTION
If user logged in from an allowed IP and then their IP is no longer allowed they will be logged out.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
