### PR TITLE
FIX: Don't force show topic map on non-first posts

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/transform-post.js
+++ b/app/assets/javascripts/discourse/app/lib/transform-post.js
@@ -178,7 +178,7 @@ export default function transformPost(
   }
 
   const showTopicMap =
-    _additionalAttributes.includes("topicMap") ||
+    (_additionalAttributes.includes("topicMap") && post.post_number === 1) ||
     showPMMap ||
     (post.post_number === 1 &&
       topic.archetype === "regular" &&


### PR DESCRIPTION
By default, the topic map in the OP shows only if there are replies. Some themes may want to show it at all times, and to do so, they can use the API via `api.includePostAttributes('topicMap');`.

But this was including the topic map in every post. This change ensures that attribute is only set for the first post (and it only affects that API endpoint).

