### PR TITLE
DEV: Minor hashtag to-markdown fix

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/to-markdown.js
+++ b/app/assets/javascripts/discourse/app/lib/to-markdown.js
@@ -315,7 +315,7 @@ export class Tag {
           return text;
         }
 
-        if ("hashtag-cooked" === attr.class) {
+        if (attr.class?.includes("hashtag-cooked")) {
           if (attr["data-ref"]) {
             return `#${attr["data-ref"]}`;
           } else {


### PR DESCRIPTION
Follow-up to 3846b6248f6ee8dac63db11da286939b6c0207cc, check if class contains hashtag-cooked rather than it being the only class.