### PR TITLE
UX: improve emoji alignment for text

### DIFF
--- a/app/assets/stylesheets/common/base/emoji.scss
+++ b/app/assets/stylesheets/common/base/emoji.scss
@@ -1,7 +1,7 @@
 img.emoji {
   width: 20px;
   height: 20px;
-  vertical-align: middle;
+  vertical-align: text-bottom;
 }
 
 img.emoji.only-emoji {

--- a/app/assets/stylesheets/common/base/emoji.scss
+++ b/app/assets/stylesheets/common/base/emoji.scss
@@ -2,6 +2,15 @@ img.emoji {
   width: 20px;
   height: 20px;
   vertical-align: text-bottom;
+
+  h1 &,
+  h2 &,
+  h3 &,
+  h4 &,
+  h5 &,
+  h6 & {
+    vertical-align: middle;
+  }
 }
 
 img.emoji.only-emoji {


### PR DESCRIPTION
Changing the alignment of emoji's to text-bottom for a bit of improvement:

**before**
![image](https://user-images.githubusercontent.com/101828855/211517532-173a642d-f5bf-425c-ad5a-5a8ea766a7f6.png)

**after**
![image](https://user-images.githubusercontent.com/101828855/211517569-91315c9c-58ed-4d86-9d58-530813d878fa.png)
