### PR TITLE
FIX: move min tag setting to tags section in edit category

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
@@ -181,20 +181,6 @@
     </div>
   </section>
 
-  {{#if this.siteSettings.tagging_enabled}}
-    <section class="field minimum-required-tags">
-      <label for="category-minimum-tags">
-        {{i18n "category.minimum_required_tags"}}
-      </label>
-      <TextField
-        @value={{this.category.minimum_required_tags}}
-        @id="category-minimum-tags"
-        @type="number"
-        @min="0"
-      />
-    </section>
-  {{/if}}
-
   <section class="field num-auto-bump-daily">
     <label for="category-number-daily-bump">
       {{i18n "category.num_auto_bump_daily"}}

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-tags.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-tags.hbs
@@ -1,3 +1,14 @@
+<section class="field minimum-required-tags">
+  <label for="category-minimum-tags">
+    {{i18n "category.minimum_required_tags"}}
+  </label>
+  <TextField
+    @value={{this.category.minimum_required_tags}}
+    @id="category-minimum-tags"
+    @type="number"
+    @min="0"
+  />
+</section>
 <section class="field allowed-tags">
   <label>{{i18n "category.tags_allowed_tags"}}</label>
   <TagChooser

--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -77,6 +77,8 @@ acceptance("Category Edit", function (needs) {
   test("Editing required tag groups", async function (assert) {
     await visit("/c/bug/edit/tags");
 
+    assert.ok(exists(".minimum-required-tags"));
+
     assert.ok(exists(".required-tag-groups"));
     assert.strictEqual(count(".required-tag-group-row"), 0);
 

--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -102,7 +102,8 @@ div.edit-category {
     }
   }
 
-  .edit-category-tab-settings {
+  .edit-category-tab-settings,
+  .edit-category-tab-tags {
     > section {
       margin-bottom: 1.5em;
     }


### PR DESCRIPTION
`Minimum number of tags required in a topic` should be in `Tags` panel instead of `Settings`

<img width="1142" alt="Screenshot 2023-01-09 at 11 50 42 am" src="https://user-images.githubusercontent.com/72780/211227378-b0b2e47e-8ef9-45d7-8edb-36e747346685.png">
