### PR TITLE
UX: Styling adjustments for filters page

### DIFF
--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -5,7 +5,6 @@
       <Input
         class="topic-query-filter__filter-term"
         @value={{this.queryString}}
-        placeholder="status:closed"
         @enter={{action @updateTopicsListQueryParams this.queryString}}
         @type="text"
       />

--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -5,6 +5,7 @@
       <Input
         class="topic-query-filter__filter-term"
         @value={{this.queryString}}
+        placeholder="status:closed"
         @enter={{action @updateTopicsListQueryParams this.queryString}}
         @type="text"
       />

--- a/app/assets/javascripts/discourse/app/components/d-navigation.hbs
+++ b/app/assets/javascripts/discourse/app/components/d-navigation.hbs
@@ -1,17 +1,14 @@
 {{#if this.isQueryFilterMode}}
   <div class="topic-query-filter">
-    <Input
-      class="topic-query-filter__input"
-      @value={{this.queryString}}
-      @enter={{action @updateTopicsListQueryParams this.queryString}}
-    />
-
-    <DButton
-      @action={{action @updateTopicsListQueryParams this.queryString}}
-      @icon="filter"
-      @class="btn-primary topic-query-filter__button"
-      @label="filters.filter.button.label"
-    />
+    <div class="topic-query-filter__input">
+      {{d-icon "filter" class="topic-query-filter__icon"}}
+      <Input
+        class="topic-query-filter__filter-term"
+        @value={{this.queryString}}
+        @enter={{action @updateTopicsListQueryParams this.queryString}}
+        @type="text"
+      />
+    </div>
   </div>
 {{else}}
   <BreadCrumbs

--- a/app/assets/stylesheets/common/components/topic-query-filter.scss
+++ b/app/assets/stylesheets/common/components/topic-query-filter.scss
@@ -3,8 +3,41 @@
   flex-direction: row;
   margin-right: auto;
   margin-bottom: var(--nav-space);
+  min-width: 50%;
 
-  .topic-query-filter__input {
+  &__label {
+    background-color: var(--primary-low);
+    display: flex;
+    align-items: center;
+    padding: 0.25em 0.65em;
+    border: 1px solid var(--primary-low-mid);
+    border-right: 0;
+  }
+
+  &__input {
+    position: relative;
+    flex: 1 1;
+  }
+
+  &__icon {
+    position: absolute;
+    left: 0.5em;
+    top: 0.65em;
+    color: var(--primary-low-mid);
+  }
+
+  input.topic-query-filter__filter-term {
     margin: 0 0.5em 0 0;
+    border-color: var(--primary-low-mid);
+    padding-left: 1.75em;
+    color: var(--primary);
+    width: 100%;
+
+    &:focus {
+      border-color: var(--tertiary);
+      outline: none;
+      outline-offset: 0;
+      box-shadow: inset 0px 0px 0px 1px var(--tertiary);
+    }
   }
 }

--- a/spec/system/page_objects/components/topic_query_filter.rb
+++ b/spec/system/page_objects/components/topic_query_filter.rb
@@ -4,12 +4,7 @@ module PageObjects
   module Components
     class TopicQueryFilter < PageObjects::Components::Base
       def fill_in(text)
-        page.fill_in(class: "topic-query-filter__input", with: text)
-
-        page.click_button(
-          I18n.t("js.filters.filter.button.label"),
-          class: "topic-query-filter__button",
-        )
+        page.fill_in(class: "topic-query-filter__filter-term", with: "#{text}\n")
       end
     end
   end


### PR DESCRIPTION
Change styling of filter input & remove button.

This follows the same pattern of design we use for search. In the search dropdown we do not have a button to search. We rely on pressing enter. I've also provided an example of Github's PR filter UI at the bottom of this comment.

We also do not have buttons like this on any other topic-list header. On tag and category dropdowns, we also rely on pressing enter to filter the topic list by chosen categories & tags.

### After
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/30537603/222826405-744e5bd1-554a-4938-b847-3e9b47c01d51.png">

### Before
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/30537603/222556237-1e7e8932-9848-49d5-8c9f-4d30a1d2c29b.png">

### Example in the wild (Github)

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/30537603/222561483-c44d0631-07e6-4c45-bc37-c92217f0688a.png">


