### PR TITLE
FIX: correct various mistakes in chat-notification-manager

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
@@ -11,8 +11,8 @@ import { bind, observes } from "discourse-common/utils/decorators";
 export default class ChatNotificationManager extends Service {
   @service presence;
   @service chat;
+  @service chatStateManager;
 
-  _inChat = false;
   _subscribedToCore = true;
   _subscribedToChat = false;
   _countChatInDocTitle = true;
@@ -57,8 +57,7 @@ export default class ChatNotificationManager extends Service {
 
   @bind
   _pageChanged(path) {
-    this.set("_inChat", path.startsWith("/chat/c/"));
-    if (this._inChat) {
+    if (this.chatStateManager.isActive) {
       this._chatPresenceChannel.enter({ onlyWhileActive: false });
       this._corePresenceChannel.leave();
     } else {
@@ -85,7 +84,7 @@ export default class ChatNotificationManager extends Service {
       this._chatPresenceChannel.count > 0 &&
       this._corePresenceChannel.count > 0;
     if (oneTabForEachOpen) {
-      this._inChat
+      this.chatStateManager.isActive
         ? this._subscribeToChat({ only: true })
         : this._subscribeToCore({ only: true });
     } else {
@@ -119,7 +118,7 @@ export default class ChatNotificationManager extends Service {
       this.messageBus.subscribe(this._coreAlertChannel(), this.onMessage);
     }
 
-    if (this.only && this._subscribedToChat) {
+    if (opts.only && this._subscribedToChat) {
       this.messageBus.unsubscribe(this._chatAlertChannel(), this.onMessage);
       this.set("_subscribedToChat", false);
     }


### PR DESCRIPTION
- The code was still handling global chat through its own variable instead of relying on `ChatStateManager`
- There was a typo were the code was using `this` instead of `opts`

Note notifications are a future big work of this year and this should be heavily reworked and tested.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
