### PR TITLE
DEV: Limit and validate category settings inputs

### DIFF
--- a/app/assets/javascripts/discourse/app/components/number-field.js
+++ b/app/assets/javascripts/discourse/app/components/number-field.js
@@ -5,6 +5,22 @@ import discourseComputed from "discourse-common/utils/decorators";
 export default TextField.extend({
   classNameBindings: ["invalid"],
 
+  keyDown: function (e) {
+    const key = e.which;
+
+    return (
+      key === 13 || // Enter
+      key === 8 || // Backspace
+      key === 9 || // Tab
+      key === 46 || // Delete
+      ((key === 109 || key === 189) && // Negative sign
+        parseInt(this.get("min"), 10) < 0) ||
+      (key >= 35 && key <= 40) || // Cursor keys
+      (key >= 48 && key <= 57) || // Numbers
+      (key >= 96 && key <= 105) // Numpad
+    );
+  },
+
   @discourseComputed("number")
   value: {
     get(number) {

--- a/app/assets/javascripts/discourse/app/components/number-field.js
+++ b/app/assets/javascripts/discourse/app/components/number-field.js
@@ -2,22 +2,34 @@ import I18n from "I18n";
 import TextField from "discourse/components/text-field";
 import discourseComputed from "discourse-common/utils/decorators";
 
+const ALLOWED_KEYS = [
+  "Enter",
+  "Backspace",
+  "Tab",
+  "Delete",
+  "ArrowLeft",
+  "ArrowUp",
+  "ArrowRight",
+  "ArrowDown",
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+];
+
 export default TextField.extend({
   classNameBindings: ["invalid"],
 
   keyDown: function (e) {
-    const key = e.which;
-
     return (
-      key === 13 || // Enter
-      key === 8 || // Backspace
-      key === 9 || // Tab
-      key === 46 || // Delete
-      ((key === 109 || key === 189) && // Negative sign
-        parseInt(this.get("min"), 10) < 0) ||
-      (key >= 35 && key <= 40) || // Cursor keys
-      (key >= 48 && key <= 57) || // Numbers
-      (key >= 96 && key <= 105) // Numpad
+      ALLOWED_KEYS.includes(e.key) ||
+      (e.key === "-" && parseInt(this.get("min"), 10) < 0)
     );
   },
 

--- a/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/edit-category-settings.hbs
@@ -4,11 +4,12 @@
       <label for="category-position">
         {{i18n "category.position"}}
       </label>
-      <TextField
-        @value={{this.category.position}}
+      <NumberField
+        @number={{this.category.position}}
         @id="category-position"
         @class="position-input"
         @type="number"
+        @min="0"
       />
     </section>
   {{/if}}
@@ -34,10 +35,11 @@
         {{i18n "category.num_featured_topics"}}
       {{/if}}
     </label>
-    <TextField
-      @value={{this.category.num_featured_topics}}
+    <NumberField
+      @number={{this.category.num_featured_topics}}
       @id="category-number-featured-topics"
       @type="number"
+      @min="1"
     />
   </section>
 
@@ -185,10 +187,11 @@
     <label for="category-number-daily-bump">
       {{i18n "category.num_auto_bump_daily"}}
     </label>
-    <TextField
-      @value={{this.category.custom_fields.num_auto_bump_daily}}
+    <NumberField
+      @number={{this.category.custom_fields.num_auto_bump_daily}}
       @id="category-number-daily-bump"
       @type="number"
+      @min="0"
     />
   </section>
 </section>

--- a/app/assets/javascripts/discourse/app/templates/modal/reorder-categories.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/reorder-categories.hbs
@@ -21,6 +21,7 @@
             <NumberField
               @number={{readonly cat.position}}
               @change={{action "change" cat}}
+              @min="0"
             />
             <DButton
               @class="btn-default no-text"

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -73,6 +73,12 @@ class Category < ActiveRecord::Base
   validate :ensure_slug
   validate :permissions_compatibility_validator
 
+  validates :default_slow_mode_seconds,
+            numericality: {
+              only_integer: true,
+              greater_than: 0,
+            },
+            allow_nil: true
   validates :auto_close_hours,
             numericality: {
               greater_than: 0,

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Category do
   it { is_expected.to validate_presence_of :user_id }
   it { is_expected.to validate_presence_of :name }
 
+  it do
+    is_expected.to validate_numericality_of(:default_slow_mode_seconds).is_greater_than(
+      0,
+    ).only_integer
+  end
+
   it "validates uniqueness of name" do
     Fabricate(:category_with_definition)
     is_expected.to validate_uniqueness_of(:name).scoped_to(:parent_category_id).case_insensitive


### PR DESCRIPTION
### Background

We recently had a bug which caused auto-bumping to "not work". The problem was that the value had been set to `0.5`, which when coerced to an integer turned into `0`. So the feature is "working as intended", but there's a possibility of misconfiguration.

When looking into this, I noticed that the inputs on the category settings page doesn't have any particular sanitisation in the front-end, and also one or two validations missing in the back-end.

### What is this change?

This change:

1. Takes an existing component, `NumberField` and enhances that by only allowing numeric input, essentially turning it into a managed input using the same approach as our `PasswordField`.
2. Changes the numeric inputs on category settings page to use this component.
3. Adds appropriate `min` constraints to the fields to disallow out-of-range values.
4. Adds missing back-end validations to relevant fields.

### Does this break other instances of this component?

This component was only used in one other place, which is category position re-ordering. This instance also benefits from the having some input sanitisation.

### What's not in this PR

- The `num_auto_bump_daily` is a custom field, and doesn't have any reasonable coercion on validation. The decision is to introduce a `CategorySetting` model and promote this to an attribute. (PR coming up.)
- You can still input a `0` in a `NumberField` with a `min` of `1`, and it won't hound you in the front-end, but will fail on post. A follow-up to this could be to add some nice feedback on the component, or potentially coerce the value to within the range automatically.