### PR TITLE
FEATURE: Allow `after_email_send` event

### DIFF
--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -294,6 +294,8 @@ module Email
         return skip(SkippedEmailLog.reason_types[:custom], custom_reason: e.message)
       end
 
+      DiscourseEvent.trigger(:after_email_send, @message, @email_type)
+
       email_log.save!
       email_log
     end


### PR DESCRIPTION
Allow `after_email_send` event for the use of plugins to listen on successful email sends.