### PR TITLE
FIX: correctly add user info data to message serializer

### DIFF
--- a/plugins/chat/app/controllers/chat_controller.rb
+++ b/plugins/chat/app/controllers/chat_controller.rb
@@ -446,7 +446,7 @@ class Chat::ChatController < Chat::ChatBaseController
       ChatMessage
         .includes(in_reply_to: [:user, chat_webhook_event: [:incoming_chat_webhook]])
         .includes(:revisions)
-        .includes(:user)
+        .includes(user: :primary_group)
         .includes(chat_webhook_event: :incoming_chat_webhook)
         .includes(reactions: :user)
         .includes(:bookmarks)

--- a/plugins/chat/app/serializers/chat_message_serializer.rb
+++ b/plugins/chat/app/serializers/chat_message_serializer.rb
@@ -17,7 +17,7 @@ class ChatMessageSerializer < ApplicationSerializer
              :thread_id,
              :chat_channel_id
 
-  has_one :user, serializer: BasicUserWithStatusSerializer, embed: :objects
+  has_one :user, serializer: ChatMessageUserSerializer, embed: :objects
   has_one :chat_webhook_event, serializer: ChatWebhookEventSerializer, embed: :objects
   has_one :in_reply_to, serializer: ChatInReplyToSerializer, embed: :objects
   has_many :uploads, serializer: UploadSerializer, embed: :objects

--- a/plugins/chat/app/serializers/chat_message_user_serializer.rb
+++ b/plugins/chat/app/serializers/chat_message_user_serializer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class ChatMessageUserSerializer < BasicUserWithStatusSerializer
+  attributes :moderator?, :admin?, :staff?, :moderator?, :new_user?, :primary_group_name
+
+  def moderator?
+    !!(object&.moderator?)
+  end
+
+  def admin?
+    !!(object&.admin?)
+  end
+
+  def staff?
+    !!(object&.staff?)
+  end
+
+  def new_user?
+    object.trust_level == TrustLevel[0]
+  end
+
+  def primary_group_name
+    return nil unless object && object.primary_group_id
+    object.primary_group.name if object.primary_group
+  end
+end

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-info.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-info.js
@@ -18,6 +18,7 @@ export default class ChatMessageInfo extends Component {
 
   get usernameClasses() {
     const user = this.#user;
+
     const classes = this.prioritizeName ? ["is-full-name"] : ["is-username"];
     if (!user) {
       return classes;
@@ -30,9 +31,6 @@ export default class ChatMessageInfo extends Component {
     }
     if (user.moderator) {
       classes.push("is-moderator");
-    }
-    if (user.groupModerator) {
-      classes.push("is-category-moderator");
     }
     if (user.new_user) {
       classes.push("is-new-user");

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -148,6 +148,7 @@ after_initialize do
   load File.expand_path("../app/models/reviewable_chat_message.rb", __FILE__)
   load File.expand_path("../app/models/chat_view.rb", __FILE__)
   load File.expand_path("../app/models/category_channel.rb", __FILE__)
+  load File.expand_path("../app/serializers/chat_message_user_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/structured_channel_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_webhook_event_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_in_reply_to_serializer.rb", __FILE__)

--- a/plugins/chat/spec/serializer/chat_message_user_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat_message_user_serializer_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChatMessageUserSerializer do
+  subject do
+    user = Fabricate(:user, **params)
+    guardian = Guardian.new(user)
+    described_class.new(user, scope: guardian, root: nil).as_json
+  end
+
+  let(:params) do
+    { trust_level: TrustLevel[1], admin: false, moderator: false, primary_group_id: nil }
+  end
+
+  context "with default user" do
+    it "displays user as regular" do
+      expect(subject[:new_user]).to eq(false)
+      expect(subject[:staff]).to eq(false)
+      expect(subject[:admin]).to eq(false)
+      expect(subject[:moderator]).to eq(false)
+      expect(subject[:primary_group_name]).to be_blank
+    end
+  end
+
+  context "when user is TL0" do
+    before { params[:trust_level] = TrustLevel[0] }
+
+    it "displays user as new" do
+      expect(subject[:new_user]).to eq(true)
+    end
+  end
+
+  context "when user is staff" do
+    before { params[:admin] = true }
+
+    it "displays user as staff" do
+      expect(subject[:staff]).to eq(true)
+    end
+  end
+
+  context "when user is admin" do
+    before { params[:admin] = true }
+
+    it "displays user as admin" do
+      expect(subject[:admin]).to eq(true)
+    end
+  end
+
+  context "when user is moderator" do
+    before { params[:moderator] = true }
+
+    it "displays user as moderator" do
+      expect(subject[:moderator]).to eq(true)
+    end
+  end
+
+  context "when user has a primary group" do
+    fab!(:group) { Fabricate(:group) }
+
+    before { params[:primary_group_id] = group.id }
+
+    it "displays user as moderator" do
+      expect(subject[:primary_group_name]).to eq(group.name)
+    end
+  end
+end

--- a/plugins/chat/test/javascripts/components/chat-message-info-test.js
+++ b/plugins/chat/test/javascripts/components/chat-message-info-test.js
@@ -135,7 +135,6 @@ module("Discourse Chat | Component | chat-message-info", function (hooks) {
           username: "discobot",
           admin: true,
           moderator: true,
-          groupModerator: true,
           new_user: true,
           primary_group_name: "foo",
         },
@@ -147,7 +146,6 @@ module("Discourse Chat | Component | chat-message-info", function (hooks) {
     assert.dom(".chat-message-info__username.is-staff").exists();
     assert.dom(".chat-message-info__username.is-admin").exists();
     assert.dom(".chat-message-info__username.is-moderator").exists();
-    assert.dom(".chat-message-info__username.is-category-moderator ").exists();
     assert.dom(".chat-message-info__username.is-new-user").exists();
     assert.dom(".chat-message-info__username.group--foo").exists();
   });
@@ -160,9 +158,6 @@ module("Discourse Chat | Component | chat-message-info", function (hooks) {
     assert.dom(".chat-message-info__username.is-staff").doesNotExist();
     assert.dom(".chat-message-info__username.is-admin").doesNotExist();
     assert.dom(".chat-message-info__username.is-moderator").doesNotExist();
-    assert
-      .dom(".chat-message-info__username.is-category-moderator ")
-      .doesNotExist();
     assert.dom(".chat-message-info__username.is-new-user").doesNotExist();
     assert.dom(".chat-message-info__username.group--foo").doesNotExist();
   });


### PR DESCRIPTION
Previous commit https://github.com/discourse/discourse/commit/479c0a3051210da82b127c31088926c4f2a1074a was done with the assumption that this info was defined on user serializer but it was actually defined on post serializer in core. This commit extends the user serializer for messages to add this data to the user.

Also correctly adds serializer test to ensure we actually have this data.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
