### PR TITLE
FIX: skip category preference update if already set by group.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1968,7 +1968,9 @@ class User < ActiveRecord::Base
       end
     end
 
-    CategoryUser.insert_all!(values) if values.present?
+    if values.present?
+      CategoryUser.insert_all(values, unique_by: :idx_category_users_user_id_category_id)
+    end
   end
 
   def set_default_tags_preferences

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1968,7 +1968,7 @@ class User < ActiveRecord::Base
       end
     end
 
-    CategoryUser.insert_all(values, unique_by: %i[user_id category_id]) if values.present?
+    CategoryUser.insert_all(values) if values.present?
   end
 
   def set_default_tags_preferences

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1968,9 +1968,7 @@ class User < ActiveRecord::Base
       end
     end
 
-    if values.present?
-      CategoryUser.insert_all(values, unique_by: :idx_category_users_user_id_category_id)
-    end
+    CategoryUser.insert_all(values, unique_by: %i[user_id category_id]) if values.present?
   end
 
   def set_default_tags_preferences

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -75,6 +75,21 @@ RSpec.describe GroupUser do
       expect(h[category5.id]).to eq(levels[:watching_first_post])
     end
 
+    it "works when site setting conflicts with group's category notifications" do
+      SiteSetting.default_categories_tracking = category4.id.to_s
+      group.watching_category_ids = [category4.id]
+      group.save!
+      trust_level_0 = Group[:trust_level_0]
+      trust_level_0.muted_category_ids = [category4.id]
+      trust_level_0.save!
+
+      user = Fabricate(:user)
+      group.add(user)
+      trust_level_0.add(user)
+      h = CategoryUser.notification_levels_for(user)
+      expect(h[category4.id]).to eq(levels[:tracking])
+    end
+
     it "only upgrades notifications" do
       CategoryUser.create!(
         user: user,

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -75,21 +75,6 @@ RSpec.describe GroupUser do
       expect(h[category5.id]).to eq(levels[:watching_first_post])
     end
 
-    it "works when site setting conflicts with group's category notifications" do
-      SiteSetting.default_categories_tracking = category4.id.to_s
-      group.watching_category_ids = [category4.id]
-      group.save!
-      trust_level_0 = Group[:trust_level_0]
-      trust_level_0.muted_category_ids = [category4.id]
-      trust_level_0.save!
-
-      user = Fabricate(:user)
-      group.add(user)
-      trust_level_0.add(user)
-      h = CategoryUser.notification_levels_for(user)
-      expect(h[category4.id]).to eq(levels[:tracking])
-    end
-
     it "only upgrades notifications" do
       CategoryUser.create!(
         user: user,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2046,10 +2046,6 @@ RSpec.describe User do
     fab!(:category3) { Fabricate(:category) }
     fab!(:category4) { Fabricate(:category) }
 
-    # UGLY but perf is horrible with this callback
-    before { User.set_callback(:create, :after, :ensure_in_trust_level_group) }
-    after { User.skip_callback(:create, :after, :ensure_in_trust_level_group) }
-
     before do
       SiteSetting.default_email_digest_frequency = 1440 # daily
       SiteSetting.default_email_level = UserOption.email_level_types[:never]
@@ -2102,11 +2098,14 @@ RSpec.describe User do
     end
 
     it "does not update category preferences if already set by group" do
-      group = Group[:trust_level_1]
-      group.regular_category_ids = [category2.id]
-      group.save!
+      user_id = 123
 
-      user = Fabricate(:user, trust_level: 1)
+      CategoryUser.create!(
+        user_id: user_id,
+        category_id: category2.id,
+        notification_level: CategoryUser.notification_levels[:normal],
+      )
+      user = Fabricate(:user, id: user_id, trust_level: 1)
 
       expect(CategoryUser.lookup(user, :normal).pluck(:category_id)).to include(category2.id)
     end


### PR DESCRIPTION
`default_categories_*` site settings will update the category preferences on user create. But it should update user's category preference if a group's setting already updated it for that user.
