### PR TITLE
DEV: adds expandedOnInsert option to sk

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
@@ -411,4 +411,17 @@ module("Integration | Component | select-kit/single-select", function (hooks) {
 
     assert.ok(header.bottom > body.top, "it correctly offsets the body");
   });
+
+  test("options.expandedOnInsert", async function (assert) {
+    setDefaultState(this);
+    await render(hbs`
+      <SingleSelect
+        @value={{this.value}}
+        @content={{this.content}}
+        @options={{hash expandedOnInsert=true}}
+      />
+    `);
+
+    assert.dom(".single-select.is-expanded").exists();
+  });
 });

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -188,6 +188,14 @@ export default Component.extend(
       this.handleDeprecations();
     },
 
+    didInsertElement() {
+      this._super(...arguments);
+
+      if (this.selectKit.options.expandedOnInsert) {
+        this._open();
+      }
+    },
+
     click(event) {
       event.preventDefault();
       event.stopPropagation();
@@ -296,6 +304,7 @@ export default Component.extend(
       desktopPlacementStrategy: null,
       hiddenValues: null,
       disabled: false,
+      expandedOnInsert: false,
     },
 
     autoFilterable: computed("content.[]", "selectKit.filter", function () {


### PR DESCRIPTION
Allows to display a select-kit component expanded by default.

Usage:

```
<SingleSelect
  @value={{this.value}}
  @content={{this.content}}
  @options={{hash expandedOnInsert=true}}
/>
```
