### PR TITLE
FIX: missing translation for 'reset_bounce_score' staff action log

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5463,6 +5463,7 @@ en:
             create_public_sidebar_section: "create public sidebar section"
             update_public_sidebar_section: "update public sidebar section"
             destroy_public_sidebar_section: "destroy public sidebar section"
+            reset_bounce_score: "reset bounce score"
         screened_emails:
           title: "Screened Emails"
           description: "When someone tries to create a new account, the following email addresses will be checked and the registration will be blocked, or some other action performed."


### PR DESCRIPTION
Follow up to 37609897e84f7d26944acdcc61c7bc20cb563bf1 which was missing the translation string for the new 'reset_bounce_score` staff action log.