### PR TITLE
A11Y: Allow header logo/title to hide, if needed

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/home-logo.js
+++ b/app/assets/javascripts/discourse/app/widgets/home-logo.js
@@ -13,6 +13,12 @@ export default createWidget("home-logo", {
     href: getURL("/"),
   },
 
+  buildClasses() {
+    if (this.attrs.minimized) {
+      return "title--minimized";
+    }
+  },
+
   href() {
     const href = this.settings.href;
     return typeof href === "function" ? href() : href;

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -46,9 +46,11 @@
     display: flex;
     align-items: center;
     height: 100%;
+    overflow: hidden;
     a,
     a:visited {
       color: var(--header_primary);
+      min-width: 0;
     }
   }
 

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -46,11 +46,18 @@
     display: flex;
     align-items: center;
     height: 100%;
-    overflow: hidden;
     a,
     a:visited {
       color: var(--header_primary);
-      min-width: 0;
+    }
+
+    &:not(.title--minimized) {
+      // allows large logos to be hidden if there are too many other header elements
+      // this prioritizes nav elements, especially in cases of high zoom levels
+      overflow: hidden;
+      a {
+        min-width: 0;
+      }
     }
   }
 


### PR DESCRIPTION
This allows text site names, as well as large logos, to truncate or hide overflow in cases where there isn't enough space available for all the header elements. This is useful for people using high zoom levels, as previous to this change the logo could push nav elements out of view and require horizontal scrolling. 

This isn't applied within topics when the title docks, as the logo is already expected to be small and occupy a lesser amount of space (and the docked title already truncates as needed). 

Before:

![Screenshot 2023-02-10 at 2 43 03 PM](https://user-images.githubusercontent.com/1681963/218183585-635d9b98-ee00-48b0-969f-f9cfc2c8c100.png)


After: 

![Screenshot 2023-02-10 at 2 02 11 PM](https://user-images.githubusercontent.com/1681963/218179206-f246c50a-5b50-456b-9fae-03c3aca4d068.png)

