### PR TITLE
DEV: Apply optimistic update pattern to badge toggle

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-badges/show.js
@@ -248,8 +248,13 @@ export default class AdminBadgesShowController extends Controller.extend(
 
   @action
   toggleBadge() {
-    this.model
-      .save({ enabled: !this.buffered.get("enabled") })
-      .catch(popupAjaxError);
+    const originalState = this.buffered.get("enabled");
+    const newState = !this.buffered.get("enabled");
+
+    this.buffered.set("enabled", newState);
+    this.model.save({ enabled: newState }).catch((error) => {
+      this.buffered.set("enabled", originalState);
+      return popupAjaxError(error);
+    });
   }
 }


### PR DESCRIPTION
A follow up to https://github.com/discourse/discourse/pull/20225, this PR applies the optimistic update pattern to the badge toggle switch so that it looks better on slower networks.


## Before:
https://user-images.githubusercontent.com/30090424/220445297-219fb3cf-8678-4e12-b397-a77cde0e0b25.mov

## After
https://user-images.githubusercontent.com/30090424/220445298-7afe7a97-4a30-4893-9714-aaa71fe20d5e.mov


