### PR TITLE
FIX: Pass period filter to plugin outlet

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/dashboard_moderation.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_moderation.hbs
@@ -25,6 +25,11 @@
 
     <AdminReport @dataSourceName="user_flagging_ratio" @filters={{this.lastWeekfilters}} @reportOptions={{this.userFlaggingRatioOptions}} />
 
-    <PluginOutlet @name="admin-dashboard-moderation-bottom" @tagName="span" @connectorTagName="div" />
+    <PluginOutlet
+      @name="admin-dashboard-moderation-bottom"
+      @tagName="span"
+      @connectorTagName="div"
+      @args={{hash filters=this.lastWeekfilters}}
+    />
   </div>
 </div>


### PR DESCRIPTION
Pass period filter to `admin-dashboard-moderation-bottom` plugin outlet.

This allows plugins to render period filtered moderation data/report

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
