### PR TITLE
REFACTOR: Make chat summary email notifications easier to translate

### DIFF
--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -162,7 +162,7 @@ en:
     notify_moderators:
       chat_pm_title: 'A chat message in "%{channel_name}" requires staff attention'
       chat_pm_body: "%{link}\n\n%{message}"
-  
+
   reviewables:
     reasons:
       chat_message_queued_by_staff: "A staff member thinks this chat message needs review."
@@ -174,14 +174,17 @@ en:
         other: "You have new chat messages"
       from: "%{site_name}"
       subject:
-        direct_message:
-          one: "[%{email_prefix}] New message from %{message_title}"
-          other: "[%{email_prefix}] New messages from %{message_title} and %{others}"
-        chat_channel:
-          one: "[%{email_prefix}] New message in %{message_title}"
-          other: "[%{email_prefix}] New messages in %{message_title} and %{others}"
-        other_direct_message: "from %{dm_title}"
-        others: "%{count} others"
+        direct_message_from_1: "[%{email_prefix}] New message from %{username}"
+        direct_message_from_2: "[%{email_prefix}] New message from %{username1} and %{username2}"
+        direct_message_from_more:
+          one: "[%{email_prefix}] New message from %{username} and %{count} other"
+          other: "[%{email_prefix}] New message from %{username} and %{count} others"
+        chat_channel_1: "[%{email_prefix}] New message in %{channel}"
+        chat_channel_2: "[%{email_prefix}] New message in %{channel1} and %{channel2}"
+        chat_channel_more:
+          one: "[%{email_prefix}] New message in %{channel} and %{count} other"
+          other: "[%{email_prefix}] New message in %{channel} and %{count} others"
+        chat_channel_and_direct_message: "[%{email_prefix}] New message in %{channel} and from %{username}"
       unsubscribe: "This chat summary is sent from %{site_link} when you are away. Change your %{email_preferences_link}, or %{unsubscribe_link} to unsubscribe."
       unsubscribe_no_link: "This chat summary is sent from %{site_link} when you are away. Change your %{email_preferences_link}."
       view_messages:

--- a/plugins/chat/lib/extensions/user_notifications_extension.rb
+++ b/plugins/chat/lib/extensions/user_notifications_extension.rb
@@ -60,67 +60,76 @@ module Chat::UserNotificationsExtension
   end
 
   def summary_subject(user, grouped_messages)
-    channels = grouped_messages.keys
-    grouped_channels = channels.partition { |c| !c.direct_message_channel? }
-    non_dm_channels = grouped_channels.first
+    all_channels = grouped_messages.keys
+    grouped_channels = all_channels.partition { |c| !c.direct_message_channel? }
+    channels = grouped_channels.first
     dm_users = grouped_channels.last.flat_map { |c| grouped_messages[c].map(&:user) }.uniq
 
-    total_count_for_subject = non_dm_channels.size + dm_users.size
-
-    # Prioritize messages from regular channels.
-    first_message_from = non_dm_channels.pop
-    if first_message_from
-      first_message_title = first_message_from.title(user)
-      subject_key = "chat_channel"
+    # Prioritize messages from regular channels over direct messages
+    if channels.any?
+      channel_notification_text(channels, dm_users)
     else
-      subject_key = "direct_message"
-      first_message_from = dm_users.pop
-      first_message_title = first_message_from.username
+      direct_message_notification_text(dm_users)
     end
-
-    subject_opts = {
-      email_prefix: @email_prefix,
-      count: total_count_for_subject,
-      message_title: first_message_title,
-      others:
-        other_channels_text(
-          user,
-          total_count_for_subject,
-          first_message_from,
-          non_dm_channels,
-          dm_users,
-        ),
-    }
-
-    I18n.t(with_subject_prefix(subject_key), **subject_opts)
   end
 
-  def with_subject_prefix(key)
-    "user_notifications.chat_summary.subject.#{key}"
+  private
+
+  def channel_notification_text(channels, dm_users)
+    total_count = channels.size + dm_users.size
+
+    if total_count > 2
+      I18n.t(
+        "user_notifications.chat_summary.subject.chat_channel_more",
+        email_prefix: @email_prefix,
+        channel: channels.first.title,
+        count: total_count - 1
+      )
+    elsif channels.size == 1 && dm_users.size == 0
+      I18n.t(
+        "user_notifications.chat_summary.subject.chat_channel_1",
+        email_prefix: @email_prefix,
+        channel: channels.first.title
+      )
+    elsif channels.size == 1 && dm_users.size == 1
+      I18n.t(
+        "user_notifications.chat_summary.subject.chat_channel_and_direct_message",
+        email_prefix: @email_prefix,
+        channel: channels.first.title,
+        username: dm_users.first.username
+      )
+    elsif channels.size == 2
+      I18n.t(
+        "user_notifications.chat_summary.subject.chat_channel_2",
+        email_prefix: @email_prefix,
+        channel1: channels.first.title,
+        channel2: channels.second.title
+      )
+    end
   end
 
-  def other_channels_text(
-    user,
-    total_count,
-    first_message_from,
-    other_non_dm_channels,
-    other_dm_users
-  )
-    return if total_count <= 1
-    return I18n.t(with_subject_prefix("others"), count: total_count - 1) if total_count > 2
-
-    # The summary contains exactly two messages.
-    if other_non_dm_channels.empty?
-      second_message_from = other_dm_users.first
-      second_message_title = second_message_from.username
+  def direct_message_notification_text(dm_users)
+    case dm_users.size
+    when 1
+      I18n.t(
+        "user_notifications.chat_summary.subject.direct_message_from_1",
+        email_prefix: @email_prefix,
+        username: dm_users.first.username
+      )
+    when 2
+      I18n.t(
+        "user_notifications.chat_summary.subject.direct_message_from_2",
+        email_prefix: @email_prefix,
+        username1: dm_users.first.username,
+        username2: dm_users.second.username
+      )
     else
-      second_message_from = other_non_dm_channels.first
-      second_message_title = second_message_from.title(user)
+      I18n.t(
+        "user_notifications.chat_summary.subject.direct_message_from_more",
+        email_prefix: @email_prefix,
+        username: dm_users.first.username,
+        count: dm_users.size - 1
+      )
     end
-
-    second_message_is_from_channel = first_message_from.class == second_message_from.class
-    return second_message_title if second_message_is_from_channel
-
-    I18n.t(with_subject_prefix("other_direct_message"), dm_title: second_message_title)
   end
 end


### PR DESCRIPTION
This corrects a couple of issues which complicated the work of translators:
* Uses explicit translation keys instead of calculating them at runtime. The new code makes it easier to see when each translation is used.
* Uses separate translations for each case instead of concatenating multiple translations with the `%{others}` key.
* Uses self-explanatory interpolation keys instead of generic ones like `%{message_title}` which could be a username or channel name.