### PR TITLE
FIX: Badge granting recursion error

### DIFF
--- a/app/assets/javascripts/admin/addon/controllers/admin-user-badges.js
+++ b/app/assets/javascripts/admin/addon/controllers/admin-user-badges.js
@@ -69,7 +69,7 @@ export default class AdminUserBadgesController extends Controller.extend(
   }
 
   @action
-  grantBadge() {
+  performGrantBadge() {
     this.grantBadge(
       this.selectedBadgeId,
       this.get("user.username"),

--- a/app/assets/javascripts/admin/addon/templates/user-badges.hbs
+++ b/app/assets/javascripts/admin/addon/templates/user-badges.hbs
@@ -34,7 +34,7 @@
         </div>
         <DButton
           @class="btn-primary"
-          @action={{action "grantBadge"}}
+          @action={{this.performGrantBadge}}
           @type="submit"
           @label="admin.badges.grant"
         />


### PR DESCRIPTION
Moving the `grantBadge` action out of the actions hash caused it to clash with a method of the same name from the GrantBadgeController mixin. This commit renames the action.

Followup to https://github.com/discourse/discourse/commit/be354e7950da98f75a587413601abffade4da8e8, supersedes https://github.com/discourse/discourse/pull/20749

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
