### PR TITLE
DEV: Silence discourse.custom_html_template in its own test

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/custom-html-template-test.js
@@ -3,6 +3,7 @@ import { hbs } from "ember-cli-htmlbars";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 import { registerTemporaryModule } from "discourse/tests/helpers/temporary-module-helper";
+import { withSilencedDeprecationsAsync } from "discourse-common/lib/deprecated";
 
 acceptance("CustomHTML template", function (needs) {
   needs.hooks.beforeEach(() => {
@@ -13,11 +14,16 @@ acceptance("CustomHTML template", function (needs) {
   });
 
   test("renders custom template", async function (assert) {
-    await visit("/static/faq");
-    assert.strictEqual(
-      query("span.top-span").innerText,
-      "TOP",
-      "it inserted the template"
+    await withSilencedDeprecationsAsync(
+      "discourse.custom_html_template",
+      async () => {
+        await visit("/static/faq");
+        assert.strictEqual(
+          query("span.top-span").innerText,
+          "TOP",
+          "it inserted the template"
+        );
+      }
     );
   });
 });


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
