### PR TITLE
FIX: Preload user sidebar attrs when `?enable_sidebar=1`

### DIFF
--- a/app/assets/javascripts/bootstrap-json/index.js
+++ b/app/assets/javascripts/bootstrap-json/index.js
@@ -252,6 +252,11 @@ async function buildFromBootstrap(proxy, baseURL, req, response, preload) {
       url.searchParams.append("safe_mode", reqUrlSafeMode);
     }
 
+    const enableSidebar = forUrlSearchParams.get("enable_sidebar");
+    if (enableSidebar) {
+      url.searchParams.append("enable_sidebar", enableSidebar);
+    }
+
     const reqUrlPreviewThemeId = forUrlSearchParams.get("preview_theme_id");
     if (reqUrlPreviewThemeId) {
       url.searchParams.append("preview_theme_id", reqUrlPreviewThemeId);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -640,15 +640,25 @@ class ApplicationController < ActionController::Base
   def preload_current_user_data
     store_preloaded(
       "currentUser",
-      MultiJson.dump(CurrentUserSerializer.new(current_user, scope: guardian, root: false)),
+      MultiJson.dump(
+        CurrentUserSerializer.new(
+          current_user,
+          scope: guardian,
+          root: false,
+          enable_sidebar_param: params[:enable_sidebar],
+        ),
+      ),
     )
+
     report = TopicTrackingState.report(current_user)
+
     serializer =
       ActiveModel::ArraySerializer.new(
         report,
         each_serializer: TopicTrackingStateSerializer,
         scope: guardian,
       )
+
     store_preloaded("topicTrackingStates", MultiJson.dump(serializer))
   end
 

--- a/app/serializers/concerns/user_sidebar_mixin.rb
+++ b/app/serializers/concerns/user_sidebar_mixin.rb
@@ -45,6 +45,6 @@ module UserSidebarMixin
   private
 
   def sidebar_navigation_menu?
-    !SiteSetting.legacy_navigation_menu?
+    !SiteSetting.legacy_navigation_menu? || options[:enable_sidebar_param] == "1"
   end
 end

--- a/spec/system/page_objects/components/sidebar.rb
+++ b/spec/system/page_objects/components/sidebar.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class Sidebar < PageObjects::Components::Base
+      def visible?
+        page.has_css?("#d-sidebar")
+      end
+
+      def has_category_section_link?(category)
+        page.has_link?(category.name, class: "sidebar-section-link")
+      end
+    end
+  end
+end

--- a/spec/system/viewing_sidebar_spec.rb
+++ b/spec/system/viewing_sidebar_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe "Viewing sidebar", type: :system, js: true do
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:user) { Fabricate(:user) }
+  fab!(:category_sidebar_section_link) { Fabricate(:category_sidebar_section_link, user: user) }
+
+  describe "when using the legacy navigation menu" do
+    before { SiteSetting.navigation_menu = "legacy" }
+
+    it "should display the sidebar when `enable_sidebar` query param is '1'" do
+      sign_in(user)
+
+      visit("/latest?enable_sidebar=1")
+
+      sidebar = PageObjects::Components::Sidebar.new
+
+      expect(sidebar).to be_visible
+      expect(sidebar).to have_category_section_link(category_sidebar_section_link.linkable)
+    end
+  end
+end


### PR DESCRIPTION
This allows users to preview the sidebar even when
`SiteSetting.naviation_menu` is set to `false`.