### PR TITLE
UX: Skip applying link-type watched words to user custom fields

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1524,7 +1524,7 @@ class User < ActiveRecord::Base
   def apply_watched_words
     validatable_user_fields.each do |id, value|
       field = WordWatcher.censor_text(value)
-      field = WordWatcher.replace_text(field, watch_word_type: [:replace])
+      field = WordWatcher.replace_text(field)
       set_user_field(id, field)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1523,7 +1523,9 @@ class User < ActiveRecord::Base
 
   def apply_watched_words
     validatable_user_fields.each do |id, value|
-      set_user_field(id, WordWatcher.apply_to_text(value))
+      field = WordWatcher.censor_text(value)
+      field = WordWatcher.replace_text(field, watch_word_type: [:replace])
+      set_user_field(id, field)
     end
   end
 

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -130,20 +130,20 @@ class WordWatcher
     regexps.inject(text) { |txt, regexp| censor_text_with_regexp(txt, regexp) }
   end
 
-  def self.replace_text(text, watch_word_type: %i[replace link])
+  def self.replace_text(text)
     return text if text.blank?
+    replace(text, :replace)
+  end
 
-    watch_word_type
-      .flat_map { |type| word_matcher_regexps(type).to_a }
-      .reduce(text) do |t, (word_regexp, attrs)|
-        case_flag = attrs[:case_sensitive] ? nil : Regexp::IGNORECASE
-        replace_text_with_regexp(t, Regexp.new(word_regexp, case_flag), attrs[:replacement])
-      end
+  def self.replace_link(text)
+    return text if text.blank?
+    replace(text, :link)
   end
 
   def self.apply_to_text(text)
     text = censor_text(text)
     text = replace_text(text)
+    text = replace_link(text)
     text
   end
 
@@ -246,4 +246,15 @@ class WordWatcher
   end
 
   private_class_method :censor_text_with_regexp
+
+  private
+
+  def self.replace(text, watch_word_type)
+    word_matcher_regexps(watch_word_type)
+      .to_a
+      .reduce(text) do |t, (word_regexp, attrs)|
+        case_flag = attrs[:case_sensitive] ? nil : Regexp::IGNORECASE
+        replace_text_with_regexp(t, Regexp.new(word_regexp, case_flag), attrs[:replacement])
+      end
+  end
 end

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -130,10 +130,10 @@ class WordWatcher
     regexps.inject(text) { |txt, regexp| censor_text_with_regexp(txt, regexp) }
   end
 
-  def self.replace_text(text)
+  def self.replace_text(text, watch_word_type: %i[replace link])
     return text if text.blank?
 
-    %i[replace link]
+    watch_word_type
       .flat_map { |type| word_matcher_regexps(type).to_a }
       .reduce(text) do |t, (word_regexp, attrs)|
         case_flag = attrs[:case_sensitive] ? nil : Regexp::IGNORECASE

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -362,6 +362,23 @@ RSpec.describe User do
             end
           end
         end
+
+        context "when watched words are of type 'link'" do
+          let(:value) { "don't replace me" }
+          let!(:replace_word) do
+            Fabricate(
+              :watched_word,
+              word: "replace",
+              replacement: "touch",
+              action: WatchedWord.actions[:link],
+            )
+          end
+
+          it "does not replace anything" do
+            user.save!
+            expect(user_field_value).to eq value
+          end
+        end
       end
 
       context "when user fields do not contain watched words" do


### PR DESCRIPTION
We currently apply `type: :link` watched words to custom user fields.

This makes the user card pretty ugly because we don't allow html / links there.

![nathan's](https://d11a6trkgmumsb.cloudfront.net/original/4X/b/8/5/b8541e4318290bbfa83394c7959c83d7dfa4f8ca.png)

Additionally, the UI also does not say that we apply this to custom user fields, but only words in posts

<img width="472" alt="Screenshot 2023-02-27 at 7 58 15 PM" src="https://user-images.githubusercontent.com/1555215/221558001-db8bbcb0-ba2e-477f-bf2d-021a108dc810.png">

So this PR is to remove the replacement of link-type watch words for custom user fields.

Related: 
- https://meta.discourse.org/t/when-a-watched-word-link-is-in-a-user-field-it-is-changed-to-the-html-link-and-it-looks-terrible/234460
- /92440/42