### PR TITLE
DEV: Move plugin about stats registration to DiscoursePluginRegistry

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -108,6 +108,8 @@ class DiscoursePluginRegistry
 
   define_filtered_register :search_groups_set_query_callbacks
 
+  define_filtered_register :about_stat_groups
+
   def self.register_auth_provider(auth_provider)
     self.auth_providers << auth_provider
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1129,7 +1129,17 @@ class Plugin::Instance
   # table. Some stats may be needed purely for reporting purposes and thus
   # do not need to be shown in the UI to admins/users.
   def register_about_stat_group(plugin_stat_group_name, show_in_ui: false, &block)
-    About.add_plugin_stat_group(plugin_stat_group_name, show_in_ui: show_in_ui, &block)
+    # We do not want to register and display the same group multiple times.
+    if DiscoursePluginRegistry.about_stat_groups.any? { |stat_group|
+         stat_group[:name] == plugin_stat_group_name
+       }
+      return
+    end
+
+    DiscoursePluginRegistry.register_about_stat_group(
+      { name: plugin_stat_group_name, show_in_ui: show_in_ui, block: block },
+      self,
+    )
   end
 
   ##

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -769,7 +769,7 @@ RSpec.describe Plugin::Instance do
   describe "#register_about_stat_group" do
     let(:plugin) { Plugin::Instance.new }
 
-    after { About.clear_plugin_stat_groups }
+    after { DiscoursePluginRegistry.reset! }
 
     it "registers an about stat group correctly" do
       stats = { :last_day => 1, "7_days" => 10, "30_days" => 100, :count => 1000 }
@@ -788,6 +788,13 @@ RSpec.describe Plugin::Instance do
       stats = { :last_day => 1, "7_days" => 10, "30_days" => 100, :count => 1000 }
       plugin.register_about_stat_group("some_group") { stats }
       expect(About.displayed_plugin_stat_groups).to eq([])
+    end
+
+    it "does not allow duplicate named stat groups" do
+      stats = { :last_day => 1, "7_days" => 10, "30_days" => 100, :count => 1000 }
+      plugin.register_about_stat_group("some_group") { stats }
+      plugin.register_about_stat_group("some_group") { stats }
+      expect(DiscoursePluginRegistry.about_stat_groups.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
Follow up to 098ab29d4150a5a39880d59ef6cad5f6795a18fd. Since
we just used a `cattr_reader` on `About` this was not safe
for multisite, since some sites could have the chat plugin
enabled and some may not. Using `DiscoursePluginRegistry` gets
around this issue, and makes it so the chat stats only show
for a site if `chat_enabled` is true.
