### PR TITLE
FIX: Correctly support DiscourseEvent kwargs

### DIFF
--- a/lib/discourse_event.rb
+++ b/lib/discourse_event.rb
@@ -9,9 +9,9 @@ class DiscourseEvent
     @events ||= Hash.new { |hash, key| hash[key] = Set.new }
   end
 
-  def self.trigger(event_name, *params)
+  def self.trigger(event_name, *args, **kwargs)
     events[event_name].each do |event|
-      event.call(*params)
+      event.call(*args, **kwargs)
     end
   end
 

--- a/spec/lib/discourse_event_spec.rb
+++ b/spec/lib/discourse_event_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseEvent do
-
   describe "#events" do
     it "defaults to {}" do
       begin
@@ -21,7 +20,6 @@ RSpec.describe DiscourseEvent do
   end
 
   context 'when calling events' do
-
     let(:harvey) {
       OpenStruct.new(
         name: 'Harvey Dent',
@@ -42,15 +40,12 @@ RSpec.describe DiscourseEvent do
     end
 
     context 'when event does not exist' do
-
       it "does not raise an error" do
         DiscourseEvent.trigger(:missing_event)
       end
-
     end
 
     context 'when single event exists' do
-
       it "doesn't raise an error" do
         DiscourseEvent.trigger(:acid_face, harvey)
       end
@@ -59,11 +54,9 @@ RSpec.describe DiscourseEvent do
         DiscourseEvent.trigger(:acid_face, harvey)
         expect(harvey.name).to eq('Two Face')
       end
-
     end
 
     context 'when multiple events exist' do
-
       let(:event_handler_2) do
         Proc.new { |user| user.job = 'Supervillain' }
       end
@@ -84,7 +77,6 @@ RSpec.describe DiscourseEvent do
     end
 
     describe '#all_off' do
-
       let(:event_handler_2) do
         Proc.new { |user| user.job = 'Supervillain' }
       end
@@ -99,7 +91,20 @@ RSpec.describe DiscourseEvent do
         DiscourseEvent.trigger(:acid_face, harvey) # Doesn't change anything
         expect(harvey.job).to eq('gardening')
       end
+    end
+  end
 
+  it "allows using kwargs" do
+    begin
+      handler = Proc.new do |name:, message:|
+        expect(name).to eq("Supervillain")
+        expect(message).to eq("Two Face")
+      end
+
+      DiscourseEvent.on(:acid_face, &handler)
+      DiscourseEvent.trigger(:acid_face, name: "Supervillain", message: "Two Face")
+    ensure
+      DiscourseEvent.off(:acid_face, &handler)
     end
   end
 end

--- a/spec/lib/system_message_spec.rb
+++ b/spec/lib/system_message_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe SystemMessage do
       }
 
       expect(event[:event_name]).to eq(:system_message_sent)
-      expect(event[:params].last[:post]).to eq(Post.last)
-      expect(event[:params].last[:message_type]).to eq(:tl2_promotion_message)
+      expect(event[:params].first[:post]).to eq(Post.last)
+      expect(event[:params].first[:message_type]).to eq(:tl2_promotion_message)
     end
 
     it 'sends an event before the system message is sent' do
@@ -97,8 +97,8 @@ RSpec.describe SystemMessage do
       }
 
       expect(event[:event_name]).to eq(:before_system_message_sent)
-      expect(event[:params].last[:message_type]).to eq(:tl2_promotion_message)
-      expect(event[:params].last[:recipient]).to eq(user)
+      expect(event[:params].first[:message_type]).to eq(:tl2_promotion_message)
+      expect(event[:params].first[:recipient]).to eq(user)
     end
   end
 end

--- a/spec/lib/system_message_spec.rb
+++ b/spec/lib/system_message_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe SystemMessage do
       }
 
       expect(event[:event_name]).to eq(:system_message_sent)
-      expect(event[:kwargs][:post]).to eq(Post.last)
-      expect(event[:kwargs][:message_type]).to eq(:tl2_promotion_message)
+      expect(event[:params].last[:post]).to eq(Post.last)
+      expect(event[:params].last[:message_type]).to eq(:tl2_promotion_message)
     end
 
     it 'sends an event before the system message is sent' do
@@ -97,8 +97,8 @@ RSpec.describe SystemMessage do
       }
 
       expect(event[:event_name]).to eq(:before_system_message_sent)
-      expect(event[:kwargs][:message_type]).to eq(:tl2_promotion_message)
-      expect(event[:kwargs][:recipient]).to eq(user)
+      expect(event[:params].last[:message_type]).to eq(:tl2_promotion_message)
+      expect(event[:params].last[:recipient]).to eq(user)
     end
   end
 end

--- a/spec/lib/system_message_spec.rb
+++ b/spec/lib/system_message_spec.rb
@@ -4,9 +4,7 @@ require 'system_message'
 require 'topic_subtype'
 
 RSpec.describe SystemMessage do
-
   describe '#create' do
-
     fab!(:admin) { Fabricate(:admin) }
     fab!(:user) { Fabricate(:user) }
 
@@ -81,12 +79,26 @@ RSpec.describe SystemMessage do
 
     it 'sends event with post object' do
       system_message = SystemMessage.new(user)
+
       event = DiscourseEvent.track(:system_message_sent) {
         system_message.create(:tl2_promotion_message)
       }
+
       expect(event[:event_name]).to eq(:system_message_sent)
-      expect(event[:params].first[:post]).to eq(Post.last)
-      expect(event[:params].first[:message_type]).to eq(:tl2_promotion_message)
+      expect(event[:kwargs][:post]).to eq(Post.last)
+      expect(event[:kwargs][:message_type]).to eq(:tl2_promotion_message)
+    end
+
+    it 'sends an event before the system message is sent' do
+      system_message = SystemMessage.new(user)
+
+      event = DiscourseEvent.track(:before_system_message_sent) {
+        system_message.create(:tl2_promotion_message)
+      }
+
+      expect(event[:event_name]).to eq(:before_system_message_sent)
+      expect(event[:kwargs][:message_type]).to eq(:tl2_promotion_message)
+      expect(event[:kwargs][:recipient]).to eq(user)
     end
   end
 end

--- a/spec/support/discourse_event_helper.rb
+++ b/spec/support/discourse_event_helper.rb
@@ -5,11 +5,12 @@ module DiscourseEvent::TestHelper
     super(event_name, *params, **kwargs)
 
     if @events_trigger
-      @events_trigger << { event_name: event_name, params: params, kwargs: kwargs }
+      params << kwargs if kwargs != {}
+      @events_trigger << { event_name: event_name, params: params }
     end
   end
 
-  def track_events(event_name = nil, args: nil, kwargs: nil)
+  def track_events(event_name = nil, args: nil)
     @events_trigger = events_trigger = []
     yield
     @events_trigger = nil
@@ -18,7 +19,6 @@ module DiscourseEvent::TestHelper
       events_trigger = events_trigger.filter do |event|
         next if event[:event_name] != event_name
         next if args && event[:params] != args
-        next if kwargs && event[:kwargs] != kwargs
         true
       end
     end
@@ -26,8 +26,8 @@ module DiscourseEvent::TestHelper
     events_trigger
   end
 
-  def track(event_name, args: nil, kwargs: nil)
-    events = track_events(event_name, args: args, kwargs: kwargs) { yield }
+  def track(event_name, args: nil)
+    events = track_events(event_name, args: args) { yield }
     events.first
   end
 end

--- a/spec/support/discourse_event_helper.rb
+++ b/spec/support/discourse_event_helper.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module DiscourseEvent::TestHelper
-  def trigger(event_name, *params)
-    super(event_name, *params)
+  def trigger(event_name, *params, **kwargs)
+    super(event_name, *params, **kwargs)
 
     if @events_trigger
-      @events_trigger << { event_name: event_name, params: params }
+      @events_trigger << { event_name: event_name, params: params, kwargs: kwargs }
     end
   end
 
-  def track_events(event_name = nil, args: nil)
+  def track_events(event_name = nil, args: nil, kwargs: nil)
     @events_trigger = events_trigger = []
     yield
     @events_trigger = nil
@@ -18,6 +18,7 @@ module DiscourseEvent::TestHelper
       events_trigger = events_trigger.filter do |event|
         next if event[:event_name] != event_name
         next if args && event[:params] != args
+        next if kwargs && event[:kwargs] != kwargs
         true
       end
     end
@@ -25,11 +26,10 @@ module DiscourseEvent::TestHelper
     events_trigger
   end
 
-  def track(event_name, args: nil)
-    events = track_events(event_name, args: args) { yield }
+  def track(event_name, args: nil, kwargs: nil)
+    events = track_events(event_name, args: args, kwargs: kwargs) { yield }
     events.first
   end
-
 end
 
 DiscourseEvent.singleton_class.prepend DiscourseEvent::TestHelper


### PR DESCRIPTION
Fixes the support for kwargs in `DiscourseEvent.trigger()` on Ruby 3, e.g.

```rb
DiscourseEvent.trigger(:before_system_message_sent, message_type: type, recipient: @recipient, post_creator_args: post_creator_args, params: method_params)
```

Fixes https://github.com/discourse/discourse-local-site-contacts

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
