### PR TITLE
FIX: Disable clientside image optimization in iOS Safari

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/register-media-optimization-upload-processor.js
+++ b/app/assets/javascripts/discourse/app/initializers/register-media-optimization-upload-processor.js
@@ -6,8 +6,27 @@ export default {
   name: "register-media-optimization-upload-processor",
 
   initialize(container) {
-    let siteSettings = container.lookup("service:site-settings");
+    const siteSettings = container.lookup("service:site-settings");
+    const capabilities = container.lookup("capabilities:main");
+
     if (siteSettings.composer_media_optimization_image_enabled) {
+      // NOTE: There are various performance issues with the Canvas
+      // in iOS Safari that are causing crashes when processing images
+      // with spikes of over 100% CPU usage. The cause of this is unknown,
+      // but profiling points to CanvasRenderingContext2D.getImageData()
+      // and CanvasRenderingContext2D.drawImage().
+      //
+      // Until Safari makes some progress with OffscreenCanvas or other
+      // alternatives we cannot support this workflow.
+      //
+      // TODO (martin): Revisit around 2022-06-01 to see the state of iOS Safari.
+      if (
+        capabilities.isIOS &&
+        !siteSettings.composer_ios_media_optimisation_image_enabled
+      ) {
+        return;
+      }
+
       addComposerUploadPreProcessor(
         UppyMediaOptimization,
         ({ isMobileDevice }) => {

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1549,6 +1549,10 @@ files:
     default: false
     client: true
     hidden: true
+  composer_ios_media_optimisation_image_enabled:
+    default: false
+    client: true
+    hidden: true
 
 trust:
   default_trust_level:


### PR DESCRIPTION
There are various performance issues with the Canvas in iOS Safari
that are causing crashes when processing images with spikes of over 100%
CPU usage. The cause of this is unknown, but profiling points to
CanvasRenderingContext2D.getImageData() and
CanvasRenderingContext2D.drawImage().

Until Safari makes some progress with OffscreenCanvas or other
alternatives we cannot support this workflow. We will revisit in 6
months.

This is gated behind the hidden `composer_ios_media_optimisation_image_enabled`
site setting for people who really still want to try using this.
