### PR TITLE
FIX: Minor hashtag autocomplete fixes

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -30,8 +30,8 @@ a.hashtag-cooked {
 }
 
 .hashtag-autocomplete {
-  max-height: 300px;
-  overflow-y: scroll;
+  max-height: 210px;
+  overflow-y: auto;
 
   .hashtag-autocomplete__option {
     .hashtag-autocomplete__link {
@@ -46,6 +46,9 @@ a.hashtag-cooked {
       .hashtag-autocomplete__text {
         flex: 1;
         margin-left: 0;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
 
         .emoji {
           width: 15px;

--- a/plugins/chat/lib/chat_channel_fetcher.rb
+++ b/plugins/chat/lib/chat_channel_fetcher.rb
@@ -99,8 +99,15 @@ module Chat::ChatChannelFetcher
     channels = channels.where(status: options[:status]) if options[:status].present?
 
     if options[:filter].present?
+      category_filter = \
+        if options[:filter_on_category_name]
+          "OR categories.name ILIKE :filter"
+        else
+          ""
+        end
+
       sql =
-        "chat_channels.name ILIKE :filter OR chat_channels.slug ILIKE :filter OR categories.name ILIKE :filter"
+        "chat_channels.name ILIKE :filter OR chat_channels.slug ILIKE :filter #{category_filter}"
       channels =
         channels.where(sql, filter: "%#{options[:filter].downcase}%").order(
           "chat_channels.name ASC, categories.name ASC",
@@ -142,7 +149,7 @@ module Chat::ChatChannelFetcher
     channels =
       secured_public_channel_search(
         guardian,
-        options.merge(include_archives: true),
+        options.merge(include_archives: true, filter_on_category_name: true),
       )
     decorate_memberships_with_tracking_data(guardian, channels, memberships)
     channels = channels.to_a

--- a/plugins/chat/spec/lib/chat_channel_hashtag_data_source_spec.rb
+++ b/plugins/chat/spec/lib/chat_channel_hashtag_data_source_spec.rb
@@ -55,20 +55,10 @@ RSpec.describe Chat::ChatChannelHashtagDataSource do
   end
 
   describe "#search" do
-    it "finds a channel by category name" do
+    it "does not find channels by category name" do
       category.update!(name: "Randomizer")
       result = described_class.search(guardian, "randomiz", 10).first
-      expect(result.to_h).to eq(
-        {
-          relative_url: channel1.relative_url,
-          text: "Zany Things",
-          description: "Just weird stuff",
-          icon: "comment",
-          type: "channel",
-          ref: nil,
-          slug: "random",
-        },
-      )
+      expect(result.to_h).to eq({})
     end
 
     it "finds a channel by slug" do


### PR DESCRIPTION
* Do not search category name when searching channels to avoid confusing results
* Overflow text in autocomplete menu with ... if it is too long
* Make autocomplete menu less height