### PR TITLE
FIX: correctly uses request_uri to generate load_more_url

### DIFF
--- a/plugins/chat/app/controllers/api/chat_channels_controller.rb
+++ b/plugins/chat/app/controllers/api/chat_channels_controller.rb
@@ -23,7 +23,7 @@ class Chat::Api::ChatChannelsController < Chat::Api
       end
 
     load_more_params = options.merge(offset: options[:offset] + options[:limit]).to_query
-    load_more_url = URI::HTTP.build(path: "/chat/api/channels", query: load_more_params)
+    load_more_url = URI::HTTP.build(path: "/chat/api/channels", query: load_more_params).request_uri
 
     render json: serialized_channels, root: "channels", meta: { load_more_url: load_more_url }
   end

--- a/plugins/chat/spec/system/browse_page_spec.rb
+++ b/plugins/chat/spec/system/browse_page_spec.rb
@@ -134,6 +134,17 @@ RSpec.describe "Browse page", type: :system, js: true do
           expect(browse_view).to have_content(category_channel_4.name)
         end
 
+        context "when loading more" do
+          before { 25.times { Fabricate(:chat_channel, status: :open) } }
+
+          it "works" do
+            visit("/chat/browse/all")
+            scroll_to(find(".chat-channel-card:last-child"))
+
+            expect(page).to have_selector(".chat-channel-card", count: 29)
+          end
+        end
+
         include_examples "never visible channels" do
           before { visit("/chat/browse/all") }
         end


### PR DESCRIPTION
Before this change we were generating an incorrect absolute URL: `https://chat/api/channels...`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
