### PR TITLE
DEV: Add classes to user profile's collapsed-info-panel

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -340,22 +340,25 @@
           <div class="secondary" id="collapsed-info-panel">
             <dl>
               {{#if this.model.created_at}}
-                <div><dt>{{i18n "user.created"}}</dt><dd>{{bound-date
-                      this.model.created_at
-                    }}</dd></div>
+                <div><dt class="created-at">{{i18n "user.created"}}</dt><dd
+                    class="created-at"
+                  >{{bound-date this.model.created_at}}</dd></div>
               {{/if}}
               {{#if this.model.last_posted_at}}
-                <div><dt>{{i18n "user.last_posted"}}</dt><dd>{{bound-date
+                <div><dt class="last-posted-at">{{i18n
+                      "user.last_posted"
+                    }}</dt><dd class="last-posted-at">{{bound-date
                       this.model.last_posted_at
                     }}</dd></div>
               {{/if}}
               {{#if this.model.last_seen_at}}
-                <div><dt>{{i18n "user.last_seen"}}</dt><dd>{{bound-date
-                      this.model.last_seen_at
-                    }}</dd></div>
+                <div><dt class="last-seen-at">{{i18n "user.last_seen"}}</dt><dd
+                    class="last-seen-at"
+                  >{{bound-date this.model.last_seen_at}}</dd></div>
               {{/if}}
               {{#if this.model.profile_view_count}}
-                <div><dt>{{i18n "views"}}</dt><dd
+                <div><dt class="profile-view-count">>{{i18n "views"}}</dt><dd
+                    class="profile-view-count"
                   >{{this.model.profile_view_count}}</dd></div>
               {{/if}}
               {{#if this.model.invited_by}}
@@ -372,8 +375,8 @@
                   >{{this.model.trustLevel.name}}</dd></div>
               {{/if}}
               {{#if this.canCheckEmails}}
-                <div><dt>{{i18n "user.email.title"}}</dt>
-                  <dd title={{this.model.email}}>
+                <div><dt class="email">{{i18n "user.email.title"}}</dt>
+                  <dd class="email" title={{this.model.email}}>
                     {{#if this.model.email}}
                       {{this.model.email}}
                     {{else}}


### PR DESCRIPTION
This change modifies the following section of a user's profile:

<img width="1121" alt="Screenshot 2023-02-24 at 1 43 24 PM" src="https://user-images.githubusercontent.com/22733864/221299110-ce0ce5ce-6607-4c8d-b778-b3b8213d5557.png">

Some of the `dt` and `dd` elements already included classes (e.g. `invited-by` and `groups`). This simply makes things consistent by adding classes to the other `dt` and `dd` elements and should allow for easier customization.