### PR TITLE
DEV: Add helper to wait for MessageBus to be started.

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -40,4 +40,17 @@ module SystemHelpers
   ensure
     page.driver.browser.manage.window.resize_to(original_size.width, original_size.height)
   end
+
+  def wait_for_message_bus
+    timeout = 2
+
+    while !page.evaluate_script("MessageBus.status() === 'started'") do
+      if timeout <= 0
+        raise 'MessageBus took longer than #{timeout} seconds to be started.'
+      end
+
+      timeout -= 0.01
+      sleep 0.01
+    end
+  end
 end


### PR DESCRIPTION
On the client side, we delay MessageBus from starting by 500ms so
messages being published can end up being lost in system tests unless we
provide a `last_message_id` when creating a subscription. However, it is
not practical to do so every time so we introduce a helper to wait until
MessageBus to be started before testing certain scenarios.