### PR TITLE
UX: apply same style for highlight mention span

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -136,6 +136,12 @@
     .mention.highlighted {
       background: var(--tertiary-low);
       color: var(--primary);
+      display: inline-block;
+      font-size: 0.93em;
+      font-weight: normal;
+      padding: 0 0.3em 0.07em;
+      border-radius: 0.6em;
+      text-decoration: none;
     }
 
     img.ytp-thumbnail-image {


### PR DESCRIPTION
Styling of highlighted tag was not applied to non-clickable mentions
<img width="222" alt="image" src="https://user-images.githubusercontent.com/101828855/216895536-0a3a8a2b-efd6-4758-95d4-885d3f96d141.png">

If we want to differentiate between a-tag and span element, we need to do it with something else, but not like this because this just seems broken.
