### PR TITLE
DEV: Fix flaky specs by explicitly ordering tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -42,6 +42,7 @@ class TagsController < ::ApplicationController
     if SiteSetting.tags_listed_by_group
       ungrouped_tags = Tag.where("tags.id NOT IN (SELECT tag_id FROM tag_group_memberships)")
       ungrouped_tags = ungrouped_tags.used_tags_in_regular_topics(guardian) unless show_all_tags
+      ungrouped_tags = ungrouped_tags.order(:id)
 
       grouped_tag_counts =
         TagGroup
@@ -60,6 +61,7 @@ class TagsController < ::ApplicationController
       @extras = { tag_groups: grouped_tag_counts }
     else
       tags = show_all_tags ? Tag.all : Tag.used_tags_in_regular_topics(guardian)
+      tags = tags.order(:id)
       unrestricted_tags = DiscourseTagging.filter_visible(tags.where(target_tag_id: nil), guardian)
 
       categories =


### PR DESCRIPTION
This should fix the following flaky spec failures:

```
1) TagsController#index with tags_listed_by_group disabled does not result in N+1 queries when there are multiple categories configured with tags for an admin user
     Failure/Error: expect(tags.map { |tag| tag["name"] }).to eq([test_tag.name, topic_tag.name])

       expected: ["test", "topic-test"]
            got: ["topic-test", "test"]

       (compared using ==)
     # ./spec/requests/tags_controller_spec.rb:274:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:366:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

  2) TagsController#index with tags_listed_by_group disabled returns the right tags and categories tags for admin user
     Failure/Error: expect(tags[0]["name"]).to eq(test_tag.name)

       expected: "test"
            got: "topic-test"

       (compared using ==)
     # ./spec/requests/tags_controller_spec.rb:241:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:366:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

  3) TagsController#index with tags_listed_by_group disabled does not include pm_count attribute when user cannot tag PM topics even if display_personal_messages_tag_counts site setting has been enabled
     Failure/Error: expect(tags[0]["name"]).to eq(test_tag.name)

       expected: "test"
            got: "topic-test"

       (compared using ==)
     Shared Example Group: "retrieves the right tags" called from ./spec/requests/tags_controller_spec.rb:226
     # ./spec/requests/tags_controller_spec.rb:66:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:366:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

  4) TagsController#index with tags_listed_by_group enabled does not include pm_count attribute when user cannot tag PM topics even if display_personal_messages_tag_counts site setting has been enabled
     Failure/Error: expect(tags[0]["name"]).to eq(test_tag.name)

       expected: "test"
            got: "topic-test"

       (compared using ==)
     Shared Example Group: "retrieves the right tags" called from ./spec/requests/tags_controller_spec.rb:[166](https://github.com/discourse/discourse/actions/runs/4052877565/jobs/6972822899#step:23:167)
     # ./spec/requests/tags_controller_spec.rb:66:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:366:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```