### PR TITLE
UX: style improvements to new user tables

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -241,7 +241,13 @@
               </div>
             {{/if}}
 
-            <div class="directory-table__cell user-status">
+            <div
+              class="directory-table__cell user-role{{if
+                  (or user.admin user.moderator user.second_factor_enabled)
+                  ''
+                  '--empty'
+                }}"
+            >
               <span class="directory-table__label">
                 <span>{{i18n "admin.users.status"}}</span>
               </span>

--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -174,7 +174,12 @@
                   {{bound-date m.added_at}}
                 </span>
               </div>
-              <div class="directory-table__cell">
+              <div
+                class="directory-table__cell{{unless
+                    m.last_posted_at
+                    '--empty'
+                  }}"
+              >
                 {{#if m.last_posted_at}}
                   <span class="directory-table__label">
                     <span>{{i18n "last_post"}}</span>
@@ -184,7 +189,9 @@
                   {{bound-date m.last_posted_at}}
                 </span>
               </div>
-              <div class="directory-table__cell">
+              <div
+                class="directory-table__cell{{unless m.last_seen_at '--empty'}}"
+              >
                 {{#if m.last_seen_at}}
                   <span class="directory-table__label">
                     <span>{{i18n "last_seen"}}</span>

--- a/app/assets/javascripts/discourse/app/templates/group-requests.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-requests.hbs
@@ -30,9 +30,9 @@
             @labelKey="groups.member_requested"
             @automatic={{true}}
           />
-          <div class="directory-table__column-header">{{i18n
-              "groups.requests.reason"
-            }}</div>
+          <div
+            class="directory-table__column-header group-request-reason__column-header"
+          >{{i18n "groups.requests.reason"}}</div>
           <div class="directory-table__column-header"></div>
         </:header>
         <:body>
@@ -49,7 +49,7 @@
                   <span>{{bound-date m.requested_at}}</span>
                 </span>
               </div>
-              <div class="directory-table__cell">
+              <div class="directory-table__cell group-request-reason__content">
                 <span class="directory-table__label">
                   <span>{{i18n "groups.requests.reason"}}</span>
                 </span>

--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -132,6 +132,7 @@
     border-bottom: 1px solid var(--primary-low);
     justify-content: center;
     align-items: center;
+    box-sizing: border-box;
   }
 
   &__column-header {
@@ -260,6 +261,7 @@
     &__value {
       font-size: var(--font-0);
       color: var(--primary);
+      align-self: start;
     }
 
     &__row {
@@ -269,8 +271,8 @@
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(11em, 1fr));
       border-bottom: 1px solid var(--primary-low);
-      padding: 0.85em 0.75em 1em;
-      gap: 0 15%;
+      padding: 0.85em 0.5em 1em;
+      gap: 0 10%;
     }
 
     &__header {
@@ -302,6 +304,10 @@
           margin-right: 0.25em;
         }
       }
+    }
+
+    [class*="--empty"] {
+      display: none;
     }
   }
 }

--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -154,7 +154,7 @@ table.group-manage-logs {
   }
 
   &.group-members__requests {
-    grid-template-columns: 3fr repeat(3, minmax(min-content, 1fr));
+    grid-template-columns: 3fr repeat(3, minmax(max-content, 1fr));
   }
 
   .directory-table__value {
@@ -166,7 +166,27 @@ table.group-manage-logs {
     gap: 0.5em;
   }
 
+  [class*="group-request-reason__"] {
+    justify-content: start;
+  }
+
+  .group-request-reason__content {
+    .directory-table__value {
+      white-space: normal;
+      max-width: 30em;
+    }
+  }
+
   @container (max-width: 47em) {
+    .directory-table__cell {
+      grid-column-start: 1;
+      grid-column-end: -1;
+    }
+
+    .group-accept-deny-buttons {
+      justify-content: start;
+    }
+
     .directory-table__cell.group-owner {
       order: 2;
     }

--- a/app/assets/stylesheets/mobile/group.scss
+++ b/app/assets/stylesheets/mobile/group.scss
@@ -16,10 +16,6 @@
   position: relative;
 }
 
-.group-accept-deny-buttons {
-  justify-content: start;
-}
-
 .group-info {
   flex-wrap: wrap;
   .group-details-button button {


### PR DESCRIPTION
Some general improvements for the new user table layouts, mostly on small screens. This is a follow-up to e206bd8

* This adjusts some gap and padding to allow more information to fit into less space on mobile-sized screens. 

* Avoids an issue where horizontal scrollbars would sometimes appear on mobile

* It also prevents some empty fields from showing on small screens with the `--empty` class modifier:

    Before (little space between posted/status due to an empty cell):
    ![Screenshot 2023-03-03 at 5 01 12 PM](https://user-images.githubusercontent.com/1681963/222838701-204d410c-8cb8-4668-a136-5844ffd7ed81.png)


    After:
    ![Screenshot 2023-03-03 at 5 01 20 PM](https://user-images.githubusercontent.com/1681963/222838707-724fa35e-a305-4885-873b-7bcd1424b1ba.png)

* Prevents long group request reasons from blowing out the mobile layout

    Before:
    ![Screenshot 2023-03-03 at 4 48 10 PM](https://user-images.githubusercontent.com/1681963/222838859-b3193c9f-efdf-47b6-ab7c-2971185739bc.png)

    After:
    ![Screenshot 2023-03-03 at 4 47 55 PM](https://user-images.githubusercontent.com/1681963/222838872-7fbf8719-fed5-4a0d-8f61-450c080255d3.png)

