### PR TITLE
FIX: properly count DistributedMutex locking attempts

### DIFF
--- a/lib/distributed_mutex.rb
+++ b/lib/distributed_mutex.rb
@@ -88,14 +88,11 @@ class DistributedMutex
       # Exponential backoff, max duration 1s
       interval = attempts < 10 ? (0.001 * 2**attempts) : 1
       sleep interval
+      attempts += 1
 
       # in readonly we will never be able to get a lock
-      if @using_global_redis && Discourse.recently_readonly?
-        attempts += 1
-
-        if attempts > CHECK_READONLY_ATTEMPTS
-          raise Discourse::ReadOnly
-        end
+      if @using_global_redis && Discourse.recently_readonly? && attempts > CHECK_READONLY_ATTEMPTS
+        raise Discourse::ReadOnly
       end
     end
   end


### PR DESCRIPTION
When originally introduced, `attempts` was only used in the read-only check
context.

With the introduction of the exponential backoff in cda370db, `attempts` was
also used to count loop iterations, but was left inside the if block instead of
being incremented every loop, meaning the exponential backoff was only
happening when the site was recently readonly.

Co-authored-by: jbrw <jamie.wilson@discourse.org>

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
