### PR TITLE
FIX: Do not reset seen popups when skip_new_user_tips is false 

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/sidebar.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/sidebar.js
@@ -13,6 +13,12 @@ export default class extends Controller {
   @tracked selectedSidebarCategories = [];
   @tracked selectedSidebarTagNames = [];
 
+  saveAttrNames = [
+    "sidebar_category_ids",
+    "sidebar_tag_names",
+    "sidebar_list_destination",
+  ];
+
   sidebarListDestinations = [
     {
       name: I18n.t("user.experimental_sidebar.list_destination_default"),
@@ -42,7 +48,7 @@ export default class extends Controller {
     );
 
     this.model
-      .save()
+      .save(this.saveAttrNames)
       .then((result) => {
         if (result.user.sidebar_tags) {
           this.model.set("sidebar_tags", result.user.sidebar_tags);

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -180,8 +180,8 @@ class UserUpdater
       end
     end
 
-    if attributes.key?(:skip_new_user_tips)
-      user.user_option.seen_popups = user.user_option.skip_new_user_tips ? [-1] : nil
+    if attributes.key?(:skip_new_user_tips) && user.user_option.skip_new_user_tips
+      user.user_option.seen_popups = [-1]
     end
 
     # automatically disable digests when mailing_list_mode is enabled

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -535,6 +535,15 @@ RSpec.describe UserUpdater do
         expect(user.user_option.seen_popups).to eq([-1])
         expect(messages.map(&:data)).to contain_exactly([-1])
       end
+
+      it 'does not reset seen_popups' do
+        user.user_option.update!(seen_popups: [1, 2, 3])
+
+        UserUpdater.new(Discourse.system_user, user).update(skip_new_user_tips: false)
+
+        expect(user.user_option.skip_new_user_tips).to eq(false)
+        expect(user.user_option.seen_popups).to eq([1, 2, 3])
+      end
     end
 
     context 'when seen_popups is edited' do

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -534,14 +534,6 @@ RSpec.describe UserUpdater do
         expect(user.user_option.skip_new_user_tips).to eq(true)
         expect(user.user_option.seen_popups).to eq([-1])
         expect(messages.map(&:data)).to contain_exactly([-1])
-
-        messages = MessageBus.track_publish('/user-tips') do
-          UserUpdater.new(Discourse.system_user, user).update(skip_new_user_tips: false)
-        end
-
-        expect(user.user_option.skip_new_user_tips).to eq(false)
-        expect(user.user_option.seen_popups).to eq(nil)
-        expect(messages.map(&:data)).to contain_exactly(nil)
       end
     end
 


### PR DESCRIPTION
If the option was unchecked, but it was not changed at all by the user
it was still sent to the server as a 'false' value which reset all seen
popups. This removes that behavior and resetting the list of seen popups
must be done using the "skip new user tips" button.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
