### PR TITLE
DEV: Use isSecureContext for service worker registrations

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/register-service-worker.js
+++ b/app/assets/javascripts/discourse/app/lib/register-service-worker.js
@@ -5,9 +5,7 @@ export function registerServiceWorker(
   serviceWorkerURL,
   registerOptions = {}
 ) {
-  const isSecured = document.location.protocol === "https:";
-
-  if (isSecured && "serviceWorker" in navigator) {
+  if (window.isSecureContext && "serviceWorker" in navigator) {
     const caps = container.lookup("capabilities:main");
     const isAppleBrowser =
       caps.isSafari ||


### PR DESCRIPTION
Currently, we check if the site is loaded over `https` before registering the service worker. This prevents the service worker from being registered in a standard dev/test setup.

This change replaces the protocol check with `isSecureContext` property check.

In addition to resources delivered over `https`, `isSecureContext` returns `true` for resources loaded over `http://127.0.0.1`, `http://localhost`, `http://*.localhost` and `file://`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
