### PR TITLE
DEV: Start threading for chat

### DIFF
--- a/plugins/chat/app/models/chat_channel.rb
+++ b/plugins/chat/app/models/chat_channel.rb
@@ -164,6 +164,7 @@ end
 #  user_count_stale             :boolean          default(FALSE), not null
 #  slug                         :string
 #  type                         :string
+#  threading_enabled            :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/plugins/chat/config/settings.yml
+++ b/plugins/chat/config/settings.yml
@@ -113,3 +113,6 @@ chat:
   max_chat_draft_length:
     default: 50_000
     hidden: true
+  enable_experimental_chat_threaded_discussions:
+    default: false
+    hidden: true

--- a/plugins/chat/db/migrate/20230130053144_add_threading_enabled_to_chat_channels.rb
+++ b/plugins/chat/db/migrate/20230130053144_add_threading_enabled_to_chat_channels.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddThreadingEnabledToChatChannels < ActiveRecord::Migration[7.0]
+  def change
+    add_column :chat_channels, :threading_enabled, :boolean, default: false, null: false
+  end
+end


### PR DESCRIPTION
Adds hidden `enable_experimental_chat_threaded_discussions`
setting which will control whether threads show in the UI,
alongside the `ChatChannel.threading_enabled` boolean column,
which does the same. The former is a global switch for this
feature, while the latter can be used to allow single channels
to show this new functionality if the site setting is true.

Neither setting impacts whether `ChatThread` records (which will
be added in a future PR) will be created, they will always be
made regardless.
