### PR TITLE
PERF: Fix N+1 queries on /categories route

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -62,7 +62,13 @@ class CategoryList
 
     category_featured_topics = CategoryFeaturedTopic.select([:category_id, :topic_id]).order(:rank)
 
-    @all_topics = Topic.where(id: category_featured_topics.map(&:topic_id)).includes(:shared_draft, :category)
+    @all_topics = Topic
+      .where(id: category_featured_topics.map(&:topic_id))
+      .includes(
+        :shared_draft,
+        :category,
+        { topic_thumbnails: [:optimized_image, :upload] }
+      )
 
     @all_topics = @all_topics.joins(:tags).where(tags: { name: @options[:tag] }) if @options[:tag].present?
 
@@ -140,6 +146,7 @@ class CategoryList
     end
 
     allowed_topic_create = Set.new(Category.topic_create_allowed(@guardian).pluck(:id))
+
     categories_with_descendants.each do |category|
       category.notification_level = notification_levels[category.id] || default_notification_level
       category.permission = CategoryGroup.permission_types[:full] if allowed_topic_create.include?(category.id)


### PR DESCRIPTION
Featured topics are eventually serialized by `ListableTopicSerializer`
which calls `Topic#image_url` which requires us to preload
`Topic#topic_thumbnails`.