### PR TITLE
DEV: relocate `:root` CSS custom properties

### DIFF
--- a/app/assets/stylesheets/common/foundation/base.scss
+++ b/app/assets/stylesheets/common/foundation/base.scss
@@ -1,3 +1,17 @@
+// These CSS custom properties are added here instead of in variables.scss
+// because variables.scss is injected into every theme CSS file
+// which causes problems when overriding custom properties in themes
+
+:root {
+  --topic-body-width: #{$topic-body-width};
+  --topic-body-width-padding: #{$topic-body-width-padding};
+  --topic-avatar-width: #{$topic-avatar-width};
+  --d-border-radius: initial;
+  --d-nav-pill-border-radius: var(--d-border-radius);
+  --d-button-border-radius: var(--d-border-radius);
+  --d-input-border-radius: var(--d-border-radius);
+}
+
 // --------------------------------------------------
 // Base styles for HTML elements
 // --------------------------------------------------

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -1,5 +1,6 @@
 // --------------------------------------------------
 // Variables used throughout the theme
+// this file is injected into every theme CSS file
 // --------------------------------------------------
 
 // Layout dimensions
@@ -13,16 +14,6 @@ $topic-body-width: 690px;
 $topic-body-width-padding: 11px;
 $topic-avatar-width: 45px;
 $reply-area-max-width: 1475px !default;
-
-:root {
-  --topic-body-width: #{$topic-body-width};
-  --topic-body-width-padding: #{$topic-body-width-padding};
-  --topic-avatar-width: #{$topic-avatar-width};
-  --d-border-radius: initial;
-  --d-nav-pill-border-radius: var(--d-border-radius);
-  --d-button-border-radius: var(--d-border-radius);
-  --d-input-border-radius: var(--d-border-radius);
-}
 
 $d-sidebar-width: 16em !default;
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require 'json_schemer'
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 68
+  BASE_COMPILER_VERSION = 69
 
   attr_accessor :child_components
 


### PR DESCRIPTION
The variables in `variables.scss` are injected into all theme CSS files so the SASS variables are available. Doing this with CSS custom properties causes situations where they'll unintentionally override intentional overrides. 

Moving these to `base.scss` ensures they're only defined once, and can be overridden properly in themes. 

More details: https://meta.discourse.org/t/override-border-radius-variables-with-theme/246574/1