### PR TITLE
DEV: DRY up PageObject::Topic and PageObject::Components::Composer

### DIFF
--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -3,12 +3,6 @@
 module PageObjects
   module Components
     class Composer < PageObjects::Components::Base
-      def open_new_topic
-        visit("/latest")
-        find("button#create-topic").click
-        self
-      end
-
       def open_composer_actions
         find(".composer-action-title .btn").click
         self
@@ -20,8 +14,21 @@ module PageObjects
       end
 
       def fill_content(content)
-        find("#reply-control .d-editor-input").fill_in(with: content)
+        composer_input.fill_in(with: content)
         self
+      end
+
+      def type_content(content)
+        composer_input.send_keys(content)
+        self
+      end
+
+      def clear_content
+        fill_content("")
+      end
+
+      def has_content?(content)
+        composer_input.value == content
       end
 
       def select_action(action)
@@ -39,6 +46,10 @@ module PageObjects
 
       def button_label
         find("#reply-control .btn-primary .d-button-label")
+      end
+
+      def composer_input
+        find("#reply-control .d-editor .d-editor-input")
       end
     end
   end

--- a/spec/system/page_objects/pages/base.rb
+++ b/spec/system/page_objects/pages/base.rb
@@ -4,10 +4,6 @@ module PageObjects
   module Pages
     class Base
       include Capybara::DSL
-
-      def setup_component_classes!(component_classes)
-        @component_classes = component_classes
-      end
     end
   end
 end

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -4,17 +4,22 @@ module PageObjects
   module Pages
     class Topic < PageObjects::Pages::Base
       def initialize
-        setup_component_classes!(
-          post_show_more_actions: ".show-more-actions",
-          post_action_button_bookmark: ".bookmark.with-reminder",
-          reply_button: ".topic-footer-main-buttons > .create",
-          composer: "#reply-control",
-          composer_textarea: "#reply-control .d-editor .d-editor-input",
-        )
+        @composer_component = PageObjects::Components::Composer.new
       end
 
       def visit_topic(topic)
         page.visit "/t/#{topic.id}"
+        self
+      end
+
+      def open_new_topic
+        page.visit "/"
+        find("button#create-topic").click
+        self
+      end
+
+      def open_new_message
+        page.visit "/new-message"
         self
       end
 
@@ -85,24 +90,20 @@ module PageObjects
         has_css?("#reply-control.open")
       end
 
-      def find_composer
-        find("#reply-control .d-editor .d-editor-input")
-      end
-
       def type_in_composer(input)
-        find_composer.send_keys(input)
+        @composer_component.type_content(input)
       end
 
       def fill_in_composer(input)
-        find_composer.fill_in(with: input)
+        @composer_component.fill_content(input)
       end
 
       def clear_composer
-        fill_in_composer("")
+        @composer_component.clear_content
       end
 
       def has_composer_content?(content)
-        find_composer.value == content
+        @composer_component.has_content?(content)
       end
 
       def send_reply
@@ -110,7 +111,7 @@ module PageObjects
       end
 
       def fill_in_composer_title(title)
-        find("#reply-title").fill_in(with: title)
+        @composer_component.fill_title(title)
       end
 
       private


### PR DESCRIPTION
The latter can be called directly from the Topic page object,
so we can remove some duplication between the two. There are
levels of page objects (e.g. entire page, component, complete flow)
and its perfectly valid to call one from another.
