### PR TITLE
FIX: correctly allows admin to visit a user chat's preferences page

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/preferences-chat-link.hbs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/preferences-chat-link.hbs
@@ -1,4 +1,4 @@
-{{#if (or this.model.can_chat this.model.admin)}}
+{{#if (or this.model.can_chat this.currentUser.admin)}}
   <LinkTo @route="preferences.chat">
     {{i18n "chat.title_capitalized"}}
   </LinkTo>

--- a/plugins/chat/assets/javascripts/discourse/routes/preferences-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/preferences-chat.js
@@ -8,7 +8,7 @@ export default class PreferencesChatRoute extends RestrictedUserRoute {
   showFooter = true;
 
   setupController(controller, user) {
-    if (!user?.can_chat && !user.admin) {
+    if (!user?.can_chat && !this.currentUser.admin) {
       return this.transitionTo(`discovery.${defaultHomepage()}`);
     }
     controller.set("model", user);

--- a/plugins/chat/spec/system/user_chat_preferences_spec.rb
+++ b/plugins/chat/spec/system/user_chat_preferences_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "User chat preferences", type: :system, js: true do
 
   context "as an admin on another user's preferences" do
     fab!(:current_user) { Fabricate(:admin) }
-    fab!(:user_1) { Fabricate(:admin) }
+    fab!(:user_1) { Fabricate(:user) }
 
     before { sign_in(current_user) }
 


### PR DESCRIPTION
This commit fixes a mistake in the spec which was creating a false positive.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
