### PR TITLE
FIX: email summary subject order should be consistent

### DIFF
--- a/plugins/chat/lib/extensions/user_notifications_extension.rb
+++ b/plugins/chat/lib/extensions/user_notifications_extension.rb
@@ -63,7 +63,9 @@ module Chat::UserNotificationsExtension
     all_channels = grouped_messages.keys
     grouped_channels = all_channels.partition { |c| !c.direct_message_channel? }
     channels = grouped_channels.first
-    dm_users = grouped_channels.last.flat_map { |c| grouped_messages[c].map(&:user) }.uniq
+
+    dm_messages = grouped_channels.last.flat_map { |c| grouped_messages[c] }
+    dm_users = dm_messages.sort_by(&:created_at).uniq { |m| m.user_id }.map(&:user)
 
     # Prioritize messages from regular channels over direct messages
     if channels.any?


### PR DESCRIPTION
Recent changes made this more evident, so tests became flaky. Ensure order is consistent.