### PR TITLE
FIX: Reset admin theme controller on modal cancel event

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
+++ b/app/assets/javascripts/admin/addon/controllers/modals/admin-install-theme.js
@@ -135,6 +135,11 @@ export default Controller.extend(ModalFunctionality, {
       branch: null,
       selection: "popular",
     });
+
+    this.themesController.setProperties({
+      repoName: null,
+      repoUrl: null,
+    });
   },
 
   themeHasSameUrl(theme, url) {

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-install-theme-modal-test.js
@@ -1,5 +1,5 @@
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import I18n from "I18n";
 
@@ -81,6 +81,13 @@ acceptance("Admin - Themes - Install modal", function (needs) {
       query(".install-theme code").textContent.trim(),
       "testUrl",
       "repo url is visible"
+    );
+
+    await click(".d-modal-cancel");
+    assert.strictEqual(
+      currentURL(),
+      "/admin/customize/themes",
+      "query params are cleared after dismissing the modal"
     );
   });
 


### PR DESCRIPTION
When installing themes using the "Install this theme component" button on meta.discourse.org, we pass the repo name and URL via query params.

However, these stick. So if a user cancels the installation, on the next navigation to the same route, they'll see the modal again.

This PR clears the query params  of the controller when dismissing the modal.