### PR TITLE
FIX: Allow svg in local Oneboxes in certain cases

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -322,7 +322,7 @@ module Oneboxer
     return if !post || post.hidden || !allowed_post_types.include?(post.post_type)
 
     if post_number > 1 && opts[:topic_id] == topic.id
-      excerpt = post.excerpt(SiteSetting.post_onebox_maxlength)
+      excerpt = post.excerpt(SiteSetting.post_onebox_maxlength, keep_svg: true)
       excerpt.gsub!(/[\r\n]+/, " ")
       excerpt.gsub!("[/quote]", "[quote]") # don't break my quote
 
@@ -337,7 +337,7 @@ module Oneboxer
         original_url: url,
         title: PrettyText.unescape_emoji(CGI::escapeHTML(topic.title)),
         category_html: CategoryBadge.html_for(topic.category),
-        quote: PrettyText.unescape_emoji(post.excerpt(SiteSetting.post_onebox_maxlength)),
+        quote: PrettyText.unescape_emoji(post.excerpt(SiteSetting.post_onebox_maxlength, keep_svg: true)),
       }
 
       template = template("discourse_topic_onebox")

--- a/spec/lib/excerpt_parser_spec.rb
+++ b/spec/lib/excerpt_parser_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe ExcerptParser do
     expect(ExcerptParser.get_excerpt(html, 2, {})).to match_html('<details class="disabled"><summary>fo&hellip;</summary></details>')
   end
 
+  it "allows <svg> with <use> inside for icons when keep_svg is true" do
+    html = '<svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg>'
+    expect(ExcerptParser.get_excerpt(html, 100, { keep_svg: true })).to match_html('<svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg>')
+    expect(ExcerptParser.get_excerpt(html, 100, {})).to match_html('')
+
+    html = '<svg class="blah"><use href="#folder"></use></svg>'
+    expect(ExcerptParser.get_excerpt(html, 100, { keep_svg: true })).to match_html('')
+
+    html = '<use href="#user"></use><svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg>'
+    expect(ExcerptParser.get_excerpt(html, 100, { keep_svg: true })).to match_html('<svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg>')
+  end
+
   describe "keep_onebox_body parameter" do
     it "keeps the body content for external oneboxes" do
       html = <<~HTML.strip

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -146,6 +146,16 @@ RSpec.describe Oneboxer do
 
       expect(preview("/u/#{user.username}")).to include("Thunderland")
     end
+
+    it "includes hashtag HTML and icons" do
+      SiteSetting.enable_experimental_hashtag_autocomplete = true
+      category = Fabricate(:category, slug: "random")
+      Fabricate(:tag, name: "bug")
+      public_post = Fabricate(:post, raw: "This post has some hashtags, #random and #bug")
+      expect(preview(public_post.url).chomp).to include(<<~HTML.chomp)
+        <a class="hashtag-cooked" href="#{category.url}" data-type="category" data-slug="random"><svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg>#{category.name}</a> and <a class="hashtag-cooked" href="/tag/bug" data-type="tag" data-slug="bug"><svg class="fa d-icon d-icon-tag svg-icon svg-node"><use href="#tag"></use></svg>bug</a>
+      HTML
+    end
   end
 
   describe ".onebox_raw" do


### PR DESCRIPTION
When doing local oneboxes we sometimes want to allow
SVGs in the final preview HTML. The main case currently
is for the new cooked hashtags, which include an SVG
icon.

SVGs will be included in local oneboxes via `ExcerptParser` _only_
if they have the d-icon class, and if the caller for `post.excerpt`
specifies the `keep_svg: true` option.

Before:

<img src="https://user-images.githubusercontent.com/920448/204681932-5f2606d9-fbd7-4a1f-bdf8-369d9b980658.png" width="500">

After: 

<img src="https://user-images.githubusercontent.com/920448/204681917-1178d771-1b95-4be8-aa30-7a6c077fbd02.png" width="500">
