### PR TITLE
FIX: URL fragments not purging

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -216,7 +216,7 @@ const DiscourseURL = EmberObject.extend({
     const m = /^#(.+)$/.exec(path);
     if (m) {
       this.jumpToElement(m[1]);
-      return;
+      return this.replaceState(path);
     }
 
     const oldPath = this.router.currentURL;

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -154,10 +154,15 @@ module("Unit | Utility | url", function () {
 
   test("anchor handling", async function (assert) {
     sinon.stub(DiscourseURL, "jumpToElement");
+    sinon.stub(DiscourseURL, "replaceState");
     DiscourseURL.routeTo("#heading1");
     assert.ok(
       DiscourseURL.jumpToElement.calledWith("heading1"),
       "in-page anchors call jumpToElement"
+    );
+    assert.ok(
+      DiscourseURL.replaceState.calledWith("#heading1"),
+      "in-page anchors call replaceState with the url fragment"
     );
   });
 });


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/discourse/discourse/commit/2704a02e3a23401f8225a3bd1ceebc528ee43919

See also: https://meta.discourse.org/t/anchors-url-not-purge-when-page-changed/244484 

