### PR TITLE
FIX: Use correct property for theme's `color_scheme_id`

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-customize-themes-show.js
@@ -31,7 +31,7 @@ export default Route.extend({
       model,
       parentController,
       allThemes: parentController.get("model"),
-      colorSchemeId: model.get("user_option.color_scheme_id"),
+      colorSchemeId: model.get("color_scheme_id"),
       colorSchemes: parentController.get("model.extras.color_schemes"),
       editingName: false,
     });


### PR DESCRIPTION
Regressed in 7d7551adfcee90f61297d261742338b8bfe72255
