### PR TITLE
PERF: Use user-specific channel for message-bus logout

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/logout.js
+++ b/app/assets/javascripts/discourse/app/initializers/logout.js
@@ -12,12 +12,16 @@ export default {
   initialize(container) {
     this.messageBus = container.lookup("service:message-bus");
     this.dialog = container.lookup("service:dialog");
+    this.currentUser = container.lookup("service:current-user");
 
-    this.messageBus.subscribe("/logout", this.onMessage);
+    this.messageBus.subscribe(`/logout/${this.currentUser.id}`, this.onMessage);
   },
 
   teardown() {
-    this.messageBus.unsubscribe("/logout", this.onMessage);
+    this.messageBus.unsubscribe(
+      `/logout/${this.currentUser.id}`,
+      this.onMessage
+    );
   },
 
   @bind

--- a/app/assets/javascripts/discourse/app/initializers/logout.js
+++ b/app/assets/javascripts/discourse/app/initializers/logout.js
@@ -14,14 +14,21 @@ export default {
     this.dialog = container.lookup("service:dialog");
     this.currentUser = container.lookup("service:current-user");
 
-    this.messageBus.subscribe(`/logout/${this.currentUser.id}`, this.onMessage);
+    if (this.currentUser) {
+      this.messageBus.subscribe(
+        `/logout/${this.currentUser.id}`,
+        this.onMessage
+      );
+    }
   },
 
   teardown() {
-    this.messageBus.unsubscribe(
-      `/logout/${this.currentUser.id}`,
-      this.onMessage
-    );
+    if (this.currentUser) {
+      this.messageBus.unsubscribe(
+        `/logout/${this.currentUser.id}`,
+        this.onMessage
+      );
+    }
   },
 
   @bind

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -335,7 +335,7 @@ acceptance("User - Logout", function (needs) {
   test("Dialog works", async function (assert) {
     sinon.stub(logout, "default");
     await visit("/u/eviltrout");
-    await publishToMessageBus("/logout");
+    await publishToMessageBus("/logout/19");
 
     assert.ok(exists(".dialog-body"));
     assert.ok(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1497,7 +1497,7 @@ class User < ActiveRecord::Base
   end
 
   def logged_out
-    MessageBus.publish "/logout", self.id, user_ids: [self.id]
+    MessageBus.publish "/logout/#{self.id}", self.id, user_ids: [self.id]
     DiscourseEvent.trigger(:user_logged_out, self)
   end
 

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -103,7 +103,7 @@ class UserDestroyer
           StaffActionLogger.new(deleted_by).log_user_deletion(user, opts.slice(:context))
           Rails.logger.warn("User destroyed without context from: #{caller_locations(14, 1)[0]}") if opts.slice(:context).blank?
         end
-        MessageBus.publish "/logout", result.id, user_ids: [result.id]
+        MessageBus.publish "/logout/#{result.id}", result.id, user_ids: [result.id]
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2020,7 +2020,7 @@ RSpec.describe User do
     fab!(:user) { Fabricate(:user) }
 
     it 'should publish the right message' do
-      message = MessageBus.track_publish('/logout') { user.logged_out }.first
+      message = MessageBus.track_publish("/logout/#{user.id}") { user.logged_out }.first
 
       expect(message.data).to eq(user.id)
     end


### PR DESCRIPTION
Using a shared channel means that every user receives an update to the 'last_id' when *any* other user is logged out. If many users are being programmatically logged out at the same time, this can cause a very large number of message-bus polls.

This commit switches to use a user-specific channel, which means that each user has its own 'last id' which will only increment when they are logged out

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
