### PR TITLE
FIX: a string usage that was lost during git merge

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/do-not-disturb.js
+++ b/app/assets/javascripts/discourse/app/widgets/do-not-disturb.js
@@ -45,7 +45,7 @@ export default createWidget("do-not-disturb", {
   },
 
   label() {
-    const content = [h("span", I18n.t("do_not_disturb.label"))];
+    const content = [h("span", I18n.t("pause_notifications.label"))];
 
     const until = this.currentUser.do_not_disturb_until;
     if (!DoNotDisturb.isEternal(until)) {


### PR DESCRIPTION
I've somehow lost this change when merging 2d628c80a1e7d43344a362edb92c3d256761eb5e.
