### PR TITLE
UX: update chat icon to d-chat

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -98,7 +98,7 @@ acceptance("Sidebar - Plugin API", function (needs) {
                   }
 
                   get prefixValue() {
-                    return "hashtag";
+                    return "d-chat";
                   }
 
                   get prefixColor() {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-plugin-api-test.js
@@ -285,7 +285,7 @@ acceptance("Sidebar - Plugin API", function (needs) {
     );
 
     assert.strictEqual(
-      links[0].children[0].children[0].classList.contains("d-icon-hashtag"),
+      links[0].children[0].children[0].classList.contains("d-icon-d-chat"),
       true,
       "displays prefix icon"
     );

--- a/lib/wizard/builder.rb
+++ b/lib/wizard/builder.rb
@@ -86,7 +86,7 @@ class Wizard
           step.add_field(
             id: "chat_enabled",
             type: "checkbox",
-            icon: "comment",
+            icon: "d-chat",
             value: SiteSetting.chat_enabled,
           )
         end

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-title.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-title.hbs
@@ -53,7 +53,7 @@
         class="chat-channel-title__category-badge"
         style={{this.channelColorStyle}}
       >
-        {{d-icon "hashtag"}}
+        {{d-icon "d-chat"}}
         {{#if this.channel.chatable.read_restricted}}
           {{d-icon "lock" class="chat-channel-title__restricted-category-icon"}}
         {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-draft-channel-screen.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-draft-channel-screen.hbs
@@ -8,7 +8,7 @@
         @action={{action "onCancelChatDraft"}}
       />
       <h2 class="chat-draft-header__title">
-        {{d-icon "comment"}}
+        {{d-icon "d-chat"}}
         {{i18n "chat.draft_channel_screen.header"}}
       </h2>
     </header>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-header-icon.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-header-icon.hbs
@@ -3,7 +3,7 @@
   tabindex="0"
   class={{concat-class "icon btn-flat" (if this.isActive "active")}}
 >
-  {{d-icon "comment"}}
+  {{d-icon "d-chat"}}
 
   {{#unless this.currentUserInDnD}}
     <ChatHeaderIconUnreadIndicator />

--- a/plugins/chat/assets/javascripts/discourse/components/user-card-chat-button.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/user-card-chat-button.hbs
@@ -3,6 +3,6 @@
     @class="btn-primary user-card-chat-btn"
     @action={{action "startChatting"}}
     @label="chat.title_capitalized"
-    @icon="comment"
+    @icon="d-chat"
   />
 {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/user-nav__preferences-chat.hbs
+++ b/plugins/chat/assets/javascripts/discourse/connectors/user-preferences-nav/user-nav__preferences-chat.hbs
@@ -1,6 +1,6 @@
 {{#if (or this.model.can_chat this.currentUser.admin)}}
   <LinkTo @route="preferences.chat">
-    {{d-icon "comment"}}
+    {{d-icon "d-chat"}}
     <span>{{i18n "chat.title_capitalized"}}</span>
   </LinkTo>
 {{/if}}

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-setup.js
@@ -4,9 +4,12 @@ import { bind } from "discourse-common/utils/decorators";
 import { getOwner } from "discourse-common/lib/get-owner";
 import { MENTION_KEYWORDS } from "discourse/plugins/chat/discourse/components/chat-message";
 import { clearChatComposerButtons } from "discourse/plugins/chat/discourse/lib/chat-composer-buttons";
+import { replaceIcon } from "discourse-common/lib/icon-library";
 
 let _lastForcedRefreshAt;
 const MIN_REFRESH_DURATION_MS = 180000; // 3 minutes
+
+replaceIcon("d-chat", "comment");
 
 export default {
   name: "chat-setup",

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -68,7 +68,7 @@ export default {
             }
 
             get prefixValue() {
-              return "hashtag";
+              return "d-chat";
             }
 
             get prefixColor() {

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-user-menu.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-user-menu.js
@@ -69,7 +69,7 @@ export default {
               }
 
               get icon() {
-                return "comment";
+                return "d-chat";
               }
 
               get label() {
@@ -112,7 +112,7 @@ export default {
             }
 
             get icon() {
-              return "comment";
+              return "d-chat";
             }
 
             get count() {

--- a/plugins/chat/assets/javascripts/discourse/widgets/chat-mention-notification-item.js
+++ b/plugins/chat/assets/javascripts/discourse/widgets/chat-mention-notification-item.js
@@ -33,7 +33,7 @@ const chatNotificationItem = {
     const title = this.notificationTitle(notificationName, data);
     const text = this.text(notificationName, data);
     const html = new RawHtml({ html: `<div>${text}</div>` });
-    const contents = [iconNode("comment"), html];
+    const contents = [iconNode("d-chat"), html];
     const href = this.url(data);
 
     return h(

--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -179,7 +179,7 @@ html.rtl {
       text-overflow: ellipsis;
     }
 
-    .d-icon:not(.d-icon-hashtag) {
+    .d-icon:not(.d-icon-d-chat) {
       color: var(--primary-high);
     }
     .category-hashtag {

--- a/plugins/chat/lib/onebox/templates/discourse_chat.mustache
+++ b/plugins/chat/lib/onebox/templates/discourse_chat.mustache
@@ -5,7 +5,7 @@
       <a href="{{url}}">
         {{#is_category}}
           <span class="category-chat-badge" style="color: #{{color}}">
-            <svg class="fa d-icon d-icon-hashtag svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#hashtag"></use></svg>
+            <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
           </span>
         {{/is_category}}
         <span class="clear-badge">{{{channel_name}}}</span>
@@ -42,7 +42,7 @@
     <a class="chat-transcript-channel" href="/chat/c/-/{{channel_id}}">
       {{#is_category}}
         <span class="category-chat-badge" style="color: #{{color}}">
-          <svg class="fa d-icon d-icon-hashtag svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#hashtag"></use></svg>
+          <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
         </span>
       {{/is_category}}
       {{#is_topic}}

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -74,7 +74,6 @@ register_asset "stylesheets/common/chat-side-panel.scss"
 
 register_svg_icon "comments"
 register_svg_icon "comment-slash"
-register_svg_icon "hashtag"
 register_svg_icon "lock"
 
 register_svg_icon "file-audio"

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -178,7 +178,7 @@ describe Chat do
               <h3 class="chat-onebox-title">
                 <a href="#{chat_url}">
                   <span class="category-chat-badge" style="color: ##{chat_channel.chatable.color}">
-                    <svg class="fa d-icon d-icon-hashtag svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#hashtag"></use></svg>
+                    <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
                  </span>
                   <span class="clear-badge">#{chat_channel.name}</span>
                 </a>
@@ -210,7 +210,7 @@ describe Chat do
               </div>
               <a class="chat-transcript-channel" href="/chat/c/-/#{chat_channel.id}">
                 <span class="category-chat-badge" style="color: ##{chat_channel.chatable.color}">
-                  <svg class="fa d-icon d-icon-hashtag svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#hashtag"></use></svg>
+                  <svg class="fa d-icon d-icon-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
                 </span>
                 #{chat_channel.name}
               </a>

--- a/plugins/chat/spec/plugin_spec.rb
+++ b/plugins/chat/spec/plugin_spec.rb
@@ -210,7 +210,7 @@ describe Chat do
               </div>
               <a class="chat-transcript-channel" href="/chat/c/-/#{chat_channel.id}">
                 <span class="category-chat-badge" style="color: ##{chat_channel.chatable.color}">
-                  <svg class="fa d-icon d-icon-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
+                  <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
                 </span>
                 #{chat_channel.name}
               </a>

--- a/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
+++ b/plugins/chat/spec/system/sidebar_navigation_menu_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Sidebar navigation menu", type: :system, js: true do
       visit("/")
 
       expect(sidebar_page.channels_section).to have_css(
-        ".sidebar-section-link-#{channel_1.slug} .sidebar-section-link-prefix svg.prefix-icon.d-icon-hashtag",
+        ".sidebar-section-link-#{channel_1.slug} .sidebar-section-link-prefix svg.prefix-icon.d-icon-d-chat",
       )
     end
 


### PR DESCRIPTION
This replaces the hashtag icon used for channels in the sidebar and also replaces our use of the `comment` icon for chat with a `d-chat` alias. 

This makes the chat icon consistent everywhere, and allows it to be replaced without replacing non-chat related instances of `comment` 

For example, a theme could do `replaceIcon("d-chat", "hashtag");` to switch all chat icons to the hashtag icon. 