### PR TITLE
FIX: broken emoji url on password reset w/ subfolder

### DIFF
--- a/app/views/invites/show.html.erb
+++ b/app/views/invites/show.html.erb
@@ -2,7 +2,7 @@
   <%if flash[:error]%>
     <div class='invite-error'>
       <div class="error-image">
-        <img src="/images/sweat-smile-face.svg" alt="sweat-smile-face emoji">
+        <img src="<%= Emoji.url_for("sweat_smile") %>" alt="sweat-smile-face emoji">
       </div>
       <div class="error-info">
         <%=flash[:error].html_safe%>

--- a/app/views/invites/show.html.erb
+++ b/app/views/invites/show.html.erb
@@ -2,7 +2,7 @@
   <%if flash[:error]%>
     <div class='invite-error'>
       <div class="error-image">
-        <img src="<%= Emoji.url_for("sweat_smile") %>" alt="sweat-smile-face emoji">
+        <img src="<%= Discourse.base_path + '/images/sweat-smile-face.svg' %>" alt="sweat-smile-face emoji">
       </div>
       <div class="error-info">
         <%=flash[:error].html_safe%>

--- a/app/views/users/password_reset.html.erb
+++ b/app/views/users/password_reset.html.erb
@@ -2,7 +2,7 @@
   <%if @error%>
     <div class='invite-error'>
       <div class="error-image">
-        <img src="/images/sweat-smile-face.svg" alt="sweat-smile-face emoji">
+        <img src="<%= Emoji.url_for("sweat_smile") %>" alt="sweat-smile-face emoji">
       </div>
       <div class="error-info">
         <%= @error.html_safe %>

--- a/app/views/users/password_reset.html.erb
+++ b/app/views/users/password_reset.html.erb
@@ -2,7 +2,7 @@
   <%if @error%>
     <div class='invite-error'>
       <div class="error-image">
-        <img src="<%= Emoji.url_for("sweat_smile") %>" alt="sweat-smile-face emoji">
+        <img src="<%= Discourse.base_path + '/images/sweat-smile-face.svg' %>" alt="sweat-smile-face emoji">
       </div>
       <div class="error-info">
         <%= @error.html_safe %>


### PR DESCRIPTION
The emojis on the password reset/invite pages are broken on a subfolder install:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/3530/206325974-e9b03b63-b3f0-42c9-adca-62df3bfcfb4b.png">

This PR fixes it by using `Emoji.url_for`, so the emoji will be shown via a `png` instead of a `svg` (I don't know if there's a similar helper returning a `svg` path).

Before, rendering a `svg`
<img width="300" alt="image" src="https://user-images.githubusercontent.com/3530/206327091-d9316424-1aa3-45e7-b224-55eef1914efa.png">

After, rendering a `png`
<img width="300" alt="image" src="https://user-images.githubusercontent.com/3530/206327126-af4e0f1a-3e9a-496a-a569-ff55b80cc7bc.png">