### PR TITLE
UX: remove fixed width from buttons

### DIFF
--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -76,7 +76,6 @@
     button {
       margin-top: 10px;
       display: block;
-      width: 300px;
     }
 
     form {

--- a/app/assets/stylesheets/mobile/modal.scss
+++ b/app/assets/stylesheets/mobile/modal.scss
@@ -68,7 +68,6 @@
   button {
     margin-top: 10px;
     display: block;
-    width: 300px;
   }
 
   form {


### PR DESCRIPTION
Removing width so the buttons don't take up this unnecessary space

![image](https://user-images.githubusercontent.com/101828855/220021758-a8cfc569-90cb-4848-9749-bb3084e77147.png)

CSS seems very scoped to this usecase, so don't forsee conflict elsewhere (famous last words)

