### PR TITLE
FIX: Add support for Europe/Kyiv timezone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -279,3 +279,5 @@ gem "webrick", require: false
 
 # Workaround until Ruby ships with cgi version 0.3.6 or higher.
 gem "cgi", ">= 0.3.6", require: false
+
+gem "tzinfo-data"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,6 +486,8 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2022.7)
+      tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
@@ -657,6 +659,7 @@ DEPENDENCIES
   syntax_tree-disable_ternary
   test-prof
   thor
+  tzinfo-data
   uglifier
   unf
   unicorn

--- a/spec/models/user_option_spec.rb
+++ b/spec/models/user_option_spec.rb
@@ -178,6 +178,13 @@ RSpec.describe UserOption do
           ActiveSupport::TimeZone.find_tzinfo("Europe/Paris"),
         )
       end
+
+      it "works for Europe/Kyiv" do
+        user.user_option.update(timezone: "Europe/Kyiv")
+        expect(UserOption.user_tzinfo(user.id)).to eq(
+          ActiveSupport::TimeZone.find_tzinfo("Europe/Kyiv"),
+        )
+      end
     end
 
     context "with user with invalid timezone given" do


### PR DESCRIPTION
This adds the `tzinfo-data` gem explicitly, given that the Debian image is not up-to-date with the latest upstream changes.