### PR TITLE
FEATURE: Create SQL-only backup if there are no uploads

### DIFF
--- a/lib/backup_restore/backuper.rb
+++ b/lib/backup_restore/backuper.rb
@@ -11,7 +11,7 @@ module BackupRestore
       @user_id = user_id
       @client_id = opts[:client_id]
       @publish_to_message_bus = opts[:publish_to_message_bus] || false
-      @with_uploads = opts[:with_uploads].nil? ? include_uploads? : opts[:with_uploads]
+      @with_uploads = opts[:with_uploads] == false ? false : include_uploads?
       @filename_override = opts[:filename]
       @ticket = opts[:ticket]
 


### PR DESCRIPTION
It doesn't make sense to double-compress the backup when there are no uploads even when the admin requested a backup with uploads.