### PR TITLE
FIX: Broken `?status=(listed|unlisted)` query param support

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -22,6 +22,10 @@ class TopicsFilter
       @scope = @scope.where("topics.closed")
     when "archived"
       @scope = @scope.where("topics.archived")
+    when "listed"
+      @scope = @scope.where("topics.visible")
+    when "unlisted"
+      @scope = @scope.where("NOT topics.visible")
     when "deleted"
       if @guardian.can_see_deleted_topics?(@category)
         @scope = @scope.unscope(where: :deleted_at).where("topics.deleted_at IS NOT NULL")

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -17,28 +17,46 @@ RSpec.describe TopicsFilter do
     end
 
     context "when filtering by topic's status" do
-      it "should only return topics that have not been closed or archived when input is `status:open`" do
+      it "should only return topics that have not been closed or archived when status is `open`" do
         expect(
           TopicsFilter.new(guardian: Guardian.new).filter(status: "open").pluck(:id),
         ).to contain_exactly(topic.id)
       end
 
-      it "should only return topics that have been deleted when input is `status:deleted` and user can see deleted topics" do
+      it "should only return topics that have been deleted when status is `deleted` and user can see deleted topics" do
         expect(
           TopicsFilter.new(guardian: Guardian.new(admin)).filter(status: "deleted").pluck(:id),
         ).to contain_exactly(deleted_topic_id)
       end
 
-      it "should status filter when input is `status:deleted` and user cannot see deleted topics" do
+      it "should status filter when status is `deleted` and user cannot see deleted topics" do
         expect(
           TopicsFilter.new(guardian: Guardian.new).filter(status: "deleted").pluck(:id),
         ).to contain_exactly(topic.id, closed_topic.id, archived_topic.id)
       end
 
-      it "should only return topics that have been archived when input is `status:archived`" do
+      it "should only return topics that have been archived when status is `archived`" do
         expect(
           TopicsFilter.new(guardian: Guardian.new).filter(status: "archived").pluck(:id),
         ).to contain_exactly(archived_topic.id)
+      end
+
+      it "should only return topics that are visible when status is `listed`" do
+        Topic.update_all(visible: false)
+        topic.update!(visible: true)
+
+        expect(
+          TopicsFilter.new(guardian: Guardian.new).filter(status: "listed").pluck(:id),
+        ).to contain_exactly(topic.id)
+      end
+
+      it "should only return topics that are not visible when status is `unlisted`" do
+        Topic.update_all(visible: true)
+        topic.update!(visible: false)
+
+        expect(
+          TopicsFilter.new(guardian: Guardian.new).filter(status: "unlisted").pluck(:id),
+        ).to contain_exactly(topic.id)
       end
     end
   end


### PR DESCRIPTION
In 66c50547b4ef89969241a1f8d27bb4248ace6c07, the support for filtering a
topics list based on the `visible` attribute of a topic via the `status` query param
was accidentally removed.