### PR TITLE
FIX: Avoid race conditions when toggling presence state

### DIFF
--- a/app/assets/javascripts/discourse/app/services/presence.js
+++ b/app/assets/javascripts/discourse/app/services/presence.js
@@ -67,16 +67,16 @@ class PresenceChannel extends EmberObject.extend(Evented) {
 
     this.setProperties({ activeOptions });
     if (!this.present) {
-      await this.presenceService._enter(this);
       this.set("present", true);
+      await this.presenceService._enter(this);
     }
   }
 
   // Mark the current user as leaving this channel
   async leave() {
     if (this.present) {
-      await this.presenceService._leave(this);
       this.set("present", false);
+      await this.presenceService._leave(this);
     }
   }
 


### PR DESCRIPTION
We need to set the local state of a channel before performing any async operations. Otherwise, multiple leave/join calls can race against each other and cause the local state to get out-of-sync with the server.

Followup to e70ed31a

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
