### PR TITLE
FIX: New hashtag support for narrative bot advanced narrative

### DIFF
--- a/plugins/discourse-narrative-bot/config/locales/server.en.yml
+++ b/plugins/discourse-narrative-bot/config/locales/server.en.yml
@@ -401,8 +401,18 @@ en:
           Did you know that you can refer to categories and tags in your post? For example, have you seen the %{category} category?
 
           Type `#` in the middle of a sentence and select any category or tag.
+        instructions_experimental: |-
+          Did you know that you can refer to categories and tags in your post? For example, have you seen the %{category} category?
+
+          Type `#` anywhere in a sentence and select any category or tag.
         not_found: |-
           Hmm, I don’t see a category in there anywhere. Note that `#` can't be the first character. Can you copy this in your next reply?
+
+          ```text
+          I can create a category link via #
+          ```
+        not_found_experimental: |-
+          Hmm, I don’t see a category in there anywhere. Can you copy this in your next reply?
 
           ```text
           I can create a category link via #

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/advanced_user_narrative_spec.rb
@@ -377,6 +377,9 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
 
         context "when reply contains the skip trigger" do
           it "should create the right reply" do
+            # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+            SiteSetting.enable_experimental_hashtag_autocomplete = false
+
             parent_category = Fabricate(:category, name: "a")
             _category = Fabricate(:category, parent_category: parent_category, name: "b")
 
@@ -414,6 +417,9 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
 
       context "when user recovers a post in the right topic" do
         it "should create the right reply" do
+          # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+          SiteSetting.enable_experimental_hashtag_autocomplete = false
+
           parent_category = Fabricate(:category, name: "a")
           _category = Fabricate(:category, parent_category: parent_category, name: "b")
           post
@@ -442,6 +448,9 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
           topic_id: topic.id,
           track: described_class.to_s,
         )
+
+        # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
+        SiteSetting.enable_experimental_hashtag_autocomplete = false
       end
 
       context "when post is not in the right topic" do
@@ -494,9 +503,6 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
       end
 
       it "should create the right reply" do
-        # TODO (martin) Remove when enable_experimental_hashtag_autocomplete is default for all sites
-        SiteSetting.enable_experimental_hashtag_autocomplete = false
-
         category = Fabricate(:category)
 
         post.update!(raw: "Check out this ##{category.slug}")
@@ -512,6 +518,28 @@ RSpec.describe DiscourseNarrativeBot::AdvancedUserNarrative do
         expect(narrative.get_data(user)[:state].to_sym).to eq(
           :tutorial_change_topic_notification_level,
         )
+      end
+
+      context "when enable_experimental_hashtag_autocomplete is true" do
+        before { SiteSetting.enable_experimental_hashtag_autocomplete = true }
+
+        it "should create the right reply" do
+          category = Fabricate(:category)
+
+          post.update!(raw: "Check out this ##{category.slug}")
+          narrative.input(:reply, user, post: post)
+
+          expected_raw = <<~RAW
+            #{I18n.t("discourse_narrative_bot.advanced_user_narrative.category_hashtag.reply", base_uri: "")}
+
+            #{I18n.t("discourse_narrative_bot.advanced_user_narrative.change_topic_notification_level.instructions", base_uri: "")}
+          RAW
+
+          expect(Post.last.raw).to eq(expected_raw.chomp)
+          expect(narrative.get_data(user)[:state].to_sym).to eq(
+            :tutorial_change_topic_notification_level,
+          )
+        end
       end
     end
 


### PR DESCRIPTION
The discobot advanced tutorial was failing when the new hashtags
were enabled with enable_experimental_hashtag_autocomplete set
to true, since the CSS selector is different. This commit fixes
the issue and also changes the instructions if this is enabled since
we no longer require the hashtag to not be at the start of the line.

c.f. https://meta.discourse.org/t/it-is-impossible-to-complete-the-hashtag-section-of-the-discobot-advanced-tutorial/251494
