### PR TITLE
PERF: allow notification ids a larger range

### DIFF
--- a/db/migrate/20230302044150_change_notifications_to_big_int.rb
+++ b/db/migrate/20230302044150_change_notifications_to_big_int.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ChangeNotificationsToBigInt < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    change_column :notifications, :id, :bigint
+    change_column :users, :seen_notification_id, :bigint
+    change_column :user_badges, :notification_id, :bigint
+    change_column :shelved_notifications, :notification_id, :bigint
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/chat/db/migrate/20230302044151_change_notifications_to_big_int_chat.rb
+++ b/plugins/chat/db/migrate/20230302044151_change_notifications_to_big_int_chat.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ChangeNotificationsToBigIntChat < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    change_column :chat_mentions, :notification_id, :bigint
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Out of the box we allow 2.2 billion notification, certain exceptionally
bit forums may overflow. This premtively raises the bar to big int.

The trade off is that all forums in the wild store an extra 4 byte in a bunch
of tables.
