### PR TITLE
DEV: Use template-only for RenderGlimmer helper

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/render-glimmer.js
+++ b/app/assets/javascripts/discourse/app/widgets/render-glimmer.js
@@ -1,4 +1,4 @@
-import Component from "@glimmer/component";
+import templateOnly from "@ember/component/template-only";
 import { setComponentTemplate } from "@ember/component";
 import { tracked } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
@@ -129,7 +129,8 @@ export default class RenderGlimmer {
   connectComponent() {
     const { element, template, widget } = this;
 
-    const component = class extends Component {};
+    const component = templateOnly();
+    component.name = "Widgets/RenderGlimmer";
     setComponentTemplate(template, component);
 
     this._componentInfo = {


### PR DESCRIPTION
We don't need a full glimmer component here - the class definition was empty. We can use templateOnly() for slightly improved performance.

Setting `component.name` improves how MountWidget is displayed for debugging in the Ember Inspector browser extension.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
