### PR TITLE
UI: Fix timeline handle positioning

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -251,6 +251,7 @@
       float: left;
       z-index: z("base") + 1;
       outline: 1px solid transparent;
+      margin-left: 0.5px;
     }
 
     .timeline-scroller-content {

--- a/plugins/styleguide/assets/javascripts/discourse/routes/styleguide.js
+++ b/plugins/styleguide/assets/javascripts/discourse/routes/styleguide.js
@@ -1,6 +1,5 @@
 import Route from "@ember/routing/route";
 import { allCategories } from "discourse/plugins/styleguide/discourse/lib/styleguide";
-
 export default Route.extend({
   model() {
     return allCategories();


### PR DESCRIPTION
Positioning of the timeline handle was slightly off on the glimmer-topic-timeline

# Before
<img width="451" alt="Screenshot 2023-02-08 at 11 30 18 AM" src="https://user-images.githubusercontent.com/50783505/217606919-2f07b69f-4820-4b72-805b-ed28b34c79dc.png">


# After
<img width="447" alt="Screenshot 2023-02-08 at 11 29 53 AM" src="https://user-images.githubusercontent.com/50783505/217606811-977f52df-6070-4127-80c1-27c97174a9a7.png">
