### PR TITLE
DEV: Let unread topics come through to /new when new new view is enabled

### DIFF
--- a/app/assets/javascripts/discourse/app/components/count-i18n.js
+++ b/app/assets/javascripts/discourse/app/components/count-i18n.js
@@ -8,9 +8,14 @@ export default Component.extend({
 
   didReceiveAttrs() {
     this._super(...arguments);
-    this.set(
-      "i18nCount",
-      htmlSafe(I18n.t(this.key + (this.suffix || ""), { count: this.count }))
-    );
+
+    let fullKey = this.key + (this.suffix || "");
+    if (
+      this.currentUser?.new_new_view_enabled &&
+      fullKey === "topic_count_new"
+    ) {
+      fullKey = "topic_count_latest";
+    }
+    this.set("i18nCount", htmlSafe(I18n.t(fullKey, { count: this.count })));
   },
 });

--- a/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
+++ b/app/assets/javascripts/discourse/app/models/topic-tracking-state.js
@@ -284,11 +284,12 @@ const TopicTrackingState = EmberObject.extend({
       this._addIncoming(data.topic_id);
     }
 
+    const unreadRecipients = ["all", "unread", "unseen"];
+    if (this.currentUser?.new_new_view_enabled) {
+      unreadRecipients.push("new");
+    }
     // count an unread topic as incoming
-    if (
-      ["all", "unread", "unseen"].includes(filter) &&
-      data.message_type === "unread"
-    ) {
+    if (unreadRecipients.includes(filter) && data.message_type === "unread") {
       const old = this.findState(data);
 
       // the highest post number is equal to last read post number here

--- a/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/models/topic-tracking-state-test.js
@@ -893,6 +893,42 @@ module("Unit | Model | topic-tracking-state | /unread", function (hooks) {
     );
   });
 
+  test("adds unread incoming to the new topic list if new new view is enabled", async function (assert) {
+    this.currentUser.new_new_view_enabled = true;
+
+    this.trackingState.trackIncoming("new");
+    await publishToMessageBus("/unread", unreadTopicPayload);
+
+    assert.deepEqual(
+      this.trackingState.newIncoming,
+      [111],
+      "unread topic is incoming"
+    );
+    assert.strictEqual(
+      this.trackingState.incomingCount,
+      1,
+      "incoming count is increased"
+    );
+  });
+
+  test("doesn't add unread incoming to the new topic list if new new view is disabled", async function (assert) {
+    this.currentUser.new_new_view_enabled = false;
+
+    this.trackingState.trackIncoming("new");
+    await publishToMessageBus("/unread", unreadTopicPayload);
+
+    assert.deepEqual(
+      this.trackingState.newIncoming,
+      [],
+      "unread topic is not incoming"
+    );
+    assert.strictEqual(
+      this.trackingState.incomingCount,
+      0,
+      "incoming count isn't increased"
+    );
+  });
+
   test("correct tag and category filters for different lists", function (assert) {
     this.trackingState.trackIncoming("unread");
     assert.strictEqual(this.trackingState.filterCategory, undefined);


### PR DESCRIPTION
Currently, if a user has opted into the new new experiment (introduced in https://github.com/discourse/discourse/commit/a5094411487f3fa5d1b7922717104ae4c80e5bfd) and they click on the "See # new or updated topics" banner (screenshot below) at the top of the `/new` topics list, only new topics are loaded even if there are tracked topics with new replies.

This is unexpected in the new new view experiment because `/new` in this experiment is supposed to show both new and unread topics so it should listen for both new topics and new replies for existing/tracked topics. This PR addresses this inconsistency and makes it so that clicking the banner load all new and updated topics.

<img src="https://user-images.githubusercontent.com/17474474/224186876-421e94a9-e02b-40e7-93c4-13e15e66d161.png" width=400>

Internal topic: t/77234/25.