### PR TITLE
DEV: Convert composer controller to native class syntax

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -754,6 +754,15 @@ export default class ComposerController extends Controller {
   }
 
   @action
+  saveAction(ignore, event) {
+    this.save(false, {
+      jump:
+        !(event?.shiftKey && this.get("model.replyingToTopic")) &&
+        !this.skipJumpOnSave,
+    });
+  }
+
+  @action
   displayEditReason() {
     this.set("showEditReason", true);
   }
@@ -873,20 +882,7 @@ export default class ComposerController extends Controller {
     );
   }
 
-  @action
-  save(force, optionsOrEvent = {}) {
-    let options;
-    if (optionsOrEvent instanceof Event) {
-      // Called from `KeyEnterEscape` mixin
-      options = {
-        jump:
-          !(event?.shiftKey && this.get("model.replyingToTopic")) &&
-          !this.skipJumpOnSave,
-      };
-    } else {
-      options = optionsOrEvent;
-    }
-
+  save(force, options = {}) {
     if (this.disableSubmit) {
       return;
     }

--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -4,7 +4,7 @@
   @openIfDraft={{action "openIfDraft"}}
   @typed={{action "typed"}}
   @cancelled={{action "cancelled"}}
-  @save={{action "save"}}
+  @save={{this.saveAction}}
 >
   <div class="grippie"></div>
 
@@ -234,7 +234,7 @@
 
           <div class="save-or-cancel">
             <ComposerSaveButton
-              @action={{action "save"}}
+              @action={{this.saveAction}}
               @icon={{this.saveIcon}}
               @label={{this.saveLabel}}
               @forwardEvent={{true}}


### PR DESCRIPTION
Actions are moved from `actions: {}` to top-level functions with `@action` decorator. Previously we had a `save()` action and a top-level function of the same name, so this commit renames the action to avoid a clash.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
