### PR TITLE
UX: Remove color attribute from `<kbd>` tag

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1063,7 +1063,6 @@ kbd {
   border-bottom-width: 2px;
   border-radius: 3px;
   box-sizing: border-box;
-  color: var(--primary);
   display: inline-flex;
   gap: 0 0.5em; // space between text and images/emoji
   font-size: var(--font-down-1);


### PR DESCRIPTION
As a single example, if a `<kbd>` tag is wrapped by a `<a>` link, it doesn't inherit the link color:

`[<kbd>:question: **Support**</kbd>](https://meta.discourse.org)`

Result (screenshot):
![image](https://user-images.githubusercontent.com/5654300/220988647-ed0d7f20-3c75-4dc0-a68e-bc0f7503bb6d.png)

It's because the `<kbd>` tag has a `color: var(--primary);` CSS rule which seems superfluous.

If we disable it, the `<kbd>` tag inherits all the normal colors (including the link color :ok_hand:).

The direct `<kbd>` parent that assigns the text color is `<html>` (can't go higher!) which has an identical `color: var(--primary);`. 

WCAG palettes don't seem to assign specific colors in this context.

It seems fairly safe to remove `color: var(--primary);` from `<kbd>` so it won't interfere anymore with its content.