### PR TITLE
PERF: Skip metadata routes for mini_profiler

### DIFF
--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -53,6 +53,8 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
     %r{^/stylesheets/},
     %r{^/favicon/proxied},
     %r{^/theme-javascripts},
+    %r{^/manifest.webmanifest},
+    %r{^/opensearch.xml},
   ]
 
   # we DO NOT WANT mini-profiler loading on anything but real desktops and laptops


### PR DESCRIPTION
Mini-profiler causes routes to become uncacheable. When using mini_profiler in production, the lack of cache on these routes can have a noticeable impact on performance/rate-limiting.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
