### PR TITLE
FEATURE: Allow user_status scope for UserApiKey

### DIFF
--- a/app/models/user_api_key_scope.rb
+++ b/app/models/user_api_key_scope.rb
@@ -16,7 +16,12 @@ class UserApiKeyScope < ActiveRecord::Base
       RouteMatcher.new(methods: :get, actions: 'session#current'),
       RouteMatcher.new(methods: :get, actions: 'users#topic_tracking_state')
     ],
-    bookmarks_calendar: [ RouteMatcher.new(methods: :get, actions: 'users#bookmarks', formats: :ics, params: %i[username]) ]
+    bookmarks_calendar: [ RouteMatcher.new(methods: :get, actions: 'users#bookmarks', formats: :ics, params: %i[username]) ],
+    user_status: [
+      RouteMatcher.new(methods: :get, actions: 'user_status#get'),
+      RouteMatcher.new(methods: :put, actions: 'user_status#set'),
+      RouteMatcher.new(methods: :delete, actions: 'user_status#clear')
+    ]
   }
 
   def self.all_scopes
@@ -36,7 +41,6 @@ class UserApiKeyScope < ActiveRecord::Base
   def matchers
     @matchers ||= Array(self.class.all_scopes[name.to_sym])
   end
-
 end
 
 # == Schema Information

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1089,6 +1089,7 @@ en:
       write: "Write all"
       one_time_password: "Create a one-time login token"
       bookmarks_calendar: "Read bookmark reminders"
+      user_status: "Read and update user status"
     invalid_public_key: "Sorry, the public key is invalid."
     invalid_auth_redirect: "Sorry, this auth_redirect host is not allowed."
     invalid_token: "Missing, invalid or expired token."


### PR DESCRIPTION
Follow-up to 6357a3ce337bdf59c7a6a0f362897a46ffbd6304
where we allowed a general API key scope for user status
GET/PUT/DELETE, this commit allows the same for the
UserApiKey system.

For example:

```
// get status
curl http://localhost:4200/user-status.json -H "User-Api-Key: 46f71d2a66f4ccdd1862f943ecd16cbf"
=> {"description":"The Man In Me - Bob Dylan","emoji":"musical_note","ends_at":null}

// set status
curl http://localhost:4200/user-status.json -X PUT -H "User-Api-Key: 46f71d2a66f4ccdd1862f943ecd16cbf" -H "Content-Type: application/json" -d '{"description": "The Man In Me - Bob Dylan", "emoji": "musical_note"}'

// clear status
curl http://localhost:4200/user-status.json -X DELETE -H "User-Api-Key: 46f71d2a66f4ccdd1862f943ecd16cbf"
```