### PR TITLE
FIX: Allow reviewable-item components to be template-only

### DIFF
--- a/app/assets/javascripts/discourse/app/components/reviewable-item.js
+++ b/app/assets/javascripts/discourse/app/components/reviewable-item.js
@@ -107,9 +107,10 @@ export default Component.extend({
     }
 
     const dasherized = dasherize(type);
-    const componentExists = getOwner(this).hasRegistration(
-      `component:${dasherized}`
-    );
+    const owner = getOwner(this);
+    const componentExists =
+      owner.hasRegistration(`component:${dasherized}`) ||
+      owner.hasRegistration(`template:components/${dasherized}`);
     _components[type] = componentExists ? dasherized : null;
     return _components[type];
   },


### PR DESCRIPTION
The akismet plugin defines the `reviewable-akismet-post` component using a template under `discourse/templates/components/reviewable-akismet-post.hbs` without an associated `.js` file. The change to our resolution logic in c1397670 wasn't considering this.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
