### PR TITLE
DEV: Run system tests with documentation and profiling on actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,11 +172,11 @@ jobs:
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
-        run: bin/system_rspec
+        run: bin/rspec spec/system --format documentation --profile
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
-        run: LOAD_PLUGINS=1 bin/system_rspec plugins/*/spec/system
+        run: LOAD_PLUGINS=1 bin/rspec plugins/*/spec/system
 
       - name: Upload failed system test screenshots
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
When a test takes too long, we want to know which test and at what step

Things are starting to timeout on github

![Screenshot from 2022-12-01 05-27-19](https://user-images.githubusercontent.com/4335742/204911620-95bc3fb9-147f-42da-af3d-63985bfdb531.png)
