### PR TITLE
FIX: correctly opens drawer to message id when given

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/plugins/chat/assets/javascripts/discourse/components/topic-chat-float.js
@@ -203,6 +203,7 @@ export default Component.extend({
 
   @action
   openURL(URL = null) {
+    this.chat.setActiveChannel(null);
     this.set("hidden", false);
     this.set("expanded", true);
 
@@ -214,12 +215,10 @@ export default Component.extend({
 
     switch (route.name) {
       case "chat":
-        this.chat.setActiveChannel(null);
         this.set("view", LIST_VIEW);
         this.appEvents.trigger("chat:float-toggled", false);
         return;
       case "chat.draft-channel":
-        this.chat.setActiveChannel(null);
         this.set("view", DRAFT_CHANNEL_VIEW);
         this.appEvents.trigger("chat:float-toggled", false);
         return;
@@ -227,6 +226,7 @@ export default Component.extend({
         return this.chat
           .getChannelBy("id", route.params.channelId)
           .then((channel) => {
+            this.chat.set("messageId", route.queryParams.messageId);
             this.chat.setActiveChannel(channel);
             this.set("view", CHAT_VIEW);
             this.appEvents.trigger("chat:float-toggled", false);

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -99,6 +99,33 @@ RSpec.describe "Navigation", type: :system, js: true do
     end
   end
 
+  context "when opening full page with a link containing a message id" do
+    it "highlights correct message" do
+      visit("/chat/channel/#{category_channel.id}/#{category_channel.slug}?messageId=#{message.id}")
+
+      expect(page).to have_css(
+        ".full-page-chat .chat-message-container.highlighted[data-id='#{message.id}']",
+      )
+    end
+  end
+
+  context "when opening drawer with a link containing a message id" do
+    it "highlights correct message" do
+      Fabricate(
+        :post,
+        topic: topic,
+        raw:
+          "<a href=\"/chat/channel/#{category_channel.id}/#{category_channel.slug}?messageId=#{message.id}\">foo</a>",
+      )
+      visit("/t/-/#{topic.id}")
+      find("a", text: "foo").click
+
+      expect(page).to have_css(
+        ".topic-chat-container.expanded.visible .chat-message-container.highlighted[data-id='#{message.id}']",
+      )
+    end
+  end
+
   context "when sidebar is enabled" do
     before do
       SiteSetting.enable_experimental_sidebar_hamburger = true


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
