### PR TITLE
A11Y: history modal mode toggles need aria-labels

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/history.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/history.hbs
@@ -58,6 +58,7 @@
               class={{this.inlineClass}}
               {{on "click" this.displayInline}}
               title={{i18n "post.revisions.displays.inline.title"}}
+              aria-label={{i18n "post.revisions.displays.inline.title"}}
             >
               {{d-icon "far-square"}}
               {{i18n "post.revisions.displays.inline.button"}}
@@ -69,6 +70,7 @@
               class={{this.sideBySideClass}}
               {{on "click" this.displaySideBySide}}
               title={{i18n "post.revisions.displays.side_by_side.title"}}
+              aria-label={{i18n "post.revisions.displays.side_by_side.title"}}
             >
               {{d-icon "columns"}}
               {{i18n "post.revisions.displays.side_by_side.button"}}
@@ -80,6 +82,9 @@
               class={{this.sideBySideMarkdownClass}}
               {{on "click" this.displaySideBySideMarkdown}}
               title={{i18n
+                "post.revisions.displays.side_by_side_markdown.title"
+              }}
+              aria-label={{i18n
                 "post.revisions.displays.side_by_side_markdown.title"
               }}
             >


### PR DESCRIPTION
These links were lacking more descriptive labels, so would be both read as "HTML" by some screen readers. This gives them more descriptive `aria-label`s

![Screenshot 2023-02-01 at 5 40 30 PM](https://user-images.githubusercontent.com/1681963/216180431-d4bfbaef-3301-4bdc-bb64-c41483d50521.png)

(note that NVDA used to read both the `aria-label` and `title`, but now only reads `aria-label` if the title matches. JAWS ignores title tags.)