### PR TITLE
FIX: Show chat channel info on reviewable items

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/reviewable-chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/reviewable-chat-message.js
@@ -1,0 +1,13 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+export default class ReviewableChatMessage extends Component {
+  @service store;
+
+  get chatChannel() {
+    return this.store.createRecord(
+      "chat-channel",
+      this.args.reviewable.chat_channel
+    );
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/templates/components/reviewable-chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/templates/components/reviewable-chat-message.hbs
@@ -1,21 +1,21 @@
 <div class="flagged-post-header">
-  <LinkTo @route="chat.channel" @models={{array this.reviewable.chat_channel.id this.reviewable.chat_channel.title}} @query={{hash messageId=this.reviewable.target_id}}>
-    <ChatChannelTitle @channel={{this.reviewable.chat_channel}} />
+  <LinkTo @route="chat.channel" @models={{array this.chatChannel.id this.chatChannel.title}} @query={{hash messageId=@reviewable.target_id}}>
+    <ChatChannelTitle @channel={{this.chatChannel}} />
   </LinkTo>
 </div>
 
 <div class="post-contents-wrapper">
-  <ReviewableCreatedBy @user={{this.reviewable.target_created_by}} @tagName="" />
+  <ReviewableCreatedBy @user={{@reviewable.target_created_by}} @tagName="" />
   <div class="post-contents">
-    <ReviewablePostHeader @reviewable={{this.reviewable}} @createdBy={{this.reviewable.target_created_by}} @tagName="" />
+    <ReviewablePostHeader @reviewable={{@reviewable}} @createdBy={{@reviewable.target_created_by}} @tagName="" />
 
     <div class="post-body">
-      {{html-safe (or this.reviewable.payload.message_cooked this.reviewable.cooked)}}
+      {{html-safe (or @reviewable.payload.message_cooked @reviewable.cooked)}}
     </div>
 
-    {{#if this.reviewable.payload.transcript_topic_id}}
+    {{#if @reviewable.payload.transcript_topic_id}}
       <div class="transcript">
-        <LinkTo @route="topic" @models={{array "-" this.reviewable.payload.transcript_topic_id}} class="btn btn-small">
+        <LinkTo @route="topic" @models={{array "-" @reviewable.payload.transcript_topic_id}} class="btn btn-small">
           {{i18n "review.transcript.view"}}
         </LinkTo>
       </div>


### PR DESCRIPTION
`reviewable.chat_channel` is a plain javascript object from the server's JSON response. We need to turn it into a true `ChatChannel` object before passing to `<ChatChannelTitle>`

This commit also converts `<ReviewableChatMessage>` to a Glimmer component

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
