### PR TITLE
DEV: Use rspec instead of turbo_rspec with one core

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,11 +182,11 @@ jobs:
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'
-        run: PARALLEL_TEST_PROCESSORS=1 bin/turbo_rspec --verbose spec/system
+        run: bin/rspec spec/system
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
-        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=1 bin/turbo_rspec --verbose plugins/*/spec/system
+        run: LOAD_PLUGINS=1 bin/rspec plugins/*/spec/system
 
       - name: Upload failed system test screenshots
         uses: actions/upload-artifact@v3

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -11,6 +11,7 @@
 # => SKIP_PLUGINS              set to 1 to skip plugin tests (rspec and qunit)
 # => SKIP_INSTALL_PLUGINS      comma separated list of plugins you want to skip installing
 # => INSTALL_OFFICIAL_PLUGINS  set to 1 to install all core plugins before running tests
+# => RUN_SYSTEM_TESTS          set to 1 to run the system tests as well
 # => RUBY_ONLY                 set to 1 to skip all qunit tests
 # => JS_ONLY                   set to 1 to skip all rspec tests
 # => SINGLE_PLUGIN             set to plugin name to only run plugin-specific rspec tests (you'll probably want to SKIP_CORE as well)
@@ -211,6 +212,8 @@ task "docker:test" do
           else
             @good &&= run_or_fail("bundle exec rspec #{params.join(" ")}".strip)
           end
+
+          @good &&= run_or_fail("bundle exec rspec spec/system".strip) if ENV["RUN_SYSTEM_TESTS"]
         end
 
         unless ENV["SKIP_PLUGINS"]
@@ -219,6 +222,10 @@ task "docker:test" do
           else
             fail_fast = "RSPEC_FAILFAST=1" unless ENV["SKIP_FAILFAST"]
             @good &&= run_or_fail("#{fail_fast} bundle exec rake plugin:spec")
+          end
+
+          if ENV["RUN_SYSTEM_TESTS"]
+            @good &&= run_or_fail("LOAD_PLUGINS=1 bundle exec rspec plugins/*/spec/system".strip)
           end
         end
       end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
