### PR TITLE
FIX: Glimmer component arg access

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.js
@@ -521,7 +521,7 @@ export default class ChatMessage extends Component {
     }
 
     this._updateReactionsList(busData.emoji, busData.action, busData.user);
-    this.afterReactionAdded();
+    this.args.afterReactionAdded();
   }
 
   get capabilities() {


### PR DESCRIPTION
This regressed in b94fa3b87a035fceff95909f0e866ccd9142ef7c as the component was migrated to a glimmer component.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
