### PR TITLE
UX: Adjust emoji size in mentions

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -27,6 +27,12 @@ a.hashtag-cooked {
     font-size: var(--font-down-1);
     margin: 0 0.2em 0 0.1em;
   }
+
+  img.emoji {
+    width: 15px;
+    height: 15px;
+    vertical-align: text-bottom;
+  }
 }
 
 .hashtag-autocomplete {


### PR DESCRIPTION
Using pixel sizes to match what we do with a similar element in sidebar.

Before
<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/206209858-45cefcf8-a85c-4f7b-866f-84edac760954.png">

After
<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/206209799-76c513bb-f42f-4cf3-beac-345a0825d279.png">

