### PR TITLE
FIX: Pop up dialog correctly when fail to delete a user

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/preferences/account.js
+++ b/app/assets/javascripts/discourse/app/controllers/preferences/account.js
@@ -216,7 +216,11 @@ export default Controller.extend(CanCheckEmails, {
                   });
                 },
                 () => {
-                  this.dialog.alert(I18n.t("user.delete_yourself_not_allowed"));
+                  next(() =>
+                    this.dialog.alert(
+                      I18n.t("user.delete_yourself_not_allowed")
+                    )
+                  );
                   this.set("deleting", false);
                 }
               );


### PR DESCRIPTION
I mentioned this bug on meta: https://meta.discourse.org/t/when-deleting-a-user-fails-the-alert-dialog-did-not-pop-up-properly/257699

Here is the change:

before:

![before](https://user-images.githubusercontent.com/51732678/224479032-4b2e447b-9412-4503-bf68-198ceec886b9.gif)

after:

![after](https://user-images.githubusercontent.com/51732678/224479085-73499557-cbd5-49d9-9f38-7edca69b3eca.gif)
