### PR TITLE
FIX: Make sure "last visit" is not shown after marking all messages read

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -329,7 +329,7 @@ export default class ChatLivePane extends Component {
         messageData.expanded = !(messageData.hidden || messageData.deleted_at);
       }
 
-      // newest has to be in after fetcg callback as we don't want to make it
+      // newest has to be in after fetch callback as we don't want to make it
       // dynamic or it will make the pane jump around, it will disappear on reload
       if (
         !foundFirstNew &&

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -91,6 +91,8 @@ export default class ChatChannelsManager extends Service {
         if (channel) {
           channel.currentUserMembership.unread_count = 0;
           channel.currentUserMembership.unread_mentions = 0;
+          channel.currentUserMembership.last_read_message_id =
+            membership.last_read_message_id;
         }
       });
     });

--- a/plugins/chat/spec/system/shortcuts/mark_all_read_spec.rb
+++ b/plugins/chat/spec/system/shortcuts/mark_all_read_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "Shortcuts | mark all read", type: :system, js: true do
   fab!(:channel_2) { Fabricate(:chat_channel) }
   fab!(:channel_3) { Fabricate(:chat_channel) }
 
-  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:chat_sidebar) { PageObjects::Pages::Sidebar.new }
+  let(:channel_page) { PageObjects::Pages::ChatChannel.new }
   let(:drawer) { PageObjects::Pages::ChatDrawer.new }
 
   before do
@@ -15,8 +16,9 @@ RSpec.describe "Shortcuts | mark all read", type: :system, js: true do
     sign_in(user_1)
     Fabricate(:chat_message, chat_channel: channel_1)
     Fabricate(:chat_message, chat_channel: channel_1)
-    Fabricate(:chat_message, chat_channel: channel_2)
-    Fabricate(:chat_message, chat_channel: channel_2)
+    10.times do |i|
+      Fabricate(:chat_message, chat_channel: channel_2, message: "all read message #{i}")
+    end
   end
 
   context "when chat is open" do
@@ -37,6 +39,9 @@ RSpec.describe "Shortcuts | mark all read", type: :system, js: true do
         expect(page).not_to have_css(
           ".sidebar-section-link.channel-#{channel_2.id} .sidebar-section-link-suffix.unread",
         )
+        chat_sidebar.open_channel(channel_2)
+        expect(page).to have_content("all read message 9")
+        expect(page).not_to have_content(I18n.t("js.chat.last_visit"))
       end
     end
   end


### PR DESCRIPTION
Followup to a0381157e9e06b29d2f5fb182330581b6eea803a, we just
need to make sure we set currentUserMembership.last_read_message_id
to the last_read_message_id from the updated memberships after marking
all channels read, otherwise we do not scroll to the bottom and still
show the "last visit" separators in channels that have been
marked read.
