### PR TITLE
FEATURE: Support tags filtering query language on topics list routes

### DIFF
--- a/app/assets/javascripts/discourse/app/adapters/topic-list.js
+++ b/app/assets/javascripts/discourse/app/adapters/topic-list.js
@@ -12,7 +12,13 @@ export function finderFor(filter, params) {
 
       for (const [key, value] of Object.entries(params)) {
         if (typeof value !== "undefined") {
-          urlSearchParams.set(key, value);
+          if (Array.isArray(value)) {
+            value.forEach((v) => {
+              urlSearchParams.append(`${key}[]`, v);
+            });
+          } else {
+            urlSearchParams.set(key, value);
+          }
         }
       }
 

--- a/app/assets/javascripts/discourse/app/controllers/discovery-filter.js
+++ b/app/assets/javascripts/discourse/app/controllers/discovery-filter.js
@@ -1,32 +1,93 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
+import { isEmpty } from "@ember/utils";
 
 export default class extends Controller {
-  @tracked status = "";
+  @tracked status;
+  @tracked tags;
+  @tracked exclude_tags;
+  @tracked match_all_tags;
 
-  queryParams = ["status"];
+  queryParams = ["status", "tags", "exclude_tags", "match_all_tags"];
+  queryStringKeys = ["status", "tags"];
+
+  constructor() {
+    super(...arguments);
+    this.#resetQueryParams();
+  }
+
+  #resetQueryParams() {
+    this.status = "";
+    this.tags = [];
+    this.exclude_tags = [];
+    this.match_all_tags = null;
+  }
 
   get queryString() {
-    let paramStrings = [];
+    let querySegments = [];
 
-    this.queryParams.forEach((key) => {
-      if (this[key]) {
-        paramStrings.push(`${key}:${this[key]}`);
+    this.queryStringKeys.forEach((key) => {
+      if (!isEmpty(this[key])) {
+        switch (key) {
+          case "tags":
+            let tagQueryString = "tags:";
+            let delimiter;
+
+            if (this.match_all_tags === "true") {
+              delimiter = "+";
+            } else {
+              delimiter = ",";
+            }
+
+            if (this.exclude_tags.length) {
+              tagQueryString += `-s${this.exclude_tags.join(delimiter)}`;
+            } else if (this.tags.length) {
+              tagQueryString += this.tags.join(delimiter);
+            }
+
+            querySegments.push(tagQueryString);
+            break;
+          default:
+            querySegments.push(`${key}:${this[key]}`);
+        }
       }
     });
-
-    return paramStrings.join(" ");
+    return querySegments.join(" ");
   }
 
   @action
   updateTopicsListQueryParams(queryString) {
-    for (const match of queryString.matchAll(/(\w+):([^:\s]+)/g)) {
-      const key = match[1];
-      const value = match[2];
+    this.#resetQueryParams();
 
-      if (this.queryParams.includes(key)) {
-        this.set(key, value);
+    for (const match of queryString.matchAll(
+      /(?<exclude>-)?(?<key>\w+):(?<value>[^:\s]+)/g
+    )) {
+      const key = match.groups.key;
+      const value = match.groups.value;
+      const exclude = match.groups.exclude;
+
+      switch (key) {
+        case "tags":
+          for (const tagMatch of value.matchAll(
+            /^(?<tags>([a-zA-Z0-9\-]+)(?<delimiter>[,+])?([a-zA-Z0-9\-]+)?(\k<delimiter>[a-zA-Z0-9\-]+)*)$/g
+          )) {
+            const delimiter = tagMatch.groups.delimiter;
+
+            if (delimiter === ",") {
+              this.match_all_tags = false;
+            } else if (delimiter === "+") {
+              this.match_all_tags = true;
+            }
+
+            const tags = tagMatch.groups.tags.split(delimiter);
+            this.set(`${exclude ? "exclude_" : ""}tags`, tags);
+          }
+
+          break;
+        case "status":
+          this.set(key, value);
+          break;
       }
     }
   }

--- a/app/assets/javascripts/discourse/app/routes/discovery-filter.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-filter.js
@@ -7,6 +7,9 @@ import { action } from "@ember/object";
 export default class extends DiscourseRoute {
   queryParams = {
     status: { replace: true, refreshModel: true },
+    tags: { replace: true, refreshModel: true, type: "customArray" },
+    exclude_tags: { replace: true, refreshModel: true, type: "customArray" },
+    match_all_tags: { replace: true, refreshModel: true },
   };
 
   model(data) {
@@ -32,6 +35,17 @@ export default class extends DiscourseRoute {
       controller: "discovery/topics",
       outlet: "list-container",
     });
+  }
+
+  // This is required because by default Ember router will serialize Array type query param with JSON.stringify which
+  // results in a query param like `tags=tag1,tag2` which is not what we want. By doing nothing here, the query param
+  // will be serialized as `tags[]=tag1&tags[]=tag2`.
+  serializeQueryParam(value, urlKey, type) {
+    if (type === "customArray") {
+      return value;
+    } else {
+      return super.serializeQueryParam(value, urlKey, type);
+    }
   }
 
   // TODO(tgxworld): This action is required by the `discovery/topics` controller which is not necessary for this route.

--- a/lib/topic_query_params.rb
+++ b/lib/topic_query_params.rb
@@ -4,6 +4,7 @@ module TopicQueryParams
   def build_topic_list_options
     options = {}
     params[:tags] = [params[:tag_id], *Array(params[:tags])].uniq if params[:tag_id].present?
+    params[:exclude_tags] = [params[:exlude_tag]] if params[:exclude_tag].present?
 
     TopicQuery.public_valid_options.each do |key|
       if params.key?(key)

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -21,6 +21,8 @@ class TopicsFilter
     tag_ids.uniq!
     tag_ids.compact!
 
+    yield tag_ids if block_given?
+
     return @scope.none if match_all && tag_ids.length != tag_names.length
     return @scope if tag_ids.empty?
 

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -415,12 +415,12 @@ RSpec.describe TopicQuery do
       let(:synonym) { Fabricate(:tag, target_tag: tag, name: "synonym") }
 
       it "excludes a tag if desired" do
-        topics = TopicQuery.new(moderator, exclude_tag: tag.name).list_latest.topics
+        topics = TopicQuery.new(moderator, exclude_tags: [tag.name]).list_latest.topics
         expect(topics.any? { |t| t.tags.include?(tag) }).to eq(false)
       end
 
       it "does not exclude a tagged topic without permission" do
-        topics = TopicQuery.new(user, exclude_tag: other_tag.name).list_latest.topics
+        topics = TopicQuery.new(user, exclude_tags: [other_tag.name]).list_latest.topics
         expect(topics.map(&:id)).to include(tagged_topic2.id)
       end
 

--- a/spec/system/filtering_topics_spec.rb
+++ b/spec/system/filtering_topics_spec.rb
@@ -2,40 +2,139 @@
 
 describe "Filtering topics", type: :system, js: true do
   fab!(:user) { Fabricate(:user) }
-  fab!(:topic) { Fabricate(:topic) }
-  fab!(:closed_topic) { Fabricate(:topic, closed: true) }
   let(:topic_list) { PageObjects::Components::TopicList.new }
+  let(:topic_query_filter) { PageObjects::Components::TopicQueryFilter.new }
 
   before { SiteSetting.experimental_topics_filter = true }
 
-  it "should allow users to input a custom query string to filter through topics" do
-    sign_in(user)
+  context "when filtering with multiple filters" do
+    fab!(:tag) { Fabricate(:tag, name: "tag1") }
+    fab!(:topic_with_tag) { Fabricate(:topic, tags: [tag]) }
+    fab!(:topic) { Fabricate(:topic) }
+    fab!(:closed_topic_with_tag) { Fabricate(:topic, closed: true, tags: [tag]) }
 
-    visit("/filter")
+    it "should display the right topics when query string is `tags:tag1 status:closed`" do
+      sign_in(user)
 
-    expect(topic_list).to have_topic(topic)
-    expect(topic_list).to have_topic(closed_topic)
+      visit("/filter")
 
-    topic_query_filter = PageObjects::Components::TopicQueryFilter.new
-    topic_query_filter.fill_in("status:open")
+      topic_query_filter.fill_in("tags:tag1 status:closed")
 
-    expect(topic_list).to have_topic(topic)
-    expect(topic_list).to have_no_topic(closed_topic)
-    expect(page).to have_current_path("/filter?status=open")
-
-    topic_query_filter.fill_in("status:closed")
-
-    expect(topic_list).to have_no_topic(topic)
-    expect(topic_list).to have_topic(closed_topic)
-    expect(page).to have_current_path("/filter?status=closed")
+      expect(page).to have_current_path("/filter?status=closed&tags[]=tag1")
+      expect(topic_list).to have_topics(count: 1)
+      expect(topic_list).to have_topic(closed_topic_with_tag)
+    end
   end
 
-  it "should filter topics when 'status' query params is present" do
-    sign_in(user)
+  context "when filtering by tags" do
+    fab!(:tag) { Fabricate(:tag, name: "tag1") }
+    fab!(:tag2) { Fabricate(:tag, name: "tag2") }
+    fab!(:topic_with_tag) { Fabricate(:topic, tags: [tag]) }
+    fab!(:topic_with_tag2) { Fabricate(:topic, tags: [tag2]) }
+    fab!(:topic_with_tag_and_tag2) { Fabricate(:topic, tags: [tag, tag2]) }
 
-    visit("/filter?status=open")
+    it "should display the right topics when query string is `tags:tag1`" do
+      sign_in(user)
 
-    expect(topic_list).to have_topic(topic)
-    expect(topic_list).to have_no_topic(closed_topic)
+      visit("/filter")
+
+      topic_query_filter.fill_in("tags:tag1")
+
+      expect(page).to have_current_path("/filter?tags[]=tag1")
+      expect(topic_list).to have_topics(count: 2)
+      expect(topic_list).to have_topic(topic_with_tag)
+      expect(topic_list).to have_topic(topic_with_tag_and_tag2)
+    end
+
+    it "should display the right topics when query string is `tags:tag1+tag2`" do
+      sign_in(user)
+
+      visit("/filter")
+
+      topic_query_filter.fill_in("tags:tag1+tag2")
+
+      expect(page).to have_current_path("/filter?match_all_tags=true&tags[]=tag1&tags[]=tag2")
+      expect(topic_list).to have_topics(count: 1)
+      expect(topic_list).to have_topic(topic_with_tag_and_tag2)
+    end
+
+    it "should display the right topics when query string is `tags:tag1,tag2`" do
+      sign_in(user)
+
+      visit("/filter")
+
+      topic_query_filter.fill_in("tags:tag1,tag2")
+
+      expect(page).to have_current_path("/filter?match_all_tags=false&tags[]=tag1&tags[]=tag2")
+      expect(topic_list).to have_topics(count: 3)
+      expect(topic_list).to have_topic(topic_with_tag)
+      expect(topic_list).to have_topic(topic_with_tag2)
+      expect(topic_list).to have_topic(topic_with_tag_and_tag2)
+    end
+
+    it "should display the right topics when query string is `-tags:tag1+tag2`" do
+      sign_in(user)
+
+      visit("/filter")
+
+      topic_query_filter.fill_in("-tags:tag1+tag2")
+
+      expect(page).to have_current_path(
+        "/filter?exclude_tags[]=tag1&exclude_tags[]=tag2&match_all_tags=true",
+      )
+
+      expect(topic_list).to have_topics(count: 2)
+      expect(topic_list).to have_topic(topic_with_tag)
+      expect(topic_list).to have_topic(topic_with_tag2)
+    end
+
+    it "should display the right topics when query string is `-tags:tag1,tag2`" do
+      sign_in(user)
+
+      visit("/filter")
+
+      topic_query_filter.fill_in("-tags:tag1,tag2")
+
+      expect(page).to have_current_path(
+        "/filter?exclude_tags[]=tag1&exclude_tags[]=tag2&match_all_tags=false",
+      )
+
+      expect(topic_list).to be_empty
+    end
+  end
+
+  context "when filtering by status" do
+    fab!(:topic) { Fabricate(:topic) }
+    fab!(:closed_topic) { Fabricate(:topic, closed: true) }
+
+    it "should allow users to input a custom query string to filter through topics" do
+      sign_in(user)
+
+      visit("/filter")
+
+      expect(topic_list).to have_topic(topic)
+      expect(topic_list).to have_topic(closed_topic)
+
+      topic_query_filter.fill_in("status:open")
+
+      expect(topic_list).to have_topic(topic)
+      expect(topic_list).to have_no_topic(closed_topic)
+      expect(page).to have_current_path("/filter?status=open")
+
+      topic_query_filter.fill_in("status:closed")
+
+      expect(topic_list).to have_no_topic(topic)
+      expect(topic_list).to have_topic(closed_topic)
+      expect(page).to have_current_path("/filter?status=closed")
+    end
+
+    it "should filter topics when 'status' query params is present" do
+      sign_in(user)
+
+      visit("/filter?status=open")
+
+      expect(topic_list).to have_topic(topic)
+      expect(topic_list).to have_no_topic(closed_topic)
+    end
   end
 end

--- a/spec/system/page_objects/components/topic_list.rb
+++ b/spec/system/page_objects/components/topic_list.rb
@@ -14,6 +14,10 @@ module PageObjects
         page.has_css?(TOPIC_LIST_ITEM_SELECTOR, count: count)
       end
 
+      def empty?
+        page.has_css?(TOPIC_LIST_ITEM_SELECTOR, count: 0)
+      end
+
       def has_topic?(topic)
         page.has_css?(topic_list_item_class(topic))
       end


### PR DESCRIPTION
The following are the changes being introduced in this commit:

1. On the `/filter` route, the tags filtering query language is now
   supported in the input per the example provided below:

   ```
   tags:bug+feature tagged both bug and feature
   tags:bug,feature tagged either bug or feature
   tags:-bug+feature excluding topics tagged bug and feature
   tags:-bug,feature excluding topics tagged bug or feature
   ```

2. At a higher level, the query params for filtering a topics list have
been improved. The `exclude_tag` query param which used to only take in
a single tag has been changed to the `exclude_tags` query param.
However, backwards compatibility for the `exclude_tag` query param is
still supported and is automatically convered to the `exclude_tags`
query param on the server side.

### Recording

![Peek 2023-03-29 08-06](https://user-images.githubusercontent.com/4335742/228395152-5b766446-8309-4d9c-8f4d-a6f7a25f2088.gif)
