### PR TITLE
FIX: corrects a regression hiding avatar in user selector

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user-selector-autocomplete.hbr
+++ b/app/assets/javascripts/discourse/app/templates/user-selector-autocomplete.hbr
@@ -4,7 +4,7 @@
       {{#if item.isUser}}
         <li>
           <a href title="{{item.name}}" class="{{item.cssClasses}}">
-            {{avatar user imageSize="tiny"}}
+            {{avatar item imageSize="tiny"}}
             <span class='username'>{{format-username item.username}}</span>
             {{#if item.name}}
               <span class='name'>{{item.name}}</span>

--- a/spec/system/user_selector_spec.rb
+++ b/spec/system/user_selector_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe "User selector", type: :system, js: true do
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  fab!(:current_user) { Fabricate(:admin) }
+
+  before do
+    current_user.activate
+    sign_in(current_user)
+  end
+
+  context "when autocompleting a username" do
+    it "correctly shows the user" do
+      visit("/t/-/#{topic.id}")
+      find(".btn-primary.create").click
+      find(".d-editor-input").fill_in(with: "Hello @dis")
+
+      within(".autocomplete.ac-user") do |el|
+        expect(el).to have_selector(".selected .avatar[title=discobot]")
+        expect(el.find(".selected .username")).to have_content("discobot")
+      end
+    end
+  end
+
+  context "when autocompleting a group" do
+    it "correctly shows the user" do
+      visit("/t/-/#{topic.id}")
+      find(".btn-primary.create").click
+      find(".d-editor-input").fill_in(with: "Hello @adm")
+
+      within(".autocomplete.ac-user") do |el|
+        expect(el).to have_selector(".selected .d-icon-users")
+        expect(el.find(".selected .username")).to have_content("admins")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Due to the way templates works the incorrect variable (user instead of item) was not causing any error, and just failing silently to display the avatar.

This commit is also providing a basic spec for completion of users and groups.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
