### PR TITLE
DEV: allow themes to more easily set border-radii

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -219,7 +219,7 @@ input {
     color: var(--primary);
     background-color: var(--secondary);
     border: 1px solid var(--primary-medium);
-    border-radius: 0;
+    border-radius: var(--d-input-border-radius);
     &:focus {
       @include default-focus;
     }

--- a/app/assets/stylesheets/common/base/login.scss
+++ b/app/assets/stylesheets/common/base/login.scss
@@ -158,7 +158,6 @@ body.invite-page {
       input,
       .select-kit-header {
         padding: 0.75em 0.77em;
-        border-radius: 0.25em;
         min-width: 250px;
         box-shadow: none;
         margin-bottom: 0.25em;
@@ -186,7 +185,6 @@ body.invite-page {
         left: 1em;
         top: 10px;
         box-shadow: 0 0 0 0px rgba(var(--tertiary-rgb), 0);
-        border-radius: 0.25em;
         transition: 0.2s ease all;
       }
       .user-field.dropdown label.control-label {
@@ -235,7 +233,6 @@ body.invite-page {
       input {
         width: 100%;
         padding: 0.75em 0.5em;
-        border-radius: 0.25em;
         min-width: 250px;
         box-shadow: none;
         margin-bottom: 2em;

--- a/app/assets/stylesheets/common/components/buttons.scss
+++ b/app/assets/stylesheets/common/components/buttons.scss
@@ -21,6 +21,7 @@
   font-weight: normal;
   color: $text-color;
   background: $bg-color;
+  border-radius: var(--d-button-border-radius);
   cursor: pointer;
   transition: all 0.25s;
   .d-icon {
@@ -178,6 +179,7 @@
   color: #000;
   background: #fff;
   border: 1px solid transparent;
+  border-radius: var(--d-border-radius);
   &:hover,
   &:focus {
     box-shadow: shadow("card");
@@ -340,6 +342,7 @@
 }
 
 .btn-mini-toggle {
+  border-radius: var(--d-border-radius);
   padding: 0.4em 0.467em;
   .d-icon {
     color: var(--primary-high);

--- a/app/assets/stylesheets/common/components/navs.scss
+++ b/app/assets/stylesheets/common/components/navs.scss
@@ -31,6 +31,7 @@
     > a,
     button {
       border: none;
+      border-radius: var(--d-nav-pill-border-radius);
       padding: 6px 12px;
       color: var(--primary);
       font-size: var(--font-up-1);

--- a/app/assets/stylesheets/common/d-editor.scss
+++ b/app/assets/stylesheets/common/d-editor.scss
@@ -25,6 +25,7 @@
   background-color: var(--secondary);
   position: relative;
   border: 1px solid var(--primary-medium);
+  border-radius: var(--d-input-border-radius);
   min-height: 0;
 
   textarea {

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -18,6 +18,10 @@ $reply-area-max-width: 1475px !default;
   --topic-body-width: #{$topic-body-width};
   --topic-body-width-padding: #{$topic-body-width-padding};
   --topic-avatar-width: #{$topic-avatar-width};
+  --d-border-radius: initial;
+  --d-nav-pill-border-radius: var(--d-border-radius);
+  --d-button-border-radius: var(--d-border-radius);
+  --d-input-border-radius: var(--d-border-radius);
 }
 
 $d-sidebar-width: 16em !default;

--- a/app/assets/stylesheets/common/select-kit/select-kit.scss
+++ b/app/assets/stylesheets/common/select-kit/select-kit.scss
@@ -74,6 +74,7 @@
     display: flex;
     align-items: stretch;
     &:not(.btn) {
+      border-radius: var(--d-input-border-radius);
       padding-left: 0.5em;
       padding-right: 0.5em;
     }

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -50,6 +50,7 @@
       margin-right: 0;
       font-size: var(--font-down-1);
       border: 1px solid var(--primary-medium);
+      border-radius: var(--d-input-border-radius);
     }
     > li > a {
       line-height: var(--line-height-large);


### PR DESCRIPTION
This sets up some new variables in `variables.scss`

```
:root {
  --d-border-radius: initial;
  --d-nav-pill-border-radius: var(--d-border-radius);
  --d-button-border-radius: var(--d-border-radius);
  --d-input-border-radius: var(--d-border-radius);
}
```

The idea is that a theme could do something like this to add a border radius to buttons, inputs (including select kit), and nav-pills:

```
:root {
 --d-border-radius: 10px;
}
```

or alternatively, only one of those element types, like buttons: 

```
:root {
 --d-button-border-radius: 10px;
}
```

Ideally, if a theme developer finds that some element is missing from `--d-border-radius`'s effects they could add another `border-radius: var(--d-border-radius)` in the relevant place, or add a relevant class (for example `.btn`) to their element. 
