### PR TITLE
SECURITY: Show only visible tags in metadata

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1231,7 +1231,7 @@ class TopicsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        @tags = SiteSetting.tagging_enabled ? @topic_view.topic.tags : []
+        @tags = SiteSetting.tagging_enabled ? @topic_view.topic.tags.visible(guardian) : []
         @breadcrumbs = helpers.categories_breadcrumb(@topic_view.topic) || []
         @description_meta =
           @topic_view.topic.excerpt.present? ? @topic_view.topic.excerpt : @topic_view.summary

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -38,6 +38,7 @@ class Tag < ActiveRecord::Base
         ->(guardian) { where("tags.#{Tag.topic_count_column(guardian)} > 0") }
 
   scope :base_tags, -> { where(target_tag_id: nil) }
+  scope :visible, ->(guardian = nil) { merge(DiscourseTagging.visible_tags(guardian)) }
 
   has_many :tag_users, dependent: :destroy # notification settings
 

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -129,7 +129,7 @@
 
   <% content_for :head do %>
     <%= auto_discovery_link_tag(@topic_view, {action: :feed, slug: @topic_view.topic.slug, topic_id: @topic_view.topic.id}, rel: 'alternate nofollow', title: t('rss_posts_in_topic', topic: @topic_view.title), type: 'application/rss+xml') %>
-    <%= raw crawlable_meta_data(title: @topic_view.title, description: @topic_view.summary(strip_images: true), image: @topic_view.image_url, read_time: @topic_view.read_time, like_count: @topic_view.like_count, ignore_canonical: true, published_time: @topic_view.published_time, breadcrumbs: @breadcrumbs, tags: @topic_view.tags) %>
+    <%= raw crawlable_meta_data(title: @topic_view.title, description: @topic_view.summary(strip_images: true), image: @topic_view.image_url, read_time: @topic_view.read_time, like_count: @topic_view.like_count, ignore_canonical: true, published_time: @topic_view.published_time, breadcrumbs: @breadcrumbs, tags: @tags.map(&:name)) %>
 
     <% if @topic_view.prev_page || @topic_view.next_page %>
       <% if @topic_view.prev_page %>

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -244,9 +244,9 @@ class TopicView
       if @topic.category_id != SiteSetting.uncategorized_category_id && @topic.category_id &&
            @topic.category
         title += " - #{@topic.category.name}"
-      elsif SiteSetting.tagging_enabled && @topic.tags.exists?
+      elsif SiteSetting.tagging_enabled && visible_tags.exists?
         title +=
-          " - #{@topic.tags.order("tags.#{Tag.topic_count_column(@guardian)} DESC").first.name}"
+          " - #{visible_tags.order("tags.#{Tag.topic_count_column(@guardian)} DESC").first.name}"
       end
     end
     title
@@ -713,10 +713,6 @@ class TopicView
       end
   end
 
-  def tags
-    @topic.tags.map(&:name)
-  end
-
   protected
 
   def read_posts_set
@@ -820,7 +816,7 @@ class TopicView
   def find_topic(topic_or_topic_id)
     return topic_or_topic_id if topic_or_topic_id.is_a?(Topic)
     # with_deleted covered in #check_and_raise_exceptions
-    Topic.with_deleted.includes(:category, :tags).find_by(id: topic_or_topic_id)
+    Topic.with_deleted.includes(:category).find_by(id: topic_or_topic_id)
   end
 
   def unfiltered_posts
@@ -989,5 +985,9 @@ class TopicView
         StaffActionLogger.new(@user).log_check_personal_message(@topic)
       end
     end
+  end
+
+  def visible_tags
+    @visible_tags ||= topic.tags.visible(guardian)
   end
 end

--- a/spec/views/topics/show.html.erb_spec.rb
+++ b/spec/views/topics/show.html.erb_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "topics/show.html.erb" do
     view.stubs(:crawler_layout?).returns(false)
     view.stubs(:url_for).returns("https://www.example.com/test.rss")
     view.instance_variable_set("@topic_view", topic_view)
+    assign(:tags, [])
+
     render template: "topics/show", formats: [:html]
 
     expect(view.content_for(:head)).to match(


### PR DESCRIPTION
Currently, the topic metadata show both public and private tags whereas only visible ones should be exposed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
