### PR TITLE
A11Y: share label needs corresponding ID on input

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/share-topic.hbs
@@ -17,6 +17,7 @@
       </label>
       <div class="link-share-container">
         <Input
+          id="invite-link"
           name="invite-link"
           class="invite-link"
           @value={{this.url}}


### PR DESCRIPTION
The label already has `for="invite-link"` but the input needs a corresponding ID. 