### PR TITLE
DEV: Print system test logs with other test metadata

### DIFF
--- a/lib/turbo_tests/json_rows_formatter.rb
+++ b/lib/turbo_tests/json_rows_formatter.rb
@@ -57,7 +57,8 @@ module TurboTests
           shared_group_inclusion_backtrace:
             example
               .metadata[:shared_group_inclusion_backtrace]
-              .map(&method(:stack_frame_to_json))
+              .map(&method(:stack_frame_to_json)),
+          extra_failure_lines: example.metadata[:extra_failure_lines]
         },
         location_rerun_argument: example.location_rerun_argument
       }


### PR DESCRIPTION
Previously, browser logs would be printed to STDOUT halfway through the test run. This commit changes the behaviour so that the logs are included in the failure summary along with other rspec failure information.

(extracted from https://github.com/discourse/discourse/pull/19584)

![image](https://user-images.githubusercontent.com/6270921/209798650-845256f4-214b-4f52-9e56-54b44ea116d4.png)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
