### PR TITLE
FIX: Intercept old channel URLs in drawer mode

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
@@ -211,6 +211,17 @@ export default Component.extend({
       URL || this.chatStateManager.lastKnownChatURL
     );
 
+    let highlightCb = null;
+
+    if (route.queryParams.messageId) {
+      highlightCb = () => {
+        this.appEvents.trigger(
+          "chat-live-pane:highlight-message",
+          route.queryParams.messageId
+        );
+      };
+    }
+
     switch (route.name) {
       case "chat":
         this.set("view", LIST_VIEW);
@@ -221,23 +232,24 @@ export default Component.extend({
         this.appEvents.trigger("chat:float-toggled", false);
         return;
       case "chat.channel":
-        return this.chatChannelsManager
-          .find(route.params.channelId)
-          .then((channel) => {
-            this.chat.setActiveChannel(channel);
-            this.set("view", CHAT_VIEW);
-            this.appEvents.trigger("chat:float-toggled", false);
-
-            if (route.queryParams.messageId) {
-              schedule("afterRender", () => {
-                this.appEvents.trigger(
-                  "chat-live-pane:highlight-message",
-                  route.queryParams.messageId
-                );
-              });
-            }
-          });
+        return this._openChannel(route, highlightCb);
+      case "chat.channel-legacy":
+        return this._openChannel(route, highlightCb);
     }
+  },
+
+  _openChannel(route, afterRenderFunc = null) {
+    return this.chatChannelsManager
+      .find(route.params.channelId)
+      .then((channel) => {
+        this.chat.setActiveChannel(channel);
+        this.set("view", CHAT_VIEW);
+        this.appEvents.trigger("chat:float-toggled", false);
+
+        if (afterRenderFunc) {
+          schedule("afterRender", afterRenderFunc);
+        }
+      });
   },
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
@@ -16,6 +16,7 @@ export default class ChatChannelRoute extends DiscourseRoute {
     this.chat.setActiveChannel(model);
 
     const { channelTitle, messageId } = this.paramsFor(this.routeName);
+
     if (channelTitle !== model.slugifiedTitle) {
       this.router.replaceWith("chat.channel.index", ...model.routeModels, {
         queryParams: { messageId },

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -23,6 +23,7 @@ export default class ChatRoute extends DiscourseRoute {
     const INTERCEPTABLE_ROUTES = [
       "chat.channel.index",
       "chat.channel",
+      "chat.channel-legacy",
       "chat",
       "chat.index",
       "chat.draft-channel",
@@ -36,7 +37,10 @@ export default class ChatRoute extends DiscourseRoute {
       transition.abort();
 
       let URL = transition.intent.url;
-      if (transition.targetName.startsWith("chat.channel")) {
+      if (
+        transition.targetName.startsWith("chat.channel") ||
+        transition.targetName.startsWith("chat.channel-legacy")
+      ) {
         URL ??= this.router.urlFor(
           transition.targetName,
           ...transition.intent.contexts


### PR DESCRIPTION
Follow-up to https://github.com/discourse/discourse/pull/19782. 

We need to be able to intercept the legacy channel route during drawer mode navigation to
maintain backwards-compatibility with existing oneboxed links.