### PR TITLE
FIX: styles of user status on mentions

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1248,6 +1248,12 @@ a.mention-group {
   @include mention;
 }
 
+.mention .emoji {
+  margin-left: 0.3em;
+  width: 15px;
+  height: 15px;
+}
+
 span.mention {
   // unlinked, invalid mention
   color: var(--primary-high);


### PR DESCRIPTION
Reported in https://meta.discourse.org/t/users-mentions-wrongly-show-their-status-with-the-emoji/249534.

The problem was that we had styles for user status on mentions in the calendar plugin. So it looked fine on sites with Discourse Calendar but not on sites without it.

Before:

<img width="459" alt="image" src="https://user-images.githubusercontent.com/1274517/208973333-7293771d-beb9-4737-a81b-afa41798e7e6.png">

After:

<img width="385" alt="image" src="https://user-images.githubusercontent.com/1274517/208973390-25f5b1c4-0880-415d-947c-04f80db42c9f.png">

