### PR TITLE
FIX: leaking callbacks to synchronize state

### DIFF
--- a/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
+++ b/app/assets/javascripts/discourse/app/components/discovery-topics-list.js
@@ -27,12 +27,16 @@ export default Component.extend(UrlRefresh, LoadMore, {
 
   @on("didInsertElement")
   _monitorTrackingState() {
-    this.topicTrackingState.onStateChange(() => this._updateTrackingTopics());
+    this.stateChangeCallbackId = this.topicTrackingState.onStateChange(() =>
+      this._updateTrackingTopics()
+    );
   },
 
   @on("willDestroyElement")
   _removeTrackingStateChangeMonitor() {
-    this.topicTrackingState.offStateChange(this.stateChangeCallbackId);
+    if (this.stateChangeCallbackId) {
+      this.topicTrackingState.offStateChange(this.stateChangeCallbackId);
+    }
   },
 
   _updateTrackingTopics() {


### PR DESCRIPTION
Every time we created a topic list we would leak a state change callback

This happens on any topic list -> topic -> topic list sequence

This can cause corruption of tracking state and memory bloating given that
all information may be sent to the sync function.
