### PR TITLE
FIX: Don't change the default allowed_attribute when calling #sanitize_field

### DIFF
--- a/app/models/concerns/has_sanitizable_fields.rb
+++ b/app/models/concerns/has_sanitizable_fields.rb
@@ -6,7 +6,7 @@ module HasSanitizableFields
   def sanitize_field(field, additional_attributes: [])
     if field
       sanitizer = Rails::Html::SafeListSanitizer.new
-      allowed_attributes = Rails::Html::SafeListSanitizer.allowed_attributes
+      allowed_attributes = Rails::Html::SafeListSanitizer.allowed_attributes.dup
 
       if additional_attributes.present?
         allowed_attributes = allowed_attributes.merge(additional_attributes)


### PR DESCRIPTION
It causes a flaky test.