### PR TITLE
DEV: Remove old event preventDefault hack

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark-list.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark-list.js
@@ -75,10 +75,9 @@ export default Component.extend(Scrolling, {
 
   @action
   screenExcerptForExternalLink(event) {
-    if (event.target && event.target.tagName === "A") {
-      let link = event.target;
-      if (shouldOpenInNewTab(link.href)) {
-        openLinkInNewTab(link);
+    if (event?.target?.tagName === "A") {
+      if (shouldOpenInNewTab(event.target.href)) {
+        openLinkInNewTab(event, event.target);
       }
     }
   },

--- a/app/assets/javascripts/discourse/app/components/html-with-links.js
+++ b/app/assets/javascripts/discourse/app/components/html-with-links.js
@@ -8,7 +8,7 @@ export default Component.extend({
   click(event) {
     if (event?.target?.tagName === "A") {
       if (shouldOpenInNewTab(event.target.href)) {
-        openLinkInNewTab(event.target);
+        openLinkInNewTab(event, event.target);
       }
     }
   },

--- a/app/assets/javascripts/discourse/app/lib/click-track.js
+++ b/app/assets/javascripts/discourse/app/lib/click-track.js
@@ -5,7 +5,6 @@ import User from "discourse/models/user";
 import { ajax } from "discourse/lib/ajax";
 import getURL, { samePrefix } from "discourse-common/lib/get-url";
 import { isTesting } from "discourse-common/config/environment";
-import discourseLater from "discourse-common/lib/later";
 import { selectedText } from "discourse/lib/utilities";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import deprecated from "discourse-common/lib/deprecated";
@@ -59,7 +58,7 @@ export function shouldOpenInNewTab(href) {
   return !isInternal && openExternalInNewTab;
 }
 
-export function openLinkInNewTab(link) {
+export function openLinkInNewTab(event, link) {
   let href = (link.href || link.dataset.href || "").trim();
   if (href === "") {
     return;
@@ -69,23 +68,7 @@ export function openLinkInNewTab(link) {
   newWindow.opener = null;
   newWindow.focus();
 
-  // Hack to prevent changing current window.location.
-  // e.preventDefault() does not work.
-  if (!link.dataset.href) {
-    link.classList.add("no-href");
-    link.dataset.href = link.href;
-    link.dataset.autoRoute = true;
-    link.removeAttribute("href");
-
-    discourseLater(() => {
-      if (link) {
-        link.classList.remove("no-href");
-        link.setAttribute("href", link.dataset.href);
-        delete link.dataset.href;
-        delete link.dataset.autoRoute;
-      }
-    }, 50);
-  }
+  event.preventDefault();
 }
 
 export default {
@@ -185,7 +168,7 @@ export default {
 
     if (!wantsNewWindow(e)) {
       if (shouldOpenInNewTab(href)) {
-        openLinkInNewTab(link);
+        openLinkInNewTab(e, link);
       } else {
         trackPromise.finally(() => {
           if (DiscourseURL.isInternal(href) && samePrefix(href)) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/click-track-test.js
@@ -3,7 +3,6 @@ import { module, skip, test } from "qunit";
 import ClickTrack from "discourse/lib/click-track";
 import DiscourseURL from "discourse/lib/url";
 import User from "discourse/models/user";
-import discourseLater from "discourse-common/lib/later";
 import pretender from "discourse/tests/helpers/create-pretender";
 import sinon from "sinon";
 import { setPrefix } from "discourse-common/lib/get-url";
@@ -189,36 +188,6 @@ module("Unit | Utility | click-track", function (hooks) {
 
   test("does not track clicks on mailto", async function (assert) {
     assert.ok(track(generateClickEventOn(".mailto")));
-  });
-
-  test("removes the href and put it as a data attribute", async function (assert) {
-    User.currentProp("external_links_in_new_tab", true);
-
-    assert.notOk(track(generateClickEventOn("a")));
-
-    let link = fixture("a");
-    assert.ok(link.classList.contains("no-href"));
-    assert.strictEqual(link.dataset.href, "http://www.google.com/");
-    assert.blank(link.getAttribute("href"));
-    assert.ok(link.dataset.autoRoute);
-    assert.ok(window.open.calledWith("http://www.google.com/", "_blank"));
-  });
-
-  test("restores the href after a while", async function (assert) {
-    assert.expect(2);
-
-    assert.notOk(track(generateClickEventOn("a")));
-
-    assert.timeout(75);
-
-    const done = assert.async();
-    discourseLater(() => {
-      assert.strictEqual(
-        fixture("a").getAttribute("href"),
-        "http://www.google.com"
-      );
-      done();
-    });
   });
 
   function badgeClickCount(assert, id, expected) {


### PR DESCRIPTION
Opening of links in a new tab was difficult because it used a hack to remove the 'href' attribute and adding it back to prevent the event taking place instead of calling preventDefault.

This hack is no longer necessary because event handling has been normalized since it has been implemented (see commit 0221855ba783c6d96d2dbf2ec9f7e92b5297499b).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
