### PR TITLE
PERF: Don't parse posts for mentions when user status is disabled

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -561,13 +561,18 @@ class PostSerializer < BasicPostSerializer
   end
 
   def mentioned_users
-    if @topic_view && (mentions = @topic_view.mentions[object.id])
-      users = mentions.map { |username| @topic_view.mentioned_users[username] }.compact
-    else
-      users = User.where(username: object.mentions)
-    end
+    users =
+      if @topic_view && (mentioned_users = @topic_view.mentioned_users[object.id])
+        mentioned_users
+      else
+        User.where(username: object.mentions)
+      end
 
     users.map { |user| BasicUserWithStatusSerializer.new(user, root: false) }
+  end
+
+  def include_mentioned_users?
+    SiteSetting.enable_user_status
   end
 
   private


### PR DESCRIPTION
Prior to this change, we were parsing `Post#cooked` every time we
serialize a post to extract the usernames of mentioned users in the
post. However, the only reason we have to do this is to support
displaying a user's status beside each mention in a post on the client side when
the `enable_user_status` site setting is enabled. When
`enable_user_status` is disabled, we should avoid having to parse
`Post#cooked` since there is no point in doing so.