### PR TITLE
DEV: Move back to web-push gem (stable)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -261,12 +261,7 @@ if ENV["IMPORT"] == "1"
   gem "parallel", require: false
 end
 
-# workaround for openssl 3.0, see
-# https://github.com/pushpad/web-push/pull/2
-gem "web-push",
-    require: false,
-    git: "https://github.com/xfalcox/web-push",
-    branch: "openssl-3-compat"
+gem "web-push"
 gem "colored2", require: false
 gem "maxminddb"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,15 +5,6 @@ GIT
     mail (2.8.0.edge)
       mini_mime (>= 0.1.1)
 
-GIT
-  remote: https://github.com/xfalcox/web-push
-  revision: 369df8f475a4cd4832a7679bec16576665f24d24
-  branch: openssl-3-compat
-  specs:
-    web-push (2.1.0)
-      hkdf (~> 1.0)
-      jwt (~> 2.0)
-      openssl (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -483,6 +474,10 @@ GEM
     uri (0.12.0)
     uri_template (0.7.0)
     version_gem (1.1.1)
+    web-push (3.0.0)
+      hkdf (~> 1.0)
+      jwt (~> 2.0)
+      openssl (~> 3.0)
     webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -638,7 +633,7 @@ DEPENDENCIES
   uglifier
   unf
   unicorn
-  web-push!
+  web-push
   webdrivers
   webmock
   webrick


### PR DESCRIPTION
The original description from `main` also applies to `stable` branch now as the stable hosted sites are now running on the Ruby 3+ version:

>Our fork was needed for OpenSSL 3 and Ruby 2.X compatibility.
>The OpenSSL 3 part was merged into the gem for version 3.
>Discourse dropped support for Ruby 2.X.
>That means we don't need our fork anymore.