### PR TITLE
FIX: Welcome topic banner showing after general category is deleted

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -371,7 +371,10 @@ class Category < ActiveRecord::Base
   end
 
   def clear_related_site_settings
-    SiteSetting.general_category_id = -1 if self.id == SiteSetting.general_category_id
+    if self.id == SiteSetting.general_category_id
+      SiteSetting.general_category_id = -1
+      Site.clear_show_welcome_topic_cache
+    end
   end
 
   def topic_url

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -232,19 +232,22 @@ class Site
       .exists?
   end
 
+  def self.clear_show_welcome_topic_cache
+    Discourse
+      .cache
+      .keys("show_welcome_topic_banner:*")
+      .each { |key| Discourse.cache.redis.del(key) }
+  end
+
   def self.show_welcome_topic_banner?(guardian)
     return false if !guardian.is_admin?
+    return false if guardian.user.id != User.first_login_admin_id
     user_id = guardian.user.id
 
     show_welcome_topic_banner = Discourse.cache.read(welcome_topic_banner_cache_key(user_id))
     return show_welcome_topic_banner unless show_welcome_topic_banner.nil?
 
-    show_welcome_topic_banner =
-      if (user_id == User.first_login_admin_id)
-        welcome_topic_exists_and_is_not_edited?
-      else
-        false
-      end
+    show_welcome_topic_banner = welcome_topic_exists_and_is_not_edited?
 
     Discourse.cache.write(welcome_topic_banner_cache_key(user_id), show_welcome_topic_banner)
     show_welcome_topic_banner

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -203,7 +203,6 @@ RSpec.describe Site do
       SiteSetting.welcome_topic_id = first_post.topic.id
 
       expect(Site.show_welcome_topic_banner?(Guardian.new(admin))).to eq(false)
-      expect(Discourse.cache.read(Site.welcome_topic_banner_cache_key(admin.id))).to eq(false)
     end
 
     it "returns true when welcome topic is less than month old" do


### PR DESCRIPTION
If you happen to delete the general category before editing the welcome
topic, the banner will still display. This fix adds a after destroy hook
that will clear the entries for the welcome topic banner in the redis
cache.

See https://meta.discourse.org/t/welcome-topic-cant-be-created-if-general-category-is-deleted/253773?u=blake