### PR TITLE
DEV: prevents flakey test

### DIFF
--- a/plugins/chat/spec/requests/api/chat_channels_controller_spec.rb
+++ b/plugins/chat/spec/requests/api/chat_channels_controller_spec.rb
@@ -238,16 +238,19 @@ RSpec.describe Chat::Api::ChatChannelsController do
         end
 
         it "generates a valid new slug to prevent collisions" do
-          SiteSetting.max_topic_title_length = 15
+          SiteSetting.max_topic_title_length = 20
+          channel_1 = Fabricate(:chat_channel, name: "a" * SiteSetting.max_topic_title_length)
           freeze_time(DateTime.parse("2022-07-08 09:30:00"))
           old_slug = channel_1.slug
 
-          delete "/chat/api/channels/#{channel_1.id}",
-                 params: {
-                   channel: {
-                     name_confirmation: channel_1.title(current_user),
-                   },
-                 }
+          delete(
+            "/chat/api/channels/#{channel_1.id}",
+            params: {
+              channel: {
+                name_confirmation: channel_1.title(current_user),
+              },
+            },
+          )
 
           expect(response.status).to eq(200)
           expect(channel_1.reload.slug).to eq(


### PR DESCRIPTION
`SiteSetting.max_topic_title_length` is changed after `channel_1` creation, which has chances to make the future model invalid. The randomness comes from the fixed list of channel titles and the sequence appended to it which makes it more likely to have a long title name if the test happens at the end of the run.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
