### PR TITLE
FIX: account for cursor drift when completing terms

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -236,7 +236,10 @@ export default function (options) {
           // resync in case of drift (upload for example)
           let pos = guessCompletePosition();
 
-          if (pos.completeStart && pos.completeEnd) {
+          if (
+            pos.completeStart !== undefined &&
+            pos.completeEnd !== undefined
+          ) {
             completeStart = pos.completeStart;
             completeEnd = pos.completeEnd;
           } else {
@@ -578,17 +581,7 @@ export default function (options) {
 
     let start, end;
 
-    let letterRegex = /[a-zA-Z\.-]/;
-
-    while (
-      element.value[c] !== undefined &&
-      letterRegex.test(element.value[c])
-    ) {
-      c += 1;
-    }
     let initial = c;
-
-    c -= 1;
 
     while (prevIsGood && c >= 0) {
       c -= 1;
@@ -600,7 +593,7 @@ export default function (options) {
 
         if (
           checkTriggerRule({ backSpace: true }) &&
-          (!prev || allowedLettersRegex.test(prev))
+          (prev === undefined || allowedLettersRegex.test(prev))
         ) {
           start = c;
           term = element.value.substring(c + 1, initial);
@@ -609,7 +602,7 @@ export default function (options) {
           break;
         }
       }
-      prevIsGood = letterRegex.test(prev);
+      prevIsGood = !allowedLettersRegex.test(prev);
     }
 
     return { completeStart: start, completeEnd: end, term };

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -246,11 +246,14 @@ export default function (options) {
             completeStart = completeEnd = caretPosition(me[0]);
           }
 
+          let space =
+            text.substring(completeEnd + 1, completeEnd + 2) === " " ? "" : " ";
+
           text =
             text.substring(0, completeStart) +
             (options.preserveKey ? options.key || "" : "") +
             term +
-            " " +
+            space +
             text.substring(completeEnd + 1, text.length);
 
           me.val(text);

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -234,7 +234,7 @@ export default function (options) {
           let text = me.val();
 
           // resync in case of drift (upload for example)
-          let pos = guessCompletePosition();
+          let pos = guessCompletePosition({ completeTerm: true });
 
           if (
             pos.completeStart !== undefined &&
@@ -581,6 +581,7 @@ export default function (options) {
     let prevIsGood = true;
     let element = me[0];
     let backSpace = opts && opts.backSpace;
+    let completeTermOption = opts && opts.completeTerm;
 
     let c = caretPosition(element);
 
@@ -614,6 +615,9 @@ export default function (options) {
         }
       }
       prevIsGood = !allowedLettersRegex.test(prev);
+      if (completeTermOption) {
+        prevIsGood ||= prev === " ";
+      }
     }
 
     return { completeStart: start, completeEnd: end, term };

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -583,33 +583,33 @@ export default function (options) {
     let backSpace = opts && opts.backSpace;
     let completeTermOption = opts && opts.completeTerm;
 
-    let c = caretPosition(element);
+    let caretPos = caretPosition(element);
 
     if (backSpace) {
-      c -= 1;
+      caretPos -= 1;
     }
 
     let start = null;
     let end = null;
 
-    let initial = c;
+    let initialCaretPos = caretPos;
 
-    while (prevIsGood && c >= 0) {
-      c -= 1;
-      prev = element.value[c];
+    while (prevIsGood && caretPos >= 0) {
+      caretPos -= 1;
+      prev = element.value[caretPos];
 
       stopFound = prev === options.key;
 
       if (stopFound) {
-        prev = element.value[c - 1];
+        prev = element.value[caretPos - 1];
 
         if (
           checkTriggerRule({ backSpace }) &&
           (prev === undefined || allowedLettersRegex.test(prev))
         ) {
-          start = c;
-          term = element.value.substring(c + 1, initial);
-          end = c + term.length;
+          start = caretPos;
+          term = element.value.substring(caretPos + 1, initialCaretPos);
+          end = caretPos + term.length;
 
           break;
         }

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -234,7 +234,11 @@ export default function (options) {
         if (term) {
           let text = me.val();
 
-          // resync in case of drift (upload for example)
+          // After completion is done our position for completeStart may have
+          // drifted. This can happen if the TEXTAREA changed out-of-band between
+          // the time autocomplete was first displayed and the time of completion
+          // Specifically this may happen due to uploads which inject a placeholder
+          // which is later replaced with a different length string.
           let pos = guessCompletePosition({ completeTerm: true });
 
           if (

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -588,7 +588,8 @@ export default function (options) {
       c -= 1;
     }
 
-    let start, end;
+    let start = null;
+    let end = null;
 
     let initial = c;
 

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -576,11 +576,17 @@ export default function (options) {
     }
   }
 
-  function guessCompletePosition() {
+  function guessCompletePosition(opts) {
     let prev, stopFound, term;
     let prevIsGood = true;
     let element = me[0];
+    let backSpace = opts && opts.backSpace;
+
     let c = caretPosition(element);
+
+    if (backSpace) {
+      c -= 1;
+    }
 
     let start, end;
 
@@ -589,13 +595,14 @@ export default function (options) {
     while (prevIsGood && c >= 0) {
       c -= 1;
       prev = element.value[c];
+
       stopFound = prev === options.key;
 
       if (stopFound) {
         prev = element.value[c - 1];
 
         if (
-          checkTriggerRule({ backSpace: true }) &&
+          checkTriggerRule({ backSpace }) &&
           (prev === undefined || allowedLettersRegex.test(prev))
         ) {
           start = c;
@@ -647,7 +654,7 @@ export default function (options) {
     }
 
     if (completeStart === null && e.which === keys.backSpace && options.key) {
-      let position = guessCompletePosition();
+      let position = guessCompletePosition({ backSpace: true });
       completeStart = position.completeStart;
 
       if (position.completeEnd) {

--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -91,7 +91,6 @@ export default function (options) {
   let autocompleteOptions = null;
   let selectedOption = null;
   let completeStart = null;
-  let completeEnd = null;
   let me = this;
   let div = null;
   let scrollElement = null;
@@ -218,6 +217,8 @@ export default function (options) {
   }
 
   let completeTerm = async function (term) {
+    let completeEnd = null;
+
     if (term) {
       if (isInput) {
         me.val("");
@@ -552,7 +553,6 @@ export default function (options) {
 
         if (match) {
           completeStart = cp - match[0].length;
-          completeEnd = completeStart + match[0].length - 1;
           let term = match[0].substring(1, match[0].length);
           updateAutoComplete(dataSource(term, options));
         }
@@ -566,7 +566,7 @@ export default function (options) {
           checkTriggerRule() &&
           (!prevChar || allowedLettersRegex.test(prevChar))
         ) {
-          completeStart = completeEnd = cp - 1;
+          completeStart = cp - 1;
           updateAutoComplete(dataSource("", options));
         }
       }
@@ -663,7 +663,6 @@ export default function (options) {
       completeStart = position.completeStart;
 
       if (position.completeEnd) {
-        completeEnd = position.completeEnd;
         updateAutoComplete(dataSource(position.term, options));
         return true;
       }
@@ -746,7 +745,6 @@ export default function (options) {
         case keys.backSpace:
           autocompleteOptions = null;
           cp--;
-          completeEnd = cp;
 
           if (cp < 0) {
             closeAutocomplete();
@@ -770,7 +768,6 @@ export default function (options) {
           return true;
         default:
           autocompleteOptions = null;
-          completeEnd = cp;
           return true;
       }
     }

--- a/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
@@ -1,0 +1,101 @@
+import { module, test } from "qunit";
+import autocomplete from "discourse/lib/autocomplete";
+import { compile } from "handlebars";
+
+module("Unit | Utility | autocomplete", function (hooks) {
+  let elements = [];
+
+  function textArea(value) {
+    let element = document.createElement("TEXTAREA");
+    element.value = value;
+    document.getElementById("ember-testing").appendChild(element);
+    elements.push(element);
+    return element;
+  }
+
+  function cleanup() {
+    elements.forEach((e) => {
+      e.remove();
+      autocomplete.call($(e), { cancel: true });
+      autocomplete.call($(e), "destroy");
+    });
+    elements = [];
+  }
+
+  hooks.afterEach(function () {
+    cleanup();
+  });
+
+  test("Autocomplete can account for cursor drift correctly", function (assert) {
+    let element = textArea("01234 @");
+    let $element = $(element);
+
+    autocomplete.call($element, {
+      key: "@",
+      dataSource: () => ["test1", "test2"],
+      template: compile(`<div id='ac-testing' class='autocomplete ac-test'>
+  <ul>
+    {{#each options as |option|}}
+      <li>
+        <a href>
+          {{option}}
+        </a>
+      </li>
+    {{/each}}
+  </ul>
+</div>`),
+    });
+
+    element.dispatchEvent(new KeyboardEvent("keydown", { key: "@" }));
+    element.dispatchEvent(new KeyboardEvent("keyup", { key: "@" }));
+
+    element.value = "0123456 @t hello";
+
+    element.setSelectionRange(9, 9);
+
+    element.dispatchEvent(new KeyboardEvent("keydown", { key: "t" }));
+    element.dispatchEvent(new KeyboardEvent("keyup", { key: "t" }));
+
+    element.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "\n", keyCode: 13 })
+    );
+    element.dispatchEvent(
+      new KeyboardEvent("keyup", { key: "\n", keyCode: 13 })
+    );
+
+    assert.strictEqual(element.value, "0123456 @test1  hello");
+    assert.strictEqual(15, element.selectionStart);
+    assert.strictEqual(15, element.selectionEnd);
+  });
+
+  test("Autocomplete can render on @", function (assert) {
+    let element = textArea("@");
+    let $element = $(element);
+
+    autocomplete.call($element, {
+      key: "@",
+      dataSource: () => ["test1", "test2"],
+      template: compile(`<div id='ac-testing' class='autocomplete ac-test'>
+  <ul>
+    {{#each options as |option|}}
+      <li>
+        <a href>
+          {{option}}
+        </a>
+      </li>
+    {{/each}}
+  </ul>
+</div>`),
+    });
+
+    element.dispatchEvent(new KeyboardEvent("keydown", { key: "@" }));
+    element.dispatchEvent(new KeyboardEvent("keyup", { key: "@" }));
+
+    let list = document.querySelectorAll("#ac-testing ul li");
+    assert.strictEqual(2, list.length);
+
+    let selected = document.querySelectorAll("#ac-testing ul li a.selected");
+    assert.strictEqual(1, selected.length);
+    assert.strictEqual("test1", selected[0].innerText);
+  });
+});

--- a/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
@@ -109,6 +109,18 @@ module("Unit | Utility | autocomplete", function (hooks) {
     simulateKey(element, "\b");
     list = document.querySelectorAll("#ac-testing ul li");
     assert.strictEqual(list.length, 2);
+
+    // close autocomplete
+    simulateKey(element, "\r");
+
+    // does not trigger by mistake at the start
+    element.value = "test";
+    element.selectionStart = element.value.length;
+    element.selectionEnd = element.value.length;
+
+    simulateKey(element, "\b");
+    list = document.querySelectorAll("#ac-testing ul li");
+    assert.strictEqual(list.length, 0);
   });
 
   test("Autocomplete can render on @", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
@@ -98,6 +98,17 @@ module("Unit | Utility | autocomplete", function (hooks) {
     assert.strictEqual(element.value, "@test1 @test2 ");
     assert.strictEqual(element.selectionStart, 7);
     assert.strictEqual(element.selectionEnd, 7);
+
+    // lets see that deleting last space triggers autocomplete
+    element.selectionStart = element.value.length;
+    element.selectionEnd = element.value.length;
+    simulateKey(element, "\b");
+    let list = document.querySelectorAll("#ac-testing ul li");
+    assert.strictEqual(list.length, 1);
+
+    simulateKey(element, "\b");
+    list = document.querySelectorAll("#ac-testing ul li");
+    assert.strictEqual(list.length, 2);
   });
 
   test("Autocomplete can render on @", function (assert) {

--- a/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/autocomplete-test.js
@@ -36,9 +36,16 @@ module("Unit | Utility | autocomplete", function (hooks) {
     if (!options.skipValueChange) {
       let pos = element.selectionStart;
       let value = element.value;
-      element.value = value.slice(0, pos) + key + value.slice(pos);
-      element.selectionStart = pos + 1;
-      element.selectionEnd = pos + 1;
+      // backspace
+      if (key === "\b") {
+        element.value = value.slice(0, pos - 1) + value.slice(pos);
+        element.selectionStart = pos - 1;
+        element.selectionEnd = pos - 1;
+      } else {
+        element.value = value.slice(0, pos) + key + value.slice(pos);
+        element.selectionStart = pos + 1;
+        element.selectionEnd = pos + 1;
+      }
     }
     element.dispatchEvent(
       new KeyboardEvent("keyup", { key, keyCode, which: keyCode })
@@ -81,7 +88,16 @@ module("Unit | Utility | autocomplete", function (hooks) {
     assert.strictEqual(element.selectionStart, 14);
     assert.strictEqual(element.selectionEnd, 14);
 
-    element.selection;
+    element.selectionStart = 6;
+    element.selectionEnd = 6;
+
+    simulateKey(element, "\b");
+    simulateKey(element, "\b");
+    simulateKey(element, "\r", { skipValueChange: true });
+
+    assert.strictEqual(element.value, "@test1 @test2 ");
+    assert.strictEqual(element.selectionStart, 7);
+    assert.strictEqual(element.selectionEnd, 7);
   });
 
   test("Autocomplete can render on @", function (assert) {


### PR DESCRIPTION
Previously after uploads completed post raw would drift.
If you autocompleted text after the upload stub got replaced it would
insert in the wrong position.
