### PR TITLE
PERF: Delay updating Group user_count

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -101,7 +101,7 @@ class Admin::GroupsController < Admin::StaffController
       GroupActionLogger.new(current_user, group).log_remove_user_as_group_owner(user)
     end
 
-    Group.reset_counters(group.id, :group_users)
+    Group.reset_all_counters!(group.name)
 
     render json: success_json
   end

--- a/app/jobs/regular/automatic_group_membership.rb
+++ b/app/jobs/regular/automatic_group_membership.rb
@@ -20,7 +20,7 @@ module Jobs
         GroupActionLogger.new(Discourse.system_user, group).log_add_user_to_group(user)
       end
 
-      Group.reset_counters(group.id, :group_users)
+      Group.reset_all_counters!(group.name)
     end
 
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -542,7 +542,7 @@ class Group < ActiveRecord::Base
     refresh_has_messages!
   end
 
-  def self.reset_all_counters!(groups)
+  def self.reset_all_counters!(groups = [])
 
     where = ''
     if groups.present?

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class GroupUser < ActiveRecord::Base
-  belongs_to :group, counter_cache: "user_count"
+  belongs_to :group
   belongs_to :user
 
   after_save :update_title

--- a/script/import_scripts/vbulletin.rb
+++ b/script/import_scripts/vbulletin.rb
@@ -196,7 +196,7 @@ class ImportScripts::VBulletin < ImportScripts::Base
           INSERT INTO group_users (group_id, user_id, created_at, updated_at) VALUES #{values}
         SQL
 
-        Group.reset_counters(group.id, :group_users)
+        Group.reset_all_counters!(group.name)
       rescue Exception => e
         puts e.message
         puts e.backtrace.join("\n")

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe GroupSmtpMailer do
   let(:user) do
     user = Fabricate(:user)
     group.add_owner(user)
+    Group.reset_all_counters!
     user
   end
 
@@ -63,7 +64,6 @@ RSpec.describe GroupSmtpMailer do
     SiteSetting.manual_polling_enabled = true
     SiteSetting.reply_by_email_address = "test+%{reply_key}@test.com"
     SiteSetting.reply_by_email_enabled = true
-    Group.reset_all_counters!
   end
 
   it 'sends an email as reply' do

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe GroupSmtpMailer do
     SiteSetting.manual_polling_enabled = true
     SiteSetting.reply_by_email_address = "test+%{reply_key}@test.com"
     SiteSetting.reply_by_email_enabled = true
+    Group.reset_all_counters!
   end
 
   it 'sends an email as reply' do

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1115,7 +1115,10 @@ RSpec.describe UserNotifications do
         Fabricate(:post, topic: topic, post_number: 7, user: user4)
       ]
     end
-    Group.reset_all_counters!
+
+    before do
+      Group.reset_all_counters!
+    end
 
     it "returns a list of participants (except for the recipient), groups first, followed by users in order of their last reply" do
       expect(UserNotifications.participants(posts.last, user3)).to eq("[group1 (3)](http://test.localhost/g/group1), " \

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -596,6 +596,8 @@ RSpec.describe UserNotifications do
       user1 = Fabricate(:user, username: "one", groups: [group1, group2])
       user2 = Fabricate(:user, username: "two", groups: [group1], staged: true)
 
+      Group.reset_all_counters!
+
       topic.allowed_users = [user, user1, user2]
       topic.allowed_groups = [group1, group2]
 
@@ -1113,6 +1115,7 @@ RSpec.describe UserNotifications do
         Fabricate(:post, topic: topic, post_number: 7, user: user4)
       ]
     end
+    Group.reset_all_counters!
 
     it "returns a list of participants (except for the recipient), groups first, followed by users in order of their last reply" do
       expect(UserNotifications.participants(posts.last, user3)).to eq("[group1 (3)](http://test.localhost/g/group1), " \

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -88,11 +88,11 @@ RSpec.describe GroupsController do
     context 'with sortable' do
       before do
         group
+        Group.reset_all_counters!
         sign_in(user)
       end
 
       fab!(:group_with_2_users) { Fabricate(:group, name: "other_group", users: [user, other_user]) }
-      Group.reset_all_counters!
 
       context "with default (descending) order" do
         it "sorts by name" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe GroupsController do
       end
 
       fab!(:group_with_2_users) { Fabricate(:group, name: "other_group", users: [user, other_user]) }
+      Group.reset_all_counters!
 
       context "with default (descending) order" do
         it "sorts by name" do

--- a/spec/services/user_merger_spec.rb
+++ b/spec/services/user_merger_spec.rb
@@ -227,6 +227,7 @@ RSpec.describe UserMerger do
     group3.add(walter)
 
     merge_users!
+    Group.reset_all_counters!
 
     [group1, group2, group3].each do |g|
       owner = [group1, group3].include?(g)


### PR DESCRIPTION
In events where *many* users are created quickly, the counter_cache
automatic behavior can become a bottleneck.

counter_cache will issue an UPDATE to PostgreSQL on every new object,
which will hold a lock over the group row on the table, and the table
bloat generated by the constant UPDATE churn will not help too.

Since we already have a recurrent backgroup job to ensure_consistency!
of those counts, we can safely remove the counter_cache annotation from
the association and let the count be updated only via the backgroud
routine.
