### PR TITLE
FIX: Revert to old hashtag style for hashtag-raw

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
@@ -105,7 +105,9 @@ export function linkSeenHashtagsInContext(
   if (hashtagSpans.length === 0) {
     return [];
   }
-  const slugs = [...hashtagSpans.mapBy("innerText")];
+  const slugs = [
+    ...hashtagSpans.map((span) => span.innerText.replace("#", "")),
+  ];
 
   hashtagSpans.forEach((hashtagSpan, index) => {
     _findAndReplaceSeenHashtagPlaceholder(

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/hashtag-autocomplete.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/hashtag-autocomplete.js
@@ -75,22 +75,9 @@ function addHashtag(buffer, matches, state) {
     token.attrs = [["class", "hashtag-raw"]];
     buffer.push(token);
 
-    token = new state.Token("svg_open", "svg", 1);
-    token.block = false;
-    token.attrs = [["class", `fa d-icon d-icon-hashtag svg-icon svg-node`]];
-    buffer.push(token);
-
-    token = new state.Token("use_open", "use", 1);
-    token.block = false;
-    token.attrs = [["href", `#hashtag`]];
-    buffer.push(token);
-
-    buffer.push(new state.Token("use_close", "use", -1));
-    buffer.push(new state.Token("svg_close", "svg", -1));
-
     token = new state.Token("span_open", "span", 1);
     token = new state.Token("text", "", 0);
-    token.content = matches[0].replace("#", "");
+    token.content = matches[0];
     buffer.push(token);
     token = new state.Token("span_close", "span", -1);
 

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -14,6 +14,19 @@ a.hashtag {
   }
 }
 
+a.hashtag-cooked {
+  @include mention;
+
+  &:visited,
+  &:hover {
+    color: var(--primary-high-or-secondary-low);
+  }
+
+  .d-icon {
+    margin-right: 3px;
+  }
+}
+
 .hashtag-autocomplete {
   .hashtag-autocomplete__option {
     .hashtag-autocomplete__link {
@@ -29,19 +42,5 @@ a.hashtag {
         flex: 1;
       }
     }
-  }
-}
-
-.hashtag-raw,
-.hashtag-cooked {
-  @include mention;
-
-  &:visited,
-  &:hover {
-    color: var(--primary-high-or-secondary-low);
-  }
-
-  .d-icon {
-    margin-right: 3px;
   }
 }

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1463,7 +1463,7 @@ RSpec.describe PrettyText do
     cooked = PrettyText.cook(" #unknown::tag #known #known::tag #testing", user_id: user.id)
 
     [
-      "<span class=\"hashtag-raw\"><svg class=\"fa d-icon d-icon-hashtag svg-icon svg-node\"><use href=\"#hashtag\"></use></svg>unknown::tag</span>",
+      "<span class=\"hashtag-raw\">#unknown::tag</span>",
       "<a class=\"hashtag-cooked\" href=\"#{category2.url}\" data-type=\"category\" data-slug=\"known\"><svg class=\"fa d-icon d-icon-folder svg-icon svg-node\"><use href=\"#folder\"></use></svg><span>known</span></a>",
       "<a class=\"hashtag-cooked\" href=\"/tag/known\" data-type=\"tag\" data-slug=\"known\"><svg class=\"fa d-icon d-icon-tag svg-icon svg-node\"><use href=\"#tag\"></use></svg><span>known</span></a>",
       "<a class=\"hashtag-cooked\" href=\"#{category.url}\" data-type=\"category\" data-slug=\"testing\"><svg class=\"fa d-icon d-icon-folder svg-icon svg-node\"><use href=\"#folder\"></use></svg><span>testing</span></a>"


### PR DESCRIPTION
This fix changes the hashtag-raw hashtags, which are the ones
that do not actually match anything, back to the old style for unmatched
hashtags which does not look like mentions and is not bolded.

<img src="https://user-images.githubusercontent.com/920448/203253224-1ba4c905-9cb9-46e9-bf65-e3ee3225f0eb.png" width="200px" />

