### PR TITLE
DEV: Improve chat `system/create_channel_spec`

### DIFF
--- a/plugins/chat/spec/system/create_channel_spec.rb
+++ b/plugins/chat/spec/system/create_channel_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Create channel", type: :system, js: true do
         find(".category-chooser").click
         find(".category-row[data-value=\"#{private_category_1.id}\"]").click
 
+        expect(page).to have_css(".create-channel-hint")
         expect(find(".create-channel-hint")["innerHTML"].strip).to include(
           "&lt;script&gt;e&lt;/script&gt;",
         )


### PR DESCRIPTION
Using `find()["innerHTML"]` doesn't allow any time for Ember to finish rendering. Adding a `have_css` beforehand will wait for the element to be rendered before checking the innerHTML.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
