### PR TITLE
UX: allows drawer to take most of height space

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -56,7 +56,6 @@ html.rtl {
   }
 
   box-sizing: border-box;
-  max-height: 90vh;
   padding-bottom: var(--composer-height, 0);
   transition: all 100ms ease-in;
   transition-property: bottom, padding-bottom;
@@ -67,7 +66,7 @@ html.rtl {
   width: 400px;
   min-width: 250px !important; // important to override inline styles
   max-width: calc(100% - var(--composer-right));
-  max-height: 85vh;
+  max-height: calc(100vh - var(--header-offset) - 15px);
   min-height: 300px !important; // important to override inline styles
 
   .chat-drawer-container {


### PR DESCRIPTION
Only the header's height and 15px spacing are removed from the height of the viewport.

Previously it was limited to 90vh and there was also a useless property on a child node limiting it to 85vh. We now use only one property.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
