### PR TITLE
DEV: Introduce regex_timeout_seconds global setting

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -371,3 +371,6 @@ pg_force_readonly_mode = false
 
 # default DNS query timeout for FinalDestination (used when not explicitely given programmatically)
 dns_query_timeout_secs =
+
+# Default global regex timeout
+regex_timeout_seconds = 

--- a/config/initializers/100-regex-timeout.rb
+++ b/config/initializers/100-regex-timeout.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+Regexp.timeout =
+  GlobalSetting.regex_timeout_seconds.to_i if GlobalSetting.regex_timeout_seconds.present?


### PR DESCRIPTION
This is introduced as `nil` by default. We intend to set a sensible default once we have performed some real-world testing.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
