### PR TITLE
DEV: Introduce `enable_new_notifications_menu` site setting

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1805,7 +1805,7 @@ class User < ActiveRecord::Base
   end
 
   def redesigned_user_menu_enabled?
-    !SiteSetting.legacy_navigation_menu?
+    !SiteSetting.legacy_navigation_menu? || SiteSetting.enable_new_notifications_menu
   end
 
   protected

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2388,6 +2388,7 @@ en:
     navigation_menu: "Determine which navigation menu to use. Sidebar and header navigation are customizable by users. Legacy option is available for backward compatibility."
     default_sidebar_categories: "Selected categories will be displayed under Sidebar's Categories section by default."
     default_sidebar_tags: "Selected tags will be displayed under Sidebar's Tags section by default."
+    enable_new_notifications_menu: "Enables the new notifications menu for the legacy navigation menu."
     enable_new_user_profile_nav_groups: "EXPERIMENTAL: Users of the selected groups will be shown the new user profile navigation menu"
     enable_experimental_topic_timeline_groups: "EXPERIMENTAL: Users of the selected groups will be shown the refactored topic timeline"
     enable_experimental_hashtag_autocomplete: "EXPERIMENTAL: Use the new #hashtag autocompletion system for categories and tags that renders the selected item differently and has improved search"
@@ -2449,6 +2450,7 @@ en:
       discourse_connect_cannot_be_enabled_if_second_factor_enforced: "You cannot enable DiscourseConnect if 2FA is enforced."
       delete_rejected_email_after_days: "This setting cannot be set lower than the delete_email_logs_after_days setting or greater than %{max}"
       invalid_uncategorized_category_setting: "The Uncategorized category cannot be selected if allow uncategorized topics is not allowed"
+      enable_new_notifications_menu_not_legacy_navigation_menu: "You must set `navigation_menu` to `legacy` before enabling this setting."
 
     placeholder:
       discourse_connect_provider_secrets:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2084,6 +2084,9 @@ navigation:
     choices:
       - "default"
       - "unread_new"
+  enable_new_notifications_menu:
+    default: false
+    validator: "EnableNewNotificationsMenuValidator"
 
 embedding:
   embed_by_username:

--- a/lib/validators/enable_new_notifications_menu_validator.rb
+++ b/lib/validators/enable_new_notifications_menu_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class EnableNewNotificationsMenuValidator
+  def initialize(opts = {})
+  end
+
+  def valid_value?(value)
+    return true if value == "f"
+    SiteSetting.navigation_menu == "legacy"
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.enable_new_notifications_menu_not_legacy_navigation_menu")
+  end
+end

--- a/spec/lib/validators/enable_new_notifications_menu_validator_spec.rb
+++ b/spec/lib/validators/enable_new_notifications_menu_validator_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe EnableNewNotificationsMenuValidator do
+  it "does not allow `enable_new_notifications_menu` site settings to be enabled when `navigation_menu` site settings is not set to `legacy`" do
+    SiteSetting.navigation_menu = "sidebar"
+
+    expect { SiteSetting.enable_new_notifications_menu = true }.to raise_error(
+      Discourse::InvalidParameters,
+      /#{I18n.t("site_settings.errors.enable_new_notifications_menu_not_legacy_navigation_menu")}/,
+    )
+  end
+
+  it "allows `enable_new_notifications_menu` site settings to be enabled when `navigation_menu` site settings is set to `legacy`" do
+    SiteSetting.navigation_menu = "legacy"
+
+    expect { SiteSetting.enable_new_notifications_menu = true }.to_not raise_error
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3399,4 +3399,32 @@ RSpec.describe User do
       expect(user.new_personal_messages_notifications_count).to eq(1)
     end
   end
+
+  describe "#redesigned_user_menu_enabled?" do
+    it "returns true when `navigation_menu` site settings is `legacy` and `enable_new_notifications_menu` site settings is enabled" do
+      SiteSetting.navigation_menu = "legacy"
+      SiteSetting.enable_new_notifications_menu = true
+
+      expect(user.redesigned_user_menu_enabled?).to eq(true)
+    end
+
+    it "returns false when `navigation_menu` site settings is `legacy` and `enable_new_notifications_menu` site settings is not enabled" do
+      SiteSetting.navigation_menu = "legacy"
+      SiteSetting.enable_new_notifications_menu = false
+
+      expect(user.redesigned_user_menu_enabled?).to eq(false)
+    end
+
+    it "returns true when `navigation_menu` site settings is `sidebar`" do
+      SiteSetting.navigation_menu = "sidebar"
+
+      expect(user.redesigned_user_menu_enabled?).to eq(true)
+    end
+
+    it "returns true when `navigation_menu` site settings is `header_dropdown`" do
+      SiteSetting.navigation_menu = "header dropdown"
+
+      expect(user.redesigned_user_menu_enabled?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
The `enable_new_notifications_menu` site setting allows sites that have
`navigation_menu` set to `legacy` to use the redesigned notifications
menu before switching to the new sidebar navigation menu.