### PR TITLE
DEV: Remove bookmark column ignores

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class Bookmark < ActiveRecord::Base
-  self.ignored_columns = [
-    "post_id", # TODO (martin) (2022-08-01) remove
-    "for_topic", # TODO (martin) (2022-08-01) remove
-  ]
-
   cattr_accessor :registered_bookmarkables
   self.registered_bookmarkables = []
 


### PR DESCRIPTION
These columns were deleted in https://github.com/discourse/discourse/commit/f8f55cef678726ecc8c9470150e6478d1c351cd5
