### PR TITLE
FIX: text selection breaks opening of links in new tabs

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/click-track.js
+++ b/app/assets/javascripts/discourse/app/lib/click-track.js
@@ -5,7 +5,6 @@ import User from "discourse/models/user";
 import { ajax } from "discourse/lib/ajax";
 import getURL, { samePrefix } from "discourse-common/lib/get-url";
 import { isTesting } from "discourse-common/config/environment";
-import { selectedText } from "discourse/lib/utilities";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import deprecated from "discourse-common/lib/deprecated";
 import { getOwner } from "discourse-common/lib/get-owner";
@@ -78,14 +77,6 @@ export default {
     // right clicks are not tracked
     if (e.which === 3) {
       return true;
-    }
-
-    // Cancel click if triggered as part of selection.
-    const selection = window.getSelection();
-    if (selection.type === "Range" || selection.rangeCount > 0) {
-      if (selectedText() !== "") {
-        return true;
-      }
     }
 
     const link = e.currentTarget;


### PR DESCRIPTION
When a user checks "Open all external links in a new tab" preference he expects not to be overruled by unrelated text selections. Yet if text is selected during a link click the link is followed on the same tab. This change corrects that.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
