### PR TITLE
FIX: hides user card button when current user can't DM

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/templates/components/user-card-chat-button.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/user-card-chat-button.hbs
@@ -1,1 +1,8 @@
-<DButton @class="btn-primary user-card-chat-btn" @action={{action "startChatting"}} @label="chat.title_capitalized" @icon="comment" />
+{{#if this.chat.userCanDirectMessage}}
+  <DButton
+    @class="btn-primary user-card-chat-btn"
+    @action={{action "startChatting"}}
+    @label="chat.title_capitalized"
+    @icon="comment"
+  />
+{{/if}}

--- a/plugins/chat/test/javascripts/components/user-card-chat-button-test.js
+++ b/plugins/chat/test/javascripts/components/user-card-chat-button-test.js
@@ -1,0 +1,33 @@
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { exists } from "discourse/tests/helpers/qunit-helpers";
+
+module("Discourse Chat | Component | user-card-chat-button", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("when current user can send direct messages", async function (assert) {
+    sinon
+      .stub(this.owner.lookup("service:chat"), "userCanDirectMessage")
+      .value(true);
+
+    await render(hbs`<UserCardChatButton/>`);
+
+    assert.ok(exists(".user-card-chat-btn"), "it shows the chat button");
+  });
+
+  test("when current user can’t send direct messages", async function (assert) {
+    sinon
+      .stub(this.owner.lookup("service:chat"), "userCanDirectMessage")
+      .value(false);
+
+    await render(hbs`<UserCardChatButton/>`);
+
+    assert.notOk(
+      exists(".user-card-chat-btn"),
+      "it doesn’t show the chat button"
+    );
+  });
+});


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
