### PR TITLE
Adjust user avatar redirect cache-control header

### DIFF
--- a/app/controllers/user_avatars_controller.rb
+++ b/app/controllers/user_avatars_controller.rb
@@ -192,7 +192,9 @@ class UserAvatarsController < ApplicationController
   end
 
   def redirect_s3_avatar(url)
-    immutable_for 1.day
+    response.cache_control[:max_age] = 1.hour.to_i
+    response.cache_control[:public] = true
+    response.cache_control[:extras] = ["immutable", "stale-while-revalidate=#{1.day.to_i}"]
     redirect_to url, allow_other_host: true
   end
 

--- a/spec/requests/user_avatars_controller_spec.rb
+++ b/spec/requests/user_avatars_controller_spec.rb
@@ -139,7 +139,9 @@ RSpec.describe UserAvatarsController do
 
       expect(response.status).to eq(302)
       expect(response.location).to eq("https://s3-cdn.example.com/optimized/path")
-      expect(response.headers["Cache-Control"]).to eq("max-age=86400, public, immutable")
+      expect(response.headers["Cache-Control"]).to eq(
+        "max-age=3600, public, immutable, stale-while-revalidate=86400",
+      )
     end
 
     it "serves new version for old urls" do


### PR DESCRIPTION
Previously, a user avatar redirect had a lifetime of 24h. That means that a change to the S3 CDN URL would take up to 24h to propagate to clients and intermediate CDNs.

This commit reduces the max age to 1 hour, but also introduces a `stale-while-revalidate` directive. This allows clients and CDNs to use a 'stale' value if it was received between 1h and 24h ago, as long as they make a background request to update the cache. This should reduce the impact of S3 URL changes. 1 hour after the change, the CDN will start serving updated values. Plus, if users have cached bad responses, their browser will automatically fetch the correct version and use it on the next page load.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
