### PR TITLE
FIX: hide add section button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/footer.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/footer.hbs
@@ -3,12 +3,14 @@
     <div class="sidebar-footer-actions">
       <PluginOutlet @name="sidebar-footer-actions" />
 
-      <DButton
-        @icon="plus"
-        @action={{action this.addSection}}
-        @class="btn-flat add-section"
-        @title="sidebar.sections.custom.add"
-      />
+      {{#if this.currentUser.custom_sidebar_sections_enabled}}
+        <DButton
+          @icon="plus"
+          @action={{action this.addSection}}
+          @class="btn-flat add-section"
+          @title="sidebar.sections.custom.add"
+        />
+      {{/if}}
 
       {{#if
         (or

--- a/app/assets/javascripts/discourse/app/components/sidebar/footer.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/footer.js
@@ -7,6 +7,7 @@ import showModal from "discourse/lib/show-modal";
 export default class SidebarFooter extends Component {
   @service site;
   @service siteSettings;
+  @service currentUser;
 
   get capabilities() {
     return getOwner(this).lookup("capabilities:main");

--- a/db/migrate/20230207042719_add_limits_to_sidebar_sections_and_sidebar_urls.rb
+++ b/db/migrate/20230207042719_add_limits_to_sidebar_sections_and_sidebar_urls.rb
@@ -2,6 +2,7 @@
 
 class AddLimitsToSidebarSectionsAndSidebarUrls < ActiveRecord::Migration[7.0]
   def change
+    execute "UPDATE sidebar_urls SET icon = 'link' WHERE icon IS NULL"
     change_column :sidebar_sections, :title, :string, limit: 30, null: false
     change_column :sidebar_urls, :icon, :string, limit: 40, null: false
     change_column :sidebar_urls, :name, :string, limit: 80, null: false


### PR DESCRIPTION
Custom section feature is currently hidden behind feature flag - https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/sidebar/user/sections.hbs#L3

In last PR, add section button was moved to footer. It should be hidden as well.

In addition, migration was fixed to set default "link" icon 
