### PR TITLE
A11Y: add live area for search menu, labels

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -92,7 +92,7 @@ function createSearchResult({ type, linkField, builder }) {
 
     buildAttributes() {
       return {
-        "aria-label": `${type} results`,
+        "aria-label": `${type} ${I18n.t("search.results")}`,
       };
     },
 
@@ -649,7 +649,7 @@ createWidget("search-menu-assistant-item", {
     let content = [
       h(
         "span",
-        { attributes: { "aria-label": "search" } },
+        { attributes: { "aria-label": I18n.t("search.title") } },
         iconNode(attrs.icon || "search")
       ),
     ];

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -90,6 +90,12 @@ function createSearchResult({ type, linkField, builder }) {
   return createWidget(`search-result-${type}`, {
     tagName: "ul.list",
 
+    buildAttributes() {
+      return {
+        "aria-label": `${type} results`,
+      };
+    },
+
     html(attrs) {
       return attrs.results.map((r) => {
         let searchResultId;
@@ -640,7 +646,13 @@ createWidget("search-menu-assistant-item", {
     const attributes = {};
     attributes.href = "#";
 
-    let content = [iconNode(attrs.icon || "search")];
+    let content = [
+      h(
+        "span",
+        { attributes: { "aria-label": "search" } },
+        iconNode(attrs.icon || "search")
+      ),
+    ];
 
     if (prefix) {
       content.push(h("span.search-item-prefix", `${prefix} `));

--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -193,6 +193,12 @@ export default createWidget("search-menu", {
   services: ["search"],
   searchData,
 
+  buildAttributes() {
+    return {
+      "aria-live": "polite",
+    };
+  },
+
   buildKey: () => "search-menu",
 
   defaultState(attrs) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2500,6 +2500,7 @@ en:
         other: "<span>%{count}%{plus} results for</span><span class='term'>%{term}</span>"
       title: "Search"
       full_page_title: "Search"
+      results: "results"
       no_results: "No results found."
       no_more_results: "No more results found."
       post_format: "#%{post_number} by %{username}"


### PR DESCRIPTION
1. This makes the header search dropdown an aria live region, so contents will be read after the search input is modified. This gives screen reader users feedback that we're updating the panel contents as they input their search term. 

2. This labels the search icon with "search"... so for example, in the case someone inputs  the term "test"

    ![Screenshot 2022-11-16 at 1 27 18 PM](https://user-images.githubusercontent.com/1681963/202262834-46310bf5-31b9-431e-a59e-f4eb07b76e8d.png)

    Instead of ignoring the search icon and reading "test in all topics and posts or press enter" it will read "<ins>search</ins> test in all topics and posts or press enter" 

3. This labels search result sections like topics, categories, tags, and users. 

    ![Screenshot 2022-11-16 at 1 29 08 PM](https://user-images.githubusercontent.com/1681963/202263351-1882546f-116e-4eaa-8f02-ea7a037f7377.png)

    So when a screen reader user tabs to the tag section in the screenshot above, instead of simply saying "1 item, test" the screen reader will say "tag results, 1 item, test" 
