### PR TITLE
FIX: Use correct plural rules for Russian

### DIFF
--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -83,7 +83,7 @@
   pt: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| [0, 1].include?(n) ? :one : :other } } } },
   pt_BR: { i18n: { plural: { keys: [:one, :other], rule: lambda { |n| n == 1 ? :one : :other } } } },
   ro: { i18n: { plural: { keys: [:one, :few, :other], rule: lambda { |n| n == 1 ? :one : n == 0 || ((n % 100) >= 1 && (n % 100) <= 19) ? :few : :other } } } },
-  ru: { i18n: { plural: { keys: [:one, :few, :other], rule: lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : :other } } } },
+  ru: { i18n: { plural: { keys: [:one, :few, :many, :other], rule: lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : n % 10 == 0 || [5, 6, 7, 8, 9].include?(n % 10) || [11, 12, 13, 14].include?(n % 100) ? :many : :other } } } },
   se: { i18n: { plural: { keys: [:one, :two, :other], rule: lambda { |n| n == 1 ? :one : n == 2 ? :two : :other } } } },
   sh: { i18n: { plural: { keys: [:one, :few, :many, :other], rule: lambda { |n| n % 10 == 1 && n % 100 != 11 ? :one : [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100) ? :few : n % 10 == 0 || [5, 6, 7, 8, 9].include?(n % 10) || [11, 12, 13, 14].include?(n % 100) ? :many : :other } } } },
   sk: { i18n: { plural: { keys: [:one, :few, :other], rule: lambda { |n| n == 1 ? :one : [2, 3, 4].include?(n) ? :few : :other } } } },

--- a/lib/javascripts/locale/ru.js
+++ b/lib/javascripts/locale/ru.js
@@ -7,5 +7,10 @@ MessageFormat.locale.ru = function (n) {
   if (r10 >= 2 && r10 <= 4 && (r100 < 12 || r100 > 14) && n == Math.floor(n))
     return 'few';
 
+  if (r10 === 0 || (r10 >= 5 && r10 <= 9) ||
+    (r100 >= 11 && r100 <= 14) && n == Math.floor(n)) {
+    return 'many';
+  }
+
   return 'other';
 };

--- a/spec/lib/i18n/discourse_i18n_spec.rb
+++ b/spec/lib/i18n/discourse_i18n_spec.rb
@@ -84,13 +84,14 @@ RSpec.describe I18n::Backend::DiscourseI18n do
     it 'uses fallback locales when a pluralization key is missing' do
       SiteSetting.default_locale = 'ru'
 
-      backend.store_translations(:ru, items: { one: '%{count} Russian item', other: '%{count} Russian items' })
+      backend.store_translations(:ru, items: { one: '%{count} Russian item', many: '%{count} Russian items are many', other: '%{count} Russian items' })
 
       expect(backend.translate(:ru, :items, count: 1)).to eq('1 Russian item')
       expect(backend.translate(:ru, :items, count: 2)).to eq('2 items')
-      expect(backend.translate(:ru, :items, count: 5)).to eq('5 Russian items')
+      expect(backend.translate(:ru, :items, count: 5)).to eq('5 Russian items are many')
+      expect(backend.translate(:ru, :items, count: 10.2)).to eq('10.2 Russian items')
 
-      backend.store_translations(:ru, items: { one: '%{count} Russian item', few: '%{count} Russian items are a few', other: '%{count} Russian items' })
+      backend.store_translations(:ru, items: { one: '%{count} Russian item', few: '%{count} Russian items are a few', many: '%{count} Russian items are many', other: '%{count} Russian items' })
       expect(backend.translate(:ru, :items, count: 2)).to eq('2 Russian items are a few')
 
       backend.store_translations(:en, airplanes: { one: '%{count} airplane' })

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Admin::SiteTextsController do
 
         context 'with language with different plural keys and missing translations' do
           let(:locale) { :ru }
-          let(:expected_translations) { { one: '%{count} colour', few: '%{count} colours', other: '%{count} colours' } }
+          let(:expected_translations) { { one: '%{count} colour', few: '%{count} colours', many: '%{count} colours', other: '%{count} colours' } }
 
           include_examples 'finds correct plural keys'
         end
@@ -182,7 +182,7 @@ RSpec.describe Admin::SiteTextsController do
           end
 
           let(:locale) { :ru }
-          let(:expected_translations) { { one: '%{count} colour', few: '%{count} цвета', other: '%{count} colours' } }
+          let(:expected_translations) { { one: '%{count} colour', few: '%{count} цвета', many: '%{count} цветов', other: '%{count} colours' } }
 
           include_examples 'finds correct plural keys'
         end
@@ -195,7 +195,7 @@ RSpec.describe Admin::SiteTextsController do
           end
 
           let(:locale) { :ru }
-          let(:expected_translations) { { one: 'ONE', few: 'FEW', other: '%{count} colours' } }
+          let(:expected_translations) { { one: 'ONE', few: 'FEW', many: '%{count} цветов', other: '%{count} colours' } }
           let(:expected_overridden) { { one: true, few: true } }
 
           include_examples 'finds correct plural keys'


### PR DESCRIPTION
Previously this didn't work because Transifex didn't support "many".