### PR TITLE
FIX: Emoji preview showing incorrect preview on keyboard focus

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -211,10 +211,7 @@ export default Component.extend({
       return false;
     }
 
-    this.set(
-      "hoveredEmoji",
-      this._codeWithDiversity(event.target.title, this.selectedDiversity)
-    );
+    this._updateEmojiPreview(event.target.title);
   },
 
   @action
@@ -255,15 +252,11 @@ export default Component.extend({
 
     let currentEmoji;
 
-    this.set(
-      "hoveredEmoji",
-      this._codeWithDiversity(event.target.title, this.selectedDiversity)
-    );
-
     if (
       event.key === "ArrowDown" &&
       this._focusedOn(this.elements.searchInput)
     ) {
+      this._updateEmojiPreview(emojis[0].title);
       emojis[0].focus();
       event.preventDefault();
       return false;
@@ -306,8 +299,10 @@ export default Component.extend({
         let nextEmoji = currentEmoji + 1;
 
         if (nextEmoji < emojis.length) {
+          this._updateEmojiPreview(emojis[nextEmoji].title);
           emojis[nextEmoji].focus();
         } else if (nextEmoji >= emojis.length) {
+          this._updateEmojiPreview(emojis[0].title);
           emojis[0].focus();
         }
       }
@@ -315,6 +310,7 @@ export default Component.extend({
       if (event.key === "ArrowLeft") {
         const previousEmoji = currentEmoji - 1;
         if (currentEmoji > 0) {
+          this._updateEmojiPreview(emojis[previousEmoji].title);
           emojis[previousEmoji].focus();
         }
       }
@@ -329,7 +325,7 @@ export default Component.extend({
         const emojiBelow = [...emojis]
           .filter((c) => c.offsetTop > active.offsetTop)
           .find((c) => c.offsetLeft === active.offsetLeft);
-
+        this._updateEmojiPreview(emojiBelow.title);
         emojiBelow?.focus();
       }
 
@@ -343,8 +339,10 @@ export default Component.extend({
           .find((c) => c.offsetLeft === active.offsetLeft);
 
         if (emojiAbove) {
+          this._updateEmojiPreview(emojiAbove.title);
           emojiAbove.focus();
         } else {
+          this.set("hoveredEmoji", null);
           document.querySelector(this.elements.searchInput).focus();
         }
       }
@@ -464,6 +462,13 @@ export default Component.extend({
     return (
       document.querySelector(".emoji-picker-anchor") ??
       document.querySelector(".d-editor-textarea-wrapper")
+    );
+  },
+
+  _updateEmojiPreview(title) {
+    return this.set(
+      "hoveredEmoji",
+      this._codeWithDiversity(title, this.selectedDiversity)
     );
   },
 


### PR DESCRIPTION
This PR fixes a minor issue where the emoji preview doesn't show the correct emoji being focused on and instead shows the previous emoji.

Previously the emoji shown in the preview was only being updated each time there was a new keyboard input, so it would always be off by one. This fix ensures that the `hoveredEmoji` attribute is set each time an emoji is focused through an arrow key focus on keyboard input.

This PR also updates the preview so that the emoji in the preview is removed when focusing back on the search input.

https://user-images.githubusercontent.com/30090424/216146482-f594f3f4-34f9-4a6c-ac44-fb2d6bc19d1e.mov


