### PR TITLE
FIX: ensures user with multiple tabs see own reactions

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -675,13 +675,11 @@ export default class ChatLivePane extends Component {
   }
 
   handleReactionMessage(data) {
-    if (data.user.id !== this.currentUser.id) {
-      const message = this.args.channel.messagesManager.findMessage(
-        data.chat_message_id
-      );
-      if (message) {
-        message.react(data.emoji, data.action, data.user, this.currentUser.id);
-      }
+    const message = this.args.channel.messagesManager.findMessage(
+      data.chat_message_id
+    );
+    if (message) {
+      message.react(data.emoji, data.action, data.user, this.currentUser.id);
     }
   }
 

--- a/plugins/chat/spec/system/react_to_message_spec.rb
+++ b/plugins/chat/spec/system/react_to_message_spec.rb
@@ -81,15 +81,19 @@ RSpec.describe "React to message", type: :system, js: true do
               chat.visit_channel(category_channel_1)
             end
 
-            using_session(:tab_1) do
+            using_session(:tab_1) do |session|
               channel.hover_message(message_1)
               find(".chat-message-react-btn").click
               find(".chat-emoji-picker [data-emoji=\"#{reaction.emoji}\"]").click
 
               expect(channel).to have_reaction(message_1, reaction)
+              session.quit
             end
 
-            using_session(:tab_2) { expect(channel).to have_reaction(message_1, reaction) }
+            using_session(:tab_2) do |session|
+              expect(channel).to have_reaction(message_1, reaction)
+              session.quit
+            end
           end
         end
       end

--- a/plugins/chat/spec/system/react_to_message_spec.rb
+++ b/plugins/chat/spec/system/react_to_message_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "React to message", type: :system, js: true do
   before do
     chat_system_bootstrap
     category_channel_1.add(current_user)
-    sign_in(current_user)
   end
 
   context "when other user has reacted" do
@@ -25,11 +24,13 @@ RSpec.describe "React to message", type: :system, js: true do
 
     shared_examples "inline reactions" do
       it "shows existing reactions under the message" do
+        sign_in(current_user)
         chat.visit_channel(category_channel_1)
         expect(channel).to have_reaction(message_1, reaction_1)
       end
 
       it "increments when clicking it" do
+        sign_in(current_user)
         chat.visit_channel(category_channel_1)
         channel.click_reaction(message_1, reaction_1)
         expect(channel).to have_reaction(message_1, reaction_1, 2)
@@ -57,6 +58,7 @@ RSpec.describe "React to message", type: :system, js: true do
     context "when desktop" do
       context "when using inline reaction button" do
         it "adds a reaction" do
+          sign_in(current_user)
           chat.visit_channel(category_channel_1)
           channel.hover_message(message_1)
           find(".chat-message-react-btn").click
@@ -65,19 +67,37 @@ RSpec.describe "React to message", type: :system, js: true do
           expect(channel).to have_reaction(message_1, reaction_1)
         end
 
-        xit "adds the reaction to the frequently used list" do
-          chat.visit_channel(category_channel_1)
-          channel.hover_message(message_1)
-          find(".chat-message-react-btn").click
-          find(".chat-emoji-picker [data-emoji=\"nerd_face\"]").click
+        context "when current user has multiple sessions" do
+          it "adds reaction on each session" do
+            reaction = OpenStruct.new(emoji: "nerd_face")
 
-          channel.hover_message(message_1)
+            using_session(:tab_1) do
+              sign_in(current_user)
+              chat.visit_channel(category_channel_1)
+            end
+
+            using_session(:tab_2) do
+              sign_in(current_user)
+              chat.visit_channel(category_channel_1)
+            end
+
+            using_session(:tab_1) do
+              channel.hover_message(message_1)
+              find(".chat-message-react-btn").click
+              find(".chat-emoji-picker [data-emoji=\"#{reaction.emoji}\"]").click
+
+              expect(channel).to have_reaction(message_1, reaction)
+            end
+
+            using_session(:tab_2) { expect(channel).to have_reaction(message_1, reaction) }
+          end
         end
       end
 
       context "when using message actions menu" do
         context "when using the emoji picker" do
           it "adds a reaction" do
+            sign_in(current_user)
             chat.visit_channel(category_channel_1)
             channel.hover_message(message_1)
             find(".chat-message-actions .react-btn").click
@@ -85,19 +105,11 @@ RSpec.describe "React to message", type: :system, js: true do
 
             expect(channel).to have_reaction(message_1, reaction_1)
           end
-
-          xit "adds the reaction to the frequently used list" do
-            chat.visit_channel(category_channel_1)
-            channel.hover_message(message_1)
-            find(".chat-message-actions .react-btn").click
-            find(".chat-emoji-picker [data-emoji=\"nerd_face\"]").click
-
-            channel.hover_message(message_1)
-          end
         end
 
         context "when using frequent reactions" do
           it "adds a reaction" do
+            sign_in(current_user)
             chat.visit_channel(category_channel_1)
             channel.hover_message(message_1)
             find(".chat-message-actions [data-emoji-name=\"+1\"").click
@@ -122,11 +134,13 @@ RSpec.describe "React to message", type: :system, js: true do
 
     shared_examples "inline reactions" do
       it "shows existing reactions under the message" do
+        sign_in(current_user)
         chat.visit_channel(category_channel_1)
         expect(channel).to have_reaction(message_1, reaction_1)
       end
 
       it "removes it when clicking it" do
+        sign_in(current_user)
         chat.visit_channel(category_channel_1)
         channel.click_reaction(message_1, reaction_1)
         expect(channel).to have_no_reactions(message_1)
@@ -153,6 +167,7 @@ RSpec.describe "React to message", type: :system, js: true do
       end
 
       it "doesn’t create duplicate reactions" do
+        sign_in(current_user)
         chat.visit_channel(category_channel_1)
 
         Chat::Publisher.publish_reaction!(category_channel_1, message_1, "add", user_1, "heart")


### PR DESCRIPTION
Prior to this fix, we wouldn't display reactions done on different tabs. So, if user A was reacting on tab 1, tab 2 wouldn't display this reaction.

Since few weeks ago we now have the guarantee to have uniq reactions on a message which should prevent any duplicate.

This commit also removes various skipped tests related to reactions and makes `sign_in` explicit at the beginning of each test.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
