### PR TITLE
FIX: do not refresh metadata of not followed channel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -270,14 +270,16 @@ export default class ChatSubscriptionsManager extends Service {
 
   @bind
   _onChannelMetadata(busData) {
-    this.chatChannelsManager.find(busData.chat_channel_id).then((channel) => {
-      if (channel) {
-        channel.setProperties({
-          memberships_count: busData.memberships_count,
-        });
-        this.appEvents.trigger("chat:refresh-channel-members");
-      }
-    });
+    this.chatChannelsManager
+      .find(busData.chat_channel_id, { fetchIfNotFound: false })
+      .then((channel) => {
+        if (channel) {
+          channel.setProperties({
+            memberships_count: busData.memberships_count,
+          });
+          this.appEvents.trigger("chat:refresh-channel-members");
+        }
+      });
   }
 
   @bind


### PR DESCRIPTION
No tests for now, this is a temporary fix to avoid an edge case.