### PR TITLE
FIX: more specific class name to avoid collision

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -364,7 +364,7 @@ createWidget("search-menu-results", {
       if (["topic"].includes(rt.type)) {
         const more = buildMoreNode(rt);
         if (more) {
-          resultNodeContents.push(h("div.search-menu-show-more", more));
+          resultNodeContents.push(h("div.search-menu__show-more", more));
         }
       }
 

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -364,7 +364,7 @@ createWidget("search-menu-results", {
       if (["topic"].includes(rt.type)) {
         const more = buildMoreNode(rt);
         if (more) {
-          resultNodeContents.push(h("div.show-more", more));
+          resultNodeContents.push(h("div.search-menu-show-more", more));
         }
       }
 


### PR DESCRIPTION
fixes this issue: 
<img width="681" alt="Screenshot 2022-12-12 at 2 49 27 PM" src="https://user-images.githubusercontent.com/1681963/207140347-fdf67ba8-ae56-4006-9ff5-81dd076991a4.png">



This class name is also used to the "show N unread/new topics" banner — since there are no styles associated with the below use of the class, making this one more verbose seems to be the way to go 

follow-up to 9d03f20