### PR TITLE
DEV: Update README to reflect that at least Ruby 3.1 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To get your environment setup, follow the community setup guide for your operati
 
 If you're familiar with how Rails works and are comfortable setting up your own environment, you can also try out the [**Discourse Advanced Developer Guide**](docs/DEVELOPER-ADVANCED.md), which is aimed primarily at Ubuntu and macOS environments.
 
-Before you get started, ensure you have the following minimum versions: [Ruby 2.7+](https://www.ruby-lang.org/en/downloads/), [PostgreSQL 13+](https://www.postgresql.org/download/), [Redis 6.2+](https://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
+Before you get started, ensure you have the following minimum versions: [Ruby 3.1+](https://www.ruby-lang.org/en/downloads/), [PostgreSQL 13+](https://www.postgresql.org/download/), [Redis 6.2+](https://redis.io/download). If you're having trouble, please see our [**TROUBLESHOOTING GUIDE**](docs/TROUBLESHOOTING.md) first!
 
 ## Setting up Discourse
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,10 +2,10 @@
 
 > :bell: The only officially supported installs of Discourse are [Docker](https://www.docker.io/) based. You must have SSH access to a 64-bit Linux server **with Docker support**. We regret that we cannot support any other methods of installation including cpanel, plesk, webmin, etc.
 
-Simple 30 minute basic install:  
+Simple 30 minute basic install:
 [**Beginner Docker install guide**][basic]
 
-Powerful, flexible, large / multiple server install:  
+Powerful, flexible, large / multiple server install:
 [**Advanced Docker install guide**][advanced]
 
 ### Why do you only officially support Docker?
@@ -23,8 +23,7 @@ Hosting Rails applications is complicated. Even if you already have Postgres, Re
 
 - [Postgres 13+](https://www.postgresql.org/download/)
 - [Redis 6+](https://redis.io/download)
-- [Ruby 2.7](https://www.ruby-lang.org/en/downloads/) (we recommend 2.7.2)
-
+- [Ruby 3.1+](https://www.ruby-lang.org/en/downloads/)
 ## Security
 
 We take security very seriously at Discourse, and all our code is 100% open source and peer reviewed. Please read [our security guide](https://github.com/discourse/discourse/blob/main/docs/SECURITY.md) for an overview of security measures in Discourse.


### PR DESCRIPTION
Minimum Ruby version required was bumped in https://github.com/discourse/discourse/commit/ab9ea509170c07569c007bd8bd6a24bd03a33434