### PR TITLE
FIX: Duplicate hashtag lookup results based on permissions

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
@@ -221,19 +221,13 @@ function _searchRequest(term, contextualHashtagConfiguration, resultFunc) {
 }
 
 function _findAndReplaceSeenHashtagPlaceholder(
-  slug,
+  slugRef,
   contextualHashtagConfiguration,
   hashtagSpan
 ) {
   contextualHashtagConfiguration.forEach((type) => {
-    // remove type suffixes
-    const typePostfix = `::${type}`;
-    if (slug.endsWith(typePostfix)) {
-      slug = slug.slice(0, slug.length - typePostfix.length);
-    }
-
     // replace raw span for the hashtag with a cooked one
-    const matchingSeenHashtag = seenHashtags[type]?.[slug];
+    const matchingSeenHashtag = seenHashtags[type]?.[slugRef];
     if (matchingSeenHashtag) {
       // NOTE: When changing the HTML structure here, you must also change
       // it in the hashtag-autocomplete markdown rule, and vice-versa.

--- a/spec/lib/pretty_text/helpers_spec.rb
+++ b/spec/lib/pretty_text/helpers_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe PrettyText::Helpers do
           description: "Coolest things ever",
           icon: "tag",
           slug: "somecooltag",
-          ref: "somecooltag",
+          ref: "somecooltag::tag",
           type: "tag",
         },
       )
@@ -73,7 +73,7 @@ RSpec.describe PrettyText::Helpers do
           description: "Really great stuff here",
           icon: "folder",
           slug: "someawesomecategory",
-          ref: "someawesomecategory",
+          ref: "someawesomecategory::category",
           type: "category",
         },
       )

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1462,14 +1462,10 @@ RSpec.describe PrettyText do
 
     cooked = PrettyText.cook(" #unknown::tag #known #known::tag #testing", user_id: user.id)
 
-    [
-      "<span class=\"hashtag-raw\">#unknown::tag</span>",
-      "<a class=\"hashtag-cooked\" href=\"#{category2.url}\" data-type=\"category\" data-slug=\"known\"><svg class=\"fa d-icon d-icon-folder svg-icon svg-node\"><use href=\"#folder\"></use></svg><span>known</span></a>",
-      "<a class=\"hashtag-cooked\" href=\"/tag/known\" data-type=\"tag\" data-slug=\"known\"><svg class=\"fa d-icon d-icon-tag svg-icon svg-node\"><use href=\"#tag\"></use></svg><span>known</span></a>",
-      "<a class=\"hashtag-cooked\" href=\"#{category.url}\" data-type=\"category\" data-slug=\"testing\"><svg class=\"fa d-icon d-icon-folder svg-icon svg-node\"><use href=\"#folder\"></use></svg><span>testing</span></a>"
-    ].each do |element|
-      expect(cooked).to include(element)
-    end
+    expect(cooked).to include("<span class=\"hashtag-raw\">#unknown::tag</span>")
+    expect(cooked).to include("<a class=\"hashtag-cooked\" href=\"#{category2.url}\" data-type=\"category\" data-slug=\"known\"><svg class=\"fa d-icon d-icon-folder svg-icon svg-node\"><use href=\"#folder\"></use></svg><span>known</span></a>")
+    expect(cooked).to include("<a class=\"hashtag-cooked\" href=\"/tag/known\" data-type=\"tag\" data-slug=\"known\" data-ref=\"known::tag\"><svg class=\"fa d-icon d-icon-tag svg-icon svg-node\"><use href=\"#tag\"></use></svg><span>known</span></a>")
+    expect(cooked).to include("<a class=\"hashtag-cooked\" href=\"#{category.url}\" data-type=\"category\" data-slug=\"testing\"><svg class=\"fa d-icon d-icon-folder svg-icon svg-node\"><use href=\"#folder\"></use></svg><span>testing</span></a>")
 
     cooked = PrettyText.cook("[`a` #known::tag here](http://example.com)", user_id: user.id)
 
@@ -1485,7 +1481,7 @@ RSpec.describe PrettyText do
 
     cooked = PrettyText.cook("<A href='/a'>test</A> #known::tag", user_id: user.id)
     html = <<~HTML
-      <p><a href="/a">test</a> <a class="hashtag-cooked" href="/tag/known" data-type="tag" data-slug="known"><svg class="fa d-icon d-icon-tag svg-icon svg-node"><use href="#tag"></use></svg><span>known</span></a></p>
+      <p><a href="/a">test</a> <a class="hashtag-cooked" href="/tag/known" data-type="tag" data-slug="known" data-ref="known::tag"><svg class="fa d-icon d-icon-tag svg-icon svg-node"><use href="#tag"></use></svg><span>known</span></a></p>
     HTML
     expect(cooked).to eq(html.strip)
 

--- a/spec/services/hashtag_autocomplete_service_spec.rb
+++ b/spec/services/hashtag_autocomplete_service_spec.rb
@@ -377,6 +377,14 @@ RSpec.describe HashtagAutocompleteService do
       expect(result[:bookmark].map(&:slug)).to eq(["coolrock"])
     end
 
+    it "handles type suffix lookups where there is another type with a conflicting slug that the user cannot access" do
+      category1.update!(read_restricted: true)
+      Fabricate(:tag, name: "book-club")
+      result = subject.lookup(%w[book-club::tag book-club], %w[category tag])
+      expect(result[:category].map(&:ref)).to eq([])
+      expect(result[:tag].map(&:ref)).to eq(["book-club::tag"])
+    end
+
     context "when not tagging_enabled" do
       before { SiteSetting.tagging_enabled = false }
 


### PR DESCRIPTION
When looking up hashtags which were conflicting (e.g.
management::tag and management) where the user did
not have permission for one of them, we ended up returning
the one they did have permission to (e.g. the tag) twice
because of the way the lookup fallback code worked. This
fixes the issue, and another related one where the
`::type` was not added to the found item's .ref, and
so the hashtag replacement on the client was not working
correctly.