### PR TITLE
FIX: MaxMindDB download failures caused a crash on rebuild

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -277,8 +277,12 @@ task "assets:precompile" => "assets:precompile:before" do
       puts "Downloading MaxMindDB..."
       mmdb_thread =
         Thread.new do
+          name = "unknown"
           begin
-            geolite_dbs.each { |db| DiscourseIpInfo.mmdb_download(db) }
+            geolite_dbs.each do |db|
+              name = db
+              DiscourseIpInfo.mmdb_download(db)
+            end
 
             if GlobalSetting.maxmind_backup_path.present?
               copy_maxmind(DiscourseIpInfo.path, GlobalSetting.maxmind_backup_path)


### PR DESCRIPTION
We did not properly define the "name" variable leading to the error handling to crash.

This quick fix ensures it can gracefully fail.
