### PR TITLE
PERF: Disable auto-import sourcemaps in production

### DIFF
--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -58,16 +58,10 @@ module.exports = function (defaults) {
       forbidEval: true,
       insertScriptsAt: "ember-auto-import-scripts",
       webpack: {
-        output: {
-          // Workaround for https://github.com/ef4/ember-auto-import/issues/519
-          // Upstreamed in https://github.com/ef4/ember-auto-import/pull/548
-          filename: `chunk.[id].[contenthash].js`,
-          chunkFilename: `chunk.[id].[contenthash].js`,
-        },
+        // Workarounds for https://github.com/ef4/ember-auto-import/issues/519 and https://github.com/ef4/ember-auto-import/issues/478
+        devtool: isProduction ? false : "source-map", // Sourcemaps contain reference to the ephemeral broccoli cache dir, which changes on every deploy
         optimization: {
-          // Workaround to provide deterministic chunk output
-          // See https://github.com/ef4/ember-auto-import/issues/478#issuecomment-1000526638
-          moduleIds: "size",
+          moduleIds: "size", // Consistent module references https://github.com/ef4/ember-auto-import/issues/478#issuecomment-1000526638
         },
       },
     },


### PR DESCRIPTION
Even with the `chunkFilename` change, the sourcemaps are non-deterministic because they include references to the broccoli cache directory which has a different name for each build. This commit disables auto-import sourcemaps in production to improve caching performance.

Followup to 3673d3359ce466d35a65e3e3e4b5f3a6457682c0

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
