### PR TITLE
FIX: Correct issues in admin-embeddable-host

### DIFF
--- a/app/assets/javascripts/admin/addon/components/embeddable-host.js
+++ b/app/assets/javascripts/admin/addon/components/embeddable-host.js
@@ -21,8 +21,8 @@ export default class EmbeddableHost extends Component.extend(
 
   @or("host.isNew", "editToggled") editing;
 
-  constructor() {
-    super(...arguments);
+  init() {
+    super.init(...arguments);
 
     const host = this.host;
     const categoryId = host.category_id || this.site.uncategorized_category_id;


### PR DESCRIPTION
Classic Component arguments are not available in the constructor. Switch back to using `init()` for this component

Followup to a433b30650d125e6685fb13f679f613003f246aa

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
