### PR TITLE
FIX: Switch email domain site settings type to host_list

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1682,10 +1682,10 @@ en:
     whispers_allowed_groups: "Allow private communication within topics for members of specified groups."
 
     allow_index_in_robots_txt: "Specify in robots.txt that this site is allowed to be indexed by web search engines. In exceptional cases you can permanently <a href='%{base_path}/admin/customize/robots'>override robots.txt</a>."
-    blocked_email_domains: "A pipe-delimited list of email domains that users are not allowed to register accounts with. Example: mailinator.com|trashmail.net"
-    allowed_email_domains: "A pipe-delimited list of email domains that users MUST register accounts with. WARNING: Users with email domains other than those listed will not be allowed!"
+    blocked_email_domains: "A pipe-delimited list of email domains that users are not allowed to register accounts with. Subdomains are automatically handled for the specified domains. Wildcard symbols * and ? are not supported. Example: mailinator.com|trashmail.net"
+    allowed_email_domains: "A pipe-delimited list of email domains that users MUST register accounts with. Subdomains are automatically handled for the specified domains. Wildcard symbols * and ? are not supported. WARNING: Users with email domains other than those listed will not be allowed!"
     normalize_emails: "Check if normalized email is unique. Normalized email removes all dots from the username and everything between + and @ symbols."
-    auto_approve_email_domains: "Users with email addresses from this list of domains will be automatically approved."
+    auto_approve_email_domains: "Users with email addresses from this list of domains will be automatically approved. Subdomains are automatically handled for the specified domains. Wildcard symbols * and ? are not supported."
     hide_email_address_taken: "Don't inform users that an account exists with a given email address during signup or during forgot password flow. Require full email for 'forgotten password' requests."
     log_out_strict: "When logging out, log out ALL sessions for the user on all devices"
     version_checks: "Ping the Discourse Hub for version updates and show new version messages on the <a href='%{base_path}/admin' target='_blank'>/admin</a> dashboard"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -532,17 +532,17 @@ login:
       value: "sso_provider.value_placeholder"
   blocked_email_domains:
     default: "mailinator.com"
-    type: list
+    type: host_list
     list_type: simple
   allowed_email_domains:
     default: ""
-    type: list
+    type: host_list
     list_type: simple
   normalize_emails:
     default: false
   auto_approve_email_domains:
     default: ""
-    type: list
+    type: host_list
     list_type: simple
   hide_email_address_taken:
     client: true

--- a/db/migrate/20230119094939_remove_wildcard_from_email_domain_site_settings.rb
+++ b/db/migrate/20230119094939_remove_wildcard_from_email_domain_site_settings.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RemoveWildcardFromEmailDomainSiteSettings < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~'SQL'
+      UPDATE site_settings
+      SET value = regexp_replace(value, '\*(\.)?|\?', '', 'g')
+      WHERE name IN (
+        'auto_approve_email_domains',
+        'allowed_email_domains',
+        'blocked_email_domains'
+      )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Specifying wildcard characters which also happen to be regex meta characters for `auto_approve_email_domains`, `allowed_email_domains` and `blocked_email_domains` site settings currently breaks email validation.

This change prevents these characters from being specified for these site settings. It does this by switching the site setting type from `list` to `host_list`. The `host_list` validator checks for these characters.

In addition, this change also improves the site setting descriptions and introduces a migration to  fix existing records.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
