### PR TITLE
FIX: Category permission change not creating a log

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -196,6 +196,7 @@ class CategoriesController < ApplicationController
       category_params[:minimum_required_tags] = 0 if category_params[:minimum_required_tags]&.blank?
 
       old_permissions = cat.permissions_params
+      old_permissions = { "everyone" => 1 } if old_permissions.empty?
 
       if result = cat.update(category_params)
         Scheduler::Defer.later "Log staff action change category settings" do

--- a/spec/services/staff_action_logger_spec.rb
+++ b/spec/services/staff_action_logger_spec.rb
@@ -439,18 +439,18 @@ RSpec.describe StaffActionLogger do
       expect(name_user_history.new_value).to eq("new_name")
     end
 
-    it "does not log permissions changes for category visible to everyone" do
+    it "logs permissions changes even if the category is visible to everyone" do
       attributes = { name: "new_name" }
-      old_permission = category.permissions_params
+      old_permission = { "everyone" => 1 }
       category.update!(attributes)
 
       logger.log_category_settings_change(
         category,
-        attributes.merge(permissions: { "everyone" => 1 }),
+        attributes.merge(permissions: { "trust_level_3" => 1 }),
         old_permissions: old_permission,
       )
 
-      expect(UserHistory.count).to eq(1)
+      expect(UserHistory.count).to eq(2)
       expect(UserHistory.find_by_subject("name").category).to eq(category)
     end
 


### PR DESCRIPTION
It didn't create a log if the category was public { "everyone" => 1 }

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
