### PR TITLE
A11Y: aria-label for the post edit history button

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-edits-indicator.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-edits-indicator.js
@@ -56,6 +56,7 @@ export default createWidget("post-edits-indicator", {
       translatedTitle: title,
       className,
       action: "onPostEditsIndicatorClick",
+      translatedAriaLabel: I18n.t("post.edit_history"),
       translatedLabel: attrs.version > 1 ? attrs.version - 1 : "",
     });
   },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3362,6 +3362,7 @@ en:
       ignored: "Ignored content"
       wiki_last_edited_on: "wiki last edited on %{dateTime}"
       last_edited_on: "post last edited on %{dateTime}"
+      edit_history: "post edit history"
       reply_as_new_topic: "Reply as linked Topic"
       reply_as_new_private_message: "Reply as new message to the same recipients"
       continue_discussion: "Continuing the discussion from %{postLink}:"


### PR DESCRIPTION
Without an accessible label the button only reads the number of edits without context. 