### PR TITLE
UX: fix banner overlapping issue at breakpoint of around 1260px width

### DIFF
--- a/app/assets/stylesheets/desktop/topic-list.scss
+++ b/app/assets/stylesheets/desktop/topic-list.scss
@@ -227,17 +227,6 @@
   }
 }
 
-@include breakpoint(large, $sidebar: true) {
-  .topic-list {
-    .topic-list-item .topic-list-data:first-of-type {
-      padding: 0.8em 0.33em;
-    }
-    .topic-list-data {
-      padding: 0.33em;
-    }
-  }
-}
-
 @include breakpoint(medium) {
   .nav-pills {
     > li > a {


### PR DESCRIPTION
There seems to be a breakpoint around 1260px width. When the window is narrower than that breakpoint, the “new or updated topics” banner seems to overlap the list below it.

Before:

![before](https://user-images.githubusercontent.com/11170663/221532440-338c1ed9-bf17-40c4-870c-900bb695b358.png)

After:

![after](https://user-images.githubusercontent.com/11170663/221532471-ffa9a657-ae61-4a1b-bfa7-e44794cdf140.png)
