### PR TITLE
DEV: Only focus user card first link if not mouse input

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -280,10 +280,12 @@ export default Mixin.create({
         // note: we DO NOT use afterRender here cause _positionCard may
         // run afterwards, if we allowed this to happen the usercard
         // may be offscreen and we may scroll all the way to it on focus
-        discourseLater(() => {
-          const firstLink = this.element.querySelector("a");
-          firstLink && firstLink.focus();
-        }, 350);
+        if (event.pointerId === -1) {
+          discourseLater(() => {
+            const firstLink = this.element.querySelector("a");
+            firstLink && firstLink.focus();
+          }, 350);
+        }
       }
     });
   },


### PR DESCRIPTION
This PR adds a check to ensure that the focus of the first item of the user card is only present when the click was not by a mouse (i.e. a keyboard). This helps prevent the focus ring from appearing when simply clicking a user card.