### PR TITLE
DEV: Introduces a wait_for_animation system spec helper

### DIFF
--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -39,11 +39,8 @@ module PageObjects
       end
 
       def click_message_action_mobile(message, message_action)
-        i = 0.5
-        try_until_success(timeout: 20) do
-          expand_message_actions_mobile(message, delay: i)
-          first(".chat-message-action-item[data-id=\"#{message_action}\"]")
-        end
+        expand_message_actions_mobile(message, delay: 0.5)
+        wait_for_animation(find(".chat-message-actions"), timeout: 5)
         find(".chat-message-action-item[data-id=\"#{message_action}\"] button").click
       end
 

--- a/plugins/chat/spec/system/single_thread_spec.rb
+++ b/plugins/chat/spec/system/single_thread_spec.rb
@@ -69,8 +69,8 @@ describe "Single thread in side panel", type: :system, js: true do
     end
 
     context "when using mobile" do
-      xit "opens the side panel for a single thread from the mobile message actions menu",
-          mobile: true do
+      it "opens the side panel for a single thread from the mobile message actions menu",
+         mobile: true do
         chat_page.visit_channel(channel)
         channel_page.click_message_action_mobile(thread.chat_messages.last, "openThread")
         expect(side_panel).to have_open_thread(thread)

--- a/plugins/chat/spec/system/transcript_spec.rb
+++ b/plugins/chat/spec/system/transcript_spec.rb
@@ -205,8 +205,8 @@ RSpec.describe "Quoting chat message transcripts", type: :system, js: true do
     end
 
     context "when on mobile" do
-      xit "first navigates to the channel's category before opening the topic composer with the quote prefilled",
-          mobile: true do
+      it "first navigates to the channel's category before opening the topic composer with the quote prefilled",
+         mobile: true do
         chat_page.visit_channel(chat_channel_1)
 
         chat_channel_page.click_message_action_mobile(message_1, "selectMessage")


### PR DESCRIPTION
This is used when calling click_message_action_mobile to wait
for the message actions menu to finish animating up before
attempting to click on it using capybara. Without this, in
the time between capybara getting the x,y position of a menu
item to click on and the click being fired, the animating menu
can move that item out of the way.

With the new helper, we constantly compare x,y client rect positions
for the animating element and wait for them to stabilise. Once they
do, it means the animation is done, and it is safe to click on
anything within the element.

Re-enables mobile system specs for chat that were ignored because
of this.
