### PR TITLE
FIX: TL4 user is not redirected to latest when delete topic

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -471,6 +471,10 @@ const Topic = RestModel.extend({
           !deleted_by.staff &&
           !deleted_by.groups.some(
             (group) => group.name === this.category.reviewable_by_group_name
+          ) &&
+          !(
+            this.siteSettings.tl4_delete_posts_and_topics &&
+            deleted_by.trust_level >= 4
           )
         ) {
           DiscourseURL.redirectTo("/");


### PR DESCRIPTION
Continue of https://github.com/discourse/discourse/pull/19766

When TL4 is allowed to delete topic, they should not be redirected to / after that action.
