### PR TITLE
DEV: Add syntax_tree check to lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,6 +11,9 @@ pre-commit:
     rubocop:
       glob: "*.rb"
       run: bundle exec rubocop --parallel --force-exclusion {staged_files}
+    syntax_tree:
+      glob: "*.{rb,rake}"
+      run: bundle exec stree check Gemfile {staged_files}
     prettier:
       glob: "*.js"
       include: "app/assets/javascripts|plugins/.+?/assets/javascripts"


### PR DESCRIPTION
Adds the pre-commit hook for syntax_tree to lefthook. Didn't
add the normal linter because it seems to have a max file
limit, which we exceed with a combination of *.rb and *.rake.
If the format doesn't match on commit we get this:

```
EXECUTE > syntax_tree
[warn] lib/post_jobs_enqueuer.rb
[warn] lib/tasks/s3.rake
The listed files did not match the expected format.
```
