### PR TITLE
UX: some admin theme list style adjustments

### DIFF
--- a/app/assets/javascripts/admin/addon/components/themes-list.hbs
+++ b/app/assets/javascripts/admin/addon/components/themes-list.hbs
@@ -56,6 +56,7 @@
     {{#if this.hasInactiveThemes}}
       {{#each this.inactiveThemes as |theme|}}
         <ThemesListItem
+          @classNames="inactive-theme"
           @theme={{theme}}
           @navigateToTheme={{action "navigateToTheme" theme}}
         />

--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -191,7 +191,9 @@
       &.active {
         background-color: var(--quaternary);
         color: var(--secondary);
-        font-weight: 700;
+        .d-icon {
+          color: currentColor;
+        }
       }
     }
   }
@@ -219,15 +221,24 @@
       border-bottom: 1px solid var(--primary-low);
       display: flex;
 
+      &.inactive-theme {
+        color: var(--primary-high);
+        background: var(--primary-very-low);
+        font-size: var(--font-down-1);
+        &:not(.selected):hover {
+          color: var(--primary);
+        }
+      }
+
       &.inactive-indicator {
         border-right: 0;
         border-left: 0;
-        font-weight: bold;
-        color: var(--primary-medium);
+        margin-top: 1em;
+        padding-left: 0.33em;
 
         span.empty {
-          padding-left: 5px;
-          padding-top: 15px;
+          padding-left: 0.33em;
+          padding-top: 1em;
         }
       }
       &:not(.inactive-indicator):not(.selected):hover {
@@ -263,7 +274,6 @@
       .info {
         overflow: hidden;
         display: flex;
-        font-weight: bold;
         font-size: var(--font-up-1);
 
         .icons {


### PR DESCRIPTION
"When everything is bold, nothing is bold"

This fixes a minor hover issue with the headers, and generally calms these styles down with less bold and less prominence for inactive themes.

Before/After
![Screenshot 2023-03-09 at 6 00 16 PM](https://user-images.githubusercontent.com/1681963/224180140-4f906f41-14f0-4c47-9943-95c3ec660c9c.png)![Screenshot 2023-03-09 at 5 59 19 PM](https://user-images.githubusercontent.com/1681963/224180133-60b97e49-267d-48ef-b438-11421c23c4c4.png)
