### PR TITLE
DEV: Remove unused JS style rspec test

### DIFF
--- a/spec/integrity/coding_style_spec.rb
+++ b/spec/integrity/coding_style_spec.rb
@@ -4,10 +4,6 @@ def list_files(base_dir, pattern = "*")
   Dir[File.join("#{base_dir}", pattern)]
 end
 
-def list_js_files(base_dir)
-  list_files(base_dir, "**/*.es6")
-end
-
 def grep_files(files, regex)
   files.select { |file| grep_file(file, regex) }
 end
@@ -18,21 +14,6 @@ def grep_file(file, regex)
 end
 
 RSpec.describe "Coding style" do
-  describe "Javascript" do
-    it 'prevents this.get("foo") pattern' do
-      js_files = list_js_files("app/assets/javascripts")
-      offenses = grep_files(js_files, /this\.get\("\w+"\)/)
-
-      expect(offenses).to be_empty, <<~TEXT
-        Do not use this.get("foo") accessor for single property, instead
-        prefer to use this.foo
-
-        Offenses:
-        #{offenses.join("\n")}
-      TEXT
-    end
-  end
-
   describe "Post Migrations" do
     def check_offenses(files, method_name, constant_name)
       method_name_regex = /#{Regexp.escape(method_name)}/


### PR DESCRIPTION
This hasn't functioned since we removed the `.es6` extensions from our JS files. Plus, during the migration from classic reactivity to octane, there are legitimate reasons to use `this.get` for single properties of Ember Objects

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
