### PR TITLE
DEV: introduces `pause_test` system tests helper

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
+require "highline/import"
 
 module SystemHelpers
+  def pause_test
+    result =
+      ask(
+        "\n\e[33mTest paused, press enter to resume, type `d` and press enter to start debugger.\e[0m",
+      )
+    byebug if result == "d" # rubocop:disable Lint/Debugger
+    self
+  end
+
   def sign_in(user)
     visit "/session/#{user.encoded_username}/become"
   end


### PR DESCRIPTION
This helper is intended only for dev purposes. It allows you to pause a test while still being able to interact with the browser.

When paused the test can be resumed by pressing <kbd>Enter</kbd> or you can start a debugging session by typing <kbd>d</kbd> and <kbd>Enter</kbd>.

Usage:

```
it "works" do
  visit("/")
  pause_test
  expect(page).to have_css(".foo")
end
```

![Kapture 2022-12-08 at 11 07 55](https://user-images.githubusercontent.com/339945/206419477-f774c81e-df95-4900-b9e2-ab28cad7e204.gif)
