### PR TITLE
DEV: Make 'username' optional for bookmark notifications

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
@@ -70,7 +70,7 @@ createWidgetFrom(QuickAccessPanel, "quick-access-bookmarks", {
       href,
       title: bookmark.name,
       content: bookmark.title,
-      username: bookmark.user.username,
+      username: bookmark.user?.username,
     });
   },
 

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/quick-access-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/quick-access-item-test.js
@@ -32,5 +32,21 @@ module(
       const contentDiv = query(CONTENT_DIV_SELECTOR);
       assert.strictEqual(contentDiv.innerText, '"quote"');
     });
+
+    test("Renders the notification content with no username when username is not present", async function (assert) {
+      this.set("args", {
+        content: "content",
+        username: undefined,
+      });
+
+      await render(
+        hbs`<MountWidget @widget="quick-access-item" @args={{this.args}} />`
+      );
+
+      const contentDiv = query(CONTENT_DIV_SELECTOR);
+      const usernameSpan = query("li a div span");
+      assert.strictEqual(contentDiv.innerText, "content");
+      assert.strictEqual(usernameSpan.innerText, "");
+    });
   }
 );


### PR DESCRIPTION
Data Explorer queries have a `user_id` assigned to each query created. DE Reports can be bookmarked for later reference. 

When creating the bookmark notification there was the possibility of a notification error being thrown (that made the notification menu inaccessible) due to a DE Query not having a owner (associated user_id). This can happen in a couple ways: 
- having a query created by a user that was then later deleted leaving the query without ownership
- having a TA create a query for a customer using a temporary account, that would then later be deleted leaving the query without ownership

Since there is a case that `bookmark.user` is not valid the PR makes the `bookmark.user.username` optional for a bookmark notification. As [tested](https://github.com/discourse/discourse/pull/19851/files#diff-5b5154de37f96988d551feff6f1dfe5ba804fbcbc1c33b5478dde02a447a634f) in the case a username is not present, we will still render the `content` of the notification minus the username. This creates a safe fallback when looking up non-valid users.
