### PR TITLE
FIX: show status on mentions on just posted posts

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -563,13 +563,14 @@ class PostSerializer < BasicPostSerializer
 
   def mentioned_users
     if @topic_view && (mentions = @topic_view.mentions[object.id])
-      return mentions
-          .map { |username| @topic_view.mentioned_users[username] }
-          .compact
-          .map { |user| BasicUserWithStatusSerializer.new(user, root: false) }
+      users =  mentions
+        .map { |username| @topic_view.mentioned_users[username] }
+        .compact
+    else
+      users = User.where(username: object.mentions)
     end
 
-    []
+    users.map { |user| BasicUserWithStatusSerializer.new(user, root: false) }
   end
 
 private


### PR DESCRIPTION
We show live user status on mentions starting from a76d864c5136b7a52160b5394cac5f98b746ea43. But status didn’t appear on the post that appears on the bottom of the topic just after a user posted it (status appeared only after page reloading). This adds status to just posted posts.

Here is how the problem looks like:

<img width="878" alt="image" src="https://user-images.githubusercontent.com/1274517/209938078-55a334d6-a789-4d46-8a91-e3611a551928.png">

After the fix status will be everywhere without reloading the page:

<img width="814" alt="image" src="https://user-images.githubusercontent.com/1274517/209938264-e412e91a-79c3-4ac6-9710-9bfb603c817f.png">





