### PR TITLE
FIX: correctly open channel info

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer/header/channel-title.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer/header/channel-title.hbs
@@ -1,5 +1,5 @@
 {{#if @channel}}
-  {{#if @this.chatStateManager.isDrawerExpanded}}
+  {{#if this.chatStateManager.isDrawerExpanded}}
     <LinkTo
       @route={{if
         @channel.isDirectMessageChannel

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -10,6 +10,24 @@ RSpec.describe "Drawer", type: :system, js: true do
     sign_in(current_user)
   end
 
+  context "when on channel" do
+    fab!(:channel) { Fabricate(:chat_channel) }
+    fab!(:membership) do
+      Fabricate(:user_chat_channel_membership, user: current_user, chat_channel: channel)
+    end
+
+    context "when clicking channel title" do
+      it "opens channel info page" do
+        visit("/")
+        chat_page.open_from_header
+        drawer.open_channel(channel)
+        page.find(".chat-channel-title").click
+
+        expect(page).to have_current_path("/chat/c/#{channel.slug}/#{channel.id}/info/about")
+      end
+    end
+  end
+
   context "when opening" do
     it "uses stored size" do
       visit("/") # we need to visit the page first to set the local storage


### PR DESCRIPTION
A typo was preventing a click on channel title when in drawer mode to correctly open the channel info in full page.

This commit fixes the typo and adds a test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
