### PR TITLE
UX: catch edge cases in tooltip

### DIFF
--- a/app/assets/stylesheets/common/components/d-tooltip.scss
+++ b/app/assets/stylesheets/common/components/d-tooltip.scss
@@ -8,4 +8,5 @@
   background: var(--secondary);
   border: 1px solid var(--primary-low);
   box-shadow: shadow("menu-panel");
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
To avoid long, mildly unrealistic, strings overflowing like:
![image](https://user-images.githubusercontent.com/101828855/219323195-147857a2-8506-41bb-befa-800cb568038d.png)

