### PR TITLE
DEV: Use binding.pry instead of byebug for system pause_test

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -7,7 +7,7 @@ module SystemHelpers
       ask(
         "\n\e[33mTest paused, press enter to resume, type `d` and press enter to start debugger.\e[0m",
       )
-    byebug if result == "d" # rubocop:disable Lint/Debugger
+    binding.pry if result == "d" # rubocop:disable Lint/Debugger
     self
   end
 


### PR DESCRIPTION
binding.pry gives a nicer syntax-highlighted environment
and better formatting for inspecting objects, and we still
have the byebug continue/step/next commands (which you can
also alias via .pryrc) via the pry-byebug gem

**Before**

![2022-12-12_15-05](https://user-images.githubusercontent.com/920448/206965216-74abaaff-f84f-4ba5-a439-8154b0b970c2.png)

**After**

![2022-12-12_15-06](https://user-images.githubusercontent.com/920448/206965212-648b75c7-4d59-46b3-8223-96deab5fdc6a.png)