### PR TITLE
FIX: Don't validate channel slug if it hasn't changed

### DIFF
--- a/plugins/chat/app/models/chat_channel.rb
+++ b/plugins/chat/app/models/chat_channel.rb
@@ -21,7 +21,7 @@ class ChatChannel < ActiveRecord::Base
             },
             presence: true,
             allow_nil: true
-  validate :ensure_slug_ok
+  validate :ensure_slug_ok, if: :slug_changed?
   before_validation :generate_auto_slug
 
   scope :public_channels,


### PR DESCRIPTION
This is generating lots of log noise for operations that aren't even touching the slug.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
