### PR TITLE
DEV: Change default bootstrap min users for private sites

### DIFF
--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -30,9 +30,17 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
   end
 
   # Set bootstrap min users for private sites to a lower default
+  PRIVATE_BOOTSTRAP_MODE_MIN_USERS ||= 10.freeze
   if name == :login_required && new_value == true && SiteSetting.bootstrap_mode_enabled == true
-    if SiteSetting.bootstrap_mode_min_users == 50 # The default
-      SiteSetting.bootstrap_mode_min_users = 10
+    if SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users) # The default
+      SiteSetting.bootstrap_mode_min_users = PRIVATE_BOOTSTRAP_MODE_MIN_USERS
+    end
+  end
+
+  # Set bootstrap min users for public sites back to the default
+  if name == :login_required && new_value == false && SiteSetting.bootstrap_mode_enabled == true
+    if SiteSetting.bootstrap_mode_min_users == PRIVATE_BOOTSTRAP_MODE_MIN_USERS
+      SiteSetting.bootstrap_mode_min_users = SiteSetting.defaults.get(:bootstrap_mode_min_users)
     end
   end
 

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+PRIVATE_BOOTSTRAP_MODE_MIN_USERS = 10
+
 DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
   Category.clear_subcategory_ids if name === :max_category_nesting
 
@@ -30,7 +32,7 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
   end
 
   # Set bootstrap min users for private sites to a lower default
-  PRIVATE_BOOTSTRAP_MODE_MIN_USERS ||= 10.freeze
+  #PRIVATE_BOOTSTRAP_MODE_MIN_USERS ||= 10.freeze
   if name == :login_required && new_value == true && SiteSetting.bootstrap_mode_enabled == true
     if SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users)
       SiteSetting.bootstrap_mode_min_users = PRIVATE_BOOTSTRAP_MODE_MIN_USERS

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -33,12 +33,14 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
 
   # Set bootstrap min users for private sites to a lower default
   if name == :login_required && SiteSetting.bootstrap_mode_enabled == true
-    if new_value == true && SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users)
+    if new_value == true &&
+         SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users)
       SiteSetting.bootstrap_mode_min_users = PRIVATE_BOOTSTRAP_MODE_MIN_USERS
     end
 
     # Set bootstrap min users for public sites back to the default
-    if new_value == false && SiteSetting.bootstrap_mode_min_users == PRIVATE_BOOTSTRAP_MODE_MIN_USERS
+    if new_value == false &&
+         SiteSetting.bootstrap_mode_min_users == PRIVATE_BOOTSTRAP_MODE_MIN_USERS
       SiteSetting.bootstrap_mode_min_users = SiteSetting.defaults.get(:bootstrap_mode_min_users)
     end
   end

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -29,6 +29,13 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
     end
   end
 
+  # Set bootstrap min users for private sites to a lower default
+  if name == :login_required && new_value == true && SiteSetting.bootstrap_mode_enabled == true
+    if SiteSetting.bootstrap_mode_min_users == 50 # The default
+      SiteSetting.bootstrap_mode_min_users = 10
+    end
+  end
+
   Stylesheet::Manager.clear_color_scheme_cache! if %i[base_font heading_font].include?(name)
 
   Report.clear_cache(:storage_stats) if %i[backup_location s3_backup_bucket].include?(name)

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -33,15 +33,13 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
 
   # Set bootstrap min users for private sites to a lower default
   #PRIVATE_BOOTSTRAP_MODE_MIN_USERS ||= 10.freeze
-  if name == :login_required && new_value == true && SiteSetting.bootstrap_mode_enabled == true
-    if SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users)
+  if name == :login_required && SiteSetting.bootstrap_mode_enabled == true
+    if new_value == true && SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users)
       SiteSetting.bootstrap_mode_min_users = PRIVATE_BOOTSTRAP_MODE_MIN_USERS
     end
-  end
 
-  # Set bootstrap min users for public sites back to the default
-  if name == :login_required && new_value == false && SiteSetting.bootstrap_mode_enabled == true
-    if SiteSetting.bootstrap_mode_min_users == PRIVATE_BOOTSTRAP_MODE_MIN_USERS
+    # Set bootstrap min users for public sites back to the default
+    if new_value == false && SiteSetting.bootstrap_mode_min_users == PRIVATE_BOOTSTRAP_MODE_MIN_USERS
       SiteSetting.bootstrap_mode_min_users = SiteSetting.defaults.get(:bootstrap_mode_min_users)
     end
   end

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -32,7 +32,6 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
   end
 
   # Set bootstrap min users for private sites to a lower default
-  #PRIVATE_BOOTSTRAP_MODE_MIN_USERS ||= 10.freeze
   if name == :login_required && SiteSetting.bootstrap_mode_enabled == true
     if new_value == true && SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users)
       SiteSetting.bootstrap_mode_min_users = PRIVATE_BOOTSTRAP_MODE_MIN_USERS

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -32,7 +32,7 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
   # Set bootstrap min users for private sites to a lower default
   PRIVATE_BOOTSTRAP_MODE_MIN_USERS ||= 10.freeze
   if name == :login_required && new_value == true && SiteSetting.bootstrap_mode_enabled == true
-    if SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users) # The default
+    if SiteSetting.bootstrap_mode_min_users == SiteSetting.defaults.get(:bootstrap_mode_min_users)
       SiteSetting.bootstrap_mode_min_users = PRIVATE_BOOTSTRAP_MODE_MIN_USERS
     end
   end

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -176,6 +176,35 @@ RSpec.describe SiteSettingExtension do
       expect(changed_event_1[:params]).to eq([:test_setting, 1, 2])
       expect(changed_event_2[:params]).to eq([:test_setting, 2, 1])
     end
+
+  end
+
+  describe "DiscourseEvent for login_required changed to true" do
+    before do
+      SiteSetting.login_required = false
+      SiteSetting.bootstrap_mode_min_users = 50
+      SiteSetting.bootstrap_mode_enabled = true
+    end
+
+    it "lowers bootstrap mode min users for private sites" do
+      SiteSetting.login_required = true
+
+      expect(SiteSetting.bootstrap_mode_min_users).to eq(10)
+    end
+  end
+
+  describe "DiscourseEvent for login_required changed to false" do
+    before do
+      SiteSetting.login_required = true
+      SiteSetting.bootstrap_mode_min_users = 50
+      SiteSetting.bootstrap_mode_enabled = true
+    end
+
+    it "resets bootstrap mode min users for public sites" do
+      SiteSetting.login_required = false
+
+      expect(SiteSetting.bootstrap_mode_min_users).to eq(50)
+    end
   end
 
   describe "int setting" do

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -176,7 +176,6 @@ RSpec.describe SiteSettingExtension do
       expect(changed_event_1[:params]).to eq([:test_setting, 1, 2])
       expect(changed_event_2[:params]).to eq([:test_setting, 2, 1])
     end
-
   end
 
   describe "DiscourseEvent for login_required changed to true" do


### PR DESCRIPTION
Private sites should have a lower min users to escape bootstrap mode.
