### PR TITLE
DEV: Remove chat_channel_id from chat-live-pane details

### DIFF
--- a/plugins/chat/app/serializers/chat_message_serializer.rb
+++ b/plugins/chat/app/serializers/chat_message_serializer.rb
@@ -14,12 +14,17 @@ class ChatMessageSerializer < ApplicationSerializer
              :reactions,
              :bookmark,
              :available_flags,
-             :thread_id
+             :thread_id,
+             :chat_channel_id
 
   has_one :user, serializer: BasicUserWithStatusSerializer, embed: :objects
   has_one :chat_webhook_event, serializer: ChatWebhookEventSerializer, embed: :objects
   has_one :in_reply_to, serializer: ChatInReplyToSerializer, embed: :objects
   has_many :uploads, serializer: UploadSerializer, embed: :objects
+
+  def channel
+    @channel ||= @options.dig(:chat_channel) || object.chat_channel
+  end
 
   def user
     object.user || DeletedChatUser.new
@@ -130,8 +135,6 @@ class ChatMessageSerializer < ApplicationSerializer
   def available_flags
     return [] if !scope.can_flag_chat_message?(object)
     return [] if reviewable_id.present? && user_flag_status == ReviewableScore.statuses[:pending]
-
-    channel = @options.dig(:chat_channel) || object.chat_channel
 
     PostActionType.flag_types.map do |sym, id|
       next if channel.direct_message_channel? && %i[notify_moderators notify_user].include?(sym)

--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -402,8 +402,6 @@ export default Component.extend({
     this.setProperties({
       messages: this._prepareMessages(messages),
       details: {
-        chat_channel_id: this.chatChannel.id,
-        chatable_type: this.chatChannel.chatable_type,
         can_delete_self: meta.can_delete_self,
         can_delete_others: meta.can_delete_others,
         can_flag: meta.can_flag,

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-info.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-info.hbs
@@ -25,7 +25,7 @@
   {{/if}}
 
   <span class="chat-message-info__date">
-    {{format-chat-date @message @details}}
+    {{format-chat-date @message}}
   </span>
 
   {{#if @message.bookmark}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-left-gutter.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-left-gutter.hbs
@@ -13,7 +13,7 @@
     </div>
   {{else}}
     <span class="chat-message-left-gutter__date">
-      {{format-chat-date @message @details "tiny"}}
+      {{format-chat-date @message "tiny"}}
     </span>
   {{/if}}
   {{#if @message.bookmark}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -115,14 +115,14 @@
         {{/if}}
 
         {{#if this.hideUserInfo}}
-          <ChatMessageLeftGutter @message={{@message}} @details={{@details}} />
+          <ChatMessageLeftGutter @message={{@message}} />
         {{else}}
           <ChatMessageAvatar @message={{@message}} />
         {{/if}}
 
         <div class="chat-message-content">
           {{#unless this.hideUserInfo}}
-            <ChatMessageInfo @message={{@message}} @details={{@details}} />
+            <ChatMessageInfo @message={{@message}} />
           {{/unless}}
 
           <ChatMessageText

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -458,7 +458,7 @@ export default class ChatMessage extends Component {
   inviteMentioned() {
     const userIds = this.mentionWarning.without_membership.mapBy("id");
 
-    ajax(`/chat/${this.args.details.chat_channel_id}/invite`, {
+    ajax(`/chat/${this.args.message.chat_channel_id}/invite`, {
       method: "PUT",
       data: { user_ids: userIds, chat_message_id: this.args.message.id },
     }).then(() => {
@@ -607,7 +607,7 @@ export default class ChatMessage extends Component {
 
   _publishReaction(emoji, reactAction) {
     return ajax(
-      `/chat/${this.args.details.chat_channel_id}/react/${this.args.message.id}`,
+      `/chat/${this.args.message.chat_channel_id}/react/${this.args.message.id}`,
       {
         type: "PUT",
         data: {
@@ -686,7 +686,7 @@ export default class ChatMessage extends Component {
   @action
   restore() {
     return ajax(
-      `/chat/${this.args.details.chat_channel_id}/restore/${this.args.message.id}`,
+      `/chat/${this.args.message.chat_channel_id}/restore/${this.args.message.id}`,
       {
         type: "PUT",
       }
@@ -730,7 +730,7 @@ export default class ChatMessage extends Component {
   @action
   rebakeMessage() {
     return ajax(
-      `/chat/${this.args.details.chat_channel_id}/${this.args.message.id}/rebake`,
+      `/chat/${this.args.message.chat_channel_id}/${this.args.message.id}/rebake`,
       {
         type: "PUT",
       }
@@ -740,7 +740,7 @@ export default class ChatMessage extends Component {
   @action
   deleteMessage() {
     return ajax(
-      `/chat/${this.args.details.chat_channel_id}/${this.args.message.id}`,
+      `/chat/${this.args.message.chat_channel_id}/${this.args.message.id}`,
       {
         type: "DELETE",
       }
@@ -775,7 +775,7 @@ export default class ChatMessage extends Component {
 
     const { protocol, host } = window.location;
     let url = getURL(
-      `/chat/c/-/${this.args.details.chat_channel_id}/${this.args.message.id}`
+      `/chat/c/-/${this.args.message.chat_channel_id}/${this.args.message.id}`
     );
     url = url.indexOf("/") === 0 ? protocol + "//" + host + url : url;
     clipboardCopy(url);

--- a/plugins/chat/assets/javascripts/discourse/helpers/format-chat-date.js
+++ b/plugins/chat/assets/javascripts/discourse/helpers/format-chat-date.js
@@ -4,22 +4,14 @@ import getURL from "discourse-common/lib/get-url";
 import I18n from "I18n";
 import User from "discourse/models/user";
 
-registerUnbound("format-chat-date", function (message, details, mode) {
-  let currentUser = User.current();
+registerUnbound("format-chat-date", function (message, mode) {
+  const currentUser = User.current();
+  const tz = currentUser ? currentUser.user_option.timezone : moment.tz.guess();
+  const date = moment(new Date(message.created_at), tz);
+  const url = getURL(`/chat/c/-/${message.chat_channel_id}/${message.id}`);
+  const title = date.format(I18n.t("dates.long_with_year"));
 
-  let tz = currentUser ? currentUser.user_option.timezone : moment.tz.guess();
-
-  let date = moment(new Date(message.created_at), tz);
-
-  let url = "";
-
-  if (details) {
-    url = getURL(`/chat/c/-/${details.chat_channel_id}/${message.id}`);
-  }
-
-  let title = date.format(I18n.t("dates.long_with_year"));
-
-  let display =
+  const display =
     mode === "tiny"
       ? date.format(I18n.t("chat.dates.time_tiny"))
       : date.format(I18n.t("dates.time"));

--- a/plugins/chat/test/javascripts/unit/helpers/format-chat-date-test.js
+++ b/plugins/chat/test/javascripts/unit/helpers/format-chat-date-test.js
@@ -8,9 +8,8 @@ module("Discourse Chat | Unit | Helpers | format-chat-date", function (hooks) {
   setupRenderingTest(hooks);
 
   test("link to chat message", async function (assert) {
-    this.set("details", { chat_channel_id: 1 });
-    this.set("message", { id: 1 });
-    await render(hbs`{{format-chat-date this.message this.details}}`);
+    this.set("message", { id: 1, chat_channel_id: 1 });
+    await render(hbs`{{format-chat-date this.message}}`);
 
     assert.equal(query(".chat-time").getAttribute("href"), "/chat/c/-/1/1");
   });


### PR DESCRIPTION
This is unnecessary indirection, we can just have the
chat_channel_id in the message serializer and use that.
