### PR TITLE
DEV: Centralise user preferences account route tests into single file

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/avatar-selector.js
+++ b/app/assets/javascripts/discourse/app/controllers/avatar-selector.js
@@ -6,6 +6,7 @@ import { allowsImages } from "discourse/lib/uploads";
 import discourseComputed from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { setting } from "discourse/lib/computed";
+import { isTesting } from "discourse-common/config/environment";
 
 export default Controller.extend(ModalFunctionality, {
   gravatarName: setting("gravatar_name"),
@@ -175,7 +176,11 @@ export default Controller.extend(ModalFunctionality, {
 
       this.user
         .pickAvatar(selectedUploadId, type)
-        .then(() => window.location.reload())
+        .then(() => {
+          if (!isTesting()) {
+            window.location.reload();
+          }
+        })
         .catch(popupAjaxError);
     },
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -11,7 +11,6 @@ import {
   fillIn,
   visit,
 } from "@ember/test-helpers";
-import User from "discourse/models/user";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
 
@@ -26,13 +25,6 @@ function preferencesPretender(server, helper) {
   server.put("/u/second_factors_backup.json", () => {
     return helper.response({
       backup_codes: ["dsffdsd", "fdfdfdsf", "fddsds"],
-    });
-  });
-
-  server.post("/user_avatar/eviltrout/refresh_gravatar.json", () => {
-    return helper.response({
-      gravatar_upload_id: 6543,
-      gravatar_avatar_template: "/images/avatar.png",
     });
   });
 
@@ -124,178 +116,7 @@ acceptance("User Preferences", function (needs) {
     await visit("/u/eviltrout/preferences/username");
     assert.ok(exists("#change_username"), "it has the input element");
   });
-
-  test("default avatar selector", async function (assert) {
-    await visit("/u/eviltrout/preferences");
-
-    await click(".pref-avatar .btn");
-    assert.ok(exists(".avatar-choice", "opens the avatar selection modal"));
-
-    await click(".avatar-selector-refresh-gravatar");
-
-    assert.strictEqual(
-      User.currentProp("gravatar_avatar_upload_id"),
-      6543,
-      "it should set the gravatar_avatar_upload_id property"
-    );
-  });
 });
-
-acceptance(
-  "Avatar selector when selectable avatars is enabled",
-  function (needs) {
-    needs.user();
-    needs.settings({ selectable_avatars_mode: "no_one" });
-    needs.pretender((server, helper) => {
-      server.get("/site/selectable-avatars.json", () =>
-        helper.response([
-          "https://www.discourse.org",
-          "https://meta.discourse.org",
-        ])
-      );
-    });
-
-    test("selectable avatars", async function (assert) {
-      await visit("/u/eviltrout/preferences");
-      await click(".pref-avatar .btn");
-      assert.ok(
-        exists(".selectable-avatars", "opens the avatar selection modal")
-      );
-      assert.notOk(
-        exists(
-          "#uploaded-avatar",
-          "avatar selection modal does not include option to upload"
-        )
-      );
-    });
-  }
-);
-
-acceptance(
-  "Avatar selector when selectable avatars allows staff to upload",
-  function (needs) {
-    needs.user();
-    needs.settings({ selectable_avatars_mode: "staff" });
-    needs.pretender((server, helper) => {
-      server.get("/site/selectable-avatars.json", () =>
-        helper.response([
-          "https://www.discourse.org",
-          "https://meta.discourse.org",
-        ])
-      );
-    });
-
-    test("allows staff to upload", async function (assert) {
-      updateCurrentUser({
-        trust_level: 3,
-        moderator: true,
-        admin: false,
-      });
-      await visit("/u/eviltrout/preferences");
-      await click(".pref-avatar .btn");
-      assert.ok(
-        exists(".selectable-avatars", "opens the avatar selection modal")
-      );
-      assert.ok(
-        exists(
-          "#uploaded-avatar",
-          "avatar selection modal includes option to upload"
-        )
-      );
-    });
-
-    test("disallow non-staff", async function (assert) {
-      await visit("/u/eviltrout/preferences");
-      updateCurrentUser({
-        trust_level: 3,
-        moderator: false,
-        admin: false,
-      });
-      await click(".pref-avatar .btn");
-      assert.ok(
-        exists(".selectable-avatars", "opens the avatar selection modal")
-      );
-      assert.notOk(
-        exists(
-          "#uploaded-avatar",
-          "avatar selection modal does not include option to upload"
-        )
-      );
-    });
-  }
-);
-acceptance(
-  "Avatar selector when selectable avatars allows trust level 3+ to upload",
-  function (needs) {
-    needs.user();
-    needs.settings({ selectable_avatars_mode: "tl3" });
-    needs.pretender((server, helper) => {
-      server.get("/site/selectable-avatars.json", () =>
-        helper.response([
-          "https://www.discourse.org",
-          "https://meta.discourse.org",
-        ])
-      );
-    });
-
-    test("with a tl3 user", async function (assert) {
-      await visit("/u/eviltrout/preferences");
-      updateCurrentUser({
-        trust_level: 3,
-        moderator: false,
-        admin: false,
-      });
-      await click(".pref-avatar .btn");
-      assert.ok(
-        exists(".selectable-avatars", "opens the avatar selection modal")
-      );
-      assert.ok(
-        exists(
-          "#uploaded-avatar",
-          "avatar selection modal does includes option to upload"
-        )
-      );
-    });
-
-    test("with a tl2 user", async function (assert) {
-      await visit("/u/eviltrout/preferences");
-      updateCurrentUser({
-        trust_level: 2,
-        moderator: false,
-        admin: false,
-      });
-      await click(".pref-avatar .btn");
-      assert.ok(
-        exists(".selectable-avatars", "opens the avatar selection modal")
-      );
-      assert.notOk(
-        exists(
-          "#uploaded-avatar",
-          "avatar selection modal does not include option to upload"
-        )
-      );
-    });
-
-    test("always allow staff to upload", async function (assert) {
-      await visit("/u/eviltrout/preferences");
-      updateCurrentUser({
-        trust_level: 2,
-        moderator: true,
-        admin: false,
-      });
-      await click(".pref-avatar .btn");
-      assert.ok(
-        exists(".selectable-avatars", "opens the avatar selection modal")
-      );
-      assert.ok(
-        exists(
-          "#uploaded-avatar",
-          "avatar selection modal includes option to upload"
-        )
-      );
-    });
-  }
-);
 
 acceptance("Custom User Fields", function (needs) {
   needs.user();

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-account-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-account-test.js
@@ -1,35 +1,72 @@
+import { test } from "qunit";
+import I18n from "I18n";
+import sinon from "sinon";
+import { click, visit } from "@ember/test-helpers";
 import {
   acceptance,
   exists,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import { click, visit } from "@ember/test-helpers";
-import { test } from "qunit";
 import DiscourseURL from "discourse/lib/url";
-import I18n from "I18n";
-import sinon from "sinon";
+import { fixturesByUrl } from "discourse/tests/helpers/create-pretender";
+import { cloneJSON } from "discourse-common/lib/object";
 
 acceptance("User Preferences - Account", function (needs) {
-  needs.user({
-    username: "charlie",
-  });
+  needs.user();
+
+  let customUserProps = {};
+  let pickAvatarRequestData = null;
+  let gravatarUploadId = 123456789;
 
   needs.pretender((server, helper) => {
-    server.delete("/u/charlie.json", () => helper.response({ success: true }));
+    server.get("/u/eviltrout.json", () => {
+      const json = cloneJSON(fixturesByUrl["/u/eviltrout.json"]);
+      json.user.can_edit = true;
+
+      for (const [key, value] of Object.entries(customUserProps)) {
+        json.user[key] = value;
+      }
+
+      return helper.response(json);
+    });
+
+    server.delete("/u/eviltrout.json", () =>
+      helper.response({ success: true })
+    );
 
     server.post("/u/eviltrout/preferences/revoke-account", () => {
       return helper.response({
         success: true,
       });
     });
+
+    server.put("/u/eviltrout/preferences/avatar/pick", (request) => {
+      pickAvatarRequestData = helper.parsePostData(request.requestBody);
+      return helper.response({ success: true });
+    });
+
+    server.post("/user_avatar/eviltrout/refresh_gravatar.json", () => {
+      return helper.response({
+        gravatar_upload_id: gravatarUploadId,
+        gravatar_avatar_template: "/images/gravatar_is_not_avatar.png",
+      });
+    });
+  });
+
+  needs.hooks.afterEach(() => {
+    customUserProps = {};
+    pickAvatarRequestData = null;
   });
 
   test("Delete dialog", async function (assert) {
     sinon.stub(DiscourseURL, "redirectAbsolute");
 
-    await visit("/u/charlie/preferences/account");
-    await click(".delete-account .btn-danger");
+    customUserProps = {
+      can_delete_account: true,
+    };
 
+    await visit("/u/eviltrout/preferences/account");
+    await click(".delete-account .btn-danger");
     await click(".dialog-footer .btn-danger");
 
     assert.strictEqual(
@@ -69,6 +106,166 @@ acceptance("User Preferences - Account", function (needs) {
       query(
         ".pref-associated-accounts table tr:nth-of-type(1) td:last-of-type"
       ).innerHTML.includes("Connect")
+    );
+  });
+
+  test("avatars are selectable for staff user when `selectable_avatars_mode` site setting is set to `staff`", async function (assert) {
+    this.siteSettings.selectable_avatars_mode = "staff";
+
+    customUserProps = {
+      moderator: true,
+      admin: false,
+    };
+
+    await visit("/u/eviltrout/preferences/account");
+    await click(".pref-avatar .btn");
+
+    assert.ok(
+      exists(".selectable-avatars"),
+      "opens the avatar selection modal"
+    );
+
+    assert.ok(
+      exists("#uploaded-avatar"),
+      "avatar selection modal includes option to upload"
+    );
+  });
+
+  test("avatars are not selectable for non-staff user when `selectable_avatars_mode` site setting is set to `staff`", async function (assert) {
+    this.siteSettings.selectable_avatars_mode = "staff";
+
+    customUserProps = {
+      moderator: false,
+      admin: false,
+    };
+
+    await visit("/u/eviltrout/preferences/account");
+    await click(".pref-avatar .btn");
+
+    assert.ok(
+      exists(".selectable-avatars"),
+      "opens the avatar selection modal"
+    );
+
+    assert.notOk(
+      exists("#uploaded-avatar"),
+      "avatar selection modal does not include option to upload"
+    );
+  });
+
+  test("avatars not selectable when `selectable_avatars_mode` site setting is set to `no_one`", async function (assert) {
+    this.siteSettings.selectable_avatars_mode = "no_one";
+
+    customUserProps = {
+      admin: true,
+    };
+
+    await visit("/u/eviltrout/preferences/account");
+    await click(".pref-avatar .btn");
+
+    assert.ok(
+      exists(".selectable-avatars"),
+      "opens the avatar selection modal"
+    );
+
+    assert.notOk(
+      exists("#uploaded-avatar"),
+      "avatar selection modal does not include option to upload"
+    );
+  });
+
+  test("avatars are selectable for user with required trust level when `selectable_avatars_mode` site setting is set to `tl3`", async function (assert) {
+    this.siteSettings.selectable_avatars_mode = "tl3";
+
+    customUserProps = {
+      trust_level: 3,
+      moderator: false,
+      admin: false,
+    };
+
+    await visit("/u/eviltrout/preferences/account");
+    await click(".pref-avatar .btn");
+
+    assert.ok(
+      exists(".selectable-avatars"),
+      "opens the avatar selection modal"
+    );
+
+    assert.ok(
+      exists("#uploaded-avatar"),
+      "avatar selection modal includes option to upload"
+    );
+  });
+
+  test("avatars are not selectable for user without required trust level when `selectable_avatars_mode` site setting is set to `tl3`", async function (assert) {
+    this.siteSettings.selectable_avatars_mode = "tl3";
+
+    customUserProps = {
+      trust_level: 2,
+      moderator: false,
+      admin: false,
+    };
+
+    await visit("/u/eviltrout/preferences/account");
+    await click(".pref-avatar .btn");
+
+    assert.ok(
+      exists(".selectable-avatars"),
+      "opens the avatar selection modal"
+    );
+
+    assert.notOk(
+      exists("#uploaded-avatar"),
+      "avatar selection modal does not include option to upload"
+    );
+  });
+
+  test("avatars are selectable for staff user when `selectable_avatars_mode` site setting is set to `tl3`", async function (assert) {
+    this.siteSettings.selectable_avatars_mode = "tl3";
+
+    customUserProps = {
+      trust_level: 2,
+      moderator: true,
+      admin: false,
+    };
+
+    await visit("/u/eviltrout/preferences/account");
+    await click(".pref-avatar .btn");
+
+    assert.ok(
+      exists(".selectable-avatars"),
+      "opens the avatar selection modal"
+    );
+
+    assert.ok(
+      exists("#uploaded-avatar"),
+      "avatar selection modal includes option to upload"
+    );
+  });
+
+  test("default avatar selector", async function (assert) {
+    await visit("/u/eviltrout/preferences/account");
+    await click(".pref-avatar .btn");
+
+    assert.ok(exists(".avatar-choice"), "opens the avatar selection modal");
+
+    await click(".avatar-selector-refresh-gravatar");
+
+    assert.ok(
+      exists(".avatar[src='/images/gravatar_is_not_avatar.png']"),
+      "displays the new gravatar image"
+    );
+
+    await click("#gravatar");
+    await click(".modal-footer .btn");
+
+    assert.deepEqual(
+      pickAvatarRequestData,
+      {
+        type: "gravatar",
+        upload_id: `${gravatarUploadId}`,
+      },
+      "includes the right pick avatar request params"
     );
   });
 });


### PR DESCRIPTION
Makes it easier to associate the route with the tests instead of
squeezing difference acceptance modules into a single file