### PR TITLE
FIX: Failing system spec for rate limited search

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -159,15 +159,15 @@
             />
 
             <ConditionalLoadingSpinner @condition={{this.loading}}>
+              {{#if this.error}}
+                <div class="warning">
+                  {{this.error}}
+                </div>
+              {{/if}}
+
               {{#unless this.hasResults}}
                 {{#if this.searchActive}}
                   <h3>{{i18n "search.no_results"}}</h3>
-
-                  {{#if this.error}}
-                    <div class="warning">
-                      {{this.error}}
-                    </div>
-                  {{/if}}
 
                   {{#if this.showSuggestion}}
                     <div class="no-results-suggestion">

--- a/app/assets/stylesheets/common/base/search.scss
+++ b/app/assets/stylesheets/common/base/search.scss
@@ -18,6 +18,7 @@
   .warning {
     background-color: var(--danger-medium);
     padding: 5px 8px;
+    margin-block: 0.5rem;
     color: var(--secondary);
   }
 

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -41,30 +41,14 @@ describe "Search", type: :system, js: true do
     before do
       SearchIndexer.enable
       SearchIndexer.index(topic, force: true)
-      SiteSetting.rate_limit_search_anon_user_per_minute = 15
+      SiteSetting.rate_limit_search_anon_user_per_minute = 4
       RateLimiter.enable
     end
 
     after { SearchIndexer.disable }
 
     it "rate limits searches for anonymous users" do
-      queries = %w[
-        one
-        two
-        three
-        four
-        five
-        six
-        seven
-        eight
-        nine
-        ten
-        eleven
-        twelve
-        thirteen
-        fourteen
-        fifteen
-      ]
+      queries = %w[one two three four]
 
       visit("/search?expanded=true")
 


### PR DESCRIPTION
This PR fixes a failing system spec testing rate limited searches. It does so by ensuring the warning is seen even when there are no search results.

This PR also:
- makes a minor CSS change due to re-ordering of warning alert
- simplifies rate limit searches down to `4`