### PR TITLE
FEATURE: Add rake task to mark old hashtag format for rebake

### DIFF
--- a/lib/tasks/hashtags.rake
+++ b/lib/tasks/hashtags.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+desc "Mark posts with the old hashtag cooked format (pre enable_experimental_hashtag_autocomplete) for rebake"
+task "hashtags:mark_old_format_for_rebake" => :environment do
+  # See Post#rebake_old, which is called via the PeriodicalUpdates job
+  # on a schedule.
+  puts "Finding posts matching old format, this could take some time..."
+  posts_to_rebake = Post.where("cooked like '%class=\"hashtag\"%'")
+  STDOUT.puts(
+    "[!] You are about to mark #{posts_to_rebake.count} posts containing hashtags in the old format to rebake. [CTRL+c] to cancel, [ENTER] to continue",
+  )
+  STDIN.gets.chomp if !Rails.env.test?
+  posts_to_rebake.update_all(baked_version: 0)
+  puts "Done, rebakes will happen when periodal updates job runs."
+end

--- a/spec/tasks/hashtags_spec.rb
+++ b/spec/tasks/hashtags_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe "tasks/hashtags" do
+  before do
+    Rake::Task.clear
+    Discourse::Application.load_tasks
+  end
+
+  describe "hashtag:mark_old_format_for_rebake" do
+    fab!(:category) { Fabricate(:category, slug: "support") }
+
+    before { SiteSetting.enable_experimental_hashtag_autocomplete = false }
+
+    it "sets the baked_version to 0 for matching posts" do
+      post_1 = Fabricate(:post, raw: "This is a cool #support hashtag")
+      post_2 =
+        Fabricate(
+          :post,
+          raw:
+            "Some other thing which will not match <a class=\"hashtag-wow\">some weird custom thing</a>",
+        )
+
+      SiteSetting.enable_experimental_hashtag_autocomplete = true
+      post_3 = Fabricate(:post, raw: "This is a cool #support hashtag")
+      SiteSetting.enable_experimental_hashtag_autocomplete = false
+
+      Rake::Task["hashtags:mark_old_format_for_rebake"].invoke
+
+      [post_1, post_2, post_3].each(&:reload)
+
+      expect(post_1.baked_version).to eq(0)
+      expect(post_2.baked_version).to eq(Post::BAKED_VERSION)
+      expect(post_3.baked_version).to eq(Post::BAKED_VERSION)
+    end
+  end
+end


### PR DESCRIPTION
Since the new hashtag format has been added, we want site
admins to be able to rebake old posts with the old hashtag
format. This can now be done with `rake hashtags:mark_old_format_for_rebake`
which goes and marks posts with the old cooked version of hashtags
in this format for rebake:

```
<a class=\"hashtag\" href=\"/c/ux/14\">#<span>ux</span></a>
```

c.f. https://meta.discourse.org/t/what-rebake-is-required-for-the-new-autocomplete-styling/249642/12
