### PR TITLE
Hide allowed_user_api_push_urls site setting from admin UI

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2701,6 +2701,7 @@ user_api:
   allowed_user_api_push_urls:
     default: ""
     type: list
+    hidden: true
   allowed_user_api_auth_redirects:
     default: "https://api.discourse.org/api/auth_redirect|discourse://auth_redirect"
     type: list


### PR DESCRIPTION
This setting is only intended for configuration by hosting providers

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
