### PR TITLE
FIX: class for section link when name has space

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -28,7 +28,11 @@ export default class SectionLink extends Component {
     let classNames = ["sidebar-section-link", "sidebar-row"];
 
     if (this.args.linkName) {
-      classNames.push(`sidebar-section-link-${this.args.linkName}`);
+      classNames.push(
+        `sidebar-section-link-${this.args.linkName
+          .replace(" ", "-")
+          .toLowerCase()}`
+      );
     }
 
     if (this.args.class) {

--- a/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/section-link.js
@@ -30,7 +30,9 @@ export default class SectionLink extends Component {
     if (this.args.linkName) {
       classNames.push(
         `sidebar-section-link-${this.args.linkName
-          .replace(" ", "-")
+          .split(" ")
+          .filter((s) => s)
+          .join("-")
           .toLowerCase()}`
       );
     }

--- a/app/assets/javascripts/discourse/tests/integration/components/sidebar/section-link-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/sidebar/section-link-test.js
@@ -18,7 +18,7 @@ module("Integration | Component | sidebar | section-link", function (hooks) {
   setupRenderingTest(hooks);
 
   test("default class attribute for link", async function (assert) {
-    const template = hbs`<Sidebar::SectionLink @linkName="test" @route="discovery.latest" />`;
+    const template = hbs`<Sidebar::SectionLink @linkName="Test Meta" @route="discovery.latest" />`;
 
     await render(template);
 
@@ -29,14 +29,14 @@ module("Integration | Component | sidebar | section-link", function (hooks) {
         "ember-view",
         "sidebar-row",
         "sidebar-section-link",
-        "sidebar-section-link-test",
+        "sidebar-section-link-test-meta",
       ],
       "has the right class attribute for the link"
     );
   });
 
   test("custom class attribute for link", async function (assert) {
-    const template = hbs`<Sidebar::SectionLink @linkName="test" @route="discovery.latest" @class="123 abc" />`;
+    const template = hbs`<Sidebar::SectionLink @linkName="Test Meta" @route="discovery.latest" @class="123 abc" />`;
 
     await render(template);
 
@@ -49,7 +49,7 @@ module("Integration | Component | sidebar | section-link", function (hooks) {
         "ember-view",
         "sidebar-row",
         "sidebar-section-link",
-        "sidebar-section-link-test",
+        "sidebar-section-link-test-meta",
       ],
       "has the right class attribute for the link"
     );

--- a/app/assets/javascripts/discourse/tests/integration/components/sidebar/section-link-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/sidebar/section-link-test.js
@@ -18,7 +18,7 @@ module("Integration | Component | sidebar | section-link", function (hooks) {
   setupRenderingTest(hooks);
 
   test("default class attribute for link", async function (assert) {
-    const template = hbs`<Sidebar::SectionLink @linkName="Test Meta" @route="discovery.latest" />`;
+    const template = hbs`<Sidebar::SectionLink @linkName="Test   Meta" @route="discovery.latest" />`;
 
     await render(template);
 
@@ -36,7 +36,7 @@ module("Integration | Component | sidebar | section-link", function (hooks) {
   });
 
   test("custom class attribute for link", async function (assert) {
-    const template = hbs`<Sidebar::SectionLink @linkName="Test Meta" @route="discovery.latest" @class="123 abc" />`;
+    const template = hbs`<Sidebar::SectionLink @linkName="Test   Meta" @route="discovery.latest" @class="123 abc" />`;
 
     await render(template);
 


### PR DESCRIPTION
Sidebar section link has class name based on link title. Title can contain spaces, therefore they should be replaced.

