### PR TITLE
A11Y: Improve "my posts" sidebar link title

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
@@ -47,7 +47,11 @@ export default class MyPostsSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return I18n.t("sidebar.sections.community.links.my_posts.title");
+    if (this._hasDraft) {
+      return I18n.t("sidebar.sections.community.links.my_posts.title_drafts");
+    } else {
+      return I18n.t("sidebar.sections.community.links.my_posts.title");
+    }
   }
 
   get text() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -564,6 +564,26 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     );
   });
 
+  test("my posts title changes when drafts are present", async function (assert) {
+    await visit("/");
+
+    assert.strictEqual(
+      query(".sidebar-section-link-my-posts").title,
+      "My recent topic activity",
+      "displays the default title when no drafts are present"
+    );
+
+    await publishToMessageBus(`/user-drafts/${loggedInUser().id}`, {
+      draft_count: 1,
+    });
+
+    assert.strictEqual(
+      query(".sidebar-section-link-my-posts").title,
+      "My unposted drafts",
+      "displays the draft title when drafts are present"
+    );
+  });
+
   test("visiting top route", async function (assert) {
     await visit("/top");
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4246,7 +4246,8 @@ en:
               title: "All users"
             my_posts:
               content: "My Posts"
-              title: "My posts"
+              title: "My recent topic activity"
+              title_drafts: "My unposted drafts"
               draft_count:
                 one: "%{count} draft"
                 other: "%{count} drafts"


### PR DESCRIPTION
This adds a more descriptive title for the "my posts" link, updates the title when there's a draft present (because the link changes), and adds a test to ensure the title changes when a draft is present. 