### PR TITLE
FIX: Use correct Regexp flag to ignore case

### DIFF
--- a/lib/text_cleaner.rb
+++ b/lib/text_cleaner.rb
@@ -71,7 +71,7 @@ class TextCleaner
     text
   end
 
-  @@whitespaces_regexp = Regexp.new("(\u00A0|\u1680|\u180E|[\u2000-\u200A]|\u2028|\u2029|\u202F|\u205F|\u3000)", "u").freeze
+  @@whitespaces_regexp = Regexp.new("(\u00A0|\u1680|\u180E|[\u2000-\u200A]|\u2028|\u2029|\u202F|\u205F|\u3000)", Regexp::IGNORECASE).freeze
 
   def self.normalize_whitespaces(text)
     text&.gsub(@@whitespaces_regexp, ' ')


### PR DESCRIPTION
Ruby 3.2 started enforcing valid string flags in Regexp constructor.
