### PR TITLE
FIX: Bug with admin trust level growth report

### DIFF
--- a/app/models/concerns/reports/trust_level_growth.rb
+++ b/app/models/concerns/reports/trust_level_growth.rb
@@ -39,6 +39,7 @@ module Reports::TrustLevelGrowth
         OR action = #{UserHistory.actions[:auto_trust_level_change]}
       )
       GROUP BY date(created_at)
+      ORDER BY date(created_at)
       SQL
 
       data = Hash[ filters.collect { |x| [x, []] } ]


### PR DESCRIPTION
When the Trust Level Growth report in the admin dashboard has lots of data ( > 6 months of activity), the dates weren't ordered properly and this resulted in broken data in the chart and CSV export. Explicitly ordering by date fixes the issue. 

Before
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/368961/202085874-e48bf783-aa6b-406c-a903-93b23416ca8f.png">

After
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/368961/202085914-be106a9c-c3eb-440d-a821-3fbde5ef0f66.png">

This PR does not include a test because the bug relies on lots of data and it would be very time-consuming to write a test that generates all that data, and the resulting test would probably be slow on every run. 