### PR TITLE
UX: Prevents letters from being partially cut off on the profile summary page

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -776,7 +776,7 @@
 .user-profile-names__primary {
   font-weight: bold;
   font-size: var(--font-up-5);
-  line-height: var(--line-height-small);
+  line-height: var(--line-height-medium);
   .d-icon {
     font-size: 0.8em;
     vertical-align: baseline;


### PR DESCRIPTION
Prevents the full name letters that go below the line-height from being partially cut off.
It affects both mobile and desktop views.

Before (look at the lower part of the `j` letters:
![before](https://user-images.githubusercontent.com/5654300/225852647-4a1dabe7-092c-43df-bf60-b889c064d32d.png)

After:
![after](https://user-images.githubusercontent.com/5654300/225852709-2a5064dc-4040-4c65-8ba2-cef6bf81afe0.png)
