### PR TITLE
FIX: admin always see configure default sidebar categories

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.hbs
@@ -1,4 +1,4 @@
-{{#if this.shouldDisplay}}
+{{#if (or this.shouldDisplay this.shouldDisplayDefaultConfig)}}
   <Sidebar::Section
     @sectionName="categories"
     @headerLinkText={{i18n "sidebar.sections.categories.header_link_text"}}
@@ -12,44 +12,48 @@
     @collapsable={{@collapsable}}
   >
 
-    {{#if (gt this.sectionLinks.length 0)}}
-      {{#each this.sectionLinks as |sectionLink|}}
+    {{#if this.shouldDisplay}}
+      {{#if (gt this.sectionLinks.length 0)}}
+        {{#each this.sectionLinks as |sectionLink|}}
+          <Sidebar::SectionLink
+            @route={{sectionLink.route}}
+            @query={{sectionLink.query}}
+            @title={{sectionLink.title}}
+            @content={{sectionLink.text}}
+            @currentWhen={{sectionLink.currentWhen}}
+            @model={{sectionLink.model}}
+            @badgeText={{sectionLink.badgeText}}
+            @prefixBadge={{sectionLink.prefixBadge}}
+            @prefixType={{sectionLink.prefixType}}
+            @prefixValue={{sectionLink.prefixValue}}
+            @prefixColor={{sectionLink.prefixColor}}
+            @prefixElementColors={{sectionLink.prefixElementColors}}
+            @suffixCSSClass={{sectionLink.suffixCSSClass}}
+            @suffixValue={{sectionLink.suffixValue}}
+            @suffixType={{sectionLink.suffixType}}
+            data-category-id={{sectionLink.category.id}}
+          />
+        {{/each}}
+      {{else}}
         <Sidebar::SectionLink
-          @route={{sectionLink.route}}
-          @query={{sectionLink.query}}
-          @title={{sectionLink.title}}
-          @content={{sectionLink.text}}
-          @currentWhen={{sectionLink.currentWhen}}
-          @model={{sectionLink.model}}
-          @badgeText={{sectionLink.badgeText}}
-          @prefixBadge={{sectionLink.prefixBadge}}
-          @prefixType={{sectionLink.prefixType}}
-          @prefixValue={{sectionLink.prefixValue}}
-          @prefixColor={{sectionLink.prefixColor}}
-          @prefixElementColors={{sectionLink.prefixElementColors}}
-          @suffixCSSClass={{sectionLink.suffixCSSClass}}
-          @suffixValue={{sectionLink.suffixValue}}
-          @suffixType={{sectionLink.suffixType}}
-          data-category-id={{sectionLink.category.id}}
+          @linkName="configure-categories"
+          @route="preferences.sidebar"
+          @prefixType="icon"
+          @prefixValue="pencil-alt"
+          @model={{this.currentUser}}
+          @content={{i18n
+            "sidebar.sections.categories.links.add_categories.content"
+          }}
+          @title={{i18n
+            "sidebar.sections.categories.links.add_categories.title"
+          }}
         />
-      {{/each}}
-    {{else}}
-      <Sidebar::SectionLink
-        @linkName="configure-categories"
-        @route="preferences.sidebar"
-        @prefixType="icon"
-        @prefixValue="pencil-alt"
-        @model={{this.currentUser}}
-        @content={{i18n
-          "sidebar.sections.categories.links.add_categories.content"
-        }}
-        @title={{i18n "sidebar.sections.categories.links.add_categories.title"}}
-      />
+      {{/if}}
+
+      <Sidebar::Common::AllCategoriesSectionLink />
     {{/if}}
 
-    <Sidebar::Common::AllCategoriesSectionLink />
-
-    {{#if (and this.currentUser.admin (not this.hasDefaultSidebarCategories))}}
+    {{#if this.shouldDisplayDefaultConfig}}
       <Sidebar::SectionLink
         @linkName="configure-default-sidebar-categories"
         @content={{i18n "sidebar.sections.categories.configure_defaults"}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/categories-section.js
@@ -64,6 +64,10 @@ export default class SidebarUserCategoriesSection extends SidebarCommonCategorie
     }
   }
 
+  get shouldDisplayDefaultConfig() {
+    return this.currentUser.admin && !this.hasDefaultSidebarCategories;
+  }
+
   get hasDefaultSidebarCategories() {
     return this.siteSettings.default_sidebar_categories.length > 0;
   }

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.hbs
@@ -1,4 +1,4 @@
-{{#if this.shouldDisplay}}
+{{#if (or this.shouldDisplay this.shouldDisplayDefaultConfig)}}
   <Sidebar::Section
     @sectionName="tags"
     @headerLinkText={{i18n "sidebar.sections.tags.header_link_text"}}
@@ -12,38 +12,40 @@
     @collapsable={{@collapsable}}
   >
 
-    {{#if (gt this.sectionLinks.length 0)}}
-      {{#each this.sectionLinks as |sectionLink|}}
+    {{#if this.shouldDisplay}}
+      {{#if (gt this.sectionLinks.length 0)}}
+        {{#each this.sectionLinks as |sectionLink|}}
+          <Sidebar::SectionLink
+            @route={{sectionLink.route}}
+            @title={{sectionLink.title}}
+            @content={{sectionLink.text}}
+            @currentWhen={{sectionLink.currentWhen}}
+            @prefixType={{sectionLink.prefixType}}
+            @prefixValue={{sectionLink.prefixValue}}
+            @badgeText={{sectionLink.badgeText}}
+            @models={{sectionLink.models}}
+            @suffixCSSClass={{sectionLink.suffixCSSClass}}
+            @suffixValue={{sectionLink.suffixValue}}
+            @suffixType={{sectionLink.suffixType}}
+            data-tag-name={{sectionLink.tagName}}
+          />
+        {{/each}}
+      {{else}}
         <Sidebar::SectionLink
-          @route={{sectionLink.route}}
-          @title={{sectionLink.title}}
-          @content={{sectionLink.text}}
-          @currentWhen={{sectionLink.currentWhen}}
-          @prefixType={{sectionLink.prefixType}}
-          @prefixValue={{sectionLink.prefixValue}}
-          @badgeText={{sectionLink.badgeText}}
-          @models={{sectionLink.models}}
-          @suffixCSSClass={{sectionLink.suffixCSSClass}}
-          @suffixValue={{sectionLink.suffixValue}}
-          @suffixType={{sectionLink.suffixType}}
-          data-tag-name={{sectionLink.tagName}}
+          @linkName="configure-tags"
+          @route="preferences.sidebar"
+          @prefixType="icon"
+          @prefixValue="pencil-alt"
+          @model={{this.currentUser}}
+          @content={{i18n "sidebar.sections.tags.links.add_tags.content"}}
+          @title={{i18n "sidebar.sections.tags.links.add_tags.title"}}
         />
-      {{/each}}
-    {{else}}
-      <Sidebar::SectionLink
-        @linkName="configure-tags"
-        @route="preferences.sidebar"
-        @prefixType="icon"
-        @prefixValue="pencil-alt"
-        @model={{this.currentUser}}
-        @content={{i18n "sidebar.sections.tags.links.add_tags.content"}}
-        @title={{i18n "sidebar.sections.tags.links.add_tags.title"}}
-      />
+      {{/if}}
+
+      <Sidebar::Common::AllTagsSectionLink />
     {{/if}}
 
-    <Sidebar::Common::AllTagsSectionLink />
-
-    {{#if (and this.currentUser.admin (not this.hasDefaultSidebarTags))}}
+    {{#if this.shouldDisplayDefaultConfig}}
       <Sidebar::SectionLink
         @linkName="configure-default-sidebar-tags"
         @content={{i18n "sidebar.sections.tags.configure_defaults"}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/tags-section.js
@@ -69,6 +69,10 @@ export default class SidebarUserTagsSection extends Component {
     }
   }
 
+  get shouldDisplayDefaultConfig() {
+    return this.currentUser.admin && !this.hasDefaultSidebarTags;
+  }
+
   get hasDefaultSidebarTags() {
     return this.siteSettings.default_sidebar_tags.length > 0;
   }

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -954,7 +954,6 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
   });
 
   test("section link to admin site settings page when default sidebar categories have not been configured", async function (assert) {
-    setupUserSidebarCategories();
     updateCurrentUser({ admin: true });
 
     await visit("/");

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-tags-section-test.js
@@ -666,7 +666,11 @@ acceptance("Sidebar - Logged on user - Tags section", function (needs) {
   });
 
   test("section link to admin site settings page when default sidebar tags have not been configured", async function (assert) {
-    updateCurrentUser({ admin: true });
+    updateCurrentUser({ admin: true, sidebar_tags: [] });
+
+    updateCurrentUser({
+      sidebar_tags: [],
+    });
 
     await visit("/");
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-sidebar-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-sidebar-test.js
@@ -109,6 +109,7 @@ acceptance("User Preferences - Sidebar", function (needs) {
   });
 
   test("user adding categories to sidebar when default sidebar categories have not been configured", async function (assert) {
+    updateCurrentUser({ admin: false, display_sidebar_tags: false });
     await visit("/u/eviltrout/preferences/sidebar");
 
     assert.notOk(exists(".sidebar-section[data-section-name='categories']"));


### PR DESCRIPTION
When an admin removes all the categories from their personal sidebar configuration, the section should remain visible to them with the “Configure default categories” prompt.

Similar solution for tags.

/t/95036
