### PR TITLE
DEV: Explicitly define primary_email_verified? method for managed authenticators

### DIFF
--- a/lib/auth/discord_authenticator.rb
+++ b/lib/auth/discord_authenticator.rb
@@ -70,4 +70,9 @@ class Auth::DiscordAuthenticator < Auth::ManagedAuthenticator
 
     super
   end
+
+  # the `info` block above only picks the email from Discord API if it's verified
+  def primary_email_verified?(auth_token)
+    true
+  end
 end

--- a/lib/auth/facebook_authenticator.rb
+++ b/lib/auth/facebook_authenticator.rb
@@ -25,4 +25,10 @@ class Auth::FacebookAuthenticator < Auth::ManagedAuthenticator
            scope: "email"
   end
 
+  # facebook doesn't return unverified email addresses so it's safe to assume
+  # whatever email we get from them is verified
+  # https://developers.facebook.com/docs/graph-api/reference/user/
+  def primary_email_verified?(auth_token)
+    true
+  end
 end

--- a/lib/auth/github_authenticator.rb
+++ b/lib/auth/github_authenticator.rb
@@ -57,4 +57,10 @@ class Auth::GithubAuthenticator < Auth::ManagedAuthenticator
            },
            scope: "user:email"
   end
+
+  # the omniauth-github gem only picks up the primary email if it's verified:
+  # https://github.com/omniauth/omniauth-github/blob/0ac46b59ccdabd4cbe5be4a665df269355081915/lib/omniauth/strategies/github.rb#L58-L61
+  def primary_email_verified?(auth_token)
+    true
+  end
 end

--- a/lib/auth/twitter_authenticator.rb
+++ b/lib/auth/twitter_authenticator.rb
@@ -23,4 +23,10 @@ class Auth::TwitterAuthenticator < Auth::ManagedAuthenticator
               strategy.options[:consumer_secret] = SiteSetting.twitter_consumer_secret
            }
   end
+
+  # twitter doesn't return unverfied email addresses in the API
+  # https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
+  def primary_email_verified?(auth_token)
+    true
+  end
 end


### PR DESCRIPTION
We're going to change the default return value of the `primary_email_verified?` method of `Auth::ManagedAuthenticator` to false, so we need to explicitly define the method on authenticators to return true where it makes sense to do so. Internal topic: t/82084.