### PR TITLE
Fix keyboard shortcut button hover color for WCAG color schemes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/footer.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/footer.hbs
@@ -31,7 +31,7 @@
           @action={{route-action "showKeyboardShortcutsHelp"}}
           @title="keyboard_shortcuts_help.title"
           @icon="keyboard"
-          @class="sidebar-footer-actions-button sidebar-footer-actions-keyboard-shortcuts"
+          @class="btn-flat sidebar-footer-actions-button sidebar-footer-actions-keyboard-shortcuts"
         />
       {{/if}}
     </div>


### PR DESCRIPTION
The color of the keyboard icon when hovering with the mouse was wrong on WCAG color schemes. This fixes it.

Before:
![chrome_WHaHbJN3h9](https://user-images.githubusercontent.com/5654300/221008499-0045e477-de6d-43fb-8f3f-758e739b3e28.gif) ![chrome_NwEbLvJvIS](https://user-images.githubusercontent.com/5654300/221008519-cf0dc040-e5d9-4671-adcf-a09e3a7d7887.gif)

After:
![chrome_RbFlE9kmsM](https://user-images.githubusercontent.com/5654300/221008746-8aa7684f-354b-4846-b783-fd6e356aa9d8.gif) ![chrome_wa61DYLlDc](https://user-images.githubusercontent.com/5654300/221010099-a7049388-b40e-4fff-bdaa-7adebfbc7419.gif)


