### PR TITLE
FIX: PMs displaying outdated unread counts when read status is processing

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/user-topic-list.js
+++ b/app/assets/javascripts/discourse/app/routes/user-topic-list.js
@@ -1,5 +1,6 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import ViewingActionType from "discourse/mixins/viewing-action-type";
+import { setTopicList } from "discourse/lib/topic-list-tracker";
 
 export default DiscourseRoute.extend(ViewingActionType, {
   renderTemplate() {
@@ -7,6 +8,8 @@ export default DiscourseRoute.extend(ViewingActionType, {
   },
 
   setupController(controller, model) {
+    setTopicList(model);
+
     const userActionType = this.userActionType;
     this.controllerFor("user").set("userActionType", userActionType);
     this.controllerFor("user-activity").set("userActionType", userActionType);

--- a/app/assets/javascripts/discourse/app/services/screen-track.js
+++ b/app/assets/javascripts/discourse/app/services/screen-track.js
@@ -139,6 +139,7 @@ export default class ScreenTrack extends Service {
 
     const highestRead = parseInt(Object.keys(timings).lastObject, 10);
     const cachedHighestRead = this.highestReadFromCache(topicId);
+
     if (!cachedHighestRead || cachedHighestRead < highestRead) {
       setHighestReadCache(topicId, highestRead);
     }


### PR DESCRIPTION
When a client "reads" a post, we do no immediately send the data of the
post for processing on the server. Instead, read posts data is batched
together and sent to the server for processing at regular intervals. On
the server side, processing of read posts data is done in the
background. As such, there is a small window of delay before a post is
marked as read by a user on the server side.

If a client reads a topic and loads the messages topic list before the
server has processed the read post, the unread posts count for the topic
which the client just read will appear to be incorrect/outdated.

As part of tracking a post as read, we are already tracking the highest
read post number for the last read topic by the client. Therefore, we
can use this information to correct the highest post read number in the
scenario that was described above. This solution is the same as what
we've been doing for the regular topics list.