### PR TITLE
DEV: Allow `DROP NOT NULL` in pre-deploy migrations

### DIFF
--- a/lib/migration/safe_migrate.rb
+++ b/lib/migration/safe_migrate.rb
@@ -129,7 +129,7 @@ class Migration::SafeMigrate
         in use by live applications.
       TEXT
       raise Discourse::InvalidMigration, "Attempt was made to drop a table"
-    elsif sql =~ /\A\s*alter\s+table.*(?:rename|drop)\s+/i
+    elsif sql =~ /\A\s*alter\s+table.*(?:rename|drop(?!\s+not\s+null))\s+/i
       $stdout.puts("", <<~TEXT)
         WARNING
         -------------------------------------------------------------------------------------

--- a/spec/fixtures/db/migrate/drop_not_null/20990309014015_drop_not_null.rb
+++ b/spec/fixtures/db/migrate/drop_not_null/20990309014015_drop_not_null.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DropNotNull < ActiveRecord::Migration[5.1]
+  def up
+    change_column_null :users, :username, false
+  end
+
+  def down
+    raise "not tested"
+  end
+end

--- a/spec/fixtures/db/migrate/drop_not_null/20990309014015_drop_not_null.rb
+++ b/spec/fixtures/db/migrate/drop_not_null/20990309014015_drop_not_null.rb
@@ -2,7 +2,7 @@
 
 class DropNotNull < ActiveRecord::Migration[5.1]
   def up
-    change_column_null :users, :username, false
+    change_column_null :users, :username, true
   end
 
   def down

--- a/spec/lib/migration/safe_migrate_spec.rb
+++ b/spec/lib/migration/safe_migrate_spec.rb
@@ -70,6 +70,16 @@ RSpec.describe Migration::SafeMigrate do
     expect { User.first.username }.not_to raise_error
   end
 
+  it "allows dropping NOT NULL" do
+    Migration::SafeMigrate.enable!
+
+    path = File.expand_path "#{Rails.root}/spec/fixtures/db/migrate/drop_not_null"
+
+    output = capture_stdout { migrate_up(path) }
+
+    expect(output).to include("change_column_null(:users, :username, false)")
+  end
+
   it "supports being disabled" do
     Migration::SafeMigrate.enable!
     Migration::SafeMigrate.disable!

--- a/spec/lib/migration/safe_migrate_spec.rb
+++ b/spec/lib/migration/safe_migrate_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Migration::SafeMigrate do
 
     output = capture_stdout { migrate_up(path) }
 
-    expect(output).to include("change_column_null(:users, :username, false)")
+    expect(output).to include("change_column_null(:users, :username, true)")
   end
 
   it "supports being disabled" do


### PR DESCRIPTION
Our SafeMigrate system is designed to prevent tables/columns being dropped in pre-deploy migrations. Its regex-based detection was triggering incorrectly on `ALTER COLUMN DROP NOT NULL`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
