### PR TITLE
FIX: pretty-text shims - getURL's baseUri

### DIFF
--- a/lib/pretty_text/shims.js
+++ b/lib/pretty_text/shims.js
@@ -78,7 +78,9 @@ function __getURLNoCDN(url) {
     return url;
   }
 
-  if (url.includes(__paths.baseUri)) {
+  const baseUriMatcher = new RegExp(`^${__paths.baseUri}(/|$)`);
+
+  if (baseUriMatcher.test(url)) {
     return url;
   }
   if (url[0] !== "/") {

--- a/lib/pretty_text/shims.js
+++ b/lib/pretty_text/shims.js
@@ -78,9 +78,7 @@ function __getURLNoCDN(url) {
     return url;
   }
 
-  const baseUriMatcher = new RegExp(`^${__paths.baseUri}(/|$)`);
-
-  if (baseUriMatcher.test(url)) {
+  if (url.startsWith(`${__paths.baseUri}/`) || url === __paths.baseUri) {
     return url;
   }
   if (url[0] !== "/") {

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1530,7 +1530,8 @@ RSpec.describe PrettyText do
       it "prepends the subfolder path even if it is part of the emoji url" do
         set_subfolder "/info"
 
-        expected = "src=\"/info/images/emoji/twitter/information_source.png?v=#{Emoji::EMOJI_VERSION}\""
+        expected =
+          "src=\"/info/images/emoji/twitter/information_source.png?v=#{Emoji::EMOJI_VERSION}\""
 
         expect(PrettyText.cook("ℹ️")).to include(expected)
         expect(PrettyText.cook(":information_source:")).to include(expected)

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1516,6 +1516,26 @@ RSpec.describe PrettyText do
     it "replaces Emoji from Unicode 14.0" do
       expect(PrettyText.cook("🫣")).to match(/\:face_with_peeking_eye\:/)
     end
+
+    context "with subfolder" do
+      it "prepends the subfolder path to the emoji url" do
+        set_subfolder "/forum"
+
+        expected = "src=\"/forum/images/emoji/twitter/grinning.png?v=#{Emoji::EMOJI_VERSION}\""
+
+        expect(PrettyText.cook("😀")).to include(expected)
+        expect(PrettyText.cook(":grinning:")).to include(expected)
+      end
+
+      it "prepends the subfolder path even if it is part of the emoji url" do
+        set_subfolder "/info"
+
+        expected = "src=\"/info/images/emoji/twitter/information_source.png?v=#{Emoji::EMOJI_VERSION}\""
+
+        expect(PrettyText.cook("ℹ️")).to include(expected)
+        expect(PrettyText.cook(":information_source:")).to include(expected)
+      end
+    end
   end
 
   describe "custom emoji" do


### PR DESCRIPTION
I've noticed that all emojis with names starting with the subfolder path don't work, I found that `__getURLNoCDN` was returning the non-modified `url` instead of prepending `baseUri` for any URL that contained the `baseUri`, not only for emojis. Some examples that can currently fail:
* `/forum` subfolder with a URL like `/t/forums-are-awesome/1234` returns the unmodified URL instead of `/forum/t/forums-...`
* `/info` subfolder with an emoji like `:information_source:`
* `/f` subfolder (my scenario) with a `:frowning:` emoji

This last example can be seen [here](https://www.comparajogos.com.br/f/t/jogo-ark-nova-com-defeito-de-fabrica-cartas-cortadas/35806/8), but basically it renders a broken image because the `src` is wrong (missing `baseUri`):
![broken emoji example](https://user-images.githubusercontent.com/3530/228310346-0e498373-070f-461f-b203-7bd7a01cc407.png)


There are possibly other edge cases.