### PR TITLE
DEV: fixes deprecation warning in SendMessageNotifications

### DIFF
--- a/plugins/chat/lib/chat_notifier.rb
+++ b/plugins/chat/lib/chat_notifier.rb
@@ -41,7 +41,7 @@ class Chat::ChatNotifier
         :send_message_notifications,
         chat_message_id: chat_message.id,
         timestamp: timestamp.iso8601(6),
-        reason: :edit,
+        reason: "edit",
       )
     end
 
@@ -50,7 +50,7 @@ class Chat::ChatNotifier
         :send_message_notifications,
         chat_message_id: chat_message.id,
         timestamp: timestamp.iso8601(6),
-        reason: :new,
+        reason: "new",
       )
     end
   end


### PR DESCRIPTION
We were calling the job with a symbol as one of the values:

```ruby
Jobs.enqueue(
  :send_message_notifications,
  chat_message_id: 1,
  timestamp: Time.now.iso8601(6),
  reason: :new,
)
```

Which is a bad pattern as when the job serialisation will happen, `:new` will become `"new"` and you have to deal with a string in your job and not a symbol, which can be confusing and lead to bugs.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
