### PR TITLE
UX: add channel header offset to browse page height

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-browse.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-browse.scss
@@ -1,6 +1,6 @@
 .chat-browse-view {
   position: relative;
-  height: calc(100vh - var(--header-offset));
+  height: calc(100vh - var(--header-offset) - 65px);
   overflow-y: scroll;
   @include chat-scrollbar(var(--secondary));
 

--- a/plugins/chat/assets/stylesheets/common/chat-browse.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-browse.scss
@@ -1,6 +1,9 @@
 .chat-browse-view {
   position: relative;
-  height: calc(100vh - var(--header-offset) - 65px);
+  height: calc(100vh - var(--header-offset) - var(--chat-header-offset));
+  padding-top: 1em;
+  padding-bottom: 41px;
+  box-sizing: border-box;
   overflow-y: scroll;
   @include chat-scrollbar(var(--secondary));
 
@@ -12,7 +15,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    margin-bottom: 1em;
+    // margin-bottom: 1em;
 
     .new-channel-btn {
       margin-left: auto;
@@ -25,7 +28,7 @@
   }
 
   &__content_wrapper {
-    margin: 2rem 0 1rem 1rem;
+    margin: 2rem 0 0 1rem;
     box-sizing: border-box;
 
     @include breakpoint(tablet) {

--- a/plugins/chat/assets/stylesheets/common/chat-browse.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-browse.scss
@@ -15,7 +15,6 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    // margin-bottom: 1em;
 
     .new-channel-btn {
       margin-left: auto;

--- a/plugins/chat/assets/stylesheets/common/common.scss
+++ b/plugins/chat/assets/stylesheets/common/common.scss
@@ -4,6 +4,7 @@ $float-height: 530px;
   --message-left-width: 42px;
   --full-page-border-radius: 12px;
   --full-page-sidebar-width: 275px;
+  --chat-header-offset: 65px;
 }
 
 .chat-message-move-to-channel-modal-modal {

--- a/plugins/chat/assets/stylesheets/desktop/desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/desktop.scss
@@ -19,8 +19,8 @@
 
   .chat-full-page-header {
     padding: 0 1rem;
-    height: 65px;
-    min-height: 65px;
+    height: var(--chat-header-offset);
+    min-height: var(--chat-header-offset);
     flex-shrink: 0;
   }
 


### PR DESCRIPTION
* fixed overflow issue by adding the missing offset
*  added some padding to the bottom because it's best practice to not end your content right at the edge of the screen
<img width="1409" alt="image" src="https://user-images.githubusercontent.com/101828855/201873976-aa7cb48a-2b77-4185-aef5-1a2a0eaf2744.png">

