### PR TITLE
FIX: ensures composer is focused after edit

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -246,7 +246,7 @@ export default Component.extend({
             this.highlightOrFetchMessage(this.targetMessageId);
           }
 
-          this.focusComposer();
+          this._focusComposer();
         })
         .catch(this._handleErrors)
         .finally(() => {
@@ -1165,6 +1165,7 @@ export default Component.extend({
     }
     if (lastUserMessage) {
       this.set("editingMessage", lastUserMessage);
+      this._focusComposer();
     }
   },
 
@@ -1395,21 +1396,6 @@ export default Component.extend({
     return this._fetchAndScrollToLatest();
   },
 
-  focusComposer() {
-    if (
-      this._selfDeleted ||
-      this.site.mobileView ||
-      this.chatChannel?.isDraft
-    ) {
-      return;
-    }
-
-    schedule("afterRender", () => {
-      document.querySelector(".chat-composer-input")?.focus();
-    });
-  },
-
-  @afterRender
   _focusComposer() {
     this.appEvents.trigger("chat:focus-composer");
   },


### PR DESCRIPTION
- afterRender is not needed as it's already done in the `chat:focus-composer` event
- removes `focusComposer` function which is duplicating logic

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
