### PR TITLE
SECURITY: BCC active user emails from group SMTP

### DIFF
--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -5,7 +5,7 @@ require_dependency 'email/message_builder'
 class GroupSmtpMailer < ActionMailer::Base
   include Email::BuildEmailHelper
 
-  def send_mail(from_group, to_address, post, cc_addresses = nil)
+  def send_mail(from_group, to_address, post, cc_addresses: nil, bcc_addresses: nil)
     raise 'SMTP is disabled' if !SiteSetting.enable_smtp
 
     op_incoming_email = post.topic.first_post.incoming_email
@@ -51,7 +51,8 @@ class GroupSmtpMailer < ActionMailer::Base
       from: from_group.email_username,
       from_alias: I18n.t('email_from_without_site', user_name: group_name),
       html_override: html_override(post),
-      cc: cc_addresses
+      cc: cc_addresses,
+      bcc: bcc_addresses
     )
   end
 

--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -132,6 +132,7 @@ end
 #  cc_user_ids   :integer          is an Array
 #  raw           :text
 #  topic_id      :integer
+#  bcc_addresses :text
 #
 # Indexes
 #

--- a/db/migrate/20221125001635_add_bcc_addresses_to_email_log.rb
+++ b/db/migrate/20221125001635_add_bcc_addresses_to_email_log.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBccAddressesToEmailLog < ActiveRecord::Migration[7.0]
+  def change
+    add_column :email_logs, :bcc_addresses, :text, null: true
+  end
+end

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -141,7 +141,8 @@ module Email
         body: body,
         charset: 'UTF-8',
         from: from_value,
-        cc: @opts[:cc]
+        cc: @opts[:cc],
+        bcc: @opts[:bcc]
       }
 
       args[:delivery_method_options] = @opts[:delivery_method_options] if @opts[:delivery_method_options]

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -98,6 +98,10 @@ module Email
         email_log.cc_user_ids = User.with_email(cc_addresses).pluck(:id)
       end
 
+      if bcc_addresses.any?
+        email_log.bcc_addresses = bcc_addresses.join(";")
+      end
+
       host = Email::Sender.host_for(Discourse.base_url)
 
       post_id   = header_value('X-Discourse-Post-Id')
@@ -320,6 +324,12 @@ module Email
     def cc_addresses
       @cc_addresses ||= begin
         @message.try(:cc) || []
+      end
+    end
+
+    def bcc_addresses
+      @bcc_addresses ||= begin
+        @message.try(:bcc) || []
       end
     end
 

--- a/spec/jobs/regular/group_smtp_email_spec.rb
+++ b/spec/jobs/regular/group_smtp_email_spec.rb
@@ -40,7 +40,16 @@ RSpec.describe Jobs::GroupSmtpEmail do
 
   it "sends an email using the GroupSmtpMailer and Email::Sender" do
     message = Mail::Message.new(body: "hello", to: "myemail@example.invalid")
-    GroupSmtpMailer.expects(:send_mail).with(group, "test@test.com", post, ["otherguy@test.com", "cormac@lit.com"]).returns(message)
+    GroupSmtpMailer
+      .expects(:send_mail)
+      .with(
+        group,
+        "test@test.com",
+        post,
+        cc_addresses: %w[otherguy@test.com cormac@lit.com],
+        bcc_addresses: [],
+      )
+      .returns(message)
     subject.execute(args)
   end
 
@@ -176,10 +185,26 @@ RSpec.describe Jobs::GroupSmtpEmail do
     it "has the cc_addresses and cc_user_ids filled in correctly" do
       subject.execute(args)
       expect(ActionMailer::Base.deliveries.count).to eq(1)
-      expect(ActionMailer::Base.deliveries.last.subject).to eq("Re: Help I need support")
+      sent_mail = ActionMailer::Base.deliveries.last
+      expect(sent_mail.subject).to eq("Re: Help I need support")
+      expect(sent_mail.cc).to eq(["otherguy@test.com", "cormac@lit.com"])
       email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
       expect(email_log.cc_addresses).to eq("otherguy@test.com;cormac@lit.com")
       expect(email_log.cc_user_ids).to match_array([staged1.id, staged2.id])
+    end
+
+    it "where cc_addresses match non-staged users, convert to bcc_addresses" do
+      staged2.update!(staged: false, active: true)
+      subject.execute(args)
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      sent_mail = ActionMailer::Base.deliveries.last
+      expect(sent_mail.subject).to eq("Re: Help I need support")
+      expect(sent_mail.cc).to eq(["otherguy@test.com"])
+      expect(sent_mail.bcc).to eq(["cormac@lit.com"])
+      email_log = EmailLog.find_by(post_id: post.id, topic_id: post.topic_id, user_id: recipient_user.id)
+      expect(email_log.cc_addresses).to eq("otherguy@test.com")
+      expect(email_log.bcc_addresses).to eq("cormac@lit.com")
+      expect(email_log.cc_user_ids).to match_array([staged1.id])
     end
   end
 

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -36,6 +36,7 @@ describe GroupSmtpMailer do
     Message-ID: <a52f67a3d3560f2a35276cda8519b10b595623bcb66912bb92df6651ad5f75be@mail.gmail.com>
     Subject: Hello from John
     To: "bugs@gmail.com" <bugs@gmail.com>
+    Cc: someotherperson@test.com
     Content-Type: text/plain; charset="UTF-8"
 
     Hello,
@@ -76,6 +77,7 @@ describe GroupSmtpMailer do
 
     sent_mail = ActionMailer::Base.deliveries[0]
     expect(sent_mail.to).to contain_exactly('john@doe.com')
+    expect(sent_mail.cc).to contain_exactly('someotherperson@test.com')
     expect(sent_mail.reply_to).to eq(nil)
     expect(sent_mail.subject).to eq('Re: Hello from John')
     expect(sent_mail.to_s).to include(raw)


### PR DESCRIPTION
When sending emails out via group SMTP, if we
are sending them to non-staged users we want
to mask those emails with BCC, just so we don't
expose them to anyone we shouldn't. Staged users
are ones that have likely only interacted with
support via email, and will likely include other
people who were CC'd on the original email to the
group.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
