### PR TITLE
UX: Improve menu panel height fallback for older browsers

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -711,9 +711,10 @@ body.footer-nav-ipad {
   top: var(--header-top);
   box-sizing: border-box;
 
-  /* Use dvh where supported, with fallback to vh */
-  --100dvh: 100vh;
-  --100dvh: 100dvh;
+  --100dvh: 100%;
+  @supports (height: 100dvh) {
+    --100dvh: 100dvh;
+  }
 
   --base-height: calc(
     var(--100dvh) - var(--header-top) - env(safe-area-inset-bottom, 0px)


### PR DESCRIPTION
Tested with Chrome <100, Firefox <100 and Samsung Internet 20, using percentage-based height here works better for these browsers.

This was especially a problem for the Samsung Internet browser, because it previously was hiding the "Dismiss" button on the user profile menu.
