### PR TITLE
DEV: Remove older ruby version logic

### DIFF
--- a/config/initializers/100-logster.rb
+++ b/config/initializers/100-logster.rb
@@ -7,15 +7,6 @@ if GlobalSetting.skip_redis?
   return
 end
 
-if Rails.env.development? && RUBY_VERSION.match?(/^2\.5\.[23]/)
-  STDERR.puts "WARNING: Discourse development environment runs slower on Ruby 2.5.3 or below"
-  STDERR.puts "We recommend you upgrade to the latest Ruby 2.x for the optimal development performance"
-
-  # we have to used to older and slower version of the logger cause the new one exposes a Ruby bug in
-  # the Queue class which causes segmentation faults
-  Logster::Scheduler.disable
-end
-
 if Rails.env.development? && !Sidekiq.server? && ENV["RAILS_LOGS_STDOUT"] == "1"
   Rails.application.config.after_initialize do
     console = ActiveSupport::Logger.new(STDOUT)

--- a/lib/site_settings/yaml_loader.rb
+++ b/lib/site_settings/yaml_loader.rb
@@ -38,10 +38,6 @@ class SiteSettings::YamlLoader
   private
 
   def load_yaml(path)
-    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1.0")
-      YAML.load_file(path, aliases: true)
-    else
-      YAML.load_file(path)
-    end
+    YAML.load_file(path, aliases: true)
   end
 end


### PR DESCRIPTION
Discourse no longer boots on anything less than 3.1, so these code paths will never be used

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
