### PR TITLE
DEV: Add 'chat_message_deleted' Discourse event

### DIFF
--- a/plugins/chat/app/services/chat_message_destroyer.rb
+++ b/plugins/chat/app/services/chat_message_destroyer.rb
@@ -15,6 +15,7 @@ class ChatMessageDestroyer
     ChatMessage.transaction do
       message.trash!(actor)
       ChatMention.where(chat_message: message).destroy_all
+      DiscourseEvent.trigger(:chat_message_deleted, message, message.chat_channel, actor)
 
       # FIXME: We should do something to prevent the blue/green bubble
       # of other channel members from getting out of sync when a message

--- a/plugins/chat/app/services/chat_message_destroyer.rb
+++ b/plugins/chat/app/services/chat_message_destroyer.rb
@@ -15,7 +15,7 @@ class ChatMessageDestroyer
     ChatMessage.transaction do
       message.trash!(actor)
       ChatMention.where(chat_message: message).destroy_all
-      DiscourseEvent.trigger(:chat_message_deleted, message, message.chat_channel, actor)
+      DiscourseEvent.trigger(:chat_message_trashed, message, message.chat_channel, actor)
 
       # FIXME: We should do something to prevent the blue/green bubble
       # of other channel members from getting out of sync when a message

--- a/plugins/chat/spec/requests/chat_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat_controller_spec.rb
@@ -574,8 +574,10 @@ RSpec.describe Chat::ChatController do
             delete "/chat/#{chat_channel.id}/#{ChatMessage.last.id}.json"
           end
       end.to change { ChatMessage.count }.by(-1)
+
       expect(response.status).to eq(200)
-      expect(events.map { _1[:event_name] }).to include(:chat_message_deleted)
+      expect(events.size).to eq(1)
+      expect(events.first[:event_name]).to eq(:chat_message_trashed)
     end
 
     it "does not allow message delete when chat channel is read_only" do

--- a/plugins/chat/spec/requests/chat_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat_controller_spec.rb
@@ -567,10 +567,15 @@ RSpec.describe Chat::ChatController do
     it "Allows admin to delete others' messages" do
       sign_in(admin)
 
-      expect { delete "/chat/#{chat_channel.id}/#{ChatMessage.last.id}.json" }.to change {
-        ChatMessage.count
-      }.by(-1)
+      events = nil
+      expect do
+        events =
+          DiscourseEvent.track_events do
+            delete "/chat/#{chat_channel.id}/#{ChatMessage.last.id}.json"
+          end
+      end.to change { ChatMessage.count }.by(-1)
       expect(response.status).to eq(200)
+      expect(events.map { _1[:event_name] }).to include(:chat_message_deleted)
     end
 
     it "does not allow message delete when chat channel is read_only" do

--- a/plugins/chat/spec/services/chat_message_destroyer_spec.rb
+++ b/plugins/chat/spec/services/chat_message_destroyer_spec.rb
@@ -86,5 +86,13 @@ RSpec.describe ChatMessageDestroyer do
       expect(message_data[:deleted_id]).to eq(message_1.id)
       expect(message_data[:deleted_at]).to be_present
     end
+
+    it "triggers a DiscourseEvent" do
+      delete_event =
+        DiscourseEvent.track_events { described_class.new.trash_message(message_1, actor) }.first
+
+      expect(delete_event[:event_name]).to eq(:chat_message_trashed)
+      expect(delete_event[:params]).to eq([message_1, message_1.chat_channel, actor])
+    end
   end
 end


### PR DESCRIPTION
Triggers a DiscourseEvent when a message is deleted, similar to `:chat_message_created` and `:chat_message_edited`. This is not used in this plugin, but can be used by other plugins to act when a message is deleted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
