### PR TITLE
DEV: Move tests for user preferences change email into own file

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -57,12 +57,6 @@ function preferencesPretender(server, helper) {
     });
   });
 
-  server.put("/u/eviltrout/preferences/email", () => {
-    return helper.response({
-      success: true,
-    });
-  });
-
   server.post("/user_avatar/eviltrout/refresh_gravatar.json", () => {
     return helper.response({
       gravatar_upload_id: 6543,
@@ -157,34 +151,6 @@ acceptance("User Preferences", function (needs) {
   test("username", async function (assert) {
     await visit("/u/eviltrout/preferences/username");
     assert.ok(exists("#change_username"), "it has the input element");
-  });
-
-  test("email", async function (assert) {
-    await visit("/u/eviltrout/preferences/email");
-
-    assert.ok(exists("#change-email"), "it has the input element");
-
-    await fillIn("#change-email", "invalid-email");
-
-    assert.strictEqual(
-      query(".tip.bad").innerText.trim(),
-      I18n.t("user.email.invalid"),
-      "it should display invalid email tip"
-    );
-  });
-
-  test("email field always shows up", async function (assert) {
-    await visit("/u/eviltrout/preferences/email");
-
-    assert.ok(exists("#change-email"), "it has the input element");
-
-    await fillIn("#change-email", "eviltrout@discourse.org");
-    await click(".user-preferences button.btn-primary");
-
-    await visit("/u/eviltrout/preferences");
-    await visit("/u/eviltrout/preferences/email");
-
-    assert.ok(exists("#change-email"), "it has the input element");
   });
 
   test("connected accounts", async function (assert) {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-email-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-email-test.js
@@ -1,0 +1,48 @@
+import { test } from "qunit";
+import I18n from "I18n";
+import { click, fillIn, visit } from "@ember/test-helpers";
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("User Preferences - Email", function (needs) {
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    server.put("/u/eviltrout/preferences/email", () => {
+      return helper.response({
+        success: true,
+      });
+    });
+  });
+
+  test("email", async function (assert) {
+    await visit("/u/eviltrout/preferences/email");
+
+    assert.ok(exists("#change-email"), "it has the input element");
+
+    await fillIn("#change-email", "invalid-email");
+
+    assert.strictEqual(
+      query(".tip.bad").innerText.trim(),
+      I18n.t("user.email.invalid"),
+      "it should display invalid email tip"
+    );
+  });
+
+  test("email field always shows up", async function (assert) {
+    await visit("/u/eviltrout/preferences/email");
+
+    assert.ok(exists("#change-email"), "it has the input element");
+
+    await fillIn("#change-email", "eviltrout@discourse.org");
+    await click(".user-preferences button.btn-primary");
+
+    await visit("/u/eviltrout/preferences");
+    await visit("/u/eviltrout/preferences/email");
+
+    assert.ok(exists("#change-email"), "it has the input element");
+  });
+});


### PR DESCRIPTION
This helps to make it easier to identify the test file for the
particular route.