### PR TITLE
FIX: Update nginx config for v1.23

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -33,7 +33,7 @@ large_client_header_buffers 4 32k;
 # attempt to preserve the proto, must be in http context
 map $http_x_forwarded_proto $thescheme {
   default $scheme;
-  https https;
+  "~https$" https;
 }
 
 log_format log_discourse '[$time_local] "$http_host" $remote_addr "$request" "$http_user_agent" "$sent_http_x_discourse_route" $status $bytes_sent "$http_referer" $upstream_response_time $request_time "$upstream_http_x_discourse_username" "$upstream_http_x_discourse_trackview" "$upstream_http_x_queue_time" "$upstream_http_x_redis_calls" "$upstream_http_x_redis_time" "$upstream_http_x_sql_calls" "$upstream_http_x_sql_time"';


### PR DESCRIPTION
NGINX v1.23 concatenates duplicate headers into a single comma-separated string. We were doing an equality check on `x-forwarded-proto`. If the request includes multiple `x-forwarded-proto` headers then this check would fail under NGINX v1.23, and our config assumed an `http` connection.

This commit updates the config to check for `https` at the end of the header, thereby restoring the old behavior when multiple `x-forwarded-proto` request headers are sent.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
