### PR TITLE
FIX: better chat-message-actions position

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -5,7 +5,7 @@ import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 
 const MSG_ACTIONS_HORIZONTAL_PADDING = 2;
-const MSG_ACTIONS_VERTICAL_PADDING = -15;
+const MSG_ACTIONS_VERTICAL_PADDING = -28;
 
 export default Component.extend({
   tagName: "",

--- a/plugins/chat/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
@@ -21,7 +21,7 @@
     {{/if}}
 
     {{#if this.secondaryButtons.length}}
-      <DropdownSelectBox @class="more-buttons" @options={{hash icon="ellipsis-v" placement="bottom-end"}} @content={{this.secondaryButtons}} @onChange={{action "handleSecondaryButtons"}} />
+      <DropdownSelectBox @class="more-buttons" @options={{hash icon="ellipsis-v" placement="left"}} @content={{this.secondaryButtons}} @onChange={{action "handleSecondaryButtons"}} />
     {{/if}}
   </div>
 </div>


### PR DESCRIPTION
- prevents menu to hide underlying text
- prevents `chat-message-actions` to close when hovering dropdown of 3 dots button as mouse would hover an other message due to the small space between `chat-message-actions` menu and the dropdown of the 3 dots button

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
