### PR TITLE
DEV: Ensure `withSilencedDeprecations` waits for async function

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -70,6 +70,9 @@ export async function withSilencedDeprecations(deprecationIds, callback) {
   try {
     idArray.forEach((id) => disabledDeprecations.add(id));
     result = callback();
+    if (result instanceof Promise) {
+      result = await result;
+    }
   } finally {
     idArray.forEach((id) => disabledDeprecations.delete(id));
     return result;

--- a/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/deprecated.js
@@ -60,21 +60,37 @@ export function registerDeprecationHandler(callback) {
 
 /**
  * Silence one or more deprecations while running `callback`
- * @async
  * @param {(string|string[])} deprecationIds A single id, or an array of ids, of deprecations to silence
- * @param {function} callback The function to call while deprecations are silenced. Can be asynchronous.
+ * @param {function} callback The function to call while deprecations are silenced.
  */
-export async function withSilencedDeprecations(deprecationIds, callback) {
+export function withSilencedDeprecations(deprecationIds, callback) {
   const idArray = [].concat(deprecationIds);
-  let result;
   try {
     idArray.forEach((id) => disabledDeprecations.add(id));
-    result = callback();
+    const result = callback();
     if (result instanceof Promise) {
-      result = await result;
+      throw new Error(
+        "withSilencedDeprecations callback returned a promise. Use withSilencedDeprecationsAsync instead."
+      );
     }
+    return result;
   } finally {
     idArray.forEach((id) => disabledDeprecations.delete(id));
-    return result;
+  }
+}
+
+/**
+ * Silence one or more deprecations while running an async `callback`
+ * @async
+ * @param {(string|string[])} deprecationIds A single id, or an array of ids, of deprecations to silence
+ * @param {function} callback The asynchronous function to call while deprecations are silenced.
+ */
+export async function withSilencedDeprecationsAsync(deprecationIds, callback) {
+  const idArray = [].concat(deprecationIds);
+  try {
+    idArray.forEach((id) => disabledDeprecations.add(id));
+    return await callback();
+  } finally {
+    idArray.forEach((id) => disabledDeprecations.delete(id));
   }
 }

--- a/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-selector-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { withSilencedDeprecations } from "discourse-common/lib/deprecated";
+import { withSilencedDeprecationsAsync } from "discourse-common/lib/deprecated";
 
 function paste(element, text) {
   let e = new Event("paste");
@@ -17,7 +17,7 @@ module("Integration | Component | user-selector", function (hooks) {
   test("pasting a list of usernames", async function (assert) {
     this.set("usernames", "evil,trout");
 
-    await withSilencedDeprecations(
+    await withSilencedDeprecationsAsync(
       "discourse.user-selector-component",
       async () => {
         await render(
@@ -51,7 +51,7 @@ module("Integration | Component | user-selector", function (hooks) {
     this.set("usernames", "mark");
     this.set("excludedUsernames", ["jeff", "sam", "robin"]);
 
-    await withSilencedDeprecations(
+    await withSilencedDeprecationsAsync(
       "discourse.user-selector-component",
       async () => {
         await render(

--- a/app/assets/javascripts/discourse/tests/unit/lib/deprecated-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/deprecated-test.js
@@ -1,6 +1,7 @@
 import {
   default as deprecated,
   withSilencedDeprecations,
+  withSilencedDeprecationsAsync,
 } from "discourse-common/lib/deprecated";
 import DeprecationCounter from "discourse/tests/helpers/deprecation-counter";
 import { module, test } from "qunit";
@@ -177,9 +178,10 @@ module("Unit | Utility | deprecated", function (hooks) {
   });
 
   test("can silence deprecations with async callback in tests", async function (assert) {
-    await withSilencedDeprecations("discourse.one", async () =>
-      deprecated("message", { id: "discourse.one" })
-    );
+    await withSilencedDeprecationsAsync("discourse.one", async () => {
+      await Promise.resolve();
+      deprecated("message", { id: "discourse.one" });
+    });
     assert.strictEqual(
       this.warnStub.callCount,
       0,

--- a/app/assets/javascripts/discourse/tests/unit/lib/deprecated-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/deprecated-test.js
@@ -175,4 +175,32 @@ module("Unit | Utility | deprecated", function (hooks) {
       "counter is not incremented"
     );
   });
+
+  test("can silence deprecations with async callback in tests", async function (assert) {
+    await withSilencedDeprecations("discourse.one", async () =>
+      deprecated("message", { id: "discourse.one" })
+    );
+    assert.strictEqual(
+      this.warnStub.callCount,
+      0,
+      "console.warn is not called"
+    );
+    assert.strictEqual(
+      this.counterStub.callCount,
+      0,
+      "counter is not incremented"
+    );
+
+    deprecated("message", { id: "discourse.one" });
+    assert.strictEqual(
+      this.warnStub.callCount,
+      1,
+      "console.warn is called outside the silenced function"
+    );
+    assert.strictEqual(
+      this.counterStub.callCount,
+      1,
+      "counter is incremented outside the silenced function"
+    );
+  });
 });


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
