### PR TITLE
DEV: Set containing block for Popper dropdowns

### DIFF
--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -101,6 +101,10 @@
 .directory-table-container {
   container-type: inline-size;
   container-name: directory-table;
+  transform: translateX(0px);
+  // transform here creates a containing blocks which
+  // is used by fixed-positioned dropdowns
+  // if omitted, `overflow-x: auto;` below will clip them
 }
 
 .directory-table {

--- a/app/assets/stylesheets/common/components/group-member-dropdown.scss
+++ b/app/assets/stylesheets/common/components/group-member-dropdown.scss
@@ -1,12 +1,3 @@
 .group-member-dropdown {
   text-align: left;
-
-  .select-kit-body {
-    // this is a little hacky
-    // but solves an issue with a wrapping container query on .directory-table-container
-    // which breaks our popper positioning in this one specific instance
-    inset: unset !important;
-    transform: unset !important;
-    right: 0 !important;
-  }
 }


### PR DESCRIPTION
Popper dropdowns used `position: fixed` or `position: absolute`. But in tables, we want the content to use auto overflow horizontally, and that causes the dropdowns to be hidden vertically in some scenarios.

Setting a containing block on the parent container fixes both placement and overflow issues.

