### PR TITLE
REFACTOR: channel retention reminder text

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings-view.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-settings-view.hbs
@@ -60,10 +60,7 @@
   {{/unless}}
   <div class="chat-retention-info">
     {{d-icon "info-circle"}}
-    {{i18n
-      "chat.settings.retention_info"
-      days=this.siteSettings.chat_channel_retention_days
-    }}
+    <ChatRetentionReminderText @channel={{this.channel}} />
   </div>
 </div>
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder-text.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder-text.hbs
@@ -1,0 +1,3 @@
+<span class="chat-retention-reminder-text">
+  {{this.text}}
+</span>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder-text.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder-text.js
@@ -8,15 +8,26 @@ export default class ChatRetentionReminderText extends Component {
   get text() {
     if (this.args.channel.isDirectMessageChannel) {
       if (this.#countForChannelType > 0) {
-        return I18n.t("chat.retention_reminders.dm", { count: this.siteSettings.chat_dm_retention_days });
+        return I18n.t("chat.retention_reminders.dm", {
+          count: this.siteSettings.chat_dm_retention_days,
+        });
       } else {
         return I18n.t("chat.retention_reminders.dm_none");
       }
     } else {
       if (this.#countForChannelType > 0) {
-        return I18n.t("chat.retention_reminders.public", { count: this.siteSettings.chat_channel_retention_days });
+        return I18n.t("chat.retention_reminders.public", {
+          count: this.siteSettings.chat_channel_retention_days,
+        });
       } else {
         return I18n.t("chat.retention_reminders.public_none");
       }
     }
   }
+
+  get #countForChannelType() {
+    return this.args.channel.isDirectMessageChannel
+      ? this.siteSettings.chat_dm_retention_days
+      : this.siteSettings.chat_channel_retention_days;
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder-text.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder-text.js
@@ -1,0 +1,31 @@
+import Component from "@glimmer/component";
+import I18n from "I18n";
+import { inject as service } from "@ember/service";
+
+export default class ChatRetentionReminderText extends Component {
+  @service siteSettings;
+
+  get text() {
+    let prefix = `${this.#baseKey}.${this.#channelTypeKey}`;
+
+    if (this.#countForChannelType > 0) {
+      return I18n.t(prefix, { count: this.#countForChannelType });
+    }
+
+    return I18n.t(`${prefix}_none`);
+  }
+
+  get #baseKey() {
+    return "chat.retention_reminders";
+  }
+
+  get #channelTypeKey() {
+    return this.args.channel.isDirectMessageChannel ? "dm" : "public";
+  }
+
+  get #countForChannelType() {
+    return this.args.channel.isDirectMessageChannel
+      ? this.siteSettings.chat_dm_retention_days
+      : this.siteSettings.chat_channel_retention_days;
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder-text.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder-text.js
@@ -6,26 +6,17 @@ export default class ChatRetentionReminderText extends Component {
   @service siteSettings;
 
   get text() {
-    let prefix = `${this.#baseKey}.${this.#channelTypeKey}`;
-
-    if (this.#countForChannelType > 0) {
-      return I18n.t(prefix, { count: this.#countForChannelType });
+    if (this.args.channel.isDirectMessageChannel) {
+      if (this.#countForChannelType > 0) {
+        return I18n.t("chat.retention_reminders.dm", { count: this.siteSettings.chat_dm_retention_days });
+      } else {
+        return I18n.t("chat.retention_reminders.dm_none");
+      }
+    } else {
+      if (this.#countForChannelType > 0) {
+        return I18n.t("chat.retention_reminders.public", { count: this.siteSettings.chat_channel_retention_days });
+      } else {
+        return I18n.t("chat.retention_reminders.public_none");
+      }
     }
-
-    return I18n.t(`${prefix}_none`);
   }
-
-  get #baseKey() {
-    return "chat.retention_reminders";
-  }
-
-  get #channelTypeKey() {
-    return this.args.channel.isDirectMessageChannel ? "dm" : "public";
-  }
-
-  get #countForChannelType() {
-    return this.args.channel.isDirectMessageChannel
-      ? this.siteSettings.chat_dm_retention_days
-      : this.siteSettings.chat_channel_retention_days;
-  }
-}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder.hbs
@@ -1,9 +1,9 @@
 {{#if this.show}}
   <div class="chat-retention-reminder">
-    <span class="chat-retention-reminder-text">{{this.text}}</span>
+    <ChatRetentionReminderText @channel={{this.chatChannel}} />
     <DButton
       @class="btn-flat dismiss-btn"
-      @action={{action "dismiss"}}
+      @action={{this.dismiss}}
       @icon="times"
     />
   </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -1,6 +1,5 @@
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
-import I18n from "I18n";
 import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -18,28 +17,9 @@ export default Component.extend({
       !this.chatChannel.isDraft &&
       ((this.chatChannel.isDirectMessageChannel &&
         this.currentUser.needs_dm_retention_reminder) ||
-        (!this.chatChannel.isDirectMessageChannel &&
+        (this.chatChannel.isCategoryChannel &&
           this.currentUser.needs_channel_retention_reminder))
     );
-  },
-
-  @discourseComputed("chatChannel.chatable_type")
-  text() {
-    let days = this.siteSettings.chat_channel_retention_days;
-    let translationKey = "chat.retention_reminders.public";
-
-    if (this.chatChannel.isDirectMessageChannel) {
-      days = this.siteSettings.chat_dm_retention_days;
-      translationKey = "chat.retention_reminders.dm";
-    }
-    return I18n.t(translationKey, { days });
-  },
-
-  @discourseComputed("chatChannel.chatable_type")
-  daysCount() {
-    return this.chatChannel.isDirectMessageChannel
-      ? this.siteSettings.chat_dm_retention_days
-      : this.siteSettings.chat_channel_retention_days;
   },
 
   @action

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -343,7 +343,6 @@ en:
         saved: "Saved"
         unfollow: "Leave"
         admin_title: "Admin"
-        retention_info: "Chat history will be saved for %{days} days."
 
       admin:
         title: "Chat"
@@ -415,8 +414,14 @@ en:
           other: "%{commaSeparatedUsernames} and %{count} others are typing"
 
       retention_reminders:
-        public: "Channel history is retained for %{days} days."
-        dm: "Personal chat history is retained for %{days} days."
+        public_none: "Channel history is retained indefinitely."
+        public:
+          one: "Channel history is retained for %{count} day."
+          other: "Channel history is retained for %{count} days."
+        dm_none: "Personal chat history is retained indefinitely."
+        dm:
+          one: "Personal chat history is retained for %{count} day."
+          other: "Personal chat history is retained for %{count} days."
 
       flags:
         off_topic: "This message is not relevant to the current discussion as defined by the channel title, and should probably be moved elsewhere."

--- a/plugins/chat/test/javascripts/components/chat-channel-settings-view-test.js
+++ b/plugins/chat/test/javascripts/components/chat-channel-settings-view-test.js
@@ -6,19 +6,16 @@ import { module, test } from "qunit";
 import { render } from "@ember/test-helpers";
 
 module(
-  "Discourse Chat | Component | chat-retention-reminder",
+  "Discourse Chat | Component | chat-channel-settings-view",
   function (hooks) {
     setupRenderingTest(hooks);
 
     test("display retention info", async function (assert) {
-      this.channel = ChatChannel.create({ chatable_type: "Category" });
-      this.currentUser.set("needs_channel_retention_reminder", true);
+      this.set("channel", ChatChannel.create({ chatable_type: "Category" }));
 
-      await render(
-        hbs`<ChatRetentionReminder @chatChannel={{this.channel}} />`
-      );
+      await render(hbs`<ChatChannelSettingsView @channel={{this.channel}} />`);
 
-      assert.dom(".chat-retention-reminder").includesText(
+      assert.dom(".chat-retention-info").hasText(
         I18n.t("chat.retention_reminders.public", {
           count: this.siteSettings.chat_channel_retention_days,
         })

--- a/plugins/chat/test/javascripts/components/chat-retention-reminder-text-test.js
+++ b/plugins/chat/test/javascripts/components/chat-retention-reminder-text-test.js
@@ -1,0 +1,54 @@
+import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import I18n from "I18n";
+import { module, test } from "qunit";
+import { render } from "@ember/test-helpers";
+
+module(
+  "Discourse Chat | Component | chat-retention-reminder-text",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("when setting is set on 0", async function (assert) {
+      this.channel = ChatChannel.create({ chatable_type: "Category" });
+      this.siteSettings.chat_channel_retention_days = 0;
+
+      await render(
+        hbs`<ChatRetentionReminderText @channel={{this.channel}} />`
+      );
+
+      assert
+        .dom(".chat-retention-reminder-text")
+        .includesText(I18n.t("chat.retention_reminders.public_none"));
+    });
+
+    test("when channel is a public channel", async function (assert) {
+      const count = 10;
+      this.channel = ChatChannel.create({ chatable_type: "Category" });
+      this.siteSettings.chat_channel_retention_days = count;
+
+      await render(
+        hbs`<ChatRetentionReminderText @channel={{this.channel}} />`
+      );
+
+      assert
+        .dom(".chat-retention-reminder-text")
+        .includesText(I18n.t("chat.retention_reminders.public", { count }));
+    });
+
+    test("when channel is a DM channel", async function (assert) {
+      const count = 10;
+      this.channel = ChatChannel.create({ chatable_type: "DirectMessage" });
+      this.siteSettings.chat_dm_retention_days = count;
+
+      await render(
+        hbs`<ChatRetentionReminderText @channel={{this.channel}} />`
+      );
+
+      assert
+        .dom(".chat-retention-reminder-text")
+        .includesText(I18n.t("chat.retention_reminders.dm", { count }));
+    });
+  }
+);


### PR DESCRIPTION
- Moves logic into one specialized component
- Adds more tests
- Removes duplicate key
- Uses pluralization
- Handles 0 case properly

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
