### PR TITLE
UX: Fix chat separator alignment

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -384,6 +384,7 @@ $float-height: 530px;
 
       .d-icon {
         color: var(--secondary);
+        margin-left: 1px; // "fixes" the 1px svg shift
       }
     }
 

--- a/plugins/chat/assets/stylesheets/common/chat-message-separator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-separator.scss
@@ -56,7 +56,9 @@
     }
 
     .chat-message-separator__text-container {
-      padding-top: 7px;
+      align-items: center;
+      display: flex;
+      height: 40px;
       position: sticky;
       top: -1px;
 
@@ -98,11 +100,7 @@
 
       .chat-message-separator__line {
         border-top: 1px solid var(--secondary-high);
-        left: 0;
         margin: 0 0 -1px;
-        position: relative;
-        right: 0;
-        top: -1px;
       }
     }
   }


### PR DESCRIPTION
Before / After

<img width="842" alt="Screenshot 2023-03-14 at 11 59 53" src="https://user-images.githubusercontent.com/66961/224982097-4da9beac-2de2-4197-b1b5-0ca084d75826.png">
<img width="842" alt="Screenshot 2023-03-14 at 11 59 21" src="https://user-images.githubusercontent.com/66961/224982109-f30524c2-6282-4930-94be-85ad2b5f41ea.png">


Also: work around 1px svg shift in scroll-to-bottom button

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
