### PR TITLE
SECURITY: Prevent email from being nil in InviteRedeemer

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -760,7 +760,7 @@ class SessionController < ApplicationController
     end
 
     if invite.redeemable?
-      if !invite.is_invite_link? && sso.email != invite.email
+      if invite.is_email_invite? && sso.email != invite.email
         raise Invite::ValidationFailed.new(I18n.t("invite.not_matching_email"))
       end
     elsif invite.expired?

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -74,8 +74,16 @@ class Invite < ActiveRecord::Base
     end
   end
 
+  # Even if a domain is specified on the invite, it still counts as
+  # an invite link.
   def is_invite_link?
-    email.blank?
+    self.email.blank?
+  end
+
+  # Email invites have specific behaviour and it's easier to visually
+  # parse is_email_invite? than !is_invite_link?
+  def is_email_invite?
+    self.email.present?
   end
 
   def redeemable?
@@ -200,8 +208,6 @@ class Invite < ActiveRecord::Base
     redeeming_user: nil
   )
     return if !redeemable?
-
-    email = self.email if email.blank? && !is_invite_link?
 
     InviteRedeemer.new(
       invite: self,

--- a/db/migrate/20221103051248_remove_invalid_topic_allowed_users_from_invites.rb
+++ b/db/migrate/20221103051248_remove_invalid_topic_allowed_users_from_invites.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class RemoveInvalidTopicAllowedUsersFromInvites < ActiveRecord::Migration[7.0]
+  def up
+    # We are getting all the topic_allowed_users records that
+    # match an invited user, which is created as part of the invite
+    # redemption flow. The original invite would _not_ have had a topic_invite
+    # record, and the user should have been added to the topic in the brief
+    # period between creation of the invited_users record and the update of
+    # that record.
+    #
+    # Having > 2 topic allowed users disqualifies messages sent only
+    # by the system or an admin to the user.
+    subquery_sql = <<~SQL
+      SELECT DISTINCT id
+      FROM (
+               SELECT tau.id, tau.user_id, COUNT(*) OVER (PARTITION BY tau.user_id)
+               FROM topic_allowed_users tau
+                    JOIN invited_users iu ON iu.user_id = tau.user_id
+                    LEFT JOIN topic_invites ti ON ti.invite_id = iu.invite_id AND tau.topic_id = ti.topic_id
+               WHERE ti.id IS NULL
+                 AND tau.created_at BETWEEN iu.created_at AND iu.updated_at
+                 AND iu.redeemed_at > '2022-10-27'
+           ) AS matching_topic_allowed_users
+      WHERE matching_topic_allowed_users.count > 2
+    SQL
+
+    # Back up the records we are going to change in case we are too
+    # brutal, and for further inspection.
+    #
+    # TODO DROP this table (topic_allowed_users_backup_nov_2022) in a later migration.
+    DB.exec(<<~SQL)
+      CREATE TABLE topic_allowed_users_backup_nov_2022
+      (
+          id       INT NOT NULL,
+          user_id  INT NOT NULL,
+          topic_id INT NOT NULL
+      );
+      INSERT INTO topic_allowed_users_backup_nov_2022(id, user_id, topic_id)
+      SELECT id, user_id, topic_id
+      FROM topic_allowed_users
+      WHERE id IN (
+                      #{subquery_sql}
+                  )
+    SQL
+
+    # Delete the invalid topic allowed users that should not be there.
+    DB.query(<<~SQL)
+      DELETE
+      FROM topic_allowed_users
+      WHERE id IN (
+                      #{subquery_sql}
+                  )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -912,76 +912,144 @@ RSpec.describe InvitesController do
     end
 
     context 'when user is already logged in' do
-      fab!(:invite) { Fabricate(:invite, email: 'test@example.com') }
-      fab!(:user) { Fabricate(:user, email: 'test@example.com') }
-      fab!(:group) { Fabricate(:group) }
-
       before { sign_in(user) }
 
-      it 'redeems the invitation and creates the invite accepted notification' do
-        put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
-        invite.reload
-        expect(invite.invited_users.first.user).to eq(user)
-        expect(invite.redeemed?).to be_truthy
-        expect(
-          Notification.exists?(
-            user: invite.invited_by, notification_type: Notification.types[:invitee_accepted]
-          )
-        ).to eq(true)
-      end
+      context "for an email invite" do
+        fab!(:invite) { Fabricate(:invite, email: 'test@example.com') }
+        fab!(:user) { Fabricate(:user, email: 'test@example.com') }
+        fab!(:group) { Fabricate(:group) }
 
-      it 'redirects to the first topic the user was invited to and creates the topic notification' do
-        topic = Fabricate(:topic)
-        TopicInvite.create!(invite: invite, topic: topic)
-        put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
-        expect(response.status).to eq(200)
-        expect(response.parsed_body['redirect_to']).to eq(topic.relative_url)
-        expect(Notification.where(notification_type: Notification.types[:invited_to_topic], topic: topic).count).to eq(1)
-      end
-
-      it "adds the user to the groups specified on the invite and allows them to access the secure topic" do
-        group.add_owner(invite.invited_by)
-        secured_category = Fabricate(:category)
-        secured_category.permissions = { group.name => :full }
-        secured_category.save!
-
-        topic = Fabricate(:topic, category: secured_category)
-        TopicInvite.create!(invite: invite, topic: topic)
-        InvitedGroup.create!(invite: invite, group: group)
-
-        put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
-        expect(response.parsed_body['redirect_to']).to eq(topic.relative_url)
-        invite.reload
-        expect(invite.redeemed?).to be_truthy
-        expect(user.reload.groups).to include(group)
-        expect(Notification.where(notification_type: Notification.types[:invited_to_topic], topic: topic).count).to eq(1)
-      end
-
-      it "does not try to log in the user automatically" do
-        expect do
+        it 'redeems the invitation and creates the invite accepted notification' do
           put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
-        end.not_to change { UserAuthToken.count }
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
+          invite.reload
+          expect(invite.invited_users.first.user).to eq(user)
+          expect(invite.redeemed?).to be_truthy
+          expect(
+            Notification.exists?(
+              user: invite.invited_by, notification_type: Notification.types[:invitee_accepted]
+            )
+          ).to eq(true)
+        end
+
+        it 'redirects to the first topic the user was invited to and creates the topic notification' do
+          topic = Fabricate(:topic)
+          TopicInvite.create!(invite: invite, topic: topic)
+          put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body['redirect_to']).to eq(topic.relative_url)
+          expect(Notification.where(notification_type: Notification.types[:invited_to_topic], topic: topic).count).to eq(1)
+        end
+
+        it "adds the user to the private topic" do
+          topic = Fabricate(:private_message_topic)
+          TopicInvite.create!(invite: invite, topic: topic)
+          put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body['redirect_to']).to eq(topic.relative_url)
+          expect(TopicAllowedUser.exists?(user: user, topic: topic)).to eq(true)
+        end
+
+        it "adds the user to the groups specified on the invite and allows them to access the secure topic" do
+          group.add_owner(invite.invited_by)
+          secured_category = Fabricate(:category)
+          secured_category.permissions = { group.name => :full }
+          secured_category.save!
+
+          topic = Fabricate(:topic, category: secured_category)
+          TopicInvite.create!(invite: invite, topic: topic)
+          InvitedGroup.create!(invite: invite, group: group)
+
+          put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
+          expect(response.parsed_body['redirect_to']).to eq(topic.relative_url)
+          invite.reload
+          expect(invite.redeemed?).to be_truthy
+          expect(user.reload.groups).to include(group)
+          expect(Notification.where(notification_type: Notification.types[:invited_to_topic], topic: topic).count).to eq(1)
+        end
+
+        it "does not try to log in the user automatically" do
+          expect do
+            put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          end.not_to change { UserAuthToken.count }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
+        end
+
+        it "errors if the user's email doesn't match the invite email" do
+          user.update!(email: "blah@test.com")
+          put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          expect(response.status).to eq(412)
+          expect(response.parsed_body["message"]).to eq(I18n.t("invite.not_matching_email"))
+        end
+
+        it "errors if the user's email domain doesn't match the invite domain" do
+          user.update!(email: "blah@test.com")
+          invite.update!(email: nil, domain: "example.com")
+          put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          expect(response.status).to eq(412)
+          expect(response.parsed_body["message"]).to eq(I18n.t("invite.domain_not_allowed"))
+        end
       end
 
-      it "errors if the user's email doesn't match the invite email" do
-        user.update!(email: "blah@test.com")
-        put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
-        expect(response.status).to eq(412)
-        expect(response.parsed_body["message"]).to eq(I18n.t("invite.not_matching_email"))
-      end
+      context "for an invite link" do
+        fab!(:invite) { Fabricate(:invite, email: nil) }
+        fab!(:user) { Fabricate(:user, email: 'test@example.com') }
+        fab!(:group) { Fabricate(:group) }
 
-      it "errors if the user's email domain doesn't match the invite domain" do
-        user.update!(email: "blah@test.com")
-        invite.update!(email: nil, domain: "example.com")
-        put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
-        expect(response.status).to eq(412)
-        expect(response.parsed_body["message"]).to eq(I18n.t("invite.domain_not_allowed"))
+        it 'redeems the invitation and creates the invite accepted notification' do
+          put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
+          invite.reload
+          expect(invite.invited_users.first.user).to eq(user)
+          expect(invite.redeemed?).to be_truthy
+          expect(
+            Notification.exists?(
+              user: invite.invited_by, notification_type: Notification.types[:invitee_accepted]
+            )
+          ).to eq(true)
+        end
+
+        it 'redirects to the first topic the user was invited to and creates the topic notification' do
+          topic = Fabricate(:topic)
+          TopicInvite.create!(invite: invite, topic: topic)
+          put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body['redirect_to']).to eq(topic.relative_url)
+          expect(Notification.where(notification_type: Notification.types[:invited_to_topic], topic: topic).count).to eq(1)
+        end
+
+        it "adds the user to the groups specified on the invite and allows them to access the secure topic" do
+          group.add_owner(invite.invited_by)
+          secured_category = Fabricate(:category)
+          secured_category.permissions = { group.name => :full }
+          secured_category.save!
+
+          topic = Fabricate(:topic, category: secured_category)
+          TopicInvite.create!(invite: invite, topic: topic)
+          InvitedGroup.create!(invite: invite, group: group)
+
+          put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
+          expect(response.parsed_body['redirect_to']).to eq(topic.relative_url)
+          invite.reload
+          expect(invite.redeemed?).to be_truthy
+          expect(user.reload.groups).to include(group)
+          expect(Notification.where(notification_type: Notification.types[:invited_to_topic], topic: topic).count).to eq(1)
+        end
+
+        it "does not try to log in the user automatically" do
+          expect do
+            put "/invites/show/#{invite.invite_key}.json", params: { id: invite.invite_key }
+          end.not_to change { UserAuthToken.count }
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["message"]).to eq(I18n.t("invite.existing_user_success"))
+        end
       end
     end
 


### PR DESCRIPTION
This commit adds some protections in InviteRedeemer to ensure that email
can never be nil, which could cause issues with inviting the invited
person to private topics since there was an incorrect inner join.

If the email is nil and the invite is scoped to an email, we just use
that invite.email unconditionally.  If a redeeming_user (an existing
user) is passed in when redeeming an email, we use their email to
override the passed in email.  Otherwise we just use the passed in
email.  We now raise an error after all this if the email is still nil.
This commit also adds some tests to catch the private topic fix, and
some general improvements and comments around the invite code.

This commit also includes a migration to delete TopicAllowedUser records
for users who were mistakenly added to topics as part of the invite
redemption process.