### PR TITLE
FIX: Allow hashtag autocomplete at start of line

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
@@ -50,22 +50,15 @@ export function setupHashtagAutocomplete(
 export function hashtagTriggerRule(textarea, opts) {
   const result = caretRowCol(textarea);
   const row = result.rowNum;
-  let col = result.colNum;
   let line = textarea.value.split("\n")[row - 1];
 
   if (opts && opts.backSpace) {
-    col = col - 1;
     line = line.slice(0, line.length - 1);
 
     // Don't trigger autocomplete when backspacing into a `#category |` => `#category|`
     if (/^#{1}\w+/.test(line)) {
       return false;
     }
-  }
-
-  // Don't trigger autocomplete when ATX-style headers are used
-  if (col < 6 && line.slice(0, col) === "#".repeat(col)) {
-    return false;
   }
 
   if (inCodeBlock(textarea.value, caretPosition(textarea))) {


### PR DESCRIPTION
Back when we introduced hashtag autocomplete in
c1dbf5c1c421f6e485c0552df0d280739e061270 we had to
disallow triggering it using # at the start of the
line because our old markdown engine rendered headers
with `#abc`, but now our new engine does `# abc` so
it is safe to allow hashtag autocompletion straight
away.