### PR TITLE
SECURITY: Hide PM count for tags by default (#20061)

### DIFF
--- a/app/assets/javascripts/discourse/app/models/tag.js
+++ b/app/assets/javascripts/discourse/app/models/tag.js
@@ -1,15 +1,13 @@
 import RestModel from "discourse/models/rest";
 import discourseComputed from "discourse-common/utils/decorators";
+import { readOnly } from "@ember/object/computed";
 
 export default RestModel.extend({
-  @discourseComputed("count", "pm_count")
-  totalCount(count, pmCount) {
-    return count + pmCount;
-  },
+  pmOnly: readOnly("pm_only"),
 
   @discourseComputed("count", "pm_count")
-  pmOnly(count, pmCount) {
-    return count === 0 && pmCount > 0;
+  totalCount(count, pmCount) {
+    return pmCount ? count + pmCount : count;
   },
 
   @discourseComputed("id")

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -100,8 +100,8 @@ export function applyDefaultHandlers(pretender) {
     return response({
       tags: [
         { id: "eviltrout", count: 1 },
-        { id: "planned", text: "planned", count: 7, pm_count: 0 },
-        { id: "private", text: "private", count: 0, pm_count: 7 },
+        { id: "planned", text: "planned", count: 7, pm_only: false },
+        { id: "private", text: "private", count: 0, pm_only: true },
       ],
       extras: {
         tag_groups: [
@@ -109,24 +109,24 @@ export function applyDefaultHandlers(pretender) {
             id: 2,
             name: "Ford Cars",
             tags: [
-              { id: "Escort", text: "Escort", count: 1, pm_count: 0 },
-              { id: "focus", text: "focus", count: 3, pm_count: 0 },
+              { id: "Escort", text: "Escort", count: 1, pm_only: false },
+              { id: "focus", text: "focus", count: 3, pm_only: false },
             ],
           },
           {
             id: 1,
             name: "Honda Cars",
             tags: [
-              { id: "civic", text: "civic", count: 4, pm_count: 0 },
-              { id: "accord", text: "accord", count: 2, pm_count: 0 },
+              { id: "civic", text: "civic", count: 4, pm_only: false },
+              { id: "accord", text: "accord", count: 2, pm_only: false },
             ],
           },
           {
             id: 1,
             name: "Makes",
             tags: [
-              { id: "ford", text: "ford", count: 5, pm_count: 0 },
-              { id: "honda", text: "honda", count: 6, pm_count: 0 },
+              { id: "ford", text: "ford", count: 5, pm_only: false },
+              { id: "honda", text: "honda", count: 6, pm_only: false },
             ],
           },
         ],

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/tag-drop-test.js
@@ -28,7 +28,7 @@ module("Integration | Component | select-kit/tag-drop", function (hooks) {
     pretender.get("/tags/filter/search", (params) => {
       if (params.queryParams.q === "dav") {
         return response({
-          results: [{ id: "David", name: "David", count: 2, pm_count: 0 }],
+          results: [{ id: "David", name: "David", count: 2, pm_only: false }],
         });
       }
     });

--- a/app/assets/javascripts/discourse/tests/unit/models/tag-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/tag-test.js
@@ -1,0 +1,31 @@
+import { module, test } from "qunit";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { setupTest } from "ember-qunit";
+
+module("Unit | Model | tag", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = getOwner(this).lookup("service:store");
+  });
+
+  test("totalCount when pm_count is not present", function (assert) {
+    const tag = this.store.createRecord("tag", { count: 5 });
+    assert.strictEqual(tag.totalCount, 5);
+  });
+
+  test("totalCount when pm_count is present", function (assert) {
+    const tag = this.store.createRecord("tag", { count: 5, pm_count: 8 });
+    assert.strictEqual(tag.totalCount, 13);
+  });
+
+  test("pmOnly", function (assert) {
+    const tag = this.store.createRecord("tag", { pm_only: false });
+
+    assert.notOk(tag.pmOnly);
+
+    tag.set("pm_only", true);
+
+    assert.ok(tag.pmOnly);
+  });
+});

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -396,16 +396,22 @@ class TagsController < ::ApplicationController
 
         next if topic_count == 0 && t.pm_topic_count > 0 && !show_pm_tags
 
-        {
+        attrs = {
           id: t.name,
           text: t.name,
           name: t.name,
           description: t.description,
           count: topic_count,
-          pm_count: show_pm_tags ? t.pm_topic_count : 0,
+          pm_only: topic_count == 0 && t.pm_topic_count > 0,
           target_tag:
             t.target_tag_id ? target_tags.find { |x| x.id == t.target_tag_id }&.name : nil,
         }
+
+        if show_pm_tags && SiteSetting.display_personal_messages_tag_counts
+          attrs[:pm_count] = t.pm_topic_count
+        end
+
+        attrs
       end
       .compact
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1652,6 +1652,7 @@ en:
     content_security_policy_script_src: "Additional allowlisted script sources. The current host and CDN are included by default. See <a href='https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243' target='_blank'>Mitigate XSS Attacks with Content Security Policy.</a>"
     invalidate_inactive_admin_email_after_days: "Admin accounts that have not visited the site in this number of days will need to re-validate their email address before logging in. Set to 0 to disable."
     include_secure_categories_in_tag_counts: "When enabled, count of topics for a tag will include topics that are in read restricted categories for all users. When disabled, normal users are only shown a count of topics for a tag where all the topics are in public categories."
+    display_personal_messages_tag_counts: "When enabled, count of personal messages tagged with a given tag will be displayed."
     top_menu: "Determine which items appear in the homepage navigation, and in what order. Example latest|new|unread|categories|top|read|posted|bookmarks"
     post_menu: "Determine which items appear on the post menu, and in what order. Example like|edit|flag|delete|share|bookmark|reply"
     post_menu_hidden_items: "The menu items to hide by default in the post menu unless an expansion ellipsis is clicked on."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1788,6 +1788,8 @@ security:
     hidden: true
   include_secure_categories_in_tag_counts:
     default: false
+  display_personal_messages_tag_counts:
+    default: false
 
 onebox:
   post_onebox_maxlength:


### PR DESCRIPTION
Currently `Topic#pm_topic_count` is a count of all personal messages tagged for a given tag. As a result, any user with access to PM tags can poll a sensitive tag to determine if a new personal message has been created using that tag even if the user does not have access to the personal message. We classify this as a minor leak in sensitive information.

With this commit, `Topic#pm_topic_count` is hidden from users by default unless the `display_personal_messages_tag_counts` site setting is enabled.
