### PR TITLE
FIX: only checks for full page instead of preference

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
@@ -1,6 +1,6 @@
 <div class="chat-message-actions-container" data-id={{this.message.id}}>
   <div class="chat-message-actions">
-    {{#if this.chatStateManager.isFullPagePreferred}}
+    {{#if this.chatStateManager.isFullPage}}
       {{#each this.emojiReactions as |reaction|}}
         <ChatMessageReaction @reaction={{reaction}} @react={{this.messageActions.react}} @class="show" />
       {{/each}}


### PR DESCRIPTION
Checking for preference is unsure when in standalone chat app (eg: electron app), this is much more resilient and simple.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
