### PR TITLE
UX: Exclude child catgegories of muted category in similar to search

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -642,7 +642,7 @@ class Topic < ActiveRecord::Base
       excluded_category_ids_sql = <<~SQL
       #{excluded_category_ids_sql}
       UNION
-      #{CategoryUser.where(notification_level: CategoryUser.notification_levels[:muted], user: user).select(:category_id).to_sql}
+      #{CategoryUser.muted_category_ids_query(user, include_direct: true).select("categories.id").to_sql}
       SQL
     end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -701,6 +701,17 @@ RSpec.describe Topic do
         expect(Topic.similar_to("has evil trout made any topics?", "", user)).to eq([])
       end
 
+      it 'does not return topics from child categories where the user has muted the parent category' do
+        expect(Topic.similar_to("has evil trout made any topics?", "", user)).to eq([topic])
+
+        parent_category = topic.category
+        child_category = Fabricate(:category, parent_category: parent_category)
+        topic.update!(category: child_category)
+        CategoryUser.create!(category: parent_category, user: user, notification_level: CategoryUser.notification_levels[:muted])
+
+        expect(Topic.similar_to("has evil trout made any topics?", "", user)).to eq([])
+      end
+
       context "with secure categories" do
         fab!(:group) { Fabricate(:group) }
         fab!(:private_category) { Fabricate(:private_category, group: group) }


### PR DESCRIPTION
Follow-up to 207b764ea37f13469db1117c5c1102ace05fd2f9