### PR TITLE
FIX: Extend username updates to self-mentions

### DIFF
--- a/app/jobs/regular/update_username.rb
+++ b/app/jobs/regular/update_username.rb
@@ -48,8 +48,7 @@ module Jobs
 
       Post
         .with_deleted
-        .joins(mentioned("posts.id"))
-        .where("a.user_id = :user_id", user_id: @user_id)
+        .where("raw ILIKE ?", "%@#{@old_username}%")
         .find_each do |post|
           update_post(post)
           updated_post_ids << post.id
@@ -64,8 +63,7 @@ module Jobs
 
     def update_revisions
       PostRevision
-        .joins(mentioned("post_revisions.post_id"))
-        .where("a.user_id = :user_id", user_id: @user_id)
+        .where("modifications SIMILAR TO ?", "%(raw|cooked)%@#{@old_username}%")
         .find_each { |revision| update_revision(revision) }
 
       PostRevision

--- a/spec/services/username_changer_spec.rb
+++ b/spec/services/username_changer_spec.rb
@@ -327,6 +327,54 @@ RSpec.describe UsernameChanger do
           )
         end
 
+        it "replaces mentions of oneself in posts" do
+          post = create_post_and_change_username(raw: "Hello @#{user.username}", user: user)
+
+          expect(post.raw).to eq("Hello @bar")
+          expect(post.cooked).to eq(%Q(<p>Hello <a class="mention" href="/u/bar">@bar</a></p>))
+        end
+
+        it "replaces mentions of oneself in revisions" do
+          revisions = [
+            { raw: "Hello Foo" },
+            { title: "new topic title" },
+            { raw: "Hello @#{user.username}!" },
+            { raw: "Hello @#{user.username}!!" },
+          ]
+
+          post =
+            create_post_and_change_username(raw: "Hello @#{user.username}", revisions: revisions)
+
+          expect(post.raw).to eq("Hello @bar!!")
+          expect(post.cooked).to eq(%Q(<p>Hello <a class="mention" href="/u/bar">@bar</a>!!</p>))
+
+          expect(post.revisions.count).to eq(4)
+
+          expect(post.revisions[0].modifications["raw"][0]).to eq("Hello @bar")
+          expect(post.revisions[0].modifications["cooked"][0]).to eq(
+            %Q(<p>Hello <a class="mention" href="/u/bar">@bar</a></p>),
+          )
+          expect(post.revisions[0].modifications["cooked"][1]).to eq("<p>Hello Foo</p>")
+
+          expect(post.revisions[1].modifications).to include("title")
+
+          expect(post.revisions[2].modifications["raw"][0]).to eq("Hello Foo")
+          expect(post.revisions[2].modifications["raw"][1]).to eq("Hello @bar!")
+          expect(post.revisions[2].modifications["cooked"][0]).to eq("<p>Hello Foo</p>")
+          expect(post.revisions[2].modifications["cooked"][1]).to eq(
+            %Q(<p>Hello <a class="mention" href="/u/bar">@bar</a>!</p>),
+          )
+
+          expect(post.revisions[3].modifications["raw"][0]).to eq("Hello @bar!")
+          expect(post.revisions[3].modifications["raw"][1]).to eq("Hello @bar!!")
+          expect(post.revisions[3].modifications["cooked"][0]).to eq(
+            %Q(<p>Hello <a class="mention" href="/u/bar">@bar</a>!</p>),
+          )
+          expect(post.revisions[3].modifications["cooked"][1]).to eq(
+            %Q(<p>Hello <a class="mention" href="/u/bar">@bar</a>!!</p>),
+          )
+        end
+
         context "when using Unicode usernames" do
           before { SiteSetting.unicode_usernames = true }
           let(:user) { Fabricate(:user, username: "թռչուն") }


### PR DESCRIPTION
Posts with self-mentions aren't updated with username updates. This happens because mention `UserAction` entries aren't logged for self-mentions.

This change updates the lookup of `Post` and `PostRevision` with mentions to bypass `UserAction` entries.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
