### PR TITLE
FIX: Remove magic time ranges

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -124,18 +124,24 @@ function _rangeElements(element) {
     return [];
   }
 
-  // TODO: element.parentElement.children.length !== 2 is a fallback to old solution for ranges
-  // Condition can be removed after migration to [date-range]
-  if (
-    element.dataset.range !== "true" &&
-    element.parentElement.children.length !== 2
-  ) {
-    return [element];
+  if (element.dataset.range) {
+    return _partitionedRanges(element).find((pair) => pair.includes(element));
   }
 
-  return Array.from(element.parentElement.children).filter(
-    (span) => span.dataset.date
+  return [element];
+}
+
+function _partitionedRanges(element) {
+  const partitions = [];
+  const ranges = Array.from(element.parentElement.children).filter(
+    (span) => span.dataset.range
   );
+
+  while (ranges.length > 0) {
+    partitions.push(ranges.splice(0, 2));
+  }
+
+  return partitions;
 }
 
 function initializeDiscourseLocalDates(api) {

--- a/plugins/discourse-local-dates/spec/system/local_dates_spec.rb
+++ b/plugins/discourse-local-dates/spec/system/local_dates_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe "Local dates", type: :system, js: true do
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:user) { Fabricate(:user) }
+
+  before do
+    create_post(
+      user: user,
+      topic: topic,
+      title: "Date range test post",
+      raw: <<~RAW
+        First option: [date=2022-12-15 time=14:19:00 timezone="Asia/Singapore"]
+        Second option: [date=2022-12-15 time=01:20:00 timezone="Asia/Singapore"], or [date=2022-12-15 time=02:40:00 timezone="Asia/Singapore"]
+        Third option: [date-range from=2022-12-15T11:25:00 to=2022-12-16T00:26:00 timezone="Asia/Singapore"] or [date-range from=2022-12-22T11:57:00 to=2022-12-23T11:58:00 timezone="Asia/Singapore"]
+      RAW
+    )
+  end
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+
+  it "renders local dates and date ranges correctly" do
+    using_browser_timezone("Asia/Singapore") do
+      sign_in user
+
+      topic_page.visit_topic(topic)
+
+      expect(topic_page).to have_content(topic.title)
+
+      post_dates = topic_page.find_all("span[data-date]")
+
+      # Single date in a paragraph.
+      #
+      post_dates[0].click
+      tippy_date = topic_page.find(".tippy-content .current .date-time")
+
+      expect(tippy_date).to have_text("Thursday, December 15, 2022\n2:19 PM", exact: true)
+
+      # Two single dates in the same paragraph.
+      #
+      post_dates[1].click
+      tippy_date = topic_page.find(".tippy-content .current .date-time")
+
+      expect(tippy_date).to have_text("Thursday, December 15, 2022\n1:20 AM", exact: true)
+
+      post_dates[2].click
+      tippy_date = topic_page.find(".tippy-content .current .date-time")
+
+      expect(tippy_date).to have_text("Thursday, December 15, 2022\n2:40 AM", exact: true)
+
+      # Two date ranges in the same paragraph.
+      #
+      post_dates[3].click
+      tippy_date = topic_page.find(".tippy-content .current .date-time")
+
+      expect(tippy_date).to have_text("Thursday, December 15, 2022\n11:25 AM → 12:26 AM", exact: true)
+
+      post_dates[5].click
+      tippy_date = topic_page.find(".tippy-content .current .date-time")
+
+      expect(tippy_date).to have_text("Thursday, December 22, 2022 11:57 AM → Friday, December 23, 2022 11:58 AM", exact: true)
+    end
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -40,4 +40,16 @@ module SystemHelpers
   ensure
     page.driver.browser.manage.window.resize_to(original_size.width, original_size.height)
   end
+
+  def using_browser_timezone(timezone, &example)
+    previous_browser_timezone = ENV["TZ"]
+
+    ENV["TZ"] = timezone
+
+    Capybara.using_session(timezone) do
+      freeze_time(&example)
+    end
+
+    ENV["TZ"] = previous_browser_timezone
+  end
 end


### PR DESCRIPTION
### History

In #15474 we introduced dedicated support for date ranges. As part of that change we added a fallback of "magic" date ranges, which treats dates in any paragraph with _exactly_ two dates as a range. There were discussions about migrating all such paragraphs to use the new date range element, but it was ultimately decided against.

### What's the problem?

1️⃣ A minor [bug](https://meta.discourse.org/t/timezone-bug/248674) was reported relating to the "magic" date range. If a Tippy was already open when expanding a date, the date would be considered a single date, but if no Tippy was open, it would be considered a range. So expanding the same date could have different results based on the initial conditions.

(The reason this happened is the fallback relies on the number of elements in the paragraph being exactly 2, but the Tippy element was also added as a child of the same paragraph, resulting in 3 children.)

2️⃣ While working on this, I additionally found that using two date ranges in the same paragraph would result in all dates in the paragraph being treated as single dates, rather than being grouped together in ranges.

### How does this fix it?

Firstly, we remove the fallback to "magic" date ranges, as decided. This fixes the 1️⃣  problem.

Secondly, when looking at an element and it's parent paragraph, we now select all date range children and partition them two-by-two. This fixes the 2️⃣ problem.

### In summary

- Single dates are now always rendered as single dates.
- Multiple date ranges in the same paragraph now works correctly.

### In action

![discourse-date-ranges](https://user-images.githubusercontent.com/5259935/207788658-f754ab5e-53bb-40a2-83c6-57ad2334f63d.gif)
