### PR TITLE
A11Y: discourse-tags should have a list `role` and `aria-label`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/render-tags.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tags.js
@@ -1,3 +1,4 @@
+import I18n from "I18n";
 import renderTag from "discourse/lib/render-tag";
 
 let callbacks = null;
@@ -56,7 +57,8 @@ export default function (topic, params) {
   }
 
   if (customHtml || (tags && tags.length > 0)) {
-    buffer = "<div class='discourse-tags'>";
+    buffer = `<div class='discourse-tags' role='list' 
+                aria-label=${I18n.t("tagging.tags")}>`;
     if (tags) {
       for (let i = 0; i < tags.length; i++) {
         buffer +=


### PR DESCRIPTION
This isn't marked up as a list at the moment, so tag lists on topics and the topic lists are read as plain individual links without context. For example, if a topic has the tags `cat, dog, rat` the tags are read as "cat link" "dog link" "rat link." 

Adding the list `role` groups the tags together as a single list, and adding the `aria-label` gives the list context. Based on the previous example, when tabbing to the first item in a list of tags, it will now read "tags list with 3 items, cat link"   