### PR TITLE
UX: padding adjustment for empty channel message

### DIFF
--- a/plugins/chat/assets/stylesheets/common/common.scss
+++ b/plugins/chat/assets/stylesheets/common/common.scss
@@ -169,6 +169,7 @@ $float-height: 530px;
 
   .public-channel-empty-message {
     margin: 0 0.5em 0.5em 0.5em;
+    padding: 0 1em;
   }
 
   .chat-channel-divider {


### PR DESCRIPTION
Before: 
![Screenshot 2022-11-18 at 1 01 40 PM](https://user-images.githubusercontent.com/1681963/202772280-ca552668-9b90-4c59-ab84-93ff0a5f6e23.png)


After:
![Screenshot 2022-11-18 at 1 00 02 PM](https://user-images.githubusercontent.com/1681963/202772227-a20173b3-5c91-471c-a13c-2f936d0cda42.png)
