### PR TITLE
DEV: Change system spec JS log level to SEVERE by default

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -257,8 +257,17 @@ RSpec.configure do |config|
       capybara_config.server_port = 31337 + ENV['TEST_ENV_NUMBER'].to_i
     end
 
+    # The valid values for SELENIUM_BROWSER_LOG_LEVEL are:
+    #
+    # OFF
+    # SEVERE
+    # WARNING
+    # INFO
+    # DEBUG
+    # ALL
+    browser_log_level = ENV["SELENIUM_BROWSER_LOG_LEVEL"] || "SEVERE"
     chrome_browser_options = Selenium::WebDriver::Chrome::Options.new(
-      logging_prefs: { "browser" => "INFO", "driver" => "ALL" }
+      logging_prefs: { "browser" => browser_log_level, "driver" => "ALL" }
     ).tap do |options|
       options.add_argument("--window-size=1400,1400")
       options.add_argument("--no-sandbox")


### PR DESCRIPTION
Having this set to ALL pollutes the JS system spec
logs with a bunch of unnecessary noise like this:

> "PresenceChannel '/chat-user/core/1' dropped message (received 315, expecting 246), resyncing..."

Or:

> "DEPRECATION: The \u003Cdiscourse@component:plugin-connector::ember1112>#save computed property was just overridden. This removes the computed property and replaces it with a plain value, and has been deprecated.

Now, we will only log errors. To configure this set
the `SELENIUM_BROWSER_LOG_LEVEL` env var.
