### PR TITLE
FIX: Allow sidebar links to register didInsert actions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
@@ -1,5 +1,5 @@
 {{#if this.shouldDisplay}}
-  <div class="sidebar-section-link-wrapper">
+  <div class="sidebar-section-link-wrapper" {{did-insert this.didInsert}}>
     {{#if @href}}
       <a href={{@href}} rel="noopener noreferrer" target="_blank" class={{this.classNames}} title={{@title}}>
         <Sidebar::SectionLinkPrefix

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { action } from "@ember/object";
 
 export default class SectionLink extends Component {
   willDestroy() {
@@ -65,5 +66,12 @@ export default class SectionLink extends Component {
     }
 
     return prefixElementColors.map((color) => `#${color} 50%`).join(", ");
+  }
+
+  @action
+  didInsert() {
+    if (this.args.didInsert) {
+      this.args.didInsert();
+    }
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/sections.hbs
@@ -43,6 +43,7 @@
           @hoverAction={{link.hoverAction}}
           @hoverTitle={{link.hoverTitle}}
           @currentWhen={{link.currentWhen}}
+          @didInsert={{link.didInsert}}
           @willDestroy={{link.willDestroy}}
           @content={{link.text}} />
       {{/each}}

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -19,11 +19,12 @@ acceptance("Sidebar - Plugin API", function (needs) {
   });
 
   needs.hooks.afterEach(() => {
+    linkDidInsert = undefined;
     linkDestroy = undefined;
     sectionDestroy = undefined;
   });
 
-  let linkDestroy, sectionDestroy;
+  let linkDidInsert, linkDestroy, sectionDestroy;
 
   test("Multiple header actions and links", async function (assert) {
     withPluginApi("1.3.0", (api) => {
@@ -118,6 +119,11 @@ acceptance("Sidebar - Plugin API", function (needs) {
                   }
 
                   @bind
+                  didInsert() {
+                    linkDidInsert = "link test";
+                  }
+
+                  @bind
                   willDestroy() {
                     linkDestroy = "link test";
                   }
@@ -200,6 +206,12 @@ acceptance("Sidebar - Plugin API", function (needs) {
     });
 
     await visit("/");
+
+    assert.strictEqual(
+      linkDidInsert,
+      "link test",
+      "calls link didInsert function"
+    );
 
     assert.strictEqual(
       query(

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -34,16 +34,19 @@ export default {
               super(...arguments);
               this.channel = channel;
               this.chatService = chatService;
+            }
 
-              this.chatService.appEvents.on(
+            @bind
+            willDestroy() {
+              this.chatService.appEvents.off(
                 "chat:user-tracking-state-changed",
                 this._refreshTrackingState
               );
             }
 
             @bind
-            willDestroy() {
-              this.chatService.appEvents.off(
+            didInsert() {
+              this.chatService.appEvents.on(
                 "chat:user-tracking-state-changed",
                 this._refreshTrackingState
               );


### PR DESCRIPTION
Previously `this.chatService.appEvents.on(
"chat:user-tracking-state-changed"...)` was registered on constructor and disabled on `willDestroy`. Constructor is evaluated only once, so when the section was collapsed and collapsed, then the events were not observed anymore.

didInsert allows evaluating code each time a component is rendered.

