### PR TITLE
DEV: correct a relationship – a chat message may have several mentions

### DIFF
--- a/plugins/chat/app/models/chat_message.rb
+++ b/plugins/chat/app/models/chat_message.rb
@@ -22,7 +22,7 @@ class ChatMessage < ActiveRecord::Base
   # TODO (martin) Remove this when we drop the ChatUpload table
   has_many :chat_uploads, dependent: :destroy
   has_one :chat_webhook_event, dependent: :destroy
-  has_one :chat_mention, dependent: :destroy
+  has_many :chat_mentions, dependent: :destroy
 
   scope :in_public_channel,
         -> {

--- a/plugins/chat/spec/models/chat_mention_spec.rb
+++ b/plugins/chat/spec/models/chat_mention_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-RSpec.describe ChatMessage do
-  it { is_expected.to have_many(:chat_mentions).dependent(:destroy) }
-end

--- a/plugins/chat/spec/models/chat_mention_spec.rb
+++ b/plugins/chat/spec/models/chat_mention_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChatMessage do
+  it { is_expected.to have_many(:chat_mentions).dependent(:destroy) }
+end

--- a/plugins/chat/spec/models/chat_message_spec.rb
+++ b/plugins/chat/spec/models/chat_message_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 describe ChatMessage do
   fab!(:message) { Fabricate(:chat_message, message: "hey friend, what's up?!") }
 
+  it { is_expected.to have_many(:chat_mentions).dependent(:destroy) }
+
   describe ".cook" do
     it "does not support HTML tags" do
       cooked = ChatMessage.cook("<h1>test</h1>")


### PR DESCRIPTION
This change only makes the model reflect correctly what's already happening in the database. Note that there are no calls to 
`chat_message.chat_mention` in Core and plugins so this change should be safe.

Also note, that at the moment we use the `chat_mentions` db table only to support notifications about mentions, but we're going to start using it for other cases. This commit is the first step in that direction.
