### PR TITLE
DEV: Add ruby_lsp gem to development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -181,6 +181,7 @@ group :development do
   gem "binding_of_caller"
   gem "yaml-lint"
   gem "yard"
+  gem "ruby-lsp", require: false
 end
 
 if ENV["ALLOW_DEV_POPULATE"] == "1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
       uri_template (~> 0.7)
     jwt (2.7.0)
     kgio (2.11.4)
+    language_server-protocol (3.17.0.3)
     libv8-node (16.10.0.0)
     libv8-node (16.10.0.0-aarch64-linux)
     libv8-node (16.10.0.0-arm64-darwin)
@@ -431,6 +432,10 @@ GEM
     rubocop-rspec (2.18.1)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
+    ruby-lsp (0.4.1)
+      language_server-protocol (~> 3.17.0)
+      sorbet-runtime
+      syntax_tree (>= 6, < 7)
     ruby-prof (1.6.1)
     ruby-progressbar (1.12.0)
     ruby-readability (0.7.0)
@@ -471,6 +476,7 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    sorbet-runtime (0.5.10693)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -643,6 +649,7 @@ DEPENDENCIES
   rswag-specs
   rtlcss
   rubocop-discourse
+  ruby-lsp
   ruby-prof
   ruby-readability
   rubyzip


### PR DESCRIPTION
In order to use the ruby-lsp vscode extension, the ruby_lsp gem needs to
be added to the project's Gemfile. That may soon change with
https://github.com/Shopify/vscode-ruby-lsp/pull/419 but this will do for
now.