### PR TITLE
FIX: prevents chat-api to generate double slash URLS

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-api.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-api.js
@@ -213,28 +213,28 @@ export default class ChatApi extends Service {
   }
 
   #getRequest(endpoint, data = {}) {
-    return ajax(`${this.#basePath}/${endpoint}`, {
+    return ajax(`${this.#basePath}${endpoint}`, {
       type: "GET",
       data,
     });
   }
 
   #putRequest(endpoint, data = {}) {
-    return ajax(`${this.#basePath}/${endpoint}`, {
+    return ajax(`${this.#basePath}${endpoint}`, {
       type: "PUT",
       data,
     });
   }
 
   #postRequest(endpoint, data = {}) {
-    return ajax(`${this.#basePath}/${endpoint}`, {
+    return ajax(`${this.#basePath}${endpoint}`, {
       type: "POST",
       data,
     });
   }
 
   #deleteRequest(endpoint, data = {}) {
-    return ajax(`${this.#basePath}/${endpoint}`, {
+    return ajax(`${this.#basePath}${endpoint}`, {
       type: "DELETE",
       data,
     });


### PR DESCRIPTION
It was not causing any visible issue, but better generate the proper URL. I plan to have full tests for chat-api service, but this is already very much tested by system tests.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
