### PR TITLE
DEV: Enable `@cached` decorator for themes and plugins

### DIFF
--- a/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
@@ -31,3 +31,18 @@ define("ember-jquery-legacy", ["exports"], function (exports) {
     return e.__originalEvent || e.originalEvent;
   };
 });
+
+// ember-cached-decorator-polyfill uses a Babel transformation to apply this polyfill in core.
+// Adding that Babel transformation to themes and plugins will be complex, so we use this to
+// patch it at runtime. This can be removed once `@glimmer/tracking` is updated to a version
+// with native `@cached` support.
+const glimmerTracking = require("@glimmer/tracking");
+if (glimmerTracking.cached) {
+  console.error(
+    "@glimmer/tracking natively supports the @cached decorator. The polyfill can be removed."
+  );
+} else {
+  Object.defineProperty(glimmerTracking, "cached", {
+    get: () => require("ember-cached-decorator-polyfill").cached,
+  });
+}

--- a/plugins/chat/assets/javascripts/discourse/components/reviewable-chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/reviewable-chat-message.js
@@ -1,9 +1,11 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
+import { cached } from "@glimmer/tracking";
 
 export default class ReviewableChatMessage extends Component {
   @service store;
 
+  @cached
   get chatChannel() {
     return this.store.createRecord(
       "chat-channel",


### PR DESCRIPTION
`ember-cached-decorator-polyfill` uses a Babel transformation to apply this polyfill in core. Adding that Babel transformation to themes and plugins will be complex, so we use this simpler approach to patch it at runtime. This can be removed once `@glimmer/tracking` is updated to a version with native `@cached` support.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
