### PR TITLE
Add username template variables to Welcome User email template

### DIFF
--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -35,14 +35,7 @@ class TranslationOverride < ActiveRecord::Base
       optional_cat
       optional_tags
     ],
-
-    %w[
-      system_messages.welcome_user
-    ] => %w[
-      username
-      name
-      name_or_username
-    ]
+    %w[system_messages.welcome_user] => %w[username name name_or_username],
   }
 
   include HasSanitizableFields

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -35,6 +35,14 @@ class TranslationOverride < ActiveRecord::Base
       optional_cat
       optional_tags
     ],
+
+    %w[
+      system_messages.welcome_user
+    ] => %w[
+      username
+      name
+      name_or_username
+    ]
   }
 
   include HasSanitizableFields

--- a/lib/system_message.rb
+++ b/lib/system_message.rb
@@ -88,6 +88,8 @@ class SystemMessage
     {
       site_name: SiteSetting.title,
       username: @recipient.username,
+      name: @recipient.name,
+      name_or_username: @recipient.name.presence || @recipient.username,
       user_preferences_url: "#{@recipient.full_url}/preferences",
       new_user_tips:
         I18n.with_locale(@recipient.effective_locale) do

--- a/spec/models/translation_override_spec.rb
+++ b/spec/models/translation_override_spec.rb
@@ -84,6 +84,19 @@ RSpec.describe TranslationOverride do
         end
       end
 
+      describe "with valid custom interpolation keys" do
+        it "works" do
+          translation_override =
+            TranslationOverride.upsert!(
+              I18n.locale,
+              "system_messages.welcome_user.text_body_template",
+              "Hello %{name} %{username} %{name_or_username} and welcome to %{site_name}!",
+            )
+
+          expect(translation_override.errors).to be_empty
+        end
+      end
+
       describe "pluralized keys" do
         describe "valid keys" do
           it "converts zero to other" do


### PR DESCRIPTION
Allow using `%{user}`, `%{username}` and `%{name_or_username}` variables in Welcome User email templates