### PR TITLE
UX: add btn-primary class on email confirm page

### DIFF
--- a/app/views/users_email/show_confirm_new_email.html.erb
+++ b/app/views/users_email/show_confirm_new_email.html.erb
@@ -4,7 +4,7 @@
       <%= t 'change_email.confirmed' %>
     </h2>
     <p>
-    <a class="btn" href="<%= path "/" %>"><%= t('change_email.please_continue', site_name: SiteSetting.title) %></a>
+    <a class="btn btn-primary" href="<%= path "/" %>"><%= t('change_email.please_continue', site_name: SiteSetting.title) %></a>
     </p>
   <% elsif @error %>
     <div class='alert alert-error'>


### PR DESCRIPTION
This helps a customer that noticed some missing styles on this button. 