### PR TITLE
FIX: removes uneeded footer-nav-height subtraction

### DIFF
--- a/plugins/chat/assets/stylesheets/common/common.scss
+++ b/plugins/chat/assets/stylesheets/common/common.scss
@@ -606,8 +606,7 @@ html.has-full-page-chat {
     #main-outlet-wrapper {
       // restrict the row height, including when virtual keyboard is open
       grid-template-rows: calc(
-        var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-          var(--footer-nav-height, 0px)
+        var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px)
       );
       .sidebar-wrapper {
         // prevents sidebar from overflowing behind the virtual keyboard


### PR DESCRIPTION
This was incorrectly added in https://github.com/discourse/discourse/commit/7391f8e077f6cc18057617423e23409df3054701

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
