### PR TITLE
FIX: Category settings migration failing on '' integer

### DIFF
--- a/db/migrate/20230208020404_populate_category_settings.rb
+++ b/db/migrate/20230208020404_populate_category_settings.rb
@@ -16,15 +16,15 @@ class PopulateCategorySettings < ActiveRecord::Migration[7.0]
         category_id,
         MAX(
           CASE WHEN (name = 'require_topic_approval')
-          THEN value ELSE NULL END
+          THEN NULLIF(value, '') ELSE NULL END
         )::boolean AS require_topic_approval,
         MAX(
           CASE WHEN (name = 'require_reply_approval')
-          THEN value ELSE NULL END
+          THEN NULLIF(value, '') ELSE NULL END
         )::boolean AS require_reply_approval,
         MAX(
           CASE WHEN (name = 'num_auto_bump_daily')
-          THEN value ELSE NULL END
+          THEN NULLIF(value, '') ELSE NULL END
         )::integer AS num_auto_bump_daily,
         NOW() AS created_at,
         NOW() AS updated_at


### PR DESCRIPTION
Fixes migration introduced in a90ad52dffb2e1dfa41db9d259454dbbe99ff64f,
some category custom fields like `num_auto_bump_daily` which should be
an integer are actually empty string ''.
