### PR TITLE
FIX: Error calling LazyYT from chat when the plugin it's disabled

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-plugin-decorators.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-plugin-decorators.js
@@ -34,19 +34,20 @@ export default {
         }
       );
     }
-
-    api.decorateChatMessage(
-      (element) => {
-        element
-          .querySelectorAll(".lazyYT:not(.lazyYT-video-loaded)")
-          .forEach((iframe) => {
-            $(iframe).lazyYT();
-          });
-      },
-      {
-        id: "lazy-yt",
-      }
-    );
+    if (siteSettings.lazy_yt_enabled) {
+      api.decorateChatMessage(
+        (element) => {
+          element
+            .querySelectorAll(".lazyYT:not(.lazyYT-video-loaded)")
+            .forEach((iframe) => {
+              $(iframe).lazyYT();
+            });
+        },
+        {
+          id: "lazy-yt",
+        }
+      );
+    }
   },
 
   initialize(container) {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
