### PR TITLE
SECURITY: Correctly render link title in draft preview (#18906)

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/text.js
+++ b/app/assets/javascripts/discourse/app/lib/text.js
@@ -157,7 +157,6 @@ export function excerpt(cooked, length) {
         resultLength += element.textContent.length;
       }
     } else if (element.tagName === "A") {
-      element.innerHTML = element.innerText;
       result += element.outerHTML;
       resultLength += element.innerText.length;
     } else if (element.tagName === "IMG") {

--- a/app/assets/javascripts/discourse/tests/unit/lib/text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/text-test.js
@@ -1,5 +1,5 @@
 import { module, test } from "qunit";
-import { parseAsync } from "discourse/lib/text";
+import { cookAsync, excerpt, parseAsync } from "discourse/lib/text";
 
 module("Unit | Utility | text", function () {
   test("parseAsync", async function (assert) {
@@ -10,5 +10,28 @@ module("Unit | Utility | text", function () {
         "it parses the raw markdown"
       );
     });
+  });
+
+  test("excerpt", async function (assert) {
+    let cooked = await cookAsync("Hello! :wave:");
+    assert.strictEqual(
+      await excerpt(cooked, 300),
+      'Hello! <img src="/images/emoji/google_classic/wave.png?v=12" title=":wave:" class="emoji" alt=":wave:" loading="lazy" width="20" height="20">'
+    );
+
+    cooked = await cookAsync("[:wave:](https://example.com)");
+    assert.strictEqual(
+      await excerpt(cooked, 300),
+      '<a href="https://example.com"><img src="/images/emoji/google_classic/wave.png?v=12" title=":wave:" class="emoji only-emoji" alt=":wave:" loading="lazy" width="20" height="20"></a>'
+    );
+
+    cooked = await cookAsync('<script>alert("hi")</script>');
+    assert.strictEqual(await excerpt(cooked, 300), "");
+
+    cooked = await cookAsync("[`<script>alert('hi')</script>`]()");
+    assert.strictEqual(
+      await excerpt(cooked, 300),
+      "<a><code>&lt;script&gt;alert('hi')&lt;/script&gt;</code></a>"
+    );
   });
 });


### PR DESCRIPTION
The additional unescaping could cause link titles to be rendered incorrectly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
