### PR TITLE
DEV: avoid mocking FinalDestination (#20570)

### DIFF
--- a/lib/final_destination/ssrf_detector.rb
+++ b/lib/final_destination/ssrf_detector.rb
@@ -71,6 +71,14 @@ class FinalDestination
       ips
     end
 
+    def self.allow_ip_lookups_in_test!
+      @allow_ip_lookups_in_test = true
+    end
+
+    def self.disallow_ip_lookups_in_test!
+      @allow_ip_lookups_in_test = false
+    end
+
     private
 
     def self.ip_in_ranges?(ip, ranges)
@@ -78,7 +86,7 @@ class FinalDestination
     end
 
     def self.lookup_ips(name, timeout: nil)
-      if Rails.env.test?
+      if Rails.env.test? && !@allow_ip_lookups_in_test
         ["1.2.3.4"]
       else
         FinalDestination::Resolver.lookup(name, timeout: timeout)

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -26,15 +26,6 @@ describe FinalDestination::HTTP do
     end
   end
 
-  def stub_ip_lookup(stub_addr, ips)
-    Addrinfo
-      .stubs(:getaddrinfo)
-      .with { |addr, _| addr == stub_addr }
-      .returns(
-        ips.map { |ip| Addrinfo.new([IPAddr.new(ip).ipv6? ? "AF_INET6" : "AF_INET", 80, nil, ip]) },
-      )
-  end
-
   def stub_tcp_to_raise(stub_addr, exception)
     Socket.stubs(:tcp).with { |addr| addr == stub_addr }.once.raises(exception)
   end


### PR DESCRIPTION
This is to make backporting security patches which we're landing soon easier.