### PR TITLE
DEV: fix a flakey spec in slugs_controller

### DIFF
--- a/spec/integration/rate_limiting_spec.rb
+++ b/spec/integration/rate_limiting_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe "rate limiter integration" do
       expect(response.cookies.has_key?(name)).to eq(true)
       expect(response.cookies[name]).to be_nil
     end
+
+    RateLimiter.clear_all!
   end
 
   it "can cleanly limit requests and sets a Retry-After header" do

--- a/spec/requests/slugs_controller_spec.rb
+++ b/spec/requests/slugs_controller_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe SlugsController do
 
       it "rate limits" do
         RateLimiter.enable
+        RateLimiter.clear_all!
 
         stub_const(SlugsController, "MAX_SLUG_GENERATIONS_PER_MINUTE", 1) do
           post "/slugs.json?name=#{name}"


### PR DESCRIPTION
This was reproducible with the following invocation:

```
bundle exec rspec --seed 50393 ./spec/integration/rate_limiting_spec.rb:37 ./spec/requests/slugs_controller_spec.rb:25
```

Technically this is solved only by the change in rate_limiting_spec, as this is the spec leaking the rate limited state, but the pattern used in slugs_controller is quite frequent in the codebase, so I used it here too.

Example of the error before the fix:

```
1) SlugsController#generate when user is logged in rate limits
   Failure/Error: expect(response.status).to eq(429)

     expected: 429
          got: 403

     (compared using ==)
   # ./spec/requests/slugs_controller_spec.rb:34:in `block (4 levels) in <main>'
   # ./spec/rails_helper.rb:358:in `block (2 levels) in <top (required)>'
```
