### PR TITLE
A11Y: add aria-label to header notification counts

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -95,6 +95,14 @@ createWidget("header-notifications", {
               titleOptions: {
                 count: user.new_personal_messages_notifications_count,
               },
+              attributes: {
+                "aria-label": I18n.t(
+                  "notifications.tooltip.new_message_notification",
+                  {
+                    count: user.new_personal_messages_notifications_count,
+                  }
+                ),
+              },
             })
           );
         } else if (user.unseen_reviewable_count) {
@@ -106,6 +114,11 @@ createWidget("header-notifications", {
               omitSpan: true,
               title: "notifications.tooltip.new_reviewable",
               titleOptions: { count: user.unseen_reviewable_count },
+              attributes: {
+                "aria-label": I18n.t("notifications.tooltip.new_reviewable", {
+                  count: user.unseen_reviewable_count,
+                }),
+              },
             })
           );
         } else if (user.all_unread_notifications_count) {
@@ -118,6 +131,9 @@ createWidget("header-notifications", {
               omitSpan: true,
               title: "notifications.tooltip.regular",
               titleOptions: { count: user.all_unread_notifications_count },
+              attributes: {
+                "aria-label": I18n.t("user.notifications"),
+              },
             })
           );
         }


### PR DESCRIPTION
Originally reported as: 

> When the user menu control has an indication that there is an unread notification, the link within the link has for its accessible name only the number of notifications. While an attempt has been made to provide a better accessible name using a title attribute, this will not be consistently announced by screen readers. When combining the user menu control links in to one control, use hidden text or an aria-label attribute to provide a more expansive accessible name

This adds the label "notifications" for standard notification counts, and adds more descriptive text for priority notifications like flags and messages. 