### PR TITLE
DEV: adds a `addChatDrawerStateCallback` API

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -117,6 +117,14 @@ export default {
 
       api.addToHeaderIcons("chat-header-icon");
 
+      api.addChatDrawerStateCallback(({ isDrawerActive }) => {
+        if (isDrawerActive) {
+          document.body.classList.add("chat-drawer-active");
+        } else {
+          document.body.classList.remove("chat-drawer-active");
+        }
+      });
+
       api.decorateChatMessage(function (chatMessage, chatChannel) {
         if (!this.currentUser) {
           return;

--- a/plugins/chat/assets/javascripts/discourse/pre-initializers/chat-plugin-api.js
+++ b/plugins/chat/assets/javascripts/discourse/pre-initializers/chat-plugin-api.js
@@ -4,6 +4,7 @@ import {
   resetChatMessageDecorators,
 } from "discourse/plugins/chat/discourse/components/chat-message";
 import { registerChatComposerButton } from "discourse/plugins/chat/discourse/lib/chat-composer-buttons";
+import { addChatDrawerStateCallback } from "discourse/plugins/chat/discourse/services/chat-state-manager";
 
 /**
  * Class exposing the javascript API available to plugins and themes.
@@ -17,6 +18,15 @@ import { registerChatComposerButton } from "discourse/plugins/chat/discourse/lib
  * @param {ChatMessage} chatMessage - model
  * @param {HTMLElement} messageContainer - DOM node
  * @param {ChatChannel} chatChannel - model
+ */
+
+/**
+ * Callback used to decorate a chat message
+ *
+ * @callback PluginApi~chatDrawerStateCallbak
+ * @param {Object} state
+ * @param {boolean} state.isDrawerActive - is the chat drawer active
+ * @param {boolean} state.isDrawerExpanded - is the chat drawer expanded
  */
 
 /**
@@ -65,6 +75,22 @@ import { registerChatComposerButton } from "discourse/plugins/chat/discourse/lib
  * });
  */
 
+/**
+ * Callback when the sate of the chat drawer changes
+ *
+ * @memberof PluginApi
+ * @instance
+ * @function addChatDrawerStateCallback
+ * @param {PluginApi~chatDrawerStateCallbak} callback
+ * @example
+ *
+ * api.addChatDrawerStateCallback(({isDrawerExpanded, isDrawerActive}) => {
+ *   if (isDrawerActive && isDrawerExpanded) {
+ *     // do something
+ *   }
+ * });
+ */
+
 export default {
   name: "chat-plugin-api",
   after: "inject-discourse-objects",
@@ -85,6 +111,14 @@ export default {
         Object.defineProperty(apiPrototype, "registerChatComposerButton", {
           value(button) {
             registerChatComposerButton(button);
+          },
+        });
+      }
+
+      if (!apiPrototype.hasOwnProperty("addChatDrawerStateCallback")) {
+        Object.defineProperty(apiPrototype, "addChatDrawerStateCallback", {
+          value(callback) {
+            addChatDrawerStateCallback(callback);
           },
         });
       }

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe "Drawer", type: :system, js: true do
     end
   end
 
+  context "when toggling open/close" do
+    it "toggles a css class on body" do
+      visit("/")
+
+      chat_page.open_from_header
+
+      expect(page.find("body.chat-drawer-active")).to be_visible
+
+      drawer.close
+
+      expect(page.find("body:not(.chat-drawer-active)")).to be_visible
+    end
+  end
+
   context "when going from drawer to full page" do
     fab!(:channel_1) { Fabricate(:chat_channel) }
     fab!(:channel_2) { Fabricate(:chat_channel) }

--- a/plugins/chat/test/javascripts/unit/services/chat-state-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-state-manager-test.js
@@ -2,6 +2,11 @@ import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
 import Site from "discourse/models/site";
 import sinon from "sinon";
+import { getOwner } from "discourse-common/lib/get-owner";
+import {
+  addChatDrawerStateCallback,
+  resetChatDrawerStateCallbacks,
+} from "discourse/plugins/chat/discourse/services/chat-state-manager";
 
 module(
   "Discourse Chat | Unit | Service | chat-state-manager",
@@ -9,7 +14,7 @@ module(
     setupTest(hooks);
 
     hooks.beforeEach(function () {
-      this.subject = this.owner.lookup("service:chat-state-manager");
+      this.subject = getOwner(this).lookup("service:chat-state-manager");
     });
 
     hooks.afterEach(function () {
@@ -128,6 +133,25 @@ module(
 
       assert.strictEqual(this.subject.lastKnownChatURL, "/foo");
       sinon.assert.calledTwice(stub);
+    });
+
+    test("callbacks", function (assert) {
+      this.state = null;
+      addChatDrawerStateCallback((state) => {
+        this.state = state;
+      });
+
+      this.subject.didOpenDrawer();
+
+      assert.strictEqual(this.state.isDrawerActive, true);
+      assert.strictEqual(this.state.isDrawerExpanded, true);
+
+      this.subject.didCloseDrawer();
+
+      assert.strictEqual(this.state.isDrawerActive, false);
+      assert.strictEqual(this.state.isDrawerExpanded, false);
+
+      resetChatDrawerStateCallbacks();
     });
   }
 );


### PR DESCRIPTION
Usage:

```javascript
api.addChatDrawerStateCallback(({ isDrawerActive, isDrawerExpanded }) => {
  // do something
});
```

Note this commit also uses this new API to add a css class (chat-drawer-active) on the body when the drawer is active.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
