### PR TITLE
A11Y: add accessible label for bookmark name input

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bookmark.hbs
@@ -16,6 +16,7 @@
       @enter={{action "saveAndClose"}}
       placeholder={{i18n "post.bookmarks.name_placeholder"}}
       maxlength="100"
+      aria-label={{i18n "post.bookmarks.name_input_label"}}
     />
     <DButton
       @icon="cog"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3586,6 +3586,7 @@ en:
         updated: "Updated"
         name: "Name"
         name_placeholder: "What is this bookmark for?"
+        name_input_label: "Bookmark name"
         set_reminder: "Remind me"
         options: "Options"
         actions:


### PR DESCRIPTION
The bookmark name input doesn't have an accessible label, so this adds one. 