### PR TITLE
DEV: Fix caching issues with CI license checks

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Check RubyGems Licenses
         if: ${{ !cancelled() }}
         run: |
-          licensed cache
+          licensed cache --force
           licensed status
 
       - name: Yarn install


### PR DESCRIPTION
This command is pretty quick (takes 4-5 seconds locally), and it looks like forcing a recalculation resolves some flakiness in recent runs. 