### PR TITLE
FEATURE: allow site owners to disable impersonation

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -373,4 +373,7 @@ pg_force_readonly_mode = false
 dns_query_timeout_secs =
 
 # Default global regex timeout
-regex_timeout_seconds = 
+regex_timeout_seconds =
+
+# Allow impersonation function on the cluster to admins
+allow_impersonation = true

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -297,7 +297,7 @@ class Guardian
 
   # Can we impersonate this user?
   def can_impersonate?(target)
-    target &&
+    GlobalSetting.allow_impersonation && target &&
       # You must be an admin to impersonate
       is_admin? &&
       # You may not impersonate other admins unless you are a dev

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -539,6 +539,10 @@ RSpec.describe Guardian do
   end
 
   describe "can_impersonate?" do
+    it "disallows impersonation when disabled globally" do
+      global_setting :allow_impersonation, false
+      expect(Guardian.new(admin).can_impersonate?(moderator)).to be_falsey
+    end
     it "allows impersonation correctly" do
       expect(Guardian.new(admin).can_impersonate?(nil)).to be_falsey
       expect(Guardian.new.can_impersonate?(user)).to be_falsey


### PR DESCRIPTION
Site owners can now disable impersonation using the global setting
`allow_impersonation` (Eg: DISCOURSE_ALLOW_IMPERSONATION: false)

see:

https://meta.discourse.org/t/thoughts-about-impersonate-user/258795
