### PR TITLE
DEV: Only patch bootbox methods once in tests

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/jquery-plugins.js
+++ b/app/assets/javascripts/discourse/app/initializers/jquery-plugins.js
@@ -3,9 +3,15 @@ import bootbox from "bootbox";
 import { getOwner } from "discourse-common/lib/get-owner";
 import deprecated from "discourse-common/lib/deprecated";
 
+let jqueryPluginsConfigured = false;
+
 export default {
   name: "jquery-plugins",
   initialize() {
+    if (jqueryPluginsConfigured) {
+      return;
+    }
+
     // Settings for bootbox
     bootbox.animate(false);
     bootbox.backdrop(true);
@@ -46,5 +52,7 @@ export default {
 
     // Initialize the autocomplete tool
     $.fn.autocomplete = autocomplete;
+
+    jqueryPluginsConfigured = true;
   },
 };


### PR DESCRIPTION
We were re-patching the deprecated bootbox methods during every app initialization, which would lead to hundreds of deprecation messages being printed for a single invocation.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
