### PR TITLE
REFACTOR: Expand mentions and create notifications in batches

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -913,7 +913,6 @@ posting:
   max_mentions_per_post: 10
   max_users_notified_per_group_mention:
     default: 100
-    max: 250
     client: true
   newuser_max_replies_per_topic: 3
   newuser_max_mentions_per_post: 2

--- a/plugins/chat/app/jobs/regular/chat_notify_mentioned.rb
+++ b/plugins/chat/app/jobs/regular/chat_notify_mentioned.rb
@@ -12,10 +12,21 @@ module Jobs
         return
       end
 
+      mention_type = args[:mention_type]&.to_sym
+      return if (
+        mention_type.blank? ||
+        (
+          !Chat::ChatNotifier::STATIC_MENTION_TYPES.include?(mention_type) &&
+          !Group.where("LOWER(name) = ?", mention_type).exists?
+        )
+      )
+
       @creator = @chat_message.user
       @chat_channel = @chat_message.chat_channel
-      user_ids_to_notify = args[:to_notify_ids_map] || {}
-      user_ids_to_notify.each { |mention_type, ids| process_mentions(ids, mention_type.to_sym) }
+
+      user_ids_to_notify = args[:user_ids].to_a
+
+      process_mentions(user_ids_to_notify, mention_type)
     end
 
     private

--- a/plugins/chat/app/jobs/regular/chat_notify_watching.rb
+++ b/plugins/chat/app/jobs/regular/chat_notify_watching.rb
@@ -37,9 +37,9 @@ module Jobs
           )
           .merge(User.not_suspended)
 
-      if global_mentions.include?("all")
+      if global_mentions.include?(Chat::ChatNotifier::ALL_KEYWORD)
         members = members.where(user_option: { ignore_channel_wide_mention: true })
-      elsif global_mentions.include?("here")
+      elsif global_mentions.include?(Chat::ChatNotifier::HERE_KEYWORD)
         members = members.where("last_seen_at < ?", 5.minutes.ago)
       end
 

--- a/plugins/chat/app/jobs/regular/send_message_notifications.rb
+++ b/plugins/chat/app/jobs/regular/send_message_notifications.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Jobs
+  class SendMessageNotifications < ::Jobs::Base
+    def execute(args)
+      reason = args[:reason]
+      return if (timestamp = args[:timestamp]).blank?
+
+      return if (message = ChatMessage.find_by(id: args[:chat_message_id])).nil?
+
+      if reason == "new"
+        Chat::ChatNotifier.new(message, timestamp).notify_new
+      elsif reason == "edit"
+        Chat::ChatNotifier.new(message, timestamp).notify_edit
+      end
+    end
+  end
+end

--- a/plugins/chat/app/models/chat_mention.rb
+++ b/plugins/chat/app/models/chat_mention.rb
@@ -3,7 +3,7 @@
 class ChatMention < ActiveRecord::Base
   belongs_to :user
   belongs_to :chat_message
-  belongs_to :notification
+  belongs_to :notification, dependent: :destroy
 end
 
 # == Schema Information

--- a/plugins/chat/app/models/user_chat_channel_membership.rb
+++ b/plugins/chat/app/models/user_chat_channel_membership.rb
@@ -13,6 +13,10 @@ class UserChatChannelMembership < ActiveRecord::Base
 
   attribute :unread_count, default: 0
   attribute :unread_mentions, default: 0
+
+  def has_seen_message?(chat_message)
+    (last_read_message_id || 0) >= chat_message.id
+  end
 end
 
 # == Schema Information

--- a/plugins/chat/lib/chat_notifier.rb
+++ b/plugins/chat/lib/chat_notifier.rb
@@ -31,9 +31,10 @@ class Chat::ChatNotifier
   HERE_MENTIONS = :here_mentions
   GLOBAL_MENTIONS = :global_mentions
   STATIC_MENTION_TYPES = [DIRECT_MENTIONS, HERE_MENTIONS, GLOBAL_MENTIONS]
+  HERE_KEYWORD = 'here'
+  ALL_KEYWORD = 'all'
 
   MENTION_BATCH_SIZE = 250
-
   class << self
     def push_notification_tag(type, chat_channel_id)
       "#{Discourse.current_hostname}-chat-#{type}-#{chat_channel_id}"
@@ -73,8 +74,8 @@ class Chat::ChatNotifier
     end
 
     global_mentions = []
-    global_mentions << "all" if typed_global_mention?
-    global_mentions << "here" if typed_here_mention?
+    global_mentions << ALL_KEYWORD if typed_global_mention?
+    global_mentions << HERE_KEYWORD if typed_here_mention?
 
     notify_watching_users(
       mentioned_channel_member_ids,
@@ -168,9 +169,6 @@ class Chat::ChatNotifier
       classified.each do |group_name, member_ids|
         notify_mentioned_users(group_name, member_ids)
       end
-
-      inaccessible_mentions[:welcome_to_join] = inaccessible_mentions[:welcome_to_join].concat(grouped[:welcome_to_join])
-      inaccessible_mentions[:unreachable] = inaccessible_mentions[:unreachable].concat(grouped[:unreachable])
     end
   end
 

--- a/plugins/chat/lib/chat_notifier.rb
+++ b/plugins/chat/lib/chat_notifier.rb
@@ -37,11 +37,21 @@ class Chat::ChatNotifier
     end
 
     def notify_edit(chat_message:, timestamp:)
-      new(chat_message, timestamp).notify_edit
+      Jobs.enqueue(
+        :send_message_notifications,
+        chat_message_id: chat_message.id,
+        timestamp: timestamp.iso8601(6),
+        reason: "edit"
+      )
     end
 
     def notify_new(chat_message:, timestamp:)
-      new(chat_message, timestamp).notify_new
+      Jobs.enqueue(
+        :send_message_notifications,
+        chat_message_id: chat_message.id,
+        timestamp: timestamp.iso8601(6),
+        reason: "new"
+      )
     end
   end
 
@@ -333,7 +343,7 @@ class Chat::ChatNotifier
         chat_message_id: @chat_message.id,
         to_notify_ids_map: to_notify.as_json,
         already_notified_user_ids: already_notified_user_ids,
-        timestamp: @timestamp.iso8601(6),
+        timestamp: @timestamp,
       },
     )
   end
@@ -344,7 +354,7 @@ class Chat::ChatNotifier
       {
         chat_message_id: @chat_message.id,
         except_user_ids: except,
-        timestamp: @timestamp.iso8601(6),
+        timestamp: @timestamp,
       },
     )
   end

--- a/plugins/chat/lib/chat_notifier.rb
+++ b/plugins/chat/lib/chat_notifier.rb
@@ -134,7 +134,7 @@ class Chat::ChatNotifier
 
   def chat_users
     users =
-      User.includes(:do_not_disturb_timings, :push_subscriptions, :user_chat_channel_memberships)
+      User.includes(:user_chat_channel_memberships, :group_users)
 
     users
       .distinct
@@ -275,7 +275,9 @@ class Chat::ChatNotifier
     mentionable.each { |g| to_notify[g.name.downcase] = [] }
 
     reached_by_group =
-      chat_users.joins(:groups).where(groups: mentionable).where.not(id: already_covered_ids)
+      chat_users
+        .includes(:groups)
+        .joins(:groups).where(groups: mentionable).where.not(id: already_covered_ids)
 
     grouped = group_users_to_notify(reached_by_group)
 

--- a/plugins/chat/lib/chat_notifier.rb
+++ b/plugins/chat/lib/chat_notifier.rb
@@ -154,6 +154,8 @@ class Chat::ChatNotifier
     inaccessible_mentions[:group_mentions_disabled] = mentions_disabled
     inaccessible_mentions[:too_many_members] = too_many_members
 
+    return if mentionable.blank?
+
     mentioned_by_group(mentionable).find_in_batches(batch_size: MENTION_BATCH_SIZE) do |reached_by_group|
       grouped = group_users_to_notify(reached_by_group)
       ordered_group_names = group_name_mentions & mentionable.map { |mg| mg.name.downcase }
@@ -321,7 +323,7 @@ class Chat::ChatNotifier
   # Jobs to create notifications
 
   def notify_mentioned_users(mention_type, user_ids)
-    return if user_ids.blank?
+    return if user_ids.blank? || mention_type.blank?
 
     Jobs.enqueue(
       :chat_notify_mentioned,

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -198,6 +198,7 @@ after_initialize do
   load File.expand_path("../app/jobs/regular/chat_notify_watching.rb", __FILE__)
   load File.expand_path("../app/jobs/regular/update_channel_user_count.rb", __FILE__)
   load File.expand_path("../app/jobs/regular/delete_user_messages.rb", __FILE__)
+  load File.expand_path("../app/jobs/regular/send_message_notifications.rb", __FILE__)
   load File.expand_path("../app/jobs/scheduled/delete_old_chat_messages.rb", __FILE__)
   load File.expand_path("../app/jobs/scheduled/update_user_counts_for_chat_channels.rb", __FILE__)
   load File.expand_path("../app/jobs/scheduled/email_chat_notifications.rb", __FILE__)

--- a/plugins/chat/spec/jobs/regular/chat_notify_watching_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat_notify_watching_spec.rb
@@ -5,21 +5,136 @@ RSpec.describe Jobs::ChatNotifyWatching do
   fab!(:user2) { Fabricate(:user) }
   fab!(:user3) { Fabricate(:user) }
   fab!(:group) { Fabricate(:group) }
-  let(:except_user_ids) { [] }
 
   before do
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
   end
 
-  def run_job
-    described_class.new.execute(chat_message_id: message.id, except_user_ids: except_user_ids)
+  def listen_for_notifications(user, direct_mentioned_user_ids: [], global_mentions: [], mentioned_group_ids: [])
+    MessageBus.track_publish("/chat/notification-alert/#{user.id}") do
+      subject.execute(
+        chat_message_id: message.id,
+        direct_mentioned_user_ids: direct_mentioned_user_ids,
+        global_mentions: global_mentions,
+        mentioned_group_ids: mentioned_group_ids
+      )
+    end
   end
 
-  def notification_messages_for(user)
-    MessageBus
-      .track_publish { run_job }
-      .filter { |m| m.channel == "/chat/notification-alert/#{user.id}" }
+  def build_notification_translation(channel)
+    if channel.direct_message_channel?
+      "discourse_push_notifications.popup.new_direct_chat_message"
+    else
+      "discourse_push_notifications.popup.new_chat_message"
+    end
+  end
+
+  def expects_push_notification(sender, receiver, message)
+    PostAlerter.expects(:push_notification).with(
+      receiver,
+      has_entries(
+        {
+          username: sender.username,
+          notification_type: Notification.types[:chat_message],
+          post_url: message.chat_channel.relative_url,
+          translated_title:
+            I18n.t(
+              build_notification_translation(message.chat_channel),
+              { username: sender.username, channel: message.chat_channel.title(receiver) },
+            ),
+          tag: Chat::ChatNotifier.push_notification_tag(:message, message.chat_channel.id),
+          excerpt: message.message,
+        },
+      ),
+    )
+  end
+
+  def assert_notification_alert_is_correct(alert_data, sender, receiver, message)
+    expect(alert_data).to include(
+      {
+        username: sender.username,
+        notification_type: Notification.types[:chat_message],
+        post_url: message.chat_channel.relative_url,
+        translated_title:
+          I18n.t(
+            build_notification_translation(message.chat_channel),
+            { username: sender.username, channel: channel.title(receiver) },
+          ),
+        tag: Chat::ChatNotifier.push_notification_tag(:message, message.chat_channel.id),
+        excerpt: message.message,
+      },
+    )
+  end
+
+  context "when the chat message has mentions" do
+    fab!(:channel) { Fabricate(:category_channel) }
+    fab!(:membership) do
+      Fabricate(:user_chat_channel_membership, user: user2, chat_channel: channel)
+    end
+    fab!(:message) do
+      Fabricate(:chat_message, chat_channel: channel, user: user1, message: "this is a new message")
+    end
+
+    before do
+      membership.update!(
+        desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+        mobile_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+      )
+    end
+
+    it "skips the watching notifications if it was mentioned directly" do
+      PostAlerter.expects(:push_notification).never
+
+      messages = listen_for_notifications(user2, direct_mentioned_user_ids: [user2.id])
+
+      expect(messages.size).to be_zero
+    end
+
+    it "skips the watching notifications if it was mentioned through a group" do
+      group.add(user1)
+      PostAlerter.expects(:push_notification).never
+
+      messages = listen_for_notifications(user2, mentioned_group_ids: [group.id])
+
+      expect(messages.size).to be_zero
+    end
+
+    it "skips the watching notifications if it was mentioned via @all mention" do
+      PostAlerter.expects(:push_notification).never
+
+      messages = listen_for_notifications(user2, global_mentions: ["all"])
+
+      expect(messages.size).to be_zero
+    end
+
+    it "doesn't skip the watching notifications on @all and ignoring channel wide mention" do
+      user2.user_option.update!(ignore_channel_wide_mention: true)
+
+      expects_push_notification(user1, user2, message)
+
+      messages = listen_for_notifications(user2, global_mentions: ["all"])
+
+      assert_notification_alert_is_correct(messages.first.data, user1, user2, message)
+    end
+
+    it "skips the watching notifications if it was mentioned via @here mention" do
+      PostAlerter.expects(:push_notification).never
+
+      messages = listen_for_notifications(user2, global_mentions: ["here"])
+
+      expect(messages.size).to be_zero
+    end
+
+    it "doesn't skip the watching notifications on @here if the user last seen is more than 5 minutes ago" do
+      user2.update!(last_seen_at: 6.minutes.ago)
+
+      expects_push_notification(user1, user2, message)
+
+      messages = listen_for_notifications(user2, global_mentions: ["here"])
+
+      assert_notification_alert_is_correct(messages.first.data, user1, user2, message)
+    end
   end
 
   context "for a category channel" do
@@ -44,22 +159,9 @@ RSpec.describe Jobs::ChatNotifyWatching do
     end
 
     it "sends a desktop notification" do
-      messages = notification_messages_for(user2)
+      messages = listen_for_notifications(user2)
 
-      expect(messages.first.data).to include(
-        {
-          username: user1.username,
-          notification_type: Notification.types[:chat_message],
-          post_url: channel.relative_url,
-          translated_title:
-            I18n.t(
-              "discourse_push_notifications.popup.new_chat_message",
-              { username: user1.username, channel: channel.title(user2) },
-            ),
-          tag: Chat::ChatNotifier.push_notification_tag(:message, channel.id),
-          excerpt: message.message,
-        },
-      )
+      assert_notification_alert_is_correct(messages.first.data, user1, user2, message)
     end
 
     context "when the channel is muted via membership preferences" do
@@ -67,7 +169,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
 
       it "does not send a desktop or mobile notification" do
         PostAlerter.expects(:push_notification).never
-        messages = notification_messages_for(user2)
+        messages = listen_for_notifications(user2)
         expect(messages).to be_empty
       end
     end
@@ -81,24 +183,10 @@ RSpec.describe Jobs::ChatNotifyWatching do
       end
 
       it "sends a mobile notification" do
-        PostAlerter.expects(:push_notification).with(
-          user2,
-          has_entries(
-            {
-              username: user1.username,
-              notification_type: Notification.types[:chat_message],
-              post_url: channel.relative_url,
-              translated_title:
-                I18n.t(
-                  "discourse_push_notifications.popup.new_chat_message",
-                  { username: user1.username, channel: channel.title(user2) },
-                ),
-              tag: Chat::ChatNotifier.push_notification_tag(:message, channel.id),
-              excerpt: message.message,
-            },
-          ),
-        )
-        messages = notification_messages_for(user2)
+        expects_push_notification(user1, user2, message)
+
+        messages = listen_for_notifications(user2)
+
         expect(messages.length).to be_zero
       end
 
@@ -107,7 +195,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
 
         it "does not send a desktop or mobile notification" do
           PostAlerter.expects(:push_notification).never
-          messages = notification_messages_for(user2)
+          messages = listen_for_notifications(user2)
           expect(messages).to be_empty
         end
       end
@@ -117,7 +205,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { SiteSetting.chat_allowed_groups = group.id }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -125,7 +213,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { channel.update!(chatable: Fabricate(:private_category, group: group)) }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -133,7 +221,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { membership2.update!(last_read_message_id: message.id) }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -141,7 +229,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { PresenceChannel.any_instance.expects(:user_ids).returns([user2.id]) }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -149,15 +237,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { user2.update!(suspended_till: 1.year.from_now) }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
-      end
-    end
-
-    context "when the target user is inside the except_user_ids array" do
-      let(:except_user_ids) { [user2.id] }
-
-      it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
   end
@@ -184,22 +264,9 @@ RSpec.describe Jobs::ChatNotifyWatching do
     end
 
     it "sends a desktop notification" do
-      messages = notification_messages_for(user2)
+      messages = listen_for_notifications(user2)
 
-      expect(messages.first.data).to include(
-        {
-          username: user1.username,
-          notification_type: Notification.types[:chat_message],
-          post_url: channel.relative_url,
-          translated_title:
-            I18n.t(
-              "discourse_push_notifications.popup.new_direct_chat_message",
-              { username: user1.username, channel: channel.title(user2) },
-            ),
-          tag: Chat::ChatNotifier.push_notification_tag(:message, channel.id),
-          excerpt: message.message,
-        },
-      )
+      assert_notification_alert_is_correct(messages.first.data, user1, user2, message)
     end
 
     context "when the channel is muted via membership preferences" do
@@ -207,7 +274,9 @@ RSpec.describe Jobs::ChatNotifyWatching do
 
       it "does not send a desktop or mobile notification" do
         PostAlerter.expects(:push_notification).never
-        messages = notification_messages_for(user2)
+
+        messages = listen_for_notifications(user2)
+
         expect(messages).to be_empty
       end
     end
@@ -221,24 +290,10 @@ RSpec.describe Jobs::ChatNotifyWatching do
       end
 
       it "sends a mobile notification" do
-        PostAlerter.expects(:push_notification).with(
-          user2,
-          has_entries(
-            {
-              username: user1.username,
-              notification_type: Notification.types[:chat_message],
-              post_url: channel.relative_url,
-              translated_title:
-                I18n.t(
-                  "discourse_push_notifications.popup.new_direct_chat_message",
-                  { username: user1.username, channel: channel.title(user2) },
-                ),
-              tag: Chat::ChatNotifier.push_notification_tag(:message, channel.id),
-              excerpt: message.message,
-            },
-          ),
-        )
-        messages = notification_messages_for(user2)
+        expects_push_notification(user1, user2, message)
+
+        messages = listen_for_notifications(user2)
+
         expect(messages.length).to be_zero
       end
 
@@ -247,7 +302,9 @@ RSpec.describe Jobs::ChatNotifyWatching do
 
         it "does not send a desktop or mobile notification" do
           PostAlerter.expects(:push_notification).never
-          messages = notification_messages_for(user2)
+
+          messages = listen_for_notifications(user2)
+
           expect(messages).to be_empty
         end
       end
@@ -257,7 +314,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { SiteSetting.chat_allowed_groups = group.id }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -265,7 +322,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { membership2.destroy! }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -273,7 +330,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { membership2.update!(last_read_message_id: message.id) }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -281,7 +338,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { PresenceChannel.any_instance.expects(:user_ids).returns([user2.id]) }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -289,15 +346,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { user2.update!(suspended_till: 1.year.from_now) }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
-      end
-    end
-
-    context "when the target user is inside the except_user_ids array" do
-      let(:except_user_ids) { [user2.id] }
-
-      it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
 
@@ -305,7 +354,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       before { UserCommScreener.any_instance.expects(:allowing_actor_communication).returns([]) }
 
       it "does not send a desktop notification" do
-        expect(notification_messages_for(user2).count).to be_zero
+        expect(listen_for_notifications(user2).count).to be_zero
       end
     end
   end

--- a/plugins/chat/spec/jobs/regular/send_message_notifications_spec.rb
+++ b/plugins/chat/spec/jobs/regular/send_message_notifications_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::SendMessageNotifications do
+  describe "#execute" do
+    context "when the message doesn't exist" do
+      it "does nothing" do
+        Chat::ChatNotifier.any_instance.expects(:notify_new).never
+        Chat::ChatNotifier.any_instance.expects(:notify_edit).never
+
+        subject.execute(eason: "new", timestamp: 1.minute.ago)
+      end
+    end
+
+    context "when there's a message" do
+      fab!(:chat_message) { Fabricate(:chat_message) }
+
+      it "does nothing when the reason is invalid" do
+        Chat::ChatNotifier.expects(:notify_new).never
+        Chat::ChatNotifier.expects(:notify_edit).never
+
+        subject.execute(
+          chat_message_id: chat_message.id,
+          reason: "invalid",
+          timestamp: 1.minute.ago
+        )
+      end
+
+      it "does nothing if there is no timestamp" do
+        Chat::ChatNotifier.any_instance.expects(:notify_new).never
+        Chat::ChatNotifier.any_instance.expects(:notify_edit).never
+
+        subject.execute(
+          chat_message_id: chat_message.id,
+          reason: "invalid"
+        )
+      end
+
+      it "calls notify_new when the reason is 'new'" do
+        Chat::ChatNotifier.any_instance.expects(:notify_new).once
+        Chat::ChatNotifier.any_instance.expects(:notify_edit).never
+
+        subject.execute(
+          chat_message_id: chat_message.id,
+          reason: "new",
+          timestamp: 1.minute.ago
+        )
+      end
+
+      it "calls notify_edit when the reason is 'edit'" do
+        Chat::ChatNotifier.any_instance.expects(:notify_new).never
+        Chat::ChatNotifier.any_instance.expects(:notify_edit).once
+
+        subject.execute(
+          chat_message_id: chat_message.id,
+          reason: "edit",
+          timestamp: 1.minute.ago
+        )
+      end
+    end
+  end
+end

--- a/plugins/chat/spec/lib/chat_notifier_spec.rb
+++ b/plugins/chat/spec/lib/chat_notifier_spec.rb
@@ -335,31 +335,6 @@ describe Chat::ChatNotifier do
           unreachable_users = unreachable_msg.data[:cannot_see].map { |u| u["id"] }
           expect(unreachable_users).to contain_exactly(user_3.id)
         end
-
-        it "notify posts of users who are part of the mentioned group but participating" do
-          group =
-            Fabricate(
-              :public_group,
-              users: [user_2, user_3],
-              mentionable_level: Group::ALIAS_LEVELS[:everyone],
-            )
-          msg =
-            build_cooked_msg("Hello @#{group.name}", user_1, chat_channel: personal_chat_channel)
-
-          messages =
-            MessageBus.track_publish("/chat/#{personal_chat_channel.id}") do
-              described_class.new(msg, msg.created_at).notify_new
-
-              assert_users_were_notifier_with_mention_type(group.name, [user_2.id])
-            end
-
-          unreachable_msg = messages.first
-
-          expect(unreachable_msg).to be_present
-          expect(unreachable_msg.data[:without_membership]).to be_empty
-          unreachable_users = unreachable_msg.data[:cannot_see].map { |u| u["id"] }
-          expect(unreachable_users).to contain_exactly(user_3.id)
-        end
       end
     end
 
@@ -422,30 +397,6 @@ describe Chat::ChatNotifier do
           following: false,
         )
         msg = build_cooked_msg("Hello @#{user_3.username}", user_1)
-
-        messages =
-          MessageBus.track_publish("/chat/#{channel.id}") do
-            described_class.new(msg, msg.created_at).notify_new
-
-            assert_users_were_notifier_with_mention_type(:direct_mentions, [])
-          end
-
-        not_participating_msg = messages.first
-
-        expect(not_participating_msg).to be_present
-        expect(not_participating_msg.data[:cannot_see]).to be_empty
-        not_participating_users = not_participating_msg.data[:without_membership].map { |u| u["id"] }
-        expect(not_participating_users).to contain_exactly(user_3.id)
-      end
-
-      it "can invite other group members to channel" do
-        group =
-          Fabricate(
-            :public_group,
-            users: [user_2, user_3],
-            mentionable_level: Group::ALIAS_LEVELS[:everyone],
-          )
-        msg = build_cooked_msg("Hello @#{group.name}", user_1)
 
         messages =
           MessageBus.track_publish("/chat/#{channel.id}") do

--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
   let(:chat) { PageObjects::Pages::Chat.new }
 
   before do
+    Jobs.run_immediately!
     channel_1.add(current_user)
     chat_system_bootstrap
     sign_in(current_user)

--- a/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
+++ b/plugins/chat/spec/system/message_notifications_with_sidebar_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe "Message notifications - with sidebar", type: :system, js: true d
           end
 
           context "when a message with mentions is created" do
+            before { Jobs.run_immediately! }
+
             it "correctly renders notifications" do
               visit("/")
               using_session(:user_1) do

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
     fab!(:other_user) { Fabricate(:user) }
 
     before do
+      Jobs.run_immediately!
       channel_1.add(current_user)
     end
 


### PR DESCRIPTION
Depends on #19666.

This PR implements batching for sending channel wide and group notifications when expanding mentions. We had to simplify the internals of the chat notifier so every mention expansion step, notifying watching users and purging old mentions can be independent and not rely on the class tracking mentioned user IDs.

Before this change, the component had to expand all mentions before doing anything, building a big hash to classify users per mention type. Tracking all this state not only makes the code more complex, but it's also not free from a memory perspective when dealing with large channel wide mentions or groups.

Memory profile report when expanding a mention of a group with 3k users:

|   | Before  | After  | Diff  |
|---|---|---|---|
| Allocated bytes  | 405075642 |  69287097 | ~82%  |
| Retained bytes  | 1531110 |  1041145 | ~32%  |
| Allocated objects  | 1495980  | 640619  | ~57%  |
| Retained objects  | 12263 | 7850 | ~35%  |

These two reports were generated running against this branch vs main:

```ruby
cm = ...find message mentioning group...

report = MemoryProfiler.report do 
  Chat::ChatNotifier.new(cm, cm.created_at).notify_new
end

report.pretty_print
```
