### PR TITLE
FIX: Update sidebar links when promoted to admin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,7 +138,7 @@ class User < ActiveRecord::Base
   after_create :set_default_sidebar_section_links
 
   after_update :set_default_sidebar_section_links, if: Proc.new  {
-    self.saved_change_to_staged?
+    self.saved_change_to_staged? || self.saved_change_to_admin?
   }
 
   after_update :trigger_user_updated_event, if: Proc.new {
@@ -1944,7 +1944,7 @@ class User < ActiveRecord::Base
       end
     end
 
-    SidebarSectionLink.insert_all!(records) if records.present?
+    SidebarSectionLink.insert_all(records) if records.present?
   end
 
   def stat

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,7 +53,20 @@ RSpec.describe User do
           tag.id
         )
 
-        user = Fabricate(:admin)
+        admin = Fabricate(:admin)
+
+        expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: admin.id).pluck(:linkable_id)).to contain_exactly(
+          category.id,
+          secured_category.id
+        )
+
+        expect(SidebarSectionLink.where(linkable_type: 'Tag', user_id: admin.id).pluck(:linkable_id)).to contain_exactly(
+          tag.id,
+          hidden_tag.id
+        )
+
+        # A user promoted to admin should get secured sidebar records
+        user.update(admin: true)
 
         expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: user.id).pluck(:linkable_id)).to contain_exactly(
           category.id,


### PR DESCRIPTION
It is likely that a new admin user was created as just a regular user
before being promoted to admin so this change will update the sidebar
link records for any users that are promoted to admin. This way if any
of the default side bar categories or tags are restricted to admins
these new admins will have those added to their sidebar as well.

You can easily replicate this issue locally (prior to this fix) by using
`rails admin:create` where it creates a user first, then it is promoted
to admin. This means it would receive the default categories of regular
user, but never receive the ones they should have access to as an admin.

As part of this change I did drop the `!` from
`SidebarSectionLink.insert_all` so that it would add any new records
that were missing, but not throw a unique constraint error trying to add
any existing records.

Follow up to: 1b56a55f5087091a8573849a42c78f63992e1142

And: e320bbe513dc4a713ee4e44f81412915b213d7ec
