### PR TITLE
FIX: horizontal scrolling was not working correctly

### DIFF
--- a/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
+++ b/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
@@ -3,7 +3,8 @@ import { action } from "@ember/object";
 import { bind } from "discourse-common/utils/decorators";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
-
+import discourseLater from "discourse-common/lib/later";
+import { cancel } from "@ember/runloop";
 export default class HorizontalOverflowNav extends Component {
   @service site;
   @tracked hasScroll;
@@ -34,7 +35,7 @@ export default class HorizontalOverflowNav extends Component {
 
   @bind
   stopScroll() {
-    clearInterval(this.scrollInterval);
+    cancel(this.scrollInterval);
   }
 
   @bind
@@ -48,14 +49,14 @@ export default class HorizontalOverflowNav extends Component {
       event.target.scrollWidth
     ) {
       this.hideRightScroll = true;
-      clearInterval(this.scrollInterval);
+      cancel(this.scrollInterval);
     } else {
       this.hideRightScroll = false;
     }
 
     if (event.target.scrollLeft === 0) {
       this.hideLeftScroll = true;
-      clearInterval(this.scrollInterval);
+      cancel(this.scrollInterval);
     } else {
       this.hideLeftScroll = false;
     }
@@ -107,11 +108,9 @@ export default class HorizontalOverflowNav extends Component {
       siblingTarget = event.target.nextElementSibling;
     }
 
-    this.scrollInterval = setInterval(function () {
+    this.scrollInterval = discourseLater(() => {
       siblingTarget.scrollLeft += scrollSpeed;
+      this.stopScroll();
     }, 50);
-
-    event.target.addEventListener("mouseup", this.stopScroll);
-    event.target.addEventListener("mouseleave", this.stopScroll);
   }
 }

--- a/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
+++ b/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
@@ -94,8 +94,8 @@ export default class HorizontalOverflowNav extends Component {
       });
     };
 
-    document.addEventListener("mousemove", mouseDragScroll);
-    document.addEventListener("mouseup", removeDragScroll);
+    document.addEventListener("mousemove", mouseDragScroll, { once: true });
+    document.addEventListener("mouseup", removeDragScroll, { once: true });
   }
 
   @action
@@ -110,7 +110,7 @@ export default class HorizontalOverflowNav extends Component {
 
     this.scrollInterval = discourseLater(() => {
       siblingTarget.scrollLeft += scrollSpeed;
-      this.stopScroll();
+      this.horizScroll(event);
     }, 50);
   }
 }

--- a/app/assets/javascripts/discourse/app/templates/components/horizontal-overflow-nav.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/horizontal-overflow-nav.hbs
@@ -6,8 +6,10 @@
     <a
       role="button"
       {{on "mousedown" this.horizScroll}}
+      {{on "mouseup" this.stopScroll}}
+      {{on "mouseleave" this.stopScroll}}
       data-direction="left"
-      class="horizontal-overflow-nav__scroll-left {{if this.hideLeftScroll "disabled"}}"
+      class={{concat-class "horizontal-overflow-nav__scroll-left" (if this.hideLeftScroll "disabled")}}
     >
       {{d-icon "chevron-left"}}
     </a>
@@ -27,7 +29,9 @@
     <a
       role="button"
       {{on "mousedown" this.horizScroll}}
-      class="horizontal-overflow-nav__scroll-right {{if this.hideRightScroll "disabled"}}"
+      {{on "mouseup" this.stopScroll}}
+      {{on "mouseleave" this.stopScroll}}
+      class={{concat-class "horizontal-overflow-nav__scroll-right" (if this.hideRightScroll "disabled")}}
     >
       {{d-icon "chevron-right"}}
     </a>


### PR DESCRIPTION
- fixes broken behavior of arrow buttons for certain users probably due to the `mouseup` being called instantly and stopping scroll right after click
- removes use of `clearInterval`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
