### PR TITLE
DEV: Add dedicated category settings model - Part 1

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -46,6 +46,8 @@ class Category < ActiveRecord::Base
   has_many :topic_timers, dependent: :destroy
   has_many :upload_references, as: :target, dependent: :destroy
 
+  has_one :category_setting, dependent: :destroy
+
   has_and_belongs_to_many :web_hooks
 
   validates :user_id, presence: true

--- a/app/models/category_setting.rb
+++ b/app/models/category_setting.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CategorySetting < ActiveRecord::Base
+  belongs_to :category
+
+  validates :num_auto_bump_daily,
+            numericality: {
+              only_integer: true,
+              greater_than_or_equal_to: 0,
+              allow_nil: true,
+            }
+end
+
+# == Schema Information
+#
+# Table name: category_settings
+#
+#  id                     :bigint           not null, primary key
+#  category_id            :bigint           not null
+#  require_topic_approval :boolean
+#  require_reply_approval :boolean
+#  num_auto_bump_daily    :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+# Indexes
+#
+#  index_category_settings_on_category_id  (category_id) UNIQUE
+#

--- a/db/migrate/20230207093514_create_category_settings.rb
+++ b/db/migrate/20230207093514_create_category_settings.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateCategorySettings < ActiveRecord::Migration[7.0]
+  def change
+    # Moving the custom fields in core into a dedicated table for
+    # better type casting, validations, etc.
+    create_table :category_settings do |t|
+      t.references :category, null: false, index: { unique: true }
+
+      t.boolean :require_topic_approval, null: true
+      t.boolean :require_reply_approval, null: true
+      t.integer :num_auto_bump_daily, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230208020404_populate_category_settings.rb
+++ b/db/migrate/20230208020404_populate_category_settings.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class PopulateCategorySettings < ActiveRecord::Migration[7.0]
+  def up
+    execute(<<~SQL)
+      INSERT INTO
+        category_settings(
+          category_id,
+          require_topic_approval,
+          require_reply_approval,
+          num_auto_bump_daily,
+          created_at,
+          updated_at
+        )
+      SELECT
+        category_id,
+        MAX(
+          CASE WHEN (name = 'require_topic_approval')
+          THEN value ELSE NULL END
+        )::boolean AS require_topic_approval,
+        MAX(
+          CASE WHEN (name = 'require_reply_approval')
+          THEN value ELSE NULL END
+        )::boolean AS require_reply_approval,
+        MAX(
+          CASE WHEN (name = 'num_auto_bump_daily')
+          THEN value ELSE NULL END
+        )::integer AS num_auto_bump_daily,
+        NOW() AS created_at,
+        NOW() AS updated_at
+      FROM category_custom_fields
+      WHERE name IN (
+        'require_topic_approval',
+        'require_reply_approval',
+        'num_auto_bump_daily'
+      )
+      GROUP BY category_id;
+    SQL
+  end
+
+  def down
+    execute(<<~SQL)
+      TRUNCATE category_settings;
+    SQL
+  end
+end

--- a/spec/models/category_setting_spec.rb
+++ b/spec/models/category_setting_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe CategorySetting do
+  it { is_expected.to belong_to(:category) }
+
+  it do
+    is_expected.to validate_numericality_of(:num_auto_bump_daily)
+      .only_integer
+      .is_greater_than_or_equal_to(0)
+      .allow_nil
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe Category do
   end
 
   describe "Associations" do
+    it { is_expected.to have_one(:category_setting).dependent(:destroy) }
+
     it "should delete associated sidebar_section_links when category is destroyed" do
       category_sidebar_section_link = Fabricate(:category_sidebar_section_link)
       category_sidebar_section_link_2 =


### PR DESCRIPTION
### Background

We have had some bugs where category custom fields have been configured with invalid data, e.g. in one case a setting expecting an integer has been set to `0.5`.

We have added some measures to prevent this in the front-end [here](https://github.com/discourse/discourse/pull/20135), but the ability to misconfigure still remains in the back-end.

After some discussion where we considered three different options:

1. Extend the custom fields system with features like type casting, validation, etc.
2. Move the custom fields into columns on the `categories` table.
3. Move the custom fields to a new `category_settings` table.

We decided to go with the last option, because we want to leverage ActiveRecord functionality for type casting and validation, but the settings don't need to be loaded most of the time.

### What is this change?

This is the first in a multi-part change to move the custom fields to a new table. It includes:

- Adding a new `CategorySetting` model and corresponding table.
- Populating it with data from the `category_custom_fields` table.

**Note:** This PR doesn't change the source of truth for the application code. It just adds the new model and populates the data in preparation for the change-over.

### What are the next steps?

The next PR will switch the category attributes over from custom fields to this new model and jig everything up so that updating settings works, detect any +1 queries, etc.