### PR TITLE
FIX: relies only on message bus to set tracking state

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -172,8 +172,6 @@ export default class ChatChannel extends RestModel {
     // class not to use RestModel
     return ajax(`/chat/api/channels/${this.id}/read/${messageId}`, {
       method: "PUT",
-    }).then(() => {
-      this.currentUserMembership.last_read_message_id = messageId;
     });
   }
 }


### PR DESCRIPTION
This manual set was happening only after the request, so was not much faster than just waiting on message bus update. It's not by itself changing any behavior or fixing any bug but it makes reasoning about the whole state easier as it happens in only one central place.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
