### PR TITLE
PERF: Memoize topic level checks in PostGuardian

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -228,7 +228,7 @@ class Category < ActiveRecord::Base
         staged: guardian.is_staged?,
         permissions: permissions,
         user_id: guardian.user.id,
-        everyone: Group[:everyone].id)
+        everyone: Group::AUTO_GROUPS[:everyone])
     end
   end
 


### PR DESCRIPTION
When loading posts in a topic, the topic level guardian
checks are run multiple times even though all the posts belong to the
same topic. Profiling in production revealed that this accounted for a
significant amount of request time for a user that is not staff or anon.
Therefore, we're optimizing this by adding memoizing the topic level
calls in `PostGuardian`. Speficifally, the result of
`TopicGuardian#can_see_topic?` and `PostGuardian#can_create_post?`
method calls are memoized per topic.

Locally profiling shows a significant improvement for normal users
loading a topic with 100 posts.

Benchmark script command: `ruby script/bench.rb --unicorn --skip-bundle-assets --iterations 100`

Before:

```
topic user:
  50: 114
  75: 117
  90: 122
  99: 209
topic.json user:
  50: 67
  75: 69
  90: 72
  99: 162
```

After:

```
topic user:
  50: 101
  75: 104
  90: 107
  99: 184
topic.json user:
  50: 53
  75: 53
  90: 56
  99: 138
```

### Graphs of local profiling results

![Screenshot from 2022-12-29 08-26-08](https://user-images.githubusercontent.com/4335742/209888385-d92e91c7-218c-43c3-b56c-9c16769c5ae3.png)
![Screenshot from 2022-12-29 08-26-03](https://user-images.githubusercontent.com/4335742/209888393-e7ace994-1c81-4b9e-bafd-d3bb903bdfe0.png)
