### PR TITLE
UX: Temporarily revert autocomplete highlight change

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -425,7 +425,7 @@ html.composer-open {
         }
 
         &.selected {
-          background-color: var(--highlight);
+          background-color: var(--tertiary-low);
 
           .username,
           .name,


### PR DESCRIPTION
This change did not look great on non-default and custom color schemes, reverting for now while we work on a more robust solution.