### PR TITLE
DEV: Remove unused string

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2668,7 +2668,6 @@ en:
     activated_by_staff: "Activated by staff"
     new_user_typed_too_fast: "New user typed too fast"
     content_matches_auto_silence_regex: "Content matches auto silence regex"
-    content_matches_auto_block_regex: "Content matches auto block regex"
     username:
       short: "must be at least %{min} characters"
       long: "must be no more than %{max} characters"


### PR DESCRIPTION
"block" was renamed to "silence" in 1f14350220b4df9ee0bdc3c6bf1e7794b7c494fc, but we missed removing that string