### PR TITLE
DEV: configurable public sidebar sections

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
@@ -4,12 +4,7 @@
       @sectionName={{section.slug}}
       @headerLinkText={{section.title}}
       @collapsable={{true}}
-      @headerActions={{array
-        (hash
-          action=(action this.editSection section)
-          title=(i18n "sidebar.sections.custom.edit")
-        )
-      }}
+      @headerActions={{section.headerActions}}
       @headerActionsIcon="pencil-alt"
     >
       {{#each section.links as |link|}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
@@ -2,7 +2,7 @@
   {{#each this.sections as |section|}}
     <Sidebar::Section
       @sectionName={{section.slug}}
-      @headerLinkText={{section.title}}
+      @headerLinkText={{section.decoratedTitle}}
       @collapsable={{true}}
       @headerActions={{section.headerActions}}
       @headerActionsIcon="pencil-alt"

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
@@ -1,8 +1,8 @@
 import Component from "@glimmer/component";
-import { action } from "@ember/object";
 import showModal from "discourse/lib/show-modal";
 import { inject as service } from "@ember/service";
 import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
+import I18n from "I18n";
 
 export default class SidebarUserCustomSections extends Component {
   @service currentUser;
@@ -10,6 +10,16 @@ export default class SidebarUserCustomSections extends Component {
 
   get sections() {
     this.currentUser.sidebarSections.forEach((section) => {
+      if (!section.public || this.currentUser.staff) {
+        section.headerActions = [
+          {
+            action: () => {
+              return showModal("sidebar-section-form", { model: section });
+            },
+            title: I18n.t("sidebar.sections.custom.edit"),
+          },
+        ];
+      }
       section.links.forEach((link) => {
         const routeInfoHelper = new RouteInfoHelper(this.router, link.value);
         link.route = routeInfoHelper.route;
@@ -18,10 +28,5 @@ export default class SidebarUserCustomSections extends Component {
       });
     });
     return this.currentUser.sidebarSections;
-  }
-
-  @action
-  editSection(section) {
-    showModal("sidebar-section-form", { model: section });
   }
 }

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
@@ -4,6 +4,8 @@ import { inject as service } from "@ember/service";
 import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
 import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
+import { iconHTML } from "discourse-common/lib/icon-library";
+import { htmlSafe } from "@ember/template";
 
 export default class SidebarUserCustomSections extends Component {
   @service currentUser;
@@ -34,6 +36,10 @@ export default class SidebarUserCustomSections extends Component {
           },
         ];
       }
+      section.decoratedTitle =
+        section.public && this.currentUser.staff
+          ? htmlSafe(`${iconHTML("globe")} ${section.title}`)
+          : section.title;
       section.links.forEach((link) => {
         const routeInfoHelper = new RouteInfoHelper(this.router, link.value);
         link.route = routeInfoHelper.route;

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
@@ -6,6 +6,7 @@ import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import { iconHTML } from "discourse-common/lib/icon-library";
 import { htmlSafe } from "@ember/template";
+import { bind } from "discourse-common/utils/decorators";
 
 export default class SidebarUserCustomSections extends Component {
   @service currentUser;
@@ -14,10 +15,7 @@ export default class SidebarUserCustomSections extends Component {
 
   constructor() {
     super(...arguments);
-    this.messageBus.subscribe(
-      "/refresh-sidebar-sections",
-      this._refresh.bind(this)
-    );
+    this.messageBus.subscribe("/refresh-sidebar-sections", this._refresh);
   }
 
   willDestroy() {
@@ -50,6 +48,7 @@ export default class SidebarUserCustomSections extends Component {
     return this.currentUser.sidebarSections;
   }
 
+  @bind
   _refresh() {
     return ajax("/sidebar_sections.json", {}).then((json) => {
       this.currentUser.set("sidebar_sections", json.sidebar_sections);

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -13,8 +13,9 @@ class Section {
   @tracked title;
   @tracked links;
 
-  constructor({ title, links, id }) {
+  constructor({ title, links, id, publicSection }) {
     this.title = title;
+    this.public = publicSection;
     this.links = links;
     this.id = id;
   }
@@ -112,6 +113,7 @@ export default Controller.extend(ModalFunctionality, {
     if (this.model) {
       return new Section({
         title: this.model.title,
+        publicSection: this.model.public,
         links: A(
           this.model.links.map(
             (link) =>
@@ -140,6 +142,7 @@ export default Controller.extend(ModalFunctionality, {
       dataType: "json",
       data: JSON.stringify({
         title: this.model.title,
+        public: this.model.public,
         links: this.model.links.map((link) => {
           return {
             icon: link.icon,
@@ -168,6 +171,7 @@ export default Controller.extend(ModalFunctionality, {
       dataType: "json",
       data: JSON.stringify({
         title: this.model.title,
+        public: this.model.public,
         links: this.model.links.map((link) => {
           return {
             id: link.id,

--- a/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
@@ -70,10 +70,16 @@
       @label="sidebar.sections.custom.links.add"
     />
     {{#if this.currentUser.staff}}
-      <label class="checkbox-label">
-        <Input @type="checkbox" @checked={{this.model.public}} />
-        {{i18n "sidebar.sections.custom.public"}}
-      </label>
+      <div class="row-wrapper">
+        <label class="checkbox-label">
+          <Input
+            @type="checkbox"
+            @checked={{this.model.public}}
+            class="mark-public"
+          />
+          {{i18n "sidebar.sections.custom.public"}}
+        </label>
+      </div>
     {{/if}}
   </form>
 </DModalBody>

--- a/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/sidebar-section-form.hbs
@@ -69,6 +69,12 @@
       @icon="plus"
       @label="sidebar.sections.custom.links.add"
     />
+    {{#if this.currentUser.staff}}
+      <label class="checkbox-label">
+        <Input @type="checkbox" @checked={{this.model.public}} />
+        {{i18n "sidebar.sections.custom.public"}}
+      </label>
+    {{/if}}
   </form>
 </DModalBody>
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -143,6 +143,15 @@
   input.warning {
     border: 1px solid var(--danger);
   }
+  .checkbox-label {
+    clear: both;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    cursor: pointer;
+    input {
+      width: auto;
+    }
+  }
   .row-wrapper {
     display: grid;
     grid-template-columns: auto auto auto 2em;

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -129,6 +129,14 @@
   .sidebar-section-wrapper {
     padding-bottom: 0;
   }
+  .d-icon-globe {
+    position: absolute;
+    left: 0.5em;
+    height: 0.75em;
+    width: 0.75em;
+    margin-top: 0.15em;
+    align-items: center;
+  }
 }
 .sidebar-section-form-modal {
   .modal-inner-container {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -137,20 +137,11 @@
   form {
     margin-bottom: 0;
   }
-  input {
+  .input-group input {
     width: 100%;
   }
   input.warning {
     border: 1px solid var(--danger);
-  }
-  .checkbox-label {
-    clear: both;
-    margin-top: 1em;
-    margin-bottom: 1em;
-    cursor: pointer;
-    input {
-      width: auto;
-    }
   }
   .row-wrapper {
     display: grid;

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -57,8 +57,7 @@ class SidebarSectionsController < ApplicationController
   private
 
   def check_access_if_public
-    guardian.ensure_can_create_public_sidebar_section! if params[:public]
-      raise Discourse::InvalidAccess.new
-    end
+    return true if !params[:public]
+    raise Discourse::InvalidAccess.new if !guardian.can_create_public_sidebar_section?
   end
 end

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -22,7 +22,11 @@ class SidebarSectionsController < ApplicationController
 
     if sidebar_section.public?
       StaffActionLogger.new(current_user).log_create_public_sidebar_section(sidebar_section)
-      MessageBus.publish("/refresh-sidebar-sections", nil)
+      MessageBus.publish(
+        "/refresh-sidebar-sections",
+        nil,
+        group_ids: SiteSetting.enable_custom_sidebar_sections_map,
+      )
     end
 
     render json: SidebarSectionSerializer.new(sidebar_section)
@@ -38,7 +42,11 @@ class SidebarSectionsController < ApplicationController
 
     if sidebar_section.public?
       StaffActionLogger.new(current_user).log_update_public_sidebar_section(sidebar_section)
-      MessageBus.publish("/refresh-sidebar-sections", nil)
+      MessageBus.publish(
+        "/refresh-sidebar-sections",
+        nil,
+        group_ids: SiteSetting.enable_custom_sidebar_sections_map,
+      )
     end
 
     render json: SidebarSectionSerializer.new(sidebar_section)
@@ -55,7 +63,11 @@ class SidebarSectionsController < ApplicationController
 
     if sidebar_section.public?
       StaffActionLogger.new(current_user).log_destroy_public_sidebar_section(sidebar_section)
-      MessageBus.publish("/refresh-sidebar-sections", nil)
+      MessageBus.publish(
+        "/refresh-sidebar-sections",
+        nil,
+        group_ids: SiteSetting.enable_custom_sidebar_sections_map,
+      )
     end
     render json: SidebarSectionSerializer.new(sidebar_section)
   rescue Discourse::InvalidAccess

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -57,7 +57,7 @@ class SidebarSectionsController < ApplicationController
   private
 
   def check_access_if_public
-    if params[:public] && !@guardian.can_create_public_sidebar_section?
+    guardian.ensure_can_create_public_sidebar_section! if params[:public]
       raise Discourse::InvalidAccess.new
     end
   end

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -3,6 +3,7 @@
 class SidebarSectionsController < ApplicationController
   requires_login
   before_action :check_if_member_of_group
+  before_action :check_access_if_public
 
   def create
     sidebar_section =
@@ -38,7 +39,7 @@ class SidebarSectionsController < ApplicationController
   end
 
   def section_params
-    params.permit(:id, :title)
+    params.permit(:id, :title, :public)
   end
 
   def links_params
@@ -50,6 +51,14 @@ class SidebarSectionsController < ApplicationController
     if !SiteSetting.enable_custom_sidebar_sections.present? ||
          !current_user.in_any_groups?(SiteSetting.enable_custom_sidebar_sections_map)
       raise Discourse::InvalidAccess
+    end
+  end
+
+  private
+
+  def check_access_if_public
+    if params[:public] && !@guardian.can_create_public_sidebar_section?
+      raise Discourse::InvalidAccess.new
     end
   end
 end

--- a/app/models/sidebar_section.rb
+++ b/app/models/sidebar_section.rb
@@ -22,6 +22,7 @@ end
 #  title      :string(30)       not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  public     :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -120,6 +120,9 @@ class UserHistory < ActiveRecord::Base
         watched_word_destroy: 98,
         delete_group: 99,
         permanently_delete_post_revisions: 100,
+        create_public_sidebar_section: 101,
+        update_public_sidebar_section: 102,
+        destroy_public_sidebar_section: 103,
       )
   end
 
@@ -215,6 +218,9 @@ class UserHistory < ActiveRecord::Base
       watched_word_destroy
       delete_group
       permanently_delete_post_revisions
+      create_public_sidebar_section
+      update_public_sidebar_section
+      destroy_public_sidebar_section
     ]
   end
 

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -80,6 +80,7 @@ class CurrentUserSerializer < BasicUserSerializer
   def sidebar_sections
     SidebarSection
       .where("public OR user_id = ?", object.id)
+      .order("(public IS TRUE) DESC")
       .map { |section| SidebarSectionSerializer.new(section, root: false) }
   end
 

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -77,6 +77,12 @@ class CurrentUserSerializer < BasicUserSerializer
 
   has_one :user_option, embed: :object, serializer: CurrentUserOptionSerializer
 
+  def sidebar_sections
+    SidebarSection
+      .where("public IS TRUE OR user_id = ?", object.id)
+      .map { |section| SidebarSectionSerializer.new(section, root: false) }
+  end
+
   def groups
     owned_group_ids = GroupUser.where(user_id: id, owner: true).pluck(:group_id).to_set
 

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -79,7 +79,7 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def sidebar_sections
     SidebarSection
-      .where("public IS TRUE OR user_id = ?", object.id)
+      .where("public OR user_id = ?", object.id)
       .map { |section| SidebarSectionSerializer.new(section, root: false) }
   end
 

--- a/app/serializers/sidebar_section_serializer.rb
+++ b/app/serializers/sidebar_section_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SidebarSectionSerializer < ApplicationSerializer
-  attributes :id, :title, :links, :slug
+  attributes :id, :title, :links, :slug, :public
 
   def links
     object.sidebar_section_links.map(&:linkable)

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -964,6 +964,35 @@ class StaffActionLogger
     )
   end
 
+  def log_create_public_sidebar_section(section)
+    raise Discourse::InvalidParameters.new(:section) if section.nil?
+    UserHistory.create!(
+      action: UserHistory.actions[:create_public_sidebar_section],
+      acting_user_id: @admin.id,
+      subject: section.title,
+      details: custom_section_details(section),
+    )
+  end
+
+  def log_update_public_sidebar_section(section)
+    raise Discourse::InvalidParameters.new(:section) if section.nil?
+    UserHistory.create!(
+      action: UserHistory.actions[:update_public_sidebar_section],
+      acting_user_id: @admin.id,
+      subject: section.title,
+      details: custom_section_details(section),
+    )
+  end
+
+  def log_destroy_public_sidebar_section(section)
+    raise Discourse::InvalidParameters.new(:section) if section.nil?
+    UserHistory.create!(
+      action: UserHistory.actions[:destroy_public_sidebar_section],
+      acting_user_id: @admin.id,
+      subject: section.title,
+    )
+  end
+
   private
 
   def get_changes(changes)
@@ -989,5 +1018,10 @@ class StaffActionLogger
 
   def validate_category(category)
     raise Discourse::InvalidParameters.new(:category) unless category && category.is_a?(Category)
+  end
+
+  def custom_section_details(section)
+    urls = section.sidebar_urls.map { |url| "#{url.name} - #{url.value}" }
+    "links: #{urls.join(", ")}"
   end
 end

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -965,7 +965,6 @@ class StaffActionLogger
   end
 
   def log_create_public_sidebar_section(section)
-    raise Discourse::InvalidParameters.new(:section) if section.nil?
     UserHistory.create!(
       action: UserHistory.actions[:create_public_sidebar_section],
       acting_user_id: @admin.id,
@@ -975,7 +974,6 @@ class StaffActionLogger
   end
 
   def log_update_public_sidebar_section(section)
-    raise Discourse::InvalidParameters.new(:section) if section.nil?
     UserHistory.create!(
       action: UserHistory.actions[:update_public_sidebar_section],
       acting_user_id: @admin.id,
@@ -985,7 +983,6 @@ class StaffActionLogger
   end
 
   def log_destroy_public_sidebar_section(section)
-    raise Discourse::InvalidParameters.new(:section) if section.nil?
     UserHistory.create!(
       action: UserHistory.actions[:destroy_public_sidebar_section],
       acting_user_id: @admin.id,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5414,6 +5414,9 @@ en:
             delete_group: "delete group"
             watched_word_create: "add watched word"
             watched_word_destroy: "delete watched word"
+            create_public_sidebar_section: "create public sidebar section"
+            update_public_sidebar_section: "update public sidebar section"
+            destroy_public_sidebar_section: "destroy public sidebar section"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4367,6 +4367,7 @@ en:
           save: "Save"
           delete: "Delete"
           delete_confirm: "Are you sure you want to delete this section?"
+          public: "Make this section public and visible to everyone"
           links:
             icon: "Icon"
             name: "Name"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1589,7 +1589,7 @@ Discourse::Application.routes.draw do
     put "user-status" => "user_status#set"
     delete "user-status" => "user_status#clear"
 
-    resources :sidebar_sections, only: %i[create update destroy]
+    resources :sidebar_sections, only: %i[index create update destroy]
 
     get "*url", to: "permalinks#show", constraints: PermalinkConstraint.new
   end

--- a/db/migrate/20230214044350_add_public_to_sidebar_sections.rb
+++ b/db/migrate/20230214044350_add_public_to_sidebar_sections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPublicToSidebarSections < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sidebar_sections, :public, :boolean, null: false, default: false
+  end
+end

--- a/lib/guardian/sidebar_guardian.rb
+++ b/lib/guardian/sidebar_guardian.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 module SidebarGuardian
+  def can_create_public_sidebar_section?
+    @user.staff?
+  end
+
   def can_edit_sidebar_section?(sidebar_section)
+    return @user.staff? if sidebar_section.public?
     is_my_own?(sidebar_section)
   end
 
   def can_delete_sidebar_section?(sidebar_section)
+    return @user.staff? if sidebar_section.public?
     is_my_own?(sidebar_section)
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -12,6 +12,29 @@ RSpec.describe SidebarSectionsController do
     SiteSetting.enable_custom_sidebar_sections = group.id.to_s
   end
 
+  describe "#index" do
+    fab!(:sidebar_section) { Fabricate(:sidebar_section, title: "private section", user: user) }
+    fab!(:sidebar_url_1) { Fabricate(:sidebar_url, name: "tags", value: "/tags") }
+    fab!(:section_link_1) do
+      Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url_1)
+    end
+    fab!(:sidebar_section_2) do
+      Fabricate(:sidebar_section, title: "public section", user: admin, public: true)
+    end
+    fab!(:section_link_2) do
+      Fabricate(:sidebar_section_link, sidebar_section: sidebar_section, linkable: sidebar_url_1)
+    end
+
+    it "returns public and private sections" do
+      sign_in(user)
+      get "/sidebar_sections.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["sidebar_sections"].map { |section| section["title"] }).to eq(
+        ["public section", "private section"],
+      )
+    end
+  end
+
   describe "#create" do
     it "is not available for anonymous" do
       post "/sidebar_sections.json",
@@ -22,7 +45,6 @@ RSpec.describe SidebarSectionsController do
                { icon: "link", name: "tags", value: "/tags" },
              ],
            }
-
       expect(response.status).to eq(403)
     end
 

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe SidebarSectionsController do
       expect(sidebar_section.title).to eq("custom section")
       expect(sidebar_section.user).to eq(user)
       expect(sidebar_section.public).to be false
+      expect(UserHistory.count).to eq(0)
       expect(sidebar_section.sidebar_urls.count).to eq(2)
       expect(sidebar_section.sidebar_urls.first.icon).to eq("link")
       expect(sidebar_section.sidebar_urls.first.name).to eq("categories")
@@ -84,6 +85,11 @@ RSpec.describe SidebarSectionsController do
       sidebar_section = SidebarSection.last
       expect(sidebar_section.title).to eq("custom section")
       expect(sidebar_section.public).to be true
+
+      user_history = UserHistory.last
+      expect(user_history.action).to eq(UserHistory.actions[:create_public_sidebar_section])
+      expect(user_history.subject).to eq("custom section")
+      expect(user_history.details).to eq("links: categories - /categories, tags - /tags")
     end
   end
 
@@ -112,6 +118,7 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(200)
 
       expect(sidebar_section.reload.title).to eq("custom section edited")
+      expect(UserHistory.count).to eq(0)
       expect(sidebar_url_1.reload.name).to eq("latest")
       expect(sidebar_url_1.value).to eq("/latest")
       expect { section_link_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -137,6 +144,11 @@ RSpec.describe SidebarSectionsController do
       expect(sidebar_url_1.value).to eq("/latest")
       expect { section_link_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect { sidebar_url_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+      user_history = UserHistory.last
+      expect(user_history.action).to eq(UserHistory.actions[:update_public_sidebar_section])
+      expect(user_history.subject).to eq("custom section edited")
+      expect(user_history.details).to eq("links: latest - /latest")
     end
 
     it "doesn't allow to edit other's sections" do
@@ -197,6 +209,8 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(200)
 
       expect { sidebar_section.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+      expect(UserHistory.count).to eq(0)
     end
 
     it "allows admin to delete public section" do
@@ -207,6 +221,10 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(200)
 
       expect { sidebar_section.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+      user_history = UserHistory.last
+      expect(user_history.action).to eq(UserHistory.actions[:destroy_public_sidebar_section])
+      expect(user_history.subject).to eq("Sidebar section")
     end
 
     it "doesn't allow to delete other's sidebar section" do

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -88,7 +88,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(page).not_to have_button("My section")
   end
 
-  it "allows admin to created, edit and delete public section" do
+  it "allows admin to create, edit and delete public section" do
     sign_in admin
     visit("/latest")
     sidebar.open_new_custom_section

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -71,6 +71,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(page).not_to have_css(
       ".sidebar-section-public-section button.sidebar-section-header-button",
     )
+    expect(page).not_to have_css(".sidebar-section-public-section .d-icon-globe")
   end
 
   it "allows the user to delete custom section" do
@@ -100,6 +101,7 @@ describe "Custom sidebar sections", type: :system, js: true do
 
     expect(page).to have_button("Public section")
     expect(page).to have_link("Sidebar Tags")
+    expect(page).to have_css(".sidebar-section-public-section .d-icon-globe")
 
     sidebar.edit_custom_section("Public section")
     section_modal.fill_name("Edited public section")

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -13,7 +13,7 @@ module PageObjects
       end
 
       def mark_as_public
-        find(".modal .checkbox-label").click
+        find(".modal .mark-public").click
       end
 
       def remove_last_link

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -12,6 +12,10 @@ module PageObjects
         fill_in "link-url", with: url, match: :first
       end
 
+      def mark_as_public
+        find(".modal .checkbox-label").click
+      end
+
       def remove_last_link
         all(".delete-link").last.click
       end


### PR DESCRIPTION
Extension of https://github.com/discourse/discourse/pull/20057

Admin can create a public session visible to everyone. An additional checkbox is displayed for staff members.

![image](https://user-images.githubusercontent.com/72780/218927281-72c4b076-05d6-4cac-9cee-33dd2d11dcba.png)

<img width="211" alt="Screenshot 2023-02-21 at 3 43 09 pm" src="https://user-images.githubusercontent.com/72780/220249696-1fa7682e-074f-4e45-950b-f705f6144b0f.png">

<img width="1120" alt="Screenshot 2023-02-20 at 4 43 48 pm" src="https://user-images.githubusercontent.com/72780/220250233-31d7ef17-e86f-4f2b-ae0c-348ecfa9433f.png">






