### PR TITLE
Revert "FEATURE: hidden site setting to disable search prefix matching (#20058)"

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2192,9 +2192,6 @@ backups:
     client: true
 
 search:
-  enable_search_prefix_matching:
-    default: true
-    hidden: true
   use_pg_headlines_for_excerpt:
     default: false
     hidden: true

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1237,8 +1237,7 @@ class Search
   end
 
   def self.set_tsquery_weight_filter(term, weight_filter)
-    optional_star = SiteSetting.enable_search_prefix_matching ? "*" : ""
-    "'#{self.escape_string(term)}':#{optional_star}#{weight_filter}"
+    "'#{self.escape_string(term)}':*#{weight_filter}"
   end
 
   def self.escape_string(term)

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -2580,25 +2580,4 @@ RSpec.describe Search do
       expect(result.categories.length).to eq(0)
     end
   end
-
-  context "when enable_search_prefix_matching is disabled" do
-    before do
-      SearchIndexer.enable
-      SiteSetting.enable_search_prefix_matching = false
-    end
-
-    fab!(:post) do
-      Fabricate(:post, topic: topic, raw: "this body of the post contains abracadabra")
-    end
-
-    it "omits prefix search results" do
-      SearchIndexer.index(post, force: true)
-
-      result = Search.execute("abra")
-      expect(result.posts.length).to eq(0)
-
-      result = Search.execute("abracadabra")
-      expect(result.posts.length).to eq(1)
-    end
-  end
 end


### PR DESCRIPTION
This reverts commit 64f7b97d083a99a99f6bf91c32f4a2ba6b781d86.

Too many side effects for this setting, we have decided to remove it
