### PR TITLE
DEV: Get rid of all discourseModule uses

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/computed-test.js
@@ -9,12 +9,15 @@ import {
 } from "discourse/lib/computed";
 import EmberObject from "@ember/object";
 import I18n from "I18n";
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { setPrefix } from "discourse-common/lib/get-url";
 import sinon from "sinon";
-import { test } from "qunit";
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
 
-discourseModule("Unit | Utility | computed", function (hooks) {
+module("Unit | Utility | computed", function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
     sinon.stub(I18n, "t").callsFake(function (scope) {
       return "%@ translated: " + scope;
@@ -26,20 +29,22 @@ discourseModule("Unit | Utility | computed", function (hooks) {
   });
 
   test("setting", function (assert) {
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+
     let t = EmberObject.extend({
-      siteSettings: this.siteSettings,
+      siteSettings,
       vehicle: setting("vehicle"),
       missingProp: setting("madeUpThing"),
     }).create();
 
-    this.siteSettings.vehicle = "airplane";
+    siteSettings.vehicle = "airplane";
     assert.strictEqual(
-      t.get("vehicle"),
+      t.vehicle,
       "airplane",
       "it has the value of the site setting"
     );
     assert.ok(
-      !t.get("missingProp"),
+      !t.missingProp,
       "it is falsy when the site setting is not defined"
     );
   });
@@ -52,9 +57,9 @@ discourseModule("Unit | Utility | computed", function (hooks) {
       biscuits: 10,
     });
 
-    assert.ok(t.get("same"), "it is true when the properties are the same");
+    assert.ok(t.same, "it is true when the properties are the same");
     t.set("biscuits", 9);
-    assert.ok(!t.get("same"), "it isn't true when one property is different");
+    assert.ok(!t.same, "it isn't true when one property is different");
   });
 
   test("propertyNotEqual", function (assert) {
@@ -65,9 +70,9 @@ discourseModule("Unit | Utility | computed", function (hooks) {
       biscuits: 10,
     });
 
-    assert.ok(!t.get("diff"), "it isn't true when the properties are the same");
+    assert.ok(!t.diff, "it isn't true when the properties are the same");
     t.set("biscuits", 9);
-    assert.ok(t.get("diff"), "it is true when one property is different");
+    assert.ok(t.diff, "it is true when one property is different");
   });
 
   test("fmt", function (assert) {
@@ -80,25 +85,25 @@ discourseModule("Unit | Utility | computed", function (hooks) {
     });
 
     assert.strictEqual(
-      t.get("exclaimyUsername"),
+      t.exclaimyUsername,
       "!!! eviltrout !!!",
       "it inserts the string"
     );
     assert.strictEqual(
-      t.get("multiple"),
+      t.multiple,
       "eviltrout is happy",
       "it inserts multiple strings"
     );
 
     t.set("username", "codinghorror");
     assert.strictEqual(
-      t.get("multiple"),
+      t.multiple,
       "codinghorror is happy",
       "it supports changing properties"
     );
     t.set("mood", "ecstatic");
     assert.strictEqual(
-      t.get("multiple"),
+      t.multiple,
       "codinghorror is ecstatic",
       "it supports changing another property"
     );
@@ -114,25 +119,25 @@ discourseModule("Unit | Utility | computed", function (hooks) {
     });
 
     assert.strictEqual(
-      t.get("exclaimyUsername"),
+      t.exclaimyUsername,
       "%@ translated: !!! eviltrout !!!",
       "it inserts the string and then translates"
     );
     assert.strictEqual(
-      t.get("multiple"),
+      t.multiple,
       "%@ translated: eviltrout is happy",
       "it inserts multiple strings and then translates"
     );
 
     t.set("username", "codinghorror");
     assert.strictEqual(
-      t.get("multiple"),
+      t.multiple,
       "%@ translated: codinghorror is happy",
       "it supports changing properties"
     );
     t.set("mood", "ecstatic");
     assert.strictEqual(
-      t.get("multiple"),
+      t.multiple,
       "%@ translated: codinghorror is ecstatic",
       "it supports changing another property"
     );
@@ -147,7 +152,7 @@ discourseModule("Unit | Utility | computed", function (hooks) {
 
     t = testClass.create({ username: "eviltrout" });
     assert.strictEqual(
-      t.get("userUrl"),
+      t.userUrl,
       "/u/eviltrout",
       "it supports urls without a prefix"
     );
@@ -155,7 +160,7 @@ discourseModule("Unit | Utility | computed", function (hooks) {
     setPrefix("/prefixed");
     t = testClass.create({ username: "eviltrout" });
     assert.strictEqual(
-      t.get("userUrl"),
+      t.userUrl,
       "/prefixed/u/eviltrout",
       "it supports urls with a prefix"
     );
@@ -167,6 +172,6 @@ discourseModule("Unit | Utility | computed", function (hooks) {
       desc: htmlSafe("cookies"),
     }).create({ cookies });
 
-    assert.strictEqual(t.get("desc").string, cookies);
+    assert.strictEqual(t.desc.string, cookies);
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/lib/dom-from-string-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/dom-from-string-test.js
@@ -1,8 +1,10 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import domFromString from "discourse-common/lib/dom-from-string";
+import { setupTest } from "ember-qunit";
 
-discourseModule("Unit | Utility | domFromString", function () {
+module("Unit | Utility | domFromString", function (hooks) {
+  setupTest(hooks);
+
   test("constructing DOM node from a string", function (assert) {
     const node = domFromString(
       '<div class="foo">foo</div><div class="boo">boo</div>'

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/bookmark-reminder-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/bookmark-reminder-test.js
@@ -1,11 +1,11 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { deepMerge } from "discourse-common/lib/object";
 import { createRenderDirector } from "discourse/tests/helpers/notification-types-helper";
 import { htmlSafe } from "@ember/template";
 import Notification from "discourse/models/notification";
 import I18n from "I18n";
+import { setupTest } from "ember-qunit";
 
 function getNotification(overrides = {}) {
   return Notification.create(
@@ -33,7 +33,9 @@ function getNotification(overrides = {}) {
   );
 }
 
-discourseModule("Unit | Notification Types | bookmark-reminder", function () {
+module("Unit | Notification Types | bookmark-reminder", function (hooks) {
+  setupTest(hooks);
+
   test("linkTitle", function (assert) {
     const notification = getNotification({
       data: { bookmark_name: "My awesome bookmark" },

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/granted-badge-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/granted-badge-test.js
@@ -1,10 +1,10 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { deepMerge } from "discourse-common/lib/object";
 import { createRenderDirector } from "discourse/tests/helpers/notification-types-helper";
 import Notification from "discourse/models/notification";
 import I18n from "I18n";
+import { setupTest } from "ember-qunit";
 
 function getNotification(overrides = {}) {
   return Notification.create(
@@ -28,7 +28,9 @@ function getNotification(overrides = {}) {
   );
 }
 
-discourseModule("Unit | Notification Types | granted-badge", function () {
+module("Unit | Notification Types | granted-badge", function (hooks) {
+  setupTest(hooks);
+
   test("linkHref", function (assert) {
     const notification = getNotification();
     const director = createRenderDirector(

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-mentioned-test.js
@@ -1,9 +1,9 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { deepMerge } from "discourse-common/lib/object";
 import { createRenderDirector } from "discourse/tests/helpers/notification-types-helper";
 import Notification from "discourse/models/notification";
+import { setupTest } from "ember-qunit";
 
 function getNotification(overrides = {}) {
   return Notification.create(
@@ -34,7 +34,9 @@ function getNotification(overrides = {}) {
   );
 }
 
-discourseModule("Unit | Notification Types | group-mentioned", function () {
+module("Unit | Notification Types | group-mentioned", function (hooks) {
+  setupTest(hooks);
+
   test("label", function (assert) {
     const notification = getNotification();
     const director = createRenderDirector(

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-message-summary-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/group-message-summary-test.js
@@ -1,10 +1,10 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { deepMerge } from "discourse-common/lib/object";
 import { createRenderDirector } from "discourse/tests/helpers/notification-types-helper";
 import Notification from "discourse/models/notification";
 import I18n from "I18n";
+import { setupTest } from "ember-qunit";
 
 function getNotification(overrides = {}) {
   return Notification.create(
@@ -28,38 +28,37 @@ function getNotification(overrides = {}) {
   );
 }
 
-discourseModule(
-  "Unit | Notification Types | group-message-summary",
-  function () {
-    test("description", function (assert) {
-      const notification = getNotification();
-      const director = createRenderDirector(
-        notification,
-        "group_message_summary",
-        this.siteSettings
-      );
-      assert.strictEqual(
-        director.description,
-        I18n.t("notifications.group_message_summary", {
-          group_name: "drummers",
-          count: 13,
-        }),
-        "displays the right content"
-      );
-    });
+module("Unit | Notification Types | group-message-summary", function (hooks) {
+  setupTest(hooks);
 
-    test("linkHref", function (assert) {
-      const notification = getNotification();
-      const director = createRenderDirector(
-        notification,
-        "group_message_summary",
-        this.siteSettings
-      );
-      assert.strictEqual(
-        director.linkHref,
-        "/u/drummers.boss/messages/group/drummers",
-        "links to the group inbox in the user profile"
-      );
-    });
-  }
-);
+  test("description", function (assert) {
+    const notification = getNotification();
+    const director = createRenderDirector(
+      notification,
+      "group_message_summary",
+      this.siteSettings
+    );
+    assert.strictEqual(
+      director.description,
+      I18n.t("notifications.group_message_summary", {
+        group_name: "drummers",
+        count: 13,
+      }),
+      "displays the right content"
+    );
+  });
+
+  test("linkHref", function (assert) {
+    const notification = getNotification();
+    const director = createRenderDirector(
+      notification,
+      "group_message_summary",
+      this.siteSettings
+    );
+    assert.strictEqual(
+      director.linkHref,
+      "/u/drummers.boss/messages/group/drummers",
+      "links to the group inbox in the user profile"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/liked-consolidated-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/liked-consolidated-test.js
@@ -1,10 +1,10 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { deepMerge } from "discourse-common/lib/object";
 import { createRenderDirector } from "discourse/tests/helpers/notification-types-helper";
 import Notification from "discourse/models/notification";
 import I18n from "I18n";
+import { setupTest } from "ember-qunit";
 
 function getNotification(overrides = {}) {
   return Notification.create(
@@ -31,7 +31,9 @@ function getNotification(overrides = {}) {
   );
 }
 
-discourseModule("Unit | Notification Types | liked-consolidated", function () {
+module("Unit | Notification Types | liked-consolidated", function (hooks) {
+  setupTest(hooks);
+
   test("linkHref", function (assert) {
     const notification = getNotification();
     const director = createRenderDirector(

--- a/app/assets/javascripts/discourse/tests/unit/lib/notification-types/liked-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/notification-types/liked-test.js
@@ -1,10 +1,10 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { deepMerge } from "discourse-common/lib/object";
 import { createRenderDirector } from "discourse/tests/helpers/notification-types-helper";
 import Notification from "discourse/models/notification";
 import I18n from "I18n";
+import { setupTest } from "ember-qunit";
 
 function getNotification(overrides = {}) {
   return Notification.create(
@@ -33,7 +33,9 @@ function getNotification(overrides = {}) {
   );
 }
 
-discourseModule("Unit | Notification Types | liked", function () {
+module("Unit | Notification Types | liked", function (hooks) {
+  setupTest(hooks);
+
   test("label", function (assert) {
     const notification = getNotification();
     const director = createRenderDirector(

--- a/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
@@ -1,10 +1,13 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import EmberObject from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupTest } from "ember-qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
 
-discourseModule("Unit | Utility | plugin-api", function () {
+module("Unit | Utility | plugin-api", function (hooks) {
+  setupTest(hooks);
+
   test("modifyClass works with classic Ember objects", function (assert) {
     const TestThingy = EmberObject.extend({
       @discourseComputed
@@ -13,7 +16,7 @@ discourseModule("Unit | Utility | plugin-api", function () {
       },
     });
 
-    this.registry.register("test-thingy:main", TestThingy);
+    getOwner(this).register("test-thingy:main", TestThingy);
 
     withPluginApi("1.1.0", (api) => {
       api.modifyClass("test-thingy:main", {
@@ -26,7 +29,7 @@ discourseModule("Unit | Utility | plugin-api", function () {
       });
     });
 
-    const thingy = this.container.lookup("test-thingy:main");
+    const thingy = getOwner(this).lookup("test-thingy:main");
     assert.strictEqual(thingy.prop, "hello there");
   });
 
@@ -38,7 +41,7 @@ discourseModule("Unit | Utility | plugin-api", function () {
       }
     }
 
-    this.registry.register("native-test-thingy:main", NativeTestThingy);
+    getOwner(this).register("native-test-thingy:main", NativeTestThingy);
 
     withPluginApi("1.1.0", (api) => {
       api.modifyClass("native-test-thingy:main", {
@@ -51,7 +54,7 @@ discourseModule("Unit | Utility | plugin-api", function () {
       });
     });
 
-    const thingy = this.container.lookup("native-test-thingy:main");
+    const thingy = getOwner(this).lookup("native-test-thingy:main");
     assert.strictEqual(thingy.prop, "howdy partner");
   });
 
@@ -66,7 +69,7 @@ discourseModule("Unit | Utility | plugin-api", function () {
       }
     }
 
-    this.registry.register("class-test-thingy:main", new ClassTestThingy(), {
+    getOwner(this).register("class-test-thingy:main", new ClassTestThingy(), {
       instantiate: false,
     });
 
@@ -80,7 +83,7 @@ discourseModule("Unit | Utility | plugin-api", function () {
       });
     });
 
-    const thingy = this.container.lookup("class-test-thingy:main");
+    const thingy = getOwner(this).lookup("class-test-thingy:main");
     assert.strictEqual(thingy.keep, "hey!");
     assert.strictEqual(thingy.prop, "g'day");
   });

--- a/app/assets/javascripts/discourse/tests/unit/lib/reviewable-types/flagged-post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/reviewable-types/flagged-post-test.js
@@ -1,10 +1,10 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import { createRenderDirector } from "discourse/tests/helpers/reviewable-types-helper";
 import { htmlSafe } from "@ember/template";
 import { emojiUnescape } from "discourse/lib/text";
 import UserMenuReviewable from "discourse/models/user-menu-reviewable";
 import I18n from "I18n";
+import { setupTest } from "ember-qunit";
 
 function getReviewable(overrides = {}) {
   return UserMenuReviewable.create(
@@ -22,7 +22,9 @@ function getReviewable(overrides = {}) {
   );
 }
 
-discourseModule("Unit | Reviewable Items | flagged-post", function () {
+module("Unit | Reviewable Items | flagged-post", function (hooks) {
+  setupTest(hooks);
+
   test("description", function (assert) {
     const reviewable = getReviewable({
       topic_fancy_title: "This is safe title &lt;a&gt; :heart:",

--- a/app/assets/javascripts/discourse/tests/unit/lib/reviewable-types/queued-post-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/reviewable-types/queued-post-test.js
@@ -1,10 +1,10 @@
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import { createRenderDirector } from "discourse/tests/helpers/reviewable-types-helper";
 import { htmlSafe } from "@ember/template";
 import { emojiUnescape } from "discourse/lib/text";
 import UserMenuReviewable from "discourse/models/user-menu-reviewable";
 import I18n from "I18n";
+import { setupTest } from "ember-qunit";
 
 function getReviewable(overrides = {}) {
   return UserMenuReviewable.create(
@@ -21,7 +21,9 @@ function getReviewable(overrides = {}) {
   );
 }
 
-discourseModule("Unit | Reviewable Items | queued-post", function () {
+module("Unit | Reviewable Items | queued-post", function (hooks) {
+  setupTest(hooks);
+
   test("description", function (assert) {
     const reviewable = getReviewable({
       topic_fancy_title: "This is safe title &lt;a&gt; :heart:",

--- a/app/assets/javascripts/discourse/tests/unit/lib/time-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/time-utils-test.js
@@ -1,8 +1,4 @@
-import {
-  discourseModule,
-  withFrozenTime,
-} from "discourse/tests/helpers/qunit-helpers";
-
+import { withFrozenTime } from "discourse/tests/helpers/qunit-helpers";
 import {
   laterThisWeek,
   laterToday,
@@ -10,11 +6,14 @@ import {
   startOfDay,
   tomorrow,
 } from "discourse/lib/time-utils";
-import { test } from "qunit";
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
 
 const timezone = "Australia/Brisbane";
 
-discourseModule("Unit | lib | timeUtils", function () {
+module("Unit | lib | timeUtils", function (hooks) {
+  setupTest(hooks);
+
   test("nextMonth gets next month correctly", function (assert) {
     withFrozenTime("2019-12-11T08:00:00", timezone, () => {
       assert.strictEqual(

--- a/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/uploads-test.js
@@ -11,11 +11,18 @@ import {
 } from "discourse/lib/uploads";
 import I18n from "I18n";
 import User from "discourse/models/user";
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import sinon from "sinon";
-import { test } from "qunit";
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
 
-discourseModule("Unit | Utility | uploads", function () {
+module("Unit | Utility | uploads", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.siteSettings = getOwner(this).lookup("service:site-settings");
+  });
+
   test("validateUploadedFiles", function (assert) {
     assert.notOk(
       validateUploadedFiles(null, { siteSettings: this.siteSettings }),

--- a/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/utilities-test.js
@@ -1,4 +1,3 @@
-import { Promise } from "rsvp";
 import {
   avatarImg,
   avatarUrl,
@@ -20,18 +19,19 @@ import {
   toAsciiPrintable,
 } from "discourse/lib/utilities";
 import sinon from "sinon";
-import { test } from "qunit";
+import { module, test } from "qunit";
 import Handlebars from "handlebars";
-import {
-  chromeTest,
-  discourseModule,
-} from "discourse/tests/helpers/qunit-helpers";
+import { chromeTest } from "discourse/tests/helpers/qunit-helpers";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupURL } from "discourse-common/lib/get-url";
+import { setupTest } from "ember-qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
 
-discourseModule("Unit | Utilities", function () {
+module("Unit | Utilities", function (hooks) {
+  setupTest(hooks);
+
   test("escapeExpression", function (assert) {
     assert.strictEqual(
       escapeExpression(">"),
@@ -161,7 +161,10 @@ discourseModule("Unit | Utilities", function () {
     meta.name = "discourse_current_homepage";
     meta.content = "hot";
     document.body.appendChild(meta);
-    initializeDefaultHomepage(this.siteSettings);
+
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+    initializeDefaultHomepage(siteSettings);
+
     assert.strictEqual(
       defaultHomepage(),
       "hot",
@@ -171,8 +174,10 @@ discourseModule("Unit | Utilities", function () {
   });
 
   test("defaultHomepage via site settings", function (assert) {
-    this.siteSettings.top_menu = "top|latest|hot";
-    initializeDefaultHomepage(this.siteSettings);
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+    siteSettings.top_menu = "top|latest|hot";
+    initializeDefaultHomepage(siteSettings);
+
     assert.strictEqual(
       defaultHomepage(),
       "top",
@@ -181,8 +186,11 @@ discourseModule("Unit | Utilities", function () {
   });
 
   test("setDefaultHomepage", function (assert) {
-    initializeDefaultHomepage(this.siteSettings);
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+    initializeDefaultHomepage(siteSettings);
+
     assert.strictEqual(defaultHomepage(), "latest");
+
     setDefaultHomepage("top");
     assert.strictEqual(defaultHomepage(), "top");
   });
@@ -346,75 +354,71 @@ discourseModule("Unit | Utilities", function () {
       "it correctly merges lists that share common items"
     );
   });
+});
 
-  discourseModule("modKeysPressed", function (hooks) {
-    setupRenderingTest(hooks);
+module("Unit | Utilities | modKeysPressed", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("returns an array of modifier keys pressed during keyboard or mouse event", async function (assert) {
-      let i = 0;
+  test("returns an array of modifier keys pressed during keyboard or mouse event", async function (assert) {
+    let i = 0;
 
-      this.handleClick = (event) => {
-        if (i === 0) {
-          assert.deepEqual(modKeysPressed(event), []);
-        } else if (i === 1) {
-          assert.deepEqual(modKeysPressed(event), ["alt"]);
-        } else if (i === 2) {
-          assert.deepEqual(modKeysPressed(event), ["shift"]);
-        } else if (i === 3) {
-          assert.deepEqual(modKeysPressed(event), ["meta"]);
-        } else if (i === 4) {
-          assert.deepEqual(modKeysPressed(event), ["ctrl"]);
-        } else if (i === 5) {
-          assert.deepEqual(modKeysPressed(event), [
-            "alt",
-            "shift",
-            "meta",
-            "ctrl",
-          ]);
-        }
-      };
+    this.handleClick = (event) => {
+      if (i === 0) {
+        assert.deepEqual(modKeysPressed(event), []);
+      } else if (i === 1) {
+        assert.deepEqual(modKeysPressed(event), ["alt"]);
+      } else if (i === 2) {
+        assert.deepEqual(modKeysPressed(event), ["shift"]);
+      } else if (i === 3) {
+        assert.deepEqual(modKeysPressed(event), ["meta"]);
+      } else if (i === 4) {
+        assert.deepEqual(modKeysPressed(event), ["ctrl"]);
+      } else if (i === 5) {
+        assert.deepEqual(modKeysPressed(event), [
+          "alt",
+          "shift",
+          "meta",
+          "ctrl",
+        ]);
+      }
+    };
 
-      await render(hbs`<button id="btn" {{on "click" this.handleClick}} />`);
+    await render(hbs`<button id="btn" {{on "click" this.handleClick}} />`);
 
-      await click("#btn");
-      i++;
-      await click("#btn", { altKey: true });
-      i++;
-      await click("#btn", { shiftKey: true });
-      i++;
-      await click("#btn", { metaKey: true });
-      i++;
-      await click("#btn", { ctrlKey: true });
-      i++;
-      await click("#btn", {
-        altKey: true,
-        shiftKey: true,
-        metaKey: true,
-        ctrlKey: true,
-      });
+    await click("#btn");
+    i++;
+    await click("#btn", { altKey: true });
+    i++;
+    await click("#btn", { shiftKey: true });
+    i++;
+    await click("#btn", { metaKey: true });
+    i++;
+    await click("#btn", { ctrlKey: true });
+    i++;
+    await click("#btn", {
+      altKey: true,
+      shiftKey: true,
+      metaKey: true,
+      ctrlKey: true,
     });
   });
 });
 
-discourseModule("Unit | Utilities | clipboard", function (hooks) {
-  let mockClipboard;
+module("Unit | Utilities | clipboard", function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
-    mockClipboard = {
+    this.mockClipboard = {
       writeText: sinon.stub().resolves(true),
       write: sinon.stub().resolves(true),
     };
-    sinon.stub(window.navigator, "clipboard").get(() => mockClipboard);
+    sinon.stub(window.navigator, "clipboard").get(() => this.mockClipboard);
   });
 
-  function getPromiseFunction() {
-    return () =>
-      new Promise((resolve) => {
-        resolve(
-          new Blob(["some text to copy"], {
-            type: "text/plain",
-          })
-        );
-      });
+  async function asyncFunction() {
+    return new Blob(["some text to copy"], {
+      type: "text/plain",
+    });
   }
 
   test("clipboardCopyAsync - browser does not support window.ClipboardItem", async function (assert) {
@@ -423,9 +427,9 @@ discourseModule("Unit | Utilities | clipboard", function (hooks) {
       sinon.stub(window, "ClipboardItem").value(null);
     }
 
-    await clipboardCopyAsync(getPromiseFunction());
+    await clipboardCopyAsync(asyncFunction);
     assert.strictEqual(
-      mockClipboard.writeText.calledWith("some text to copy"),
+      this.mockClipboard.writeText.calledWith("some text to copy"),
       true,
       "it writes to the clipboard using writeText instead of write"
     );
@@ -434,9 +438,9 @@ discourseModule("Unit | Utilities | clipboard", function (hooks) {
   chromeTest(
     "clipboardCopyAsync - browser does support window.ClipboardItem",
     async function (assert) {
-      await clipboardCopyAsync(getPromiseFunction());
+      await clipboardCopyAsync(asyncFunction);
       assert.strictEqual(
-        mockClipboard.write.called,
+        this.mockClipboard.write.called,
         true,
         "it writes to the clipboard using write"
       );

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -1,10 +1,9 @@
-import { test } from "qunit";
+import { module, test } from "qunit";
 import DiscourseURL from "discourse/lib/url";
 import { getProperties } from "@ember/object";
 import Category from "discourse/models/category";
 import MessageBus from "message-bus-client";
 import {
-  discourseModule,
   fakeTime,
   publishToMessageBus,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -13,8 +12,11 @@ import TopicTrackingState from "discourse/models/topic-tracking-state";
 import User from "discourse/models/user";
 import sinon from "sinon";
 import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
 
-discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
+module("Unit | Model | topic-tracking-state", function (hooks) {
+  setupTest(hooks);
+
   hooks.beforeEach(function () {
     this.clock = fakeTime("2012-12-31 12:00");
     this.store = getOwner(this).lookup("service:store");
@@ -489,381 +491,6 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     );
   });
 
-  discourseModule(
-    "establishChannels - /unread MessageBus channel payloads processed",
-    function (unreadHooks) {
-      let trackingState;
-      let unreadTopicPayload = {
-        topic_id: 111,
-        message_type: "unread",
-        payload: {
-          category_id: 123,
-          topic_tag_ids: [44],
-          tags: ["pending"],
-          highest_post_number: 10,
-          created_at: "2012-11-31 12:00:00 UTC",
-          archetype: "regular",
-        },
-      };
-      let currentUser;
-
-      unreadHooks.beforeEach(function () {
-        currentUser = User.create({
-          username: "chuck",
-        });
-        User.resetCurrent(currentUser);
-
-        trackingState = TopicTrackingState.create({
-          messageBus: MessageBus,
-          currentUser,
-          siteSettings: this.siteSettings,
-        });
-        trackingState.establishChannels();
-        trackingState.loadStates([
-          {
-            topic_id: 111,
-            last_read_post_number: 4,
-            highest_post_number: 4,
-            notification_level: NotificationLevels.TRACKING,
-          },
-        ]);
-      });
-
-      test("message count is incremented", async function (assert) {
-        await publishToMessageBus(`/unread`, unreadTopicPayload);
-
-        assert.strictEqual(
-          trackingState.messageCount,
-          1,
-          "message count incremented"
-        );
-      });
-
-      test("state is modified and callback is called", async function (assert) {
-        let stateCallbackCalled = 0;
-
-        trackingState.onStateChange(() => {
-          stateCallbackCalled += 1;
-        });
-
-        await publishToMessageBus(`/unread`, unreadTopicPayload);
-
-        assert.deepEqual(
-          trackingState.findState(111),
-          {
-            topic_id: 111,
-            category_id: 123,
-            topic_tag_ids: [44],
-            tags: ["pending"],
-            last_read_post_number: 4,
-            highest_post_number: 10,
-            notification_level: NotificationLevels.TRACKING,
-            created_at: "2012-11-31 12:00:00 UTC",
-            archetype: "regular",
-          },
-          "topic state updated"
-        );
-
-        assert.strictEqual(
-          stateCallbackCalled,
-          1,
-          "state change callback called"
-        );
-      });
-
-      test("adds incoming so it is counted in topic lists", async function (assert) {
-        trackingState.trackIncoming("all");
-        await publishToMessageBus(`/unread`, unreadTopicPayload);
-
-        assert.deepEqual(
-          trackingState.newIncoming,
-          [111],
-          "unread topic is incoming"
-        );
-        assert.strictEqual(
-          trackingState.incomingCount,
-          1,
-          "incoming count is increased"
-        );
-      });
-
-      test("correct tag and category filters for different lists", function (assert) {
-        trackingState.trackIncoming("unread");
-        assert.strictEqual(trackingState.filterCategory, undefined);
-        assert.strictEqual(trackingState.filterTag, undefined);
-        assert.strictEqual(trackingState.filter, "unread");
-
-        trackingState.trackIncoming("tag/test/l/latest");
-        assert.strictEqual(trackingState.filterCategory, undefined);
-        assert.strictEqual(trackingState.filterTag, "test");
-        assert.strictEqual(trackingState.filter, "latest");
-
-        trackingState.trackIncoming("c/cat/sub-cat/6/l/latest");
-        assert.strictEqual(trackingState.filterCategory.id, 6);
-        assert.strictEqual(trackingState.filterTag, undefined);
-        assert.strictEqual(trackingState.filter, "latest");
-
-        trackingState.trackIncoming("tags/c/cat/sub-cat/6/test/l/latest");
-        assert.strictEqual(trackingState.filterCategory.id, 6);
-        assert.strictEqual(trackingState.filterTag, "test");
-        assert.strictEqual(trackingState.filter, "latest");
-      });
-
-      test("correctly infers missing information", async function (assert) {
-        await publishToMessageBus(`/unread`, {
-          ...unreadTopicPayload,
-          topic_id: 999,
-        });
-        assert.deepEqual(
-          trackingState.findState(999),
-          {
-            category_id: 123,
-            topic_tag_ids: [44],
-            tags: ["pending"],
-            last_read_post_number: 9,
-            highest_post_number: 10,
-            notification_level: NotificationLevels.TRACKING,
-            created_at: "2012-11-31 12:00:00 UTC",
-            archetype: "regular",
-          },
-          "topic state updated with guesses for last_read_post_number and notification_level"
-        );
-      });
-
-      test("adds incoming in the categories latest topics list", async function (assert) {
-        trackingState.trackIncoming("categories");
-        const unreadCategoriesLatestTopicsPayload = {
-          ...unreadTopicPayload,
-          message_type: "latest",
-        };
-
-        await publishToMessageBus(
-          `/latest`,
-          unreadCategoriesLatestTopicsPayload
-        );
-        assert.deepEqual(
-          trackingState.newIncoming,
-          [111],
-          "unread topic is incoming"
-        );
-        assert.strictEqual(
-          trackingState.incomingCount,
-          1,
-          "incoming count is increased"
-        );
-      });
-
-      test("dismisses new topic", async function (assert) {
-        trackingState.loadStates([
-          {
-            last_read_post_number: null,
-            topic_id: 112,
-            notification_level: NotificationLevels.TRACKING,
-            category_id: 1,
-            is_seen: false,
-            tags: ["foo"],
-          },
-        ]);
-
-        await publishToMessageBus(`/unread/${currentUser.id}`, {
-          message_type: "dismiss_new",
-          payload: { topic_ids: [112] },
-        });
-
-        assert.strictEqual(trackingState.findState(112).is_seen, true);
-      });
-
-      test("marks a topic as read", async function (assert) {
-        trackingState.loadStates([
-          {
-            last_read_post_number: null,
-            topic_id: 112,
-            notification_level: NotificationLevels.TRACKING,
-            category_id: 1,
-            is_seen: false,
-            tags: ["foo"],
-          },
-        ]);
-        await publishToMessageBus(`/unread/${currentUser.id}`, {
-          message_type: "read",
-          topic_id: 112,
-          payload: {
-            last_read_post_number: 4,
-            highest_post_number: 4,
-            notification_level: NotificationLevels.TRACKING,
-          },
-        });
-
-        assert.propEqual(
-          getProperties(
-            trackingState.findState(112),
-            "highest_post_number",
-            "last_read_post_number"
-          ),
-          { highest_post_number: 4, last_read_post_number: 4 },
-          "highest_post_number and last_read_post_number are set for a topic"
-        );
-        assert.deepEqual(
-          trackingState.findState(112).tags,
-          ["foo"],
-          "tags are not accidentally cleared"
-        );
-      });
-    }
-  );
-
-  discourseModule(
-    "establishChannels - /new MessageBus channel payloads processed",
-    function (establishChannelsHooks) {
-      let trackingState;
-      let newTopicPayload = {
-        topic_id: 222,
-        message_type: "new_topic",
-        payload: {
-          category_id: 123,
-          topic_tag_ids: [44],
-          tags: ["pending"],
-          last_read_post_number: null,
-          highest_post_number: 1,
-          created_at: "2012-11-31 12:00:00 UTC",
-          archetype: "regular",
-        },
-      };
-      let currentUser;
-
-      establishChannelsHooks.beforeEach(function () {
-        currentUser = User.create({
-          username: "chuck",
-        });
-        User.resetCurrent(currentUser);
-
-        trackingState = TopicTrackingState.create({
-          messageBus: MessageBus,
-          currentUser,
-          siteSettings: this.siteSettings,
-        });
-        trackingState.establishChannels();
-      });
-
-      test("topics in muted categories do not get added to the state", async function (assert) {
-        trackingState.currentUser.set("muted_category_ids", [123]);
-        await publishToMessageBus("/new", newTopicPayload);
-
-        assert.strictEqual(
-          trackingState.findState(222),
-          undefined,
-          "the new topic is not in the state"
-        );
-      });
-
-      test("topics in indirectly muted categories do not get added to the state", async function (assert) {
-        trackingState.currentUser.setProperties({
-          muted_category_ids: [],
-          indirectly_muted_category_ids: [123],
-        });
-        await publishToMessageBus("/new", newTopicPayload);
-
-        assert.strictEqual(
-          trackingState.findState(222),
-          undefined,
-          "the new topic is not in the state"
-        );
-      });
-
-      test("watched topics in muted categories are added to the state", async function (assert) {
-        trackingState.currentUser.setProperties({
-          muted_category_ids: [123],
-        });
-
-        trackingState.trackMutedOrUnmutedTopic({
-          topic_id: 222,
-          message_type: "unmuted",
-        });
-
-        await publishToMessageBus("/new", newTopicPayload);
-
-        assert.deepEqual(
-          trackingState.findState(222),
-          {
-            category_id: 123,
-            topic_tag_ids: [44],
-            tags: ["pending"],
-            last_read_post_number: null,
-            highest_post_number: 1,
-            created_at: "2012-11-31 12:00:00 UTC",
-            archetype: "regular",
-          },
-          "topic state updated"
-        );
-      });
-
-      test("topics in muted tags do not get added to the state", async function (assert) {
-        trackingState.currentUser.set("muted_tags", ["pending"]);
-
-        await publishToMessageBus("/new", newTopicPayload);
-
-        assert.strictEqual(
-          trackingState.findState(222),
-          undefined,
-          "the new topic is not in the state"
-        );
-      });
-
-      test("message count is incremented", async function (assert) {
-        await publishToMessageBus("/new", newTopicPayload);
-
-        assert.strictEqual(
-          trackingState.messageCount,
-          1,
-          "message count incremented"
-        );
-      });
-
-      test("state is modified and callback is called", async function (assert) {
-        let stateCallbackCalled = false;
-        trackingState.onStateChange(() => {
-          stateCallbackCalled = true;
-        });
-        await publishToMessageBus("/new", newTopicPayload);
-
-        assert.deepEqual(
-          trackingState.findState(222),
-          {
-            category_id: 123,
-            topic_tag_ids: [44],
-            tags: ["pending"],
-            last_read_post_number: null,
-            highest_post_number: 1,
-            created_at: "2012-11-31 12:00:00 UTC",
-            archetype: "regular",
-          },
-          "new topic loaded into state"
-        );
-        assert.strictEqual(
-          stateCallbackCalled,
-          true,
-          "state change callback called"
-        );
-      });
-
-      test("adds incoming so it is counted in topic lists", async function (assert) {
-        trackingState.trackIncoming("all");
-        await publishToMessageBus("/new", newTopicPayload);
-
-        assert.deepEqual(
-          trackingState.newIncoming,
-          [222],
-          "new topic is incoming"
-        );
-        assert.strictEqual(
-          trackingState.incomingCount,
-          1,
-          "incoming count is increased"
-        );
-      });
-    }
-  );
-
   test("establishChannels - /delete MessageBus channel payloads processed", async function (assert) {
     const trackingState = TopicTrackingState.create({ messageBus: MessageBus });
     trackingState.establishChannels();
@@ -1060,7 +687,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     });
     sinon.stub(Category, "list").returns([foo, bar, baz, qux]);
 
-    let currentUser = User.create({
+    let currentUser = this.store.createRecord("user", {
       username: "chuck",
       muted_category_ids: [4],
     });
@@ -1141,7 +768,7 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
   });
 
   test("mute and unmute topic", function (assert) {
-    let currentUser = User.create({
+    let currentUser = this.store.createRecord("user", {
       username: "chuck",
       muted_category_ids: [],
     });
@@ -1168,5 +795,373 @@ discourseModule("Unit | Model | topic-tracking-state", function (hooks) {
     trackingState.pruneOldMutedAndUnmutedTopics();
     assert.strictEqual(trackingState.isMutedTopic(1), false);
     assert.strictEqual(trackingState.isUnmutedTopic(2), false);
+  });
+});
+
+module("Unit | Model | topic-tracking-state | /unread", function (hooks) {
+  setupTest(hooks);
+
+  const unreadTopicPayload = {
+    topic_id: 111,
+    message_type: "unread",
+    payload: {
+      category_id: 123,
+      topic_tag_ids: [44],
+      tags: ["pending"],
+      highest_post_number: 10,
+      created_at: "2012-11-31 12:00:00 UTC",
+      archetype: "regular",
+    },
+  };
+
+  hooks.beforeEach(function () {
+    const store = getOwner(this).lookup("service:store");
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+
+    this.currentUser = store.createRecord("user", {
+      username: "chuck",
+    });
+    User.resetCurrent(this.currentUser);
+
+    this.trackingState = TopicTrackingState.create({
+      currentUser: this.currentUser,
+      messageBus: MessageBus,
+      siteSettings,
+    });
+    this.trackingState.establishChannels();
+    this.trackingState.loadStates([
+      {
+        topic_id: 111,
+        last_read_post_number: 4,
+        highest_post_number: 4,
+        notification_level: NotificationLevels.TRACKING,
+      },
+    ]);
+  });
+
+  test("message count is incremented", async function (assert) {
+    await publishToMessageBus(`/unread`, unreadTopicPayload);
+
+    assert.strictEqual(
+      this.trackingState.messageCount,
+      1,
+      "message count incremented"
+    );
+  });
+
+  test("state is modified and callback is called", async function (assert) {
+    let stateCallbackCalled = 0;
+
+    this.trackingState.onStateChange(() => {
+      stateCallbackCalled += 1;
+    });
+
+    await publishToMessageBus(`/unread`, unreadTopicPayload);
+
+    assert.deepEqual(
+      this.trackingState.findState(111),
+      {
+        topic_id: 111,
+        category_id: 123,
+        topic_tag_ids: [44],
+        tags: ["pending"],
+        last_read_post_number: 4,
+        highest_post_number: 10,
+        notification_level: NotificationLevels.TRACKING,
+        created_at: "2012-11-31 12:00:00 UTC",
+        archetype: "regular",
+      },
+      "topic state updated"
+    );
+
+    assert.strictEqual(stateCallbackCalled, 1, "state change callback called");
+  });
+
+  test("adds incoming so it is counted in topic lists", async function (assert) {
+    this.trackingState.trackIncoming("all");
+    await publishToMessageBus(`/unread`, unreadTopicPayload);
+
+    assert.deepEqual(
+      this.trackingState.newIncoming,
+      [111],
+      "unread topic is incoming"
+    );
+    assert.strictEqual(
+      this.trackingState.incomingCount,
+      1,
+      "incoming count is increased"
+    );
+  });
+
+  test("correct tag and category filters for different lists", function (assert) {
+    this.trackingState.trackIncoming("unread");
+    assert.strictEqual(this.trackingState.filterCategory, undefined);
+    assert.strictEqual(this.trackingState.filterTag, undefined);
+    assert.strictEqual(this.trackingState.filter, "unread");
+
+    this.trackingState.trackIncoming("tag/test/l/latest");
+    assert.strictEqual(this.trackingState.filterCategory, undefined);
+    assert.strictEqual(this.trackingState.filterTag, "test");
+    assert.strictEqual(this.trackingState.filter, "latest");
+
+    this.trackingState.trackIncoming("c/cat/sub-cat/6/l/latest");
+    assert.strictEqual(this.trackingState.filterCategory.id, 6);
+    assert.strictEqual(this.trackingState.filterTag, undefined);
+    assert.strictEqual(this.trackingState.filter, "latest");
+
+    this.trackingState.trackIncoming("tags/c/cat/sub-cat/6/test/l/latest");
+    assert.strictEqual(this.trackingState.filterCategory.id, 6);
+    assert.strictEqual(this.trackingState.filterTag, "test");
+    assert.strictEqual(this.trackingState.filter, "latest");
+  });
+
+  test("correctly infers missing information", async function (assert) {
+    await publishToMessageBus(`/unread`, {
+      ...unreadTopicPayload,
+      topic_id: 999,
+    });
+    assert.deepEqual(
+      this.trackingState.findState(999),
+      {
+        category_id: 123,
+        topic_tag_ids: [44],
+        tags: ["pending"],
+        last_read_post_number: 9,
+        highest_post_number: 10,
+        notification_level: NotificationLevels.TRACKING,
+        created_at: "2012-11-31 12:00:00 UTC",
+        archetype: "regular",
+      },
+      "topic state updated with guesses for last_read_post_number and notification_level"
+    );
+  });
+
+  test("adds incoming in the categories latest topics list", async function (assert) {
+    this.trackingState.trackIncoming("categories");
+    const unreadCategoriesLatestTopicsPayload = {
+      ...unreadTopicPayload,
+      message_type: "latest",
+    };
+
+    await publishToMessageBus(`/latest`, unreadCategoriesLatestTopicsPayload);
+    assert.deepEqual(
+      this.trackingState.newIncoming,
+      [111],
+      "unread topic is incoming"
+    );
+    assert.strictEqual(
+      this.trackingState.incomingCount,
+      1,
+      "incoming count is increased"
+    );
+  });
+
+  test("dismisses new topic", async function (assert) {
+    this.trackingState.loadStates([
+      {
+        last_read_post_number: null,
+        topic_id: 112,
+        notification_level: NotificationLevels.TRACKING,
+        category_id: 1,
+        is_seen: false,
+        tags: ["foo"],
+      },
+    ]);
+
+    await publishToMessageBus(`/unread/${this.currentUser.id}`, {
+      message_type: "dismiss_new",
+      payload: { topic_ids: [112] },
+    });
+
+    assert.strictEqual(this.trackingState.findState(112).is_seen, true);
+  });
+
+  test("marks a topic as read", async function (assert) {
+    this.trackingState.loadStates([
+      {
+        last_read_post_number: null,
+        topic_id: 112,
+        notification_level: NotificationLevels.TRACKING,
+        category_id: 1,
+        is_seen: false,
+        tags: ["foo"],
+      },
+    ]);
+    await publishToMessageBus(`/unread/${this.currentUser.id}`, {
+      message_type: "read",
+      topic_id: 112,
+      payload: {
+        last_read_post_number: 4,
+        highest_post_number: 4,
+        notification_level: NotificationLevels.TRACKING,
+      },
+    });
+
+    assert.propEqual(
+      getProperties(
+        this.trackingState.findState(112),
+        "highest_post_number",
+        "last_read_post_number"
+      ),
+      { highest_post_number: 4, last_read_post_number: 4 },
+      "highest_post_number and last_read_post_number are set for a topic"
+    );
+    assert.deepEqual(
+      this.trackingState.findState(112).tags,
+      ["foo"],
+      "tags are not accidentally cleared"
+    );
+  });
+});
+
+module("Unit | Model | topic-tracking-state | /new", function (hooks) {
+  setupTest(hooks);
+
+  const newTopicPayload = {
+    topic_id: 222,
+    message_type: "new_topic",
+    payload: {
+      category_id: 123,
+      topic_tag_ids: [44],
+      tags: ["pending"],
+      last_read_post_number: null,
+      highest_post_number: 1,
+      created_at: "2012-11-31 12:00:00 UTC",
+      archetype: "regular",
+    },
+  };
+
+  hooks.beforeEach(function () {
+    const store = getOwner(this).lookup("service:store");
+    const siteSettings = getOwner(this).lookup("service:site-settings");
+
+    this.currentUser = store.createRecord("user", {
+      username: "chuck",
+    });
+    User.resetCurrent(this.currentUser);
+
+    this.trackingState = TopicTrackingState.create({
+      currentUser: this.currentUser,
+      messageBus: MessageBus,
+      siteSettings,
+    });
+    this.trackingState.establishChannels();
+  });
+
+  test("topics in muted categories do not get added to the state", async function (assert) {
+    this.currentUser.set("muted_category_ids", [123]);
+    await publishToMessageBus("/new", newTopicPayload);
+
+    assert.strictEqual(
+      this.trackingState.findState(222),
+      undefined,
+      "the new topic is not in the state"
+    );
+  });
+
+  test("topics in indirectly muted categories do not get added to the state", async function (assert) {
+    this.currentUser.setProperties({
+      muted_category_ids: [],
+      indirectly_muted_category_ids: [123],
+    });
+    await publishToMessageBus("/new", newTopicPayload);
+
+    assert.strictEqual(
+      this.trackingState.findState(222),
+      undefined,
+      "the new topic is not in the state"
+    );
+  });
+
+  test("watched topics in muted categories are added to the state", async function (assert) {
+    this.currentUser.setProperties({
+      muted_category_ids: [123],
+    });
+
+    this.trackingState.trackMutedOrUnmutedTopic({
+      topic_id: 222,
+      message_type: "unmuted",
+    });
+
+    await publishToMessageBus("/new", newTopicPayload);
+
+    assert.deepEqual(
+      this.trackingState.findState(222),
+      {
+        category_id: 123,
+        topic_tag_ids: [44],
+        tags: ["pending"],
+        last_read_post_number: null,
+        highest_post_number: 1,
+        created_at: "2012-11-31 12:00:00 UTC",
+        archetype: "regular",
+      },
+      "topic state updated"
+    );
+  });
+
+  test("topics in muted tags do not get added to the state", async function (assert) {
+    this.currentUser.set("muted_tags", ["pending"]);
+
+    await publishToMessageBus("/new", newTopicPayload);
+
+    assert.strictEqual(
+      this.trackingState.findState(222),
+      undefined,
+      "the new topic is not in the state"
+    );
+  });
+
+  test("message count is incremented", async function (assert) {
+    await publishToMessageBus("/new", newTopicPayload);
+
+    assert.strictEqual(
+      this.trackingState.messageCount,
+      1,
+      "message count incremented"
+    );
+  });
+
+  test("state is modified and callback is called", async function (assert) {
+    let stateCallbackCalled = false;
+    this.trackingState.onStateChange(() => {
+      stateCallbackCalled = true;
+    });
+    await publishToMessageBus("/new", newTopicPayload);
+
+    assert.deepEqual(
+      this.trackingState.findState(222),
+      {
+        category_id: 123,
+        topic_tag_ids: [44],
+        tags: ["pending"],
+        last_read_post_number: null,
+        highest_post_number: 1,
+        created_at: "2012-11-31 12:00:00 UTC",
+        archetype: "regular",
+      },
+      "new topic loaded into state"
+    );
+    assert.strictEqual(
+      stateCallbackCalled,
+      true,
+      "state change callback called"
+    );
+  });
+
+  test("adds incoming so it is counted in topic lists", async function (assert) {
+    this.trackingState.trackIncoming("all");
+    await publishToMessageBus("/new", newTopicPayload);
+
+    assert.deepEqual(
+      this.trackingState.newIncoming,
+      [222],
+      "new topic is incoming"
+    );
+    assert.strictEqual(
+      this.trackingState.incomingCount,
+      1,
+      "incoming count is increased"
+    );
   });
 });

--- a/app/assets/javascripts/discourse/tests/unit/utils/dom-utils-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/utils/dom-utils-test.js
@@ -1,39 +1,33 @@
-import componentTest, {
-  setupRenderingTest,
-} from "discourse/tests/helpers/component-test";
-import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { hbs } from "ember-cli-htmlbars";
 import domUtils from "discourse-common/utils/dom-utils";
+import { module, test } from "qunit";
+import { render } from "@ember/test-helpers";
 
-discourseModule("utils:dom-utils", function (hooks) {
+module("Unit | Utils | dom-utils", function (hooks) {
   setupRenderingTest(hooks);
 
-  componentTest("offset", {
-    template: hbs`{{d-button translatedLabel="baz"}}`,
+  test("offset", async function (assert) {
+    await render(hbs`<DButton @translatedLabel="baz" />`);
+    const element = document.querySelector(".btn");
+    const offset = domUtils.offset(element);
+    const rect = element.getBoundingClientRect();
 
-    async test(assert) {
-      const element = document.querySelector(".btn");
-      const offset = domUtils.offset(element);
-      const rect = element.getBoundingClientRect();
-
-      assert.deepEqual(offset, {
-        top: rect.top + window.scrollY,
-        left: rect.left + window.scrollX,
-      });
-    },
+    assert.deepEqual(offset, {
+      top: rect.top + window.scrollY,
+      left: rect.left + window.scrollX,
+    });
   });
 
-  componentTest("position", {
-    template: hbs`{{d-button translatedLabel="baz"}}`,
+  test("position", async function (assert) {
+    await render(hbs`<DButton @translatedLabel="baz" />`);
 
-    async test(assert) {
-      const element = document.querySelector(".btn");
-      const position = domUtils.position(element);
+    const element = document.querySelector(".btn");
+    const position = domUtils.position(element);
 
-      assert.deepEqual(position, {
-        top: element.offsetTop,
-        left: element.offsetLeft,
-      });
-    },
+    assert.deepEqual(position, {
+      top: element.offsetTop,
+      left: element.offsetLeft,
+    });
   });
 });


### PR DESCRIPTION
QUnit's `module` and `setupTest` is the way

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
