### PR TITLE
FIX: Avoid double-encoding featured topic title in user card

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.hbs
@@ -241,8 +241,8 @@
                 this.user.featured_topic.slug
                 this.user.featured_topic.id
               }}
-            >{{html-safe
-                (replace-emoji this.user.featured_topic.fancy_title)
+            >{{replace-emoji
+                (html-safe this.user.featured_topic.fancy_title)
               }}</LinkTo>
           </div>
         </div>


### PR DESCRIPTION
a373bf2a updated the behavior of `replace-emoji` so that the input is treated as unsafe-by-default. `fancy_title` is already escaped, so we need to mark it as html-safe to avoid it being double-escaped.

There is no need to html-safe the result of replace-emoji - it's already done as part of the helper.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
