### PR TITLE
FIX: global sidebar section icon not moving on scroll

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-custom-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-custom-section.scss
@@ -2,9 +2,12 @@
   .sidebar-section-wrapper {
     padding-bottom: 0;
   }
+  .sidebar-section-header {
+    position: relative;
+  }
   .d-icon-globe {
     position: absolute;
-    left: 0.5em;
+    left: -0.75em;
     height: 0.75em;
     width: 0.75em;
     margin-top: 0.15em;


### PR DESCRIPTION
Global section icon is using absolute position. To make it move on scroll, the parent element has to be relative.

https://meta.discourse.org/t/globe-icon-at-sidebar-behaves-badly/259382

https://user-images.githubusercontent.com/72780/228084568-23d9fd1d-7399-403b-81f3-ae020857cfd0.mov

