### PR TITLE
DEV: Fix tag route fixture param

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -139,7 +139,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     assert.strictEqual(
       queryAll(contextSelector)[0].firstChild.textContent.trim(),
-      `${I18n.t("search.in")} test`,
+      `${I18n.t("search.in")} important`,
       "contextual tag search is first available option with no term"
     );
 
@@ -147,7 +147,7 @@ acceptance("Search - Anonymous", function (needs) {
 
     assert.strictEqual(
       queryAll(contextSelector)[1].firstChild.textContent.trim(),
-      `smth ${I18n.t("search.in")} test`,
+      `smth ${I18n.t("search.in")} important`,
       "tag-scoped search is second available option"
     );
 

--- a/app/assets/javascripts/discourse/tests/fixtures/discovery-fixtures.js
+++ b/app/assets/javascripts/discourse/tests/fixtures/discovery-fixtures.js
@@ -4077,7 +4077,7 @@ export default {
       tags: [
         {
           id: 1,
-          name: "test",
+          name: "important",
           topic_count: 2,
           staff: false,
         },


### PR DESCRIPTION
This tag route is `/tag/important/l/latest.json` so the tag name should also be `important`.

This is likely not used in any current tag tests in core, but I found the issue when using this fixture on a theme test: https://github.com/discourse/discourse-right-sidebar-blocks/pull/33/files