### PR TITLE
DEV: `rtlcss_wrapper` renamed to `rtlcss`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem "pg"
 gem "mini_sql"
 gem "pry-rails", require: false
 gem "pry-byebug", require: false
-gem "rtlcss_wrapper", require: false
+gem "rtlcss", require: false
 gem "rake"
 
 gem "thor", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,7 +408,7 @@ GEM
       json-schema (>= 2.2, < 4.0)
       railties (>= 3.1, < 7.1)
       rspec-core (>= 2.14)
-    rtlcss_wrapper (0.1.0)
+    rtlcss (0.2.0)
       mini_racer (~> 0.6.3)
     rubocop (1.44.1)
       json (~> 2.3)
@@ -638,7 +638,7 @@ DEPENDENCIES
   rspec-rails
   rss
   rswag-specs
-  rtlcss_wrapper
+  rtlcss
   rubocop-discourse
   ruby-prof
   ruby-readability

--- a/lib/stylesheet/compiler.rb
+++ b/lib/stylesheet/compiler.rb
@@ -66,8 +66,8 @@ module Stylesheet
       result = engine.render
 
       if options[:rtl]
-        require "rtlcss_wrapper"
-        [RtlcssWrapper.flip_css(result), nil]
+        require "rtlcss"
+        [Rtlcss.flip_css(result), nil]
       else
         source_map = engine.source_map
         source_map.force_encoding("UTF-8")


### PR DESCRIPTION
The `rtlcss_wrapper` gem has been renamed to `rtlcss` per https://github.com/discourse/rtlcss/commit/bd89847a39ef61f823afe3fe4dd05403b63bbcf8. 