### PR TITLE
UX: hide chat button on user card when suspended

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/user-card-chat-button.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-card-chat-button.hbs
@@ -1,4 +1,4 @@
-{{#if this.chat.userCanDirectMessage}}
+{{#if (and this.chat.userCanDirectMessage (not @user.suspended))}}
   <DButton
     @class="btn-primary user-card-chat-btn"
     @action={{action "startChatting"}}

--- a/plugins/chat/test/javascripts/components/user-card-chat-button-test.js
+++ b/plugins/chat/test/javascripts/components/user-card-chat-button-test.js
@@ -4,6 +4,7 @@ import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
 import { exists } from "discourse/tests/helpers/qunit-helpers";
+import User from "discourse/models/user";
 
 module("Discourse Chat | Component | user-card-chat-button", function (hooks) {
   setupRenderingTest(hooks);
@@ -24,6 +25,23 @@ module("Discourse Chat | Component | user-card-chat-button", function (hooks) {
       .value(false);
 
     await render(hbs`<UserCardChatButton/>`);
+
+    assert.false(
+      exists(".user-card-chat-btn"),
+      "it doesn’t show the chat button"
+    );
+  });
+
+  test("when displayed user is suspended", async function (assert) {
+    sinon
+      .stub(this.owner.lookup("service:chat"), "userCanDirectMessage")
+      .value(true);
+
+    this.user = User.create({
+      suspended_till: moment().add(1, "year").toDate(),
+    });
+
+    await render(hbs`<UserCardChatButton @user={{user}}/>`);
 
     assert.false(
       exists(".user-card-chat-btn"),


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
