### PR TITLE
DEV: Update `namespaceModules` argument name

### DIFF
--- a/app/assets/javascripts/discourse-plugins/index.js
+++ b/app/assets/javascripts/discourse-plugins/index.js
@@ -56,10 +56,10 @@ function unColocateConnectors(tree) {
   });
 }
 
-function namespaceModules(tree, pluginDirectoryName) {
+function namespaceModules(tree, pluginName) {
   return new Funnel(tree, {
     getDestinationPath: function (relativePath) {
-      return `discourse/plugins/${pluginDirectoryName}/${relativePath}`;
+      return `discourse/plugins/${pluginName}/${relativePath}`;
     },
   });
 }


### PR DESCRIPTION
In 1279966f we started namespacing modules based on the plugin's defined name rather than the directory name. This commit updates the argument name to match what we're passing in. This it just a readability change - there is no change in behaviour.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
