### PR TITLE
FIX: Fix failing spec caused by unpersisted user instance

### DIFF
--- a/spec/components/search_spec.rb
+++ b/spec/components/search_spec.rb
@@ -953,7 +953,7 @@ describe Search do
     context 'post searching' do
       before do
         SiteSetting.tagging_enabled = true
-        DiscourseTagging.tag_topic_by_names(post.topic, Guardian.new(Fabricate.build(:admin)), [tag.name, uppercase_tag.name])
+        DiscourseTagging.tag_topic_by_names(post.topic, Guardian.new(admin), [tag.name, uppercase_tag.name])
         post.topic.save
       end
 


### PR DESCRIPTION
Active Record's `to_sql` method seems to return an empty string instead of the expected SQL query when called on a query involving an unpersisted model instance.

This replaces the admin `user` used in the specs with a persisted instance.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
