### PR TITLE
UX: orders public channels by slug instead of title

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -99,7 +99,7 @@ export default class ChatChannelsManager extends Service {
         (channel) =>
           channel.isCategoryChannel && channel.currentUserMembership.following
       )
-      .sort((a, b) => a.title.localeCompare(b.title));
+      .sort((a, b) => a?.slug?.localeCompare?.(b?.slug));
   }
 
   get directMessageChannels() {

--- a/plugins/chat/spec/system/list_channels/sidebar_spec.rb
+++ b/plugins/chat/spec/system/list_channels/sidebar_spec.rb
@@ -42,15 +42,15 @@ RSpec.describe "List channels | sidebar", type: :system, js: true do
     end
 
     context "when multiple category channels are present" do
-      fab!(:channel_1) { Fabricate(:category_channel, name: "b channel") }
-      fab!(:channel_2) { Fabricate(:category_channel, name: "a channel") }
+      fab!(:channel_1) { Fabricate(:category_channel, name: ":art: b channel") }
+      fab!(:channel_2) { Fabricate(:category_channel, name: ":art: a channel") }
 
       before do
         channel_1.add(current_user)
         channel_2.add(current_user)
       end
 
-      it "sorts them alphabetically" do
+      it "sorts them by slug" do
         visit("/")
 
         expect(page.find("#sidebar-section-content-chat-channels li:nth-child(1)")).to have_css(


### PR DESCRIPTION
Public channels were previously sorted by name, however, channels with a leading emoji in the name would always appear first in the list. By using slug we avoid this issue.