### PR TITLE
FIX: deactivate is not called in every cases

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -66,8 +66,6 @@ export default class ChatRoute extends DiscourseRoute {
   }
 
   deactivate() {
-    this.chat.setActiveChannel(null);
-
     schedule("afterRender", () => {
       document.body.classList.remove("has-full-page-chat");
       document.documentElement.classList.remove("has-full-page-chat");
@@ -77,6 +75,8 @@ export default class ChatRoute extends DiscourseRoute {
 
   @action
   willTransition(transition) {
+    this.chat.setActiveChannel(null);
+
     if (!transition?.to?.name?.startsWith("chat.")) {
       this.chatStateManager.storeChatURL();
       this.chat.updatePresence();


### PR DESCRIPTION
Resets active channel each time we transition through "chat" route.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
