### PR TITLE
DEV: Dock glimmer-topic-timeline with animation

### DIFF
--- a/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.hbs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.hbs
@@ -1,5 +1,8 @@
 <div
-  class={{concat "timeline-container " this.addFullscreenClass}}
+  class={{concat-class
+    "timeline-container"
+    (if @fullscreen "timeline-fullscreen")
+  }}
   {{did-insert this.addShowClass}}
 >
   <div class="topic-timeline" {{did-insert this.addUserTip}}>

--- a/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.hbs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.hbs
@@ -1,8 +1,5 @@
 <div
-  class={{concat-class
-    "timeline-container"
-    (if @fullscreen "timeline-fullscreen")
-  }}
+  class={{concat-class "timeline-container" this.classes}}
   {{did-insert this.addShowClass}}
 >
   <div class="topic-timeline" {{did-insert this.addUserTip}}>
@@ -30,6 +27,8 @@
       @convertToPublicTopic={{@convertToPublicTopic}}
       @convertToPrivateMessage={{@convertToPrivateMessage}}
       @replyToPost={{@replyToPost}}
+      @setDocked={{this.setDocked}}
+      @setDockedBottom={{this.setDockedBottom}}
     />
   </div>
 </div>

--- a/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.hbs
+++ b/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.hbs
@@ -1,5 +1,5 @@
 <div
-  class={{concat "timeline-container " this.classes}}
+  class={{concat "timeline-container " this.addFullscreenClass}}
   {{did-insert this.addShowClass}}
 >
   <div class="topic-timeline" {{did-insert this.addUserTip}}>
@@ -13,7 +13,6 @@
       @jumpToPostPrompt={{@jumpToPostPrompt}}
       @fullscreen={{@fullscreen}}
       @mobileView={{@mobileView}}
-      @currentUser={{this.currentUser}}
       @toggleMultiSelect={{@toggleMultiSelect}}
       @showTopicSlowModeUpdate={{@showTopicSlowModeUpdate}}
       @deleteTopic={{@deleteTopic}}

--- a/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.js
@@ -4,11 +4,15 @@ import optionalService from "discourse/lib/optional-service";
 import { inject as service } from "@ember/service";
 import { bind } from "discourse-common/utils/decorators";
 import I18n from "I18n";
+import { action } from "@ember/object";
 
 export default class GlimmerTopicTimeline extends Component {
   @service siteSettings;
+  @service currentUser;
 
   @tracked enteredIndex = this.args.enteredIndex;
+  @tracked docked = false;
+  @tracked dockedBottom = false;
 
   adminTools = optionalService();
 
@@ -33,6 +37,22 @@ export default class GlimmerTopicTimeline extends Component {
     return new Date(this.args.model.created_at);
   }
 
+  get classes() {
+    const classes = [];
+    if (this.args.fullscreen) {
+      classes.push("timeline-fullscreen");
+    }
+
+    if (this.docked) {
+      classes.push("timeline-docked");
+      if (this.dockedBottom) {
+        classes.push("timeline-docked-bottom");
+      }
+    }
+
+    return classes.join(" ");
+  }
+
   @bind
   addShowClass(element) {
     if (this.args.fullscreen && !this.args.addShowClass) {
@@ -50,5 +70,19 @@ export default class GlimmerTopicTimeline extends Component {
       appendTo: element,
       placement: "left",
     });
+  }
+
+  @action
+  setDocked(value) {
+    if (this.docked !== value) {
+      this.docked = value;
+    }
+  }
+
+  @action
+  setDockedBottom(value) {
+    if (this.dockedBottom !== value) {
+      this.dockedBottom = value;
+    }
   }
 }

--- a/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.js
@@ -8,43 +8,16 @@ import I18n from "I18n";
 export default class GlimmerTopicTimeline extends Component {
   @service site;
   @service siteSettings;
-  @service currentUser;
 
-  @tracked dockAt = null;
-  @tracked dockBottom = null;
   @tracked enteredIndex = this.args.enteredIndex;
 
   adminTools = optionalService();
-  intersectionObserver = null;
 
   constructor() {
     super(...arguments);
 
     if (this.args.prevEvent) {
       this.enteredIndex = this.args.prevEvent.postIndex - 1;
-    }
-
-    if (!this.site.mobileView) {
-      this.intersectionObserver = new IntersectionObserver((entries) => {
-        for (const entry of entries) {
-          const bounds = entry.boundingClientRect;
-
-          if (entry.target.id === "topic-bottom") {
-            this.topicBottom = bounds.y + window.scrollY;
-          } else {
-            this.topicTop = bounds.y + window.scrollY;
-          }
-        }
-      });
-
-      const elements = [
-        document.querySelector(".container.posts"),
-        document.querySelector("#topic-bottom"),
-      ];
-
-      for (let i = 0; i < elements.length; i++) {
-        this.intersectionObserver.observe(elements[i]);
-      }
     }
   }
 
@@ -57,20 +30,10 @@ export default class GlimmerTopicTimeline extends Component {
     );
   }
 
-  get classes() {
-    const classes = [];
+  get addFullscreenClass() {
     if (this.args.fullscreen) {
-      classes.push("timeline-fullscreen");
+      return "timeline-fullscreen";
     }
-
-    if (this.dockAt) {
-      classes.push("timeline-docked");
-      if (this.dockBottom) {
-        classes.push("timeline-docked-bottom");
-      }
-    }
-
-    return classes.join(" ");
   }
 
   get createdAt() {
@@ -94,12 +57,5 @@ export default class GlimmerTopicTimeline extends Component {
       appendTo: element,
       placement: "left",
     });
-  }
-
-  willDestroy() {
-    if (!this.site.mobileView) {
-      this.intersectionObserver?.disconnect();
-      this.intersectionObserver = null;
-    }
   }
 }

--- a/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/components/glimmer-topic-timeline.js
@@ -6,7 +6,6 @@ import { bind } from "discourse-common/utils/decorators";
 import I18n from "I18n";
 
 export default class GlimmerTopicTimeline extends Component {
-  @service site;
   @service siteSettings;
 
   @tracked enteredIndex = this.args.enteredIndex;
@@ -28,12 +27,6 @@ export default class GlimmerTopicTimeline extends Component {
       this.args.model.has_summary &&
       !this.args.model.postStream.summary
     );
-  }
-
-  get addFullscreenClass() {
-    if (this.args.fullscreen) {
-      return "timeline-fullscreen";
-    }
   }
 
   get createdAt() {

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -34,7 +34,7 @@
   </div>
 {{/if}}
 
-{{#if (and (not @fullscreen) @currentUser)}}
+{{#if (and (not @fullscreen) this.currentUser)}}
   <div class="timeline-controls">
     <PluginOutlet
       @name="timeline-controls-before"
@@ -130,7 +130,7 @@
       </button>
     {{/if}}
 
-    {{#if (and @currentUser (not @fullscreen))}}
+    {{#if (and this.currentUser (not @fullscreen))}}
       {{#if this.canCreatePost}}
         <button
           type="button"
@@ -156,7 +156,7 @@
       </button>
     {{/if}}
 
-    {{#if @currentUser}}
+    {{#if this.currentUser}}
       <TopicNotificationsButton
         @notificationLevel={{@model.details.notification_level}}
         @topic={{@model}}

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
@@ -36,8 +36,6 @@ export default class TopicTimelineScrollArea extends Component {
   @tracked timelineScrollareaStyle;
   @tracked dragging = false;
   @tracked excerpt = "";
-  @tracked dockAt = null;
-  @tracked dockBottom = null;
 
   intersectionObserver = null;
 
@@ -76,6 +74,7 @@ export default class TopicTimelineScrollArea extends Component {
     }
 
     this.calculatePosition();
+    this.dockCheck();
   }
 
   get displayTimeLineScrollArea() {
@@ -326,17 +325,14 @@ export default class TopicTimelineScrollArea extends Component {
     }
 
     if (this.dockAt !== prevDockAt) {
-      const timelineContainer = document.querySelector(".timeline-container");
       if (this.dockAt) {
-        timelineContainer.classList.add("timeline-docked");
+        this.args.setDocked(true);
         if (this.dockBottom) {
-          timelineContainer.classList.add("timeline-docked-bottom");
+          this.args.setDockedBottom(true);
         }
       } else {
-        timelineContainer.classList.remove(
-          "timeline-docked",
-          "timeline-docked-bottom"
-        );
+        this.args.setDocked(false);
+        this.args.setDockedBottom(false);
       }
     }
   }


### PR DESCRIPTION
- Move docking logic (intersection / dockAt / etc) from `glimmer-topic-timeline` -> `topic-timeline/container` to live alongside the `postScrolled` hook.
- Toggle `timeline-docked` and `timeline-docked-bottom` when we are at the bottom of a topic. This returns the missing animation to the glimmer-topic-timeline (pictured below).

https://user-images.githubusercontent.com/50783505/216655735-906ccd2a-b77e-45af-9a7b-c22680eca2dc.mov

