### PR TITLE
FIX: Add missing email template for `user_watching_category_or_tag`

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3791,6 +3791,18 @@ en:
 
         %{respond_instructions}
 
+    user_watching_category_or_tag:
+      title: "User Watching Category or Tag"
+      subject_template: "[%{email_prefix}] %{topic_title}"
+      text_body_template: |
+        %{header_instructions}
+
+        %{message}
+
+        %{context}
+
+        %{respond_instructions}
+
     user_watching_first_post:
       title: "User Watching First Post"
       subject_template: "[%{email_prefix}] %{topic_title}"


### PR DESCRIPTION
Adds a spec to hopefully prevent this in the future.

Follow-up to aa3a9b6fea9190eadd4e0152f1b8e26cee3de0be