### PR TITLE
DEV: Remove discobot pm scrolling code

### DIFF
--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
@@ -1,6 +1,3 @@
-import { debounce } from "discourse-common/utils/decorators";
-import { headerOffset } from "discourse/lib/offset-calculator";
-import isElementInViewport from "discourse/lib/is-element-in-viewport";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 const PLUGIN_ID = "new-user-narrative";
@@ -15,59 +12,6 @@ function initialize(api) {
     didInsertElement() {
       this._super(...arguments);
       this.dispatch("header:search-context-trigger", "header");
-    },
-  });
-
-  api.modifyClass("controller:topic", {
-    pluginId: PLUGIN_ID,
-
-    subscribe() {
-      this._super(...arguments);
-
-      this.messageBus.subscribe(`/topic/${this.model.id}`, (data) => {
-        const topic = this.model;
-
-        // scroll only for discobot (-2 is discobot id)
-        if (
-          topic.isPrivateMessage &&
-          this.currentUser &&
-          this.currentUser.id !== data.user_id &&
-          data.user_id === -2 &&
-          data.type === "created"
-        ) {
-          const postNumber = data.post_number;
-          const notInPostStream =
-            topic.get("highest_post_number") <= postNumber;
-          const postNumberDifference = postNumber - topic.currentPost;
-
-          if (
-            notInPostStream &&
-            postNumberDifference > 0 &&
-            postNumberDifference < 7
-          ) {
-            this._scrollToDiscobotPost(data.post_number);
-          }
-        }
-      });
-      // No need to unsubscribe, core unsubscribes /topic/* routes
-    },
-
-    @debounce(500)
-    _scrollToDiscobotPost(postNumber) {
-      const post = document.querySelector(
-        `.topic-post article#post_${postNumber}`
-      );
-
-      if (!post || isElementInViewport(post)) {
-        return;
-      }
-
-      const viewportOffset = post.getBoundingClientRect();
-
-      window.scrollTo({
-        top: window.scrollY + viewportOffset.top - headerOffset(),
-        behavior: "smooth",
-      });
     },
   });
 


### PR DESCRIPTION
1. Originally the feature did "Scroll to new posts when user is near bottom of PM" (74e188992483e8d55376a98b33a440c022c098de)
2. Then that feature was limited to "Only scroll to posts that are not your own in PMs." (4a2656192733ca84de8a702cbaf2c36651bf2368)
3. It was limited further to "Only scroll PMs on new message" (eaf7746ec9c73ea41cbf94775a9a6f842076cad7)
4. And later to "only scroll to bottom for discobot" (267d129f38d6d45d0863014bf93ad1bf932c70b3)
5. And the code was relegated to new-user-narrative plugin (48b7696dbc96e2d49a1d7ee84b68c1754bfaa0ea)

I don't think it's worth it to keep this scrolling code just for this very small specific case.

This did potentially confict with other post scrolling code, and also using `modifyClass` is something we'd like to avoid.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
