### PR TITLE
FIX: Text selection breaking with hashtag SVG in Firefox

### DIFF
--- a/app/assets/stylesheets/common/components/hashtag.scss
+++ b/app/assets/stylesheets/common/components/hashtag.scss
@@ -33,6 +33,10 @@ a.hashtag-cooked {
     height: 15px;
     vertical-align: text-bottom;
   }
+
+  svg {
+    display: inline;
+  }
 }
 
 .hashtag-autocomplete {


### PR DESCRIPTION
The new hashtags render with an `<svg>` element inside a `<a>`
tag, which is an icon to indicate the "type" of the hashtag.
In Firefox, this was disrupting both triple-click text selection
and simple dragging cursor text selection. The selection would
stop at the SVG rather than continuing past it. This works fine
in Chrome -- either Chrome is not doing the right thing or Firefox
is.

Either way the issue is fixed by simply making the `svg` an inline
element inside the link, which it should be anyway.

**Before**

![2023-02-22_13-31](https://user-images.githubusercontent.com/920448/220514961-e86a26bb-e689-4087-817b-a2176162d745.png)

**After**

![2023-02-22_13-31_1](https://user-images.githubusercontent.com/920448/220514952-ededc880-de1c-4ec1-ae6e-4dc41891d6a3.png)
