### PR TITLE
DEV: Improve/Fix script/bench.rb

### DIFF
--- a/lib/rate_limiter.rb
+++ b/lib/rate_limiter.rb
@@ -17,6 +17,8 @@ class RateLimiter
     @disabled = false
   end
 
+  disable if Rails.env.profile?
+
   # We don't observe rate limits in test mode
   def self.disabled?
     @disabled

--- a/lib/tasks/profile.rake
+++ b/lib/tasks/profile.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+desc "generate a user api key for given user in profiling environment"
+task "user_api_key:create", [:username] => :environment do |task, args|
+  raise "user_api_key:create rake task is only meant for the profiling env" if ENV["RAILS_ENV"] != "profile"
+  raise "Supply a username for the key" if !args[:username]
+
+  user = User.find_by_username(args[:username])
+
+  raise "'#{args[:username]}' is not a valid username" if !user
+
+  application_name = 'perf test application'
+
+  user_api_key = UserApiKey.where(application_name: application_name).destroy_all
+
+  user_api_key = UserApiKey.create!(
+    application_name: application_name,
+    client_id: '1234',
+    scopes: ['read'].map { |name| UserApiKeyScope.new(name: name) },
+    user_id: user.id
+  )
+
+  puts user_api_key.key
+end

--- a/script/profile_db_generator.rb
+++ b/script/profile_db_generator.rb
@@ -43,16 +43,20 @@ def sentence
   sentence
 end
 
-def create_admin(seq)
-  User.new.tap { |admin|
-    admin.email = "admin@localhost#{seq}.fake"
-    admin.username = "admin#{seq}"
-    admin.password = "password12345abc"
-    admin.save!
-    admin.grant_admin!
-    admin.change_trust_level!(TrustLevel[4])
-    admin.activate
-  }
+def create_user(seq, admin: false, username: nil)
+  User.new.tap do |user|
+    user.email = "user@localhost#{seq}.fake"
+    user.username = username || "user#{seq}"
+    user.password = "password12345abc"
+    user.save!
+
+    if admin
+      user.grant_admin!
+      user.change_trust_level!(TrustLevel[4])
+    end
+
+    user.activate
+  end
 end
 
 require File.expand_path(File.dirname(__FILE__) + "/../config/environment")
@@ -64,20 +68,9 @@ unless Rails.env == "profile"
   exit
 end
 
-def ensure_perf_test_topic_has_right_title!
-  title = "I am a topic used for perf tests"
-  # in case we have an old run and picked the wrong topic
-  Topic.where(title: title).update_all(title: "Test topic #{SecureRandom.hex}")
-  t = Topic.where(archetype: :regular, posts_count: 30).order(id: :desc).first
-  t.title = title
-  t.save!
-end
-
 # by default, Discourse has a "system" and `discobot` account
 if User.count > 2
   puts "Only run this script against an empty DB"
-
-  ensure_perf_test_topic_has_right_title!
   exit
 end
 
@@ -90,38 +83,58 @@ rescue LoadError
   unbundled_require 'gabbler'
 end
 
-puts "Creating 100 users"
-users = 100.times.map do |i|
+number_of_users = 100
+puts "Creating #{number_of_users} users"
+number_of_users.times.map do |i|
   putc "."
-  create_admin(i)
+  create_user(i)
 end
+
+puts
+puts "Creating 1 admin user"
+admin_user = create_user(number_of_users + 1, admin: true, username: "admin1")
+
+users = User.human_users.all
 
 puts
 puts "Creating 10 categories"
 categories = 10.times.map do |i|
   putc "."
-  Category.create(name: "category#{i}", text_color: "ffffff", color: "000000", user: users.first)
+  Category.create(name: "category#{i}", text_color: "ffffff", color: "000000", user: admin_user)
 end
 
 puts
 puts "Creating 100 topics"
-
 topic_ids = 100.times.map do
-  post = PostCreator.create(users.sample, raw: sentence, title: sentence[0..50].strip, category:  categories.sample.id, skip_validations: true)
-
+  post = PostCreator.create(admin_user, raw: sentence, title: sentence[0..50].strip, category:  categories.sample.id, skip_validations: true)
   putc "."
   post.topic_id
 end
 
 puts
-puts "creating 2000 replies"
+puts "Creating 2000 replies"
 2000.times do
   putc "."
   PostCreator.create(users.sample, raw: sentence, topic_id: topic_ids.sample, skip_validations: true)
 end
 
+puts
+puts "creating perf test topic"
+first_post = PostCreator.create(
+  users.sample,
+  raw: sentence,
+  title: "I am a topic used for perf tests",
+  category: categories.sample.id,
+  skip_validations: true
+)
+
+puts
+puts "Creating 100 replies for perf test topic"
+100.times do
+  putc "."
+  PostCreator.create(users.sample, raw: sentence, topic_id: first_post.topic_id, skip_validations: true)
+end
+
 # no sidekiq so update some stuff
 Category.update_stats
 Jobs::PeriodicalUpdates.new.execute(nil)
-
-ensure_perf_test_topic_has_right_title!


### PR DESCRIPTION
1. Fix bug where we were not waiting for all unicorn workers to start up
before running benchmarks.

2. Fix a bug where headers were not used when benchmarking. Admin
benchmarks were basically running as anon user.

3. Disable rate limits when in profile env. We're pretty much going to
hit the rate limit every time as a normal user.

4. Benchmark against topic with a fixed posts count of 100. Previously profiling script was just randomly creating posts
and we would benchmark against a topic with a fixed posts count of 30.
Sometimes, the script fails because no topics with a posts count of 30
exists.

5. Benchmarks are now run against a normal user on top of anon and
admin.