### PR TITLE
DEV: adds basic sorting to avoid flakey test

### DIFF
--- a/plugins/chat/lib/extensions/user_notifications_extension.rb
+++ b/plugins/chat/lib/extensions/user_notifications_extension.rb
@@ -69,7 +69,7 @@ module Chat::UserNotificationsExtension
 
     # Prioritize messages from regular channels over direct messages
     if channels.any?
-      channel_notification_text(channels, dm_users)
+      channel_notification_text(channels.sort_by(&:last_message_sent_at), dm_users)
     else
       direct_message_notification_text(dm_users)
     end


### PR DESCRIPTION
`last_message_sent_at` has a `NOT_NULL` constraint in the DB so it should be safe to use for sorting.

This was causing two flakeys:

```
  1) UserNotifications.chat_summary with public channel email subject with regular mentions includes both channel titles when there are exactly two with unread mentions
     Failure/Error: example.run

       expected: "[Discourse] New message in Random 62 and Test channel"
            got: "[Discourse] New message in Test channel and Random 62"

       (compared using ==)
     # ./plugins/chat/spec/mailers/user_notifications_spec.rb:203:in `block (6 levels) in <main>'
     # ./spec/rails_helper.rb:356:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

  2) UserNotifications.chat_summary with public channel email subject with regular mentions displays a count when there are more than two channels with unread mentions
     Failure/Error: example.run

       expected: "[Discourse] New message in Random 62 and 2 others"
            got: "[Discourse] New message in Test channel 0 and 2 others"

       (compared using ==)
     # ./plugins/chat/spec/mailers/user_notifications_spec.rb:236:in `block (6 levels) in <main>'
     # ./spec/rails_helper.rb:356:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
