### PR TITLE
FIX: do not refresh when accessing loaded reply

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -103,6 +103,10 @@ export default class ChatLivePane extends Component {
 
   @action
   updateChannel() {
+    // Technically we could keep messages to avoid re-fetching them, but
+    // it's not worth the complexity for now
+    this.args.channel?.clearMessages();
+
     if (this._loadedChannelId !== this.args.channel?.id) {
       this._unsubscribeToUpdates(this._loadedChannelId);
       this.selectingMessages = false;

--- a/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat-channel.js
@@ -10,10 +10,6 @@ export default class ChatChannelRoute extends DiscourseRoute {
 
   @action
   willTransition(transition) {
-    // Technically we could keep messages to avoid re-fetching them, but
-    // it's not worth the complexity for now
-    this.chat.activeChannel?.clearMessages();
-
     this.chat.activeChannel.activeThread = null;
     this.chatStateManager.closeSidePanel();
 

--- a/plugins/chat/spec/system/reply_indicator_spec.rb
+++ b/plugins/chat/spec/system/reply_indicator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Reply indicator", type: :system, js: true do
     sign_in(current_user)
   end
 
-  context "clicking on a reply indicator of a loaded message" do
+  context "when clicking on a reply indicator of a loaded message" do
     fab!(:replied_to_message) do
       Fabricate(:chat_message, chat_channel: channel_1, created_at: 2.hours.ago)
     end

--- a/plugins/chat/spec/system/reply_indicator_spec.rb
+++ b/plugins/chat/spec/system/reply_indicator_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe "Reply indicator", type: :system, js: true do
+  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:channel_page) { PageObjects::Pages::ChatChannel.new }
+
+  fab!(:channel_1) { Fabricate(:category_channel) }
+  fab!(:current_user) { Fabricate(:admin) }
+
+  before do
+    chat_system_bootstrap
+    channel_1.add(current_user)
+    sign_in(current_user)
+  end
+
+  context "clicking on a reply indicator of a loaded message" do
+    fab!(:replied_to_message) do
+      Fabricate(:chat_message, chat_channel: channel_1, created_at: 2.hours.ago)
+    end
+    fab!(:reply) do
+      Fabricate(
+        :chat_message,
+        chat_channel: channel_1,
+        in_reply_to: replied_to_message,
+        created_at: 1.minute.ago,
+      )
+    end
+
+    before do
+      10.times { Fabricate(:chat_message, chat_channel: channel_1, created_at: 1.hour.ago) }
+    end
+
+    it "highlights the message without refreshing the pane" do
+      chat_page.visit_channel(channel_1)
+
+      find("[data-id='#{reply.id}'] .chat-reply").click
+
+      expect(page).to have_no_selector(".chat-skeleton")
+      expect(page).to have_selector("[data-id='#{replied_to_message.id}'].highlighted", wait: 0.1)
+    end
+  end
+end


### PR DESCRIPTION
Note this test might prove to be flakey, so I might have to remove it or find a different solution. It's extremely complicated to test for something which shouldn't appear in a period of time and is not a present at T=0

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
