### PR TITLE
FIX: Make sure marking channels read propagates to all tabs

### DIFF
--- a/plugins/chat/app/services/chat/mark_all_user_channels_read.rb
+++ b/plugins/chat/app/services/chat/mark_all_user_channels_read.rb
@@ -17,6 +17,7 @@ module Chat
     transaction do
       step :update_last_read_message_ids
       step :mark_associated_mentions_as_read
+      step :publish_user_tracking_state
     end
 
     private
@@ -50,6 +51,16 @@ module Chat
         guardian.user,
         channel_ids: updated_memberships.map(&:channel_id),
       )
+    end
+
+    def publish_user_tracking_state(guardian:, updated_memberships:, **)
+      updated_memberships.each do |membership|
+        Chat::Publisher.publish_user_tracking_state(
+          guardian.user,
+          membership.channel_id,
+          membership.last_read_message_id,
+        )
+      end
     end
   end
 end

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channels-manager.js
@@ -85,17 +85,8 @@ export default class ChatChannelsManager extends Service {
 
   @debounce(300)
   async markAllChannelsRead() {
-    return this.chatApi.markAllChannelsAsRead().then((response) => {
-      response.updated_memberships.forEach((membership) => {
-        let channel = this.channels.findBy("id", membership.channel_id);
-        if (channel) {
-          channel.currentUserMembership.unread_count = 0;
-          channel.currentUserMembership.unread_mentions = 0;
-          channel.currentUserMembership.last_read_message_id =
-            membership.last_read_message_id;
-        }
-      });
-    });
+    // The user tracking state for each channel marked read will be propagated by MessageBus
+    return this.chatApi.markAllChannelsAsRead();
   }
 
   remove(model) {

--- a/plugins/chat/spec/services/chat/mark_all_user_channels_read_spec.rb
+++ b/plugins/chat/spec/services/chat/mark_all_user_channels_read_spec.rb
@@ -128,6 +128,13 @@ RSpec.describe Chat::MarkAllUserChannelsRead do
           ).count
         }.by(-2)
       end
+
+      it "publishes tracking state for all affected channels" do
+        messages = MessageBus.track_publish { result }
+        expect(
+          messages.select { |m| m.channel == "/chat/user-tracking-state/#{current_user.id}" }.count,
+        ).to eq(3)
+      end
     end
   end
 end


### PR DESCRIPTION
Instead of just marking the state read in JS for each channel
after the AJAX call, we can instead just rely on the MessageBus
user-tracking-state chat channel, and publish the state to all
the channels affected in MarkAllUserChannelsRead. This will make
it so the blue dots for the channels are cleared across all tabs.
