### PR TITLE
DEV: Add support for HTML in `popupAjaxError`

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-index.js
@@ -232,7 +232,7 @@ export default Controller.extend(CanCheckEmails, {
               queryParams: { nonce },
             });
           } else {
-            popupAjaxError(error);
+            popupAjaxError(error, { htmlMessage: true });
           }
         });
     },

--- a/app/assets/javascripts/discourse/app/lib/ajax-error.js
+++ b/app/assets/javascripts/discourse/app/lib/ajax-error.js
@@ -1,5 +1,6 @@
 import I18n from "I18n";
 import { getOwner } from "discourse-common/lib/get-owner";
+import { htmlSafe } from "@ember/template";
 
 export function extractError(error, defaultMessage) {
   if (error instanceof Error) {
@@ -69,7 +70,11 @@ export function throwAjaxError(undoCallback) {
   };
 }
 
-export function popupAjaxError(error) {
+export function popupAjaxError(error, opts = {}) {
   const dialog = getOwner(this).lookup("service:dialog");
-  dialog.alert(extractError(error));
+  dialog.alert({
+    message: opts.htmlMessage
+      ? htmlSafe(extractError(error))
+      : extractError(error),
+  });
 }

--- a/app/assets/javascripts/discourse/tests/unit/ajax-errors-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/ajax-errors-test.js
@@ -1,0 +1,51 @@
+import { module, test } from "qunit";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import { click, render, settled } from "@ember/test-helpers";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { hbs } from "ember-cli-htmlbars";
+
+module("Unit | Utility | ajax errors", function (hooks) {
+  setupRenderingTest(hooks);
+  hooks.beforeEach(async function () {
+    await render(hbs`<DialogHolder />`);
+  });
+
+  hooks.afterEach(async function () {
+    await click(".dialog-footer .btn-primary");
+  });
+
+  test("popupAjaxError", async function (assert) {
+    const message = "here is the error message";
+    const error = {
+      jqXHR: {
+        status: 422,
+        responseJSON: { message },
+      },
+    };
+
+    await popupAjaxError(error);
+    await settled();
+
+    assert.strictEqual(
+      document.querySelector(".dialog-body").textContent.trim(),
+      message
+    );
+  });
+
+  test("popupAjaxError with HTML", async function (assert) {
+    const error = {
+      jqXHR: {
+        status: 422,
+        responseJSON: { message: "here is a <b>special</b> error message" },
+      },
+    };
+
+    await popupAjaxError(error, { htmlMessage: true });
+    await settled();
+
+    assert.strictEqual(
+      document.querySelector(".dialog-body b").textContent.trim(),
+      "special"
+    );
+  });
+});


### PR DESCRIPTION
Adds an option to allow HTML to be rendered in `popupAjaxError` dialogs.

