### PR TITLE
DEV: handle ember-cli test proxying for relative roots

### DIFF
--- a/app/assets/javascripts/bootstrap-json/index.js
+++ b/app/assets/javascripts/bootstrap-json/index.js
@@ -465,7 +465,7 @@ to serve API requests. For example:
 
     app.use(rawMiddleware, async (req, res, next) => {
       try {
-        if (this.shouldForwardRequest(req)) {
+        if (this.shouldForwardRequest(req, baseURL)) {
           await handleRequest(proxy, baseURL, req, res);
         } else {
           // Fixes issues when using e.g. "localhost" instead of loopback IP address
@@ -486,13 +486,13 @@ to serve API requests. For example:
     });
   },
 
-  shouldForwardRequest(request) {
+  shouldForwardRequest(request, baseURL) {
     if (
       [
-        "/tests/index.html",
-        "/ember-cli-live-reload.js",
-        "/testem.js",
-        "/assets/test-i18n.js",
+        `${baseURL}tests/index.html`,
+        `${baseURL}ember-cli-live-reload.js`,
+        `${baseURL}testem.js`,
+        `${baseURL}assets/test-i18n.js`,
       ].includes(request.path)
     ) {
       return false;


### PR DESCRIPTION
Allow tests to be able to be found and run
when DISCOURSE_RELATIVE_ROOT is set.