### PR TITLE
FIX: edit custom section title

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -203,6 +203,12 @@ export default Controller.extend(ModalFunctionality, {
     return this.model.links.filter((link) => !link._destroy);
   },
 
+  get header() {
+    return this.model.id
+      ? "sidebar.sections.custom.edit"
+      : "sidebar.sections.custom.add";
+  },
+
   actions: {
     addLink() {
       this.model.links.pushObject(new SectionLink({ router: this.router }));

--- a/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
@@ -3,7 +3,7 @@
     {{this.flashText}}
   </div>
 {{/if}}
-<DModalBody @title="sidebar.sections.custom.add">
+<DModalBody @title={{this.header}}>
   <form class="form-horizontal">
     <div class="input-group">
       <label for="section-name">{{i18n "sidebar.sections.custom.name"}}</label>

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -19,6 +19,7 @@ describe "Custom sidebar sections", type: :system, js: true do
 
     expect(section_modal).to be_visible
     expect(section_modal).to have_disabled_save
+    expect(find("#discourse-modal-title")).to have_content("Add custom section")
 
     section_modal.fill_name("My section")
 
@@ -41,6 +42,8 @@ describe "Custom sidebar sections", type: :system, js: true do
     visit("/latest")
 
     sidebar.edit_custom_section("My section")
+    expect(find("#discourse-modal-title")).to have_content("Edit custom section")
+
     section_modal.fill_name("Edited section")
     section_modal.fill_link("Edited Tags", "/tags")
     section_modal.remove_last_link


### PR DESCRIPTION
When custom section is edited, it should say "Edit custom section" instead of "Add custom section"
