### PR TITLE
Revert "DEV: uses popperjs for positioning user and group card"

### DIFF
--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -37,17 +37,14 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
   color: var(--primary);
   background: var(--secondary) center center;
   background-size: cover;
+  transition: opacity 0.2s, transform 0.2s;
+  opacity: 0;
   outline: 2px solid transparent;
-
-  &[data-popper-placement] {
-    opacity: 0;
-  }
-
-  &[data-popper-placement]:not([data-popper-placement=""]) {
+  @include transform(scale(0.9));
+  &.show {
     opacity: 1;
-    transition: opacity 0.5s;
+    @include transform(scale(1));
   }
-
   .card-content {
     padding: 10px;
     background: rgba(var(--secondary-rgb), 0.85);

--- a/app/assets/stylesheets/desktop/components/user-card.scss
+++ b/app/assets/stylesheets/desktop/components/user-card.scss
@@ -1,6 +1,7 @@
 // shared styles for user and group cards
 .user-card,
 .group-card {
+  position: absolute;
   z-index: z("usercard");
   &.fixed {
     position: fixed;

--- a/app/assets/stylesheets/mobile/components/user-card.scss
+++ b/app/assets/stylesheets/mobile/components/user-card.scss
@@ -3,6 +3,7 @@ $avatar_width: 120px;
 // shared styles for user and group cards
 .user-card,
 .group-card {
+  position: fixed;
   // mobile cards should always be on top of everything - 1102
   z-index: z("mobile-composer") + 2;
   max-width: 95vw;


### PR DESCRIPTION
We have noted that User Cards can’t be seen, so we’re reverting as instructed. 