### PR TITLE
DEV: Add `{{yield}}` to user-stream-item for plugins/themes

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-stream-item.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-stream-item.hbs
@@ -114,3 +114,5 @@
     />
   </div>
 {{/if}}
+
+{{yield to="bottom"}}


### PR DESCRIPTION
This means that plugins/themes can re-use the core component and also introduce their own footer

https://meta.discourse.org/t/user-stream-item-templates-needs-some-update/253476/9
