### PR TITLE
FIX: add index to sidebar_section_link

### DIFF
--- a/app/models/sidebar_section_link.rb
+++ b/app/models/sidebar_section_link.rb
@@ -40,5 +40,6 @@ end
 #
 # Indexes
 #
-#  idx_unique_sidebar_section_links  (user_id,linkable_type,linkable_id) UNIQUE
+#  idx_unique_sidebar_section_links                              (user_id,linkable_type,linkable_id) UNIQUE
+#  index_sidebar_section_links_on_linkable_type_and_linkable_id  (linkable_type,linkable_id)
 #

--- a/app/services/sidebar_site_settings_backfiller.rb
+++ b/app/services/sidebar_site_settings_backfiller.rb
@@ -81,7 +81,7 @@ class SidebarSiteSettingsBackfiller
       FROM users
       WHERE users.id NOT IN (
         SELECT
-          sidebar_section_links.user_id
+          DISTINCT(sidebar_section_links.user_id)
         FROM sidebar_section_links
         WHERE sidebar_section_links.linkable_type = '#{@linkable_klass.to_s}'
         AND sidebar_section_links.linkable_id IN (#{@added_ids.join(",")})

--- a/db/migrate/20230209222225_add_linkable_index_to_sidebar_section_links.rb
+++ b/db/migrate/20230209222225_add_linkable_index_to_sidebar_section_links.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLinkableIndexToSidebarSectionLinks < ActiveRecord::Migration[7.0]
+  def change
+    add_index :sidebar_section_links, %i[linkable_type linkable_id]
+  end
+end

--- a/db/migrate/20230209222225_add_linkable_index_to_sidebar_section_links.rb
+++ b/db/migrate/20230209222225_add_linkable_index_to_sidebar_section_links.rb
@@ -5,6 +5,10 @@ class AddLinkableIndexToSidebarSectionLinks < ActiveRecord::Migration[7.0]
 
   def up
     execute <<~SQL
+    DROP INDEX CONCURRENTLY IF EXISTS index_sidebar_section_links_on_linkable_type_and_linkable_id
+    SQL
+
+    execute <<~SQL
     CREATE INDEX CONCURRENTLY index_sidebar_section_links_on_linkable_type_and_linkable_id
     ON sidebar_section_links (linkable_type,linkable_id)
     SQL

--- a/db/migrate/20230209222225_add_linkable_index_to_sidebar_section_links.rb
+++ b/db/migrate/20230209222225_add_linkable_index_to_sidebar_section_links.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 class AddLinkableIndexToSidebarSectionLinks < ActiveRecord::Migration[7.0]
-  def change
-    add_index :sidebar_section_links, %i[linkable_type linkable_id]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+    CREATE INDEX CONCURRENTLY index_sidebar_section_links_on_linkable_type_and_linkable_id
+    ON sidebar_section_links (linkable_type,linkable_id)
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+    DROP INDEX CONCURRENTLY IF EXISTS index_sidebar_section_links_on_linkable_type_and_linkable_id
+    SQL
   end
 end


### PR DESCRIPTION
Index on linkable_type and linkable_id should increase performance of this subquery - https://github.com/discourse/discourse/blob/main/app/services/sidebar_site_settings_backfiller.rb#L86

Also, distinct is removing duplicates which are unnecessary.
