### PR TITLE
FEATURE: Introduce pg_force_readonly_mode GlobalSetting

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -365,3 +365,6 @@ preload_link_header = false
 
 # When using an external upload store, redirect `user_avatar` requests instead of proxying
 redirect_avatar_requests = false
+
+# Force the entire cluster into postgres readonly mode. Equivalent to running `Discourse.enable_pg_force_readonly_mode`
+pg_force_readonly_mode = false

--- a/config/initializers/002-rails_failover.rb
+++ b/config/initializers/002-rails_failover.rb
@@ -69,7 +69,11 @@ if defined?(RailsFailover::ActiveRecord)
   end
 
   RailsFailover::ActiveRecord.register_force_reading_role_callback do
-    Discourse.redis.exists?(Discourse::PG_READONLY_MODE_KEY, Discourse::PG_FORCE_READONLY_MODE_KEY)
+    GlobalSetting.pg_force_readonly_mode ||
+      Discourse.redis.exists?(
+        Discourse::PG_READONLY_MODE_KEY,
+        Discourse::PG_FORCE_READONLY_MODE_KEY,
+      )
   rescue => e
     if !e.is_a?(Redis::CannotConnectError)
       Rails.logger.warn "#{e.class} #{e.message}: #{e.backtrace.join("\n")}"

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -679,7 +679,7 @@ module Discourse
   end
 
   def self.readonly_mode?(keys = READONLY_KEYS)
-    recently_readonly? || Discourse.redis.exists?(*keys)
+    recently_readonly? || GlobalSetting.pg_force_readonly_mode || Discourse.redis.exists?(*keys)
   end
 
   def self.staff_writes_only_mode?

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -300,6 +300,12 @@ RSpec.describe Discourse do
         Discourse.disable_readonly_mode(user_readonly_mode_key)
         expect(Discourse.readonly_mode?).to eq(false)
       end
+
+      it "returns true when forced via global setting" do
+        expect(Discourse.readonly_mode?).to eq(false)
+        global_setting :pg_force_readonly_mode, true
+        expect(Discourse.readonly_mode?).to eq(true)
+      end
     end
 
     describe ".received_postgres_readonly!" do


### PR DESCRIPTION
This allows the entire cluster to be forced into pg readonly mode. Equivalent to running `Discourse.enable_pg_force_readonly_mode` on the console.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
