### PR TITLE
UX: show full topic title for reply-where

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -940,17 +940,17 @@ export default Controller.extend({
         return;
       }
 
-      let topicLabelContent = function (topicOption) {
-        let topicClosed = topicOption.closed
+      const topicLabelContent = function (topicOption) {
+        const topicClosed = topicOption.closed
           ? `<span class="topic-status">${iconHTML("lock")}</span>`
           : "";
-        let topicPinned = topicOption.pinned
+        const topicPinned = topicOption.pinned
           ? `<span class="topic-status">${iconHTML("thumbtack")}</span>`
           : "";
-        let topicBookmarked = topicOption.bookmarked
+        const topicBookmarked = topicOption.bookmarked
           ? `<span class="topic-status">${iconHTML("bookmark")}</span>`
           : "";
-        let topicPM =
+        const topicPM =
           topicOption.archetype === "private_message"
             ? `<span class="topic-status">${iconHTML("envelope")}</span>`
             : "";

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -279,6 +279,12 @@
 }
 
 .reply-where-modal {
+  .dialog-content {
+    width: 100%;
+    min-width: unset;
+    max-width: 30em;
+  }
+
   .dialog-footer {
     display: block;
   }
@@ -291,19 +297,67 @@
     overflow: hidden;
     width: 100%;
 
-    &:first-of-type {
-      margin-top: 0.25em;
+    &.dialog-close {
+      display: none;
     }
 
-    &.btn-reply-on-original,
+    &.btn-reply-on-original {
+      --text-color: var(--secondary);
+    }
+
+    &.btn-reply-where__cancel {
+      padding-left: 0;
+      margin: 0;
+    }
+
     &.btn-reply-here {
-      font-size: var(--font-up-1);
-      line-height: var(--line-height-medium);
-      font-weight: bold;
+      --text-color: var(--primary);
+      .discourse-no-touch & {
+        &:hover {
+          --text-color: var(--secondary);
+        }
+      }
+    }
+
+    &.btn-reply-where {
+      min-height: 3em; // for situations when there are no categories/tags
     }
 
     .topic-title {
-      font-weight: normal;
+      .d-icon {
+        color: var(--text-color);
+        margin: 0;
+      }
+    }
+
+    .fancy-title {
+      display: inline-block;
+      width: 100%;
+
+      @include ellipsis;
+    }
+
+    .topic-title__top-line {
+      display: flex;
+      align-items: baseline;
+      color: var(--text-color);
+      font-size: var(--font-up-1);
+    }
+
+    .topic-statuses {
+      display: flex;
+      font-size: 0.95em;
+    }
+
+    .topic-title__bottom-line {
+      margin-top: 0.15em;
+      .discourse-tags {
+        font-size: var(--font-down-1);
+      }
+      .category-name,
+      .discourse-tag {
+        color: var(--text-color);
+      }
     }
   }
 }

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -351,6 +351,8 @@
 
     .topic-title__bottom-line {
       margin-top: 0.15em;
+      display: flex;
+      align-items: baseline;
       .discourse-tags {
         font-size: var(--font-down-1);
       }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2373,8 +2373,6 @@ en:
 
       save_edit: "Save Edit"
       overwrite_edit: "Overwrite Edit"
-      reply_original: "Reply on Original Topic"
-      reply_here: "Reply Here"
       reply: "Reply"
       cancel: "Cancel"
       create_topic: "Create Topic"


### PR DESCRIPTION
This shows the full topic title along with topic status, category, and tags to give users better context when they're deciding where to reply. 

I also improved some styles, like constraining the max-width. 

Before:

![image](https://user-images.githubusercontent.com/1681963/216090041-3838ed8b-4e82-44bf-aa8b-61948e16f474.png)



After: 

![Screenshot 2023-02-01 at 10 14 51 AM](https://user-images.githubusercontent.com/1681963/216089888-f550e123-e322-4b90-8464-728ed8b8c145.png)
![Screenshot 2023-02-01 at 10 15 29 AM](https://user-images.githubusercontent.com/1681963/216089892-76ac4860-fa4a-4d0e-93e3-c146b387867c.png)


/t/91318