### PR TITLE
Use en-dash (–) instead of hyphen (-) for date formatting

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/period-title.js
+++ b/app/assets/javascripts/discourse/app/helpers/period-title.js
@@ -28,7 +28,7 @@ export default htmlHelper((period, options) => {
             .clone()
             .subtract(1, "year")
             .format(I18n.t("dates.long_with_year_no_time")) +
-          " - " +
+          " – " +
           finish.format(I18n.t("dates.long_with_year_no_time"));
         break;
       case "quarterly":
@@ -37,7 +37,7 @@ export default htmlHelper((period, options) => {
             .clone()
             .subtract(3, "month")
             .format(I18n.t("dates.long_no_year_no_time")) +
-          " - " +
+          " – " +
           finish.format(I18n.t("dates.long_no_year_no_time"));
         break;
       case "weekly":
@@ -50,7 +50,7 @@ export default htmlHelper((period, options) => {
 
         dateString =
           start.format(I18n.t("dates.long_no_year_no_time")) +
-          " - " +
+          " – " +
           finish.format(I18n.t("dates.long_no_year_no_time"));
         break;
       case "monthly":
@@ -59,7 +59,7 @@ export default htmlHelper((period, options) => {
             .clone()
             .subtract(1, "month")
             .format(I18n.t("dates.long_no_year_no_time")) +
-          " - " +
+          " – " +
           finish.format(I18n.t("dates.long_no_year_no_time"));
         break;
       case "daily":


### PR DESCRIPTION
(A petty but important typography fix)

Use en dash (–) instead of hyphen (-) for ranges (including dates) For example — $1–$2, May 2–June 4, 1:00pm–2:00pm

A space before and after the dash (like `May 2 – June 4`) is usually not present in writing but on user interfaces can be stylistic choice. (See Apple's below.) The space is left unchanged in this PR.

<img width="321" alt="image" src="https://user-images.githubusercontent.com/37538241/220825979-09cad02e-b056-49d7-8c4a-6ba792c8ad63.png">

References
- https://learn.microsoft.com/en-us/style-guide/punctuation/dashes-hyphens/enes
- https://www.thepunctuationguide.com/en-dash.html