### PR TITLE
DEV: Skip s3 asset deletion when in readonly mode

### DIFF
--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -206,6 +206,11 @@ task 's3:expire_missing_assets' => :environment do
 
   puts "Checking for stale S3 assets..."
 
+  if Discourse.readonly_mode?
+    puts "Discourse is in readonly mode. Skipping s3 asset deletion in case this is a read-only mirror of a live site."
+    exit 0
+  end
+
   assets_to_delete = existing_assets.dup
 
   # Check that all current assets are uploaded, and remove them from the to_delete list


### PR DESCRIPTION
In some situations (e.g. disaster recovery), it may make sense to spin up a temporary readonly version of a cluster. In that situation, the s3 `expire_missing_assets` job would delete assets which are still in use by the canonical read-write version of the cluster.

To avoid that, this commit will skip deletion if the site is currently in readonly mode.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
