### PR TITLE
FIX: IconPicker option to display only available icons

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
@@ -26,6 +26,7 @@
             @value={{link.icon}}
             @options={{hash maximum=1}}
             class={{link.iconCssClass}}
+            @available={{true}}
             @onChange={{action (mut link.icon)}}
           />
         </div>

--- a/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
@@ -26,7 +26,7 @@
             @value={{link.icon}}
             @options={{hash maximum=1}}
             class={{link.iconCssClass}}
-            @available={{true}}
+            @onlyAvailable={{true}}
             @onChange={{action (mut link.icon)}}
           />
         </div>

--- a/app/assets/javascripts/select-kit/addon/components/icon-picker.js
+++ b/app/assets/javascripts/select-kit/addon/components/icon-picker.js
@@ -36,7 +36,10 @@ export default MultiSelectComponent.extend({
       return this._cachedIconsList;
     } else {
       return ajax("/svg-sprite/picker-search", {
-        data: { filter },
+        data: {
+          filter,
+          available: this.available,
+        },
       }).then((icons) => {
         icons = icons.map(this._processIcon);
         if (filter === "") {

--- a/app/assets/javascripts/select-kit/addon/components/icon-picker.js
+++ b/app/assets/javascripts/select-kit/addon/components/icon-picker.js
@@ -38,7 +38,7 @@ export default MultiSelectComponent.extend({
       return ajax("/svg-sprite/picker-search", {
         data: {
           filter,
-          available: this.available,
+          only_available: this.onlyAvailable,
         },
       }).then((icons) => {
         icons = icons.map(this._processIcon);

--- a/app/controllers/svg_sprite_controller.rb
+++ b/app/controllers/svg_sprite_controller.rb
@@ -46,10 +46,11 @@ class SvgSpriteController < ApplicationController
 
   def icon_picker_search
     RailsMultisite::ConnectionManagement.with_hostname(params[:hostname]) do
-      params.permit(:filter)
+      params.permit(:filter, :available)
       filter = params[:filter] || ""
+      available = params[:available]
 
-      icons = SvgSprite.icon_picker_search(filter)
+      icons = SvgSprite.icon_picker_search(filter, available)
       render json: icons.take(200), root: false
     end
   end

--- a/app/controllers/svg_sprite_controller.rb
+++ b/app/controllers/svg_sprite_controller.rb
@@ -46,11 +46,11 @@ class SvgSpriteController < ApplicationController
 
   def icon_picker_search
     RailsMultisite::ConnectionManagement.with_hostname(params[:hostname]) do
-      params.permit(:filter, :available)
+      params.permit(:filter, :only_available)
       filter = params[:filter] || ""
-      available = params[:available]
+      only_available = params[:only_available]
 
-      icons = SvgSprite.icon_picker_search(filter, available)
+      icons = SvgSprite.icon_picker_search(filter, only_available)
       render json: icons.take(200), root: false
     end
   end

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -426,7 +426,8 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     false
   end
 
-  def self.icon_picker_search(keyword)
+  def self.icon_picker_search(keyword, available = false)
+    icons = all_icons(SiteSetting.default_theme_id) if available
     results = Set.new
 
     sprite_sources(SiteSetting.default_theme_id).each do |item|
@@ -436,6 +437,7 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
         .css("symbol")
         .each do |sym|
           icon_id = prepare_symbol(sym, item[:filename])
+          next if available && !icons.include?(icon_id)
           if keyword.empty? || icon_id.include?(keyword)
             sym.attributes["id"].value = icon_id
             sym.css("title").each(&:remove)

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -426,8 +426,8 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
     false
   end
 
-  def self.icon_picker_search(keyword, available = false)
-    icons = all_icons(SiteSetting.default_theme_id) if available
+  def self.icon_picker_search(keyword, only_available = false)
+    icons = all_icons(SiteSetting.default_theme_id) if only_available
     results = Set.new
 
     sprite_sources(SiteSetting.default_theme_id).each do |item|
@@ -437,7 +437,7 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
         .css("symbol")
         .each do |sym|
           icon_id = prepare_symbol(sym, item[:filename])
-          next if available && !icons.include?(icon_id)
+          next if only_available && !icons.include?(icon_id)
           if keyword.empty? || icon_id.include?(keyword)
             sym.attributes["id"].value = icon_id
             sym.css("title").each(&:remove)

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe SvgSpriteController do
       data = response.parsed_body
       beer_icon = response.parsed_body.find { |i| i["id"] == "beer" }
       expect(beer_icon).to be nil
-      expect(data[0]["id"]).to eq("ad")
+      expect(data.length).to eq(200)
     end
   end
 

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -99,6 +99,21 @@ RSpec.describe SvgSpriteController do
       expect(data.length).to eq(1)
       expect(data[0]["id"]).to eq("fab-500px")
     end
+
+    it "should display only available" do
+      sign_in(Fabricate(:user))
+
+      get "/svg-sprite/picker-search"
+      data = response.parsed_body
+      beer_icon = response.parsed_body.find { |i| i["id"] == "beer" }
+      expect(beer_icon).to be_present
+
+      get "/svg-sprite/picker-search", params: { available: "true" }
+      data = response.parsed_body
+      beer_icon = response.parsed_body.find { |i| i["id"] == "beer" }
+      expect(beer_icon).to be nil
+      expect(data[0]["id"]).to eq("ad")
+    end
   end
 
   describe "#svg_icon" do

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe SvgSpriteController do
       beer_icon = response.parsed_body.find { |i| i["id"] == "beer" }
       expect(beer_icon).to be_present
 
-      get "/svg-sprite/picker-search", params: { available: "true" }
+      get "/svg-sprite/picker-search", params: { only_available: "true" }
       data = response.parsed_body
       beer_icon = response.parsed_body.find { |i| i["id"] == "beer" }
       expect(beer_icon).to be nil


### PR DESCRIPTION
Not all icons are shipped by default. Sidebar section icon picker should only display available icons.


