### PR TITLE
Revert "DEV: enables threadsafe for system tests"

### DIFF
--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe "Chat channel", type: :system, js: true do
       expect(channel).to have_no_loading_skeleton
       expect(page).to have_no_css("[data-id='#{unloaded_message.id}']")
 
-      channel.send_message("test_message")
+      find(".chat-composer-input").fill_in(with: "test message")
+      find(".send-btn").click
 
       expect(channel).to have_no_loading_skeleton
       expect(page).to have_css("[data-id='#{unloaded_message.id}']")

--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "JIT messages", type: :system, js: true do
   fab!(:other_user) { Fabricate(:user) }
 
   let(:chat) { PageObjects::Pages::Chat.new }
-  let(:channel) { PageObjects::Pages::ChatChannel.new }
 
   before do
     Jobs.run_immediately!
@@ -18,7 +17,8 @@ RSpec.describe "JIT messages", type: :system, js: true do
   context "when mentioning a user not on the channel" do
     it "displays a mention warning" do
       chat.visit_channel(channel_1)
-      channel.send_message("hi @#{other_user.username}")
+      find(".chat-composer-input").fill_in(with: "hi @#{other_user.username}")
+      find(".send-btn").click
 
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.without_membership.one", username: other_user.username),
@@ -37,7 +37,9 @@ RSpec.describe "JIT messages", type: :system, js: true do
 
     it "displays a mention warning" do
       chat.visit_channel(private_channel_1)
-      channel.send_message("hi @#{other_user.username}")
+      find(".chat-composer-input").fill_in(with: "hi @#{other_user.username}")
+      find(".chat-composer-input").click
+      find(".send-btn").click
 
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.cannot_see.one", username: other_user.username),
@@ -51,7 +53,8 @@ RSpec.describe "JIT messages", type: :system, js: true do
 
       it "displays a mention warning" do
         chat.visit_channel(channel_1)
-        channel.send_message("hi @#{group_1.name}")
+        find(".chat-composer-input").fill_in(with: "hi @#{group_1.name}")
+        find(".send-btn").click
 
         expect(page).to have_content(
           I18n.t("js.chat.mention_warning.group_mentions_disabled.one", group_name: group_1.name),

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -12,7 +12,7 @@ module PageObjects
       end
 
       def click_send_message
-        find(".chat-composer .send-btn:enabled").click
+        find(".chat-composer .send-btn").click
       end
 
       def message_by_id(id)

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -173,14 +173,15 @@ RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
     context "when quoting a message in another message" do
       fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
 
-      xit "quotes the message" do
+      it "quotes the message" do
         chat_page.visit_channel(chat_channel_1)
 
         expect(chat_channel_page).to have_no_loading_skeleton
 
         clip_text = copy_messages_to_clipboard(message_1)
         click_selection_button("cancel")
-        chat_channel_page.send_message(clip_text)
+        chat_channel_page.fill_composer(clip_text)
+        chat_channel_page.click_send_message
 
         expect(page).to have_selector(".chat-message", count: 2)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -245,7 +245,6 @@ RSpec.configure do |config|
       allow: [Webdrivers::Chromedriver.base_url]
     )
 
-    Capybara.threadsafe = true
     Capybara.disable_animation = true
 
     Capybara.configure do |capybara_config|


### PR DESCRIPTION
This reverts commit b8100ad1ae38ee62236b497b8f2a56da1822f15b.

This was causing many issues in CI, including AR connections
not being expired because of threading issues, which was also
causing rails_helper to raise an error because we had busy
connections at the end of spec runs.

```
Cannot expire connection, it is owned by a different thread:
/__w/discourse/discourse/vendor/bundle/ruby/3.1.0/gems/puma-6.0.1/lib/puma/thread_pool.rb:106
sleep_forever>. Current thread: #<Thread:0x00007f541966fcc8 run>.
```

And:

```
Failure/Error: raise ActiveRecord::Base.connection_pool.stat.inspect

RuntimeError:
  {:size=>5, :connections=>2, :busy=>2, :dead=>0, :idle=>0, :waiting=>0, :checkout_timeout=>5.0}
```

See https://github.com/discourse/discourse/actions/runs/3825882529/jobs/6509204143
for examples.
