### PR TITLE
FIX: Make sure generated tsqueries are valid

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -623,13 +623,16 @@ class Topic < ActiveRecord::Base
       prepared_data = cooked.present? && Search.prepare_data(cooked)
 
       if prepared_data.present?
-        raw_tsquery = Search.set_tsquery_weight_filter(prepared_data, 'B')
+        raw_tsquery = Search.set_tsquery_weight_filter(
+          prepared_data,
+          'B'
+        )
 
         tsquery = "#{tsquery} & #{raw_tsquery}"
       end
     end
 
-    tsquery = Search.to_tsquery(term: tsquery, joiner: '|')
+    tsquery = Search.to_tsquery(term: tsquery, joiner: "|")
 
     guardian = Guardian.new(user)
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -623,16 +623,13 @@ class Topic < ActiveRecord::Base
       prepared_data = cooked.present? && Search.prepare_data(cooked)
 
       if prepared_data.present?
-        raw_tsquery = Search.set_tsquery_weight_filter(
-          prepared_data,
-          'B'
-        )
+        raw_tsquery = Search.set_tsquery_weight_filter(prepared_data, 'B')
 
-        tsquery = "#{tsquery} & #{raw_tsquery}"
+        tsquery = "#{tsquery} | #{raw_tsquery}"
       end
     end
 
-    tsquery = Search.to_tsquery(term: tsquery, joiner: "|")
+    tsquery = Search.to_tsquery(term: tsquery)
 
     guardian = Guardian.new(user)
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -625,11 +625,11 @@ class Topic < ActiveRecord::Base
       if prepared_data.present?
         raw_tsquery = Search.set_tsquery_weight_filter(prepared_data, 'B')
 
-        tsquery = "#{tsquery} | #{raw_tsquery}"
+        tsquery = "#{tsquery} & #{raw_tsquery}"
       end
     end
 
-    tsquery = Search.to_tsquery(term: tsquery)
+    tsquery = Search.to_tsquery(term: tsquery, joiner: '|')
 
     guardian = Guardian.new(user)
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1168,18 +1168,19 @@ class Search
     self.class.default_ts_config
   end
 
-  def self.ts_query(term:, ts_config: nil, weight_filter: nil)
+  def self.ts_query(term:, ts_config: nil, joiner: nil, weight_filter: nil)
     to_tsquery(
       ts_config: ts_config,
       term: set_tsquery_weight_filter(term, weight_filter),
     )
   end
 
-  def self.to_tsquery(ts_config: nil, term:)
+  def self.to_tsquery(ts_config: nil, term:, joiner: nil)
     ts_config = ActiveRecord::Base.connection.quote(ts_config) if ts_config
-
     escaped_term = wrap_unaccent("'#{escape_string(term)}'")
-    "TO_TSQUERY(#{ts_config || default_ts_config}, #{escaped_term})"
+    tsquery = "TO_TSQUERY(#{ts_config || default_ts_config}, #{escaped_term})"
+    tsquery = "REPLACE(#{tsquery}::text, '&', '#{escape_string(joiner)}')::tsquery" if joiner
+    tsquery
   end
 
   def self.set_tsquery_weight_filter(term, weight_filter)

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1168,29 +1168,18 @@ class Search
     self.class.default_ts_config
   end
 
-  def self.ts_query(term: , ts_config:  nil, joiner: nil, weight_filter: nil)
+  def self.ts_query(term:, ts_config: nil, weight_filter: nil)
     to_tsquery(
       ts_config: ts_config,
       term: set_tsquery_weight_filter(term, weight_filter),
-      joiner: joiner
     )
   end
 
-  def self.to_tsquery(ts_config: nil, term:, joiner: nil)
+  def self.to_tsquery(ts_config: nil, term:)
     ts_config = ActiveRecord::Base.connection.quote(ts_config) if ts_config
 
-    # unaccent can be used only when a joiner is present because the
-    # additional processing and the final conversion to tsquery does not
-    # work well with characters that are converted to quotes by unaccent.
-    if joiner
-      tsquery = "TO_TSQUERY(#{ts_config || default_ts_config}, '#{self.escape_string(term)}')"
-      tsquery = "REPLACE(#{tsquery}::text, '&', '#{self.escape_string(joiner)}')::tsquery"
-    else
-      escaped_term = Search.wrap_unaccent("'#{self.escape_string(term)}'")
-      tsquery = "TO_TSQUERY(#{ts_config || default_ts_config}, #{escaped_term})"
-    end
-
-    tsquery
+    escaped_term = wrap_unaccent("'#{escape_string(term)}'")
+    "TO_TSQUERY(#{ts_config || default_ts_config}, #{escaped_term})"
   end
 
   def self.set_tsquery_weight_filter(term, weight_filter)
@@ -1198,6 +1187,10 @@ class Search
   end
 
   def self.escape_string(term)
+    # HACK: The ’ has to be "unaccented" before it is escaped or the resulting
+    # tsqueries will be invalid
+    term = term.gsub("\u{2019}", "'") if SiteSetting.search_ignore_accents
+
     PG::Connection.escape_string(term).gsub('\\', '\\\\\\')
   end
 

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -115,6 +115,37 @@ RSpec.describe Search do
     end
   end
 
+  context "with apostrophes" do
+    fab!(:post_1) { Fabricate(:post, raw: "searching for: John's") }
+    fab!(:post_2) { Fabricate(:post, raw: "searching for: Johns") }
+
+    before do
+      SearchIndexer.enable
+    end
+
+    after do
+      SearchIndexer.disable
+    end
+
+    it "returns correct results" do
+      SiteSetting.search_ignore_accents = false
+      [post_1, post_2].each { |post| SearchIndexer.index(post.topic, force: true) }
+
+      expect(Search.execute("John's").posts).to contain_exactly(post_1, post_2)
+      expect(Search.execute("John’s").posts).to contain_exactly(post_1)
+      expect(Search.execute("Johns").posts).to contain_exactly(post_1, post_2)
+    end
+
+    it "returns correct results with accents" do
+      SiteSetting.search_ignore_accents = true
+      [post_1, post_2].each { |post| SearchIndexer.index(post.topic, force: true) }
+
+      expect(Search.execute("John's").posts).to contain_exactly(post_1, post_2)
+      expect(Search.execute("John’s").posts).to contain_exactly(post_1, post_2)
+      expect(Search.execute("Johns").posts).to contain_exactly(post_1, post_2)
+    end
+  end
+
   describe "custom_eager_load" do
     fab!(:topic) { Fabricate(:topic) }
     fab!(:post) { Fabricate(:post, topic: topic) }

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Search do
       [post_1, post_2].each { |post| SearchIndexer.index(post.topic, force: true) }
 
       expect(Search.execute("John's").posts).to contain_exactly(post_1, post_2)
-      expect(Search.execute("John’s").posts).to contain_exactly(post_1)
+      expect(Search.execute("John’s").posts).to contain_exactly(post_1, post_2)
       expect(Search.execute("Johns").posts).to contain_exactly(post_1, post_2)
     end
 


### PR DESCRIPTION
The tsquery used for searching is generated using both functions from Ruby and Postgresql (for example, unaccent function). Depending on the term used, it generated an invalid tsquery. For example "can’t" generated "''can''t''" instead of "''can''''t''".

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
