### PR TITLE
UX: prevent user card status overflow

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -111,7 +111,7 @@
           {{#if this.hasStatus}}
             <h3 class="user-status">
               {{html-safe this.userStatusEmoji}}
-              {{this.user.status.description}}
+              <span>{{this.user.status.description}}</span>
               {{format-date this.user.status.ends_at format="tiny"}}
             </h3>
           {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -111,7 +111,9 @@
           {{#if this.hasStatus}}
             <h3 class="user-status">
               {{html-safe this.userStatusEmoji}}
-              <span>{{this.user.status.description}}</span>
+              <span class="user-status__description">
+                {{this.user.status.description}}
+              </span>
               {{format-date this.user.status.ends_at format="tiny"}}
             </h3>
           {{/if}}

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -307,6 +307,7 @@ h3.user-status {
   }
 
   .relative-date {
+    flex: 1 0 auto;
     text-align: left;
     font-size: var(--font-down-3);
     padding-top: 0.5em;


### PR DESCRIPTION
Before:
![Screenshot 2023-01-24 at 1 34 16 PM](https://user-images.githubusercontent.com/1681963/214378937-0e264f5d-4f78-4b94-bfbc-fd89325d8b83.png)

After: 
![Screenshot 2023-01-24 at 1 34 29 PM](https://user-images.githubusercontent.com/1681963/214378908-741dcb73-d199-48fd-9720-fdd71f7a8a1a.png)
