### PR TITLE
UX: improve mention styling

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1249,27 +1249,26 @@ blockquote > *:last-child {
 }
 
 a.mention {
+  // linked
   @include mention;
 }
 
 span.mention {
-  font-weight: bold;
-  font-size: 0.93em;
-  color: var(--primary);
+  // unlinked
+  color: var(--primary-high);
 }
 
 a.mention-group {
+  // unlinked
   display: inline-block;
-  font-weight: bold;
-  font-size: 0.93em;
-  color: var(--primary);
+  color: var(--primary-high);
+  cursor: default;
 
   &.notify,
   .small-action-desc & {
-    color: var(--primary-high-or-secondary-low);
-    padding: 2px 4px;
-    background: var(--primary-low);
-    border-radius: 8px;
+    // linked
+    cursor: pointer;
+    @include mention;
   }
 }
 

--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -19,11 +19,13 @@ a.hashtag-cooked {
 
   &:visited,
   &:hover {
-    color: var(--primary-high-or-secondary-low);
+    color: var(--primary);
   }
 
   .d-icon {
-    margin-right: 3px;
+    color: var(--primary-high);
+    font-size: var(--font-down-1);
+    margin: 0 0.2em 0 0.1em;
   }
 }
 

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -238,9 +238,8 @@ $hpad: 0.65em;
 
 @mixin mention() {
   display: inline-block; // https://bugzilla.mozilla.org/show_bug.cgi?id=1656119
-  font-weight: bold;
   font-size: 0.93em;
-  color: var(--primary-high-or-secondary-low);
+  color: var(--primary);
   padding: 0 4px 1px;
   background: var(--primary-low);
   border-radius: 8px;


### PR DESCRIPTION
This updates mention styling. This reduces bold, increases contrast, and makes inactive mentions look more inactive. 

Before:
![Screenshot 2022-11-22 at 5 01 02 PM](https://user-images.githubusercontent.com/1681963/203430672-82dd6b67-e610-48ad-bc1c-f2980b679d3a.png)


After:
![Screenshot 2022-11-22 at 5 00 38 PM](https://user-images.githubusercontent.com/1681963/203430699-708f91ee-f5eb-45f9-8740-ac02d056f7e1.png)
