### PR TITLE
DEV: Make it obvious that `joined` translation is used by onebox

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5074,7 +5074,9 @@ en:
   search_logs:
     graph_title: "Search Count"
 
-  joined: "Joined"
+  onebox:
+    discourse:
+      user_joined_community: "Joined %{date}"
 
   discourse_push_notifications:
     popup:

--- a/lib/onebox/templates/discourse_user_onebox.mustache
+++ b/lib/onebox/templates/discourse_user_onebox.mustache
@@ -26,7 +26,7 @@
     {{#bio}}
       <p>{{{bio}}}</p>
     {{/bio}}
-    <span>{{joined}} {{created_at}}</span>
+    <span>{{joined}}</span>
   </article>
   <div class="clearfix"></div>
 </aside>

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -459,8 +459,11 @@ module Oneboxer
         name: name,
         bio: user.user_profile.bio_excerpt(230),
         location: Onebox::Helpers.sanitize(user.user_profile.location),
-        joined: I18n.t("joined"),
-        created_at: user.created_at.strftime(I18n.t("datetime_formats.formats.date_only")),
+        joined:
+          I18n.t(
+            "onebox.discourse.user_joined_community",
+            date: user.created_at.strftime(I18n.t("datetime_formats.formats.date_only")),
+          ),
         website: user.user_profile.website,
         website_name: UserSerializer.new(user).website_name,
         original_url: url,


### PR DESCRIPTION
This also moves the date as interpolation key into the string which makes translation easier.