### PR TITLE
FIX: Fix incorrect hashtag setting migration

### DIFF
--- a/db/migrate/20230103004613_make_experimental_hashtag_feature_default_for_new_sites.rb
+++ b/db/migrate/20230103004613_make_experimental_hashtag_feature_default_for_new_sites.rb
@@ -2,11 +2,21 @@
 
 class MakeExperimentalHashtagFeatureDefaultForNewSites < ActiveRecord::Migration[7.0]
   def up
-    execute(<<~SQL)
-      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
-      VALUES ('enable_experimental_hashtag_autocomplete', 5, 'f', now(), now())
-      ON CONFLICT DO NOTHING
+    result = execute <<~SQL
+      SELECT created_at
+      FROM schema_migration_details
+      ORDER BY created_at
+      LIMIT 1
     SQL
+
+    # keep enable_experimental_hashtag_autocomplete disabled for for existing sites
+    if result.first['created_at'].to_datetime < 1.hour.ago
+      execute <<~SQL
+        INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+        VALUES ('enable_experimental_hashtag_autocomplete', 5, 'f', now(), now())
+        ON CONFLICT DO NOTHING
+      SQL
+    end
   end
 
   def down

--- a/db/migrate/20230103004613_make_experimental_hashtag_feature_default_for_new_sites.rb
+++ b/db/migrate/20230103004613_make_experimental_hashtag_feature_default_for_new_sites.rb
@@ -9,14 +9,14 @@ class MakeExperimentalHashtagFeatureDefaultForNewSites < ActiveRecord::Migration
       LIMIT 1
     SQL
 
+    settings_insert_query = <<~SQL
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      VALUES ('enable_experimental_hashtag_autocomplete', 5, 'f', now(), now())
+      ON CONFLICT DO NOTHING
+    SQL
+
     # keep enable_experimental_hashtag_autocomplete disabled for for existing sites
-    if result.first['created_at'].to_datetime < 1.hour.ago
-      execute <<~SQL
-        INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
-        VALUES ('enable_experimental_hashtag_autocomplete', 5, 'f', now(), now())
-        ON CONFLICT DO NOTHING
-      SQL
-    end
+    execute settings_insert_query if result.first["created_at"].to_datetime < 1.hour.ago
   end
 
   def down

--- a/plugins/chat/spec/models/chat_message_spec.rb
+++ b/plugins/chat/spec/models/chat_message_spec.rb
@@ -234,8 +234,10 @@ describe ChatMessage do
       expect(cooked).to eq("<p><span class=\"mention\">@mention</span></p>")
     end
 
-    # TODO (martin) Remove this when enable_experimental_hashtag_autocomplete is default
     it "supports category-hashtag plugin" do
+      # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+      SiteSetting.enable_experimental_hashtag_autocomplete = false
+
       category = Fabricate(:category)
 
       cooked = ChatMessage.cook("##{category.slug}")

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -494,6 +494,9 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
       end
 
       it "should create the right reply" do
+        # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+        SiteSetting.enable_experimental_hashtag_autocomplete = false
+
         category = Fabricate(:category)
 
         post.update!(raw: "Check out this ##{category.slug}")

--- a/spec/integrity/common_mark_spec.rb
+++ b/spec/integrity/common_mark_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe "CommonMark" do
     SiteSetting.enable_markdown_typographer = false
     SiteSetting.highlighted_languages = "ruby|aa"
 
+    # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+    SiteSetting.enable_experimental_hashtag_autocomplete = false
+
     html, state, md = nil
     failed = 0
 

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1619,6 +1619,9 @@ RSpec.describe PrettyText do
   end
 
   it "produces hashtag links" do
+    # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+    SiteSetting.enable_experimental_hashtag_autocomplete = false
+
     category = Fabricate(:category, name: "testing")
     category2 = Fabricate(:category, name: "known")
     Fabricate(:topic, tags: [Fabricate(:tag, name: "known")])
@@ -1908,6 +1911,9 @@ HTML
     end
 
     it "does not replace hashtags and mentions" do
+      # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+      SiteSetting.enable_experimental_hashtag_autocomplete = false
+
       Fabricate(:user, username: "test")
       category = Fabricate(:category, slug: "test")
       Fabricate(
@@ -1927,6 +1933,9 @@ HTML
     end
 
     it "does not replace hashtags and mentions when watched words are regular expressions" do
+      # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+      SiteSetting.enable_experimental_hashtag_autocomplete = false
+
       SiteSetting.watched_words_regular_expressions = true
 
       Fabricate(:user, username: "test")

--- a/spec/requests/hashtags_controller_spec.rb
+++ b/spec/requests/hashtags_controller_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe HashtagsController do
 
   before do
     SiteSetting.tagging_enabled = true
+
+    # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+    SiteSetting.enable_experimental_hashtag_autocomplete = false
+
     tag_group
   end
 


### PR DESCRIPTION
Added in c2013865d78d353280ae68135b4c218e21ffb566,
this migration was supposed to only turn off the hashtag
setting for existing sites (since that was the old default)
but its doing it for new ones too because we run all migrations
on new sites.

Instead, we should only run this if the first migration was
only just created, meaning its a new site.
