### PR TITLE
DEV: Allow registering a widget shim which renders using hbs

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -30,6 +30,10 @@ export function queryRegistry(name) {
   return _registry[name];
 }
 
+export function deleteFromRegistry(name) {
+  return delete _registry[name];
+}
+
 const _decorators = {};
 
 export function decorateWidget(widgetName, cb) {


### PR DESCRIPTION
This is an alternative way to use `RenderGlimmer` which can be more ergonomic for iterative updates of a codebase. For documentation, see `widgets/render-glimmer.js`

Example usage in https://github.com/discourse/discourse-prometheus-alert-receiver/pull/61

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
