### PR TITLE
FIX: return valid JSON when a post in enqueued

### DIFF
--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -865,6 +865,25 @@ RSpec.describe PostsController do
         expect(response.body).to eq(original)
       end
 
+      it "returns a valid JSON response when the post is enqueued" do
+        SiteSetting.approve_unless_trust_level = 4
+
+        master_key = Fabricate(:api_key).key
+
+        post "/posts.json",
+             params: {
+               raw: "this is test post #{SecureRandom.alphanumeric}",
+               title: "tthis is a test title #{SecureRandom.alphanumeric}",
+             },
+             headers: {
+               HTTP_API_USERNAME: user.username,
+               HTTP_API_KEY: master_key,
+             }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["action"]).to eq("enqueued")
+      end
+
       it "allows to create posts in import_mode" do
         Jobs.run_immediately!
         NotificationEmailer.enable


### PR DESCRIPTION
When a post is created using the API and goes into the review queue, we would return a 'null' string in the response which isn't valid JSON.

Internal ref: /t/92419

Co-authored-by: Leonardo Mosquera <ldmosquera@gmail.com>

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
