### PR TITLE
FIX: Deliver chat summaries when allowed groups include "everyone"

### DIFF
--- a/plugins/chat/spec/components/chat_mailer_spec.rb
+++ b/plugins/chat/spec/components/chat_mailer_spec.rb
@@ -197,6 +197,14 @@ describe Chat::ChatMailer do
       assert_summary_skipped
     end
 
+    it "queues a job when the chat_allowed_groups is set to everyone" do
+      SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+
+      described_class.send_unread_mentions_summary
+
+      assert_only_queued_once
+    end
+
     describe "update the user membership after we send the email" do
       before { Jobs.run_immediately! }
 


### PR DESCRIPTION
The mailer in charge of sending chat summary emails applies a filter to ensure only members of groups listed in the `chat allowed groups` setting receive them. However, when you set it to `everyone`, nobody will be notified because we treat this group differently and don't create `GroupUser` records for every user on the site.

This commit changes the mailer to skip the filter when the `everyone` ID is in the list.
