### PR TITLE
FIX: Validate tags parameter of TopicQuery

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -15,10 +15,15 @@ class TopicQuery
     @validators ||=
       begin
         int = lambda { |x| Integer === x || (String === x && x.match?(/^-?[0-9]+$/)) }
-
         zero_up_to_max_int = lambda { |x| int.call(x) && x.to_i.between?(0, PG_MAX_INT) }
+        array_or_string = lambda { |x| Array === x || String === x }
 
-        { max_posts: zero_up_to_max_int, min_posts: zero_up_to_max_int, page: zero_up_to_max_int }
+        {
+          max_posts: zero_up_to_max_int,
+          min_posts: zero_up_to_max_int,
+          page: zero_up_to_max_int,
+          tags: array_or_string,
+        }
       end
   end
 

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe ListController do
 
       get "/latest?page=1111111111111111111111111111111111111111"
       expect(response.status).to eq(400)
+
+      get '/latest?tags[1]=hello'
+      expect(response.status).to eq(400)
     end
 
     it "returns 200 for legit requests" do
@@ -58,6 +61,9 @@ RSpec.describe ListController do
       expect(response.status).to eq(200)
 
       get "/latest.json?topic_ids=14583%2C14584"
+      expect(response.status).to eq(200)
+
+      get '/latest?tags[]=hello'
       expect(response.status).to eq(200)
     end
 

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ListController do
       get "/latest?page=1111111111111111111111111111111111111111"
       expect(response.status).to eq(400)
 
-      get '/latest?tags[1]=hello'
+      get "/latest?tags[1]=hello"
       expect(response.status).to eq(400)
     end
 
@@ -63,7 +63,7 @@ RSpec.describe ListController do
       get "/latest.json?topic_ids=14583%2C14584"
       expect(response.status).to eq(200)
 
-      get '/latest?tags[]=hello'
+      get "/latest?tags[]=hello"
       expect(response.status).to eq(200)
     end
 


### PR DESCRIPTION
Recently, we have seen some errors related to invalid tags value being passed to TopicQuery.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
