### PR TITLE
DEV: Only show plugins tab for admins

### DIFF
--- a/app/assets/javascripts/admin/addon/templates/admin.hbs
+++ b/app/assets/javascripts/admin/addon/templates/admin.hbs
@@ -27,8 +27,8 @@
             {{#if this.siteSettings.enable_backups}}
               <NavItem @route="admin.backups" @label="admin.backups.title" />
             {{/if}}
+            <NavItem @route="adminPlugins" @label="admin.plugins.title" />
           {{/if}}
-          <NavItem @route="adminPlugins" @label="admin.plugins.title" />
           <PluginOutlet @name="admin-menu" />
         </ul>
       </div>


### PR DESCRIPTION
### Background

As part of another regression, we realized that the plugins tab is visible to moderators, but they cannot interact with anything inside without triggering authorization errors.

### What is this change

Hide the plugin tab for non-admin users.

### Does it work?

**Admin user:**

<img width="324" alt="Screenshot 2023-03-27 at 3 14 33 PM" src="https://user-images.githubusercontent.com/5259935/227867830-a1fb0ff3-afee-41ea-9be7-acca94365880.png">

**Moderator (before):**

<img width="457" alt="Screenshot 2023-03-27 at 3 15 19 PM" src="https://user-images.githubusercontent.com/5259935/227867876-89bd74c8-ec56-4973-9a28-e9d99e0c89c4.png">

**Moderator (after):**

<img width="515" alt="Screenshot 2023-03-27 at 3 15 07 PM" src="https://user-images.githubusercontent.com/5259935/227867910-4051faa7-4a21-4cba-980e-b63769ce3a59.png">