### PR TITLE
FIX: do not notify admins on suppressed categories

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -468,7 +468,7 @@ class PostAlerter
     end
 
     # Make sure the user can see the post
-    return unless Guardian.new(user).can_see?(post)
+    return unless Guardian.new(user).can_notify_post?(post)
 
     return if user.staged? && topic.category&.mailinglist_mirror?
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -467,7 +467,7 @@ class PostAlerter
       return
     end
 
-    return if !Guardian.new(user).can_notify_post?(post)
+    return if !Guardian.new(user).can_receive_post_notifications?(post)
 
     return if user.staged? && topic.category&.mailinglist_mirror?
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -467,8 +467,7 @@ class PostAlerter
       return
     end
 
-    # Make sure the user can see the post
-    return unless Guardian.new(user).can_notify_post?(post)
+    return if !Guardian.new(user).can_notify_post?(post)
 
     return if user.staged? && topic.category&.mailinglist_mirror?
 

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -249,7 +249,7 @@ module PostGuardian
       !post_action.post&.topic&.archived?
   end
 
-  def can_notify_post?(post)
+  def can_receive_post_notifications?(post)
     return false if !authenticated?
 
     if is_admin? && SiteSetting.suppress_secured_categories_from_admin

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -249,6 +249,18 @@ module PostGuardian
       !post_action.post&.topic&.archived?
   end
 
+  def can_notify_post?(post)
+    return false if !authenticated?
+
+    if is_admin? && SiteSetting.suppress_secured_categories_from_admin
+      topic = post.topic
+      if !topic.private_message? && topic.category.read_restricted
+        return secure_category_ids.include?(post.topic.category_id)
+      end
+    end
+    can_see_post?(post)
+  end
+
   def can_see_post?(post)
     return false if post.blank?
     return true if is_admin?

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -255,7 +255,7 @@ module PostGuardian
     if is_admin? && SiteSetting.suppress_secured_categories_from_admin
       topic = post.topic
       if !topic.private_message? && topic.category.read_restricted
-        return secure_category_ids.include?(post.topic.category_id)
+        return secure_category_ids.include?(topic.category_id)
       end
     end
     can_see_post?(post)

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -820,6 +820,42 @@ RSpec.describe Guardian do
     end
   end
 
+  describe "can_notify_post?" do
+    it "returns false with a nil object" do
+      expect(Guardian.new.can_notify_post?(nil)).to be_falsey
+      expect(Guardian.new(user).can_notify_post?(nil)).to be_falsey
+    end
+
+    it "does not allow anonymous to be notified" do
+      expect(Guardian.new.can_notify_post?(post)).to be_falsey
+    end
+
+    it "allows public categories" do
+      expect(Guardian.new(trust_level_0).can_notify_post?(post)).to be_truthy
+      expect(Guardian.new(admin).can_notify_post?(post)).to be_truthy
+    end
+
+    it "diallows secure categories with no access" do
+      secure_category = Fabricate(:category, read_restricted: true)
+      post.topic.update!(category_id: secure_category.id)
+
+      expect(Guardian.new(trust_level_0).can_notify_post?(post)).to be_falsey
+      expect(Guardian.new(admin).can_notify_post?(post)).to be_truthy
+
+      SiteSetting.suppress_secured_categories_from_admin = true
+
+      expect(Guardian.new(admin).can_notify_post?(post)).to be_falsey
+
+      secure_category.set_permissions(group => :write)
+      secure_category.save!
+
+      group.add(admin)
+      group.save!
+
+      expect(Guardian.new(admin).can_notify_post?(post)).to be_truthy
+    end
+  end
+
   describe "can_see?" do
     it "returns false with a nil object" do
       expect(Guardian.new.can_see?(nil)).to be_falsey

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -820,31 +820,31 @@ RSpec.describe Guardian do
     end
   end
 
-  describe "can_notify_post?" do
+  describe "can_receive_post_notifications?" do
     it "returns false with a nil object" do
-      expect(Guardian.new.can_notify_post?(nil)).to be_falsey
-      expect(Guardian.new(user).can_notify_post?(nil)).to be_falsey
+      expect(Guardian.new.can_receive_post_notifications?(nil)).to be_falsey
+      expect(Guardian.new(user).can_receive_post_notifications?(nil)).to be_falsey
     end
 
     it "does not allow anonymous to be notified" do
-      expect(Guardian.new.can_notify_post?(post)).to be_falsey
+      expect(Guardian.new.can_receive_post_notifications?(post)).to be_falsey
     end
 
     it "allows public categories" do
-      expect(Guardian.new(trust_level_0).can_notify_post?(post)).to be_truthy
-      expect(Guardian.new(admin).can_notify_post?(post)).to be_truthy
+      expect(Guardian.new(trust_level_0).can_receive_post_notifications?(post)).to be_truthy
+      expect(Guardian.new(admin).can_receive_post_notifications?(post)).to be_truthy
     end
 
     it "diallows secure categories with no access" do
       secure_category = Fabricate(:category, read_restricted: true)
       post.topic.update!(category_id: secure_category.id)
 
-      expect(Guardian.new(trust_level_0).can_notify_post?(post)).to be_falsey
-      expect(Guardian.new(admin).can_notify_post?(post)).to be_truthy
+      expect(Guardian.new(trust_level_0).can_receive_post_notifications?(post)).to be_falsey
+      expect(Guardian.new(admin).can_receive_post_notifications?(post)).to be_truthy
 
       SiteSetting.suppress_secured_categories_from_admin = true
 
-      expect(Guardian.new(admin).can_notify_post?(post)).to be_falsey
+      expect(Guardian.new(admin).can_receive_post_notifications?(post)).to be_falsey
 
       secure_category.set_permissions(group => :write)
       secure_category.save!
@@ -852,7 +852,7 @@ RSpec.describe Guardian do
       group.add(admin)
       group.save!
 
-      expect(Guardian.new(admin).can_notify_post?(post)).to be_truthy
+      expect(Guardian.new(admin).can_receive_post_notifications?(post)).to be_truthy
     end
   end
 


### PR DESCRIPTION
Avoid notifying admins on categories where they are not explicitly members
in cases where SiteSetting.suppress_secured_categories_from_admin is
enabled.

This helps keep notification stream clean and avoids admins mistakenly
being invited to discussions that should be suppressed
