### PR TITLE
FIX: do not preload topic list for new topic/message routes

### DIFF
--- a/app/controllers/new_topic_controller.rb
+++ b/app/controllers/new_topic_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class NewTopicController < ApplicationController
+  def index; end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -838,8 +838,8 @@ Discourse::Application.routes.draw do
     get 'embed/count' => 'embed#count'
     get 'embed/info' => 'embed#info'
 
-    get "new-topic" => "list#latest"
-    get "new-message" => "list#latest"
+    get "new-topic" => "new_topic#index"
+    get "new-message" => "new_topic#index"
 
     # Topic routes
     get "t/id_for/:slug" => "topics#id_for_slug"


### PR DESCRIPTION
This commit fixes the issue where the sub-category topic list was not loading for new-topic routes. Since we do not need to preload topic lists for new topic/message routes this commit adds a no-op controller that prevents topic lists pre loading and at the same time fixes the sub category topics not loading issue.