### PR TITLE
FIX: Allow non-persisted color-scheme colors to be edited

### DIFF
--- a/app/serializers/color_scheme_serializer.rb
+++ b/app/serializers/color_scheme_serializer.rb
@@ -11,4 +11,11 @@ class ColorSchemeSerializer < ApplicationSerializer
   def theme_id
     object.theme&.id
   end
+
+  def colors
+    db_colors = object.colors.index_by(&:name)
+    object.resolved_colors.map do |name, default|
+      db_colors[name] || ColorSchemeColor.new(name: name, hex: default, color_scheme: object)
+    end
+  end
 end

--- a/spec/requests/admin/color_schemes_controller_spec.rb
+++ b/spec/requests/admin/color_schemes_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::ColorSchemesController do
 
       it "serializes default colors even when not present in database" do
         scheme = ColorScheme.create_from_base({ name: "my color scheme" })
-        scheme.colors.find_by(name: "primary").destroy
+        scheme.colors.find_by(name: "primary").destroy!
         scheme_name = scheme.name
 
         get "/admin/color_schemes.json"

--- a/spec/requests/admin/color_schemes_controller_spec.rb
+++ b/spec/requests/admin/color_schemes_controller_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe Admin::ColorSchemesController do
         expect(scheme_colors[0]["name"]).to eq(base_scheme_colors[0].name)
         expect(scheme_colors[0]["hex"]).to eq(base_scheme_colors[0].hex)
       end
+
+      it "serializes default colors even when not present in database" do
+        scheme = ColorScheme.create_from_base({ name: "my color scheme" })
+        scheme.colors.find_by(name: "primary").destroy
+        scheme_name = scheme.name
+
+        get "/admin/color_schemes.json"
+        expect(response.status).to eq(200)
+
+        serialized_scheme = response.parsed_body.find { |s| s["name"] == "my color scheme" }
+        scheme_colors = serialized_scheme["colors"]
+        expect(scheme_colors[0]["name"]).to eq("primary")
+        expect(scheme_colors[0]["hex"]).to eq(scheme.resolved_colors["primary"])
+      end
     end
 
     shared_examples "color schemes inaccessible" do


### PR DESCRIPTION
When we introduce new color scheme colors, they are not immediately persisted to the database for all color schemes. Previously, this meant that they would be unavailable in the admin UI for editing. The only way to work with the new colors was to create a new color scheme.

This commit updates the serializer so that all colors are serialized, even if they are not yet persisted to the database for the current scheme. This means that they now show up in the admin UI and can be edited.

---

Before:
<img width="300" alt="Screenshot 2023-01-31 at 16 35 18" src="https://user-images.githubusercontent.com/6270921/215824271-53cf1bab-e5ae-46f1-a770-1684cb08b91e.png">

After:

<img width="300" alt="Screenshot 2023-01-31 at 16 36 41" src="https://user-images.githubusercontent.com/6270921/215824347-a4e54108-1fea-4621-ab8c-3ecd9ed88898.png">
