### PR TITLE
FIX: Observe unlisted topic creation restrictions in topic creator specs

### DIFF
--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -41,15 +41,25 @@ RSpec.describe PostCreator do
       expect(post.wiki).to eq(true)
     end
 
-    it "can be created with a hidden reason" do
+    it "creates post with a hidden reason for staff user" do
       hri = Post.hidden_reasons[:flag_threshold_reached]
-      post = PostCreator.create(user, basic_topic_params.merge(hidden_reason_id: hri))
+      post = PostCreator.create(admin, basic_topic_params.merge(hidden_reason_id: hri))
       expect(post.hidden).to eq(true)
       expect(post.hidden_at).to be_present
       expect(post.hidden_reason_id).to eq(hri)
       expect(post.topic.visible).to eq(false)
       expect(post.user.topic_count).to eq(0)
       expect(post.user.post_count).to eq(0)
+    end
+
+    it "fails to create post with a hidden reason for non-staff user" do
+      hri = Post.hidden_reasons[:flag_threshold_reached]
+
+      expect do
+        post = PostCreator.create(user, basic_topic_params.merge(hidden_reason_id: hri))
+
+        expect(post).to be_nil
+      end.not_to change { Post.count }
     end
 
     it "ensures the user can create the topic" do


### PR DESCRIPTION
Update failing spec which previously used non-staff user to create hidden posts.

Also add new spec for non-staff use cases to prevent future regressions.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
