### PR TITLE
DEV: Bind connector actions when made available under `this`

### DIFF
--- a/app/assets/javascripts/discourse/app/components/plugin-connector.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-connector.js
@@ -51,7 +51,7 @@ export default Component.extend({
     this.set("actions", connectorClass.actions);
 
     for (const [name, action] of Object.entries(this.actions)) {
-      this.set(name, action);
+      this.set(name, action.bind(this));
     }
 
     const merged = buildArgsWithDeprecations(args, deprecatedArgs);

--- a/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/plugin-outlet-connector-class-test.js
@@ -18,7 +18,7 @@ acceptance("Plugin Outlet - Connector Class", function (needs) {
     extraConnectorClass("user-profile-primary/hello", {
       actions: {
         sayHello() {
-          this.set("hello", "hello!");
+          this.set("hello", `${this.hello || ""}hello!`);
         },
       },
     });
@@ -53,6 +53,7 @@ acceptance("Plugin Outlet - Connector Class", function (needs) {
       `${PREFIX}/user-profile-primary/hello`
     ] = hbs`<span class='hello-username'>{{model.username}}</span>
         <button class='say-hello' {{on "click" (action "sayHello")}}></button>
+        <button class='say-hello-using-this' {{on "click" this.sayHello}}></button>
         <span class='hello-result'>{{hello}}</span>`;
     Ember.TEMPLATES[
       `${PREFIX}/user-profile-primary/hi`
@@ -86,6 +87,12 @@ acceptance("Plugin Outlet - Connector Class", function (needs) {
       query(".hello-result").innerText,
       "hello!",
       "actions delegate properly"
+    );
+    await click(".say-hello-using-this");
+    assert.strictEqual(
+      query(".hello-result").innerText,
+      "hello!hello!",
+      "actions are made available on `this` and are bound correctly"
     );
 
     await click(".say-hi");


### PR DESCRIPTION
Connector actions are already added as properties of the generated component, but they were not bound. Using them like `{{on "click" this.someAction}}` and trying to access `this` would not work as expected. This commit binds all actions to the generated component instance.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
