### PR TITLE
FIX: Do not override channel name when category selected

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/controllers/create-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/controllers/create-channel.js
@@ -156,7 +156,7 @@ export default class CreateChannelController extends Controller.extend(
     this.setProperties({
       categoryId,
       category,
-      name: category?.name || "",
+      name: this.name || category?.name || "",
     });
   }
 

--- a/plugins/chat/spec/system/create_channel_spec.rb
+++ b/plugins/chat/spec/system/create_channel_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe "Create channel", type: :system, js: true do
         expect(find(".create-channel-hint")).to have_content(Group[:everyone].name)
       end
 
+      it "does not override channel name if that was already specified" do
+        visit("/chat")
+        find(".new-channel-btn").click
+        fill_in("channel-name", with: "My Cool Channel")
+        find(".category-chooser").click
+        find(".category-row[data-value=\"#{category_1.id}\"]").click
+
+        expect(page).to have_field("channel-name", with: "My Cool Channel")
+      end
+
       context "when category is private" do
         fab!(:group_1) { Fabricate(:group) }
         fab!(:private_category_1) { Fabricate(:private_category, group: group_1) }
@@ -95,6 +105,7 @@ RSpec.describe "Create channel", type: :system, js: true do
           name = "Cats"
           find(".category-chooser").click
           find(".category-row[data-value=\"#{category_1.id}\"]").click
+          expect(page).to have_field("channel-name", with: category_1.name)
           fill_in("channel-name", with: name)
           fill_in("channel-description", with: "All kind of cute cats")
           find(".create-channel-modal .create").click


### PR DESCRIPTION
In 1d4c1fe002ed5ade80a7f4839cd38979ba75431e we changed the order
of create channel modal fields to have the category selector at
the bottom. However, we did not update the logic to set the channel
name when the category is selected. This was also a bug before
as well, but its now more obvious because of the order of the fields.

This commit fixes the issue by only using the category name to prefill
the channel name field _if_ the channel name has not already been
specified by the user.
