### PR TITLE
FIX: fix dragging in horizontal overflow component

### DIFF
--- a/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
+++ b/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
@@ -78,19 +78,20 @@ export default class HorizontalOverflowNav extends Component {
     const mouseDragScroll = function (e) {
       let mouseChange = e.clientX - position.x;
       navPills.scrollLeft = position.left - mouseChange;
-
-      navPills.querySelectorAll("a").forEach((a) => {
-        a.style.cursor = "grabbing";
-      });
     };
 
+    navPills.querySelectorAll("a").forEach((a) => {
+      a.style.cursor = "grabbing";
+    });
+
     const removeDragScroll = function () {
+      document.removeEventListener("mousemove", mouseDragScroll);
       navPills.querySelectorAll("a").forEach((a) => {
         a.style.cursor = "pointer";
       });
     };
 
-    document.addEventListener("mousemove", mouseDragScroll, { once: true });
+    document.addEventListener("mousemove", mouseDragScroll);
     document.addEventListener("mouseup", removeDragScroll, { once: true });
   }
 


### PR DESCRIPTION
Since `mouseDragScroll` has `{ once: true }` we only get `mouseChange` at the drag start, and it's typically 0 because nothing has changed yet. So nothing happens on click and drag. 

`mouseChange` needs to continuously update along with `e.clientX` to adjust the scroll position, so I've removed `once` and have the listener removed on `mouseup`... 