### PR TITLE
FIX: Don't send image sizes for emojis/avatars

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.hbs
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.hbs
@@ -23,5 +23,9 @@
 </DEditor>
 
 {{#if this.allowUpload}}
-  <PickFilesButton @fileInputId="file-uploader" @allowMultiple={{true}} />
+  <PickFilesButton
+    @fileInputId="file-uploader"
+    @allowMultiple={{true}}
+    name="file-uploader"
+  />
 {{/if}}

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1008,7 +1008,9 @@ export default Controller.extend({
     // TODO: This should not happen in model
     const imageSizes = {};
     document
-      .querySelectorAll("#reply-control .d-editor-preview img")
+      .querySelectorAll(
+        "#reply-control .d-editor-preview img:not(.avatar):not(.emoji)"
+      )
       .forEach((e) => {
         const src = e.src;
 

--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1009,7 +1009,7 @@ export default Controller.extend({
     const imageSizes = {};
     document
       .querySelectorAll(
-        "#reply-control .d-editor-preview img:not(.avatar):not(.emoji)"
+        "#reply-control .d-editor-preview img:not(.avatar, .emoji)"
       )
       .forEach((e) => {
         const src = e.src;

--- a/spec/system/composer/review_media_unless_trust_level_spec.rb
+++ b/spec/system/composer/review_media_unless_trust_level_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe "Composer using review_media", type: :system, js: true do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:topic) { Fabricate(:topic, category: Category.find(SiteSetting.uncategorized_category_id)) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  fab!(:upload) { Fabricate(:upload) }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+
+  before do
+    SiteSetting.review_media_unless_trust_level = 3
+    sign_in user
+  end
+
+  it "does not flag a post with an emoji" do
+    topic_page.visit_topic_and_open_composer(topic)
+    topic_page.fill_in_composer(" this one has an emoji: :mask: ")
+
+    within(".d-editor-preview") { expect(page).to have_css(".emoji") }
+    topic_page.send_reply
+
+    expect(topic_page).to have_post_number(2)
+    expect(page).not_to have_css(".post-enqueued-modal")
+  end
+
+  it "flags a post with an image" do
+    topic_page.visit_topic_and_open_composer(topic)
+    topic_page.fill_in_composer(" this one has an upload: ")
+
+    attach_file "file-uploader", "#{Rails.root}/spec/fixtures/images/logo.jpg", make_visible: true
+    within(".d-editor-preview") { expect(page).to have_css("img") }
+    topic_page.send_reply
+
+    expect(page).to have_css(".post-enqueued-modal")
+  end
+end


### PR DESCRIPTION
#### What's the problem? 

Related: https://meta.discourse.org/t/review-media-unless-trust-level-setting-causes-reviews-with-emojis/230189 

When using the "review media unless trust level" setting, posts with emojis or quotes will end up in the review queue even though they don't have any uploaded media. That is because our heuristic for this in the new post manager relies on `image_sizes`: 

https://github.com/discourse/discourse/blob/main/lib/new_post_manager.rb#L117-L118 

Those image sizes are sent from the frontend, and they are gathered via the preview pane. Currently, the selector includes all images, uploaded images but also emojis, avatars in quotes and onebox images. 

#### What's the fix? 

The fix is quite simple: it changes the selector so that avatar and emoji image sizes aren't sent in the payload. This doesn't seem to have any adverse effects, the image sizes are only used as a fallback when limiting the size of images during post processing, and avatars/emojis don't need to be size restricted, they're already small. 

#### Caveats

This isn't a perfect fix. Onebox image will still be considered media, but that is probably desirable behaviour.  Long-term, the heuristic here should not rely on image sizes, but that is a much bigger change, outside the current scope. 

