### PR TITLE
DEV: Bump Dependabot's bundler PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       interval: daily
       time: "08:00"
       timezone: Australia/Sydney
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     versioning-strategy: lockfile-only
     allow:
       - dependency-type: direct


### PR DESCRIPTION
We don't want long standing open PRs blocking the creation of new upgrades.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
