### PR TITLE
FIX: Don't fallback to original implementation for linkTitle in the `custom` type

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-types/custom.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/custom.js
@@ -6,7 +6,6 @@ export default class extends NotificationTypeBase {
     if (this.notification.data.title) {
       return I18n.t(this.notification.data.title);
     }
-    return super.linkTitle;
   }
 
   get icon() {


### PR DESCRIPTION
The `custom` notification type is a generic notification type that plugins can use for their own notifications, so it doesn't make sense to fallback to the implementation of `linkTitle` in the base notification type because core can't possibly come up with a title suitable for all custom notifications from any plugin.