### PR TITLE
adding spaces around images inside <kbd> tag

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1065,7 +1065,15 @@ kbd {
   margin: 0 0.15em;
   min-width: 24px;
   padding: 0.15em 0.6em;
-
+  img {
+    margin: 0 .5em;
+    &:first-child {
+      margin-left: 0;
+    }
+    &:last-child {
+      margin-right: 0;
+    }
+  }
   // don't allow more than 3 nested elements to prevent FF from crashing
   // cf. http://what.thedailywtf.com/t/nested-elements/7927
   // 3 levels are needed to prevent highlighted words being hidden


### PR DESCRIPTION
Improves readability since currently spaces between an image and text are ignored because of `<kbd>` inline-flex property
See: https://meta.discourse.org/t/cant-insert-space-next-to-an-emoji-inside-kbd-tags/248059/3?u=canapin