### PR TITLE
UX: force sidebar to occupy full height

### DIFF
--- a/app/assets/stylesheets/mobile/menu-panel.scss
+++ b/app/assets/stylesheets/mobile/menu-panel.scss
@@ -6,6 +6,7 @@
   }
   .panel-body-contents {
     max-height: unset;
+    min-height: 100%;
   }
 }
 .header-cloak {
@@ -89,6 +90,7 @@
       display: flex;
       flex-direction: column;
       padding-top: 0.5em;
+      flex: 1 1 auto;
     }
   }
 
@@ -125,6 +127,7 @@
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
+    flex: 1 1 auto;
   }
 
   .sidebar-section-content {


### PR DESCRIPTION
Fixes this issue on mobile, where the sidebar is too short when there's not much content: 



<img src="https://user-images.githubusercontent.com/1681963/201944139-6fd7b8ff-cade-4ecf-964d-ed70bd2ba227.png" height=400 />