### PR TITLE
A11Y: post avatars should not be tabbable

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -64,6 +64,7 @@ export function avatarImg(wanted, attrs) {
       title,
       "aria-label": title,
       loading: "lazy",
+      tabindex: "-1",
     },
     className,
   };


### PR DESCRIPTION
The link wrapping avatars already has `aria-hidden="true"` and `tabindex=-1` but the image within only has `alt=""` — this means the image is tabbable, but not read. The image should also have `tabindex=-1` so it's not tabbable. 

(in the case of posts avatars are considered decorative and redundant, because assistive technologies will read the username, which we expose in text immediately following the avatar) 