### PR TITLE
DEV: Show active categories in form templates customize table

### DIFF
--- a/app/assets/javascripts/admin/addon/components/form-template/row-item.hbs
+++ b/app/assets/javascripts/admin/addon/components/form-template/row-item.hbs
@@ -1,5 +1,10 @@
 <tr class="admin-list-item">
   <td class="col first">{{@template.name}}</td>
+  <td class="col categories">
+    {{#each this.activeCategories as |category|}}
+      {{category-link category}}
+    {{/each}}
+  </td>
   <td class="col action">
     <DButton
       @title="admin.form_templates.list_table.actions.view"

--- a/app/assets/javascripts/admin/addon/components/form-template/row-item.js
+++ b/app/assets/javascripts/admin/addon/components/form-template/row-item.js
@@ -9,6 +9,13 @@ import I18n from "I18n";
 export default class FormTemplateRowItem extends Component {
   @service router;
   @service dialog;
+  @service site;
+
+  get activeCategories() {
+    return this.site?.categories?.filter((c) =>
+      c["form_template_ids"].includes(this.args.template.id)
+    );
+  }
 
   @action
   viewTemplate() {

--- a/app/assets/javascripts/admin/addon/templates/customize-form-templates-index.hbs
+++ b/app/assets/javascripts/admin/addon/templates/customize-form-templates-index.hbs
@@ -7,6 +7,9 @@
         <th class="col heading">
           {{i18n "admin.form_templates.list_table.headings.name"}}
         </th>
+        <th class="col heading">
+          {{i18n "admin.form_templates.list_table.headings.active_categories"}}
+        </th>
         <th class="col heading sr-only">
           {{i18n "admin.form_templates.list_table.headings.actions"}}
         </th>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5538,6 +5538,7 @@ en:
         list_table:
           headings:
             name: "Name"
+            active_categories: "Active Categories"
             actions: "Actions"
           actions:
             view: "View Template"

--- a/spec/system/admin_customize_form_templates_spec.rb
+++ b/spec/system/admin_customize_form_templates_spec.rb
@@ -5,6 +5,9 @@ describe "Admin Customize Form Templates", type: :system, js: true do
   let(:ace_editor) { PageObjects::Components::AceEditor.new }
   fab!(:admin) { Fabricate(:admin) }
   fab!(:form_template) { Fabricate(:form_template) }
+  fab!(:category) do
+    Fabricate(:category, name: "Cool Category", slug: "cool-cat", topic_count: 3234)
+  end
 
   before do
     SiteSetting.experimental_form_templates = true
@@ -12,10 +15,18 @@ describe "Admin Customize Form Templates", type: :system, js: true do
   end
 
   describe "when visiting the page to customize form templates" do
+    before { category.update(form_template_ids: [form_template.id]) }
+
     it "should show the existing form templates in a table" do
       visit("/admin/customize/form-templates")
       expect(form_template_page).to have_form_template_table
       expect(form_template_page).to have_form_template(form_template.name)
+    end
+
+    it "should show the categories the form template is used in" do
+      visit("/admin/customize/form-templates")
+      expect(form_template_page).to have_form_template_table
+      expect(form_template_page).to have_category_in_template_row(category.name)
     end
 
     it "should show the form template structure in a modal" do

--- a/spec/system/page_objects/pages/form_template.rb
+++ b/spec/system/page_objects/pages/form_template.rb
@@ -21,6 +21,10 @@ module PageObjects
         find(".form-templates__table tbody tr td", text: name).present?
       end
 
+      def has_category_in_template_row?(category_name)
+        find(".form-templates__table .categories .category-name", text: category_name).present?
+      end
+
       def has_template_structure?(structure)
         find("code", text: structure).present?
       end


### PR DESCRIPTION
> Note: This PR is part of the in progress experimental_form_templates feature

⭐ **This PR** updates the table structure in `Admin > Customize > Templates` to show which categories a form template is currently active in.

**Before**
<img width="1083" alt="Screenshot 2023-03-01 at 11 55 14" src="https://user-images.githubusercontent.com/30090424/222251452-374c0611-1bd3-47b3-9d5d-c7ea9bcffafa.png">

**After**
<img width="1081" alt="Screenshot 2023-03-01 at 11 54 44" src="https://user-images.githubusercontent.com/30090424/222251361-5c8e29fe-52a7-4646-8696-5d352064f01a.png">

