### PR TITLE
FIX: When following redirects before cloning, use the first git request

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -67,7 +67,7 @@ class FinalDestination
 
     @status = :ready
     @follow_canonical = @opts[:follow_canonical]
-    @http_verb = http_verb(@force_get_hosts, @follow_canonical)
+    @http_verb = @opts[:http_verb] || http_verb(@force_get_hosts, @follow_canonical)
     @cookie = nil
     @limited_ips = []
     @verbose = @opts[:verbose] || false
@@ -82,8 +82,8 @@ class FinalDestination
     20
   end
 
-  def self.resolve(url)
-    new(url).resolve
+  def self.resolve(url, opts = nil)
+    new(url, opts).resolve
   end
 
   def http_verb(force_get_hosts, follow_canonical)

--- a/spec/lib/theme_store/git_importer_spec.rb
+++ b/spec/lib/theme_store/git_importer_spec.rb
@@ -6,6 +6,7 @@ require 'theme_store/git_importer'
 RSpec.describe ThemeStore::GitImporter do
   describe "#import" do
     let(:url) { "https://github.com/example/example.git" }
+    let(:first_fetch_url) { "https://github.com/example/example.git/info/refs?service=git-upload-pack" }
     let(:trailing_slash_url) { "https://github.com/example/example/" }
     let(:ssh_url) { "git@github.com:example/example.git" }
     let(:branch) { "dev" }
@@ -13,8 +14,17 @@ RSpec.describe ThemeStore::GitImporter do
     before do
       hex = "xxx"
       SecureRandom.stubs(:hex).returns(hex)
-      FinalDestination.stubs(:resolve).with(url).returns(URI.parse(url))
-      FinalDestination::SSRFDetector.stubs(:lookup_and_filter_ips).with("github.com").returns(["192.0.2.100"])
+
+      FinalDestination::SSRFDetector
+        .stubs(:lookup_and_filter_ips)
+        .with("github.com")
+        .returns(["192.0.2.100"])
+
+      FinalDestination
+        .stubs(:resolve)
+        .with(first_fetch_url, http_verb: :get)
+        .returns(URI.parse(first_fetch_url))
+
       @temp_folder = "#{Pathname.new(Dir.tmpdir).realpath}/discourse_theme_#{hex}"
       @ssh_folder = "#{Pathname.new(Dir.tmpdir).realpath}/discourse_theme_ssh_#{hex}"
     end


### PR DESCRIPTION
This is closer to git's redirect following behaviour. We prevented git following redirects when we clone in order to prevent SSRF attacks.

Follow-up-to: 291bbc4fb966165c9f7bbc7af6bea705b8c09a7d

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
