### PR TITLE
UX: Remove unused strings

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-colors-show.hbs
@@ -106,7 +106,7 @@
                     }}
                     @action={{action "revert" c}}
                     @title="admin.customize.colors.revert_title"
-                    @label="revert"
+                    @label="admin.customize.colors.revert"
                   />
                   <DButton
                     @class={{concat
@@ -115,7 +115,7 @@
                     }}
                     @action={{action "undo" c}}
                     @title="admin.customize.colors.undo_title"
-                    @label="undo"
+                    @label="admin.customize.colors.undo"
                   />
                 {{/unless}}
               </td>

--- a/app/assets/javascripts/discourse/app/templates/group-requests.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-requests.hbs
@@ -49,7 +49,7 @@
                   <DButton
                     @action={{action "undoAcceptRequest"}}
                     @actionParam={{m}}
-                    @label="undo"
+                    @label="groups.requests.undo"
                   />
                 {{else if m.request_denied}}
                   {{i18n "groups.requests.denied"}}

--- a/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/password-reset-test.js
@@ -31,7 +31,8 @@ acceptance("Password Reset", function (needs) {
       } else {
         return helper.response({
           success: "OK",
-          message: I18n.t("password_reset.success"),
+          message:
+            "You successfully changed your password and are now logged in.",
         });
       }
     });
@@ -44,7 +45,8 @@ acceptance("Password Reset", function (needs) {
       ) {
         return helper.response({
           success: "OK",
-          message: I18n.t("password_reset.success"),
+          message:
+            "You successfully changed your password and are now logged in.",
         });
       } else if (body.second_factor_token === "123123") {
         return helper.response({

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -429,7 +429,6 @@ en:
     enable: "Enable"
     disable: "Disable"
     continue: "Continue"
-    undo: "Undo"
 
     switch_to_anon: "Enter Anonymous Mode"
     switch_from_anon: "Exit Anonymous Mode"
@@ -747,6 +746,7 @@ en:
         denied: "denied"
         undone: "request undone"
         handle: "handle membership request"
+        undo: "Undo"
       manage:
         title: "Manage"
         name: "Name"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5105,9 +5105,9 @@ en:
           new_name: "New Color Palette"
           copy_name_prefix: "Copy of"
           delete_confirm: "Delete this color palette?"
-          undo: "undo"
+          undo: "Undo"
           undo_title: "Undo your changes to this color since the last time it was saved."
-          revert: "revert"
+          revert: "Revert"
           revert_title: "Reset this color to Discourse's default color palette."
           primary:
             name: "primary"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3907,7 +3907,6 @@ en:
     category_title: "Category"
     history_capped_revisions: "History, last 100 revisions"
     history: "History"
-    changed_by: "by %{author}"
 
     raw_email:
       title: "Incoming Email"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3581,7 +3581,6 @@ en:
         create_for_topic: "Create bookmark for topic"
         edit: "Edit bookmark"
         edit_for_topic: "Edit bookmark for topic"
-        created: "Created"
         updated: "Updated"
         name: "Name"
         name_placeholder: "What is this bookmark for?"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1049,7 +1049,7 @@ en:
     mailing_list_mode: "Turn off mailing list mode"
     all: "Don’t send me any mail from %{sitename}"
     different_user_description: "You are currently logged in as a different user than the one we emailed. Please log out, or enter anonymous mode, and try again."
-    not_found_description: Sorry, we couldn't find that subscription. It's possible the link in your email is too old and has expired?"
+    not_found_description: "Sorry, we couldn't find that subscription. It's possible the link in your email is too old and has expired?"
     user_not_found_description: "Sorry, we couldn't find a user for this subscription. You are probably attempting to unsubscribe an account that no longer exists."
     log_out: "Log Out"
     submit: "Save preferences"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -833,10 +833,6 @@ en:
 
   password_reset:
     no_token: 'Oops! The link you used no longer works. You can <a href="%{base_url}/login">Log In</a> now. If you forgot your password, you can <a href="%{base_url}/password-reset">request a link</a> to reset it.'
-    choose_new: "Choose a new password"
-    choose: "Choose a password"
-    update: "Update Password"
-    save: "Set Password"
     title: "Reset Password"
     success: "You successfully changed your password and are now logged in."
     success_unapproved: "You successfully changed your password."


### PR DESCRIPTION
Removes multiple (hopefully) unused English source strings and stop using of kitchen sink translations like `js.undo` and `js.revert` by replacing them with more specific translations.