### PR TITLE
DEV: permission type for private category fabricator

### DIFF
--- a/plugins/chat/spec/lib/chat_channel_fetcher_spec.rb
+++ b/plugins/chat/spec/lib/chat_channel_fetcher_spec.rb
@@ -139,30 +139,20 @@ describe Chat::ChatChannelFetcher do
 
       context "when restricted category" do
         fab!(:group) { Fabricate(:group) }
-        fab!(:category_group) do
-          Fabricate(
-            :category_group,
-            category: private_category,
-            group: group,
-            permission_type: CategoryGroup.permission_types[:readonly],
-          )
-        end
-        fab!(:group_user) do
-          Fabricate(:group_user, group: private_category.groups.last, user: user1)
-        end
-        before { category_channel.update!(chatable: private_category) }
+        fab!(:group_user) { Fabricate(:group_user, group: group, user: user1) }
 
         it "does not include the category channel for member of group with readonly access" do
+          category_channel.update!(chatable: Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:readonly]))
           expect(subject.all_secured_channel_ids(guardian)).to be_empty
         end
 
         it "includes the category channel for member of group with create_post access" do
-          category_group.update!(permission_type: CategoryGroup.permission_types[:create_post])
+          category_channel.update!(chatable: Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:create_post]))
           expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
         end
 
         it "includes the category channel for member of group with full access" do
-          category_group.update!(permission_type: CategoryGroup.permission_types[:full])
+          category_channel.update!(chatable: Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:full]))
           expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
         end
       end

--- a/plugins/chat/spec/lib/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/guardian_extensions_spec.rb
@@ -88,23 +88,23 @@ RSpec.describe Chat::GuardianExtensions do
       end
 
       context "for category channel" do
-        fab!(:category) { Fabricate(:category, read_restricted: true) }
-
-        before { channel.update(chatable: category) }
+        fab!(:group) { Fabricate(:group) }
+        fab!(:group_user) { Fabricate(:group_user, group: group, user: user) }
 
         it "returns true if the user can join the category" do
+          category = Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:readonly])
+          channel.update(chatable: category)
           guardian = Guardian.new(user)
-
-          readonly_group = Fabricate(:group)
-          CategoryGroup.create(group: readonly_group, category: category, permission_type: CategoryGroup.permission_types[:readonly])
-          GroupUser.create(group: readonly_group, user: user)
-
-          create_post_group = Fabricate(:group)
-          CategoryGroup.create(group: create_post_group, category: category, permission_type: CategoryGroup.permission_types[:create_post])
-
           expect(guardian.can_join_chat_channel?(channel)).to eq(false)
 
-          GroupUser.create(group: create_post_group, user: user)
+          category = Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:create_post])
+          channel.update(chatable: category)
+          guardian = Guardian.new(user)
+          expect(guardian.can_join_chat_channel?(channel)).to eq(true)
+
+          category = Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:full])
+          channel.update(chatable: category)
+          guardian = Guardian.new(user)
           expect(guardian.can_join_chat_channel?(channel)).to eq(true)
         end
       end

--- a/spec/fabricators/category_fabricator.rb
+++ b/spec/fabricators/category_fabricator.rb
@@ -12,6 +12,7 @@ end
 
 Fabricator(:private_category, from: :category) do
   transient :group
+  transient :permission_type
 
   name { sequence(:name) { |n| "Private Category #{n}" } }
   slug { sequence(:slug) { |n| "private#{n}" } }
@@ -19,7 +20,7 @@ Fabricator(:private_category, from: :category) do
 
   after_build do |cat, transients|
     cat.update!(read_restricted: true)
-    cat.category_groups.build(group_id: transients[:group].id, permission_type: CategoryGroup.permission_types[:full])
+    cat.category_groups.build(group_id: transients[:group].id, permission_type: transients[:permission_type] || CategoryGroup.permission_types[:full])
   end
 end
 

--- a/spec/lib/category_guardian_spec.rb
+++ b/spec/lib/category_guardian_spec.rb
@@ -21,10 +21,9 @@ RSpec.describe CategoryGuardian do
     end
 
     context "when restricted category" do
-      fab!(:category) { Fabricate(:category, read_restricted: true) }
       fab!(:group) { Fabricate(:group) }
+      fab!(:category) { Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:readonly]) }
       fab!(:group_user) { Fabricate(:group_user, group: group, user: user) }
-      fab!(:category_group) { Fabricate(:category_group, group: group, category: category, permission_type: CategoryGroup.permission_types[:readonly]) }
 
       it "returns false for anonymous user" do
         expect(Guardian.new.can_post_in_category?(category)).to eq(false)
@@ -39,13 +38,13 @@ RSpec.describe CategoryGuardian do
       end
 
       it "returns true for member of group with create_post access" do
-        category_group.update!(permission_type: CategoryGroup.permission_types[:create_post])
-        expect(Guardian.new(admin).can_post_in_category?(category)).to eq(true)
+        category = Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:create_post])
+        expect(Guardian.new(user).can_post_in_category?(category)).to eq(true)
       end
 
       it "returns true for member of group with full access" do
-        category_group.update!(permission_type: CategoryGroup.permission_types[:full])
-        expect(Guardian.new(admin).can_post_in_category?(category)).to eq(true)
+        category = Fabricate(:private_category, group: group, permission_type: CategoryGroup.permission_types[:full])
+        expect(Guardian.new(user).can_post_in_category?(category)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Allow to specify permission type for category fabricator to test `:readonly`, `:create_post` and `:full` rights.
