### PR TITLE
FIX: use reviewer's guardian permissions to create post/topic while approve.

### DIFF
--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -74,13 +74,15 @@ class ReviewableQueuedPost < Reviewable
 
   def perform_approve_post(performed_by, args)
     created_post = nil
-
-    creator = PostCreator.new(created_by, create_options.merge(
+    opts = create_options.merge(
       skip_validations: true,
       skip_jobs: true,
       skip_events: true,
       skip_guardian: true
-    ))
+    )
+    opts.merge!(guardian: Guardian.new(performed_by)) if performed_by.staff?
+
+    creator = PostCreator.new(created_by, opts)
     created_post = creator.create
 
     unless created_post && creator.errors.blank?

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe ReviewableQueuedPost, type: :model do
       expect(Post.count).to eq(post_count + 1)
     end
 
-    it "creates a topic with staff tag" do
+    it "creates a topic with staff tag when approved" do
       hidden_tag = Fabricate(:tag)
       staff_tag_group = Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
       reviewable.payload['tags'] += [hidden_tag.name]

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -180,7 +180,21 @@ RSpec.describe ReviewableQueuedPost, type: :model do
       expect(Post.count).to eq(post_count + 1)
     end
 
-    it "creates the post and topic when rejected" do
+    it "creates a topic with staff tag" do
+      hidden_tag = Fabricate(:tag)
+      staff_tag_group = Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
+      reviewable.payload['tags'] += [hidden_tag.name]
+
+      result = reviewable.perform(moderator, :approve_post)
+
+      expect(result.success?).to eq(true)
+      expect(result.created_post_topic).to be_present
+      expect(result.created_post_topic).to be_valid
+      expect(reviewable.topic_id).to eq(result.created_post_topic.id)
+      expect(result.created_post_topic.tags.pluck(:name)).to match_array(reviewable.payload['tags'])
+    end
+
+    it "does not create the post and topic when rejected" do
       topic_count, post_count = Topic.count, Post.count
       result = reviewable.perform(moderator, :reject_post)
 


### PR DESCRIPTION
We previously used post creator's guardian permissions which will raise an error if reviewer added a staff-only (restricted) tag. Now we're using the reviewer's "`guardian`" to check permissions **everywhere** while creating posts/topics by approval.