### PR TITLE
UX: add h1 tag to user page

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -116,7 +116,7 @@
           <UserProfileAvatar @user={{this.model}} @tagName="" />
           <div class="primary-textual">
             <div class="user-profile-names">
-              <div
+              <h1
                 class="{{if this.nameFirst 'full-name' 'username'}}
                   user-profile-names__primary"
               >
@@ -129,7 +129,7 @@
                 {{#if this.model.status}}
                   <UserStatusMessage @status={{this.model.status}} />
                 {{/if}}
-              </div>
+              </h1>
               <div
                 class="{{if this.nameFirst 'username' 'full-name'}}
                   user-profile-names__secondary"


### PR DESCRIPTION
Every page needs a h1 tag, if possible.
And in heading, the user status is automatically aligned in the middle, which looks better.

**Before with a div**
<img width="445" alt="image" src="https://user-images.githubusercontent.com/101828855/220153113-5123fbf7-9279-464c-86e9-56e851904bf7.png">
![Uploading image.png…]()



**After with an h1 tag**
<img width="411" alt="image" src="https://user-images.githubusercontent.com/101828855/220153197-eb5b1244-01c4-4bd1-8ab9-961ec6f99fba.png">
<img width="295" alt="image" src="https://user-images.githubusercontent.com/101828855/220153731-787a6bf3-7f25-4ec5-a1e6-92a6a27af60d.png">




