### PR TITLE
FIX: relative URL routing on ember-cli only page

### DIFF
--- a/app/views/layouts/ember_cli.html.erb
+++ b/app/views/layouts/ember_cli.html.erb
@@ -17,7 +17,7 @@
 
     <p>Then visit the following URL to use Discourse:</p>
 
-   <h3><a href="http://<%= Discourse.current_hostname %>:4200/">http://<%= Discourse.current_hostname %>:4200</a></h3>
+    <h3><a href="http://<%= Discourse.current_hostname %>:4200<%= Discourse.base_path %>">http://<%= Discourse.current_hostname %>:4200<%= Discourse.base_path %></a></h3>
   </div>
 </body>
 </html>


### PR DESCRIPTION
Developing in ember-cli with `DISCOURSE_RELATIVE_URL_ROOT` set should display the correct links to the ember-cli dev environment