### PR TITLE
PERF: Fix N+1 queries when serializing topic posters

### DIFF
--- a/lib/user_lookup.rb
+++ b/lib/user_lookup.rb
@@ -21,7 +21,9 @@ class UserLookup
   def primary_groups
     @primary_groups ||= users.values.each_with_object({}) do |user, hash|
       if user.primary_group_id
-        hash[user.id] = groups[user.primary_group_id]
+        group = groups[user.primary_group_id]
+        set_user_group_preload(user, group, :primary_group)
+        hash[user.id] = group
       end
     end
   end
@@ -29,12 +31,19 @@ class UserLookup
   def flair_groups
     @flair_groups ||= users.values.each_with_object({}) do |user, hash|
       if user.flair_group_id
-        hash[user.id] = groups[user.flair_group_id]
+        group = groups[user.flair_group_id]
+        set_user_group_preload(user, group, :flair_group)
+        hash[user.id] = group
       end
     end
   end
 
   private
+
+  def set_user_group_preload(user, group, group_association_name)
+    association = user.association(group_association_name)
+    association.target = group
+  end
 
   def users
     @users ||= User


### PR DESCRIPTION
At the time of writing, this is how the `TopicPosterSerializer` looks
like:

```
class TopicPosterSerializer < ApplicationSerializer
  attributes :extras, :description

  has_one :user, serializer: PosterSerializer
  has_one :primary_group, serializer: PrimaryGroupSerializer
  has_one :flair_group, serializer: FlairGroupSerializer
end
```

Within `PosterSerializer`, the `primary_group` and `flair_group`
association is requested on the `user` object. However, the associations
have not been loaded on the `user` object at this point leading to the
N+1 queries problem. One may wonder
why the associations have not been loaded when the `TopicPosterSerializer`
has `has_one :primary_group` and `has_one :flair_group`. It turns out that `TopicPoster`
is just a struct containing the  `user`, `primary_group` and
`flair_group` objects. The `primary_group` and `flair_group`
ActiveRecord objects are loaded seperately in `UserLookup` and not preloaded when querying for
the users. This is done for performance reason so that we are able to
load the `primary_group` and `flair_group` records in a single query
without duplication.