### PR TITLE
UX: only allow scroll grab if nav is scrollable

### DIFF
--- a/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
+++ b/app/assets/javascripts/discourse/app/components/horizontal-overflow-nav.js
@@ -62,7 +62,7 @@ export default class HorizontalOverflowNav extends Component {
 
   @bind
   scrollDrag(event) {
-    if (this.site.mobileView) {
+    if (this.site.mobileView || !this.hasScroll) {
       return;
     }
 


### PR DESCRIPTION
Discussed here: https://meta.discourse.org/t/new-nav-layout-uses-cursor-grab-when-mouse-is-pushed/256004

At the moment we allow `scrollDrag()` even if the nav isn't scrollable... so on click and hold the cursor is swapped to `grabbing` even though there's no effect, which can be a little misleading. 