### PR TITLE
FIX: Regression with special `a` keyword in search

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -367,7 +367,7 @@ export default createWidget("search-menu", {
       return;
     }
 
-    if (e.key === "A") {
+    if (e.which === 65 /* a */) {
       if (document.activeElement?.classList.contains("search-link")) {
         if (document.querySelector("#reply-control.open")) {
           // add a link and focus composer

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -374,6 +374,17 @@ acceptance("Search - Authenticated", function (needs) {
 
       return helper.response(searchFixtures["search/query"]);
     });
+
+    server.get("/inline-onebox", () =>
+      helper.response({
+        "inline-oneboxes": [
+          {
+            url: "http://www.something.com",
+            title: searchFixtures["search/query"].topics[0].title,
+          },
+        ],
+      })
+    );
   });
 
   test("Right filters are shown in full page search", async function (assert) {
@@ -517,6 +528,30 @@ acceptance("Search - Authenticated", function (needs) {
     assert.ok(exists(query(`${container} ul li`)), "has a list of items");
     await triggerKeyEvent("#search-term", "keydown", "Enter");
     assert.ok(exists(query(`.search-menu`)), "search dropdown is visible");
+  });
+
+  test("search while composer is open", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click(".reply");
+    await fillIn(".d-editor-input", "a link");
+    await click("#search-button");
+    await fillIn("#search-term", "dev");
+
+    await triggerKeyEvent("#search-term", "keydown", "Enter");
+    await triggerKeyEvent(".search-menu", "keydown", "ArrowDown");
+    await triggerKeyEvent("#search-term", "keydown", 65); // maps to lowercase a
+
+    assert.ok(
+      query(".d-editor-input").value.includes("a link"),
+      "still has the original composer content"
+    );
+
+    assert.ok(
+      query(".d-editor-input").value.includes(
+        searchFixtures["search/query"].topics[0].slug
+      ),
+      "adds link from search to composer"
+    );
   });
 
   test("Shows recent search results", async function (assert) {


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/discourse/discourse/commit/ac7bf98ad10e529b02a9cddce4367ecb9428b5e1. 