### PR TITLE
DEV: Remove use of redesigned_user_page_nav_enabled prop client side 2

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-nav/messages-secondary-nav.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-nav/messages-secondary-nav.hbs
@@ -1,5 +1,3 @@
-{{#if this.currentUser.redesigned_user_page_nav_enabled}}
-  {{#in-element this.messagesNav}}
-    {{yield}}
-  {{/in-element}}
-{{/if}}
+{{#in-element this.messagesNav}}
+  {{yield}}
+{{/in-element}}

--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -1,5 +1,5 @@
 import Controller, { inject as controller } from "@ember/controller";
-import { action, computed } from "@ember/object";
+import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { alias, and, equal, readOnly } from "@ember/object/computed";
 import { cached, tracked } from "@glimmer/tracking";
@@ -34,9 +34,7 @@ export default class extends Controller {
   @alias("group.name") groupFilter;
   @and("user.viewingSelf", "currentUser.can_send_private_messages") showNewPM;
   @equal("currentParentRouteName", "userPrivateMessages.group") isGroup;
-  @equal("currentParentRouteName", "userPrivateMessages.user") isPersonal;
   @readOnly("user.viewingSelf") viewingSelf;
-  @readOnly("router.currentRouteName") currentRouteName;
   @readOnly("router.currentRoute.parent.name") currentParentRouteName;
   @readOnly("site.can_tag_pms") pmTaggingEnabled;
 
@@ -99,34 +97,6 @@ export default class extends Controller {
     });
 
     return content;
-  }
-
-  @computed(
-    "pmTopicTrackingState.newIncoming.[]",
-    "pmTopicTrackingState.statesModificationCounter",
-    "group"
-  )
-  get newLinkText() {
-    return this.#linkText("new");
-  }
-
-  @computed(
-    "pmTopicTrackingState.newIncoming.[]",
-    "pmTopicTrackingState.statesModificationCounter",
-    "group"
-  )
-  get unreadLinkText() {
-    return this.#linkText("unread");
-  }
-
-  #linkText(type) {
-    const count = this.pmTopicTrackingState?.lookupCount(type) || 0;
-
-    if (count === 0) {
-      return I18n.t(`user.messages.${type}`);
-    } else {
-      return I18n.t(`user.messages.${type}_with_count`, { count });
-    }
   }
 
   @action

--- a/app/assets/javascripts/discourse/app/templates/user/messages.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user/messages.hbs
@@ -1,210 +1,50 @@
-{{#if this.currentUser.redesigned_user_page_nav_enabled}}
-  <DSection @pageClass="user-messages" />
+<DSection @pageClass="user-messages" />
 
-  <div class="user-navigation user-navigation-secondary">
-    <ol class="category-breadcrumb">
-      <li>
-        <UserNav::MessagesDropdown
-          @content={{this.messagesDropdownContent}}
-          @value={{this.messagesDropdownValue}}
-          @onChange={{this.onMessagesDropdownChange}}
-        />
-      </li>
-    </ol>
+<div class="user-navigation user-navigation-secondary">
+  <ol class="category-breadcrumb">
+    <li>
+      <UserNav::MessagesDropdown
+        @content={{this.messagesDropdownContent}}
+        @value={{this.messagesDropdownValue}}
+        @onChange={{this.onMessagesDropdownChange}}
+      />
+    </li>
+  </ol>
 
-    <HorizontalOverflowNav
-      @className="messages-nav"
-      @ariaLabel="User secondary - messages"
-      id="user-navigation-secondary__horizontal-nav"
-    />
+  <HorizontalOverflowNav
+    @className="messages-nav"
+    @ariaLabel="User secondary - messages"
+    id="user-navigation-secondary__horizontal-nav"
+  />
 
-    <div class="navigation-controls">
-      {{#if this.site.mobileView}}
-        {{#if this.currentUser.admin}}
-          <BulkSelectToggle
-            @parentController={{"user-topics-list"}}
-            @tagName=""
-          />
-        {{/if}}
-      {{/if}}
-
-      {{#if this.isGroup}}
-        <GroupNotificationsButton
-          @value={{this.group.group_user.notification_level}}
-          @onChange={{this.changeGroupNotificationLevel}}
+  <div class="navigation-controls">
+    {{#if this.site.mobileView}}
+      {{#if this.currentUser.admin}}
+        <BulkSelectToggle
+          @parentController={{"user-topics-list"}}
+          @tagName=""
         />
       {{/if}}
+    {{/if}}
 
-      {{#if this.showNewPM}}
-        <DButton
-          @class="btn-primary new-private-message"
-          @action={{route-action "composePrivateMessage"}}
-          @icon="envelope"
-          @label="user.new_private_message"
-        />
-      {{/if}}
-    </div>
+    {{#if this.isGroup}}
+      <GroupNotificationsButton
+        @value={{this.group.group_user.notification_level}}
+        @onChange={{this.changeGroupNotificationLevel}}
+      />
+    {{/if}}
+
+    {{#if this.showNewPM}}
+      <DButton
+        @class="btn-primary new-private-message"
+        @action={{route-action "composePrivateMessage"}}
+        @icon="envelope"
+        @label="user.new_private_message"
+      />
+    {{/if}}
   </div>
-{{else}}
-  <DSection @class="user-secondary-navigation" @pageClass="user-messages">
-    <MobileNav @class="messages-nav" @desktopClass="nav-stacked action-list">
-      <li>
-        <LinkTo @route="userPrivateMessages.user.index" @model={{this.model}}>
-          {{i18n "user.messages.inbox"}}
-        </LinkTo>
-      </li>
-
-      {{#if this.isPersonal}}
-        <li class="archive">
-          <LinkTo @route="userPrivateMessages.user.sent" @model={{this.model}}>
-            {{i18n "user.messages.sent"}}
-          </LinkTo>
-        </li>
-
-        {{#if this.viewingSelf}}
-          <li class="archive">
-            <LinkTo
-              @route="userPrivateMessages.user.new"
-              @model={{this.model}}
-              class="new"
-            >
-              {{this.newLinkText}}
-            </LinkTo>
-          </li>
-
-          <li class="archive">
-            <LinkTo
-              @route="userPrivateMessages.user.unread"
-              @model={{this.model}}
-              class="unread"
-            >
-              {{this.unreadLinkText}}
-            </LinkTo>
-          </li>
-        {{/if}}
-
-        <li class="archive">
-          <LinkTo
-            @route="userPrivateMessages.user.archive"
-            @model={{this.model}}
-          >
-            {{i18n "user.messages.archive"}}
-          </LinkTo>
-        </li>
-      {{/if}}
-
-      {{#each this.model.groupsWithMessages as |group|}}
-        <li>
-          <LinkTo @route="userPrivateMessages.group" @model={{group.name}}>
-            {{d-icon "users"}}
-            {{capitalize-string group.name}}
-          </LinkTo>
-        </li>
-
-        {{#if (and this.isGroup (eq this.groupFilter group.name))}}
-          {{#if this.viewingSelf}}
-            <li class="archive">
-              <LinkTo
-                @route="userPrivateMessages.group.new"
-                @model={{group.name}}
-                class="new"
-              >
-                {{this.newLinkText}}
-              </LinkTo>
-            </li>
-
-            <li class="archive">
-              <LinkTo
-                @route="userPrivateMessages.group.unread"
-                @model={{group.name}}
-                class="unread"
-              >
-                {{this.unreadLinkText}}
-              </LinkTo>
-            </li>
-          {{/if}}
-
-          <li class="archive">
-            <LinkTo
-              @route="userPrivateMessages.group.archive"
-              @model={{group.name}}
-            >
-              {{i18n "user.messages.archive"}}
-            </LinkTo>
-          </li>
-        {{/if}}
-      {{/each}}
-
-      {{#if this.pmTaggingEnabled}}
-        <li class="tags">
-          <LinkTo @route="userPrivateMessages.tags.index" @model={{this.model}}>
-            {{i18n "user.messages.tags"}}
-          </LinkTo>
-        </li>
-
-        {{#if this.tagId}}
-          <li class="archive">
-            <LinkTo
-              @route="userPrivateMessages.tags.show"
-              @model={{this.tagId}}
-            >
-              {{this.tagId}}
-            </LinkTo>
-          </li>
-        {{/if}}
-      {{/if}}
-
-      <span>
-        <PluginOutlet
-          @name="user-messages-nav"
-          @connectorTagName="li"
-          @outletArgs={{hash model=this.model}}
-        />
-      </span>
-    </MobileNav>
-  </DSection>
-
-  {{#unless this.site.mobileView}}
-    <section class="user-additional-controls">
-      {{#if this.group}}
-        <GroupNotificationsButton
-          @value={{this.group.group_user.notification_level}}
-          @onChange={{action "changeGroupNotificationLevel"}}
-        />
-      {{/if}}
-
-      {{#if this.showNewPM}}
-        <DButton
-          @class="btn-primary new-private-message"
-          @action={{route-action "composePrivateMessage"}}
-          @icon="envelope"
-          @label="user.new_private_message"
-        />
-      {{/if}}
-    </section>
-  {{/unless}}
-{{/if}}
+</div>
 
 <section class="user-content" id="user-content">
-  {{#unless this.currentUser.redesigned_user_page_nav_enabled}}
-    <div class="list-actions">
-      {{#if this.site.mobileView}}
-        {{#if this.showNewPM}}
-          <DButton
-            @class="btn-primary new-private-message"
-            @action={{route-action "composePrivateMessage"}}
-            @icon="envelope"
-            @label="user.new_private_message"
-          />
-        {{/if}}
-        {{#if this.currentUser.admin}}
-          <BulkSelectToggle
-            @parentController={{"user-topics-list"}}
-            @tagName=""
-          />
-        {{/if}}
-      {{/if}}
-    </div>
-  {{/unless}}
   {{outlet}}
 </section>


### PR DESCRIPTION
The property has been deprecated and will be dropped from Discourse core
soon.

See https://github.com/discourse/discourse/blob/452539bf5b3e58d30699a3d158589ac3da3b72ff/app/serializers/current_user_serializer.rb#L296-L299