### PR TITLE
FIX: Unable to change homepage style via wizard

### DIFF
--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -166,7 +166,7 @@ class Wizard
           if updater.fields[:homepage_style] == 'latest' && top_menu[0] != "latest"
             top_menu.delete("latest")
             top_menu.insert(0, "latest")
-          elsif updater.fields[:homepage_style] != 'latest' && top_menu[0] != "categories"
+          elsif updater.fields[:homepage_style] != 'latest'
             top_menu.delete("categories")
             top_menu.insert(0, "categories")
             updater.update_setting(:desktop_category_page_style, updater.fields[:homepage_style])

--- a/spec/lib/wizard/step_updater_spec.rb
+++ b/spec/lib/wizard/step_updater_spec.rb
@@ -257,6 +257,27 @@ RSpec.describe Wizard::StepUpdater do
         expect(SiteSetting.top_menu).to eq('latest|categories|new|top')
       end
 
+      it "updates style even when categories is first in top menu" do
+        SiteSetting.top_menu = "categories|new|latest"
+        updater = wizard.create_updater('styling',
+          body_font: 'arial',
+          heading_font: 'arial',
+          homepage_style: "categories_with_featured_topics"
+        )
+        updater.update
+        expect(updater).to be_success
+        expect(SiteSetting.desktop_category_page_style).to eq('categories_with_featured_topics')
+
+        updater = wizard.create_updater('styling',
+          body_font: 'arial',
+          heading_font: 'arial',
+          homepage_style: "subcategories_with_featured_topics"
+        )
+        updater.update
+        expect(updater).to be_success
+        expect(SiteSetting.desktop_category_page_style).to eq('subcategories_with_featured_topics')
+      end
+
       it "does not overwrite top_menu site setting" do
         SiteSetting.top_menu = "latest|unread|unseen|categories"
         updater = wizard.create_updater('styling',


### PR DESCRIPTION
Depending on the current state of things, sometimes the homepage style
wouldn't update because we were incorrectly blocking updates the
`desktop_category_page_style` site setting if the first item in the top
menu was 'categories'.

Added a test case to handle this situation.

See https://meta.discourse.org/t/248354
