### PR TITLE
DEV: correctly tests text is rendered in replies

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer-message-details.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer-message-details.hbs
@@ -3,9 +3,9 @@
     {{d-icon this.icon}}
     <ChatUserAvatar @user={{this.message.user}} />
     <span class="chat-reply__username">{{this.message.user.username}}</span>
-    <span class="chat-reply__excerpt">{{replace-emoji
-        this.message.excerpt
-      }}</span>
+    <span class="chat-reply__excerpt">
+      {{replace-emoji this.message.excerpt}}
+    </span>
   </div>
 
   <FlatButton

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe "Chat channel", type: :system, js: true do
     end
   end
 
-  context "when replying to message that has tags" do
+  context "when replying to message that has HTML tags" do
     fab!(:other_user) { Fabricate(:user) }
     fab!(:message_2) do
       Fabricate(
@@ -208,12 +208,10 @@ RSpec.describe "Chat channel", type: :system, js: true do
       sign_in(current_user)
     end
 
-    xit "escapes the reply-to line" do
+    it "renders text in the reply-to" do
       chat.visit_channel(channel_1)
 
-      expect(find(".chat-reply .chat-reply__excerpt")["innerHTML"].strip).to eq(
-        "&lt;mark&gt;not marked&lt;/mark&gt;",
-      )
+      expect(find(".chat-reply .chat-reply__excerpt")["innerHTML"].strip).to eq("not marked")
     end
   end
 

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe "Chat composer", type: :system, js: true do
         text: message_1.user.username,
       )
     end
+
+    context "with HTML tags" do
+      before { message_1.update!(message: "<mark>not marked</mark>") }
+
+      it "renders text in the details" do
+        chat.visit_channel(channel_1)
+        channel.reply_to(message_1)
+
+        expect(
+          find(".chat-composer-message-details .chat-reply__excerpt")["innerHTML"].strip,
+        ).to eq("not marked")
+      end
+    end
   end
 
   context "when editing a message" do


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
