### PR TITLE
FEATURE: allow external links in custom sidebar sections

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.hbs
@@ -7,7 +7,7 @@
       <a
         href={{@href}}
         rel="noopener noreferrer"
-        target="_blank"
+        target={{this.target}}
         class={{this.classNames}}
         title={{@title}}
         ...attributes

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -1,6 +1,9 @@
 import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
 
 export default class SectionLink extends Component {
+  @service currentUser;
+
   willDestroy() {
     if (this.args.willDestroy) {
       this.args.willDestroy();
@@ -33,6 +36,12 @@ export default class SectionLink extends Component {
     }
 
     return classNames.join(" ");
+  }
+
+  get target() {
+    return this.currentUser.user_option.external_links_in_new_tab
+      ? "_blank"
+      : "_self";
   }
 
   get models() {

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
@@ -8,15 +8,25 @@
       @headerActionsIcon="pencil-alt"
     >
       {{#each section.links as |link|}}
-        <Sidebar::SectionLink
-          @linkName={{link.name}}
-          @route={{link.route}}
-          @models={{link.models}}
-          @query={{link.query}}
-          @content={{replace-emoji link.name}}
-          @prefixType="icon"
-          @prefixValue={{link.icon}}
-        />
+        {{#if link.external}}
+          <Sidebar::SectionLink
+            @linkName={{link.name}}
+            @content={{replace-emoji link.name}}
+            @prefixType="icon"
+            @prefixValue={{link.icon}}
+            @href={{link.value}}
+          />
+        {{else}}
+          <Sidebar::SectionLink
+            @linkName={{link.name}}
+            @route={{link.route}}
+            @models={{link.models}}
+            @query={{link.query}}
+            @content={{replace-emoji link.name}}
+            @prefixType="icon"
+            @prefixValue={{link.icon}}
+          />
+        {{/if}}
       {{/each}}
     </Sidebar::Section>
   {{/each}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
@@ -39,10 +39,14 @@ export default class SidebarUserCustomSections extends Component {
           ? htmlSafe(`${iconHTML("globe")} ${section.title}`)
           : section.title;
       section.links.forEach((link) => {
-        const routeInfoHelper = new RouteInfoHelper(this.router, link.value);
-        link.route = routeInfoHelper.route;
-        link.models = routeInfoHelper.models;
-        link.query = routeInfoHelper.query;
+        if (link.value.startsWith("http", "https")) {
+          link.external = true;
+        } else {
+          const routeInfoHelper = new RouteInfoHelper(this.router, link.value);
+          link.route = routeInfoHelper.route;
+          link.models = routeInfoHelper.models;
+          link.query = routeInfoHelper.query;
+        }
       });
     });
     return this.currentUser.sidebarSections;

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
@@ -39,9 +39,7 @@ export default class SidebarUserCustomSections extends Component {
           ? htmlSafe(`${iconHTML("globe")} ${section.title}`)
           : section.title;
       section.links.forEach((link) => {
-        if (link.value.startsWith("http", "https")) {
-          link.external = true;
-        } else {
+        if (!link.external) {
           const routeInfoHelper = new RouteInfoHelper(this.router, link.value);
           link.route = routeInfoHelper.route;
           link.models = routeInfoHelper.models;

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -94,7 +94,7 @@ class SectionLink {
     }
   }
 
-  get validInternal() {
+  #validInternal() {
     if (!this.internal) {
       return false;
     }

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -148,6 +148,7 @@ export default Controller.extend(ModalFunctionality, {
                 icon: link.icon,
                 name: link.name,
                 value: link.value,
+                external: !link.internal,
                 id: link.id,
               })
           )
@@ -174,6 +175,7 @@ export default Controller.extend(ModalFunctionality, {
             icon: link.icon,
             name: link.name,
             value: link.path,
+            external: !link.internal,
           };
         }),
       }),

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -205,6 +205,7 @@ export default Controller.extend(ModalFunctionality, {
             icon: link.icon,
             name: link.name,
             value: link.path,
+            external: link.external,
             _destroy: link._destroy,
           };
         }),

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -77,14 +77,36 @@ class SectionLink {
     return this.name === undefined || this.validName ? "" : "warning";
   }
 
+  get internal() {
+    return (
+      this.value.startsWith(this.protocolAndHost) || this.value.startsWith("/")
+    );
+  }
+
+  get validExternal() {
+    if (this.internal) {
+      return false;
+    }
+    try {
+      return new URL(this.value);
+    } catch {
+      return false;
+    }
+  }
+
+  get validInternal() {
+    if (!this.internal) {
+      return false;
+    }
+    return this.internal && this.router.recognize(this.path).name !== "unknown";
+  }
+
   get validValue() {
     return (
       !isEmpty(this.value) &&
-      (this.value.startsWith(this.protocolAndHost) ||
-        this.value.startsWith("/")) &&
       this.value.length <= 200 &&
       this.path &&
-      this.router.recognize(this.path).name !== "unknown"
+      (this.validExternal || this.validInternal)
     );
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -83,7 +83,7 @@ class SectionLink {
     );
   }
 
-  get validExternal() {
+  #validExternal() {
     if (this.internal) {
       return false;
     }

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -46,9 +46,6 @@ class SectionLink {
     this.icon = icon || "link";
     this.name = name;
     this.value = value;
-    if (this.internal) {
-      this.value = `${this.httpsHost}${value}`;
-    }
     this.id = id;
   }
 
@@ -84,12 +81,14 @@ class SectionLink {
     return this.name === undefined || this.validName ? "" : "warning";
   }
 
-  get internal() {
+  get external() {
     return (
       this.value &&
-      (this.value.startsWith(this.httpHost) ||
+      !(
+        this.value.startsWith(this.httpHost) ||
         this.value.startsWith(this.httpsHost) ||
-        this.value.startsWith("/"))
+        this.value.startsWith("/")
+      )
     );
   }
 
@@ -106,12 +105,12 @@ class SectionLink {
   }
 
   get validValue() {
-    return !isEmpty(this.value) &&
+    return (
+      !isEmpty(this.value) &&
       this.value.length <= 200 &&
       this.path &&
-      this.internal
-      ? this.#validInternal()
-      : this.#validExternal();
+      (this.external ? this.#validExternal() : this.#validInternal())
+    );
   }
 
   get valueCssClass() {
@@ -148,7 +147,7 @@ export default Controller.extend(ModalFunctionality, {
                 icon: link.icon,
                 name: link.name,
                 value: link.value,
-                external: !link.internal,
+                external: link.external,
                 id: link.id,
               })
           )
@@ -175,7 +174,7 @@ export default Controller.extend(ModalFunctionality, {
             icon: link.icon,
             name: link.name,
             value: link.path,
-            external: !link.internal,
+            external: link.external,
           };
         }),
       }),

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -141,7 +141,6 @@ export default Controller.extend(ModalFunctionality, {
                 icon: link.icon,
                 name: link.name,
                 value: link.value,
-                external: link.external,
                 id: link.id,
               })
           )
@@ -168,7 +167,6 @@ export default Controller.extend(ModalFunctionality, {
             icon: link.icon,
             name: link.name,
             value: link.path,
-            external: link.external,
           };
         }),
       }),

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -106,7 +106,7 @@ class SectionLink {
       !isEmpty(this.value) &&
       this.value.length <= 200 &&
       this.path &&
-      (this.validExternal || this.validInternal)
+      this.internal ? this.validInternal : this.validExternal
     );
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -47,14 +47,8 @@ class SectionLink {
     this.name = name;
     this.value = value;
     this.id = id;
-  }
-
-  get httpHost() {
-    return "http://" + window.location.host;
-  }
-
-  get httpsHost() {
-    return "https://" + window.location.host;
+    this.httpHost = "http://" + window.location.host;
+    this.httpsHost = "https://" + window.location.host;
   }
 
   get path() {

--- a/app/assets/javascripts/discourse/tests/integration/components/sidebar/section-link-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/sidebar/section-link-test.js
@@ -54,4 +54,19 @@ module("Integration | Component | sidebar | section-link", function (hooks) {
       "has the right class attribute for the link"
     );
   });
+
+  test("target attribute for link", async function (assert) {
+    const template = hbs`<Sidebar::SectionLink @linkName="test" @href="https://discourse.org" />`;
+    await render(template);
+
+    assert.strictEqual(query("a").target, "_self");
+  });
+
+  test("target attribute for link when user set external links in new tab", async function (assert) {
+    this.currentUser.user_option.external_links_in_new_tab = true;
+    const template = hbs`<Sidebar::SectionLink @linkName="test" @href="https://discourse.org" />`;
+    await render(template);
+
+    assert.strictEqual(query("a").target, "_blank");
+  });
 });

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -79,7 +79,7 @@ class SidebarSectionsController < ApplicationController
   end
 
   def links_params
-    params.permit(links: %i[icon name value id _destroy])["links"]
+    params.permit(links: %i[icon name value id external _destroy])["links"]
   end
 
   def check_if_member_of_group

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -79,7 +79,7 @@ class SidebarSectionsController < ApplicationController
   end
 
   def links_params
-    params.permit(links: %i[icon name value id external _destroy])["links"]
+    params.permit(links: %i[icon name value id _destroy])["links"]
   end
 
   def check_if_member_of_group

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -8,12 +8,20 @@ class SidebarUrl < ActiveRecord::Base
   validate :path_validator
 
   def path_validator
-    Rails.application.routes.recognize_path(value)
+    if external?
+      raise ActionController::RoutingError if value !~ Discourse::Utils::URI_REGEXP
+    else
+      Rails.application.routes.recognize_path(value)
+    end
   rescue ActionController::RoutingError
     errors.add(
       :value,
       I18n.t("activerecord.errors.models.sidebar_section_link.attributes.linkable_type.invalid"),
     )
+  end
+
+  def external?
+    value.start_with?("http://", "https://")
   end
 end
 

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -7,6 +7,8 @@ class SidebarUrl < ActiveRecord::Base
 
   validate :path_validator
 
+  before_save :set_external
+
   def path_validator
     if external?
       raise ActionController::RoutingError if value !~ Discourse::Utils::URI_REGEXP
@@ -18,6 +20,10 @@ class SidebarUrl < ActiveRecord::Base
       :value,
       I18n.t("activerecord.errors.models.sidebar_section_link.attributes.linkable_type.invalid"),
     )
+  end
+
+  def set_external
+    self.external = value.start_with?("http://", "https://")
   end
 end
 

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -19,10 +19,6 @@ class SidebarUrl < ActiveRecord::Base
       I18n.t("activerecord.errors.models.sidebar_section_link.attributes.linkable_type.invalid"),
     )
   end
-
-  def external?
-    value.start_with?("http://", "https://")
-  end
 end
 
 # == Schema Information

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -26,7 +26,8 @@ class SidebarUrl < ActiveRecord::Base
     self.value =
       self
         .value
-        .sub(/\Ahttp(s)?://#{Discourse.current_hostname}\z/, "")
+        .sub("http://#{Discourse.current_hostname}", "")
+        .sub("https://#{Discourse.current_hostname}", "")
   end
 
   def set_external

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -31,4 +31,5 @@ end
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  icon       :string(40)       not null
+#  external   :boolean          default(FALSE), not null
 #

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -7,7 +7,7 @@ class SidebarUrl < ActiveRecord::Base
 
   validate :path_validator
 
-  before_save :set_external
+  before_save :remove_internal_hostname, :set_external
 
   def path_validator
     if external?
@@ -20,6 +20,14 @@ class SidebarUrl < ActiveRecord::Base
       :value,
       I18n.t("activerecord.errors.models.sidebar_section_link.attributes.linkable_type.invalid"),
     )
+  end
+
+  def remove_internal_hostname
+    self.value =
+      self
+        .value
+        .sub("http://#{Discourse.current_hostname}", "")
+        .sub("https://#{Discourse.current_hostname}", "")
   end
 
   def set_external

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -23,11 +23,7 @@ class SidebarUrl < ActiveRecord::Base
   end
 
   def remove_internal_hostname
-    self.value =
-      self
-        .value
-        .sub("http://#{Discourse.current_hostname}", "")
-        .sub("https://#{Discourse.current_hostname}", "")
+    self.value = self.value.sub(%r{\Ahttp(s)?://#{Discourse.current_hostname}}, "")
   end
 
   def set_external

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -26,8 +26,7 @@ class SidebarUrl < ActiveRecord::Base
     self.value =
       self
         .value
-        .sub("http://#{Discourse.current_hostname}", "")
-        .sub("https://#{Discourse.current_hostname}", "")
+        .sub(/\Ahttp(s)?://#{Discourse.current_hostname}\z/, "")
   end
 
   def set_external

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2399,6 +2399,7 @@ en:
     enable_new_notifications_menu: "Enables the new notifications menu for the legacy navigation menu."
     enable_experimental_hashtag_autocomplete: "EXPERIMENTAL: Use the new #hashtag autocompletion system for categories and tags that renders the selected item differently and has improved search"
     experimental_new_new_view_groups: "EXPERIMENTAL: Enable a new topics list that combines unread and new topics and make the \"Everything\" link in the sidebar link to it."
+    enable_custom_sidebar_sections: "EXPERIMENTAL: Enable custom sidebar sections"
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2116,7 +2116,6 @@ navigation:
     default: ""
     allow_any: false
     refresh: true
-    hidden: false
 
 embedding:
   embed_by_username:

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2116,7 +2116,7 @@ navigation:
     default: ""
     allow_any: false
     refresh: true
-    hidden: true
+    hidden: false
 
 embedding:
   embed_by_username:

--- a/db/migrate/20230303015952_add_external_to_sidebar_urls.rb
+++ b/db/migrate/20230303015952_add_external_to_sidebar_urls.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExternalToSidebarUrls < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sidebar_urls, :external, :boolean, default: false, null: false
+  end
+end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe SidebarSectionsController do
                  icon: "external-link-alt",
                  name: "Discourse",
                  value: "https://discourse.org",
-                 external: true,
                },
              ],
            }

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -56,7 +56,12 @@ RSpec.describe SidebarSectionsController do
              links: [
                { icon: "link", name: "categories", value: "/categories" },
                { icon: "address-book", name: "tags", value: "/tags" },
-               { icon: "external-link-alt", name: "Discourse", value: "https://discourse.org" },
+               {
+                 icon: "external-link-alt",
+                 name: "Discourse",
+                 value: "https://discourse.org",
+                 external: true,
+               },
              ],
            }
 
@@ -73,12 +78,15 @@ RSpec.describe SidebarSectionsController do
       expect(sidebar_section.sidebar_urls.first.icon).to eq("link")
       expect(sidebar_section.sidebar_urls.first.name).to eq("categories")
       expect(sidebar_section.sidebar_urls.first.value).to eq("/categories")
+      expect(sidebar_section.sidebar_urls.first.external).to be false
       expect(sidebar_section.sidebar_urls.second.icon).to eq("address-book")
       expect(sidebar_section.sidebar_urls.second.name).to eq("tags")
       expect(sidebar_section.sidebar_urls.second.value).to eq("/tags")
+      expect(sidebar_section.sidebar_urls.second.external).to be false
       expect(sidebar_section.sidebar_urls.third.icon).to eq("external-link-alt")
       expect(sidebar_section.sidebar_urls.third.name).to eq("Discourse")
       expect(sidebar_section.sidebar_urls.third.value).to eq("https://discourse.org")
+      expect(sidebar_section.sidebar_urls.third.external).to be true
     end
 
     it "does not allow regular user to create public section" do

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe SidebarSectionsController do
              links: [
                { icon: "link", name: "categories", value: "/categories" },
                { icon: "address-book", name: "tags", value: "/tags" },
+               { icon: "external-link-alt", name: "Discourse", value: "https://discourse.org" },
              ],
            }
 
@@ -68,13 +69,16 @@ RSpec.describe SidebarSectionsController do
       expect(sidebar_section.user).to eq(user)
       expect(sidebar_section.public).to be false
       expect(UserHistory.count).to eq(0)
-      expect(sidebar_section.sidebar_urls.count).to eq(2)
+      expect(sidebar_section.sidebar_urls.count).to eq(3)
       expect(sidebar_section.sidebar_urls.first.icon).to eq("link")
       expect(sidebar_section.sidebar_urls.first.name).to eq("categories")
       expect(sidebar_section.sidebar_urls.first.value).to eq("/categories")
       expect(sidebar_section.sidebar_urls.second.icon).to eq("address-book")
       expect(sidebar_section.sidebar_urls.second.name).to eq("tags")
       expect(sidebar_section.sidebar_urls.second.value).to eq("/tags")
+      expect(sidebar_section.sidebar_urls.third.icon).to eq("external-link-alt")
+      expect(sidebar_section.sidebar_urls.third.name).to eq("Discourse")
+      expect(sidebar_section.sidebar_urls.third.value).to eq("https://discourse.org")
     end
 
     it "does not allow regular user to create public section" do

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -54,7 +54,11 @@ RSpec.describe SidebarSectionsController do
            params: {
              title: "custom section",
              links: [
-               { icon: "link", name: "categories", value: "/categories" },
+               {
+                 icon: "link",
+                 name: "categories",
+                 value: "http://#{Discourse.current_hostname}/categories",
+               },
                { icon: "address-book", name: "tags", value: "/tags" },
                {
                  icon: "external-link-alt",

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -60,11 +60,7 @@ RSpec.describe SidebarSectionsController do
                  value: "http://#{Discourse.current_hostname}/categories",
                },
                { icon: "address-book", name: "tags", value: "/tags" },
-               {
-                 icon: "external-link-alt",
-                 name: "Discourse",
-                 value: "https://discourse.org",
-               },
+               { icon: "external-link-alt", name: "Discourse", value: "https://discourse.org" },
              ],
            }
 

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -34,6 +34,25 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(page).to have_link("Sidebar Tags")
   end
 
+  it "allows the user to create custom section with external link" do
+    visit("/latest")
+    sidebar.open_new_custom_section
+
+    expect(section_modal).to be_visible
+    expect(section_modal).to have_disabled_save
+    expect(find("#discourse-modal-title")).to have_content("Add custom section")
+
+    section_modal.fill_name("My section")
+
+    section_modal.fill_link("Discourse Homepage", "https://discourse.org")
+    expect(section_modal).to have_enabled_save
+
+    section_modal.save
+
+    expect(page).to have_button("My section")
+    expect(page).to have_link("Discourse Homepage", href: "https://discourse.org")
+  end
+
   it "allows the user to edit custom section" do
     sidebar_section = Fabricate(:sidebar_section, title: "My section", user: user)
     sidebar_url_1 = Fabricate(:sidebar_url, name: "Sidebar Tags", value: "/tags")

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -39,7 +39,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     sidebar.open_new_custom_section
 
     expect(section_modal).to be_visible
-    expect(section_modal).to have_disabled_save
+    expect(section_modal).to have_disabled_save_button
     expect(find("#discourse-modal-title")).to have_content("Add custom section")
 
     section_modal.fill_name("My section")

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -45,7 +45,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     section_modal.fill_name("My section")
 
     section_modal.fill_link("Discourse Homepage", "https://discourse.org")
-    expect(section_modal).to have_enabled_save
+    expect(section_modal).to have_enabled_save_button
 
     section_modal.save
 

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -31,7 +31,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     section_modal.save
 
     expect(page).to have_button("My section")
-    sidebar.has_link?("Sidebar Tags")
+    expect(sidebar).to have_link("Sidebar Tags")
   end
 
   it "allows the user to create custom section with external link" do
@@ -53,7 +53,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     section_modal.save
 
     expect(page).to have_button("My section")
-    sidebar.has_link?("Discourse Homepage", href: "https://discourse.org")
+    expect(sidebar).to have_link("Discourse Homepage", href: "https://discourse.org")
   end
 
   it "allows the user to edit custom section" do
@@ -75,7 +75,8 @@ describe "Custom sidebar sections", type: :system, js: true do
     section_modal.save
 
     expect(page).to have_button("Edited section")
-    sidebar.has_link?("Edited Tags")
+    expect(sidebar).to have_link("Edited Tag")
+
     expect(page).not_to have_link("Sidebar Categories")
   end
 
@@ -122,7 +123,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     section_modal.save
 
     expect(page).to have_button("Public section")
-    sidebar.has_link?("Sidebar Tags")
+    expect(sidebar).to have_link("Sidebar Tags")
     expect(page).to have_css(".sidebar-section-public-section .d-icon-globe")
 
     sidebar.edit_custom_section("Public section")

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -21,7 +21,7 @@ describe "Custom sidebar sections", type: :system, js: true do
 
     expect(section_modal).to be_visible
     expect(section_modal).to have_disabled_save
-    expect(find("#discourse-modal-title")).to have_content("Add custom section")
+    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
 
     section_modal.fill_name("My section")
 
@@ -31,7 +31,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     section_modal.save
 
     expect(page).to have_button("My section")
-    expect(page).to have_link("Sidebar Tags")
+    sidebar.has_link?("Sidebar Tags")
   end
 
   it "allows the user to create custom section with external link" do
@@ -39,18 +39,21 @@ describe "Custom sidebar sections", type: :system, js: true do
     sidebar.open_new_custom_section
 
     expect(section_modal).to be_visible
-    expect(section_modal).to have_disabled_save_button
-    expect(find("#discourse-modal-title")).to have_content("Add custom section")
+    expect(section_modal).to have_disabled_save
+    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
 
     section_modal.fill_name("My section")
 
+    section_modal.fill_link("Discourse Homepage", "htt")
+    expect(section_modal).to have_disabled_save
+
     section_modal.fill_link("Discourse Homepage", "https://discourse.org")
-    expect(section_modal).to have_enabled_save_button
+    expect(section_modal).to have_enabled_save
 
     section_modal.save
 
     expect(page).to have_button("My section")
-    expect(page).to have_link("Discourse Homepage", href: "https://discourse.org")
+    sidebar.has_link?("Discourse Homepage", href: "https://discourse.org")
   end
 
   it "allows the user to edit custom section" do
@@ -72,7 +75,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     section_modal.save
 
     expect(page).to have_button("Edited section")
-    expect(page).to have_link("Edited Tags")
+    sidebar.has_link?("Edited Tags")
     expect(page).not_to have_link("Sidebar Categories")
   end
 
@@ -119,7 +122,7 @@ describe "Custom sidebar sections", type: :system, js: true do
     section_modal.save
 
     expect(page).to have_button("Public section")
-    expect(page).to have_link("Sidebar Tags")
+    sidebar.has_link?("Sidebar Tags")
     expect(page).to have_css(".sidebar-section-public-section .d-icon-globe")
 
     sidebar.edit_custom_section("Public section")

--- a/spec/system/page_objects/components/sidebar.rb
+++ b/spec/system/page_objects/components/sidebar.rb
@@ -25,8 +25,9 @@ module PageObjects
       end
 
       def has_link?(name, href: nil)
-        return page.has_link?(name, href: href) if href
-        page.has_link?(name)
+        attributes = {}
+        attributes[:href] = href if href
+        page.has_link?(name, attributes)
       end
 
       def custom_section_modal_title

--- a/spec/system/page_objects/components/sidebar.rb
+++ b/spec/system/page_objects/components/sidebar.rb
@@ -25,7 +25,7 @@ module PageObjects
       end
 
       def has_link?(name, href: nil)
-        return page.has_link?(name, href: "https://discourse.org") if href
+        return page.has_link?(name, href: href) if href
         page.has_link?(name)
       end
 

--- a/spec/system/page_objects/components/sidebar.rb
+++ b/spec/system/page_objects/components/sidebar.rb
@@ -23,6 +23,15 @@ module PageObjects
         find(".sidebar-section-#{name.parameterize}").hover
         find(".sidebar-section-#{name.parameterize} button.sidebar-section-header-button").click
       end
+
+      def has_link?(name, href: nil)
+        return page.has_link?(name, href: "https://discourse.org") if href
+        page.has_link?(name)
+      end
+
+      def custom_section_modal_title
+        find("#discourse-modal-title")
+      end
     end
   end
 end


### PR DESCRIPTION
Originally, only Discourse site links were available. After feedback, it was decided to extend this feature to external URLs.

/t/93491