### PR TITLE
DEV: Bump sprockets to include ERB kwargs fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ end
 gem "json"
 
 # TODO: At the moment Discourse does not work with Sprockets 4, we would need to correct internals
-# This is a desired upgrade we should get to.
-gem "sprockets", "3.7.2"
+# We intend to drop sprockets rather than upgrade to 4.x
+gem "sprockets", git: "https://github.com/rails/sprockets", branch: "3.x"
 
 # this will eventually be added to rails,
 # allows us to precompile all our templates in the unicorn master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,15 @@ GIT
     mail (2.8.0.edge)
       mini_mime (>= 0.1.1)
 
+GIT
+  remote: https://github.com/rails/sprockets
+  revision: f4d3dae71ef29c44b75a49cfbf8032cce07b423a
+  branch: 3.x
+  specs:
+    sprockets (3.7.2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -442,9 +451,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sprockets (3.7.2)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -621,7 +627,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simplecov
-  sprockets (= 3.7.2)
+  sprockets!
   sprockets-rails
   sshkey
   stackprof


### PR DESCRIPTION
This should resolve these warnings under Ruby 3.1

```
warning: Passing safe_level with the 2nd argument of ERB.new is deprecated
```

Unfortunately Sprockets 3.x has not seen a rubygems release since 2018, so we need to fetch these improvements via git.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
