### PR TITLE
PERF: Avoid running redundant bookmarks query for anon viewing topic

### DIFF
--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -412,12 +412,13 @@ class TopicView
   end
 
   def has_bookmarks?
-    return false if @user.blank?
-    return false if @topic.trashed?
     bookmarks.any?
   end
 
   def bookmarks
+    return [] if @user.blank?
+    return [] if @topic.trashed?
+
     @bookmarks ||= Bookmark.for_user_in_topic(@user, @topic.id).select(
       :id, :bookmarkable_id, :bookmarkable_type, :reminder_at, :name, :auto_delete_preference
     )


### PR DESCRIPTION
The `TopicView#bookmarks` method is called by `TopicViewSerializer` and `PostSerializer`
so we want to avoid running a meaningless query when user is not
present.