### PR TITLE
DEV: Remove emoji cache dead code

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -65,19 +65,12 @@ class Emoji
     found_emoji = nil
 
     [[global_emoji_cache, :standard], [site_emoji_cache, :custom]].each do |cache, list_key|
-      cache_postfix, found_emoji =
+      found_emoji =
         cache.defer_get_set(normalized_name) do
-          emoji =
-            Emoji
-              .public_send(list_key)
-              .detect { |e| e.name == normalized_name && (!is_toned || (is_toned && e.tonable)) }
-          [self.cache_postfix, emoji]
+          Emoji
+            .public_send(list_key)
+            .detect { |e| e.name == normalized_name && (!is_toned || (is_toned && e.tonable)) }
         end
-
-      if found_emoji && (cache_postfix != self.cache_postfix)
-        cache.delete(normalized_name)
-        redo
-      end
 
       break if found_emoji
     end

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -91,31 +91,6 @@ RSpec.describe Emoji do
     end
   end
 
-  describe "version updates" do
-    it "should correct cache when global emojis cache is stale" do
-      Emoji.global_emoji_cache["blonde_man"] = ["invalid", Emoji.new]
-
-      emoji = Emoji[":blonde_man:t3"]
-
-      expect(emoji.name).to eq("blonde_man")
-      expect(emoji.tonable).to eq(true)
-    end
-
-    it "should correct cache when site emojis cache is stale" do
-      CustomEmoji.create!(name: "test123", upload_id: 9999)
-      Emoji.clear_cache
-
-      Emoji.site_emoji_cache["test123"] = ["invalid", Emoji.new]
-
-      emoji = Emoji[":test123:"]
-
-      expect(emoji.name).to eq("test123")
-      expect(emoji.tonable).to be_falsey
-
-      Emoji.clear_cache
-    end
-  end
-
   describe ".codes_to_img" do
     before { Plugin::CustomEmoji.clear_cache }
     after { Plugin::CustomEmoji.clear_cache }


### PR DESCRIPTION
The cache is already not shared between app servers that have difference
app_versions, so this check was redundant.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
