### PR TITLE
UX: prevents scroll in chat to propagate to parents

### DIFF
--- a/plugins/chat/assets/stylesheets/common/common.scss
+++ b/plugins/chat/assets/stylesheets/common/common.scss
@@ -277,6 +277,7 @@ $float-height: 530px;
   .chat-messages-scroll {
     flex-grow: 1;
     overflow-y: scroll;
+    overscroll-behavior: contain;
     scrollbar-color: var(--primary-low) transparent;
     transition: scrollbar-color 0.2s ease-in-out;
     display: flex;


### PR DESCRIPTION
Prior to this fix, scrolling in the drawer for example, would also scroll the full page when reaching bottom of available messages.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
