### PR TITLE
UX: Make table wrapper popup button icon only

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -141,7 +141,7 @@ export default {
           "open-popup-link",
           "btn-default",
           "btn",
-          "btn-icon-text",
+          "btn-icon",
           "btn-expand-table",
           "no-text"
         );

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -142,15 +142,14 @@ export default {
           "btn-default",
           "btn",
           "btn-icon-text",
-          "btn-expand-table"
+          "btn-expand-table",
+          "no-text"
         );
         const expandIcon = create(
           iconNode("discourse-expand", { class: "expand-table-icon" })
         );
-        const openPopupText = document.createTextNode(
-          I18n.t("fullscreen_table.expand_btn")
-        );
-        openPopupBtn.append(expandIcon, openPopupText);
+        openPopupBtn.title = I18n.t("fullscreen_table.expand_btn");
+        openPopupBtn.append(expandIcon);
         return openPopupBtn;
       }
 


### PR DESCRIPTION
Based on suggestion from previous PR: https://github.com/discourse/discourse/pull/18810#discussion_r1147861590

This PR makes the table wrapper expand button as an icon-only button to maximize space. The label is moved to the title so that it shows in the default HTML tooltip on hover.

<img width="369" alt="Screenshot 2023-03-24 at 12 34 53" src="https://user-images.githubusercontent.com/30090424/227622797-afc85558-2bd9-4281-81cb-6ac33a04d3e9.png">

<img width="366" alt="Screenshot 2023-03-24 at 12 35 05" src="https://user-images.githubusercontent.com/30090424/227622833-d17fd1fe-f62b-41b6-aa7a-82ead251f4f1.png">
