### PR TITLE
FIX: Ensure `required_tag_group` is defined on new category records

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/new-category.js
+++ b/app/assets/javascripts/discourse/app/routes/new-category.js
@@ -32,6 +32,7 @@ export default DiscourseRoute.extend({
       topic_featured_link_allowed: true,
       custom_fields: {},
       search_priority: SEARCH_PRIORITIES.normal,
+      required_tag_groups: [],
     });
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -8,6 +8,7 @@ import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 import sinon from "sinon";
 import { test } from "qunit";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Category New", function (needs) {
   needs.user();
@@ -21,12 +22,30 @@ acceptance("Category New", function (needs) {
     await fillIn("input.category-name", "testing");
     assert.strictEqual(query(".badge-category").innerText, "testing");
 
+    await click(".edit-category-nav .edit-category-tags a");
+    await click("button.add-required-tag-group");
+
+    const tagSelector = selectKit(
+      ".required-tag-group-row .select-kit.tag-group-chooser"
+    );
+    await tagSelector.expand();
+    await tagSelector.selectRowByValue("TagGroup1");
+
     await click("#save-category");
 
     assert.strictEqual(
       currentURL(),
       "/c/testing/edit/general",
       "it transitions to the category edit route"
+    );
+
+    await click(".edit-category-nav .edit-category-tags a");
+
+    assert.ok(
+      exists(
+        ".required-tag-group-row .select-kit-header[data-value='TagGroup1']"
+      ),
+      "it shows saved required tag group"
     );
 
     assert.strictEqual(


### PR DESCRIPTION
Attaching required tag groups to new categories failed because `required_tag_group` was undefined on the new category records

This fix sets an empty `required_tag_group` property on the new category records.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
