### PR TITLE
FIX: reverts part of thread css

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer-uploads.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer-uploads.scss
@@ -1,4 +1,6 @@
 .chat-composer-uploads {
+  max-width: 100%;
+
   .chat-composer-uploads-container {
     padding: 0.5rem 10px;
     display: flex;

--- a/plugins/chat/assets/stylesheets/common/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-side-panel.scss
@@ -1,10 +1,4 @@
 #main-chat-outlet.chat-view {
-  min-height: 0;
-  display: grid;
-  grid-template-rows: 1fr;
-  grid-template-areas: "main threads";
-  grid-template-columns: 1fr;
-
   &.has-side-panel-expanded {
     grid-template-columns: 3fr 2fr;
   }


### PR DESCRIPTION
This css was causing the view on mobile to take more space than the available width. This was particularly visible with uploads due to a bug preventing the overflow, this is also fixed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
