### PR TITLE
UX: new user message controls need some padding

### DIFF
--- a/app/assets/stylesheets/common/base/new-user.scss
+++ b/app/assets/stylesheets/common/base/new-user.scss
@@ -103,6 +103,7 @@
     }
 
     .category-breadcrumb {
+      padding-top: var(--navigation-secondary-padding-top);
       @include breakpoint(large) {
         font-size: var(--font-down-1);
       }
@@ -112,6 +113,7 @@
     }
 
     .navigation-controls {
+      padding-top: var(--navigation-secondary-padding-top);
       flex-wrap: nowrap;
       @include breakpoint(large) {
         font-size: var(--font-down-1);


### PR DESCRIPTION
before:
![Screenshot 2022-11-17 at 11 16 11 AM](https://user-images.githubusercontent.com/1681963/202499525-b2a14b88-8a14-4c80-a96b-f0c521f6ebe0.png)


after: 
![Screenshot 2022-11-17 at 11 07 28 AM](https://user-images.githubusercontent.com/1681963/202499535-afe94389-e5d2-48b1-9408-c715c539ccd6.png)

Follow-up to e071ba5