### PR TITLE
UX: switch categories-boxes layouts from flexbox to grid

### DIFF
--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -43,9 +43,9 @@
 
 .category-boxes,
 .category-boxes-with-topics {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15em, 1fr));
+  gap: 1.5em;
   margin-top: 1em;
   margin-bottom: 1em;
   width: 100%;
@@ -118,8 +118,6 @@
 
 .category-boxes {
   .category-box {
-    width: 23%;
-    margin: 0 1% 1.5em 1%;
     > a {
       width: 100%;
       padding: 0;
@@ -254,8 +252,6 @@
 
 .category-boxes-with-topics {
   .category-box {
-    width: 31%;
-    margin: 0 1% 1.5em 1%;
     padding: 0;
   }
 

--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -44,7 +44,6 @@
 .category-boxes,
 .category-boxes-with-topics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(15em, 1fr));
   gap: 1.5em;
   margin-top: 1em;
   margin-bottom: 1em;
@@ -117,6 +116,7 @@
 }
 
 .category-boxes {
+  grid-template-columns: repeat(auto-fit, minmax(15em, 1fr));
   .category-box {
     > a {
       width: 100%;
@@ -251,6 +251,7 @@
 }
 
 .category-boxes-with-topics {
+  grid-template-columns: repeat(auto-fit, minmax(18em, 1fr));
   .category-box {
     padding: 0;
   }


### PR DESCRIPTION
This moves the `boxes with subcategories` and `boxes with featured categories` layouts to grid instead of flexbox. Using grid means that we can use the gap property, which better handles space between objects (it doesn't add unneeded margin to the left/right boxes). 

Before:

![Screenshot 2022-12-16 at 3 19 01 PM](https://user-images.githubusercontent.com/1681963/208182978-5bc76e54-2a46-408a-85f8-01a72212cc99.png)
![Screenshot 2022-12-16 at 3 19 14 PM](https://user-images.githubusercontent.com/1681963/208182979-f38228b2-e77c-4794-9d53-89ced69db0be.png)

After:

![Screenshot 2022-12-16 at 3 18 04 PM](https://user-images.githubusercontent.com/1681963/208182985-31cb07f0-9e38-47bc-8e6a-50549b068dbd.png)
![Screenshot 2022-12-16 at 3 26 06 PM](https://user-images.githubusercontent.com/1681963/208183501-20fd4aaa-d7eb-4097-804c-3f97d7480514.png)
