### PR TITLE
FIX: ensures lightbox is working after collapse/expand

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-collapser.hbs
@@ -2,30 +2,18 @@
   {{#if this.hasUploads}}
     {{html-safe @cooked}}
 
-    <Collapser
-      @header={{this.uploadsHeader}}
-      @onToggle={{@onToggleCollapse}}
-      as |collapsed|
-    >
-      {{#unless collapsed}}
-        <div class="chat-uploads">
-          {{#each @uploads as |upload|}}
-            <ChatUpload @upload={{upload}} />
-          {{/each}}
-        </div>
-      {{/unless}}
+    <Collapser @header={{this.uploadsHeader}} @onToggle={{@onToggleCollapse}}>
+      <div class="chat-uploads">
+        {{#each @uploads as |upload|}}
+          <ChatUpload @upload={{upload}} />
+        {{/each}}
+      </div>
     </Collapser>
   {{else}}
     {{#each this.cookedBodies as |cooked|}}
       {{#if cooked.needsCollapser}}
-        <Collapser
-          @header={{cooked.header}}
-          @onToggle={{@onToggleCollapse}}
-          as |collapsed|
-        >
-          {{#unless collapsed}}
-            {{cooked.body}}
-          {{/unless}}
+        <Collapser @header={{cooked.header}} @onToggle={{@onToggleCollapse}}>
+          {{cooked.body}}
         </Collapser>
       {{else}}
         {{cooked.body}}

--- a/plugins/chat/spec/system/channel_message_upload_spec.rb
+++ b/plugins/chat/spec/system/channel_message_upload_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe "Channel message selection", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:channel_1) { Fabricate(:chat_channel) }
+  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+
+  let(:chat) { PageObjects::Pages::Chat.new }
+  let(:channel) { PageObjects::Pages::ChatChannel.new }
+  let(:image) do
+    Fabricate(
+      :upload,
+      original_filename: "test_image.jpg",
+      width: 400,
+      height: 300,
+      extension: "jpg",
+    )
+  end
+
+  before do
+    chat_system_bootstrap
+    channel_1.add(current_user)
+    sign_in(current_user)
+    message_1.attach_uploads([image])
+  end
+
+  it "can collapse/expand an image and still have lightbox working" do
+    chat.visit_channel(channel_1)
+
+    find(".chat-message-collapser-button").click
+    expect(page).to have_css(".chat-message-collapser-body.hidden", visible: :false)
+    find(".chat-message-collapser-button").click
+    expect(page).to have_no_css(".chat-message-collapser-body.hidden")
+    find(".chat-img-upload").click
+
+    # visible false is because the upload doesn’t exist but it's enough to know lightbox is working
+    expect(page).to have_css(".mfp-image-holder img[src*='#{image.url}']", visible: false)
+  end
+end


### PR DESCRIPTION
Prior to this fix, the upload was removed from DOM when collapsed and not decorated again on expand, which was causing lightbox to not get reapplied. The fix is reverting to previous state where content was not removed from DOM.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
