### PR TITLE
DEV: do not fabricate a notification when fabricating a chat_mention

### DIFF
--- a/plugins/chat/spec/components/chat_mailer_spec.rb
+++ b/plugins/chat/spec/components/chat_mailer_spec.rb
@@ -170,13 +170,12 @@ describe Chat::ChatMailer do
     it "doesn't mix mentions from other users" do
       mention.destroy!
       user_2 = Fabricate(:user, groups: [chatters_group], last_seen_at: 20.minutes.ago)
-      user_2_membership =
-        Fabricate(
-          :user_chat_channel_membership,
-          user: user_2,
-          chat_channel: chat_channel,
-          last_read_message_id: nil,
-        )
+      Fabricate(
+        :user_chat_channel_membership,
+        user: user_2,
+        chat_channel: chat_channel,
+        last_read_message_id: nil,
+      )
       new_message = Fabricate(:chat_message, chat_channel: chat_channel, user: sender)
       Fabricate(:chat_mention, user: user_2, chat_message: new_message)
 

--- a/plugins/chat/spec/components/chat_mailer_spec.rb
+++ b/plugins/chat/spec/components/chat_mailer_spec.rb
@@ -40,10 +40,7 @@ describe Chat::ChatMailer do
   end
 
   describe "for chat mentions" do
-    fab!(:notification) { Fabricate(:notification) }
-    fab!(:mention) do
-      Fabricate(:chat_mention, user: user_1, chat_message: chat_message, notification: notification)
-    end
+    fab!(:mention) { Fabricate(:chat_mention, user: user_1, chat_message: chat_message) }
 
     it "skips users without chat access" do
       chatters_group.remove(user_1)
@@ -154,13 +151,7 @@ describe Chat::ChatMailer do
         last_unread_mention_when_emailed_id: chat_message.id,
       )
       unread_message = Fabricate(:chat_message, chat_channel: chat_channel, user: sender)
-      notification = Fabricate(:notification)
-      Fabricate(
-        :chat_mention,
-        user: user_1,
-        chat_message: unread_message,
-        notification: notification,
-      )
+      Fabricate(:chat_mention, user: user_1, chat_message: unread_message)
 
       described_class.send_unread_mentions_summary
 
@@ -187,8 +178,7 @@ describe Chat::ChatMailer do
           last_read_message_id: nil,
         )
       new_message = Fabricate(:chat_message, chat_channel: chat_channel, user: sender)
-      notification = Fabricate(:notification)
-      Fabricate(:chat_mention, user: user_2, chat_message: new_message, notification: notification)
+      Fabricate(:chat_mention, user: user_2, chat_message: new_message)
 
       described_class.send_unread_mentions_summary
 
@@ -227,13 +217,7 @@ describe Chat::ChatMailer do
         )
 
         another_channel_message = Fabricate(:chat_message, chat_channel: chat_channel, user: sender)
-        notification = Fabricate(:notification)
-        Fabricate(
-          :chat_mention,
-          user: user_1,
-          chat_message: another_channel_message,
-          notification: notification,
-        )
+        Fabricate(:chat_mention, user: user_1, chat_message: another_channel_message)
 
         expect { described_class.send_unread_mentions_summary }.not_to change(
           Jobs::UserEmail.jobs,
@@ -245,13 +229,7 @@ describe Chat::ChatMailer do
         another_channel = Fabricate(:category_channel)
         another_channel_message =
           Fabricate(:chat_message, chat_channel: another_channel, user: sender)
-        notification = Fabricate(:notification)
-        Fabricate(
-          :chat_mention,
-          user: user_1,
-          chat_message: another_channel_message,
-          notification: notification,
-        )
+        Fabricate(:chat_mention, user: user_1, chat_message: another_channel_message)
         another_channel_membership =
           Fabricate(
             :user_chat_channel_membership,
@@ -281,15 +259,14 @@ describe Chat::ChatMailer do
     end
 
     it "only queues the job once when the user has mentions and private messages" do
-      notification = Fabricate(:notification)
-      Fabricate(:chat_mention, user: user_1, chat_message: chat_message, notification: notification)
+      Fabricate(:chat_mention, user: user_1, chat_message: chat_message)
 
       described_class.send_unread_mentions_summary
 
       assert_only_queued_once
     end
 
-    it "Doesn't mix or update mentions from other users when joining tables" do
+    it "doesn't mix or update mentions from other users when joining tables" do
       user_2 = Fabricate(:user, groups: [chatters_group], last_seen_at: 20.minutes.ago)
       user_2_membership =
         Fabricate(
@@ -298,8 +275,7 @@ describe Chat::ChatMailer do
           chat_channel: chat_channel,
           last_read_message_id: chat_message.id,
         )
-      notification = Fabricate(:notification)
-      Fabricate(:chat_mention, user: user_2, chat_message: chat_message, notification: notification)
+      Fabricate(:chat_mention, user: user_2, chat_message: chat_message)
 
       described_class.send_unread_mentions_summary
 

--- a/plugins/chat/spec/lib/message_mover_spec.rb
+++ b/plugins/chat/spec/lib/message_mover_spec.rb
@@ -109,14 +109,7 @@ describe Chat::MessageMover do
     it "updates references for reactions, uploads, revisions, mentions, etc." do
       reaction = Fabricate(:chat_message_reaction, chat_message: message1)
       upload = Fabricate(:upload_reference, target: message1)
-      notification = Fabricate(:notification)
-      mention =
-        Fabricate(
-          :chat_mention,
-          chat_message: message2,
-          user: acting_user,
-          notification: notification,
-        )
+      mention = Fabricate(:chat_mention, chat_message: message2, user: acting_user)
       revision = Fabricate(:chat_message_revision, chat_message: message3)
       webhook_event = Fabricate(:chat_webhook_event, chat_message: message3)
       move!

--- a/plugins/chat/spec/models/chat_message_spec.rb
+++ b/plugins/chat/spec/models/chat_message_spec.rb
@@ -471,6 +471,7 @@ describe ChatMessage do
       message_1.destroy!
 
       expect { mention_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "destroys chat_webhook_event" do


### PR DESCRIPTION
This is just a little clean-up in tests. In the past, when creating a `chat_mention` record, we always created a related notification. Starting from fa543cda notifications and chat_mentions are fully decoupled from each other. So if we're testing just chat mentions there is no need to fabricate notifications for them.