### PR TITLE
DEV: Remove deprecation config for ember-modifier

### DIFF
--- a/app/assets/javascripts/discourse/config/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/config/deprecation-workflow.js
@@ -23,29 +23,5 @@ globalThis.deprecationWorkflow.config = {
       handler: "silence",
       matchId: "ember.built-in-components.legacy-arguments",
     },
-    {
-      handler: "throw",
-      matchId: "ember-modifier.use-modify",
-    },
-    {
-      handler: "throw",
-      matchId: "ember-modifier.use-destroyables",
-    },
-    {
-      handler: "throw",
-      matchId: "ember-modifier.no-args-property",
-    },
-    {
-      handler: "throw",
-      matchId: "ember-modifier.no-element-property",
-    },
-    {
-      handler: "throw",
-      matchId: "ember-modifier.function-based-options",
-    },
-    {
-      handler: "throw",
-      matchId: "ember-modifier.function-based-options",
-    },
   ],
 };


### PR DESCRIPTION
These deprecation messages were removed in 4.x, which we upgraded to in 2e22453057

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
