### PR TITLE
FEATURE: Optionally allow a separate `s3_asset_cdn_url` to be specified

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,9 +95,10 @@ module ApplicationHelper
     path = ActionController::Base.helpers.asset_path("#{script}.js")
 
     if GlobalSetting.use_s3? && GlobalSetting.s3_cdn_url
+      resolved_s3_asset_cdn_url = GlobalSetting.s3_asset_cdn_url.presence || GlobalSetting.s3_cdn_url
       if GlobalSetting.cdn_url
         folder = ActionController::Base.config.relative_url_root || "/"
-        path = path.gsub(File.join(GlobalSetting.cdn_url, folder, "/"), File.join(GlobalSetting.s3_cdn_url, "/"))
+        path = path.gsub(File.join(GlobalSetting.cdn_url, folder, "/"), File.join(resolved_s3_asset_cdn_url, "/"))
       else
         # we must remove the subfolder path here, assets are uploaded to s3
         # without it getting involved
@@ -105,7 +106,7 @@ module ApplicationHelper
           path = path.sub(ActionController::Base.config.relative_url_root, "")
         end
 
-        path = "#{GlobalSetting.s3_cdn_url}#{path}"
+        path = "#{resolved_s3_asset_cdn_url}#{path}"
       end
 
       # assets needed for theme testing are not compressed because they take a fair

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -229,6 +229,9 @@ s3_endpoint =
 s3_http_continue_timeout =
 s3_install_cors_rule =
 
+# Optionally, specify a separate CDN to be used for static JS assets stored on S3
+s3_asset_cdn_url =
+
 ### rate limits apply to all sites
 max_user_api_reqs_per_minute = 20
 max_user_api_reqs_per_day = 2880

--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -37,7 +37,7 @@ class ContentSecurityPolicy
       ['/svg-sprite/',         false, true, false],
     ]
 
-    def script_assets(base = base_url, s3_cdn = GlobalSetting.s3_cdn_url, cdn = GlobalSetting.cdn_url, worker: false)
+    def script_assets(base = base_url, s3_cdn = GlobalSetting.s3_asset_cdn_url.presence || GlobalSetting.s3_cdn_url, cdn = GlobalSetting.cdn_url, worker: false)
       SCRIPT_ASSET_DIRECTORIES.map do |dir, can_use_s3_cdn, can_use_cdn, for_worker|
         next if worker && !for_worker
         if can_use_s3_cdn && s3_cdn

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -88,6 +88,12 @@ RSpec.describe ApplicationHelper do
         link = helper.preload_script('discourse/tests/theme_qunit_ember_jquery')
         expect(link).to eq(script_tag("https://s3cdn.com/assets/discourse/tests/theme_qunit_ember_jquery.js"))
       end
+
+      it "uses separate asset CDN if configured" do
+        global_setting :s3_asset_cdn_url, "https://s3-asset-cdn.example.com"
+        expect(helper.preload_script("discourse")).to include("https://s3-asset-cdn.example.com/assets/discourse.js")
+      end
+
     end
   end
 

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -133,6 +133,19 @@ RSpec.describe ContentSecurityPolicy do
         https://cdn.com/theme-javascripts/
         http://test.localhost/extra-locales/
       ])
+
+      global_setting(:s3_asset_cdn_url, 'https://s3-asset-cdn.com')
+
+      script_srcs = parse(policy)['script-src']
+      expect(script_srcs).to include(*%w[
+        https://s3-asset-cdn.com/assets/
+        https://s3-asset-cdn.com/brotli_asset/
+        https://cdn.com/highlight-js/
+        https://cdn.com/javascripts/
+        https://cdn.com/plugins/
+        https://cdn.com/theme-javascripts/
+        http://test.localhost/extra-locales/
+      ])
     end
 
     it 'adds subfolder to CDN assets' do


### PR DESCRIPTION
If configured, this will be used for static JS assets which are stored on S3. This can be useful if you want to use different CDN providers/configuration for Uploads and JS

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
