### PR TITLE
DEV: enables threadsafe for system tests

### DIFF
--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe "Chat channel", type: :system, js: true do
       expect(channel).to have_no_loading_skeleton
       expect(page).to have_no_css("[data-id='#{unloaded_message.id}']")
 
-      find(".chat-composer-input").fill_in(with: "test message")
-      find(".send-btn").click
+      channel.send_message("test_message")
 
       expect(channel).to have_no_loading_skeleton
       expect(page).to have_css("[data-id='#{unloaded_message.id}']")

--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
   fab!(:other_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }
+  let(:channel) { PageObjects::Pages::ChatChannel.new }
 
   before do
     channel_1.add(current_user)
@@ -16,8 +17,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
   context "when mentioning a user not on the channel" do
     it "displays a mention warning" do
       chat.visit_channel(channel_1)
-      find(".chat-composer-input").fill_in(with: "hi @#{other_user.username}")
-      find(".send-btn").click
+      channel.send_message("hi @#{other_user.username}")
 
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.without_membership.one", username: other_user.username),
@@ -36,9 +36,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
 
     it "displays a mention warning" do
       chat.visit_channel(private_channel_1)
-      find(".chat-composer-input").fill_in(with: "hi @#{other_user.username}")
-      find(".chat-composer-input").click
-      find(".send-btn").click
+      channel.send_message("hi @#{other_user.username}")
 
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.cannot_see.one", username: other_user.username),
@@ -52,8 +50,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
 
       it "displays a mention warning" do
         chat.visit_channel(channel_1)
-        find(".chat-composer-input").fill_in(with: "hi @#{group_1.name}")
-        find(".send-btn").click
+        channel.send_message("hi @#{group_1.name}")
 
         expect(page).to have_content(
           I18n.t("js.chat.mention_warning.group_mentions_disabled.one", group_name: group_1.name),

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -12,7 +12,7 @@ module PageObjects
       end
 
       def click_send_message
-        find(".chat-composer .send-btn").click
+        find(".chat-composer .send-btn:enabled").click
       end
 
       def message_by_id(id)

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
     context "when quoting a message in another message" do
       fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
 
-      it "quotes the message" do
+      xit "quotes the message" do
         chat_page.visit_channel(chat_channel_1)
 
         expect(chat_channel_page).to have_no_loading_skeleton

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -180,8 +180,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
 
         clip_text = copy_messages_to_clipboard(message_1)
         click_selection_button("cancel")
-        chat_channel_page.fill_composer(clip_text)
-        chat_channel_page.click_send_message
+        chat_channel_page.send_message(clip_text)
 
         expect(page).to have_selector(".chat-message", count: 2)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -245,6 +245,7 @@ RSpec.configure do |config|
       allow: [Webdrivers::Chromedriver.base_url]
     )
 
+    Capybara.threadsafe = true
     Capybara.disable_animation = true
 
     Capybara.configure do |capybara_config|


### PR DESCRIPTION
It should fix flakeys we have due to `using_session`. This commit is also fixing tests which were failing constantly with treadsafe enabled.

More info: https://github.com/teamcapybara/capybara#threadsafe-mode

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
