### PR TITLE
FIX: new pm notification should take precedence over mention

### DIFF
--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe PostAlerter do
 
     end
 
+    it "notifies about private message even if direct mention" do
+      pm = Fabricate(:topic, archetype: 'private_message', category_id: nil)
+      op = Fabricate(:post, topic: pm, user: pm.user, raw: "Hello @#{user.username}, nice to meet you")
+      pm.allowed_users << pm.user
+      pm.allowed_users << user
+      TopicUser.create!(user_id: user.id, topic_id: pm.id, notification_level: TopicUser.notification_levels[:watching])
+      PostAlerter.post_created(op)
+
+      expect(Notification.where(user_id: user.id).pluck_first(:notification_type)).to eq(Notification.types[:private_message])
+    end
+
     context "with group inboxes" do
       fab!(:user1) { Fabricate(:user) }
       fab!(:user2) { Fabricate(:user) }
@@ -758,15 +769,18 @@ RSpec.describe PostAlerter do
             before do
               set_topic_notification_level(alice, pm_topic, notification_level)
             end
+            let(:expected_notification) {
+              notification_level == :watching ? :private_message : :mentioned
+            }
 
             it "notifies about @username mention" do
               args = { user: bob, topic: pm_topic, raw: 'Hello @alice' }
-              expect { create_post_with_alerts(args) }.to add_notification(alice, :mentioned)
+              expect { create_post_with_alerts(args) }.to add_notification(alice, expected_notification)
             end
 
             it "notifies about @username mentions by non-human users" do
               args = { user: Discourse.system_user, topic: pm_topic, raw: 'Hello @alice' }
-              expect { create_post_with_alerts(args) }.to add_notification(alice, :mentioned)
+              expect { create_post_with_alerts(args) }.to add_notification(alice, expected_notification)
             end
 
             it "notifies about @group mention when allowed user is part of group" do


### PR DESCRIPTION
When a new private message is created with mention inside, notification about private message should take precedence over mention notification.

https://meta.discourse.org/t/notification-badge-for-pm-mentioning-you/232950
