### PR TITLE
Deprecate plugin outlet tagname

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/themes-list-item.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/themes-list-item.hbs
@@ -1,10 +1,11 @@
 <div class="inner-wrapper">
-  <PluginOutlet
-    @name="admin-customize-themes-list-item"
-    @tagName="span"
-    @connectorTagName="span"
-    @args={{hash theme=this.theme}}
-  />
+  <span>
+    <PluginOutlet
+      @name="admin-customize-themes-list-item"
+      @connectorTagName="span"
+      @args={{hash theme=this.theme}}
+    />
+  </span>
 
   <div class="info">
     <span class="name">

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -1,10 +1,11 @@
 <div class="show-current-style">
-  <PluginOutlet
-    @name="admin-customize-themes-show-top"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash theme=this.model}}
-  />
+  <span>
+    <PluginOutlet
+      @name="admin-customize-themes-show-top"
+      @connectorTagName="div"
+      @args={{hash theme=this.model}}
+    />
+  </span>
   <div class="title">
     {{#if this.editingName}}
       <TextField @value={{this.model.name}} @autofocus="true" />

--- a/app/assets/javascripts/admin/addon/templates/dashboard.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard.hbs
@@ -1,8 +1,6 @@
-<PluginOutlet
-  @name="admin-dashboard-top"
-  @tagName="span"
-  @connectorTagName="div"
-/>
+<span>
+  <PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />
+</span>
 
 {{#if this.showVersionChecks}}
   <div class="section-top">
@@ -57,8 +55,6 @@
 
 <DashboardNewFeatures @tagName="div" />
 
-<PluginOutlet
-  @name="admin-dashboard-bottom"
-  @tagName="span"
-  @connectorTagName="div"
-/>
+<span>
+  <PluginOutlet @name="admin-dashboard-bottom" @connectorTagName="div" />
+</span>

--- a/app/assets/javascripts/admin/addon/templates/dashboard_general.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_general.hbs
@@ -1,9 +1,7 @@
 <ConditionalLoadingSpinner @condition={{this.isLoading}}>
-  <PluginOutlet
-    @name="admin-dashboard-general-top"
-    @tagName="span"
-    @connectorTagName="div"
-  />
+  <span>
+    <PluginOutlet @name="admin-dashboard-general-top" @connectorTagName="div" />
+  </span>
 
   {{#if this.isCommunityHealthVisible}}
     <div class="community-health section">
@@ -197,9 +195,10 @@
     {{/if}}
   </div>
 
-  <PluginOutlet
-    @name="admin-dashboard-general-bottom"
-    @tagName="span"
-    @connectorTagName="div"
-  />
+  <span>
+    <PluginOutlet
+      @name="admin-dashboard-general-bottom"
+      @connectorTagName="div"
+    />
+  </span>
 </ConditionalLoadingSpinner>

--- a/app/assets/javascripts/admin/addon/templates/dashboard_moderation.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_moderation.hbs
@@ -1,9 +1,10 @@
 <div class="sections">
-  <PluginOutlet
-    @name="admin-dashboard-moderation-top"
-    @tagName="span"
-    @connectorTagName="div"
-  />
+  <span>
+    <PluginOutlet
+      @name="admin-dashboard-moderation-top"
+      @connectorTagName="div"
+    />
+  </span>
 
   {{#if this.isModeratorsActivityVisible}}
     <div class="moderators-activity section">
@@ -49,11 +50,12 @@
       @reportOptions={{this.userFlaggingRatioOptions}}
     />
 
-    <PluginOutlet
-      @name="admin-dashboard-moderation-bottom"
-      @tagName="span"
-      @connectorTagName="div"
-      @args={{hash filters=this.lastWeekfilters}}
-    />
+    <span>
+      <PluginOutlet
+        @name="admin-dashboard-moderation-bottom"
+        @connectorTagName="div"
+        @args={{hash filters=this.lastWeekfilters}}
+      />
+    </span>
   </div>
 </div>

--- a/app/assets/javascripts/admin/addon/templates/dashboard_security.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_security.hbs
@@ -1,9 +1,10 @@
 <div class="sections">
-  <PluginOutlet
-    @name="admin-dashboard-security-top"
-    @tagName="span"
-    @connectorTagName="div"
-  />
+  <span>
+    <PluginOutlet
+      @name="admin-dashboard-security-top"
+      @connectorTagName="div"
+    />
+  </span>
 
   <div class="main-section">
     <AdminReport
@@ -16,10 +17,11 @@
       @filters={{this.lastWeekfilters}}
     />
 
-    <PluginOutlet
-      @name="admin-dashboard-security-bottom"
-      @tagName="span"
-      @connectorTagName="div"
-    />
+    <span>
+      <PluginOutlet
+        @name="admin-dashboard-security-bottom"
+        @connectorTagName="div"
+      />
+    </span>
   </div>
 </div>

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.hbs
@@ -81,9 +81,10 @@
     href="https://meta.discourse.org/t/install-a-plugin/19157"
   >{{i18n "admin.plugins.howto"}}</a></p>
 
-<PluginOutlet
-  @name="admin-below-plugins-index"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="admin-below-plugins-index"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -259,12 +259,13 @@
   </section>
 {{/if}}
 
-<PluginOutlet
-  @name="admin-user-details"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="admin-user-details"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 <section class="details">
   <h1>{{i18n "admin.user.permissions"}}</h1>
@@ -857,12 +858,13 @@
   </section>
 {{/if}}
 
-<PluginOutlet
-  @name="after-user-details"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="after-user-details"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 <section>
   <hr />

--- a/app/assets/javascripts/admin/addon/templates/web-hooks-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/web-hooks-edit.hbs
@@ -115,12 +115,13 @@
       </div>
     </div>
 
-    <PluginOutlet
-      @name="web-hook-fields"
-      @tagName="span"
-      @connectorTagName="div"
-      @args={{hash model=this.model}}
-    />
+    <span>
+      <PluginOutlet
+        @name="web-hook-fields"
+        @connectorTagName="div"
+        @args={{hash model=this.model}}
+      />
+    </span>
 
     <label>
       <Input

--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.js
@@ -14,6 +14,8 @@ const PARENT_VIEW_DEPRECATION_MSG =
   "parentView should not be used within plugin outlets. Use the available outlet arguments, or inject a service which can provide the context you need.";
 const GET_DEPRECATION_MSG =
   "Plugin outlet context is no longer an EmberObject - using `get()` is deprecated.";
+const TAG_NAME_DEPRECATION_MSG =
+  "The `tagName` argument to PluginOutlet is deprecated. If a wrapper element is required, define it manually around the outlet call.";
 
 /**
    A plugin outlet is an extension point for templates where other templates can
@@ -55,6 +57,18 @@ export default class PluginOutletComponent extends GlimmerComponentWithDeprecate
       return get(this, ...arguments);
     },
   };
+
+  constructor() {
+    const result = super(...arguments);
+
+    if (this.args.tagName) {
+      deprecated(`${TAG_NAME_DEPRECATION_MSG} (outlet: ${this.args.name})`, {
+        id: "discourse.plugin-outlet-tag-name",
+      });
+    }
+
+    return result;
+  }
 
   get connectors() {
     return renderedConnectorsFor(

--- a/app/assets/javascripts/discourse/app/components/user-preferences/categories.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/categories.hbs
@@ -91,18 +91,20 @@
   {{/if}}
 </div>
 
-<PluginOutlet
-  @name="user-preferences-categories"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=@model save=@save}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-categories"
+    @connectorTagName="div"
+    @args={{hash model=@model save=@save}}
+  />
+</span>
 
 <br />
 
-<PluginOutlet
-  @name="user-custom-controls"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=@model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-controls"
+    @connectorTagName="div"
+    @args={{hash model=@model}}
+  />
+</span>

--- a/app/assets/javascripts/discourse/app/templates/about.hbs
+++ b/app/assets/javascripts/discourse/app/templates/about.hbs
@@ -46,12 +46,13 @@
         </section>
       {{/if}}
 
-      <PluginOutlet
-        @name="about-after-admins"
-        @tagName="span"
-        @connectorTagName="section"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="about-after-admins"
+          @connectorTagName="section"
+          @args={{hash model=this.model}}
+        />
+      </span>
 
       {{#if this.model.moderators}}
         <section class="about moderators">
@@ -64,12 +65,13 @@
         </section>
       {{/if}}
 
-      <PluginOutlet
-        @name="about-after-moderators"
-        @tagName="span"
-        @connectorTagName="section"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="about-after-moderators"
+          @connectorTagName="section"
+          @args={{hash model=this.model}}
+        />
+      </span>
 
       {{#if this.model.category_moderators.length}}
         {{#each this.model.category_moderators as |cm|}}

--- a/app/assets/javascripts/discourse/app/templates/badges/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/badges/index.hbs
@@ -2,11 +2,9 @@
   <div class="container badges">
     <h1>{{i18n "badges.title"}}</h1>
 
-    <PluginOutlet
-      @name="below-badges-title"
-      @tagName="span"
-      @connectorTagName="div"
-    />
+    <span>
+      <PluginOutlet @name="below-badges-title" @connectorTagName="div" />
+    </span>
 
     <div class="badge-groups">
       {{#each this.badgeGroups as |bg|}}

--- a/app/assets/javascripts/discourse/app/templates/components/composer-toggles.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/composer-toggles.hbs
@@ -1,9 +1,7 @@
 <div class="composer-controls">
-  <PluginOutlet
-    @name="before-composer-toggles"
-    @tagName="span"
-    @connectorTagName="div"
-  />
+  <span>
+    <PluginOutlet @name="before-composer-toggles" @connectorTagName="div" />
+  </span>
 
   {{#if this.site.mobileView}}
     <DButton

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -51,7 +51,6 @@
   <PluginOutlet
     @name="before-create-topic-button"
     @connectorTagName="div"
-    @tagName=""
     @args={{hash
       canCreateTopic=this.canCreateTopic
       createTopicDisabled=this.createTopicDisabled
@@ -74,7 +73,6 @@
   <PluginOutlet
     @name="after-create-topic-button"
     @connectorTagName="div"
-    @tagName=""
     @args={{hash
       canCreateTopic=this.canCreateTopic
       createTopicDisabled=this.createTopicDisabled

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-security.hbs
@@ -55,8 +55,9 @@
   {{/unless}}
 </section>
 
-<PluginOutlet
-  @name="category-custom-security"
-  @args={{hash category=this.category}}
-  @tagName="section"
-/>
+<section>
+  <PluginOutlet
+    @name="category-custom-security"
+    @args={{hash category=this.category}}
+  />
+</section>

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
@@ -342,12 +342,13 @@
       </label>
     </section>
 
-    <PluginOutlet
-      @name="category-email-in"
-      @tagName="span"
-      @connectorTagName="div"
-      @args={{hash category=this.category}}
-    />
+    <span>
+      <PluginOutlet
+        @name="category-email-in"
+        @connectorTagName="div"
+        @args={{hash category=this.category}}
+      />
+    </span>
   {{/if}}
 
   {{#unless this.emailInEnabled}}
@@ -360,8 +361,9 @@
   {{/unless}}
 </section>
 
-<PluginOutlet
-  @name="category-custom-settings"
-  @args={{hash category=this.category}}
-  @tagName="section"
-/>
+<section>
+  <PluginOutlet
+    @name="category-custom-settings"
+    @args={{hash category=this.category}}
+  />
+</section>

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
@@ -105,12 +105,13 @@
       @placeholderKey="admin.groups.manage.interaction.incoming_email_placeholder"
     />
 
-    <PluginOutlet
-      @name="group-email-in"
-      @tagName="span"
-      @connectorTagName="div"
-      @args={{hash model=this.model}}
-    />
+    <span>
+      <PluginOutlet
+        @name="group-email-in"
+        @connectorTagName="div"
+        @args={{hash model=this.model}}
+      />
+    </span>
   </div>
 {{/if}}
 
@@ -129,9 +130,10 @@
   />
 </div>
 
-<PluginOutlet
-  @name="groups-interaction-custom-options"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="groups-interaction-custom-options"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-membership-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-membership-fields.hbs
@@ -94,12 +94,13 @@
     {{/if}}
   </div>
 
-  <PluginOutlet
-    @name="groups-form-membership-below-automatic"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash model=this.model}}
-  />
+  <span>
+    <PluginOutlet
+      @name="groups-form-membership-below-automatic"
+      @connectorTagName="div"
+      @args={{hash model=this.model}}
+    />
+  </span>
 
   <div class="control-group">
     <label class="control-label">{{i18n

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-profile-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-profile-fields.hbs
@@ -44,10 +44,11 @@
 {{#if this.canEdit}}
   {{yield}}
 
-  <PluginOutlet
-    @name="group-edit"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash group=this.model}}
-  />
+  <span>
+    <PluginOutlet
+      @name="group-edit"
+      @connectorTagName="div"
+      @args={{hash group=this.model}}
+    />
+  </span>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-flagged-post.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-flagged-post.hbs
@@ -21,12 +21,13 @@
         {{html-safe this.reviewable.cooked}}
       {{/if}}
     </div>
-    <PluginOutlet
-      @name="after-reviewable-flagged-post-body"
-      @tagName="span"
-      @connectorTagName="div"
-      @args={{hash model=this.reviewable}}
-    />
+    <span>
+      <PluginOutlet
+        @name="after-reviewable-flagged-post-body"
+        @connectorTagName="div"
+        @args={{hash model=this.reviewable}}
+      />
+    </span>
     {{yield}}
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/search-result-entry.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-result-entry.hbs
@@ -41,12 +41,13 @@
       {{#if this.post.topic}}
         {{discourse-tags this.post.topic}}
       {{/if}}
-      <PluginOutlet
-        @name="full-page-search-category"
-        @tagName="span"
-        @connectorTagName="div"
-        @args={{hash post=this.post}}
-      />
+      <span>
+        <PluginOutlet
+          @name="full-page-search-category"
+          @connectorTagName="div"
+          @args={{hash post=this.post}}
+        />
+      </span>
     </div>
   </div>
 

--- a/app/assets/javascripts/discourse/app/templates/components/suggested-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/suggested-topics.hbs
@@ -27,9 +27,10 @@
   </h3>
 </div>
 
-<PluginOutlet
-  @name="below-suggested-topics"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash topic=this.topic}}
-/>
+<span>
+  <PluginOutlet
+    @name="below-suggested-topics"
+    @connectorTagName="div"
+    @args={{hash topic=this.topic}}
+  />
+</span>

--- a/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
@@ -131,11 +131,12 @@
       </section>
     {{/if}}
     {{#if this.canAdminTag}}
-      <PluginOutlet
-        @name="tag-custom-settings"
-        @args={{hash tag=this.tagInfo}}
-        @tagName="section"
-      />
+      <section>
+        <PluginOutlet
+          @name="tag-custom-settings"
+          @args={{hash tag=this.tagInfo}}
+        />
+      </section>
       <div class="tag-actions">
         <DButton
           @class="btn-default"

--- a/app/assets/javascripts/discourse/app/templates/components/topic-category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-category.hbs
@@ -12,9 +12,10 @@
   {{/if}}
 </div>
 
-<PluginOutlet
-  @name="topic-category"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash topic=this.topic category=this.topic.category}}
-/>
+<span>
+  <PluginOutlet
+    @name="topic-category"
+    @connectorTagName="div"
+    @args={{hash topic=this.topic category=this.topic.category}}
+  />
+</span>

--- a/app/assets/javascripts/discourse/app/templates/components/topic-progress.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-progress.hbs
@@ -29,8 +29,4 @@
   <div class="bg"></div>
 </nav>
 
-<PluginOutlet
-  @name="after-topic-progress"
-  @tagName=""
-  @connectorTagName="div"
-/>
+<PluginOutlet @name="after-topic-progress" @connectorTagName="div" />

--- a/app/assets/javascripts/discourse/app/templates/components/topic-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-title.hbs
@@ -2,10 +2,11 @@
   <div class="title-wrapper">
     {{yield}}
   </div>
-  <PluginOutlet
-    @name="topic-title"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash model=this.model}}
-  />
+  <span>
+    <PluginOutlet
+      @name="topic-title"
+      @connectorTagName="div"
+      @args={{hash model=this.model}}
+    />
+  </span>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -43,12 +43,13 @@
 
           <UserAvatarFlair @user={{this.user}} />
 
-          <PluginOutlet
-            @name="user-card-avatar-flair"
-            @connectorTagName="div"
-            @args={{hash user=this.user}}
-            @tagName="div"
-          />
+          <div>
+            <PluginOutlet
+              @name="user-card-avatar-flair"
+              @connectorTagName="div"
+              @args={{hash user=this.user}}
+            />
+          </div>
         </div>
         <div class="names">
           <h1
@@ -117,12 +118,13 @@
               {{format-date this.user.status.ends_at format="tiny"}}
             </h3>
           {{/if}}
-          <PluginOutlet
-            @name="user-card-post-names"
-            @connectorTagName="div"
-            @args={{hash user=this.user}}
-            @tagName="div"
-          />
+          <div>
+            <PluginOutlet
+              @name="user-card-post-names"
+              @connectorTagName="div"
+              @args={{hash user=this.user}}
+            />
+          </div>
         </div>
         <ul class="usercard-controls">
           {{#if this.user.can_send_private_message_to_user}}
@@ -139,7 +141,6 @@
             @name="user-card-below-message-button"
             @connectorTagName="li"
             @args={{hash user=this.user close=(action "close")}}
-            @tagName=""
           />
           {{#if this.showFilter}}
             <li>
@@ -171,12 +172,13 @@
               />
             </li>
           {{/if}}
-          <PluginOutlet
-            @name="user-card-additional-buttons"
-            @connectorTagName="div"
-            @args={{hash user=this.user close=(action "close")}}
-            @tagName="li"
-          />
+          <li>
+            <PluginOutlet
+              @name="user-card-additional-buttons"
+              @connectorTagName="div"
+              @args={{hash user=this.user close=(action "close")}}
+            />
+          </li>
         </ul>
         <PluginOutlet
           @name="user-card-additional-controls"
@@ -278,12 +280,13 @@
                 <span>{{this.formattedUserLocalTime}}</span>
               </span>
             {{/if}}
-            <PluginOutlet
-              @name="user-card-location-and-website"
-              @tagName="span"
-              @connectorTagName="div"
-              @args={{hash user=this.user}}
-            />
+            <span>
+              <PluginOutlet
+                @name="user-card-location-and-website"
+                @connectorTagName="div"
+                @args={{hash user=this.user}}
+              />
+            </span>
           </div>
         </div>
       {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/user-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-info.hbs
@@ -37,12 +37,13 @@
         @showTooltip={{@showStatusTooltip}}
       />
     {{/if}}
-    <PluginOutlet
-      @name="after-user-name"
-      @tagName="span"
-      @connectorTagName="span"
-      @args={{hash user=this.user}}
-    />
+    <span>
+      <PluginOutlet
+        @name="after-user-name"
+        @connectorTagName="span"
+        @args={{hash user=this.user}}
+      />
+    </span>
   </div>
   <div class="title">{{@user.title}}</div>
 
@@ -54,9 +55,10 @@
 
 </div>
 
-<PluginOutlet
-  @name="after-user-info"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash user=this.user}}
-/>
+<span>
+  <PluginOutlet
+    @name="after-user-info"
+    @connectorTagName="div"
+    @args={{hash user=this.user}}
+  />
+</span>

--- a/app/assets/javascripts/discourse/app/templates/components/user-profile-avatar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-profile-avatar.hbs
@@ -1,10 +1,11 @@
 <div class="user-profile-avatar">
   {{bound-avatar @user "huge"}}
   <UserAvatarFlair @user={{@user}} />
-  <PluginOutlet
-    @name="user-profile-avatar-flair"
-    @connectorTagName="div"
-    @args={{hash model=@user}}
-    @tagName="div"
-  />
+  <div>
+    <PluginOutlet
+      @name="user-profile-avatar-flair"
+      @connectorTagName="div"
+      @args={{hash model=@user}}
+    />
+  </div>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/user-stream-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-stream-item.hbs
@@ -43,12 +43,13 @@
     </span>
   {{/if}}
 
-  <PluginOutlet
-    @name="user-stream-item-header"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash item=@item}}
-  />
+  <span>
+    <PluginOutlet
+      @name="user-stream-item-header"
+      @connectorTagName="div"
+      @args={{hash item=@item}}
+    />
+  </span>
 </div>
 
 {{#if this.actionDescription}}

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -27,12 +27,13 @@
         aria-label={{I18n this.saveLabel}}
         class="reply-area {{if this.canEditTags 'with-tags' 'without-tags'}}"
       >
-        <PluginOutlet
-          @name="composer-open"
-          @tagName="span"
-          @connectorTagName="div"
-          @args={{hash model=this.model}}
-        />
+        <span>
+          <PluginOutlet
+            @name="composer-open"
+            @connectorTagName="div"
+            @args={{hash model=this.model}}
+          />
+        </span>
 
         <div class="reply-to">
           {{#unless this.model.viewFullscreen}}
@@ -201,29 +202,32 @@
                 </div>
               {{/if}}
 
-              <PluginOutlet
-                @name="composer-fields"
-                @tagName="span"
-                @connectorTagName="div"
-                @args={{hash model=this.model showPreview=this.showPreview}}
-              />
+              <span>
+                <PluginOutlet
+                  @name="composer-fields"
+                  @connectorTagName="div"
+                  @args={{hash model=this.model showPreview=this.showPreview}}
+                />
+              </span>
             {{/unless}}
           </div>
         </ComposerEditor>
 
-        <PluginOutlet
-          @name="composer-after-composer-editor"
-          @tagName="span"
-          @args={{hash model=this.model}}
-        />
-
-        <div class="submit-panel">
+        <span>
           <PluginOutlet
-            @name="composer-fields-below"
-            @tagName="span"
-            @connectorTagName="div"
+            @name="composer-after-composer-editor"
             @args={{hash model=this.model}}
           />
+        </span>
+
+        <div class="submit-panel">
+          <span>
+            <PluginOutlet
+              @name="composer-fields-below"
+              @connectorTagName="div"
+              @args={{hash model=this.model}}
+            />
+          </span>
 
           <div class="save-or-cancel">
             <ComposerSaveButton
@@ -304,19 +308,21 @@
               {{/if}}
             </div>
 
-            <PluginOutlet
-              @name="composer-after-save-or-cancel"
-              @tagName="span"
-              @args={{hash model=this.model}}
-            />
+            <span>
+              <PluginOutlet
+                @name="composer-after-save-or-cancel"
+                @args={{hash model=this.model}}
+              />
+            </span>
           </div>
 
           {{#if this.site.mobileView}}
-            <PluginOutlet
-              @name="composer-mobile-buttons-bottom"
-              @tagName="span"
-              @args={{hash model=this.model}}
-            />
+            <span>
+              <PluginOutlet
+                @name="composer-mobile-buttons-bottom"
+                @args={{hash model=this.model}}
+              />
+            </span>
 
             {{#if this.allowUpload}}
               <a

--- a/app/assets/javascripts/discourse/app/templates/discovery.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery.hbs
@@ -8,11 +8,9 @@
   {{/unless}}
 </div>
 
-<PluginOutlet
-  @name="discovery-list-controls-above"
-  @tagName="span"
-  @connectorTagName="div"
-/>
+<span>
+  <PluginOutlet @name="discovery-list-controls-above" @connectorTagName="div" />
+</span>
 
 <div class="list-controls">
   <PluginOutlet
@@ -26,7 +24,9 @@
 
 <ConditionalLoadingSpinner @condition={{this.loading}} />
 
-<PluginOutlet @name="discovery-above" @tagName="span" @connectorTagName="div" />
+<span>
+  <PluginOutlet @name="discovery-above" @connectorTagName="div" />
+</span>
 
 {{#if this.showEditWelcomeTopicBanner}}
   <WelcomeTopicBanner />
@@ -50,7 +50,6 @@
       <div id="list-area">
         <PluginOutlet
           @name="discovery-list-container-top"
-          @tagName=""
           @connectorTagName="span"
           @args={{hash category=this.category listLoading=this.loading}}
         />
@@ -60,4 +59,6 @@
   </div>
 </div>
 
-<PluginOutlet @name="discovery-below" @tagName="span" @connectorTagName="div" />
+<span>
+  <PluginOutlet @name="discovery-below" @connectorTagName="div" />
+</span>

--- a/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
@@ -59,12 +59,13 @@
       </div>
     {{/if}}
   {{/if}}
-  <PluginOutlet
-    @name="before-topic-list"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash category=this.category}}
-  />
+  <span>
+    <PluginOutlet
+      @name="before-topic-list"
+      @connectorTagName="div"
+      @args={{hash category=this.category}}
+    />
+  </span>
 
   {{#if this.hasTopics}}
     <TopicList
@@ -95,12 +96,13 @@
     />
   {{/if}}
 
-  <PluginOutlet
-    @name="after-topic-list"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash category=this.category}}
-  />
+  <span>
+    <PluginOutlet
+      @name="after-topic-list"
+      @connectorTagName="div"
+      @args={{hash category=this.category}}
+    />
+  </span>
 </DiscoveryTopicsList>
 
 <footer class="topic-list-bottom">

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -137,12 +137,13 @@
       {{/if}}
     {{/if}}
 
-    <PluginOutlet
-      @name="full-page-search-below-search-info"
-      @tagName="span"
-      @connectorTagName="div"
-      @args={{hash search=this.searchTerm}}
-    />
+    <span>
+      <PluginOutlet
+        @name="full-page-search-below-search-info"
+        @connectorTagName="div"
+        @args={{hash search=this.searchTerm}}
+      />
+    </span>
 
     {{#if this.searching}}
       {{loading-spinner size="medium"}}

--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -1,9 +1,10 @@
-<PluginOutlet
-  @name="before-group-container"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash group=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="before-group-container"
+    @connectorTagName="div"
+    @args={{hash group=this.model}}
+  />
+</span>
 
 <div class="container group group-{{this.model.name}}">
   {{#if this.showTooltip}}
@@ -73,12 +74,13 @@
         {{/if}}
       </div>
 
-      <PluginOutlet
-        @name="group-details-after"
-        @tagName="span"
-        @connectorTagName="div"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="group-details-after"
+          @connectorTagName="div"
+          @args={{hash model=this.model}}
+        />
+      </span>
     </div>
 
     {{#if this.model.bio_cooked}}

--- a/app/assets/javascripts/discourse/app/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.hbs
@@ -102,12 +102,13 @@
                       {{/if}}
                     </GroupMembershipButton>
 
-                    <PluginOutlet
-                      @name="group-index-box-after"
-                      @tagName="span"
-                      @connectorTagName="div"
-                      @args={{hash model=group}}
-                    />
+                    <span>
+                      <PluginOutlet
+                        @name="group-index-box-after"
+                        @connectorTagName="div"
+                        @args={{hash model=group}}
+                      />
+                    </span>
                   </div>
                 </div>
               </LinkTo>

--- a/app/assets/javascripts/discourse/app/templates/mobile/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/users.hbs
@@ -1,12 +1,13 @@
 <LoadMore @selector=".directory .user" @action={{action "loadMore"}}>
   <div class="container">
     <div class="users-directory directory">
-      <PluginOutlet
-        @name="users-top"
-        @tagName="span"
-        @connectorTagName="div"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="users-top"
+          @connectorTagName="div"
+          @args={{hash model=this.model}}
+        />
+      </span>
 
       <div class="directory-controls">
         <PeriodChooser

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -4,11 +4,12 @@
   @action={{action "createAccount"}}
 >
   {{#unless this.complete}}
-    <PluginOutlet
-      @name="create-account-before-modal-body"
-      @tagName="span"
-      @connectorTagName="div"
-    />
+    <span>
+      <PluginOutlet
+        @name="create-account-before-modal-body"
+        @connectorTagName="div"
+      />
+    </span>
     <DModalBody
       @class={{this.modalBodyClasses}}
       @preventModalAlertHiding={{true}}

--- a/app/assets/javascripts/discourse/app/templates/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/history.hbs
@@ -158,12 +158,13 @@
       </div>
     {{/if}}
 
-    <PluginOutlet
-      @name="post-revisions"
-      @tagName="span"
-      @connectorTagName="div"
-      @args={{hash model=this.model}}
-    />
+    <span>
+      <PluginOutlet
+        @name="post-revisions"
+        @connectorTagName="div"
+        @args={{hash model=this.model}}
+      />
+    </span>
 
     <LinksRedirect @class="row">
       {{html-safe this.bodyDiff}}

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -8,12 +8,13 @@
     {{/if}}
   {{/if}}
 
-  <PluginOutlet
-    @name="category-heading"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash category=this.category}}
-  />
+  <span>
+    <PluginOutlet
+      @name="category-heading"
+      @connectorTagName="div"
+      @args={{hash category=this.category}}
+    />
+  </span>
 </section>
 
 <DSection @class="navigation-container category-navigation">

--- a/app/assets/javascripts/discourse/app/templates/preferences.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences.hbs
@@ -79,12 +79,13 @@
         </li>
       {{/if}}
 
-      <PluginOutlet
-        @name="user-preferences-nav-under-interface"
-        @tagName="span"
-        @connectorTagName="div"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="user-preferences-nav-under-interface"
+          @connectorTagName="div"
+          @args={{hash model=this.model}}
+        />
+      </span>
 
       {{#if this.model.userApiKeys}}
         <li class="nav-apps">
@@ -94,23 +95,25 @@
         </li>
       {{/if}}
 
-      <PluginOutlet
-        @name="user-preferences-nav"
-        @tagName="span"
-        @connectorTagName="li"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="user-preferences-nav"
+          @connectorTagName="li"
+          @args={{hash model=this.model}}
+        />
+      </span>
     </MobileNav>
   </DSection>
 {{/if}}
 
 <section class="user-content user-preferences" id="user-content">
-  <PluginOutlet
-    @name="above-user-preferences"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash model=this.model}}
-  />
+  <span>
+    <PluginOutlet
+      @name="above-user-preferences"
+      @connectorTagName="div"
+      @args={{hash model=this.model}}
+    />
+  </span>
 
   <form class="form-vertical">
     {{outlet}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
@@ -263,21 +263,23 @@
   </div>
 {{/if}}
 
-<PluginOutlet
-  @name="user-preferences-account"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model save=(action "save")}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-account"
+    @connectorTagName="div"
+    @args={{hash model=this.model save=(action "save")}}
+  />
+</span>
 
 <br />
 
-<PluginOutlet
-  @name="user-custom-controls"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-controls"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 {{#if this.canSaveUser}}
   <SaveControls

--- a/app/assets/javascripts/discourse/app/templates/preferences/apps.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/apps.hbs
@@ -1,8 +1,9 @@
 <UserPreferences::UserApiKeys @model={{@model}} />
 
-<PluginOutlet
-  @name="user-preferences-apps"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-apps"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>

--- a/app/assets/javascripts/discourse/app/templates/preferences/emails.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/emails.hbs
@@ -52,12 +52,13 @@
     @checked={{this.model.user_option.email_in_reply_to}}
   />
 
-  <PluginOutlet
-    @name="user-preferences-emails-pref-email-settings"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash model=this.model save=(action "save")}}
-  />
+  <span>
+    <PluginOutlet
+      @name="user-preferences-emails-pref-email-settings"
+      @connectorTagName="div"
+      @args={{hash model=this.model save=(action "save")}}
+    />
+  </span>
 </div>
 
 {{#unless this.siteSettings.disable_digest_emails}}
@@ -112,21 +113,23 @@
   </div>
 {{/unless}}
 
-<PluginOutlet
-  @name="user-preferences-emails"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model save=(action "save")}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-emails"
+    @connectorTagName="div"
+    @args={{hash model=this.model save=(action "save")}}
+  />
+</span>
 
 <br />
 
-<PluginOutlet
-  @name="user-custom-controls"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-controls"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 <SaveControls
   @model={{this.model}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
@@ -1,9 +1,10 @@
-<PluginOutlet
-  @name="user-preferences-interface-top"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model save=(action "save")}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-interface-top"
+    @connectorTagName="div"
+    @args={{hash model=this.model save=(action "save")}}
+  />
+</span>
 
 {{#if this.showThemeSelector}}
   <div class="control-group theme">
@@ -233,21 +234,23 @@
   {{/if}}
 </fieldset>
 
-<PluginOutlet
-  @name="user-preferences-interface"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model save=(action "save")}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-interface"
+    @connectorTagName="div"
+    @args={{hash model=this.model save=(action "save")}}
+  />
+</span>
 
 <br />
 
-<PluginOutlet
-  @name="user-custom-controls"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-controls"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 <SaveControls
   @model={{this.model}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
@@ -32,12 +32,13 @@
     <div class="instructions">{{i18n
         "user.desktop_notifications.each_browser_note"
       }}</div>
-    <PluginOutlet
-      @name="user-preferences-desktop-notifications"
-      @tagName="span"
-      @connectorTagName="div"
-      @args={{hash model=this.model save=(action "save")}}
-    />
+    <span>
+      <PluginOutlet
+        @name="user-preferences-desktop-notifications"
+        @connectorTagName="div"
+        @args={{hash model=this.model save=(action "save")}}
+      />
+    </span>
   </div>
 {{/unless}}
 
@@ -49,21 +50,23 @@
   {{/unless}}
 {{/if}}
 
-<PluginOutlet
-  @name="user-preferences-notifications"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model save=(action "save")}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-notifications"
+    @connectorTagName="div"
+    @args={{hash model=this.model save=(action "save")}}
+  />
+</span>
 
 <br />
 
-<PluginOutlet
-  @name="user-custom-controls"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-controls"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 <SaveControls
   @model={{this.model}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
@@ -155,28 +155,31 @@
   </div>
 {{/if}}
 
-<PluginOutlet
-  @name="user-preferences-profile"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model save=(action "save")}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-profile"
+    @connectorTagName="div"
+    @args={{hash model=this.model save=(action "save")}}
+  />
+</span>
 
-<PluginOutlet
-  @name="user-custom-preferences"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-preferences"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 <br />
 
-<PluginOutlet
-  @name="user-custom-controls"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-controls"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 <SaveControls
   @model={{this.model}}

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
@@ -104,18 +104,20 @@
   <UserPreferences::UserApiKeys @model={{@model}} />
 {{/if}}
 
-<PluginOutlet
-  @name="user-preferences-security"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model save=(action "save")}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-preferences-security"
+    @connectorTagName="div"
+    @args={{hash model=this.model save=(action "save")}}
+  />
+</span>
 
 <br />
 
-<PluginOutlet
-  @name="user-custom-controls"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-controls"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>

--- a/app/assets/javascripts/discourse/app/templates/preferences/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/users.hbs
@@ -56,12 +56,13 @@
   </div>
 {{/if}}
 
-<PluginOutlet
-  @name="user-custom-controls"
-  @tagName="span"
-  @connectorTagName="div"
-  @args={{hash model=this.model}}
-/>
+<span>
+  <PluginOutlet
+    @name="user-custom-controls"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</span>
 
 <SaveControls
   @model={{this.model}}

--- a/app/assets/javascripts/discourse/app/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.hbs
@@ -28,12 +28,16 @@
 
     {{#if this.filtersExpanded}}
 
-      <PluginOutlet
-        @name="above-review-filters"
-        @tagName="span"
-        @connectorTagName="div"
-        @args={{hash model=this.model additionalFilters=this.additionalFilters}}
-      />
+      <span>
+        <PluginOutlet
+          @name="above-review-filters"
+          @connectorTagName="div"
+          @args={{hash
+            model=this.model
+            additionalFilters=this.additionalFilters
+          }}
+        />
+      </span>
 
       <div class="reviewable-filter">
         <label class="filter-label">{{i18n "review.filters.type.title"}}</label>

--- a/app/assets/javascripts/discourse/app/templates/static.hbs
+++ b/app/assets/javascripts/discourse/app/templates/static.hbs
@@ -2,11 +2,9 @@
   <WatchRead @action={{action "markFaqRead"}} @path={{this.model.path}}>
     <div class="contents clearfix body-page">
 
-      <PluginOutlet
-        @name="above-static"
-        @tagName="span"
-        @connectorTagName="div"
-      />
+      <span>
+        <PluginOutlet @name="above-static" @connectorTagName="div" />
+      </span>
 
       {{html-safe this.model.html}}
 

--- a/app/assets/javascripts/discourse/app/templates/tag/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag/show.hbs
@@ -13,11 +13,12 @@
     <DiscourseBanner @user={{this.currentUser}} @banner={{this.site.banner}} />
   </div>
 
-  <PluginOutlet
-    @name="discovery-list-controls-above"
-    @tagName="span"
-    @connectorTagName="div"
-  />
+  <span>
+    <PluginOutlet
+      @name="discovery-list-controls-above"
+      @connectorTagName="div"
+    />
+  </span>
 
   <div class="list-controls">
     <PluginOutlet
@@ -61,12 +62,13 @@
     />
   {{/if}}
 
-  <PluginOutlet
-    @name="discovery-list-container-top"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash category=this.category}}
-  />
+  <span>
+    <PluginOutlet
+      @name="discovery-list-container-top"
+      @connectorTagName="div"
+      @args={{hash category=this.category}}
+    />
+  </span>
 
   <TopicDismissButtons
     @position="top"
@@ -77,11 +79,9 @@
     @resetNew={{action "resetNew"}}
   />
 
-  <PluginOutlet
-    @name="discovery-above"
-    @tagName="span"
-    @connectorTagName="div"
-  />
+  <span>
+    <PluginOutlet @name="discovery-above" @connectorTagName="div" />
+  </span>
 
   <div class="container list-container">
     <div class="row">
@@ -178,9 +178,7 @@
     </div>
   </div>
 
-  <PluginOutlet
-    @name="discovery-below"
-    @tagName="span"
-    @connectorTagName="div"
-  />
+  <span>
+    <PluginOutlet @name="discovery-below" @connectorTagName="div" />
+  </span>
 </DSection>

--- a/app/assets/javascripts/discourse/app/templates/tags/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/index.hbs
@@ -11,12 +11,13 @@
   </div>
 </div>
 
-<PluginOutlet
-  @name="tags-below-title"
-  @connectorTagName="div"
-  @tagName="div"
-  @args={{hash model=this.model}}
-/>
+<div>
+  <PluginOutlet
+    @name="tags-below-title"
+    @connectorTagName="div"
+    @args={{hash model=this.model}}
+  />
+</div>
 
 <div class="tag-sort-options">
   {{i18n "tagging.sort_by"}}

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -24,12 +24,13 @@
     <SharedDraftControls @topic={{this.model}} />
   {{/if}}
 
-  <PluginOutlet
-    @name="topic-above-post-stream"
-    @tagName="span"
-    @connectorTagName="div"
-    @args={{hash model=this.model editFirstPost=(action "editFirstPost")}}
-  />
+  <span>
+    <PluginOutlet
+      @name="topic-above-post-stream"
+      @connectorTagName="div"
+      @args={{hash model=this.model editFirstPost=(action "editFirstPost")}}
+    />
+  </span>
 
   {{#if this.model.postStream.loaded}}
     {{#if this.model.postStream.firstPostPresent}}
@@ -72,12 +73,13 @@
               />
             {{/if}}
 
-            <PluginOutlet
-              @name="edit-topic"
-              @tagName="span"
-              @connectorTagName="div"
-              @args={{hash model=this.model buffered=this.buffered}}
-            />
+            <span>
+              <PluginOutlet
+                @name="edit-topic"
+                @connectorTagName="div"
+                @args={{hash model=this.model buffered=this.buffered}}
+              />
+            </span>
 
             <div class="edit-controls">
               <DButton
@@ -148,7 +150,6 @@
 
             <PluginOutlet
               @name="topic-title-suffix"
-              @tagName=""
               @args={{hash model=this.model}}
             />
           </h1>
@@ -291,12 +292,13 @@
             @expanded={{info.topicProgressExpanded}}
             @jumpToPost={{action "jumpToPost"}}
           >
-            <PluginOutlet
-              @name="before-topic-progress"
-              @tagName="span"
-              @connectorTagName="div"
-              @args={{hash model=this.model jumpToPost=(action "jumpToPost")}}
-            />
+            <span>
+              <PluginOutlet
+                @name="before-topic-progress"
+                @connectorTagName="div"
+                @args={{hash model=this.model jumpToPost=(action "jumpToPost")}}
+              />
+            </span>
             <TopicAdminMenuButton
               @topic={{this.model}}
               @openUpwards="true"
@@ -329,12 +331,13 @@
               @condition={{this.model.postStream.loadingAbove}}
             />
 
-            <PluginOutlet
-              @name="topic-above-posts"
-              @tagName="span"
-              @connectorTagName="div"
-              @args={{hash model=this.model}}
-            />
+            <span>
+              <PluginOutlet
+                @name="topic-above-posts"
+                @connectorTagName="div"
+                @args={{hash model=this.model}}
+              />
+            </span>
 
             {{#unless this.model.postStream.loadingFilter}}
               <ScrollingPostStream
@@ -519,12 +522,13 @@
         <SignupCta />
       {{else}}
         {{#if this.currentUser}}
-          <PluginOutlet
-            @name="topic-above-footer-buttons"
-            @tagName="span"
-            @connectorTagName="div"
-            @args={{hash model=this.model}}
-          />
+          <span>
+            <PluginOutlet
+              @name="topic-above-footer-buttons"
+              @connectorTagName="div"
+              @args={{hash model=this.model}}
+            />
+          </span>
 
           <TopicFooterButtons
             @topic={{this.model}}
@@ -560,12 +564,13 @@
         {{/if}}
       {{/if}}
 
-      <PluginOutlet
-        @name="topic-above-suggested"
-        @tagName="span"
-        @connectorTagName="div"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="topic-above-suggested"
+          @connectorTagName="div"
+          @args={{hash model=this.model}}
+        />
+      </span>
       <div
         class="{{if
             this.model.relatedMessages.length

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -146,12 +146,13 @@
                   class="user-profile-names__title"
                 >{{this.model.title}}</div>
               {{/if}}
-              <PluginOutlet
-                @name="user-post-names"
-                @tagName="span"
-                @connectorTagName="div"
-                @args={{hash model=this.model}}
-              />
+              <span>
+                <PluginOutlet
+                  @name="user-post-names"
+                  @connectorTagName="div"
+                  @args={{hash model=this.model}}
+                />
+              </span>
             </div>
 
             {{#if this.showFeaturedTopic}}
@@ -196,12 +197,13 @@
                   {{/if}}
                 </div>
               {{/if}}
-              <PluginOutlet
-                @name="user-location-and-website"
-                @tagName="span"
-                @connectorTagName="div"
-                @args={{hash model=this.model}}
-              />
+              <span>
+                <PluginOutlet
+                  @name="user-location-and-website"
+                  @connectorTagName="div"
+                  @args={{hash model=this.model}}
+                />
+              </span>
             </div>
 
             <div class="bio">
@@ -250,24 +252,26 @@
                   {{/if}}
                 {{/each}}
 
-                <PluginOutlet
-                  @name="user-profile-public-fields"
-                  @tagName="span"
-                  @connectorTagName="div"
-                  @args={{hash
-                    publicUserFields=this.publicUserFields
-                    model=this.model
-                  }}
-                />
+                <span>
+                  <PluginOutlet
+                    @name="user-profile-public-fields"
+                    @connectorTagName="div"
+                    @args={{hash
+                      publicUserFields=this.publicUserFields
+                      model=this.model
+                    }}
+                  />
+                </span>
               </div>
             {{/if}}
 
-            <PluginOutlet
-              @name="user-profile-primary"
-              @tagName="span"
-              @connectorTagName="div"
-              @args={{hash model=this.model}}
-            />
+            <span>
+              <PluginOutlet
+                @name="user-profile-primary"
+                @connectorTagName="div"
+                @args={{hash model=this.model}}
+              />
+            </span>
           </div>
 
           <section class="controls">

--- a/app/assets/javascripts/discourse/app/templates/user/activity.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/activity.hbs
@@ -67,12 +67,13 @@
             }}</DNavigationItem>
         {{/if}}
 
-        <PluginOutlet
-          @name="user-activity-bottom"
-          @tagName="span"
-          @connectorTagName="li"
-          @args={{hash model=this.model}}
-        />
+        <span>
+          <PluginOutlet
+            @name="user-activity-bottom"
+            @connectorTagName="li"
+            @args={{hash model=this.model}}
+          />
+        </span>
       </MobileNav>
     </nav>
   </DSection>

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -154,12 +154,13 @@
         {{/if}}
       {{/if}}
 
-      <PluginOutlet
-        @name="user-messages-nav"
-        @tagName="span"
-        @connectorTagName="li"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="user-messages-nav"
+          @connectorTagName="li"
+          @args={{hash model=this.model}}
+        />
+      </span>
     </MobileNav>
   </DSection>
 

--- a/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
@@ -56,12 +56,13 @@
           {{i18n "user_action_groups.11"}}
         </LinkTo>
       </li>
-      <PluginOutlet
-        @name="user-notifications-bottom"
-        @tagName="span"
-        @connectorTagName="li"
-        @args={{hash model=this.model}}
-      />
+      <span>
+        <PluginOutlet
+          @name="user-notifications-bottom"
+          @connectorTagName="li"
+          @args={{hash model=this.model}}
+        />
+      </span>
     </MobileNav>
 
   </DSection>

--- a/app/assets/javascripts/discourse/app/templates/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/users.hbs
@@ -2,12 +2,13 @@
   <LoadMore @selector=".directory tbody tr" @action={{action "loadMore"}}>
     <div class="container">
       <div class="users-directory directory">
-        <PluginOutlet
-          @name="users-top"
-          @tagName="span"
-          @connectorTagName="div"
-          @args={{hash model=this.model}}
-        />
+        <span>
+          <PluginOutlet
+            @name="users-top"
+            @connectorTagName="div"
+            @args={{hash model=this.model}}
+          />
+        </span>
         <div class="directory-controls">
           <div class="period-controls">
             <PeriodChooser


### PR DESCRIPTION
(see commit messages - to be rebased-and-merged)

---

**DEV: Deprecate PluginOutlet tagName argument**

---

**DEV: Remove use of PluginOutlet `@tagName` argument in core**

The `tagName` argument is now deprecated. This commit uses a codemod (https://github.com/discourse/discourse-ember-codemods/tree/main/transforms/extract-plugin-outlet-tagname) to automatically remove the `@tagName` from all PluginOutlet invocations, and create a matching wrapper element so that the HTML structure is unchanged. We may want to remove some/all of these wrappers entirely in future, but that would be a riskier change which we should tackle on a case-by-case basis.

---

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
