### PR TITLE
DEV: Introduce syntax_tree code formatter

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -68,6 +68,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: bundle exec rubocop --parallel .
 
+      - name: syntax_tree
+        if: ${{ !cancelled() }}
+        run: bundle exec stree check Gemfile $(git ls-files '*.rb') $(git ls-files '*.rake')
+
       - name: ESLint (core)
         if: ${{ !cancelled() }}
         run: yarn eslint app/assets/javascripts

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_gem:
-  rubocop-discourse: default.yml
+  rubocop-discourse: stree-compat.yml
 
 # Still work to do in ensuring we don't link old files
 Discourse/NoAddReferenceOrAliasesActiveRecordMigration:

--- a/.streerc
+++ b/.streerc
@@ -1,2 +1,10 @@
 --print-width=100
---plugins=plugin/trailing_comma
+--plugins=plugin/trailing_comma,disable_ternary
+--ignore-files=Gemfile
+--ignore-files=app/*
+--ignore-files=config/*
+--ignore-files=db/*
+--ignore-files=lib/*
+--ignore-files=plugins/*
+--ignore-files=script/*
+--ignore-files=spec/*

--- a/Gemfile
+++ b/Gemfile
@@ -169,6 +169,9 @@ group :test, :development do
   gem 'rswag-specs'
 
   gem 'annotate'
+
+  gem "syntax_tree"
+  gem 'syntax_tree-disable_ternary'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,7 @@ GEM
     parser (3.2.0.0)
       ast (~> 2.4.1)
     pg (1.4.5)
+    prettier_print (1.2.0)
     progress (3.6.0)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -408,7 +409,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
-    rubocop-discourse (3.0.1)
+    rubocop-discourse (3.0.2)
       rubocop (>= 1.1.0)
       rubocop-rspec (>= 2.0.0)
     rubocop-rspec (2.16.0)
@@ -460,6 +461,9 @@ GEM
       sprockets (>= 3.0.0)
     sshkey (2.0.0)
     stackprof (0.2.23)
+    syntax_tree (5.2.0)
+      prettier_print (>= 1.2.0)
+    syntax_tree-disable_ternary (1.0.0)
     test-prof (1.1.0)
     thor (1.2.1)
     tilt (2.0.11)
@@ -627,6 +631,8 @@ DEPENDENCIES
   sprockets-rails
   sshkey
   stackprof
+  syntax_tree
+  syntax_tree-disable_ternary
   test-prof
   thor
   uglifier


### PR DESCRIPTION
This commit introduces the necessary gems and config, but adds all our ruby code directories to the `--ignore-files` list.

Future commits will apply syntax_tree to parts of the codebase, removing the ignore patterns as we go

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
