### PR TITLE
DEV: Require pry-byebug in development mode

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,7 @@ if !GlobalSetting.skip_redis?
 end
 
 require 'pry-rails' if Rails.env.development?
+require 'pry-byebug' if Rails.env.development?
 
 require 'discourse_fonts'
 


### PR DESCRIPTION
We already do this in test mode, so let's do it in development mode too. It adds better step-by-step
debugging and callstack navigation, see the readme for more details:

https://github.com/deivid-rodriguez/pry-byebug
