### PR TITLE
DEV: Deprecate CustomHTML hbs templates

### DIFF
--- a/app/assets/javascripts/discourse/app/components/custom-html.js
+++ b/app/assets/javascripts/discourse/app/components/custom-html.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import { getCustomHTML } from "discourse/helpers/custom-html";
 import { getOwner } from "discourse-common/lib/get-owner";
+import deprecated from "discourse-common/lib/deprecated";
 
 export default Component.extend({
   triggerAppEvent: null,
@@ -16,6 +17,10 @@ export default Component.extend({
     } else {
       const template = getOwner(this).lookup(`template:${name}`);
       if (template) {
+        deprecated(
+          "Defining an hbs template for CustomHTML rendering is deprecated. Use plugin outlets instead.",
+          { id: "discourse.custom_html_template" }
+        );
         this.set("layoutName", name);
       }
     }


### PR DESCRIPTION
This is an old system for introducing custom content into Discourse. Nowadays, plugins and themes should be using Plugin Outlets for this.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
