### PR TITLE
FIX: Make sure user status on mentions doesn't fail in plugins

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -431,15 +431,15 @@ export default class PostCooked {
 
   _trackMentionedUsersStatus() {
     this._post()?.mentioned_users?.forEach((user) => {
-      user.trackStatus();
-      user.on("status-changed", this, "_rerenderUserStatusOnMentions");
+      user.trackStatus?.();
+      user.on?.("status-changed", this, "_rerenderUserStatusOnMentions");
     });
   }
 
   _stopTrackingMentionedUsersStatus() {
     this._post()?.mentioned_users?.forEach((user) => {
-      user.stopTrackingStatus();
-      user.off("status-changed", this, "_rerenderUserStatusOnMentions");
+      user.stopTrackingStatus?.();
+      user.off?.("status-changed", this, "_rerenderUserStatusOnMentions");
     });
   }
 


### PR DESCRIPTION
This fixes the problem reported in https://meta.discourse.org/t/trackstatus-error-in-docs-topics/248717 and also guarantees that the same problem won't appear in other plugins.

The problem was that we're calling `trackStatus()` and `on()` on a user object, but that only works if it's a user model and fails on plain js objects.

I'm not adding tests here because in Core we always have a properly wrapped user model here. But this fix makes sure that plugins that don't won't fail here.