### PR TITLE
FIX: do not escape slash for category text description

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/categories-section/category-section-link.js
@@ -131,7 +131,7 @@ export default class CategorySectionLink {
   }
 
   get title() {
-    return this.category.description;
+    return this.category.description_text;
   }
 
   get text() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -615,7 +615,7 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
     assert.strictEqual(
       query(`.sidebar-section-link[data-category-id="${category.id}"]`).title,
-      category.description,
+      category.description_text,
       "category description without HTML entity is used as the link's title"
     );
   });

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -388,7 +388,7 @@ class Category < ActiveRecord::Base
     @@cache_text ||= LruRedux::ThreadSafeCache.new(1000)
     @@cache_text.getset(self.description) do
       text = Nokogiri::HTML5.fragment(self.description).text.strip
-      Rack::Utils.escape_html(text).html_safe
+      ERB::Util.html_escape(text).html_safe
     end
   end
 

--- a/spec/lib/category_badge_spec.rb
+++ b/spec/lib/category_badge_spec.rb
@@ -18,6 +18,6 @@ RSpec.describe CategoryBadge do
     c = Fabricate(:category, description: '<code>\' &lt;b id="x"&gt;</code>')
     html = CategoryBadge.html_for(c)
 
-    expect(html).to include("title='&#x27; &lt;b id=&quot;x&quot;&gt;'")
+    expect(html).to include("title='&#39; &lt;b id=&quot;x&quot;&gt;'")
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -400,8 +400,8 @@ RSpec.describe Category do
     it "correctly generates text description as needed" do
       c = Category.new
       expect(c.description_text).to be_nil
-      c.description = "&lt;hello <a>test</a>."
-      expect(c.description_text).to eq("&lt;hello test.")
+      c.description = "&lt;hello <a>foo/bar</a>."
+      expect(c.description_text).to eq("&lt;hello foo/bar.")
     end
   end
 


### PR DESCRIPTION
Original solution to use `description` instead of `text_description` was wrong: https://github.com/discourse/discourse/pull/20436

Problem is that we have to escape HTML tags.

<img width="282" alt="Screenshot 2023-02-27 at 10 33 28 am" src="https://user-images.githubusercontent.com/72780/221447911-558ef636-bb93-42a2-a18e-ee8a7beb4540.png">


However, we would like to use escape method which is keep `/` intact.   Expected behavior is given by  ERB::Util.html_escape instead of Rack::Utils.escape_html

/t/92015

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
