### PR TITLE
Revert "FIX: tag dropdown not working with default_list_filter (#20608)"

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/url.js
+++ b/app/assets/javascripts/discourse/app/lib/url.js
@@ -506,12 +506,9 @@ export function getCategoryAndTagUrl(category, subcategories, tag) {
 
   if (category) {
     url = category.path;
-    if (subcategories && (category.default_list_filter === "none" || tag)) {
+    if (subcategories && category.default_list_filter === "none") {
       url += "/all";
-    } else if (
-      !subcategories &&
-      (category.default_list_filter === "all" || tag)
-    ) {
+    } else if (!subcategories && category.default_list_filter === "all") {
       url += "/none";
     }
   }

--- a/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/url-test.js
@@ -141,34 +141,6 @@ module("Unit | Utility | url", function () {
       ),
       "/c/foo/1"
     );
-
-    assert.strictEqual(
-      getCategoryAndTagUrl(
-        { path: "/c/foo/1", default_list_filter: "none" },
-        false,
-        "bar"
-      ),
-      "/tags/c/foo/1/none/bar"
-    );
-
-    assert.strictEqual(
-      getCategoryAndTagUrl({ path: "/c/foo/1" }, false, "bar"),
-      "/tags/c/foo/1/none/bar"
-    );
-
-    assert.strictEqual(
-      getCategoryAndTagUrl(
-        { path: "/c/foo/1", default_list_filter: "all" },
-        true,
-        "bar"
-      ),
-      "/tags/c/foo/1/all/bar"
-    );
-
-    assert.strictEqual(
-      getCategoryAndTagUrl({ path: "/c/foo/1" }, true, "bar"),
-      "/tags/c/foo/1/all/bar"
-    );
   });
 
   test("routeTo redirects secure uploads URLS because they are server side only", async function (assert) {


### PR DESCRIPTION
This reverts commit 0df7743d78cf3fadb1540fd2a4cf47bc57e3517d.

This causes too much instability in the unit test system, reverting
