### PR TITLE
DEV: Remove unused `render()` calls

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-logs-screened-emails.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-screened-emails.js
@@ -1,10 +1,6 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default DiscourseRoute.extend({
-  renderTemplate() {
-    this.render("admin/templates/logs/screened-emails", { into: "adminLogs" });
-  },
-
   setupController() {
     return this.controllerFor("adminLogsScreenedEmails").show();
   },

--- a/app/assets/javascripts/admin/addon/routes/admin-logs-screened-ip-addresses.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-screened-ip-addresses.js
@@ -1,12 +1,6 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default DiscourseRoute.extend({
-  renderTemplate() {
-    this.render("admin/templates/logs/screened-ip-addresses", {
-      into: "adminLogs",
-    });
-  },
-
   setupController() {
     return this.controllerFor("adminLogsScreenedIpAddresses").show();
   },

--- a/app/assets/javascripts/admin/addon/routes/admin-logs-screened-urls.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-screened-urls.js
@@ -1,10 +1,6 @@
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default DiscourseRoute.extend({
-  renderTemplate() {
-    this.render("admin/templates/logs/screened-urls", { into: "adminLogs" });
-  },
-
   setupController() {
     return this.controllerFor("adminLogsScreenedUrls").show();
   },

--- a/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
@@ -34,13 +34,6 @@ export default DiscourseRoute.extend({
     return this._super(value, urlKey, defaultValueType);
   },
 
-  // TODO: make this automatic using an `{{outlet}}`
-  renderTemplate() {
-    this.render("admin/templates/logs/staff-action-logs", {
-      into: "adminLogs",
-    });
-  },
-
   actions: {
     onFiltersChange(filters) {
       if (filters && Object.keys(filters) === 0) {

--- a/app/assets/javascripts/admin/addon/routes/admin-user.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-user.js
@@ -14,10 +14,6 @@ export default DiscourseRoute.extend({
     return AdminUser.find(get(params, "user_id"));
   },
 
-  renderTemplate() {
-    this.render({ into: "admin" });
-  },
-
   afterModel(adminUser) {
     return adminUser.loadDetails().then(function () {
       adminUser.setOriginalTrustLevel();

--- a/app/assets/javascripts/admin/addon/routes/admin-web-hooks-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-web-hooks-show.js
@@ -23,8 +23,4 @@ export default DiscourseRoute.extend({
     model.set("group_ids", model.get("group_ids"));
     controller.setProperties({ model, saved: false });
   },
-
-  renderTemplate() {
-    this.render("admin/templates/web-hooks-show", { into: "adminApi" });
-  },
 });

--- a/app/assets/javascripts/discourse/app/routes/build-admin-user-posts-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-admin-user-posts-route.js
@@ -33,7 +33,7 @@ export default function (filter) {
     },
 
     renderTemplate() {
-      this.render("user/posts", { into: "user" });
+      this.render("user/posts");
     },
   });
 }

--- a/app/assets/javascripts/discourse/app/routes/user-badges.js
+++ b/app/assets/javascripts/discourse/app/routes/user-badges.js
@@ -17,7 +17,7 @@ export default DiscourseRoute.extend(ViewingActionType, {
   },
 
   renderTemplate() {
-    this.render("user/badges", { into: "user" });
+    this.render("user/badges");
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/user-notifications.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications.js
@@ -6,10 +6,6 @@ export default DiscourseRoute.extend(ViewingActionType, {
   controllerName: "user-notifications",
   queryParams: { filter: { refreshModel: true } },
 
-  renderTemplate() {
-    this.render("user/notifications");
-  },
-
   @action
   didTransition() {
     this.controllerFor("user-notifications")._showFooter();


### PR DESCRIPTION
Those templates are automatically inserted into `{{outlet}}`s

(Just the low hanging fruits for now)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
