### PR TITLE
UX: Fix menu panel padding on non-safe-area contexts

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -155,7 +155,7 @@
   .quick-access-panel {
     width: 320px;
     padding: 0.75em;
-    padding-bottom: env(safe-area-inset-bottom, 0.75em);
+    padding-bottom: max(env(safe-area-inset-bottom), 0.75em);
     justify-content: space-between;
     box-sizing: border-box;
     min-width: 0; // makes sure menu tabs don't go off screen

--- a/app/assets/stylesheets/common/base/sidebar-footer.scss
+++ b/app/assets/stylesheets/common/base/sidebar-footer.scss
@@ -11,7 +11,7 @@
     border-top: 1.5px solid var(--primary-low);
     background: var(--primary-very-low);
     padding: 0.5em 0.8em;
-    padding-bottom: env(safe-area-inset-bottom, 0.5em);
+    padding-bottom: max(env(safe-area-inset-bottom), 0.5em);
     &:before {
       // fade to make scroll more apparent
       position: absolute;


### PR DESCRIPTION
Followup to 32ad46c. Only picks the `safe-area-inset-bottom` if it is greater than the default padding value for the element.

Without this, the menu panel buttons would have zero bottom spacing: 

<img width="250" alt="image" src="https://user-images.githubusercontent.com/368961/226450495-ab8135d2-b93f-4295-b6e5-8cca32e99fe4.png">
