### PR TITLE
clear security keys in disable_2fa rake task

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -146,6 +146,7 @@ task "users:disable_2fa", [:username] => [:environment] do |_, args|
   username = args[:username]
   user = find_user(username)
   UserSecondFactor.where(user_id: user.id, method: UserSecondFactor.methods[:totp]).each(&:destroy!)
+  UserSecurityKey.where(user_id: user.id).destroy_all
   puts "2FA disabled for #{username}"
 end
 


### PR DESCRIPTION
https://meta.discourse.org/t/task-users-disable-2fa-does-not-disable-security-keys/256547

I thought I'd need to add a test, but I don't see any tests for this rake task, and the change is pretty straightforward, so maybe this single line is all that's needed.