### PR TITLE
FIX: Correct issues in admin-theme-editor

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-theme-editor.hbs
+++ b/app/assets/javascripts/admin/addon/components/admin-theme-editor.hbs
@@ -44,7 +44,7 @@
             @checked={{this.onlyOverridden}}
             {{on
               "click"
-              (action "onlyOverriddenChanged" value="target.checked")
+              (action this.onlyOverriddenChanged value="target.checked")
             }}
           />
           {{i18n "admin.customize.theme.hide_unused_fields"}}
@@ -125,6 +125,6 @@
   @autofocus="true"
   @placeholder={{this.placeholder}}
   @htmlPlaceholder={{true}}
-  @save={{action "save"}}
+  @save={{this.save}}
   @setWarning={{action "setWarning"}}
 />

--- a/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
+++ b/app/assets/javascripts/admin/addon/components/admin-theme-editor.js
@@ -3,7 +3,7 @@ import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
 import { fmt } from "discourse/lib/computed";
 import { isDocumentRTL } from "discourse/lib/text-direction";
-import { action } from "@ember/object";
+import { action, computed } from "@ember/object";
 import { next } from "@ember/runloop";
 
 export default class AdminThemeEditor extends Component {
@@ -62,13 +62,13 @@ export default class AdminThemeEditor extends Component {
     return "";
   }
 
-  @discourseComputed("fieldName", "currentTargetName", "theme")
+  @computed("fieldName", "currentTargetName", "theme")
   get activeSection() {
-    return this.model.getField(this.currentTargetName, this.fieldName);
+    return this.theme.getField(this.currentTargetName, this.fieldName);
   }
 
   set activeSection(value) {
-    this.theme.setField(this.fieldName, value);
+    this.theme.setField(this.currentTargetName, this.fieldName, value);
     return value;
   }
 
@@ -124,16 +124,6 @@ export default class AdminThemeEditor extends Component {
     this.theme.setField(this.currentTargetName, name, "");
     this.setProperties({ newFieldName: "", addingField: false });
     this.fieldAdded(this.currentTargetName, name);
-  }
-
-  @action
-  onlyOverriddenChanged(value) {
-    this.onlyOverriddenChanged(value);
-  }
-
-  @action
-  save() {
-    this.attrs.save();
   }
 
   @action


### PR DESCRIPTION
Followup to a433b30650d125e6685fb13f679f613003f246aa

- `discourseComputed` -> `computed` on a getter (human error)
- `this.model` -> `this.theme` (human error)
- `onlyOverriddenChanged` and `save` action method name clashes (caused by the native-class-codemod)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
