### PR TITLE
DEV: Add `discourse/tests` to jsconfig

### DIFF
--- a/app/assets/javascripts/admin/jsconfig.json
+++ b/app/assets/javascripts/admin/jsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "admin/*": ["./addon/*"],
       "discourse/*": ["../discourse/app/*"],
+      "discourse/tests/*": ["../discourse/tests/*"],
       "discourse-common/*": ["../discourse-common/addon/*"],
       "pretty-text/*": ["../pretty-text/addon/*"],
     }

--- a/app/assets/javascripts/discourse-widget-hbs/jsconfig.json
+++ b/app/assets/javascripts/discourse-widget-hbs/jsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "discourse-widget-hbs/*": ["./addon/*"],
       "discourse/*": ["../discourse/app/*"],
+      "discourse/tests/*": ["../discourse/tests/*"],
       "discourse-common/*": ["../discourse-common/addon/*"]
     }
   },

--- a/app/assets/javascripts/discourse/jsconfig.json
+++ b/app/assets/javascripts/discourse/jsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "discourse/*": ["./app/*"],
+      "discourse/tests/*": ["./tests/*"],
       "discourse-common/*": ["../discourse-common/addon/*"],
       "pretty-text/*": ["../pretty-text/addon/*"],
       "select-kit/*": ["../select-kit/addon/*"],

--- a/app/assets/javascripts/pretty-text/jsconfig.json
+++ b/app/assets/javascripts/pretty-text/jsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "pretty-text/*": ["./addon/*"],
       "discourse/*": ["../discourse/app/*"],
+      "discourse/tests/*": ["../discourse/tests/*"],
       "discourse-common/*": ["../discourse-common/addon/*"]
     }
   },

--- a/app/assets/javascripts/select-kit/jsconfig.json
+++ b/app/assets/javascripts/select-kit/jsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "select-kit/*": ["./addon/*"],
       "discourse/*": ["../discourse/app/*"],
+      "discourse/tests/*": ["../discourse/tests/*"],
       "discourse-common/*": ["../discourse-common/addon/*"],
     }
   },

--- a/app/assets/javascripts/wizard/jsconfig.json
+++ b/app/assets/javascripts/wizard/jsconfig.json
@@ -5,6 +5,7 @@
     "paths": {
       "wizard/*": ["./addon/*"],
       "discourse/*": ["../discourse/app/*"],
+      "discourse/tests/*": ["../discourse/tests/*"],
       "discourse-common/*": ["../discourse-common/addon/*"],
     }
   },


### PR DESCRIPTION
This allows IDEs to resolve imports under `discourse/tests`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
