### PR TITLE
UX: Restore reviewable counts on hamburger for legacy navigation

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -324,7 +324,7 @@ createWidget("header-icons", {
         let { currentUser } = this;
         if (
           currentUser?.reviewable_count &&
-          !this.currentUser.redesigned_user_menu_enabled
+          this.siteSettings.navigation_menu === "legacy"
         ) {
           return h(
             "div.badge-notification.reviewables",

--- a/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/site-header-test.js
@@ -39,6 +39,7 @@ module("Integration | Component | site-header", function (hooks) {
   });
 
   test("hamburger menu icon shows pending reviewables count", async function (assert) {
+    this.siteSettings.navigation_menu = "legacy";
     this.currentUser.set("reviewable_count", 1);
     await render(hbs`<SiteHeader />`);
     let pendingReviewablesBadge = query(
@@ -47,9 +48,9 @@ module("Integration | Component | site-header", function (hooks) {
     assert.strictEqual(pendingReviewablesBadge.textContent, "1");
   });
 
-  test("hamburger menu icon doesn't show pending reviewables count when revamped user menu is enabled", async function (assert) {
+  test("hamburger menu icon doesn't show pending reviewables count for non-legacy navigation menu", async function (assert) {
     this.currentUser.set("reviewable_count", 1);
-    this.currentUser.set("redesigned_user_menu_enabled", true);
+    this.siteSettings.navigation_menu = "sidebar";
     await render(hbs`<SiteHeader />`);
     assert.ok(!exists(".hamburger-dropdown .badge-notification"));
   });


### PR DESCRIPTION
Previously we disabled the hamburger reviewable count badge when the redesigned user menu was enabled. This commit updates the logic so that the hamburger reviewable count is tied the legacy navigation mode instead. This ensures that there is always a persistent reviewable count visible. (in the non-legacy navigation modes, the total reviewable count is shown in the sidebar)

<img width="192" alt="SCR-20230324-g82" src="https://user-images.githubusercontent.com/6270921/227522775-79514866-be57-4752-a4bd-60e1b388fdf6.png">



<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
