### PR TITLE
DEV: Patch capybara to ignore client-triggered errors

### DIFF
--- a/config/initializers/004-message_bus.rb
+++ b/config/initializers/004-message_bus.rb
@@ -105,8 +105,6 @@ MessageBus.on_middleware_error do |env, e|
     [403, {}, ["Invalid Access"]]
   elsif RateLimiter::LimitExceeded === e
     [429, { "Retry-After" => e.available_in.to_s }, [e.description]]
-  elsif Errno::EPIPE === e
-    [422, {}, ["Closed by Client"]]
   end
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -252,6 +252,17 @@ RSpec.configure do |config|
       capybara_config.server_port = 31_337 + ENV["TEST_ENV_NUMBER"].to_i
     end
 
+    module IgnoreUnicornCapturedErrors
+      def raise_server_error!
+        super
+      rescue EOFError, Errno::ECONNRESET, Errno::EPIPE, Errno::ENOTCONN => e
+        # Ignore these exceptions - caused by client. Handled by unicorn in dev/prod
+        # https://github.com/defunkt/unicorn/blob/d947cb91cf/lib/unicorn/http_server.rb#L570-L573
+      end
+    end
+
+    Capybara::Session.class_eval { prepend IgnoreUnicornCapturedErrors }
+
     # The valid values for SELENIUM_BROWSER_LOG_LEVEL are:
     #
     # OFF


### PR DESCRIPTION
In dev/prod, these are absorbed by unicorn. Most commonly, they occur when a client interrupts a message-bus long-polling request.

Also reverts the EPIPE workaround introduced in 011c9b997331a0c5a88a5d498bfcc0d8b06cf22d

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
