### PR TITLE
FEATURE: Add api scope for search endpoint

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -146,6 +146,16 @@ class ApiKeyScope < ActiveRecord::Base
             actions: %w[user_badges#destroy],
           },
         },
+        search: {
+          show: {
+            actions: %w[search#show],
+            params: %i[q page],
+          },
+          query: {
+            actions: %w[search#query],
+            params: %i[term],
+          },
+        },
         wordpress: {
           publishing: {
             actions: %w[site#site posts#create topics#update topics#status topics#show],

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4703,6 +4703,9 @@ en:
               list_user_badges: List user badges.
               assign_badge_to_user: Assign a badge to a user.
               revoke_badge_from_user: Revoke a badge from a user.
+            search:
+              show: Search using the `/search.json?q=term` endpoint.
+              query: Search using the /search/query?term=term` endpoint.
             wordpress:
               publishing: Necessary for the WP Discourse plugin publishing features (required).
               commenting: Necessary for the WP Discourse plugin commenting features.

--- a/spec/requests/admin/api_controller_spec.rb
+++ b/spec/requests/admin/api_controller_spec.rb
@@ -428,6 +428,7 @@ RSpec.describe Admin::ApiController do
           "global",
           "badges",
           "categories",
+          "search",
           "wordpress",
         )
       end


### PR DESCRIPTION
Adds two new api scopes for the /search endpoints:

- `/search.json?q=term`
- `/search/query.json?term=term`

see: https://meta.discourse.org/t/search-api-key-permissions/227244
