### PR TITLE
UX: Add flex container and use baseline alignment for text based items

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user-selector-autocomplete.hbr
+++ b/app/assets/javascripts/discourse/app/templates/user-selector-autocomplete.hbr
@@ -1,22 +1,27 @@
-<div class='autocomplete ac-user'>
+<div class="autocomplete ac-user">
   <ul>
     {{#each options.users as |user|}}
       <li>
         <a href title="{{user.name}}" class="{{user.cssClasses}}">
           {{avatar user imageSize="tiny"}}
-          <span class='username'>{{format-username user.username}}</span>
-          {{#if user.name}}
-            <span class='name'>{{user.name}}</span>
-          {{/if}}
-          {{#if user.status}}
-            {{emoji user.status.emoji}}
-            <span class='status-description' title='{{user.status.description}}'>
-              {{user.status.description}}
-            </span>
-            {{#if user.status.ends_at}}
-              {{format-age user.status.ends_at}}
+          <div class="ac-user--metadata">
+            <span class="username">{{format-username user.username}}</span>
+            {{#if user.name}}
+              <span class="name">{{user.name}}</span>
             {{/if}}
-          {{/if}}
+            {{#if user.status}}
+              {{emoji user.status.emoji}}
+              <span
+                class="status-description"
+                title="{{user.status.description}}"
+              >
+                {{user.status.description}}
+              </span>
+              {{#if user.status.ends_at}}
+                {{format-age user.status.ends_at}}
+              {{/if}}
+            {{/if}}
+          </div>
         </a>
       </li>
     {{/each}}
@@ -25,8 +30,8 @@
       {{#each options.emails as |email|}}
         <li>
           <a href title="{{email.username}}">
-            {{d-icon 'envelope'}}
-            <span class='username'>{{format-username email.username}}</span>
+            {{d-icon "envelope"}}
+            <span class="username">{{format-username email.username}}</span>
           </a>
         </li>
       {{/each}}
@@ -37,8 +42,8 @@
         <li>
           <a href title="{{group.full_name}}">
             {{d-icon "users"}}
-            <span class='username'>{{group.name}}</span>
-            <span class='name'>{{group.full_name}}</span>
+            <span class="username">{{group.name}}</span>
+            <span class="name">{{group.full_name}}</span>
           </a>
         </li>
       {{/each}}

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -434,13 +434,20 @@ html.composer-open {
           }
         }
 
+        .ac-user--metadata {
+          display: flex;
+          align-items: baseline;
+          gap: 0.25rem;
+        }
+
         .avatar {
           margin-right: 0.25em;
         }
 
         .name {
-          display: contents;
           font-size: var(--font-down-1);
+          padding: 0;
+          margin: 0;
           color: var(--primary-high);
         }
 


### PR DESCRIPTION
This PR improves the logic for aligning the user autocomplete. Text items varying in font size cause issues with center alignment, therefore, this PR adds an additional container for text based items (everything that's not the avatar), and aligns them to a baseline, which is then center aligned in the original container wrapper.

<img width="990" alt="Screenshot 2023-01-03 at 10 53 15" src="https://user-images.githubusercontent.com/30090424/210422536-f354f7b9-f5ee-48ce-950b-5a15b13e8512.png">
