### PR TITLE
FIX: correctly always return a promise from loadMore

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-api.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-api.js
@@ -71,18 +71,18 @@ class Collection {
 
   @bind
   loadMore() {
+    let promise = Promise.resolve();
+
     if (this.loading) {
-      return;
+      return promise;
     }
 
     if (
       this._fetchedAll ||
       (this.totalRows && this.items.length >= this.totalRows)
     ) {
-      return;
+      return promise;
     }
-
-    let promise;
 
     this.loading = true;
 
@@ -97,8 +97,6 @@ class Collection {
         }
         this.meta = result.meta;
       });
-    } else {
-      promise = Promise.resolve();
     }
 
     return promise.finally(() => {


### PR DESCRIPTION
This commit also fixes an issue where `loading = false` was never called when the server had nothing new to return.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
