### PR TITLE
FIX: Allow attr updates of over-size-limit uploads

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -34,6 +34,7 @@ class Upload < ActiveRecord::Base
   attr_accessor :for_export
   attr_accessor :for_site_setting
   attr_accessor :for_gravatar
+  attr_accessor :validate_file_size
 
   validates_presence_of :filesize
   validates_presence_of :original_filename
@@ -90,6 +91,11 @@ class Upload < ActiveRecord::Base
     self
       .joins("LEFT JOIN upload_references ur ON ur.upload_id = uploads.id AND ur.target_type != 'Post'")
       .where("ur.upload_id IS NULL")
+  end
+
+  def initialize(*args)
+    super
+    self.validate_file_size = true
   end
 
   def to_s

--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -1189,6 +1189,10 @@ task "uploads:downsize" => :environment do
       log "After:  #{w}x#{h} #{ww}x#{hh} (#{upload.filesize})"
 
       dimensions_count += 1
+
+      # Don't validate the size - max image size setting might have
+      # changed since the file was uploaded, so this could fail
+      upload.validate_file_size = false
       upload.save!
     end
 

--- a/lib/validators/upload_validator.rb
+++ b/lib/validators/upload_validator.rb
@@ -2,10 +2,7 @@
 
 require "file_helper"
 
-module Validators; end
-
 class UploadValidator < ActiveModel::Validator
-
   def validate(upload)
     # staff can upload any file in PM
     if (upload.for_private_message && SiteSetting.allow_staff_to_upload_any_file_in_pm)
@@ -141,6 +138,8 @@ class UploadValidator < ActiveModel::Validator
   end
 
   def maximum_file_size(upload, type)
+    return if !upload.validate_file_size
+
     max_size_kb = if upload.for_export
       SiteSetting.max_export_file_size_kb
     else
@@ -157,5 +156,4 @@ class UploadValidator < ActiveModel::Validator
       upload.errors.add(:filesize, message)
     end
   end
-
 end

--- a/spec/tasks/uploads_spec.rb
+++ b/spec/tasks/uploads_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe "tasks/uploads" do
       upload.update!(thumbnail_height: 0)
       SiteSetting.max_image_size_kb = 0.001 # 1 byte
 
-      invoke_task
+      expect { invoke_task }.to change { upload.reload.thumbnail_height }.to(200)
     end
   end
 end

--- a/spec/tasks/uploads_spec.rb
+++ b/spec/tasks/uploads_spec.rb
@@ -236,7 +236,6 @@ RSpec.describe "tasks/uploads" do
       expect { invoke_task }.to change { upload.reload.thumbnail_height }.to(200)
     end
 
-
     it "updates attributes of uploads that are over the size limit" do
       upload.update!(thumbnail_height: 0)
       SiteSetting.max_image_size_kb = 0.001 # 1 byte

--- a/spec/tasks/uploads_spec.rb
+++ b/spec/tasks/uploads_spec.rb
@@ -235,5 +235,13 @@ RSpec.describe "tasks/uploads" do
 
       expect { invoke_task }.to change { upload.reload.thumbnail_height }.to(200)
     end
+
+
+    it "updates attributes of uploads that are over the size limit" do
+      upload.update!(thumbnail_height: 0)
+      SiteSetting.max_image_size_kb = 0.001 # 1 byte
+
+      invoke_task
+    end
   end
 end


### PR DESCRIPTION
Alternative impl, simpler but more prone to issues: just `upload.save!(validate: false)`