### PR TITLE
FIX: Invalid route path for staff info warnings link

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -39,8 +39,8 @@
             {{/if}}
             {{#if this.model.warnings_received_count}}
               <div>
-                <LinkTo @route="userPrivateMessages.warnings" @model={{this.model}}>
-                  <span class="warnings-received">{{this.model.warnings_received_count}}</span>{{i18n "user.staff_counters.warnings_received"}}
+                <LinkTo @route="userPrivateMessages.user.warnings" @model={{this.model}}>
+                  <span class="warnings-received">{{this.model.warnings_received_count}}</span> {{i18n "user.staff_counters.warnings_received"}}
                 </LinkTo>
               </div>
             {{/if}}

--- a/spec/system/page_objects/pages/user.rb
+++ b/spec/system/page_objects/pages/user.rb
@@ -3,6 +3,11 @@
 module PageObjects
   module Pages
     class User < PageObjects::Pages::Base
+      def visit(user)
+        page.visit("/u/#{user.username}")
+        self
+      end
+
       def find(selector)
         page.find(".user-content-wrapper #{selector}")
       end
@@ -13,6 +18,16 @@ module PageObjects
 
       def active_user_secondary_navigation
         find(".user-secondary-navigation li a.active")
+      end
+
+      def has_warning_messages_path?(user)
+        page.has_current_path?("/u/#{user.username}/messages/warnings")
+      end
+
+      def click_staff_info_warnings_link(warnings_count: 0)
+        staff_counters = page.find(".staff-counters")
+        staff_counters.click_link("#{warnings_count} #{I18n.t("js.user.staff_counters.warnings_received")}")
+        self
       end
     end
   end

--- a/spec/system/user_page/staff_info_spec.rb
+++ b/spec/system/user_page/staff_info_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe 'Viewing user staff info as an admin', type: :system, js: true do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:admin) { Fabricate(:admin) }
+  let(:user_page) { PageObjects::Pages::User.new }
+
+  before do
+    sign_in(admin)
+  end
+
+  context 'for warnings' do
+    fab!(:topic) { Fabricate(:private_message_topic, user: admin, recipient: user) }
+    fab!(:user_warning) { UserWarning.create!(user: user, created_by: admin, topic: topic) }
+
+    it "should display the right link to user's warnings with the right count in text" do
+      user_page
+        .visit(user)
+        .click_staff_info_warnings_link(warnings_count: 1)
+
+      expect(user_page).to have_warning_messages_path(user)
+    end
+  end
+end


### PR DESCRIPTION
This regressed in 4da2e3fef4102e0d3d2f24a4b0c54d4431755391