### PR TITLE
DEV: add topic timeline plugin outlets

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -32,6 +32,7 @@
 
 {{#if (and (not @fullscreen) @currentUser)}}
   <div class="timeline-controls">
+    <PluginOutlet @name="timeline-controls-before" @tagName="span" @connectorTagName="span" @args={{hash model=@model}} />
     <TopicAdminMenuButton
       @topic={{@model}}
       @addKeyboardTargetClass={{true}}
@@ -137,5 +138,6 @@
         <TopicAdminMenuButton @topic={{@model}} @addKeyboardTargetClass={{true}} @openUpwards={{true}} />
       {{/if}}
     {{/if}}
+    <PluginOutlet @name="timeline-footer-controls-after" @tagName="span" @connectorTagName="span" @args={{hash model=@model}}/>
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -32,7 +32,7 @@
 
 {{#if (and (not @fullscreen) @currentUser)}}
   <div class="timeline-controls">
-    <PluginOutlet @name="timeline-controls-before" @tagName="span" @connectorTagName="span" @args={{hash model=@model}} />
+    <PluginOutlet @name="timeline-controls-before" @args={{hash model=@model}} />
     <TopicAdminMenuButton
       @topic={{@model}}
       @addKeyboardTargetClass={{true}}
@@ -138,6 +138,6 @@
         <TopicAdminMenuButton @topic={{@model}} @addKeyboardTargetClass={{true}} @openUpwards={{true}} />
       {{/if}}
     {{/if}}
-    <PluginOutlet @name="timeline-footer-controls-after" @tagName="span" @connectorTagName="span" @args={{hash model=@model}}/>
+    <PluginOutlet @name="timeline-footer-controls-after" @args={{hash model=@model}}/>
   </div>
 {{/if}}


### PR DESCRIPTION
Add plugin outlets to replace decorateWidget functionality for `timeline-controls:before` and `timeline-footer-controls:after`.