### PR TITLE
FIX: Do not error when anon user looks at secure upload for deleted post

### DIFF
--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -239,8 +239,15 @@ module PostGuardian
     return false unless can_see_post_topic?(post)
     return false unless post.user == @user || Topic.visible_post_types(@user).include?(post.post_type)
     return true if is_moderator? || is_category_group_moderator?(post.topic.category)
-    return true if post.deleted_at.blank? || (post.deleted_by_id == @user.id && @user.has_trust_level?(TrustLevel[4]))
+    return true if !post.trashed? || can_see_deleted_post?(post)
     false
+  end
+
+  def can_see_deleted_post?(post)
+    return false if !post.trashed?
+    return false if @user.anonymous?
+    return true if is_staff?
+    post.deleted_by_id == @user.id && @user.has_trust_level?(TrustLevel[4])
   end
 
   def can_view_edit_history?(post)


### PR DESCRIPTION
If a secure upload's access_control_post was trashed, and an anon user
tried to look at that upload, they would get a 500 error rather than
the correct 403 because of an error inside the PostGuardian logic.

```
NoMethodError (undefined method `id' for #<Guardian::AnonymousUser:0x00007f9a99f005d8>)
lib/guardian/post_guardian.rb:242:in `can_see_post?'
lib/guardian.rb:163:in `public_send'
lib/guardian.rb:163:in `can_see?'
app/controllers/uploads_controller.rb:164:in `handle_secure_upload_request'
app/controllers/uploads_controller.rb:149:in `show_secure'
app/controllers/application_controller.rb:413:in `block in with_resolved_locale'
app/controllers/application_controller.rb:413:in `with_resolved_locale'
```
