### PR TITLE
DEV: Drop impossible conditional from admin-logs-staff-action-logs

### DIFF
--- a/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
+++ b/app/assets/javascripts/admin/addon/routes/admin-logs-staff-action-logs.js
@@ -36,12 +36,8 @@ export default class AdminLogsStaffActionLogsRoute extends DiscourseRoute {
 
   @action
   onFiltersChange(filters) {
-    if (filters && Object.keys(filters) === 0) {
-      this.transitionTo("adminLogs.staffActionLogs");
-    } else {
-      this.transitionTo("adminLogs.staffActionLogs", {
-        queryParams: { filters },
-      });
-    }
+    this.transitionTo("adminLogs.staffActionLogs", {
+      queryParams: { filters },
+    });
   }
 }


### PR DESCRIPTION
`Object.keys(filters)` will never return 0

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
