### PR TITLE
DEV: Add default results option to user-chooser

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/user-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/user-chooser-test.js
@@ -28,4 +28,18 @@ module("Integration | Component | select-kit/user-chooser", function (hooks) {
     await this.subject.deselectItemByValue("bob");
     assert.strictEqual(this.subject.header().name(), "martin");
   });
+
+  test("can display default search results", async function (assert) {
+    this.set("options", {
+      customSearchOptions: {
+        defaultSearchResults: [{ username: "foo" }, { username: "bar" }],
+      },
+    });
+
+    await render(hbs`<UserChooser @options={{this.options}} />`);
+
+    await this.subject.expand();
+    assert.strictEqual(this.subject.rowByIndex(0).value(), "foo");
+    assert.strictEqual(this.subject.rowByIndex(1).value(), "bar");
+  });
 });

--- a/app/assets/javascripts/select-kit/addon/components/user-chooser.js
+++ b/app/assets/javascripts/select-kit/addon/components/user-chooser.js
@@ -57,6 +57,9 @@ export default MultiSelectComponent.extend({
     filter = filter || "";
     filter = filter.replace(/^@/, "");
     const options = this.selectKit.options;
+    if (filter === "" && options?.customSearchOptions?.defaultSearchResults) {
+      return Promise.resolve(options.customSearchOptions.defaultSearchResults);
+    }
 
     // prevents doing ajax request for nothing
     const skippedSearch = skipSearch(filter, options.allowEmails);


### PR DESCRIPTION
defaultSearchResults search option can be used to show a list of results by default, before any search ran, when the filter is empty.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
