### PR TITLE
A11Y: more descriptive user page titles

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/emails.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/emails.js
@@ -11,6 +11,7 @@ const EMAIL_LEVELS = {
 };
 
 export default Controller.extend({
+  subpageTitle: I18n.t("user.preferences_nav.emails"),
   emailMessagesLevelAway: equal(
     "model.user_option.email_messages_level",
     EMAIL_LEVELS.ONLY_WHEN_AWAY

--- a/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/interface.js
@@ -36,6 +36,7 @@ export default Controller.extend({
   preferencesController: controller("preferences"),
   makeColorSchemeDefault: true,
   canPreviewColorScheme: propertyEqual("model.id", "currentUser.id"),
+  subpageTitle: I18n.t("user.preferences_nav.interface"),
 
   init() {
     this._super(...arguments);

--- a/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
@@ -5,6 +5,8 @@ import { NotificationLevels } from "discourse/lib/notification-levels";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Controller.extend({
+  subpageTitle: I18n.t("user.preferences_nav.notifications"),
+
   init() {
     this._super(...arguments);
 

--- a/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/profile.js
@@ -12,6 +12,7 @@ import { inject as service } from "@ember/service";
 
 export default Controller.extend({
   dialog: service(),
+  subpageTitle: I18n.t("user.preferences_nav.profile"),
   init() {
     this._super(...arguments);
     this.saveAttrNames = [

--- a/app/assets/javascripts/discourse/app/controllers/preferences/security.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/security.js
@@ -15,7 +15,7 @@ const DEFAULT_AUTH_TOKENS_COUNT = 2;
 
 export default Controller.extend(CanCheckEmails, {
   passwordProgress: null,
-
+  subpageTitle: I18n.t("user.preferences_nav.security"),
   showAllAuthTokens: false,
 
   @discourseComputed("model.is_anonymous")

--- a/app/assets/javascripts/discourse/app/controllers/preferences/sidebar.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/sidebar.js
@@ -12,6 +12,7 @@ export default class extends Controller {
   @tracked saved = false;
   @tracked selectedSidebarCategories = [];
   @tracked selectedSidebarTagNames = [];
+  subpageTitle = I18n.t("user.preferences_nav.sidebar");
 
   saveAttrNames = [
     "sidebar_category_ids",

--- a/app/assets/javascripts/discourse/app/routes/preferences-account.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences-account.js
@@ -2,6 +2,7 @@ import RestrictedUserRoute from "discourse/routes/restricted-user";
 import UserBadge from "discourse/models/user-badge";
 import showModal from "discourse/lib/show-modal";
 import { action } from "@ember/object";
+import I18n from "I18n";
 
 export default RestrictedUserRoute.extend({
   showFooter: true,
@@ -32,6 +33,7 @@ export default RestrictedUserRoute.extend({
       newPrimaryGroupInput: user.get("primary_group_id"),
       newFlairGroupId: user.get("flair_group_id"),
       newStatus: user.status,
+      subpageTitle: I18n.t("user.preferences_nav.account"),
     });
   },
 

--- a/app/assets/javascripts/discourse/app/routes/preferences.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences.js
@@ -1,7 +1,12 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
+import I18n from "I18n";
 
 export default RestrictedUserRoute.extend({
   model() {
     return this.modelFor("user");
+  },
+
+  titleToken() {
+    return I18n.t("user.preferences");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/preferences.js
+++ b/app/assets/javascripts/discourse/app/routes/preferences.js
@@ -1,12 +1,19 @@
 import RestrictedUserRoute from "discourse/routes/restricted-user";
 import I18n from "I18n";
+import { inject as service } from "@ember/service";
 
 export default RestrictedUserRoute.extend({
+  router: service(),
+
   model() {
     return this.modelFor("user");
   },
 
   titleToken() {
-    return I18n.t("user.preferences");
+    let controller = this.controllerFor(this.router.currentRouteName);
+    let subpageTitle = controller?.subpageTitle;
+    return subpageTitle
+      ? `${subpageTitle} - ${I18n.t("user.preferences")}`
+      : I18n.t("user.preferences");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-bookmarks.js
@@ -2,6 +2,7 @@ import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import DiscourseRoute from "discourse/routes/discourse";
 import { Promise } from "rsvp";
+import I18n from "I18n";
 
 export default DiscourseRoute.extend({
   queryParams: {
@@ -48,6 +49,10 @@ export default DiscourseRoute.extend({
 
   renderTemplate() {
     this.render("user_bookmarks");
+  },
+
+  titleToken() {
+    return I18n.t("user_action_groups.3");
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-drafts.js
@@ -38,6 +38,10 @@ export default DiscourseRoute.extend({
     this.appEvents.off("draft:destroyed", this, this.refresh);
   },
 
+  titleToken() {
+    return I18n.t("user_action_groups.15");
+  },
+
   @action
   didTransition() {
     this.controllerFor("user-activity")._showFooter();

--- a/app/assets/javascripts/discourse/app/routes/user-activity-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-index.js
@@ -25,4 +25,8 @@ export default UserActivityStreamRoute.extend({
 
     return { title, body };
   },
+
+  titleToken() {
+    return I18n.t("user.filters.all");
+  },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-activity-likes-given.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-likes-given.js
@@ -25,6 +25,10 @@ export default UserActivityStreamRoute.extend({
     return { title, body };
   },
 
+  titleToken() {
+    return I18n.t("user_action_groups.1");
+  },
+
   @action
   didTransition() {
     this.controllerFor("application").set("showFooter", true);

--- a/app/assets/javascripts/discourse/app/routes/user-activity-read.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-read.js
@@ -42,6 +42,10 @@ export default UserTopicListRoute.extend({
     return { title, body };
   },
 
+  titleToken() {
+    return `${I18n.t("user.read")}`;
+  },
+
   @action
   triggerRefresh() {
     this.refresh();

--- a/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-replies.js
@@ -29,6 +29,10 @@ export default UserActivityStreamRoute.extend({
     return { title, body };
   },
 
+  titleToken() {
+    return I18n.t("user_action_groups.5");
+  },
+
   @action
   didTransition() {
     this.controllerFor("application").set("showFooter", true);

--- a/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity-topics.js
@@ -50,6 +50,10 @@ export default UserTopicListRoute.extend({
     return { title, body };
   },
 
+  titleToken() {
+    return I18n.t("user_action_groups.4");
+  },
+
   @action
   triggerRefresh() {
     this.refresh();

--- a/app/assets/javascripts/discourse/app/routes/user-activity.js
+++ b/app/assets/javascripts/discourse/app/routes/user-activity.js
@@ -1,4 +1,5 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import I18n from "I18n";
 
 export default DiscourseRoute.extend({
   model() {
@@ -18,5 +19,9 @@ export default DiscourseRoute.extend({
 
   setupController(controller, user) {
     this.controllerFor("user-activity").set("model", user);
+  },
+
+  titleToken() {
+    return I18n.t("user.activity_stream");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-badges.js
+++ b/app/assets/javascripts/discourse/app/routes/user-badges.js
@@ -2,6 +2,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 import UserBadge from "discourse/models/user-badge";
 import ViewingActionType from "discourse/mixins/viewing-action-type";
 import { action } from "@ember/object";
+import I18n from "I18n";
 
 export default DiscourseRoute.extend(ViewingActionType, {
   model() {
@@ -18,6 +19,10 @@ export default DiscourseRoute.extend(ViewingActionType, {
 
   renderTemplate() {
     this.render("user/badges");
+  },
+
+  titleToken() {
+    return I18n.t("badges.title");
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/user-invited-show.js
+++ b/app/assets/javascripts/discourse/app/routes/user-invited-show.js
@@ -1,6 +1,7 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import Invite from "discourse/models/invite";
 import { action } from "@ember/object";
+import I18n from "I18n";
 
 export default DiscourseRoute.extend({
   model(params) {
@@ -25,6 +26,10 @@ export default DiscourseRoute.extend({
       filter: this.inviteFilter,
       searchTerm: "",
     });
+  },
+
+  titleToken() {
+    return I18n.t("user.invited." + this.inviteFilter + "_tab");
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/routes/user-invited.js
+++ b/app/assets/javascripts/discourse/app/routes/user-invited.js
@@ -1,4 +1,5 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import I18n from "I18n";
 
 export default DiscourseRoute.extend({
   setupController(controller) {
@@ -9,5 +10,9 @@ export default DiscourseRoute.extend({
     controller.setProperties({
       can_see_invite_details,
     });
+  },
+
+  titleToken() {
+    return I18n.t("user.invited.title");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-edits.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-edits.js
@@ -1,6 +1,11 @@
 import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
+import I18n from "I18n";
 
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["edits"],
+
+  titleToken() {
+    return I18n.t("user_action_groups.11");
+  },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-index.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-index.js
@@ -1,9 +1,14 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import I18n from "I18n";
 
 export default DiscourseRoute.extend({
   controllerName: "user-notifications",
   renderTemplate() {
     this.render("user/notifications-index");
+  },
+
+  titleToken() {
+    return I18n.t("user.filters.all");
   },
 
   afterModel(model) {

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-likes-received.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-likes-received.js
@@ -1,6 +1,11 @@
 import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
+import I18n from "I18n";
 
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["likes_received"],
+
+  titleToken() {
+    return I18n.t("user_action_groups.1");
+  },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-mentions.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-mentions.js
@@ -1,6 +1,11 @@
 import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
+import I18n from "I18n";
 
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["mentions"],
+
+  titleToken() {
+    return I18n.t("user_action_groups.7");
+  },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-notifications-responses.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications-responses.js
@@ -1,6 +1,11 @@
 import UserAction from "discourse/models/user-action";
 import UserActivityStreamRoute from "discourse/routes/user-activity-stream";
+import I18n from "I18n";
 
 export default UserActivityStreamRoute.extend({
   userActionType: UserAction.TYPES["replies"],
+
+  titleToken() {
+    return I18n.t("user_action_groups.6");
+  },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-notifications.js
+++ b/app/assets/javascripts/discourse/app/routes/user-notifications.js
@@ -1,6 +1,7 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import ViewingActionType from "discourse/mixins/viewing-action-type";
 import { action } from "@ember/object";
+import I18n from "I18n";
 
 export default DiscourseRoute.extend(ViewingActionType, {
   controllerName: "user-notifications",
@@ -30,5 +31,9 @@ export default DiscourseRoute.extend(ViewingActionType, {
     controller.set("model", model);
     controller.set("user", this.modelFor("user"));
     this.viewingActionType(-1);
+  },
+
+  titleToken() {
+    return I18n.t("user.notifications");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user-summary.js
+++ b/app/assets/javascripts/discourse/app/routes/user-summary.js
@@ -1,4 +1,5 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import I18n from "I18n";
 
 export default DiscourseRoute.extend({
   showFooter: true,
@@ -10,5 +11,9 @@ export default DiscourseRoute.extend({
     }
 
     return user.summary();
+  },
+
+  titleToken() {
+    return I18n.t("user.summary.title");
   },
 });

--- a/app/assets/javascripts/discourse/app/routes/user.js
+++ b/app/assets/javascripts/discourse/app/routes/user.js
@@ -1,5 +1,4 @@
 import DiscourseRoute from "discourse/routes/discourse";
-import I18n from "I18n";
 import User from "discourse/models/user";
 import { action } from "@ember/object";
 import { bind } from "discourse-common/utils/decorators";
@@ -98,9 +97,7 @@ export default DiscourseRoute.extend({
 
   titleToken() {
     const username = this.modelFor("user").username;
-    if (username) {
-      return [I18n.t("user.profile"), username];
-    }
+    return username ? username : null;
   },
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/controllers/preferences-chat.js
+++ b/plugins/chat/assets/javascripts/discourse/controllers/preferences-chat.js
@@ -22,6 +22,7 @@ const EMAIL_FREQUENCY_OPTIONS = [
 
 export default class PreferencesChatController extends Controller {
   @service chatAudioManager;
+  subpageTitle = I18n.t("chat.admin.title");
 
   emailFrequencyOptions = EMAIL_FREQUENCY_OPTIONS;
 


### PR DESCRIPTION
Currently on user profiles most of the page titles are generic and don't change along with the route... like this:

`Profile - Username - Site Name`

This drops "profile" and updates page titles to be more specific: 

`Summary - Username - Site Name`
`Preferences - Username - Site Name`
`Account - Preferences - Username - Site Name`
`Replies — Activity — Username — Site Name`
etc... 

This change will make it easier to know where you are when you're using a screen reader.  