### PR TITLE
FIX: Watched words replacement emoji render

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -149,6 +149,14 @@ acceptance("Admin - Watched Words", function (needs) {
 
 acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {
   needs.user();
+  needs.site({
+    watched_words_replace: {
+      "(?:\\W|^)(betis)(?=\\W|$)": {
+        replacement: ":poop:",
+        case_sensitive: false,
+      },
+    },
+  });
   needs.pretender((server, helper) => {
     server.get("/admin/customize/watched_words.json", () => {
       return helper.response({

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -162,16 +162,13 @@ acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {
     await click("button.reply-to-post");
     await fillIn(".d-editor-input", "betis betis betis");
     const cooked = query(".d-editor-preview p");
-    const threeEmojis = `<img src="/images/emoji/twitter/poop.png?v=12" title=":poop:" class="emoji only-emoji" alt=":poop:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"> <img src="/images/emoji/twitter/poop.png?v=12" title=":poop:" class="emoji only-emoji" alt=":poop:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"> <img src="/images/emoji/twitter/poop.png?v=12" title=":poop:" class="emoji only-emoji" alt=":poop:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;">`;
+    const cookedChildren = Array.from(cooked.children);
+    const emojis = cookedChildren.filter((child) => child.nodeName === "IMG");
+    assert.strictEqual(emojis.length, 3, "three emojis have been rendered");
     assert.strictEqual(
-      cooked.children.length,
-      3,
-      "3 elements have been rendered"
-    );
-    assert.strictEqual(
-      cooked.innerHTML,
-      threeEmojis,
-      "3 emojis have been rendered"
+      emojis.every((emoji) => emoji.title === ":poop:"),
+      true,
+      "all emojis are :poop:"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -8,7 +8,6 @@ import {
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
-import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Admin - Watched Words", function (needs) {
   needs.user();
@@ -157,46 +156,10 @@ acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {
       },
     },
   });
-  needs.pretender((server, helper) => {
-    server.get("/admin/customize/watched_words.json", () => {
-      return helper.response({
-        actions: ["block", "censor", "require_approval", "flag", "replace"],
-        words: [
-          {
-            id: 81,
-            word: "betis",
-            regexp: "(?:\\W|^)(betis)(?=\\W|$)",
-            replacement: ":poop:",
-            action: "replace",
-            case_sensitive: false,
-          },
-        ],
-        compiled_regular_expressions: {
-          block: null,
-          censor: null,
-          require_approval: null,
-          flag: null,
-          replace: [
-            {
-              "(?:\\W|^)(betis)(?=\\W|$)": {
-                case_sensitive: false,
-              },
-            },
-          ],
-        },
-      });
-    });
-  });
 
   test("emoji renders successfully after replacement", async function (assert) {
-    await visit("/admin/customize/watched_words/action/replace");
-    // await this.pauseTest();
-    await visit("/");
-    await click("#create-topic");
-    const categoryChooser = selectKit(".category-chooser");
-    await categoryChooser.expand();
-    await categoryChooser.selectRowByValue(2);
-    await fillIn("#reply-title", "Watched Words Replacement Test");
+    await visit("/t/internationalization-localization/280");
+    await click("button.reply-to-post");
     await fillIn(".d-editor-input", "betis betis betis");
     const cooked = query(".d-editor-preview p");
     const threeEmojis = `<img src="/images/emoji/twitter/poop.png?v=12" title=":poop:" class="emoji only-emoji" alt=":poop:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"> <img src="/images/emoji/twitter/poop.png?v=12" title=":poop:" class="emoji only-emoji" alt=":poop:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;"> <img src="/images/emoji/twitter/poop.png?v=12" title=":poop:" class="emoji only-emoji" alt=":poop:" loading="lazy" width="20" height="20" style="aspect-ratio: 20 / 20;">`;

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-watched-words-test.js
@@ -136,14 +136,6 @@ acceptance("Admin - Watched Words", function (needs) {
     assert.strictEqual(query(".modal-body li .match").innerText, "Hello");
     assert.strictEqual(query(".modal-body li .tag").innerText, "greeting");
   });
-
-  test("emoji replacement", async function (assert) {
-    await visit("/admin/customize/watched_words/action/replace");
-    await click(".watched-word-test");
-    await fillIn(".modal-body textarea", "Hi there!");
-    assert.strictEqual(query(".modal-body li .match").innerText, "Hi");
-    assert.strictEqual(query(".modal-body li .replacement").innerText, "hello");
-  });
 });
 
 acceptance("Admin - Watched Words - Emoji Replacement", function (needs) {

--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/emoji.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/emoji.js
@@ -195,13 +195,33 @@ function applyEmoji(
   emojiUnicodeReplacer,
   enableShortcuts,
   inlineEmoji,
-  customEmojiTranslation
+  customEmojiTranslation,
+  watchedWordsReplacer
 ) {
   let result = null;
   let start = 0;
 
   if (emojiUnicodeReplacer) {
     content = emojiUnicodeReplacer(content);
+  }
+
+  if (watchedWordsReplacer) {
+    const watchedWordRegex = Object.keys(watchedWordsReplacer);
+
+    watchedWordRegex.forEach((watchedWord) => {
+      if (content?.match(watchedWord)) {
+        const regex = new RegExp(watchedWord, "g");
+        const matches = content.match(regex);
+        const replacement = watchedWordsReplacer[watchedWord].replacement;
+
+        matches.forEach(() => {
+          const matchingRegex = regex.exec(content);
+          if (matchingRegex) {
+            content = content.replace(matchingRegex[1], replacement);
+          }
+        });
+      }
+    });
   }
 
   let end = content.length;
@@ -337,7 +357,8 @@ export function setup(helper) {
           md.options.discourse.emojiUnicodeReplacer,
           md.options.discourse.features.emojiShortcuts,
           md.options.discourse.features.inlineEmoji,
-          md.options.discourse.customEmojiTranslation
+          md.options.discourse.customEmojiTranslation,
+          md.options.discourse.watchedWordsReplace
         )
       )
     );


### PR DESCRIPTION
This PR resolves a 🐛 Bug Report brought up on [Meta](https://meta.discourse.org/t/replace-word-feature-stopped-working-with-emojis/242216).

The fix ensures that watched words replacements that trigger an emoji short code should render an emoji successfully.

For example the replacement:

`betis` to `:poop:`

Should trigger 💩 rather than `:poop:`