### PR TITLE
DEV: Add logging for flaky FinalDestination spec

### DIFF
--- a/spec/lib/final_destination/resolver_spec.rb
+++ b/spec/lib/final_destination/resolver_spec.rb
@@ -17,13 +17,17 @@ describe FinalDestination::Resolver do
     Addrinfo.stubs(:getaddrinfo).with { |addr| addr == "example.com" }.returns(mock_response)
 
     expect {
-      FinalDestination::Resolver.lookup("sleep.example.com", timeout: 0.001)
+      result = FinalDestination::Resolver.lookup("sleep.example.com", timeout: 0.001)
+      # If the test gets this far, it failed
+      puts "Flaky test debug: Result was #{result.inspect}"
     }.to raise_error(Timeout::Error)
 
     start_thread_count = alive_thread_count
 
     expect {
-      FinalDestination::Resolver.lookup("sleep.example.com", timeout: 0.001)
+      result = FinalDestination::Resolver.lookup("sleep.example.com", timeout: 0.001)
+      # If the test gets this far, it failed
+      puts "Flaky test debug: Result was #{result.inspect}"
     }.to raise_error(Timeout::Error)
 
     expect(alive_thread_count).to eq(start_thread_count)


### PR DESCRIPTION
This test occasionally fails in CI. I haven't been able to reproduce the issue locally. This logging will print some extra information when the assertion fails.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
