### PR TITLE
PERF: Use `MessageBus.last_ids` instead of `MessageBus.last_id` for chat

### DIFF
--- a/plugins/chat/app/serializers/chat_channel_serializer.rb
+++ b/plugins/chat/app/serializers/chat_channel_serializer.rb
@@ -24,6 +24,8 @@ class ChatChannelSerializer < ApplicationSerializer
 
   def initialize(object, opts)
     super(object, opts)
+
+    @opts = opts
     @current_user_membership = opts[:membership]
   end
 
@@ -98,8 +100,8 @@ class ChatChannelSerializer < ApplicationSerializer
 
   def message_bus_last_ids
     {
-      new_messages: MessageBus.last_id("/chat/#{object.id}/new-messages"),
-      new_mentions: MessageBus.last_id("/chat/#{object.id}/new-mentions"),
+      new_messages: @opts[:new_messages_message_bus_last_id] || MessageBus.last_id(ChatPublisher.new_messages_message_bus_channel(object.id)),
+      new_mentions: @opts[:new_mentions_message_bus_last_id] || MessageBus.last_id(ChatPublisher.new_mentions_message_bus_channel(object.id)),
     }
   end
 


### PR DESCRIPTION
Prior to this change, each request executed 2 Redis calls per chat channel
that was loaded. The number of Redis calls quickly adds up once a user
is following multiple channels.