### PR TITLE
UX: allow sidebar to appear inline down to 768px

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/narrow-desktop.js
+++ b/app/assets/javascripts/discourse/app/lib/narrow-desktop.js
@@ -10,7 +10,7 @@ const NarrowDesktop = {
   },
 
   isNarrowDesktopView(width) {
-    return width < 1000;
+    return width < 768;
   },
 };
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-narrow-desktop-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-narrow-desktop-test.js
@@ -25,7 +25,7 @@ acceptance("Sidebar - Narrow Desktop", function (needs) {
     assert.ok(exists("#d-sidebar"), "wide sidebar is displayed");
 
     const bodyElement = document.querySelector("body");
-    bodyElement.style.width = "990px";
+    bodyElement.style.width = "767";
 
     await waitUntil(
       () => document.querySelector(".btn-sidebar-toggle.narrow-desktop"),
@@ -60,7 +60,7 @@ acceptance("Sidebar - Narrow Desktop", function (needs) {
     await settled();
 
     const bodyElement = document.querySelector("body");
-    bodyElement.style.width = "990px";
+    bodyElement.style.width = "767px";
 
     await waitUntil(
       () => document.querySelector(".btn-sidebar-toggle.narrow-desktop"),

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-narrow-desktop-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-narrow-desktop-test.js
@@ -18,14 +18,14 @@ acceptance("Sidebar - Narrow Desktop", function (needs) {
 
     await click(".header-sidebar-toggle .btn");
 
-    assert.ok(!exists("#d-sidebar"), "widge sidebar is collapsed");
+    assert.ok(!exists("#d-sidebar"), "wide sidebar is collapsed");
 
     await click(".header-sidebar-toggle .btn");
 
     assert.ok(exists("#d-sidebar"), "wide sidebar is displayed");
 
     const bodyElement = document.querySelector("body");
-    bodyElement.style.width = "767";
+    bodyElement.style.width = "767px";
 
     await waitUntil(
       () => document.querySelector(".btn-sidebar-toggle.narrow-desktop"),

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -1,5 +1,8 @@
 :root {
   --d-sidebar-width: #{$d-sidebar-width};
+  @include breakpoint(large) {
+    --d-sidebar-width: #{$d-sidebar-narrow-width};
+  }
   --d-sidebar-animation-time: 0.25s;
   --d-sidebar-animation-ease: ease-in-out;
   --d-sidebar-row-height: 30px;

--- a/app/assets/stylesheets/common/foundation/variables.scss
+++ b/app/assets/stylesheets/common/foundation/variables.scss
@@ -18,6 +18,7 @@ $topic-avatar-width: 45px;
 $reply-area-max-width: 1475px !default;
 
 $d-sidebar-width: 16em !default;
+$d-sidebar-narrow-width: 14em !default;
 
 // Brand color variables
 // --------------------------------------------------

--- a/app/assets/stylesheets/desktop/discourse.scss
+++ b/app/assets/stylesheets/desktop/discourse.scss
@@ -205,6 +205,9 @@ body.has-sidebar-page {
   #main-outlet-wrapper {
     grid-template-columns: var(--d-sidebar-width) minmax(0, 1fr);
     gap: 0 2em;
+    @include breakpoint(large) {
+      gap: 0 1em;
+    }
     padding-left: 0;
   }
 }

--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -202,10 +202,10 @@
     }
     // reduce width for more title space
     .posts {
-      width: 50px;
+      width: 3em;
     }
     .posters {
-      width: 30px;
+      width: 2em;
       text-align: center;
     }
     // show only the first poster
@@ -227,25 +227,33 @@
   }
 }
 
+@include breakpoint(large, $sidebar: true) {
+  .topic-list {
+    .topic-list-item .topic-list-data:first-of-type {
+      padding: 0.8em 0.33em;
+    }
+    .topic-list-data {
+      padding: 0.33em;
+    }
+  }
+}
+
 @include breakpoint(medium) {
-  // slightly smaller font, tighten spacing on nav pills
   .nav-pills {
     > li > a {
       font-size: var(--font-0);
-      padding: 7px 10px;
+      padding: 0.45em 0.67em;
     }
   }
 
   .topic-list {
-    // tighter table header spacing
-    .topic-list-item .topic-list-data:first-of-type {
-      padding: 12px 5px;
-    }
-    // smaller table cell spacing
     .topic-list-data {
-      padding: 10px;
       font-size: var(--font-0);
     }
+  }
+
+  .topic-list-header {
+    font-size: var(--font-down-1);
   }
 }
 


### PR DESCRIPTION
This allows the sidebar to display inline with the content down to the somewhat standard portrait tablet width of 768px... 

This doesn't make any changes to the content that weren't already here... we already hide the views column for narrow screens, for example. But it does introduce a narrower sidebar at viewport widths under 1000px (30px less wide with default font-size), and reduces some gaps and padding so everything can fit more reasonably. 

Here's what it looks like at 768px:

![Screenshot 2023-02-13 at 4 15 58 PM](https://user-images.githubusercontent.com/1681963/218577637-d8d8809a-edf9-49a9-8a2a-d5442223ff2e.png)

