### PR TITLE
UX: fix tag & category taps on mobile topic list

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-list-item.js
+++ b/app/assets/javascripts/discourse/app/components/topic-list-item.js
@@ -260,9 +260,9 @@ export default Component.extend({
     // make full row click target on mobile, due to size constraints
     if (
       this.site.mobileView &&
-      (e.target.classList.contains("right") ||
-        e.target.classList.contains("topic-item-stats") ||
-        e.target.classList.contains("main-link"))
+      e.target.matches(
+        ".topic-list-data, .main-link, .right, .topic-item-stats, .topic-item-stats__category-tags, .discourse-tags"
+      )
     ) {
       if (wantsNewWindow(e)) {
         return true;

--- a/app/assets/stylesheets/mobile/topic-list.scss
+++ b/app/assets/stylesheets/mobile/topic-list.scss
@@ -189,9 +189,13 @@
 
   .topic-item-stats__category-tags {
     margin-right: 0.5em;
-    .category,
+
     .discourse-tags {
       display: inline;
+    }
+
+    .badge-wrapper,
+    .discourse-tag {
       // disabling clicks because these targets are too small on mobile
       pointer-events: none;
     }


### PR DESCRIPTION
Until recently tags and categories on the mobile topic list would click through to the topic because they're too-small targets that can be easily mis-tapped. That behavior regressed due to some topic list changes and this update makes sure these elements always click through to the topic correctly again. 

More discussion here: https://meta.discourse.org/t/tag-is-not-tappable-in-topic-list-on-mobile/255774

Previously: https://meta.discourse.org/t/extra-padding-makes-it-hard-for-users-to-click-on-tag-and-category-under-topic-title/214978