### PR TITLE
SECURITY: use rstrip instead of regex gsub to prevent ReDOS

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -514,7 +514,7 @@ class PostCreator
   end
 
   def setup_post
-    @opts[:raw] = TextCleaner.normalize_whitespaces(@opts[:raw] || '').gsub(/\s+\z/, "")
+    @opts[:raw] = TextCleaner.normalize_whitespaces(@opts[:raw] || '').rstrip
 
     post = Post.new(raw: @opts[:raw],
                     topic_id: @topic.try(:id),

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -274,7 +274,7 @@ class PostRevisor
   end
 
   def cleanup_whitespaces(raw)
-    raw.present? ? TextCleaner.normalize_whitespaces(raw).gsub(/\s+\z/, "") : ""
+    raw.present? ? TextCleaner.normalize_whitespaces(raw).rstrip : ""
   end
 
   def should_revise?


### PR DESCRIPTION
`rstrip` implementation is much more performant than regex