### PR TITLE
DEV: Prevent defer stats exception when thread aborted

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -191,6 +191,18 @@ module Discourse
 
   reset_job_exception_stats!
 
+  if Rails.env.test?
+    def self.catch_job_exceptions!
+      raise "tests only" if !Rails.env.test?
+      @catch_job_exceptions = true
+    end
+
+    def self.reset_catch_job_exceptions!
+      raise "tests only" if !Rails.env.test?
+      remove_instance_variable(:@catch_job_exceptions)
+    end
+  end
+
   # Log an exception.
   #
   # If your code is in a scheduled job, it is recommended to use the
@@ -220,7 +232,7 @@ module Discourse
       { current_db: cm.current_db, current_hostname: cm.current_hostname }.merge(context),
     )
 
-    raise ex if Rails.env.test?
+    raise ex if Rails.env.test? && !@catch_job_exceptions
   end
 
   # Expected less matches than what we got in a find

--- a/spec/lib/scheduler/defer_spec.rb
+++ b/spec/lib/scheduler/defer_spec.rb
@@ -12,11 +12,15 @@ RSpec.describe Scheduler::Defer do
   end
 
   before do
+    Discourse.catch_job_exceptions!
     @defer = DeferInstance.new
     @defer.async = true
   end
 
-  after { @defer.stop! }
+  after do
+    @defer.stop!
+    Discourse.reset_catch_job_exceptions!
+  end
 
   it "supports basic instrumentation" do
     @defer.later("first") {}


### PR DESCRIPTION
When the thread is aborted, an exception is raised before the `start` of a job is set, and therefore raises an exception in the `ensure` block. This commit checks that `start` exists, and also adds `abort_on_exception=true` so that this issue would have caused test failures.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
