### PR TITLE
FIX: reword generic site policy defaults

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4352,7 +4352,11 @@ en:
   tos_topic:
     title: "Terms of Service"
     body: |
-      These terms govern use of the Internet forum at <%{base_url}>. To use the forum, you must agree to these terms with %{company_name}, the company that runs the forum.
+      <h2 id="heading--change-me"><a href="#heading--change-me">Change Me</a></h2>
+
+      Forum Admin, please find below an example starting template for a privacy policy that you should customise to meet your site's needs.
+
+      These terms do not, but might one day, govern use of the Internet forum at <%{base_url}>. In that event, to use the forum, you must agree to these terms with %{company_name}, the company that runs the forum.
 
       The company may offer other products and services, under different terms. These terms apply only to use of the forum.
 
@@ -4520,13 +4524,15 @@ en:
 
       <h2 id="heading--changes"><a href="#heading--changes">Changes</a></h2>
 
-      The company last updated these terms on July 12, 2018, and may update these terms again. The company will post all updates to the forum. For updates that contain substantial changes, the company agrees to e-mail you, if you've created an account and provided a valid e-mail address. The company may also announce updates with special messages or alerts on the forum.
+      The company last updated these terms on [INSERT LAST UPDATE DATE HERE], and may update these terms again. The company will post all updates to the forum. For updates that contain substantial changes, the company agrees to e-mail you, if you've created an account and provided a valid e-mail address. The company may also announce updates with special messages or alerts on the forum.
 
       Once you get notice of an update to these terms, you must agree to the new terms in order to keep using the forum.
 
   privacy_topic:
     title: "Privacy Policy"
     body: |
+      ## [Forum Admin, please find below an example starting template for a privacy policy that you should customise to your site.]
+
       <a name="collect"></a>
 
       ## [What information do we collect?](#collect)
@@ -4560,8 +4566,7 @@ en:
 
       We will make a good faith effort to:
 
-      * Retain server logs containing the IP address of all requests to this server no more than 90 days.
-      * Retain the IP addresses associated with registered users and their posts no more than 5 years.
+      * Retain server logs containing the IP address of all requests to this server no more than [NUMBER OF DAYS] days.
 
       <a name="cookies"></a>
 
@@ -4607,7 +4612,7 @@ en:
 
       If we decide to change our privacy policy, we will post those changes on this page.
 
-      This document is CC-BY-SA. It was last updated May 31, 2013.
+      This document is CC-BY-SA. It was last updated [INSERT LAST UPDATE DATE HERE].
 
   badges:
     mass_award:


### PR DESCRIPTION
Reword the default Terms of Service and Privacy Policy to more strongly
denote they are templates which must be customised by the forum admin.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
