### PR TITLE
DEV: Move `form_template_ids` serializer location

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -78,6 +78,7 @@ class Site
               :uploaded_background,
               :tags,
               :tag_groups,
+              :form_templates,
               category_required_tag_groups: :tag_group,
             )
             .joins("LEFT JOIN topics t on t.id = categories.topic_id")

--- a/app/serializers/basic_category_serializer.rb
+++ b/app/serializers/basic_category_serializer.rb
@@ -19,7 +19,6 @@ class BasicCategorySerializer < ApplicationSerializer
              :notification_level,
              :can_edit,
              :topic_template,
-             :form_template_ids,
              :has_children,
              :sort_order,
              :sort_ascending,
@@ -91,9 +90,5 @@ class BasicCategorySerializer < ApplicationSerializer
 
   def include_custom_fields?
     custom_fields.present?
-  end
-
-  def include_form_template_ids?
-    SiteSetting.experimental_form_templates
   end
 end

--- a/app/serializers/site_category_serializer.rb
+++ b/app/serializers/site_category_serializer.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class SiteCategorySerializer < BasicCategorySerializer
-  attributes :allowed_tags, :allowed_tag_groups, :allow_global_tags, :read_only_banner
+  attributes :allowed_tags,
+             :allowed_tag_groups,
+             :allow_global_tags,
+             :read_only_banner,
+             :form_template_ids
 
   has_many :category_required_tag_groups, key: :required_tag_groups, embed: :objects
 

--- a/spec/requests/api/schemas/json/category_create_request.json
+++ b/spec/requests/api/schemas/json/category_create_request.json
@@ -39,6 +39,10 @@
     },
     "search_priority": {
       "type": "integer"
+    },
+    "form_template_ids": {
+      "type": "array",
+      "items": []
     }
   },
   "required": [

--- a/spec/requests/api/schemas/json/category_create_response.json
+++ b/spec/requests/api/schemas/json/category_create_response.json
@@ -74,6 +74,10 @@
             "null"
           ]
         },
+        "form_template_ids": {
+          "type": "array",
+          "items": []
+        },
         "has_children": {
           "type": [
             "string",

--- a/spec/requests/api/schemas/json/category_update_response.json
+++ b/spec/requests/api/schemas/json/category_update_response.json
@@ -77,6 +77,10 @@
             "null"
           ]
         },
+        "form_template_ids": {
+          "type": "array",
+          "items": []
+        },
         "has_children": {
           "type": [
             "string",
@@ -273,6 +277,7 @@
         "notification_level",
         "can_edit",
         "topic_template",
+        "form_template_ids",
         "has_children",
         "sort_order",
         "sort_ascending",

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -678,6 +678,10 @@
             },
             "parent_category_id": {
               "type": "integer"
+            },
+            "form_template_ids": {
+              "type": "array",
+              "items": []
             }
           },
           "required": [


### PR DESCRIPTION
**This PR**: Moves the attribute `form_template_ids` from `BasicCategorySerializer` to `SiteCategorySerializer` and adds the property to the cached category attributes in the site model to avoid the N + 1 query.