### PR TITLE
UX: Adjust menu panels on iOS

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -155,6 +155,7 @@
   .quick-access-panel {
     width: 320px;
     padding: 0.75em;
+    padding-bottom: env(safe-area-inset-bottom, 0.75em);
     justify-content: space-between;
     box-sizing: border-box;
     min-width: 0; // makes sure menu tabs don't go off screen
@@ -716,9 +717,7 @@ body.footer-nav-ipad {
     --100dvh: 100dvh;
   }
 
-  --base-height: calc(
-    var(--100dvh) - var(--header-top) - env(safe-area-inset-bottom, 0px)
-  );
+  --base-height: calc(var(--100dvh) - var(--header-top));
 
   height: var(--base-height);
 

--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -11,6 +11,7 @@
     border-top: 1.5px solid var(--primary-low);
     background: var(--primary-very-low);
     padding: 0.5em 0.8em;
+    padding-bottom: env(safe-area-inset-bottom, 0.5em);
     &:before {
       // fade to make scroll more apparent
       position: absolute;


### PR DESCRIPTION
Use `env(safe-area-inset-bottom)` for padding vs menu panel height. (Mostly affects pages loaded in DiscourseHub.) 

Before
<img width="200" alt="image" src="https://user-images.githubusercontent.com/368961/225694695-3f9703eb-062b-43d8-bacc-23611a6d50ec.png"> <img width="200" alt="image" src="https://user-images.githubusercontent.com/368961/225694996-45a67da2-8992-4437-8810-99cc08e72f33.png">

After
<img width="200" alt="image" src="https://user-images.githubusercontent.com/368961/225694788-e1efc9b8-7d0a-4372-9470-e914ee9fe2d8.png"> <img width="200" alt="image" src="https://user-images.githubusercontent.com/368961/225694835-4f1c8eb3-48dd-4e77-8649-471e69b3a92d.png">
