### PR TITLE
FIX: Ensure `ColorScheme#resolve` falls back to base for missing color

### DIFF
--- a/app/models/color_scheme.rb
+++ b/app/models/color_scheme.rb
@@ -448,10 +448,11 @@ class ColorScheme < ActiveRecord::Base
   end
 
   def resolved_colors
-    from_base = base_colors.except("hover", "selected")
+    from_base = ColorScheme.base_colors
+    from_custom_scheme = base_colors
     from_db = colors.map { |c| [c.name, c.hex] }.to_h
 
-    resolved = from_base.merge(from_db)
+    resolved = from_base.merge(from_custom_scheme).except("hover", "selected").merge(from_db)
 
     # Equivalent to primary-100 in light mode, or primary-low in dark mode
     resolved["hover"] ||= ColorMath.dark_light_diff(

--- a/spec/models/color_scheme_spec.rb
+++ b/spec/models/color_scheme_spec.rb
@@ -144,6 +144,21 @@ RSpec.describe ColorScheme do
       expect(resolved["secondary"]).to eq(ColorScheme.base_colors["secondary"])
     end
 
+    it "falls back to default scheme if base scheme does not have color" do
+      custom_scheme_id = "BaseSchemeWithNoHighlightColor"
+      ColorScheme::CUSTOM_SCHEMES[custom_scheme_id.to_sym] = { "secondary" => "123123" }
+
+      color_scheme = ColorScheme.new(base_scheme_id: custom_scheme_id)
+      color_scheme.color_scheme_colors << ColorSchemeColor.new(name: "primary", hex: "121212")
+
+      resolved = color_scheme.resolved_colors
+      expect(resolved["primary"]).to eq("121212") # From db
+      expect(resolved["secondary"]).to eq("123123") # From custom scheme
+      expect(resolved["tertiary"]).to eq("0088cc") # From `foundation/colors.scss`
+    ensure
+      ColorScheme::CUSTOM_SCHEMES.delete(custom_scheme_id)
+    end
+
     it "calculates 'hover' and 'selected' from existing db colors in dark mode" do
       color_scheme = ColorScheme.new
       color_scheme.color_scheme_colors << ColorSchemeColor.new(name: "primary", hex: "ddd")


### PR DESCRIPTION
When a CUSTOM_SCHEME is missing a color (e.g. 'Dracula' is missing a 'highlight' color), we need to fallback to `ColorScheme.base_colors`. This regressed in 66256c15bd81c633d4a363acd262766618573396

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
