### PR TITLE
UX: Allow wrapping on horizontal form controls

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -156,6 +156,7 @@ input {
 
   .controls {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     margin-left: 160px;
   }


### PR DESCRIPTION
The changes made in #20098 force form controls into one line, which results in them looking like this:
<img width="943" alt="Screenshot 2023-02-07 at 8 51 23 PM" src="https://user-images.githubusercontent.com/72576136/217408460-4225e16c-2d87-4aca-975d-fc8301d44d48.png">
<img width="484" alt="Screenshot 2023-02-07 at 8 49 54 PM" src="https://user-images.githubusercontent.com/72576136/217408462-806d44f4-60e6-4b19-9c17-6afb96edc888.png">

After wrapping:
<img width="553" alt="Screenshot 2023-02-07 at 8 51 57 PM" src="https://user-images.githubusercontent.com/72576136/217408633-58be1ba0-398a-47a4-994c-6323b7a9c24a.png">
<img width="428" alt="Screenshot 2023-02-07 at 8 50 18 PM" src="https://user-images.githubusercontent.com/72576136/217408634-b450acba-9d22-4453-a060-0a0088c5f1a9.png">
