### PR TITLE
DEV: Limit concurrency of NotifyReviewables job

### DIFF
--- a/lib/distributed_mutex.rb
+++ b/lib/distributed_mutex.rb
@@ -30,16 +30,28 @@ class DistributedMutex
     end
   LUA
 
-  def self.synchronize(key, redis: nil, validity: DEFAULT_VALIDITY, &blk)
-    self.new(key, redis: redis, validity: validity).synchronize(&blk)
+  def self.synchronize(
+    key,
+    redis: nil,
+    validity: DEFAULT_VALIDITY,
+    max_get_lock_attempts: nil,
+    &blk
+  )
+    self.new(
+      key,
+      redis: redis,
+      validity: validity,
+      max_get_lock_attempts: max_get_lock_attempts,
+    ).synchronize(&blk)
   end
 
-  def initialize(key, redis: nil, validity: DEFAULT_VALIDITY)
+  def initialize(key, redis: nil, validity: DEFAULT_VALIDITY, max_get_lock_attempts: nil)
     @key = key
     @using_global_redis = true if !redis
     @redis = redis || Discourse.redis
     @mutex = Mutex.new
     @validity = validity
+    @max_get_lock_attempts = max_get_lock_attempts
   end
 
   # NOTE wrapped in mutex to maintain its semantics
@@ -69,11 +81,15 @@ class DistributedMutex
     result
   end
 
+  class MaximumAttemptsExceeded < StandardError
+  end
+
   private
 
   attr_reader :key
   attr_reader :redis
   attr_reader :validity
+  attr_reader :max_get_lock_attempts
 
   def get_lock
     attempts = 0
@@ -91,6 +107,10 @@ class DistributedMutex
       # in readonly we will never be able to get a lock
       if @using_global_redis && Discourse.recently_readonly? && attempts > CHECK_READONLY_ATTEMPTS
         raise Discourse::ReadOnly
+      end
+
+      if max_get_lock_attempts && attempts > max_get_lock_attempts
+        raise DistributedMutex::MaximumAttemptsExceeded
       end
     end
   end


### PR DESCRIPTION
Under scenarios of extremely high load where large numbers of `Reviewable*` items are being created, it has been observed that multiple instances of the `NotifyReviewable` job may run simultaneously.

These jobs will work satisfactorily if the concurrency is limited to 1, and the different types of jobs (items reviewable by admins, vs moderators, vs particular groups, etc.) are run eventually.

This change introduces a new option to `DistributedMutex` which allows the `max_get_lock_attempts` to be specified. If the number is exceeded an error will be raised, which will cause Sidekiq to requeue the job. Sidekiq has existing logic to back-off on retry times for jobs that have failed multiple times.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
