### PR TITLE
FIX: consistent narrow desktop width

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -367,9 +367,7 @@ const SiteHeaderComponent = MountWidget.extend(
       const menuPanels = document.querySelectorAll(".menu-panel");
 
       if (menuPanels.length === 0) {
-        if (this.site.mobileView || this.site.narrowDesktopView) {
-          this._animate = true;
-        }
+        this._animate = this.site.mobileView || this.site.narrowDesktopView;
         return;
       }
 

--- a/app/assets/javascripts/discourse/app/lib/narrow-desktop.js
+++ b/app/assets/javascripts/discourse/app/lib/narrow-desktop.js
@@ -6,7 +6,7 @@ const NarrowDesktop = {
   init() {
     this.narrowDesktopView =
       narrowDesktopForced ||
-      this.isNarrowDesktopView(bodyElement.getBoundingClientRect().width);
+      this.isNarrowDesktopView(document.body.getBoundingClientRect().width);
   },
 
   isNarrowDesktopView(width) {

--- a/app/assets/javascripts/discourse/app/lib/narrow-desktop.js
+++ b/app/assets/javascripts/discourse/app/lib/narrow-desktop.js
@@ -4,7 +4,6 @@ const NarrowDesktop = {
   narrowDesktopView: false,
 
   init() {
-    const bodyElement = document.querySelector("body");
     this.narrowDesktopView =
       narrowDesktopForced ||
       this.isNarrowDesktopView(bodyElement.getBoundingClientRect().width);

--- a/app/assets/javascripts/discourse/app/lib/narrow-desktop.js
+++ b/app/assets/javascripts/discourse/app/lib/narrow-desktop.js
@@ -4,8 +4,10 @@ const NarrowDesktop = {
   narrowDesktopView: false,
 
   init() {
+    const bodyElement = document.querySelector("body");
     this.narrowDesktopView =
-      narrowDesktopForced || this.isNarrowDesktopView(window.innerWidth);
+      narrowDesktopForced ||
+      this.isNarrowDesktopView(bodyElement.getBoundingClientRect().width);
   },
 
   isNarrowDesktopView(width) {


### PR DESCRIPTION
- use client rect instead of innerWidth to determine if screen is narrow
- disable _animate when exit mobile/narrow view

https://meta.discourse.org/t/site-header-issue-when-resizing/246826
