### PR TITLE
UX: more descriptive sidebar titles, casing consistency

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/messages-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/messages-section.hbs
@@ -2,7 +2,10 @@
   @sectionName="messages"
   @headerActionIcon="plus"
   @headerActions={{array
-    (hash action=(fn (route-action "composePrivateMessage") null null))
+    (hash
+      action=(fn (route-action "composePrivateMessage") null null)
+      title=(i18n "sidebar.sections.messages.header_action_title")
+    )
   }}
   @headerActionsIcon="plus"
   @headerLinkText={{i18n "sidebar.sections.messages.header_link_text"}}

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/about-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/about-section-link.js
@@ -12,12 +12,13 @@ export default class AboutSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return I18n.t("sidebar.sections.community.links.about.content");
+    return I18n.t("sidebar.sections.community.links.about.title");
   }
 
   get text() {
     return I18n.t("sidebar.sections.community.links.about.content");
   }
+
   get prefixValue() {
     return "info-circle";
   }

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/badges-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/badges-section-link.js
@@ -12,7 +12,7 @@ export default class BadgesSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return I18n.t("sidebar.sections.community.links.badges.content");
+    return I18n.t("sidebar.sections.community.links.badges.title");
   }
 
   get text() {

--- a/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/faq-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/common/community-section/faq-section-link.js
@@ -16,7 +16,7 @@ export default class FAQSectionLink extends BaseSectionLink {
   }
 
   get title() {
-    return I18n.t("sidebar.sections.community.links.faq.content");
+    return I18n.t("sidebar.sections.community.links.faq.title");
   }
 
   get text() {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4353,7 +4353,7 @@ en:
       new_count:
         one: "%{count} new"
         other: "%{count} new"
-      toggle_section: "toggle section"
+      toggle_section: "Toggle section"
       more: "More"
       all_categories: "All categories"
       all_tags: "All tags"
@@ -4362,7 +4362,7 @@ en:
           header_link_text: "About"
         messages:
           header_link_text: "Messages"
-          header_action_title: "create a personal message"
+          header_action_title: "Create a personal message"
           links:
             inbox: "Inbox"
             sent: "Sent"
@@ -4379,7 +4379,7 @@ en:
           none: "You have not added any tags."
           click_to_get_started: "Click here to get started."
           header_link_text: "Tags"
-          header_action_title: "edit your sidebar tags"
+          header_action_title: "Edit your sidebar tags"
           configure_defaults: "Configure defaults"
         categories:
           links:
@@ -4389,29 +4389,33 @@ en:
           none: "You have not added any categories."
           click_to_get_started: "Click here to get started."
           header_link_text: "Categories"
-          header_action_title: "edit your sidebar categories"
+          header_action_title: "Edit your sidebar categories"
           configure_defaults: "Configure defaults"
         community:
           header_link_text: "Community"
-          header_action_title: "create a new topic"
+          header_action_title: "Create a topic"
           links:
             about:
               content: "About"
+              title: "More details about this site"
             admin:
               content: "Admin"
+              title: "Site settings and reports"
             badges:
               content: "Badges"
+              title: "All the badges available to earn"
             everything:
               content: "Everything"
               title: "All topics"
             faq:
               content: "FAQ"
+              title: "Guidelines for using this site"
             groups:
               content: "Groups"
-              title: "All groups"
+              title: "List of available user groups"
             users:
               content: "Users"
-              title: "All users"
+              title: "List of all users"
             my_posts:
               content: "My Posts"
               title: "My recent topic activity"
@@ -4421,7 +4425,7 @@ en:
                 other: "%{count} drafts"
             review:
               content: "Review"
-              title: "review"
+              title: "Flagged posts and other queued items"
               pending_count: "%{count} pending"
 
     welcome_topic_banner:

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -345,7 +345,7 @@ en:
 
       direct_messages:
         title: "Personal chat"
-        new: "New personal chat"
+        new: "Create a personal chat"
         create: "Go"
         leave: "Leave this personal chat"
         cannot_create: "Sorry, you cannot send direct messages."


### PR DESCRIPTION
Improves sidebar `title`s 

* Adds a missing title implementation for creating a new personal message in the messages section
* Updates sidebar titles to consistently use sentence case 
* Adds more descriptive titles for groups, users, review, FAQ, about, badges, and admin links (duplicating the link text as a title is useless to users) 