### PR TITLE
FEATURE: hidden site setting to disable search prefix matching

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2192,6 +2192,9 @@ backups:
     client: true
 
 search:
+  enable_search_prefix_matching:
+    default: true
+    hidden: true
   use_pg_headlines_for_excerpt:
     default: false
     hidden: true

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1237,7 +1237,8 @@ class Search
   end
 
   def self.set_tsquery_weight_filter(term, weight_filter)
-    "'#{self.escape_string(term)}':*#{weight_filter}"
+    optional_star = SiteSetting.enable_search_prefix_matching ? "*" : ""
+    "'#{self.escape_string(term)}':#{optional_star}#{weight_filter}"
   end
 
   def self.escape_string(term)

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2580,4 +2580,25 @@ RSpec.describe Search do
       expect(result.categories.length).to eq(0)
     end
   end
+
+  context "when enable_search_prefix_matching is disabled" do
+    before do
+      SearchIndexer.enable
+      SiteSetting.enable_search_prefix_matching = false
+    end
+
+    fab!(:post) do
+      Fabricate(:post, topic: topic, raw: "this body of the post contains abracadabra")
+    end
+
+    it "omits prefix search results" do
+      SearchIndexer.index(post, force: true)
+
+      result = Search.execute("abra")
+      expect(result.posts.length).to eq(0)
+
+      result = Search.execute("abracadabra")
+      expect(result.posts.length).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Many users seems surprised by prefix matching in search leading to
unexpected results.

Over the years we always would return results starting with a search term
and not expect exact matches.

Meaning a search for `abra` would find `abracadabra`

This introduces the Site Setting `enable_search_prefix_matching` which
defaults to true. (behavior unchanged)

We plan to experiment on select sites with exact matches to see if the
results are less surprising
