### PR TITLE
UX: update chat draft icon colour

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-draft-channel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-draft-channel.scss
@@ -32,7 +32,7 @@
       .d-icon {
         height: 1.5em;
         width: 1.5em;
-        color: var(--quaternary);
+        color: var(--primary-medium);
       }
     }
   }


### PR DESCRIPTION
Fixing wrong colour of icon in chat draft:
![image](https://user-images.githubusercontent.com/101828855/219285678-a17b8f87-e464-4e84-8688-2356e1c0cfb8.png)

