### PR TITLE
DEV: Remove ruby-lsp from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -181,7 +181,6 @@ group :development do
   gem "binding_of_caller"
   gem "yaml-lint"
   gem "yard"
-  gem "ruby-lsp", require: false
 end
 
 if ENV["ALLOW_DEV_POPULATE"] == "1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,6 @@ GEM
       uri_template (~> 0.7)
     jwt (2.7.0)
     kgio (2.11.4)
-    language_server-protocol (3.17.0.3)
     libv8-node (16.10.0.0)
     libv8-node (16.10.0.0-aarch64-linux)
     libv8-node (16.10.0.0-arm64-darwin)
@@ -432,10 +431,6 @@ GEM
     rubocop-rspec (2.18.1)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
-    ruby-lsp (0.4.1)
-      language_server-protocol (~> 3.17.0)
-      sorbet-runtime
-      syntax_tree (>= 6, < 7)
     ruby-prof (1.6.1)
     ruby-progressbar (1.13.0)
     ruby-readability (0.7.0)
@@ -476,7 +471,6 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sorbet-runtime (0.5.10705)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -649,7 +643,6 @@ DEPENDENCIES
   rswag-specs
   rtlcss
   rubocop-discourse
-  ruby-lsp
   ruby-prof
   ruby-readability
   rubyzip


### PR DESCRIPTION
With the vscode-ruby-lsp v0.2.0 release, it is no longer required to add
the ruby-lsp gem to the Gemfile. Do note that the ruby-lsp vscode plugin
needs to be updated to the latest version for the extension to work
without ruby-lsp being declared in our Gemfile.