### PR TITLE
DEV: Update glimmer-topic-timeline visibility state when a post is created

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
@@ -45,6 +45,7 @@ export default class TopicTimelineScrollArea extends Component {
       this.appEvents.on("composer:opened", this.calculatePosition);
       this.appEvents.on("composer:resized", this.calculatePosition);
       this.appEvents.on("composer:closed", this.calculatePosition);
+      this.appEvents.on("post-stream:posted", this.calculatePosition);
     }
 
     this.calculatePosition();
@@ -55,8 +56,7 @@ export default class TopicTimelineScrollArea extends Component {
       return true;
     }
 
-    const streamLength = this.args.model.postStream?.stream?.length;
-    if (streamLength === 1) {
+    if (this.total === 1) {
       const postsWrapper = document.querySelector(".posts-wrapper");
       if (postsWrapper && postsWrapper.offsetHeight < 1000) {
         return false;
@@ -302,6 +302,7 @@ export default class TopicTimelineScrollArea extends Component {
       this.appEvents.off("composer:resized", this.calculatePosition);
       this.appEvents.off("composer:closed", this.calculatePosition);
       this.appEvents.off("topic:current-post-scrolled", this.postScrolled);
+      this.appEvents.off("post-stream:posted", this.calculatePosition);
     }
   }
 


### PR DESCRIPTION
# Problem
Creating a post on a topic, where the timeline is not shown by default, does not update the visibility state dynamically. You must refresh the page to have the timeline appear. 

# Solution 
This PR hooks into the `post-stream:posted` app event and checks if we can now display the timeline after a post has been created. This will update the visibility state dynamically.