### PR TITLE
FIX: my links in sidebar section

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -9,6 +9,8 @@ import { sanitize } from "discourse/lib/text";
 import { tracked } from "@glimmer/tracking";
 import { A } from "@ember/array";
 
+const MY_LINKS_REGEX = /^\/my\/[a-z_\-\/]+$/;
+
 class Section {
   @tracked title;
   @tracked links;
@@ -97,7 +99,7 @@ class SectionLink {
   #validInternal() {
     return (
       this.router.recognize(this.path).name !== "unknown" ||
-      this.path.match(/^\/my\/[a-z_\-\/]+$/)
+      this.path.match(MY_LINKS_REGEX)
     );
   }
 

--- a/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
+++ b/app/assets/javascripts/discourse/app/controllers/sidebar-section-form.js
@@ -95,7 +95,10 @@ class SectionLink {
   }
 
   #validInternal() {
-    return this.router.recognize(this.path).name !== "unknown";
+    return (
+      this.router.recognize(this.path).name !== "unknown" ||
+      this.path.match(/^\/my\/[a-z_\-\/]+$/)
+    );
   }
 
   get validValue() {
@@ -197,7 +200,6 @@ export default Controller.extend(ModalFunctionality, {
             icon: link.icon,
             name: link.name,
             value: link.path,
-            external: link.external,
             _destroy: link._destroy,
           };
         }),

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -10,8 +10,8 @@ class SidebarUrl < ActiveRecord::Base
   before_validation :remove_internal_hostname, :set_external
 
   def path_validator
-    if external?
-      raise ActionController::RoutingError if value !~ Discourse::Utils::URI_REGEXP
+    if external? && !my_link?
+      raise ActionController::RoutingError.new("Not Found") if value !~ Discourse::Utils::URI_REGEXP
     else
       Rails.application.routes.recognize_path(value)
     end
@@ -27,7 +27,11 @@ class SidebarUrl < ActiveRecord::Base
   end
 
   def set_external
-    self.external = value.start_with?("http://", "https://")
+    self.external = value.start_with?("http://", "https://") || my_link?
+  end
+
+  def my_link?
+    value.start_with?("/my/")
   end
 end
 

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe SidebarSectionsController do
                },
                { icon: "address-book", name: "tags", value: "/tags" },
                { icon: "external-link-alt", name: "Discourse", value: "https://discourse.org" },
+               { icon: "external-link-alt", name: "My preferences", value: "/my/preferences" },
              ],
            }
 
@@ -73,7 +74,7 @@ RSpec.describe SidebarSectionsController do
       expect(sidebar_section.user).to eq(user)
       expect(sidebar_section.public).to be false
       expect(UserHistory.count).to eq(0)
-      expect(sidebar_section.sidebar_urls.count).to eq(3)
+      expect(sidebar_section.sidebar_urls.count).to eq(4)
       expect(sidebar_section.sidebar_urls.first.icon).to eq("link")
       expect(sidebar_section.sidebar_urls.first.name).to eq("categories")
       expect(sidebar_section.sidebar_urls.first.value).to eq("/categories")
@@ -86,6 +87,10 @@ RSpec.describe SidebarSectionsController do
       expect(sidebar_section.sidebar_urls.third.name).to eq("Discourse")
       expect(sidebar_section.sidebar_urls.third.value).to eq("https://discourse.org")
       expect(sidebar_section.sidebar_urls.third.external).to be true
+      expect(sidebar_section.sidebar_urls.fourth.icon).to eq("external-link-alt")
+      expect(sidebar_section.sidebar_urls.fourth.name).to eq("My preferences")
+      expect(sidebar_section.sidebar_urls.fourth.value).to eq("/my/preferences")
+      expect(sidebar_section.sidebar_urls.fourth.external).to be true
     end
 
     it "does not allow regular user to create public section" do

--- a/spec/system/custom_sidebar_sections_spec.rb
+++ b/spec/system/custom_sidebar_sections_spec.rb
@@ -34,6 +34,25 @@ describe "Custom sidebar sections", type: :system, js: true do
     expect(sidebar).to have_link("Sidebar Tags")
   end
 
+  it "allows the user to create custom section with /my link" do
+    visit("/latest")
+    sidebar.open_new_custom_section
+
+    expect(section_modal).to be_visible
+    expect(section_modal).to have_disabled_save
+    expect(sidebar.custom_section_modal_title).to have_content("Add custom section")
+
+    section_modal.fill_name("My section")
+
+    section_modal.fill_link("My preferences", "/my/preferences")
+    expect(section_modal).to have_enabled_save
+
+    section_modal.save
+
+    expect(page).to have_button("My section")
+    expect(sidebar).to have_link("My preferences")
+  end
+
   it "allows the user to create custom section with external link" do
     visit("/latest")
     sidebar.open_new_custom_section


### PR DESCRIPTION
Links like `/my/preferences` were invalid in custom section. The reason is that `/my` links are just redirects from backend, and they are not recognized as valid Ember paths.

https://github.com/discourse/discourse/blob/main/config/routes.rb#L433

Therefore, regex match allowlist was added - similar to backend check:

https://github.com/discourse/discourse/blob/main/app/controllers/users_controller.rb#L471
