### PR TITLE
FIX: Whisper tooltip shows the allowed groups

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -308,7 +308,7 @@ createWidget("post-meta-data", {
         h(
           "div.post-info.whisper",
           {
-            attributes: { title: title },
+            attributes: { title },
           },
           iconNode("far-eye-slash")
         )

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -293,11 +293,22 @@ createWidget("post-meta-data", {
     let postInfo = [];
 
     if (attrs.isWhisper) {
+      const groups = this.site.get("whispers_allowed_groups_names");
+      let title = "";
+
+      if (groups?.length > 0) {
+        title = I18n.t("post.whisper_groups", {
+          groupNames: groups.join(", "),
+        });
+      } else {
+        title = I18n.t("post.whisper");
+      }
+
       postInfo.push(
         h(
           "div.post-info.whisper",
           {
-            attributes: { title: I18n.t("post.whisper") },
+            attributes: { title: title },
           },
           iconNode("far-eye-slash")
         )

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -248,7 +248,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def whispers_allowed_groups_names
-    SiteSetting.whispers_allowed_groups_map&.map { |id| Group::AUTO_GROUP_IDS[id].to_s }
+    SiteSetting.whispers_allowed_groups_map&.map { |id| Group.where(id: id).pluck_first(:name)  }
   end
 
   private

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -248,7 +248,11 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def whispers_allowed_groups_names
-    SiteSetting.whispers_allowed_groups_map&.map { |id| Group.where(id: id).pluck_first(:name) } if scope.can_see_whispers?
+    SiteSetting.whispers_allowed_groups_map&.map { |id| Group.where(id: id).pluck_first(:name) }
+  end
+
+  def include_whispers_allowed_groups_names?
+    scope.can_see_whispers?
   end
 
   private

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -248,7 +248,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def whispers_allowed_groups_names
-    SiteSetting.whispers_allowed_groups_map&.map { |id| Group.where(id: id).pluck_first(:name)  }
+    SiteSetting.whispers_allowed_groups_map&.map { |id| Group.where(id: id).pluck_first(:name) } if scope.can_see_whispers?
   end
 
   private

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -248,7 +248,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def whispers_allowed_groups_names
-    SiteSetting.whispers_allowed_groups_map&.map { |id| Group::AUTO_GROUP_IDS[id] }
+    SiteSetting.whispers_allowed_groups_map&.map { |id| Group::AUTO_GROUP_IDS[id].to_s }
   end
 
   private

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -39,7 +39,8 @@ class SiteSerializer < ApplicationSerializer
     :hashtag_icons,
     :displayed_about_plugin_stat_groups,
     :show_welcome_topic_banner,
-    :anonymous_default_sidebar_tags
+    :anonymous_default_sidebar_tags,
+    :whispers_allowed_groups_names
   )
 
   has_many :archetypes, embed: :objects, serializer: ArchetypeSerializer
@@ -244,6 +245,10 @@ class SiteSerializer < ApplicationSerializer
 
   def include_anonymous_default_sidebar_tags?
     scope.anonymous? && !SiteSetting.legacy_navigation_menu? && SiteSetting.tagging_enabled && SiteSetting.default_sidebar_tags.present?
+  end
+
+  def whispers_allowed_groups_names
+    SiteSetting.whispers_allowed_groups_map&.map { |id| Group::AUTO_GROUP_IDS[id] }
   end
 
   private

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3443,7 +3443,7 @@ en:
       via_email: "this post arrived via email"
       via_auto_generated_email: "this post arrived via an auto generated email"
       whisper: "this post is a private whisper for moderators"
-      whisper_groups: "this post is a private whisper for members of groups: %{groupNames}"
+      whisper_groups: "this post is a private whisper only visible to %{groupNames}"
 
       wiki:
         about: "this post is a wiki"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3443,6 +3443,7 @@ en:
       via_email: "this post arrived via email"
       via_auto_generated_email: "this post arrived via an auto generated email"
       whisper: "this post is a private whisper for moderators"
+      whisper_groups: "this post is a private whisper for members of groups: %{groupNames}"
 
       wiki:
         about: "this post is a wiki"

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -748,10 +748,7 @@
       }
     },
     "whispers_allowed_groups_names" : {
-      "type": [
-        "array",
-        "null"
-      ]
+      "type": "array"
     }
   },
   "required": [

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -746,6 +746,9 @@
       "items": {
 
       }
+    },
+    "whispers_allowed_groups_names" : {
+      "type": "array"
     }
   },
   "required": [

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -748,7 +748,10 @@
       }
     },
     "whispers_allowed_groups_names" : {
-      "type": "array"
+      "type": [
+        "array",
+        "null"
+      ]
     }
   },
   "required": [

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -234,4 +234,11 @@ RSpec.describe SiteSerializer do
       end
     end
   end
+
+  it "returns correct whispers allowed groups names" do
+    SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}|#{Group::AUTO_GROUPS[:trust_level_4]}"
+
+    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    expect(serialized[:whispers_allowed_groups_names]).to eq(["staff", "trust_level_4"])
+  end
 end

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -236,22 +236,42 @@ RSpec.describe SiteSerializer do
   end
 
   describe '#whispers_allowed_groups_names' do
-    fab!(:group1) { Fabricate(:group, name: 'whisperers1') }
-    fab!(:group2) { Fabricate(:group, name: 'whisperers2') }
+    fab!(:admin) { Fabricate(:admin) }
+    fab!(:allowed_user) { Fabricate(:user) }
+    fab!(:not_allowed_user) { Fabricate(:user) }
+    fab!(:group1) { Fabricate(:group, name: 'whisperers1', users: [allowed_user]) }
+    fab!(:group2) { Fabricate(:group, name: 'whisperers2', users: [allowed_user]) }
 
-    it "returns correct whispers allowed names for new created groups" do
+    it "returns correct group names for created groups" do
+      admin_guardian = Guardian.new(admin)
       SiteSetting.whispers_allowed_groups = "#{group1.id}|#{group2.id}"
 
-      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+      serialized = described_class.new(Site.new(admin_guardian), scope: admin_guardian, root: false).as_json
       expect(serialized[:whispers_allowed_groups_names]).to eq(["whisperers1", "whisperers2"])
     end
 
-    it "returns correct whispers allowed names for automatic groups" do
+    it "returns correct group names for automatic groups" do
+      admin_guardian = Guardian.new(admin)
       SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}|#{Group::AUTO_GROUPS[:trust_level_4]}"
 
-      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+      serialized = described_class.new(Site.new(admin_guardian), scope: admin_guardian, root: false).as_json
       expect(serialized[:whispers_allowed_groups_names]).to eq(["staff", "trust_level_4"])
     end
 
+    it "returns group names when user is allowed to whisper" do
+      user_guardian = Guardian.new(allowed_user)
+      SiteSetting.whispers_allowed_groups = "#{group1.id}|#{group2.id}"
+
+      serialized = described_class.new(Site.new(user_guardian), scope: user_guardian, root: false).as_json
+      expect(serialized[:whispers_allowed_groups_names]).to eq(["whisperers1", "whisperers2"])
+    end
+
+    it "returns nil when user is not allowed to whisper" do
+      user_guardian = Guardian.new(not_allowed_user)
+      SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}|#{Group::AUTO_GROUPS[:trust_level_4]}"
+
+      serialized = described_class.new(Site.new(user_guardian), scope: user_guardian, root: false).as_json
+      expect(serialized[:whispers_allowed_groups_names]).to eq(nil)
+    end
   end
 end

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -235,10 +235,23 @@ RSpec.describe SiteSerializer do
     end
   end
 
-  it "returns correct whispers allowed groups names" do
-    SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}|#{Group::AUTO_GROUPS[:trust_level_4]}"
+  describe '#whispers_allowed_groups_names' do
+    fab!(:group1) { Fabricate(:group, name: 'whisperers1') }
+    fab!(:group2) { Fabricate(:group, name: 'whisperers2') }
 
-    serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
-    expect(serialized[:whispers_allowed_groups_names]).to eq(["staff", "trust_level_4"])
+    it "returns correct whispers allowed names for new created groups" do
+      SiteSetting.whispers_allowed_groups = "#{group1.id}|#{group2.id}"
+
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+      expect(serialized[:whispers_allowed_groups_names]).to eq(["whisperers1", "whisperers2"])
+    end
+
+    it "returns correct whispers allowed names for automatic groups" do
+      SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}|#{Group::AUTO_GROUPS[:trust_level_4]}"
+
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+      expect(serialized[:whispers_allowed_groups_names]).to eq(["staff", "trust_level_4"])
+    end
+
   end
 end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
