### PR TITLE
PERF: ensure sidebar section link index is correctly ordered

### DIFF
--- a/app/models/sidebar_section_link.rb
+++ b/app/models/sidebar_section_link.rb
@@ -47,7 +47,7 @@ end
 #
 # Indexes
 #
+#  idx_sidebar_section_links_on_sidebar_section_id               (sidebar_section_id,user_id,position) UNIQUE
 #  idx_unique_sidebar_section_links                              (user_id,linkable_type,linkable_id) UNIQUE
 #  index_sidebar_section_links_on_linkable_type_and_linkable_id  (linkable_type,linkable_id)
-#  links_user_id_section_id_position                             (user_id,sidebar_section_id,position) UNIQUE
 #

--- a/db/migrate/20230328034956_add_sidebar_section_id_index_to_sidebar_section_link.rb
+++ b/db/migrate/20230328034956_add_sidebar_section_id_index_to_sidebar_section_link.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddSidebarSectionIdIndexToSidebarSectionLink < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL
+    DROP INDEX CONCURRENTLY IF EXISTS idx_sidebar_section_links_on_sidebar_section_id
+    SQL
+
+    execute <<~SQL
+    CREATE UNIQUE INDEX CONCURRENTLY idx_sidebar_section_links_on_sidebar_section_id
+    ON sidebar_section_links (sidebar_section_id, user_id, position)
+    SQL
+
+    execute <<~SQL
+    DROP INDEX CONCURRENTLY IF EXISTS links_user_id_section_id_position
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+    DROP INDEX CONCURRENTLY IF EXISTS idx_sidebar_section_links_on_sidebar_section_id
+    SQL
+
+    add_index :sidebar_section_links,
+              %i[user_id sidebar_section_id position],
+              unique: true,
+              name: "links_user_id_section_id_position"
+  end
+end


### PR DESCRIPTION
We perform lookups on sidebar section links based on sidebar_section_id
totally ignoring user. This ensures we have an index to work with.

This removes the previous index `links_user_id_section_id_position` which
partially doubled up `idx_unique_sidebar_section_links`
