### PR TITLE
DEV: Refactor svg sprite parsing

### DIFF
--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -269,6 +269,13 @@ module SvgSprite
       end
   end
 
+  def self.core_svgs
+    @core_svgs ||=
+      core_svg_sprites.reduce({}) do |symbols, item|
+        symbols.merge!(symbols_for(*item.values_at(:filename, :sprite), strict: true))
+      end
+  end
+
   # Just used in tests
   def self.clear_plugin_svg_sprite_cache!
     @plugin_svg_sprites = nil
@@ -360,14 +367,6 @@ module SvgSprite
     sprites = core_svg_sprites
     sprites += custom_svg_sprites(theme_id) if theme_id.present?
     sprites
-  end
-
-  def self.core_svgs
-    @core_svgs ||=
-      CORE_SVG_SPRITES.reduce({}) do |symbols, filename|
-        svg_filename = "#{File.basename(filename, ".svg")}"
-        symbols.merge!(symbols_for(svg_filename, File.open(filename), strict: true))
-      end
   end
 
   def self.bundle(theme_id = nil)

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -260,19 +260,10 @@ module SvgSprite
       .to_h
   end
 
-  def self.core_svg_sprites
-    @core_svg_sprites ||=
-      begin
-        CORE_SVG_SPRITES.map do |path|
-          { filename: File.basename(path, ".svg"), sprite: File.read(path) }
-        end
-      end
-  end
-
   def self.core_svgs
     @core_svgs ||=
-      core_svg_sprites.reduce({}) do |symbols, item|
-        symbols.merge!(symbols_for(*item.values_at(:filename, :sprite), strict: true))
+      CORE_SVG_SPRITES.reduce({}) do |symbols, path|
+        symbols.merge!(symbols_for(File.basename(path, ".svg"), File.read(path), strict: true))
       end
   end
 

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -318,6 +318,7 @@ module SvgSprite
               "Bad XML in custom sprite in theme with ID=#{theme_id}. Error info: #{e.inspect}",
             )
           end
+
           symbols
         end
       end
@@ -397,8 +398,8 @@ License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL
 
     symbols = svgs_for(SiteSetting.default_theme_id)
     symbols.slice!(*icons) if only_available
-    symbols.delete_if! { |icon_id, sym| !icon_id.include?(keyword) } unless keyword.empty?
-    symbols.sort_by(&:first).map(&:second)
+    symbols.reject! { |icon_id, sym| !icon_id.include?(keyword) } unless keyword.empty?
+    symbols.sort_by(&:first).map { |icon_id, symbol| { id: icon_id, symbol: symbol } }
   end
 
   # For use in no_ember .html.erb layouts

--- a/spec/lib/svg_sprite/svg_sprite_spec.rb
+++ b/spec/lib/svg_sprite/svg_sprite_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe SvgSprite do
       )
       theme.save!
 
-      sprite_files = SvgSprite.custom_svg_sprites(theme.id).join("|")
+      sprite_files = SvgSprite.custom_svgs(theme.id).values.join("|")
       expect(sprite_files).to match(/my-custom-theme-icon/)
 
       SvgSprite.bundle(theme.id)
@@ -230,9 +230,9 @@ RSpec.describe SvgSprite do
     expect(SvgSprite.bundle).to match(/far-building/)
   end
 
-  describe "#custom_svg_sprites" do
+  describe "#custom_svgs" do
     it "is empty by default" do
-      expect(SvgSprite.custom_svg_sprites(nil)).to be_empty
+      expect(SvgSprite.custom_svgs(nil)).to be_empty
       expect(SvgSprite.bundle).not_to be_empty
     end
 
@@ -254,7 +254,7 @@ RSpec.describe SvgSprite do
       end
 
       it "includes custom icons from plugins" do
-        expect(SvgSprite.custom_svg_sprites(nil).size).to eq(1)
+        expect(SvgSprite.custom_svgs(nil).size).to eq(1)
         expect(SvgSprite.bundle).to match(/custom-icon/)
       end
     end

--- a/spec/models/theme_field_spec.rb
+++ b/spec/models/theme_field_spec.rb
@@ -612,7 +612,7 @@ HTML
 
   describe "SVG sprite theme fields" do
     let :svg_content do
-      "<svg></svg>"
+      "<svg><symbol id='test'></symbol></svg>"
     end
 
     let :upload_file do
@@ -651,10 +651,10 @@ HTML
 
     it "clears SVG sprite cache when upload is deleted" do
       theme_field
-      expect(SvgSprite.custom_svg_sprites(theme.id).size).to eq(1)
+      expect(SvgSprite.custom_svgs(theme.id).size).to eq(1)
 
       theme_field.destroy!
-      expect(SvgSprite.custom_svg_sprites(theme.id).size).to eq(0)
+      expect(SvgSprite.custom_svgs(theme.id).size).to eq(0)
     end
 
     it "crashes gracefully when svg is invalid" do


### PR DESCRIPTION
There was a lot of duplication in the svg parsing and coercion code. This reduces that duplication and causes svg sprite parsing to happen earlier so that more computation is cached.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
