### PR TITLE
DEV: Add `digest` to licensed's default gems list (#20355)

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -15,6 +15,7 @@ ignored:
   bundler:
     - cgi # Ruby (default gem)
     - date # Ruby (default gem)
+    - digest # Ruby (default gem)
     - io-wait # Ruby (default gem)
     - json # Ruby (default gem)
     - net-http # Ruby (default gem)


### PR DESCRIPTION
Backport to `stable` in order to fix Licenses check in GitHub Actions.