### PR TITLE
DEV: Fix syntax error in spec file

### DIFF
--- a/plugins/chat/spec/system/jit_messages_spec.rb
+++ b/plugins/chat/spec/system/jit_messages_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "JIT messages", type: :system, js: true do
       expect(page).to have_content(
         I18n.t("js.chat.mention_warning.cannot_see.one", username: other_user.username),
         wait: 5,
+      )
     end
   end
 


### PR DESCRIPTION
Follow-up to b4adb806e572dfb8244b02d1a8331e4f533c1118