### PR TITLE
UX: Styling backwards compatibility for old user page navigation

### DIFF
--- a/app/assets/stylesheets/desktop/new-user.scss
+++ b/app/assets/stylesheets/desktop/new-user.scss
@@ -3,7 +3,7 @@
     // Grid layout
     width: 100%;
     display: grid;
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 5fr;
     grid-template-rows: auto 1fr;
     grid-gap: 0;
 
@@ -37,6 +37,20 @@
       align-self: start;
       justify-self: start;
       grid-row-start: 2;
+    }
+
+    // For backwards compatibility with legacy design
+    .user-secondary-navigation {
+      margin-top: 2em;
+      grid-column-start: 1;
+      grid-column-end: 2;
+    }
+
+    // For backwards compatibility with legacy design
+    .user-secondary-navigation ~ .user-content {
+      min-width: 100%;
+      grid-column-start: 2;
+      grid-column-end: 3;
     }
   }
 

--- a/app/assets/stylesheets/mobile/new-user.scss
+++ b/app/assets/stylesheets/mobile/new-user.scss
@@ -12,6 +12,11 @@
     }
   }
 
+  // For backwards compatibility with legacy design
+  .user-secondary-navigation {
+    margin-top: 1.5em;
+  }
+
   .user-navigation-secondary {
     font-size: var(--font-up-1);
 


### PR DESCRIPTION
While updating all user pages to use the new horizontal, scrollable user
page navigation, we've inadvertently broken the interface for plugins which rely on the
`user-main-nav` plugin outlet to extend the user profile page. Such
plugins usually add a new user profile page with the following
template structure which is copied from Discourse core before the user
page navigation redesign:

```
{{#d-section pageClass="..." class="user-secondary-navigation" scrollTop=false}}
  {{#mobile-nav class="..." desktopClass="action-list nav-stacked"}}
    ...
  {{/mobile-nav}}
{{/d-section}}

<section class="user-content">
  {{outlet}}
</section>
```

This commit seeks to add backwards compatibility in terms of the styling
of the interface such that even if the old template structure is used,
it would not look completely broken.


## Screenshots

The following screenshots uses the https://github.com/discourse/discourse-follow plugin as an example

### Desktop

#### Before

![Screenshot from 2022-11-23 11-06-39](https://user-images.githubusercontent.com/4335742/203462044-52c9683a-7559-4c9f-b0f9-78e59fcf8397.png)

#### After

![Screenshot from 2022-11-23 11-07-06](https://user-images.githubusercontent.com/4335742/203462070-9c91fda1-62bb-4e77-a844-1a8600384c10.png)

### Mobile

#### Before

![Screenshot from 2022-11-23 11-22-57](https://user-images.githubusercontent.com/4335742/203463411-0788595d-a1c6-473c-9912-d870493c1bbf.png)

#### After

![Screenshot from 2022-11-23 11-14-41](https://user-images.githubusercontent.com/4335742/203463426-603e92c4-472c-4052-b954-c949f1ae560d.png)





