### PR TITLE
UX: tweaks to msg actions menu

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
@@ -4,6 +4,7 @@ import { render } from "@ember/test-helpers";
 import I18n from "I18n";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { query } from "discourse/tests/helpers/qunit-helpers";
 
 const DEFAULT_CONTENT = [
   { id: 1, name: "foo" },
@@ -390,5 +391,24 @@ module("Integration | Component | select-kit/single-select", function (hooks) {
         name: this.content.firstObject.name,
       })
     );
+  });
+
+  test("options.verticalOffset", async function (assert) {
+    setDefaultState(this, { verticalOffset: -50 });
+    await render(hbs`
+      <SingleSelect
+        @value={{this.value}}
+        @content={{this.content}}
+        @nameProperty={{this.nameProperty}}
+        @valueProperty={{this.valueProperty}}
+        @onChange={{this.onChange}}
+        @options={{hash verticalOffset=this.verticalOffset}}
+      />
+    `);
+    await this.subject.expand();
+    const header = query(".select-kit-header").getBoundingClientRect();
+    const body = query(".select-kit-body").getBoundingClientRect();
+
+    assert.ok(header.bottom > body.top, "it correctly offsets the body");
   });
 });

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -283,6 +283,7 @@ export default Component.extend(
       closeOnChange: true,
       limitMatches: null,
       placement: isDocumentRTL() ? "bottom-end" : "bottom-start",
+      verticalOffset: 3,
       filterComponent: "select-kit/select-kit-filter",
       selectedNameComponent: "selected-name",
       selectedChoiceComponent: "selected-choice",
@@ -898,7 +899,7 @@ export default Component.extend(
             {
               name: "offset",
               options: {
-                offset: [0, 3],
+                offset: [0, this.selectKit.options.verticalOffset],
               },
             },
             {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -2,11 +2,15 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import { createPopper } from "@popperjs/core";
 import { schedule } from "@ember/runloop";
+import { inject as service } from "@ember/service";
 
-const MSG_ACTIONS_PADDING = 2;
+const MSG_ACTIONS_HORIZONTAL_PADDING = 2;
+const MSG_ACTIONS_VERTICAL_PADDING = -15;
 
 export default Component.extend({
   tagName: "",
+
+  chatPreferredMode: service(),
 
   messageActions: null,
 
@@ -32,9 +36,9 @@ export default Component.extend({
               options: {
                 offset: ({ popper, placement }) => {
                   return [
-                    MSG_ACTIONS_PADDING,
+                    MSG_ACTIONS_VERTICAL_PADDING,
                     -(placement.includes("left") || placement.includes("right")
-                      ? popper.width + MSG_ACTIONS_PADDING
+                      ? popper.width + MSG_ACTIONS_HORIZONTAL_PADDING
                       : popper.height),
                   ];
                 },

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -28,7 +28,6 @@
 <ChatRetentionReminder @chatChannel={{this.chatChannel}} />
 
 <div class="chat-message-actions-mobile-anchor"></div>
-<div class="chat-message-actions-desktop-anchor"></div>
 <div
   class={{concat-class
     "chat-message-emoji-picker-anchor"
@@ -44,6 +43,7 @@
 </div>
 
 <div class="chat-messages-scroll chat-messages-container">
+  <div class="chat-message-actions-desktop-anchor"></div>
   <div class="chat-messages-container">
     {{#if (or this.loading this.loadingMorePast)}}
       <ChatSkeleton @tagName="" />

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
@@ -1,8 +1,10 @@
 <div class="chat-msgactions-hover" data-id={{this.message.id}}>
   <div class="chat-msgactions">
-    {{#each this.emojiReactions as |reaction|}}
-      <ChatMessageReaction @reaction={{reaction}} @react={{this.messageActions.react}} @class="show" />
-    {{/each}}
+    {{#if this.chatPreferredMode.isFullPage}}
+      {{#each this.emojiReactions as |reaction|}}
+        <ChatMessageReaction @reaction={{reaction}} @react={{this.messageActions.react}} @class="show" />
+      {{/each}}
+    {{/if}}
 
     {{#if this.messageCapabilities.canReact}}
       <DButton @class="btn-flat react-btn" @action={{this.messageActions.startReactionForMsgActions}} @icon="discourse-emojis" @title="chat.react" />

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -23,6 +23,7 @@
   {{chat/track-message-visibility}}
   class={{concat-class
     "chat-message-container"
+    (if this.isHovered "is-hovered")
     (if this.selectingMessages "selecting-messages")
   }}
   data-id={{or this.message.id this.message.stagedId}}

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -14,6 +14,11 @@
   }
 }
 
+.chat-message-actions-desktop-anchor {
+  position: relative;
+  z-index: z("dropdown");
+}
+
 @mixin chat-reaction {
   align-items: center;
   display: inline-flex;
@@ -258,16 +263,7 @@
 
 .chat-msgactions-hover {
   @include unselectable;
-  position: absolute;
-  padding-right: 1rem;
-  padding-top: 0.25rem;
-  right: 0;
-  top: -1.5em;
-  z-index: 2;
-}
-
-.chat-message.is-reply .chat-msgactions-hover {
-  top: 0.5em;
+  position: relative;
 }
 
 .chat-msgactions {
@@ -339,7 +335,6 @@
       &:focus {
         border-color: var(--primary-low);
         border-left-color: transparent;
-        background: var(--primary-low);
 
         .select-kit-header-wrapper .d-icon {
           color: var(--primary);
@@ -398,9 +393,11 @@
     margin-right: -1px;
     padding: 0.5em 0;
     width: 2.5em;
+    filter: grayscale(50%);
 
     &:hover {
       z-index: 2;
+      filter: grayscale(0);
     }
 
     &:focus {
@@ -469,7 +466,7 @@
   font-style: italic;
 }
 
-.chat-message-container:hover,
+.chat-message-container.is-hovered,
 .chat-message.chat-message-selected {
   background: var(--primary-very-low);
 }

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -270,6 +270,7 @@
   border-radius: 0.25em;
   background-color: var(--secondary);
   display: flex;
+  box-shadow: 0 0.75px 0px rgba(0, 0, 0, 0.15);
 
   .emoji-picker-anchor {
     position: absolute;
@@ -393,10 +394,9 @@
     margin-right: -1px;
     padding: 0.5em 0;
     width: 2.5em;
-    filter: grayscale(50%);
+    filter: grayscale(100%);
 
     &:hover {
-      z-index: 2;
       filter: grayscale(0);
     }
 

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -318,17 +318,11 @@
     }
 
     .d-icon {
-      color: var(--primary-low-mid);
+      color: var(--primary-medium);
 
       &.bookmark-icon__bookmarked {
         color: var(--tertiary);
       }
-    }
-  }
-
-  .reply-btn {
-    .d-icon {
-      color: var(--tertiary);
     }
   }
 
@@ -356,7 +350,7 @@
         justify-content: center;
 
         .d-icon {
-          color: var(--primary-low-mid);
+          color: var(--primary-medium);
           margin: 0;
         }
       }


### PR DESCRIPTION
- allows scrolling while hovering over the menu
- correctly changes message background color while hovering the menu
- prevents a bug where it would sometimes close the menu while moving from the menu to the three dots expanded dropdown. This was caused by the gap between the header/body of the three dots dropdown, which would sometimes allow creating a mouseover event on a possibly different underlying message
- removes recent/favorite reactions on drawer mode
- slightly grayscale reactions until hover
- moves menu slightly higher
- changes icon color to be slightly darker and similar to the text message color
- removes useless code