### PR TITLE
FIX: Workaround a bug in the R2 gem

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -55,7 +55,7 @@ a.hashtag-cooked {
       background: linear-gradient(
         to bottom,
         rgba(var(--secondary-rgb), 0),
-        rgba(var(--secondary-rgb), 100%)
+        rgba(var(--secondary-rgb), 1)
       );
     }
   }


### PR DESCRIPTION
R2 seems to have a problem with the 100% in this context. Before the fix the generated CSS looks like this:

```css
.hashtag-autocomplete__fadeout:after {
    content: "";
    position: absolute;
    bottom: 0;
    width: 100%;
    height: 1.5em;
    background: linear-gradient(to 0%;
}
```

After the fix it looks like this:

```css
.hashtag-autocomplete__fadeout:after {
    content: "";
    position: absolute;
    bottom: 0;
    width: 100%;
    height: 1.5em;
    background: linear-gradient(to bottom,rgba(var(--secondary-rgb),0),rgba(var(--secondary-rgb),1));
}
```