### PR TITLE
FIX: increment wait to prevent a specific flakey spec

### DIFF
--- a/plugins/chat/spec/system/channel_members_page_spec.rb
+++ b/plugins/chat/spec/system/channel_members_page_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Channel - Info - Members page", type: :system, js: true do
 
         scroll_to(find(".channel-members-view__list-item:nth-child(50)"))
 
-        expect(page).to have_selector(".channel-members-view__list-item", count: 100)
+        expect(page).to have_selector(".channel-members-view__list-item", count: 100, wait: 5)
 
         scroll_to(find(".channel-members-view__list-item:nth-child(100)"))
 


### PR DESCRIPTION
I could repro the same failure by doing: `page.driver.browser.network_conditions = { offline: false, latency: 3000, throughput: 0 }`

Wait shouldn't be needed as we wait for selector, but I couldn't find a better solution on this case for now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
