### PR TITLE
DEV: remove unused string

### DIFF
--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -242,7 +242,6 @@ en:
       restore: "Restore deleted message"
       save: "Save"
       select: "Select"
-      silence: "Silence user"
       return_to_list: "Return to channels list"
       scroll_to_bottom: "Scroll to bottom"
       scroll_to_new_messages: "See new messages"


### PR DESCRIPTION
The button that used this string was removed in fca6805a.

