### PR TITLE
FIX: access to category chat only when user can create post

### DIFF
--- a/lib/guardian/category_guardian.rb
+++ b/lib/guardian/category_guardian.rb
@@ -54,6 +54,14 @@ module CategoryGuardian
     secure_category_ids.include?(category.id)
   end
 
+  def can_post_in_category?(category)
+    return false unless category
+    return false if is_anonymous?
+    return true if is_admin?
+    return true if !category.read_restricted
+    Category.post_create_allowed(self).exists?(id: category.id)
+  end
+
   def can_edit_category_description?(category)
     can_perform_action_available_to_group_moderators?(category.topic)
   end

--- a/plugins/chat/app/controllers/api/category_chatables_controller.rb
+++ b/plugins/chat/app/controllers/api/category_chatables_controller.rb
@@ -9,6 +9,7 @@ class Chat::Api::CategoryChatablesController < ApplicationController
         Group
           .joins(:category_groups)
           .where(category_groups: { category_id: category.id })
+          .where("category_groups.permission_type IN (?)", [CategoryGroup.permission_types[:full], CategoryGroup.permission_types[:create_post]])
           .joins("LEFT OUTER JOIN group_users ON groups.id = group_users.group_id")
           .group("groups.id", "groups.name")
           .pluck("groups.name", "COUNT(group_users.user_id)")

--- a/plugins/chat/app/controllers/api/chat_channels_controller.rb
+++ b/plugins/chat/app/controllers/api/chat_channels_controller.rb
@@ -61,7 +61,7 @@ class Chat::Api::ChatChannelsController < Chat::Api
 
   def find_chat_channel
     chat_channel = ChatChannel.find(params.require(:chat_channel_id))
-    guardian.ensure_can_see_chat_channel!(chat_channel)
+    guardian.ensure_can_join_chat_channel!(chat_channel)
     chat_channel
   end
 

--- a/plugins/chat/app/controllers/chat_controller.rb
+++ b/plugins/chat/app/controllers/chat_controller.rb
@@ -32,7 +32,7 @@ class Chat::ChatController < Chat::ChatBaseController
   def enable_chat
     chat_channel = ChatChannel.with_deleted.find_by(chatable: @chatable)
 
-    guardian.ensure_can_see_chat_channel!(chat_channel) if chat_channel
+    guardian.ensure_can_join_chat_channel!(chat_channel) if chat_channel
 
     if chat_channel && chat_channel.trashed?
       chat_channel.recover!
@@ -40,7 +40,7 @@ class Chat::ChatController < Chat::ChatBaseController
       return render_json_error I18n.t("chat.already_enabled")
     else
       chat_channel = @chatable.chat_channel
-      guardian.ensure_can_see_chat_channel!(chat_channel)
+      guardian.ensure_can_join_chat_channel!(chat_channel)
     end
 
     success = chat_channel.save
@@ -61,7 +61,7 @@ class Chat::ChatController < Chat::ChatBaseController
 
   def disable_chat
     chat_channel = ChatChannel.with_deleted.find_by(chatable: @chatable)
-    guardian.ensure_can_see_chat_channel!(chat_channel)
+    guardian.ensure_can_join_chat_channel!(chat_channel)
     return render json: success_json if chat_channel.trashed?
     chat_channel.trash!(current_user)
 
@@ -346,7 +346,7 @@ class Chat::ChatController < Chat::ChatBaseController
         .where(id: params[:user_ids])
     users.each do |user|
       guardian = Guardian.new(user)
-      if guardian.can_chat? && guardian.can_see_chat_channel?(@chat_channel)
+      if guardian.can_chat? && guardian.can_join_chat_channel?(@chat_channel)
         data = {
           message: "chat.invitation_notification",
           chat_channel_id: @chat_channel.id,

--- a/plugins/chat/app/jobs/regular/chat_notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat_notify_watching.rb
@@ -43,7 +43,7 @@ module Jobs
     def send_notifications(membership)
       user = membership.user
       guardian = Guardian.new(user)
-      return unless guardian.can_chat? && guardian.can_see_chat_channel?(@chat_channel)
+      return unless guardian.can_chat? && guardian.can_join_chat_channel?(@chat_channel)
       return if Chat::ChatNotifier.user_has_seen_message?(membership, @chat_message.id)
       return if online_user_ids.include?(user.id)
 

--- a/plugins/chat/lib/chat_channel_fetcher.rb
+++ b/plugins/chat/lib/chat_channel_fetcher.rb
@@ -246,7 +246,7 @@ module Chat::ChatChannelFetcher
     end
 
     raise Discourse::NotFound if chat_channel.blank?
-    raise Discourse::InvalidAccess if !guardian.can_see_chat_channel?(chat_channel)
+    raise Discourse::InvalidAccess if !guardian.can_join_chat_channel?(chat_channel)
     chat_channel
   end
 end

--- a/plugins/chat/lib/chat_channel_fetcher.rb
+++ b/plugins/chat/lib/chat_channel_fetcher.rb
@@ -30,18 +30,10 @@ module Chat::ChatChannelFetcher
   end
 
   def self.generate_allowed_channel_ids_sql(guardian, exclude_dm_channels: false)
-    category_channel_sql =
-      ChatChannel
-        .select(:id)
-        .joins(
-          "INNER JOIN categories ON categories.id = chat_channels.chatable_id AND chat_channels.chatable_type = 'Category'",
-        )
-        .where(
-          "categories.id IN (:allowed_category_ids)",
-          allowed_category_ids: guardian.allowed_category_ids,
-        )
-        .to_sql
-
+    category_channel_sql = Category.post_create_allowed(guardian)
+      .joins("INNER JOIN chat_channels ON chat_channels.chatable_id = categories.id AND chat_channels.chatable_type = 'Category'")
+      .select("chat_channels.id")
+      .to_sql
     dm_channel_sql = ""
     if !exclude_dm_channels
       dm_channel_sql = <<~SQL

--- a/plugins/chat/lib/chat_message_bookmarkable.rb
+++ b/plugins/chat/lib/chat_message_bookmarkable.rb
@@ -31,7 +31,7 @@ class ChatMessageBookmarkable < BaseBookmarkable
   end
 
   def self.validate_before_create(guardian, bookmarkable)
-    if bookmarkable.blank? || !guardian.can_see_chat_channel?(bookmarkable.chat_channel)
+    if bookmarkable.blank? || !guardian.can_join_chat_channel?(bookmarkable.chat_channel)
       raise Discourse::InvalidAccess
     end
   end
@@ -55,7 +55,7 @@ class ChatMessageBookmarkable < BaseBookmarkable
   end
 
   def self.can_see?(guardian, bookmark)
-    guardian.can_see_chat_channel?(bookmark.bookmarkable.chat_channel)
+    guardian.can_join_chat_channel?(bookmark.bookmarkable.chat_channel)
   end
 
   def self.cleanup_deleted

--- a/plugins/chat/lib/chat_message_reactor.rb
+++ b/plugins/chat/lib/chat_message_reactor.rb
@@ -12,7 +12,7 @@ class Chat::ChatMessageReactor
   end
 
   def react!(message_id:, react_action:, emoji:)
-    @guardian.ensure_can_see_chat_channel!(@chat_channel)
+    @guardian.ensure_can_join_chat_channel!(@chat_channel)
     @guardian.ensure_can_react!
     validate_channel_status!
     validate_reaction!(react_action, emoji)

--- a/plugins/chat/lib/chat_notifier.rb
+++ b/plugins/chat/lib/chat_notifier.rb
@@ -195,7 +195,7 @@ class Chat::ChatNotifier
     potential_participants, unreachable =
       users.partition do |user|
         guardian = Guardian.new(user)
-        guardian.can_chat? && guardian.can_see_chat_channel?(@chat_channel)
+        guardian.can_chat? && guardian.can_join_chat_channel?(@chat_channel)
       end
 
     participants, welcome_to_join =

--- a/plugins/chat/lib/extensions/user_notifications_extension.rb
+++ b/plugins/chat/lib/extensions/user_notifications_extension.rb
@@ -28,7 +28,7 @@ module Chat::UserNotificationsExtension
     return if @messages.empty?
     @grouped_messages = @messages.group_by { |message| message.chat_channel }
     @grouped_messages =
-      @grouped_messages.select { |channel, _| guardian.can_see_chat_channel?(channel) }
+      @grouped_messages.select { |channel, _| guardian.can_join_chat_channel?(channel) }
     return if @grouped_messages.empty?
 
     @grouped_messages.each do |chat_channel, messages|

--- a/plugins/chat/lib/guardian_extensions.rb
+++ b/plugins/chat/lib/guardian_extensions.rb
@@ -93,6 +93,7 @@ module Chat::GuardianExtensions
   end
 
   def can_join_chat_channel?(chat_channel)
+    return false if !@user
     can_preview_chat_channel?(chat_channel) &&
       (!chat_channel.category_channel? || can_post_in_category?(chat_channel.chatable))
   end

--- a/plugins/chat/lib/guardian_extensions.rb
+++ b/plugins/chat/lib/guardian_extensions.rb
@@ -86,8 +86,7 @@ module Chat::GuardianExtensions
     if chat_channel.direct_message_channel?
       chat_channel.chatable.user_can_access?(@user)
     elsif chat_channel.category_channel?
-      return true if !chat_channel.chatable.read_restricted
-      Category.post_create_allowed(self).where(id: chat_channel.chatable_id).present?
+      can_post_in_category?(chat_channel.chatable)
     else
       true
     end

--- a/plugins/chat/lib/guardian_extensions.rb
+++ b/plugins/chat/lib/guardian_extensions.rb
@@ -86,7 +86,7 @@ module Chat::GuardianExtensions
     if chat_channel.direct_message_channel?
       chat_channel.chatable.user_can_access?(@user)
     elsif chat_channel.category_channel?
-      can_see_category?(chat_channel.chatable)
+      Category.post_create_allowed(self).where(id: chat_channel.chatable_id).present?
     else
       true
     end

--- a/plugins/chat/lib/guardian_extensions.rb
+++ b/plugins/chat/lib/guardian_extensions.rb
@@ -80,16 +80,21 @@ module Chat::GuardianExtensions
     is_staff? || @user.has_trust_level?(TrustLevel[4])
   end
 
-  def can_see_chat_channel?(chat_channel)
+  def can_preview_chat_channel?(chat_channel)
     return false unless chat_channel.chatable
 
     if chat_channel.direct_message_channel?
       chat_channel.chatable.user_can_access?(@user)
     elsif chat_channel.category_channel?
-      can_post_in_category?(chat_channel.chatable)
+      can_see_category?(chat_channel.chatable)
     else
       true
     end
+  end
+
+  def can_join_chat_channel?(chat_channel)
+    can_preview_chat_channel?(chat_channel) &&
+      (!chat_channel.category_channel? || can_post_in_category?(chat_channel.chatable))
   end
 
   def can_flag_chat_messages?
@@ -102,7 +107,7 @@ module Chat::GuardianExtensions
   def can_flag_in_chat_channel?(chat_channel)
     return false if !can_modify_channel_message?(chat_channel)
 
-    can_see_chat_channel?(chat_channel)
+    can_join_chat_channel?(chat_channel)
   end
 
   def can_flag_chat_message?(chat_message)

--- a/plugins/chat/lib/guardian_extensions.rb
+++ b/plugins/chat/lib/guardian_extensions.rb
@@ -86,6 +86,7 @@ module Chat::GuardianExtensions
     if chat_channel.direct_message_channel?
       chat_channel.chatable.user_can_access?(@user)
     elsif chat_channel.category_channel?
+      return true if !chat_channel.chatable.read_restricted
       Category.post_create_allowed(self).where(id: chat_channel.chatable_id).present?
     else
       true

--- a/plugins/chat/lib/guardian_extensions.rb
+++ b/plugins/chat/lib/guardian_extensions.rb
@@ -93,9 +93,9 @@ module Chat::GuardianExtensions
   end
 
   def can_join_chat_channel?(chat_channel)
-    return false if !@user
+    return false if anonymous?
     can_preview_chat_channel?(chat_channel) &&
-      (!chat_channel.category_channel? || can_post_in_category?(chat_channel.chatable))
+      (chat_channel.direct_message_channel? || can_post_in_category?(chat_channel.chatable))
   end
 
   def can_flag_chat_messages?

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -271,7 +271,7 @@ after_initialize do
         next if !chat_channel
       end
 
-      next if !Guardian.new.can_see_chat_channel?(chat_channel)
+      next if !Guardian.new.can_preview_chat_channel?(chat_channel)
 
       name = (chat_channel.name if chat_channel.name.present?)
 
@@ -353,7 +353,7 @@ after_initialize do
           end
       end
 
-      next if !Guardian.new.can_see_chat_channel?(chat_channel)
+      next if !Guardian.new.can_preview_chat_channel?(chat_channel)
 
       { url: url, title: title }
     end

--- a/plugins/chat/spec/lib/chat_channel_fetcher_spec.rb
+++ b/plugins/chat/spec/lib/chat_channel_fetcher_spec.rb
@@ -137,15 +137,27 @@ describe Chat::ChatChannelFetcher do
         expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
       end
 
-      it "does not include the category channel if the category is a private category the user can only see" do
-        group = Fabricate(:group)
-        category_group = Fabricate(:category_group, category: private_category, group: group, permission_type: CategoryGroup.permission_types[:readonly])
-        category_channel.update!(chatable: private_category)
-        GroupUser.create!(group: private_category.groups.last, user: user1)
-        expect(subject.all_secured_channel_ids(guardian)).to be_empty
+      context "when restricted category" do
+        fab!(:group) { Fabricate(:group) }
+        fab!(:category_group) { Fabricate(:category_group, category: private_category, group: group, permission_type: CategoryGroup.permission_types[:readonly]) }
+        fab!(:group_user) { Fabricate(:group_user, group: private_category.groups.last, user: user1) }
+        before do
+          category_channel.update!(chatable: private_category)
+        end
 
-        category_group.update!(permission_type: CategoryGroup.permission_types[:create_post])
-        expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
+        it "does not include the category channel for member of group with readonly access" do
+          expect(subject.all_secured_channel_ids(guardian)).to be_empty
+        end
+
+        it "includes the category channel for member of group with create_post access" do
+          category_group.update!(permission_type: CategoryGroup.permission_types[:create_post])
+          expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
+        end
+
+        it "includes the category channel for member of group with full access" do
+          category_group.update!(permission_type: CategoryGroup.permission_types[:full])
+          expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
+        end
       end
     end
   end

--- a/plugins/chat/spec/lib/chat_channel_fetcher_spec.rb
+++ b/plugins/chat/spec/lib/chat_channel_fetcher_spec.rb
@@ -136,6 +136,17 @@ describe Chat::ChatChannelFetcher do
         GroupUser.create!(group: private_category.groups.last, user: user1)
         expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
       end
+
+      it "does not include the category channel if the category is a private category the user can only see" do
+        group = Fabricate(:group)
+        category_group = Fabricate(:category_group, category: private_category, group: group, permission_type: CategoryGroup.permission_types[:readonly])
+        category_channel.update!(chatable: private_category)
+        GroupUser.create!(group: private_category.groups.last, user: user1)
+        expect(subject.all_secured_channel_ids(guardian)).to be_empty
+
+        category_group.update!(permission_type: CategoryGroup.permission_types[:create_post])
+        expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
+      end
     end
   end
 

--- a/plugins/chat/spec/lib/chat_message_reactor_spec.rb
+++ b/plugins/chat/spec/lib/chat_message_reactor_spec.rb
@@ -9,6 +9,11 @@ describe Chat::ChatMessageReactor do
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel, user: reacting_user) }
   let(:subject) { described_class.new(reacting_user, channel) }
 
+  it 'calls guardian ensure_can_join_chat_channel!' do
+    Guardian.any_instance.expects(:ensure_can_join_chat_channel!).once
+    subject.react!(message_id: message_1.id, react_action: :add, emoji: ":+1:")
+  end
+
   it "raises an error if the user cannot see the channel" do
     channel.update!(chatable: Fabricate(:private_category, group: Group[:staff]))
     expect {

--- a/plugins/chat/spec/lib/chat_notifier_spec.rb
+++ b/plugins/chat/spec/lib/chat_notifier_spec.rb
@@ -275,6 +275,12 @@ describe Chat::ChatNotifier do
 
       include_examples "ensure only channel members are notified"
 
+      it 'calls guardian can_join_chat_channel?' do
+        Guardian.any_instance.expects(:can_join_chat_channel?).at_least_once
+        msg = build_cooked_msg("Hello @#{group.name} and @#{user_2.username}", user_1)
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+      end
+
       it "establishes a far-left precedence among group mentions" do
         Fabricate(
           :user_chat_channel_membership,

--- a/plugins/chat/spec/lib/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/guardian_extensions_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Chat::GuardianExtensions do
 
         before { channel.update(chatable: category) }
 
-        it "returns true if the user can create post in the category" do
+        it "returns true if the user can join the category" do
           guardian = Guardian.new(user)
 
           readonly_group = Fabricate(:group)

--- a/plugins/chat/spec/lib/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/guardian_extensions_spec.rb
@@ -72,18 +72,18 @@ RSpec.describe Chat::GuardianExtensions do
       expect(staff_guardian.can_change_channel_status?(channel, :read_only)).to eq(true)
     end
 
-    describe "#can_see_chat_channel?" do
+    describe "#can_join_chat_channel?" do
       context "for direct message channels" do
         fab!(:chatable) { Fabricate(:direct_message) }
         fab!(:channel) { Fabricate(:direct_message_channel, chatable: chatable) }
 
         it "returns false if the user is not part of the direct message" do
-          expect(guardian.can_see_chat_channel?(channel)).to eq(false)
+          expect(guardian.can_join_chat_channel?(channel)).to eq(false)
         end
 
         it "returns true if the user is part of the direct message" do
           DirectMessageUser.create!(user: user, direct_message: chatable)
-          expect(guardian.can_see_chat_channel?(channel)).to eq(true)
+          expect(guardian.can_join_chat_channel?(channel)).to eq(true)
         end
       end
 
@@ -102,10 +102,10 @@ RSpec.describe Chat::GuardianExtensions do
           create_post_group = Fabricate(:group)
           CategoryGroup.create(group: create_post_group, category: category, permission_type: CategoryGroup.permission_types[:create_post])
 
-          expect(guardian.can_see_chat_channel?(channel)).to eq(false)
+          expect(guardian.can_join_chat_channel?(channel)).to eq(false)
 
           GroupUser.create(group: create_post_group, user: user)
-          expect(guardian.can_see_chat_channel?(channel)).to eq(true)
+          expect(guardian.can_join_chat_channel?(channel)).to eq(true)
         end
       end
     end

--- a/plugins/chat/spec/mailers/user_notifications_spec.rb
+++ b/plugins/chat/spec/mailers/user_notifications_spec.rb
@@ -25,6 +25,13 @@ describe UserNotifications do
         Chat::DirectMessageChannelCreator.create!(acting_user: sender, target_users: [sender, user])
       end
 
+      it 'calls guardian can_join_chat_channel?' do
+        Fabricate(:chat_message, user: sender, chat_channel: channel)
+        Guardian.any_instance.expects(:can_join_chat_channel?).once
+        email = described_class.chat_summary(user, {})
+        email.subject
+      end
+
       describe "email subject" do
         it "includes the sender username in the subject" do
           expected_subject = I18n.t(

--- a/plugins/chat/spec/requests/api/category_chatables_controller_spec.rb
+++ b/plugins/chat/spec/requests/api/category_chatables_controller_spec.rb
@@ -13,9 +13,13 @@ describe Chat::Api::CategoryChatablesController do
       before { sign_in(admin) }
 
       it "returns a list with the group names that could access a chat channel" do
+        readonly_group = Fabricate(:group)
+        Fabricate(:category_group, category: private_category, group: readonly_group, permission_type: CategoryGroup.permission_types[:readonly])
+        create_post_group = Fabricate(:group)
+        create_post_category_group = Fabricate(:category_group, category: private_category, group: create_post_group, permission_type: CategoryGroup.permission_types[:create_post])
         get "/chat/api/category-chatables/#{private_category.id}/permissions.json"
 
-        expect(response.parsed_body["allowed_groups"]).to contain_exactly("@#{group.name}")
+        expect(response.parsed_body["allowed_groups"]).to contain_exactly("@#{group.name}", "@#{create_post_group.name}")
         expect(response.parsed_body["members_count"]).to eq(0)
         expect(response.parsed_body["private"]).to eq(true)
       end

--- a/plugins/chat/spec/requests/chat_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat_controller_spec.rb
@@ -1137,6 +1137,8 @@ RSpec.describe Chat::ChatController do
 
     it "returns a 403 if the user can't see the channel" do
       category.update!(read_restricted: true)
+      group = Fabricate(:group)
+      CategoryGroup.create(group: group, category: category, permission_type: CategoryGroup.permission_types[:create_post])
       sign_in(user)
       post "/chat/#{channel.id}/quote.json",
            params: {

--- a/plugins/chat/spec/requests/chat_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat_controller_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe Chat::ChatController do
       let(:channel) { Fabricate(:category_channel, chatable: category) }
 
       it "ensures created channel can be seen" do
-        Guardian.any_instance.expects(:can_see_chat_channel?).with(channel)
+        Guardian.any_instance.expects(:can_join_chat_channel?).with(channel)
 
         sign_in(admin)
         post "/chat/enable.json", params: { chatable_type: "category", chatable_id: category.id }
@@ -255,7 +255,7 @@ RSpec.describe Chat::ChatController do
 
       # TODO: rewrite specs to ensure no exception is raised
       it "ensures existing channel can be seen" do
-        Guardian.any_instance.expects(:can_see_chat_channel?)
+        Guardian.any_instance.expects(:can_join_chat_channel?)
 
         sign_in(admin)
         post "/chat/enable.json", params: { chatable_type: "category", chatable_id: category.id }
@@ -270,7 +270,7 @@ RSpec.describe Chat::ChatController do
         channel = Fabricate(:category_channel, chatable: category)
         message = Fabricate(:chat_message, chat_channel: channel)
 
-        Guardian.any_instance.expects(:can_see_chat_channel?).with(channel)
+        Guardian.any_instance.expects(:can_join_chat_channel?).with(channel)
 
         sign_in(admin)
         post "/chat/disable.json", params: { chatable_type: "category", chatable_id: category.id }
@@ -1312,7 +1312,7 @@ RSpec.describe Chat::ChatController do
       channel = Fabricate(:category_channel, chatable: Fabricate(:category))
       message = Fabricate(:chat_message, chat_channel: channel)
 
-      Guardian.any_instance.expects(:can_see_chat_channel?).with(channel)
+      Guardian.any_instance.expects(:can_join_chat_channel?).with(channel)
 
       sign_in(Fabricate(:user))
       get "/chat/message/#{message.id}.json"
@@ -1328,7 +1328,7 @@ RSpec.describe Chat::ChatController do
     before { sign_in(user) }
 
     it "ensures message's channel can be seen" do
-      Guardian.any_instance.expects(:can_see_chat_channel?).with(channel)
+      Guardian.any_instance.expects(:can_join_chat_channel?).with(channel)
       get "/chat/lookup/#{message.id}.json", { params: { chat_channel_id: channel.id } }
     end
 

--- a/spec/lib/category_guardian_spec.rb
+++ b/spec/lib/category_guardian_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CategoryGuardian do
       expect(Guardian.new(user).can_post_in_category?(category)).to eq(true)
     end
 
-    it 'returns true for admin and memebers of priviliged groups for restricted category' do
+    it 'returns true for admin and members of priviliged groups for restricted category' do
       category.update!(read_restricted: true)
       group = Fabricate(:group)
       GroupUser.create(group: group, user: user)

--- a/spec/lib/category_guardian_spec.rb
+++ b/spec/lib/category_guardian_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe CategoryGuardian do
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:user) { Fabricate(:user) }
+  fab!(:can_create_user) { Fabricate(:user) }
+  fab!(:category) { Fabricate(:category) }
+
+  describe "can_post_in_category?" do
+    it 'returns true for admin and regular user when not restricted category' do
+      expect(Guardian.new.can_post_in_category?(category)).to eq(false)
+      expect(Guardian.new(admin).can_post_in_category?(category)).to eq(true)
+      expect(Guardian.new(user).can_post_in_category?(category)).to eq(true)
+    end
+
+    it 'returns true for admin and memebers of priviliged groups for restricted category' do
+      category.update!(read_restricted: true)
+      group = Fabricate(:group)
+      GroupUser.create(group: group, user: user)
+      category_group = CategoryGroup.create(group: group, category: category, permission_type: CategoryGroup.permission_types[:readonly])
+      expect(Guardian.new.can_post_in_category?(category)).to eq(false)
+      expect(Guardian.new(user).can_post_in_category?(category)).to eq(false)
+      expect(Guardian.new(admin).can_post_in_category?(category)).to eq(true)
+
+      category_group.update!(permission_type: CategoryGroup.permission_types[:create_post])
+      expect(Guardian.new.can_post_in_category?(category)).to eq(false)
+      expect(Guardian.new(user).can_post_in_category?(category)).to eq(true)
+      expect(Guardian.new(admin).can_post_in_category?(category)).to eq(true)
+
+      category_group.update!(permission_type: CategoryGroup.permission_types[:full])
+      expect(Guardian.new.can_post_in_category?(category)).to eq(false)
+      expect(Guardian.new(user).can_post_in_category?(category)).to eq(true)
+      expect(Guardian.new(admin).can_post_in_category?(category)).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Previously, restricted category chat channel was available for all groups - even `readonly`. From now on, only user who belong to group with `create_post` or `full` permissions can access that chat channel.

I separated `can_see` guardian to `can_join` and `can_preview`

Onebox is using `can_preview` guard because technically as long as the user has even `readonly` access to category, they should be able to see preview.

However, to join, they need `create_post` or `full` permission

<img width="673" alt="Screenshot 2022-12-16 at 11 02 35 am" src="https://user-images.githubusercontent.com/72780/207992248-5f087ff3-6ee4-4337-9fca-97467c587690.png">

<img width="541" alt="Screenshot 2022-12-16 at 11 04 28 am" src="https://user-images.githubusercontent.com/72780/207992258-c5d199d8-82f6-4ff8-adc8-e620663a938b.png">

