### PR TITLE
FIX: Reset search controller state

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/controllers/full-page-search.js
@@ -62,6 +62,7 @@ export default Controller.extend({
   page: 1,
   resultCount: null,
   searchTypes: null,
+  selected: [],
 
   init() {
     this._super(...arguments);
@@ -76,7 +77,6 @@ export default Controller.extend({
       },
       { name: I18n.t("search.type.users"), id: SEARCH_TYPE_USERS },
     ]);
-    this.selected = [];
   },
 
   @discourseComputed("resultCount")
@@ -298,6 +298,7 @@ export default Controller.extend({
 
     if (args.page === 1) {
       this.set("bulkSelectEnabled", false);
+
       this.selected.clear();
       this.set("searching", true);
       scrollTop();
@@ -390,6 +391,22 @@ export default Controller.extend({
           });
         break;
     }
+  },
+
+  _afterTransition() {
+    this._showFooter();
+    if (Object.keys(this.model).length === 0) {
+      this.reset();
+    }
+  },
+
+  reset() {
+    this.setProperties({
+      searching: false,
+      page: 1,
+      resultCount: null,
+      selected: [],
+    });
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/routes/full-page-search.js
@@ -40,7 +40,6 @@ export default DiscourseRoute.extend({
     }
 
     const searchKey = getSearchKey(args);
-
     if (cached && cached.data.searchKey === searchKey) {
       // extend expiry
       setTransient("lastSearch", { searchKey, model: cached.data.model }, 5);
@@ -54,12 +53,7 @@ export default DiscourseRoute.extend({
         return null;
       }
     }).then(async (results) => {
-      const grouped_search_result = results
-        ? results.grouped_search_result
-        : {};
-      const model = (results && (await translateResults(results))) || {
-        grouped_search_result,
-      };
+      const model = (results && (await translateResults(results))) || {};
       setTransient("lastSearch", { searchKey, model }, 5);
       return model;
     });
@@ -67,7 +61,8 @@ export default DiscourseRoute.extend({
 
   @action
   didTransition() {
-    this.controllerFor("full-page-search")._showFooter();
+    this.controllerFor("full-page-search")._afterTransition();
+    this.controllerFor("full-page-search").reset();
     return true;
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/full-page-search.js
+++ b/app/assets/javascripts/discourse/app/routes/full-page-search.js
@@ -62,7 +62,6 @@ export default DiscourseRoute.extend({
   @action
   didTransition() {
     this.controllerFor("full-page-search")._afterTransition();
-    this.controllerFor("full-page-search").reset();
     return true;
   },
 });

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class Search < PageObjects::Pages::Base
+
+      def type_in_search(input)
+        find("input.full-page-search").send_keys(input)
+        self
+      end
+
+      def heading_text
+        find("h1.search-page-heading").text
+      end
+
+      def click_search_button
+        find(".search-cta").click
+      end
+
+      def click_home_logo
+        find(".d-header .logo-mobile").click
+      end
+
+      def click_search_icon
+        find(".d-header #search-button").click
+      end
+
+      def has_search_result?
+        within(".search-results") do
+          page.has_selector?(".fps-result", visible: true)
+        end
+      end
+
+      def is_search_page
+        has_css?("body.search-page")
+      end
+
+    end
+  end
+end

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -28,6 +28,7 @@ describe 'Search', type: :system, js: true do
       expect(search_page.is_search_page).to be_falsey
 
       page.go_back
+      # ensure results are still there when using browser's history
       expect(search_page).to have_search_result
 
       search_page.click_home_logo

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe 'Search', type: :system, js: true do
+  let(:search_page) { PageObjects::Pages::Search.new }
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:post) { Fabricate(:post, topic: topic, raw: "This is a test post in a test topic") }
+
+  describe "when using full page search on mobile" do
+    before do
+      SearchIndexer.enable
+      SearchIndexer.index(topic, force: true)
+    end
+
+    after do
+      SearchIndexer.disable
+    end
+
+    it "works and clears search page state", mobile: true do
+      visit("/search")
+
+      search_page.type_in_search("test")
+      search_page.click_search_button
+
+      expect(search_page).to have_search_result
+      expect(search_page.heading_text).not_to eq("Search")
+
+      search_page.click_home_logo
+      expect(search_page.is_search_page).to be_falsey
+
+      page.go_back
+      expect(search_page).to have_search_result
+
+      search_page.click_home_logo
+      search_page.click_search_icon
+
+      expect(search_page).not_to have_search_result
+      expect(search_page.heading_text).to eq("Search")
+    end
+  end
+end


### PR DESCRIPTION
Repro steps: 

- search for a keyword that has N results
- navigate away from search (say to chat or app homepage)
- click on search icon again

Result: 
<img width="396" alt="image" src="https://user-images.githubusercontent.com/368961/206733165-e315dce6-2110-43e9-85a3-913ec2b3ff20.png">

This happens because the state of the search controller isn't reset properly, the model is empty but the computed properties don't get recalculated. 

This issue is easier to repro on mobile, but can also happen in desktop. 