### PR TITLE
DEV: Increase Capybara.default_max_wait_time on github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
       PGUSER: discourse
       PGPASSWORD: discourse
       USES_PARALLEL_DATABASES: ${{ matrix.build_type == 'backend' }}
+      CAPBYARA_DEFAULT_MAX_WAIT_TIME: 4
 
     strategy:
       fail-fast: false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -245,6 +245,10 @@ RSpec.configure do |config|
       allow: [Webdrivers::Chromedriver.base_url]
     )
 
+    if ENV["CAPBYARA_DEFAULT_MAX_WAIT_TIME"].present?
+      Capybara.default_max_wait_time = ENV["CAPBYARA_DEFAULT_MAX_WAIT_TIME"].to_i
+    end
+
     Capybara.threadsafe = true
     Capybara.disable_animation = true
 


### PR DESCRIPTION
Our working theory is that system tests on Github run on much less
powerful hardware as compared to our work machines.
Hopefully, increasing the wait time now will help reduce some flakes
that we're seeing on Github.