### PR TITLE
FIX: Add missing user_id args for ChatMessage.cook

### DIFF
--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -111,8 +111,13 @@ module PrettyText
     end
 
     def hashtag_lookup(slug, cooking_user_id, types_in_priority_order)
-      # This is _somewhat_ expected since we need to be able to cook posts
+      # NOTE: This is _somewhat_ expected since we need to be able to cook posts
       # etc. without a user sometimes, but it is still an edge case.
+      #
+      # The Discourse.system_user is usually an admin with access to _all_
+      # categories, however if the suppress_secured_categories_from_admin
+      # site setting is activated then this user will not be able to access
+      # secure categories, so hashtags that are secure will not render.
       if cooking_user_id.blank?
         cooking_user = Discourse.system_user
       else

--- a/plugins/chat/lib/chat_message_processor.rb
+++ b/plugins/chat/lib/chat_message_processor.rb
@@ -10,7 +10,7 @@ class Chat::ChatMessageProcessor
     @size_cache = {}
     @opts = {}
 
-    cooked = ChatMessage.cook(chat_message.message)
+    cooked = ChatMessage.cook(chat_message.message, user_id: chat_message.last_editor_id)
     @doc = Loofah.fragment(cooked)
   end
 

--- a/plugins/chat/spec/lib/chat_message_processor_spec.rb
+++ b/plugins/chat/spec/lib/chat_message_processor_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe Chat::ChatMessageProcessor do
+  fab!(:message) { Fabricate(:chat_message) }
+
+  it "cooks using the last_editor_id of the message" do
+    ChatMessage.expects(:cook).with(message.message, user_id: message.last_editor_id)
+    described_class.new(message)
+  end
+end


### PR DESCRIPTION
In both ChatMessage#rebake! and in ChatMessageProcessor when we were calling ChatMessage.cook we were missing the user_id to cook with, which causes missed hashtag cooks because of missing permissions. This was especially apparent because when the chat message is first posted it may have correct hashtags, but then ChatMessageProcessor does another cook and the hashtags are lost, and rebaking would not help.