### PR TITLE
DEV: Add preload API to CategoryList

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -8,6 +8,21 @@ class CategoryList
 
   attr_accessor :categories, :uncategorized
 
+  def self.on_preload(&blk)
+    (@preload ||= Set.new) << blk
+  end
+
+  def self.cancel_preload(&blk)
+    if @preload
+      @preload.delete blk
+      @preload = nil if @preload.length == 0
+    end
+  end
+
+  def self.preload(category_list)
+    @preload.each { |preload| preload.call(category_list) } if @preload
+  end
+
   def initialize(guardian = nil, options = {})
     @guardian = guardian || Guardian.new
     @options = options
@@ -104,14 +119,17 @@ class CategoryList
   end
 
   def find_categories
-    @categories =
-      Category.includes(
-        :uploaded_background,
-        :uploaded_logo,
-        :uploaded_logo_dark,
-        :topic_only_relative_url,
-        subcategories: [:topic_only_relative_url],
-      ).secured(@guardian)
+    @categories = Category.includes(
+      :uploaded_background,
+      :uploaded_logo,
+      :uploaded_logo_dark,
+      :topic_only_relative_url,
+      subcategories: [:topic_only_relative_url],
+    )
+
+    CategoryList.preload(self)
+
+    @categories = @categories.secured(@guardian)
 
     @categories =
       @categories.where(

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -119,13 +119,14 @@ class CategoryList
   end
 
   def find_categories
-    @categories = Category.includes(
-      :uploaded_background,
-      :uploaded_logo,
-      :uploaded_logo_dark,
-      :topic_only_relative_url,
-      subcategories: [:topic_only_relative_url],
-    )
+    @categories =
+      Category.includes(
+        :uploaded_background,
+        :uploaded_logo,
+        :uploaded_logo_dark,
+        :topic_only_relative_url,
+        subcategories: [:topic_only_relative_url],
+      )
 
     CategoryList.preload(self)
 

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -12,6 +12,21 @@ RSpec.describe CategoryList do
   fab!(:admin) { Fabricate(:admin) }
   let(:category_list) { CategoryList.new(Guardian.new(user), include_topics: true) }
 
+  describe "preload" do
+    it "allows preloading of data" do
+      preloaded_list = nil
+      preloader = lambda { |view| preloaded_list = view }
+
+      CategoryList.on_preload(&preloader)
+
+      expect(preloaded_list).to eq(nil)
+      category_list
+      expect(preloaded_list).to eq(preloaded_list)
+
+      CategoryList.cancel_preload(&preloader)
+    end
+  end
+
   describe "security" do
     it "properly hide secure categories" do
       cat = Fabricate(:category_with_definition)


### PR DESCRIPTION
This follows the exact same patten in the `TopicList`.. The main purpose for this change is the ability to inject/modifyy the `categories` instance variable (by adding more `includes`) before the query is run.

[discourse/discourse/blob/7070f81596a1c8334467019e5bc356f977bf648b/lib/topic_view.rb#L7-L20](https://github.com/discourse/discourse/blob/f12e77d500e5cab129fedc67127d7ceaf3a32192/app/models/topic_list.rb#L9-L22)