### PR TITLE
DEV: Correct test waiter for requestAnimationFrame

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -59,7 +59,7 @@ const SiteHeaderComponent = MountWidget.extend(
     _animateOpening(panel) {
       let waiter;
       if (DEBUG && isTesting()) {
-        waiter = () => true;
+        waiter = () => false;
         registerWaiter(waiter);
       }
 


### PR DESCRIPTION
Followup to 207c0dd88c6d5450aa1c0de6e9a929840972c940. Waiters should return false to 'wait', true to continue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
