### PR TITLE
FIX: reverts value check when reseting composer value

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -223,7 +223,6 @@ export default Component.extend(TextareaTextManipulation, {
     this._super(...arguments);
 
     if (
-      !this.value &&
       !this.editingMessage &&
       this.draft &&
       this.chatChannel?.canModifyMessages(this.currentUser)


### PR DESCRIPTION
This change was made to prevent composer input to be reset randomly during tests but this is causing more issues for now: most notably composer state not being reset when changing channel. This will need a better solution.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
