### PR TITLE
DEV: Resolve flaky test caused by requestAnimationFrame

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -10,6 +10,9 @@ import ItsATrap from "@discourse/itsatrap";
 import RerenderOnDoNotDisturbChange from "discourse/mixins/rerender-on-do-not-disturb-change";
 import { observes } from "discourse-common/utils/decorators";
 import { topicTitleDecorators } from "discourse/components/topic-title";
+import { isTesting } from "discourse-common/config/environment";
+import { DEBUG } from "@glimmer/env";
+import { registerWaiter, unregisterWaiter } from "@ember/test";
 
 const SiteHeaderComponent = MountWidget.extend(
   Docking,
@@ -54,9 +57,18 @@ const SiteHeaderComponent = MountWidget.extend(
     },
 
     _animateOpening(panel) {
-      window.requestAnimationFrame(
-        this._setAnimateOpeningProperties.bind(this, panel)
-      );
+      let waiter;
+      if (DEBUG && isTesting()) {
+        waiter = () => true;
+        registerWaiter(waiter);
+      }
+
+      window.requestAnimationFrame(() => {
+        this._setAnimateOpeningProperties(panel);
+        if (DEBUG && isTesting()) {
+          unregisterWaiter(waiter);
+        }
+      });
     },
 
     _setAnimateOpeningProperties(panel) {


### PR DESCRIPTION
We need to register a waiter so that any calls to `await settled()` will wait for the `requestAnimationFrame` call to return. Wrapping in `DEBUG` as well as `isTesting()` means that this extra logic will be totally optimized out of production builds.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
