### PR TITLE
FEATURE: Warn admins about private group name's exposure to anonymous users.

### DIFF
--- a/app/assets/javascripts/discourse/app/components/group-manage-save-button.js
+++ b/app/assets/javascripts/discourse/app/components/group-manage-save-button.js
@@ -64,13 +64,6 @@ export default Component.extend({
             saved: true,
             updateExistingUsers: null,
           });
-          group.setProperties({
-            buffer: {
-              visibilityLevel: group.visibility_level,
-              primaryGroup: group.primary_group,
-              flairEmpty: !(group.flair_icon || group.flair_upload_id),
-            },
-          });
 
           if (this.afterSave) {
             this.afterSave();

--- a/app/assets/javascripts/discourse/app/components/group-manage-save-button.js
+++ b/app/assets/javascripts/discourse/app/components/group-manage-save-button.js
@@ -4,13 +4,13 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { popupAutomaticMembershipAlert } from "discourse/controllers/groups-new";
 import showModal from "discourse/lib/show-modal";
-import { and } from "@ember/object/computed";
+import { or } from "@ember/object/computed";
 
 export default Component.extend({
   saving: null,
   disabled: false,
   updateExistingUsers: null,
-  hasFlair: and("model.flair_icon", "model.flair_upload_id"),
+  hasFlair: or("model.flair_icon", "model.flair_upload_id"),
 
   @discourseComputed("saving")
   savingText(saving) {

--- a/app/assets/javascripts/discourse/app/templates/components/group-manage-save-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-manage-save-button.hbs
@@ -1,3 +1,10 @@
+{{#if this.privateGroupNameNotice}}
+  <div class="row">
+    <div class="alert alert-info alert-private-group-name">
+      {{this.privateGroupNameNotice}}
+    </div>
+  </div>
+{{/if}}
 <div class="control-group buttons group-manage-save-button">
   <DButton @action={{action "save"}} @disabled={{or this.disabled this.saving}} @class="btn btn-primary group-manage-save" @translatedLabel={{this.savingText}} />
   {{#if this.saved}}

--- a/app/assets/javascripts/discourse/app/templates/components/group-manage-save-button.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-manage-save-button.hbs
@@ -1,6 +1,6 @@
 {{#if this.privateGroupNameNotice}}
   <div class="row">
-    <div class="alert alert-info alert-private-group-name">
+    <div class="alert alert-warning alert-private-group-name">
       {{this.privateGroupNameNotice}}
     </div>
   </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-save-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-save-button-test.js
@@ -1,0 +1,48 @@
+import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+
+acceptance("Managing Group - Save Button", function (needs) {
+  needs.user();
+
+  test("restricting visibility and selecting primary group checkbox", async function (assert) {
+    await visit("/g/discourse/manage/membership");
+
+    await click(".groups-form-primary-group");
+
+    await click('a[href="/g/discourse/manage/interaction"]');
+
+    const visibilitySelector = selectKit(
+      ".select-kit.groups-form-visibility-level"
+    );
+    await visibilitySelector.expand();
+    await visibilitySelector.selectRowByValue(1);
+
+    assert.ok(exists(".alert-private-group-name"), "alert is shown");
+
+    await visibilitySelector.expand();
+    await visibilitySelector.selectRowByValue(0);
+
+    assert.ok(exists(".alert-private-group-name"), "alert is hidden");
+  });
+
+  test("restricting visibility and selecting flair icon", async function (assert) {
+    await visit("/g/discourse/manage/interaction");
+
+    const visibilitySelector = selectKit(
+      ".select-kit.groups-form-visibility-level"
+    );
+    await visibilitySelector.expand();
+    await visibilitySelector.selectRowByValue(3);
+
+    await click('a[href="/g/discourse/manage/membership"]');
+    await click("inpout#group-flair-icon");
+
+    const iconSelector = selectKit(".select-kit.icon-picker");
+    await iconSelector.expand();
+    await iconSelector.selectRowByValue("ad");
+
+    assert.ok(exists(".alert-private-group-name"), "alert is shown");
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-save-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-save-button-test.js
@@ -7,42 +7,23 @@ acceptance("Managing Group - Save Button", function (needs) {
   needs.user();
 
   test("restricting visibility and selecting primary group checkbox", async function (assert) {
-    await visit("/g/discourse/manage/membership");
+    await visit("/g/alternative-group/manage/membership");
 
     await click(".groups-form-primary-group");
 
-    await click('a[href="/g/discourse/manage/interaction"]');
+    await click('a[href="/g/alternative-group/manage/interaction"]');
 
     const visibilitySelector = selectKit(
       ".select-kit.groups-form-visibility-level"
     );
     await visibilitySelector.expand();
-    await visibilitySelector.selectRowByValue(1);
+    await visibilitySelector.selectRowByValue("1");
 
     assert.ok(exists(".alert-private-group-name"), "alert is shown");
 
     await visibilitySelector.expand();
-    await visibilitySelector.selectRowByValue(0);
+    await visibilitySelector.selectRowByValue("0");
 
-    assert.ok(exists(".alert-private-group-name"), "alert is hidden");
-  });
-
-  test("restricting visibility and selecting flair icon", async function (assert) {
-    await visit("/g/discourse/manage/interaction");
-
-    const visibilitySelector = selectKit(
-      ".select-kit.groups-form-visibility-level"
-    );
-    await visibilitySelector.expand();
-    await visibilitySelector.selectRowByValue(3);
-
-    await click('a[href="/g/discourse/manage/membership"]');
-    await click("inpout#group-flair-icon");
-
-    const iconSelector = selectKit(".select-kit.icon-picker");
-    await iconSelector.expand();
-    await iconSelector.selectRowByValue("ad");
-
-    assert.ok(exists(".alert-private-group-name"), "alert is shown");
+    assert.notOk(exists(".alert-private-group-name"), "alert is hidden");
   });
 });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4588,7 +4588,7 @@ en:
             primary_group: "Automatically set as primary group"
           alert:
             primary_group: "Since this is a primary group, the name '%{group_name}' will be used in CSS classes which can be viewed by anyone."
-            flair_group: "Since this group has flair for its members, the name '%{group_name}' will be used in CSS classes which can be viewable by anyone. Please ensure the name is safe."
+            flair_group: "Since this group has flair for its members, the name '%{group_name}' will be visible to anyone."
         name_placeholder: "Group name, no spaces, same as username rule"
         primary: "Primary Group"
         no_primary: "(no primary group)"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4586,6 +4586,9 @@ en:
               other: "%{count} users have the new email domains and will be added to the group."
             automatic_membership_associated_groups: "Users who are members of a group on a service listed here will be automatically added to this group when they log in with the service."
             primary_group: "Automatically set as primary group"
+          alert:
+            primary_group: "Since this is a primary group for its members, the name '%{group_name}' will be used in CSS classes which can be viewable by anyone. Please ensure the name is safe."
+            flair_group: "Since this group has flair for its members, the name '%{group_name}' will be used in CSS classes which can be viewable by anyone. Please ensure the name is safe."
         name_placeholder: "Group name, no spaces, same as username rule"
         primary: "Primary Group"
         no_primary: "(no primary group)"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4587,7 +4587,7 @@ en:
             automatic_membership_associated_groups: "Users who are members of a group on a service listed here will be automatically added to this group when they log in with the service."
             primary_group: "Automatically set as primary group"
           alert:
-            primary_group: "Since this is a primary group for its members, the name '%{group_name}' will be used in CSS classes which can be viewable by anyone. Please ensure the name is safe."
+            primary_group: "Since this is a primary group, the name '%{group_name}' will be used in CSS classes which can be viewed by anyone."
             flair_group: "Since this group has flair for its members, the name '%{group_name}' will be used in CSS classes which can be viewable by anyone. Please ensure the name is safe."
         name_placeholder: "Group name, no spaces, same as username rule"
         primary: "Primary Group"


### PR DESCRIPTION
Group names will be used as CSS classes in some components while rendering the public HTML output. It will happen when a group is set as the default primary for users. Or when a group has either a flair icon or flair upload. So we should warn the admins when they restrict the group's visibility level.