### PR TITLE
FIX: nullify active channel only when not on a chat channel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -36,10 +36,7 @@ export default class ChatRoute extends DiscourseRoute {
       transition.abort();
 
       let URL = transition.intent.url;
-      if (
-        transition.targetName === "chat.channel.index" ||
-        transition.targetName === "chat.channel"
-      ) {
+      if (transition.targetName.startsWith("chat.channel")) {
         URL ??= this.router.urlFor(
           transition.targetName,
           ...transition.intent.contexts
@@ -75,7 +72,9 @@ export default class ChatRoute extends DiscourseRoute {
 
   @action
   willTransition(transition) {
-    this.chat.setActiveChannel(null);
+    if (!transition?.to?.name?.startsWith("chat.channel")) {
+      this.chat.setActiveChannel(null);
+    }
 
     if (!transition?.to?.name?.startsWith("chat.")) {
       this.chatStateManager.storeChatURL();

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -278,6 +278,14 @@ RSpec.describe "Navigation", type: :system, js: true do
       end
     end
 
+    context "when going back to channel from channel settings in full page" do
+      it "activates the channel in the sidebar" do
+        visit("/chat/channel/#{category_channel.id}/#{category_channel.slug}/info/settings")
+        find(".chat-full-page-header__back-btn").click
+        expect(page).to have_content(message.message)
+      end
+    end
+
     context "when clicking logo from a channel in full page" do
       it "deactivates the channel in the sidebar" do
         visit("/chat/channel/#{category_channel.id}/#{category_channel.slug}")


### PR DESCRIPTION
This would nullify the active channel when going from channel settings page to the channel.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
