### PR TITLE
A11Y: add aria-label to embedded jump link

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/embedded-post.js
+++ b/app/assets/javascripts/discourse/app/widgets/embedded-post.js
@@ -8,15 +8,15 @@ createWidget("post-link-arrow", {
   tagName: "div.post-link-arrow",
 
   template: hbs`
-    {{#if attrs.above}}
-      <a href={{attrs.shareUrl}} class="post-info arrow" title={{i18n "topic.jump_reply_up"}}>
+      <a href={{attrs.shareUrl}} class="post-info arrow" title={{i18n "topic.jump_reply"}} aria-label={{i18n 
+        "topic.jump_reply_aria" username=attrs.name
+      }}>
+      {{#if attrs.above}}
         {{d-icon "arrow-up"}}
-      </a>
-    {{else}}
-      <a href={{attrs.shareUrl}} class="post-info arrow" title={{i18n "topic.jump_reply_down"}}>
+      {{else}}
         {{d-icon "arrow-down"}}
+      {{/if}}
       </a>
-    {{/if}}
   `,
 });
 
@@ -44,6 +44,7 @@ export default createWidget("embedded-post", {
           h("div.topic-meta-data.embedded-reply", [
             this.attach("poster-name", attrs),
             this.attach("post-link-arrow", {
+              name: attrs.username,
               above: state.above,
               shareUrl: attrs.customShare,
             }),

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2976,8 +2976,8 @@ en:
       browse_all_tags_or_latest: "<a href='%{basePath}/tags'>Browse all tags</a> or <a href='%{basePath}/latest'>view latest topics</a>."
 
       suggest_create_topic: Ready to <a href>start a new conversation?</a>
-      jump_reply_up: jump to earlier reply
-      jump_reply_down: jump to later reply
+      jump_reply: "Jump to post's original location"
+      jump_reply_aria: "Jump to @%{username}'s post in its original location"
       deleted: "The topic has been deleted"
 
       slow_mode_update:


### PR DESCRIPTION
Originally reported as:

> The “jump to later reply” links lack an accessible name as screen readers will generally ignore title attributes on links. Even changing the accessible name to match the current title attribute will mean that it fails SC 2.4.4 Link Purpose (In Context) as it is not possible to distinguish between the many links with the same title attribute text.


The newly added aria-label will read `Jump to @%{username}'s post in its original location` — the username helps distinguish the link's purpose from successive replies. 

Additionally the `jump to [later/earlier] post` language for the title tag seemed a little vague (is it a post later/earlier than the one I'm reading?), so I've updated it to `Jump to post's original location` which is more descriptive and eliminates the need for two strings. 