### PR TITLE
FIX: Trim whitespace on email field for invites

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-invite.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-invite.js
@@ -34,12 +34,12 @@ export default Controller.extend(
 
     @discourseComputed("buffered.emailOrDomain")
     isEmail(emailOrDomain) {
-      return emailValid(emailOrDomain);
+      return emailValid(emailOrDomain?.trim());
     },
 
     @discourseComputed("buffered.emailOrDomain")
     isDomain(emailOrDomain) {
-      return hostnameValid(emailOrDomain);
+      return hostnameValid(emailOrDomain?.trim());
     },
 
     isLink: not("isEmail"),
@@ -83,9 +83,9 @@ export default Controller.extend(
 
       if (data.emailOrDomain) {
         if (emailValid(data.emailOrDomain)) {
-          data.email = data.emailOrDomain;
+          data.email = data.emailOrDomain?.trim();
         } else if (hostnameValid(data.emailOrDomain)) {
-          data.domain = data.emailOrDomain;
+          data.domain = data.emailOrDomain?.trim();
         }
         delete data.emailOrDomain;
       }

--- a/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/create-invite-modal-test.js
@@ -155,7 +155,7 @@ acceptance("Invites - Email Invites", function (needs) {
       "sends skip_email to server"
     );
 
-    await fillIn("#invite-email", "test2@example.com");
+    await fillIn("#invite-email", "test2@example.com ");
     assert.ok(exists(".send-invite"), "shows save and send email button");
     await click(".send-invite");
     assert.ok(


### PR DESCRIPTION
If the whitespace isn't trimmed from the input field the email is
considered invalid, and the button remains greyed out. We should handle
removing any trailing whitespace and not rely on the user trying to see
it themselves.
