### PR TITLE
UX: change color of preview card in channels

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -1,7 +1,7 @@
 .chat-channel-preview-card {
   margin: 1rem 1rem 2rem 1rem;
   padding: 1.5rem 1rem;
-  background-color: var(--primary-50);
+  background-color: var(--secondary-very-high);
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
Was using the primary var for the background:
<img width="854" alt="image" src="https://user-images.githubusercontent.com/101828855/207897879-2559fb3e-0652-4ae9-a887-7ee46d1d5841.png">

Is using the secondary var for the background:
<img width="858" alt="image" src="https://user-images.githubusercontent.com/101828855/207898009-81c2eafd-e15a-4b62-9e93-188e4d17a336.png">

