### PR TITLE
FIX: Allow floats for zoom level in Google Maps onebox

### DIFF
--- a/lib/onebox/engine/google_maps_onebox.rb
+++ b/lib/onebox/engine/google_maps_onebox.rb
@@ -96,7 +96,7 @@ module Onebox
           # Fallback for map URLs that don't resolve into an easily embeddable old-style URI
           # Roadmaps use a "z" zoomlevel, satellite maps use "m" the horizontal width in meters
           # TODO: tilted satellite maps using "a,y,t"
-          match = @url.match(/@(?<lon>[\d.-]+),(?<lat>[\d.-]+),(?<zoom>\d+)(?<mz>[mz])/)
+          match = @url.match(/@(?<lon>[\d.-]+),(?<lat>[\d.-]+),(?<zoom>\d+)(\.\d+)?(?<mz>[mz])/)
           raise "unexpected standard url #{@url}" unless match
           zoom = match[:mz] == "z" ? match[:zoom] : Math.log2(57280048.0 / match[:zoom].to_f).round
           location = "#{match[:lon]},#{match[:lat]}"

--- a/spec/lib/onebox/engine/google_maps_onebox_spec.rb
+++ b/spec/lib/onebox/engine/google_maps_onebox_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe Onebox::Engine::GoogleMapsOnebox do
     },
     unresolveable: {
       test:
-        "https://www.google.com/maps/place/Den+Abattoir/@51.2285173,4.4336702,17z/data=!4m7!1m4!3m3!1s0x47c3f7a5ac48e237:0x63d716018f584a33!2zUGnDqXRyYWlu!3b1!3m1!1s0x0000000000000000:0xfbfac0c41c32471a",
+        "https://www.google.com/maps/place/Den+Abattoir/@51.2285173,4.4336702,17.5z/data=!4m7!1m4!3m3!1s0x47c3f7a5ac48e237:0x63d716018f584a33!2zUGnDqXRyYWlu!3b1!3m1!1s0x0000000000000000:0xfbfac0c41c32471a",
       redirect: [
         302,
-        "https://www.google.com/maps/place/Den+Abattoir/@51.2285173,4.4336702,17z/data=!4m7!1m4!3m3!1s0x47c3f7a5ac48e237:0x63d716018f584a33!2zUGnDqXRyYWlu!3b1!3m1!1s0x0000000000000000:0xfbfac0c41c32471a?dg=dbrw&newdg=1",
+        "https://www.google.com/maps/place/Den+Abattoir/@51.2285173,4.4336702,17.5z/data=!4m7!1m4!3m3!1s0x47c3f7a5ac48e237:0x63d716018f584a33!2zUGnDqXRyYWlu!3b1!3m1!1s0x0000000000000000:0xfbfac0c41c32471a?dg=dbrw&newdg=1",
       ],
       expect:
         "https://maps.google.com/maps?ll=51.2285173,4.4336702&z=17&output=embed&dg=ntvb&q=Den+Abattoir&cid=18157036796216755994",


### PR DESCRIPTION
Sometimes we get Maps URL containing a zoom level as a float (17.5z and not 17z) but this doesn’t work with our current onebox implementation.

While Google accepts those float zoom levels, it removes automatically the floating part in the URL (thus when visiting a Maps URL containing 17.5z, the URL will be rewritten shortly after as 17z). When putting a float zoom level in an embedded URL, this actually breaks (Maps API returns a 400 error).

This PR addresses the issue by allowing the onebox engine to match on a zoom level expressed as a float but we only keep the integer part, thus rendering properly maps.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
