### PR TITLE
FIX: Exclude claimed reviewables from user menu

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/review-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/review-section-link.js
@@ -57,7 +57,9 @@ export default class ReviewSectionLink extends BaseSectionLink {
   }
 
   get badgeText() {
-    if (this.currentUser.reviewable_count > 0) {
+    // force a tracker for reviewable_count by using .get to ensure badgeText
+    // rerenders when reviewable_count changes
+    if (this.currentUser.get("reviewable_count") > 0) {
       return I18n.t("sidebar.sections.community.links.review.pending_count", {
         count: this.currentUser.reviewable_count,
       });

--- a/app/controllers/reviewable_claimed_topics_controller.rb
+++ b/app/controllers/reviewable_claimed_topics_controller.rb
@@ -51,5 +51,8 @@ class ReviewableClaimedTopicsController < ApplicationController
     end
 
     MessageBus.publish("/reviewable_claimed", data, group_ids: group_ids.to_a)
+    if SiteSetting.enable_experimental_sidebar_hamburger
+      Jobs.enqueue(:refresh_users_reviewable_counts, group_ids: group_ids.to_a)
+    end
   end
 end

--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -59,7 +59,7 @@ class ReviewablesController < ApplicationController
       meta: filters.merge(
         total_rows_reviewables: total_rows, types: meta_types, reviewable_types: Reviewable.types,
         reviewable_count: current_user.reviewable_count,
-        unseen_reviewable_count: current_user.unseen_reviewable_count
+        unseen_reviewable_count: Reviewable.unseen_reviewable_count(current_user)
       )
     }
     if (offset + PER_PAGE) < total_rows

--- a/app/jobs/regular/notify_reviewable.rb
+++ b/app/jobs/regular/notify_reviewable.rb
@@ -99,12 +99,6 @@ class Jobs::NotifyReviewable < ::Jobs::Base
   end
 
   def notify_user(user, updates)
-    data = {
-      reviewable_count: user.reviewable_count,
-      unseen_reviewable_count: user.unseen_reviewable_count
-    }
-    data[:updates] = updates if updates.present?
-
-    user.publish_reviewable_counts(data)
+    user.publish_reviewable_counts(updates.present? ? { updates: updates } : nil)
   end
 end

--- a/app/jobs/regular/refresh_users_reviewable_counts.rb
+++ b/app/jobs/regular/refresh_users_reviewable_counts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Jobs::RefreshUsersReviewableCounts < ::Jobs::Base
+  def execute(args)
+    user_ids = args[:user_ids]
+    return if user_ids.blank?
+    User.where(id: user_ids).each(&:publish_reviewable_counts)
+  end
+end

--- a/app/jobs/regular/refresh_users_reviewable_counts.rb
+++ b/app/jobs/regular/refresh_users_reviewable_counts.rb
@@ -2,8 +2,10 @@
 
 class Jobs::RefreshUsersReviewableCounts < ::Jobs::Base
   def execute(args)
-    user_ids = args[:user_ids]
-    return if user_ids.blank?
-    User.where(id: user_ids).each(&:publish_reviewable_counts)
+    group_ids = args[:group_ids]
+    return if group_ids.blank?
+    User.where(
+      id: GroupUser.where(group_id: group_ids).distinct.pluck(:user_id)
+    ).each(&:publish_reviewable_counts)
   end
 end

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -431,6 +431,10 @@ class Reviewable < ActiveRecord::Base
     list_for(user).count
   end
 
+  def self.unseen_reviewable_count(user)
+    self.unseen_list_for(user).count
+  end
+
   def self.list_for(
     user,
     ids: nil,

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -447,7 +447,8 @@ class Reviewable < ActiveRecord::Base
     from_date: nil,
     to_date: nil,
     additional_filters: {},
-    preload: true
+    preload: true,
+    include_claimed_by_others: true
   )
     order = case sort_order
             when 'score_asc'
@@ -518,13 +519,18 @@ class Reviewable < ActiveRecord::Base
       )
     end
 
+    if !include_claimed_by_others
+      result = result
+        .joins("LEFT JOIN reviewable_claimed_topics rct ON reviewables.topic_id = rct.topic_id")
+        .where("rct.user_id IS NULL OR rct.user_id = ?", user.id)
+    end
     result = result.limit(limit) if limit
     result = result.offset(offset) if offset
     result
   end
 
   def self.unseen_list_for(user, preload: true, limit: nil)
-    results = list_for(user, preload: preload, limit: limit)
+    results = list_for(user, preload: preload, limit: limit, include_claimed_by_others: false)
     if user.last_seen_reviewable_id
       results = results.where(
         "reviewables.id > ?",
@@ -535,7 +541,7 @@ class Reviewable < ActiveRecord::Base
   end
 
   def self.user_menu_list_for(user, limit: 30)
-    list_for(user, limit: limit, status: :pending).to_a
+    list_for(user, limit: limit, status: :pending, include_claimed_by_others: false).to_a
   end
 
   def self.basic_serializers_for_list(reviewables, user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -669,10 +669,6 @@ class User < ActiveRecord::Base
     ).count
   end
 
-  def unseen_reviewable_count
-    Reviewable.unseen_list_for(self).count
-  end
-
   def saw_notification_id(notification_id)
     Discourse.deprecate(<<~TEXT, since: "2.9", drop_from: "3.0")
       User#saw_notification_id is deprecated. Please use User#bump_last_seen_notification! instead.
@@ -715,7 +711,7 @@ class User < ActiveRecord::Base
   def publish_reviewable_counts(extra_data = nil)
     data = {
       reviewable_count: self.reviewable_count,
-      unseen_reviewable_count: self.unseen_reviewable_count
+      unseen_reviewable_count: Reviewable.unseen_reviewable_count(self)
     }
     data.merge!(extra_data) if extra_data.present?
     MessageBus.publish("/reviewable_counts/#{self.id}", data, user_ids: [self.id])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -663,7 +663,10 @@ class User < ActiveRecord::Base
   end
 
   def reviewable_count
-    Reviewable.list_for(self).count
+    Reviewable.list_for(
+      self,
+      include_claimed_by_others: !redesigned_user_menu_enabled?
+    ).count
   end
 
   def unseen_reviewable_count
@@ -699,17 +702,22 @@ class User < ActiveRecord::Base
     query = Reviewable.unseen_list_for(self, preload: false)
 
     if last_seen_reviewable_id
-      query = query.where("id > ?", last_seen_reviewable_id)
+      query = query.where("reviewables.id > ?", last_seen_reviewable_id)
     end
     max_reviewable_id = query.maximum(:id)
 
     if max_reviewable_id
       update!(last_seen_reviewable_id: max_reviewable_id)
-      publish_reviewable_counts(unseen_reviewable_count: self.unseen_reviewable_count)
+      publish_reviewable_counts
     end
   end
 
-  def publish_reviewable_counts(data)
+  def publish_reviewable_counts(extra_data = nil)
+    data = {
+      reviewable_count: self.reviewable_count,
+      unseen_reviewable_count: self.unseen_reviewable_count
+    }
+    data.merge!(extra_data) if extra_data.present?
     MessageBus.publish("/reviewable_counts/#{self.id}", data, user_ids: [self.id])
   end
 

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -354,6 +354,10 @@ class CurrentUserSerializer < BasicUserSerializer
     UserStatusSerializer.new(object.user_status, root: false)
   end
 
+  def unseen_reviewable_count
+    Reviewable.unseen_reviewable_count(object)
+  end
+
   def redesigned_user_menu_enabled
     object.redesigned_user_menu_enabled?
   end

--- a/app/serializers/reviewable_perform_result_serializer.rb
+++ b/app/serializers/reviewable_perform_result_serializer.rb
@@ -47,7 +47,7 @@ class ReviewablePerformResultSerializer < ApplicationSerializer
   end
 
   def unseen_reviewable_count
-    scope.user.unseen_reviewable_count
+    Reviewable.unseen_reviewable_count(scope.user)
   end
 
   def include_unseen_reviewable_count?

--- a/spec/jobs/refresh_users_reviewable_counts_spec.rb
+++ b/spec/jobs/refresh_users_reviewable_counts_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::RefreshUsersReviewableCounts do
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:moderator) { Fabricate(:moderator) }
+  fab!(:user) { Fabricate(:user) }
+
+  fab!(:group) { Fabricate(:group) }
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:reviewable1) { Fabricate(:reviewable, reviewable_by_group: group, reviewable_by_moderator: true, topic: topic) }
+
+  fab!(:reviewable2) { Fabricate(:reviewable, reviewable_by_moderator: false) }
+  fab!(:reviewable3) { Fabricate(:reviewable, reviewable_by_moderator: true) }
+
+  before do
+    SiteSetting.enable_category_group_moderation = true
+    group.add(user)
+    topic.category.update!(reviewable_by_group: group)
+  end
+
+  describe '#execute' do
+    it "publishes reviewable counts for the specified users" do
+      messages = MessageBus.track_publish do
+        described_class.new.execute(user_ids: [moderator.id, admin.id])
+      end
+      expect(messages.size).to eq(2)
+      expect(messages.map(&:user_ids).flatten).to contain_exactly(moderator.id, admin.id)
+
+      messages = MessageBus.track_publish do
+        described_class.new.execute(user_ids: [moderator.id, user.id])
+      end
+      expect(messages.size).to eq(2)
+      expect(messages.map(&:user_ids).flatten).to contain_exactly(moderator.id, user.id)
+    end
+
+    it "published counts respect reviewables visibility" do
+      messages = MessageBus.track_publish do
+        described_class.new.execute(user_ids: [moderator.id, admin.id, user.id])
+      end
+      expect(messages.size).to eq(3)
+
+      admin_message = messages.find { |m| m.user_ids == [admin.id] }
+      moderator_message = messages.find { |m| m.user_ids == [moderator.id] }
+      user_message = messages.find { |m| m.user_ids == [user.id] }
+
+      expect(admin_message.channel).to eq("/reviewable_counts/#{admin.id}")
+      expect(admin_message.data).to eq(
+        reviewable_count: 3,
+        unseen_reviewable_count: 3
+      )
+
+      expect(moderator_message.channel).to eq("/reviewable_counts/#{moderator.id}")
+      expect(moderator_message.data).to eq(
+        reviewable_count: 2,
+        unseen_reviewable_count: 2
+      )
+
+      expect(user_message.channel).to eq("/reviewable_counts/#{user.id}")
+      expect(user_message.data).to eq(
+        reviewable_count: 1,
+        unseen_reviewable_count: 1
+      )
+    end
+  end
+end

--- a/spec/jobs/refresh_users_reviewable_counts_spec.rb
+++ b/spec/jobs/refresh_users_reviewable_counts_spec.rb
@@ -24,13 +24,23 @@ RSpec.describe Jobs::RefreshUsersReviewableCounts do
         described_class.new.execute(user_ids: [moderator.id, admin.id])
       end
       expect(messages.size).to eq(2)
-      expect(messages.map(&:user_ids).flatten).to contain_exactly(moderator.id, admin.id)
+
+      moderator_message = messages.find { |m| m.user_ids == [moderator.id] }
+      expect(moderator_message.channel).to eq("/reviewable_counts/#{moderator.id}")
+
+      admin_message = messages.find { |m| m.user_ids == [admin.id] }
+      expect(moderator_message.channel).to eq("/reviewable_counts/#{moderator.id}")
 
       messages = MessageBus.track_publish do
         described_class.new.execute(user_ids: [moderator.id, user.id])
       end
       expect(messages.size).to eq(2)
-      expect(messages.map(&:user_ids).flatten).to contain_exactly(moderator.id, user.id)
+
+      moderator_message = messages.find { |m| m.user_ids == [moderator.id] }
+      expect(moderator_message.channel).to eq("/reviewable_counts/#{moderator.id}")
+
+      user_message = messages.find { |m| m.user_ids == [user.id] }
+      expect(user_message.channel).to eq("/reviewable_counts/#{user.id}")
     end
 
     it "published counts respect reviewables visibility" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2972,48 +2972,6 @@ RSpec.describe User do
     end
   end
 
-  describe "#unseen_reviewable_count" do
-    fab!(:admin_reviewable) { Fabricate(:reviewable, reviewable_by_moderator: false) }
-    fab!(:mod_reviewable) { Fabricate(:reviewable, reviewable_by_moderator: true) }
-    fab!(:group_reviewable) { Fabricate(:reviewable, reviewable_by_moderator: false, reviewable_by_group: group) }
-
-    it "doesn't include reviewables that can't be seen by the user" do
-      SiteSetting.enable_category_group_moderation = true
-      expect(user.unseen_reviewable_count).to eq(0)
-      user.groups << group
-      user.save!
-      expect(user.unseen_reviewable_count).to eq(1)
-      user.update!(moderator: true)
-      expect(user.unseen_reviewable_count).to eq(2)
-      user.update!(admin: true)
-      expect(user.unseen_reviewable_count).to eq(3)
-    end
-
-    it "returns count of unseen reviewables" do
-      user.update!(admin: true)
-      expect(user.unseen_reviewable_count).to eq(3)
-      user.update!(last_seen_reviewable_id: mod_reviewable.id)
-      expect(user.unseen_reviewable_count).to eq(1)
-      user.update!(last_seen_reviewable_id: group_reviewable.id)
-      expect(user.unseen_reviewable_count).to eq(0)
-    end
-
-    it "doesn't include reviewables that are claimed by other users" do
-      user.update!(admin: true)
-
-      claimed_by_user = Fabricate(:reviewable, topic: Fabricate(:topic))
-      Fabricate(:reviewable_claimed_topic, topic: claimed_by_user.topic, user: user)
-
-      user2 = Fabricate(:user)
-      claimed_by_user2 = Fabricate(:reviewable, topic: Fabricate(:topic))
-      Fabricate(:reviewable_claimed_topic, topic: claimed_by_user2.topic, user: user2)
-
-      unclaimed = Fabricate(:reviewable, topic: Fabricate(:topic))
-
-      expect(user.unseen_reviewable_count).to eq(5)
-    end
-  end
-
   describe "#bump_last_seen_reviewable!" do
     it "doesn't error if there are no reviewables" do
       Reviewable.destroy_all


### PR DESCRIPTION
Users who can access the review queue can claim a pending reviewable(s) which means that the claimed reviewable(s) can only be handled by the user who claimed it. Currently, we show claimed reviewables in the user menu, but this can be annoying for other reviewers because they can't do anything about a reviewable claimed by someone. So this PR makes sure that we only show in the user menu reviewables that are claimed by nobody or claimed by the current user.

Internal topic: t/77235.