### PR TITLE
FIX: replace unitless 0 in CSS calc() with '0px'

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -31,9 +31,9 @@
 
   .footer-nav-ipad & {
     top: calc(var(--header-offset) + var(--footer-nav-height));
-    height: calc(100vh - var(--header-offset, 0) - var(--footer-nav-height, 0));
+    height: calc(100vh - var(--header-offset, 0px) - var(--footer-nav-height, 0px));
   }
-  height: calc(100vh - var(--header-offset, 0));
+  height: calc(100vh - var(--header-offset, 0px));
   align-self: start;
   overflow-y: auto;
 
@@ -46,7 +46,7 @@
     padding: 0;
     overflow-x: hidden;
     // allows sidebar to scroll to the bottom when the composer is open
-    height: calc(100% - var(--composer-height, 0));
+    height: calc(100% - var(--composer-height, 0px));
   }
 
   .sidebar-sections {


### PR DESCRIPTION
Using the unitless number 0 in CSS calc() functions is recognized as invalid (tested in Chrome 110 & Firefox 111).

In the previous code, this would disable the style definition for the 'height' property when one of the custom properties is undefined and the fallback '0' is used.

For more insight on this topic, see https://stackoverflow.com/questions/55406001/why-doesnt-css-calc-work-when-using-0-inside-the-equation
