### PR TITLE
FEATURE: Allow TL4 users to see unlisted topics

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -277,6 +277,10 @@ module TopicGuardian
       )
   end
 
+  def can_see_unlisted_topics?
+    is_staff? || @user.has_trust_level?(TrustLevel[4])
+  end
+
   def can_get_access_to_topic?(topic)
     topic&.access_topic_via_group.present? && authenticated?
   end

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -642,9 +642,13 @@ class TopicQuery
     options.reverse_merge!(@options)
     options.reverse_merge!(per_page: per_page_setting) unless options[:limit] == false
 
-    # Whether to return visible topics
-    options[:visible] = true if @user.nil? || @user.regular?
-    options[:visible] = false if @user && @user.id == options[:filtered_to_user]
+    # Whether to include unlisted (visible = false) topics
+    viewing_own_topics = @user && @user.id == options[:filtered_to_user]
+
+    if options[:visible].nil?
+      options[:visible] = true if @user.nil? || @user.regular?
+      options[:visible] = false if @guardian.can_see_unlisted_topics? || viewing_own_topics
+    end
 
     # Start with a list of all topics
     result = Topic.unscoped.includes(:category)

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -100,6 +100,8 @@ Fabricator(:trust_level_0, from: :user) { trust_level TrustLevel[0] }
 
 Fabricator(:trust_level_1, from: :user) { trust_level TrustLevel[1] }
 
+Fabricator(:trust_level_3, from: :user) { trust_level TrustLevel[3] }
+
 Fabricator(:trust_level_4, from: :user) do
   name "Leader McElderson"
   username { sequence(:username) { |i| "tl4#{i}" } }

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -3,7 +3,8 @@
 RSpec.describe TopicGuardian do
   fab!(:user) { Fabricate(:user) }
   fab!(:admin) { Fabricate(:admin) }
-  fab!(:tl3_user) { Fabricate(:leader) }
+  fab!(:tl3_user) { Fabricate(:trust_level_3) }
+  fab!(:tl4_user) { Fabricate(:trust_level_4) }
   fab!(:moderator) { Fabricate(:moderator) }
   fab!(:category) { Fabricate(:category) }
   fab!(:group) { Fabricate(:group) }
@@ -121,7 +122,6 @@ RSpec.describe TopicGuardian do
 
   describe "#can_review_topic?" do
     it "returns false for TL4 users" do
-      tl4_user = Fabricate(:user, trust_level: TrustLevel[4])
       topic = Fabricate(:topic)
 
       expect(Guardian.new(tl4_user).can_review_topic?(topic)).to eq(false)
@@ -134,13 +134,25 @@ RSpec.describe TopicGuardian do
     end
 
     it "returns true for TL4 users" do
-      tl4_user = Fabricate(:user, trust_level: TrustLevel[4])
-
       expect(Guardian.new(tl4_user).can_create_unlisted_topic?(topic)).to eq(true)
     end
 
     it "returns false for regular users" do
       expect(Guardian.new(user).can_create_unlisted_topic?(topic)).to eq(false)
+    end
+  end
+
+  describe "#can_see_unlisted_topics?" do
+    it "is allowed for staff users" do
+      expect(Guardian.new(moderator).can_see_unlisted_topics?).to eq(true)
+    end
+
+    it "is allowed for TL4 users" do
+      expect(Guardian.new(tl4_user).can_see_unlisted_topics?).to eq(true)
+    end
+
+    it "is not allowed for lower level users" do
+      expect(Guardian.new(tl3_user).can_see_unlisted_topics?).to eq(false)
     end
   end
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe TopicQuery do
   fab!(:creator) { Fabricate(:user) }
   let(:topic_query) { TopicQuery.new(user) }
 
+  fab!(:tl4_user) { Fabricate(:trust_level_4) }
   fab!(:moderator) { Fabricate(:moderator) }
   fab!(:admin) { Fabricate(:admin) }
 
@@ -795,8 +796,11 @@ RSpec.describe TopicQuery do
         # includes the invisible topic if you're a moderator
         expect(TopicQuery.new(moderator).list_latest.topics.include?(invisible_topic)).to eq(true)
 
-        # includes the invisible topic if you're an admin" do
+        # includes the invisible topic if you're an admin
         expect(TopicQuery.new(admin).list_latest.topics.include?(invisible_topic)).to eq(true)
+
+        # includes the invisible topic if you're a TL4 user
+        expect(TopicQuery.new(tl4_user).list_latest.topics.include?(invisible_topic)).to eq(true)
       end
 
       context "with sort_order" do


### PR DESCRIPTION
### What is this change?

In response to [this Meta topic](https://meta.discourse.org/t/allow-tl4-or-cat-mod-to-see-unlisted-topics-in-topic-list/245069).

TL4 users can already list and unlist topics, but can not see topics that have been unlisted. This change brings that back to par by giving TL4 users the ability to see unlisted topics as well.

(This could technically be considered a fix, but it's a bit unclear, and so I labelled it as feature to highlight the change in behaviour.)

### What's the approach?

I've added a new `TopicGuardian#can_see_unlisted_topics?` which grants permission to staff and TL4 users. This encodes the fact that staff users can see unlisted posts explicitly. This was previously implicit in the `TopicQuery` code. (See inline comment for more details.)

### What else was considered?

It originally looked to me as though this could be yet another alias of `#can_perform_action_available_to_group_moderators?`, which is used as a shared check for a number of actions, such as archiving, pinning/unpinning, opening/closing, etc.

However, as I went down this route, I encountered more and more friction stemming from the fact that all the other actions are operations on a particular topic. The end result was that the `#can_perform_action_available_to_group_moderators?` lost its conceptual clarity, and so I decided on a separate method instead.

### Manual verification

- [x] Staff can still see unlisted topics.
- [x] Users can still see unlisted topics _when viewing their own topics_.
- [x] Users can not see unlisted topics under other filters.
- [x] TL4 users can now see unlisted topics.