### PR TITLE
FIX: update LoadMore selector for user tables

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
+++ b/app/assets/javascripts/admin/addon/templates/users-list-show.hbs
@@ -28,7 +28,7 @@
 </div>
 <LoadMore
   @class="users-list-container"
-  @selector=".users-list tr"
+  @selector=".directory-table .directory-table__cell"
   @action={{action "loadMore"}}
 >
   {{#if this.model}}

--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -71,7 +71,7 @@
 
   {{#if this.hasMembers}}
     <LoadMore
-      @selector=".group-members .directory-table-row"
+      @selector=".directory-table .directory-table__cell"
       @action={{action "loadMore"}}
     >
 

--- a/app/assets/javascripts/discourse/app/templates/group-requests.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-requests.hbs
@@ -10,7 +10,7 @@
 
   {{#if this.hasRequesters}}
     <LoadMore
-      @selector=".group-members .directory-table__row"
+      @selector=".directory-table .directory-table__cell"
       @action={{action "loadMore"}}
     >
       <ResponsiveTable @className="group-members group-members__requests">

--- a/app/assets/javascripts/discourse/app/templates/users.hbs
+++ b/app/assets/javascripts/discourse/app/templates/users.hbs
@@ -1,5 +1,8 @@
 <DSection @pageClass="users">
-  <LoadMore @selector=".directory tbody tr" @action={{action "loadMore"}}>
+  <LoadMore
+    @selector=".directory-table .directory-table__cell"
+    @action={{action "loadMore"}}
+  >
     <div class="container">
       <div class="users-directory directory">
         <span>


### PR DESCRIPTION
follow-up to fac7841, the selectors weren't updated here, so more results weren't showing on scroll (going to try to add a test for this in another commit) 