### PR TITLE
DEV: Cleanup unrelated comment from `development.rb`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,7 +9,6 @@ Discourse::Application.configure do
   config.cache_classes = false
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Log error messages when you accidentally call methods on nil.
   config.eager_load = false
 
   # Use the schema_cache.yml file generated during db:migrate (via db:schema:cache:dump)


### PR DESCRIPTION
This comment has nothing to do with the `eager_load` configuration. It must be left over from some historical refactoring. Removing to avoid confusion.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
