### PR TITLE
UX: fix for misalignment in autocomplete

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -439,6 +439,7 @@ html.composer-open {
         }
 
         .name {
+          display: contents;
           font-size: var(--font-down-1);
           color: var(--primary-high);
         }


### PR DESCRIPTION
Fix for the full name in the autocomplete being misaligned in safari and firefox
![image](https://user-images.githubusercontent.com/101828855/210366649-e727e8f1-ada5-49cc-abcf-70c315672471.png)

