### PR TITLE
DEV: Fix broken plugin specs because of bookmarkable changes

### DIFF
--- a/plugins/chat/spec/lib/chat_message_bookmarkable_spec.rb
+++ b/plugins/chat/spec/lib/chat_message_bookmarkable_spec.rb
@@ -15,7 +15,7 @@ describe ChatMessageBookmarkable do
     UserChatChannelMembership.create(chat_channel: channel, user: user, following: true)
   end
 
-  after { DiscoursePluginRegistry.reset! }
+  after { DiscoursePluginRegistry.reset_register!(:bookmarkables) }
 
   let!(:message1) { Fabricate(:chat_message, chat_channel: channel) }
   let!(:message2) { Fabricate(:chat_message, chat_channel: channel) }


### PR DESCRIPTION
Followup to 360d0dde650704a0f01fd6d8b525e933b1d7fcf2,
this causes other plugin tests to fail because
`DiscoursePluginRegistry.reset!` is
a shotgun. We can use the more surgical version
`DiscoursePluginRegistry.reset_register!(:bookmarkables)`
instead.
