### PR TITLE
A11Y: Header icons should be buttons, not links

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -230,7 +230,7 @@ createWidget(
 
       html(attrs) {
         return h(
-          "a.icon",
+          "button.icon.btn-flat",
           {
             attributes: {
               "aria-haspopup": true,
@@ -263,7 +263,7 @@ createWidget(
         }
 
         return h(
-          "a.icon.btn-flat",
+          "button.icon.btn-flat",
           {
             attributes: {
               "aria-expanded": attrs.active,

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -117,6 +117,8 @@
     float: left;
   }
   .icon {
+    box-sizing: content-box;
+    appearance: none;
     position: relative;
     display: flex;
     align-items: center;

--- a/plugins/chat/assets/javascripts/discourse/components/chat-header-icon.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-header-icon.hbs
@@ -1,7 +1,7 @@
 <a
   href={{this.href}}
   tabindex="0"
-  class={{concat-class "icon" (if this.isActive "active")}}
+  class={{concat-class "icon btn-flat" (if this.isActive "active")}}
 >
   {{d-icon "comment"}}
 


### PR DESCRIPTION
Reported as:

> A link has been used for the search and hamburger menu controls when buttons would be the appropriate element.

> As with the search and hamburger menu controls, a link has been used for the user menu control when a button would be the appropriate element.

I switched these elements from links to buttons, and also added a corresponding class to the chat icon (which functions as a link, so I've left it as one)