### PR TITLE
FIX: correctly syncs current user message in multiple sessions

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -516,7 +516,8 @@ export default class ChatLivePane extends Component {
     }
   }
 
-  handleMessage(data) {
+  @bind
+  onMessage(data) {
     switch (data.type) {
       case "sent":
         this.handleSentMessage(data);
@@ -554,29 +555,26 @@ export default class ChatLivePane extends Component {
     }
   }
 
-  _handleOwnSentMessage(data) {
-    const stagedMessage = this.args.channel.findStagedMessage(data.staged_id);
-    if (stagedMessage) {
-      stagedMessage.error = null;
-      stagedMessage.id = data.chat_message.id;
-      stagedMessage.staged = false;
-      stagedMessage.excerpt = data.chat_message.excerpt;
-      stagedMessage.threadId = data.chat_message.thread_id;
-      stagedMessage.channelId = data.chat_message.chat_channel_id;
-      stagedMessage.createdAt = data.chat_message.created_at;
+  _handleStagedMessage(stagedMessage, data) {
+    stagedMessage.error = null;
+    stagedMessage.id = data.chat_message.id;
+    stagedMessage.staged = false;
+    stagedMessage.excerpt = data.chat_message.excerpt;
+    stagedMessage.threadId = data.chat_message.thread_id;
+    stagedMessage.channelId = data.chat_message.chat_channel_id;
+    stagedMessage.createdAt = data.chat_message.created_at;
 
-      const inReplyToMsg = this.args.channel.findMessage(
-        data.chat_message.in_reply_to?.id
-      );
-      if (inReplyToMsg && !inReplyToMsg.threadId) {
-        inReplyToMsg.threadId = data.chat_message.thread_id;
-      }
+    const inReplyToMsg = this.args.channel.findMessage(
+      data.chat_message.in_reply_to?.id
+    );
+    if (inReplyToMsg && !inReplyToMsg.threadId) {
+      inReplyToMsg.threadId = data.chat_message.thread_id;
+    }
 
-      // some markdown is cooked differently on the server-side, e.g.
-      // quotes, avatar images etc.
-      if (data.chat_message?.cooked !== stagedMessage.cooked) {
-        stagedMessage.cooked = data.chat_message.cooked;
-      }
+    // some markdown is cooked differently on the server-side, e.g.
+    // quotes, avatar images etc.
+    if (data.chat_message?.cooked !== stagedMessage.cooked) {
+      stagedMessage.cooked = data.chat_message.cooked;
     }
   }
 
@@ -586,7 +584,10 @@ export default class ChatLivePane extends Component {
     }
 
     if (data.chat_message.user.id === this.currentUser.id && data.staged_id) {
-      return this._handleOwnSentMessage(data);
+      const stagedMessage = this.args.channel.findStagedMessage(data.staged_id);
+      if (stagedMessage) {
+        return this._handleStagedMessage(stagedMessage, data);
+      }
     }
 
     if (this.args.channel.canLoadMoreFuture) {
@@ -1135,13 +1136,6 @@ export default class ChatLivePane extends Component {
       this.onMessage,
       this.args.channel.channelMessageBusLastId
     );
-  }
-
-  @bind
-  onMessage(busData) {
-    if (!this.args.channel.canLoadMoreFuture || busData.type !== "sent") {
-      this.handleMessage(busData);
-    }
   }
 
   @bind

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe "Chat channel", type: :system, js: true do
       end
     end
 
+    context "with two sessions opened on same channel" do
+      it "syncs the messages" do
+        using_session(:tab_1) do
+          sign_in(current_user)
+          chat.visit_channel(channel_1)
+        end
+
+        using_session(:tab_2) do
+          sign_in(current_user)
+          chat.visit_channel(channel_1)
+        end
+
+        using_session(:tab_1) { channel.send_message("test_message") }
+
+        using_session(:tab_2) { expect(channel).to have_message(text: "test_message") }
+      end
+    end
+
     it "allows to edit this message once persisted" do
       chat.visit_channel(channel_1)
       channel.send_message("aaaaaaaaaaaaaaaaaaaa")


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
