### PR TITLE
UX: Show if MaxMind key is missing on IP lookup

### DIFF
--- a/app/assets/javascripts/admin/addon/components/ip-lookup.hbs
+++ b/app/assets/javascripts/admin/addon/components/ip-lookup.hbs
@@ -31,7 +31,15 @@
 
         <dt>{{i18n "ip_lookup.location"}}</dt>
         <dd>
-          {{#if this.location.location}}
+          {{#if this.location.no_license}}
+            <a
+              href="https://meta.discourse.org/t/configure-maxmind-for-reverse-ip-lookups/173941"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {{i18n "ip_lookup.no_license"}}
+            </a>
+          {{else if this.location.location}}
             <a
               href="https://maps.google.com/maps?q={{this.location.latitude}},{{this.location.longitude}}"
               rel="noopener noreferrer"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1077,6 +1077,7 @@ en:
       confirm_delete_other_accounts: "Are you sure you want to delete these accounts?"
       powered_by: "using <a href='https://maxmind.com'>MaxMindDB</a>"
       copied: "copied"
+      no_license: "Configure MaxMind to enable GeoIP information"
 
     user_fields:
       none: "(select an option)"

--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -11,8 +11,10 @@ class DiscourseIpInfo
   end
 
   def open_db(path)
-    @loc_mmdb = mmdb_load(File.join(path, "GeoLite2-City.mmdb"))
-    @asn_mmdb = mmdb_load(File.join(path, "GeoLite2-ASN.mmdb"))
+    unless GlobalSetting.maxmind_license_key.blank?
+      @loc_mmdb = mmdb_load(File.join(path, "GeoLite2-City.mmdb"))
+      @asn_mmdb = mmdb_load(File.join(path, "GeoLite2-ASN.mmdb"))
+    end
     @cache = LruRedux::ThreadSafeCache.new(2000)
   end
 
@@ -105,6 +107,8 @@ class DiscourseIpInfo
           message: "IP #{ip} could not be looked up in MaxMind GeoLite2-City database.",
         )
       end
+    else
+      ret[:no_license] = true
     end
 
     if @asn_mmdb

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1153,6 +1153,8 @@ RSpec.describe Report do
         freeze_time DateTime.parse("2017-03-01 12:00")
 
         ip = [81, 2, 69, 142]
+        # Assign a dummy MaxMind license key, which is now checked in open_db
+        global_setting "maxmind_license_key", "dummy"
 
         DiscourseIpInfo.open_db(File.join(Rails.root, "spec", "fixtures", "mmdb"))
         Resolv::DNS

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -1680,6 +1680,8 @@ RSpec.describe Admin::UsersController do
     shared_examples "IP info retrieval possible" do
       it "retrieves IP info" do
         ip = "81.2.69.142"
+        # Assign a dummy MaxMind license key, which is now checked in open_db
+        global_setting "maxmind_license_key", "dummy"
 
         DiscourseIpInfo.open_db(File.join(Rails.root, "spec", "fixtures", "mmdb"))
         Resolv::DNS.any_instance.stubs(:getname).with(ip).returns("ip-81-2-69-142.example.com")
@@ -1717,6 +1719,8 @@ RSpec.describe Admin::UsersController do
 
       it "prevents retrieval of IP info with a 404 response" do
         ip = "81.2.69.142"
+        # Assign a dummy MaxMind license key, which is now checked in open_db
+        global_setting "maxmind_license_key", "dummy"
 
         DiscourseIpInfo.open_db(File.join(Rails.root, "spec", "fixtures", "mmdb"))
         Resolv::DNS.any_instance.stubs(:getname).with(ip).returns("ip-81-2-69-142.example.com")

--- a/spec/serializers/user_auth_token_serializer_spec.rb
+++ b/spec/serializers/user_auth_token_serializer_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe UserAuthTokenSerializer do
   fab!(:user) { Fabricate(:moderator) }
   let(:token) { UserAuthToken.generate!(user_id: user.id, client_ip: "2a02:ea00::", staff: true) }
+  # Assign a dummy MaxMind license key, which is now checked in open_db
+  global_setting "maxmind_license_key", "dummy"
 
   before(:each) { DiscourseIpInfo.open_db(File.join(Rails.root, "spec", "fixtures", "mmdb")) }
 


### PR DESCRIPTION
as discussed in https://meta.discourse.org/t/maxminddb-not-found-error/148512/7.

This also aims to mute the related error messages in logs, when Discourse tries to open the two non-existent MaxMind database files.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

I just read the note about the tests. I'm completely new to Ruby and qunit, so would have to look into it. This is currently completely untested since I need to find out first how to apply best to a running Discourse instance 😉.