### PR TITLE
FIX: Enqueue notify_mailing_list_subscribers when post is recovered

### DIFF
--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -110,6 +110,7 @@ class PostDestroyer
     UserActionManager.post_created(@post)
     DiscourseEvent.trigger(:post_recovered, @post, @opts, @user)
     Jobs.enqueue(:sync_topic_user_bookmarked, topic_id: topic.id) if topic
+    Jobs.enqueue(:notify_mailing_list_subscribers, post_id: @post.id)
 
     if @post.is_first_post?
       UserActionManager.topic_created(topic)

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -1201,4 +1201,26 @@ RSpec.describe PostDestroyer do
       )
     end
   end
+
+  describe "mailing_list_mode emails on recovery" do
+    fab!(:topic) { Fabricate(:topic) }
+    fab!(:post_1) { Fabricate(:post, topic: topic) }
+    fab!(:post_2) { Fabricate(:post, topic: topic) }
+
+    it "enqueues the notify_mailing_list_subscribers_job for the post" do
+      PostDestroyer.new(admin, post_2).destroy
+      post_2.reload
+      expect_enqueued_with(job: :notify_mailing_list_subscribers, args: { post_id: post_2.id }) do
+        PostDestroyer.new(admin, post_2).recover
+      end
+    end
+
+    it "enqueues the notify_mailing_list_subscribers_job for the op" do
+      PostDestroyer.new(admin, post_1).destroy
+      post_1.reload
+      expect_enqueued_with(job: :notify_mailing_list_subscribers, args: { post_id: post_1.id }) do
+        PostDestroyer.new(admin, post_1).recover
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit fixes the following issue:

* User creates a post
* Akismet or some other thing like requiring posts to be approved puts
  the post in the review queue, deleting it
* Admin approves the post
* Email is never sent to mailing list mode subscribers

We intentionally do not enqueue this for every single post when
recovering a topic (i.e. recovering the first post) since the topics
could have a lot of posts with emails already sent, and we don't want
to clog sidekiq with thousands of notify jobs.
