### PR TITLE
SECURITY: Remove bypass for base_url

### DIFF
--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -45,9 +45,6 @@ class EmbeddableHost < ActiveRecord::Base
   def self.url_allowed?(url)
     return false if url.nil?
 
-    # Work around IFRAME reload on WebKit where the referer will be set to the Forum URL
-    return true if url&.starts_with?(Discourse.base_url) && EmbeddableHost.exists?
-
     uri =
       begin
         URI(UrlHelper.normalized_encode(url))

--- a/spec/models/embeddable_host_spec.rb
+++ b/spec/models/embeddable_host_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe EmbeddableHost do
       expect(EmbeddableHost.url_allowed?("http://discourse.org")).to eq(true)
     end
 
-    it "always allow forum own URL" do
-      expect(EmbeddableHost.url_allowed?(Discourse.base_url)).to eq(true)
+    it "does not allow forum own URL" do
+      expect(EmbeddableHost.url_allowed?(Discourse.base_url)).to eq(false)
     end
   end
 


### PR DESCRIPTION
The check used to be necessary because we validated the referrer too and this bypass was a workaround a bug that is present in some browsers that do not send the correct referrer.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
