### PR TITLE
FIX: Make sure regular users can delete their PMs

### DIFF
--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -471,7 +471,7 @@ const Topic = RestModel.extend({
           opts.force_destroy ||
           (!deleted_by.staff &&
             !deleted_by.groups.some(
-              (group) => group.name === this.category.reviewable_by_group_name
+              (group) => group.name === this.category?.reviewable_by_group_name
             ) &&
             !(
               this.siteSettings.tl4_delete_posts_and_topics &&

--- a/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/personal-message-test.js
@@ -1,7 +1,13 @@
-import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
+import { click, visit } from "@ember/test-helpers";
+import DiscourseURL from "discourse/lib/url";
+import {
+  acceptance,
+  publishToMessageBus,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { test } from "qunit";
-import { visit } from "@ember/test-helpers";
+import sinon from "sinon";
 
 acceptance("Personal Message", function (needs) {
   needs.user();
@@ -13,5 +19,40 @@ acceptance("Personal Message", function (needs) {
       query("#suggested-topics .suggested-topics-title").innerText.trim(),
       I18n.t("suggested_topics.pm_title")
     );
+  });
+});
+
+acceptance("Personal Message (regular user)", function (needs) {
+  needs.user({ admin: false, moderator: false });
+
+  needs.pretender((server) => {
+    server.get("/posts/15", () => [
+      403,
+      {},
+      {
+        errors: ["You are not permitted to view the requested resource."],
+        error_type: "invalid_access",
+      },
+    ]);
+  });
+
+  test("redirects to homepage after topic is deleted", async function (assert) {
+    sinon.stub(DiscourseURL, "redirectTo");
+
+    await visit("/t/pm-for-testing/12");
+
+    await click(".post-controls .show-more-actions");
+    await click(".post-controls .delete");
+    await publishToMessageBus("/topic/12", {
+      id: 15,
+      post_number: 1,
+      updated_at: "2017-01-27T03:53:58.394Z",
+      user_id: 8,
+      last_editor_id: 8,
+      type: "deleted",
+      version: 1,
+    });
+
+    assert.true(DiscourseURL.redirectTo.calledWith("/"));
   });
 });


### PR DESCRIPTION
Regular users should be redirected to the homepage after the topic is no longer accessible by them (only staff members can view deleted topics). There was a problem with permission checking for category moderators which stopped the redirect from happening.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
