### PR TITLE
FIX: Include tags inside tag groups for hashtag search

### DIFF
--- a/app/services/tag_hashtag_data_source.rb
+++ b/app/services/tag_hashtag_data_source.rb
@@ -56,7 +56,6 @@ class TagHashtagDataSource
           ),
         with_context: true,
         limit: limit,
-        for_input: true,
         order_search_results: true,
       )
 
@@ -78,7 +77,6 @@ class TagHashtagDataSource
         guardian,
         with_context: true,
         limit: limit,
-        for_input: true,
         order_popularity: true,
         excluded_tag_names: DiscourseTagging.muted_tags(guardian.user),
       )

--- a/spec/services/tag_hashtag_data_source_spec.rb
+++ b/spec/services/tag_hashtag_data_source_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe TagHashtagDataSource do
       SiteSetting.tagging_enabled = false
       expect(described_class.search(guardian, "fact", 5)).to be_empty
     end
+
+    it "returns tags that are children of a TagGroup" do
+      parent_tag = Fabricate(:tag, name: "sidebar")
+      child_tag = Fabricate(:tag, name: "sidebar-v1")
+      tag_group = Fabricate(:tag_group, parent_tag: parent_tag, name: "Sidebar TG")
+      TagGroupMembership.create!(tag: child_tag, tag_group: tag_group)
+      expect(described_class.search(guardian, "sidebar-v", 5).map(&:slug)).to eq(%w[sidebar-v1])
+    end
   end
 
   describe "#search_without_term" do


### PR DESCRIPTION
We were using the `for_input: true` param when calling DiscourseTagging, which is really meant for selecting tags in the UI, which often need a parent tag selected first before the child tags in tag group will show. We just want to show all tags regardless of grouping in hashtag search.