### PR TITLE
FEATURE: add db:resize:notification_id task for growing table

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -575,3 +575,18 @@ task "db:status:json" do
     puts({ status: "ok" }.to_json)
   end
 end
+
+desc "Grow notification id column to a big int in case of overflow"
+task "db:resize:notification_id" => :environment do
+  sql = <<~SQL
+    SELECT table_name, column_name FROM INFORMATION_SCHEMA.columns
+    WHERE (column_name like '%notification_id' OR column_name = 'id' and table_name = 'notifications') AND data_type = 'integer'
+  SQL
+
+  DB
+    .query(sql)
+    .each do |row|
+      puts "Changing #{row.table_name}(#{row.column_name}) to a bigint"
+      DB.exec("ALTER table #{row.table_name} ALTER COLUMN #{row.column_name} TYPE BIGINT")
+    end
+end


### PR DESCRIPTION
Under exceptional cases people may need to resize the notification table.
This only happens on forums with a total of more than 2.5 billion notifications.

This rake task can be used to convert all the notification columns to
bigint to make more room.
