### PR TITLE
FIX: prevents exception on required login sites with chat

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-cook-function.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-cook-function.js
@@ -16,7 +16,8 @@ export default {
       markdownItRules:
         site.markdown_additional_options?.chat
           ?.limited_pretty_text_markdown_rules,
-      hashtagTypesInPriorityOrder: site.hashtag_configurations["chat-composer"],
+      hashtagTypesInPriorityOrder:
+        site.hashtag_configurations?.["chat-composer"],
       hashtagIcons: site.hashtag_icons,
     };
 


### PR DESCRIPTION
On require login sites, the `site` is not setup on login page and as a result `hashtag_configurations` was blank and causing an error when attempting to access `["chat-composer"]` on it.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
