### PR TITLE
DEV: Unsilence two ember deprecations

### DIFF
--- a/app/assets/javascripts/discourse/config/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/config/deprecation-workflow.js
@@ -14,13 +14,5 @@ globalThis.deprecationWorkflow.config = {
     { handler: "silence", matchId: "this-property-fallback" },
     { handler: "silence", matchId: "ember.globals-resolver" },
     { handler: "silence", matchId: "globals-resolver" },
-    {
-      handler: "silence",
-      matchId: "deprecated-run-loop-and-computed-dot-access",
-    },
-    {
-      handler: "silence",
-      matchId: "ember.built-in-components.legacy-arguments",
-    },
   ],
 };


### PR DESCRIPTION
Neither of these are triggered in the core test suite. Unsilence so that plugins/themes receive deprecation notices.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
