### PR TITLE
FIX: Do not enqueue UpdatePostUploadsSecureStatus unnecessarily

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1035,7 +1035,7 @@ class Post < ActiveRecord::Base
   end
 
   def update_uploads_secure_status(source:)
-    if Discourse.store.external?
+    if Discourse.store.external? && SiteSetting.secure_uploads?
       Jobs.enqueue(:update_post_uploads_secure_status, post_id: self.id, source: source)
     end
   end

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -190,7 +190,7 @@ class PostCreator
         update_user_counts
         create_embedded_topic
         @post.link_post_uploads
-        update_uploads_secure_status
+        @post.update_uploads_secure_status(source: "post creator")
         delete_owned_bookmarks
         ensure_in_allowed_users if guardian.is_staff?
         unarchive_message if !@opts[:import_mode]
@@ -400,10 +400,6 @@ class PostCreator
     embed =
       TopicEmbed.new(topic_id: @post.topic_id, post_id: @post.id, embed_url: @opts[:embed_url])
     rollback_from_errors!(embed) unless embed.save
-  end
-
-  def update_uploads_secure_status
-    @post.update_uploads_secure_status(source: "post creator") if SiteSetting.secure_uploads?
   end
 
   def delete_owned_bookmarks


### PR DESCRIPTION
We call `post.update_uploads_secure_status` in both
`PostCreator` and `PostRevisor`. Only the former was checking
if `SiteSetting.secure_uploads?` was enabled, but the latter
was not. There is no need to enqueue the job
`UpdatePostUploadsSecureStatus` if secure_uploads is not
enabled for the site.
