### PR TITLE
DEV: Skip failing modifyClass test

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
@@ -1,4 +1,4 @@
-import { module, test, todo } from "qunit";
+import { module, skip, test } from "qunit";
 import EmberObject from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -88,7 +88,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
     assert.strictEqual(thingy.prop, "g'day");
   });
 
-  todo("modifyClass works with getters", function (assert) {
+  skip("modifyClass works with getters", function (assert) {
     let Base = EmberObject.extend({
       get foo() {
         throw new Error("base getter called");


### PR DESCRIPTION
This is a known failure. Using todo causes it to show up at the bottom of all test runs, which is annoying. Let's just skip it instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
