### PR TITLE
DEV: Re-enable chat transcript nested system spec

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -69,6 +69,7 @@ module PageObjects
       end
 
       def send_message(text = nil)
+        text = text.chomp if text.present? # having \n on the end of the string counts as an Enter keypress
         find(".chat-composer-input").click # makes helper more reliable by ensuring focus is not lost
         find(".chat-composer-input").fill_in(with: text)
         click_send_message

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
     context "when quoting a message in another message" do
       fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel_1) }
 
-      xit "quotes the message" do
+      it "quotes the message" do
         chat_page.visit_channel(chat_channel_1)
 
         expect(chat_channel_page).to have_no_loading_skeleton


### PR DESCRIPTION
The problem here was that if your input has an Enter listener (such as the chat message input) and the
`fill_in(with: str)` string has a `\n` at the end, this is treated as an Enter keypress, so this `fill_in` was submitting the chat message.