### PR TITLE
FIX: Handle null svg class for excerpt parsing

### DIFF
--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -136,7 +136,7 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
 
     when "svg"
       attributes = Hash[*attributes.flatten]
-      if attributes["class"].include?("d-icon") && @keep_svg
+      if attributes["class"]&.include?("d-icon") && @keep_svg
         include_tag(name, attributes)
         @in_svg = true
       end

--- a/spec/lib/excerpt_parser_spec.rb
+++ b/spec/lib/excerpt_parser_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe ExcerptParser do
     html = '<svg class="blah"><use href="#folder"></use></svg>'
     expect(ExcerptParser.get_excerpt(html, 100, { keep_svg: true })).to match_html('')
 
+    html = '<svg><use href="#folder"></use></svg>'
+    expect(ExcerptParser.get_excerpt(html, 100, { keep_svg: true })).to match_html('')
+
     html = '<use href="#user"></use><svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg>'
     expect(ExcerptParser.get_excerpt(html, 100, { keep_svg: true })).to match_html('<svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg>')
   end


### PR DESCRIPTION
Follow-up to 9d50790530459535164870bd49e712c30d2d5e8e

In certain cases the svg may not a class, so we just need safe navigation to avoid an error here.
