### PR TITLE
DEV: Flip `primary_email_verified?` default to false

### DIFF
--- a/lib/auth/managed_authenticator.rb
+++ b/lib/auth/managed_authenticator.rb
@@ -32,7 +32,7 @@ class Auth::ManagedAuthenticator < Auth::Authenticator
   def primary_email_verified?(auth_token)
     # Omniauth providers should only provide verified emails in the :info hash.
     # This method allows additional checks to be added
-    true
+    false
   end
 
   def can_revoke?


### PR DESCRIPTION
This PR changes the default return value of `Auth::ManagedAuthenticator#primary_email_verified?` to false. We're changing the default to force developers to think about email verification when building a new authentication method. All existing authenticators (in core and official plugins) have been updated to explicitly define the `primary_email_verified?` method in their subclass of `Auth::ManagedAuthenticator` (example commit https://github.com/discourse/discourse/commit/65f57a4d05496d05a4de9a6a641ec760c7004c7a).

Internal topic: t/82084.