### PR TITLE
PERF: Remove request for PM topic tracking state initiated from sidebar

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/messages-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/messages-section.js
@@ -38,10 +38,6 @@ export default class SidebarUserMessagesSection extends Component {
       this._refreshSectionLinksDisplayState
     );
 
-    this.pmTopicTrackingState
-      .startTracking()
-      .then(this._refreshSectionLinkCounts);
-
     this._pmTopicTrackingStateKey = "messages-section";
 
     this.pmTopicTrackingState.onStateChange(

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-messages-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-messages-section-test.js
@@ -376,6 +376,10 @@ acceptance(
         "service:pm-topic-tracking-state"
       );
 
+      await click(
+        ".sidebar-section-messages .sidebar-section-link-group-messages-inbox.group1"
+      );
+
       await publishToMessageBus(pmTopicTrackingState.groupChannel(1), {
         topic_id: 1,
         message_type: "unread",
@@ -397,10 +401,6 @@ acceptance(
           group_ids: [1],
         },
       });
-
-      await click(
-        ".sidebar-section-messages .sidebar-section-link-group-messages-inbox.group1"
-      );
 
       assert.strictEqual(
         query(
@@ -449,6 +449,10 @@ acceptance(
         "service:pm-topic-tracking-state"
       );
 
+      await click(
+        ".sidebar-section-messages .sidebar-section-link-personal-messages-inbox"
+      );
+
       await publishToMessageBus(pmTopicTrackingState.userChannel(), {
         topic_id: 1,
         message_type: "unread",
@@ -459,10 +463,6 @@ acceptance(
           group_ids: [],
         },
       });
-
-      await click(
-        ".sidebar-section-messages .sidebar-section-link-personal-messages-inbox"
-      );
 
       assert.strictEqual(
         query(


### PR DESCRIPTION
What is the problem?

When constructing the "Messages" section in Sidebar, we call
`startTracking()` on the `pm-topic-tracking-state` service in order to
get the counts for new/unread for the private message inboxes for each
user. However, this is unnecessary because the inboxes are in a
collapsed state by default in the sidebar and are only expanded when the
current route correspond to the inbox's route. Therefore, we can avoid
calling `startTracking()` on the `pm-topic-tracking-state` service until
an inbox's route is loaded. This allows us to cut out one extra request
to the server on page load and defer it until it is necessarily.