### PR TITLE
DEV: Remove site setting "diags"

### DIFF
--- a/app/assets/javascripts/discourse/tests/fixtures/site-settings.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/site-settings.js
@@ -78,8 +78,5 @@ export default {
         value: "",
       },
     ],
-    diags: {
-      last_message_processed: null,
-    },
   },
 };

--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -6,7 +6,7 @@ class Admin::SiteSettingsController < Admin::AdminController
   end
 
   def index
-    render_json_dump(site_settings: SiteSetting.all_settings, diags: SiteSetting.diags)
+    render_json_dump(site_settings: SiteSetting.all_settings)
   end
 
   def update

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -323,16 +323,11 @@ module SiteSettingExtension
 
   def process_message(message)
     begin
-      @last_message_processed = message.global_id
       MessageBus.on_connect.call(message.site_id)
       refresh!
     ensure
       MessageBus.on_disconnect.call(message.site_id)
     end
-  end
-
-  def diags
-    { last_message_processed: @last_message_processed }
   end
 
   def process_id


### PR DESCRIPTION
Added almost exactly 10 years ago (in a2cca2540efc9a5b7a2091a98fb2e5153d395ca5), I don't think they're useful anymore 😅

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
