### PR TITLE
DEV: Fix new features notification flakey specs

### DIFF
--- a/spec/jobs/check_new_features_spec.rb
+++ b/spec/jobs/check_new_features_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Jobs::CheckNewFeatures do
     expect(DiscourseUpdates.get_last_viewed_feature_date(admin1.id).iso8601).to eq(Time.zone.now.iso8601)
   end
 
-  xit "notifies admins about new features that are available in the site's version" do
+  it "notifies admins about new features that are available in the site's version" do
     Notification.destroy_all
 
     described_class.new.execute({})
@@ -90,7 +90,7 @@ RSpec.describe Jobs::CheckNewFeatures do
     ).count).to eq(1)
   end
 
-  xit "consolidates new features notifications" do
+  it "consolidates new features notifications" do
     Notification.destroy_all
 
     described_class.new.execute({})

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -154,6 +154,10 @@ RSpec.describe DiscourseUpdates do
       Discourse.redis.set('new_features', MultiJson.dump(sample_features))
     end
 
+    after do
+      Discourse.redis.del('new_features')
+    end
+
     it 'returns all items on the first run' do
       result = DiscourseUpdates.new_features
 


### PR DESCRIPTION
A few specs in `spec/lib/discourse_updates_spec.rb` were leaking some state in redis that caused the specs in `spec/jobs/check_new_features_spec.rb` to fail.

Related PRs: https://github.com/discourse/discourse/pull/19460 and https://github.com/discourse/discourse/pull/19511.