### PR TITLE
UX: Fix chat-reply overflow

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -131,10 +131,6 @@
   border-top: 1px solid var(--primary-low);
   display: flex;
   align-items: center;
-  @include ellipsis;
-  position: relative;
-  height: 100%;
-  max-height: calc(2em - 5px);
 
   .cancel-message-action {
     margin-left: auto;

--- a/plugins/chat/assets/stylesheets/common/chat-reply.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-reply.scss
@@ -1,12 +1,8 @@
 .chat-reply {
-  display: contents;
   align-items: center;
-  box-sizing: border-box;
+  display: grid;
   font-size: var(--font-down-1);
-  padding-left: 0.5em;
-  height: 100%;
-  width: 100%;
-  white-space: nowrap;
+  grid: 1fr / auto-flow;
 
   .d-icon {
     color: var(--primary-low-mid);


### PR DESCRIPTION
Before / After

<img width="950" alt="Screenshot 2023-03-08 at 20 08 46" src="https://user-images.githubusercontent.com/66961/223815658-90d597a1-4fa8-45d8-8064-2f83c1852680.png">

<img width="950" alt="Screenshot 2023-03-08 at 20 09 01" src="https://user-images.githubusercontent.com/66961/223815633-0aa26986-68e3-4d95-b232-be3bc70fff02.png">
