### PR TITLE
DEV: experiments disabling request tracker in system test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -81,4 +81,7 @@ Discourse::Application.configure do
 
     SiteSetting.refresh!
   end
+
+  # this is a lot of async work which can cause issues and is not necessary
+  config.middleware.delete Middleware::RequestTracker if ENV["SYSTEM_TEST"]
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -369,6 +369,8 @@ RSpec.configure do |config|
 
   last_driven_by = nil
   config.before(:each, type: :system) do |example|
+    ENV["SYSTEM_TEST"] = "1"
+
     if example.metadata[:js]
       driver = [:selenium]
       driver << :mobile if example.metadata[:mobile]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -421,6 +421,8 @@ RSpec.configure do |config|
     end
 
     Discourse.redis.flushdb
+
+    ENV.delete("SYSTEM_TEST")
   end
 
   config.before(:each, type: :multisite) do


### PR DESCRIPTION
Multiple "random" spec failures look like this:

```
  1) Navigation when opening chat with drawer as preferred mode opens the full page
     Failure/Error: result = @app.call(env)

     Errno::ECONNRESET:
       Connection reset by peer
     # ./lib/middleware/request_tracker.rb:228:in `call'
     # ./config/initializers/200-first_middlewares.rb:27:in `call'
     # ------------------
     # --- Caused by: ---
     # Capybara::CapybaraError:
     #   Your application server raised an error - It has been raised in your test code because Capybara.raise_server_errors == true
     #   ./spec/rails_helper.rb:355:in `block (2 levels) in <top (required)>'
```

And moreover it doesn’t seem like necessary work to test for this in system tests, so I would like to try removing this from the chain for now at least.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
