### PR TITLE
FIX: Restore class-property babel transform for themes

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -6,7 +6,7 @@ require "json_schemer"
 class Theme < ActiveRecord::Base
   include GlobalPath
 
-  BASE_COMPILER_VERSION = 70
+  BASE_COMPILER_VERSION = 71
 
   attr_accessor :child_components
 

--- a/lib/discourse_js_processor.rb
+++ b/lib/discourse_js_processor.rb
@@ -10,6 +10,8 @@ class DiscourseJsProcessor
   # babel: { debug: true } in ember-cli-build.js, then run `yarn ember build -prod`
   DISCOURSE_COMMON_BABEL_PLUGINS = [
     ["proposal-decorators", { legacy: true }],
+    "proposal-class-properties",
+    "proposal-private-methods",
     "proposal-class-static-block",
     "transform-parameters",
     "proposal-export-namespace-from",

--- a/spec/lib/discourse_js_processor_spec.rb
+++ b/spec/lib/discourse_js_processor_spec.rb
@@ -41,13 +41,6 @@ RSpec.describe DiscourseJsProcessor do
     script = <<~JS.chomp
       optional?.chaining;
       const template = func`test`;
-      class MyClass {
-        classProperty = 1;
-        #privateProperty = 1;
-        #privateMethod() {
-          console.log("hello world");
-        }
-      }
       let numericSeparator = 100_000_000;
       logicalAssignment ||= 2;
       nullishCoalescing ?? 'works';
@@ -74,6 +67,24 @@ RSpec.describe DiscourseJsProcessor do
       #{script.indent(2)}
       });
     JS
+  end
+
+  it "supports decorators and class properties without error" do
+    script = <<~JS.chomp
+      class MyClass {
+        classProperty = 1;
+        #privateProperty = 1;
+        #privateMethod() {
+          console.log("hello world");
+        }
+        @decorated
+        myMethod(){
+        }
+      }
+    JS
+
+    result = DiscourseJsProcessor.transpile(script, "blah", "blah/mymodule")
+    expect(result).to include("_applyDecoratedDescriptor")
   end
 
   it "correctly transpiles widget hbs" do


### PR DESCRIPTION
This seems to be required for decorators to work on class properties. Followup to 624f4a7de92d8a464c91a334bf9fad510af7e4ef

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
