### PR TITLE
FIX: Override navigation menu to "legacy" via query param not working

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -511,7 +511,8 @@ export default createWidget("header", {
       } else if (state.hamburgerVisible) {
         if (
           attrs.navigationMenuQueryParamOverride === "header_dropdown" ||
-          (this.siteSettings.navigation_menu !== "legacy" &&
+          (attrs.navigationMenuQueryParamOverride !== "legacy" &&
+            this.siteSettings.navigation_menu !== "legacy" &&
             (!attrs.sidebarEnabled || this.site.narrowDesktopView))
         ) {
           panels.push(this.attach("revamped-hamburger-menu-wrapper", {}));

--- a/spec/system/page_objects/components/legacy_header_dropdown.rb
+++ b/spec/system/page_objects/components/legacy_header_dropdown.rb
@@ -8,7 +8,7 @@ module PageObjects
       end
 
       def visible?
-        page.has_css?(".menu-panel.drop-down")
+        page.has_css?(".menu-container-general-links")
       end
     end
   end

--- a/spec/system/page_objects/components/sidebar_header_dropdown.rb
+++ b/spec/system/page_objects/components/sidebar_header_dropdown.rb
@@ -8,7 +8,7 @@ module PageObjects
       end
 
       def visible?
-        page.has_css?(".revamped.menu-panel.drop-down")
+        page.has_css?(".sidebar-hamburger-dropdown")
       end
     end
   end

--- a/spec/system/viewing_sidebar_spec.rb
+++ b/spec/system/viewing_sidebar_spec.rb
@@ -34,6 +34,32 @@ describe "Viewing sidebar", type: :system, js: true do
     end
   end
 
+  describe "when using the header dropdown navigation menu" do
+    before { SiteSetting.navigation_menu = "header dropdown" }
+
+    it "should display the sidebar when `navigation_menu` query param is 'sidebar'" do
+      visit("/latest?navigation_menu=sidebar")
+
+      sidebar = PageObjects::Components::Sidebar.new
+
+      expect(sidebar).to be_visible
+      expect(page).not_to have_css(".hamburger-dropdown")
+    end
+
+    it "should display the legacy dropdown menu when `navigation_menu` query param is 'legacy'" do
+      visit("/latest?navigation_menu=legacy")
+
+      sidebar = PageObjects::Components::Sidebar.new
+
+      expect(sidebar).to be_not_visible
+
+      legacy_header_dropdown = PageObjects::Components::LegacyHeaderDropdown.new
+      legacy_header_dropdown.click
+
+      expect(legacy_header_dropdown).to be_visible
+    end
+  end
+
   describe "when using the sidebar navigation menu" do
     before { SiteSetting.navigation_menu = "sidebar" }
 


### PR DESCRIPTION
When the `navigation_menu` site setting has been set to `sidebar` or
`header dropdown`, overriding the site setting via the `navigation_menu`
query params did not work.

Follow-up to c47015b861fa538003d4d7d1267f9acedc6d2948