### PR TITLE
UX: Do not automatically refresh page while composer is open

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -196,7 +196,7 @@ const DiscourseURL = EmberObject.extend({
       return;
     }
 
-    if (Session.currentProp("requiresRefresh")) {
+    if (Session.currentProp("requiresRefresh") && !this.isComposerOpen) {
       return this.redirectTo(path);
     }
 
@@ -407,6 +407,10 @@ const DiscourseURL = EmberObject.extend({
   origin() {
     let prefix = getURL("/");
     return window.location.origin + (prefix === "/" ? "" : prefix);
+  },
+
+  get isComposerOpen() {
+    return this.controllerFor("composer")?.visible;
   },
 
   get router() {

--- a/app/assets/javascripts/discourse/tests/acceptance/assets-version-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/assets-version-test.js
@@ -1,0 +1,51 @@
+import {
+  acceptance,
+  publishToMessageBus,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { click, visit } from "@ember/test-helpers";
+import DiscourseURL from "discourse/lib/url";
+import Sinon from "sinon";
+
+acceptance("Software update refresh", function (needs) {
+  needs.user();
+
+  test("Refreshes page on next navigation", async function (assert) {
+    const redirectStub = Sinon.stub(DiscourseURL, "redirectTo");
+
+    await visit("/");
+    await click(".nav-item_top a");
+    assert.true(
+      redirectStub.notCalled,
+      "redirect was not triggered by default"
+    );
+
+    await publishToMessageBus("/global/asset-version", "somenewversion");
+
+    redirectStub.resetHistory();
+    await visit("/");
+    await click(".nav-item_top a");
+    assert.true(
+      redirectStub.calledWith("/top"),
+      "redirect was triggered after asset change"
+    );
+
+    redirectStub.resetHistory();
+    await visit("/");
+    await click("#create-topic");
+    await click(".nav-item_top a");
+    assert.true(
+      redirectStub.notCalled,
+      "redirect is not triggered while composer is open"
+    );
+
+    redirectStub.resetHistory();
+    await visit("/");
+    await click(".save-or-cancel .cancel");
+    await click(".nav-item_top a");
+    assert.true(
+      redirectStub.calledWith("/top"),
+      "redirect is triggered on next navigation after composer closed"
+    );
+  });
+});


### PR DESCRIPTION
We automatically refresh the page 'on the next navigation' whenever a new version of the JS client is available. If the composer is open when this happens then it will be closed and you'll have to reopen the draft. In some circumstances, this refresh can also cause some composer content to be lost.

This commit updates the auto-refresh logic so that it doesn't trigger while the composer is open, and adds an acceptance test for the behaviour.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
