### PR TITLE
FIX: server side support for default_list_filter none

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -59,6 +59,11 @@ class ListController < ApplicationController
         list_opts[:no_definitions] = true
       end
 
+      if @category && options[:no_subcategories].nil? &&
+           @category.default_list_filter == Category::LIST_FILTER_NONE
+        list_opts[:no_subcategories] = true
+      end
+
       list = TopicQuery.new(user, list_opts).public_send("list_#{filter}")
 
       if guardian.can_create_shared_draft? && @category.present?

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -531,6 +531,15 @@ class TagsController < ::ApplicationController
       )
     options[:no_subcategories] = true if params[:no_subcategories] == true ||
       params[:no_subcategories] == "true"
+
+    if options[:category] && params[:no_subcategories].nil? && !options[:no_subcategories] &&
+         Category.where(
+           id: options[:category].to_i,
+           default_list_filter: Category::LIST_FILTER_NONE,
+         ).exists?
+      options[:no_subcategories] = true
+    end
+
     options[:per_page] = params[:per_page].to_i.clamp(1, 30) if params[:per_page].present?
 
     if params[:tag_id] == "none"

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,6 +2,7 @@
 
 class Category < ActiveRecord::Base
   RESERVED_SLUGS = ["none"]
+  LIST_FILTER_NONE = "none"
 
   self.ignored_columns = [
     :suppress_from_latest, # TODO(2020-11-18): remove

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -685,7 +685,10 @@ class TopicQuery
         result = result.where("topics.category_id IN (?)", Category.subcategory_ids(category_id))
         if !SiteSetting.show_category_definitions_in_topic_lists
           result =
-            result.where("categories.topic_id <> topics.id OR topics.category_id = ?", category_id)
+            result.where(
+              "categories.topic_id IS NULL OR categories.topic_id <> topics.id OR topics.category_id = ?",
+              category_id,
+            )
         end
       end
       result = result.references(:categories)

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -5,9 +5,8 @@ RSpec.describe TagsController do
   fab!(:admin) { Fabricate(:admin) }
   fab!(:regular_user) { Fabricate(:trust_level_4) }
   fab!(:moderator) { Fabricate(:moderator) }
-  # -1 keeps tests more stable TopicQuery has `categories.topic_id <> topics.id` which will fail if this is null
-  fab!(:category) { Fabricate(:category, topic_id: -1) }
-  fab!(:subcategory) { Fabricate(:category, topic_id: -1, parent_category_id: category.id) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:subcategory) { Fabricate(:category, parent_category_id: category.id) }
 
   before { SiteSetting.tagging_enabled = true }
 


### PR DESCRIPTION
default_list_filter for categories was previously only respected on the
client side. This meant you could "reload" a page with invalid info:

Eg: `https://example.com/c/departments/1` would show sub departments on
fresh load.

This logic sort of worked client side on category routes but was totally
broken on server side.

This attempts to teach the server about this special option
