### PR TITLE
DEV: Update template-lint-disable in user.hbs

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -180,7 +180,7 @@
                   {{this.model.location}}</div>{{/if}}
               {{#if this.model.website_name}}
                 <div class="user-profile-website">
-                  {{! template-lint-disable link-rel-noopener}}
+                  {{! template-lint-disable link-rel-noopener }}
                   {{d-icon "globe"~}}
                   {{#if this.linkWebsite~}}
                     <a
@@ -196,7 +196,7 @@
                       title={{this.model.website}}
                     >{{this.model.website_name}}</span>
                   {{/if}}
-                  {{! template-lint-enable link-rel-noopener}}
+                  {{! template-lint-enable link-rel-noopener }}
                 </div>
               {{/if}}
               <span>

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -179,9 +179,10 @@
                 >{{d-icon "map-marker-alt"~}}
                   {{this.model.location}}</div>{{/if}}
               {{#if this.model.website_name}}
-                <div class="user-profile-website">{{d-icon "globe"~}}
+                <div class="user-profile-website">
+                  {{! template-lint-disable link-rel-noopener}}
+                  {{d-icon "globe"~}}
                   {{#if this.linkWebsite~}}
-                    {{~! template-lint-disable ~}}
                     <a
                       href={{this.model.website}}
                       rel="noopener {{unless
@@ -195,6 +196,7 @@
                       title={{this.model.website}}
                     >{{this.model.website_name}}</span>
                   {{/if}}
+                  {{! template-lint-enable link-rel-noopener}}
                 </div>
               {{/if}}
               <span>


### PR DESCRIPTION
Having a template-lint-disable comment with whitespace trimming was triggering a message during build, likely due to a bug in the build process.

```
unexpectedly found "! template-lint-disable ~" when slicing source, but expected " template-lint-disable "
```

This commit avoids the problem by moving the template-lint-disable comment outside of the stripped-whitespace area.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
