### PR TITLE
UX: Show titles on site settings navigation menu items

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/site-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings.hbs
@@ -39,9 +39,9 @@
           class={{category.nameKey}}
         >
           {{category.name}}
-          {{#if category.count}}<span
-              class="count"
-            >({{category.count}})</span>{{/if}}
+          {{#if category.count}}
+            <span class="count">({{category.count}})</span>
+          {{/if}}
         </LinkTo>
       </li>
     {{/each}}

--- a/app/assets/javascripts/admin/addon/templates/site-settings.hbs
+++ b/app/assets/javascripts/admin/addon/templates/site-settings.hbs
@@ -37,6 +37,7 @@
           @route="adminSiteSettingsCategory"
           @model={{category.nameKey}}
           class={{category.nameKey}}
+          title={{category.name}}
         >
           {{category.name}}
           {{#if category.count}}

--- a/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/admin-site-settings-test.js
@@ -3,6 +3,7 @@ import {
   count,
   exists,
   query,
+  queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import {
   click,
@@ -189,5 +190,18 @@ acceptance("Admin - Site Settings", function (needs) {
         .requestBody,
       "blocked_onebox_domains=proper.com"
     );
+  });
+
+  test("nav menu items have titles", async (assert) => {
+    await visit("/admin/site_settings");
+
+    const navItems = queryAll(".admin-nav .nav-stacked li a");
+    navItems.each((_, item) => {
+      assert.equal(
+        item.title,
+        item.innerText,
+        "menu item has title, and the title is equal to menu item's label"
+      );
+    });
   });
 });


### PR DESCRIPTION
In some languages, labels on the site settings navigation menu get truncated, for example in Portuguese:

<img width="1152" alt="Screenshot 2023-03-23 at 23 56 28" src="https://user-images.githubusercontent.com/1274517/227337362-d212a222-1580-4f44-b42d-d8e6d14198fb.png">

This PR adds titles to menu items:

<img width="408" alt="Screenshot 2023-03-23 at 23 57 59" src="https://user-images.githubusercontent.com/1274517/227337466-fa8c5d4e-ebbe-4c0d-a752-253113c91ccf.png">


