### PR TITLE
FIX: flakey spec due to autocomplete

### DIFF
--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
     it "displays a mention warning" do
       chat.visit_channel(private_channel_1)
       find(".chat-composer-input").fill_in(with: "hi @#{other_user.username}")
+      find(".chat-composer-input").click
       find(".send-btn").click
 
       expect(page).to have_content(


### PR DESCRIPTION
The autocomplete could show and hide the invite link causing the test to fail. Clicking the composer input forces the autocomplete disappear.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
