### PR TITLE
FEATURE: Add separate api scope for topic status

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -45,6 +45,10 @@ class ApiKeyScope < ActiveRecord::Base
               category_id: :category_slug_path_with_id,
             },
           },
+          status: {
+            actions: %w[topics#status],
+            params: %i[topic_id category_id status enabled],
+          },
         },
         posts: {
           edit: {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4673,6 +4673,7 @@ en:
               write: Create a new topic or post to an existing one.
               update: Update a topic. Change the title, category, tags, status, archetype, featured_link etc.
               read_lists: Read topic lists like top, new, latest, etc. RSS is also supported.
+              status: "Update a topic's status. Status: closed, archive, visisble, pinned. Enabled: true, false. Specify a category_id here and in the request payload to only allow status changes on topics in that category."
             posts:
               edit: Edit any post or a specific one.
             categories:


### PR DESCRIPTION
This will allow us more granular control over changing a topic status.
For example you can now force the scope to only allow closing topics in
a specific category. This means that the same scope can't be used to
re-open topics, or close topics in a different category.
