### PR TITLE
DEV: Add `user-tip` back to glimmer-topic-timeline

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.hbs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.hbs
@@ -2,7 +2,7 @@
   class={{concat "timeline-container " this.classes}}
   {{did-insert this.addShowClass}}
 >
-  <div class="topic-timeline">
+  <div class="topic-timeline" {{did-insert this.addUserTip}}>
     <TopicTimeline::Container
       @model={{@model}}
       @enteredIndex={{this.enteredIndex}}

--- a/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.js
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import optionalService from "discourse/lib/optional-service";
 import { inject as service } from "@ember/service";
 import { bind } from "discourse-common/utils/decorators";
+import I18n from "I18n";
 
 export default class GlimmerTopicTimeline extends Component {
   @service site;
@@ -81,6 +82,18 @@ export default class GlimmerTopicTimeline extends Component {
     if (this.args.fullscreen && !this.args.addShowClass) {
       element.classList.add("show");
     }
+  }
+
+  @bind
+  addUserTip(element) {
+    this.currentUser.showUserTip({
+      id: "topic_timeline",
+      titleText: I18n.t("user_tips.topic_timeline.title"),
+      contentText: I18n.t("user_tips.topic_timeline.content"),
+      reference: document.querySelector("div.timeline-scrollarea-wrapper"),
+      appendTo: element,
+      placement: "left",
+    });
   }
 
   willDestroy() {


### PR DESCRIPTION
Add the user-tip back to the glimmer topic timeline

<img width="555" alt="Screenshot 2023-02-03 at 9 38 45 AM" src="https://user-images.githubusercontent.com/50783505/216644897-cdd3244f-e565-49ea-a929-5faa87f8ce57.png">
