### PR TITLE
DEV: Add unique ids to deprecations

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/config/environment.js
+++ b/app/assets/javascripts/discourse-common/addon/config/environment.js
@@ -19,6 +19,7 @@ export function isTesting() {
 // Generally means "before we migrated to Ember CLI"
 export function isLegacyEmber() {
   deprecated("`isLegacyEmber()` is now deprecated and always returns false", {
+    id: "discourse.is-legacy-ember",
     dropFrom: "3.0.0.beta1",
   });
   return false;

--- a/app/assets/javascripts/discourse-common/addon/lib/get-owner.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/get-owner.js
@@ -33,7 +33,8 @@ export function getRegister(obj) {
       Object.defineProperty(target, "container", {
         get() {
           deprecated(
-            "Use `this.register` or `getOwner` instead of `this.container`"
+            "Use `this.register` or `getOwner` instead of `this.container`",
+            { id: "discourse.this-container" }
           );
           return register;
         },

--- a/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
@@ -169,6 +169,7 @@ registerIconRenderer({
       deprecated(`use 'translatedTitle' option instead of 'translatedtitle'`, {
         since: "2.9.0.beta6",
         dropFrom: "2.10.0.beta1",
+        id: "discourse.icon-renderer-translatedtitle",
       });
       params.translatedTitle = params.translatedtitle;
     }

--- a/app/assets/javascripts/discourse-common/addon/lib/legacy-resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/legacy-resolver.js
@@ -66,7 +66,11 @@ export function buildResolver(baseName) {
       if (fullName === "app-events:main") {
         deprecated(
           "`app-events:main` has been replaced with `service:app-events`",
-          { since: "2.4.0", dropFrom: "2.9.0.beta1" }
+          {
+            since: "2.4.0",
+            dropFrom: "2.9.0.beta1",
+            id: "discourse.app-events-main",
+          }
         );
         return "service:app-events";
       }
@@ -84,7 +88,10 @@ export function buildResolver(baseName) {
         "route:tagsShow": "route:tagShow",
       })) {
         if (fullName === key) {
-          deprecated(`${key} was replaced with ${value}`, { since: "2.6.0" });
+          deprecated(`${key} was replaced with ${value}`, {
+            since: "2.6.0",
+            id: "discourse.legacy-resolver-resolutions",
+          });
           return value;
         }
       }

--- a/app/assets/javascripts/discourse-common/addon/resolver.js
+++ b/app/assets/javascripts/discourse-common/addon/resolver.js
@@ -168,6 +168,7 @@ export function buildResolver(baseName) {
             {
               since: deprecationInfo.since,
               dropFrom: deprecationInfo.dropFrom,
+              id: "discourse.resolver-resolutions",
             }
           );
         }
@@ -264,7 +265,8 @@ export function buildResolver(baseName) {
         resolved = this.legacyResolver.resolveOther(legacyParsedName);
         if (resolved) {
           deprecated(
-            `Unable to resolve with new resolver, but resolved with legacy resolver: ${parsedName.fullName}`
+            `Unable to resolve with new resolver, but resolved with legacy resolver: ${parsedName.fullName}`,
+            { id: "discourse.legacy-resolver-fallback" }
           );
         }
       }

--- a/app/assets/javascripts/discourse-common/addon/utils/macro-alias.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/macro-alias.js
@@ -18,7 +18,8 @@ export default function macroAlias(fn) {
       return handleDescriptor(...params, fn);
     } else {
       deprecated(
-        `Importing ${fn.name} from 'discourse-common/utils/decorators' is deprecated. You should instead import it from '@ember/object/computed' directly.`
+        `Importing ${fn.name} from 'discourse-common/utils/decorators' is deprecated. You should instead import it from '@ember/object/computed' directly.`,
+        { id: "discourse.utils-decorators-import" }
       );
       return function (target, property, desc) {
         return handleDescriptor(target, property, desc, fn, params);

--- a/app/assets/javascripts/discourse/app/components/bread-crumbs.js
+++ b/app/assets/javascripts/discourse/app/components/bread-crumbs.js
@@ -57,14 +57,16 @@ export default Component.extend({
   @discourseComputed("category")
   parentCategory(category) {
     deprecated(
-      "The parentCategory property of the bread-crumbs component is deprecated"
+      "The parentCategory property of the bread-crumbs component is deprecated",
+      { id: "discourse.breadcrumbs.parentCategory" }
     );
     return category && category.parentCategory;
   },
 
   parentCategories: filter("categories", function (c) {
     deprecated(
-      "The parentCategories property of the bread-crumbs component is deprecated"
+      "The parentCategories property of the bread-crumbs component is deprecated",
+      { id: "discourse.breadcrumbs.parentCategories" }
     );
     if (
       c.id === this.site.get("uncategorized_category_id") &&
@@ -80,7 +82,8 @@ export default Component.extend({
   @discourseComputed("parentCategories")
   parentCategoriesSorted(parentCategories) {
     deprecated(
-      "The parentCategoriesSorted property of the bread-crumbs component is deprecated"
+      "The parentCategoriesSorted property of the bread-crumbs component is deprecated",
+      { id: "discourse.breadcrumbs.parentCategoriesSorted" }
     );
     if (this.siteSettings.fixed_category_positions) {
       return parentCategories;
@@ -97,7 +100,8 @@ export default Component.extend({
   @discourseComputed("category", "parentCategory")
   firstCategory(category, parentCategory) {
     deprecated(
-      "The firstCategory property of the bread-crumbs component is deprecated"
+      "The firstCategory property of the bread-crumbs component is deprecated",
+      { id: "discourse.breadcrumbs.firstCategory" }
     );
     return parentCategory || category;
   },
@@ -105,7 +109,8 @@ export default Component.extend({
   @discourseComputed("category", "parentCategory")
   secondCategory(category, parentCategory) {
     deprecated(
-      "The secondCategory property of the bread-crumbs component is deprecated"
+      "The secondCategory property of the bread-crumbs component is deprecated",
+      { id: "discourse.breadcrumbs.secondCategory" }
     );
     return parentCategory && category;
   },
@@ -113,7 +118,8 @@ export default Component.extend({
   @discourseComputed("firstCategory", "hideSubcategories")
   childCategories(firstCategory, hideSubcategories) {
     deprecated(
-      "The childCategories property of the bread-crumbs component is deprecated"
+      "The childCategories property of the bread-crumbs component is deprecated",
+      { id: "discourse.breadcrumbs.childCategories" }
     );
     if (hideSubcategories) {
       return [];

--- a/app/assets/javascripts/discourse/app/components/composer-message.js
+++ b/app/assets/javascripts/discourse/app/components/composer-message.js
@@ -14,7 +14,8 @@ export default Component.extend({
   actions: {
     closeMessage() {
       deprecated(
-        'You should use `action=(closeMessage message)` instead of `action=(action "closeMessage")`'
+        'You should use `action=(closeMessage message)` instead of `action=(action "closeMessage")`',
+        { id: "discourse.composer-message.closeMessage" }
       );
       this.closeMessage(this.message);
     },

--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -209,7 +209,9 @@ export function clearToolbarCallbacks() {
 }
 
 export function onToolbarCreate(func) {
-  deprecated("`onToolbarCreate` is deprecated, use the plugin api instead.");
+  deprecated("`onToolbarCreate` is deprecated, use the plugin api instead.", {
+    id: "discourse.d-editor.on-toolbar-create",
+  });
   addToolbarCallback(func);
 }
 

--- a/app/assets/javascripts/discourse/app/components/d-section.js
+++ b/app/assets/javascripts/discourse/app/components/d-section.js
@@ -18,6 +18,7 @@ export default class extends Component {
       deprecated("Uses boolean instead of string for scrollTop.", {
         since: "2.8.0.beta9",
         dropFrom: "2.9.0.beta1",
+        id: "discourse.d-section.scroll-top-boolean",
       });
 
       return;

--- a/app/assets/javascripts/discourse/app/components/header-extra-info.js
+++ b/app/assets/javascripts/discourse/app/components/header-extra-info.js
@@ -2,6 +2,7 @@ import deprecated from "discourse-common/lib/deprecated";
 
 export function needsSecondRowIf() {
   deprecated(
-    "`needsSecondRowIf` is deprecated. Use widget hooks on `header-second-row`"
+    "`needsSecondRowIf` is deprecated. Use widget hooks on `header-second-row`",
+    { id: "discourse.header-extra-info.needs-second-row-if" }
   );
 }

--- a/app/assets/javascripts/discourse/app/components/highlight-text.js
+++ b/app/assets/javascripts/discourse/app/components/highlight-text.js
@@ -5,7 +5,8 @@ export default highlightSearch.extend({
   init() {
     this._super(...arguments);
     deprecated(
-      "`highlight-text` component is deprecated,  use the `highlight-search` instead."
+      "`highlight-text` component is deprecated,  use the `highlight-search` instead.",
+      { id: "discourse.highlight-text-component" }
     );
   },
 });

--- a/app/assets/javascripts/discourse/app/components/mobile-nav.js
+++ b/app/assets/javascripts/discourse/app/components/mobile-nav.js
@@ -19,6 +19,7 @@ export default Component.extend({
       deprecated("{{mobile-nav}} no longer requires the currentPath property", {
         since: "2.7.0.beta4",
         dropFrom: "2.9.0.beta1",
+        id: "discourse.mobile-nav.currentPath",
       });
     }
   },

--- a/app/assets/javascripts/discourse/app/components/plugin-connector.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-connector.js
@@ -39,7 +39,10 @@ export default Component.extend({
         key,
         computed("deprecatedArgs", () => {
           deprecated(
-            `The ${key} property is deprecated, but is being used in ${this.layoutName}`
+            `The ${key} property is deprecated, but is being used in ${this.layoutName}`,
+            {
+              id: "discourse.plugin-connector.deprecated-arg",
+            }
           );
 
           return (this.deprecatedArgs || {})[key];

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1234,7 +1234,9 @@ export default Controller.extend({
 
     if (!this.model.targetRecipients) {
       if (opts.usernames) {
-        deprecated("`usernames` is deprecated, use `recipients` instead.");
+        deprecated("`usernames` is deprecated, use `recipients` instead.", {
+          id: "discourse.composer.usernames",
+        });
         this.model.set("targetRecipients", opts.usernames);
       } else if (opts.recipients) {
         this.model.set("targetRecipients", opts.recipients);

--- a/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery/topics.js
@@ -71,7 +71,11 @@ const controllerOpts = {
     changeSort() {
       deprecated(
         "changeSort has been changed from an (action) to a (route-action)",
-        { since: "2.6.0", dropFrom: "2.7.0" }
+        {
+          since: "2.6.0",
+          dropFrom: "2.7.0",
+          id: "discourse.topics.change-sort",
+        }
       );
       return routeAction("changeSort", this.router._router, ...arguments)();
     },

--- a/app/assets/javascripts/discourse/app/initializers/inject-objects.js
+++ b/app/assets/javascripts/discourse/app/initializers/inject-objects.js
@@ -17,6 +17,7 @@ export default {
           {
             since: "2.8",
             dropFrom: "2.9",
+            id: "discourse.global.site-settings",
           }
         );
         return container.lookup("service:site-settings");
@@ -29,6 +30,7 @@ export default {
           {
             since: "2.8",
             dropFrom: "2.9",
+            id: "discourse.global.user",
           }
         );
         return User;
@@ -41,6 +43,7 @@ export default {
           {
             since: "2.8",
             dropFrom: "2.9",
+            id: "discourse.global.site",
           }
         );
         return Site;

--- a/app/assets/javascripts/discourse/app/initializers/jquery-plugins.js
+++ b/app/assets/javascripts/discourse/app/initializers/jquery-plugins.js
@@ -19,7 +19,9 @@ export default {
           deprecated(
             "`bootbox.alert` is deprecated, please use the dialog service instead.",
             {
+              id: "discourse.bootbox",
               dropFrom: "3.1.0.beta5",
+              url: "https://meta.discourse.org/t/244902",
             }
           );
           return dialog.alert(arguments[0]);
@@ -34,7 +36,9 @@ export default {
       deprecated(
         "`bootbox` is now deprecated, please use the dialog service instead.",
         {
+          id: "discourse.bootbox",
           dropFrom: "3.1.0.beta5",
+          url: "https://meta.discourse.org/t/244902",
         }
       );
       return originalDialog(...arguments);

--- a/app/assets/javascripts/discourse/app/lib/category-hashtags.js
+++ b/app/assets/javascripts/discourse/app/lib/category-hashtags.js
@@ -16,6 +16,7 @@ export function categoryHashtagTriggerRule(textarea, opts) {
     {
       since: "2.9.0.beta10",
       dropFrom: "3.0.0.beta1",
+      id: "discourse.category-hashtags.categoryHashtagTriggerRule",
     }
   );
   return hashtagTriggerRule(textarea, opts);

--- a/app/assets/javascripts/discourse/app/lib/click-track.js
+++ b/app/assets/javascripts/discourse/app/lib/click-track.js
@@ -18,6 +18,7 @@ export function isValidLink(link) {
 
     deprecated("isValidLink now expects an Element, not a jQuery object", {
       since: "2.9.0.beta7",
+      id: "discourse.click-track.is-valid-link-jquery",
     });
   }
 

--- a/app/assets/javascripts/discourse/app/lib/cookie.js
+++ b/app/assets/javascripts/discourse/app/lib/cookie.js
@@ -76,7 +76,11 @@ export function removeCookie(key, options) {
 }
 
 if (window && window.$) {
-  const depOpts = { since: "2.6.0", dropFrom: "2.7.0" };
+  const depOpts = {
+    since: "2.6.0",
+    dropFrom: "2.7.0",
+    id: "discourse.jquery-cookie",
+  };
   window.$.cookie = function () {
     deprecated(
       "$.cookie is being removed from Discourse. Please import our cookie module and use that instead.",

--- a/app/assets/javascripts/discourse/app/lib/formatter.js
+++ b/app/assets/javascripts/discourse/app/lib/formatter.js
@@ -56,6 +56,7 @@ export function updateRelativeAge(elems) {
     deprecated("updateRelativeAge now expects a DOM NodeList", {
       since: "2.8.0.beta7",
       dropFrom: "2.9.0.beta1",
+      id: "discourse.formatter.update-relative-age-node-list",
     });
   }
 

--- a/app/assets/javascripts/discourse/app/lib/link-hashtags.js
+++ b/app/assets/javascripts/discourse/app/lib/link-hashtags.js
@@ -15,6 +15,7 @@ export function linkSeenHashtags(elem) {
     deprecated("linkSeenHashtags now expects a DOM node as first parameter", {
       since: "2.8.0.beta7",
       dropFrom: "2.9.0.beta1",
+      id: "discourse.link-hashtags.dom-node",
     });
   }
 

--- a/app/assets/javascripts/discourse/app/lib/link-mentions.js
+++ b/app/assets/javascripts/discourse/app/lib/link-mentions.js
@@ -74,6 +74,7 @@ export function linkSeenMentions(elem, siteSettings) {
     deprecated("linkSeenMentions now expects a DOM node as first parameter", {
       since: "2.8.0.beta7",
       dropFrom: "2.9.0.beta1",
+      id: "discourse.link-mentions.dom-node",
     });
   }
 

--- a/app/assets/javascripts/discourse/app/lib/offset-calculator.js
+++ b/app/assets/javascripts/discourse/app/lib/offset-calculator.js
@@ -10,6 +10,7 @@ export function minimumOffset() {
     {
       since: "2.8.0.beta10",
       dropFrom: "2.9.0.beta2",
+      id: "discourse.offset-calculator.minimumOffset",
     }
   );
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -531,7 +531,8 @@ class PluginApi {
           this.addCommunitySectionLink(args, name.match(/footerLinks/));
         } catch {
           deprecated(
-            `Usage of \`api.decorateWidget('hamburger-menu:generalLinks')\` is incompatible with the \`enable_experimental_sidebar_hamburger\` site setting. Please use \`api.addCommunitySectionLink\` instead.`
+            `Usage of \`api.decorateWidget('hamburger-menu:generalLinks')\` is incompatible with the \`enable_experimental_sidebar_hamburger\` site setting. Please use \`api.addCommunitySectionLink\` instead.`,
+            { id: "discourse.decorate-widget.hamburger-widget-links" }
           );
         }
 
@@ -798,7 +799,8 @@ class PluginApi {
 
   addFlagProperty() {
     deprecated(
-      "addFlagProperty has been removed. Use the reviewable API instead."
+      "addFlagProperty has been removed. Use the reviewable API instead.",
+      { id: "discourse.add-flag-property" }
     );
   }
 

--- a/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-connectors.js
@@ -109,7 +109,9 @@ export function buildArgsWithDeprecations(args, deprecatedArgs) {
   Object.keys(deprecatedArgs).forEach((key) => {
     Object.defineProperty(output, key, {
       get() {
-        deprecated(`${key} is deprecated`);
+        deprecated(`${key} is deprecated`, {
+          id: "discourse.plugin-connector.deprecated-arg",
+        });
 
         return deprecatedArgs[key];
       },

--- a/app/assets/javascripts/discourse/app/lib/theme-selector.js
+++ b/app/assets/javascripts/discourse/app/lib/theme-selector.js
@@ -11,7 +11,8 @@ export function currentThemeKey() {
   if (console && console.warn && console.trace) {
     // TODO: Remove this code Jan 2019
     deprecated(
-      "'currentThemeKey' is is deprecated use 'currentThemeId' instead. A theme component may require updating."
+      "'currentThemeKey' is is deprecated use 'currentThemeId' instead. A theme component may require updating.",
+      { id: "discourse.current-theme-key" }
     );
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/uploads.js
+++ b/app/assets/javascripts/discourse/app/lib/uploads.js
@@ -296,7 +296,8 @@ export function getUploadMarkdown(upload) {
 export function displayErrorForUpload(data, siteSettings, fileName) {
   if (!fileName) {
     deprecated(
-      "Calling displayErrorForUpload without a fileName is deprecated and will be removed in a future version."
+      "Calling displayErrorForUpload without a fileName is deprecated and will be removed in a future version.",
+      { id: "discourse.uploads.display-error-for-upload" }
     );
     fileName = data.files[0].name;
   }

--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -335,6 +335,7 @@ export function safariHacksDisabled() {
     {
       since: "2.8.0.beta8",
       dropFrom: "2.9.0.beta1",
+      id: "discourse.safari-hacks-disabled",
     }
   );
 

--- a/app/assets/javascripts/discourse/app/models/composer.js
+++ b/app/assets/javascripts/discourse/app/models/composer.js
@@ -772,7 +772,9 @@ const Composer = RestModel.extend({
     }
 
     if (opts.usernames) {
-      deprecated("`usernames` is deprecated, use `recipients` instead.");
+      deprecated("`usernames` is deprecated, use `recipients` instead.", {
+        id: "discourse.composer.usernames",
+      });
     }
 
     this.setProperties({

--- a/app/assets/javascripts/discourse/app/models/nav-item.js
+++ b/app/assets/javascripts/discourse/app/models/nav-item.js
@@ -243,6 +243,7 @@ NavItem.reopenClass({
       deprecated("You must supply `buildList` with a `siteSettings` object", {
         since: "2.6.0",
         dropFrom: "2.7.0",
+        id: "discourse.nav-item.built-list-site-settings",
       });
       args.siteSettings = getOwner(this).lookup("service:site-settings");
     }

--- a/app/assets/javascripts/discourse/app/models/post-stream.js
+++ b/app/assets/javascripts/discourse/app/models/post-stream.js
@@ -697,7 +697,10 @@ export default RestModel.extend({
    * */
   triggerNewPostInStream(postId, opts) {
     deprecated(
-      "Please use triggerNewPostsInStream, this method will be removed July 2021"
+      "Please use triggerNewPostsInStream, this method will be removed July 2021",
+      {
+        id: "discourse.post-stream.trigger-new-post",
+      }
     );
     return this.triggerNewPostsInStream([postId], opts);
   },

--- a/app/assets/javascripts/discourse/app/models/site.js
+++ b/app/assets/javascripts/discourse/app/models/site.js
@@ -229,6 +229,7 @@ if (typeof Discourse !== "undefined") {
       if (!warned) {
         deprecated("Import the Site class instead of using Discourse.Site", {
           since: "2.4.0",
+          id: "discourse.globals.site",
         });
         warned = true;
       }

--- a/app/assets/javascripts/discourse/app/models/store.js
+++ b/app/assets/javascripts/discourse/app/models/store.js
@@ -6,5 +6,6 @@ deprecated(
   {
     since: "2.8.0.beta8",
     dropFrom: "2.9.0.beta1",
+    id: "discourse.models-store",
   }
 );

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -240,13 +240,18 @@ const Topic = RestModel.extend({
 
   @discourseComputed("unread_posts", "new_posts")
   totalUnread(unreadPosts, newPosts) {
-    deprecated("The totalUnread property of the topic model is deprecated");
+    deprecated("The totalUnread property of the topic model is deprecated", {
+      id: "discourse.topic.totalUnread",
+    });
     return unreadPosts || newPosts;
   },
 
   @discourseComputed("unread_posts", "new_posts")
   displayNewPosts(unreadPosts, newPosts) {
-    deprecated("The displayNewPosts property of the topic model is deprecated");
+    deprecated(
+      "The displayNewPosts property of the topic model is deprecated",
+      { id: "discourse.topic.totalUnread" }
+    );
     return unreadPosts || newPosts;
   },
 

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1392,6 +1392,7 @@ if (typeof Discourse !== "undefined") {
       if (!warned) {
         deprecated("Import the User class instead of using Discourse.User", {
           since: "2.4.0",
+          id: "discourse.globals.user",
         });
         warned = true;
       }

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -275,7 +275,11 @@ export function acceptance(name, optionsOrCallback) {
   } else if (typeof optionsOrCallback === "object") {
     deprecated(
       `${name}: The second parameter to \`acceptance\` should be a function that encloses your tests.`,
-      { since: "2.6.0", dropFrom: "2.9.0.beta1" }
+      {
+        since: "2.6.0",
+        dropFrom: "2.9.0.beta1",
+        id: "discourse.qunit.acceptance-function",
+      }
     );
     options = optionsOrCallback;
   }
@@ -407,6 +411,7 @@ QUnit.assert.not = function (actual, message) {
   deprecated("assert.not() is deprecated. Use assert.notOk() instead.", {
     since: "2.9.0.beta1",
     dropFrom: "2.10.0.beta1",
+    id: "discourse.qunit.assert-not",
   });
 
   this.pushResult({

--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -231,6 +231,7 @@ export default function setupTests(config) {
         {
           since: "2.6.0.beta.4",
           dropFrom: "2.6.0",
+          id: "discourse.qunit.global-exists",
         }
       );
       return exists;

--- a/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
+++ b/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
@@ -41,6 +41,7 @@ function createHelper(
     deprecated("`whiteList` has been replaced with `allowList`", {
       since: "2.6.0.beta.4",
       dropFrom: "2.7.0",
+      id: "discourse.markdown-it.whitelist",
     });
     helper.allowList(info);
   };

--- a/app/assets/javascripts/pretty-text/addon/pretty-text.js
+++ b/app/assets/javascripts/pretty-text/addon/pretty-text.js
@@ -11,6 +11,7 @@ export function registerOption() {
     {
       since: "2.8.0.beta9",
       dropFrom: "2.9.0.beta1",
+      id: "discourse.pretty-text.registerOption",
     }
   );
 }

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1073,7 +1073,11 @@ export default Component.extend(
         discourseSetup &&
         discourseSetup.getAttribute("data-environment") === "development"
       ) {
-        deprecated(text, { since: "v2.4.0", dropFrom: "2.9.0.beta1" });
+        deprecated(text, {
+          since: "v2.4.0",
+          dropFrom: "2.9.0.beta1",
+          id: "discourse.select-kit",
+        });
       }
     },
 


### PR DESCRIPTION
This will improve the QUnit deprecation summaries introduced via 8c482851454d2a2aead6f072950bdbfae10a46a1

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
