### PR TITLE
DEV: Added notification type for 'discourse-circles'

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -155,6 +155,7 @@ class Notification < ActiveRecord::Base
         following: 800, # Used by https://github.com/discourse/discourse-follow
         following_created_topic: 801, # Used by https://github.com/discourse/discourse-follow
         following_replied: 802, # Used by https://github.com/discourse/discourse-follow
+        circles_activity: 900, # Used by https://github.com/discourse/discourse-circles
       )
   end
 

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -127,6 +127,9 @@
         },
         "following_replied": {
           "type": "integer"
+        },
+        "circles_activity": {
+          "type": "integer"
         }
       },
       "required": [


### PR DESCRIPTION
Reserved an id to be used by notification generated by the `discourse-circles` plugin.