### PR TITLE
DEV: Fix `FinalDestination::Resolver` race condition

### DIFF
--- a/lib/final_destination/resolver.rb
+++ b/lib/final_destination/resolver.rb
@@ -8,11 +8,13 @@ class FinalDestination::Resolver
       @result = nil
 
       @queue ||= Queue.new
-      @queue << ""
       ensure_lookup_thread
 
       @lookup = addr
       @parent = Thread.current
+
+      # Wakeup the worker thread
+      @queue << ""
 
       # This sleep will be interrupted by the lookup thread
       # if completed within timeout

--- a/spec/lib/final_destination/resolver_spec.rb
+++ b/spec/lib/final_destination/resolver_spec.rb
@@ -18,16 +18,12 @@ describe FinalDestination::Resolver do
 
     expect {
       result = FinalDestination::Resolver.lookup("sleep.example.com", timeout: 0.001)
-      # If the test gets this far, it failed
-      puts "Flaky test debug: Result was #{result.inspect}"
     }.to raise_error(Timeout::Error)
 
     start_thread_count = alive_thread_count
 
     expect {
       result = FinalDestination::Resolver.lookup("sleep.example.com", timeout: 0.001)
-      # If the test gets this far, it failed
-      puts "Flaky test debug: Result was #{result.inspect}"
     }.to raise_error(Timeout::Error)
 
     expect(alive_thread_count).to eq(start_thread_count)


### PR DESCRIPTION
We were adding to the resolver's work queue before setting up the `@lookup` and `@parent` information. That could lead to the lookup being performed on the wrong (or `nil`) hostname. This was causing some flakiness in specs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
