### PR TITLE
FIX: anonymous users cannot load topics with mentions with a user status that has an end date

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post-cooked.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-cooked.js
@@ -421,11 +421,11 @@ export default class PostCooked {
       return status.description;
     }
 
-    const until_ = until(
-      status.ends_at,
-      this.currentUser.timezone,
-      this.currentUser.locale
-    );
+    const timezone = this.currentUser
+      ? this.currentUser.user_option?.timezone
+      : moment.tz.guess();
+
+    const until_ = until(status.ends_at, timezone, this.currentUser?.locale);
     return escapeExpression(`${status.description} ${until_}`);
   }
 


### PR DESCRIPTION
Steps to reproduce:
1. Create a post with a mention of a user that has user status with an end date
2. Try to load the topic with that post as an anonymous user

You'll see a topic with blank content:

<img width="1136" alt="Screenshot 2023-03-13 at 19 10 20" src="https://user-images.githubusercontent.com/1274517/224743920-3413433c-76b1-495c-93f6-ffdba0402cb1.png">



