### PR TITLE
A11Y: improve sidebar accessibility

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar.hbs
@@ -1,4 +1,4 @@
-<DSection @pageClass="has-sidebar" @class="sidebar-container" @scrollTop={{false}}>
+<DSection @pageClass="has-sidebar" @id="d-sidebar" @class="sidebar-container" @scrollTop={{false}}>
   <Sidebar::Sections @currentUser={{this.currentUser}} @collapsableSections={{true}} />
   <Sidebar::Footer />
 </DSection>

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-header.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-header.hbs
@@ -2,8 +2,9 @@
   <DButton
     @title="sidebar.toggle_section"
     @class="sidebar-section-header sidebar-section-header-collapsable btn-flat"
-    @action={{@toggleSectionDisplay}} >
-
+    @action={{@toggleSectionDisplay}}
+    @ariaExpanded={{@isExpanded}}
+    @ariaControls={{@sidebarSectionID}} >
     {{yield}}
   </DButton>
 {{else}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
@@ -1,5 +1,5 @@
 {{#if this.shouldDisplay}}
-  <div class="sidebar-section-link-wrapper" {{did-insert this.didInsert this.args}}>
+  <li class="sidebar-section-link-wrapper" {{did-insert this.didInsert this.args}}>
     {{#if @href}}
       <a href={{@href}} rel="noopener noreferrer" target="_blank" class={{this.classNames}} title={{@title}}>
         <Sidebar::SectionLinkPrefix
@@ -68,5 +68,5 @@
         {{/if}}
       </Sidebar::SectionLinkTo>
     {{/if}}
-  </div>
+  </li>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section.hbs
@@ -1,7 +1,7 @@
 {{#if this.displaySection}}
   <div class={{concat "sidebar-section-wrapper sidebar-section-" @sectionName}}>
     <div class="sidebar-section-header-wrapper sidebar-row">
-      <Sidebar::SectionHeader @collapsable={{@collapsable}} @toggleSectionDisplay={{this.toggleSectionDisplay}}>
+      <Sidebar::SectionHeader @collapsable={{@collapsable}} @sidebarSectionID={{this.sidebarSectionID}} @toggleSectionDisplay={{this.toggleSectionDisplay}} @isExpanded={{this.displaySectionContent}}>
         {{#if @collapsable}}
           <span class="sidebar-section-header-caret">
             {{d-icon this.headerCaretIcon}}
@@ -36,9 +36,9 @@
     </div>
 
     {{#if this.displaySectionContent}}
-      <div class="sidebar-section-content">
+      <ul class="sidebar-section-content" id={{this.sidebarSectionID}}>
         {{yield}}
-      </div>
+      </ul>
     {{/if}}
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section.js
@@ -8,7 +8,8 @@ export default class SidebarSection extends Component {
   @service keyValueStore;
 
   @tracked displaySectionContent;
-  collapsedSidebarSectionKey = `sidebar-section-${this.args.sectionName}-collapsed`;
+  sidebarSectionID = `sidebar-section-${this.args.sectionName}`;
+  collapsedSidebarSectionKey = `${this.sidebarSectionID}-collapsed`;
 
   constructor() {
     super(...arguments);

--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -335,6 +335,7 @@ const SiteHeaderComponent = MountWidget.extend(
         topic: this._topic,
         canSignUp: this.canSignUp,
         sidebarEnabled: this.sidebarEnabled,
+        showSidebar: this.showSidebar,
       };
     },
 

--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
@@ -47,7 +47,11 @@ export default class MyPostsSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return I18n.t("sidebar.sections.community.links.my_posts.title");
+    if (this._hasDraft) {
+      return I18n.t("sidebar.sections.community.links.my_posts.title_drafts");
+    } else {
+      return I18n.t("sidebar.sections.community.links.my_posts.title");
+    }
   }
 
   get text() {

--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -13,6 +13,7 @@
       @toggleAnonymous={{route-action "toggleAnonymous"}}
       @logout={{route-action "logout"}}
       @sidebarEnabled={{this.sidebarEnabled}}
+      @showSidebar={{this.showSidebar}}
       @toggleSidebar={{action "toggleSidebar"}} />
   {{/if}}
 

--- a/app/assets/javascripts/discourse/app/widgets/button.js
+++ b/app/assets/javascripts/discourse/app/widgets/button.js
@@ -49,6 +49,14 @@ export const ButtonClass = {
       attributes["aria-label"] = attrs.translatedAriaLabel;
     }
 
+    if (attrs.ariaExpanded) {
+      attributes["aria-expanded"] = attrs.ariaExpanded;
+    }
+
+    if (attrs.ariaControls) {
+      attributes["aria-controls"] = attrs.ariaControls;
+    }
+
     if (attrs.ariaPressed) {
       attributes["aria-pressed"] = attrs.ariaPressed;
     }

--- a/app/assets/javascripts/discourse/app/widgets/sidebar-toggle.js
+++ b/app/assets/javascripts/discourse/app/widgets/sidebar-toggle.js
@@ -4,12 +4,17 @@ export default createWidget("sidebar-toggle", {
   tagName: "span.header-sidebar-toggle",
 
   html() {
+    const attrs = this.attrs;
     return [
       this.attach("button", {
-        title: "",
+        title: attrs.showSidebar
+          ? "sidebar.hide_sidebar"
+          : "sidebar.show_sidebar",
         icon: "bars",
         action: "toggleSidebar",
         className: "btn btn-flat btn-sidebar-toggle",
+        ariaExpanded: attrs.showSidebar ? "true" : "false",
+        ariaControls: "d-sidebar",
       }),
     ];
   },

--- a/app/assets/stylesheets/common/base/sidebar-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section.scss
@@ -134,7 +134,7 @@
 
   .sidebar-section-content {
     padding-bottom: 1em;
-
+    margin: 0;
     hr {
       margin: 0em 1.5em;
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4177,6 +4177,8 @@ en:
       redirect_after_success: "Second factor authentication is successful. Redirecting to the previous page…"
 
     sidebar:
+      show_sidebar: "Show sidebar"
+      hide_sidebar: "Hide sidebar"
       unread_count:
         one: "%{count} unread"
         other: "%{count} unread"
@@ -4247,7 +4249,8 @@ en:
               title: "All users"
             my_posts:
               content: "My Posts"
-              title: "My posts"
+              title: "My recent topic activity"
+              title_drafts: "My unposted drafts"
               draft_count:
                 one: "%{count} draft"
                 other: "%{count} drafts"

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -88,7 +88,7 @@ export default {
             }
 
             get text() {
-              return htmlSafe(emojiUnescape(this.title));
+              return htmlSafe(emojiUnescape(this.channel.escapedTitle));
             }
 
             get prefixType() {
@@ -104,7 +104,9 @@ export default {
             }
 
             get title() {
-              return this.channel.escapedTitle;
+              return this.channel.description
+                ? this.channel.description
+                : `${this.channel.escapedTitle} ${I18n.t("chat.title")}`;
             }
 
             get prefixBadge() {
@@ -276,7 +278,9 @@ export default {
             }
 
             get title() {
-              return this.channel.escapedTitle;
+              return I18n.t("chat.placeholder_others", {
+                messageRecipient: this.channel.escapedTitle,
+              });
             }
 
             get oneOnOneMessage() {
@@ -284,7 +288,7 @@ export default {
             }
 
             get text() {
-              const username = this.title.replaceAll("@", "");
+              const username = this.channel.escapedTitle.replaceAll("@", "");
               if (this.oneOnOneMessage) {
                 const status = this.channel.chatable.users[0].get("status");
                 const statusHtml = status ? this._userStatusHtml(status) : "";

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Navigation", type: :system, js: true do
         visit("/t/-/#{topic.id}")
         chat_page.open_from_header
         chat_drawer_page.close
-        find("a[title='#{category_channel.title}'] chat").click
+        find("a[class*='sidebar-section-link-#{category_channel.slug}']").click
 
         expect(page).to have_css(".chat-message-container[data-id='#{message.id}']")
       end
@@ -149,7 +149,7 @@ RSpec.describe "Navigation", type: :system, js: true do
         chat_page.open_from_header
         chat_drawer_page.maximize
         visit("/")
-        find("a[title='#{category_channel.title}'] chat").click
+        find("a[class*='sidebar-section-link-#{category_channel.slug}']").click
 
         expect(page).to have_current_path(
           chat.channel_path(category_channel.id, category_channel.slug),
@@ -268,7 +268,7 @@ RSpec.describe "Navigation", type: :system, js: true do
       it "activates the channel in the sidebar" do
         visit("/")
         chat_page.open_from_header
-        find("a[title='#{category_channel.title} chat']").click
+        find("a[class*='#{category_channel.slug}']").click
 
         expect(page).to have_css(
           ".sidebar-section-link-#{category_channel.slug}.sidebar-section-link--active",
@@ -280,7 +280,7 @@ RSpec.describe "Navigation", type: :system, js: true do
       it "deactivates the channel in the sidebar" do
         visit("/")
         chat_page.open_from_header
-        find("a[title='#{category_channel.title}'] chat").click
+        find("a[class*='sidebar-section-link-#{category_channel.slug}']").click
         chat_drawer_page.close
 
         expect(page).not_to have_css(

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Navigation", type: :system, js: true do
         visit("/t/-/#{topic.id}")
         chat_page.open_from_header
         chat_drawer_page.close
-        find("a[title='#{category_channel.title}']").click
+        find("a[title='#{category_channel.title}'] chat").click
 
         expect(page).to have_css(".chat-message-container[data-id='#{message.id}']")
       end
@@ -149,7 +149,7 @@ RSpec.describe "Navigation", type: :system, js: true do
         chat_page.open_from_header
         chat_drawer_page.maximize
         visit("/")
-        find("a[title='#{category_channel.title}']").click
+        find("a[title='#{category_channel.title}'] chat").click
 
         expect(page).to have_current_path(
           chat.channel_path(category_channel.id, category_channel.slug),
@@ -268,7 +268,7 @@ RSpec.describe "Navigation", type: :system, js: true do
       it "activates the channel in the sidebar" do
         visit("/")
         chat_page.open_from_header
-        find("a[title='#{category_channel.title}']").click
+        find("a[title='#{category_channel.title} chat']").click
 
         expect(page).to have_css(
           ".sidebar-section-link-#{category_channel.slug}.sidebar-section-link--active",
@@ -280,7 +280,7 @@ RSpec.describe "Navigation", type: :system, js: true do
       it "deactivates the channel in the sidebar" do
         visit("/")
         chat_page.open_from_header
-        find("a[title='#{category_channel.title}']").click
+        find("a[title='#{category_channel.title}'] chat").click
         chat_drawer_page.close
 
         expect(page).not_to have_css(

--- a/plugins/chat/test/javascripts/acceptance/core-sidebar-test.js
+++ b/plugins/chat/test/javascripts/acceptance/core-sidebar-test.js
@@ -456,7 +456,7 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
 
     assert.strictEqual(
       evilChannel.title,
-      "chat with @&lt;script&gt;sam&lt;/script&gt;"
+      "Chat with @&lt;script&gt;sam&lt;/script&gt;"
     );
 
     assert.ok(

--- a/plugins/chat/test/javascripts/acceptance/core-sidebar-test.js
+++ b/plugins/chat/test/javascripts/acceptance/core-sidebar-test.js
@@ -428,7 +428,10 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
       ".sidebar-section-chat-channels .sidebar-section-link-wrapper .sidebar-section-link"
     );
 
-    assert.strictEqual(evilChannel.title, "&lt;script&gt;evil&lt;/script&gt;");
+    assert.strictEqual(
+      evilChannel.title,
+      "&lt;script&gt;evil&lt;/script&gt; chat"
+    );
 
     assert.ok(
       evilChannel.className.includes(
@@ -451,7 +454,10 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
       ".sidebar-section-chat-dms .sidebar-section-link-wrapper .sidebar-section-link"
     )[3];
 
-    assert.strictEqual(evilChannel.title, "@&lt;script&gt;sam&lt;/script&gt;");
+    assert.strictEqual(
+      evilChannel.title,
+      "chat with @&lt;script&gt;sam&lt;/script&gt;"
+    );
 
     assert.ok(
       evilChannel.className.includes(


### PR DESCRIPTION
Lots of sidebar accessibility improvements, including: 

* Adding a title to the sidebar toggle button (show/hide sidebar, depending on state) 
* Add `aria-expanded` and `aria-controls` to the sidebar toggle button
* Add `aria-expanded` and `aria-controls` to each sidebar section header
* Change sidebar items from `div`s to `ul`s and `li`s
* Improve the titles for chat channels in the sidebar. If there's a channel description available it will use that for the title, if there's no description it will use `[channel_name] chat` 
* Improve the titles for personal chats in the sidebar, instead of duplicating the user list they say `chat with [@x, @y, @z]`
* Improve the title for "my posts" including changing the title when there are drafts present 




/t/76881