### PR TITLE
FIX: ensures staged message are set with channel id

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -774,6 +774,7 @@ export default Component.extend({
           staged_id: null,
           excerpt: data.chat_message.excerpt,
           thread_id: data.chat_message.thread_id,
+          chat_channel_id: data.chat_message.chat_channel_id,
         });
 
         const inReplyToMsg =

--- a/plugins/chat/spec/system/deleted_message_spec.rb
+++ b/plugins/chat/spec/system/deleted_message_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Deleted message", type: :system, js: true do
 
   fab!(:current_user) { Fabricate(:user) }
   fab!(:channel_1) { Fabricate(:category_channel) }
-  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1, user: current_user) }
 
   before do
     chat_system_bootstrap
@@ -18,9 +17,10 @@ RSpec.describe "Deleted message", type: :system, js: true do
     it "shows as deleted" do
       chat_page.visit_channel(channel_1)
       expect(channel_page).to have_no_loading_skeleton
-
-      channel_page.expand_message_actions(message_1)
-      find("[data-value='deleteMessage']").click
+      channel_page.send_message("aaaaaaaaaaaaaaaaaaaa")
+      expect(page).to have_no_css("[data-staged-id]")
+      last_message = find(".chat-message-container:last-child")
+      channel_page.delete_message(OpenStruct.new(id: last_message["data-id"]))
 
       expect(page).to have_content(I18n.t("js.chat.deleted"))
     end

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -31,7 +31,7 @@ module PageObjects
 
       def expand_message_actions(message)
         hover_message(message)
-        click_more_buttons(message)
+        click_more_button
       end
 
       def expand_message_actions_mobile(message, delay: 2)
@@ -56,13 +56,19 @@ module PageObjects
         find(".bookmark-btn").click
       end
 
-      def click_more_buttons(message)
+      def click_more_button
         find(".more-buttons").click
       end
 
       def flag_message(message)
         hover_message(message)
-        click_more_buttons(message)
+        click_more_button
+        find("[data-value='flag']").click
+      end
+
+      def flag_message(message)
+        hover_message(message)
+        click_more_button
         find("[data-value='flag']").click
       end
 
@@ -73,13 +79,19 @@ module PageObjects
 
       def select_message(message)
         hover_message(message)
-        click_more_buttons(message)
+        click_more_button
         find("[data-value='selectMessage']").click
+      end
+
+      def delete_message(message)
+        hover_message(message)
+        click_more_button
+        find("[data-value='deleteMessage']").click
       end
 
       def open_edit_message(message)
         hover_message(message)
-        click_more_buttons(message)
+        click_more_button
         find("[data-value='edit']").click
       end
 


### PR DESCRIPTION
This behavior has been altered in https://github.com/discourse/discourse/commit/c65cdc07792a3c8ab88178795057c274c6b7fc1e

This commit adds a fix and a spec for one case. In the near future I would want staged message and message to be model objects and stop doing this manual set.

This commit also changes a name and arity of a helper: `s/click_more_buttons(message)/click_more_button` to better represent its action.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
