### PR TITLE
UX: more consistent style for the new topic banner

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -84,9 +84,11 @@
 .show-more {
   width: 100%;
   z-index: z("base");
-  &.has-topics {
-    position: absolute;
-    top: 7px;
+  position: absolute;
+  top: 0;
+  .alert {
+    margin: 0;
+    padding: 1.1em 2em 1.1em 0.65em;
   }
 }
 

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -163,12 +163,6 @@
   h2 {
     margin: 20px 0 10px;
   }
-  .show-more.has-topics {
-    top: 0;
-    .alert {
-      padding: 16px 35px 16px 14px;
-    }
-  }
 }
 
 .bulk-select-topics {


### PR DESCRIPTION
The "See N new or updated topic(s)" banner isn't being correctly positioned or styled on the `/categories` or `/tag/foo` routes — this fixes that. 

Before:
![Screenshot 2022-12-09 at 5 49 41 PM](https://user-images.githubusercontent.com/1681963/206808296-922bb8dc-3800-4685-9d2c-ce822eedd887.png)
![Screenshot 2022-12-09 at 5 50 24 PM](https://user-images.githubusercontent.com/1681963/206808297-468a4078-e303-4b84-97fa-54285fe9d58e.png)


After:
![Screenshot 2022-12-09 at 5 45 26 PM](https://user-images.githubusercontent.com/1681963/206808313-bfd8c076-8748-4e98-96fc-e0454f19e41e.png)
![Screenshot 2022-12-09 at 5 46 29 PM](https://user-images.githubusercontent.com/1681963/206808315-c3a2fc74-8061-4893-b4f6-c525affcb72d.png)
