### PR TITLE
FIX(cache_critical_dns): use DB port sourced from environment

### DIFF
--- a/script/cache_critical_dns
+++ b/script/cache_critical_dns
@@ -107,6 +107,7 @@ CRITICAL_HOST_ENV_VARS = %w{
 )
 
 DEFAULT_DB_NAME = "discourse"
+DEFAULT_DB_PORT = 5432
 DEFAULT_REDIS_PORT = 6379
 
 HOST_RESOLVER_CACHE = {}
@@ -267,12 +268,13 @@ ensure
   client.close if client
 end
 
-def postgres_healthcheck(host:, user:, password:, dbname:)
+def postgres_healthcheck(host:, user:, password:, dbname:, port: DEFAULT_DB_PORT)
   client = PG::Connection.new(
     host: host,
     user: user,
     password: password,
     dbname: dbname,
+    port: port,
     connect_timeout: 2,  # minimum
   )
   client.exec(';').none?
@@ -291,12 +293,14 @@ HEALTH_CHECKS = Hash.new(
       host: addr,
       user: ENV["DISCOURSE_DB_USERNAME"] || DEFAULT_DB_NAME,
       dbname: ENV["DISCOURSE_DB_NAME"] || DEFAULT_DB_NAME,
+      port: ENV["DISCOURSE_DB_PORT"] || DEFAULT_DB_PORT,
       password: ENV["DISCOURSE_DB_PASSWORD"])},
   "DISCOURSE_DB_REPLICA_HOST": lambda { |addr|
     postgres_healthcheck(
       host: addr,
       user: ENV["DISCOURSE_DB_USERNAME"] || DEFAULT_DB_NAME,
       dbname: ENV["DISCOURSE_DB_NAME"] || DEFAULT_DB_NAME,
+      port: ENV["DISCOURSE_DB_REPLICA_PORT"] || DEFAULT_DB_PORT,
       password: ENV["DISCOURSE_DB_PASSWORD"])},
   "DISCOURSE_REDIS_HOST": lambda { |addr|
     redis_healthcheck(


### PR DESCRIPTION
Fixes an assumption that the PostgreSQL port will always be reachable at the discovered host on the default port when performing the healthcheck.

Instead we should be sourcing this from the same environment variable that the application will be using to connect to.

Defaults to the standard PG port, 5432.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
