### PR TITLE
DEV: Revert syntax-tree line change in unicorn.conf.rb listen

### DIFF
--- a/config/unicorn.conf.rb
+++ b/config/unicorn.conf.rb
@@ -16,8 +16,9 @@ worker_processes (ENV["UNICORN_WORKERS"] || 3).to_i
 working_directory discourse_path
 
 # listen "#{discourse_path}/tmp/sockets/unicorn.sock"
-listen ENV["UNICORN_LISTENER"] ||
-         "#{(ENV["UNICORN_BIND_ALL"] ? "" : "127.0.0.1:")}#{(ENV["UNICORN_PORT"] || 3000).to_i}"
+
+# stree-ignore
+listen ENV["UNICORN_LISTENER"] || "#{(ENV["UNICORN_BIND_ALL"] ? "" : "127.0.0.1:")}#{(ENV["UNICORN_PORT"] || 3000).to_i}"
 
 FileUtils.mkdir_p("#{discourse_path}/tmp/pids") if !File.exist?("#{discourse_path}/tmp/pids")
 


### PR DESCRIPTION
Some internal tooling expects this to be one line, see /t/90198/13
