### PR TITLE
DEV: adds row index support

### DIFF
--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/single-select-test.js
@@ -393,6 +393,24 @@ module("Integration | Component | select-kit/single-select", function (hooks) {
     );
   });
 
+  test("row index", async function (assert) {
+    this.setProperties({
+      content: [
+        { id: 1, name: "john" },
+        { id: 2, name: "jane" },
+      ],
+      value: null,
+    });
+
+    await render(
+      hbs`<SingleSelect @value={{this.value}} @content={{this.content}} />`
+    );
+    await this.subject.expand();
+
+    assert.dom('.select-kit-row[data-index="0"][data-value="1"]').exists();
+    assert.dom('.select-kit-row[data-index="1"][data-value="2"]').exists();
+  });
+
   test("options.verticalOffset", async function (assert) {
     setDefaultState(this, { verticalOffset: -50 });
     await render(hbs`

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
@@ -18,6 +18,7 @@ export default Component.extend(UtilsMixin, {
     "title",
     "rowValue:data-value",
     "rowName:data-name",
+    "index:data-index",
     "role",
     "ariaChecked:aria-checked",
     "guid:data-guid",
@@ -30,6 +31,7 @@ export default Component.extend(UtilsMixin, {
     "isNone:none",
     "item.classNames",
   ],
+  index: 0,
 
   role: "menuitemradio",
 

--- a/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-collection.hbs
+++ b/app/assets/javascripts/select-kit/addon/templates/components/select-kit/select-kit-collection.hbs
@@ -1,8 +1,9 @@
 {{#if this.collection.content.length}}
   <ul class="select-kit-collection" aria-live="polite" role="menu">
-    {{#each this.collection.content as |item|}}
+    {{#each this.collection.content as |item index|}}
       {{component
         (component-for-row this.collection.identifier item this.selectKit)
+        index=index
         item=item
         value=this.value
         selectKit=this.selectKit


### PR DESCRIPTION
This commits adds a data-index attribute on each `select-kit-row` DOM node and also makes available `this.index` in each `select-kit-row` template.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
