### PR TITLE
FIX: DBHelper.find quotation mark

### DIFF
--- a/lib/db_helper.rb
+++ b/lib/db_helper.rb
@@ -86,7 +86,7 @@ class DbHelper
       rows = DB.query(<<~SQL, like: like)
         SELECT \"#{r.column_name}\"
           FROM \"#{r.table_name}\"
-         WHERE \""#{r.column_name}"\" LIKE :like
+         WHERE \"#{r.column_name}\" LIKE :like
       SQL
 
       if rows.size > 0


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

This PR fixes the following error when using DbHelper.find:

```
LINE 3:  WHERE ""action"" LIKE '%test%'
               ^

from /var/www/discourse/vendor/bundle/ruby/2.7.0/gems/rack-mini-profiler-3.0.0/lib/patches/db/pg.rb:110:in `exec'
```

It just removes the additional quotation marks in the DB Query