### PR TITLE
PERF: Add GlobalSetting to redirect avatars instead of proxying

### DIFF
--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -182,7 +182,7 @@ class UserAvatarsController < ApplicationController
   end
 
   def redirect_s3_avatar(url)
-    immutable_for 1.year
+    immutable_for 1.hour
     redirect_to url, allow_other_host: true
   end
 

--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -125,12 +125,10 @@ class UserAvatarsController < ApplicationController
       if optimized.local?
         optimized_path = Discourse.store.path_for(optimized)
         image = optimized_path if File.exist?(optimized_path)
+      elsif GlobalSetting.redirect_avatar_requests
+        return redirect_s3_avatar(Discourse.store.cdn_url(optimized.url))
       else
-        if GlobalSetting.redirect_avatar_requests
-          return redirect_s3_avatar(Discourse.store.cdn_url(optimized.url))
-        else
-          return proxy_avatar(Discourse.store.cdn_url(optimized.url), upload.created_at)
-        end
+        return proxy_avatar(Discourse.store.cdn_url(optimized.url), upload.created_at)
       end
     end
 

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -359,3 +359,6 @@ long_polling_interval =
 
 # Moves asset preloading from tags in the response document head to response headers
 preload_link_header = false
+
+# When using an external upload store, redirect `user_avatar` requests instead of proxying
+redirect_avatar_requests = false


### PR DESCRIPTION
When uploads are stored on S3, by default Discourse will fetch the avatars and proxy them through to the requesting client. This is simple, but it can lead to significant inbound/outbound network load in the hosting environment.

This commit adds an optional `redirect_avatar_requests` GlobalSetting. When enabled, requests for user avatars will be redirected to the S3 asset instead of being proxied. This adds an extra round-trip for clients, but it should significantly reduce server load. To mitigate that extra round-trip for clients, a CDN with 'follow redirect' capability could be used.