### PR TITLE
FIX: anonymous FAQ link to external URL

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -39,7 +39,7 @@ export default class SectionLink extends Component {
   }
 
   get target() {
-    return this.currentUser.user_option.external_links_in_new_tab
+    return this.currentUser?.user_option?.external_links_in_new_tab
       ? "_blank"
       : "_self";
   }

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
@@ -13,6 +13,7 @@ import { click, visit } from "@ember/test-helpers";
 acceptance("Sidebar - Anonymous user - Community Section", function (needs) {
   needs.settings({
     navigation_menu: "sidebar",
+    faq_url: "https://discourse.org",
   });
 
   test("display short site description site setting when it is set", async function (assert) {


### PR DESCRIPTION
When FAQ URL is set to external resource, site is failing for anonymous user.
