### PR TITLE
Fix create/edit button overflowing on other icons

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -340,7 +340,7 @@ html.composer-open {
     flex: 1 1 auto;
 
     .btn-primary {
-      flex: 0 0 auto;
+      flex: 0 1 auto;
     }
 
     .cancel {


### PR DESCRIPTION
More info: https://meta.discourse.org/t/trash-can-is-covering-up-other-icons/256032?u=canapin

The button overflows on very narrow screens of if its text is long (it's the case in some translations)

Before and after:

![image](https://user-images.githubusercontent.com/5654300/220937937-10cb7855-0877-43af-9a83-5d015dfafd5a.png) ![image](https://user-images.githubusercontent.com/5654300/220938121-1d5f37f3-f8a3-4ced-b075-76aea70bc352.png)

