### PR TITLE
FIX: Do not add empty use/svg tags in ExcerptParser

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -23,7 +23,14 @@ class PostAlerter
         topic_title: post.topic.title,
         topic_id: post.topic.id,
         excerpt:
-          excerpt || post.excerpt(400, text_entities: true, strip_links: true, remap_emoji: true),
+          excerpt ||
+            post.excerpt(
+              400,
+              text_entities: true,
+              strip_links: true,
+              remap_emoji: true,
+              plain_hashtags: true,
+            ),
         username: username || post.username,
         post_url: post_url,
       }

--- a/lib/email/styles.rb
+++ b/lib/email/styles.rb
@@ -216,7 +216,7 @@ module Email
       correct_first_body_margin
       correct_footer_style
       correct_footer_style_highlight_first
-      decorate_hashtags
+      strip_hashtag_link_icons
       reset_tables
 
       html_lang = SiteSetting.default_locale.sub("_", "-")
@@ -396,7 +396,7 @@ module Email
         end
     end
 
-    def decorate_hashtags
+    def strip_hashtag_link_icons
       @fragment
         .search(".hashtag-cooked")
         .each do |hashtag|

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -181,10 +181,10 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
     when "div", "span"
       throw :done if @start_excerpt
     when "svg"
-      characters("</svg>", truncate: false, count_it: false, encode: false)
+      characters("</svg>", truncate: false, count_it: false, encode: false) if @keep_svg
       @in_svg = false
     when "use"
-      characters("</use>", truncate: false, count_it: false, encode: false)
+      characters("</use>", truncate: false, count_it: false, encode: false) if @keep_svg
     end
   end
 

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -469,8 +469,19 @@ module PrettyText
     DiscourseEvent.trigger(:reduce_excerpt, doc, options)
     strip_image_wrapping(doc)
     strip_oneboxed_media(doc)
+
+    if SiteSetting.enable_experimental_hashtag_autocomplete && options[:plain_hashtags]
+      convert_hashtag_links_to_plaintext(doc)
+    end
+
     html = doc.to_html
     ExcerptParser.get_excerpt(html, max_length, options)
+  end
+
+  def self.convert_hashtag_links_to_plaintext(doc)
+    doc
+      .css("a.hashtag-cooked")
+      .each { |hashtag| hashtag.replace("##{hashtag.attributes["data-slug"]}") }
   end
 
   def self.strip_links(string)


### PR DESCRIPTION
There was an issue where if hashtag-cooked HTML was sent
to the ExcerptParser without the keep_svg option, we would
end up with empty </use> and </svg> tags on the parts of the
excerpt where the hashtag was, in this case when a post
push notification was sent.

Fixed this, and also added a way to only display a plaintext
version of the hashtag for cases like this via PrettyText#excerpt.

Followup to 9d50790530459535164870bd49e712c30d2d5e8e

**Example**:

![image](https://user-images.githubusercontent.com/920448/214204584-96c70b61-b947-449e-b563-d999383c3938.png)

c.f. https://meta.discourse.org/t/icon-html-closing-tags-in-push-notification/249607
