### PR TITLE
FIX: Chat's user autocomplete threw errors

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -91,6 +91,7 @@ export default Component.extend(TextareaTextManipulation, {
 
     this._textarea = this.element.querySelector(".chat-composer-input");
     this._$textarea = $(this._textarea);
+    this._applyUserAutocomplete(this._$textarea);
     this._applyCategoryHashtagAutocomplete(this._$textarea);
     this._applyEmojiAutocomplete(this._$textarea);
     this.appEvents.on("chat:focus-composer", this, "_focusTextArea");
@@ -302,7 +303,6 @@ export default Component.extend(TextareaTextManipulation, {
 
   @bind
   _handleTextareaInput() {
-    this._applyUserAutocomplete();
     this.onValueChange?.(this.value, this._uploads, this.replyToMsg);
   },
 
@@ -344,9 +344,9 @@ export default Component.extend(TextareaTextManipulation, {
     this.resizeTextarea();
   },
 
-  _applyUserAutocomplete() {
+  _applyUserAutocomplete($textarea) {
     if (this.siteSettings.enable_mentions) {
-      $(this._textarea).autocomplete({
+      $textarea.autocomplete({
         template: findRawTemplate("user-selector-autocomplete"),
         key: "@",
         width: "100%",
@@ -360,7 +360,7 @@ export default Component.extend(TextareaTextManipulation, {
                 this.chat.presenceChannel.users?.mapBy("username");
               result.users.forEach((user) => {
                 if (presentUserNames.includes(user.username)) {
-                  user.cssClasses = "mention-user-is-online";
+                  user.cssClasses = "is-online";
                 }
               });
             }


### PR DESCRIPTION
The function was called multiple times when pressing the arrow keys.

![image](https://user-images.githubusercontent.com/66427541/217980660-a7e26554-d472-4a8b-85eb-d40c0188e4c5.png)

I also fixed the presence indicator in chat's autocomplete, which was introduced in https://github.com/discourse/discourse/pull/19426, but it had the classes mismatched

![Screenshot from 2023-02-09 22-51-20](https://user-images.githubusercontent.com/66427541/217981476-8ba34941-c6e8-44fc-9e49-4cb32fec07d2.png)
