### PR TITLE
PERF: Add index for chat unread counts query

### DIFF
--- a/plugins/chat/app/models/chat_message.rb
+++ b/plugins/chat/app/models/chat_message.rb
@@ -252,5 +252,6 @@ end
 #
 #  idx_chat_messages_by_created_at_not_deleted            (created_at) WHERE (deleted_at IS NULL)
 #  index_chat_messages_on_chat_channel_id_and_created_at  (chat_channel_id,created_at)
+#  index_chat_messages_on_chat_channel_id_and_id          (chat_channel_id,id) WHERE (deleted_at IS NULL)
 #  index_chat_messages_on_last_editor_id                  (last_editor_id)
 #

--- a/plugins/chat/db/migrate/20221219082223_add_index_to_chat_messages.rb
+++ b/plugins/chat/db/migrate/20221219082223_add_index_to_chat_messages.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToChatMessages < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :chat_messages, [:chat_channel_id, :id], where: "deleted_at IS NULL", algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
This commit adds an index for the query which the chat plugin executes
multiple times when preloading user data in `Chat::ChatChannelFetcher.unread_counts`.

Sample query plan from a query I grabbed from one of our production
instance.

Before:

```
                                                                                        QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=10.77..696.67 rows=7 width=16) (actual time=7.735..7.736 rows=0 loops=1)
   Group Key: cc.id
   ->  Nested Loop  (cost=10.77..696.54 rows=12 width=8) (actual time=7.734..7.735 rows=0 loops=1)
         Join Filter: (cc.id = cm.chat_channel_id)
         ->  Nested Loop  (cost=0.56..76.44 rows=1 width=16) (actual time=0.011..0.037 rows=7 loops=1)
               ->  Index Only Scan using chat_channels_pkey on chat_channels cc  (cost=0.28..22.08 rows=7 width=8) (actual time=0.004..0.014 rows=7 loops=1)
                     Index Cond: (id = ANY ('{192,300,228,727,8,612,1633}'::bigint[]))
                     Heap Fetches: 0
               ->  Index Scan using user_chat_channel_unique_memberships on user_chat_channel_memberships uccm  (cost=0.28..7.73 rows=1 width=8) (actual time=0.003..0.003 rows=1 loops=7)
                     Index Cond: ((user_id = 1338) AND (chat_channel_id = cc.id))
         ->  Bitmap Heap Scan on chat_messages cm  (cost=10.21..618.98 rows=89 width=12) (actual time=1.096..1.097 rows=0 loops=7)
               Recheck Cond: (chat_channel_id = uccm.chat_channel_id)
               Filter: ((deleted_at IS NULL) AND (user_id <> 1338) AND (id > COALESCE(uccm.last_read_message_id, 0)))
               Rows Removed by Filter: 2085
               Heap Blocks: exact=7106
               ->  Bitmap Index Scan on index_chat_messages_on_chat_channel_id_and_created_at  (cost=0.00..10.19 rows=270 width=0) (actual time=0.114..0.114 rows=2085 loops=7)
                     Index Cond: (chat_channel_id = uccm.chat_channel_id)
 Planning Time: 0.408 ms
 Execution Time: 7.762 ms
(19 rows)
```

After:

```
                                                                                        QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=5.84..367.39 rows=7 width=16) (actual time=0.130..0.131 rows=0 loops=1)
   Group Key: cc.id
   ->  Nested Loop  (cost=5.84..367.26 rows=12 width=8) (actual time=0.129..0.130 rows=0 loops=1)
         Join Filter: (cc.id = cm.chat_channel_id)
         ->  Nested Loop  (cost=0.56..76.44 rows=1 width=16) (actual time=0.038..0.069 rows=7 loops=1)
               ->  Index Only Scan using chat_channels_pkey on chat_channels cc  (cost=0.28..22.08 rows=7 width=8) (actual time=0.011..0.022 rows=7 loops=1)
                     Index Cond: (id = ANY ('{192,300,228,727,8,612,1633}'::bigint[]))
                     Heap Fetches: 0
               ->  Index Scan using user_chat_channel_unique_memberships on user_chat_channel_memberships uccm  (cost=0.28..7.73 rows=1 width=8) (actual time=0.006..0.006 rows=1 loops=7)
                     Index Cond: ((user_id = 1338) AND (chat_channel_id = cc.id))
         ->  Bitmap Heap Scan on chat_messages cm  (cost=5.28..289.71 rows=89 width=12) (actual time=0.008..0.008 rows=0 loops=7)
               Recheck Cond: ((chat_channel_id = uccm.chat_channel_id) AND (id > COALESCE(uccm.last_read_message_id, 0)) AND (deleted_at IS NULL))
               Filter: (user_id <> 1338)
               ->  Bitmap Index Scan on index_chat_messages_on_chat_channel_id_and_id  (cost=0.00..5.26 rows=90 width=0) (actual time=0.008..0.008 rows=0 loops=7)
                     Index Cond: ((chat_channel_id = uccm.chat_channel_id) AND (id > COALESCE(uccm.last_read_message_id, 0)))
 Planning Time: 1.217 ms
 Execution Time: 0.188 ms
(17 rows)
```