### PR TITLE
FEATURE: Allow `target` attribute in links in user_field descriptions

### DIFF
--- a/app/models/user_field.rb
+++ b/app/models/user_field.rb
@@ -28,7 +28,7 @@ class UserField < ActiveRecord::Base
 
   def sanitize_description
     if description_changed?
-      self.description = sanitize_field(self.description)
+      self.description = sanitize_field(self.description, additional_attributes: ['target'])
     end
   end
 end

--- a/spec/models/user_field_spec.rb
+++ b/spec/models/user_field_spec.rb
@@ -19,4 +19,13 @@ RSpec.describe UserField do
 
     expect(user_field.description).to eq("<b>click me!</b>alert('TEST');")
   end
+
+  it 'allows target attribute in the description' do
+    link = "<a target=\"_blank\" href=\"/elsewhere\">elsewhere</a>"
+    user_field = Fabricate(:user_field)
+
+    user_field.update!(description: link)
+
+    expect(user_field.description).to eq(link)
+  end
 end


### PR DESCRIPTION
This change adds `target` to the set of attributes allowed by the HTML sanitizer which is applied to the description of a user_field.

The rationale for this change:

 * If one puts a link (`<a>...</a>`) in the description of a user_field that is present and/or required at sign-up, the expectation is that a prospective new user will click on that link during sign-up.
 * Without an appropriate `target` attribute on the link, the new page will be loaded in the same window/tab as the sign-up form, but this will obliterate any fields that the user had already filled-out on the form.  (E.g., hitting the back-button will return to an empty form.)
 * Such UX behavior is incredibly aggravating to new users.

This change allows an admin to add a `target` attribute to links, to instruct the browser to open them in a different window/tab, leaving a sign-up form intact.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
