### PR TITLE
PERF: Remove redundant DB queries from `TopicView`

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -139,11 +139,11 @@ class TopicView
 
     if @posts && !@skip_custom_fields
       if (added_fields = User.allowed_user_custom_fields(@guardian)).present?
-        @user_custom_fields = User.custom_fields_for_ids(@posts.pluck(:user_id), added_fields)
+        @user_custom_fields = User.custom_fields_for_ids(@posts.map(&:user_id), added_fields)
       end
 
       if (allowed_fields = TopicView.allowed_post_custom_fields(@user, @topic)).present?
-        @post_custom_fields = Post.custom_fields_for_ids(@posts.pluck(:id), allowed_fields)
+        @post_custom_fields = Post.custom_fields_for_ids(@posts.map(&:id), allowed_fields)
       end
     end
 
@@ -778,7 +778,6 @@ class TopicView
         :reply_to_user,
         :deleted_by,
         :incoming_email,
-        :topic,
         :image_upload
       )
 


### PR DESCRIPTION
This commit removes 3 redundant DB queries when loading posts.

1. `@posts` will eventually have to be loaded so we can avoid two
additional queries.

2. No need to preload topic association of posts as we're already
dealing with a fixed topic in `TopicView`.