### PR TITLE
UX: fix the positioning of topic admin popup menu

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -150,7 +150,8 @@ $topic-progress-height: 42px;
   &.docked {
     position: initial;
     .topic-admin-popup-menu.right-side {
-      bottom: -150px; // Prevents menu from being too high when a topic is very short
+      bottom: unset;
+      right: 10px;
     }
   }
 


### PR DESCRIPTION
Before:

<img width="632" alt="Screenshot 2023-01-04 at 5 41 24 PM" src="https://user-images.githubusercontent.com/11170663/210552850-a8502760-5370-480b-9137-3c57841ccec7.png">

After:

<img width="632" alt="Screenshot 2023-01-04 at 5 41 42 PM" src="https://user-images.githubusercontent.com/11170663/210552859-288dab0e-7002-49cd-9d47-d4736964e75a.png">
