### PR TITLE
FIX: allow changing default DNS query timeout of 2s via GlobalSetting

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -368,3 +368,6 @@ redirect_avatar_requests = false
 
 # Force the entire cluster into postgres readonly mode. Equivalent to running `Discourse.enable_pg_force_readonly_mode`
 pg_force_readonly_mode = false
+
+# default DNS query timeout for FinalDestination (used when not explicitely given programmatically)
+dns_query_timeout_secs =

--- a/lib/final_destination/resolver.rb
+++ b/lib/final_destination/resolver.rb
@@ -3,7 +3,8 @@
 class FinalDestination::Resolver
   @mutex = Mutex.new
   def self.lookup(addr, timeout: nil)
-    timeout ||= 2
+    timeout ||= default_dns_query_timeout
+
     @mutex.synchronize do
       @result = nil
 
@@ -35,6 +36,14 @@ class FinalDestination::Resolver
   end
 
   private
+
+  def self.default_dns_query_timeout
+    if gs = GlobalSetting.dns_query_timeout_secs.presence
+      Integer(gs)
+    else
+      2
+    end
+  end
 
   def self.ensure_lookup_thread
     return if @thread&.alive?

--- a/spec/lib/final_destination/resolver_spec.rb
+++ b/spec/lib/final_destination/resolver_spec.rb
@@ -34,6 +34,11 @@ describe FinalDestination::Resolver do
     expect(alive_thread_count).to eq(start_thread_count + 1)
   end
 
+  it "reads default query timeout from configuration" do
+    GlobalSetting.stubs(:dns_query_timeout_secs).returns(123)
+    expect(FinalDestination::Resolver.send(:default_dns_query_timeout)).to eq(123)
+  end
+
   it "can lookup correctly" do
     Addrinfo.stubs(:getaddrinfo).with { |addr| addr == "example.com" }.returns(mock_response)
 


### PR DESCRIPTION
The current default timeout is hardcoded to 2 seconds which is proving too low for certain cases, resulting in sporadic timeouts due to slow DNS queries.
