### PR TITLE
UX: allow profile menu tabs to scroll if needed

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -664,14 +664,32 @@ export default createWidget("header", {
   },
 
   preventDefault(e) {
-    // prevent all scrolling on menu panels, except on overflow
-    const height = window.innerHeight ? window.innerHeight : $(window).height();
-    if (
-      !$(e.target).parents(".menu-panel").length ||
-      $(".menu-panel .panel-body-contents").height() <= height
-    ) {
-      e.preventDefault();
+    const windowHeight = window.innerHeight;
+
+    // allow profile menu tabs to scroll if they're taller than the window
+    if (e.target.closest(".menu-panel .menu-tabs-container")) {
+      const topTabs = document.querySelector(".menu-panel .top-tabs");
+      const bottomTabs = document.querySelector(".menu-panel .bottom-tabs");
+      const profileTabsHeight =
+        topTabs?.offsetHeight + bottomTabs?.offsetHeight || 0;
+
+      if (profileTabsHeight > windowHeight) {
+        return;
+      }
     }
+
+    // allow menu panels to scroll if contents are taller than the window
+    if (e.target.closest(".menu-panel")) {
+      const menuContentHeight =
+        document.querySelector(".menu-panel .panel-body-contents")
+          .offsetHeight || 0;
+
+      if (menuContentHeight > windowHeight) {
+        return;
+      }
+    }
+
+    e.preventDefault();
   },
 
   togglePageSearch() {

--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -111,6 +111,7 @@
     border-left: 1px solid var(--primary-low);
     padding: 0.75em 0 0;
     overflow-y: auto;
+    overscroll-behavior: contain;
   }
 
   .tabs-list {


### PR DESCRIPTION
Issue reported here: https://meta.discourse.org/t/make-sure-menu-always-scrollable-on-mobile/255793

On small screens, like phones in landscape, `e.preventDefault();` was preventing the profile tabs from scrolling. This checks the height and allows them to scroll if needed


![Screenshot 2023-03-09 at 3 06 41 PM](https://user-images.githubusercontent.com/1681963/224142474-216c3709-10d4-40b0-b7db-a04d72ec514b.png)
