### PR TITLE
FIX: Improve message when posting a duplicate link

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -648,12 +648,21 @@ export default Controller.extend({
           const [linkWarn, linkInfo] = linkLookup.check(post, href);
 
           if (linkWarn && !this.get("isWhispering")) {
-            const body = I18n.t("composer.duplicate_link", {
-              domain: linkInfo.domain,
-              username: linkInfo.username,
-              post_url: topic.urlForPostNumber(linkInfo.post_number),
-              ago: shortDate(linkInfo.posted_at),
-            });
+            let body;
+            if (linkInfo.username === this.currentUser.username) {
+              body = I18n.t("composer.duplicate_link_same_user", {
+                domain: linkInfo.domain,
+                post_url: topic.urlForPostNumber(linkInfo.post_number),
+                ago: shortDate(linkInfo.posted_at),
+              });
+            } else {
+              body = I18n.t("composer.duplicate_link", {
+                domain: linkInfo.domain,
+                username: linkInfo.username,
+                post_url: topic.urlForPostNumber(linkInfo.post_number),
+                ago: shortDate(linkInfo.posted_at),
+              });
+            }
             this.appEvents.trigger("composer-messages:create", {
               extraClass: "custom-body",
               templateName: "education",

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2237,6 +2237,7 @@ en:
         one: "By mentioning <b>@%{here}</b>, you are about to notify %{count} user – are you sure?"
         other: "By mentioning <b>@%{here}</b>, you are about to notify %{count} users – are you sure?"
       duplicate_link: "It looks like your link to <b>%{domain}</b> was already posted in the topic by <b>@%{username}</b> in <a href='%{post_url}'>a reply on %{ago}</a> – are you sure you want to post it again?"
+      duplicate_link_same_user: "It looks like you already posted a link to <b>%{domain}</b> in this topic in <a href='%{post_url}'>a reply on %{ago}</a> - are you sure you want to post it again?"
       reference_topic_title: "RE: %{title}"
 
       error:


### PR DESCRIPTION
If the duplicated link was posted by the user itself, it will display a different JIT message.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
