### PR TITLE
DEV: Add global glimmer-topic-timeline site setting

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/topic.hbs
@@ -224,7 +224,7 @@
         />
 
         {{#if info.renderTimeline}}
-          {{#if this.currentUser.redesigned_topic_timeline_enabled}}
+          {{#if this.siteSettings.enable_experimental_topic_timeline}}
             <GlimmerTopicTimeline
               @info={{info}}
               @model={{this.model}}

--- a/app/assets/javascripts/discourse/tests/acceptance/glimmer-topic-timeline-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/glimmer-topic-timeline-test.js
@@ -11,6 +11,9 @@ acceptance("Glimmer Topic Timeline", function (needs) {
     admin: true,
     redesigned_topic_timeline_enabled: true,
   });
+  needs.settings({
+    enable_experimental_topic_timeline: true,
+  });
   needs.pretender((server, helper) => {
     server.get("/t/129.json", () => {
       return helper.response({

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -65,7 +65,6 @@ class CurrentUserSerializer < BasicUserSerializer
              :grouped_unread_notifications,
              :redesigned_user_menu_enabled,
              :redesigned_user_page_nav_enabled,
-             :redesigned_topic_timeline_enabled,
              :display_sidebar_tags,
              :sidebar_tags,
              :sidebar_category_ids,
@@ -302,15 +301,6 @@ class CurrentUserSerializer < BasicUserSerializer
     end
   end
 
-  def redesigned_topic_timeline_enabled
-    if SiteSetting.enable_experimental_topic_timeline_groups.present?
-      object.in_any_groups?(
-        SiteSetting.enable_experimental_topic_timeline_groups.split("|").map(&:to_i),
-      )
-    else
-      false
-    end
-  end
   def custom_sidebar_sections_enabled
     if SiteSetting.enable_custom_sidebar_sections.present?
       object.in_any_groups?(SiteSetting.enable_custom_sidebar_sections_map)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2398,7 +2398,6 @@ en:
     default_sidebar_tags: "Selected tags will be displayed under Sidebar's Tags section by default."
     enable_new_notifications_menu: "Enables the new notifications menu for the legacy navigation menu."
     enable_new_user_profile_nav_groups: "EXPERIMENTAL: Users of the selected groups will be shown the new user profile navigation menu"
-    enable_experimental_topic_timeline_groups: "EXPERIMENTAL: Users of the selected groups will be shown the refactored topic timeline"
     enable_experimental_hashtag_autocomplete: "EXPERIMENTAL: Use the new #hashtag autocompletion system for categories and tags that renders the selected item differently and has improved search"
 
     errors:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2086,13 +2086,10 @@ developer:
   include_associated_account_ids:
     default: false
     hidden: true
-  enable_experimental_topic_timeline_groups:
+  enable_experimental_topic_timeline:
     client: true
-    type: group_list
-    list_type: compact
-    default: ""
-    allow_any: false
-    refresh: true
+    default: false
+    hidden: true
 
 navigation:
   navigation_menu:


### PR DESCRIPTION
Remove the per user groups based site setting in favor of a global site setting as we want to roll the glimmer topic timeline out to anon users as well as site users.

- Add `enable_experimental_topic_timeline` site setting
- Remove `enable_experimental_topic_timeline_groups` site setting
