### PR TITLE
UX: badge page styling update

### DIFF
--- a/app/assets/javascripts/discourse/app/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.hbs
@@ -42,12 +42,13 @@
 
       {{#if this.displayCount}}
         <div class="badge-granted">
-          <a
-            href={{this.url}}
-            title={{i18n "badges.granted" count=this.displayCount}}
-            class="grant-count"
-          >{{this.displayCount}}x</a>
-          <span class="grant-text">{{i18n "badges.granted_text_only"}}</span>
+          {{html-safe
+            (i18n
+              "badges.granted_with_count"
+              count=this.displayCount
+              badgeUrl=this.url
+            )
+          }}
         </div>
       {{/if}}
     </div>

--- a/app/assets/javascripts/discourse/app/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.hbs
@@ -47,7 +47,7 @@
             title={{i18n "badges.granted" count=this.displayCount}}
             class="grant-count"
           >{{this.displayCount}}x</a>
-          <span class="grant-text">{{i18n "badges.granted" count=0}}</span>
+          <span class="grant-text">{{i18n "badges.granted_text_only"}}</span>
         </div>
       {{/if}}
     </div>

--- a/app/assets/javascripts/discourse/app/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.hbs
@@ -1,10 +1,3 @@
-{{#if this.displayCount}}
-  <a
-    href={{this.url}}
-    title={{i18n "badges.granted" count=this.displayCount}}
-    class="grant-count"
-  >{{this.displayCount}}</a>
-{{/if}}
 {{#if this.badge.has_badge}}
   <a href={{this.url}} class="check-display status-checked">{{d-icon
       "check"
@@ -46,6 +39,17 @@
     <div class="badge-info-item">
       <h3><a href={{this.url}} class="badge-link">{{this.badge.name}}</a></h3>
       <div class="badge-summary">{{html-safe this.summary}}</div>
+
+      {{#if this.displayCount}}
+        <div class="badge-granted">
+          <a
+            href={{this.url}}
+            title={{i18n "badges.granted" count=this.displayCount}}
+            class="grant-count"
+          >{{this.displayCount}}x</a>
+          <span class="grant-text">{{i18n "badges.granted" count=0}}</span>
+        </div>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -552,6 +552,7 @@ table {
         &.active {
           font-weight: bold;
           color: var(--primary);
+          background: var(--d-selected);
         }
       }
     }

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -127,17 +127,23 @@
 
   .check-display {
     position: absolute;
-    left: 5px;
+    right: 5px;
     top: 5px;
   }
 
+  .badge-granted {
+    margin-top: 0.5em;
+  }
+
   .grant-count {
-    position: absolute;
-    right: 5px;
-    top: 5px;
     font-weight: bold;
     color: var(--primary-medium);
-    font-size: var(--font-up-2);
+    line-height: 1;
+  }
+
+  .grant-text {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
   }
 
   .favorite-btn {
@@ -145,11 +151,11 @@
     right: 0;
     bottom: 0;
   }
-
   .badge-contents {
     display: flex;
-    min-height: 8em;
-    padding: 0 1.5em;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1.5em 1.5em;
 
     .badge-link {
       color: var(--primary);
@@ -158,10 +164,8 @@
     .badge-icon {
       display: flex;
       flex-shrink: 0;
-      margin-right: 1.5em;
       align-items: center;
       justify-content: center;
-      width: 64px;
 
       svg {
         font-size: 3.5em;
@@ -190,7 +194,6 @@
       display: flex;
       flex: 1 1 auto;
       align-items: center;
-      padding: 1em 0;
       color: var(--primary);
 
       h3 {
@@ -245,18 +248,10 @@
 
 .badge-group-list {
   display: grid;
-  grid: auto-flow / repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(18em, 1fr));
   grid-gap: 1em;
   width: 100%;
   margin-bottom: 1.5em;
-
-  @include breakpoint(medium) {
-    grid: auto-flow / repeat(2, 1fr);
-  }
-
-  @include breakpoint(mobile-extra-large) {
-    grid: auto-flow / 1fr;
-  }
 
   .title {
     font-size: var(--font-up-1);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4118,7 +4118,9 @@ en:
       granted:
         one: "%{count} granted"
         other: "%{count} granted"
-      granted_text_only: "granted"
+      granted_with_count:
+        one: '<a href="%{badgeUrl}" title="%{count} granted" class="grant-count">%{count}x</a> <span class="grant-text">granted</span>'
+        other: '<a href="%{badgeUrl}" title="%{count} granted" class="grant-count">%{count}x</a> <span class="grant-text">granted</span>'
       select_badge_for_title: Select a badge to use as your title
       none: "(none)"
       successfully_granted: "Successfully granted %{badge} to %{username}"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4118,6 +4118,7 @@ en:
       granted:
         one: "%{count} granted"
         other: "%{count} granted"
+      granted_text_only: "granted"
       select_badge_for_title: Select a badge to use as your title
       none: "(none)"
       successfully_granted: "Successfully granted %{badge} to %{username}"


### PR DESCRIPTION
Improving the visuals for a narrow screen:
**Before:**
![image](https://user-images.githubusercontent.com/101828855/220077849-3ec91777-2ab7-410d-a1ce-606a9e0e90dc.png)

**After:**
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/101828855/220077792-92967670-0c10-416b-bf81-d43a4223c058.png">

