### PR TITLE
FIX: Link to category settings should use slug

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -72,7 +72,7 @@ class ReviewableScoreSerializer < ApplicationSerializer
     when 'watched_word'
       "#{Discourse.base_url}/admin/customize/watched_words"
     when 'category'
-      "#{Discourse.base_url}/c/#{object.reviewable.category&.name}/edit/settings"
+      "#{Discourse.base_url}/c/#{object.reviewable.category&.slug}/edit/settings"
     else
       "#{Discourse.base_url}/admin/site_settings/category/all_results?filter=#{text}"
     end

--- a/spec/fabricators/category_fabricator.rb
+++ b/spec/fabricators/category_fabricator.rb
@@ -2,6 +2,7 @@
 
 Fabricator(:category) do
   name { sequence(:name) { |n| "Amazing Category #{n}" } }
+  slug { sequence(:slug) { |n| "amazing-category-#{n}" } }
   skip_category_definition true
   user
 end

--- a/spec/fabricators/category_fabricator.rb
+++ b/spec/fabricators/category_fabricator.rb
@@ -2,7 +2,6 @@
 
 Fabricator(:category) do
   name { sequence(:name) { |n| "Amazing Category #{n}" } }
-  slug { sequence(:slug) { |n| "amazing-category-#{n}" } }
   skip_category_definition true
   user
 end

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ReviewableScoreSerializer do
       end
 
       it 'adds a link for category settings' do
-        category = Fabricate.build(:category)
+        category = Fabricate(:category, name: 'Reviewable Category', slug: 'reviewable-category')
         reviewable.category = category
         serialized = serialized_score('category')
         link_url = "#{Discourse.base_url}/c/#{category.slug}/edit/settings"

--- a/spec/serializers/reviewable_score_serializer_spec.rb
+++ b/spec/serializers/reviewable_score_serializer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ReviewableScoreSerializer do
         category = Fabricate.build(:category)
         reviewable.category = category
         serialized = serialized_score('category')
-        link_url = "#{Discourse.base_url}/c/#{category.name}/edit/settings"
+        link_url = "#{Discourse.base_url}/c/#{category.slug}/edit/settings"
         category_link = "<a href=\"#{link_url}\">#{I18n.t('reviewables.reasons.links.category')}</a>"
 
         expect(serialized.reason).to include(category_link)


### PR DESCRIPTION
Links to category settings were created using the category name. If the name was a single word, the link would be valid (regardless of capitalization).

For example, if the category was named `Awesome`

`/c/Awesome/edit/settings`

is a valid URL as that is a case-insensitive match for the category slug of `awesome`.

However, if the category had a space in it, the URL would be

`/c/Awesome%20Name/edit/settings`

which does not match the slug of `awesome-name`.

This change uses the category slug, rather than the name, which is the expected behaviour (see `Category.find_by_slug_path`).

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
