### PR TITLE
FIX: Show last match time of screened IP address

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/logs/screened-ip-addresses.hbs
+++ b/app/assets/javascripts/admin/addon/templates/logs/screened-ip-addresses.hbs
@@ -54,10 +54,8 @@
             </td>
             <td class="col last_match_at">
               {{#if item.last_match_at}}
-                <div class="label">
-                  {{i18n "admin.logs.last_match_at"}}
-                  {{age-with-tooltip item.last_match_at}}
-                </div>
+                <div class="label">{{i18n "admin.logs.last_match_at"}}</div>
+                {{age-with-tooltip item.last_match_at}}
               {{/if}}
             </td>
             <td class="col actions">


### PR DESCRIPTION
The labels are hidden on desktop and it was hidden using CSS.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
