### PR TITLE
FIX: Ruby 2 backward compatible plugin logout redirect

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -594,7 +594,7 @@ class SessionController < ApplicationController
       client_ip: request&.ip,
       user_agent: request&.user_agent,
     }
-    DiscourseEvent.trigger(:before_session_destroy, event_data)
+    DiscourseEvent.trigger(:before_session_destroy, event_data, **Discourse::Utils::EMPTY_KEYWORDS)
     redirect_url = event_data[:redirect_url]
 
     reset_session

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -12,6 +12,9 @@ module Discourse
   class Utils
     URI_REGEXP ||= URI.regexp(%w[http https])
 
+    # TODO: Remove this once we drop support for Ruby 2.
+    EMPTY_KEYWORDS ||= {}
+
     # Usage:
     #   Discourse::Utils.execute_command("pwd", chdir: 'mydirectory')
     # or with a block


### PR DESCRIPTION
### What is wrong?

This is a very subtle bug.

First, some background. Plugins setting the logout redirect URL is done by the core sessions controller passing a hash through a Discourse event, and letting the plugin modify the `redirect_url` key. This is broken on Ruby 2 since the [support for keyword arguments in events](https://github.com/discourse/discourse/pull/19788/files#diff-c1c14f2a6650932ad30a5c526996a77555d4daf0444e7efb5df0a75b3a8dccadR12) was added.

### Why is this happening?

In Ruby 2 the last argument is cast to keyword arguments if it is a hash. The key point here is when we "collect" the keyword arguments (i.e. `**kwargs`) **it creates a copy of the hash**. So what the plugin is modifying is not the hash that was passed, but a copy of it that was created when the keyword arguments were "collected". Hence the `redirect_url` remains `/`.

### How does this fix it?

There is no really easy way here. The best way I can think of is pass an empty keyword hash to the event trigger. I decided to create a constant for this so we can keep track of it and easily `grep` and remove it once we drop support for Ruby 2, and of course use if we find more similar bugs.