### PR TITLE
FIX: prevents msg-actions to show hover text

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -4,8 +4,7 @@ import { createPopper } from "@popperjs/core";
 import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 
-const MSG_ACTIONS_HORIZONTAL_PADDING = 2;
-const MSG_ACTIONS_VERTICAL_PADDING = -28;
+const MSG_ACTIONS_VERTICAL_PADDING = -10;
 
 export default Component.extend({
   tagName: "",
@@ -28,27 +27,13 @@ export default Component.extend({
           `.chat-message-actions-container[data-id="${this.message.id}"] .chat-message-actions`
         ),
         {
-          placement: "right-start",
+          placement: "top-end",
           modifiers: [
             { name: "hide", enabled: true },
-            {
-              name: "eventListeners",
-              options: {
-                scroll: false,
-              },
-            },
+            { name: "eventListeners", options: { scroll: false } },
             {
               name: "offset",
-              options: {
-                offset: ({ popper, placement }) => {
-                  return [
-                    MSG_ACTIONS_VERTICAL_PADDING,
-                    -(placement.includes("left") || placement.includes("right")
-                      ? popper.width + MSG_ACTIONS_HORIZONTAL_PADDING
-                      : popper.height),
-                  ];
-                },
-              },
+              options: { offset: [0, MSG_ACTIONS_VERTICAL_PADDING] },
             },
           ],
         }


### PR DESCRIPTION
This case was possible in restrained space when the top of the message was not visible in the viewport.

**Before**

![Screenshot 2023-01-23 at 15 27 39](https://user-images.githubusercontent.com/339945/214064668-e30f26ff-41f5-43af-8b51-d844b2975392.png)

**After**

![Screenshot 2023-01-23 at 15 26 57](https://user-images.githubusercontent.com/339945/214064680-15239cc1-44eb-43e7-a07a-3c8976838eb4.png)

