### PR TITLE
DEV: handles presence channel configured with everyone group

### DIFF
--- a/lib/presence_channel.rb
+++ b/lib/presence_channel.rb
@@ -104,6 +104,7 @@ class PresenceChannel
     return true if user_id && config.allowed_user_ids&.include?(user_id)
 
     if user_id && config.allowed_group_ids.present?
+      return true if config.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
       group_ids ||= GroupUser.where(user_id: user_id).pluck("group_id")
       return true if (group_ids & config.allowed_group_ids).present?
     end

--- a/spec/lib/presence_channel_spec.rb
+++ b/spec/lib/presence_channel_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe PresenceChannel do
         PresenceChannel::Config.new(allowed_user_ids: [user.id])
       when "/test/allowedgroup"
         PresenceChannel::Config.new(allowed_group_ids: [group.id])
+      when "/test/everyonegroup"
+        PresenceChannel::Config.new(allowed_group_ids: [Group::AUTO_GROUPS[:everyone]])
       when "/test/noaccess"
         PresenceChannel::Config.new
       when "/test/countonly"
@@ -204,11 +206,13 @@ RSpec.describe PresenceChannel do
     expect(PresenceChannel.new("/test/secureuser").can_enter?(user_id: nil)).to eq(false)
     expect(PresenceChannel.new("/test/securegroup").can_enter?(user_id: nil)).to eq(false)
     expect(PresenceChannel.new("/test/noaccess").can_enter?(user_id: nil)).to eq(false)
+    expect(PresenceChannel.new("/test/everyonegroup").can_enter?(user_id: nil)).to eq(false)
 
     expect(PresenceChannel.new("/test/public1").can_view?(user_id: nil)).to eq(true)
     expect(PresenceChannel.new("/test/secureuser").can_view?(user_id: nil)).to eq(false)
     expect(PresenceChannel.new("/test/securegroup").can_view?(user_id: nil)).to eq(false)
     expect(PresenceChannel.new("/test/noaccess").can_view?(user_id: nil)).to eq(false)
+    expect(PresenceChannel.new("/test/everyonegroup").can_view?(user_id: nil)).to eq(false)
   end
 
   it "handles security correctly for a user" do
@@ -216,12 +220,14 @@ RSpec.describe PresenceChannel do
     expect(PresenceChannel.new("/test/securegroup").can_enter?(user_id: user.id)).to eq(false)
     expect(PresenceChannel.new("/test/alloweduser").can_enter?(user_id: user.id)).to eq(true)
     expect(PresenceChannel.new("/test/allowedgroup").can_enter?(user_id: user.id)).to eq(true)
+    expect(PresenceChannel.new("/test/everyonegroup").can_enter?(user_id: user.id)).to eq(true)
     expect(PresenceChannel.new("/test/noaccess").can_enter?(user_id: user.id)).to eq(false)
 
     expect(PresenceChannel.new("/test/secureuser").can_view?(user_id: user.id)).to eq(false)
     expect(PresenceChannel.new("/test/securegroup").can_view?(user_id: user.id)).to eq(false)
     expect(PresenceChannel.new("/test/alloweduser").can_view?(user_id: user.id)).to eq(true)
     expect(PresenceChannel.new("/test/allowedgroup").can_view?(user_id: user.id)).to eq(true)
+    expect(PresenceChannel.new("/test/everyonegroup").can_view?(user_id: user.id)).to eq(true)
     expect(PresenceChannel.new("/test/noaccess").can_view?(user_id: user.id)).to eq(false)
   end
 


### PR DESCRIPTION
This commit will allow any connected user to access a presence channel configured with the automatic group "everyone"

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
