### PR TITLE
FIX: Display a proper error when user already exists and email addresses are hidden.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/create-invite.js
+++ b/app/assets/javascripts/discourse/app/controllers/create-invite.js
@@ -123,10 +123,6 @@ export default Controller.extend(
       return this.invite
         .save(data)
         .then(() => {
-          if (!this.invite.id) {
-            return;
-          }
-
           this.rollbackBuffer();
 
           if (

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -87,7 +87,6 @@ class InvitesController < ApplicationController
       render json: failed_json, status: 422
     end
   rescue Invite::UserExists => e
-    return render json: {}, status: 200 if SiteSetting.hide_email_address_taken?
     render_json_error(e.message)
   rescue ActiveRecord::RecordInvalid => e
     render_json_error(e.record.errors.full_messages.first)
@@ -206,9 +205,6 @@ class InvitesController < ApplicationController
           params.permit(:email, :custom_message, :max_redemptions_allowed, :expires_at),
         )
       rescue ActiveRecord::RecordInvalid => e
-        if SiteSetting.hide_email_address_taken? && e.record.email_already_exists?
-          return render json: {}, status: 200
-        end
         return render_json_error(e.record.errors.full_messages.first)
       end
     end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -349,7 +349,9 @@ class Invite < ActiveRecord::Base
   end
 
   def user_exists_error_msg(email)
-    I18n.t("invite.user_exists", email: CGI.escapeHTML(email))
+    error_key = SiteSetting.hide_email_address_taken? ? "generic_error_response" : "user_exists"
+
+    I18n.t("invite.#{error_key}", email: CGI.escapeHTML(email))
   end
 end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -255,6 +255,7 @@ en:
     user_exists: "There's no need to invite <b>%{email}</b>, they already have an account!"
     invite_exists: "You already invited <b>%{email}</b>."
     invalid_email: "%{email} isn't a valid email address."
+    generic_error_response: "There was a problem with your request."
     rate_limit:
       one: "You have already sent %{count} invite in the last 24 hours, please wait %{time_left} before trying again."
       other: "You have already sent %{count} invites in the last 24 hours, please wait %{time_left} before trying again."

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -444,8 +444,8 @@ RSpec.describe InvitesController do
 
           it "doesn’t inform the user" do
             create_invite
-            expect(response).to have_http_status :ok
-            expect(response.parsed_body).to be_blank
+            expect(response).to have_http_status :unprocessable_entity
+            expect(body).to match(/There was a problem with your request./)
           end
         end
       end
@@ -595,8 +595,8 @@ RSpec.describe InvitesController do
 
           it "doesn't inform the user" do
             update_invite
-            expect(response).to have_http_status :ok
-            expect(response.parsed_body).to be_blank
+            expect(response).to have_http_status :unprocessable_entity
+            expect(body).to match(/There was a problem with your request./)
           end
         end
       end


### PR DESCRIPTION
Follow-up to #16703. Returning an empty response leads to a bad UX since the user has no feedback about what happened.
