### PR TITLE
FIX: Unsilence users on chat message flag disagree.

### DIFF
--- a/plugins/chat/app/models/reviewable_chat_message.rb
+++ b/plugins/chat/app/models/reviewable_chat_message.rb
@@ -9,7 +9,6 @@ class ReviewableChatMessage < Reviewable
       agree_and_silence: :agree_and_delete,
       agree_and_suspend: :agree_and_delete,
       delete_and_agree: :agree_and_delete,
-      disagree_and_restore: :disagree,
     }
   end
 
@@ -112,6 +111,9 @@ class ReviewableChatMessage < Reviewable
 
   def disagree
     yield if block_given?
+
+    UserSilencer.unsilence(chat_message_creator)
+
     create_result(:success, :rejected) do |result|
       result.update_flag_stats = { status: :disagreed, user_ids: flagged_by_user_ids }
       result.recalculate_score = true

--- a/plugins/chat/spec/models/reviewable_chat_message_spec.rb
+++ b/plugins/chat/spec/models/reviewable_chat_message_spec.rb
@@ -31,22 +31,21 @@ RSpec.describe ReviewableChatMessage, type: :model do
     reviewable.perform(moderator, :agree_and_restore)
 
     expect(reviewable).to be_approved
-    expect(chat_message.reload.deleted_at).not_to be_present
+    expect(chat_message.reload.deleted_at).to be_nil
   end
 
   it "perform_disagree disagrees with the flag and does nothing" do
     reviewable.perform(moderator, :disagree)
 
     expect(reviewable).to be_rejected
-    expect(chat_message.reload.deleted_at).not_to be_present
   end
 
-  it "perform_disagree_and_restore disagrees with the flag and does nothing" do
+  it "perform_disagree_and_restore disagrees with the flag and restores the message" do
     chat_message.trash!(user)
     reviewable.perform(moderator, :disagree_and_restore)
 
     expect(reviewable).to be_rejected
-    expect(chat_message.reload.deleted_at).to be_present
+    expect(chat_message.reload.deleted_at).to be_nil
   end
 
   it "perform_ignore ignores the flag and does nothing" do
@@ -54,5 +53,29 @@ RSpec.describe ReviewableChatMessage, type: :model do
 
     expect(reviewable).to be_ignored
     expect(chat_message.reload.deleted_at).not_to be_present
+  end
+
+  context "when the flagged message autho is silenced" do
+    before do
+      UserSilencer.silence(
+        user,
+        Discourse.system_user,
+        silenced_till: 10.minutes.from_now,
+        reason: I18n.t("chat.errors.auto_silence_from_flags"),
+      )
+    end
+
+    it "perform_disagree unsilences the user" do
+      reviewable.perform(moderator, :disagree)
+
+      expect(user.reload.silenced?).to eq(false)
+    end
+
+    it "perform_disagree_and_restore unsilences the user" do
+      chat_message.trash!(user)
+      reviewable.perform(moderator, :disagree_and_restore)
+
+      expect(user.reload.silenced?).to eq(false)
+    end
   end
 end

--- a/plugins/chat/spec/models/reviewable_chat_message_spec.rb
+++ b/plugins/chat/spec/models/reviewable_chat_message_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ReviewableChatMessage, type: :model do
     expect(chat_message.reload.deleted_at).not_to be_present
   end
 
-  context "when the flagged message autho is silenced" do
+  context "when the flagged message author is silenced" do
     before do
       UserSilencer.silence(
         user,


### PR DESCRIPTION
We have an auto silence rule in place for chat message flags, so we need to unsilence users if the flag gets rejected.

Additionally, it also fixes the `disagree_and_restore` action, which wasn't recovering a deleted message.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
