### PR TITLE
FIX: Don't display staff-only options to non-staff in group member bulk menu

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bulk-group-member-dropdown.js
+++ b/app/assets/javascripts/discourse/app/components/bulk-group-member-dropdown.js
@@ -39,22 +39,24 @@ export default DropdownSelectBoxComponent.extend({
       });
     }
 
-    if (this.bulkSelection.some((m) => !m.primary)) {
-      items.push({
-        id: "setPrimary",
-        name: I18n.t("groups.members.make_all_primary"),
-        description: I18n.t("groups.members.make_all_primary_description"),
-        icon: "id-card",
-      });
-    }
+    if (this.currentUser.staff) {
+      if (this.bulkSelection.some((m) => !m.primary)) {
+        items.push({
+          id: "setPrimary",
+          name: I18n.t("groups.members.make_all_primary"),
+          description: I18n.t("groups.members.make_all_primary_description"),
+          icon: "id-card",
+        });
+      }
 
-    if (this.bulkSelection.some((m) => m.primary)) {
-      items.push({
-        id: "unsetPrimary",
-        name: I18n.t("groups.members.remove_all_primary"),
-        description: I18n.t("groups.members.remove_all_primary_description"),
-        icon: "id-card",
-      });
+      if (this.bulkSelection.some((m) => m.primary)) {
+        items.push({
+          id: "unsetPrimary",
+          name: I18n.t("groups.members.remove_all_primary"),
+          description: I18n.t("groups.members.remove_all_primary_description"),
+          icon: "id-card",
+        });
+      }
     }
 
     return items;

--- a/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-index-test.js
@@ -72,10 +72,9 @@ acceptance("Group Members", function (needs) {
     );
   });
 
-  test("Shows bulk actions", async function (assert) {
+  test("Shows bulk actions as an admin user", async function (assert) {
     await visit("/g/discourse");
 
-    assert.ok(exists("button.bulk-select"));
     await click("button.bulk-select");
 
     await click(queryAll("input.bulk-select")[0]);
@@ -83,7 +82,50 @@ acceptance("Group Members", function (needs) {
 
     const memberDropdown = selectKit(".bulk-group-member-dropdown");
     await memberDropdown.expand();
-    await memberDropdown.selectRowByValue("makeOwners");
+
+    assert.ok(
+      exists('[data-value="removeMembers"]'),
+      "it includes remove member option"
+    );
+
+    assert.ok(
+      exists('[data-value="makeOwners"]'),
+      "it includes make owners option"
+    );
+
+    assert.ok(
+      exists('[data-value="setPrimary"]'),
+      "it includes set primary option"
+    );
+  });
+
+  test("Shows bulk actions as a group owner", async function (assert) {
+    updateCurrentUser({ moderator: false, admin: false });
+
+    await visit("/g/discourse");
+
+    await click("button.bulk-select");
+
+    await click(queryAll("input.bulk-select")[0]);
+    await click(queryAll("input.bulk-select")[1]);
+
+    const memberDropdown = selectKit(".bulk-group-member-dropdown");
+    await memberDropdown.expand();
+
+    assert.ok(
+      exists('[data-value="removeMembers"]'),
+      "it includes remove member option"
+    );
+
+    assert.ok(
+      exists('[data-value="makeOwners"]'),
+      "it includes make owners option"
+    );
+
+    assert.notOk(
+      exists('[data-value="setPrimary"]'),
+      "it does not include set primary (staff only) option"
+    );
   });
 
   test("Bulk actions - Menu, Select all and Clear all buttons", async function (assert) {


### PR DESCRIPTION
## What's the problem?

In the group member bulk edit menu we are displaying staff-only options (specifically "make/remove primary") to non-staff, i.e. group owners who are not admins or moderators.

**Demo:**

As a non-staff group owner.

<img width="356" alt="Screenshot 2023-01-18 at 3 51 46 PM" src="https://user-images.githubusercontent.com/5259935/213114248-1b1942c4-1e5d-42f2-b043-d2fced8484c6.png">

The requests are blocked by the back-end, so there is no harm other than to the user experience.

<img width="598" alt="Screenshot 2023-01-18 at 3 52 03 PM" src="https://user-images.githubusercontent.com/5259935/213114271-816bc5f9-6b66-42e9-92d5-efda9f4409e1.png">

Notably the individual user edit menu is correctly filtering out unavailable options.

<img width="267" alt="Screenshot 2023-01-18 at 3 53 10 PM" src="https://user-images.githubusercontent.com/5259935/213114413-bbb62546-d548-4089-9596-02ffa137965e.png">

## How does this fix it?

This change brings the bulk edit menu in line with the individual user menu by filtering out staff-only options when used by non-staff. The condition used (`currentUser.staff`) is the same as for the individual user menu.

**Demo:**

As a non-staff group owner.

<img width="368" alt="Screenshot 2023-01-18 at 3 54 13 PM" src="https://user-images.githubusercontent.com/5259935/213114606-13baa73b-390e-4b95-a0c5-03e7861cb561.png">

As a staff user. (Regression test.)

<img width="346" alt="Screenshot 2023-01-18 at 3 56 14 PM" src="https://user-images.githubusercontent.com/5259935/213114990-24cf2994-f238-4a6d-a2c0-e1dc655eb747.png">

