### PR TITLE
DEV: Add tests for sidebar accessibility changes

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
@@ -195,5 +195,25 @@ acceptance(
         "the 3 topic tracking state change callbacks are removed"
       );
     });
+
+    test("accessibility of sidebar section header", async function (assert) {
+      await visit("/");
+
+      assert.ok(
+        exists(
+          ".sidebar-section-community .sidebar-section-header[aria-expanded='true'][aria-controls='sidebar-section-content-community']"
+        ),
+        "accessibility attributes are set correctly on sidebar section header when section is expanded"
+      );
+
+      await click(".sidebar-section-header");
+
+      assert.ok(
+        exists(
+          ".sidebar-section-community .sidebar-section-header[aria-expanded='false'][aria-controls='sidebar-section-content-community']"
+        ),
+        "accessibility attributes are set correctly on sidebar section header when section is collapsed"
+      );
+    });
   }
 );


### PR DESCRIPTION
Accessibility is a feature which we do not want to regress on.

Follow-up to e30df227162e08e3ff33e1217ef36051e615d726