### PR TITLE
UX: Fix large onebox avatars in img chat messages

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -141,7 +141,7 @@ aside.onebox {
       color: var(--tertiary);
     }
 
-    img:not(.avatar) {
+    img:not(.avatar, .onebox-avatar-inline) {
       max-height: 170px;
       max-width: 20%;
       @media all and (max-width: 600px) {

--- a/plugins/chat/assets/stylesheets/common/chat-message-images.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-images.scss
@@ -3,7 +3,9 @@ $max_image_height: 150px;
 .chat-message {
   // append selectors to set images to a
   // max height of $max_image_height
-  .chat-message-collapser .onebox img:not(.ytp-thumbnail-image),
+  .chat-message-collapser
+    .onebox
+    img:not(.ytp-thumbnail-image, .onebox-avatar-inline),
   .chat-message-collapser img.onebox,
   .chat-message-collapser .chat-uploads img,
   .chat-message-collapser p img,

--- a/plugins/chat/assets/stylesheets/desktop/desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/desktop.scss
@@ -39,7 +39,7 @@
 }
 
 .chat-message-text {
-  img:not(.emoji):not(.avatar) {
+  img:not(.emoji):not(.avatar, .onebox-avatar-inline) {
     transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
 
     &:hover {


### PR DESCRIPTION
When you included an image and a full-line (github) onebox in a single message the user avatar in the inbox would be incorrectly embiggened.

Before/after

<img width="400" alt="Screenshot 2023-02-27 at 19 21 31" src="https://user-images.githubusercontent.com/66961/221650165-ff007f8a-2154-4988-96bf-155ad8a8022e.png"> <img width="400" alt="Screenshot 2023-02-27 at 19 21 13" src="https://user-images.githubusercontent.com/66961/221650177-02e26b4a-1c0f-4cd7-a062-8a7f664509dc.png">
