### PR TITLE
DEV: Use internal __autoloads for zeitwork reload check

### DIFF
--- a/config/initializers/000-development_reload_warnings.rb
+++ b/config/initializers/000-development_reload_warnings.rb
@@ -20,7 +20,7 @@ if Rails.env.development? && !Rails.configuration.cache_classes && Discourse.run
 
       not_autoloaded =
         files.filter_map do |file|
-          autoloaded = Rails.autoloaders.main.autoloads.key? file
+          autoloaded = Rails.autoloaders.main.__autoloads.key? file
           Pathname.new(file).relative_path_from(Rails.root) if !autoloaded
         end
 


### PR DESCRIPTION
Since https://github.com/fxn/zeitwerk/commit/ad6c0284849b96198df9175bf367ea83a398e6c3
in the zeitwork repo which was introduced to discourse/discourse in PR #20253,
the `autoloads` attribute on the loader has been marked `internal`, which means
that it errors if we try to access it directly.

Instead we should access it via the "mangled" version so it is clear
we're accessing an internal property, which is `__autoloads`.

Without this, any time a ruby file is saved the
000-development_reload_warnings.rb initializer will error.
