### PR TITLE
FIX: more consistent scroll to bottom

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.hbs
@@ -83,7 +83,7 @@
   </div>
 
   <ChatScrollToBottomArrow
-    @scrollToBottom={{this.scrollToBottom}}
+    @scrollToBottom={{this.scrollToLatestMessage}}
     @hasNewMessages={{this.hasNewMessages}}
     @show={{or this.needsArrow @channel.canLoadMoreFuture}}
     @channel={{@channel}}


### PR DESCRIPTION
This fix uses direct `scrollTop` manipulation instead of `scrollIntoView` when we are certain we actually want the bottom of the screen. This avoids a range of issues especially in safari but also chrome where the scroll position was not correct at the end of `scrollIntoView`, especially due to images.

There are already specs for this and it's actually hard to test more than this given it's browser specific behavior most of the times and also related to network.
