### PR TITLE
DEV: add .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@
 /vendor/data/GeoLite2-City.mmdb
 /vendor/data/GeoLite2-ASN.mmdb
 
+# We provide a .sample but people can use newer versions if they want to
+.ruby-version
+
 # Front-end
 dist
 node_modules


### PR DESCRIPTION
We provide a `.ruby-version.sample` file that we use for warning developers about the minimum recommended Ruby version to run Discourse.

https://github.com/discourse/discourse/blob/d24dfe8f96c4151cbd6dbcc2313b42a0bf291c7d/config/application.rb#L15-L20

But if people copy the sample to a `.ruby-version` file it would be added next time they commit.

This adds the `.ruby-version` file to `.gitignore` so it doesn't get commited by mistake and developers can test Discourse on other versions of Ruby if they want to.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
