### PR TITLE
FIX: Filtering rows of S3 inventory files was too strict

### DIFF
--- a/lib/s3_inventory.rb
+++ b/lib/s3_inventory.rb
@@ -50,7 +50,7 @@ class S3Inventory
                 key = row[CSV_KEY_INDEX]
 
                 next if Rails.configuration.multisite && key.exclude?(multisite_prefix)
-                next if key.exclude?("/#{type}/")
+                next if key.exclude?("#{type}/")
 
                 url = File.join(Discourse.store.absolute_base_url, key)
                 connection.put_copy_data("#{url},#{row[CSV_ETAG_INDEX]}\n")


### PR DESCRIPTION
In some setups the keys start with "original/" and "optimized/" and in some setups the key is something like "foo/original/", so lets make the filter less strict.