### PR TITLE
DEV: Centralise logic for updating sidebar section links

### DIFF
--- a/app/services/sidebar_section_links_updater.rb
+++ b/app/services/sidebar_section_links_updater.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class SidebarSectionLinksUpdater
+  def self.update_category_section_links(user, category_ids:)
+    if category_ids.blank?
+      delete_section_links(user: user, linkable_type: 'Category')
+    else
+      category_ids = Category.secured(Guardian.new(user)).where(id: category_ids).pluck(:id)
+      update_section_links(user: user, linkable_type: 'Category', new_linkable_ids: category_ids)
+    end
+  end
+
+  def self.update_tag_section_links(user, tag_names:)
+    if tag_names.blank?
+      delete_section_links(user: user, linkable_type: 'Tag')
+    else
+      tag_ids = DiscourseTagging
+        .filter_visible(Tag, Guardian.new(user))
+        .where(name: tag_names)
+        .pluck(:id)
+
+      update_section_links(user: user, linkable_type: 'Tag', new_linkable_ids: tag_ids)
+    end
+  end
+
+  def self.delete_section_links(user:, linkable_type:)
+    SidebarSectionLink.where(user: user, linkable_type: linkable_type).delete_all
+  end
+  private_class_method :delete_section_links
+
+  def self.update_section_links(user:, linkable_type:, new_linkable_ids:)
+    SidebarSectionLink.transaction do
+      existing_linkable_ids = SidebarSectionLink.where(user: user, linkable_type: linkable_type).pluck(:linkable_id)
+
+      to_delete = existing_linkable_ids - new_linkable_ids
+      to_insert = new_linkable_ids - existing_linkable_ids
+
+      to_insert_attributes = to_insert.map do |linkable_id|
+        {
+          linkable_type: linkable_type,
+          linkable_id: linkable_id,
+          user_id: user.id
+        }
+      end
+
+      SidebarSectionLink.where(user: user, linkable_type: linkable_type, linkable_id: to_delete).delete_all if to_delete.present?
+      SidebarSectionLink.insert_all(to_insert_attributes) if to_insert_attributes.present?
+    end
+  end
+  private_class_method :update_section_links
+end

--- a/spec/lib/sidebar_section_links_updater_spec.rb
+++ b/spec/lib/sidebar_section_links_updater_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe SidebarSectionLinksUpdater do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+
+  describe '.update_category_section_links' do
+    fab!(:public_category) { Fabricate(:category) }
+    fab!(:public_category2) { Fabricate(:category) }
+    fab!(:group) { Fabricate(:group) }
+    fab!(:secured_category) { Fabricate(:private_category, group: group) }
+
+    fab!(:user_category_section_link) { Fabricate(:category_sidebar_section_link, linkable: public_category, user: user) }
+    fab!(:user2_category_section_link) { Fabricate(:category_sidebar_section_link, linkable: public_category, user: user2) }
+
+    it 'deletes all sidebar category section links when category ids provided is blank' do
+      described_class.update_category_section_links(user, category_ids: [])
+
+      expect(SidebarSectionLink.exists?(linkable: public_category, user: user)).to eq(false)
+      expect(SidebarSectionLink.exists?(linkable: public_category, user: user2)).to eq(true)
+    end
+
+    it "updates user's sidebar category section link records to given category ids except for category restricted to user" do
+      expect(SidebarSectionLink.where(linkable_type: 'Category', user: user).pluck(:linkable_id)).to contain_exactly(
+        public_category.id
+      )
+
+      described_class.update_category_section_links(user, category_ids: [public_category2.id, secured_category.id])
+
+      expect(SidebarSectionLink.where(linkable_type: 'Category', user: user).pluck(:linkable_id)).to contain_exactly(
+        public_category2.id
+      )
+
+      group.add(user)
+
+      described_class.update_category_section_links(user, category_ids: [public_category2.id, secured_category.id])
+
+      expect(SidebarSectionLink.where(linkable_type: 'Category', user: user).pluck(:linkable_id)).to contain_exactly(
+        public_category2.id,
+        secured_category.id
+      )
+    end
+  end
+
+  describe '.update_tag_section_links' do
+    fab!(:tag) { Fabricate(:tag) }
+    fab!(:tag2) { Fabricate(:tag) }
+    fab!(:hidden_tag) { Fabricate(:tag) }
+    fab!(:staff_tag_group) { Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name]) }
+
+    fab!(:user_tag_section_link) { Fabricate(:tag_sidebar_section_link, linkable: tag, user: user) }
+    fab!(:user2_tag_section_link) { Fabricate(:tag_sidebar_section_link, linkable: tag, user: user2) }
+
+    it 'deletes all sidebar tag section links when tag names provided is blank' do
+      described_class.update_tag_section_links(user, tag_names: [])
+
+      expect(SidebarSectionLink.exists?(linkable: tag, user: user)).to eq(false)
+      expect(SidebarSectionLink.exists?(linkable: tag, user: user2)).to eq(true)
+    end
+
+    it "updates user's sidebar tag section link records to given tag names except for tags not visible to user" do
+      expect(SidebarSectionLink.where(linkable_type: 'Tag', user: user).pluck(:linkable_id)).to contain_exactly(
+        tag.id
+      )
+
+      described_class.update_tag_section_links(user, tag_names: [tag2.name, hidden_tag.name])
+
+      expect(SidebarSectionLink.where(linkable_type: 'Tag', user: user).pluck(:linkable_id)).to contain_exactly(
+        tag2.id
+      )
+
+      user.update!(admin: true)
+
+      described_class.update_tag_section_links(user, tag_names: [tag2.name, hidden_tag.name])
+
+      expect(SidebarSectionLink.where(linkable_type: 'Tag', user: user).pluck(:linkable_id)).to contain_exactly(
+        tag2.id,
+        hidden_tag.id
+      )
+    end
+  end
+end


### PR DESCRIPTION
The centralization helps in reducing code duplication in our code base
and more importantly, centralizing logic for guardian checks into a
single spot.