### PR TITLE
FIX: Ensure `form_template_ids` is defined on new category records

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/new-category.js
+++ b/app/assets/javascripts/discourse/app/routes/new-category.js
@@ -33,6 +33,7 @@ export default DiscourseRoute.extend({
       custom_fields: {},
       search_priority: SEARCH_PRIORITIES.normal,
       required_tag_groups: [],
+      form_template_ids: [],
     });
   },
 

--- a/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-new-test.js
@@ -22,6 +22,11 @@ acceptance("Category New", function (needs) {
     await fillIn("input.category-name", "testing");
     assert.strictEqual(query(".badge-category").innerText, "testing");
 
+    await click(".edit-category-nav .edit-category-topic-template a");
+    assert
+      .dom(".edit-category-tab-topic-template")
+      .isVisible("it can switch to topic template tab");
+
     await click(".edit-category-nav .edit-category-tags a");
     await click("button.add-required-tag-group");
 


### PR DESCRIPTION
Navigating to the topic template tab on a new category form resulted in exceptions because the `form_template_ids` property was undefined.

This fix sets the `form_template_ids` property on new category records.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
