### PR TITLE
Revert "UX: flex horizontal form controls (#20098)"

### DIFF
--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -155,8 +155,6 @@ input {
   }
 
   .controls {
-    display: flex;
-    align-items: center;
     margin-left: 160px;
   }
 }


### PR DESCRIPTION
This reverts commit 15b546978f1b76d2ee58ab7d3ab0b6b949ed923f.

Was causing layout issues in 2FA screens like below: 

<img width="1183" alt="image" src="https://user-images.githubusercontent.com/368961/217892259-af3df586-b6fc-4c06-b43a-f08959aebc16.png">
