### PR TITLE
UX: Take header into account when scrolling via keyboard

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -61,6 +61,7 @@
 // Base Elements
 html {
   height: 100%;
+  scroll-padding-top: calc(var(--header-offset, 4em) + 1em);
 }
 
 body {


### PR DESCRIPTION
**Problem**: When you try to use [page down] or [space] to scroll through a topic, the scroll distance is just a bit too far. The upcoming sentence you’d want to read is below the header.

**Solution**: use the `scroll-padding-top` to tell the browser to take the sticky header into account when scrolling. The fix also uses `--header-offset`, which means that taller (or shorter) custom header heights should also work well. (The extra `1em` helps as well.) 