### PR TITLE
FIX: generates automatic slug for trashed channels

### DIFF
--- a/plugins/chat/app/controllers/api/chat_channels_controller.rb
+++ b/plugins/chat/app/controllers/api/chat_channels_controller.rb
@@ -38,6 +38,13 @@ class Chat::Api::ChatChannelsController < Chat::Api
 
     begin
       ChatChannel.transaction do
+        channel_from_params.update!(
+          slug:
+            "#{Time.now.strftime("%Y%m%d-%H%M")}-#{channel_from_params.slug}-deleted".truncate(
+              SiteSetting.max_topic_title_length,
+              omission: "",
+            ),
+        )
         channel_from_params.trash!(current_user)
         StaffActionLogger.new(current_user).log_custom(
           "chat_channel_delete",

--- a/plugins/chat/spec/requests/api/chat_channels_controller_spec.rb
+++ b/plugins/chat/spec/requests/api/chat_channels_controller_spec.rb
@@ -236,6 +236,27 @@ RSpec.describe Chat::Api::ChatChannelsController do
             ),
           ).to eq(true)
         end
+
+        it "generates a valid new slug to prevent collisions" do
+          SiteSetting.max_topic_title_length = 15
+          freeze_time(DateTime.parse("2022-07-08 09:30:00"))
+          old_slug = channel_1.slug
+
+          delete "/chat/api/channels/#{channel_1.id}",
+                 params: {
+                   channel: {
+                     name_confirmation: channel_1.title(current_user),
+                   },
+                 }
+
+          expect(response.status).to eq(200)
+          expect(channel_1.reload.slug).to eq(
+            "20220708-0930-#{old_slug}-deleted".truncate(
+              SiteSetting.max_topic_title_length,
+              omission: "",
+            ),
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
Prior to this fix trashed channels would still prevent a channel with the same slug to be created. This commit generates a new slug on trash and frees the slug for future usage.

The format used for the slug is: `YYYYMMDD-HHMM-OLD_SLUG-deleted` truncated to the max length of a channel name.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
