### PR TITLE
DEV: Support `@debounce` decorator in native class syntax

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-site-settings.js
@@ -112,6 +112,10 @@ export default Controller.extend({
   },
 
   @observes("filter", "onlyOverridden", "model")
+  optsChanged() {
+    this.filterContent();
+  },
+
   @debounce(INPUT_DELAY)
   filterContent() {
     if (this._skipBounce) {

--- a/app/assets/javascripts/discourse-common/addon/utils/decorators.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/decorators.js
@@ -100,10 +100,9 @@ export function debounce(delay, immediate = false) {
     return {
       enumerable: descriptor.enumerable,
       configurable: descriptor.configurable,
-      writable: descriptor.writable,
-      initializer() {
+      get: function () {
         const originalFunction = descriptor.value;
-        const debounced = function (...args) {
+        const debounced = (...args) => {
           return discourseDebounce(
             this,
             originalFunction,
@@ -112,6 +111,13 @@ export function debounce(delay, immediate = false) {
             immediate
           );
         };
+
+        // Memoize on instance for future access
+        Object.defineProperty(this, name, {
+          value: debounced,
+          enumerable: descriptor.enumerable,
+          configurable: descriptor.configurable,
+        });
 
         return debounced;
       },

--- a/app/assets/javascripts/discourse/app/controllers/group-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-index.js
@@ -25,6 +25,10 @@ export default Controller.extend({
   bulkSelection: null,
 
   @observes("filterInput")
+  filterInputChanged() {
+    this._setFilter();
+  },
+
   @debounce(500)
   _setFilter() {
     this.set("filter", this.filterInput);

--- a/app/assets/javascripts/discourse/app/controllers/group-requests.js
+++ b/app/assets/javascripts/discourse/app/controllers/group-requests.js
@@ -19,6 +19,10 @@ export default Controller.extend({
   loading: false,
 
   @observes("filterInput")
+  filterInputChanged() {
+    this._setFilter();
+  },
+
   @debounce(500)
   _setFilter() {
     this.set("filter", this.filterInput);

--- a/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-invited-show.js
@@ -30,6 +30,10 @@ export default Controller.extend({
   },
 
   @observes("searchTerm")
+  searchTermChanged() {
+    this._searchTermChanged();
+  },
+
   @debounce(INPUT_DELAY)
   _searchTermChanged() {
     Invite.findInvitedBy(this.user, this.filter, this.searchTerm).then(

--- a/plugins/discourse-local-dates/assets/javascripts/discourse/components/discourse-local-dates-create-form.js
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/components/discourse-local-dates-create-form.js
@@ -61,6 +61,10 @@ export default Component.extend({
   },
 
   @observes("computedConfig.{from,to,options}", "options", "isValid", "isRange")
+  configChanged() {
+    this._renderPreview();
+  },
+
   @debounce(INPUT_DELAY)
   async _renderPreview() {
     if (this.markup) {


### PR DESCRIPTION
The implementation previously generated a descriptor with an `initializer()`, and bound the function to the `this` context of the initializer. In native class syntax, the initializer of a descriptor is only called once, with a `this` context of the constructor, not the instance.

This commit updates the implementation so that it generates the bound function on-demand using a getter. This is the same strategy employed by ember's built-in `@action` decorator.

Unfortunately, this use of a getter means that the `@observes` decorator does not support being directly chained to `@debounce`. It throws the error "`observer must be provided a function or an observer definition`". The workaround is to put the observer on its own function, which then calls the debounced function. Given that we're aiming to reduce our usage of `@observes`, we've accepted the need for this workaround rather than spending the time to patch the implementation of `@observes`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
