### PR TITLE
FEATURE: Extend topic update API scope to allow status updates

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -479,7 +479,12 @@ class TopicsController < ApplicationController
     enabled = params[:enabled] == "true"
 
     check_for_status_presence(:status, status)
-    @topic = Topic.find_by(id: topic_id)
+    @topic =
+      if params[:category_id]
+        Topic.find_by(id: topic_id, category_id: params[:category_id].to_i)
+      else
+        Topic.find_by(id: topic_id)
+      end
 
     case status
     when "closed"

--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -28,8 +28,8 @@ class ApiKeyScope < ActiveRecord::Base
             params: %i[topic_id],
           },
           update: {
-            actions: %w[topics#update],
-            params: %i[topic_id],
+            actions: %w[topics#update topics#status],
+            params: %i[topic_id category_id],
           },
           read: {
             actions: %w[topics#show topics#feed topics#posts],

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4670,7 +4670,7 @@ en:
             topics:
               read: Read a topic or a specific post in it. RSS is also supported.
               write: Create a new topic or post to an existing one.
-              update: Update a topic. Change the title, category, tags, etc.
+              update: Update a topic. Change the title, category, tags, status, archetype, featured_link etc.
               read_lists: Read topic lists like top, new, latest, etc. RSS is also supported.
             posts:
               edit: Edit any post or a specific one.

--- a/lib/route_matcher.rb
+++ b/lib/route_matcher.rb
@@ -59,7 +59,7 @@ class RouteMatcher
 
     params.all? do |param|
       param_alias = aliases&.[](param)
-      allowed_values = [allowed_param_values[param.to_s]].flatten
+      allowed_values = [allowed_param_values.fetch(param.to_s, [])].flatten
 
       value = requested_params[param.to_s]
       alias_value = requested_params[param_alias.to_s]


### PR DESCRIPTION
Currently,  an API key scoped to `topics:update` allows updates to all topics or a set of topics whitelisted via the API scope's allowed parameters attribute.  This implementation does not work for a situation where we want to be able to update a dynamically changing list of topics.

This change introduces the `category_id` allowed parameter. With that, we can whitelist all topics in the whitelisted categories for updates.

In addition to allowing regular topic updates, this change also enables topic status updates.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
