### PR TITLE
DEV: allow using CDN URL for all s3 uploads

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1862,6 +1862,7 @@ en:
     s3_secret_access_key: "The Amazon S3 secret access key that will be used to upload images, attachments, and backups."
     s3_region: "The Amazon S3 region name that will be used to upload images and backups."
     s3_cdn_url: "The CDN URL to use for all s3 assets (for example: https://cdn.somewhere.com). WARNING: after changing this setting you must rebake all old posts."
+    s3_use_cdn_url_for_all_uploads: "Use CDN URL for all the files uploaded to s3 instead of only for images."
 
     avatar_sizes: "List of automatically generated avatar sizes."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1462,6 +1462,8 @@ files:
   s3_cdn_url:
     default: ""
     regex: '^https?:\/\/.+[^\/]$'
+  s3_use_cdn_url_for_all_uploads:
+    default: false
   s3_configure_tombstone_policy:
     default: true
   s3_use_acls:

--- a/lib/file_store/s3_store.rb
+++ b/lib/file_store/s3_store.rb
@@ -226,6 +226,8 @@ module FileStore
           force_download: force_download,
           filename: upload.original_filename,
         )
+      elsif SiteSetting.s3_use_cdn_url_for_all_uploads
+        cdn_url(upload.url)
       else
         upload.url
       end

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -375,6 +375,18 @@ RSpec.describe UploadCreator do
         expect(stored_upload.url).not_to eq(signed_url)
         expect(signed_url).to match(/Amz-Credential/)
       end
+
+      it "should return CDN URL when enabled" do
+        SiteSetting.s3_use_cdn_url_for_all_uploads = true
+        SiteSetting.authorized_extensions = "pdf"
+        SiteSetting.s3_cdn_url = "https://example-cdn.com"
+
+        upload = UploadCreator.new(pdf_file, pdf_filename, opts).create_for(user.id)
+        stored_upload = Upload.last
+        cdn_url = Discourse.store.url_for(stored_upload)
+
+        expect(cdn_url).to match(/example-cdn\.com/)
+      end
     end
 
     context "when the upload already exists based on the sha1" do


### PR DESCRIPTION
This adds an option to allow non-image s3 files to be downloaded through CDN URL.

Addresses the issues in:

- https://meta.discourse.org/t/s3-cdn-url-not-being-used-on-non-image-uploads/175332
- https://meta.discourse.org/t/s3-uploads-using-cdn-for-pdfs/213218
