### PR TITLE
DEV: Introduce `stub_ip_lookup` spec helper

### DIFF
--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -25,15 +25,6 @@ describe FinalDestination::HTTP do
     end
   end
 
-  def stub_ip_lookup(stub_addr, ips)
-    Addrinfo
-      .stubs(:getaddrinfo)
-      .with { |addr, _| addr == stub_addr }
-      .returns(
-        ips.map { |ip| Addrinfo.new([IPAddr.new(ip).ipv6? ? "AF_INET6" : "AF_INET", 80, nil, ip]) },
-      )
-  end
-
   def stub_tcp_to_raise(stub_addr, exception)
     TCPSocket.stubs(:open).with { |addr| addr == stub_addr }.once.raises(exception)
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -192,4 +192,13 @@ module Helpers
 
     queries
   end
+
+  def stub_ip_lookup(stub_addr, ips)
+    Addrinfo
+      .stubs(:getaddrinfo)
+      .with { |addr, _| addr == stub_addr }
+      .returns(
+        ips.map { |ip| Addrinfo.new([IPAddr.new(ip).ipv6? ? "AF_INET6" : "AF_INET", 80, nil, ip]) },
+      )
+  end
 end


### PR DESCRIPTION
Extracting the method such that it can be used in other test files as
well.