### PR TITLE
FIX: Check for staff without triggering anonymous user error

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -3,6 +3,11 @@ import hbs from "discourse/widgets/hbs-compiler";
 
 createWidget("header-contents", {
   tagName: "div.contents.clearfix",
+  transform() {
+    return {
+      staff: this.get("currentUser.staff"),
+    };
+  },
   template: hbs`
     {{#if this.site.desktopView}}
       {{#if attrs.sidebarEnabled}}
@@ -15,7 +20,7 @@ createWidget("header-contents", {
     {{#if attrs.topic}}
       {{header-topic-info attrs=attrs}}
     {{else if this.siteSettings.bootstrap_mode_enabled}}
-      {{#if this.currentUser.staff}}
+      {{#if transformed.staff}}
         {{header-bootstrap-mode attrs=attrs}}
       {{/if}}
     {{/if}}


### PR DESCRIPTION
Followup to 142d2ab65ecf31a1df1d0cd23e533d84c120b683

In Ember templates, `this.currentUser.blah` is safe, even if `currentUser` is null. However, widget handlebars templates are not 'real' handlebars, and don't have handling for this kind of situation.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
