### PR TITLE
DEV: Remove unused locale

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4903,7 +4903,6 @@ en:
 
       customize:
         title: "Customize"
-        long_title: "Site Customizations"
         preview: "preview"
         explain_preview: "See the site with this theme enabled"
         save: "Save"


### PR DESCRIPTION
This PR removes a locale string that is no longer being used:
`admin_js.admin.customize.long_title`