### PR TITLE
DEV: Add failing test for `api.modifyClass` with native getters

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
@@ -1,4 +1,4 @@
-import { module, test } from "qunit";
+import { module, test, todo } from "qunit";
 import EmberObject from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -86,5 +86,34 @@ module("Unit | Utility | plugin-api", function (hooks) {
     const thingy = getOwner(this).lookup("class-test-thingy:main");
     assert.strictEqual(thingy.keep, "hey!");
     assert.strictEqual(thingy.prop, "g'day");
+  });
+
+  todo("modifyClass works with getters", function (assert) {
+    let Base = EmberObject.extend({
+      get foo() {
+        throw new Error("base getter called");
+      },
+    });
+
+    getOwner(this).register("test-class:main", Base, {
+      instantiate: false,
+    });
+
+    // Performing this lookup triggers `factory._onLookup`. In DEBUG builds, that invokes injectedPropertyAssertion()
+    // https://github.com/emberjs/ember.js/blob/36505f1b42/packages/%40ember/-internals/runtime/lib/system/core_object.js#L1144-L1163
+    // Which in turn invokes `factory.proto()`.
+    // This puts things in a state which will trigger https://github.com/emberjs/ember.js/issues/18860 when a native getter is overridden.
+    withPluginApi("1.1.0", (api) => {
+      api.modifyClass("test-class:main", {
+        get foo() {
+          return "modified getter";
+        },
+      });
+    });
+
+    const obj = Base.create();
+    assert.true(true, "no error thrown while merging mixin with getter");
+
+    assert.strictEqual(obj.foo, "modified getter", "returns correct result");
   });
 });


### PR DESCRIPTION
https://meta.discourse.org/t/251793/8

https://github.com/emberjs/ember.js/issues/18860

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
