### PR TITLE
 UX: improve mention styling, simplify 

### DIFF
--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -2,10 +2,6 @@
 // To style group content differently, use the existing classes with a .group parent class.
 // For example: .group .user-secondary-navigation
 
-span.mention-group {
-  color: var(--primary);
-}
-
 .group-details-container {
   background: var(--primary-very-low);
   padding: 20px;

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1197,6 +1197,13 @@ blockquote > *:last-child {
       padding-right: 0.5em;
       line-height: var(--line-height-medium);
       flex: 1 1;
+      .mention {
+        // needs some special sizing and positioning due to surrounding all-caps text
+        position: relative;
+        top: -1px;
+        font-size: var(--font-0);
+        text-transform: initial;
+      }
     }
   }
 
@@ -1248,28 +1255,15 @@ blockquote > *:last-child {
   }
 }
 
-a.mention {
+a.mention,
+a.mention-group {
   // linked
   @include mention;
 }
 
 span.mention {
-  // unlinked
+  // unlinked, invalid mention
   color: var(--primary-high);
-}
-
-a.mention-group {
-  // unlinked
-  display: inline-block;
-  color: var(--primary-high);
-  cursor: default;
-
-  &.notify,
-  .small-action-desc & {
-    // linked
-    cursor: pointer;
-    @include mention;
-  }
 }
 
 .suggested-topics {

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -194,10 +194,6 @@
           max-height: 300px;
           overflow: auto;
 
-          a[href] {
-            text-decoration: underline;
-          }
-
           img {
             max-width: 100%;
           }

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -160,12 +160,8 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
     max-height: 150px;
     overflow: auto;
     .bio {
-      a {
-        color: var(--primary);
-        text-decoration: underline;
-      }
-      a.mention {
-        text-decoration: none;
+      a:not(.mention) {
+        color: var(--tertiary);
       }
       .overflow {
         max-height: 60px;
@@ -287,16 +283,12 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
     max-height: 150px;
     overflow: auto;
     .bio {
-      a {
-        color: var(--primary);
-        text-decoration: underline;
+      a:not(.mention) {
+        color: var(--tertiary);
       }
       img {
         max-width: 100%;
         height: auto;
-      }
-      a.mention {
-        text-decoration: none;
       }
       .overflow {
         max-height: 60px;

--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -239,8 +239,10 @@ $hpad: 0.65em;
 @mixin mention() {
   display: inline-block; // https://bugzilla.mozilla.org/show_bug.cgi?id=1656119
   font-size: 0.93em;
+  font-weight: normal;
   color: var(--primary);
-  padding: 0 4px 1px;
+  padding: 0 0.3em 0.07em;
   background: var(--primary-low);
-  border-radius: 8px;
+  border-radius: 0.6em;
+  text-decoration: none;
 }

--- a/app/assets/stylesheets/desktop/user.scss
+++ b/app/assets/stylesheets/desktop/user.scss
@@ -161,9 +161,6 @@ table.user-invite-list {
       .primary {
         .primary-textual {
           padding: 0 4px 4px;
-          a[href] {
-            text-decoration: underline;
-          }
           h1 {
             max-width: 100%;
             @include ellipsis;
@@ -180,10 +177,6 @@ table.user-invite-list {
 
         .bio {
           max-width: 750px;
-
-          a.mention {
-            text-decoration: none;
-          }
         }
       }
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2033,7 +2033,7 @@ developer:
     default: false
     client: true
   enable_experimental_hashtag_autocomplete:
-    default: true
+    default: false
     client: true
     hidden: true
   enable_new_user_profile_nav_groups:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2033,7 +2033,7 @@ developer:
     default: false
     client: true
   enable_experimental_hashtag_autocomplete:
-    default: false
+    default: true
     client: true
     hidden: true
   enable_new_user_profile_nav_groups:

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -138,12 +138,6 @@
       color: var(--primary);
     }
 
-    .valid-mention {
-      padding: 0 4px 1px;
-      border-radius: 8px;
-      display: inline-block;
-    }
-
     img.ytp-thumbnail-image {
       height: 100%;
       max-height: unset;


### PR DESCRIPTION
follow-up to b0f380c

This consolidates most mention styling to the mention mixin, improves consistency, and fixes an issue where group mentions appeared inactive. 

This also involved making some adjustments to the "about me" text on profiles and usercards. Within the "about me" text we have been underlining links, but we don't actually underline links in posts or most other places. This link underlining style also meant we required some additional styling to _undo_ the underline for linked mentions in "about me" text. 

So I removed link underlines from user "about me" text to be more consistent with links elsewhere in the app, which also allowed me to remove those mention-specific styles. 

/t/86289