### PR TITLE
FIX: Gracefully handle DNS issued from SSRF lookup when inline oneboxing

### DIFF
--- a/lib/retrieve_title.rb
+++ b/lib/retrieve_title.rb
@@ -9,7 +9,7 @@ module RetrieveTitle
       max_redirects: max_redirects,
       initial_https_redirect_ignore_limit: initial_https_redirect_ignore_limit
     )
-  rescue Net::ReadTimeout
+  rescue Net::ReadTimeout, FinalDestination::SSRFDetector::LookupFailedError
     # do nothing for Net::ReadTimeout errors
   end
 

--- a/spec/lib/final_destination/ssrf_detector_spec.rb
+++ b/spec/lib/final_destination/ssrf_detector_spec.rb
@@ -95,6 +95,13 @@ describe FinalDestination::SSRFDetector do
       )
     end
 
+    it "raises an exception if lookup fails" do
+      subject.stubs(:lookup_ips).raises(SocketError)
+      expect { subject.lookup_and_filter_ips("example.com") }.to raise_error(
+        subject::LookupFailedError,
+      )
+    end
+
     it "bypasses filtering for allowlisted hosts" do
       SiteSetting.allowed_internal_hosts = "example.com"
       subject.stubs(:lookup_ips).returns(["127.0.0.1"])

--- a/spec/lib/retrieve_title_spec.rb
+++ b/spec/lib/retrieve_title_spec.rb
@@ -162,7 +162,13 @@ RSpec.describe RetrieveTitle do
     it "it ignores Net::ReadTimeout errors" do
       stub_request(:get, "https://example.com").to_raise(Net::ReadTimeout)
 
-      expect { RetrieveTitle.crawl("https://example.com") }.not_to raise_error
+      expect(RetrieveTitle.crawl("https://example.com")).to eq(nil)
+    end
+
+    it "ignores SSRF lookup errors" do
+      subject.stubs(:fetch_title).raises(FinalDestination::SSRFDetector::LookupFailedError)
+
+      expect(RetrieveTitle.crawl("https://example.com")).to eq(nil)
     end
   end
 


### PR DESCRIPTION
### What's the problem?

There is an issue where chat message processing breaks due to unhandled `SocketError` exceptions originating in the SSRF check, specifically in `FinalDestination::Resolver`.

### How does this fix it?

This change gives `FinalDestination::SSRFDetector` a new error class to wrap the `SocketError` in, and haves the `RetrieveTitle` class handle that error gracefully.

### What considerations were made?

There is a lot of indirection going on here, with at least nine collaborators in the mix, and so in handling these errors there are many options that would "work".

<img width="950" alt="Screenshot 2022-12-27 at 12 11 41 PM" src="https://user-images.githubusercontent.com/5259935/209609967-7bc15e6e-39f7-4b3c-9d60-ae465c97cd26.png">

I have tried to lean as much as possible on the existing structure, and so:

- Have `SSRFDetector#lookup_and_filter_ips` (where the `SocketError` "leaks") wrap and raise a more specific error which we own.
- Have `RetrieveTitle#crawl` handle the error, since there is already error handling relating to failing network requests in this class and we can depend on the upstream behaviour already in place.

There are some other call sites for `#lookup_and_filter_ips`. This PR does not attempt to implement error handling for all of them. It will be follow-up work.