### PR TITLE
FIX: Do not click track .hashtag-cooked

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/click-track.js
+++ b/app/assets/javascripts/discourse/app/lib/click-track.js
@@ -22,11 +22,11 @@ export function isValidLink(link) {
     });
   }
 
-  // .hashtag == category/tag link
+  // .hashtag/.hashtag-cooked == category/tag link
   // .back == quote back ^ button
   if (
-    ["lightbox", "no-track-link", "hashtag", "back"].some((name) =>
-      link.classList.contains(name)
+    ["lightbox", "no-track-link", "hashtag", "hashtag-cooked", "back"].some(
+      (name) => link.classList.contains(name)
     )
   ) {
     return false;
@@ -47,7 +47,9 @@ export function isValidLink(link) {
 
   return (
     link.classList.contains("track-link") ||
-    !link.closest(".hashtag, .badge-category, .onebox-result, .onebox-body")
+    !link.closest(
+      ".hashtag, .hashtag-cooked, .badge-category, .onebox-result, .onebox-body"
+    )
   );
 }
 
@@ -104,7 +106,9 @@ export default {
     const link = e.currentTarget;
     const tracking = isValidLink(link);
 
-    // Return early for mentions and group mentions
+    // Return early for mentions and group mentions. This is not in
+    // isValidLink because returning true here allows the group card
+    // to pop up. If we returned false it would not.
     if (
       ["mention", "mention-group"].some((name) => link.classList.contains(name))
     ) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -40,7 +40,10 @@ module("Unit | Utility | click-track", function (hooks) {
           <a class="no-track-link" href="http://www.google.com.br">google.com.br</a>
           <a id="same-site" href="http://discuss.domain.com">forum</a>
           <a class="attachment" href="http://discuss.domain.com/uploads/default/1234/1532357280.txt">log.txt</a>
-          <a class="hashtag" href="http://discuss.domain.com">#hashtag</a>
+          <a class="hashtag" href="/c/staff/42">#hashtag</a>
+          <a class="mention" href="/u/joe">@joe</a>
+          <a class="hashtag-cooked" href="/c/staff/42" data-type="category" data-slug="staff"><svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg><span>staff</span></a>
+          <a class="mention-group" href="/g/support">@support</a>
           <a class="mailto" href="mailto:foo@bar.com">email-me</a>
           <a class="a-without-href">no href</a>
           <aside class="quote">
@@ -174,8 +177,14 @@ module("Unit | Utility | click-track", function (hooks) {
     assert.ok(window.open.calledWith("https://google.com/", "_blank"));
   });
 
-  test("does not track clicks on category badges", async function (assert) {
+  test("does not track clicks on hashtags for categories and tags", async function (assert) {
     assert.notOk(track(generateClickEventOn(".hashtag")));
+    assert.notOk(track(generateClickEventOn(".hashtag-cooked")));
+  });
+
+  test("returns true for tracking mentions and group mentions so the card can appear", async function (assert) {
+    assert.ok(track(generateClickEventOn(".mention")));
+    assert.ok(track(generateClickEventOn(".mention-group")));
   });
 
   test("does not track clicks on mailto", async function (assert) {


### PR DESCRIPTION
This makes it so the new hashtags are not tracked,
same as the old ones. Also slight commenting in click-track
to explain mention clicks rejection mechanics.

Also deleted the single acceptance spec
since everything is covered better by the unit spec.