### PR TITLE
FIX: Email hashtag-cooked text replacement error

### DIFF
--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -326,11 +326,10 @@ module Email
 
     def decorate_hashtags
       @fragment.search(".hashtag-cooked").each do |hashtag|
-        hashtag_text = hashtag.search("span").first
-        hashtag_text.add_next_sibling(<<~HTML)
+        hashtag.children.each(&:remove)
+        hashtag.add_child(<<~HTML)
           <span>##{hashtag["data-slug"]}</span>
         HTML
-        hashtag_text.remove
       end
     end
 

--- a/spec/lib/email/styles_spec.rb
+++ b/spec/lib/email/styles_spec.rb
@@ -104,6 +104,15 @@ RSpec.describe Email::Styles do
       expect(frag.at('a')).to be_present
       expect(frag.at('a')['href']).to eq(original_url)
     end
+
+    it "replaces hashtag-cooked text with raw #hashtag" do
+      hashtag_html = "<a class=\"hashtag-cooked\" href=\"#{Discourse.base_url}/c/123/dev\" data-type=\"category\" data-slug=\"dev\"><svg class=\"fa d-icon d-icon-folder svg-icon svg-node\"><use href=\"#folder\"></use></svg><span>Dev Zone</span></a>"
+      frag = html_fragment(hashtag_html)
+      expect(frag.at("a").text.chomp).to eq("#dev")
+      hashtag_html = "<a class=\"hashtag-cooked\" href=\"#{Discourse.base_url}/c/123/dev\" data-type=\"category\" data-slug=\"dev\"><svg class=\"fa d-icon d-icon-folder svg-icon svg-node\">Dev Zone</a>"
+      frag = html_fragment(hashtag_html)
+      expect(frag.at("a").text.chomp).to eq("#dev")
+    end
   end
 
   describe "rewriting protocol relative URLs to the forum" do


### PR DESCRIPTION
In some cases (e.g. user notification emails) we
are passing an excerpted/stripped version of the
post HTML to Email::Styles, at which point the
<span> elements surrounding the hashtag text have
been stripped. This caused an error when trying to
remove that element to replace the text.

Instead we can just remove all elements inside
a.hashtag-cooked and replace with the raw #hashtag
text which will work in more cases.