### PR TITLE
UX: improve directory user fields on small screens

### DIFF
--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -235,6 +235,7 @@
       align-self: start;
       white-space: nowrap;
       overflow: hidden;
+      flex: 1 0 calc(50% - 0.5em + 5%); // 50% - padding + half the gap
 
       span {
         // caution: display flex here can interfere with overflow hiding
@@ -263,6 +264,11 @@
       font-size: var(--font-0);
       color: var(--primary);
       align-self: start;
+      &--user-field {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+      }
     }
 
     &__row {
@@ -296,6 +302,8 @@
       }
 
       &--user-field {
+        display: flex;
+        grid-template-columns: auto fit-content;
         order: 2;
         // force full width of the cell
         // because we don't know how much content there is


### PR DESCRIPTION
This adds a little more flexibility for the content to occupy the available space without becoming too wide. 

Before:
![Screenshot 2023-03-21 at 1 43 06 PM](https://user-images.githubusercontent.com/1681963/226697385-9b47ebea-e755-466e-91fc-d6b1b0a15c0a.png)

After:
![Screenshot 2023-03-21 at 1 42 37 PM](https://user-images.githubusercontent.com/1681963/226697417-138f0d6c-be3e-48a9-afeb-f90f4019312f.png)
