### PR TITLE
DEV: Stop leaking state in dashboard controller specs

### DIFF
--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -186,6 +186,21 @@ module DiscourseUpdates
       Discourse.redis.hset(last_viewed_feature_dates_for_users_key, user_id.to_s, feature_date)
     end
 
+    def clean_state
+      Discourse.redis.del(
+        last_installed_version_key,
+        latest_version_key,
+        critical_updates_available_key,
+        missing_versions_count_key,
+        updated_at_key,
+        missing_versions_list_key,
+        new_features_key,
+        last_viewed_feature_dates_for_users_key,
+        *Discourse.redis.keys("#{missing_versions_key_prefix}*"),
+        *Discourse.redis.keys(new_features_last_seen_key("*")),
+      )
+    end
+
     private
 
     def last_installed_version_key

--- a/spec/jobs/check_new_features_spec.rb
+++ b/spec/jobs/check_new_features_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe Jobs::CheckNewFeatures do
   end
 
   after do
-    Discourse.redis.del("new_features")
-    Discourse.redis.del("last_viewed_feature_dates_for_users_hash")
+    DiscourseUpdates.clean_state
   end
 
   it "backfills last viewed feature for admins who don't have last viewed feature" do

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe DiscourseUpdates do
     end
 
     after do
-      Discourse.redis.del('new_features')
+      DiscourseUpdates.clean_state
     end
 
     it 'returns all items on the first run' do

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -173,9 +173,7 @@ RSpec.describe Admin::DashboardController do
 
   describe '#new_features' do
     after do
-      Discourse.redis.del "new_features_last_seen_user_#{admin.id}"
-      Discourse.redis.del "new_features"
-      Discourse.redis.del "last_viewed_feature_dates_for_users_hash"
+      DiscourseUpdates.clean_state
     end
 
     context "when logged in as an admin" do
@@ -288,9 +286,7 @@ RSpec.describe Admin::DashboardController do
 
   describe '#mark_new_features_as_seen' do
     after do
-      Discourse.redis.del "new_features_last_seen_user_#{admin.id}"
-      Discourse.redis.del "new_features"
-      Discourse.redis.del "last_viewed_feature_dates_for_users_hash"
+      DiscourseUpdates.clean_state
     end
 
     context "when logged in as an admin" do

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -172,12 +172,15 @@ RSpec.describe Admin::DashboardController do
   end
 
   describe '#new_features' do
+    after do
+      Discourse.redis.del "new_features_last_seen_user_#{admin.id}"
+      Discourse.redis.del "new_features"
+      Discourse.redis.del "last_viewed_feature_dates_for_users_hash"
+    end
+
     context "when logged in as an admin" do
       before do
         sign_in(admin)
-        Discourse.redis.del "new_features_last_seen_user_#{admin.id}"
-        Discourse.redis.del "new_features"
-        Discourse.redis.del "last_viewed_feature_dates_for_users_hash"
       end
 
       it 'is empty by default' do
@@ -284,6 +287,12 @@ RSpec.describe Admin::DashboardController do
   end
 
   describe '#mark_new_features_as_seen' do
+    after do
+      Discourse.redis.del "new_features_last_seen_user_#{admin.id}"
+      Discourse.redis.del "new_features"
+      Discourse.redis.del "last_viewed_feature_dates_for_users_hash"
+    end
+
     context "when logged in as an admin" do
       before { sign_in(admin) }
 


### PR DESCRIPTION
A few specs in `dashboard_controller_spec.rb` set some state in redis but don't clean it up afterwards which causes other specs to fail when they're ran after `dashboard_controller_spec.rb`.

Related PR: https://github.com/discourse/discourse/pull/19596.