### PR TITLE
Revert "FIX: TL4 user can see deleted topics (#19946)"

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -209,8 +209,7 @@ module TopicGuardian
   end
 
   def can_see_deleted_topics?(category)
-    is_staff? || is_category_group_moderator?(category) ||
-      (SiteSetting.tl4_delete_posts_and_topics && user.has_trust_level?(TrustLevel[4]))
+    is_staff? || is_category_group_moderator?(category)
   end
 
   # Accepts an array of `Topic#id` and returns an array of `Topic#id` which the user can see.

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -74,27 +74,6 @@ RSpec.describe TopicGuardian do
     end
   end
 
-  describe "#can_see_deleted_topics?" do
-    it "returns true for staff" do
-      expect(Guardian.new(admin).can_see_deleted_topics?(topic.category)).to eq(true)
-    end
-
-    it "returns true for group moderator" do
-      SiteSetting.enable_category_group_moderation = true
-      expect(Guardian.new(user).can_see_deleted_topics?(topic.category)).to eq(false)
-      category.update!(reviewable_by_group_id: group.id)
-      group.add(user)
-      topic.update!(category: category)
-      expect(Guardian.new(user).can_see_deleted_topics?(topic.category)).to eq(true)
-    end
-
-    it "returns true when tl4 can delete posts and topics" do
-      expect(Guardian.new(tl4_user).can_see_deleted_topics?(topic.category)).to eq(false)
-      SiteSetting.tl4_delete_posts_and_topics = true
-      expect(Guardian.new(tl4_user).can_see_deleted_topics?(topic.category)).to eq(true)
-    end
-  end
-
   describe "#can_edit_topic?" do
     context "when the topic is a shared draft" do
       let(:tl2_user) { Fabricate(:user, trust_level: TrustLevel[2]) }


### PR DESCRIPTION
This reverts commit d725c41d186b8910eb2a6cc7264317537c1e654d which is a 3.1 feature.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
