### PR TITLE
PERF: do not cancel debounce and prevents popper on scroll

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -99,7 +99,7 @@ export default Component.extend({
       passive: true,
     });
     window.addEventListener("resize", this.onResizeHandler);
-    window.addEventListener("mousewheel", this.onScrollHandler, {
+    window.addEventListener("wheel", this.onScrollHandler, {
       passive: true,
     });
 
@@ -124,7 +124,7 @@ export default Component.extend({
       ?.removeEventListener("scroll", this.onScrollHandler);
 
     window.removeEventListener("resize", this.onResizeHandler);
-    window.removeEventListener("mousewheel", this.onScrollHandler);
+    window.removeEventListener("wheel", this.onScrollHandler);
 
     this.appEvents.off(
       "chat-live-pane:highlight-message",
@@ -1321,8 +1321,6 @@ export default Component.extend({
 
   @action
   onHoverMessage(message, options = {}, event) {
-    cancel(this._onHoverMessageDebouncedHandler);
-
     if (this.site.mobileView && options.desktopOnly) {
       return;
     }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -32,6 +32,12 @@ export default Component.extend({
           modifiers: [
             { name: "hide", enabled: true },
             {
+              name: "eventListeners",
+              options: {
+                scroll: false,
+              },
+            },
+            {
               name: "offset",
               options: {
                 offset: ({ popper, placement }) => {


### PR DESCRIPTION
This commit also replaces deprecated `mousewheel` by `wheel` event listener