### PR TITLE
A11Y: usernames aren't meaningful section headings

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -116,7 +116,7 @@
           <UserProfileAvatar @user={{this.model}} @tagName="" />
           <div class="primary-textual">
             <div class="user-profile-names">
-              <h1
+              <div
                 class="{{if this.nameFirst 'full-name' 'username'}}
                   user-profile-names__primary"
               >
@@ -129,7 +129,7 @@
                 {{#if this.model.status}}
                   <UserStatusMessage @status={{this.model.status}} />
                 {{/if}}
-              </h1>
+              </div>
               <div
                 class="{{if this.nameFirst 'username' 'full-name'}}
                   user-profile-names__secondary"

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -781,6 +781,10 @@
     font-size: 0.8em;
     vertical-align: baseline;
   }
+  .user-status-message {
+    display: inline-flex;
+    vertical-align: baseline;
+  }
 }
 
 .user-profile-names__secondary {


### PR DESCRIPTION
The username on profile pages isn't a useful section heading for screen readers, so it should be a div instead. 