### PR TITLE
DEV: Flush redis db after each system test

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -411,6 +411,8 @@ RSpec.configure do |config|
         end
       end
     end
+
+    Discourse.redis.flushdb
   end
 
   config.before(:each, type: :multisite) do


### PR DESCRIPTION
This ensures that all system tests are starting from a clean state and
not leak state between requests. Note that we have to simplify flush the
Redis db here because it is not pratical to manually clean up Redis keys
in system tests.