### PR TITLE
UX: remove extra whitespace in search helper

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -676,7 +676,7 @@ createWidget("search-menu-initial-options", {
       slug: term,
       extraHint: I18n.t("search.enter_hint"),
       label: [
-        h("span.keyword", `${term} `),
+        h("span.keyword", `${term}`),
         opts.withLabel
           ? h("span.label-suffix", I18n.t("search.in_topics_posts"))
           : null,

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -73,7 +73,7 @@ acceptance("Search - Anonymous", function (needs) {
       query(
         ".search-menu .results ul.search-menu-initial-options li:first-child .search-item-slug"
       ).innerText.trim(),
-      `dev ${I18n.t("search.in_topics_posts")}`,
+      `dev${I18n.t("search.in_topics_posts")}`,
       "shows topic search as first dropdown item"
     );
 


### PR DESCRIPTION
We've adjusted margins on surrounding elements, so this whitespace is no longer needed 

Before:
![Screenshot 2023-01-24 at 2 09 17 PM](https://user-images.githubusercontent.com/1681963/214386100-c6bdfa3a-ccce-4f39-a981-dc65471226a4.png)

After:
![Screenshot 2023-01-24 at 2 09 07 PM](https://user-images.githubusercontent.com/1681963/214386114-0576ea91-7dba-4800-ae53-5c8cd4d013c3.png)
