### PR TITLE
DEV: Make global search context suggestion first

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -488,18 +488,6 @@ createWidget("search-menu-assistant", {
           const user = attrs.results[0];
           content.push(
             this.attach("search-menu-assistant-item", {
-              prefix,
-              user,
-              setTopicContext: true,
-              slug: `${prefix}@${user.username}`,
-              suffix: h(
-                "span.label-suffix",
-                ` ${I18n.t("search.in_this_topic")}`
-              ),
-            })
-          );
-          content.push(
-            this.attach("search-menu-assistant-item", {
               extraHint: I18n.t("search.enter_hint"),
               prefix,
               user,
@@ -507,6 +495,18 @@ createWidget("search-menu-assistant", {
               suffix: h(
                 "span.label-suffix",
                 ` ${I18n.t("search.in_topics_posts")}`
+              ),
+            })
+          );
+          content.push(
+            this.attach("search-menu-assistant-item", {
+              prefix,
+              user,
+              setTopicContext: true,
+              slug: `${prefix}@${user.username}`,
+              suffix: h(
+                "span.label-suffix",
+                ` ${I18n.t("search.in_this_topic")}`
               ),
             })
           );
@@ -552,6 +552,10 @@ createWidget("search-menu-initial-options", {
     const content = [];
 
     if (attrs.term || ctx) {
+      if (attrs.term) {
+        content.push(this.defaultRow(attrs.term, { withLabel: true }));
+      }
+
       if (ctx) {
         const term = attrs.term || "";
         switch (ctx.type) {
@@ -650,9 +654,6 @@ createWidget("search-menu-initial-options", {
         }
       }
 
-      if (attrs.term) {
-        content.push(this.defaultRow(attrs.term, { withLabel: true }));
-      }
       return content;
     }
 

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -3,6 +3,7 @@ import {
   count,
   exists,
   query,
+  queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import {
   click,
@@ -131,14 +132,13 @@ acceptance("Search - Anonymous", function (needs) {
   });
 
   test("search scope", async function (assert) {
-    const firstResult =
-      ".search-menu .results .search-menu-assistant-item:first-child";
+    const contextSelector = ".search-menu .results .search-menu-assistant-item";
 
     await visit("/tag/important");
     await click("#search-button");
 
     assert.strictEqual(
-      query(firstResult).textContent.trim(),
+      queryAll(contextSelector)[0].firstChild.textContent.trim(),
       `${I18n.t("search.in")} test`,
       "contextual tag search is first available option with no term"
     );
@@ -146,22 +146,22 @@ acceptance("Search - Anonymous", function (needs) {
     await fillIn("#search-term", "smth");
 
     assert.strictEqual(
-      query(firstResult).textContent.trim(),
+      queryAll(contextSelector)[1].firstChild.textContent.trim(),
       `smth ${I18n.t("search.in")} test`,
-      "tag-scoped search is first available option"
+      "tag-scoped search is second available option"
     );
 
     await visit("/c/bug");
     await click("#search-button");
 
     assert.strictEqual(
-      query(firstResult).textContent.trim(),
+      queryAll(contextSelector)[1].firstChild.textContent.trim(),
       `smth ${I18n.t("search.in")} bug`,
-      "category-scoped search is first available option"
+      "category-scoped search is first available option with no search term"
     );
 
     assert.ok(
-      exists(`${firstResult} span.badge-wrapper`),
+      exists(`${contextSelector} span.badge-wrapper`),
       "category badge is a span (i.e. not a link)"
     );
 
@@ -169,20 +169,20 @@ acceptance("Search - Anonymous", function (needs) {
     await click("#search-button");
 
     assert.strictEqual(
-      query(firstResult).textContent.trim(),
+      queryAll(contextSelector)[1].firstChild.textContent.trim(),
       `smth ${I18n.t("search.in_this_topic")}`,
-      "topic-scoped search is first available option"
+      "topic-scoped search is first available option with no search term"
     );
 
     await visit("/u/eviltrout");
     await click("#search-button");
 
     assert.strictEqual(
-      query(firstResult).textContent.trim(),
+      queryAll(contextSelector)[1].firstChild.textContent.trim(),
       `smth ${I18n.t("search.in_posts_by", {
         username: "eviltrout",
       })}`,
-      "user-scoped search is first available option"
+      "user-scoped search is first available option with no search term"
     );
   });
 
@@ -197,17 +197,18 @@ acceptance("Search - Anonymous", function (needs) {
     assert.strictEqual(
       query(firstResult).textContent.trim(),
       I18n.t("search.in_this_topic"),
-      "contextual topic search is first available option"
+      "contextual topic search is first available option with no search term"
     );
 
     await fillIn("#search-term", "a proper");
     await query("input#search-term").focus();
     await triggerKeyEvent(".search-menu", "keydown", "ArrowDown");
+    await triggerKeyEvent(".search-menu", "keydown", "ArrowDown");
 
     await click(document.activeElement);
     assert.ok(
       exists(".search-menu .search-result-post ul li"),
-      "clicking first option formats results as posts"
+      "clicking second option scopes search to current topic"
     );
 
     assert.strictEqual(
@@ -233,6 +234,7 @@ acceptance("Search - Anonymous", function (needs) {
     await fillIn("#search-term", "dev");
     await query("input#search-term").focus();
     await triggerKeyEvent(".search-menu", "keydown", "ArrowDown");
+    await triggerKeyEvent(".search-menu", "keydown", "ArrowDown");
     await click(document.activeElement);
 
     assert.ok(
@@ -255,17 +257,17 @@ acceptance("Search - Anonymous", function (needs) {
 
     await click("#search-button");
 
-    const firstResult =
-      ".search-menu .results .search-menu-assistant-item:first-child";
+    const contextSelector = ".search-menu .results .search-menu-assistant-item";
 
     assert.strictEqual(
-      query(firstResult).textContent.trim(),
+      queryAll(contextSelector)[0].firstChild.textContent.trim(),
       I18n.t("search.in_this_topic"),
-      "contextual topic search is first available option"
+      "contextual topic search is first available option with no search term"
     );
 
     await fillIn("#search-term", "proper");
     await query("input#search-term").focus();
+    await triggerKeyEvent(".search-menu", "keydown", "ArrowDown");
     await triggerKeyEvent(".search-menu", "keydown", "ArrowDown");
     await click(document.activeElement);
 
@@ -300,16 +302,16 @@ acceptance("Search - Anonymous", function (needs) {
       query(
         ".search-menu-assistant-item:first-child .search-item-user .label-suffix"
       ).textContent.trim(),
-      I18n.t("search.in_this_topic"),
-      "first result hints in this topic search"
+      I18n.t("search.in_topics_posts"),
+      "first result hints at global search"
     );
 
     assert.strictEqual(
       query(
         ".search-menu-assistant-item:nth-child(2) .search-item-user .label-suffix"
       ).textContent.trim(),
-      I18n.t("search.in_topics_posts"),
-      "second result hints global search"
+      I18n.t("search.in_this_topic"),
+      "second result hints at search within current topic"
     );
   });
 


### PR DESCRIPTION
Currently, the global search context suggestion("in all posts and topics") which also doubles as the default context on pressing Enter is displayed as the second item in the initial search options suggested.

This changes makes it the first item in the suggested options.

### Before
<img width="562" alt="Screenshot 2023-03-08 at 8 18 04 AM" src="https://user-images.githubusercontent.com/849886/223659477-f1db6ecc-4180-4fec-90a8-e85dfbe5f523.png">


### After
<img width="525" alt="Screenshot 2023-03-08 at 8 17 10 AM" src="https://user-images.githubusercontent.com/849886/223659439-9cc13ce2-95eb-41c9-9e1e-da8bbd07d38d.png">


<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
