### PR TITLE
UX: hide date in timeline when text has to wrap

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -259,6 +259,7 @@
       overflow: hidden;
       padding-left: 1em;
       position: absolute; // prevents text length from impacting width
+      max-height: 3em; // this hides the date when the count + date would wrap to more than 2 lines
     }
 
     .timeline-ago {


### PR DESCRIPTION
This avoids overlaps like this:

![Screenshot 2023-01-18 at 3 24 08 PM](https://user-images.githubusercontent.com/1681963/213286943-81d49629-fd46-470e-ba0a-e0aa2b53dc2a.png)

This is avoided by constraining the height of the timeline handle's content, so anything more than 2 lines of content is hidden by overflow. The height is set in `em`s so this scales appropriately with font and font-size changes. Generally this will only change things for narrow viewports.

Discussion: https://meta.discourse.org/t/timeline-scroller-height-overlap-due-to-two-line-text/248767



Before:
![Screenshot 2023-01-18 at 3 21 19 PM](https://user-images.githubusercontent.com/1681963/213286724-68dcc999-aa47-4185-80bb-92238dab4bb5.png)

After:
![Screenshot 2023-01-18 at 3 20 43 PM](https://user-images.githubusercontent.com/1681963/213286718-93b538f4-0e45-4c7f-a6be-3d8ea6c3beae.png)

