### PR TITLE
FIX: Include CDN in result of `avatarUrl` helper

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/utilities.js
+++ b/app/assets/javascripts/discourse/app/lib/utilities.js
@@ -58,12 +58,13 @@ export function replaceFormatter(fn) {
   _usernameFormatDelegate = fn;
 }
 
-export function avatarUrl(template, size) {
+export function avatarUrl(template, size, { customGetURL } = {}) {
   if (!template) {
     return "";
   }
   const rawSize = getRawSize(translateSize(size));
-  return template.replace(/\{size\}/g, rawSize);
+  const templatedPath = template.replace(/\{size\}/g, rawSize);
+  return (customGetURL || getURLWithCDN)(templatedPath);
 }
 
 export function getRawSize(size) {
@@ -79,13 +80,12 @@ export function getRawSize(size) {
 
 export function avatarImg(options, customGetURL) {
   const size = translateSize(options.size);
-  let path = avatarUrl(options.avatarTemplate, size);
+  let url = avatarUrl(options.avatarTemplate, size, { customGetURL });
 
   // We won't render an invalid url
-  if (!path || path.length === 0) {
+  if (!url) {
     return "";
   }
-  path = (customGetURL || getURLWithCDN)(path);
 
   const classes =
     "avatar" + (options.extraClasses ? " " + options.extraClasses : "");
@@ -96,7 +96,7 @@ export function avatarImg(options, customGetURL) {
     title = ` title='${escaped}' aria-label='${escaped}'`;
   }
 
-  return `<img loading='lazy' alt='' width='${size}' height='${size}' src='${path}' class='${classes}'${title}>`;
+  return `<img loading='lazy' alt='' width='${size}' height='${size}' src='${url}' class='${classes}'${title}>`;
 }
 
 export function tinyAvatar(avatarTemplate, options) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -29,6 +29,7 @@ import {
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { setupURL } from "discourse-common/lib/get-url";
 
 discourseModule("Unit | Utilities", function () {
   test("escapeExpression", function (assert) {
@@ -97,6 +98,14 @@ discourseModule("Unit | Utilities", function () {
       avatarUrl("/fake/template/{size}.png", "large"),
       "/fake/template/" + rawSize(45) + ".png",
       "different size"
+    );
+
+    setupURL("https://app-cdn.example.com", "https://example.com", "");
+
+    assert.strictEqual(
+      avatarUrl("/fake/template/{size}.png", "large"),
+      "https://app-cdn.example.com/fake/template/" + rawSize(45) + ".png",
+      "uses CDN if present"
     );
   });
 


### PR DESCRIPTION
Consumers of this utility function (e.g. the chat sidebar) expect to be able to use the resultant URL without any further transformations. Previously, it was only returning the user_avatar path without any CDN consideration. This commit ensures the result will include the app CDN URL when enabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
