### PR TITLE
FIX: do not send emails when channel-wide mentions are disabled in a channel

### DIFF
--- a/plugins/chat/lib/extensions/user_notifications_extension.rb
+++ b/plugins/chat/lib/extensions/user_notifications_extension.rb
@@ -10,7 +10,9 @@ module Chat::UserNotificationsExtension
         .joins(:user, :chat_channel)
         .where.not(user: user)
         .where("chat_messages.created_at > ?", 1.week.ago)
-        .joins("LEFT OUTER JOIN chat_mentions cm ON cm.chat_message_id = chat_messages.id")
+        .joins(
+          "LEFT OUTER JOIN chat_mentions cm ON cm.chat_message_id = chat_messages.id AND cm.notification_id IS NOT NULL",
+        )
         .joins(
           "INNER JOIN user_chat_channel_memberships uccm ON uccm.chat_channel_id = chat_channels.id",
         )


### PR DESCRIPTION
This regressed with the commit fa543cda. Starting from that commit, we create mention records even if a user shouldn't be notified. So when sending emails, we should be making sure if a notification was actually created for a mention. This is essentially the whole fix that we need here.

I'm going to provide tests in a following PR.