### PR TITLE
FIX: Remove action buttons if post has already been reviewed

### DIFF
--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -32,12 +32,10 @@ class ReviewableQueuedPost < Reviewable
       end
     end
 
-    unless rejected?
-      if pending?
-        actions.add(:reject_post) do |a|
-          a.icon = "times"
-          a.label = "reviewables.actions.reject_post.title"
-        end
+    if pending?
+      actions.add(:reject_post) do |a|
+        a.icon = "times"
+        a.label = "reviewables.actions.reject_post.title"
       end
     end
 

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -25,11 +25,9 @@ class ReviewableQueuedPost < Reviewable
           a.confirm_message = "reviewables.actions.approve_post.confirm_closed"
         end
       else
-        unless rejected?
-          actions.add(:approve_post) do |a|
-            a.icon = "check"
-            a.label = "reviewables.actions.approve_post.title"
-          end
+        actions.add(:approve_post) do |a|
+          a.icon = "check"
+          a.label = "reviewables.actions.approve_post.title"
         end
       end
     end

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -399,6 +399,12 @@ RSpec.describe Reviewable, type: :model do
       )
     end
 
+    it "triggers a notification on approve -> edit to update status" do
+      reviewable = Fabricate(:reviewable_queued_post, status: Reviewable.statuses[:approved])
+
+      expect { reviewable.perform(moderator, :edit_post) }.to raise_error(Reviewable::InvalidAction)
+    end
+
     it "triggers a notification on reject -> approve to update status" do
       reviewable = Fabricate(:reviewable_queued_post, status: Reviewable.statuses[:rejected])
 

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -394,14 +394,9 @@ RSpec.describe Reviewable, type: :model do
     it "triggers a notification on approve -> reject to update status" do
       reviewable = Fabricate(:reviewable_queued_post, status: Reviewable.statuses[:approved])
 
-      expect do reviewable.perform(moderator, :reject_post) end.to change {
-        Jobs::NotifyReviewable.jobs.size
-      }.by(1)
-
-      job = Jobs::NotifyReviewable.jobs.last
-
-      expect(job["args"].first["reviewable_id"]).to eq(reviewable.id)
-      expect(job["args"].first["updated_reviewable_ids"]).to contain_exactly(reviewable.id)
+      expect { reviewable.perform(moderator, :reject_post) }.to raise_error(
+        Reviewable::InvalidAction,
+      )
     end
 
     it "triggers a notification on reject -> approve to update status" do

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -653,6 +653,9 @@ RSpec.describe ReviewablesController do
       fab!(:reviewable_post) { Fabricate(:reviewable_queued_post) }
       fab!(:reviewable_topic) { Fabricate(:reviewable_queued_post_topic) }
       fab!(:moderator) { Fabricate(:moderator) }
+      fab!(:reviewable_approved_post) do
+        Fabricate(:reviewable_queued_post, status: Reviewable.statuses[:approved])
+      end
 
       before { sign_in(moderator) }
 
@@ -728,6 +731,19 @@ RSpec.describe ReviewablesController do
         json = response.parsed_body
         expect(json["payload"]["raw"]).to eq("new raw content")
         expect(json["version"] > 0).to eq(true)
+      end
+
+      it "prevents you from updating an approved post" do
+        put "/review/#{reviewable_approved_post.id}.json?version=#{reviewable_approved_post.version}",
+            params: {
+              reviewable: {
+                payload: {
+                  raw: "new raw content",
+                },
+              },
+            }
+
+        expect(response.code).to eq("403")
       end
 
       it "allows you to update a queued post (for new topic)" do


### PR DESCRIPTION
If a post has already been reviewed, the "reject" and "edit" buttons have been removed. This also prevents accidentally publishing multiple copies of the same post by "accepting" then "rejecting" and "accepting" again the same reviewed post.