### PR TITLE
FIX: ensures recovering network doesn't create unread mentions

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -76,7 +76,7 @@ export default class ChatSubscriptionsManager extends Service {
   _onNewMentions(busData) {
     this.chatChannelsManager.find(busData.channel_id).then((channel) => {
       const membership = channel.currentUserMembership;
-      if (membership) {
+      if (busData.message_id > membership?.last_read_message_id) {
         membership.unread_mentions = (membership.unread_mentions || 0) + 1;
       }
     });

--- a/plugins/chat/spec/system/network_reconciliation_spec.rb
+++ b/plugins/chat/spec/system/network_reconciliation_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe "Network reconciliation", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:other_user) { Fabricate(:user) }
+  fab!(:channel_1) { Fabricate(:category_channel) }
+
+  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:chat_channel_page) { PageObjects::Pages::ChatChannel.new }
+
+  before do
+    chat_system_bootstrap
+    channel_1.add(current_user)
+    channel_1.add(other_user)
+  end
+
+  context "when user recovers network" do
+    it "recovers state" do
+      using_session(:disconnected_current_user) do
+        sign_in(current_user)
+        visit("/")
+        page.driver.browser.network_conditions = { offline: true, latency: 0, throughput: 0 }
+      end
+
+      using_session(:other_user) do |session|
+        sign_in(other_user)
+        chat_page.visit_channel(channel_1)
+        chat_channel_page.send_message("hello @#{current_user.username}!")
+        session.quit
+      end
+
+      using_session(:connected_current_user) do |session|
+        sign_in(current_user)
+        visit("/")
+        expect(page).to have_css(".chat-header-icon .chat-channel-unread-indicator")
+        chat_page.visit_channel(channel_1)
+        expect(page).to have_no_css(".chat-header-icon .chat-channel-unread-indicator")
+        session.quit
+      end
+
+      using_session(:disconnected_current_user) do |session|
+        expect(page).to have_no_css(".chat-header-icon .chat-channel-unread-indicator")
+        page.driver.browser.network_conditions = { offline: false, latency: 0, throughput: 0 }
+        expect(page).to have_no_css(".chat-header-icon .chat-channel-unread-indicator")
+
+        # generally speaking sleep should be avoided in tests, but in this case
+        # we need to wait for the client to reconnect and receive the message
+        # right at the start the icon won't be there so checking for not will be true
+        # and checking for present could also be true as it might within capybara finder delay
+        # which is what we are testing here and want to avoid
+        sleep 1
+
+        expect(page).to have_no_css(".chat-header-icon .chat-channel-unread-indicator")
+        session.quit
+      end
+    end
+  end
+end

--- a/plugins/chat/spec/system/network_reconciliation_spec.rb
+++ b/plugins/chat/spec/system/network_reconciliation_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Network reconciliation", type: :system, js: true do
         # generally speaking sleep should be avoided in tests, but in this case
         # we need to wait for the client to reconnect and receive the message
         # right at the start the icon won't be there so checking for not will be true
-        # and checking for present could also be true as it might within capybara finder delay
+        # and checking for present could also be true as it might be within capybara finder delay
         # which is what we are testing here and want to avoid
         sleep 1
 


### PR DESCRIPTION
Prior to this fix, reopening a tab with missed messages would start to receive mentions events and increment `unread_mentions` even for messages which have been read by the user.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
