### PR TITLE
DEV: Fix multiple set-cookie through Ember-CLI proxy

### DIFF
--- a/app/assets/javascripts/bootstrap-json/index.js
+++ b/app/assets/javascripts/bootstrap-json/index.js
@@ -319,7 +319,13 @@ async function handleRequest(proxy, baseURL, req, res) {
   });
 
   response.headers.forEach((value, header) => {
-    res.set(header, value);
+    if (header === "set-cookie") {
+      // Special handling to get array of multiple Set-Cookie header values
+      // per https://github.com/node-fetch/node-fetch/issues/251#issuecomment-428143940
+      res.set("set-cookie", response.headers.raw()["set-cookie"]);
+    } else {
+      res.set(header, value);
+    }
   });
   res.set("content-encoding", null);
 


### PR DESCRIPTION
The `Set-Cookie` header is an exceptional case where multiple values are allowed, and should not be joined into a single header. Because of its browser-focussed origins (where set-cookie is not visible), `fetch()` does not have a clean API for this. Instead we have to access the `raw()` data.

This fixes various authentication-related issues when developing via the Ember CLI proxy.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
