### PR TITLE
DEV: Pass in site guardian for `Plugin::Instance.register_site_categories_callback`

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -134,7 +134,7 @@ class Site
       categories.reject! { |c| c[:parent_category_id] && !by_id[c[:parent_category_id]] }
 
       self.class.categories_callbacks.each do |callback|
-        callback.call(categories)
+        callback.call(categories, @guardian)
       end
 
       categories

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -649,13 +649,17 @@ RSpec.describe Plugin::Instance do
     it 'adds a callback to the Site#categories' do
       instance = Plugin::Instance.new
 
-      instance.register_site_categories_callback do |categories|
+      site_guardian = Guardian.new
+
+      instance.register_site_categories_callback do |categories, guardian|
         categories.each do |category|
           category[:test_field] = "test"
         end
+
+        expect(guardian).to eq(site_guardian)
       end
 
-      site = Site.new(Guardian.new)
+      site = Site.new(site_guardian)
 
       expect(site.categories.first[:test_field]).to eq("test")
     ensure


### PR DESCRIPTION
The guardian is useful for plugins to determine if the callback should
do anything. A common use case is to not do anything in the callback if
the user is anonymous.