### PR TITLE
FIX: Delete reviewables associated to posts automatically

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -61,6 +61,7 @@ class Post < ActiveRecord::Base
   belongs_to :image_upload, class_name: "Upload"
 
   has_many :post_hotlinked_media, dependent: :destroy, class_name: "PostHotlinkedMedia"
+  has_many :reviewables, as: :target, dependent: :destroy
 
   validates_with PostValidator, unless: :skip_validation
 

--- a/db/post_migrate/20230119091939_drop_orphaned_reviewable_flagged_posts.rb
+++ b/db/post_migrate/20230119091939_drop_orphaned_reviewable_flagged_posts.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DropOrphanedReviewableFlaggedPosts < ActiveRecord::Migration[7.0]
+  def up
+    DB.exec(<<~SQL)
+      DELETE FROM reviewables
+      WHERE reviewables.type = 'ReviewableFlaggedPost'
+        AND reviewables.status = 0
+        AND reviewables.target_type = 'Post'
+        AND NOT EXISTS(SELECT 1 FROM posts WHERE posts.id = reviewables.target_id)
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,9 +3,11 @@
 RSpec.describe Post do
   fab!(:coding_horror) { Fabricate(:coding_horror) }
 
+  let(:upload_path) { Discourse.store.upload_path }
+
   before { Oneboxer.stubs :onebox }
 
-  let(:upload_path) { Discourse.store.upload_path }
+  it { is_expected.to have_many(:reviewables).dependent(:destroy) }
 
   describe "#hidden_reasons" do
     context "when verifying enum sequence" do


### PR DESCRIPTION
Currently, we don’t have an association between reviewables and posts. This sometimes leads to inconsistencies in the DB, as a post can have been deleted but an associated reviewable is still present.

This PR addresses this issue simply by adding a new association to the `Post` model and by using the `dependent: :destroy` option.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
