### PR TITLE
FIX: Only modify secured sidebar links on user promotion/demotion

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1986,8 +1986,17 @@ class User < ActiveRecord::Base
       # Secured categories that are in the default categories list
       categories_to_update = existing_category_ids + (category_ids & secured_category_ids)
 
+      default_tag_names = SiteSetting.default_sidebar_tags.split("|")
+      default_tag_ids = Tag.where(name: [default_tag_names]).pluck(:id)
+      tag_names = DiscourseTagging.filter_visible(Tag, self.guardian).where(id: default_tag_ids).pluck(:name)
+      hidden_tag_names = DiscourseTagging.hidden_tag_names
+      existing_tag_ids = SidebarSectionLink.where(user: self, linkable_type: 'Tag').pluck(:linkable_id)
+      #existing_tag_names = DiscourseTagging.filter_visible(Tag, self.guardian).where(id: existing_tag_ids).pluck(:name)
+      existing_tag_names = Tag.where(id: [existing_tag_ids]).pluck(:name)
+      tags_to_update = existing_tag_names + (tag_names & hidden_tag_names)
+
       updater = UserUpdater.new(self, self)
-      updater.update({ sidebar_category_ids: [categories_to_update] })
+      updater.update({ sidebar_category_ids: [categories_to_update], sidebar_tag_names: [tags_to_update] })
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1985,19 +1985,22 @@ class User < ActiveRecord::Base
 
       # Secured categories that are in the default categories list
       categories_to_update = existing_category_ids + (category_ids & secured_category_ids)
+    end
 
+    if SiteSetting.tagging_enabled && SiteSetting.default_sidebar_tags.present?
       default_tag_names = SiteSetting.default_sidebar_tags.split("|")
       default_tag_ids = Tag.where(name: [default_tag_names]).pluck(:id)
       tag_names = DiscourseTagging.filter_visible(Tag, self.guardian).where(id: default_tag_ids).pluck(:name)
       hidden_tag_names = DiscourseTagging.hidden_tag_names
       existing_tag_ids = SidebarSectionLink.where(user: self, linkable_type: 'Tag').pluck(:linkable_id)
-      #existing_tag_names = DiscourseTagging.filter_visible(Tag, self.guardian).where(id: existing_tag_ids).pluck(:name)
       existing_tag_names = Tag.where(id: [existing_tag_ids]).pluck(:name)
       tags_to_update = existing_tag_names + (tag_names & hidden_tag_names)
-
-      updater = UserUpdater.new(self, self)
-      updater.update({ sidebar_category_ids: [categories_to_update], sidebar_tag_names: [tags_to_update] })
     end
+
+    updater = UserUpdater.new(self, self)
+    h = { sidebar_category_ids: categories_to_update }
+    h[:sidebar_tag_names] = tags_to_update if tags_to_update
+    updater.update(h)
   end
 
   def stat

--- a/app/services/sidebar_section_links_updater.rb
+++ b/app/services/sidebar_section_links_updater.rb
@@ -48,4 +48,5 @@ class SidebarSectionLinksUpdater
     end
   end
   private_class_method :update_section_links
+
 end

--- a/app/services/sidebar_section_links_updater.rb
+++ b/app/services/sidebar_section_links_updater.rb
@@ -48,5 +48,4 @@ class SidebarSectionLinksUpdater
     end
   end
   private_class_method :update_section_links
-
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,16 +74,21 @@ RSpec.describe User do
         )
 
         expect(SidebarSectionLink.where(linkable_type: 'Tag', user_id: user.id).pluck(:linkable_id)).to contain_exactly(
-          tag.id
+          tag.id,
+          hidden_tag.id
         )
       end
 
-      it "Should only receive new categories they didn't previously have access to" do
+      it "Should create and remove the right sidebar section link records when user is promoted/demoted as an admin" do
         user = Fabricate(:user)
+        #TODO: Customize a user's sidebar categories better than just deleting them. Remove all defaults but add one that isn't in the default list
         SidebarSectionLink.where(user: user).delete_all # User has customized their sidebar categories
         user.update(admin: true)
         expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: user.id).pluck(:linkable_id)).to contain_exactly(
           secured_category.id
+        )
+        expect(SidebarSectionLink.where(linkable_type: 'Tag', user_id: user.id).pluck(:linkable_id)).to contain_exactly(
+          hidden_tag.id
         )
         user.update(admin: false)
         expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: user.id).pluck(:linkable_id)).to be_empty

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe User do
         expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: user.id).pluck(:linkable_id)).to be_empty
       end
 
+      it "Should not receive any new categories w/ suppress secured categories from admin enabled" do
+        SiteSetting.suppress_secured_categories_from_admin = true
+        user = Fabricate(:user)
+        SidebarSectionLink.where(user: user).delete_all # User has customized their sidebar categories
+        user.update(admin: true)
+        expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: user.id).pluck(:linkable_id)).to be_empty
+        user.update(admin: false)
+        expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: user.id).pluck(:linkable_id)).to be_empty
+      end
+
       it 'should not create any sidebar section link records when experimental sidebar is disabled' do
         SiteSetting.enable_experimental_sidebar_hamburger = false
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,9 +74,19 @@ RSpec.describe User do
         )
 
         expect(SidebarSectionLink.where(linkable_type: 'Tag', user_id: user.id).pluck(:linkable_id)).to contain_exactly(
-          tag.id,
-          hidden_tag.id
+          tag.id
         )
+      end
+
+      it "Should only receive new categories they didn't previously have access to" do
+        user = Fabricate(:user)
+        SidebarSectionLink.where(user: user).delete_all # User has customized their sidebar categories
+        user.update(admin: true)
+        expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: user.id).pluck(:linkable_id)).to contain_exactly(
+          secured_category.id
+        )
+        user.update(admin: false)
+        expect(SidebarSectionLink.where(linkable_type: 'Category', user_id: user.id).pluck(:linkable_id)).to be_empty
       end
 
       it 'should not create any sidebar section link records when experimental sidebar is disabled' do


### PR DESCRIPTION
If a user is created populate their sidebar with the default
categories/tags that they have access to.

If a user is promoted to admin populate any new categories/tags that
they now have access to.

If an admin is demoted remove any categories/tags that they no longer
have access to.

This will only apply for "secured" categories. For example if these are
the default sitebar categories:

- general
- site feedback
- staff

and a user only has these sidebar categories:

- general

when they are promoted to admin they will only receive the "staff"
category. As this is a default category they didn't previously have
access to.

Follow up to: cb8746c7e79ff0aed2457484179332abbaba94b1
