### PR TITLE
FIX: Ensure poll extraction is not attempted  if post body is absent

### DIFF
--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -306,6 +306,10 @@ class DiscoursePoll::Poll
   end
 
   def self.extract(raw, topic_id, user_id = nil)
+    # Poll Post handlers get called very early in the post
+    # creation process. `raw` could be nil here.
+    return [] if raw.blank?
+
     # TODO: we should fix the callback mess so that the cooked version is available
     # in the validators instead of cooking twice
     raw = raw.sub(%r{\[quote.+/quote\]}m, "")

--- a/plugins/poll/spec/requests/posts_controller_spec.rb
+++ b/plugins/poll/spec/requests/posts_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PostsController do
+  let(:admin) { Fabricate(:admin) }
+
+  describe "#create" do
+    it "fails gracefully without a post body" do
+      key = Fabricate(:api_key).key
+
+      expect do
+        post "/posts.json",
+             params: {
+               title: "this is test body",
+             },
+             headers: {
+               HTTP_API_USERNAME: admin.username,
+               HTTP_API_KEY: key,
+             }
+      end.not_to change { Topic.count }
+
+      expect(response.status).to eq(422)
+    end
+  end
+end


### PR DESCRIPTION
Since the poll post handler runs very early in the post creation process, it's possible to run the handler on an obiviously invalid post.

This change ensures the post's `raw` value is present  before proceeding.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
