### PR TITLE
SECURITY: Prevent ReDOS by making the SSH url regex unambiguous

### DIFF
--- a/lib/git_url.rb
+++ b/lib/git_url.rb
@@ -2,7 +2,7 @@
 
 module GitUrl
   class << self
-    SSH_REGEXP = /(\w+@(\w+\.)*\w+):(.*)/
+    SSH_REGEXP = /\A(\w+@\w+(\.\w+)*):(.*)\z/
 
     def normalize(url)
       if m = SSH_REGEXP.match(url)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
