### PR TITLE
FIX: only show approved users when must_approve_users enabled

### DIFF
--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -26,6 +26,7 @@ class UserSearch
 
   def scoped_users
     users = User.where(active: true)
+    users = users.where(approved: true) if SiteSetting.must_approve_users?
     users = users.where(staged: false) unless @include_staged_users
     users = users.not_suspended unless @searching_user&.staff?
 

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -226,6 +226,18 @@ RSpec.describe UserSearch do
       expect(results).to be_blank
     end
 
+    it "does not show unapproved users when must_approve_users enabled" do
+      SiteSetting.must_approve_users = true
+      unapproved = Fabricate(:user, username: "mrunapproved", active: true, approved: false)
+      approved = Fabricate(:user, username: "mrapproved", active: true, approved: true)
+
+      users = search_for(unapproved.username)
+      expect(users).to be_blank
+
+      users = search_for(approved.username)
+      expect(users).not_to be_blank
+    end
+
     it "prioritises exact matches" do
       results = search_for("mrB")
       expect(results).to eq [mr_b, mr_brown, mr_blue].map(&:username)


### PR DESCRIPTION
When site setting is enabled for **must_approve_users**, non approved users are appearing when tagging users on topics.

Added a check for the site setting within the user search model and only return those users with approved: true.

Bug details found here: t/non-approved-users-displaying-in-autocomplete

