### PR TITLE
DEV: Deprecate `create-store` test helper

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/create-store.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-store.js
@@ -7,6 +7,7 @@ import { buildResolver } from "discourse-common/resolver";
 import { currentSettings } from "discourse/tests/helpers/site-settings";
 import Site from "discourse/models/site";
 import RestModel from "discourse/models/rest";
+import deprecated from "discourse-common/lib/deprecated";
 
 const CatAdapter = RestAdapter.extend({
   primaryKey: "cat_id",
@@ -33,6 +34,17 @@ const CachedCat = RestModel.extend({
 });
 
 export default function (customLookup = () => {}) {
+  deprecated(
+    `create-store helper is deprecated. Please use regular Store service instead, e.g.
+    \`getOwner(this).lookup("service:store")\`
+  `,
+    {
+      since: "2.9.0.beta12",
+      dropFrom: "3.1.0.beta1",
+      id: "discourse.create-store-helper",
+    }
+  );
+
   const resolver = buildResolver("discourse").create({
     namespace: { modulePrefix: "discourse" },
   });

--- a/app/assets/javascripts/discourse/tests/integration/components/pending-post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/pending-post-test.js
@@ -3,13 +3,13 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import createStore from "discourse/tests/helpers/create-store";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | pending-post", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders", async function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     store.createRecord("category", { id: 2 });
     const post = store.createRecord("pending-post", {
       id: 1,

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/category-chooser-test.js
@@ -2,9 +2,9 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import I18n from "I18n";
-import createStore from "discourse/tests/helpers/create-store";
 import { hbs } from "ember-cli-htmlbars";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 module(
   "Integration | Component | select-kit/category-chooser",
@@ -267,7 +267,7 @@ module(
     });
 
     test("filter works with non english characters", async function (assert) {
-      const store = createStore();
+      const store = getOwner(this).lookup("service:store");
       store.createRecord("category", {
         id: 1,
         name: "chữ Quốc ngữ",
@@ -287,7 +287,7 @@ module(
     });
 
     test("decodes entities in row title", async function (assert) {
-      const store = createStore();
+      const store = getOwner(this).lookup("service:store");
       store.createRecord("category", {
         id: 1,
         name: "cat-with-entities",

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/post-test.js
@@ -10,8 +10,8 @@ import {
 import { hbs } from "ember-cli-htmlbars";
 import EmberObject from "@ember/object";
 import I18n from "I18n";
-import createStore from "discourse/tests/helpers/create-store";
 import User from "discourse/models/user";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | Widget | post", function (hooks) {
   setupRenderingTest(hooks);
@@ -163,7 +163,7 @@ module("Integration | Component | Widget | post", function (hooks) {
   });
 
   test("like count button", async function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const topic = store.createRecord("topic", { id: 123 });
     const post = store.createRecord("post", {
       id: 1,
@@ -507,7 +507,7 @@ module("Integration | Component | Widget | post", function (hooks) {
   });
 
   test("expand first post", async function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     this.set("args", { expandablePost: true });
     this.set("post", store.createRecord("post", { id: 1234 }));
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-status-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/topic-status-test.js
@@ -4,13 +4,13 @@ import { click, render } from "@ember/test-helpers";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import TopicStatusIcons from "discourse/helpers/topic-status-icons";
-import createStore from "discourse/tests/helpers/create-store";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 module("Integration | Component | Widget | topic-status", function (hooks) {
   setupRenderingTest(hooks);
 
   test("basics", async function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     this.set("args", {
       topic: store.createRecord("topic", { closed: true }),
       disableActions: true,
@@ -24,7 +24,7 @@ module("Integration | Component | Widget | topic-status", function (hooks) {
   });
 
   test("extendability", async function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     TopicStatusIcons.addObject([
       "has_accepted_answer",
       "far-check-square",
@@ -45,7 +45,7 @@ module("Integration | Component | Widget | topic-status", function (hooks) {
   });
 
   test("toggling pin status", async function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     this.set("args", {
       topic: store.createRecord("topic", { closed: true, pinned: true }),
     });

--- a/app/assets/javascripts/discourse/tests/unit/controllers/reorder-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/controllers/reorder-categories-test.js
@@ -1,15 +1,15 @@
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import createStore from "discourse/tests/helpers/create-store";
+import { getOwner } from "discourse-common/lib/get-owner";
 
 module("Unit | Controller | reorder-categories", function (hooks) {
   setupTest(hooks);
 
   test("reorder set unique position number", function (assert) {
-    const controller = this.owner.lookup("controller:reorder-categories");
-    const store = createStore();
+    const controller = getOwner(this).lookup("controller:reorder-categories");
+    const store = getOwner(this).lookup("service:store");
 
-    const site = this.owner.lookup("service:site");
+    const site = getOwner(this).lookup("service:site");
     site.set("categories", [
       store.createRecord("category", { id: 1, position: 0 }),
       store.createRecord("category", { id: 2, position: 0 }),
@@ -24,8 +24,8 @@ module("Unit | Controller | reorder-categories", function (hooks) {
   });
 
   test("reorder places subcategories after their parent categories, while maintaining the relative order", function (assert) {
-    const controller = this.owner.lookup("controller:reorder-categories");
-    const store = createStore();
+    const controller = getOwner(this).lookup("controller:reorder-categories");
+    const store = getOwner(this).lookup("service:store");
 
     const parent = store.createRecord("category", {
       id: 1,
@@ -51,7 +51,7 @@ module("Unit | Controller | reorder-categories", function (hooks) {
     });
 
     const expectedOrderSlugs = ["parent", "child2", "child1", "other"];
-    const site = this.owner.lookup("service:site");
+    const site = getOwner(this).lookup("service:site");
     site.set("categories", [child2, parent, other, child1]);
 
     controller.reorder();
@@ -63,8 +63,8 @@ module("Unit | Controller | reorder-categories", function (hooks) {
   });
 
   test("changing the position number of a category should place it at given position", function (assert) {
-    const controller = this.owner.lookup("controller:reorder-categories");
-    const store = createStore();
+    const controller = getOwner(this).lookup("controller:reorder-categories");
+    const store = getOwner(this).lookup("service:store");
 
     const elem1 = store.createRecord("category", {
       id: 1,
@@ -84,7 +84,7 @@ module("Unit | Controller | reorder-categories", function (hooks) {
       slug: "test",
     });
 
-    const site = this.owner.lookup("service:site");
+    const site = getOwner(this).lookup("service:site");
     site.set("categories", [elem1, elem2, elem3]);
 
     // Move category 'foo' from position 0 to position 2
@@ -98,8 +98,8 @@ module("Unit | Controller | reorder-categories", function (hooks) {
   });
 
   test("changing the position number of a category should place it at given position and respect children", function (assert) {
-    const controller = this.owner.lookup("controller:reorder-categories");
-    const store = createStore();
+    const controller = getOwner(this).lookup("controller:reorder-categories");
+    const store = getOwner(this).lookup("service:store");
 
     const elem1 = store.createRecord("category", {
       id: 1,
@@ -126,7 +126,7 @@ module("Unit | Controller | reorder-categories", function (hooks) {
       slug: "test",
     });
 
-    const site = this.owner.lookup("service:site");
+    const site = getOwner(this).lookup("service:site");
     site.set("categories", [elem1, child1, elem2, elem3]);
 
     controller.send("change", elem1, { target: { value: 3 } });
@@ -140,8 +140,8 @@ module("Unit | Controller | reorder-categories", function (hooks) {
   });
 
   test("changing the position through click on arrow of a category should place it at given position and respect children", function (assert) {
-    const controller = this.owner.lookup("controller:reorder-categories");
-    const store = createStore();
+    const controller = getOwner(this).lookup("controller:reorder-categories");
+    const store = getOwner(this).lookup("service:store");
 
     const child2 = store.createRecord("category", {
       id: 105,
@@ -177,7 +177,7 @@ module("Unit | Controller | reorder-categories", function (hooks) {
       slug: "test",
     });
 
-    const site = this.owner.lookup("service:site");
+    const site = getOwner(this).lookup("service:site");
     site.set("categories", [elem1, child1, child2, elem2, elem3]);
 
     controller.reorder();

--- a/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/category-badge-test.js
@@ -1,17 +1,19 @@
+import { module, test } from "qunit";
 import Site from "discourse/models/site";
 import { categoryBadgeHTML } from "discourse/helpers/category-link";
-import createStore from "discourse/tests/helpers/create-store";
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import sinon from "sinon";
-import { test } from "qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
 
-discourseModule("Unit | Utility | category-badge", function () {
+module("Unit | Utility | category-badge", function (hooks) {
+  setupTest(hooks);
+
   test("categoryBadge without a category", function (assert) {
     assert.blank(categoryBadgeHTML(), "it returns no HTML");
   });
 
   test("Regular categoryBadge", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const category = store.createRecord("category", {
       name: "hello",
       id: 123,
@@ -42,7 +44,7 @@ discourseModule("Unit | Utility | category-badge", function () {
   });
 
   test("undefined color", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const noColor = store.createRecord("category", { name: "hello", id: 123 });
     const tag = $.parseHTML(categoryBadgeHTML(noColor))[0];
 
@@ -53,7 +55,7 @@ discourseModule("Unit | Utility | category-badge", function () {
   });
 
   test("topic count", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const category = store.createRecord("category", { name: "hello", id: 123 });
 
     assert.ok(
@@ -68,7 +70,7 @@ discourseModule("Unit | Utility | category-badge", function () {
   });
 
   test("allowUncategorized", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const uncategorized = store.createRecord("category", {
       name: "uncategorized",
       id: 345,
@@ -90,8 +92,10 @@ discourseModule("Unit | Utility | category-badge", function () {
   });
 
   test("category names are wrapped in dir-spans", function (assert) {
-    this.siteSettings.support_mixed_text_direction = true;
-    const store = createStore();
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+    siteSettings.support_mixed_text_direction = true;
+
+    const store = getOwner(this).lookup("service:store");
     const rtlCategory = store.createRecord("category", {
       name: "תכנות עם Ruby",
       id: 123,
@@ -115,7 +119,8 @@ discourseModule("Unit | Utility | category-badge", function () {
   });
 
   test("recursive", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
+    const siteSettings = getOwner(this).lookup("service:site-settings");
 
     const foo = store.createRecord("category", {
       name: "foo",
@@ -134,20 +139,20 @@ discourseModule("Unit | Utility | category-badge", function () {
       parent_category_id: bar.id,
     });
 
-    this.siteSettings.max_category_nesting = 0;
+    siteSettings.max_category_nesting = 0;
     assert.ok(categoryBadgeHTML(baz, { recursive: true }).includes("baz"));
     assert.ok(!categoryBadgeHTML(baz, { recursive: true }).includes("bar"));
 
-    this.siteSettings.max_category_nesting = 1;
+    siteSettings.max_category_nesting = 1;
     assert.ok(categoryBadgeHTML(baz, { recursive: true }).includes("baz"));
     assert.ok(!categoryBadgeHTML(baz, { recursive: true }).includes("bar"));
 
-    this.siteSettings.max_category_nesting = 2;
+    siteSettings.max_category_nesting = 2;
     assert.ok(categoryBadgeHTML(baz, { recursive: true }).includes("baz"));
     assert.ok(categoryBadgeHTML(baz, { recursive: true }).includes("bar"));
     assert.ok(!categoryBadgeHTML(baz, { recursive: true }).includes("foo"));
 
-    this.siteSettings.max_category_nesting = 3;
+    siteSettings.max_category_nesting = 3;
     assert.ok(categoryBadgeHTML(baz, { recursive: true }).includes("baz"));
     assert.ok(categoryBadgeHTML(baz, { recursive: true }).includes("bar"));
     assert.ok(categoryBadgeHTML(baz, { recursive: true }).includes("foo"));

--- a/app/assets/javascripts/discourse/tests/unit/models/category-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/category-test.js
@@ -1,11 +1,14 @@
 import { module, test } from "qunit";
 import Category from "discourse/models/category";
-import createStore from "discourse/tests/helpers/create-store";
 import sinon from "sinon";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
 
-module("Unit | Model | category", function () {
+module("Unit | Model | category", function (hooks) {
+  setupTest(hooks);
+
   test("slugFor", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
 
     const slugFor = function (cat, val, text) {
       assert.strictEqual(Category.slugFor(cat), val, text);
@@ -68,7 +71,7 @@ module("Unit | Model | category", function () {
   test("findBySlug", function (assert) {
     assert.expect(6);
 
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const darth = store.createRecord("category", { id: 1, slug: "darth" }),
       luke = store.createRecord("category", {
         id: 2,
@@ -133,7 +136,7 @@ module("Unit | Model | category", function () {
   test("findSingleBySlug", function (assert) {
     assert.expect(6);
 
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const darth = store.createRecord("category", { id: 1, slug: "darth" }),
       luke = store.createRecord("category", {
         id: 2,
@@ -196,7 +199,7 @@ module("Unit | Model | category", function () {
   });
 
   test("findBySlugPathWithID", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
 
     const foo = store.createRecord("category", { id: 1, slug: "foo" });
     const bar = store.createRecord("category", {
@@ -220,7 +223,7 @@ module("Unit | Model | category", function () {
   });
 
   test("minimumRequiredTags", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
 
     let foo = store.createRecord("category", {
       id: 1,
@@ -263,23 +266,23 @@ module("Unit | Model | category", function () {
   });
 
   test("search with category name", function (assert) {
-    const store = createStore(),
-      category1 = store.createRecord("category", {
-        id: 1,
-        name: "middle term",
-        slug: "different-slug",
-      }),
-      category2 = store.createRecord("category", {
-        id: 2,
-        name: "middle term",
-        slug: "another-different-slug",
-      }),
-      subcategory = store.createRecord("category", {
-        id: 3,
-        name: "middle term",
-        slug: "another-different-slug2",
-        parent_category_id: 2,
-      });
+    const store = getOwner(this).lookup("service:store");
+    const category1 = store.createRecord("category", {
+      id: 1,
+      name: "middle term",
+      slug: "different-slug",
+    });
+    const category2 = store.createRecord("category", {
+      id: 2,
+      name: "middle term",
+      slug: "another-different-slug",
+    });
+    const subcategory = store.createRecord("category", {
+      id: 3,
+      name: "middle term",
+      slug: "another-different-slug2",
+      parent_category_id: 2,
+    });
 
     sinon
       .stub(Category, "listByActivity")
@@ -369,17 +372,17 @@ module("Unit | Model | category", function () {
   });
 
   test("search with category slug", function (assert) {
-    const store = createStore(),
-      category1 = store.createRecord("category", {
-        id: 1,
-        name: "middle term",
-        slug: "different-slug",
-      }),
-      category2 = store.createRecord("category", {
-        id: 2,
-        name: "middle term",
-        slug: "another-different-slug",
-      });
+    const store = getOwner(this).lookup("service:store");
+    const category1 = store.createRecord("category", {
+      id: 1,
+      name: "middle term",
+      slug: "different-slug",
+    });
+    const category2 = store.createRecord("category", {
+      id: 2,
+      name: "middle term",
+      slug: "another-different-slug",
+    });
 
     sinon.stub(Category, "listByActivity").returns([category1, category2]);
 

--- a/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/nav-item-test.js
@@ -2,13 +2,17 @@ import { module, test } from "qunit";
 import Category from "discourse/models/category";
 import NavItem from "discourse/models/nav-item";
 import Site from "discourse/models/site";
-import createStore from "discourse/tests/helpers/create-store";
 import { run } from "@ember/runloop";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
 
 module("Unit | Model | nav-item", function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
     run(function () {
-      const fooCategory = Category.create({
+      const store = getOwner(this).lookup("service:store");
+      const fooCategory = store.createRecord("category", {
         slug: "foo",
         id: 123,
       });
@@ -39,7 +43,8 @@ module("Unit | Model | nav-item", function (hooks) {
   });
 
   test("count", function (assert) {
-    const navItem = createStore().createRecord("nav-item", { name: "new" });
+    const store = getOwner(this).lookup("service:store");
+    const navItem = store.createRecord("nav-item", { name: "new" });
 
     assert.strictEqual(navItem.get("count"), 0, "it has no count by default");
 
@@ -59,7 +64,8 @@ module("Unit | Model | nav-item", function (hooks) {
   });
 
   test("displayName", function (assert) {
-    const navItem = createStore().createRecord("nav-item", {
+    const store = getOwner(this).lookup("service:store");
+    const navItem = store.createRecord("nav-item", {
       name: "something",
     });
 
@@ -73,7 +79,8 @@ module("Unit | Model | nav-item", function (hooks) {
   });
 
   test("title", function (assert) {
-    const navItem = createStore().createRecord("nav-item", {
+    const store = getOwner(this).lookup("service:store");
+    const navItem = store.createRecord("nav-item", {
       name: "something",
     });
 

--- a/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/result-set-test.js
@@ -1,8 +1,11 @@
 import { module, test } from "qunit";
 import ResultSet from "discourse/models/result-set";
-import createStore from "discourse/tests/helpers/create-store";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
 
-module("Unit | Model | result-set", function () {
+module("Unit | Model | result-set", function (hooks) {
+  setupTest(hooks);
+
   test("defaults", function (assert) {
     const resultSet = ResultSet.create({ content: [] });
     assert.strictEqual(resultSet.get("length"), 0);
@@ -14,7 +17,7 @@ module("Unit | Model | result-set", function () {
   });
 
   test("pagination support", async function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const resultSet = await store.findAll("widget");
     assert.strictEqual(resultSet.get("length"), 2);
     assert.strictEqual(resultSet.get("totalRows"), 4);
@@ -33,7 +36,7 @@ module("Unit | Model | result-set", function () {
   });
 
   test("refresh support", async function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const resultSet = await store.findAll("widget");
     assert.strictEqual(
       resultSet.get("refreshUrl"),

--- a/app/assets/javascripts/discourse/tests/unit/models/site-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/site-test.js
@@ -1,8 +1,11 @@
 import { module, test } from "qunit";
 import Site from "discourse/models/site";
-import createStore from "discourse/tests/helpers/create-store";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
 
-module("Unit | Model | site", function () {
+module("Unit | Model | site", function (hooks) {
+  setupTest(hooks);
+
   test("create", function (assert) {
     assert.ok(Site.create(), "it can create with no parameters");
   });
@@ -26,7 +29,7 @@ module("Unit | Model | site", function () {
   });
 
   test("create categories", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const site = store.createRecord("site", {
       categories: [
         { id: 3456, name: "Test Subcategory", parent_category_id: 1234 },
@@ -78,7 +81,7 @@ module("Unit | Model | site", function () {
   });
 
   test("sortedCategories returns categories sorted by topic counts and sorts child categories after parent", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const site = store.createRecord("site", {
       categories: [
         {

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-test.js
@@ -1,13 +1,13 @@
+import { module, test } from "qunit";
 import Category from "discourse/models/category";
 import Topic from "discourse/models/topic";
-import User from "discourse/models/user";
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
-import createStore from "discourse/tests/helpers/create-store";
 import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
 
-discourseModule("Unit | Model | topic", function (hooks) {
+module("Unit | Model | topic", function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
     this.store = getOwner(this).lookup("service:store");
   });
@@ -74,8 +74,7 @@ discourseModule("Unit | Model | topic", function (hooks) {
   });
 
   test("lastUnreadUrl with navigate_to_first_post_after_read setting", function (assert) {
-    const store = createStore();
-    const category = store.createRecord("category", {
+    const category = this.store.createRecord("category", {
       id: 22,
       navigate_to_first_post_after_read: true,
     });
@@ -92,8 +91,7 @@ discourseModule("Unit | Model | topic", function (hooks) {
   });
 
   test("lastUnreadUrl with navigate_to_first_post_after_read setting and unread posts", function (assert) {
-    const store = createStore();
-    const category = store.createRecord("category", {
+    const category = this.store.createRecord("category", {
       id: 22,
       navigate_to_first_post_after_read: true,
     });
@@ -184,7 +182,7 @@ discourseModule("Unit | Model | topic", function (hooks) {
   });
 
   test("recover", async function (assert) {
-    const user = User.create({ username: "eviltrout" });
+    const user = this.store.createRecord("user", { username: "eviltrout" });
     const topic = this.store.createRecord("topic", {
       id: 1234,
       deleted_at: new Date(),
@@ -217,7 +215,9 @@ discourseModule("Unit | Model | topic", function (hooks) {
       fancy_title: "This is a test",
     });
 
-    this.siteSettings.support_mixed_text_direction = true;
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+    siteSettings.support_mixed_text_direction = true;
+
     assert.strictEqual(
       rtlTopic.get("fancyTitle"),
       `<span dir="rtl">هذا اختبار</span>`,

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -11,7 +11,6 @@ import {
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import TopicTrackingState from "discourse/models/topic-tracking-state";
 import User from "discourse/models/user";
-import createStore from "discourse/tests/helpers/create-store";
 import sinon from "sinon";
 import { getOwner } from "discourse-common/lib/get-owner";
 
@@ -1019,7 +1018,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
   });
 
   test("getSubCategoryIds", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const foo = store.createRecord("category", { id: 1, slug: "foo" });
     const bar = store.createRecord("category", {
       id: 2,
@@ -1040,7 +1039,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
   });
 
   test("countNew", function (assert) {
-    const store = createStore();
+    const store = getOwner(this).lookup("service:store");
     const foo = store.createRecord("category", {
       id: 1,
       slug: "foo",

--- a/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/document-title-test.js
@@ -1,22 +1,17 @@
-import {
-  currentUser,
-  discourseModule,
-} from "discourse/tests/helpers/qunit-helpers";
-import DocumentTitle from "discourse/services/document-title";
-import AppEvents from "discourse/services/app-events";
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { currentUser } from "discourse/tests/helpers/qunit-helpers";
 import Session from "discourse/models/session";
-import { test } from "qunit";
 
-discourseModule("Unit | Service | document-title", function (hooks) {
+module("Unit | Service | document-title", function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
     const session = Session.current();
     session.hasFocus = true;
 
-    this.documentTitle = DocumentTitle.create({
-      session,
-      appEvents: AppEvents.create(),
-    });
-    this.documentTitle.currentUser = null;
+    this.documentTitle = getOwner(this).lookup("service:document-title");
   });
 
   hooks.afterEach(function () {

--- a/app/assets/javascripts/discourse/tests/unit/services/emoji-store-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/services/emoji-store-test.js
@@ -1,9 +1,12 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
 
-discourseModule("Unit | Service | emoji-store", function (hooks) {
+module("Unit | Service | emoji-store", function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
-    this.emojiStore = this.container.lookup("service:emoji-store");
+    this.emojiStore = getOwner(this).lookup("service:emoji-store");
     this.emojiStore.reset();
   });
 


### PR DESCRIPTION
Use the regular Store service instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
