### PR TITLE
FEATURE: improve FTS search support for PG 14

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1237,7 +1237,11 @@ class Search
   end
 
   def self.set_tsquery_weight_filter(term, weight_filter)
-    "'#{self.escape_string(term)}':*#{weight_filter}"
+    term
+      .split(/[\s\.#,\?\+]+/)
+      .filter { |split_term| split_term.present? }
+      .map { |split_term| "'#{self.escape_string(split_term)}':*#{weight_filter}" }
+      .join(" & ")
   end
 
   def self.escape_string(term)

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1238,7 +1238,7 @@ class Search
 
   def self.set_tsquery_weight_filter(term, weight_filter)
     term
-      .split(/[\s\.#,\?\+]+/)
+      .split(/[\s#,\)\(\?\+]+/)
       .filter { |split_term| split_term.present? }
       .map { |split_term| "'#{self.escape_string(split_term)}':*#{weight_filter}" }
       .join(" & ")

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2288,12 +2288,18 @@ RSpec.describe Search do
     end
 
     it "escapes the term correctly" do
-      expect(Search.ts_query(term: 'Title with trailing backslash\\')).to eq(
-        "TO_TSQUERY('english', '''Title with trailing backslash\\\\\\\\'':*')",
+      document = "trailing title with backslash"
+      ts_query = Search.ts_query(term: 'Title with trailing backslash\\')
+
+      expect(DB.query_single("SELECT to_tsvector('english', ?) @@ #{ts_query}", document)).to eq(
+        [true],
       )
 
-      expect(Search.ts_query(term: "Title with trailing quote'")).to eq(
-        "TO_TSQUERY('english', '''Title with trailing quote'''''':*')",
+      document = "trailing title with quote"
+      ts_query = Search.ts_query(term: 'Title with trailing quote\\')
+
+      expect(DB.query_single("SELECT to_tsvector('english', ?) @@ #{ts_query}", document)).to eq(
+        [true],
       )
     end
   end

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -723,7 +723,7 @@ RSpec.describe Search do
         end
 
         it "returns nothing if user is not a group member" do
-          pm = create_pm(users: [current, participant], group: group)
+          create_pm(users: [current, participant], group: group)
 
           results =
             Search.execute("group_messages:#{group.name}", guardian: Guardian.new(non_participant))
@@ -735,7 +735,7 @@ RSpec.describe Search do
         end
 
         it "returns nothing if group has messages disabled" do
-          pm = create_pm(users: [current, participant], group: group)
+          create_pm(users: [current, participant], group: group)
           group.update!(has_messages: false)
 
           results = Search.execute("group_messages:#{group.name}", guardian: Guardian.new(current))
@@ -947,7 +947,7 @@ RSpec.describe Search do
 
     it "aggregates searches in a topic by returning the post with the lowest post number" do
       post = Fabricate(:post, topic: topic, raw: "this is a play post")
-      post2 = Fabricate(:post, topic: topic, raw: "play play playing played play")
+      _post2 = Fabricate(:post, topic: topic, raw: "play play playing played play")
       post3 = Fabricate(:post, raw: "this is a play post")
 
       5.times { Fabricate(:post, topic: topic, raw: "play playing played") }
@@ -1638,7 +1638,7 @@ RSpec.describe Search do
 
       it "can filter by posts in the user's bookmarks" do
         expect(search_with_bookmarks.posts.map(&:id)).to eq([])
-        bm = Fabricate(:bookmark, user: user, bookmarkable: bookmark_post1)
+        Fabricate(:bookmark, user: user, bookmarkable: bookmark_post1)
         expect(search_with_bookmarks.posts.map(&:id)).to match_array([bookmark_post1.id])
       end
     end
@@ -2474,7 +2474,7 @@ RSpec.describe Search do
       expect(results.posts.length).to eq(Search.per_facet)
       expect(results.more_posts).to eq(nil) # not 6 posts yet
 
-      post6 = Fabricate(:post, raw: "hello post #6")
+      Fabricate(:post, raw: "hello post #6")
 
       results = Search.execute("hello", search_type: :header)
       expect(results.posts.length).to eq(Search.per_facet)


### PR DESCRIPTION
Previously `to_tsquery` would split terms and join with `&` following
PG 14 terms are split and use `<->` which means followed directly by.


In PG 13:

```
discourse_test=# SELECT to_tsquery('english', '''hello world''');
     to_tsquery
---------------------
 'hello' & 'world'
(1 row)
```

In PG 14:

```
discourse_test=# SELECT to_tsquery('english', '''hello world''');
     to_tsquery
---------------------
 'hello' <-> 'world'
(1 row)
```

New behavior means that instead of sending a giant compound term to the
very vanilla `ts_query` we now split up the term upfront.

Change is backwards compatible.