### PR TITLE
FEATURE: Add support for desktop push notifications in core

### DIFF
--- a/app/assets/javascripts/discourse/app/components/desktop-notification-config.js
+++ b/app/assets/javascripts/discourse/app/components/desktop-notification-config.js
@@ -55,6 +55,7 @@ export default Component.extend({
     return isGrantedPermission ? !notificationsDisabled : false;
   },
 
+  // TODO: (selase) getter should consistently return a boolean
   @discourseComputed
   isEnabledPush: {
     set(value) {
@@ -81,6 +82,19 @@ export default Component.extend({
   },
 
   isEnabled: or("isEnabledDesktop", "isEnabledPush"),
+
+  @discourseComputed("isEnabled", "isEnabledPush", "notificationsDisabled")
+  isSubscribed(isEnabled, isEnabledPush, notificationsDisabled) {
+    if (!isEnabled) {
+      return false;
+    }
+
+    if (this.isPushNotificationsPreferred()) {
+      return isEnabledPush === "subscribed";
+    } else {
+      return notificationsDisabled === "";
+    }
+  },
 
   isPushNotificationsPreferred() {
     return (

--- a/app/assets/javascripts/discourse/app/components/desktop-notification-config.js
+++ b/app/assets/javascripts/discourse/app/components/desktop-notification-config.js
@@ -83,10 +83,11 @@ export default Component.extend({
   isEnabled: or("isEnabledDesktop", "isEnabledPush"),
 
   isPushNotificationsPreferred() {
-    if (!this.site.mobileView) {
-      return false;
-    }
-    return isPushNotificationsSupported();
+    return (
+      (this.site.mobileView ||
+        this.siteSettings.enable_desktop_push_notifications) &&
+      isPushNotificationsSupported()
+    );
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/templates/components/desktop-notification-config.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/desktop-notification-config.hbs
@@ -5,7 +5,7 @@
   <DButton @icon="bell-slash" @class="btn-default" @label="user.desktop_notifications.perm_denied_btn" @action={{action "recheckPermission"}} @disabled="true" />
   {{i18n "user.desktop_notifications.perm_denied_expl"}}
 {{else}}
-  {{#if this.isEnabled}}
+  {{#if this.isSubscribed}}
     <DButton @icon="far-bell-slash" @class="btn-default" @label="user.desktop_notifications.disable" @action={{action "turnoff"}} />
   {{else}}
     <DButton @icon="far-bell" @class="btn-default" @label="user.desktop_notifications.enable" @action={{action "turnon"}} />

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2357,6 +2357,7 @@ en:
 
     push_notifications_prompt: "Display user consent prompt."
     push_notifications_icon: "The badge icon that appears in the notification corner. A 96×96 monochromatic PNG with transparency is recommended."
+    enable_desktop_push_notifications: "Enable desktop push notifications"
 
     base_font: "Base font to use for most text on the site. Themes can override via the `--font-family` CSS custom property."
     heading_font: "Font to use for headings on the site. Themes can override via the `--heading-font-family` CSS custom property."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -348,6 +348,9 @@ basic:
   push_notifications_icon:
     default: ""
     type: upload
+  enable_desktop_push_notifications:
+    default: true
+    client: true
   short_title:
     default: ""
     max: 12


### PR DESCRIPTION
Default to push for live notifications on desktop if available and `enable_desktop_push_notifications` site setting set to true.

This removes the need for desktop-push-notifications plugin.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
