### PR TITLE
DEV: avoid mocking FinalDestination

### DIFF
--- a/lib/final_destination/ssrf_detector.rb
+++ b/lib/final_destination/ssrf_detector.rb
@@ -78,6 +78,14 @@ class FinalDestination
       ips
     end
 
+    def self.allow_ip_lookups_in_test!
+      @allow_ip_lookups_in_test = true
+    end
+
+    def self.disallow_ip_lookups_in_test!
+      @allow_ip_lookups_in_test = false
+    end
+
     private
 
     def self.ip_in_ranges?(ip, ranges)
@@ -85,7 +93,7 @@ class FinalDestination
     end
 
     def self.lookup_ips(name, timeout: nil)
-      if Rails.env.test?
+      if Rails.env.test? && !@allow_ip_lookups_in_test
         ["1.2.3.4"]
       else
         FinalDestination::Resolver.lookup(name, timeout: timeout)

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -25,15 +25,6 @@ describe FinalDestination::HTTP do
     end
   end
 
-  def stub_ip_lookup(stub_addr, ips)
-    Addrinfo
-      .stubs(:getaddrinfo)
-      .with { |addr, _| addr == stub_addr }
-      .returns(
-        ips.map { |ip| Addrinfo.new([IPAddr.new(ip).ipv6? ? "AF_INET6" : "AF_INET", 80, nil, ip]) },
-      )
-  end
-
   def stub_tcp_to_raise(stub_addr, exception)
     TCPSocket.stubs(:open).with { |addr| addr == stub_addr }.once.raises(exception)
   end

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -7,9 +7,14 @@ describe FinalDestination::HTTP do
     Socket.stubs(:tcp).never
     TCPSocket.stubs(:open).never
     Addrinfo.stubs(:getaddrinfo).never
+
+    FinalDestination::SSRFDetector.allow_ip_lookups_in_test!
   end
 
-  after { WebMock.enable! }
+  after do
+    WebMock.enable!
+    FinalDestination::SSRFDetector.disallow_ip_lookups_in_test!
+  end
 
   def expect_tcp_and_abort(stub_addr, &blk)
     success = Class.new(StandardError)
@@ -21,7 +26,12 @@ describe FinalDestination::HTTP do
   end
 
   def stub_ip_lookup(stub_addr, ips)
-    FinalDestination::SSRFDetector.stubs(:lookup_ips).with { |addr| stub_addr == addr }.returns(ips)
+    Addrinfo
+      .stubs(:getaddrinfo)
+      .with { |addr, _| addr == stub_addr }
+      .returns(
+        ips.map { |ip| Addrinfo.new([IPAddr.new(ip).ipv6? ? "AF_INET6" : "AF_INET", 80, nil, ip]) },
+      )
   end
 
   def stub_tcp_to_raise(stub_addr, exception)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -192,4 +192,13 @@ module Helpers
 
     queries
   end
+
+  def stub_ip_lookup(stub_addr, ips)
+    Addrinfo
+      .stubs(:getaddrinfo)
+      .with { |addr, _| addr == stub_addr }
+      .returns(
+        ips.map { |ip| Addrinfo.new([IPAddr.new(ip).ipv6? ? "AF_INET6" : "AF_INET", 80, nil, ip]) },
+      )
+  end
 end


### PR DESCRIPTION
Backporting commits to stable in preparation for a security PR against stable.