### PR TITLE
FIX: autocomplete failing for :(

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/autocomplete.js
+++ b/app/assets/javascripts/discourse/app/lib/autocomplete.js
@@ -618,7 +618,7 @@ export default function (options) {
           break;
         }
       }
-      prevIsGood = !allowedLettersRegex.test(prev);
+      prevIsGood = !/\s/.test(prev);
       if (completeTermOption) {
         prevIsGood ||= prev === " ";
       }


### PR DESCRIPTION
Composer was not completing :( (sad face) correctly given guessing of term
was not allowing for special chars.

New algorithm allows everything but space.

see: https://meta.discourse.org/t/some-emojis-added-with-enter-immediately-following-a-quote-will-break-the-quote/256219
