### PR TITLE
PERF: Move user-tips and narrative to per-user messagebus channels

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/user-tips.js
+++ b/app/assets/javascripts/discourse/app/initializers/user-tips.js
@@ -13,11 +13,19 @@ export default {
     this.messageBus = container.lookup("service:message-bus");
     this.site = container.lookup("service:site");
 
-    this.messageBus.subscribe("/user-tips", this.onMessage);
+    this.messageBus.subscribe(
+      `/user-tips/${this.currentUser.id}`,
+      this.onMessage
+    );
   },
 
   teardown() {
-    this.messageBus?.unsubscribe("/user-tips", this.onMessage);
+    if (this.currentUser) {
+      this.messageBus?.unsubscribe(
+        `/user-tips/${this.currentUser.id}`,
+        this.onMessage
+      );
+    }
   },
 
   @bind

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -251,7 +251,11 @@ class UserUpdater
         end
       end
       if attributes.key?(:seen_popups) || attributes.key?(:skip_new_user_tips)
-        MessageBus.publish("/user-tips", user.user_option.seen_popups, user_ids: [user.id])
+        MessageBus.publish(
+          "/user-tips/#{user.id}",
+          user.user_option.seen_popups,
+          user_ids: [user.id],
+        )
       end
       DiscourseEvent.trigger(:user_updated, user)
     end

--- a/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
+++ b/plugins/discourse-narrative-bot/assets/javascripts/initializers/new-user-narrative.js
@@ -15,9 +15,9 @@ export default {
     this.appEvents = container.lookup("service:app-events");
 
     withPluginApi("0.8.7", (api) => {
-      const currentUser = api.getCurrentUser();
+      this.currentUser = api.getCurrentUser();
 
-      if (!currentUser) {
+      if (!this.currentUser) {
         return;
       }
 
@@ -41,17 +41,19 @@ export default {
       );
 
       this.messageBus.subscribe(
-        "/new_user_narrative/tutorial_search",
+        `/new_user_narrative/tutorial_search/${this.currentUser.id}`,
         this.onMessage
       );
     });
   },
 
   teardown() {
-    this.messageBus?.unsubscribe(
-      "/new_user_narrative/tutorial_search",
-      this.onMessage
-    );
+    if (this.currentUser) {
+      this.messageBus?.unsubscribe(
+        `/new_user_narrative/tutorial_search/${this.currentUser.id}`,
+        this.onMessage
+      );
+    }
   },
 
   @bind

--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -173,7 +173,11 @@ module DiscourseNarrativeBot
       topic = @post.topic
       post = topic.first_post
 
-      MessageBus.publish("/new_user_narrative/tutorial_search", {}, user_ids: [@user.id])
+      MessageBus.publish(
+        "/new_user_narrative/tutorial_search/#{@user.id}",
+        {},
+        user_ids: [@user.id],
+      )
 
       raw = <<~MD
       #{post.raw}

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -551,7 +551,7 @@ RSpec.describe UserUpdater do
     context "when skip_new_user_tips is edited" do
       it "updates seen_popups too" do
         messages =
-          MessageBus.track_publish("/user-tips") do
+          MessageBus.track_publish("/user-tips/#{user.id}") do
             UserUpdater.new(Discourse.system_user, user).update(skip_new_user_tips: true)
           end
 
@@ -573,7 +573,7 @@ RSpec.describe UserUpdater do
     context "when seen_popups is edited" do
       it "publishes a message" do
         messages =
-          MessageBus.track_publish("/user-tips") do
+          MessageBus.track_publish("/user-tips/#{user.id}") do
             UserUpdater.new(Discourse.system_user, user).update(seen_popups: [1])
           end
 


### PR DESCRIPTION
When message-bus clients connect to a channel, they are notified of the channels 'last_id', and are sent status status pseudo-messages when the 'last_id' changes, even if they were not a recipient of any messages. Using a shared channel with per-message permissions means that every client is updated with the channel's 'last_id', even if there are no messages available to them. Per-user channel names avoid this problem - the last_id will only be incremented when there is a message for the given user.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
