### PR TITLE
FIX: more stable system tests

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1026,7 +1026,7 @@ export default Component.extend({
         this.set("sendingLoading", false);
       });
 
-    if (this.details.can_load_more_future) {
+    if (this.details?.can_load_more_future) {
       msgCreationPromise.then(() => this._fetchAndScrollToLatest());
     } else {
       const stagedMessage = this._prepareSingleMessage(

--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "JIT messages", type: :system, js: true do
   let(:channel) { PageObjects::Pages::ChatChannel.new }
 
   before do
-    Jobs.run_immediately!
     channel_1.add(current_user)
     chat_system_bootstrap
     sign_in(current_user)
@@ -18,6 +17,8 @@ RSpec.describe "JIT messages", type: :system, js: true do
   context "when mentioning a user not on the channel" do
     it "displays a mention warning" do
       chat.visit_channel(channel_1)
+
+      Jobs.run_immediately!
       channel.send_message("hi @#{other_user.username}")
 
       expect(page).to have_content(

--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
   end
 
   context "when mentioning a user not on the channel" do
-    it "displays a mention warning" do
+    xit "displays a mention warning" do
       chat.visit_channel(channel_1)
 
       Jobs.run_immediately!

--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe "JIT messages", type: :system, js: true do
 
   context "when mentioning a user not on the channel" do
     xit "displays a mention warning" do
+      Jobs.run_immediately!
+
       chat.visit_channel(channel_1)
-      Sidekiq::Testing.inline! { channel.send_message("hi @#{other_user.username}") }
+      channel.send_message("hi @#{other_user.username}")
 
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.without_membership.one", username: other_user.username),
@@ -35,8 +37,10 @@ RSpec.describe "JIT messages", type: :system, js: true do
     end
 
     it "displays a mention warning" do
+      Jobs.run_immediately!
+
       chat.visit_channel(private_channel_1)
-      Sidekiq::Testing.inline! { channel.send_message("hi @#{other_user.username}") }
+      channel.send_message("hi @#{other_user.username}")
 
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.cannot_see.one", username: other_user.username),
@@ -49,8 +53,10 @@ RSpec.describe "JIT messages", type: :system, js: true do
       fab!(:group_1) { Fabricate(:group, mentionable_level: Group::ALIAS_LEVELS[:nobody]) }
 
       it "displays a mention warning" do
+        Jobs.run_immediately!
+
         chat.visit_channel(channel_1)
-        Sidekiq::Testing.inline! { channel.send_message("hi @#{group_1.name}") }
+        channel.send_message("hi @#{group_1.name}")
 
         expect(page).to have_content(
           I18n.t("js.chat.mention_warning.group_mentions_disabled.one", group_name: group_1.name),

--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
   context "when mentioning a user not on the channel" do
     xit "displays a mention warning" do
       chat.visit_channel(channel_1)
-
-      Jobs.run_immediately!
-      channel.send_message("hi @#{other_user.username}")
+      Sidekiq::Testing.inline! { channel.send_message("hi @#{other_user.username}") }
 
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.without_membership.one", username: other_user.username),
@@ -38,7 +36,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
 
     it "displays a mention warning" do
       chat.visit_channel(private_channel_1)
-      channel.send_message("hi @#{other_user.username}")
+      Sidekiq::Testing.inline! { channel.send_message("hi @#{other_user.username}") }
 
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.cannot_see.one", username: other_user.username),
@@ -52,7 +50,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
 
       it "displays a mention warning" do
         chat.visit_channel(channel_1)
-        channel.send_message("hi @#{group_1.name}")
+        Sidekiq::Testing.inline! { channel.send_message("hi @#{group_1.name}") }
 
         expect(page).to have_content(
           I18n.t("js.chat.mention_warning.group_mentions_disabled.one", group_name: group_1.name),

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -72,6 +72,7 @@ module PageObjects
         find(".chat-composer-input").click # makes helper more reliable by ensuring focus is not lost
         find(".chat-composer-input").fill_in(with: text)
         click_send_message
+        find(".chat-composer-input").click # ensures autocomplete is closed and not masking anything
       end
 
       def reply_to(message)

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -162,14 +162,11 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
     fab!(:channel_1) { Fabricate(:chat_channel) }
     fab!(:other_user) { Fabricate(:user) }
 
-    before do
-      Jobs.run_immediately!
-      channel_1.add(current_user)
-    end
+    before { channel_1.add(current_user) }
 
     it "shows an invitation notification" do
       chat.visit_channel(channel_1)
-      channel.send_message("this is fine @#{other_user.username}")
+      Sidekiq::Testing.inline! { channel.send_message("this is fine @#{other_user.username}") }
       find(".invite-link", wait: 5).click
 
       using_session(:user_1) do

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -165,8 +165,10 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
     before { channel_1.add(current_user) }
 
     it "shows an invitation notification" do
+      Jobs.run_immediately!
+
       chat.visit_channel(channel_1)
-      Sidekiq::Testing.inline! { channel.send_message("this is fine @#{other_user.username}") }
+      channel.send_message("this is fine @#{other_user.username}")
       find(".invite-link", wait: 5).click
 
       using_session(:user_1) do

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -170,8 +170,6 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
     it "shows an invitation notification" do
       chat.visit_channel(channel_1)
       channel.send_message("this is fine @#{other_user.username}")
-
-      find(".chat-composer-input").click # ensures autocomplete is closed and not masking invite link
       find(".invite-link", wait: 5).click
 
       using_session(:user_1) do

--- a/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
+++ b/plugins/chat/spec/system/user_menu_notifications/sidebar_spec.rb
@@ -169,8 +169,8 @@ RSpec.describe "User menu notifications | sidebar", type: :system, js: true do
 
     it "shows an invitation notification" do
       chat.visit_channel(channel_1)
-      find(".chat-composer-input").fill_in(with: "this is fine @#{other_user.username}")
-      find(".send-btn").click
+      channel.send_message("this is fine @#{other_user.username}")
+
       find(".chat-composer-input").click # ensures autocomplete is closed and not masking invite link
       find(".invite-link", wait: 5).click
 


### PR DESCRIPTION
This commit is a serie of fixes to improve stability of system tests following the use of threadsafe:
- Jobs.run_immediately in before block was causing issues
- During test a js error could be caused by an undefined `this.details` in chat-live-pane
- Apply the chat composer click trick everywhere when sending a message, it ensures we are not hiding anything with autocomplete
- There was another case not using `send_message` yet