### PR TITLE
FIX: Fast edit doesn’t work on content with certain characters

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -39,9 +39,10 @@ function getQuoteTitle(element) {
 }
 
 function fixQuotes(str) {
-  // u+201c “
-  // u+201d ”
-  return str.replace(/[\u201C\u201D]/g, '"');
+  // u+201c, u+201d = “ ”
+  // u+2018, u+2019 = ‘ ’
+  let new_str = str.replace(/[\u201C\u201D]/g, '"');
+  return new_str.replace(/[\u2018\u2019]/g, "'");
 }
 
 export default Component.extend(KeyEnterEscape, {
@@ -471,7 +472,7 @@ export default Component.extend(KeyEnterEscape, {
               bestIndex = index;
               return true;
             }
-          });
+          });          
 
           this?.editPost(postModel);
 

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -472,7 +472,7 @@ export default Component.extend(KeyEnterEscape, {
               bestIndex = index;
               return true;
             }
-          });          
+          });
 
           this?.editPost(postModel);
 

--- a/spec/system/fast_edit_spec.rb
+++ b/spec/system/fast_edit_spec.rb
@@ -13,7 +13,7 @@ describe "Fast edit", type: :system, js: true do
     sign_in(current_user)
   end
 
-  context "works correctly on basic text" do
+  context "when text selected it opens contact menu and fast editor" do
     it "opens context menu and fast edit dialog" do
       topic_page.visit_topic(topic)
 
@@ -23,7 +23,7 @@ describe "Fast edit", type: :system, js: true do
       topic_page.click_fast_edit_button
       expect(topic_page.fast_edit_input).to be_visible
     end
-    
+
     it "edits first paragraph and saves changes" do
       topic_page.visit_topic(topic)
 

--- a/spec/system/fast_edit_spec.rb
+++ b/spec/system/fast_edit_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+describe "Fast edit", type: :system, js: true do
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:fast_editor) { PageObjects::Components::FastEditor.new }
+  fab!(:topic) { Fabricate(:topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  fab!(:post_2) { Fabricate(:post, topic: topic, raw: "It 'twas a great time!") }
+  fab!(:current_user) { Fabricate(:admin) }
+
+  before do
+    current_user.activate
+    sign_in(current_user)
+  end
+
+  context "works correctly on basic text" do
+    it "opens context menu and fast edit dialog" do
+      topic_page.visit_topic(topic)
+
+      topic_page.select_text("#post_1 .cooked > p", 10)
+      expect(topic_page.fast_edit_button).to be_visible
+
+      topic_page.click_fast_edit_button
+      expect(topic_page.fast_edit_input).to be_visible
+    end
+    
+    it "edits first paragraph and saves changes" do
+      topic_page.visit_topic(topic)
+
+      topic_page.select_text("#post_1 .cooked > p", 5)
+      topic_page.click_fast_edit_button
+
+      fast_editor.fill_content("Howdy")
+      fast_editor.save
+
+      within("#post_1 .cooked > p") do |el|
+        expect(el).not_to eq("Hello world")
+        expect(el).to have_content("Howdy")
+      end
+    end
+  end
+
+  context "when editing text that has strange characters" do
+    it "saves when paragraph contains apostrophe" do
+      topic_page.visit_topic(topic)
+
+      topic_page.select_text("#post_2 .cooked > p", 8)
+      topic_page.click_fast_edit_button
+
+      fast_editor.fill_content("It was")
+      fast_editor.save
+
+      expect(find("#post_2 .cooked > p")).to have_content("It was a great time!")
+    end
+  end
+end

--- a/spec/system/page_objects/components/fast_editor.rb
+++ b/spec/system/page_objects/components/fast_editor.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class FastEditor < PageObjects::Components::Base
+      def fill_content(content)
+        fast_edit_input.fill_in(with: content)
+        self
+      end
+
+      def clear_content
+        fill_content("")
+      end
+
+      def has_content?(content)
+        fast_edit_input.value == content
+      end
+
+      def save
+        find(".save-fast-edit").click
+      end
+
+      def fast_edit_input
+        find("#fast-edit-input")
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -137,7 +137,7 @@ module PageObjects
           selection.removeAllRanges();
           selection.addRange(range);
         JS
-    
+
         page.execute_script(js, selector, offset)
       end
 

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -5,6 +5,7 @@ module PageObjects
     class Topic < PageObjects::Pages::Base
       def initialize
         @composer_component = PageObjects::Components::Composer.new
+        @fast_edit_component = PageObjects::Components::FastEditor.new
       end
 
       def visit_topic(topic)
@@ -112,6 +113,32 @@ module PageObjects
 
       def fill_in_composer_title(title)
         @composer_component.fill_title(title)
+      end
+
+      def fast_edit_button
+        find(".quote-button .quote-edit-label")
+      end
+
+      def click_fast_edit_button
+        find(".quote-button .quote-edit-label").click
+      end
+
+      def fast_edit_input
+        find("#fast-edit-input")
+      end
+
+      def select_text(selector, offset = 10)
+        js = <<-JS
+          const node = document.querySelector(arguments[0]).childNodes[0];
+          const selection = window.getSelection();
+          const range = document.createRange();
+          range.selectNodeContents(node);
+          range.setEnd(node, arguments[1]);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        JS
+    
+        page.execute_script(js, selector, offset)
       end
 
       private


### PR DESCRIPTION
A small fix to allow fast edit saving when post contains apostrophe.

Quotation marks and apostrophes are stored in the db using a unicode variant (possible bigger non related issue).

This PR is to simply get the basic functionality of fast edit to work when posts have strangely formatted apostrophes in the text. This happens by using the string.replace method to replace all characters with the correct character prior to saving the updated post.

I've included a system spec for fast edit to validate the basic functionality of fast edit (selecting text to see context menu, clicking edit button to show fast editor input), along with a test for this specific change to address the strange apostrophe character. I have also added a new component to make the fast editor.

Ticket for issue:
https://meta.discourse.org/t/fast-edit-doesnt-work-on-content-with-certain-characters/223145