### PR TITLE
UX: prevent search context btn text from wrapping

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -39,6 +39,7 @@ $search-pad-horizontal: 0.5em;
     .btn.search-context {
       margin: 2px;
       margin-right: 0;
+      white-space: nowrap;
     }
     &:focus-within {
       @include default-focus;


### PR DESCRIPTION
Prevents the button text from wrapping like this with certain font & size combos

![Screenshot 2023-01-17 at 5 22 36 PM](https://user-images.githubusercontent.com/1681963/213025410-f584e7c3-e9ed-4b4a-9432-b1a1942ecc4e.png)
