### PR TITLE
UX: position of group user table dropdown, border

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -208,7 +208,6 @@
                     @canAdminGroup={{this.model.can_admin_group}}
                     @canEditGroup={{this.model.can_edit_group}}
                     @onChange={{action "actOnGroup" m}}
-                    @options={{hash placementStrategy="absolute"}}
                   />
                   {{! group parameter is used by plugins }}
                 </div>

--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -127,6 +127,7 @@
 
   &__column-header,
   &__cell,
+  &__cell--empty,
   &__cell--user-field {
     display: flex;
     border-bottom: 1px solid var(--primary-low);

--- a/app/assets/stylesheets/common/components/group-member-dropdown.scss
+++ b/app/assets/stylesheets/common/components/group-member-dropdown.scss
@@ -1,3 +1,12 @@
 .group-member-dropdown {
   text-align: left;
+
+  .select-kit-body {
+    // this is a little hacky
+    // but solves an issue with a wrapping container query on .directory-table-container
+    // which breaks our popper positioning in this one specific instance
+    inset: unset !important;
+    transform: unset !important;
+    right: 0 !important;
+  }
 }


### PR DESCRIPTION
This is a follow-up to e206bd8 that fixes two issues:

1. There's a missing border on empty fields (fixed by adding `&__cell--empty`)

    ![Screenshot 2023-03-08 at 3 39 19 PM](https://user-images.githubusercontent.com/1681963/223844992-30392092-c32b-4832-b435-95d6dd8c0919.png)

2. Due to using a container query on the `.directory-table-container`, popper.js fixed positioning is off. 

   Initially I avoided this by setting the `placementStrategy` to `absolute`, but this doesn't work when it's a short table, because we need to have overflow scrolling for extra wide tables... but the overflow clips an absolutely positioned dropdown. 
   
   So the temporary solution here is to go back to fixed positioned dropdowns and override the popper.js positioning. This makes this dropdown usable again, and I'll follow up with a developer to figure out a proper popper.js fix this different container context.  

    Before (dropdown is cropped and causes the table to have a vertical scroll)
    
    ![Screenshot 2023-03-08 at 3 39 15 PM](https://user-images.githubusercontent.com/1681963/223845055-a09339ef-a676-4eb6-90ee-3644bd83ba4c.png)
    
    After (dropdown does not force vertical scroll at the bottom of a short table) 
    
    
     ![Screenshot 2023-03-08 at 3 46 01 PM](https://user-images.githubusercontent.com/1681963/223846035-ad205538-e1b3-4ada-b242-958e2a34f135.png)

