### PR TITLE
FIX: data-popper-reference-hidden too broad

### DIFF
--- a/plugins/chat/assets/stylesheets/common/common.scss
+++ b/plugins/chat/assets/stylesheets/common/common.scss
@@ -640,8 +640,7 @@ html.has-full-page-chat {
       );
     }
   }
-}
-
-[data-popper-reference-hidden] {
-  visibility: hidden;
+  [data-popper-reference-hidden] {
+    visibility: hidden;
+  }
 }


### PR DESCRIPTION
This rule was too broad and causing issues with the flag modal. 

Before:

![Screenshot 2023-01-20 at 1 41 43 PM](https://user-images.githubusercontent.com/1681963/213780233-c1d2292f-0665-41b8-9d17-ad03792a661a.png)


After:

![Screenshot 2023-01-20 at 1 40 19 PM](https://user-images.githubusercontent.com/1681963/213780240-474e6e3b-b62c-46b3-8db4-14cbbedec714.png)
