### PR TITLE
PERF: Stop serializing user in `ChatChannelSerializer#current_user_membership`

### DIFF
--- a/plugins/chat/app/serializers/base_chat_channel_membership_serializer.rb
+++ b/plugins/chat/app/serializers/base_chat_channel_membership_serializer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BaseChatChannelMembershipSerializer < ApplicationSerializer
+  attributes :following,
+             :muted,
+             :desktop_notification_level,
+             :mobile_notification_level,
+             :chat_channel_id,
+             :last_read_message_id,
+             :unread_count,
+             :unread_mentions
+end

--- a/plugins/chat/app/serializers/chat_channel_serializer.rb
+++ b/plugins/chat/app/serializers/chat_channel_serializer.rb
@@ -91,7 +91,8 @@ class ChatChannelSerializer < ApplicationSerializer
   def current_user_membership
     return if !@current_user_membership
     @current_user_membership.chat_channel = object
-    UserChatChannelMembershipSerializer.new(
+
+    BaseChatChannelMembershipSerializer.new(
       @current_user_membership,
       scope: scope,
       root: false,

--- a/plugins/chat/app/serializers/user_chat_channel_membership_serializer.rb
+++ b/plugins/chat/app/serializers/user_chat_channel_membership_serializer.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
-class UserChatChannelMembershipSerializer < ApplicationSerializer
-  attributes :following,
-             :muted,
-             :desktop_notification_level,
-             :mobile_notification_level,
-             :chat_channel_id,
-             :last_read_message_id,
-             :unread_count,
-             :unread_mentions
-
+class UserChatChannelMembershipSerializer < BaseChatChannelMembershipSerializer
   has_one :user, serializer: BasicUserSerializer, embed: :objects
 
   def user

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -146,6 +146,7 @@ after_initialize do
   load File.expand_path("../app/serializers/structured_channel_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_webhook_event_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_in_reply_to_serializer.rb", __FILE__)
+  load File.expand_path("../app/serializers/base_chat_channel_membership_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/user_chat_channel_membership_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_message_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_channel_serializer.rb", __FILE__)


### PR DESCRIPTION
The client already has all the information about the current user so
there is no need for us to be serializing the current `User` object each
time per channel that is preloaded.

In production, profiling shows that this unneeded serializing
adds a roughly 5% overhead to a request.