### PR TITLE
PERF: N+1 queries on `/tags` with multiple categories tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -63,20 +63,22 @@ class TagsController < ::ApplicationController
       unrestricted_tags = DiscourseTagging.filter_visible(tags.where(target_tag_id: nil), guardian)
 
       categories =
-        Category
-          .where("id IN (SELECT category_id FROM category_tags)")
-          .where("id IN (?)", guardian.allowed_category_ids)
-          .includes(:tags)
+        Category.where(
+          "id IN (SELECT category_id FROM category_tags WHERE category_id IN (?))",
+          guardian.allowed_category_ids,
+        ).includes(:none_synonym_tags)
 
       category_tag_counts =
         categories
           .map do |c|
             category_tags =
               self.class.tag_counts_json(
-                DiscourseTagging.filter_visible(c.tags.where(target_tag_id: nil), guardian),
+                DiscourseTagging.filter_visible(c.none_synonym_tags, guardian),
                 guardian,
               )
+
             next if category_tags.empty?
+
             { id: c.id, tags: category_tags }
           end
           .compact

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -125,6 +125,10 @@ class Category < ActiveRecord::Base
 
   has_many :category_tags, dependent: :destroy
   has_many :tags, through: :category_tags
+  has_many :none_synonym_tags,
+           -> { where(target_tag_id: nil) },
+           through: :category_tags,
+           source: :tag
   has_many :category_tag_groups, dependent: :destroy
   has_many :tag_groups, through: :category_tag_groups
 


### PR DESCRIPTION
When the `tags_listed_by_group` site setting is disable, we were seeing
the N+1 queries problem when multiple `CategoryTag` records are listed.
This commit fixes that by ensuring that we are not filtering through the
category `tags` association after the association has been eager loaded.