### PR TITLE
DEV: Remove unused locale

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -346,7 +346,6 @@ en:
       remove_reminder_keep_bookmark: "Remove reminder and keep bookmark"
       created_with_reminder: "You've bookmarked this post with a reminder %{date}. %{name}"
       created_with_reminder_generic: "You've bookmarked this with a reminder %{date}. %{name}"
-      remove: "Remove Bookmark"
       delete: "Delete Bookmark"
       confirm_delete: "Are you sure you want to delete this bookmark? The reminder will also be deleted."
       confirm_clear: "Are you sure you want to clear all your bookmarks from this topic?"


### PR DESCRIPTION
This PR removes a locale that is no longer used: `js.bookmarks.remove`