### PR TITLE
FIX: Fix broken grid layout in user tracking preferences

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/preferences/tracking.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/tracking.hbs
@@ -11,20 +11,24 @@
 </div>
 
 <div class="user-preferences__tracking-categories-tags-wrapper">
-  <UserPreferences::Categories
-    @canSee={{this.canSee}}
-    @model={{this.model}}
-    @selectedCategories={{this.selectedCategories}}
-    @hideMutedTags={{this.hideMutedTags}}
-    @siteSettings={{this.siteSettings}}
-  />
+  <div>
+    <UserPreferences::Categories
+      @canSee={{this.canSee}}
+      @model={{this.model}}
+      @selectedCategories={{this.selectedCategories}}
+      @hideMutedTags={{this.hideMutedTags}}
+      @siteSettings={{this.siteSettings}}
+    />
+  </div>
 
-  <UserPreferences::Tags
-    @model={{this.model}}
-    @selectedTags={{this.selectedTags}}
-    @save={{this.save}}
-    @siteSettings={{this.siteSettings}}
-  />
+  <div>
+    <UserPreferences::Tags
+      @model={{this.model}}
+      @selectedTags={{this.selectedTags}}
+      @save={{this.save}}
+      @siteSettings={{this.siteSettings}}
+    />
+  </div>
 </div>
 
 {{#if this.canSave}}


### PR DESCRIPTION
### What was happening?

We're using a grid layout for users' tracking preferences. Inside the grid we render `UserPreferences::Categories` and `UserPreferences::Tags` components.

The issue is that these components have plugin outlets that are not contained within the root element of the component. Rather, they are siblings. These plugin outlets were therefore treated as grid elements as well.

<img width="763" alt="Screenshot 2023-01-09 at 5 38 40 PM" src="https://user-images.githubusercontent.com/5259935/211278743-b035415f-efe1-45e2-aca1-ce6fcbf5b563.png">

### How does this fix it?

I decided to add two `div` elements in the layout. Between this and modifying the components themselves I figure this has a smaller risk of regressions of people's CSS selectors (even though a small risk still remains if people use direct descendant selectors.) Please correct me if I'm wrong. 🙇 

### Prove it!

Okay.

<img width="771" alt="Screenshot 2023-01-09 at 5 35 22 PM" src="https://user-images.githubusercontent.com/5259935/211279183-aa3e4a4d-5eac-465e-9bdc-5fcb8ef773a6.png">
