### PR TITLE
FIX: Allow backspace into hashtag autocomplete

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/hashtag-autocomplete.js
@@ -7,7 +7,6 @@ import { ajax } from "discourse/lib/ajax";
 import discourseDebounce from "discourse-common/lib/debounce";
 import {
   caretPosition,
-  caretRowCol,
   escapeExpression,
   inCodeBlock,
 } from "discourse/lib/utilities";
@@ -54,20 +53,7 @@ export function setupHashtagAutocomplete(
   }
 }
 
-export function hashtagTriggerRule(textarea, opts) {
-  const result = caretRowCol(textarea);
-  const row = result.rowNum;
-  let line = textarea.value.split("\n")[row - 1];
-
-  if (opts && opts.backSpace) {
-    line = line.slice(0, line.length - 1);
-
-    // Don't trigger autocomplete when backspacing into a `#category |` => `#category|`
-    if (/^#{1}\w+/.test(line)) {
-      return false;
-    }
-  }
-
+export function hashtagTriggerRule(textarea) {
   if (inCodeBlock(textarea.value, caretPosition(textarea))) {
     return false;
   }


### PR DESCRIPTION
Way back in 90100378b8425d3d511e1eb00c23a6eb1650baae when we first added hashtag autocompletion, we added a rule to say we should not trigger autocomplete when backspacing into a hashtag. I think this is because we used to also not trigger it at the start of the line because of how markdown headers used to work. We removed this rule in 6f0b9bb1c4d93bc4fd865c6f9920991ded846b7d so we are safe to remove the backspace exception here too. Now you can backspace into a hashtag to trigger the autocomplete.
