### PR TITLE
DEV: Unsilence and resolve setting-on-hash deprecation

### DIFF
--- a/app/assets/javascripts/discourse/config/deprecation-workflow.js
+++ b/app/assets/javascripts/discourse/config/deprecation-workflow.js
@@ -10,7 +10,6 @@ globalThis.deprecationWorkflow.config = {
     { handler: "silence", matchId: "route-render-template" },
     { handler: "silence", matchId: "routing.transition-methods" },
     { handler: "silence", matchId: "route-disconnect-outlet" },
-    { handler: "silence", matchId: "setting-on-hash" },
     { handler: "silence", matchId: "this-property-fallback" },
     { handler: "silence", matchId: "ember.globals-resolver" },
     { handler: "silence", matchId: "globals-resolver" },


### PR DESCRIPTION
Select-kit was mutating a passed-in options hash to apply its own deprecations. This commit updates it to apply deprecated changes to the downstream `this.selectKit.options` object instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
