### PR TITLE
FIX: Broken images on subfolder installs

### DIFF
--- a/app/views/finish_installation/index.html.erb
+++ b/app/views/finish_installation/index.html.erb
@@ -13,6 +13,6 @@
   </div>
 
   <div class='row finish-installation-image'>
-    <%= image_tag "/images/wizard/tada.svg", class: "tada" %>
+    <img src="<%= Discourse.base_path + '/images/wizard/tada.svg' %>" alt="tada emoji" class="tada">
   </div>
 </div>

--- a/app/views/users/perform_account_activation.html.erb
+++ b/app/views/users/perform_account_activation.html.erb
@@ -9,7 +9,7 @@
       <br>
       <div class='perform-activation'>
         <div class="image">
-          <img src="/images/wizard/tada.svg" alt="" class="waving-hand">
+          <img src="<%= Discourse.base_path + '/images/wizard/tada.svg' %>" alt="tada emoji" class="waving-hand">
         </div>
         <% if @needs_approval %>
           <p><%= t 'activation.approval_required' %></p>


### PR DESCRIPTION
Use the `Discourse.base_path` when linking to hard coded images used in
the UI so that the correct subfolder path is used if present.

Follow up: 5c67b073aea2766a6cbbc88b1fbcc2c2c1928e14
