### PR TITLE
FIX: Autocomplete fadeout arrow key chat fix

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -377,6 +377,8 @@ export default function (options) {
       me.parent().append(div);
     }
 
+    fadeoutDiv = div.find(".hashtag-autocomplete__fadeout");
+
     if (isInput || options.treatAsTextarea) {
       _autoCompletePopper && _autoCompletePopper.destroy();
       _autoCompletePopper = createPopper(me[0], div[0], {
@@ -450,8 +452,6 @@ export default function (options) {
       top: mePos.top + pos.top - vOffset + borderTop + "px",
       left: left + "px",
     });
-
-    fadeoutDiv = div.find(".hashtag-autocomplete__fadeout");
   }
 
   function dataSource(term, opts) {


### PR DESCRIPTION
Autocomplete with fadeout was not scrolling on arrow key press in chat, since the input is treated slightly differently. We just need to find the fadeout div sooner.

Follow up to 64a7a2aac28f7a37b4d75e800e9931ff275b603c
