### PR TITLE
DEV: add title class name, prefix username class

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -27,7 +27,8 @@ createWidget("poster-name-title", {
     }
 
     classNames = classNames.map(
-      (className) => `user-title--${className.replace(/\s+/g, "-").toLowerCase()}`
+      (className) =>
+        `user-title--${className.replace(/\s+/g, "-").toLowerCase()}`
     );
 
     return classNames;

--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -26,9 +26,9 @@ createWidget("poster-name-title", {
       classNames.push(attrs.primaryGroupName);
     }
 
-    classNames = classNames.map(function (className) {
-      return `user-title--${className.replace(/\s+/g, "-").toLowerCase()}`;
-    });
+    classNames = classNames.map(
+      (className) => `user-title--${className.replace(/\s+/g, "-").toLowerCase()}`
+    );
 
     return classNames;
   },

--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -17,6 +17,22 @@ export function disableNameSuppression() {
 createWidget("poster-name-title", {
   tagName: "span.user-title",
 
+  buildClasses(attrs) {
+    let classNames = [];
+
+    classNames.push(attrs.title);
+
+    if (attrs.titleIsGroup) {
+      classNames.push(attrs.primaryGroupName);
+    }
+
+    classNames = classNames.map(function (className) {
+      return `user-title--${className.replace(/\s+/g, "-").toLowerCase()}`;
+    });
+
+    return classNames;
+  },
+
   html(attrs) {
     let titleContents = attrs.title;
     if (attrs.primaryGroupName && attrs.titleIsGroup) {
@@ -111,7 +127,7 @@ export default createWidget("poster-name", {
 
     const primaryGroupName = attrs.primary_group_name;
     if (primaryGroupName && primaryGroupName.length) {
-      classNames.push(primaryGroupName);
+      classNames.push(`group--${primaryGroupName}`);
     }
     let nameContents = [this.userLink(attrs, nameFirst ? name : username)];
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/poster-name-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/poster-name-test.js
@@ -46,7 +46,7 @@ module("Integration | Component | Widget | poster-name", function (hooks) {
     assert.ok(exists("span.moderator"));
     assert.ok(exists(".d-icon-shield-alt"));
     assert.ok(exists("span.new-user"));
-    assert.ok(exists("span.fish"));
+    assert.ok(exists("span.group--fish"));
   });
 
   test("disable display name on posts", async function (assert) {


### PR DESCRIPTION
Requested on Meta here: https://meta.discourse.org/t/additional-css-class-for-user-title/248998

We don't have a way to target user titles on posts with CSS (these sometimes align with primary group and can be targeted by the post wrapper, but not always). So I've added both a `user-title--title-name` and a `user-title--primary-group-name` class. This means any title can be targeted with CSS by its content, and group associated titles can be optionally targeted by the group name (so you can style a group's title regardless of the title's content). 

While I was here I noticed the `primaryGroupName` class on the username has no prefix, so this is susceptible to class name collisions (if you have a group named `hidden` the username would be made invisible with the `.hidden` class).  