### PR TITLE
FIX: Fix test failing on Ruby 2.7.6 resulting from PostAlerter keyword arguments

### DIFF
--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1053,10 +1053,12 @@ RSpec.describe PostAlerter do
     it "triggers :before_create_notification" do
       type = Notification.types[:private_message]
       events =
-        DiscourseEvent.track_events { PostAlerter.new.create_notification(user, type, post, {}) }
+        DiscourseEvent.track_events do
+          PostAlerter.new.create_notification(user, type, post, { revision_number: 1 })
+        end
       expect(events).to include(
         event_name: :before_create_notification,
-        params: [user, type, post, {}],
+        params: [user, type, post, { revision_number: 1 }],
       )
     end
   end


### PR DESCRIPTION
### Background

We've been doing some work to support new keyword argument semantics in Ruby 3. As part of that we made some changes to `DiscourseEvent::TestHelper`, including [this](https://github.com/discourse/discourse/pull/19788/commits/3082971ec3452104336eb1259dc22d3ad2d55820#diff-63a5d7aad5c42c4833b2502894bf2ad8653141aa0414df9d6570eb71b7a87065R8) backwards compatibility fix.

### What is the problem?

The backwards compatibility fix doesn't work if the method is called with an empty hash as the final argument. I think this is probably fine, as that is a slightly odd thing to do, and I couldn't think of anything better, bar hard-checking the Ruby version.

To illustrate:

```ruby
def foo(a, *b, **k)
  puts b.inspect, k.inspect
end

# Ruby 2
foo("a", "b", {})
#=> ["b"]
#=> {}

# Ruby 3
foo("a", "b", {})
#=> ["b", {}]
#=> {}
```

This affects at least `spec/services/post_alerter_spec.rb:1053` which passes on Ruby 3 and fails on Ruby 2.

### How does this fix it

This fix adds a valid option to the final hash in the particular test. If we can think some way to make the helper "more backwards compatible", I'm also open to hearing it. 🙂 