### PR TITLE
DEV: Add `/theme-qunit` to skipped mini profiler paths

### DIFF
--- a/config/initializers/006-mini_profiler.rb
+++ b/config/initializers/006-mini_profiler.rb
@@ -54,6 +54,7 @@ if defined?(Rack::MiniProfiler) && defined?(Rack::MiniProfiler::Config)
       /topics/timings
       /uploads/
       /user_avatar/
+      /theme-qunit
     ].map { |path| "#{Discourse.base_path}#{path}" }
 
   # we DO NOT WANT mini-profiler loading on anything but real desktops and laptops


### PR DESCRIPTION
As of a recent commit (https://github.com/discourse/discourse/pull/20544) to improve the mini profiler skipped paths, we now need to add `/theme-qunit` explicitly as well so that the mini profiler is skipped from being called in theme tests.

**This PR** adds `/theme-qunit` to the `Rack::MiniProfiler` skipped paths list.