### PR TITLE
FEATURE: Allow DTooltip interaction

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-tooltip.js
+++ b/app/assets/javascripts/discourse/app/components/d-tooltip.js
@@ -27,7 +27,6 @@ export default class DiscourseTooltip extends Component {
       const parent = viewBounds.parentElement;
       const interactive = this.interactive;
       this._tippyInstance = tippy(parent, {
-        hideOnClick: !interactive,
         interactive,
         content: element,
         trigger: this.capabilities.touch ? "click" : "mouseenter",

--- a/app/assets/javascripts/discourse/app/components/d-tooltip.js
+++ b/app/assets/javascripts/discourse/app/components/d-tooltip.js
@@ -5,6 +5,7 @@ import Ember from "ember";
 
 export default class DiscourseTooltip extends Component {
   tagName = "";
+  interactive = false;
 
   didInsertElement() {
     this._super(...arguments);
@@ -24,7 +25,10 @@ export default class DiscourseTooltip extends Component {
       const viewBounds = Ember.ViewUtils.getViewBounds(this);
       const element = viewBounds.firstNode;
       const parent = viewBounds.parentElement;
+      const interactive = this.interactive;
       this._tippyInstance = tippy(parent, {
+        hideOnClick: !interactive,
+        interactive,
         content: element,
         trigger: this.capabilities.touch ? "click" : "mouseenter",
         theme: "d-tooltip",


### PR DESCRIPTION
Adds ability to make `DTooltip` interactive.

When wanting to specify that you'd like tooltip to be used in an interactive way, you can just add `@interactive={{true}}` to the component call like so:

```handlebars
<div class="customer-flair">
  Business
  <DTooltip @interactive={{true}}>
    <h3>Customer Info:</h3>
    <span><a href="http://localhost:4200/t/coolest-thing-you-have-seen-today/57/101">https://www.customersite.com</a></span>
  </DTooltip>
</div>
```

![Kapture 2023-02-03 at 15 32 56](https://user-images.githubusercontent.com/30537603/216715955-26724d78-ad2b-4f68-a93e-757e7c1d2cdb.gif)
