### PR TITLE
DEV: Change setActiveChannel to get/set in services/chat

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
@@ -220,7 +220,7 @@ export default Component.extend({
 
   @action
   openURL(URL = null) {
-    this.chat.setActiveChannel(null);
+    this.chat.activeChannel = null;
     this.chatStateManager.didOpenDrawer(URL);
 
     const route = this._buildRouteFromURL(
@@ -264,7 +264,7 @@ export default Component.extend({
 
   _openChannel(channelId, afterRenderFunc = null) {
     return this.chatChannelsManager.find(channelId).then((channel) => {
-      this.chat.setActiveChannel(channel);
+      this.chat.activeChannel = channel;
       this.set("view", CHAT_VIEW);
       this.appEvents.trigger("chat:float-toggled", false);
 
@@ -278,7 +278,7 @@ export default Component.extend({
   openInFullPage() {
     this.chatStateManager.storeAppURL();
     this.chatStateManager.prefersFullPage();
-    this.chat.setActiveChannel(null);
+    this.chat.activeChannel = null;
 
     return this.router.transitionTo(this.chatStateManager.lastKnownChatURL);
   },
@@ -297,7 +297,7 @@ export default Component.extend({
   close() {
     this.computeDrawerStyle();
     this.chatStateManager.didCloseDrawer();
-    this.chat.setActiveChannel(null);
+    this.chat.activeChannel = null;
     this.appEvents.trigger("chat:float-toggled", true);
   },
 
@@ -315,7 +315,7 @@ export default Component.extend({
         return;
       }
 
-      this.chat.setActiveChannel(channel);
+      this.chat.activeChannel = channel;
 
       if (!channel) {
         const URL = this._buildURLFromState(LIST_VIEW);

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-browse-index.js
@@ -5,7 +5,7 @@ export default class ChatBrowseIndexRoute extends DiscourseRoute {
   @service chat;
 
   activate() {
-    this.chat.setActiveChannel(null);
+    this.chat.activeChannel = null;
   }
 
   afterModel() {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel-decorator.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel-decorator.js
@@ -12,7 +12,7 @@ export default function withChatChannel(extendedClass) {
 
     afterModel(model) {
       this.controllerFor("chat-channel").set("targetMessageId", null);
-      this.chat.setActiveChannel(model);
+      this.chat.activeChannel = model;
 
       let { messageId } = this.paramsFor(this.routeName);
       // messageId query param backwards-compatibility

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-draft-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-draft-channel.js
@@ -11,6 +11,6 @@ export default class ChatDraftChannelRoute extends DiscourseRoute {
   }
 
   activate() {
-    this.chat.setActiveChannel(null);
+    this.chat.activeChannel = null;
   }
 }

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -75,7 +75,7 @@ export default class ChatRoute extends DiscourseRoute {
   @action
   willTransition(transition) {
     if (!transition?.to?.name?.startsWith("chat.channel")) {
-      this.chat.setActiveChannel(null);
+      this.chat.activeChannel = null;
     }
 
     if (!transition?.to?.name?.startsWith("chat.")) {

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -1,4 +1,5 @@
 import deprecated from "discourse-common/lib/deprecated";
+import { tracked } from "@glimmer/tracking";
 import userSearch from "discourse/lib/user-search";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Service, { inject as service } from "@ember/service";
@@ -35,7 +36,8 @@ export default class Chat extends Service {
   @service site;
   @service chatChannelsManager;
 
-  activeChannel = null;
+  @tracked activeChannel = null;
+
   cook = null;
   presenceChannel = null;
   sidebarActive = false;
@@ -114,10 +116,6 @@ export default class Chat extends Service {
     if (this.userCanChat) {
       this.chatSubscriptionsManager.stopChannelsSubscriptions();
     }
-  }
-
-  setActiveChannel(channel) {
-    this.set("activeChannel", channel);
   }
 
   loadCookFunction(categories) {
@@ -281,12 +279,12 @@ export default class Chat extends Service {
         this.router.currentRouteName === "chat.channel.near-message") &&
       this.activeChannel?.id === channel.id
     ) {
-      this.setActiveChannel(channel);
+      this.activeChannel = channel;
       this._fireOpenMessageAppEvent(messageId);
       return Promise.resolve();
     }
 
-    this.setActiveChannel(channel);
+    this.activeChannel = channel;
 
     if (
       this.chatStateManager.isFullPageActive ||


### PR DESCRIPTION
Per PR comment in #20209, we don't need to do setActiveChannel,
we can just use native get/set instead.
