### PR TITLE
FIX: Ensure anon-cached values are never returned for API requests

### DIFF
--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -66,6 +66,7 @@ module Middleware
           !@request.path.ends_with?("srv/status") &&
           @request[Auth::DefaultCurrentUserProvider::API_KEY].nil? &&
           @env[Auth::DefaultCurrentUserProvider::USER_API_KEY].nil? &&
+          @env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY].nil? &&
           CrawlerDetection.is_blocked_crawler?(@env[USER_AGENT])
       end
 
@@ -184,11 +185,13 @@ module Middleware
         request = Rack::Request.new(@env)
         request.cookies["_bypass_cache"].nil? && (request.path != "/srv/status") &&
           request[Auth::DefaultCurrentUserProvider::API_KEY].nil? &&
+          @env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY].nil? &&
           @env[Auth::DefaultCurrentUserProvider::USER_API_KEY].nil?
       end
 
       def force_anonymous!
         @env[Auth::DefaultCurrentUserProvider::USER_API_KEY] = nil
+        @env[Auth::DefaultCurrentUserProvider::HEADER_API_KEY] = nil
         @env["HTTP_COOKIE"] = nil
         @env["HTTP_DISCOURSE_LOGGED_IN"] = nil
         @env["rack.request.cookie.hash"] = {}


### PR DESCRIPTION
Under some situations, we would inadvertently return a public (unauthenticated) result to an authenticated API request. This commit adds the `Api-Key` header to our anonymous cache bypass logic.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
