### PR TITLE
FIX: Overflowing chat content in main-chat-outlet grid

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-side-panel.scss
@@ -1,4 +1,10 @@
 #main-chat-outlet.chat-view {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: 1fr;
+  grid-template-areas: "main threads";
+  grid-template-columns: 1fr;
+
   &.has-side-panel-expanded {
     grid-template-columns: 3fr 2fr;
   }

--- a/plugins/chat/assets/stylesheets/mobile/mobile.scss
+++ b/plugins/chat/assets/stylesheets/mobile/mobile.scss
@@ -15,6 +15,10 @@ html.has-full-page-chat {
     padding: 0;
 
     .main-chat-outlet {
+      .chat-live-pane {
+        min-width: 0;
+      }
+
       &.has-side-panel-expanded {
         grid-template-columns: 1fr;
         grid-template-areas: "threads";


### PR DESCRIPTION
Follow up to 82b4a53d29b6e043001e37cb448f077a19067a33

On mobile, we just need to add `min-width: 0` to
`chat-live-pane` so it will not overflow the grid
defined in `main-chat-outlet.chat-view`.

The overflow could be triggered by:

1. Replying on mobile to a really long chat message
2. Uploading > 2 files

Both of these situations are fixed.
