### PR TITLE
DEV: Fix TurboTests::Runner fail_fast condition

### DIFF
--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -262,7 +262,7 @@ module TurboTests
     end
 
     def fail_fast_met
-      !@fail_fast.nil? && @fail_fast >= @failure_count
+      !@fail_fast.nil? && @failure_count >= @fail_fast
     end
   end
 end


### PR DESCRIPTION
It fast-failed after the first failure regardless of the param…

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
