### PR TITLE
FIX: cancels fetching messages when pane is destroyed

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -229,6 +229,10 @@ export default Component.extend({
 
   @debounce(100)
   fetchMessages(channel, options = {}) {
+    if (this._selfDeleted) {
+      return;
+    }
+
     this.set("loading", true);
 
     return this.chat.loadCookFunction(this.site.categories).then((cook) => {


### PR DESCRIPTION
Ultimately we would want a cleaner solution here where we correctly cancel in `willDestroy` hook but this is the safest move for now.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
