### PR TITLE
DEV: Label and ignore all default gems

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -13,14 +13,23 @@ allowed:
 
 ignored:
   bundler:
-    - openssl # Ruby terms
-    - rchardet # Ruby terms
-    - ruby2_keywords # BSD-2-Clause
+    - cgi # Ruby (default gem)
+    - date # Ruby (default gem)
+    - io-wait # Ruby (default gem)
+    - json # Ruby (default gem)
+    - net-http # Ruby (default gem)
+    - net-protocol # Ruby (default gem)
+    - openssl # Ruby (default gem)
+    - racc # Ruby (default gem)
+    - rchardet # LGPL
+    - ruby2_keywords # Ruby (default gem)
+    - strscan # Ruby (default gem)
+    - timeout # Ruby (default gem)
+    - uri # Ruby (default gem)
 
 reviewed:
   bundler:
     - activerecord # MIT
-    - cgi # Ruby
     - coderay # MIT
     - concurrent-ruby # MIT
     - css_parser # MIT
@@ -32,29 +41,21 @@ reviewed:
     - faraday-net_http # MIT
     - faraday-patron # MIT
     - faraday-rack # MIT
-    - highline # GPL-2.0 OR Ruby terms
+    - highline # Ruby or GPL-2.0
     - htmlentities # MIT
     - image_size # MIT
-    - io-wait # Ruby terms
-    - json # Ruby terms
     - jwt # MIT
     - kgio # LGPL-2.1+
     - logstash-event # Apache-2.0
-    - net-http # Ruby
-    - net-imap # Ruby
-    - net-pop # Ruby
-    - net-protocol # Ruby
-    - net-smtp # Ruby
+    - net-imap # Ruby (bundled gem)
+    - net-pop # Ruby (bundled gem)
+    - net-smtp # Ruby (bundled gem)
     - omniauth # MIT
-    - pg # Ruby terms
+    - pg # Ruby
     - r2 # Apache-2.0 (Twitter)
-    - racc # Ruby terms
     - raindrops # LGPL-2.1+
-    - rubyzip # Ruby terms
+    - rubyzip # Ruby
     - sidekiq # LGPL (Sidekiq)
-    - strscan # Ruby
     - tilt # MIT
-    - timeout # Ruby
     - unf # BSD-2-Clause
-    - unicorn # Ruby terms or GPLv2/GPLv3
-    - uri # Ruby
+    - unicorn # Ruby or GPLv2/GPLv3


### PR DESCRIPTION
`licensed` fails to find gem's license if it's a default gem (see: https://stdgems.org) and the version you're requiring comes with the ruby version you're using.

A ruby upgrade or any change to Gemfile could trigger `licensed` failures, so it's better to ignore all default gems we're using.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
