### PR TITLE
PERF: limits use of redis cache while building emojis list

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -29,11 +29,11 @@ class Emoji
   end
 
   def self.aliases
-    Discourse.cache.fetch(cache_key("aliases_emojis")) { db['aliases'] }
+    db['aliases']
   end
 
   def self.search_aliases
-    Discourse.cache.fetch(cache_key("search_aliases_emojis")) { db['searchAliases'] }
+    db['searchAliases']
   end
 
   def self.translations
@@ -45,7 +45,7 @@ class Emoji
   end
 
   def self.tonable_emojis
-    Discourse.cache.fetch(cache_key("tonable_emojis")) { db['tonableEmojis'] }
+    db['tonableEmojis']
   end
 
   def self.custom?(name)
@@ -118,7 +118,7 @@ class Emoji
   end
 
   def self.clear_cache
-    %w{custom standard aliases search_aliases translations all tonable}.each do |key|
+    %w{custom standard translations all}.each do |key|
       Discourse.cache.delete(cache_key("#{key}_emojis"))
     end
     global_emoji_cache.clear


### PR DESCRIPTION
We were doing get on Redis two times for each emoji while building the custom/standard/all lists which were resulting in ~3710 Redis calls. Given the emoji DB file is loaded in memory while we build/cache the emojis list this is unnecessary and slow.

As a simplification in pseudo code here is an explanation of what we were doing:

```ruby
emojis.each |emoji_name|
  aliases = get_aliases_from_redis_cache(emoji_name)
  is_tonable = get_is_tonable_from_redis_cache(emoji_name)
  build_emoji(emoji_name, aliases, is_tonable)
end
```

The two redis calls are now simplified to a simple hash access: `@db[emoji_name]`. 

Redis calls on the same endpoint are now less than 10.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
