### PR TITLE
FIX: Shorten connection attempt time

### DIFF
--- a/lib/final_destination/http.rb
+++ b/lib/final_destination/http.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FinalDestination::HTTP < Net::HTTP
+  attr_accessor :connection_attempt_timeout
+
   def connect
     original_open_timeout = @open_timeout
     return super if @ipaddr
@@ -21,7 +23,7 @@ class FinalDestination::HTTP < Net::HTTP
         raise Net::OpenTimeout.new("Operation timed out - FinalDestination::HTTP")
       end
 
-      @open_timeout = remaining_time
+      @open_timeout = [remaining_time, connection_attempt_timeout].compact.min
       return super
     rescue SystemCallError, Net::OpenTimeout => e
       debug "[FinalDestination] Error connecting to #{ip}... #{e.message}"

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -95,18 +95,4 @@ describe FinalDestination::HTTP do
       FinalDestination::HTTP.get(URI("https://blocked-ip.example.com"))
     end
   end
-
-  it "stops iterating over DNS records once timeout reached" do
-    stub_ip_lookup("example.com", %w[1.1.1.1 2.2.2.2 3.3.3.3 4.4.4.4])
-    TCPSocket.stubs(:open).with { |addr| addr == "1.1.1.1" }.raises(Errno::ECONNREFUSED)
-    TCPSocket.stubs(:open).with { |addr| addr == "2.2.2.2" }.raises(Errno::ECONNREFUSED)
-    TCPSocket
-      .stubs(:open)
-      .with { |*args, **kwargs| kwargs[:open_timeout] == 0 }
-      .raises(Errno::ETIMEDOUT)
-    FinalDestination::HTTP.any_instance.stubs(:current_time).returns(0, 1, 5)
-    expect do
-      FinalDestination::HTTP.start("example.com", 80, open_timeout: 5) {}
-    end.to raise_error(Net::OpenTimeout)
-  end
 end


### PR DESCRIPTION
So that other IPs can be tried if one times out.

This also removes a test that was no longer working as intended after this change in net-http:

https://github.com/ruby/net-http/commit/98caa3820490234eec8e8d3d8d80ecb01f779276

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
