### PR TITLE
DEV: Update docker_test to checkout specific branch by default

### DIFF
--- a/script/docker_test.rb
+++ b/script/docker_test.rb
@@ -23,7 +23,7 @@ unless ENV["NO_UPDATE"]
   run_or_fail("git reset --hard")
   run_or_fail("git fetch")
 
-  checkout = ENV["COMMIT_HASH"] || "FETCH_HEAD"
+  checkout = ENV["COMMIT_HASH"] || "origin/tests-passed"
   run_or_fail("LEFTHOOK=0 git checkout #{checkout}")
 
   run_or_fail("bundle")


### PR DESCRIPTION
Previously, FETCH_HEAD would always point to tests-passed because our base docker image was configured to only fetch the tests-passed branch. Since https://github.com/discourse/discourse_docker/commit/53bbacc882, we switched to a partial clone which means that `git fetch; git checkout FETCH_HEAD` will checkout whichever remote branch is the first alphabetically. This commit makes the checkout more specific to avoid this issue.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
