### PR TITLE
UX: Add timezone aliases for `IST`, `KST` and `JST`

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/moment.js
+++ b/app/assets/javascripts/discourse/app/initializers/moment.js
@@ -3,6 +3,7 @@ export default {
   after: "message-bus",
 
   initialize() {
+    moment.tz.link(["Asia/Kolkata|IST", "Asia/Seoul|KST", "Asia/Tokyo|JST"]);
     delete moment.tz._links["us_pacific-new"];
   },
 };


### PR DESCRIPTION
See https://meta.discourse.org/t/add-additional-timezones-to-insert-date-time/253157, it seems pretty simple (and useful) to add some commonly-used aliases here. 