### PR TITLE
DEV: Added callback to change the query used to filter groups in search

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -106,6 +106,8 @@ class DiscoursePluginRegistry
   define_filtered_register :hashtag_autocomplete_data_sources
   define_filtered_register :hashtag_autocomplete_contextual_type_priorities
 
+  define_filtered_register :search_groups_set_query_callbacks
+
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1292,6 +1292,10 @@ class Plugin::Instance
     DiscoursePluginRegistry.register_topic_preloader_association(fields, self)
   end
 
+  def register_search_group_query_callback(callback)
+    DiscoursePluginRegistry.register_search_groups_set_query_callback(callback, self)
+  end
+
   private
 
   def validate_directory_column_name(column_name)


### PR DESCRIPTION
Added plugin registry that will allow to add callbacks that can change the query that used to filter groups while running a search.

Inititally this will be needed in `discourse-circles`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
