### PR TITLE
DEV: Add missing `decorateCookedElement` id

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/topic-post-decorate-cooked-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-post-decorate-cooked-test.js
@@ -23,30 +23,34 @@ acceptance("Acceptance | decorateCookedElement", function () {
       DemoComponent
     );
 
-    withPluginApi(0, (api) => {
-      api.decorateCookedElement((cooked, helper) => {
-        if (helper.getModel().post_number !== 1) {
-          return;
-        }
-        cooked.innerHTML =
-          "<div class='existing-wrapper'>Some existing content</div>";
+    withPluginApi(
+      0,
+      (api) => {
+        api.decorateCookedElement((cooked, helper) => {
+          if (helper.getModel().post_number !== 1) {
+            return;
+          }
+          cooked.innerHTML =
+            "<div class='existing-wrapper'>Some existing content</div>";
 
-        // Create new wrapper element and append
-        cooked.appendChild(
+          // Create new wrapper element and append
+          cooked.appendChild(
+            helper.renderGlimmer(
+              "div.glimmer-wrapper",
+              hbs`<@data.component />`,
+              { component: DemoComponent }
+            )
+          );
+
+          // Append to existing element
           helper.renderGlimmer(
-            "div.glimmer-wrapper",
-            hbs`<@data.component />`,
-            { component: DemoComponent }
-          )
-        );
-
-        // Append to existing element
-        helper.renderGlimmer(
-          cooked.querySelector(".existing-wrapper"),
-          hbs` with more content from glimmer`
-        );
-      });
-    });
+            cooked.querySelector(".existing-wrapper"),
+            hbs` with more content from glimmer`
+          );
+        });
+      },
+      { id: "render-glimmer-test" }
+    );
 
     await visit("/t/internationalization-localization/280");
 


### PR DESCRIPTION
Fixes "`decorateCooked` should be supplied with an `id` option to avoid memory leaks in test mode. The id will be used to ensure the decorator is only applied once." warnings

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
