### PR TITLE
FIX: render_404 is not defined

### DIFF
--- a/plugins/chat/app/controllers/chat_controller.rb
+++ b/plugins/chat/app/controllers/chat_controller.rb
@@ -288,8 +288,8 @@ class Chat::ChatController < Chat::ChatBaseController
   end
 
   def message_link
-    return render_404 if @message.blank? || @message.deleted_at.present?
-    return render_404 if @message.chat_channel.blank?
+    raise Discourse::NotFound if @message.blank? || @message.deleted_at.present?
+    raise Discourse::NotFound if @message.chat_channel.blank?
     set_channel_and_chatable_with_access_check(chat_channel_id: @message.chat_channel_id)
     render json:
              success_json.merge(


### PR DESCRIPTION
Note this endpoint is soon going to be replaced.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
