### PR TITLE
DEV: Allow accessing sourcemaps on `/brotli_asset` path

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -193,7 +193,11 @@ class StaticController < ApplicationController
   def brotli_asset
     is_asset_path
 
-    serve_asset(".br") { response.headers["Content-Encoding"] = "br" }
+    if params[:path].end_with?(".map")
+      serve_asset
+    else
+      serve_asset(".br") { response.headers["Content-Encoding"] = "br" }
+    end
   end
 
   def cdn_asset

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -122,6 +122,22 @@ RSpec.describe StaticController do
         File.delete(file_path)
       end
     end
+
+    it "can serve sourcemaps on adjacent paths" do
+      assets_path = Rails.root.join("public/assets")
+
+      FileUtils.mkdir_p(assets_path)
+
+      file_path = assets_path.join("test.map")
+      File.write(file_path, "fake source map")
+      GlobalSetting.stubs(:cdn_url).returns("https://www.example.com/")
+
+      get "/brotli_asset/test.map"
+
+      expect(response.status).to eq(200)
+    ensure
+      File.delete(file_path)
+    end
   end
 
   describe "#cdn_asset" do


### PR DESCRIPTION
Our JS files reference sourcemaps relative to their current path. On sites with non-S3 CDN setups, we use a special path for brotli assets (39a524aa). This caused the sourcemap requests to 404.

This commit fixes the issue by allowing the `.map` files to be accessed under `/brotli_asset/*`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
