### PR TITLE
FIX: mark posted as true for post authors in the TopicUser table during ensure_consistency task

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -30,6 +30,10 @@ end
 
 MS_SPEND_CREATING_POST ||= 5000
 
+# -- TODO: We need to check the queries are actually adding/updating the necessary
+# data, post migration. The ON CONFLICT DO NOTHING may cause the clauses to be ignored
+# when we actually need them to run.
+
 def insert_post_timings
   log "Inserting post timings..."
 


### PR DESCRIPTION
As reported [here](https://meta.discourse.org/t/posted-empty-with-a-phpbb3-import/256443), the `ensure_consistency` rake task was not marking `posted` as true for post authors in the TopicUser table, post migration. 

The TopicUser records are created with posted: false (the default) during migration at the `create_topic` step, more specifically [here](https://github.com/discourse/discourse/blob/main/lib/topic_creator.rb#L69). When the rake task reached [this point](https://github.com/discourse/discourse/blob/main/lib/tasks/import.rake#L60) the SQL gets a "duplicate key" error (the records already exist) and the step is skipped.

I decided to keep the `insert_topic_users`, and create another step to set `posted='t'`. I'm not sure if this task is run outside of migrations. But [here](https://github.com/discourse/discourse/blob/main/app/models/topic_user.rb#L525) could be another place to add this check