### PR TITLE
Fix occasional bug in order of imported Drupal comment/replies

### DIFF
--- a/script/import_scripts/drupal.rb
+++ b/script/import_scripts/drupal.rb
@@ -223,6 +223,7 @@ class ImportScripts::Drupal < ImportScripts::Base
            AND c.status = 1
            AND n.type IN ('blog', 'forum')
            AND n.status = 1
+         ORDER BY c.cid ASC
          LIMIT #{BATCH_SIZE}
         OFFSET #{offset}
       SQL


### PR DESCRIPTION
This bug is actually a Drupal issue where some edited comments have their `created` and `changed` timestamps set to the same value. But even when that happens in Drupal it still maintains the correct post order in an affected thread. This PR makes the Discourse importer also maintain the original Drupal comment order by sorting comments in the source DB by their `cid`, which is sequential and never changes. More details from this post onward: https://meta.discourse.org/t/large-drupal-forum-migration-importer-errors-and-limitations/246939/24?u=rahim123

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
