### PR TITLE
DEV: Remove use of deprecated prop from user notifications templates

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-preferences/allow-private-messages.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-preferences/allow-private-messages.hbs
@@ -1,9 +1,0 @@
-<div class="control-group private-messages">
-  <label class="control-label">{{i18n "user.private_messages"}}</label>
-  <div class="controls">
-    <PreferenceCheckbox
-      @labelKey="user.allow_private_messages"
-      @checked={{@model.user_option.allow_private_messages}}
-    />
-  </div>
-</div>

--- a/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/notifications.js
@@ -1,7 +1,5 @@
 import Controller from "@ember/controller";
-import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
-import { NotificationLevels } from "discourse/lib/notification-levels";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Controller.extend({
@@ -30,71 +28,6 @@ export default Controller.extend({
       { name: I18n.t("user.like_notification_frequency.first_time"), value: 2 },
       { name: I18n.t("user.like_notification_frequency.never"), value: 3 },
     ];
-
-    this.autoTrackDurations = [
-      { name: I18n.t("user.auto_track_options.never"), value: -1 },
-      { name: I18n.t("user.auto_track_options.immediately"), value: 0 },
-      {
-        name: I18n.t("user.auto_track_options.after_30_seconds"),
-        value: 30000,
-      },
-      { name: I18n.t("user.auto_track_options.after_1_minute"), value: 60000 },
-      {
-        name: I18n.t("user.auto_track_options.after_2_minutes"),
-        value: 120000,
-      },
-      {
-        name: I18n.t("user.auto_track_options.after_3_minutes"),
-        value: 180000,
-      },
-      {
-        name: I18n.t("user.auto_track_options.after_4_minutes"),
-        value: 240000,
-      },
-      {
-        name: I18n.t("user.auto_track_options.after_5_minutes"),
-        value: 300000,
-      },
-      {
-        name: I18n.t("user.auto_track_options.after_10_minutes"),
-        value: 600000,
-      },
-    ];
-
-    this.notificationLevelsForReplying = [
-      {
-        name: I18n.t("topic.notifications.watching.title"),
-        value: NotificationLevels.WATCHING,
-      },
-      {
-        name: I18n.t("topic.notifications.tracking.title"),
-        value: NotificationLevels.TRACKING,
-      },
-      {
-        name: I18n.t("topic.notifications.regular.title"),
-        value: NotificationLevels.REGULAR,
-      },
-    ];
-
-    this.considerNewTopicOptions = [
-      { name: I18n.t("user.new_topic_duration.not_viewed"), value: -1 },
-      { name: I18n.t("user.new_topic_duration.after_1_day"), value: 60 * 24 },
-      { name: I18n.t("user.new_topic_duration.after_2_days"), value: 60 * 48 },
-      {
-        name: I18n.t("user.new_topic_duration.after_1_week"),
-        value: 7 * 60 * 24,
-      },
-      {
-        name: I18n.t("user.new_topic_duration.after_2_weeks"),
-        value: 2 * 7 * 60 * 24,
-      },
-      { name: I18n.t("user.new_topic_duration.last_here"), value: -2 },
-    ];
-  },
-
-  @discourseComputed("currentUser.can_send_private_messages")
-  showMessageSettings() {
-    return this.currentUser?.can_send_private_messages;
   },
 
   actions: {

--- a/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/notifications.hbs
@@ -1,15 +1,6 @@
 <div class="control-group notifications">
   <label class="control-label">{{i18n "user.notifications"}}</label>
 
-  {{#unless this.currentUser.redesigned_user_page_nav_enabled}}
-    <UserPreferences::TopicTracking
-      @considerNewTopicOptions={{this.considerNewTopicOptions}}
-      @model={{this.model}}
-      @autoTrackDurations={{this.autoTrackDurations}}
-      @notificationLevelsForReplying={{this.notificationLevelsForReplying}}
-    />
-  {{/unless}}
-
   <div class="controls controls-dropdown">
     <label>{{i18n "user.like_notification_frequency.title"}}</label>
     <ComboBox
@@ -43,12 +34,6 @@
 {{/unless}}
 
 <UserNotificationSchedule @model={{this.model}} />
-
-{{#if this.showMessageSettings}}
-  {{#unless this.currentUser.redesigned_user_page_nav_enabled}}
-    <UserPreferences::AllowPrivateMessages @model={{this.model}} />
-  {{/unless}}
-{{/if}}
 
 <span>
   <PluginOutlet

--- a/app/assets/javascripts/discourse/app/templates/preferences/tracking.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/tracking.hbs
@@ -2,12 +2,45 @@
 
 <div class="user-preferences__tracking-topics-wrapper">
   <label class="control-label">{{i18n "user.topics_settings"}}</label>
-  <UserPreferences::TopicTracking
-    @considerNewTopicOptions={{this.considerNewTopicOptions}}
-    @model={{this.model}}
-    @autoTrackDurations={{this.autoTrackDurations}}
-    @notificationLevelsForReplying={{this.notificationLevelsForReplying}}
-  />
+
+  <div class="user-preferences_tracking-topics-controls">
+    <div class="controls controls-dropdown">
+      <label>{{i18n "user.new_topic_duration.label"}}</label>
+      <ComboBox
+        @class="duration"
+        @valueProperty="value"
+        @content={{this.considerNewTopicOptions}}
+        @value={{this.model.user_option.new_topic_duration_minutes}}
+        @onChange={{action
+          (mut this.model.user_option.new_topic_duration_minutes)
+        }}
+      />
+    </div>
+
+    <div class="controls controls-dropdown">
+      <label>{{i18n "user.auto_track_topics"}}</label>
+      <ComboBox
+        @valueProperty="value"
+        @content={{this.autoTrackDurations}}
+        @value={{this.model.user_option.auto_track_topics_after_msecs}}
+        @onChange={{action
+          (mut this.model.user_option.auto_track_topics_after_msecs)
+        }}
+      />
+    </div>
+
+    <div class="controls controls-dropdown">
+      <label>{{i18n "user.notification_level_when_replying"}}</label>
+      <ComboBox
+        @valueProperty="value"
+        @content={{this.notificationLevelsForReplying}}
+        @value={{this.model.user_option.notification_level_when_replying}}
+        @onChange={{action
+          (mut this.model.user_option.notification_level_when_replying)
+        }}
+      />
+    </div>
+  </div>
 </div>
 
 <div class="user-preferences__tracking-categories-tags-wrapper">

--- a/app/assets/javascripts/discourse/app/templates/preferences/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/preferences/users.hbs
@@ -29,9 +29,15 @@
 </div>
 
 {{#if this.currentUser.can_send_private_messages}}
-  {{#if this.currentUser.redesigned_user_page_nav_enabled}}
-    <UserPreferences::AllowPrivateMessages @model={{this.model}} />
-  {{/if}}
+  <div class="control-group private-messages">
+    <label class="control-label">{{i18n "user.private_messages"}}</label>
+    <div class="controls">
+      <PreferenceCheckbox
+        @labelKey="user.allow_private_messages"
+        @checked={{this.model.user_option.allow_private_messages}}
+      />
+    </div>
+  </div>
 
   <div class="control-group user-allow-pm">
     <div class="controls">

--- a/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/preferences-test.js
@@ -71,14 +71,14 @@ acceptance("User Preferences", function (needs) {
     await click(".pref-activity-summary input[type=checkbox]");
     await savePreferences();
 
-    await click(".user-nav__preferences-notifications a");
+    await click(".user-nav__preferences-tracking a");
 
     await selectKit(
-      ".control-group.notifications .combo-box.duration"
+      ".user-preferences_tracking-topics-controls .combo-box.duration"
     ).expand();
 
     await selectKit(
-      ".control-group.notifications .combo-box.duration"
+      ".user-preferences_tracking-topics-controls .combo-box.duration"
     ).selectRowByValue(1440);
 
     await savePreferences();

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-tracking-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-tracking-test.js
@@ -4,9 +4,7 @@ import { test } from "qunit";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("User Preferences - Tracking", function (needs) {
-  needs.user({
-    redesigned_user_page_nav_enabled: true,
-  });
+  needs.user();
 
   let putRequestData;
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -74,7 +74,6 @@ acceptance(
       id: 5,
       username: "charlie",
       groups: [{ id: 14, name: "awesome_group", has_messages: true }],
-      redesigned_user_page_nav_enabled: true,
     });
 
     needs.site({
@@ -955,9 +954,7 @@ acceptance(
 acceptance(
   "User Private Messages - user with uppercase username",
   function (needs) {
-    needs.user({
-      redesigned_user_page_nav_enabled: true,
-    });
+    needs.user();
 
     needs.pretender((server, helper) => {
       const response = cloneJSON(userFixtures["/u/charlie.json"]);


### PR DESCRIPTION
The redesigned_user_page_nav_enabled property has been deprecated and will be dropped from Discourse core soon.