### PR TITLE
UX: fix width for top embedded reply, post notice

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1438,6 +1438,7 @@ span.mention {
 }
 
 .post-notice {
+  box-sizing: border-box;
   align-items: center;
   background-color: var(--tertiary-low);
   border-top: 1px solid var(--primary-low);

--- a/app/assets/stylesheets/desktop/topic-post.scss
+++ b/app/assets/stylesheets/desktop/topic-post.scss
@@ -203,7 +203,7 @@ pre.codeblock-buttons:hover {
     margin-left: var(--topic-avatar-width);
     width: calc(
       var(--topic-body-width) + (var(--topic-body-width-padding) * 2) +
-        var(--topic-avatar-width) - (var(--topic-avatar-width + 2px))
+        var(--topic-avatar-width) - (var(--topic-avatar-width) + 2px)
     ); // 2px accounts for left and right borders
     .row {
       border-bottom: none;


### PR DESCRIPTION
Before: 
![Screenshot 2023-03-06 at 11 22 03 AM](https://user-images.githubusercontent.com/1681963/223169503-3eb04aec-3faf-4ba3-b082-427c905d9fa2.png)



After: 
![Screenshot 2023-03-06 at 11 18 26 AM](https://user-images.githubusercontent.com/1681963/223169535-c1188a62-ae5a-4297-a0e1-f91cf8ca3641.png)
