### PR TITLE
FIX: autocomplete showing under keyboard on android

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -385,8 +385,7 @@ export default function (options) {
     if (isInput || options.treatAsTextarea) {
       _autoCompletePopper && _autoCompletePopper.destroy();
       _autoCompletePopper = createPopper(me[0], div[0], {
-        placement: "bottom-start",
-        strategy: "fixed",
+        placement: `${Site.currentProp("mobileView") ? "top" : "bottom"}-start`,
         modifiers: [
           {
             name: "offset",


### PR DESCRIPTION
"fixed" positioning was added when autocomplete was used in the discourse search header. This shouldn't be needed anymore. This was causing the preventOverflow to not work correctly on Android.

This fix also adds an optimization to refer top of the input when on mobile. This is done to avoid cases where the screen is actually slightly taller than the viewport with the keyboard visible on Android, leading popper to think there's space under the input.

If necessary "fixed" will be added again on very specific cases.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
