### PR TITLE
FIX: correct sidebar and chat height on DiscourseHub

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -31,6 +31,7 @@
 
   .footer-nav-ipad & {
     top: calc(var(--header-offset) + var(--footer-nav-height));
+    height: calc(100vh - var(--header-offset, 0) - var(--footer-nav-height, 0));
   }
   height: calc(100vh - var(--header-offset, 0));
   align-self: start;

--- a/plugins/chat/assets/stylesheets/desktop/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-composer.scss
@@ -2,4 +2,7 @@
   .chat-composer {
     margin: 0.25rem 10px 0 10px;
   }
+  html.keyboard-visible .footer-nav-ipad & {
+    margin: 0.25rem 10px 1rem 10px;
+  }
 }


### PR DESCRIPTION
Before that change, footer of the sidebar was not visible. Footer is very important, especially now, when add custom section button is located there.

![IMG_0026](https://user-images.githubusercontent.com/72780/219264404-b5da09a4-cc3f-4a58-baac-eaff5a1e9c03.PNG)

Also, distance between chat input and keyboard were increased:

![IMG_DBB516DE153C-1](https://user-images.githubusercontent.com/72780/219269047-dc60cc1f-b97c-4187-9253-0c742ac641d7.jpeg)


