### PR TITLE
FIX: Display Discourse onebox tag icon properly in chat

### DIFF
--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -131,6 +131,7 @@
 .discourse-tags {
   display: inline-flex;
   flex-wrap: wrap;
+  position: relative;
   a,
   span {
     margin-right: 0.25em;


### PR DESCRIPTION
Currently, this is how it renders in chat when scrolling:
![e7ac8c8032739662d763b2436f2f18044a2823cc_2_1380x372](https://user-images.githubusercontent.com/5648/212692240-8f4e8974-d009-448b-a646-9b4840f354cf.png)

With this fix, it renders properly:
![image](https://user-images.githubusercontent.com/5648/212692403-969fa229-8e50-4276-84d9-cdc7e7f2b9a6.png)
