### PR TITLE
DEV: fixes spec failing on CI

### DIFF
--- a/plugins/chat/app/services/base.rb
+++ b/plugins/chat/app/services/base.rb
@@ -407,18 +407,19 @@ module Chat
         @context = Context.build(initial_context.merge(__steps__: self.class.steps))
       end
 
-      private
-
+      # @!visibility private
       def run
         run!
       rescue Failure => exception
         raise if context.object_id != exception.context.object_id
       end
 
+      # @!visibility private
       def run!
         self.class.steps.each { |step| step.call(self, context) }
       end
 
+      # @!visibility private
       def fail!(message)
         step_name = caller_locations(1, 1)[0].label
         context["result.step.#{step_name}"].fail(error: message)


### PR DESCRIPTION
I could repro this by using ruby 3.2.1.

The error was:

```
Failures:

  1) Chat::Endpoint.call(service, &block) when using the on_failed_contract action when the service contract does not fail does not run the provided block
     Failure/Error: subject(:endpoint) { described_class.call(service, controller, &actions_block) }

     NoMethodError:
       private method `run' called for #<SuccessContractService:0x000000011e3b28a0 @initial_context={"guardian"=>nil}, @context=#<Chat::Service::Base::Context guardian=nil, __steps__=[#<Chat::Service::Base::ContractStep:0x000000011de51230 @name=:default, @method_name=:default, @class_name=SuccessContractService::Contract, @default_values_from=nil>]>>
     # ./plugins/chat/app/services/base.rb:305:in `call'
     # ./plugins/chat/app/helpers/with_service_helper.rb:20:in `run_service'
     # ./plugins/chat/lib/endpoint.rb:76:in `call'
     # ./plugins/chat/lib/endpoint.rb:70:in `call'
     # ./plugins/chat/spec/lib/endpoint_spec.rb:80:in `block (3 levels) in <main>'
     # ./plugins/chat/spec/lib/endpoint_spec.rb:198:in `block (5 levels) in <main>'
     # ./spec/rails_helper.rb:358:in `block (2 levels) in <top (required)>'
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
