### PR TITLE
FIX: use correct validation method name for `default_categories_normal`.

### DIFF
--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -96,7 +96,7 @@ module SiteSettings::Validations
     validate_default_categories(category_ids, default_categories_selected)
   end
 
-  def validate_default_categories_regular(new_val)
+  def validate_default_categories_normal(new_val)
     category_ids = validate_category_ids(new_val)
 
     default_categories_selected = [

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe SiteSettings::Validations do
       expect { SiteSetting.default_categories_tracking = "#{category.id}" }.to raise_error(
         Discourse::InvalidParameters,
       )
+
+      expect { SiteSetting.default_categories_normal = "#{category.id}" }.to raise_error(
+        Discourse::InvalidParameters,
+      )
     end
   end
 


### PR DESCRIPTION
When we renamed the `default_categories_regular` to `default_categories_normal` we missed a site setting validation method. It allowed the duplicate category ids in `default_categories_normal` site setting and caused the problem in user registration process.

https://github.com/discourse/discourse/commit/5176c689e953f3c91abf97ec45cd528ef36cdee1

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
