### PR TITLE
DEV: API to add classes to small actions

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -114,7 +114,7 @@ import { registerCustomUserNavMessagesDropdownRow } from "discourse/controllers/
 // based on Semantic Versioning 2.0.0. Please update the changelog at
 // docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md whenever you change the version
 // using the format described at https://keepachangelog.com/en/1.0.0/.
-const PLUGIN_API_VERSION = "1.5.0";
+const PLUGIN_API_VERSION = "1.6.0";
 
 // This helper prevents us from applying the same `modifyClass` over and over in test mode.
 function canModify(klass, type, resolverName, changes) {

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -62,6 +62,7 @@ import {
 import { addPostClassesCallback } from "discourse/widgets/post";
 import {
   addGroupPostSmallActionCode,
+  addPostSmallActionClassesCallback,
   addPostSmallActionIcon,
 } from "discourse/widgets/post-small-action";
 import { addQuickAccessProfileItem } from "discourse/widgets/quick-access-profile";
@@ -930,6 +931,22 @@ class PluginApi {
    **/
   addGroupPostSmallActionCode(actionCode) {
     addGroupPostSmallActionCode(actionCode);
+  }
+
+  /**
+   * Adds a callback to be called before rendering any small action post
+   * that returns custom classes to add to the small action post
+   *
+   * ```javascript
+   * addPostSmallActionClassesCallback(post => {
+   *   if (post.actionCode.includes("group")) {
+   *     return ["group-small-post"];
+   *   }
+   * });
+   * ```
+   **/
+  addPostSmallActionClassesCallback(callback) {
+    addPostSmallActionClassesCallback(callback);
   }
 
   /**

--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -45,6 +45,8 @@ export function actionDescription(
   });
 }
 
+const addPostSmallActionClassesCallbacks = [];
+
 const groupActionCodes = ["invited_group", "removed_group"];
 
 const icons = {
@@ -81,6 +83,10 @@ export function addGroupPostSmallActionCode(actionCode) {
   groupActionCodes.push(actionCode);
 }
 
+export function addPostSmallActionClassesCallback(callback) {
+  addPostSmallActionClassesCallbacks.push(callback);
+}
+
 export default createWidget("post-small-action", {
   buildKey: (attrs) => `post-small-act-${attrs.id}`,
   tagName: "div.small-action.onscreen-post",
@@ -90,9 +96,21 @@ export default createWidget("post-small-action", {
   },
 
   buildClasses(attrs) {
+    let classNames = [];
     if (attrs.deleted) {
-      return "deleted";
+      classNames.push("deleted");
     }
+
+    if (addPostSmallActionClassesCallbacks) {
+      addPostSmallActionClassesCallbacks.forEach((callback) => {
+        const additionalClasses = callback.call(this, attrs);
+        if (additionalClasses) {
+          classNames.push(...additionalClasses);
+        }
+      });
+    }
+
+    return classNames;
   },
 
   html(attrs) {

--- a/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
+++ b/docs/CHANGELOG-JAVASCRIPT-PLUGIN-API.md
@@ -7,6 +7,13 @@ in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2022-12-13
+
+### Added
+
+- Adds `addPostSmallActionClassesCallback`, which allows users to register a custom
+  function that adds a class to small action posts (pins, closing topics, etc)
+
 ## [1.5.0] - 2022-11-21
 
 ### Added


### PR DESCRIPTION
I haven't added an API method before, so this could use a set of developer eyes. 

I'm attempting to allow plugins to add a class to a small post action (pins, closed, assigns, etc): 

![Screenshot 2022-12-13 at 3 15 01 PM](https://user-images.githubusercontent.com/1681963/207434720-cdd1e947-d0b5-4911-ab8d-744bb2291408.png)


The specific use is adding a class when assigns are not public, so we can style the text similar to a whisper, see the PR on the assign plugin here: https://github.com/discourse/discourse-assign/pull/400