### PR TITLE
DEV: Add ChatThread model and DB table, and ChatMessage reference

### DIFF
--- a/plugins/chat/app/models/chat_message.rb
+++ b/plugins/chat/app/models/chat_message.rb
@@ -10,6 +10,8 @@ class ChatMessage < ActiveRecord::Base
   belongs_to :user
   belongs_to :in_reply_to, class_name: "ChatMessage"
   belongs_to :last_editor, class_name: "User"
+  belongs_to :thread, class_name: "ChatThread"
+
   has_many :replies, class_name: "ChatMessage", foreign_key: "in_reply_to_id", dependent: :nullify
   has_many :revisions, class_name: "ChatMessageRevision", dependent: :destroy
   has_many :reactions, class_name: "ChatMessageReaction", dependent: :destroy
@@ -255,6 +257,7 @@ end
 #  cooked          :text
 #  cooked_version  :integer
 #  last_editor_id  :integer          not null
+#  thread_id       :integer
 #
 # Indexes
 #
@@ -262,4 +265,5 @@ end
 #  index_chat_messages_on_chat_channel_id_and_created_at  (chat_channel_id,created_at)
 #  index_chat_messages_on_chat_channel_id_and_id          (chat_channel_id,id) WHERE (deleted_at IS NULL)
 #  index_chat_messages_on_last_editor_id                  (last_editor_id)
+#  index_chat_messages_on_thread_id                       (thread_id)
 #

--- a/plugins/chat/app/models/chat_thread.rb
+++ b/plugins/chat/app/models/chat_thread.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ChatThread < ActiveRecord::Base
+  belongs_to :channel, foreign_key: "channel_id", class_name: "ChatChannel"
+  belongs_to :original_message_user, foreign_key: "original_message_user_id", class_name: "User"
+  belongs_to :original_message, foreign_key: "original_message_id", class_name: "ChatMessage"
+
+  has_many :chat_messages,
+           -> { order("chat_messages.created_at ASC, chat_messages.id ASC") },
+           foreign_key: :thread_id,
+           primary_key: :id
+
+  enum :status, { open: 0, read_only: 1, closed: 2, archived: 3 }, scopes: false
+
+  def url
+    "#{channel.url}/t/#{self.id}"
+  end
+
+  def relative_url
+    "#{channel.relative_url}/t/#{self.id}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: chat_threads
+#
+#  id                       :bigint           not null, primary key
+#  channel_id               :integer          not null
+#  original_message_id      :integer          not null
+#  original_message_user_id :integer          not null
+#  status                   :integer          default("open"), not null
+#  title                    :string
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_chat_threads_on_channel_id                (channel_id)
+#  index_chat_threads_on_channel_id_and_status     (channel_id,status)
+#  index_chat_threads_on_original_message_id       (original_message_id)
+#  index_chat_threads_on_original_message_user_id  (original_message_user_id)
+#  index_chat_threads_on_status                    (status)
+#

--- a/plugins/chat/db/migrate/20230201012734_create_chat_threading_models.rb
+++ b/plugins/chat/db/migrate/20230201012734_create_chat_threading_models.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateChatThreadingModels < ActiveRecord::Migration[7.0]
+  def change
+    create_table :chat_threads do |t|
+      t.bigint :channel_id, null: false
+      t.bigint :original_message_id, null: false
+      t.bigint :original_message_user_id, null: false
+      t.integer :status, null: false, default: 0
+      t.string :title, null: true
+
+      t.timestamps
+    end
+
+    add_index :chat_threads, :channel_id
+    add_index :chat_threads, :original_message_id
+    add_index :chat_threads, :original_message_user_id
+    add_index :chat_threads, :status
+    add_index :chat_threads, %i[channel_id status]
+
+    add_column :chat_messages, :thread_id, :bigint, null: true
+    add_index :chat_messages, :thread_id
+  end
+end

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -134,6 +134,7 @@ after_initialize do
   load File.expand_path("../app/models/chat_message_reaction.rb", __FILE__)
   load File.expand_path("../app/models/chat_message_revision.rb", __FILE__)
   load File.expand_path("../app/models/chat_mention.rb", __FILE__)
+  load File.expand_path("../app/models/chat_thread.rb", __FILE__)
   load File.expand_path("../app/models/chat_upload.rb", __FILE__)
   load File.expand_path("../app/models/chat_webhook_event.rb", __FILE__)
   load File.expand_path("../app/models/direct_message_channel.rb", __FILE__)


### PR DESCRIPTION
This new table will be used to automatically group replies
for messages into one place. In future additional functionality
will be built around the thread, like pinning messages, changing
the title, etc., the columns are just the main ones needed at first.
The columns are not prefixed with `chat_*` e.g. `chat_channel` since
this is redundant and just adds duplication everywhere, we want to
move away from this generally within chat.
