### PR TITLE
UX: disables composer auto focus on drawer

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1245,6 +1245,10 @@ export default class ChatLivePane extends Component {
 
   @bind
   _autoFocus(event) {
+    if (this.chatStateManager.isDrawerActive) {
+      return;
+    }
+
     const { key, metaKey, ctrlKey, code, target } = event;
 
     if (

--- a/plugins/chat/spec/system/shortcuts/drawer_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/drawer_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe "Shortcuts | drawer", type: :system, js: true do
       end
     end
 
+    context "when pressing a letter" do
+      it "doesn’t intercept the event" do
+        drawer.open_channel(channel_1)
+        find(".header-sidebar-toggle").click # simple way to ensure composer is not focused
+
+        page.send_keys("e")
+
+        expect(find(".chat-composer-input").value).to eq("")
+      end
+    end
+
     context "when using Up/Down arrows" do
       it "navigates through the channels" do
         drawer.open_channel(channel_1)

--- a/plugins/chat/spec/system/shortcuts/full_page_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/full_page_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "Shortcuts | full page", type: :system, js: true do
+  fab!(:channel_1) { Fabricate(:chat_channel) }
+  fab!(:current_user) { Fabricate(:user) }
+
+  let(:chat) { PageObjects::Pages::Chat.new }
+
+  before do
+    chat_system_bootstrap
+    channel_1.add(current_user)
+    sign_in(current_user)
+  end
+
+  context "when pressing a letter" do
+    it "intercepts the event and propagates it to the composer" do
+      chat.visit_channel(channel_1)
+      find(".header-sidebar-toggle").click # simple way to ensure composer is not focused
+
+      page.send_keys("e")
+
+      expect(find(".chat-composer-input").value).to eq("e")
+    end
+  end
+end


### PR DESCRIPTION
This behavior was interfering with topics shortcuts.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
