### PR TITLE
FIX: Check that the node has a src attr when getting size

### DIFF
--- a/lib/cooked_processor_mixin.rb
+++ b/lib/cooked_processor_mixin.rb
@@ -149,7 +149,7 @@ module CookedProcessorMixin
     return unless image_sizes.present?
     image_sizes.each do |image_size|
       url, size = image_size[0], image_size[1]
-      if url && url.include?(src) &&
+      if url && src && url.include?(src) &&
          size && size["width"].to_i > 0 && size["height"].to_i > 0
         return [size["width"], size["height"]]
       end

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -870,9 +870,16 @@ RSpec.describe CookedPostProcessor do
     let(:post) { build(:post) }
     let(:cpp) { CookedPostProcessor.new(post) }
 
+    let(:image_sizes) do
+      { "http://my.discourse.org/image.png" => { "width" => 111, "height" => 222 } }
+    end
+
     it "returns the size" do
-      image_sizes = { "http://my.discourse.org/image.png" => { "width" => 111, "height" => 222 } }
       expect(cpp.get_size_from_image_sizes("/image.png", image_sizes)).to eq([111, 222])
+    end
+
+    it "returns nil whe img node has no src" do
+      expect(cpp.get_size_from_image_sizes(nil, image_sizes)).to eq(nil)
     end
   end
 


### PR DESCRIPTION
Error from our logs:

```
Message
Job exception: no implicit conversion of nil into String
Backtrace
/var/www/discourse/lib/cooked_processor_mixin.rb:152:in `include?'
/var/www/discourse/lib/cooked_processor_mixin.rb:152:in `block in get_size_from_image_sizes'
/var/www/discourse/lib/cooked_processor_mixin.rb:150:in `each'
/var/www/discourse/lib/cooked_processor_mixin.rb:150:in `get_size_from_image_sizes'
/var/www/discourse/lib/cooked_post_processor.rb:149:in `convert_to_link!'
/var/www/discourse/lib/cooked_post_processor.rb:366:in `block in post_process_images'
nokogiri-1.13.9-x86_64-linux/lib/nokogiri/xml/node_set.rb:234:in `block in each'
nokogiri-1.13.9-x86_64-linux/lib/nokogiri/xml/node_set.rb:233:in `upto'
nokogiri-1.13.9-x86_64-linux/lib/nokogiri/xml/node_set.rb:233:in `each'
/var/www/discourse/lib/cooked_post_processor.rb:364:in `post_process_images'
/var/www/discourse/lib/cooked_post_processor.rb:42:in `block in post_process'
```