### PR TITLE
DEV: Create new video element for crossOrigin use

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-video-thumbnail-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-video-thumbnail-uppy.js
@@ -43,73 +43,81 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
       .substring(video_src.lastIndexOf("/") + 1)
       .split(".")[0];
 
-    // Wait for the video element to load, otherwise the canvas will be empty
-    video.oncanplay = () => {
-      let canvas = document.createElement("canvas");
-      let ctx = canvas.getContext("2d");
-      let videoHeight, videoWidth;
-      videoHeight = video.videoHeight;
-      videoWidth = video.videoWidth;
-      canvas.width = videoWidth;
-      canvas.height = videoHeight;
+    let canvas = document.createElement("canvas");
+    if (canvas.getContext) {
+      let videoClone = document.createElement("video");
+      videoClone.crossOrigin = "anonymous";
+      // Wait for the video element to load, otherwise the canvas will be empty
+      videoClone.oncanplay = () => {
+        let ctx = canvas.getContext("2d");
+        canvas.width = videoClone.videoHeight;
+        canvas.height = videoClone.videoHeight;
 
-      ctx.drawImage(video, 0, 0, videoWidth, videoHeight);
+        ctx.drawImage(
+          videoClone,
+          0,
+          0,
+          videoClone.videoWidth,
+          videoClone.videoHeight
+        );
 
-      // upload video thumbnail
-      canvas.toBlob((blob) => {
-        this._uppyInstance = new Uppy({
-          id: `screenshot-placeholder`,
-          meta: {
-            upload_type: `thumbnail`,
-            video_sha1,
-          },
-          autoProceed: true,
-        });
+        // upload video thumbnail
+        canvas.toBlob((blob) => {
+          this._uppyInstance = new Uppy({
+            id: `screenshot-placeholder`,
+            meta: {
+              upload_type: `thumbnail`,
+              video_sha1,
+            },
+            autoProceed: true,
+          });
 
-        if (this.siteSettings.enable_upload_debug_mode) {
-          this._instrumentUploadTimings();
-        }
-
-        if (this.siteSettings.enable_direct_s3_uploads) {
-          this._useS3MultipartUploads();
-        } else {
-          this._useXHRUploads();
-        }
-        this._uppyInstance.use(DropTarget, { target: this.element });
-
-        this._uppyInstance.on("upload", () => {
-          this.set("uploading", true);
-        });
-
-        this._uppyInstance.on("upload-success", () => {
-          this.set("uploading", false);
-        });
-
-        this._uppyInstance.on("upload-error", (file, error, response) => {
-          let message = I18n.t("wizard.upload_error");
-          if (response.body.errors) {
-            message = response.body.errors.join("\n");
+          if (this.siteSettings.enable_upload_debug_mode) {
+            this._instrumentUploadTimings();
           }
 
-          // eslint-disable-next-line no-console
-          console.error(message);
-          this.set("uploading", false);
-        });
+          if (this.siteSettings.enable_direct_s3_uploads) {
+            this._useS3MultipartUploads();
+          } else {
+            this._useXHRUploads();
+          }
+          this._uppyInstance.use(DropTarget, { target: this.element });
 
-        try {
-          this._uppyInstance.addFile({
-            source: `${this.id} thumbnail`,
-            name: video_sha1,
-            type: blob.type,
-            data: blob,
+          this._uppyInstance.on("upload", () => {
+            this.set("uploading", true);
           });
-        } catch (err) {
-          warn(`error adding files to uppy: ${err}`, {
-            id: "discourse.upload.uppy-add-files-error",
+
+          this._uppyInstance.on("upload-success", () => {
+            this.set("uploading", false);
           });
-        }
-      });
-    };
+
+          this._uppyInstance.on("upload-error", (file, error, response) => {
+            let message = I18n.t("wizard.upload_error");
+            if (response.body.errors) {
+              message = response.body.errors.join("\n");
+            }
+
+            // eslint-disable-next-line no-console
+            console.error(message);
+            this.set("uploading", false);
+          });
+
+          try {
+            this._uppyInstance.addFile({
+              source: `${this.id} thumbnail`,
+              name: video_sha1,
+              type: blob.type,
+              data: blob,
+            });
+          } catch (err) {
+            warn(`error adding files to uppy: ${err}`, {
+              id: "discourse.upload.uppy-add-files-error",
+            });
+          }
+        });
+      };
+      videoClone.src = video_src;
+    }
   },
 
   // This should be overridden in a child component if you need to


### PR DESCRIPTION
This commit attempts to follow [this same
pattern](https://github.com/discourse/discourse/blob/e292c45924bb0b0a79497e5f494afcb8af2e1efc/app/assets/javascripts/discourse/app/lib/update-tab-count.js#L63)
by creating a new video element that can be used by the canvas for
generating the thumbnail off of. This is an attempt to get the thumbnail
generation working on production sites with a cdn configured.

Follow-up to:

- 2d0ad48dd132be3e4140bce37dd71c508eca5380
- f6063c684ba9a158e42083e57af77aeeae80c189
- f144c64e139e41f176ea2ec3433a468fa49b955f
