### PR TITLE
FIX: Use `username_lower` in user menu router lookup

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -45,6 +45,7 @@ export default class extends Controller {
 
     for (let i = this.messagesDropdownContent.length - 1; i >= 0; i--) {
       const row = this.messagesDropdownContent[i];
+
       if (this.router.currentURL.includes(row.id)) {
         value = row.id;
         break;

--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -45,7 +45,6 @@ export default class extends Controller {
 
     for (let i = this.messagesDropdownContent.length - 1; i >= 0; i--) {
       const row = this.messagesDropdownContent[i];
-
       if (this.router.currentURL.includes(row.id)) {
         value = row.id;
         break;
@@ -59,7 +58,10 @@ export default class extends Controller {
   get messagesDropdownContent() {
     const content = [
       {
-        id: this.router.urlFor("userPrivateMessages.user", this.model.username),
+        id: this.router.urlFor(
+          "userPrivateMessages.user",
+          this.model.username_lower
+        ),
         name: I18n.t("user.messages.inbox"),
       },
     ];
@@ -78,7 +80,10 @@ export default class extends Controller {
 
     if (this.pmTaggingEnabled) {
       content.push({
-        id: this.router.urlFor("userPrivateMessages.tags", this.model.username),
+        id: this.router.urlFor(
+          "userPrivateMessages.tags",
+          this.model.username_lower
+        ),
         name: I18n.t("user.messages.tags"),
         icon: "tags",
       });
@@ -86,7 +91,7 @@ export default class extends Controller {
 
     customUserNavMessagesDropdownRows.forEach((row) => {
       content.push({
-        id: this.router.urlFor(row.routeName, this.model.username),
+        id: this.router.urlFor(row.routeName, this.model.username_lower),
         name: row.name,
         icon: row.icon,
       });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -19,6 +19,7 @@ import {
 } from "discourse/lib/topic-list-tracker";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { resetCustomUserNavMessagesDropdownRows } from "discourse/controllers/user-private-messages";
+import userFixtures from "discourse/tests/fixtures/user-fixtures";
 
 acceptance(
   "User Private Messages - user with no group messages",
@@ -1043,6 +1044,31 @@ acceptance(
       await visit("/u/eviltrout/messages");
       await click(".new-private-message");
       assert.ok(!exists("#reply-control .mini-tag-chooser"));
+    });
+  }
+);
+
+acceptance(
+  "User Private Messages - user with uppercase username",
+  function (needs) {
+    needs.user({
+      redesigned_user_page_nav_enabled: true,
+    });
+
+    needs.pretender((server, helper) => {
+      const response = cloneJSON(userFixtures["/u/charlie.json"]);
+      response.user.username = "chArLIe";
+      server.get("/u/charlie.json", () => helper.response(response));
+    });
+
+    test("viewing inbox", async function (assert) {
+      await visit("/u/charlie/messages");
+
+      assert.strictEqual(
+        query(".user-nav-messages-dropdown .selected-name").textContent.trim(),
+        "Inbox",
+        "menu defaults to Inbox"
+      );
     });
   }
 );


### PR DESCRIPTION
For user whose username has an uppercase character, the new user menu dropdown was not defaulting to "Inbox" because the Ember router uses lowercased usernames which were not matching with the `username` property. Switching to `username_lower` fixes the issue.
