### PR TITLE
FIX: adds back recurring to send_message automation

### DIFF
--- a/plugins/chat/app/models/chat_channel.rb
+++ b/plugins/chat/app/models/chat_channel.rb
@@ -83,10 +83,6 @@ class ChatChannel < ActiveRecord::Base
     "/chat/channel/#{self.id}/#{self.slug || "-"}"
   end
 
-  def public_channel_title
-    chatable.name
-  end
-
   private
 
   def change_status(acting_user, target_status)

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -675,13 +675,13 @@ after_initialize do
 
       placeholder :channel_name
 
+      triggerables [:recurring]
+
       script do |context, fields, automation|
         sender = User.find_by(username: fields.dig("sender", "value")) || Discourse.system_user
         channel = ChatChannel.find_by(id: fields.dig("chat_channel_id", "value"))
 
-        placeholders = { channel_name: channel.public_channel_title }.merge(
-          context["placeholders"] || {},
-        )
+        placeholders = { channel_name: channel.title(sender) }.merge(context["placeholders"] || {})
 
         creator =
           Chat::ChatMessageCreator.create(


### PR DESCRIPTION
Also uses new way to get channel title

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
