### PR TITLE
PERF: Optimize the performance of `TopicLink.topic_map` query

### DIFF
--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -58,8 +58,7 @@ class TopicLink < ActiveRecord::Base
 
     builder.where('ftl.topic_id = :topic_id', topic_id: topic_id)
     builder.where('ft.deleted_at IS NULL')
-    # note that ILIKE means "case insensitive LIKE"
-    builder.where("NOT(ftl.url ILIKE '%.png' OR ftl.url ILIKE '%.jpg' OR ftl.url ILIKE '%.gif')")
+    builder.where("ftl.extension IS NULL OR ftl.extension NOT IN ('png','jpg','gif')")
     builder.where("COALESCE(ft.archetype, 'regular') <> :archetype", archetype: Archetype.private_message)
     builder.where("clicks > 0")
 


### PR DESCRIPTION
Instead of relying on the `ILIKE` operator to filter out image links, we
can instead rely on the `TopicLink#extension` column which allows us to
more efficiently filter out image links.

This optimization mainly affects topics that are link heavy which is
common in topics with alot of replies. When profiling a production
instance for a topic with 10K replies and 2.5K `topic_links`, this
optimization reduces the query time from ~18ms to around ~4ms.
### Sample query runtime for said production instance above

![Screenshot from 2022-12-27 10-18-25](https://user-images.githubusercontent.com/4335742/209600794-126329ab-419a-4b22-b697-9aff10c76003.png)
