### PR TITLE
FIX: Allow modals to scroll on mobile when keyboard is open

### DIFF
--- a/app/assets/stylesheets/mobile/modal.scss
+++ b/app/assets/stylesheets/mobile/modal.scss
@@ -106,6 +106,14 @@
   &.insert-hyperlink-modal .modal-inner-container {
     overflow: visible;
   }
+
+  html.keyboard-visible:not(.ios-device) & {
+    height: calc(100% - env(keyboard-inset-height));
+
+    .modal-inner-container {
+      margin: auto;
+    }
+  }
 }
 
 .modal .modal-body.reorder-categories {


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/android-keyboard-overlaps-text-when-flagging-with-something-else/249687?u=osama

On Android, it's currently not possible to scroll modals that take input from the user (such as the flagging modal) when the keyboard is open which means that the keyboard can cover up part of the modal with no way for the user to see the covered part without closing the keyboard. This PR adds some CSS to make these modals scrollable when the keyboard is open.