### PR TITLE
DEV: Fix slow topics_controller_spec regression

### DIFF
--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -36,21 +36,7 @@ RSpec.describe TopicsController do
 
   fab!(:tag) { Fabricate(:tag) }
 
-  before do
-    [
-      user,
-      user_2,
-      post_author1,
-      post_author2,
-      post_author3,
-      post_author4,
-      post_author5,
-      post_author6,
-      trust_level_0,
-      trust_level_1,
-      trust_level_4,
-    ].each { |u| Group.user_trust_level_change!(u.id, u.trust_level) }
-  end
+  before { SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:everyone] }
 
   describe "#wordpress" do
     before { sign_in(moderator) }
@@ -2141,6 +2127,7 @@ RSpec.describe TopicsController do
     end
 
     it "does not result in N+1 queries problem when multiple topic participants have primary or flair group configured" do
+      Group.user_trust_level_change!(post_author1.id, post_author1.trust_level)
       user2 = Fabricate(:user)
       user3 = Fabricate(:user)
       post2 = Fabricate(:post, topic: topic, user: user2)
@@ -4201,6 +4188,7 @@ RSpec.describe TopicsController do
 
       it "allows a category moderator to create a delete timer" do
         user.update!(trust_level: TrustLevel[4])
+        Group.user_trust_level_change!(user.id, user.trust_level)
         topic.category.update!(reviewable_by_group: user.groups.first)
 
         sign_in(user)


### PR DESCRIPTION
This commit e62e93f83a77adfa80b38fbfecf82bbee14e12fe slowed
down the spec, making it take ~4m in CI and a long time
locally.

This commit fixes the issue by just not doing the work in
the before block, it was not necessary, all we really need
to do is make sure everyone can PM.

54.37s -> 22.98s locally
