### PR TITLE
FIX: Use `/` for start_url in webmanifest on non-subfolder installs

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -47,7 +47,7 @@ class MetadataController < ApplicationController
           SiteSetting.title.truncate(12, separator: " ", omission: ""),
       description: SiteSetting.site_description,
       display: display,
-      start_url: Discourse.base_path.present? ? "#{Discourse.base_path}/" : ".",
+      start_url: Discourse.base_path.present? ? "#{Discourse.base_path}/" : "/",
       background_color: "##{ColorScheme.hex_for_name("secondary", scheme_id)}",
       theme_color: "##{ColorScheme.hex_for_name("header_background", scheme_id)}",
       icons: [],


### PR DESCRIPTION
See https://meta.discourse.org/t/i-want-to-make-changes-to-manifest-json-file/253050?u=falco
