### PR TITLE
FIX: Show titles in deleted-posts

### DIFF
--- a/app/serializers/admin_user_action_serializer.rb
+++ b/app/serializers/admin_user_action_serializer.rb
@@ -52,15 +52,15 @@ class AdminUserActionSerializer < ApplicationSerializer
   end
 
   def slug
-    object.topic&.slug
+    topic.slug
   end
 
   def title
-    object.topic&.title
+    topic.title
   end
 
   def category_id
-    object.topic&.category_id
+    topic.category_id
   end
 
   def moderator_action
@@ -79,5 +79,16 @@ class AdminUserActionSerializer < ApplicationSerializer
     object.user_actions.select { |ua| ua.user_id = object.user_id }
       .select { |ua| [UserAction::REPLY, UserAction::RESPONSE].include? ua.action_type }
       .first.try(:action_type)
+  end
+
+  # we need this to handle deleted topics which aren't loaded via
+  # Topic.unscoped do
+  #   Post.includes(:topic)
+  # end
+  # because Rails 4 "unscoped" support is still bugged (cf. https://github.com/rails/rails/issues/13775)
+  def topic
+    return @topic if @topic
+    @topic = object.topic || Topic.with_deleted.find(object.topic_id)
+    @topic
   end
 end

--- a/app/serializers/admin_user_action_serializer.rb
+++ b/app/serializers/admin_user_action_serializer.rb
@@ -52,15 +52,15 @@ class AdminUserActionSerializer < ApplicationSerializer
   end
 
   def slug
-    topic.slug
+    topic&.slug
   end
 
   def title
-    topic.title
+    topic&.title
   end
 
   def category_id
-    topic.category_id
+    topic&.category_id
   end
 
   def moderator_action
@@ -88,7 +88,6 @@ class AdminUserActionSerializer < ApplicationSerializer
   # because Rails 4 "unscoped" support is still bugged (cf. https://github.com/rails/rails/issues/13775)
   def topic
     return @topic if @topic
-    @topic = object.topic || Topic.with_deleted.find(object.topic_id)
-    @topic
+    @topic = object.topic || Topic.with_deleted.find_by_id(object.topic_id)
   end
 end

--- a/spec/serializers/admin_user_action_serializer_spec.rb
+++ b/spec/serializers/admin_user_action_serializer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe AdminUserActionSerializer do
+describe AdminUserActionSerializer do
   fab!(:user) { Fabricate(:user) }
   fab!(:admin) { Fabricate(:admin) }
   let(:guardian) { Guardian.new(admin) }
@@ -8,7 +8,7 @@ RSpec.describe AdminUserActionSerializer do
   fab!(:topic) { Fabricate(:topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }
 
-  it "returns the post's deleted topic's slug" do
+  it "includes the slug/title/category ID for a post's deleted topic" do
     topic.trash!
 
     json = AdminUserActionSerializer.new(post, scope: guardian, root: false).as_json

--- a/spec/serializers/admin_user_action_serializer_spec.rb
+++ b/spec/serializers/admin_user_action_serializer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe AdminUserActionSerializer do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:admin) { Fabricate(:admin) }
+  let(:guardian) { Guardian.new(admin) }
+
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+
+  it "returns the post's deleted topic's slug" do
+    topic.trash!
+
+    json = AdminUserActionSerializer.new(post, scope: guardian, root: false).as_json
+
+    expect(json[:slug]).to eq(topic.slug)
+    expect(json[:title]).to eq(topic.title)
+    expect(json[:category_id]).to eq(topic.category_id)
+  end
+end


### PR DESCRIPTION
https://meta.discourse.org/t/topic-titles-missing-from-deleted-posts-page-when-op-is-deleted/233350

`/u/\<username>/deleted-posts` weren't showing topic titles because sadly `Topic.unscoped` still didn't allow posts with deleted topics to associate properly. Undoing https://github.com/discourse/discourse/pull/17329 to allow it.

Before
<img width="459" alt="Screenshot 2022-12-23 at 11 00 00 PM" src="https://user-images.githubusercontent.com/1555215/209356395-57c62b7b-d6c3-4f81-82c2-f99706bae90c.png">


After
<img width="459" alt="Screenshot 2022-12-23 at 11 00 27 PM" src="https://user-images.githubusercontent.com/1555215/209356410-74683f02-1e47-44ea-8486-00e922f5c4ff.png">

