### PR TITLE
FIX: set external flag before validation

### DIFF
--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -7,7 +7,7 @@ class SidebarUrl < ActiveRecord::Base
 
   validate :path_validator
 
-  before_save :remove_internal_hostname, :set_external
+  before_validation :remove_internal_hostname, :set_external
 
   def path_validator
     if external?

--- a/spec/models/sidebar_url_spec.rb
+++ b/spec/models/sidebar_url_spec.rb
@@ -8,5 +8,39 @@ RSpec.describe SidebarUrl do
     expect(SidebarUrl.new(icon: "link", name: "categories", value: "/invalid_path").valid?).to eq(
       false,
     )
+    expect(
+      SidebarUrl.new(
+        icon: "link",
+        name: "external",
+        value: "https://www.test.com/discourse-test",
+      ).valid?,
+    ).to eq(true)
+  end
+
+  it "sets external flag" do
+    expect(
+      SidebarUrl.create!(icon: "link", name: "categories", value: "/categories").external,
+    ).to be false
+    expect(
+      SidebarUrl.create!(
+        icon: "link",
+        name: "categories",
+        value: "http://#{Discourse.current_hostname}/categories",
+      ).external,
+    ).to be false
+    expect(
+      SidebarUrl.create!(
+        icon: "link",
+        name: "categories",
+        value: "https://#{Discourse.current_hostname}/categories",
+      ).external,
+    ).to be false
+    expect(
+      SidebarUrl.create!(
+        icon: "link",
+        name: "categories",
+        value: "https://www.test.com/discourse-test",
+      ).external,
+    ).to be true
   end
 end


### PR DESCRIPTION
Previously, `before_save` callback was used, but `before_validation` has to be used to set external flag.

