### PR TITLE
DEV: Add test to check if user tips are saved once

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -447,18 +447,21 @@ const User = RestModel.extend({
       type: "PUT",
     })
       .then((result) => {
-        this.set("bio_excerpt", result.user.bio_excerpt);
-        const userProps = getProperties(
-          result.user.user_option || this.user_option,
-          "enable_quoting",
-          "enable_defer",
-          "external_links_in_new_tab",
-          "dynamic_favicon",
-          "seen_popups",
-          "skip_new_user_tips"
-        );
-        User.current()?.setProperties(userProps);
         this.setProperties(updatedState);
+        this.setProperties(getProperties(result.user, "bio_excerpt"));
+        if (User.current() === this && result.user.user_option) {
+          this.setProperties(
+            getProperties(
+              result.user.user_option,
+              "enable_quoting",
+              "enable_defer",
+              "external_links_in_new_tab",
+              "dynamic_favicon",
+              "seen_popups",
+              "skip_new_user_tips"
+            )
+          );
+        }
         return result;
       })
       .finally(() => {

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -4,6 +4,8 @@ import User from "discourse/models/user";
 import PreloadStore from "discourse/lib/preload-store";
 import sinon from "sinon";
 import { settled } from "@ember/test-helpers";
+import Site from "discourse/models/site";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 module("Unit | Model | user", function () {
   test("staff", function (assert) {
@@ -178,5 +180,28 @@ module("Unit | Model | user", function () {
       user.hasOwnProperty("_clearStatusTimerId"),
       "_clearStatusTimerId wasn't set"
     );
+  });
+
+  test("hideUserTipForever() makes a single request", async function (assert) {
+    Site.current().set("user_tips", { first_notification: 1 });
+    const user = User.create({ username: "test" });
+
+    let requestsCount = 0;
+    pretender.put("/u/test.json", () => {
+      requestsCount += 1;
+      return response(200, {
+        user: {
+          user_option: {
+            seen_popups: [1],
+          },
+        },
+      });
+    });
+
+    await user.hideUserTipForever("first_notification");
+    assert.equal(requestsCount, 1);
+
+    await user.hideUserTipForever("first_notification");
+    assert.equal(requestsCount, 1);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/models/user-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/user-test.js
@@ -199,9 +199,9 @@ module("Unit | Model | user", function () {
     });
 
     await user.hideUserTipForever("first_notification");
-    assert.equal(requestsCount, 1);
+    assert.strictEqual(requestsCount, 1);
 
     await user.hideUserTipForever("first_notification");
-    assert.equal(requestsCount, 1);
+    assert.strictEqual(requestsCount, 1);
   });
 });


### PR DESCRIPTION
Before 35980ad56eea2204ffef37d2ba55030f48091835, hidden user tips used to be saved everytime when User.hideUserTipForever was called.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
