### PR TITLE
A11Y: add aria-labels for flagging textareas

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/flag-action-type.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/flag-action-type.hbs
@@ -16,6 +16,7 @@
             name="message"
             class="flag-message"
             placeholder={{this.customPlaceholder}}
+            aria-label={{i18n "flagging.notify_user_textarea_label"}}
             @value={{this.message}}
           />
           <div
@@ -48,6 +49,7 @@
             name="message"
             class="flag-message"
             placeholder={{this.customPlaceholder}}
+            aria-label={{i18n "flagging.notify_moderators_textarea_label"}}
             @value={{this.message}}
           />
           <div

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3809,7 +3809,9 @@ en:
         inappropriate: "It's Inappropriate"
         spam: "It's Spam"
       custom_placeholder_notify_user: "Be specific, be constructive, and always be kind."
+      notify_user_textarea_label: "Message for the user"
       custom_placeholder_notify_moderators: "Let us know specifically what you are concerned about, and provide relevant links and examples where possible."
+      notify_moderators_textarea_label: "Message for the moderators"
       custom_message:
         at_least:
           one: "enter at least %{count} character"


### PR DESCRIPTION
This adds aria-labels so these flagging textareas are labeled for screenreaders 

 
![Screenshot 2023-01-20 at 5 47 50 PM](https://user-images.githubusercontent.com/1681963/213818793-cfa9b246-97c2-4951-8880-eb0f8d1b8350.png)
