### PR TITLE
FIX: prevents arrow keys to bubble into parents components

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
@@ -220,10 +220,6 @@ export default class ChatEmojiPicker extends Component {
 
   @action
   didNavigateSection(event) {
-    if (event.type !== "keyup") {
-      return;
-    }
-
     const sectionEmojis = [
       ...event.target
         .closest(".chat-emoji-picker__section")
@@ -252,6 +248,7 @@ export default class ChatEmojiPicker extends Component {
 
     if (event.key === "ArrowDown") {
       event.preventDefault();
+      event.stopPropagation();
 
       sectionEmojis
         .filter((c) => c.offsetTop > event.target.offsetTop)
@@ -261,6 +258,7 @@ export default class ChatEmojiPicker extends Component {
 
     if (event.key === "ArrowUp") {
       event.preventDefault();
+      event.stopPropagation();
 
       sectionEmojis
         .reverse()

--- a/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
@@ -86,9 +86,13 @@ export default class ChatEmojiPicker extends Component {
   }
 
   @action
-  didPressEscape(event) {
+  trapKeyUpEvents(event) {
     if (event.key === "Escape") {
       this.chatEmojiPickerManager.close();
+    }
+
+    if (event.key === "ArrowUp") {
+      event.stopPropagation();
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-emoji-picker.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-emoji-picker.hbs
@@ -8,7 +8,7 @@
   }}
   {{did-insert this.addClickOutsideEventListener}}
   {{will-destroy this.removeClickOutsideEventListener}}
-  {{on "keyup" this.didPressEscape}}
+  {{on "keydown" this.trapKeyUpEvents}}
 >
   <div class="chat-emoji-picker__filter-container">
     <DcFilterInput

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-emoji-picker.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-emoji-picker.hbs
@@ -1,5 +1,6 @@
 {{!-- template-lint-disable no-invalid-interactive --}}
 {{!-- template-lint-disable no-nested-interactive --}}
+{{!-- template-lint-disable no-down-event-binding --}}
 <div
   class={{concat-class
     "chat-emoji-picker"
@@ -150,7 +151,7 @@
               (concat "chat.emoji_picker." section)
               translatedFallback=section
             }}
-            {{on "keyup" this.didNavigateSection}}
+            {{on "keydown" this.didNavigateSection}}
           >
             <h2 class="chat-emoji-picker__section-title">
               {{i18n


### PR DESCRIPTION
ember-template-link doesn’t recommend keydown, but listening on keyup won't work to prevent the scroll of the container

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
