### PR TITLE
UX: update classname to something non-conflicting

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -53,7 +53,7 @@
                 </td>
               {{/if}}
 
-              <td class="avatar" colspan="2">
+              <td class="group-member" colspan="2">
                 <UserInfo
                   @user={{m}}
                   @skipName={{this.skipName}}

--- a/app/assets/javascripts/discourse/app/templates/group-requests.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-requests.hbs
@@ -18,7 +18,7 @@
         <tbody>
           {{#each this.model.requesters as |m|}}
             <tr>
-              <td class="avatar">
+              <td class="group-member">
                 <UserInfo @user={{m}} @skipName={{this.skipName}} />
               </td>
               <td>

--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -151,7 +151,7 @@ table.group-members {
     padding: 0.8em 0;
     text-align: center;
 
-    &.avatar {
+    &.group-member {
       text-align: left;
     }
   }


### PR DESCRIPTION
So due to the avatar-image styling being made global from chat.scss (so whenever the plugin is active the is-online status can be used anywhere, as is now already the case within the assign-modal) some regression showed on the ```/team``` and the ```/theme_authors/requests``` pages where the avatar class was wrongfully used (in hindsight). Updated to use a different, more appropriate class there to avoid this conflict.
