### PR TITLE
FEATURE: Add shortcut to insert current time in composer

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-editor.js
+++ b/app/assets/javascripts/discourse/app/components/d-editor.js
@@ -276,6 +276,11 @@ export default Component.extend(TextareaTextManipulation, {
     this._itsatrap.bind("tab", () => this.indentSelection("right"));
     this._itsatrap.bind("shift+tab", () => this.indentSelection("left"));
 
+    const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+    const mod = mac ? "meta" : "ctrl";
+
+    this._itsatrap.bind(`${mod}+shift+.`, () => this.send("insertCurrentTime"));
+
     // disable clicking on links in the preview
     this.element
       .querySelector(".d-editor-preview")
@@ -761,6 +766,15 @@ export default Component.extend(TextareaTextManipulation, {
           );
         }
       }
+    },
+
+    insertCurrentTime() {
+      const sel = this.getSelected("", { lineVal: true });
+      const timezone = this.currentUser.user_option.timezone;
+      const time = moment().format("HH:mm:ss");
+      const date = moment().format("YYYY-MM-DD");
+
+      this.addText(sel, `[date=${date} time=${time} timezone="${timezone}"]`);
     },
 
     focusIn() {

--- a/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
+++ b/app/assets/javascripts/discourse/app/controllers/keyboard-shortcuts-help.js
@@ -194,6 +194,10 @@ export default Controller.extend(ModalFunctionality, {
             keys1: [SHIFT, "F11"],
             keysDelimiter: PLUS,
           }),
+          insertCurrentTime: buildShortcut("composing.insert_current_time", {
+            keys1: [META, SHIFT, "."],
+            keysDelimiter: PLUS,
+          }),
         },
       },
       bookmarks: {

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1360,3 +1360,29 @@ acceptance("Composer - default category not set", function (needs) {
   });
 });
 // END: Default Composer Category tests
+
+acceptance("Composer - current time", function (needs) {
+  needs.user();
+
+  test("composer insert current time shortcut", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    await click("#topic-footer-buttons .btn.create");
+    assert.ok(exists(".d-editor-input"), "the composer input is visible");
+    await fillIn(".d-editor-input", "and the time now is: ");
+
+    await triggerKeyEvent(".d-editor-input", "keydown", ".", {
+      shiftKey: true,
+      metaKey: true,
+    });
+
+    const time = moment().format("HH:mm:ss");
+    const date = moment().format("YYYY-MM-DD");
+
+    assert.strictEqual(
+      query("#reply-control .d-editor-input").value.trim(),
+      `and the time now is: [date=${date} time=${time} timezone="Australia/Brisbane"]`,
+      "it adds the current date"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -1371,9 +1371,12 @@ acceptance("Composer - current time", function (needs) {
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
     await fillIn(".d-editor-input", "and the time now is: ");
 
+    const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
     await triggerKeyEvent(".d-editor-input", "keydown", ".", {
       shiftKey: true,
-      metaKey: true,
+      ctrlKey: !mac,
+      metaKey: mac,
     });
 
     const time = moment().format("HH:mm:ss");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4059,6 +4059,7 @@ en:
         title: "Composing"
         return: "%{shortcut} Return to composer"
         fullscreen: "%{shortcut} Fullscreen composer"
+        insert_current_time: "%{shortcut} Insert current time"
       bookmarks:
         title: "Bookmarking"
         enter: "%{shortcut} Save and close"


### PR DESCRIPTION
Hitting `Ctrl+Shift+.` on Windows and `Command+Shift+.` on Mac will insert the current time in the composer.
