### PR TITLE
DEV: Avoid logging routing errors

### DIFF
--- a/lib/middleware/discourse_public_exceptions.rb
+++ b/lib/middleware/discourse_public_exceptions.rb
@@ -10,6 +10,7 @@ module Middleware
           Rack::QueryParser::InvalidParameterError,
           ActionController::BadRequest,
           ActionDispatch::Http::Parameters::ParseError,
+          ActionController::RoutingError,
         ],
       )
 


### PR DESCRIPTION
The logs are usually caused by the client and is of no use to us.