### PR TITLE
FIX: Unsubscribing via key associated with deleted topic

### DIFF
--- a/lib/email_controller_helper/topic_email_unsubscriber.rb
+++ b/lib/email_controller_helper/topic_email_unsubscriber.rb
@@ -8,6 +8,8 @@ module EmailControllerHelper
 
       topic = unsubscribe_key.associated_topic
 
+      return if topic.blank?
+
       controller.instance_variable_set(:@topic, topic)
       controller.instance_variable_set(
         :@watching_topic,

--- a/spec/requests/email_controller_spec.rb
+++ b/spec/requests/email_controller_spec.rb
@@ -317,6 +317,15 @@ RSpec.describe EmailController do
         expect(response.body).not_to include("unwatch_category")
       end
 
+      it "displays form even if topic is deleted" do
+        post.topic.trash!
+
+        navigate_to_unsubscribe
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include(I18n.t("unsubscribe.all", sitename: SiteSetting.title))
+      end
+
       def create_category_user(notification_level)
         CategoryUser.create!(
           user_id: user.id,


### PR DESCRIPTION
Currently, clicking on the unsubscribe link with a `key` associated with a deleted topic results in an HTTP 500 response.

This change fixes that by skipping any attempt to run topic related flow if topic isn't present.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
