### PR TITLE
FIX: deprioritize reaction notifications

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -239,7 +239,8 @@ class Notification < ActiveRecord::Base
   def self.like_types
     [
       Notification.types[:liked],
-      Notification.types[:liked_consolidated]
+      Notification.types[:liked_consolidated],
+      Notification.types[:reaction]
     ]
   end
 


### PR DESCRIPTION
Fix for https://github.com/discourse/discourse/pull/19029

Reactions should be moved down similarly to likes

