### PR TITLE
UX: ensure header logo has dimensions, style clean-up

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -46,6 +46,11 @@
     display: flex;
     align-items: center;
     height: 100%;
+    // This acts as a placeholder if for some reason the small logo takes a while
+    // to load - prevents topic title from shifting after the small logo loads.
+    // It's hardcoded to 36px because that's the width we use inline for the small
+    // logo in the home-logo widget.
+    min-width: 36px;
     a,
     a:visited {
       color: var(--header_primary);
@@ -62,7 +67,9 @@
   }
 
   #site-logo {
+    height: 2.667em;
     width: auto;
+    max-width: 100%;
   }
 
   #site-text-logo {
@@ -119,7 +126,7 @@
 
 .d-header-icons {
   text-align: center;
-  margin: 0 0 0 5px;
+  margin: 0 0 0 0.5em;
   list-style: none;
 
   > li {

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -43,14 +43,15 @@
   }
 
   .title {
+    --d-logo-height: 2.667em;
     display: flex;
     align-items: center;
     height: 100%;
-    // This acts as a placeholder if for some reason the small logo takes a while
-    // to load - prevents topic title from shifting after the small logo loads.
-    // It's hardcoded to 36px because that's the width we use inline for the small
-    // logo in the home-logo widget.
-    min-width: 36px;
+    animation: fadein 0.5s;
+    // min-width acts as a placeholder if the small logo takes a while to load
+    // it prevents topic title from shifting after the small logo loads
+    // it's set to match the #site-logo height so square small logos don't resize when titles dock
+    min-width: var(--d-logo-height);
     a,
     a:visited {
       color: var(--header_primary);
@@ -60,16 +61,14 @@
       // allows large logos to be hidden if there are too many other header elements
       // this prioritizes nav elements, especially in cases of high zoom levels
       overflow: hidden;
-      a {
-        min-width: 0;
-      }
     }
   }
 
   #site-logo {
-    height: 2.667em;
+    height: var(--d-logo-height);
     width: auto;
     max-width: 100%;
+    object-fit: contain;
   }
 
   #site-text-logo {
@@ -295,6 +294,7 @@
 
 // topic info in the header
 .extra-info-wrapper {
+  flex: 1 0 0;
   display: flex;
   align-items: center;
   height: 100%;

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -5,16 +5,9 @@
 .d-header {
   height: 3.66em;
 
-  // some protection for text-only site titles
   .title {
-    max-width: 75%;
-    @include ellipsis;
+    @include ellipsis; // truncate long text-only site titles if needed
     animation: fadein 0.5s;
-    // This acts as a placeholder if for some reason the small logo takes a while
-    // to load - prevents topic title from shifting after the small logo loads.
-    // It's hardcoded to 36px because that's the width we use inline for the small
-    // logo in the home-logo widget.
-    min-width: 36px;
     a {
       display: block;
       width: 100%;
@@ -22,9 +15,9 @@
   }
 
   #site-logo {
-    max-height: 2.4em;
-    max-width: 100%;
+    height: 2.4em;
   }
+
   #site-text-logo {
     font-size: var(--font-up-1);
   }

--- a/app/assets/stylesheets/mobile/header.scss
+++ b/app/assets/stylesheets/mobile/header.scss
@@ -6,16 +6,7 @@
   height: 3.66em;
 
   .title {
-    @include ellipsis; // truncate long text-only site titles if needed
-    animation: fadein 0.5s;
-    a {
-      display: block;
-      width: 100%;
-    }
-  }
-
-  #site-logo {
-    height: 2.4em;
+    --d-logo-height: 2.4em;
   }
 
   #site-text-logo {


### PR DESCRIPTION
This ensures all logos have at least one dimension, which fixes an issue with dimensionless SVGs on mobile being too small, as described here: https://meta.discourse.org/t/svg-mobile-logo-scales-incorrectly/256474

This sets a fixed logo height on mobile, which is consistent with existing desktop styles.

This also eliminates some unneeded mobile styles, and moves others to common.
