### PR TITLE
UX: include space between elements in kbd tag

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1059,6 +1059,7 @@ kbd {
   box-sizing: border-box;
   color: var(--primary);
   display: inline-flex;
+  gap: 0 0.5em; // space between text and images/emoji
   font-size: var(--font-down-1);
   justify-content: center;
   line-height: var(--line-height-large);


### PR DESCRIPTION
This ensures that there's always horizontal space between elements (like text and emoji) within a KBD tag. Flexbox ignores the whitespace that would be present otherwise. 

Before:
![Screenshot 2022-12-12 at 1 34 04 PM](https://user-images.githubusercontent.com/1681963/207126355-1ac9d0e5-c50e-465c-828f-b7ea85469c1b.png)

After:
![Screenshot 2022-12-12 at 1 34 13 PM](https://user-images.githubusercontent.com/1681963/207126357-34d3c7d8-5870-4a35-bef7-fe626238a3ac.png)




Discussion here: https://meta.discourse.org/t/cant-insert-space-next-to-an-emoji-inside-kbd-tags/248059