### PR TITLE
FIX: Update user options only once

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -611,7 +611,7 @@ export default Controller.extend(bufferedProperty("model"), {
 
     // Post related methods
     replyToPost(post) {
-      if (this.currentUser) {
+      if (this.currentUser && this.siteSettings.enable_user_tips) {
         this.currentUser.hideUserTipForever("post_menu");
       }
 

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1171,11 +1171,17 @@ const User = RestModel.extend({
     // Hide any shown user tips.
     let seenUserTips = this.seen_popups || [];
     if (userTipId) {
-      hideUserTip(userTipId);
-      if (!seenUserTips.includes(userTips[userTipId])) {
-        seenUserTips.push(userTips[userTipId]);
+      if (seenUserTips.includes(userTips[userTipId])) {
+        return;
       }
+
+      hideUserTip(userTipId);
+      seenUserTips.push(userTips[userTipId]);
     } else {
+      if (seenUserTips.includes(-1)) {
+        return;
+      }
+
       hideAllUserTips();
       seenUserTips = [-1];
     }

--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -449,11 +449,13 @@ const User = RestModel.extend({
       .then((result) => {
         this.set("bio_excerpt", result.user.bio_excerpt);
         const userProps = getProperties(
-          this.user_option,
+          result.user.user_option || this.user_option,
           "enable_quoting",
           "enable_defer",
           "external_links_in_new_tab",
-          "dynamic_favicon"
+          "dynamic_favicon",
+          "seen_popups",
+          "skip_new_user_tips"
         );
         User.current()?.setProperties(userProps);
         this.setProperties(updatedState);

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -711,7 +711,7 @@ export default createWidget("post-menu", {
   },
 
   showMoreActions() {
-    if (this.currentUser) {
+    if (this.currentUser && this.siteSettings.enable_user_tips) {
       this.currentUser.hideUserTipForever("post_menu");
     }
 
@@ -734,7 +734,9 @@ export default createWidget("post-menu", {
       keyValueStore &&
         keyValueStore.set({ key: "likedPostId", value: attrs.id });
       return this.sendWidgetAction("showLogin");
-    } else {
+    }
+
+    if (this.currentUser && this.siteSettings.enable_user_tips) {
       this.currentUser.hideUserTipForever("post_menu");
     }
 

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -594,7 +594,7 @@ createWidget("post-contents", {
   },
 
   share() {
-    if (this.currentUser) {
+    if (this.currentUser && this.siteSettings.enable_user_tips) {
       this.currentUser.hideUserTipForever("post_menu");
     }
 


### PR DESCRIPTION
Performing actions that updated list of seen popups used to update user options everytime instead of checking if the change has any effect.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
