### PR TITLE
DEV: Remove use of redesigned_user_page_nav_enabled prop client side

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user.js
+++ b/app/assets/javascripts/discourse/app/controllers/user.js
@@ -194,11 +194,8 @@ export default Controller.extend(CanCheckEmails, {
     if (!this.currentUser?.staff) {
       return false;
     }
-    if (this.currentUser?.redesigned_user_page_nav_enabled) {
-      return this.site.desktopView;
-    } else {
-      return true;
-    }
+
+    return this.site.desktopView;
   },
 
   @action

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -431,81 +431,22 @@
       </div>
     </section>
 
-    {{#if this.currentUser.redesigned_user_page_nav_enabled}}
-      <div class="new-user-wrapper">
-        <UserNav
-          @user={{this.model}}
-          @showNotificationsTab={{this.showNotificationsTab}}
-          @showPrivateMessages={{this.showPrivateMessages}}
-          @canInviteToForum={{this.canInviteToForum}}
-          @showBadges={{this.showBadges}}
-          @currentParentRoute={{this.currentParentRoute}}
-          @showRead={{this.showRead}}
-          @showDrafts={{this.showDrafts}}
-          @showBookmarks={{this.showBookmarks}}
-        />
+    <div class="new-user-wrapper">
+      <UserNav
+        @user={{this.model}}
+        @showNotificationsTab={{this.showNotificationsTab}}
+        @showPrivateMessages={{this.showPrivateMessages}}
+        @canInviteToForum={{this.canInviteToForum}}
+        @showBadges={{this.showBadges}}
+        @currentParentRoute={{this.currentParentRoute}}
+        @showRead={{this.showRead}}
+        @showDrafts={{this.showDrafts}}
+        @showBookmarks={{this.showBookmarks}}
+      />
 
-        <div class="new-user-content-wrapper">
-          {{outlet}}
-        </div>
-      </div>
-    {{else}}
-      <div class="user-content-wrapper">
-        <section class="user-primary-navigation">
-          <MobileNav @class="main-nav" @desktopClass="nav nav-pills user-nav">
-            {{#unless this.model.profile_hidden}}
-              <li class="summary"><LinkTo @route="user.summary">{{i18n
-                    "user.summary.title"
-                  }}</LinkTo></li>
-              <li class="activity"><LinkTo @route="userActivity">{{i18n
-                    "user.activity_stream"
-                  }}</LinkTo></li>
-            {{/unless}}
-
-            {{#if this.showNotificationsTab}}
-              <li class="user-notifications">
-                <LinkTo @route="userNotifications">
-                  {{d-icon "bell" class="glyph"}}{{i18n "user.notifications"}}
-                </LinkTo>
-              </li>
-            {{/if}}
-
-            {{#if this.showPrivateMessages}}
-              <li class="private-messages"><LinkTo
-                  @route="userPrivateMessages"
-                >{{d-icon "envelope"}}{{i18n
-                    "user.private_messages"
-                  }}</LinkTo></li>
-            {{/if}}
-
-            {{#if this.canInviteToForum}}
-              <li class="invited"><LinkTo @route="userInvited">{{d-icon
-                    "user-plus"
-                  }}{{i18n "user.invited.title"}}</LinkTo></li>
-            {{/if}}
-
-            {{#if this.showBadges}}
-              <li class="badges"><LinkTo @route="user.badges">{{d-icon
-                    "certificate"
-                  }}{{i18n "badges.title"}}</LinkTo></li>
-            {{/if}}
-
-            <PluginOutlet
-              @name="user-main-nav"
-              @connectorTagName="li"
-              @outletArgs={{hash model=this.model}}
-            />
-
-            {{#if this.model.can_edit}}
-              <li class="preferences"><LinkTo @route="preferences">{{d-icon
-                    "cog"
-                  }}{{i18n "user.preferences"}}</LinkTo></li>
-            {{/if}}
-          </MobileNav>
-        </section>
-
+      <div class="new-user-content-wrapper">
         {{outlet}}
       </div>
-    {{/if}}
+    </div>
   </DSection>
 </div>

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -24,6 +24,7 @@ acceptance("User Routes", function (needs) {
       helper.response(400, {})
     );
   });
+
   test("Invalid usernames", async function (assert) {
     try {
       await visit("/u/eviltrout%2F..%2F..%2F/summary");
@@ -52,6 +53,7 @@ acceptance("User Routes", function (needs) {
 
   test("Notifications", async function (assert) {
     await visit("/u/eviltrout/notifications");
+
     assert.ok(
       document.body.classList.contains("user-notifications-page"),
       "has the body class"
@@ -66,16 +68,20 @@ acceptance("User Routes", function (needs) {
     );
 
     updateCurrentUser({ moderator: true, admin: false });
+
     await visit("/u/charlie/summary");
+
     assert.notOk(
-      exists(".user-nav > .user-notifications"),
+      exists(".user-nav > .user-nav__notifications"),
       "does not have the notifications tab"
     );
 
     updateCurrentUser({ moderator: false, admin: true });
+
     await visit("/u/charlie/summary");
+
     assert.ok(
-      exists(".user-nav > .user-notifications"),
+      exists(".user-nav > .user-nav__notifications"),
       "has the notifications tab"
     );
   });


### PR DESCRIPTION
Since https://github.com/tgxworld/discourse/commit/359dc1c532a50787b8a277553d5effc23d54e21f, support for the old user
profile navigation menu has been dropped. This commit seeks to remove
code from the client side that still relies on the `currentUser.redesigned_user_page_nav_enabled` prop.