### PR TITLE
DEV: Improve MessageBus subscriptions for TopicTrackingState

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -84,48 +84,51 @@ const TopicTrackingState = EmberObject.extend({
    * @method establishChannels
    */
   establishChannels(meta) {
+    meta ??= {};
+    const messageBusDefaultNewMessageId = -1;
+
     this.messageBus.subscribe(
       "/latest",
       this._processChannelPayload,
-      meta ? meta["/latest"] : -1
+      meta["/latest"] || messageBusDefaultNewMessageId
     );
 
     if (this.currentUser) {
       this.messageBus.subscribe(
         "/new",
         this._processChannelPayload,
-        meta ? meta["/new"] : -1
+        meta["/new"] || messageBusDefaultNewMessageId
       );
 
       this.messageBus.subscribe(
         `/unread`,
         this._processChannelPayload,
-        meta ? meta["/unread"] : -1
+        meta["/unread"] || messageBusDefaultNewMessageId
       );
 
       this.messageBus.subscribe(
         `/unread/${this.currentUser.id}`,
         this._processChannelPayload,
-        meta ? meta[`/unread/${this.currentUser.id}`] : -1
+        meta[`/unread/${this.currentUser.id}`] || messageBusDefaultNewMessageId
       );
     }
 
     this.messageBus.subscribe(
       "/delete",
       this.onDeleteMessage,
-      meta ? meta["/delete"] : -1
+      meta["/delete"] || messageBusDefaultNewMessageId
     );
 
     this.messageBus.subscribe(
       "/recover",
       this.onRecoverMessage,
-      meta ? meta["/recover"] : -1
+      meta["/recover"] || messageBusDefaultNewMessageId
     );
 
     this.messageBus.subscribe(
       "/destroy",
       this.onDestroyMessage,
-      meta ? meta["/destroy"] : -1
+      meta["/destroy"] || messageBusDefaultNewMessageId
     );
   },
 
@@ -1035,10 +1038,13 @@ const TopicTrackingState = EmberObject.extend({
 });
 
 export function startTracking(tracking) {
-  tracking.loadStates(PreloadStore.get("topicTrackingStates"));
-  tracking.establishChannels(PreloadStore.get("topicTrackingStateMeta"));
-  PreloadStore.remove("topicTrackingStates");
-  PreloadStore.remove("topicTrackingStateMeta");
+  PreloadStore.getAndRemove("topicTrackingStates").then((data) =>
+    tracking.loadStates(data)
+  );
+
+  PreloadStore.getAndRemove("topicTrackingStateMeta").then((meta) =>
+    tracking.establishChannels(meta)
+  );
 }
 
 export default TopicTrackingState;

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -83,20 +83,50 @@ const TopicTrackingState = EmberObject.extend({
    *
    * @method establishChannels
    */
-  establishChannels() {
-    this.messageBus.subscribe("/latest", this._processChannelPayload);
+  establishChannels(meta) {
+    this.messageBus.subscribe(
+      "/latest",
+      this._processChannelPayload,
+      meta ? meta["/latest"] : -1
+    );
+
     if (this.currentUser) {
-      this.messageBus.subscribe("/new", this._processChannelPayload);
-      this.messageBus.subscribe(`/unread`, this._processChannelPayload);
+      this.messageBus.subscribe(
+        "/new",
+        this._processChannelPayload,
+        meta ? meta["/new"] : -1
+      );
+
+      this.messageBus.subscribe(
+        `/unread`,
+        this._processChannelPayload,
+        meta ? meta["/unread"] : -1
+      );
+
       this.messageBus.subscribe(
         `/unread/${this.currentUser.id}`,
-        this._processChannelPayload
+        this._processChannelPayload,
+        meta ? meta[`/unread/${this.currentUser.id}`] : -1
       );
     }
 
-    this.messageBus.subscribe("/delete", this.onDeleteMessage);
-    this.messageBus.subscribe("/recover", this.onRecoverMessage);
-    this.messageBus.subscribe("/destroy", this.onDestroyMessage);
+    this.messageBus.subscribe(
+      "/delete",
+      this.onDeleteMessage,
+      meta ? meta["/delete"] : -1
+    );
+
+    this.messageBus.subscribe(
+      "/recover",
+      this.onRecoverMessage,
+      meta ? meta["/recover"] : -1
+    );
+
+    this.messageBus.subscribe(
+      "/destroy",
+      this.onDestroyMessage,
+      meta ? meta["/destroy"] : -1
+    );
   },
 
   @bind
@@ -1005,10 +1035,10 @@ const TopicTrackingState = EmberObject.extend({
 });
 
 export function startTracking(tracking) {
-  const data = PreloadStore.get("topicTrackingStates");
-  tracking.loadStates(data);
-  tracking.establishChannels();
+  tracking.loadStates(PreloadStore.get("topicTrackingStates"));
+  tracking.establishChannels(PreloadStore.get("topicTrackingStateMeta"));
   PreloadStore.remove("topicTrackingStates");
+  PreloadStore.remove("topicTrackingStateMeta");
 }
 
 export default TopicTrackingState;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -651,15 +651,10 @@ class ApplicationController < ActionController::Base
     )
 
     report = TopicTrackingState.report(current_user)
+    serializer = TopicTrackingStateSerializer.new(report, scope: guardian, root: false)
 
-    serializer =
-      ActiveModel::ArraySerializer.new(
-        report,
-        each_serializer: TopicTrackingStateSerializer,
-        scope: guardian,
-      )
-
-    store_preloaded("topicTrackingStates", MultiJson.dump(serializer))
+    store_preloaded("topicTrackingStates", MultiJson.dump(serializer.as_json[:data]))
+    store_preloaded("topicTrackingStateMeta", MultiJson.dump(serializer.as_json[:meta]))
   end
 
   def custom_html_json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -394,14 +394,9 @@ class UsersController < ApplicationController
     guardian.ensure_can_edit!(user)
 
     report = TopicTrackingState.report(user)
-    serializer =
-      ActiveModel::ArraySerializer.new(
-        report,
-        each_serializer: TopicTrackingStateSerializer,
-        scope: guardian,
-      )
+    serializer = TopicTrackingStateSerializer.new(report, scope: guardian, root: false)
 
-    render json: MultiJson.dump(serializer)
+    render json: MultiJson.dump(serializer.as_json[:data])
   end
 
   def private_message_topic_tracking_state

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -31,12 +31,12 @@ class TopicTrackingState
   DISMISS_NEW_MESSAGE_TYPE = "dismiss_new"
   MAX_TOPICS = 5000
 
-  PUBLISH_NEW_MESSAGE_BUS_CHANNEL = "/new"
-  PUBLISH_LATEST_MESSAGE_BUS_CHANNEL = "/latest"
-  PUBLISH_UNREAD_MESSAGE_BUS_CHANNEL = "/unread"
-  PUBLISH_RECOVER_MESSAGE_BUS_CHANNEL = "/recover"
-  PUBLISH_DELETE_MESSAGE_BUS_CHANNEL = "/delete"
-  PUBLISH_DESTROY_MESSAGE_BUS_CHANNEL = "/destroy"
+  NEW_MESSAGE_BUS_CHANNEL = "/new"
+  LATEST_MESSAGE_BUS_CHANNEL = "/latest"
+  UNREAD_MESSAGE_BUS_CHANNEL = "/unread"
+  RECOVER_MESSAGE_BUS_CHANNEL = "/recover"
+  DELETE_MESSAGE_BUS_CHANNEL = "/delete"
+  DESTROY_MESSAGE_BUS_CHANNEL = "/destroy"
 
   def self.publish_new(topic)
     return unless topic.regular?
@@ -62,7 +62,7 @@ class TopicTrackingState
 
     group_ids = secure_category_group_ids(topic)
 
-    MessageBus.publish(PUBLISH_NEW_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
+    MessageBus.publish(NEW_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
     publish_read(topic.id, 1, topic.user)
   end
 
@@ -93,7 +93,7 @@ class TopicTrackingState
       else
         secure_category_group_ids(topic)
       end
-    MessageBus.publish(PUBLISH_LATEST_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
+    MessageBus.publish(LATEST_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.unread_channel_key(user_id)
@@ -116,7 +116,7 @@ class TopicTrackingState
 
     message = { topic_id: topic.id, message_type: MUTED_MESSAGE_TYPE }
 
-    MessageBus.publish(PUBLISH_LATEST_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
+    MessageBus.publish(LATEST_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
   end
 
   def self.publish_unmuted(topic)
@@ -133,7 +133,7 @@ class TopicTrackingState
 
     message = { topic_id: topic.id, message_type: UNMUTED_MESSAGE_TYPE }
 
-    MessageBus.publish(PUBLISH_LATEST_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
+    MessageBus.publish(LATEST_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
   end
 
   def self.publish_unread(post)
@@ -182,7 +182,7 @@ class TopicTrackingState
 
     message = { topic_id: post.topic_id, message_type: UNREAD_MESSAGE_TYPE, payload: payload }
 
-    MessageBus.publish(PUBLISH_UNREAD_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
+    MessageBus.publish(UNREAD_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
   end
 
   def self.publish_recover(topic)
@@ -192,7 +192,7 @@ class TopicTrackingState
 
     message = { topic_id: topic.id, message_type: RECOVER_MESSAGE_TYPE }
 
-    MessageBus.publish(PUBLISH_RECOVER_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
+    MessageBus.publish(RECOVER_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.publish_delete(topic)
@@ -212,7 +212,7 @@ class TopicTrackingState
 
     message = { topic_id: topic.id, message_type: DESTROY_MESSAGE_TYPE }
 
-    MessageBus.publish(PUBLISH_DESTROY_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
+    MessageBus.publish(DESTROY_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.publish_read(topic_id, last_read_post_number, user, notification_level = nil)

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -31,6 +31,13 @@ class TopicTrackingState
   DISMISS_NEW_MESSAGE_TYPE = "dismiss_new"
   MAX_TOPICS = 5000
 
+  PUBLISH_NEW_MESSAGE_BUS_CHANNEL = "/new"
+  PUBLISH_LATEST_MESSAGE_BUS_CHANNEL = "/latest"
+  PUBLISH_UNREAD_MESSAGE_BUS_CHANNEL = "/unread"
+  PUBLISH_RECOVER_MESSAGE_BUS_CHANNEL = "/recover"
+  PUBLISH_DELETE_MESSAGE_BUS_CHANNEL = "/delete"
+  PUBLISH_DESTROY_MESSAGE_BUS_CHANNEL = "/destroy"
+
   def self.publish_new(topic)
     return unless topic.regular?
 
@@ -55,7 +62,7 @@ class TopicTrackingState
 
     group_ids = secure_category_group_ids(topic)
 
-    MessageBus.publish("/new", message.as_json, group_ids: group_ids)
+    MessageBus.publish(PUBLISH_NEW_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
     publish_read(topic.id, 1, topic.user)
   end
 
@@ -86,8 +93,7 @@ class TopicTrackingState
       else
         secure_category_group_ids(topic)
       end
-
-    MessageBus.publish("/latest", message.as_json, group_ids: group_ids)
+    MessageBus.publish(PUBLISH_LATEST_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.unread_channel_key(user_id)
@@ -107,8 +113,10 @@ class TopicTrackingState
         .limit(100)
         .pluck(:user_id)
     return if user_ids.blank?
+
     message = { topic_id: topic.id, message_type: MUTED_MESSAGE_TYPE }
-    MessageBus.publish("/latest", message.as_json, user_ids: user_ids)
+
+    MessageBus.publish(PUBLISH_LATEST_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
   end
 
   def self.publish_unmuted(topic)
@@ -122,8 +130,10 @@ class TopicTrackingState
         .limit(100)
         .pluck(:id)
     return if user_ids.blank?
+
     message = { topic_id: topic.id, message_type: UNMUTED_MESSAGE_TYPE }
-    MessageBus.publish("/latest", message.as_json, user_ids: user_ids)
+
+    MessageBus.publish(PUBLISH_LATEST_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
   end
 
   def self.publish_unread(post)
@@ -172,7 +182,7 @@ class TopicTrackingState
 
     message = { topic_id: post.topic_id, message_type: UNREAD_MESSAGE_TYPE, payload: payload }
 
-    MessageBus.publish("/unread", message.as_json, user_ids: user_ids)
+    MessageBus.publish(PUBLISH_UNREAD_MESSAGE_BUS_CHANNEL, message.as_json, user_ids: user_ids)
   end
 
   def self.publish_recover(topic)
@@ -182,7 +192,7 @@ class TopicTrackingState
 
     message = { topic_id: topic.id, message_type: RECOVER_MESSAGE_TYPE }
 
-    MessageBus.publish("/recover", message.as_json, group_ids: group_ids)
+    MessageBus.publish(PUBLISH_RECOVER_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.publish_delete(topic)
@@ -202,7 +212,7 @@ class TopicTrackingState
 
     message = { topic_id: topic.id, message_type: DESTROY_MESSAGE_TYPE }
 
-    MessageBus.publish("/destroy", message.as_json, group_ids: group_ids)
+    MessageBus.publish(PUBLISH_DESTROY_MESSAGE_BUS_CHANNEL, message.as_json, group_ids: group_ids)
   end
 
   def self.publish_read(topic_id, last_read_post_number, user, notification_level = nil)

--- a/app/serializers/topic_tracking_state_item_serializer.rb
+++ b/app/serializers/topic_tracking_state_item_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class TopicTrackingStateItemSerializer < ApplicationSerializer
+  attributes :topic_id,
+             :highest_post_number,
+             :last_read_post_number,
+             :created_at,
+             :category_id,
+             :notification_level,
+             :created_in_new_period,
+             :treat_as_new_topic_start_date,
+             :tags
+
+  def created_in_new_period
+    return true if !scope
+    object.created_at >= treat_as_new_topic_start_date
+  end
+
+  def include_tags?
+    object.respond_to?(:tags)
+  end
+end

--- a/app/serializers/topic_tracking_state_serializer.rb
+++ b/app/serializers/topic_tracking_state_serializer.rb
@@ -4,27 +4,20 @@ class TopicTrackingStateSerializer < ApplicationSerializer
   attributes :data, :meta
 
   def data
-    object.each do |item|
+    object.map do |item|
       TopicTrackingStateItemSerializer.new(item, scope: scope, root: false).as_json
     end
   end
 
   def meta
-    channels = [
-      TopicTrackingState::PUBLISH_LATEST_MESSAGE_BUS_CHANNEL,
-      TopicTrackingState::PUBLISH_RECOVER_MESSAGE_BUS_CHANNEL,
-      TopicTrackingState::PUBLISH_DELETE_MESSAGE_BUS_CHANNEL,
-      TopicTrackingState::PUBLISH_DESTROY_MESSAGE_BUS_CHANNEL,
-    ]
-
-    if !scope.anonymous?
-      channels.push(
-        TopicTrackingState::PUBLISH_NEW_MESSAGE_BUS_CHANNEL,
-        TopicTrackingState::PUBLISH_UNREAD_MESSAGE_BUS_CHANNEL,
-        TopicTrackingState.unread_channel_key(scope.user.id),
-      )
-    end
-
-    MessageBus.last_ids(*channels)
+    MessageBus.last_ids(
+      TopicTrackingState::LATEST_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::RECOVER_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::DELETE_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::DESTROY_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::NEW_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::UNREAD_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState.unread_channel_key(scope.user.id),
+    )
   end
 end

--- a/spec/serializers/topic_tracking_state_item_serializer_spec.rb
+++ b/spec/serializers/topic_tracking_state_item_serializer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe TopicTrackingStateSerializer do
+RSpec.describe TopicTrackingStateItemSerializer do
   fab!(:user) { Fabricate(:user) }
   fab!(:post) { create_post }
 

--- a/spec/serializers/topic_tracking_state_serializer_spec.rb
+++ b/spec/serializers/topic_tracking_state_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe TopicTrackingStateSerializer do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:post) { create_post }
+
+  it "serializes topic tracking state report correctly for a normal user" do
+    report = TopicTrackingState.report(user)
+    serialized = described_class.new(report, scope: Guardian.new(user), root: false).as_json
+
+    expect(serialized[:data].length).to eq(1)
+    expect(serialized[:data].first[:topic_id]).to eq(post.topic_id)
+
+    expect(serialized[:meta].keys).to contain_exactly(
+      TopicTrackingState::LATEST_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::RECOVER_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::DELETE_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::DESTROY_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::NEW_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState::UNREAD_MESSAGE_BUS_CHANNEL,
+      TopicTrackingState.unread_channel_key(user.id),
+    )
+  end
+end


### PR DESCRIPTION
## Why do we need this change? 

When loading the ember app, [MessageBus does not start polling immediately](https://github.com/discourse/discourse/blob/f31f0b70f82c43d93220ce6fc0d4f57440452f37/app/assets/javascripts/discourse/app/initializers/message-bus.js#L71-L81) and instead waits for `document.readyState` to be `complete`. What this means is that if there are new messages being created while we have yet to start polling, those messages will not be received by the client.

With sidebar being the default navigation menu, the counts derived from `topic-tracking-state.js` on the client side is prominently displayed on every page. Therefore, we want to ensure that we are not dropping any messages on the channels that `topic-tracking-state.js` subscribes to.  

## What does this change do? 

This includes the `MessageBus.last_id`s for the MessageBus channels which `topic-tracking-state.js` subscribes to as part of the preloaded data when loading a page. The last ids are then used when we subscribe the MessageBus channels so that messages which are published before MessageBus starts polling will not be missed.

## Review Notes

1. See https://github.com/discourse/message_bus#client-support for documentation about subscribing from a given message id.

