### PR TITLE
UX: Omit instruction note when `email_time_window_mins` is off

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/emails.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/emails.js
@@ -82,13 +82,11 @@ export default Controller.extend({
 
   @discourseComputed()
   emailFrequencyInstructions() {
-    if (this.siteSettings.email_time_window_mins) {
-      return I18n.t("user.email.frequency", {
-        count: this.siteSettings.email_time_window_mins,
-      });
-    } else {
-      return I18n.t("user.email.frequency_immediately");
-    }
+    return this.siteSettings.email_time_window_mins
+      ? I18n.t("user.email.frequency", {
+          count: this.siteSettings.email_time_window_mins,
+        })
+      : null;
   },
 
   actions: {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1496,7 +1496,6 @@ en:
         authenticated: "Your email has been authenticated by %{provider}"
         invite_auth_email_invalid: "Your invitation email does not match the email authenticated by %{provider}"
         authenticated_by_invite: "Your email has been authenticated by the invitation"
-        frequency_immediately: "We'll email you immediately if you haven't read the thing we're emailing you about."
         frequency:
           one: "We'll only email you if we haven't seen you in the last minute."
           other: "We'll only email you if we haven't seen you in the last %{count} minutes."


### PR DESCRIPTION
A translator noted that this string is odd: "We'll email you immediately if you haven't read the thing we're emailing you about." We show this note in the user profile when the user has chosen to be emailed "only when away" and the site has `email_time_window_mins` off. The message essentially says that "only when away" in this particular site's config means "Always".

I think it is best to show no description here. In an ideal world, the "Only when away" option shouldn't be there when `email_time_window_mins` is off. But it is rare to choose that override, and adding proper support for that use case would be complicated.
