### PR TITLE
FIX: Correctly update _subscribedTo* props

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-notification-manager.js
@@ -117,6 +117,7 @@ export default class ChatNotificationManager extends Service {
 
     if (!this._subscribedToChat) {
       this.messageBus.subscribe(this._chatAlertChannel(), this.onMessage);
+      this.set("_subscribedToChat", true);
     }
 
     if (opts.only && this._subscribedToCore) {
@@ -131,6 +132,7 @@ export default class ChatNotificationManager extends Service {
     }
     if (!this._subscribedToCore) {
       this.messageBus.subscribe(this._coreAlertChannel(), this.onMessage);
+      this.set("_subscribedToCore", true);
     }
 
     if (opts.only && this._subscribedToChat) {


### PR DESCRIPTION
`_subscribedToChat` was previously a never-true, and `_subscribedToCore` once set to false could no longer be flicked back to true.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
