### PR TITLE
PERF: Perform only one category update when creating a new topic

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -425,8 +425,11 @@ class PostCreator
   def track_latest_on_category
     return unless @post && @post.errors.count == 0 && @topic && @topic.category_id
 
-    Category.where(id: @topic.category_id).update_all(latest_post_id: @post.id)
-    Category.where(id: @topic.category_id).update_all(latest_topic_id: @topic.id) if @post.is_first_post?
+    if @post.is_first_post?
+      Category.where(id: @topic.category_id).update_all(latest_topic_id: @topic.id, latest_post_id: @post.id)
+    else
+      Category.where(id: @topic.category_id).update_all(latest_post_id: @post.id)
+    end
   end
 
   def ensure_in_allowed_users


### PR DESCRIPTION
When under extremely high load, it has been observed that updating the categories table when creating a new topic can become a bottleneck.

This change will reduce the two updates to one when a new topic is created within a category, and therefore should help with performance when under extremely high load.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
