### PR TITLE
FIX: tag dropdown not working with default_list_filter

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -506,9 +506,12 @@ export function getCategoryAndTagUrl(category, subcategories, tag) {
 
   if (category) {
     url = category.path;
-    if (subcategories && category.default_list_filter === "none") {
+    if (subcategories && (category.default_list_filter === "none" || tag)) {
       url += "/all";
-    } else if (!subcategories && category.default_list_filter === "all") {
+    } else if (
+      !subcategories &&
+      (category.default_list_filter === "all" || tag)
+    ) {
       url += "/none";
     }
   }

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -141,6 +141,34 @@ module("Unit | Utility | url", function () {
       ),
       "/c/foo/1"
     );
+
+    assert.strictEqual(
+      getCategoryAndTagUrl(
+        { path: "/c/foo/1", default_list_filter: "none" },
+        false,
+        "bar"
+      ),
+      "/tags/c/foo/1/none/bar"
+    );
+
+    assert.strictEqual(
+      getCategoryAndTagUrl({ path: "/c/foo/1" }, false, "bar"),
+      "/tags/c/foo/1/none/bar"
+    );
+
+    assert.strictEqual(
+      getCategoryAndTagUrl(
+        { path: "/c/foo/1", default_list_filter: "all" },
+        true,
+        "bar"
+      ),
+      "/tags/c/foo/1/all/bar"
+    );
+
+    assert.strictEqual(
+      getCategoryAndTagUrl({ path: "/c/foo/1" }, true, "bar"),
+      "/tags/c/foo/1/all/bar"
+    );
   });
 
   test("routeTo redirects secure uploads URLS because they are server side only", async function (assert) {


### PR DESCRIPTION
If you set a category to `default_list_filter` none. Information
was not passed to the tag route and routing was incorrect.

This patch fails, cause on reload route does not point to the right place.


```diff
-- a/app/assets/javascripts/discourse/app/routes/tag-show.js
+++ b/app/assets/javascripts/discourse/app/routes/tag-show.js
@@ -89,6 +89,8 @@ export default DiscourseRoute.extend(FilterModeMixin, {
       filter = `tag/${tagId}/l/${topicFilter}`;
     }
     const list = await findTopicList(
       this.store,
       this.topicTrackingState,
@@ -123,7 +125,7 @@ export default DiscourseRoute.extend(FilterModeMixin, {
   },

   setupController(controller, model) {
-    const noSubcategories =
+    this.noSubcategories =
       this.noSubcategories === undefined
         ? model.category?.default_list_filter === NONE
         : this.noSubcategories;
@@ -133,7 +135,7 @@ export default DiscourseRoute.extend(FilterModeMixin, {
       ...model,
       period: model.list.for_period,
       navMode: this.navMode,
-      noSubcategories,
+      noSubcategories: this.noSubcategories,
       loading: false,
     });
 ```

Long term we don't want to hide this logic from the routing (even in
the category case) it just cause unneeded confusion and fragility.
