### PR TITLE
DEV: Do not print verbose `console.debug` messages in system specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -251,7 +251,7 @@ RSpec.configure do |config|
     end
 
     chrome_browser_options = Selenium::WebDriver::Chrome::Options.new(
-      logging_prefs: { "browser" => "ALL", "driver" => "ALL" }
+      logging_prefs: { "browser" => "INFO", "driver" => "ALL" }
     ).tap do |options|
       options.add_argument("--window-size=1400,1400")
       options.add_argument("--no-sandbox")
@@ -404,7 +404,6 @@ RSpec.configure do |config|
         if !skip_js_errors
           puts "~~~~~~ JS ERRORS: ~~~~~~~"
           page.driver.browser.logs.get(:browser).each do |log|
-            next if log.level === "DEBUG"
             puts log.message
           end
         end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -279,7 +279,7 @@ RSpec.configure do |config|
 
     mobile_chrome_browser_options =
       Selenium::WebDriver::Chrome::Options
-        .new(logging_prefs: { "browser" => "ALL", "driver" => "ALL" })
+        .new(logging_prefs: { "browser" => "INFO", "driver" => "ALL" })
         .tap do |options|
           options.add_argument("--window-size=390,950")
           options.add_argument("--no-sandbox")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -404,6 +404,7 @@ RSpec.configure do |config|
         if !skip_js_errors
           puts "~~~~~~ JS ERRORS: ~~~~~~~"
           page.driver.browser.logs.get(:browser).each do |log|
+            next if log.level === "DEBUG"
             puts log.message
           end
         end


### PR DESCRIPTION
Verbose messages are not shown by default in the chrome dev console. This commit applies the same behavior to system specs.

The main motivation here is to hide the version info which Ember prints every time the application boots.

```text
http://localhost:31337/assets/vendor.js 47142:16 "DEBUG: -------------------------------"
http://localhost:31337/assets/vendor.js 47142:16 "DEBUG: Ember  : 3.28.11"
http://localhost:31337/assets/vendor.js 47142:16 "DEBUG: jQuery : 3.6.0"
http://localhost:31337/assets/vendor.js 47142:16 "DEBUG: -------------------------------"
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
