### PR TITLE
DEV: makes test more deterministic

### DIFF
--- a/plugins/chat/lib/extensions/user_notifications_extension.rb
+++ b/plugins/chat/lib/extensions/user_notifications_extension.rb
@@ -69,7 +69,10 @@ module Chat::UserNotificationsExtension
 
     # Prioritize messages from regular channels over direct messages
     if channels.any?
-      channel_notification_text(channels.sort_by(&:last_message_sent_at), dm_users)
+      channel_notification_text(
+        channels.sort_by { |channel| [channel.last_message_sent_at, channel.created_at] },
+        dm_users,
+      )
     else
       direct_message_notification_text(dm_users)
     end


### PR DESCRIPTION
`last_message_sent_at` could be equal and as a result the order would be random causing random spec failures in plugins/chat/spec/mailers/user_notifications_spec.rb:182

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
