### PR TITLE
DEV: Fix failing chat spec and add unexpected failure indicator

### DIFF
--- a/plugins/chat/app/services/base.rb
+++ b/plugins/chat/app/services/base.rb
@@ -197,7 +197,7 @@ module Chat
         def call(instance, context)
           method = instance.method(method_name)
           args = {}
-          args = context.to_h unless method.arity.zero?
+          args = context.to_h if method.arity.positive?
           context[result_key] = Context.build
           instance.instance_exec(**args, &method)
         end
@@ -217,7 +217,7 @@ module Chat
       class ModelStep < Step
         def call(instance, context)
           context[name] = super
-          raise ArgumentError, "Model not found" unless context[name]
+          raise ArgumentError, "Model not found" if !context[name]
         rescue ArgumentError => exception
           context[result_key].fail(exception: exception)
           context.fail!
@@ -227,7 +227,7 @@ module Chat
       # @!visibility private
       class PolicyStep < Step
         def call(instance, context)
-          unless super
+          if !super
             context[result_key].fail
             context.fail!
           end
@@ -250,7 +250,7 @@ module Chat
           contract = class_name.new(default_values.merge(context.to_h.slice(*attributes)))
           context[contract_name] = contract
           context[result_key] = Context.build
-          unless contract.valid?
+          if !contract.valid?
             context[result_key].fail(errors: contract.errors)
             context.fail!
           end
@@ -384,7 +384,7 @@ module Chat
       #   private
       #
       #   def save_channel(channel:, **)
-      #     fail!("something went wrong") unless channel.save
+      #     fail!("something went wrong") if !channel.save
       #   end
 
       # @!scope class

--- a/plugins/chat/app/services/base.rb
+++ b/plugins/chat/app/services/base.rb
@@ -197,7 +197,7 @@ module Chat
         def call(instance, context)
           method = instance.method(method_name)
           args = {}
-          args = context.to_h if method.arity.positive?
+          args = context.to_h if !method.arity.zero?
           context[result_key] = Context.build
           instance.instance_exec(**args, &method)
         end
@@ -250,7 +250,7 @@ module Chat
           contract = class_name.new(default_values.merge(context.to_h.slice(*attributes)))
           context[contract_name] = contract
           context[result_key] = Context.build
-          if !contract.valid?
+          if contract.invalid?
             context[result_key].fail(errors: contract.errors)
             context.fail!
           end

--- a/plugins/chat/lib/steps_inspector.rb
+++ b/plugins/chat/lib/steps_inspector.rb
@@ -30,7 +30,7 @@ module Chat
       end
 
       def emoji
-        return "❌" if failure?
+        return spec_fail_unexpected_result? ? "❌ 🚧" : "❌" if failure?
         return "✅" if success?
         ""
       end
@@ -47,6 +47,10 @@ module Chat
 
       def step_result
         result["result.#{type}.#{name}"]
+      end
+
+      def spec_fail_unexpected_result?
+        step_result["spec.fail_step.unexpected_result"]
       end
     end
 

--- a/plugins/chat/lib/steps_inspector.rb
+++ b/plugins/chat/lib/steps_inspector.rb
@@ -30,9 +30,7 @@ module Chat
       end
 
       def emoji
-        return spec_fail_unexpected_result? ? "❌ 🚧" : "❌" if failure?
-        return "✅" if success?
-        ""
+        "#{result_emoji}#{unexpected_result_emoji}"
       end
 
       def steps
@@ -49,8 +47,19 @@ module Chat
         result["result.#{type}.#{name}"]
       end
 
-      def spec_fail_unexpected_result?
-        step_result["spec.fail_step.unexpected_result"]
+      def result_emoji
+        return "❌" if failure?
+        return "✅" if success?
+        ""
+      end
+
+      def unexpected_result_emoji
+        " ⚠️#{unexpected_result_text}" if step_result.try(:[], "spec.unexpected_result")
+      end
+
+      def unexpected_result_text
+        return "  <= expected to return true but got false instead" if failure?
+        "  <= expected to return false but got true instead"
       end
     end
 

--- a/plugins/chat/spec/services/update_user_last_read_spec.rb
+++ b/plugins/chat/spec/services/update_user_last_read_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe Chat::Service::UpdateUserLastRead do
 
       context "when message doesn’t exist" do
         before do
-          params[:message_id] = 2
+          message = Fabricate(:chat_message)
+          params[:message_id] = message.id
+          message.trash!
           membership.update!(last_read_message_id: 1)
         end
 

--- a/plugins/chat/spec/support/chat_service_matcher.rb
+++ b/plugins/chat/spec/support/chat_service_matcher.rb
@@ -15,6 +15,7 @@ module Chat
       end
 
       def failure_message
+        set_unexpected_result
         message =
           if !step_exists?
             "Expected #{type} '#{name}' (key: '#{step}') was not found in the result object."
@@ -23,13 +24,11 @@ module Chat
           else
             "expected the service to fail but it succeeded."
           end
-
-        result[step].merge("spec.fail_step.unexpected_result" => true) if !step_failed?
-
         error_message_with_inspection(message)
       end
 
       def failure_message_when_negated
+        set_unexpected_result
         message = "Expected #{type} '#{name}' (key: '#{step}') to succeed but it failed."
         error_message_with_inspection(message)
       end
@@ -55,6 +54,11 @@ module Chat
       def error_message_with_inspection(message)
         inspector = StepsInspector.new(result)
         "#{message}\n\n#{inspector.inspect}\n\n#{inspector.error}"
+      end
+
+      def set_unexpected_result
+        return unless result[step]
+        result[step]["spec.unexpected_result"] = true
       end
     end
 

--- a/plugins/chat/spec/support/chat_service_matcher.rb
+++ b/plugins/chat/spec/support/chat_service_matcher.rb
@@ -23,6 +23,8 @@ module Chat
           else
             "expected the service to fail but it succeeded."
           end
+
+        result[step].merge("spec.fail_step.unexpected_result" => true) if !step_failed?
         error_message_with_inspection(message)
       end
 

--- a/plugins/chat/spec/support/chat_service_matcher.rb
+++ b/plugins/chat/spec/support/chat_service_matcher.rb
@@ -25,6 +25,7 @@ module Chat
           end
 
         result[step].merge("spec.fail_step.unexpected_result" => true) if !step_failed?
+
         error_message_with_inspection(message)
       end
 


### PR DESCRIPTION
This commit fixes the UpdateUserLastRead spec which was checking
for a message ID that did not exist -- this could fail at times
since message ID 2 could exist. Better to create + destroy a message
since then it's guaranteed we have a unique ID.

This also attempts to clarify a step that we expect to fail which
succeeds instead by adding another emoji next to the success tick,
to try make it even clearer for the operator which step has the problem.

Also removes some uses of unless in Services::Base, we generally prefer
to use alternatives, since unless can be hard to parse in a lot of
cases.

Before

![image](https://user-images.githubusercontent.com/920448/218898395-4fc299bf-08a4-41ad-a1a1-47ba8ecce4c9.png)

After

![image](https://user-images.githubusercontent.com/920448/218898500-20972f58-350e-4b8f-b531-5444a4be4f98.png)

