### PR TITLE
A11Y: add secondary skip link to user profiles

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/badge-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/badge-title.hbs
@@ -1,5 +1,5 @@
 <div class="badge-title">
-  <section class="user-content">
+  <section class="user-content" id="user-content">
     <form class="form-horizontal">
       <div class="control-group">
         <div class="controls">

--- a/app/assets/javascripts/discourse/app/templates/group/activity.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/activity.hbs
@@ -16,6 +16,6 @@
     <PluginOutlet @name="group-activity-bottom" @connectorTagName="li" />
   </MobileNav>
 </section>
-<section class="user-content">
+<section class="user-content" id="user-content">
   {{outlet}}
 </section>

--- a/app/assets/javascripts/discourse/app/templates/group/manage.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/manage.hbs
@@ -12,6 +12,6 @@
     {{/each}}
   </MobileNav>
 </section>
-<section class="user-content">
+<section class="user-content" id="user-content">
   {{outlet}}
 </section>

--- a/app/assets/javascripts/discourse/app/templates/group/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/messages.hbs
@@ -12,6 +12,6 @@
     </li>
   </MobileNav>
 </section>
-<section class="user-content">
+<section class="user-content" id="user-content">
   {{outlet}}
 </section>

--- a/app/assets/javascripts/discourse/app/templates/group/permissions.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/permissions.hbs
@@ -1,4 +1,4 @@
-<section class="user-content">
+<section class="user-content" id="user-content">
   {{#if this.model.permissions}}
     <label class="group-category-permissions-desc">
       {{i18n "groups.permissions.description"}}

--- a/app/assets/javascripts/discourse/app/templates/preferences.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences.hbs
@@ -104,7 +104,7 @@
   </DSection>
 {{/if}}
 
-<section class="user-content user-preferences">
+<section class="user-content user-preferences" id="user-content">
   <PluginOutlet
     @name="above-user-preferences"
     @tagName="span"

--- a/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user-invited-show.hbs
@@ -2,6 +2,7 @@
   {{#if this.canInviteToForum}}
     <LoadMore
       @class="user-content"
+      @id="user-content"
       @selector=".user-invite-list tr"
       @action={{action "loadMore"}}
     >

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -10,6 +10,9 @@
     {{this.primaryGroup}}"
 >
   <DSection @class="user-main">
+    <a href="#user-content" id="skip-link" class="skip-link__user-nav">
+      {{i18n "skip_user_nav"}}
+    </a>
     <section
       class="{{if this.collapsedInfo 'collapsed-info'}}
         about

--- a/app/assets/javascripts/discourse/app/templates/user/activity.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/activity.hbs
@@ -89,6 +89,6 @@
   {{/if}}
 {{/if}}
 
-<section class="user-content">
+<section class="user-content" id="user-content">
   {{outlet}}
 </section>

--- a/app/assets/javascripts/discourse/app/templates/user/badges.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.hbs
@@ -1,4 +1,4 @@
-<DSection @pageClass="user-badges" @class="user-content">
+<DSection @pageClass="user-badges" @class="user-content" id="user-content">
   <p class="favorite-count">
     {{i18n
       "badges.favorite_count"

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -184,7 +184,7 @@
   {{/unless}}
 {{/if}}
 
-<section class="user-content">
+<section class="user-content" id="user-content">
   {{#unless this.currentUser.redesigned_user_page_nav_enabled}}
     <div class="list-actions">
       {{#if this.site.mobileView}}

--- a/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
@@ -80,7 +80,7 @@
   {{/if}}
 {{/if}}
 
-<section class="user-content">
+<section class="user-content" id="user-content">
   <LoadMore
     @class="notification-history user-stream"
     @selector=".user-stream .notification"

--- a/app/assets/javascripts/discourse/app/templates/user/summary.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/summary.hbs
@@ -1,5 +1,5 @@
 <DSection @pageClass="user-summary" @tagName="">
-  <div class="user-content">
+  <div class="user-content" id="user-content">
     <PluginOutlet
       @name="above-user-summary-stats"
       @args={{hash model=this.model user=this.user}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -197,6 +197,7 @@ en:
 
     topic_admin_menu: "topic actions"
     skip_to_main_content: "Skip to main content"
+    skip_user_nav: "Skip to profile content"
 
     emails_are_disabled: "All outgoing email has been globally disabled by an administrator. No email notifications of any kind will be sent."
     emails_are_disabled_non_staff: "Outgoing email has been disabled for non-staff users."
@@ -1121,7 +1122,7 @@ en:
         perm_denied_expl: "You denied permission for notifications. Allow notifications via your browser settings."
         disable: "Disable Notifications"
         enable: "Enable Notifications"
-        each_browser_note: 'Note: You have to change this setting on every browser you use. All notifications will be disabled if you pause notifications from user menu, regardless of this setting.'
+        each_browser_note: "Note: You have to change this setting on every browser you use. All notifications will be disabled if you pause notifications from user menu, regardless of this setting."
         consent_prompt: "Do you want live notifications when people reply to your posts?"
       dismiss: "Dismiss"
       dismiss_notifications: "Dismiss All"


### PR DESCRIPTION
This adds an additional skip link to user profiles so that users navigating with keyboards and/or screen readers can skip the repeated profile header and user nav content. 

This appears in the tab order immediately after the skip link for the site header, so after navigating to a profile page it's very easy to skip repeated content if secondary navigation is not necessary. 

![Screenshot 2023-01-19 at 5 48 23 PM](https://user-images.githubusercontent.com/1681963/213580045-b843ce8e-4a9c-4d17-a5ee-e22185285171.png)
