### PR TITLE
DEV: Add retry logic to `plugin:install_all_official`

### DIFF
--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -32,9 +32,16 @@ task 'plugin:install_all_official' do
       repo += ".git"
     end
 
-    status = system("git clone #{repo} #{path}")
-    unless status
-      abort("Failed to clone #{repo}")
+    attempts = 0
+    begin
+      attempts += 1
+      system("git clone #{repo} #{path}", exception: true)
+    rescue StandardError
+      if attempts >= 3
+        abort("Failed to clone #{repo}")
+      end
+      STDERR.puts "Failed to clone #{repo}... trying again..."
+      retry
     end
   end
 end


### PR DESCRIPTION
This task sometimes fails in CI due to temporary network issues. Retrying twice should help resolve those situations without needing to manually restart the job.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
