### PR TITLE
DEV: Add migrations information to output of `db:status:json` rake task

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -564,14 +564,23 @@ task "db:rebuild_indexes" => "environment" do
   end
 end
 
-desc "Check that the DB can be accessed"
+desc "Check that the DB can be accessed and returns information about whether the database has been migrated or not"
 task "db:status:json" do
   begin
     Rake::Task["environment"].invoke
-    DB.query("SELECT 1")
+
+    migrated = DB.query_single(<<~SQL).first
+      SELECT ;;
+
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE  table_schema = 'public'
+        AND    table_name   = 'schema_migrations'
+      );
+    SQL
   rescue StandardError
     puts({ status: "error" }.to_json)
   else
-    puts({ status: "ok" }.to_json)
+    puts({ status: "ok", migrated: migrated }.to_json)
   end
 end

--- a/spec/tasks/db_spec.rb
+++ b/spec/tasks/db_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe "tasks/db" do
+  before do
+    Rake::Task.clear
+    Discourse::Application.load_tasks
+  end
+
+  describe "db:status:json" do
+    it "returns the right json output" do
+      expect { Rake::Task["db:status:json"].invoke }.to output(
+        /"status":"ok","migrated":true/,
+      ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
When checking the status of a database, it is also useful to know if a
database has been migrated before or not.