### PR TITLE
FIX: Allow for nested chat transcripts

### DIFF
--- a/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
+++ b/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
@@ -423,6 +423,7 @@ function unhoistForCooked(hoisted, cooked) {
         found = true;
         return hoisted[key];
       });
+      delete hoisted[key];
     };
 
     while (found) {
@@ -578,14 +579,16 @@ export function setup(opts, siteSettings, state) {
 
 export function cook(raw, opts) {
   // we still have to hoist html_raw nodes so they bypass the allowlister
-  // this is the case for oneboxes
-  let hoisted = {};
-  opts.discourse.hoisted = hoisted;
+  // this is the case for oneboxes and also certain plugins that require
+  // raw HTML rendering within markdown bbcode rules
+  opts.discourse.hoisted = opts.discourse.hoisted ??= {};
 
   const rendered = opts.engine.render(raw);
   let cooked = opts.discourse.sanitizer(rendered).trim();
-  cooked = unhoistForCooked(hoisted, cooked);
-  delete opts.discourse.hoisted;
+
+  // opts.discourse.hoisted guid keys will be deleted within here to
+  // keep the object empty
+  cooked = unhoistForCooked(opts.discourse.hoisted, cooked);
 
   return cooked;
 }

--- a/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
+++ b/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
@@ -581,7 +581,7 @@ export function cook(raw, opts) {
   // we still have to hoist html_raw nodes so they bypass the allowlister
   // this is the case for oneboxes and also certain plugins that require
   // raw HTML rendering within markdown bbcode rules
-  opts.discourse.hoisted = opts.discourse.hoisted ??= {};
+  opts.discourse.hoisted ??= {};
 
   const rendered = opts.engine.render(raw);
   let cooked = opts.discourse.sanitizer(rendered).trim();


### PR DESCRIPTION
The way our markdown raw_html hoisting worked, we only
supported one level of hoisting the HTML content. However
when nesting `[chat]` transcript BBCode we need to allow
for multiple levels of it. This commit changes `opts.discourse.hoisted`
to be more constant, and the GUID keys that have the hoisted
content are only deleted by `unhoistForCooked` rather than
the `cook` function itself, which prematurely deletes them
when they are needed further down the line.

This prevents a "Cannot set properties of undefined" error in
the composer preview when trying to change `opts.discourse.hoisted`
and also when trying to cook a post. Also fixes breakages of drafts
from excerpts encountering the same error.