### PR TITLE
FIX: Use hashtags in channel archive PMs if available

### DIFF
--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -29,17 +29,17 @@ en:
       title: "Chat Channel Archive Complete"
       subject_template: "Chat channel archive completed successfully"
       text_body_template: |
-        Archiving the chat channel **\#%{channel_name}** has been completed successfully. The messages were copied into the topic [%{topic_title}](%{topic_url}).
+        Archiving the chat channel %{channel_hashtag_or_name} has been completed successfully. The messages were copied into the topic [%{topic_title}](%{topic_url}).
     chat_channel_archive_failed:
       title: "Chat Channel Archive Failed"
       subject_template: "Chat channel archive failed"
       text_body_template: |
-        Archiving the chat channel **\#%{channel_name}** has failed. %{messages_archived} messages have been archived. Partially archived messages were copied into the topic [%{topic_title}](%{topic_url}). Visit the channel at %{channel_url} to retry.
+        Archiving the chat channel %{channel_hashtag_or_name} has failed. %{messages_archived} messages have been archived. Partially archived messages were copied into the topic [%{topic_title}](%{topic_url}). Visit the channel at %{channel_url} to retry.
     chat_channel_archive_failed_no_topic:
       title: "Chat Channel Archive Failed"
       subject_template: "Chat channel archive failed"
       text_body_template: |
-        Archiving the chat channel **\#%{channel_name}** has failed. No messages have been archived. The topic was not created successfully for the following reasons:
+        Archiving the chat channel %{channel_hashtag_or_name} has failed. No messages have been archived. The topic was not created successfully for the following reasons:
 
           %{topic_validation_errors}
 

--- a/plugins/chat/lib/chat_channel_archive_service.rb
+++ b/plugins/chat/lib/chat_channel_archive_service.rb
@@ -248,7 +248,7 @@ class Chat::ChatChannelArchiveService
 
   def notify_archiver(result, error_message: nil)
     base_translation_params = {
-      channel_name: chat_channel_title,
+      channel_hashtag_or_name: channel_hashtag_or_name,
       topic_title: chat_channel_archive.destination_topic&.title,
       topic_url: chat_channel_archive.destination_topic&.url,
       topic_validation_errors: result == :failed_no_topic ? error_message : nil,
@@ -300,5 +300,12 @@ class Chat::ChatChannelArchiveService
 
   def kick_all_users
     Chat::ChatChannelMembershipManager.new(chat_channel).unfollow_all_users
+  end
+
+  def channel_hashtag_or_name
+    if chat_channel.slug.present? && SiteSetting.enable_experimental_hashtag_autocomplete
+      return "##{chat_channel.slug}::channel"
+    end
+    chat_channel_title
   end
 end


### PR DESCRIPTION
If the `enable_experimental_hashtag_autocomplete` setting is
enabled, then we should autolink hashtag references to the
archived channels (e.g. #blah::channel) for a nicer UX, and
just show the channel name if not (since doing #channelName
can lead to weird inconsistent results).

![image](https://user-images.githubusercontent.com/920448/212218756-bc825762-2b23-4bc0-bb44-c660c7ad7141.png)
