### PR TITLE
UX: Align user page dismiss notifications btn with new navigation

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
@@ -1,18 +1,19 @@
 {{#if this.currentUser.redesigned_user_page_nav_enabled}}
   <DSection @pageClass="user-notifications" />
+
   <div class="user-navigation user-navigation-secondary">
     <HorizontalOverflowNav>
       <UserNav::NotificationsNav
           @model={{this.model}}
           @siteSettings={{this.siteSettings}}/>
     </HorizontalOverflowNav>
-  </div>
-  {{#if this.model}}
-    <div class="navigation-controls">
-      <DButton @title="user.dismiss_notifications_tooltip" @class="btn btn-default dismiss-notifications" @action={{action "resetNew"}} @label="user.dismiss_notifications" @icon="check" @disabled={{this.allNotificationsRead}} />
-    </div>
-  {{/if}}
 
+    {{#if this.model}}
+      <div class="navigation-controls">
+        <DButton @title="user.dismiss_notifications_tooltip" @class="btn btn-default dismiss-notifications" @action={{action "resetNew"}} @label="user.dismiss_notifications" @icon="check" @disabled={{this.allNotificationsRead}} />
+      </div>
+    {{/if}}
+  </div>
 {{else}}
   <DSection @pageClass="user-notifications" @class="user-secondary-navigation">
     <MobileNav @class="notifications-nav" @desktopClass="notification-list action-list nav-stacked">


### PR DESCRIPTION
This change only affects the redesign user page navigation menu. The
dismiss button was incorrectly positioned below the user notifications
stream. A side effect of this is that it affected our infinite loading
code for the notifications stream.

No tests have been added in this commit as we have yet to quite figure
out how we can reliabily test for behaviours which requires us to scroll
the page.

### Screenshots

#### Before

![Screenshot from 2022-11-29 10-20-35](https://user-images.githubusercontent.com/4335742/204422872-757e2724-6449-4d5f-9f7a-ec2a29bdcbaa.png)

#### After

![Screenshot from 2022-11-29 10-20-20](https://user-images.githubusercontent.com/4335742/204422881-1defd2a7-a5c1-4a13-9621-754ebbdf2942.png)
