### PR TITLE
FEATURE: Enable service worker for Apple devices

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/register-service-worker.js
+++ b/app/assets/javascripts/discourse/app/lib/register-service-worker.js
@@ -6,12 +6,7 @@ export function registerServiceWorker(
   registerOptions = {}
 ) {
   if (window.isSecureContext && "serviceWorker" in navigator) {
-    const caps = container.lookup("capabilities:main");
-    const isAppleBrowser =
-      caps.isSafari ||
-      (caps.isIOS && !window.matchMedia("(display-mode: standalone)").matches);
-
-    if (serviceWorkerURL && !isAppleBrowser) {
+    if (serviceWorkerURL) {
       navigator.serviceWorker.getRegistrations().then((registrations) => {
         for (let registration of registrations) {
           if (

--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -19,11 +19,12 @@ var externalCacheName = "external-" + cacheVersion;
 // https://bugs.chromium.org/p/chromium/issues/detail?id=1286367
 var chromeVersionMatch = navigator.userAgent.match(/Chrome\/97.0.(\d+)/);
 var isBrokenChrome97 = chromeVersionMatch && parseInt(chromeVersionMatch[1]) <= 4692;
+var isApple = /iPhone|iPod|Mac OS/.test(navigator.userAgent);
 
 // Cache all GET requests, so Discourse can be used while offline
 workbox.routing.registerRoute(
   function(args) {
-    return args.url.origin === location.origin && !authUrls.some(u => args.url.pathname.startsWith(u)) && !isBrokenChrome97;
+    return args.url.origin === location.origin && !authUrls.some(u => args.url.pathname.startsWith(u)) && !isBrokenChrome97 && !isApple;
   }, // Match all except auth routes
   new workbox.strategies.NetworkFirst({ // This will only use the cache when a network request fails
     cacheName: discourseCacheName,


### PR DESCRIPTION
This is necessary so MacOS Ventura (and in 2023 iOS) can use our new
default push notifications.

We still disable caching of dynamic routes on Apple devices due to it's
always being buggy there.
