### PR TITLE
SECURITY: Update to exclude tag topic filter

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -731,14 +731,17 @@ class TopicQuery
         result = result.where.not(id: TopicTag.distinct.pluck(:topic_id))
       end
 
-      result = result.where(<<~SQL, name: @options[:exclude_tag]) if @options[:exclude_tag].present?
-        topics.id NOT IN (
-          SELECT topic_tags.topic_id
-          FROM topic_tags
-          INNER JOIN tags ON tags.id = topic_tags.tag_id
-          WHERE tags.name = :name
-        )
-        SQL
+      if @options[:exclude_tag].present? &&
+           !DiscourseTagging.hidden_tag_names(@guardian).include?(@options[:exclude_tag])
+        result = result.where(<<~SQL, name: @options[:exclude_tag])
+          topics.id NOT IN (
+            SELECT topic_tags.topic_id
+            FROM topic_tags
+            INNER JOIN tags ON tags.id = topic_tags.tag_id
+            WHERE tags.name = :name
+          )
+          SQL
+      end
     end
 
     result = apply_ordering(result, options)

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -408,11 +408,19 @@ RSpec.describe TopicQuery do
       fab!(:tagged_topic3) { Fabricate(:topic, tags: [tag, other_tag]) }
       fab!(:tagged_topic4) { Fabricate(:topic, tags: [uppercase_tag]) }
       fab!(:no_tags_topic) { Fabricate(:topic) }
+      fab!(:tag_group) do
+        Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [other_tag.name])
+      end
       let(:synonym) { Fabricate(:tag, target_tag: tag, name: "synonym") }
 
       it "excludes a tag if desired" do
         topics = TopicQuery.new(moderator, exclude_tag: tag.name).list_latest.topics
         expect(topics.any? { |t| t.tags.include?(tag) }).to eq(false)
+      end
+
+      it "does not exclude a tagged topic without permission" do
+        topics = TopicQuery.new(user, exclude_tag: other_tag.name).list_latest.topics
+        expect(topics.map(&:id)).to include(tagged_topic2.id)
       end
 
       it "returns topics with the tag when filtered to it" do


### PR DESCRIPTION
Ignores tags specified in exclude_tag topics param that a user does not have access to.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
