### PR TITLE
FIX: prevents mouseover to gain focus on sk row

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
@@ -128,7 +128,6 @@ export default Component.extend(UtilsMixin, {
   @action
   handleMouseEnter() {
     if (!this.isDestroying || !this.isDestroyed) {
-      this.element.focus({ preventScroll: true });
       this.selectKit.onHover(this.rowValue, this.item);
     }
     return false;


### PR DESCRIPTION
This was causing unattended effects on other elements. eg: the select-kit header input could lose focus when the list filtered would change size and cause the cursor to be positioned over a row.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
