### PR TITLE
FIX: better chat-api error handling

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/adapters/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/adapters/chat-message.js
@@ -1,8 +1,6 @@
 import RESTAdapter from "discourse/adapters/rest";
 
 export default class ChatMessage extends RESTAdapter {
-  jsonMode = true;
-
   pathFor(store, type, findArgs) {
     if (findArgs.targetMessageId) {
       return `/chat/lookup/${findArgs.targetMessageId}.json?chat_channel_id=${findArgs.channelId}`;

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -3,6 +3,7 @@ import Promise from "rsvp";
 import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
 import { tracked } from "@glimmer/tracking";
 import { TrackedObject } from "@ember-compat/tracked-built-ins";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 
 const DIRECT_MESSAGE_CHANNELS_LIMIT = 20;
 
@@ -105,10 +106,13 @@ export default class ChatChannelsManager extends Service {
   }
 
   async #find(id) {
-    return this.chatApi.getChannel(id).then((channel) => {
-      this.#cache(channel);
-      return channel;
-    });
+    return this.chatApi
+      .getChannel(id)
+      .catch(popupAjaxError)
+      .then((channel) => {
+        this.#cache(channel);
+        return channel;
+      });
   }
 
   #cache(channel) {

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -60,27 +60,35 @@ RSpec.describe "Visit channel", type: :system, js: true do
       end
 
       context "when channel is not found" do
-        it "shows a not found page" do
+        it "shows an error" do
           visit("/chat/channel/999/-")
 
-          expect(page).to have_current_path("/404")
+          expect(page).to have_content("Not Found") # this is not a translated key
+        end
+      end
+
+      context "when loading a non existing message of a channel" do
+        it "shows an error" do
+          visit("/chat/channel/#{category_channel_1.id}/-?messageId=-999")
+
+          expect(page).to have_content(I18n.t("not_found"))
         end
       end
 
       context "when channel is not accessible" do
         context "when category channel" do
-          it "shows a forbidden page" do
+          it "shows an error" do
             chat.visit_channel(private_category_channel_1)
 
-            expect(page).to have_content(I18n.t("js.errors.reasons.forbidden"))
+            expect(page).to have_content(I18n.t("invalid_access"))
           end
         end
 
         context "when direct message channel" do
-          it "shows a forbidden page" do
+          it "shows an error" do
             chat.visit_channel(inaccessible_dm_channel_1)
 
-            expect(page).to have_content(I18n.t("js.errors.reasons.forbidden"))
+            expect(page).to have_content(I18n.t("invalid_access"))
           end
         end
       end


### PR DESCRIPTION
- chat-message is not using chat-api yet and the `jsonMode` shouldn't have been added
- correctly error on `getChannel` not found
- adds/correct relevant system tests

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
