### PR TITLE
FEATURE: Add TL1 to chat_allowed_groups by default

### DIFF
--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -6,7 +6,7 @@ chat:
     client: true
     type: group_list
     list_type: compact
-    default: "3" # 3 is staff group id
+    default: "3|11" # 3: @staff, 11: @trust_level_1
     allow_any: false
     refresh: true
   needs_chat_seeded:
@@ -85,14 +85,14 @@ chat:
     hidden: true
     client: true
   direct_message_enabled_groups:
-    default: "11" # auto group trust_level_1
+    default: "11" # @trust_level_1
     type: group_list
     client: true
     allow_any: false
     refresh: true
     validator: "DirectMessageEnabledGroupsValidator"
   chat_message_flag_allowed_groups:
-    default: "11" # auto group trust_level_1
+    default: "11" # @trust_level_1
     type: group_list
     client: true
     allow_any: false

--- a/plugins/chat/spec/lib/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/guardian_extensions_spec.rb
@@ -11,11 +11,6 @@ RSpec.describe Chat::GuardianExtensions do
   let(:guardian) { Guardian.new(user) }
   let(:staff_guardian) { Guardian.new(staff) }
 
-  before do
-    SiteSetting.chat_allowed_groups = chat_group.id
-    chat_group.add(user)
-  end
-
   it "cannot chat if the user is not in the Chat.allowed_group_ids" do
     SiteSetting.chat_allowed_groups = ""
     expect(guardian.can_chat?(user)).to eq(false)
@@ -24,6 +19,22 @@ RSpec.describe Chat::GuardianExtensions do
   it "staff can always chat regardless of chat_allowed_grups" do
     SiteSetting.chat_allowed_groups = ""
     expect(guardian.can_chat?(staff)).to eq(true)
+  end
+
+  it "allows TL1 to chat by default and by extension higher trust levels" do
+    Group.refresh_automatic_groups!
+    expect(guardian.can_chat?(user)).to eq(true)
+    user.update!(trust_level: TrustLevel[3])
+    Group.refresh_automatic_groups!
+    expect(guardian.can_chat?(user)).to eq(true)
+  end
+
+  it "allows user in specific group to chat" do
+    SiteSetting.chat_allowed_groups = chat_group.id
+    expect(guardian.can_chat?(user)).to eq(false)
+    chat_group.add(user)
+    user.reload
+    expect(guardian.can_chat?(user)).to eq(true)
   end
 
   describe "chat channel" do


### PR DESCRIPTION
By doing this, we will:

* Have an open, but safe default People reach `@trust_level_1` pretty quickly, but `@trust_level_0` is still excluded by default, to limit new accounts joining and immediately spamming or otherwise abusing channels.
* Make it easier to change the default By keeping `@staff` in the default, we make it easy for admins to remove `@trust_level_1` and optionally add additional groups to their liking.
