### PR TITLE
FIX: NoMethodError in anonymous cache

### DIFF
--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -327,7 +327,8 @@ module Middleware
 
     def call(env)
       if PAYLOAD_INVALID_REQUEST_METHODS.include?(env[Rack::REQUEST_METHOD]) &&
-        env[Rack::RACK_INPUT].respond_to?(:size) && env[Rack::RACK_INPUT].size > 0
+        env[Rack::RACK_INPUT].respond_to?(:size) &&
+        env[Rack::RACK_INPUT].size > 0
         return 413, { "Cache-Control" => "private, max-age=0, must-revalidate" }, []
       end
 

--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -327,7 +327,7 @@ module Middleware
 
     def call(env)
       if PAYLOAD_INVALID_REQUEST_METHODS.include?(env[Rack::REQUEST_METHOD]) &&
-           env[Rack::RACK_INPUT].size > 0
+        env[Rack::RACK_INPUT].respond_to?(:size) && env[Rack::RACK_INPUT].size > 0
         return 413, { "Cache-Control" => "private, max-age=0, must-revalidate" }, []
       end
 


### PR DESCRIPTION
Fix NoMethodError thrown by the anonymous cache by checking existence of `env[Rack::RACK_INPUT]` prior to checking its size.
