### PR TITLE
Revert "DEV: Add crossOrigin to video tag (#20617)"

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/pretty-text-test.js
@@ -1048,7 +1048,7 @@ eviltrout</p>
     assert.cooked(
       "![baby shark|video](upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4)",
       `<p><div class="video-container">
-    <video width="100%" height="100%" preload="metadata" crossorigin="anonymous" controls>
+    <video width="100%" height="100%" preload="metadata" controls>
       <source src="/404" data-orig-src="upload://eyPnj7UzkU0AkGkx2dx8G4YM1Jx.mp4">
       <a href="/404">/404</a>
     </video>
@@ -1074,7 +1074,7 @@ eviltrout</p>
         lookupUploadUrls,
       },
       `<p><div class="video-container">
-    <video width="100%" height="100%" preload="metadata" crossorigin="anonymous" controls>
+    <video width="100%" height="100%" preload="metadata" controls>
       <source src="/secure-uploads/original/3X/c/b/test.mp4">
       <a href="/secure-uploads/original/3X/c/b/test.mp4">/secure-uploads/original/3X/c/b/test.mp4</a>
     </video>

--- a/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
+++ b/app/assets/javascripts/pretty-text/addon/engines/discourse-markdown-it.js
@@ -160,7 +160,7 @@ function videoHTML(token) {
   const origSrc = token.attrGet("data-orig-src");
   const dataOrigSrcAttr = origSrc !== null ? `data-orig-src="${origSrc}"` : "";
   return `<div class="video-container">
-    <video width="100%" height="100%" preload="metadata" crossOrigin="anonymous" controls>
+    <video width="100%" height="100%" preload="metadata" controls>
       <source src="${src}" ${dataOrigSrcAttr}>
       <a href="${src}">${src}</a>
     </video>


### PR DESCRIPTION
This reverts commit f6063c684ba9a158e42083e57af77aeeae80c189.

Videos on sites with a cdn enabled aren't playing w/ a default cdn
config. They are showing a "CORS request did not succeed" error.
