### PR TITLE
UX: alters chat icon behavior on drawer an mobile

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/widgets/chat-header-icon.js
+++ b/plugins/chat/assets/javascripts/discourse/widgets/chat-header-icon.js
@@ -64,13 +64,21 @@ export default createWidget("header-chat-link", {
   },
 
   click() {
-    if (this.chatStateManager.isFullPageActive && !this.site.mobileView) {
+    if (this.chatStateManager.isFullPageActive && this.site.desktopView) {
       return;
     }
 
-    return this.router.transitionTo(
-      this.chatStateManager.lastKnownChatURL || "chat"
-    );
+    if (this.chatStateManager.isFullPageActive && this.site.mobileView) {
+      return this.router.transitionTo("chat");
+    }
+
+    if (this.chatStateManager.isDrawerActive) {
+      return this.router.transitionTo("chat");
+    } else {
+      return this.router.transitionTo(
+        this.chatStateManager.lastKnownChatURL || "chat"
+      );
+    }
   },
 
   chatRerenderHeader() {

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -17,6 +17,38 @@ RSpec.describe "Navigation", type: :system, js: true do
     sign_in(user)
   end
 
+  context "when clicking chat icon and drawer is viewing channel" do
+    it "navigates to index" do
+      chat_page.open_from_header
+      chat_drawer_page.open_channel(category_channel_2)
+      chat_page.open_from_header
+
+      expect(page).to have_content(I18n.t("js.chat.direct_messages.title"))
+    end
+  end
+
+  context "when clicking chat icon on mobile and is viewing channel" do
+    it "navigates to index" do
+      visit("/chat?mobile_view=1")
+      chat_page.visit_channel(category_channel_2)
+      chat_page.open_from_header
+
+      expect(page).to have_current_path(chat_path)
+    end
+  end
+
+  context "when clicking chat icon on desktop and is viewing channel" do
+    it "stays on channel page" do
+      visit("/chat")
+      chat_page.visit_channel(category_channel_2)
+      chat_page.open_from_header
+
+      expect(page).to have_current_path(
+        chat.channel_path(category_channel_2.id, category_channel_2.slug),
+      )
+    end
+  end
+
   context "when visiting /chat" do
     it "opens full page" do
       chat_page.open


### PR DESCRIPTION
Refines the behavior of clicking the chat icon in mobile and when in drawer mode as follows: If chat is open, clicking the icon takes you to the index.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
