### PR TITLE
FIX: Broken topic-timeline summarize topic button

### DIFF
--- a/app/assets/javascripts/discourse/app/components/topic-timeline.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline.hbs
@@ -15,6 +15,7 @@
       @mobileView={{@mobileView}}
       @toggleMultiSelect={{@toggleMultiSelect}}
       @showTopicSlowModeUpdate={{@showTopicSlowModeUpdate}}
+      @showSummary={{@showSummary}}
       @deleteTopic={{@deleteTopic}}
       @recoverTopic={{@recoverTopic}}
       @toggleClosed={{@toggleClosed}}

--- a/app/assets/javascripts/discourse/app/components/topic-timeline.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline.js
@@ -24,15 +24,6 @@ export default class TopicTimeline extends Component {
     }
   }
 
-  get displaySummary() {
-    return (
-      this.siteSettings.summary_timeline_button &&
-      !this.args.fullScreen &&
-      this.args.model.has_summary &&
-      !this.args.model.postStream.summary
-    );
-  }
-
   get createdAt() {
     return new Date(this.args.model.created_at);
   }

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.hbs
@@ -121,12 +121,12 @@
     {{#if this.displaySummary}}
       <button
         type="button"
-        class="show-summary btn-small"
-        label={{i18n "summary.short_label"}}
+        class="show-summary btn btn-small"
         title={{i18n "summary.short_title"}}
         {{on "click" @showSummary}}
       >
         {{d-icon "layer-group"}}
+        {{i18n "summary.short_label"}}
       </button>
     {{/if}}
 

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
@@ -77,6 +77,15 @@ export default class TopicTimelineScrollArea extends Component {
     this.dockCheck();
   }
 
+  get displaySummary() {
+    return (
+      this.siteSettings.summary_timeline_button &&
+      !this.args.fullScreen &&
+      this.args.model.has_summary &&
+      !this.args.model.postStream.summary
+    );
+  }
+
   get displayTimeLineScrollArea() {
     if (this.args.mobileView) {
       return true;


### PR DESCRIPTION
# Context
During the octane upgrade of the Topic Timeline the `summarize-topic` button was neglected, leaving it in a broken state. 

# Fix
Update the button to replicate the original functionality


<img width="351" alt="Screenshot 2023-03-13 at 12 41 25 PM" src="https://user-images.githubusercontent.com/50783505/224785657-fc8124fe-f1d9-4cc8-917b-9cd859517da3.png">

_updated timeline with summarize button_
