### PR TITLE
Revert "Version bump to v2.9.0.beta13 (#19210)"

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -10,7 +10,7 @@ module Discourse
       MAJOR = 2
       MINOR = 9
       TINY  = 0
-      PRE   = 'beta13'
+      PRE   = 'beta12'
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
     end


### PR DESCRIPTION
This reverts commit a71f6cf09bc32b45bccf2b280c32b453813ff695.

The github UI had an error I didn't notice which resulted in a security commit being merged _after_ the bump, now I have to redo the bump.
