### PR TITLE
FIX: prevents duplicate reactions

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -130,7 +130,13 @@ export default class ChatMessage {
     if (existingReaction) {
       if (action === "add") {
         if (selfReaction && existingReaction.reacted) {
-          return false;
+          return;
+        }
+
+        // we might receive a message bus event while loading a channel who would
+        // already have the reaction added to the message
+        if (existingReaction.users.find((user) => user.id === actor.id)) {
+          return;
         }
 
         existingReaction.count = existingReaction.count + 1;


### PR DESCRIPTION
This was possible due to specific events which are hard to represent in a test. The provided test is as close as possible to what was happening in production: a message bus event was played on a channel which has just loaded its state with the existing reaction.

This is not the long term fix, but should be good enough while we work our way to a better solution.