### PR TITLE
FIX: apply max-height on the outer container

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -29,6 +29,7 @@ html.rtl {
   position: fixed;
   right: var(--composer-right, 20px);
   left: 0;
+  max-height: calc(100% - var(--header-offset) - 15px);
 
   .rtl & {
     left: var(--composer-right, 20px);
@@ -66,7 +67,6 @@ html.rtl {
   width: 400px;
   min-width: 250px !important; // important to override inline styles
   max-width: calc(100% - var(--composer-right));
-  max-height: calc(100vh - var(--header-offset) - 15px);
   min-height: 300px !important; // important to override inline styles
 
   .chat-drawer-container {


### PR DESCRIPTION
This change allow to correctly work with the topic composer height changing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
