### PR TITLE
FEATURE: allow restricting duplication in search index

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2192,6 +2192,9 @@ backups:
     client: true
 
 search:
+  max_duplicate_search_index_terms:
+    default: -1
+    hidden: true
   use_pg_headlines_for_excerpt:
     default: false
     hidden: true

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -303,6 +303,20 @@ RSpec.describe SearchIndexer do
         "unca",
       )
     end
+
+    it "limits number of repeated terms when max_duplicate_search_index_terms site setting has been configured" do
+      SiteSetting.max_duplicate_search_index_terms = 5
+
+      contents = "I am #{"sam " * 10}"
+      post.update!(raw: contents)
+
+      post_search_data = post.post_search_data
+      post_search_data.reload
+
+      expect(post_search_data.search_data).to eq(
+        "'sam':12,13,14,15,16 'test':8A 'titl':4A 'uncategor':9B",
+      )
+    end
   end
 
   describe ".queue_post_reindex" do


### PR DESCRIPTION
This introduces the site setting `max_duplicate_search_index_terms`.
Using this number we can limit the amount of duplication in our search index.

This allows us to more correctly weigh title searches, so bloated posts
with many repeat words don't unfairly bump to the top of search results.

This feature is completely disabled by default and behind a site setting

We will experiment with it first. Note entire search index must be rebuilt
for it to take effect.
