### PR TITLE
DEV: Export default category link renderer to be used on plugins and TCs

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/category-link.js
+++ b/app/assets/javascripts/discourse/app/helpers/category-link.js
@@ -104,7 +104,7 @@ function buildTopicCount(count) {
   )}">&times; ${count}</span>`;
 }
 
-function defaultCategoryLinkRenderer(category, opts) {
+export function defaultCategoryLinkRenderer(category, opts) {
   let descriptionText = get(category, "description_text");
   let restricted = get(category, "read_restricted");
   let url = opts.url


### PR DESCRIPTION
Exports `defaultCategoryLinkRenderer` on helper/category-links to be used in 
plugins and theme-components together with the API `replaceCategoryLinkRenderer`