### PR TITLE
Deprecate plugin outlet args

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/components/themes-list-item.hbs
+++ b/app/assets/javascripts/admin/addon/templates/components/themes-list-item.hbs
@@ -3,7 +3,7 @@
     <PluginOutlet
       @name="admin-customize-themes-list-item"
       @connectorTagName="span"
-      @args={{hash theme=this.theme}}
+      @outletArgs={{hash theme=this.theme}}
     />
   </span>
 

--- a/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-themes-show.hbs
@@ -3,7 +3,7 @@
     <PluginOutlet
       @name="admin-customize-themes-show-top"
       @connectorTagName="div"
-      @args={{hash theme=this.model}}
+      @outletArgs={{hash theme=this.model}}
     />
   </span>
   <div class="title">

--- a/app/assets/javascripts/admin/addon/templates/dashboard_moderation.hbs
+++ b/app/assets/javascripts/admin/addon/templates/dashboard_moderation.hbs
@@ -54,7 +54,7 @@
       <PluginOutlet
         @name="admin-dashboard-moderation-bottom"
         @connectorTagName="div"
-        @args={{hash filters=this.lastWeekfilters}}
+        @outletArgs={{hash filters=this.lastWeekfilters}}
       />
     </span>
   </div>

--- a/app/assets/javascripts/admin/addon/templates/plugins-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/plugins-index.hbs
@@ -85,6 +85,6 @@
   <PluginOutlet
     @name="admin-below-plugins-index"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>

--- a/app/assets/javascripts/admin/addon/templates/user-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-index.hbs
@@ -28,7 +28,7 @@
     {{/if}}
     <PluginOutlet
       @name="admin-user-controls-after"
-      @args={{hash model=this.model}}
+      @outletArgs={{hash model=this.model}}
     />
   </div>
 
@@ -50,7 +50,10 @@
     />
   </div>
 
-  <PluginOutlet @name="admin-user-below-names" @args={{hash user=this.model}} />
+  <PluginOutlet
+    @name="admin-user-below-names"
+    @outletArgs={{hash user=this.model}}
+  />
 
   {{#if this.canCheckEmails}}
     <div class="display-row email">
@@ -263,7 +266,7 @@
   <PluginOutlet
     @name="admin-user-details"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 
@@ -862,7 +865,7 @@
   <PluginOutlet
     @name="after-user-details"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 

--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -93,7 +93,7 @@
           />
           <PluginOutlet
             @name="admin-users-list-thead-after"
-            @args={{hash order=this.order asc=this.asc}}
+            @outletArgs={{hash order=this.order asc=this.asc}}
           />
 
           {{#if this.siteSettings.must_approve_users}}
@@ -161,7 +161,7 @@
 
             <PluginOutlet
               @name="admin-users-list-td-after"
-              @args={{hash user=user query=this.query}}
+              @outletArgs={{hash user=user query=this.query}}
             />
 
             {{#if this.siteSettings.must_approve_users}}
@@ -181,7 +181,7 @@
               <PluginOutlet
                 @name="admin-users-list-icon"
                 @connectorTagName="div"
-                @args={{hash user=user query=this.query}}
+                @outletArgs={{hash user=user query=this.query}}
               />
             </td>
           </tr>

--- a/app/assets/javascripts/admin/addon/templates/web-hooks-edit.hbs
+++ b/app/assets/javascripts/admin/addon/templates/web-hooks-edit.hbs
@@ -119,7 +119,7 @@
       <PluginOutlet
         @name="web-hook-fields"
         @connectorTagName="div"
-        @args={{hash model=this.model}}
+        @outletArgs={{hash model=this.model}}
       />
     </span>
 

--- a/app/assets/javascripts/discourse/app/components/plugin-outlet.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-outlet.js
@@ -16,6 +16,8 @@ const GET_DEPRECATION_MSG =
   "Plugin outlet context is no longer an EmberObject - using `get()` is deprecated.";
 const TAG_NAME_DEPRECATION_MSG =
   "The `tagName` argument to PluginOutlet is deprecated. If a wrapper element is required, define it manually around the outlet call.";
+const ARGS_DEPRECATION_MSG =
+  "PluginOutlet arguments should now be passed using `@outletArgs=` instead of `@args=`";
 
 /**
    A plugin outlet is an extension point for templates where other templates can
@@ -64,6 +66,12 @@ export default class PluginOutletComponent extends GlimmerComponentWithDeprecate
     if (this.args.tagName) {
       deprecated(`${TAG_NAME_DEPRECATION_MSG} (outlet: ${this.args.name})`, {
         id: "discourse.plugin-outlet-tag-name",
+      });
+    }
+
+    if (this.args.args) {
+      deprecated(`${ARGS_DEPRECATION_MSG} (outlet: ${this.args.name})`, {
+        id: "discourse.plugin-outlet-args",
       });
     }
 

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -38,7 +38,7 @@
   <div class="timeline-controls">
     <PluginOutlet
       @name="timeline-controls-before"
-      @args={{hash model=@model}}
+      @outletArgs={{hash model=@model}}
     />
     <TopicAdminMenuButton
       @topic={{@model}}
@@ -178,7 +178,7 @@
     {{/if}}
     <PluginOutlet
       @name="timeline-footer-controls-after"
-      @args={{hash model=@model}}
+      @outletArgs={{hash model=@model}}
     />
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/user-nav.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-nav.hbs
@@ -63,7 +63,7 @@
     <PluginOutlet
       @name="user-main-nav"
       @connectorTagName="li"
-      @args={{hash model=@user}}
+      @outletArgs={{hash model=@user}}
     />
 
     {{#if @user.can_edit}}

--- a/app/assets/javascripts/discourse/app/components/user-nav/activity-nav.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-nav/activity-nav.hbs
@@ -80,5 +80,5 @@
 <PluginOutlet
   @name="user-activity-bottom"
   @connectorTagName="li"
-  @args={{hash model=@model}}
+  @outletArgs={{hash model=@model}}
 />

--- a/app/assets/javascripts/discourse/app/components/user-nav/notifications-nav.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-nav/notifications-nav.hbs
@@ -48,5 +48,5 @@
 <PluginOutlet
   @name="user-notifications-bottom"
   @connectorTagName="li"
-  @args={{hash model=@model}}
+  @outletArgs={{hash model=@model}}
 />

--- a/app/assets/javascripts/discourse/app/components/user-nav/preferences-nav.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-nav/preferences-nav.hbs
@@ -86,10 +86,10 @@
 <PluginOutlet
   @name="user-preferences-nav-under-interface"
   @connectorTagName="div"
-  @args={{hash model=@model}}
+  @outletArgs={{hash model=@model}}
 />
 <PluginOutlet
   @name="user-preferences-nav"
   @connectorTagName="li"
-  @args={{hash model=@model}}
+  @outletArgs={{hash model=@model}}
 />

--- a/app/assets/javascripts/discourse/app/components/user-preferences/categories.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/categories.hbs
@@ -95,7 +95,7 @@
   <PluginOutlet
     @name="user-preferences-categories"
     @connectorTagName="div"
-    @args={{hash model=@model save=@save}}
+    @outletArgs={{hash model=@model save=@save}}
   />
 </span>
 
@@ -105,6 +105,6 @@
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=@model}}
+    @outletArgs={{hash model=@model}}
   />
 </span>

--- a/app/assets/javascripts/discourse/app/components/user-preferences/tags.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/tags.hbs
@@ -65,11 +65,11 @@
   <PluginOutlet
     @name="user-preferences-tags"
     @connectorTagName="div"
-    @args={{hash model=@model save=@save}}
+    @outletArgs={{hash model=@model save=@save}}
   />
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=@model}}
+    @outletArgs={{hash model=@model}}
   />
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/about.hbs
+++ b/app/assets/javascripts/discourse/app/templates/about.hbs
@@ -34,7 +34,7 @@
       <PluginOutlet
         @name="about-after-description"
         @connectorTagName="section"
-        @args={{hash model=this.model}}
+        @outletArgs={{hash model=this.model}}
       />
 
       {{#if this.model.admins}}
@@ -50,7 +50,7 @@
         <PluginOutlet
           @name="about-after-admins"
           @connectorTagName="section"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
 
@@ -69,7 +69,7 @@
         <PluginOutlet
           @name="about-after-moderators"
           @connectorTagName="section"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
 

--- a/app/assets/javascripts/discourse/app/templates/application.hbs
+++ b/app/assets/javascripts/discourse/app/templates/application.hbs
@@ -4,7 +4,7 @@
   <PluginOutlet
     @name="above-site-header"
     @connectorTagName="div"
-    @args={{hash currentPath=this.router._router.currentPath}}
+    @outletArgs={{hash currentPath=this.router._router.currentPath}}
   />
 
   {{#if this.showSiteHeader}}
@@ -27,7 +27,7 @@
   <PluginOutlet
     @name="below-site-header"
     @connectorTagName="div"
-    @args={{hash currentPath=this.router._router.currentPath}}
+    @outletArgs={{hash currentPath=this.router._router.currentPath}}
   />
 
   <div id="main-outlet-wrapper" class="wrap" role="main">
@@ -55,7 +55,7 @@
         <PluginOutlet
           @name="top-notices"
           @connectorTagName="div"
-          @args={{hash currentPath=this.router._router.currentPath}}
+          @outletArgs={{hash currentPath=this.router._router.currentPath}}
         />
       </div>
 
@@ -67,7 +67,7 @@
   <PluginOutlet
     @name="above-footer"
     @connectorTagName="div"
-    @args={{hash showFooter=this.showFooter}}
+    @outletArgs={{hash showFooter=this.showFooter}}
   />
   {{#if this.showFooter}}
     <CustomHtml
@@ -79,7 +79,7 @@
   <PluginOutlet
     @name="below-footer"
     @connectorTagName="div"
-    @args={{hash showFooter=this.showFooter}}
+    @outletArgs={{hash showFooter=this.showFooter}}
   />
 
   {{outlet "modal"}}

--- a/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/bread-crumbs.hbs
@@ -42,7 +42,7 @@
 <PluginOutlet
   @name="bread-crumbs-right"
   @connectorTagName="li"
-  @args={{hash
+  @outletArgs={{hash
     tagId=this.tag.id
     additionalTags=this.additionalTags
     noSubcategories=this.noSubcategories

--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes-with-topics.hbs
@@ -44,7 +44,7 @@
 
       <PluginOutlet
         @name="category-box-below-each-category"
-        @args={{hash category=c}}
+        @outletArgs={{hash category=c}}
       />
     </div>
   </div>

--- a/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-boxes.hbs
@@ -1,7 +1,7 @@
 {{#each this.categories as |c|}}
   <PluginOutlet
     @name="category-box-before-each-box"
-    @args={{hash category=c}}
+    @outletArgs={{hash category=c}}
   />
 
   <div
@@ -91,15 +91,18 @@
 
       <PluginOutlet
         @name="category-box-below-each-category"
-        @args={{hash category=c}}
+        @outletArgs={{hash category=c}}
       />
     </div>
   </div>
 
-  <PluginOutlet @name="category-box-after-each-box" @args={{hash category=c}} />
+  <PluginOutlet
+    @name="category-box-after-each-box"
+    @outletArgs={{hash category=c}}
+  />
 {{/each}}
 
 <PluginOutlet
   @name="category-boxes-after-boxes"
-  @args={{hash category=this.c}}
+  @outletArgs={{hash category=this.c}}
 />

--- a/app/assets/javascripts/discourse/app/templates/components/categories-only.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/categories-only.hbs
@@ -68,5 +68,5 @@
 <PluginOutlet
   @name="below-categories-only"
   @connectorTagName="div"
-  @args={{hash categories=this.categories showTopics=this.showTopics}}
+  @outletArgs={{hash categories=this.categories showTopics=this.showTopics}}
 />

--- a/app/assets/javascripts/discourse/app/templates/components/category-title-before.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/category-title-before.hbs
@@ -1,4 +1,4 @@
 <PluginOutlet
   @name="category-title-before"
-  @args={{hash category=this.category}}
+  @outletArgs={{hash category=this.category}}
 />

--- a/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-editor.hbs
@@ -55,7 +55,7 @@
       <PluginOutlet
         @name="after-d-editor"
         @connectorTagName="div"
-        @args={{this.outletArgs}}
+        @outletArgs={{this.outletArgs}}
       />
     </div>
   </div>
@@ -72,7 +72,7 @@
       <PluginOutlet
         @name="editor-preview"
         @connectorTagName="div"
-        @args={{this.outletArgs}}
+        @outletArgs={{this.outletArgs}}
       />
     </span>
   </div>

--- a/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/d-navigation.hbs
@@ -51,7 +51,7 @@
   <PluginOutlet
     @name="before-create-topic-button"
     @connectorTagName="div"
-    @args={{hash
+    @outletArgs={{hash
       canCreateTopic=this.canCreateTopic
       createTopicDisabled=this.createTopicDisabled
       createTopicLabel=this.createTopicLabel
@@ -73,7 +73,7 @@
   <PluginOutlet
     @name="after-create-topic-button"
     @connectorTagName="div"
-    @args={{hash
+    @outletArgs={{hash
       canCreateTopic=this.canCreateTopic
       createTopicDisabled=this.createTopicDisabled
       createTopicLabel=this.createTopicLabel

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-security.hbs
@@ -58,6 +58,6 @@
 <section>
   <PluginOutlet
     @name="category-custom-security"
-    @args={{hash category=this.category}}
+    @outletArgs={{hash category=this.category}}
   />
 </section>

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
@@ -346,7 +346,7 @@
       <PluginOutlet
         @name="category-email-in"
         @connectorTagName="div"
-        @args={{hash category=this.category}}
+        @outletArgs={{hash category=this.category}}
       />
     </span>
   {{/if}}
@@ -364,6 +364,6 @@
 <section>
   <PluginOutlet
     @name="category-custom-settings"
-    @args={{hash category=this.category}}
+    @outletArgs={{hash category=this.category}}
   />
 </section>

--- a/app/assets/javascripts/discourse/app/templates/components/group-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-navigation.hbs
@@ -30,7 +30,7 @@
   {{/each}}
   <PluginOutlet
     @name="group-reports-nav-item"
-    @args={{hash group=this.group}}
+    @outletArgs={{hash group=this.group}}
     @connectorTagName="li"
   />
 </MobileNav>

--- a/app/assets/javascripts/discourse/app/templates/components/group-post.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/group-post.hbs
@@ -29,7 +29,7 @@
           >{{this.post.user.title}}</span>{{/if}}
         <PluginOutlet
           @name="group-post-additional-member-info"
-          @args={{hash user=this.post.user}}
+          @outletArgs={{hash user=this.post.user}}
         />
       </div>
     {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-interaction-fields.hbs
@@ -109,7 +109,7 @@
       <PluginOutlet
         @name="group-email-in"
         @connectorTagName="div"
-        @args={{hash model=this.model}}
+        @outletArgs={{hash model=this.model}}
       />
     </span>
   </div>
@@ -134,6 +134,6 @@
   <PluginOutlet
     @name="groups-interaction-custom-options"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-membership-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-membership-fields.hbs
@@ -98,7 +98,7 @@
     <PluginOutlet
       @name="groups-form-membership-below-automatic"
       @connectorTagName="div"
-      @args={{hash model=this.model}}
+      @outletArgs={{hash model=this.model}}
     />
   </span>
 

--- a/app/assets/javascripts/discourse/app/templates/components/groups-form-profile-fields.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/groups-form-profile-fields.hbs
@@ -48,7 +48,7 @@
     <PluginOutlet
       @name="group-edit"
       @connectorTagName="div"
-      @args={{hash group=this.model}}
+      @outletArgs={{hash group=this.model}}
     />
   </span>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/navigation-bar.hbs
@@ -9,5 +9,5 @@
 <PluginOutlet
   @name="extra-nav-item"
   @connectorTagName="li"
-  @args={{hash category=this.category filterMode=this.filterMode}}
+  @outletArgs={{hash category=this.category filterMode=this.filterMode}}
 />

--- a/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/parent-category-row.hbs
@@ -1,7 +1,7 @@
 {{#unless this.isHidden}}
   <PluginOutlet
     @name="category-list-above-each-category"
-    @args={{hash category=this.category}}
+    @outletArgs={{hash category=this.category}}
   />
 
   <tr
@@ -32,7 +32,7 @@
       <PluginOutlet
         @name="below-category-title-link"
         @connectorTagName="div"
-        @args={{hash category=this.category}}
+        @outletArgs={{hash category=this.category}}
       />
 
       {{#if this.category.description_excerpt}}

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-created-by-name.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-created-by-name.hbs
@@ -12,6 +12,6 @@
   <PluginOutlet
     @name="after-reviewable-post-user"
     @connectorTagName="div"
-    @args={{hash user=this.user}}
+    @outletArgs={{hash user=this.user}}
   />
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/reviewable-flagged-post.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/reviewable-flagged-post.hbs
@@ -25,7 +25,7 @@
       <PluginOutlet
         @name="after-reviewable-flagged-post-body"
         @connectorTagName="div"
-        @args={{hash model=this.reviewable}}
+        @outletArgs={{hash model=this.reviewable}}
       />
     </span>
     {{yield}}

--- a/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-advanced-options.hbs
@@ -6,7 +6,7 @@
     <PluginOutlet
       @name="advanced-search-options-above"
       @connectorTagName="div"
-      @args={{hash
+      @outletArgs={{hash
         searchedTerms=this.searchedTerms
         onChangeSearchedTermField=this.onChangeSearchedTermField
       }}
@@ -222,7 +222,7 @@
     <PluginOutlet
       @name="advanced-search-options-below"
       @connectorTagName="div"
-      @args={{hash
+      @outletArgs={{hash
         searchedTerms=this.searchedTerms
         onChangeSearchedTermField=this.onChangeSearchedTermField
       }}

--- a/app/assets/javascripts/discourse/app/templates/components/search-result-entry.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/search-result-entry.hbs
@@ -45,7 +45,7 @@
         <PluginOutlet
           @name="full-page-search-category"
           @connectorTagName="div"
-          @args={{hash post=this.post}}
+          @outletArgs={{hash post=this.post}}
         />
       </span>
     </div>

--- a/app/assets/javascripts/discourse/app/templates/components/suggested-topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/suggested-topics.hbs
@@ -31,6 +31,6 @@
   <PluginOutlet
     @name="below-suggested-topics"
     @connectorTagName="div"
-    @args={{hash topic=this.topic}}
+    @outletArgs={{hash topic=this.topic}}
   />
 </span>

--- a/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/tag-info.hbs
@@ -134,7 +134,7 @@
       <section>
         <PluginOutlet
           @name="tag-custom-settings"
-          @args={{hash tag=this.tagInfo}}
+          @outletArgs={{hash tag=this.tagInfo}}
         />
       </section>
       <div class="tag-actions">

--- a/app/assets/javascripts/discourse/app/templates/components/topic-category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-category.hbs
@@ -16,6 +16,6 @@
   <PluginOutlet
     @name="topic-category"
     @connectorTagName="div"
-    @args={{hash topic=this.topic category=this.topic.category}}
+    @outletArgs={{hash topic=this.topic category=this.topic.category}}
   />
 </span>

--- a/app/assets/javascripts/discourse/app/templates/components/topic-footer-buttons.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-footer-buttons.hbs
@@ -58,7 +58,7 @@
 
   <PluginOutlet
     @name="topic-footer-main-buttons-before-create"
-    @args={{hash topic=this.topic}}
+    @outletArgs={{hash topic=this.topic}}
     @connectorTagName="span"
   />
 
@@ -74,7 +74,7 @@
 
   <PluginOutlet
     @name="after-topic-footer-main-buttons"
-    @args={{hash topic=this.topic}}
+    @outletArgs={{hash topic=this.topic}}
     @connectorTagName="span"
   />
 </div>
@@ -97,6 +97,6 @@
 
 <PluginOutlet
   @name="after-topic-footer-buttons"
-  @args={{hash topic=this.topic}}
+  @outletArgs={{hash topic=this.topic}}
   @connectorTagName="span"
 />

--- a/app/assets/javascripts/discourse/app/templates/components/topic-list.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-list.hbs
@@ -18,7 +18,7 @@
 
 <PluginOutlet
   @name="before-topic-list-body"
-  @args={{hash
+  @outletArgs={{hash
     topics=this.topics
     selected=this.selected
     bulkSelectEnabled=this.bulkSelectEnabled
@@ -54,7 +54,7 @@
     }}
     <PluginOutlet
       @name="after-topic-list-item"
-      @args={{hash topic=topic index=index}}
+      @outletArgs={{hash topic=topic index=index}}
       @connectorTagName="tr"
     />
   {{/each}}
@@ -62,7 +62,7 @@
 
 <PluginOutlet
   @name="after-topic-list-body"
-  @args={{hash
+  @outletArgs={{hash
     topics=this.topics
     selected=this.selected
     bulkSelectEnabled=this.bulkSelectEnabled

--- a/app/assets/javascripts/discourse/app/templates/components/topic-status.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-status.hbs
@@ -65,5 +65,5 @@
 <PluginOutlet
   @name="after-topic-status"
   @connectorTagName="div"
-  @args={{hash topic=this.topic}}
+  @outletArgs={{hash topic=this.topic}}
 />

--- a/app/assets/javascripts/discourse/app/templates/components/topic-title.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/topic-title.hbs
@@ -6,7 +6,7 @@
     <PluginOutlet
       @name="topic-title"
       @connectorTagName="div"
-      @args={{hash model=this.model}}
+      @outletArgs={{hash model=this.model}}
     />
   </span>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -1,7 +1,7 @@
 {{#if this.visible}}
   <PluginOutlet
     @name="before-user-card-content"
-    @args={{hash user=this.user}}
+    @outletArgs={{hash user=this.user}}
   />
   <div class="card-content">
     {{#if this.loading}}
@@ -47,7 +47,7 @@
             <PluginOutlet
               @name="user-card-avatar-flair"
               @connectorTagName="div"
-              @args={{hash user=this.user}}
+              @outletArgs={{hash user=this.user}}
             />
           </div>
         </div>
@@ -91,7 +91,7 @@
           <PluginOutlet
             @name="user-card-after-username"
             @connectorTagName="div"
-            @args={{hash
+            @outletArgs={{hash
               user=this.user
               showUser=(fn this.handleShowUser this.user)
             }}
@@ -122,7 +122,7 @@
             <PluginOutlet
               @name="user-card-post-names"
               @connectorTagName="div"
-              @args={{hash user=this.user}}
+              @outletArgs={{hash user=this.user}}
             />
           </div>
         </div>
@@ -140,7 +140,7 @@
           <PluginOutlet
             @name="user-card-below-message-button"
             @connectorTagName="li"
-            @args={{hash user=this.user close=(action "close")}}
+            @outletArgs={{hash user=this.user close=(action "close")}}
           />
           {{#if this.showFilter}}
             <li>
@@ -176,14 +176,14 @@
             <PluginOutlet
               @name="user-card-additional-buttons"
               @connectorTagName="div"
-              @args={{hash user=this.user close=(action "close")}}
+              @outletArgs={{hash user=this.user close=(action "close")}}
             />
           </li>
         </ul>
         <PluginOutlet
           @name="user-card-additional-controls"
           @connectorTagName="div"
-          @args={{hash user=this.user close=(action "close")}}
+          @outletArgs={{hash user=this.user close=(action "close")}}
         />
       </div>
 
@@ -284,7 +284,7 @@
               <PluginOutlet
                 @name="user-card-location-and-website"
                 @connectorTagName="div"
-                @args={{hash user=this.user}}
+                @outletArgs={{hash user=this.user}}
               />
             </span>
           </div>
@@ -331,14 +331,14 @@
             <PluginOutlet
               @name="user-card-metadata"
               @connectorTagName="div"
-              @args={{hash user=this.user}}
+              @outletArgs={{hash user=this.user}}
             />
           </div>
         {{/unless}}
         <PluginOutlet
           @name="user-card-after-metadata"
           @connectorTagName="div"
-          @args={{hash user=this.user}}
+          @outletArgs={{hash user=this.user}}
         />
       </div>
 
@@ -369,7 +369,7 @@
       <PluginOutlet
         @name="user-card-before-badges"
         @connectorTagName="div"
-        @args={{hash user=this.user}}
+        @outletArgs={{hash user=this.user}}
       />
 
       {{#if this.showBadges}}

--- a/app/assets/javascripts/discourse/app/templates/components/user-info.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-info.hbs
@@ -41,7 +41,7 @@
       <PluginOutlet
         @name="after-user-name"
         @connectorTagName="span"
-        @args={{hash user=this.user}}
+        @outletArgs={{hash user=this.user}}
       />
     </span>
   </div>
@@ -59,6 +59,6 @@
   <PluginOutlet
     @name="after-user-info"
     @connectorTagName="div"
-    @args={{hash user=this.user}}
+    @outletArgs={{hash user=this.user}}
   />
 </span>

--- a/app/assets/javascripts/discourse/app/templates/components/user-profile-avatar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-profile-avatar.hbs
@@ -5,7 +5,7 @@
     <PluginOutlet
       @name="user-profile-avatar-flair"
       @connectorTagName="div"
-      @args={{hash model=@user}}
+      @outletArgs={{hash model=@user}}
     />
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/components/user-stream-item.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-stream-item.hbs
@@ -47,7 +47,7 @@
     <PluginOutlet
       @name="user-stream-item-header"
       @connectorTagName="div"
-      @args={{hash item=@item}}
+      @outletArgs={{hash item=@item}}
     />
   </span>
 </div>

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -31,7 +31,7 @@
           <PluginOutlet
             @name="composer-open"
             @connectorTagName="div"
-            @args={{hash model=this.model}}
+            @outletArgs={{hash model=this.model}}
           />
         </span>
 
@@ -47,7 +47,7 @@
 
               <PluginOutlet
                 @name="composer-action-after"
-                @args={{hash model=this.model}}
+                @outletArgs={{hash model=this.model}}
               />
 
               {{#unless this.site.mobileView}}
@@ -81,7 +81,7 @@
 
           <PluginOutlet
             @name="before-composer-controls"
-            @args={{hash model=this.model}}
+            @outletArgs={{hash model=this.model}}
           />
 
           <ComposerToggles
@@ -124,7 +124,7 @@
           <div class="composer-fields">
             <PluginOutlet
               @name="before-composer-fields"
-              @args={{hash model=this.model}}
+              @outletArgs={{hash model=this.model}}
             />
             {{#unless this.model.viewFullscreen}}
               {{#if this.model.canEditTitle}}
@@ -192,7 +192,7 @@
 
                   <PluginOutlet
                     @name="after-title-and-category"
-                    @args={{hash
+                    @outletArgs={{hash
                       model=this.model
                       tagValidation=this.tagValidation
                       canEditTags=this.canEditTags
@@ -206,7 +206,10 @@
                 <PluginOutlet
                   @name="composer-fields"
                   @connectorTagName="div"
-                  @args={{hash model=this.model showPreview=this.showPreview}}
+                  @outletArgs={{hash
+                    model=this.model
+                    showPreview=this.showPreview
+                  }}
                 />
               </span>
             {{/unless}}
@@ -216,7 +219,7 @@
         <span>
           <PluginOutlet
             @name="composer-after-composer-editor"
-            @args={{hash model=this.model}}
+            @outletArgs={{hash model=this.model}}
           />
         </span>
 
@@ -225,7 +228,7 @@
             <PluginOutlet
               @name="composer-fields-below"
               @connectorTagName="div"
-              @args={{hash model=this.model}}
+              @outletArgs={{hash model=this.model}}
             />
           </span>
 
@@ -311,7 +314,7 @@
             <span>
               <PluginOutlet
                 @name="composer-after-save-or-cancel"
-                @args={{hash model=this.model}}
+                @outletArgs={{hash model=this.model}}
               />
             </span>
           </div>
@@ -320,7 +323,7 @@
             <span>
               <PluginOutlet
                 @name="composer-mobile-buttons-bottom"
-                @args={{hash model=this.model}}
+                @outletArgs={{hash model=this.model}}
               />
             </span>
 

--- a/app/assets/javascripts/discourse/app/templates/discovery.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery.hbs
@@ -39,7 +39,7 @@
         {{outlet "header-list-container"}}
         <PluginOutlet
           @name="header-list-container-bottom"
-          @args={{hash category=this.category}}
+          @outletArgs={{hash category=this.category}}
         />
       </div>
     </div>
@@ -51,7 +51,7 @@
         <PluginOutlet
           @name="discovery-list-container-top"
           @connectorTagName="span"
-          @args={{hash category=this.category listLoading=this.loading}}
+          @outletArgs={{hash category=this.category listLoading=this.loading}}
         />
         {{outlet "list-container"}}
       </div>

--- a/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/categories.hbs
@@ -1,7 +1,7 @@
 <PluginOutlet
   @name="above-discovery-categories"
   @connectorTagName="div"
-  @args={{hash
+  @outletArgs={{hash
     categories=this.model.categories
     categoryPageStyle=this.categoryPageStyle
     topics=this.model.topics
@@ -45,7 +45,7 @@
 <PluginOutlet
   @name="below-discovery-categories"
   @connectorTagName="div"
-  @args={{hash
+  @outletArgs={{hash
     categories=this.model.categories
     categoryPageStyle=this.categoryPageStyle
     topics=this.model.topics

--- a/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
+++ b/app/assets/javascripts/discourse/app/templates/discovery/topics.hbs
@@ -63,7 +63,7 @@
     <PluginOutlet
       @name="before-topic-list"
       @connectorTagName="div"
-      @args={{hash category=this.category}}
+      @outletArgs={{hash category=this.category}}
     />
   </span>
 
@@ -100,7 +100,7 @@
     <PluginOutlet
       @name="after-topic-list"
       @connectorTagName="div"
-      @args={{hash category=this.category}}
+      @outletArgs={{hash category=this.category}}
     />
   </span>
 </DiscoveryTopicsList>

--- a/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
+++ b/app/assets/javascripts/discourse/app/templates/full-page-search.hbs
@@ -141,7 +141,7 @@
       <PluginOutlet
         @name="full-page-search-below-search-info"
         @connectorTagName="div"
-        @args={{hash search=this.searchTerm}}
+        @outletArgs={{hash search=this.searchTerm}}
       />
     </span>
 

--- a/app/assets/javascripts/discourse/app/templates/group.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group.hbs
@@ -2,7 +2,7 @@
   <PluginOutlet
     @name="before-group-container"
     @connectorTagName="div"
-    @args={{hash group=this.model}}
+    @outletArgs={{hash group=this.model}}
   />
 </span>
 
@@ -78,7 +78,7 @@
         <PluginOutlet
           @name="group-details-after"
           @connectorTagName="div"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
     </div>

--- a/app/assets/javascripts/discourse/app/templates/group/manage/tags.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group/manage/tags.hbs
@@ -3,7 +3,7 @@
   <PluginOutlet
     @name="before-manage-group-tags"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 
   <div class="control-group">

--- a/app/assets/javascripts/discourse/app/templates/groups/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/groups/index.hbs
@@ -106,7 +106,7 @@
                       <PluginOutlet
                         @name="group-index-box-after"
                         @connectorTagName="div"
-                        @args={{hash model=group}}
+                        @outletArgs={{hash model=group}}
                       />
                     </span>
                   </div>

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
@@ -17,7 +17,7 @@
     <PluginOutlet
       @name="extra-nav-item"
       @connectorTagName="li"
-      @args={{hash category=this.category filterMode=this.filterMode}}
+      @outletArgs={{hash category=this.category filterMode=this.filterMode}}
     />
   </ul>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/components/parent-category-row.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/parent-category-row.hbs
@@ -1,7 +1,7 @@
 {{#unless this.isHidden}}
   <PluginOutlet
     @name="category-list-above-each-category"
-    @args={{hash category=this.category}}
+    @outletArgs={{hash category=this.category}}
   />
   <div
     data-category-id={{this.category.id}}

--- a/app/assets/javascripts/discourse/app/templates/mobile/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/users.hbs
@@ -5,7 +5,7 @@
         <PluginOutlet
           @name="users-top"
           @connectorTagName="div"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
 
@@ -48,7 +48,7 @@
         </div>
         <PluginOutlet
           @name="users-directory-controls"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </div>
 

--- a/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/create-account.hbs
@@ -116,7 +116,7 @@
 
               <PluginOutlet
                 @name="create-account-before-password"
-                @args={{hash
+                @outletArgs={{hash
                   accountName=this.accountName
                   accountUsername=this.accountUsername
                   accountPassword=this.accountPassword
@@ -201,7 +201,7 @@
 
               <PluginOutlet
                 @name="create-account-after-password"
-                @args={{hash
+                @outletArgs={{hash
                   accountName=this.accountName
                   accountUsername=this.accountUsername
                   accountPassword=this.accountPassword

--- a/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/flag.hbs
@@ -24,7 +24,7 @@
   <PluginOutlet
     @name="flag-modal-bottom"
     @connectorTagName="div"
-    @args={{hash post=this.model}}
+    @outletArgs={{hash post=this.model}}
   />
 </DModalBody>
 

--- a/app/assets/javascripts/discourse/app/templates/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/history.hbs
@@ -8,7 +8,7 @@
       </LinkTo>
       <PluginOutlet
         @name="revision-user-details-after"
-        @args={{hash model=this.model}}
+        @outletArgs={{hash model=this.model}}
       />
       <span class="date">{{bound-date this.model.created_at}}</span>
       {{#if this.model.edit_reason}}
@@ -162,7 +162,7 @@
       <PluginOutlet
         @name="post-revisions"
         @connectorTagName="div"
-        @args={{hash model=this.model}}
+        @outletArgs={{hash model=this.model}}
       />
     </span>
 

--- a/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
+++ b/app/assets/javascripts/discourse/app/templates/navigation/category.hbs
@@ -12,7 +12,7 @@
     <PluginOutlet
       @name="category-heading"
       @connectorTagName="div"
-      @args={{hash category=this.category}}
+      @outletArgs={{hash category=this.category}}
     />
   </span>
 </section>
@@ -32,6 +32,6 @@
   <PluginOutlet
     @name="category-navigation"
     @connectorTagName="div"
-    @args={{hash category=this.category}}
+    @outletArgs={{hash category=this.category}}
   />
 </DSection>

--- a/app/assets/javascripts/discourse/app/templates/preferences.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences.hbs
@@ -83,7 +83,7 @@
         <PluginOutlet
           @name="user-preferences-nav-under-interface"
           @connectorTagName="div"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
 
@@ -99,7 +99,7 @@
         <PluginOutlet
           @name="user-preferences-nav"
           @connectorTagName="li"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
     </MobileNav>
@@ -111,7 +111,7 @@
     <PluginOutlet
       @name="above-user-preferences"
       @connectorTagName="div"
-      @args={{hash model=this.model}}
+      @outletArgs={{hash model=this.model}}
     />
   </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/account.hbs
@@ -267,7 +267,7 @@
   <PluginOutlet
     @name="user-preferences-account"
     @connectorTagName="div"
-    @args={{hash model=this.model save=(action "save")}}
+    @outletArgs={{hash model=this.model save=(action "save")}}
   />
 </span>
 
@@ -277,7 +277,7 @@
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/apps.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/apps.hbs
@@ -4,6 +4,6 @@
   <PluginOutlet
     @name="user-preferences-apps"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>

--- a/app/assets/javascripts/discourse/app/templates/preferences/emails.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/emails.hbs
@@ -56,7 +56,7 @@
     <PluginOutlet
       @name="user-preferences-emails-pref-email-settings"
       @connectorTagName="div"
-      @args={{hash model=this.model save=(action "save")}}
+      @outletArgs={{hash model=this.model save=(action "save")}}
     />
   </span>
 </div>
@@ -117,7 +117,7 @@
   <PluginOutlet
     @name="user-preferences-emails"
     @connectorTagName="div"
-    @args={{hash model=this.model save=(action "save")}}
+    @outletArgs={{hash model=this.model save=(action "save")}}
   />
 </span>
 
@@ -127,7 +127,7 @@
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/interface.hbs
@@ -2,7 +2,7 @@
   <PluginOutlet
     @name="user-preferences-interface-top"
     @connectorTagName="div"
-    @args={{hash model=this.model save=(action "save")}}
+    @outletArgs={{hash model=this.model save=(action "save")}}
   />
 </span>
 
@@ -238,7 +238,7 @@
   <PluginOutlet
     @name="user-preferences-interface"
     @connectorTagName="div"
-    @args={{hash model=this.model save=(action "save")}}
+    @outletArgs={{hash model=this.model save=(action "save")}}
   />
 </span>
 
@@ -248,7 +248,7 @@
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
@@ -36,7 +36,7 @@
       <PluginOutlet
         @name="user-preferences-desktop-notifications"
         @connectorTagName="div"
-        @args={{hash model=this.model save=(action "save")}}
+        @outletArgs={{hash model=this.model save=(action "save")}}
       />
     </span>
   </div>
@@ -54,7 +54,7 @@
   <PluginOutlet
     @name="user-preferences-notifications"
     @connectorTagName="div"
-    @args={{hash model=this.model save=(action "save")}}
+    @outletArgs={{hash model=this.model save=(action "save")}}
   />
 </span>
 
@@ -64,7 +64,7 @@
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/profile.hbs
@@ -159,7 +159,7 @@
   <PluginOutlet
     @name="user-preferences-profile"
     @connectorTagName="div"
-    @args={{hash model=this.model save=(action "save")}}
+    @outletArgs={{hash model=this.model save=(action "save")}}
   />
 </span>
 
@@ -167,7 +167,7 @@
   <PluginOutlet
     @name="user-custom-preferences"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 
@@ -177,7 +177,7 @@
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 

--- a/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/security.hbs
@@ -108,7 +108,7 @@
   <PluginOutlet
     @name="user-preferences-security"
     @connectorTagName="div"
-    @args={{hash model=this.model save=(action "save")}}
+    @outletArgs={{hash model=this.model save=(action "save")}}
   />
 </span>
 
@@ -118,6 +118,6 @@
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>

--- a/app/assets/javascripts/discourse/app/templates/preferences/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/users.hbs
@@ -60,7 +60,7 @@
   <PluginOutlet
     @name="user-custom-controls"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </span>
 

--- a/app/assets/javascripts/discourse/app/templates/review-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/review-index.hbs
@@ -32,7 +32,7 @@
         <PluginOutlet
           @name="above-review-filters"
           @connectorTagName="div"
-          @args={{hash
+          @outletArgs={{hash
             model=this.model
             additionalFilters=this.additionalFilters
           }}

--- a/app/assets/javascripts/discourse/app/templates/tag/show.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tag/show.hbs
@@ -48,7 +48,7 @@
         <PluginOutlet
           @name="tag-navigation"
           @connectorTagName="div"
-          @args={{hash category=this.category tag=this.tag}}
+          @outletArgs={{hash category=this.category tag=this.tag}}
         />
       </section>
     </div>
@@ -66,7 +66,7 @@
     <PluginOutlet
       @name="discovery-list-container-top"
       @connectorTagName="div"
-      @args={{hash category=this.category}}
+      @outletArgs={{hash category=this.category}}
     />
   </span>
 

--- a/app/assets/javascripts/discourse/app/templates/tags/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/tags/index.hbs
@@ -15,7 +15,7 @@
   <PluginOutlet
     @name="tags-below-title"
     @connectorTagName="div"
-    @args={{hash model=this.model}}
+    @outletArgs={{hash model=this.model}}
   />
 </div>
 

--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -28,7 +28,10 @@
     <PluginOutlet
       @name="topic-above-post-stream"
       @connectorTagName="div"
-      @args={{hash model=this.model editFirstPost=(action "editFirstPost")}}
+      @outletArgs={{hash
+        model=this.model
+        editFirstPost=(action "editFirstPost")
+      }}
     />
   </span>
 
@@ -77,7 +80,7 @@
               <PluginOutlet
                 @name="edit-topic"
                 @connectorTagName="div"
-                @args={{hash model=this.model buffered=this.buffered}}
+                @outletArgs={{hash model=this.model buffered=this.buffered}}
               />
             </span>
 
@@ -150,7 +153,7 @@
 
             <PluginOutlet
               @name="topic-title-suffix"
-              @args={{hash model=this.model}}
+              @outletArgs={{hash model=this.model}}
             />
           </h1>
 
@@ -217,7 +220,7 @@
         <PluginOutlet
           @name="topic-navigation"
           @connectorTagName="div"
-          @args={{hash topic=this.model}}
+          @outletArgs={{hash topic=this.model}}
         />
 
         {{#if info.renderTimeline}}
@@ -296,7 +299,10 @@
               <PluginOutlet
                 @name="before-topic-progress"
                 @connectorTagName="div"
-                @args={{hash model=this.model jumpToPost=(action "jumpToPost")}}
+                @outletArgs={{hash
+                  model=this.model
+                  jumpToPost=(action "jumpToPost")
+                }}
               />
             </span>
             <TopicAdminMenuButton
@@ -335,7 +341,7 @@
               <PluginOutlet
                 @name="topic-above-posts"
                 @connectorTagName="div"
-                @args={{hash model=this.model}}
+                @outletArgs={{hash model=this.model}}
               />
             </span>
 
@@ -526,7 +532,7 @@
             <PluginOutlet
               @name="topic-above-footer-buttons"
               @connectorTagName="div"
-              @args={{hash model=this.model}}
+              @outletArgs={{hash model=this.model}}
             />
           </span>
 
@@ -568,7 +574,7 @@
         <PluginOutlet
           @name="topic-above-suggested"
           @connectorTagName="div"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
       <div

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -1,7 +1,7 @@
 <PluginOutlet
   @name="above-user-profile"
   @connectorTagName="div"
-  @args={{hash model=this.model}}
+  @outletArgs={{hash model=this.model}}
 />
 <div
   class="container
@@ -111,7 +111,7 @@
         <div class="primary">
           <PluginOutlet
             @name="before-user-profile-avatar"
-            @args={{hash model=this.model}}
+            @outletArgs={{hash model=this.model}}
           />
           <UserProfileAvatar @user={{this.model}} @tagName="" />
           <div class="primary-textual">
@@ -150,7 +150,7 @@
                 <PluginOutlet
                   @name="user-post-names"
                   @connectorTagName="div"
-                  @args={{hash model=this.model}}
+                  @outletArgs={{hash model=this.model}}
                 />
               </span>
             </div>
@@ -201,7 +201,7 @@
                 <PluginOutlet
                   @name="user-location-and-website"
                   @connectorTagName="div"
-                  @args={{hash model=this.model}}
+                  @outletArgs={{hash model=this.model}}
                 />
               </span>
             </div>
@@ -256,7 +256,7 @@
                   <PluginOutlet
                     @name="user-profile-public-fields"
                     @connectorTagName="div"
-                    @args={{hash
+                    @outletArgs={{hash
                       publicUserFields=this.publicUserFields
                       model=this.model
                     }}
@@ -269,7 +269,7 @@
               <PluginOutlet
                 @name="user-profile-primary"
                 @connectorTagName="div"
-                @args={{hash model=this.model}}
+                @outletArgs={{hash model=this.model}}
               />
             </span>
           </div>
@@ -311,7 +311,7 @@
               <PluginOutlet
                 @name="user-profile-controls"
                 @connectorTagName="li"
-                @args={{hash model=this.model}}
+                @outletArgs={{hash model=this.model}}
               />
 
               {{#if this.canExpandProfile}}
@@ -332,7 +332,7 @@
         </div>
         <PluginOutlet
           @name="user-profile-above-collapsed-info"
-          @args={{hash model=this.model collapsedInfo=this.collapsedInfo}}
+          @outletArgs={{hash model=this.model collapsedInfo=this.collapsedInfo}}
         />
         {{#unless this.collapsedInfo}}
           <div class="secondary" id="collapsed-info-panel">
@@ -422,7 +422,7 @@
             <PluginOutlet
               @name="user-profile-secondary"
               @connectorTagName="div"
-              @args={{hash model=this.model}}
+              @outletArgs={{hash model=this.model}}
             />
           </div>
         {{/unless}}
@@ -491,7 +491,7 @@
             <PluginOutlet
               @name="user-main-nav"
               @connectorTagName="li"
-              @args={{hash model=this.model}}
+              @outletArgs={{hash model=this.model}}
             />
 
             {{#if this.model.can_edit}}

--- a/app/assets/javascripts/discourse/app/templates/user/activity.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/activity.hbs
@@ -71,7 +71,7 @@
           <PluginOutlet
             @name="user-activity-bottom"
             @connectorTagName="li"
-            @args={{hash model=this.model}}
+            @outletArgs={{hash model=this.model}}
           />
         </span>
       </MobileNav>

--- a/app/assets/javascripts/discourse/app/templates/user/badges.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/badges.hbs
@@ -22,7 +22,7 @@
     {{/each}}
     <PluginOutlet
       @name="after-user-profile-badges"
-      @args={{hash user=this.user.model}}
+      @outletArgs={{hash user=this.user.model}}
     />
   </div>
 </DSection>

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -158,7 +158,7 @@
         <PluginOutlet
           @name="user-messages-nav"
           @connectorTagName="li"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
     </MobileNav>

--- a/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/notifications.hbs
@@ -60,7 +60,7 @@
         <PluginOutlet
           @name="user-notifications-bottom"
           @connectorTagName="li"
-          @args={{hash model=this.model}}
+          @outletArgs={{hash model=this.model}}
         />
       </span>
     </MobileNav>

--- a/app/assets/javascripts/discourse/app/templates/user/summary.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/summary.hbs
@@ -2,7 +2,7 @@
   <div class="user-content" id="user-content">
     <PluginOutlet
       @name="above-user-summary-stats"
-      @args={{hash model=this.model user=this.user}}
+      @outletArgs={{hash model=this.model user=this.user}}
     />
     {{#if this.model.can_see_summary_stats}}
       <div class="top-section stats-section">
@@ -95,7 +95,7 @@
           <PluginOutlet
             @name="user-summary-stat"
             @connectorTagName="li"
-            @args={{hash model=this.model user=this.user}}
+            @outletArgs={{hash model=this.model user=this.user}}
           />
         </ul>
       </div>
@@ -103,7 +103,7 @@
 
     <PluginOutlet
       @name="below-user-summary-stats"
-      @args={{hash model=this.model user=this.user}}
+      @outletArgs={{hash model=this.model user=this.user}}
     />
 
     <div class="top-section">
@@ -282,7 +282,7 @@
             {{/each}}
             <PluginOutlet
               @name="after-user-summary-badges"
-              @args={{hash model=this.model user=this.user}}
+              @outletArgs={{hash model=this.model user=this.user}}
             />
           </div>
         {{else}}

--- a/app/assets/javascripts/discourse/app/templates/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/users.hbs
@@ -6,7 +6,7 @@
           <PluginOutlet
             @name="users-top"
             @connectorTagName="div"
-            @args={{hash model=this.model}}
+            @outletArgs={{hash model=this.model}}
           />
         </span>
         <div class="directory-controls">
@@ -56,7 +56,7 @@
             {{/if}}
             <PluginOutlet
               @name="users-directory-controls"
-              @args={{hash model=this.model}}
+              @outletArgs={{hash model=this.model}}
             />
           </div>
         </div>

--- a/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/plugin-outlet-test.js
@@ -69,7 +69,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
   test("Renders a template into the outlet", async function (assert) {
     this.set("shouldDisplay", false);
     await render(
-      hbs`<PluginOutlet @name="test-name" @args={{hash shouldDisplay=this.shouldDisplay}} />`
+      hbs`<PluginOutlet @name="test-name" @outletArgs={{hash shouldDisplay=this.shouldDisplay}} />`
     );
     assert.strictEqual(count(".hello-username"), 1, "renders the hello outlet");
     assert.false(
@@ -101,7 +101,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
   test("Reevaluates shouldRender for argument changes", async function (assert) {
     this.set("shouldDisplay", false);
     await render(
-      hbs`<PluginOutlet @name="test-name" @args={{hash shouldDisplay=this.shouldDisplay}} />`
+      hbs`<PluginOutlet @name="test-name" @outletArgs={{hash shouldDisplay=this.shouldDisplay}} />`
     );
     assert.false(
       exists(".conditional-render"),
@@ -116,7 +116,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
   test("Reevaluates shouldRender for other autotracked changes", async function (assert) {
     this.set("shouldDisplay", false);
     await render(
-      hbs`<PluginOutlet @name="test-name" @args={{hash shouldDisplay=this.shouldDisplay}} />`
+      hbs`<PluginOutlet @name="test-name" @outletArgs={{hash shouldDisplay=this.shouldDisplay}} />`
     );
     assert.false(
       exists(".conditional-render"),
@@ -131,7 +131,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
   test("Other outlets are not re-rendered", async function (assert) {
     this.set("shouldDisplay", false);
     await render(
-      hbs`<PluginOutlet @name="test-name" @args={{hash shouldDisplay=this.shouldDisplay}} />`
+      hbs`<PluginOutlet @name="test-name" @outletArgs={{hash shouldDisplay=this.shouldDisplay}} />`
     );
 
     const otherOutletElement = query(".hello-username");

--- a/app/assets/javascripts/wizard/addon/templates/components/wizard-field-checkbox.hbs
+++ b/app/assets/javascripts/wizard/addon/templates/components/wizard-field-checkbox.hbs
@@ -14,6 +14,6 @@
   </span>
   <PluginOutlet
     @name="below-wizard-checkbox"
-    @args={{hash disabled=this.field.disabled}}
+    @outletArgs={{hash disabled=this.field.disabled}}
   />
 </label>

--- a/plugins/chat/assets/javascripts/discourse/components/channels-list.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/channels-list.hbs
@@ -66,7 +66,7 @@
   <PluginOutlet
     @name="below-public-chat-channels"
     @tagName=""
-    @args={{hash inSidebar=this.inSidebar}}
+    @outletArgs={{hash inSidebar=this.inSidebar}}
   />
 
   {{#if this.showDirectMessageChannels}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-title.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-title.hbs
@@ -34,7 +34,7 @@
               {{/if}}
               <PluginOutlet
                 @name="after-chat-channel-username"
-                @args={{hash user=user}}
+                @outletArgs={{hash user=user}}
                 @tagName=""
                 @connectorTagName=""
               />


### PR DESCRIPTION
(see commit messages - to be rebased-and-merged)

---

**DEV: Deprecate PluginOutlet `@args` in favour of `@outletArgs`**

---

**DEV: Rename all uses of PluginOutlet `@args` in core**

The `args` argument is now deprecated. This commit uses a codemod (https://github.com/discourse/discourse-ember-codemods/tree/main/transforms/rename-plugin-outlet-args) to automatically rename all uses to `@outletArgs`.

---