### PR TITLE
DEV: Remove 'elder' from codebase and also update 'regular' to 'member'

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -368,9 +368,9 @@ const User = RestModel.extend({
   },
 
   isBasic: equal("trust_level", 0),
-  isLeader: equal("trust_level", 3),
-  isElder: equal("trust_level", 4),
-  canManageTopic: or("staff", "isElder"),
+  isRegular: equal("trust_level", 3),
+  isLeader: equal("trust_level", 4),
+  canManageTopic: or("staff", "isLeader"),
 
   @discourseComputed("previous_visit_at")
   previousVisitAt(previous_visit_at) {

--- a/app/assets/javascripts/discourse/tests/fixtures/badges-fixture.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/badges-fixture.js
@@ -141,7 +141,7 @@ export default {
       },
       {
         id: 2,
-        name: "Regular User",
+        name: "Member",
         description: null,
         grant_count: 467,
         allow_title: false,
@@ -170,7 +170,7 @@ export default {
       },
       {
         id: 4,
-        name: "Elder",
+        name: "Leader",
         description: null,
         grant_count: 4,
         allow_title: true,

--- a/app/controllers/composer_controller.rb
+++ b/app/controllers/composer_controller.rb
@@ -102,7 +102,7 @@ class ComposerController < ApplicationController
         :not_allowed
       end
 
-    # Regular users can see only basic information why the users cannot see the topic.
+    # Non-staff users can see only basic information why the users cannot see the topic.
     reason = nil if !guardian.is_staff? && reason != :private && reason != :category
 
     reason

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2197,9 +2197,9 @@ en:
 
     topic_page_title_includes_category: "Topic page <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title' target='_blank'>title tag</a> includes the category name."
 
-    native_app_install_banner_ios: "Displays DiscourseHub app banner on iOS devices to regular users (trust level 1 and up)."
+    native_app_install_banner_ios: "Displays DiscourseHub app banner on iOS devices to basic users (trust level 1) and up."
 
-    native_app_install_banner_android: "Displays DiscourseHub app banner on Android devices to regular users (trust level 1 and up)."
+    native_app_install_banner_android: "Displays DiscourseHub app banner on Android devices to basic users (trust level 1) and up."
 
     app_association_android: "Contents of <a href='%{base_path}/.well-known/assetlinks.json'>.well-known/assetlinks.json</a> endpoint, used for Google's Digital Asset Links API."
     app_association_ios: "Contents of <a href='%{base_path}/apple-app-site-association'>apple-app-site-association</a> endpoint, used to create Universal Links between this site and iOS apps."


### PR DESCRIPTION
A while back the definition of TL was changed. This commit removes the 'elder' definition in the codebase and also updates 'regular' (previously TL2).

Related: 
- https://github.com/discourse/discourse/blob/939c2a73712380b528f9bb033267b30d14bdbfb1/db/migrate/20140905055251_rename_trust_level_badges.rb#L10-L14

and
- https://github.com/discourse/discourse/blob/939c2a73712380b528f9bb033267b30d14bdbfb1/lib/trust_level.rb#L13-L15


Something else to note is that we use a lot of "regular user" in tests in the codebase, but we probably actually mean "non-admin user", since "regular user" actually has the implicit meaning of a TL3 user. I explicitly avoided doing a replacement.