### PR TITLE
DEV: Fix threading error when running jobs immediately in system tests

### DIFF
--- a/spec/jobs/create_linked_topic_spec.rb
+++ b/spec/jobs/create_linked_topic_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Jobs::CreateLinkedTopic do
   it "returns when the post cannot be found" do
-    expect { Jobs::CreateLinkedTopic.new.perform(post_id: 1, sync_exec: true) }.not_to raise_error
+    expect { Jobs::CreateLinkedTopic.new.execute(post_id: 1) }.not_to raise_error
   end
 
   context "with a post" do

--- a/spec/jobs/jobs_base_spec.rb
+++ b/spec/jobs/jobs_base_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe ::Jobs::Base do
 
   it "delegates the process call to execute" do
     ::Jobs::Base.any_instance.expects(:execute).with({ "hello" => "world" })
-    ::Jobs::Base.new.perform("hello" => "world", "sync_exec" => true)
+    ::Jobs::Base.new.perform("hello" => "world")
   end
 
   it "converts to an indifferent access hash" do
     ::Jobs::Base.any_instance.expects(:execute).with(instance_of(HashWithIndifferentAccess))
-    ::Jobs::Base.new.perform("hello" => "world", "sync_exec" => true)
+    ::Jobs::Base.new.perform("hello" => "world")
   end
 
   context "with fake jobs" do

--- a/spec/jobs/jobs_spec.rb
+++ b/spec/jobs/jobs_spec.rb
@@ -101,8 +101,9 @@ RSpec.describe Jobs do
       it "executes the job right away" do
         Jobs::ProcessPost
           .any_instance
-          .expects(:perform)
-          .with({ "post_id" => 1, "sync_exec" => true, "current_site_id" => "default" })
+          .expects(:perform_immediately)
+          .with({ "post_id" => 1, "current_site_id" => "default" })
+
         Jobs.enqueue(:process_post, post_id: 1)
       end
 

--- a/spec/jobs/process_post_spec.rb
+++ b/spec/jobs/process_post_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Jobs::ProcessPost do
   it "returns when the post cannot be found" do
-    expect { Jobs::ProcessPost.new.perform(post_id: 1, sync_exec: true) }.not_to raise_error
+    expect { Jobs::ProcessPost.new.execute(post_id: 1) }.not_to raise_error
   end
 
   context "with a post" do


### PR DESCRIPTION
```
class Jobs::DummyDelayedJob < Jobs::Base
  def execute(args = {})
  end
end

RSpec.describe "Jobs.run_immediately!" do
  before { Jobs.run_immediately! }

  it "explodes" do
    current_user = Fabricate(:user)
    Jobs.enqueue_in(1.seconds, :dummy_delayed_job)
    sign_in(current_user)
  end
end
```

The test above will fail with the following error if `ActiveRecord::Base.connection_handler.clear_active_connections!` is called before the configured Capybara server checks out a connection from the connection pool.

```
     ActiveRecord::ActiveRecordError:
       Cannot expire connection, it is owned by a different thread: #<Thread:0x00007f437391df58@puma srv tp 001 /home/tgxworld/.asdf/installs/ruby/3.1.3/lib/ruby/gems/3.1.0/gems/puma-6.0.2/lib/puma/thread_pool.rb:106 sleep_forever>. Current thread: #<Thread:0x00007f437d6cfc60 run>.
```

We're not exactly sure if this is an ActiveRecord bug or not but we've
invested too much time into investigating this problem. Fundamentally,
we also no longer understand why `ActiveRecord::Base.connection_handler.clear_active_connections!` is being called in an ensure block
within `Jobs::Base#perform` which was added in ceddb6e0da92e874b3bee9543915726f1d27d60b 10 years ago. Therefore, this commit changes the clearing of active connections only for jobs that are ran immediately and that only happens in the test environment.