### PR TITLE
FIX: ensures non existing user/group cards are not stuck

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
+++ b/app/assets/javascripts/discourse/app/mixins/card-contents-base.js
@@ -81,6 +81,7 @@ export default Mixin.create({
       post,
     });
 
+    document.querySelector(".card-cloak")?.classList.remove("hidden");
     this.appEvents.trigger("user-card:show", { username });
     this._showCallback(username, $(target)).then((user) => {
       this.appEvents.trigger("user-card:after-show", { user });
@@ -217,7 +218,6 @@ export default Mixin.create({
           ],
         });
       } else {
-        document.querySelector(".card-cloak")?.classList.remove("hidden");
         this._popperReference = createPopper(target[0], this.element, {
           modifiers: [
             { name: "eventListeners", enabled: false },


### PR DESCRIPTION
Prior to this fix on mobile the card-cloak would not get removed if the user/group card was leading to a non existing user/group.

The fix ensures hidden class is removed each time we call show.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
