### PR TITLE
DEV: Upgrade ruby-prof from 1.6.0 to 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,7 +431,7 @@ GEM
     rubocop-rspec (2.18.1)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
-    ruby-prof (1.6.0)
+    ruby-prof (1.6.1)
     ruby-progressbar (1.11.0)
     ruby-readability (0.7.0)
       guess_html_encoding (>= 0.0.4)


### PR DESCRIPTION
ruby-prof 1.6.0 was released, and we merged it in #20400, but the version was then yanked, causing Bundler to fail when installing gems.

<img width="652" alt="Screenshot 2023-02-22 at 3 38 29 PM" src="https://user-images.githubusercontent.com/5259935/220553954-88f11006-b1cc-4874-a3a3-411ac9e6bd14.png">

This change updgrades ruby-prof to 1.6.1 which was released as a replacement.