### PR TITLE
FIX: Ensure DButton uses the correct target for string actions

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-button.js
+++ b/app/assets/javascripts/discourse/app/components/d-button.js
@@ -109,8 +109,8 @@ export default class DButton extends GlimmerComponentWithDeprecatedParentView {
 
         if (typeof actionVal === "string") {
           deprecated(...ACTION_AS_STRING_DEPRECATION_ARGS);
-          if (this.parentView?.send) {
-            this.parentView.send(actionVal, actionParam);
+          if (this._target?.send) {
+            this._target.send(actionVal, actionParam);
           } else {
             throw new Error(
               "DButton could not find a target for the action. Use a closure action instead"

--- a/app/assets/javascripts/discourse/app/components/glimmer-component-with-deprecated-parent-view.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer-component-with-deprecated-parent-view.js
@@ -4,15 +4,30 @@ import {
   setInternalComponentManager,
 } from "@glimmer/manager";
 import EmberGlimmerComponentManager from "@glimmer/component/-private/ember-component-manager";
+import { valueForRef } from "@glimmer/reference";
 
 class GlimmerComponentWithParentViewManager extends CustomComponentManager {
-  create(owner, componentClass, args, environment, dynamicScope) {
+  create(
+    owner,
+    componentClass,
+    args,
+    environment,
+    dynamicScope,
+    callerSelfRef
+  ) {
     const result = super.create(...arguments);
 
     result.component.parentView = dynamicScope.view;
     dynamicScope.view = result.component;
 
+    const _target = valueForRef(callerSelfRef);
+    result.component._target = _target;
+
     return result;
+  }
+
+  getCapabilities() {
+    return { ...super.getCapabilities(), createCaller: true };
   }
 }
 

--- a/app/assets/javascripts/discourse/app/components/glimmer-component-with-deprecated-parent-view.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer-component-with-deprecated-parent-view.js
@@ -20,8 +20,7 @@ class GlimmerComponentWithParentViewManager extends CustomComponentManager {
     result.component.parentView = dynamicScope.view;
     dynamicScope.view = result.component;
 
-    const _target = valueForRef(callerSelfRef);
-    result.component._target = _target;
+    result.component._target = valueForRef(callerSelfRef);
 
     return result;
   }


### PR DESCRIPTION
Our `triggerAction` backwards-compatibility was firing the action on `parentView`. In most cases this worked, but it doesn't match the classic behaviour when the DButton is included inside a 'wrapper' component. In that case, the action should be triggered on the current 'this' context of the template that called the DButton.

This commit mimics the Ember Classic Component manager's behaviour. It adds the `createCaller` capability to the custom component manager, and then uses the `callerSelfRef` for dispatching the action.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
