### PR TITLE
FIX: do not show infinite loading state on draft with new users

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -115,6 +115,7 @@ export default class ChatLivePane extends Component {
   @action
   loadMessages() {
     if (!this.args.channel?.id) {
+      this.loadedOnce = true;
       return;
     }
 

--- a/plugins/chat/spec/system/draft_message_spec.rb
+++ b/plugins/chat/spec/system/draft_message_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe "Draft message", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:admin) }
+  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:channel_page) { PageObjects::Pages::ChatChannel.new }
+  let(:drawer) { PageObjects::Pages::ChatDrawer.new }
+
+  before do
+    chat_system_bootstrap
+    sign_in(current_user)
+  end
+
+  context "when current user never interacted with other user" do
+    fab!(:user) { Fabricate(:user) }
+
+    it "opens channel info page" do
+      visit("/chat/draft-channel")
+      expect(page).to have_selector(".results")
+
+      find(".results .user:nth-child(1)").click
+
+      expect(channel_page).to have_no_loading_skeleton
+    end
+  end
+end


### PR DESCRIPTION
When creating a new direct message with a user without any prior discussion we would forever show infinite loading until first message sent. This was due to use considering first load never happened given there was nothing to load.