### PR TITLE
FEATURE: SiteSetting for creation of small action on tag change

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -161,6 +161,7 @@ class TagsController < ::ApplicationController
         previous_value: params[:tag_id],
         new_value: new_tag_name,
       )
+
       render json: { tag: { id: tag.name, description: tag.description } }
     else
       render_json_error tag.errors.full_messages

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -175,6 +175,7 @@ en:
       removed_user: "Removed %{who} %{when}"
       removed_group: "Removed %{who} %{when}"
       autobumped: "Automatically bumped %{when}"
+      tags_changed: "Tags updated %{when}"
       autoclosed:
         enabled: "Closed %{when}"
         disabled: "Opened %{when}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -61,6 +61,11 @@ en:
   redirect_warning: "We were unable to verify that the link you selected was actually posted to the forum. If you wish to proceed anyway, select the link below."
   on_another_topic: "On another topic"
 
+  topic_tag_changes:
+    added_and_removed: "Added %{added} and removed %{removed}"
+    added: "Added %{added}"
+    removed: "Removed %{removed}"
+
   inline_oneboxer:
     topic_page_title_post_number: "#%{post_number}"
     topic_page_title_post_number_by_user: "#%{post_number} by %{username}"
@@ -2351,6 +2356,7 @@ en:
     suppress_overlapping_tags_in_list: "If tags match exact words in topic titles, don't show the tag"
     remove_muted_tags_from_latest: "Don't show topics tagged only with muted tags in the latest topic list."
     force_lowercase_tags: "Force all new tags to be entirely lowercase."
+    create_small_action_post_for_tag_changes: "Create a small action post when tags change for a topic"
 
     company_name: "Company Name"
     governing_law: "Governing Law"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2783,6 +2783,8 @@ tags:
   force_lowercase_tags:
     default: true
     client: true
+  create_small_action_post_for_tag_changes:
+    default: false
 
 dashboard:
   dashboard_hidden_reports:

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -122,9 +122,39 @@ class PostRevisor
               diff_tags: ((tags - prev_tags) | (prev_tags - tags)),
             )
           end
+
+          if SiteSetting.create_small_action_post_for_tag_changes
+            tc.topic.add_moderator_post(
+              tc.user,
+              tags_changed_raw(previous_tags: prev_tags, tags: tags),
+              post_type: Post.types[:small_action],
+              action_code: "tags_changed",
+            )
+          end
         end
       end
     end
+  end
+
+  def self.tags_changed_raw(previous_tags:, tags:)
+    removed = previous_tags - tags
+    added = tags - previous_tags
+
+    if removed.present? && added.present?
+      I18n.t(
+        "topic_tag_changes.added_and_removed",
+        added: tag_list_to_raw(added),
+        removed: tag_list_to_raw(removed),
+      )
+    elsif added.present?
+      I18n.t("topic_tag_changes.added", added: tag_list_to_raw(added))
+    elsif removed.present?
+      I18n.t("topic_tag_changes.removed", removed: tag_list_to_raw(removed))
+    end
+  end
+
+  def self.tag_list_to_raw(tag_list)
+    tag_list.sort.map { |tag_name| "##{tag_name}" }.join(", ")
   end
 
   track_topic_field(:featured_link) do |topic_changes, featured_link|


### PR DESCRIPTION
This adds a SiteSetting, which when enabled, creates a small_action post for tag changes to the topic. We don't have a great system for adding arbitrary text to small_action posts so I decided to use the `add_moderator_post` method on `Topic`, and pass `raw` text into it to describe what tags changed.

![Screen Shot 2023-03-24 at 12 19 09 PM](https://user-images.githubusercontent.com/16214023/227596096-ade6ab5c-6960-4912-91c1-8f11d53ad89e.png)

![Screen Shot 2023-03-24 at 12 15 55 PM](https://user-images.githubusercontent.com/16214023/227595986-a3beae80-9687-45c5-bcb5-cb54b88957e4.png)
