### PR TITLE
FIX: Make chat tracking payload backwards compatible

### DIFF
--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -129,7 +129,14 @@ module Chat
     end
 
     def self.publish_user_tracking_state(user, chat_channel_id, chat_message_id)
-      data = { channel_id: chat_channel_id, last_read_message_id: chat_message_id }.merge(
+      data = {
+        channel_id: chat_channel_id,
+        last_read_message_id: chat_message_id,
+        # TODO (martin) Remove old chat_channel_id and chat_message_id keys here once deploys have cycled,
+        # this will prevent JS errors from clients that are looking for the old payload.
+        chat_channel_id: chat_channel_id,
+        chat_message_id: chat_message_id,
+      }.merge(
         Chat::ChannelUnreadsQuery.call(channel_ids: [chat_channel_id], user_id: user.id).first.to_h,
       )
 


### PR DESCRIPTION
Followup cab4b2cfba20ea03adb14e994c145e15c5ae8a2c,
this was causing client JS errors in `_updateChannelTrackingData`
because the old version of the client was expecting the old keys,
but the new ruby version of the app was sending different keys via
the `MessageBus` payload. We can remove this in a couple
of weeks.
