### PR TITLE
DEV: Introduce support for Glimmer PluginOutlet connectors

### DIFF
--- a/app/assets/javascripts/discourse/app/components/plugin-connector.js
+++ b/app/assets/javascripts/discourse/app/components/plugin-connector.js
@@ -20,9 +20,6 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    const connector = this.connector;
-    this.set("layoutName", connector.templateName);
-
     const args = this.args || {};
     Object.keys(args).forEach((key) => {
       defineProperty(
@@ -50,15 +47,17 @@ export default Component.extend({
       );
     });
 
-    const connectorClass = this.get("connector.connectorClass");
-    this.set("actions", connectorClass.actions);
+    const connectorClass = this.connector.connectorClass;
+    this.set("actions", connectorClass?.actions);
 
-    for (const [name, action] of Object.entries(this.actions)) {
-      this.set(name, action.bind(this));
+    if (this.actions) {
+      for (const [name, action] of Object.entries(this.actions)) {
+        this.set(name, action.bind(this));
+      }
     }
 
     const merged = buildArgsWithDeprecations(args, deprecatedArgs);
-    connectorClass.setupComponent.call(this, merged, this);
+    connectorClass?.setupComponent?.call(this, merged, this);
   },
 
   didReceiveAttrs() {
@@ -77,13 +76,13 @@ export default Component.extend({
   willDestroyElement() {
     this._super(...arguments);
 
-    const connectorClass = this.get("connector.connectorClass");
-    connectorClass.teardownComponent.call(this, this);
+    const connectorClass = this.connector.connectorClass;
+    connectorClass?.teardownComponent?.call(this, this);
   },
 
   send(name, ...args) {
-    const connectorClass = this.get("connector.connectorClass");
-    const action = connectorClass.actions[name];
+    const connectorClass = this.connector.connectorClass;
+    const action = connectorClass?.actions?.[name];
     return action ? action.call(this, ...args) : this._super(name, ...args);
   },
 });

--- a/app/assets/javascripts/discourse/app/templates/components/plugin-outlet.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/plugin-outlet.hbs
@@ -5,24 +5,40 @@
   }}
   <this.wrapperComponent @tagName={{@tagName}}>
     {{#each this.connectors as |c|}}
-      <PluginConnector
-        @connector={{c}}
-        @args={{this.outletArgs}}
-        @deprecatedArgs={{@deprecatedArgs}}
-        @class={{c.classNames}}
-        @tagName={{or @connectorTagName ""}}
-      />
+      {{#if c.componentClass}}
+        <c.componentClass @outletArgs={{this.outletArgsWithDeprecations}} />
+      {{else if @defaultGlimmer}}
+        <c.templateOnly @outletArgs={{this.outletArgsWithDeprecations}} />
+      {{else}}
+        <PluginConnector
+          @connector={{c}}
+          @args={{this.outletArgs}}
+          @deprecatedArgs={{@deprecatedArgs}}
+          @outletArgs={{this.outletArgsWithDeprecations}}
+          @class={{c.classicClassNames}}
+          @tagName={{or @connectorTagName ""}}
+          @layout={{c.template}}
+        />
+      {{/if}}
     {{/each}}
   </this.wrapperComponent>
 {{else}}
   {{! The modern path: no wrapper element = no classic component }}
   {{#each this.connectors as |c|}}
-    <PluginConnector
-      @connector={{c}}
-      @args={{this.outletArgs}}
-      @deprecatedArgs={{@deprecatedArgs}}
-      @class={{c.classNames}}
-      @tagName={{or @connectorTagName ""}}
-    />
+    {{#if c.componentClass}}
+      <c.componentClass @outletArgs={{this.outletArgsWithDeprecations}} />
+    {{else if @defaultGlimmer}}
+      <c.templateOnly @outletArgs={{this.outletArgsWithDeprecations}} />
+    {{else}}
+      <PluginConnector
+        @connector={{c}}
+        @args={{this.outletArgs}}
+        @deprecatedArgs={{@deprecatedArgs}}
+        @outletArgs={{this.outletArgsWithDeprecations}}
+        @class={{c.classicClassNames}}
+        @tagName={{or @connectorTagName ""}}
+        @layout={{c.template}}
+      />
+    {{/if}}
   {{/each}}
 {{/if}}


### PR DESCRIPTION
Previously, all plugin connector templates would be rendered using the PluginConnector classic component definition. This commit introduces three key changes:

1. PluginOutlets can be passed `@defaultGlimmer={{true}}`, which will cause all connectors to be rendered as highly-performant 'template only glimmer components'. For now, to avoid breaking backwards compatibility, this is only intended for use on newly introduced PluginOutlets.

2. Connector js files can now directly export component definitions. This allows connectors on existing outlets to start using Glimmer components (template-only, or otherwise) straight away. It also makes it much more ergonomic to introduce custom logic to outlets. `shouldRender` continues to be supported (as a static class method).

3. Outlet arguments are now made available as `@outletArgs` in classic, glimmer and template-only-glimmer connectors. In glimmer and template-only-glimmer connectors, this is the only way to access the outlet's arguments. In classic connectors, the old methods still function - `@outletArgs` exists as a path for incremental migration

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
