### PR TITLE
FEATURE: raise redirect avatar cache to 1 day

### DIFF
--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -192,7 +192,7 @@ class UserAvatarsController < ApplicationController
   end
 
   def redirect_s3_avatar(url)
-    immutable_for 1.hour
+    immutable_for 1.day
     redirect_to url, allow_other_host: true
   end
 

--- a/spec/requests/user_avatars_controller_spec.rb
+++ b/spec/requests/user_avatars_controller_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe UserAvatarsController do
 
       expect(response.status).to eq(302)
       expect(response.location).to eq("https://s3-cdn.example.com/optimized/path")
-      expect(response.headers["Cache-Control"]).to eq("max-age=3600, public, immutable")
+      expect(response.headers["Cache-Control"]).to eq("max-age=86400, public, immutable")
     end
 
     it "serves new version for old urls" do


### PR DESCRIPTION
In "GlobalSetting.redirect_avatar_requests" mode, when the application gets
an avatar request it returns a "redirect" to the S3 CDN.

This shields the application from caching avatars and downloading from S3.
However clients will make 2 requests per avatar. (one to get redirect,
second to get avatar)

A one hour cache on a redirect means there may be an increase in CDN
traffic, given more clients will ask for the redirect every hour.

This may also lead to an increase in origin requests to the application.

To mitigate lets cache the CDN URL for 1 day.

The downside is that any changes to S3 CDN need extra care to allow for
the extra 1 day delay. (leave data around for 1 extra day)
