### PR TITLE
FIX: Better UX for timezones selector in date modal

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/templates/components/discourse-local-dates-create-form.hbs
@@ -133,6 +133,19 @@
           </div>
         {{/unless}}
 
+        <div class="control-group timezones">
+          <label>{{i18n
+            "discourse_local_dates.create.form.timezones_title"
+            }}</label>
+          <p>{{i18n
+            "discourse_local_dates.create.form.timezones_description"
+            }}</p>
+          <div class="controls">
+            <MultiSelect @valueProperty={{null}} @nameProperty={{null}} @class="timezones-input" @content={{this.allTimezones}}
+              @value={{this.timezones}} @options={{hash allowAny=false maximum=5}} />
+          </div>
+        </div>
+
         <div class="control-group format">
           <label>{{i18n
               "discourse_local_dates.create.form.format_title"
@@ -168,25 +181,6 @@
               </li>
             {{/each}}
           </ul>
-        </div>
-
-        <div class="control-group timezones">
-          <label>{{i18n
-              "discourse_local_dates.create.form.timezones_title"
-            }}</label>
-          <p>{{i18n
-              "discourse_local_dates.create.form.timezones_description"
-            }}</p>
-          <div class="controls">
-            <MultiSelect
-              @valueProperty={{null}}
-              @nameProperty={{null}}
-              @class="timezones-input"
-              @content={{this.allTimezones}}
-              @value={{this.timezones}}
-              @options={{hash allowAny=false maximum=5}}
-            />
-          </div>
         </div>
       </div>
     {{/if}}

--- a/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
+++ b/plugins/discourse-local-dates/assets/stylesheets/common/discourse-local-dates.scss
@@ -265,7 +265,7 @@ div[data-tippy-root] {
 
     .recurrence {
       .recurrence-input {
-        width: 300px;
+        width: 350px;
       }
     }
   }
@@ -298,7 +298,7 @@ div[data-tippy-root] {
   }
 
   .timezones-input {
-    width: 99%;
+    width: 350px;
   }
 }
 


### PR DESCRIPTION
When expanding the "Advanced mode" of the date modal, the Timezones picker was at the bottom of the modal, and expanding it would often overflow the viewport. This PR moves the elment higher up, therefore avoiding the overflow.

There's a small width change as well, for better consistency.

Before

<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/215194107-21508350-d6f9-48b7-bb1c-9fcb09141408.png">

After

<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/215194055-523d86db-a7b8-47dc-aa7e-a9bc63bb7a9c.png">
