### PR TITLE
FIX: my links in sidebar section

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -95,7 +95,10 @@ class SectionLink {
   }
 
   #validInternal() {
-    return this.router.recognize(this.path).name !== "unknown";
+    return (
+      this.router.recognize(this.path).name !== "unknown" ||
+      this.path.match(/^\/my\/[a-z_\-\/]+$/)
+    );
   }
 
   get validValue() {

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -34,6 +34,25 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(sidebar).to have_link("Sidebar Tags")
   end
 
+  it "allows the user to create custom section with /my link" do
+    visit("/latest")
+    sidebar.open_new_custom_section
+
+    expect(section_modal).to be_visible
+    expect(section_modal).to have_disabled_save
+    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
+
+    section_modal.fill_name("My section")
+
+    section_modal.fill_link("My preferences", "/my/preferences")
+    expect(section_modal).to have_enabled_save
+
+    section_modal.save
+
+    expect(page).to have_button("My section")
+    expect(sidebar).to have_link("My preferences")
+  end
+
   it "allows the user to create custom section with external link" do
     visit("/latest")
     sidebar.open_new_custom_section


### PR DESCRIPTION
Links like `/my/preferences` were invalid in custom section. The reason is that `/my` links are just redirects from backend, and they are not recognized as valid Ember paths.

https://github.com/discourse/discourse/blob/main/config/routes.rb#L433

Therefore, regex match allowlist was added - similar to backend check:

https://github.com/discourse/discourse/blob/main/app/controllers/users_controller.rb#L471