### PR TITLE
UX: Change JPEG to JPG for search consistency

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1864,7 +1864,7 @@ en:
     composer_media_optimization_image_bytes_optimization_threshold: "Minimum image file size to trigger client-side optimization"
     composer_media_optimization_image_resize_dimensions_threshold: "Minimum image width to trigger client-side resize"
     composer_media_optimization_image_resize_width_target: "Images with widths larger than `composer_media_optimization_image_dimensions_resize_threshold` will be resized to this width. Must be >= than `composer_media_optimization_image_dimensions_resize_threshold`."
-    composer_media_optimization_image_encode_quality: "JPEG encode quality used in the re-encode process."
+    composer_media_optimization_image_encode_quality: "JPG encode quality used in the re-encode process."
 
     min_ratio_to_crop: "Ratio used to crop tall images. Enter the result of width / height."
 


### PR DESCRIPTION
Amend 'JPEG' to 'JPG' in `composer_media_optimization_image_encode_quality:` to make it more consistent with other settings/descriptions and allow for easier admin settings search
