### PR TITLE
FIX: makes sidebar links respect drawer mode

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -27,7 +27,6 @@ import {
 } from "discourse/lib/user-presence";
 import isZoomed from "discourse/plugins/chat/discourse/lib/zoom-check";
 import { isTesting } from "discourse-common/config/environment";
-import { defaultHomepage } from "discourse/lib/utilities";
 
 const MAX_RECENT_MSGS = 100;
 const STICKY_SCROLL_LENIENCE = 50;
@@ -1268,12 +1267,7 @@ export default Component.extend({
   onCloseFullScreen(channel) {
     this.chatPreferredMode.setDrawer();
 
-    let previousURL = this.fullPageChat.exit();
-    if (!previousURL || previousURL === "/") {
-      previousURL = this.router.urlFor(`discovery.${defaultHomepage()}`);
-    }
-
-    this.router.replaceWith(previousURL).then(() => {
+    this.router.replaceWith(this.fullPageChat.exit()).then(() => {
       this.appEvents.trigger("chat:open-channel", channel);
     });
   },

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
@@ -11,17 +11,11 @@ export default class ChatChannelRoute extends DiscourseRoute {
   @service fullPageChat;
   @service chatPreferredMode;
 
-  async model(params, transition) {
+  async model(params) {
     let [chatChannel, channels] = await Promise.all([
       this.getChannel(params.channelId),
       this.chat.getChannels(),
     ]);
-
-    if (transition.from && this.chatPreferredMode.isDrawer) {
-      transition.abort();
-      this.appEvents.trigger("chat:open-channel", chatChannel);
-      return;
-    }
 
     return EmberObject.create({
       chatChannel,

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
@@ -8,22 +8,20 @@ import slugifyChannel from "discourse/plugins/chat/discourse/lib/slugify-channel
 
 export default class ChatChannelRoute extends DiscourseRoute {
   @service chat;
-  @service chatPreferredMode;
   @service fullPageChat;
+  @service chatPreferredMode;
 
-  redirect(model, transition) {
-    if (transition.from && this.chatPreferredMode.isDrawer) {
-      this.replaceWith(this.fullPageChat.exit()).then(() => {
-        this.appEvents.trigger("chat:open-channel", model.chatChannel);
-      });
-    }
-  }
-
-  async model(params) {
+  async model(params, transition) {
     let [chatChannel, channels] = await Promise.all([
       this.getChannel(params.channelId),
       this.chat.getChannels(),
     ]);
+
+    if (transition.from && this.chatPreferredMode.isDrawer) {
+      transition.abort();
+      this.appEvents.trigger("chat:open-channel", chatChannel);
+      return;
+    }
 
     return EmberObject.create({
       chatChannel,

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
@@ -8,6 +8,16 @@ import slugifyChannel from "discourse/plugins/chat/discourse/lib/slugify-channel
 
 export default class ChatChannelRoute extends DiscourseRoute {
   @service chat;
+  @service chatPreferredMode;
+  @service fullPageChat;
+
+  redirect(model, transition) {
+    if (transition.from && this.chatPreferredMode.isDrawer) {
+      this.replaceWith(this.fullPageChat.exit()).then(() => {
+        this.appEvents.trigger("chat:open-channel", model.chatChannel);
+      });
+    }
+  }
 
   async model(params) {
     let [chatChannel, channels] = await Promise.all([

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-index.js
@@ -3,8 +3,9 @@ import { inject as service } from "@ember/service";
 
 export default class ChatIndexRoute extends DiscourseRoute {
   @service chat;
+  @service router;
 
-  beforeModel() {
+  redirect() {
     if (this.site.mobileView) {
       return; // Always want the channel index on mobile.
     }
@@ -14,11 +15,10 @@ export default class ChatIndexRoute extends DiscourseRoute {
     return this.chat.getIdealFirstChannelIdAndTitle().then((channelInfo) => {
       if (channelInfo) {
         return this.chat.getChannelBy("id", channelInfo.id).then((c) => {
-          this.chat.openChannel(c);
-          return;
+          return this.chat.openChannel(c);
         });
       } else {
-        return this.transitionTo("chat.browse");
+        return this.router.transitionTo("chat.browse");
       }
     });
   }

--- a/plugins/chat/assets/javascripts/discourse/services/full-page-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/full-page-chat.js
@@ -1,6 +1,9 @@
-import Service from "@ember/service";
+import Service, { inject as service } from "@ember/service";
+import { defaultHomepage } from "discourse/lib/utilities";
 
 export default class FullPageChat extends Service {
+  @service router;
+
   _previousURL = null;
   _isActive = false;
 
@@ -11,7 +14,15 @@ export default class FullPageChat extends Service {
 
   exit() {
     this._isActive = false;
-    return this._previousURL;
+
+    let previousURL = this._previousURL;
+    if (!previousURL || previousURL === "/") {
+      previousURL = this.router.urlFor(`discovery.${defaultHomepage()}`);
+    }
+
+    this._previousURL = null;
+
+    return previousURL;
   }
 
   get isActive() {

--- a/plugins/chat/assets/javascripts/discourse/services/full-page-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/full-page-chat.js
@@ -13,6 +13,10 @@ export default class FullPageChat extends Service {
   }
 
   exit() {
+    if (this.isDestroyed || this.isDestroying) {
+      return;
+    }
+
     this._isActive = false;
 
     let previousURL = this._previousURL;

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -94,4 +94,36 @@ RSpec.describe "Navigation", type: :system, js: true do
       expect(page).to have_css(".chat-message-container[data-id='#{message.id}']")
     end
   end
+
+  context "when sidebar is enabled" do
+    before do
+      SiteSetting.enable_experimental_sidebar_hamburger = true
+      SiteSetting.enable_sidebar = true
+    end
+
+    context "when opening channel from sidebar with drawer preferred" do
+      it "opens channel in drawer" do
+        visit("/t/-/#{topic.id}")
+        chat_page.open_from_header
+        chat_page.close_drawer
+        find("a[title='#{category_channel.title}']").click
+
+        expect(page).to have_css(".chat-message-container[data-id='#{message.id}']")
+      end
+    end
+
+    context "when opening channel from sidebar with full page preferred" do
+      it "opens channel in full page" do
+        visit("/")
+        chat_page.open_from_header
+        chat_page.maximize_drawer
+        visit("/")
+        find("a[title='#{category_channel.title}']").click
+
+        expect(page).to have_current_path(
+          chat.channel_path(category_channel.id, category_channel.slug),
+        )
+      end
+    end
+  end
 end

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -15,6 +15,10 @@ module PageObjects
         find(".topic-chat-drawer-header__full-screen-btn").click
       end
 
+      def close_drawer
+        find(".topic-chat-drawer-header__close-btn").click
+      end
+
       def minimize_full_page
         find(".chat-full-screen-button").click
       end

--- a/plugins/chat/test/javascripts/unit/services/full-page-chat-test.js
+++ b/plugins/chat/test/javascripts/unit/services/full-page-chat-test.js
@@ -1,9 +1,11 @@
 import { module, test } from "qunit";
-import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
 
 module("Discourse Chat | Unit | Service | full-page-chat", function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
-    this.fullPageChat = getOwner(this).lookup("service:full-page-chat");
+    this.fullPageChat = this.owner.lookup("service:full-page-chat");
   });
 
   hooks.afterEach(function () {


### PR DESCRIPTION
Clicking a link of the sidebar will now open the drawer and load the correct channel.

This solution should correctly solve these cases:
- closing drawer, clicking sidebar channel, should open the drawer on correct channel
- visiting /chat then visiting / and clicking sidebar channel, should open full page chat on correct channel