### PR TITLE
FIX: Bookmark auto delete preference usage and default value

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -60,7 +60,9 @@ export default Component.extend({
       userTimezone: this.currentUser.user_option.timezone,
       showOptions: false,
       _itsatrap: new ItsATrap(),
-      autoDeletePreference: this.model.autoDeletePreference || 0,
+      autoDeletePreference:
+        this.model.autoDeletePreference ||
+        AUTO_DELETE_PREFERENCES.CLEAR_REMINDER,
     });
 
     this.registerOnCloseHandler(this._onModalClose);

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -836,13 +836,7 @@ export default Controller.extend(bufferedProperty("model"), {
         );
         return this._modifyPostBookmark(
           bookmarkForPost ||
-            Bookmark.create({
-              bookmarkable_id: post.id,
-              bookmarkable_type: "Post",
-              user_id: this.currentUser.id,
-              auto_delete_preference:
-                this.currentUser.user_option.bookmark_auto_delete_preference,
-            }),
+            Bookmark.createFor(this.currentUser, "Post", post.id),
           post
         );
       } else {
@@ -1350,13 +1344,7 @@ export default Controller.extend(bufferedProperty("model"), {
 
     if (this.model.bookmarkCount === 0) {
       return this._modifyTopicBookmark(
-        Bookmark.create({
-          bookmarkable_id: this.model.id,
-          bookmarkable_type: "Topic",
-          user_id: this.currentUser.id,
-          auto_delete_preference:
-            this.currentUser.user_option.bookmark_auto_delete_preference,
-        })
+        Bookmark.createFor(this.currentUser, "Topic", this.model.id)
       );
     }
   },

--- a/app/assets/javascripts/discourse/app/controllers/topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/topic.js
@@ -839,6 +839,7 @@ export default Controller.extend(bufferedProperty("model"), {
             Bookmark.create({
               bookmarkable_id: post.id,
               bookmarkable_type: "Post",
+              user_id: this.currentUser.id,
               auto_delete_preference:
                 this.currentUser.user_option.bookmark_auto_delete_preference,
             }),
@@ -1352,6 +1353,7 @@ export default Controller.extend(bufferedProperty("model"), {
         Bookmark.create({
           bookmarkable_id: this.model.id,
           bookmarkable_type: "Topic",
+          user_id: this.currentUser.id,
           auto_delete_preference:
             this.currentUser.user_option.bookmark_auto_delete_preference,
         })

--- a/app/assets/javascripts/discourse/app/models/bookmark.js
+++ b/app/assets/javascripts/discourse/app/models/bookmark.js
@@ -166,6 +166,15 @@ Bookmark.reopenClass({
     return this._super(args);
   },
 
+  createFor(user, bookmarkableType, bookmarkableId) {
+    return Bookmark.create({
+      bookmarkable_type: bookmarkableType,
+      bookmarkable_id: bookmarkableId,
+      user_id: user.id,
+      auto_delete_preference: user.user_option.bookmark_auto_delete_preference,
+    });
+  },
+
   async applyTransformations(bookmarks) {
     await applyModelTransformations("bookmark", bookmarks);
   },

--- a/lib/bookmark_manager.rb
+++ b/lib/bookmark_manager.rb
@@ -41,18 +41,24 @@ class BookmarkManager
   #                                      automatically.
   def create_for(bookmarkable_id:, bookmarkable_type:, name: nil, reminder_at: nil, options: {})
     registered_bookmarkable = Bookmark.registered_bookmarkable_from_type(bookmarkable_type)
+
+    if registered_bookmarkable.blank?
+      return add_error(I18n.t("bookmarks.errors.invalid_bookmarkable", type: bookmarkable_type))
+    end
+
     bookmarkable = registered_bookmarkable.model.find_by(id: bookmarkable_id)
     registered_bookmarkable.validate_before_create(@guardian, bookmarkable)
 
-    bookmark = Bookmark.create(
-      {
-        user_id: @user.id,
-        bookmarkable: bookmarkable,
-        name: name,
-        reminder_at: reminder_at,
-        reminder_set_at: Time.zone.now
-      }.merge(bookmark_model_options_with_defaults(options))
-    )
+    bookmark =
+      Bookmark.create(
+        {
+          user_id: @user.id,
+          bookmarkable: bookmarkable,
+          name: name,
+          reminder_at: reminder_at,
+          reminder_set_at: Time.zone.now,
+        }.merge(bookmark_model_options_with_defaults(options)),
+      )
 
     return add_errors_from(bookmark) if bookmark.errors.any?
 
@@ -97,16 +103,14 @@ class BookmarkManager
       bookmark.reminder_last_sent_at = nil
     end
 
-    success = bookmark.update(
-      {
-        name: name,
-        reminder_set_at: Time.zone.now,
-      }.merge(bookmark_model_options_with_defaults(options))
-    )
+    success =
+      bookmark.update(
+        { name: name, reminder_set_at: Time.zone.now }.merge(
+          bookmark_model_options_with_defaults(options),
+        ),
+      )
 
-    if bookmark.errors.any?
-      return add_errors_from(bookmark)
-    end
+    return add_errors_from(bookmark) if bookmark.errors.any?
 
     success
   end
@@ -116,9 +120,7 @@ class BookmarkManager
     bookmark.pinned = !bookmark.pinned
     success = bookmark.save
 
-    if bookmark.errors.any?
-      return add_errors_from(bookmark)
-    end
+    return add_errors_from(bookmark) if bookmark.errors.any?
 
     success
   end
@@ -136,20 +138,30 @@ class BookmarkManager
     # PostCreator can specify whether auto_track is enabled or not, don't want to
     # create a TopicUser in that case
     return if opts.key?(:auto_track) && !opts[:auto_track]
-    TopicUser.change(@user.id, topic, bookmarked: Bookmark.for_user_in_topic(@user.id, topic.id).exists?)
+    TopicUser.change(
+      @user.id,
+      topic,
+      bookmarked: Bookmark.for_user_in_topic(@user.id, topic.id).exists?,
+    )
   end
 
   def bookmark_model_options_with_defaults(options)
-    model_options = {
-      pinned: options[:pinned]
-    }
+    model_options = { pinned: options[:pinned] }
 
     if options[:auto_delete_preference].blank?
-      model_options[:auto_delete_preference] = Bookmark.auto_delete_preferences[:never]
+      model_options[:auto_delete_preference] = if user_auto_delete_preference.present?
+        user_auto_delete_preference
+      else
+        Bookmark.auto_delete_preferences[:clear_reminder]
+      end
     else
       model_options[:auto_delete_preference] = options[:auto_delete_preference]
     end
 
     model_options
+  end
+
+  def user_auto_delete_preference
+    @guardian.user.user_option&.bookmark_auto_delete_preference
   end
 end

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -723,13 +723,7 @@ export default Component.extend({
   toggleBookmark() {
     return openBookmarkModal(
       this.message.bookmark ||
-        Bookmark.create({
-          bookmarkable_type: "ChatMessage",
-          bookmarkable_id: this.message.id,
-          user_id: this.currentUser.id,
-          auto_delete_preference:
-            this.currentUser.user_option.bookmark_auto_delete_preference,
-        }),
+        Bookmark.createFor(this.currentUser, "ChatMessage", this.message.id),
       {
         onAfterSave: (savedData) => {
           const bookmark = Bookmark.create(savedData);

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -727,6 +727,8 @@ export default Component.extend({
           bookmarkable_type: "ChatMessage",
           bookmarkable_id: this.message.id,
           user_id: this.currentUser.id,
+          auto_delete_preference:
+            this.currentUser.user_option.bookmark_auto_delete_preference,
         }),
       {
         onAfterSave: (savedData) => {

--- a/plugins/chat/spec/system/bookmark_message_spec.rb
+++ b/plugins/chat/spec/system/bookmark_message_spec.rb
@@ -14,9 +14,6 @@ RSpec.describe "Bookmark message", type: :system, js: true do
     chat_system_bootstrap
     category_channel_1.add(current_user)
     sign_in(current_user)
-
-    # cdp_params = { source: "window.isRunningSystemSpecs = true" }
-    # page.driver.browser.execute_cdp("Page.addScriptToEvaluateOnNewDocument", **cdp_params)
   end
 
   context "when desktop" do

--- a/plugins/chat/spec/system/bookmark_message_spec.rb
+++ b/plugins/chat/spec/system/bookmark_message_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Bookmark message", type: :system, js: true do
 
   let(:chat) { PageObjects::Pages::Chat.new }
   let(:channel) { PageObjects::Pages::ChatChannel.new }
+  let(:bookmark_modal) { PageObjects::Modals::Bookmark.new }
+
   fab!(:category_channel_1) { Fabricate(:category_channel) }
   fab!(:message_1) { Fabricate(:chat_message, chat_channel: category_channel_1) }
 
@@ -12,6 +14,9 @@ RSpec.describe "Bookmark message", type: :system, js: true do
     chat_system_bootstrap
     category_channel_1.add(current_user)
     sign_in(current_user)
+
+    # cdp_params = { source: "window.isRunningSystemSpecs = true" }
+    # page.driver.browser.execute_cdp("Page.addScriptToEvaluateOnNewDocument", **cdp_params)
   end
 
   context "when desktop" do
@@ -19,12 +24,31 @@ RSpec.describe "Bookmark message", type: :system, js: true do
       chat.visit_channel(category_channel_1)
       channel.bookmark_message(message_1)
 
-      expect(page).to have_css("#bookmark-reminder-modal")
-
-      find("#bookmark-name").fill_in(with: "Check this out later")
-      find("#tap_tile_next_month").click
+      bookmark_modal.fill_name("Check this out later")
+      bookmark_modal.select_preset_reminder(:next_month)
 
       expect(channel).to have_bookmarked_message(message_1)
+    end
+
+    context "when the user has a bookmark auto_delete_preference" do
+      before do
+        current_user.user_option.update!(
+          bookmark_auto_delete_preference: Bookmark.auto_delete_preferences[:on_owner_reply],
+        )
+      end
+
+      it "is respected when the user creates a new bookmark" do
+        chat.visit_channel(category_channel_1)
+        channel.bookmark_message(message_1)
+
+        bookmark_modal.save
+        expect(channel).to have_bookmarked_message(message_1)
+
+        bookmark = Bookmark.find_by(bookmarkable: message_1, user: current_user)
+        expect(bookmark.auto_delete_preference).to eq(
+          Bookmark.auto_delete_preferences[:on_owner_reply],
+        )
+      end
     end
   end
 
@@ -34,10 +58,9 @@ RSpec.describe "Bookmark message", type: :system, js: true do
 
       channel.message_by_id(message_1.id).click(delay: 0.5)
       find(".bookmark-btn").click
-      expect(page).to have_css("#bookmark-reminder-modal")
 
-      find("#bookmark-name").fill_in(with: "Check this out later")
-      find("#tap_tile_next_month").click
+      bookmark_modal.fill_name("Check this out later")
+      bookmark_modal.select_preset_reminder(:next_month)
 
       expect(channel).to have_bookmarked_message(message_1)
     end

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -2,30 +2,31 @@
 
 describe "Bookmarking posts and topics", type: :system, js: true do
   fab!(:topic) { Fabricate(:topic) }
-  fab!(:user) { Fabricate(:user, username: "bookmarkguy") }
+  fab!(:user) { Fabricate(:user) }
   fab!(:post) { Fabricate(:post, topic: topic, raw: "This is some post to bookmark") }
   fab!(:post2) { Fabricate(:post, topic: topic, raw: "Some interesting post content") }
 
-  it "allows logged in user to create bookmarks with and without reminders" do
-    sign_in user
-    visit "/t/#{topic.id}"
-    topic_page = PageObjects::Pages::Topic.new
-    expect(topic_page).to have_post_content(post)
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:bookmark_modal) { PageObjects::Modals::Bookmark.new }
+
+  before { sign_in user }
+
+  it "allows the user to create bookmarks with and without reminders" do
+    topic_page.visit_topic(topic)
     topic_page.expand_post_actions(post)
     topic_page.click_post_action_button(post, :bookmark)
 
-    bookmark_modal = PageObjects::Modals::Bookmark.new
     bookmark_modal.fill_name("something important")
     bookmark_modal.save
 
     expect(topic_page).to have_post_bookmarked(post)
     bookmark = Bookmark.find_by(bookmarkable: post, user: user)
     expect(bookmark.name).to eq("something important")
+    expect(bookmark.reminder_at).to eq(nil)
 
     topic_page.expand_post_actions(post2)
     topic_page.click_post_action_button(post2, :bookmark)
 
-    bookmark_modal = PageObjects::Modals::Bookmark.new
     bookmark_modal.select_preset_reminder(:tomorrow)
     expect(topic_page).to have_post_bookmarked(post2)
     bookmark = Bookmark.find_by(bookmarkable: post2, user: user)
@@ -34,13 +35,10 @@ describe "Bookmarking posts and topics", type: :system, js: true do
   end
 
   it "does not create a bookmark if the modal is closed with the cancel button" do
-    sign_in user
-    visit "/t/#{topic.id}"
-    topic_page = PageObjects::Pages::Topic.new
+    topic_page.visit_topic(topic)
     topic_page.expand_post_actions(post)
     topic_page.click_post_action_button(post, :bookmark)
 
-    bookmark_modal = PageObjects::Modals::Bookmark.new
     bookmark_modal.fill_name("something important")
     bookmark_modal.cancel
 
@@ -48,20 +46,48 @@ describe "Bookmarking posts and topics", type: :system, js: true do
     expect(Bookmark.exists?(bookmarkable: post, user: user)).to eq(false)
   end
 
+  it "creates a bookmark if the modal is closed by clicking outside the modal window" do
+    topic_page.visit_topic(topic)
+    topic_page.expand_post_actions(post)
+    topic_page.click_post_action_button(post, :bookmark)
+
+    bookmark_modal.fill_name("something important")
+    bookmark_modal.click_outside
+
+    expect(topic_page).to have_post_bookmarked(post)
+  end
+
   it "allows the topic to be bookmarked" do
-    sign_in user
-    visit "/t/#{topic.id}"
-    topic_page = PageObjects::Pages::Topic.new
+    topic_page.visit_topic(topic)
     topic_page.click_topic_footer_button(:bookmark)
 
-    bookmark_modal = PageObjects::Modals::Bookmark.new
     bookmark_modal.fill_name("something important")
     bookmark_modal.save
 
     expect(topic_page).to have_topic_bookmarked
-    bookmark = try_until_success do
-      expect(Bookmark.exists?(bookmarkable: topic, user: user)).to eq(true)
-    end
+    bookmark =
+      try_until_success { expect(Bookmark.exists?(bookmarkable: topic, user: user)).to eq(true) }
     expect(bookmark).not_to eq(nil)
+  end
+
+  context "when the user has a bookmark auto_delete_preference" do
+    before do
+      user.user_option.update!(
+        bookmark_auto_delete_preference: Bookmark.auto_delete_preferences[:on_owner_reply],
+      )
+    end
+
+    it "is respected when the user creates a new bookmark" do
+      topic_page.visit_topic(topic)
+      topic_page.expand_post_actions(post)
+      topic_page.click_post_action_button(post, :bookmark)
+      bookmark_modal.save
+      expect(topic_page).to have_post_bookmarked(post)
+
+      bookmark = Bookmark.find_by(bookmarkable: post, user: user)
+      expect(bookmark.auto_delete_preference).to eq(
+        Bookmark.auto_delete_preferences[:on_owner_reply],
+      )
+    end
   end
 end

--- a/spec/system/page_objects/modals/base.rb
+++ b/spec/system/page_objects/modals/base.rb
@@ -13,6 +13,10 @@ module PageObjects
       def cancel
         find(".d-modal-cancel").click
       end
+
+      def click_outside
+        find(".modal-outer-container").click(x: 0, y: 0)
+      end
     end
   end
 end


### PR DESCRIPTION
This commit fixes an issue where the chat message bookmarks
did not respect the user's `bookmark_auto_delete_preference`
which they select in their user preference page.

Also, it changes the default for that value to "keep bookmark and clear reminder"
rather than "never", which ends up leaving a lot of expired bookmark
reminders around which are a pain to clean up.