### PR TITLE
UX: Hide hamburger dropdown when `enable_sidebar` query param is used

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -324,8 +324,8 @@ createWidget("header-icons", {
     });
 
     if (
-      this.siteSettings.navigation_menu === "legacy" ||
-      !attrs.sidebarEnabled ||
+      (!attrs.sidebarEnabled &&
+        this.siteSettings.navigation_menu === "legacy") ||
       this.site.mobileView
     ) {
       icons.push(hamburger);

--- a/spec/system/viewing_sidebar_spec.rb
+++ b/spec/system/viewing_sidebar_spec.rb
@@ -17,6 +17,7 @@ describe "Viewing sidebar", type: :system, js: true do
 
       expect(sidebar).to be_visible
       expect(sidebar).to have_category_section_link(category_sidebar_section_link.linkable)
+      expect(page).not_to have_css(".hamburger-dropdown")
     end
   end
 end


### PR DESCRIPTION
## What is the problem?

We allow users to preview the sidebar even when `navigation_menu` site setting is set to "legacy" by adding the `enable_sidebar=1` query param. However, the hamburger drop down was not hidden and this commit seeks to fix that. 

## Screenshots

### Before 

![Screenshot from 2023-02-03 12-02-24](https://user-images.githubusercontent.com/4335742/216509828-eec6faf4-0caa-4393-ae6b-b8d39c875c15.png)

### After 

![Screenshot from 2023-02-03 12-02-38](https://user-images.githubusercontent.com/4335742/216509835-9821dc0c-166b-4583-9fd1-b867208b4e2c.png)
