### PR TITLE
UX: avoid overflow clipping descenders

### DIFF
--- a/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
@@ -7,14 +7,13 @@
     .identifier {
       color: var(--primary);
       white-space: nowrap;
+      line-height: var(--line-height-medium);
     }
     .name {
       color: var(--primary-high);
       font-size: var(--font-down-1);
       margin-left: 0.5em;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
+      @include ellipsis;
     }
     .avatar,
     .d-icon {


### PR DESCRIPTION
This fixes some overflow clipping on descenders (note the bottom of the `gg`)


Before: 

![Screenshot 2023-03-10 at 3 40 02 PM](https://user-images.githubusercontent.com/1681963/224424699-700c2704-c7fb-48c8-853e-ba8fd0b3fab0.png)


After:


![Screenshot 2023-03-10 at 3 39 52 PM](https://user-images.githubusercontent.com/1681963/224424678-af5a55e7-b428-4f26-8971-9f0774f97c3e.png)

Note that this impacts name/status alignment, but I've fixed that in a commit for the plugin: https://github.com/discourse/discourse-assign/pull/451 

