### PR TITLE
FEATURE: tooltip for disabled new topic button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/create-topic-button.hbs
+++ b/app/assets/javascripts/discourse/app/components/create-topic-button.hbs
@@ -7,4 +7,5 @@
     @disabled={{this.disabled}}
     @label={{this.label}}
   />
+  {{yield}}
 {{/if}}

--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -85,7 +85,11 @@
     @label={{this.createTopicLabel}}
     @btnClass={{this.createTopicClass}}
     @canCreateTopicOnTag={{this.canCreateTopicOnTag}}
-  />
+  >
+    {{#if this.createTopicButtonDisabled}}
+      <DTooltip>{{i18n "topic.create_disabled_category"}}</DTooltip>
+    {{/if}}
+  </CreateTopicButton>
 
   <PluginOutlet
     @name="after-create-topic-button"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2893,6 +2893,7 @@ en:
         one: "%{count} post in topic"
         other: "%{count} posts in topic"
       create: "New Topic"
+      create_disabled_category: "You're not allowed to create topics in this category"
       create_long: "Create a new Topic"
       open_draft: "Open Draft"
       private_message: "Start a message"


### PR DESCRIPTION
This adds a tooltip that explains why the new topic button is disabled on topic lists

<img width="372" alt="Screenshot 2023-03-07 at 10 02 11 AM" src="https://user-images.githubusercontent.com/1681963/223461671-a5c6e4e2-579f-4976-8be0-2d04b7af7190.png">
