### PR TITLE
DEV: Correct plugin-compilation connector template module path

### DIFF
--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -36,7 +36,7 @@ function unColocateConnectors(tree) {
       if (
         match &&
         match.groups.extension === "hbs" &&
-        !match.groups.prefix.endsWith("/templates")
+        match.groups.prefix.split("/").pop() !== "templates"
       ) {
         const { prefix, outlet, name } = match.groups;
         return `${prefix}/templates/connectors/${outlet}/${name}.hbs`;
@@ -44,7 +44,7 @@ function unColocateConnectors(tree) {
       if (
         match &&
         match.groups.extension === "js" &&
-        match.groups.prefix.endsWith("/templates")
+        match.groups.prefix.split("/").pop() === "templates"
       ) {
         // Some plugins are colocating connector JS under `/templates`
         const { prefix, outlet, name } = match.groups;


### PR DESCRIPTION
Some plugins store their connectors under `{plugin}/assets/javascripts/templates/connectors`, which is read as `templates/connectors` relative to the base of the JS directory. Our connector checking logic was looking for strings including the leading slash (`/templates`), which not be the case here. Instead we can split on `/` and take the last element. This matches the logic we have for themes in https://github.com/discourse/discourse/blob/1dadf4381f/lib/theme_javascript_compiler.rb#L111

This wasn't actually breaking anything, so this is just a housekeeping commit.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
