### PR TITLE
FIX: improvements for user custom sections

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/footer.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/footer.hbs
@@ -3,6 +3,13 @@
     <div class="sidebar-footer-actions">
       <PluginOutlet @name="sidebar-footer-actions" />
 
+      <DButton
+        @icon="plus"
+        @action={{action this.addSection}}
+        @class="btn-flat add-section"
+        @title="sidebar.sections.custom.add"
+      />
+
       {{#if
         (or
           this.site.mobileView

--- a/app/assets/javascripts/discourse/app/components/sidebar/footer.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/footer.js
@@ -1,6 +1,8 @@
 import Component from "@glimmer/component";
 import { getOwner } from "discourse-common/lib/get-owner";
 import { inject as service } from "@ember/service";
+import { action } from "@ember/object";
+import showModal from "discourse/lib/show-modal";
 
 export default class SidebarFooter extends Component {
   @service site;
@@ -8,5 +10,10 @@ export default class SidebarFooter extends Component {
 
   get capabilities() {
     return getOwner(this).lookup("capabilities:main");
+  }
+
+  @action
+  addSection() {
+    showModal("sidebar-section-form");
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
@@ -7,7 +7,7 @@
       <a
         href={{@href}}
         rel="noopener noreferrer"
-        target={{or @target "_blank"}}
+        target="_blank"
         class={{this.classNames}}
         title={{@title}}
       >

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
@@ -25,11 +25,4 @@
       {{/each}}
     </Sidebar::Section>
   {{/each}}
-
-  <DButton
-    @icon="plus"
-    @action={{action this.addSection}}
-    @class="btn-flat add-section"
-    @title="sidebar.sections.custom.add"
-  />
 </div>

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
@@ -1,5 +1,5 @@
 <div class="sidebar-custom-sections">
-  {{#each this.currentUser.sidebarSections as |section|}}
+  {{#each this.sections as |section|}}
     <Sidebar::Section
       @sectionName={{section.slug}}
       @headerLinkText={{section.title}}
@@ -15,10 +15,12 @@
       {{#each section.links as |link|}}
         <Sidebar::SectionLink
           @linkName={{link.name}}
-          @href={{link.value}}
-          @target="_self"
-          @content={{link.name}}
-          @class={{link.class}}
+          @route={{link.route}}
+          @models={{link.models}}
+          @query={{link.query}}
+          @content={{replace-emoji link.name}}
+          @prefixType="icon"
+          @prefixValue={{link.icon}}
         />
       {{/each}}
     </Sidebar::Section>

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
@@ -2,22 +2,22 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
 import { inject as service } from "@ember/service";
+import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
 
 export default class SidebarUserCustomSections extends Component {
   @service currentUser;
-
-  constructor() {
-    super(...arguments);
-
-    this.sections.forEach((section) => {
-      section.links.forEach((link) => {
-        link.class = window.location.pathname === link.value ? "active" : "";
-      });
-    });
-  }
+  @service router;
 
   get sections() {
-    return this.currentUser.sidebar_sections || [];
+    this.currentUser.sidebarSections.forEach((section) => {
+      section.links.forEach((link) => {
+        const routeInfoHelper = new RouteInfoHelper(this.router, link.value);
+        link.route = routeInfoHelper.route;
+        link.models = routeInfoHelper.models;
+        link.query = routeInfoHelper.query;
+      });
+    });
+    return this.currentUser.sidebarSections;
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
@@ -24,8 +24,4 @@ export default class SidebarUserCustomSections extends Component {
   editSection(section) {
     showModal("sidebar-section-form", { model: section });
   }
-
-  addSection() {
-    showModal("sidebar-section-form");
-  }
 }

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -35,12 +35,14 @@ class Section {
 }
 
 class SectionLink {
+  @tracked icon;
   @tracked name;
   @tracked value;
   @tracked _destroy;
 
-  constructor({ router, name, value, id }) {
+  constructor({ router, icon, name, value, id }) {
     this.router = router;
+    this.icon = icon || "link";
     this.name = name;
     this.value = value ? `${this.protocolAndHost}${value}` : value;
     this.id = id;
@@ -55,7 +57,15 @@ class SectionLink {
   }
 
   get valid() {
-    return this.validName && this.validValue;
+    return this.validIcon && this.validName && this.validValue;
+  }
+
+  get validIcon() {
+    return !isEmpty(this.icon);
+  }
+
+  get iconCssClass() {
+    return this.icon === undefined || this.validIcon ? "" : "warning";
   }
 
   get validName() {
@@ -106,6 +116,7 @@ export default Controller.extend(ModalFunctionality, {
             (link) =>
               new SectionLink({
                 router: this.router,
+                icon: link.icon,
                 name: link.name,
                 value: link.value,
                 id: link.id,
@@ -130,6 +141,7 @@ export default Controller.extend(ModalFunctionality, {
         title: this.model.title,
         links: this.model.links.map((link) => {
           return {
+            icon: link.icon,
             name: link.name,
             value: link.path,
           };
@@ -158,6 +170,7 @@ export default Controller.extend(ModalFunctionality, {
         links: this.model.links.map((link) => {
           return {
             id: link.id,
+            icon: link.icon,
             name: link.name,
             value: link.path,
             _destroy: link._destroy,

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -26,7 +26,7 @@ class Section {
   }
 
   get validTitle() {
-    return !isEmpty(this.title);
+    return !isEmpty(this.title) && this.title.length <= 30;
   }
 
   get titleCssClass() {
@@ -61,7 +61,7 @@ class SectionLink {
   }
 
   get validIcon() {
-    return !isEmpty(this.icon);
+    return !isEmpty(this.icon) && this.icon.length <= 40;
   }
 
   get iconCssClass() {
@@ -69,7 +69,7 @@ class SectionLink {
   }
 
   get validName() {
-    return !isEmpty(this.name);
+    return !isEmpty(this.name) && this.name.length <= 80;
   }
 
   get nameCssClass() {
@@ -81,6 +81,7 @@ class SectionLink {
       !isEmpty(this.value) &&
       (this.value.startsWith(this.protocolAndHost) ||
         this.value.startsWith("/")) &&
+      this.value.length <= 200 &&
       this.path &&
       this.router.recognize(this.path).name !== "unknown"
     );

--- a/app/assets/javascripts/discourse/app/lib/sidebar/custom-community-section-links.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/custom-community-section-links.js
@@ -1,44 +1,8 @@
 import BaseCommunitySectionLink from "discourse/lib/sidebar/base-community-section-link";
+import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
 
 export let customSectionLinks = [];
 export let secondaryCustomSectionLinks = [];
-
-class RouteInfoHelper {
-  constructor(router, url) {
-    this.routeInfo = router.recognize(url);
-  }
-
-  get route() {
-    return this.routeInfo.name;
-  }
-
-  get models() {
-    return this.#getParameters;
-  }
-
-  get query() {
-    return this.routeInfo.queryParams;
-  }
-
-  /**
-   * Extracted from https://github.com/emberjs/rfcs/issues/658
-   * Retrieves all parameters for a `RouteInfo` object and its parents in
-   * correct oder, so that you can pass them to e.g.
-   * `transitionTo(routeName, ...params)`.
-   */
-  get #getParameters() {
-    let allParameters = [];
-    let current = this.routeInfo;
-
-    do {
-      const { params, paramNames } = current;
-      const currentParameters = paramNames.map((n) => params[n]);
-      allParameters = [...currentParameters, ...allParameters];
-    } while ((current = current.parent));
-
-    return allParameters;
-  }
-}
 
 /**
  * Appends an additional section link to the Community section under the "More..." links drawer.

--- a/app/assets/javascripts/discourse/app/lib/sidebar/route-info-helper.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/route-info-helper.js
@@ -1,0 +1,36 @@
+export default class RouteInfoHelper {
+  constructor(router, url) {
+    this.routeInfo = router.recognize(url);
+  }
+
+  get route() {
+    return this.routeInfo.name;
+  }
+
+  get models() {
+    return this.#getParameters;
+  }
+
+  get query() {
+    return this.routeInfo.queryParams;
+  }
+
+  /**
+   * Extracted from https://github.com/emberjs/rfcs/issues/658
+   * Retrieves all parameters for a `RouteInfo` object and its parents in
+   * correct oder, so that you can pass them to e.g.
+   * `transitionTo(routeName, ...params)`.
+   */
+  get #getParameters() {
+    let allParameters = [];
+    let current = this.routeInfo;
+
+    do {
+      const { params, paramNames } = current;
+      const currentParameters = paramNames.map((n) => params[n]);
+      allParameters = [...currentParameters, ...allParameters];
+    } while ((current = current.parent));
+
+    return allParameters;
+  }
+}

--- a/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
@@ -19,6 +19,18 @@
       <div class="row-wrapper">
         <div class="input-group">
           <label for="link-name">{{i18n
+              "sidebar.sections.custom.links.icon"
+            }}</label>
+          <IconPicker
+            @name="icon"
+            @value={{link.icon}}
+            @options={{hash maximum=1}}
+            class={{link.iconCssClass}}
+            @onChange={{action (mut link.icon)}}
+          />
+        </div>
+        <div class="input-group">
+          <label for="link-name">{{i18n
               "sidebar.sections.custom.links.name"
             }}</label>
           <Input
@@ -31,7 +43,7 @@
         </div>
         <div class="input-group">
           <label for="link-url">{{i18n
-              "sidebar.sections.custom.links.points_to"
+              "sidebar.sections.custom.links.value"
             }}</label>
           <Input
             name="link-url"
@@ -42,7 +54,7 @@
           />
         </div>
         <DButton
-          @icon="times"
+          @icon="trash-alt"
           @action={{action "deleteLink" link}}
           @class="btn-flat delete-link"
           @title="sidebar.sections.custom.links.delete"
@@ -53,6 +65,7 @@
       @action={{action "addLink"}}
       @class="btn-flat btn-text add-link"
       @title="sidebar.sections.custom.links.add"
+      @icon="plus"
       @label="sidebar.sections.custom.links.add"
     />
   </form>
@@ -63,7 +76,6 @@
     @id="save-section"
     @action={{action "save"}}
     @class="btn-primary"
-    @icon="plus"
     @label="sidebar.sections.custom.save"
     @disabled={{not this.model.valid}}
   />

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -138,17 +138,16 @@
       }
     }
   }
-  a.sidebar-section-link {
-    padding-left: calc(
-      var(--d-sidebar-section-link-prefix-width) +
-        var(--d-sidebar-section-link-prefix-margin-right) +
-        var(--d-sidebar-row-horizontal-padding)
-    );
+  .sidebar-section-wrapper {
+    padding-bottom: 0;
   }
 }
 .sidebar-section-form-modal {
   .modal-inner-container {
     width: var(--modal-max-width);
+  }
+  form {
+    margin-bottom: 0;
   }
   input {
     width: 100%;
@@ -158,7 +157,7 @@
   }
   .row-wrapper {
     display: grid;
-    grid-template-columns: auto auto 2em;
+    grid-template-columns: auto auto auto 2em;
     gap: 1em;
     margin-top: 1em;
   }
@@ -169,12 +168,19 @@
     margin-right: 1em;
   }
   .btn-flat.add-link {
-    float: right;
     margin-top: 1em;
-    margin-right: -0.5em;
+    margin-left: -0.65em;
     &:active,
     &:focus {
       background: none;
+    }
+    svg {
+      color: var(--tertiary);
+      width: 0.75em;
+      height: 0.75em;
+    }
+    &:hover svg {
+      color: var(--tertiary-hover);
     }
   }
   .modal-footer {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -86,6 +86,17 @@
       transition-delay: 0s;
     }
   }
+  .sidebar-footer-wrapper {
+    .btn-flat.add-section {
+      padding: 0.25em 0.4em;
+      &:hover {
+        background: var(--d-sidebar-highlight-color);
+        svg {
+          color: var(--primary-medium);
+        }
+      }
+    }
+  }
 }
 
 .sidebar-hamburger-dropdown {
@@ -112,32 +123,6 @@
 }
 
 .sidebar-custom-sections {
-  .btn-flat.add-section {
-    margin-left: calc(var(--d-sidebar-section-link-prefix-width) / 2);
-    margin-right: calc(var(--d-sidebar-section-link-prefix-width) / 2);
-    width: calc(100% - var(--d-sidebar-section-link-prefix-width));
-    svg {
-      height: 0.75em;
-      width: 0.75em;
-      padding-left: 0.5em;
-      padding-right: 0.5em;
-    }
-    &:before,
-    &:after {
-      content: "";
-      flex: 1 1;
-      border-bottom: 1px solid var(--primary-low-mid);
-      margin: auto;
-    }
-    &:hover {
-      background: var(--d-sidebar-highlight-color);
-      border-radius: 5px;
-      &:before,
-      &:after {
-        border-bottom: 1px solid var(--primary-high);
-      }
-    }
-  }
   .sidebar-section-wrapper {
     padding-bottom: 0;
   }

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -42,7 +42,7 @@ class SidebarSectionsController < ApplicationController
   end
 
   def links_params
-    params.permit(links: %i[name value id _destroy])["links"]
+    params.permit(links: %i[icon name value id _destroy])["links"]
   end
 
   def check_if_member_of_group

--- a/app/models/sidebar_section.rb
+++ b/app/models/sidebar_section.rb
@@ -10,7 +10,7 @@ class SidebarSection < ActiveRecord::Base
 
   accepts_nested_attributes_for :sidebar_urls, allow_destroy: true
 
-  validates :title, presence: true, uniqueness: { scope: %i[user_id] }
+  validates :title, presence: true, uniqueness: { scope: %i[user_id] }, length: { maximum: 30 }
 end
 
 # == Schema Information
@@ -19,7 +19,7 @@ end
 #
 #  id         :bigint           not null, primary key
 #  user_id    :integer          not null
-#  title      :string           not null
+#  title      :string(30)       not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class SidebarUrl < ActiveRecord::Base
+  validates :icon, presence: true
   validates :name, presence: true
   validates :value, presence: true
   validate :path_validator
@@ -24,4 +25,5 @@ end
 #  value      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  icon       :string
 #

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class SidebarUrl < ActiveRecord::Base
-  validates :icon, presence: true
-  validates :name, presence: true
-  validates :value, presence: true
+  validates :icon, presence: true, length: { maximum: 40 }
+  validates :name, presence: true, length: { maximum: 80 }
+  validates :value, presence: true, length: { maximum: 200 }
+
   validate :path_validator
 
   def path_validator
@@ -21,9 +22,9 @@ end
 # Table name: sidebar_urls
 #
 #  id         :bigint           not null, primary key
-#  name       :string           not null
-#  value      :string           not null
+#  name       :string(80)       not null
+#  value      :string(200)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  icon       :string
+#  icon       :string(40)       not null
 #

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4370,9 +4370,10 @@ en:
           delete: "Delete"
           delete_confirm: "Are you sure you want to delete this section?"
           links:
-            name: "Link name"
-            points_to: "Points to"
-            add: "Add link"
+            icon: "Icon"
+            name: "Name"
+            value: "Link"
+            add: "Add another link"
             delete: "Delete link"
         about:
           header_link_text: "About"

--- a/db/migrate/20230206033907_add_icon_to_sidebar_urls.rb
+++ b/db/migrate/20230206033907_add_icon_to_sidebar_urls.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIconToSidebarUrls < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sidebar_urls, :icon, :string
+  end
+end

--- a/db/migrate/20230207042719_add_limits_to_sidebar_sections_and_sidebar_urls.rb
+++ b/db/migrate/20230207042719_add_limits_to_sidebar_sections_and_sidebar_urls.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddLimitsToSidebarSectionsAndSidebarUrls < ActiveRecord::Migration[7.0]
+  def change
+    change_column :sidebar_sections, :title, :string, limit: 30, null: false
+    change_column :sidebar_urls, :icon, :string, limit: 40, null: false
+    change_column :sidebar_urls, :name, :string, limit: 80, null: false
+    change_column :sidebar_urls, :value, :string, limit: 200, null: false
+  end
+end

--- a/spec/fabricators/sidebar_url.rb
+++ b/spec/fabricators/sidebar_url.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:sidebar_url) do
+  icon "link"
   name "tags"
   value "/tags"
 end

--- a/spec/models/sidebar_url_spec.rb
+++ b/spec/models/sidebar_url_spec.rb
@@ -2,7 +2,11 @@
 
 RSpec.describe SidebarUrl do
   it "validates path" do
-    expect(SidebarUrl.new(name: "categories", value: "/categories").valid?).to eq(true)
-    expect(SidebarUrl.new(name: "categories", value: "/invalid_path").valid?).to eq(false)
+    expect(SidebarUrl.new(icon: "link", name: "categories", value: "/categories").valid?).to eq(
+      true,
+    )
+    expect(SidebarUrl.new(icon: "link", name: "categories", value: "/invalid_path").valid?).to eq(
+      false,
+    )
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe SidebarSectionsController do
            params: {
              title: "custom section",
              links: [
-               { name: "categories", value: "/categories" },
-               { name: "tags", value: "/tags" },
+               { icon: "link", name: "categories", value: "/categories" },
+               { icon: "link", name: "tags", value: "/tags" },
              ],
            }
 
@@ -30,8 +30,8 @@ RSpec.describe SidebarSectionsController do
            params: {
              title: "custom section",
              links: [
-               { name: "categories", value: "/categories" },
-               { name: "tags", value: "/tags" },
+               { icon: "link", name: "categories", value: "/categories" },
+               { icon: "address-book", name: "tags", value: "/tags" },
              ],
            }
 
@@ -43,8 +43,10 @@ RSpec.describe SidebarSectionsController do
       expect(sidebar_section.title).to eq("custom section")
       expect(sidebar_section.user).to eq(user)
       expect(sidebar_section.sidebar_urls.count).to eq(2)
+      expect(sidebar_section.sidebar_urls.first.icon).to eq("link")
       expect(sidebar_section.sidebar_urls.first.name).to eq("categories")
       expect(sidebar_section.sidebar_urls.first.value).to eq("/categories")
+      expect(sidebar_section.sidebar_urls.second.icon).to eq("address-book")
       expect(sidebar_section.sidebar_urls.second.name).to eq("tags")
       expect(sidebar_section.sidebar_urls.second.value).to eq("/tags")
     end
@@ -67,8 +69,8 @@ RSpec.describe SidebarSectionsController do
           params: {
             title: "custom section edited",
             links: [
-              { id: sidebar_url_1.id, name: "latest", value: "/latest" },
-              { id: sidebar_url_2.id, name: "tags", value: "/tags", _destroy: "1" },
+              { icon: "link", id: sidebar_url_1.id, name: "latest", value: "/latest" },
+              { icon: "link", id: sidebar_url_2.id, name: "tags", value: "/tags", _destroy: "1" },
             ],
           }
 
@@ -89,7 +91,7 @@ RSpec.describe SidebarSectionsController do
       put "/sidebar_sections/#{sidebar_section_2.id}.json",
           params: {
             title: "custom section edited",
-            links: [{ id: sidebar_url_3.id, name: "takeover", value: "/categories" }],
+            links: [{ icon: "link", id: sidebar_url_3.id, name: "takeover", value: "/categories" }],
           }
 
       expect(response.status).to eq(403)
@@ -106,7 +108,7 @@ RSpec.describe SidebarSectionsController do
       put "/sidebar_sections/#{sidebar_section.id}.json",
           params: {
             title: "custom section edited",
-            links: [{ id: sidebar_url_3.id, name: "takeover", value: "/categories" }],
+            links: [{ icon: "link", id: sidebar_url_3.id, name: "takeover", value: "/categories" }],
           }
 
       expect(response.status).to eq(404)


### PR DESCRIPTION
Improvements for this PR: https://github.com/discourse/discourse/pull/20057

What was fixed:
- [x] Use ember transitions instead of full reload
- [x] Link was inaccurately kept active
- [x] "+ save" renamed to just "save"
- [x] Render emojis in link name
- [x] UI to set icon
- [x] Delete link is trash icon instead of "x"
- [x] Add another link to on the left and rewording
- [x] Rename "link name" -> "name", "points to" ->  link
- [x] Move add section button to the bottom 

Screenshots:

<img width="692" alt="Screenshot 2023-02-07 at 11 45 45 am" src="https://user-images.githubusercontent.com/72780/217122847-5cb054f5-fcea-41f1-8641-bcc3e11298dd.png">
<img width="304" alt="Screenshot 2023-02-07 at 11 46 03 am" src="https://user-images.githubusercontent.com/72780/217122854-5d766439-bb89-4284-b6d4-c14072da250a.png">

<img width="482" alt="Screenshot 2023-02-07 at 12 18 18 pm" src="https://user-images.githubusercontent.com/72780/217123444-fb76bbaf-b53b-4d7f-8b78-fbf60d57f9b8.png">


