### PR TITLE
FIX: only applies scroll position to full page

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/channels-list.js
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list.js
@@ -92,19 +92,16 @@ export default class ChannelsList extends Component {
 
   @action
   storeScrollPosition() {
-    const scroller = document.querySelector(".channels-list");
-    if (scroller) {
-      const scrollTop = scroller.scrollTop || 0;
-      this.session.set("channels-list-position", scrollTop);
-    }
+    const scrollTop = document.querySelector(".channels-list")?.scrollTop || 0;
+    this.session.channelsListPosition = scrollTop;
   }
 
   @bind
   _applyScrollPosition() {
-    const data = this.session.get("channels-list-position");
-    if (data) {
-      const scroller = document.querySelector(".channels-list");
-      scroller.scrollTo(0, data);
-    }
+    const position = this.chatStateManager.isFullPage
+      ? this.session.channelsListPosition || 0
+      : 0;
+    const scroller = document.querySelector(".channels-list");
+    scroller.scrollTo(0, position);
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/templates/components/channels-list.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/channels-list.hbs
@@ -8,7 +8,7 @@
   role="region"
   aria-label={{i18n "chat.aria_roles.channels_list"}}
   class="channels-list"
-  {{on "scroll" (action "storeScrollPosition")}}
+  {{on "scroll" (if this.chatStateManager.isFullPage this.storeScrollPosition (noop))}}
 >
   {{#if this.displayPublicChannels}}
     <div class="chat-channel-divider public-channels-section">


### PR DESCRIPTION
No tests as:
- scroll position is not always supe reliable
- this should all be replaced by sidebar and is not supposed to change much

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
