### PR TITLE
PERF: N+1 queries when viewing tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -46,14 +46,14 @@ class TagsController < ::ApplicationController
         TagGroup
           .visible(guardian)
           .order("name ASC")
-          .includes(:tags)
+          .includes(:none_synonym_tags)
           .map do |tag_group|
             {
               id: tag_group.id,
               name: tag_group.name,
               tags:
                 self.class.tag_counts_json(
-                  tag_group.tags.where(target_tag_id: nil),
+                  tag_group.none_synonym_tags,
                   show_pm_tags: guardian.can_tag_pms?,
                 ),
             }

--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -5,6 +5,10 @@ class TagGroup < ActiveRecord::Base
 
   has_many :tag_group_memberships, dependent: :destroy
   has_many :tags, through: :tag_group_memberships
+  has_many :none_synonym_tags,
+           -> { where(target_tag_id: nil) },
+           through: :tag_group_memberships,
+           source: "tag"
   has_many :category_tag_groups, dependent: :destroy
   has_many :category_required_tag_groups, dependent: :destroy
   has_many :categories, through: :category_tag_groups


### PR DESCRIPTION
When the `tags_listed_by_group` site setting is enabled, we were seeing
the N+1 queries problem when multiple `TagGroup` records are listed.
This commit fixes that by ensuring that we are not filtering through the
`tags` association after the association has been eager loaded.