### PR TITLE
UX: User badges tweaks

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -286,10 +286,9 @@
 {{#if this.grant_count}}
   <div class="content-body current-badge-actions">
     <div>
-      <LinkTo @route="badges.show" @model={{this}}>{{i18n
-          "badges.granted"
-          count=this.grant_count
-        }}</LinkTo>
+      <LinkTo @route="badges.show" @model={{this}}>
+        {{number this.grant_count}}
+        {{i18n "badges.awarded"}}</LinkTo>
     </div>
   </div>
 {{/if}}

--- a/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin-badges/show.hbs
@@ -288,7 +288,8 @@
     <div>
       <LinkTo @route="badges.show" @model={{this}}>
         {{number this.grant_count}}
-        {{i18n "badges.awarded"}}</LinkTo>
+        {{i18n "badges.awarded"}}
+      </LinkTo>
     </div>
   </div>
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.hbs
@@ -41,12 +41,16 @@
       <div class="badge-summary">{{html-safe this.summary}}</div>
 
       {{#if this.displayCount}}
-        <div class="badge-granted">
-          <LinkTo @route="badges.show" @model={{this.badge}}>
-            {{number this.displayCount}}
-            {{i18n "badges.awarded"}}
-          </LinkTo>
-        </div>
+
+        <LinkTo
+          @route="badges.show"
+          @model={{this.badge}}
+          class="badge-granted"
+        >
+          {{number this.displayCount}}
+          {{i18n "badges.awarded"}}
+        </LinkTo>
+
       {{/if}}
     </div>
   </div>

--- a/app/assets/javascripts/discourse/app/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.hbs
@@ -42,8 +42,10 @@
 
       {{#if this.displayCount}}
         <div class="badge-granted">
-          {{number this.displayCount badgeUrl=this.url}}
-          {{html-safe (i18n "badges.awarded")}}
+          <LinkTo @route="badges.show" @model={{this.badge}}>
+            {{number this.displayCount}}
+            {{i18n "badges.awarded"}}
+          </LinkTo>
         </div>
       {{/if}}
     </div>

--- a/app/assets/javascripts/discourse/app/components/badge-card.hbs
+++ b/app/assets/javascripts/discourse/app/components/badge-card.hbs
@@ -42,13 +42,8 @@
 
       {{#if this.displayCount}}
         <div class="badge-granted">
-          {{html-safe
-            (i18n
-              "badges.granted_with_count"
-              count=this.displayCount
-              badgeUrl=this.url
-            )
-          }}
+          {{number this.displayCount badgeUrl=this.url}}
+          {{html-safe (i18n "badges.awarded")}}
         </div>
       {{/if}}
     </div>

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -216,7 +216,6 @@
     }
 
     .badge-contents {
-      padding: 0 5%;
       h3 {
         font-size: var(--font-up-3);
       }

--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -132,7 +132,10 @@
   }
 
   .badge-granted {
+    display: block;
     margin-top: 0.5em;
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
   }
 
   .grant-count {
@@ -191,9 +194,6 @@
     }
 
     .badge-info {
-      display: flex;
-      flex: 1 1 auto;
-      align-items: center;
       color: var(--primary);
 
       h3 {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4121,9 +4121,6 @@ en:
       granted:
         one: "%{count} granted"
         other: "%{count} granted"
-      granted_with_count:
-        one: '<a href="%{badgeUrl}" title="%{count} granted" class="grant-count">%{count}x</a> <span class="grant-text">granted</span>'
-        other: '<a href="%{badgeUrl}" title="%{count} granted" class="grant-count">%{count}x</a> <span class="grant-text">granted</span>'
       awarded: awarded
       select_badge_for_title: Select a badge to use as your title
       none: "(none)"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4124,6 +4124,7 @@ en:
       granted_with_count:
         one: '<a href="%{badgeUrl}" title="%{count} granted" class="grant-count">%{count}x</a> <span class="grant-text">granted</span>'
         other: '<a href="%{badgeUrl}" title="%{count} granted" class="grant-count">%{count}x</a> <span class="grant-text">granted</span>'
+      awarded: awarded
       select_badge_for_title: Select a badge to use as your title
       none: "(none)"
       successfully_granted: "Successfully granted %{badge} to %{username}"


### PR DESCRIPTION
Styling and formatting update for the "awarded" part of the badges
<img width="944" alt="image" src="https://user-images.githubusercontent.com/101828855/220553890-ad9772da-0081-49a6-8358-f19675ad73fc.png">

