### PR TITLE
DEV: Remove unused new-user-narrative code

### DIFF
--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
@@ -1,5 +1,4 @@
 import { debounce } from "discourse-common/utils/decorators";
-import { ajax } from "discourse/lib/ajax";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import isElementInViewport from "discourse/lib/is-element-in-viewport";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -21,27 +20,6 @@ function initialize(api) {
 
   api.modifyClass("controller:topic", {
     pluginId: PLUGIN_ID,
-
-    _modifyBookmark(bookmark, post) {
-      // if we are talking to discobot then any bookmarks should just
-      // be created without reminder options, to streamline the new user
-      // narrative.
-      const discobotUserId = -2;
-      if (post && post.user_id === discobotUserId && !post.bookmarked) {
-        return ajax("/bookmarks", {
-          type: "POST",
-          data: { post_id: post.id },
-        }).then((response) => {
-          post.setProperties({
-            "topic.bookmarked": true,
-            bookmarked: true,
-            bookmark_id: response.id,
-          });
-          post.appEvents.trigger("post-stream:refresh", { id: this.id });
-        });
-      }
-      return this._super(bookmark, post);
-    },
 
     subscribe() {
       this._super(...arguments);


### PR DESCRIPTION
This method override was misnamed from the beginning and nobody noticed that this special bookmark handling was missing so…

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
