### PR TITLE
FIX: enable_auto_join_users was used in create channel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings-view.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings-view.js
@@ -19,8 +19,8 @@ const MUTED_OPTIONS = [
 ];
 
 const AUTO_ADD_USERS_OPTIONS = [
-  { name: I18n.t("chat.settings.enable_auto_join_users"), value: true },
-  { name: I18n.t("chat.settings.disable_auto_join_users"), value: false },
+  { name: I18n.t("yes_value"), value: true },
+  { name: I18n.t("no_value"), value: false },
 ];
 
 export default class ChatChannelSettingsView extends Component {

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -291,8 +291,7 @@ en:
       settings:
         auto_join_users_label: "Automatically add users"
         auto_join_users_info: "Check hourly which users have been active in the last 3 months and, if they have access to the %{category} category, add them to this channel."
-        enable_auto_join_users: "Yes"
-        disable_auto_join_users: "No"
+        enable_auto_join_users: "Automatically add all recently active users"
         auto_join_users_warning: "Every user who isn't a member of this channel and has access to the %{category} category will join. Are you sure?"
         desktop_notification_level: "Desktop notifications"
         follow: "Join"


### PR DESCRIPTION
https://github.com/discourse/discourse/commit/7e39a21de1c6794ee0c225be9cda6249cb1a55ea broke the explanation of the check box on `create-channel` view.

Actions:
- uses core yes_value/no_value
- re-add the correct translation for `enable_auto_join_users`
- removes `disable_auto_join_users` which is not used anymore
