### PR TITLE
DEV: Improve performance of system test `sign_in` helper

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -113,7 +113,12 @@ class SessionController < ApplicationController
       raise "User #{params[:session_id]} not found" if user.blank?
 
       log_on_user(user)
-      redirect_to path("/")
+
+      if params[:redirect] == "false"
+        render plain: "Signed in to #{params[:session_id]} successfully"
+      else
+        redirect_to path("/")
+      end
     end
   end
 

--- a/plugins/chat/spec/system/channel_selector_modal_spec.rb
+++ b/plugins/chat/spec/system/channel_selector_modal_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Channel selector modal", type: :system, js: true do
   before do
     chat_system_bootstrap
     sign_in(current_user)
+    visit("/")
   end
 
   KEY_MODIFIER = RUBY_PLATFORM =~ /darwin/i ? :meta : :control

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe "Navigation", type: :system, js: true do
 
   context "when clicking chat icon and drawer is viewing channel" do
     it "navigates to index" do
+      visit("/")
+
       chat_page.open_from_header
       chat_drawer_page.open_channel(category_channel_2)
       chat_page.open_from_header

--- a/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
+++ b/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe "Sidebar navigation menu", type: :system, js: true do
       end
 
       it "displays all participants names" do
+        visit("/")
         expect(
           page.find(
             ".sidebar-section-chat-dms a.sidebar-section-link:nth-child(1) .sidebar-section-link-content-text",

--- a/plugins/chat/spec/system/unfollow_dm_channel_spec.rb
+++ b/plugins/chat/spec/system/unfollow_dm_channel_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Unfollow dm channel", type: :system, js: true do
 
   context "when receiving a message after unfollowing" do
     it "correctly shows the channel" do
+      visit("/")
       find(".channel-#{dm_channel_1.id}").hover
       find(".channel-#{dm_channel_1.id} .sidebar-section-link-hover").click
 

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
 
       using_session(:user_1) do
         sign_in(other_user)
+        visit("/")
         find(".header-dropdown-toggle.current-user").click
 
         expect(find("#user-menu-button-chat-notifications")).to have_content(1)

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -12,7 +12,7 @@ module SystemHelpers
   end
 
   def sign_in(user)
-    visit "/session/#{user.encoded_username}/become"
+    visit "/session/#{user.encoded_username}/become.json?redirect=false"
   end
 
   def sign_out


### PR DESCRIPTION
Previously, calling `sign_in` would cause the browser to be redirected to `/`, and would cause the Ember app to boot. We would then call `visit()`, causing the app to boot for a second time.

This commit adds a `redirect=false` option to the `/session/username/become` route. This avoids the unnecessary boot of the app, and leads to significantly faster system spec run times.

In local testing, this takes the full system-spec suite for chat from ~6min to ~4min.

A handful of places were relying on the old side-effect, so those have been updated to explicitly call `visit()`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
