### PR TITLE
FIX: de-prioritize archived topics

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1163,6 +1163,8 @@ class Search
           ELSE
             CASE WHEN topics.closed
             THEN 0.9
+            WHEN topics.archived
+            THEN 0.85
             ELSE 1
             END
           END

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -948,15 +948,22 @@ RSpec.describe Search do
       expect(result.blurb(result.posts.first)).to eq(expected_blurb)
     end
 
-    it "applies a small penalty to closed topic when ranking" do
-      post =
+    it "applies a small penalty to closed topics and archived topics when ranking" do
+      archived_post =
+        Fabricate(
+          :post,
+          raw: "My weekly update",
+          topic: Fabricate(:topic, title: "A topic that will be archived", archived: true),
+        )
+
+      closed_post =
         Fabricate(
           :post,
           raw: "My weekly update",
           topic: Fabricate(:topic, title: "A topic that will be closed", closed: true),
         )
 
-      post2 =
+      open_post =
         Fabricate(
           :post,
           raw: "My weekly update",
@@ -964,7 +971,7 @@ RSpec.describe Search do
         )
 
       result = Search.execute("weekly update")
-      expect(result.posts.pluck(:id)).to eq([post2.id, post.id])
+      expect(result.posts.pluck(:id)).to eq([open_post.id, closed_post.id, archived_post.id])
     end
 
     it "can find posts by searching for a url prefix" do


### PR DESCRIPTION
Previously due to an error archived topics were more prominent in search
than closed topics.

This amends our internal logic to ensure archived topics are bumped down
the list.
