### PR TITLE
DEV: Add useful error message for hbs register_asset

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -586,6 +586,13 @@ class Plugin::Instance
   end
 
   def register_asset(file, opts = nil)
+    if file.end_with?(".hbs", ".handlebars")
+      raise <<~ERROR
+        [#{name}] Handlebars templates can no longer be included via `register_asset`.
+        Any hbs files under `assets/javascripts` will be automatically compiled and included."
+      ERROR
+    end
+
     if opts && opts == :vendored_core_pretty_text
       full_path = DiscoursePluginRegistry.core_asset_for_name(file)
     else


### PR DESCRIPTION
This hasn't been necessary for many years, and is no longer supported following 84bec1cb. Only extremely old plugins might be trying to do this. All the affected open-source plugins I can find have already been updated.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
