### PR TITLE
FIX: Do not replace hashtag-cooked text with WatchedWords

### DIFF
--- a/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
+++ b/app/assets/javascripts/pretty-text/engines/discourse-markdown/watched-words.js
@@ -107,7 +107,10 @@ export function setup(helper) {
               currentToken.type === "span_open") &&
             currentToken.attrs &&
             currentToken.attrs.some(
-              (attr) => attr[0] === "class" && attr[1] === "hashtag"
+              (attr) =>
+                attr[0] === "class" &&
+                (attr[1].includes("hashtag") ||
+                  attr[1].includes("hashtag-cooked"))
             )
           ) {
             lastType =

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1690,13 +1690,22 @@ HTML
       SiteSetting.watched_words_regular_expressions = true
 
       Fabricate(:user, username: "test")
-      category = Fabricate(:category, slug: "test")
+      category = Fabricate(:category, slug: "test", name: "test")
       Fabricate(:watched_word, action: WatchedWord.actions[:replace], word: "es", replacement: "discourse")
 
       expect(PrettyText.cook("@test #test test")).to match_html(<<~HTML)
         <p>
           <a class="mention" href="/u/test">@test</a>
           <a class="hashtag" href="/c/test/#{category.id}">#<span>test</span></a>
+          tdiscourset
+        </p>
+      HTML
+
+      SiteSetting.enable_experimental_hashtag_autocomplete = true
+      expect(PrettyText.cook("@test #test test")).to match_html(<<~HTML)
+        <p>
+          <a class="mention" href="/u/test">@test</a>
+          <a class="hashtag-cooked" href="#{category.url}" data-type="category" data-slug="test"><svg class="fa d-icon d-icon-folder svg-icon svg-node"><use href="#folder"></use></svg><span>test</span></a>
           tdiscourset
         </p>
       HTML


### PR DESCRIPTION
Adds the .hashtag-cooked as an exception for watched words to not auto-link the text of the hashtag.