### PR TITLE
DEV: Switch My Posts link in sidebar to My Drafts when drafts are present

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
+++ b/app/assets/javascripts/discourse/app/lib/sidebar/user/community-section/my-posts-section-link.js
@@ -55,10 +55,17 @@ export default class MyPostsSectionLink extends BaseSectionLink {
   }
 
   get text() {
-    return I18n.t("sidebar.sections.community.links.my_posts.content");
+    if (this._hasDraft && this.currentUser?.new_new_view_enabled) {
+      return I18n.t("sidebar.sections.community.links.my_posts.content_drafts");
+    } else {
+      return I18n.t("sidebar.sections.community.links.my_posts.content");
+    }
   }
 
   get badgeText() {
+    if (this._hasDraft && this.currentUser?.new_new_view_enabled) {
+      return this.draftCount.toString();
+    }
     if (this._hasDraft && !this.hideCount) {
       return I18n.t("sidebar.sections.community.links.my_posts.draft_count", {
         count: this.draftCount,
@@ -71,6 +78,9 @@ export default class MyPostsSectionLink extends BaseSectionLink {
   }
 
   get prefixValue() {
+    if (this._hasDraft && this.currentUser?.new_new_view_enabled) {
+      return "pencil-alt";
+    }
     return "user";
   }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-community-section-test.js
@@ -583,6 +583,39 @@ acceptance("Sidebar - Logged on user - Community Section", function (needs) {
     );
   });
 
+  test("my posts changes its text when drafts are present and new new view experiment is enabled", async function (assert) {
+    updateCurrentUser({
+      sidebar_list_destination: "unread_new",
+      new_new_view_enabled: true,
+    });
+    await visit("/");
+
+    assert.strictEqual(
+      query(".sidebar-section-link-my-posts").textContent.trim(),
+      I18n.t("sidebar.sections.community.links.my_posts.content"),
+      "displays the default text when no drafts are present"
+    );
+
+    await publishToMessageBus(`/user-drafts/${loggedInUser().id}`, {
+      draft_count: 1,
+    });
+
+    assert.strictEqual(
+      query(
+        ".sidebar-section-link-my-posts .sidebar-section-link-content-text"
+      ).textContent.trim(),
+      I18n.t("sidebar.sections.community.links.my_posts.content_drafts"),
+      "displays the text that's appropriate for when drafts are present"
+    );
+    assert.strictEqual(
+      query(
+        ".sidebar-section-link-my-posts .sidebar-section-link-content-badge"
+      ).textContent.trim(),
+      "1",
+      "displays the draft count with no text"
+    );
+  });
+
   test("visiting top route", async function (assert) {
     await visit("/top");
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4438,6 +4438,7 @@ en:
               title: "List of all users"
             my_posts:
               content: "My Posts"
+              content_drafts: "My Drafts"
               title: "My recent topic activity"
               title_drafts: "My unposted drafts"
               draft_count:


### PR DESCRIPTION
Related to https://github.com/discourse/discourse/commit/a5094411487f3fa5d1b7922717104ae4c80e5bfd.

We're experimenting with showing counts with no text next to links in the sidebar. This PR drops the word "drafts" from the "My Posts" link and instead switches the link's text to "My Drafts" when there drafts are present.

Before:

<img width=200 src="https://user-images.githubusercontent.com/17474474/222015604-0448ff62-a099-4962-a2c9-c8b3e0e2691c.png">

After:

<img width=200 src="https://user-images.githubusercontent.com/17474474/222016179-c6ccb6fb-a7a5-49a2-9198-097b9e562bff.png">

Internal topic: t/77234.