### PR TITLE
UX: streamline avatar in topic list

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -89,9 +89,8 @@
   }
   .posters a:first-child .avatar.latest:not(.single) {
     box-shadow: 0 0 3px 1px rgba(var(--tertiary-rgb), 0.35);
-    border: 2px solid rgba(var(--tertiary-rgb), 0.5);
+    border: 1px solid rgba(var(--tertiary-rgb), 0.5);
     position: relative;
-    top: -2px;
     left: -2px;
   }
 


### PR DESCRIPTION
Due to some minor global avatar changes, some legacy code needs a mini change too.

Fixing misalignment
<img width="133" alt="image" src="https://user-images.githubusercontent.com/101828855/211830902-dafe1348-a6b1-4670-97c6-07ba6ae7e4fe.png">

by removing an older alignment fix which is no longer necessary

And also reducing thickness by 1px so it's more consistent with the is-online styling

**new:**
<img width="183" alt="image" src="https://user-images.githubusercontent.com/101828855/211831203-3dfc0922-db36-4ac4-ab71-83be3fd181d2.png">

