### PR TITLE
DEV: Properly include spec examples

### DIFF
--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Admin::UsersController do
     context "when logged in as an admin" do
       before { sign_in(admin) }
 
-      shared_examples "suspension of active user possible"
+      include_examples "suspension of active user possible"
 
       it "checks if user is suspended" do
         put "/admin/users/#{user.id}/suspend.json", params: {


### PR DESCRIPTION
It was redefining rather than including them. It was causing this warning:

```
WARNING: Shared example group suspension of active user possible was defined without a block and will have no effect. Please define a block or remove the definition
```
