### PR TITLE
FIX: prevents creating a null User object

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/user-chat-channel-membership.js
+++ b/plugins/chat/assets/javascripts/discourse/models/user-chat-channel-membership.js
@@ -19,7 +19,7 @@ UserChatChannelMembership.reopenClass({
   },
 
   _initUser(args) {
-    if (args.user instanceof User) {
+    if (!args.user || args.user instanceof User) {
       return;
     }
 


### PR DESCRIPTION
Following the removal of user in current_user_membership we were now doing: `User.create(null)`.

I don't think it has any impact but this is just wasteful and could lead to issues if used.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
