### PR TITLE
Top-level lint script aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "tidy-jsdoc": "^1.4.1"
   },
   "scripts": {
+    "lint:prettier": "yarn pprettier  --list-different 'app/assets/stylesheets/**/*.scss' 'app/assets/javascripts/**/*.js' 'app/assets/javascripts/**/*.hbs' 'plugins/**/assets/stylesheets/**/*.scss' 'plugins/**/assets/javascripts/**/*.js' 'plugins/**/assets/javascripts/**/*.hbs'",
+    "lint:prettier:fix": "yarn lint:prettier -w",
     "postinstall": "yarn --cwd app/assets/javascripts/discourse $(node -e 'if(JSON.parse(process.env.npm_config_argv).original.includes(`--frozen-lockfile`)){console.log(`--frozen-lockfile`)}')"
   },
   "engines": {


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->

It can be helpful to be able to manually run the lint scripts that C.I. runs. This could be due to a variety of reasons, -- wip work, `--no-verify` was used and you have to fix stuff that was skipped over in a pre-commit hook, or maybe pre-commit hooks are disabled?

This borrows from the ember blueprint's style of linting: https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/package.json#L15-L22

If this is something you want to add, C.I. could run `yarn lint` directly, matching more closely with what developers can more easily access.

Major downside to this though is that the command is quite long, and makes the package.json harder to read.
It could maybe be simplified to:
```js
    "lint:prettier": "yarn pprettier  --list-different 'app/**/*.scss' 'app/**/*.js' '**/*.hbs' 'plugins/**/*.scss' 'plugins/**/*.js' 'plugins/**/*.hbs'",
```
:shrug: an idea. Still getting used to this repo's workflows :sweat_smile: 

If it's an idea you like, we'd probably want all the lint options, and concurrently, so folks can have one-command-to-rule-them-all for their local quality checks