### PR TITLE
SECURITY: BCC active user emails from group SMTP

### DIFF
--- a/app/jobs/regular/group_smtp_email.rb
+++ b/app/jobs/regular/group_smtp_email.rb
@@ -44,6 +44,12 @@ module Jobs
         EmailAddressValidator.valid_value?(address)
       end
 
+      # Mask the email addresses of non-staged users so
+      # they are not revealed unnecessarily when we are sending
+      # the email notification out.
+      bcc_addresses = User.not_staged.with_email(cc_addresses).pluck(:email)
+      cc_addresses = cc_addresses - bcc_addresses
+
       # There is a rare race condition causing the Imap::Sync class to create
       # an incoming email and associated post/topic, which then kicks off
       # the PostAlerter to notify others in the PM about a reply in the topic,
@@ -66,7 +72,13 @@ module Jobs
       # The EmailLog record created by the sender will have the raw email
       # stored, the group smtp ID, and any cc addresses recorded for later
       # cross referencing.
-      message = GroupSmtpMailer.send_mail(group, email, post, cc_addresses)
+      message = GroupSmtpMailer.send_mail(
+        group,
+        email,
+        post,
+        cc_addresses: cc_addresses,
+        bcc_addresses: bcc_addresses
+      )
       Email::Sender.new(message, :group_smtp, recipient_user).send
 
       # Create an incoming email record to avoid importing again from IMAP

--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -3,7 +3,7 @@
 class GroupSmtpMailer < ActionMailer::Base
   include Email::BuildEmailHelper
 
-  def send_mail(from_group, to_address, post, cc_addresses = nil)
+  def send_mail(from_group, to_address, post, cc_addresses: nil, bcc_addresses: nil)
     raise 'SMTP is disabled' if !SiteSetting.enable_smtp
 
     op_incoming_email = post.topic.first_post.incoming_email
@@ -46,7 +46,8 @@ class GroupSmtpMailer < ActionMailer::Base
       from: from_group.smtp_from_address,
       from_alias: I18n.t('email_from_without_site', group_name: group_name),
       html_override: html_override(post),
-      cc: cc_addresses
+      cc: cc_addresses,
+      bcc: bcc_addresses
     )
   end
 

--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -144,6 +144,7 @@ end
 #  topic_id                  :integer
 #  bounce_error_code         :string
 #  smtp_transaction_response :string(500)
+#  bcc_addresses             :text
 #
 # Indexes
 #

--- a/db/migrate/20221125001635_add_bcc_addresses_to_email_log.rb
+++ b/db/migrate/20221125001635_add_bcc_addresses_to_email_log.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBccAddressesToEmailLog < ActiveRecord::Migration[7.0]
+  def change
+    add_column :email_logs, :bcc_addresses, :text, null: true
+  end
+end

--- a/lib/email/message_builder.rb
+++ b/lib/email/message_builder.rb
@@ -141,7 +141,8 @@ module Email
         body: body,
         charset: 'UTF-8',
         from: from_value,
-        cc: @opts[:cc]
+        cc: @opts[:cc],
+        bcc: @opts[:bcc]
       }
 
       args[:delivery_method_options] = @opts[:delivery_method_options] if @opts[:delivery_method_options]

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -98,6 +98,10 @@ module Email
         email_log.cc_user_ids = User.with_email(cc_addresses).pluck(:id)
       end
 
+      if bcc_addresses.any?
+        email_log.bcc_addresses = bcc_addresses.join(";")
+      end
+
       host = Email::Sender.host_for(Discourse.base_url)
 
       post_id   = header_value('X-Discourse-Post-Id')
@@ -297,6 +301,12 @@ module Email
     def cc_addresses
       @cc_addresses ||= begin
         @message.try(:cc) || []
+      end
+    end
+
+    def bcc_addresses
+      @bcc_addresses ||= begin
+        @message.try(:bcc) || []
       end
     end
 

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe GroupSmtpMailer do
       Message-ID: <a52f67a3d3560f2a35276cda8519b10b595623bcb66912bb92df6651ad5f75be@mail.gmail.com>
       Subject: Hello from John
       To: "bugs@gmail.com" <bugs@gmail.com>
+      Cc: someotherperson@test.com
       Content-Type: text/plain; charset="UTF-8"
 
       Hello,
@@ -75,6 +76,7 @@ RSpec.describe GroupSmtpMailer do
 
     sent_mail = ActionMailer::Base.deliveries[0]
     expect(sent_mail.to).to contain_exactly('john@doe.com')
+    expect(sent_mail.cc).to contain_exactly('someotherperson@test.com')
     expect(sent_mail.reply_to).to eq(nil)
     expect(sent_mail.subject).to eq('Re: Hello from John')
     expect(sent_mail.to_s).to include(raw)


### PR DESCRIPTION
When sending emails out via group SMTP, if we
are sending them to non-staged users we want
to mask those emails with BCC, just so we don't
expose them to anyone we shouldn't. Staged users
are ones that have likely only interacted with
support via email, and will likely include other
people who were CC'd on the original email to the
group.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
