### PR TITLE
FIX: adds negative skidding to popper offset

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -33,7 +33,7 @@ export default Component.extend({
             { name: "eventListeners", options: { scroll: false } },
             {
               name: "offset",
-              options: { offset: [0, MSG_ACTIONS_VERTICAL_PADDING] },
+              options: { offset: [-2, MSG_ACTIONS_VERTICAL_PADDING] },
             },
           ],
         }


### PR DESCRIPTION
Learn more about skidding here: https://popper.js.org/docs/v2/modifiers/offset/#skidding-1

This change has two goals:
- Fixes an issue when the user had zoomed the viewport and the popper would position on the opposite side
- Makes msg actions arguably more pleasant to the eye by preventing it to be right aligned with the message outter container

**Before (125% zoom on chrome)**

![Screenshot 2023-01-23 at 21 47 39](https://user-images.githubusercontent.com/339945/214146574-bb36a69a-e236-4107-9130-9ef85468c83f.png)

**After**

![Screenshot 2023-01-23 at 21 43 36](https://user-images.githubusercontent.com/339945/214145857-e727b4a3-c3c8-4d41-995f-397b9ffbf820.png)
