### PR TITLE
DEV: remove unused CSS

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -346,20 +346,6 @@ table {
   margin-left: 12px;
 }
 
-.top-space {
-  margin-top: 10px;
-}
-
-.message {
-  border-radius: 8px;
-  background-color: var(--secondary);
-  padding: 14px;
-
-  h2 {
-    margin-bottom: 20px;
-  }
-}
-
 .clear-transitions {
   transition: none !important;
 }
@@ -378,11 +364,6 @@ table {
   background-color: var(--secondary);
   display: inline-block;
   border-radius: 50%;
-}
-
-.flex-center-align {
-  display: flex;
-  align-items: center;
 }
 
 .unread-high-priority-notifications {


### PR DESCRIPTION
The `.message` class is too generic and was causing some rounded borders in the notification menu: 

![Screenshot 2022-11-16 at 6 57 45 PM](https://user-images.githubusercontent.com/1681963/202320629-52a60008-3e57-4127-bdbe-56b8ecf85941.png)

I did some looking and it appears to be an old class that's no longer used. I also noticed that `.top-space` and `.flex-center-align` appear to be unused, so I removed those while I was here. 