### PR TITLE
FIX: margin for sidebar and revamped user menu on iPad

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -661,6 +661,13 @@ div.menu-links-header {
   }
 }
 
+body.footer-nav-ipad {
+  .hamburger-panel .revamped,
+  .menu-panel.slide-in {
+    margin-top: var(--footer-nav-height);
+  }
+}
+
 .hamburger-panel .menu-panel.slide-in {
   left: 0;
 


### PR DESCRIPTION
Additional top margin when footer is visible on iPad

![IMG_0024](https://user-images.githubusercontent.com/72780/204692992-80fa66b6-f193-4e43-a8d6-bc2b31334752.PNG)
![IMG_0023](https://user-images.githubusercontent.com/72780/204693020-04b1cba7-3a38-4f6d-9f68-528e467fb30c.PNG)

https://meta.discourse.org/t/layout-of-notifications-is-a-bit-off-on-discoursehub/246721


