### PR TITLE
FIX: reorder custom sidebar links on touch screen

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.hbs
@@ -17,15 +17,11 @@
             @prefixValue={{link.icon}}
             @href={{link.value}}
             @class={{link.linkDragCss}}
-            {{(if
-              this.canReorder
-              (modifier
-                "draggable"
-                didStartDrag=link.didStartDrag
-                didEndDrag=link.didEndDrag
-                dragMove=link.dragMove
-              )
-            )}}
+            {{draggable
+              didStartDrag=link.didStartDrag
+              didEndDrag=link.didEndDrag
+              dragMove=link.dragMove
+            }}
           />
         {{else}}
           <Sidebar::SectionLink
@@ -37,15 +33,11 @@
             @prefixType="icon"
             @prefixValue={{link.icon}}
             @class={{link.linkDragCss}}
-            {{(if
-              this.canReorder
-              (modifier
-                "draggable"
-                didStartDrag=link.didStartDrag
-                didEndDrag=link.didEndDrag
-                dragMove=link.dragMove
-              )
-            )}}
+            {{draggable
+              didStartDrag=link.didStartDrag
+              didEndDrag=link.didEndDrag
+              dragMove=link.dragMove
+            }}
           />
         {{/if}}
       {{/each}}

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/custom-sections.js
@@ -28,12 +28,6 @@ export default class SidebarUserCustomSections extends Component {
     });
   }
 
-  get canReorder() {
-    return document
-      .getElementsByTagName("html")[0]
-      .classList.contains("no-touch");
-  }
-
   @bind
   _refresh() {
     return ajax("/sidebar_sections.json", {}).then((json) => {

--- a/app/assets/javascripts/discourse/app/components/sidebar/user/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/section-link.js
@@ -25,7 +25,10 @@ export default class SectionLink {
   @bind
   didStartDrag(event) {
     // 0 represents left button of the mouse
-    if (event.button === 0) {
+    if (event.button === 0 || event.targetTouches) {
+      this.startMouseY = Math.round(
+        event.targetTouches ? event.targetTouches[0].clientY : event.y
+      );
       this.willDrag = true;
       discourseLater(() => {
         this.delayedStart(event);
@@ -34,10 +37,19 @@ export default class SectionLink {
   }
   delayedStart(event) {
     if (this.willDrag) {
-      this.mouseY = event.y;
-      this.linkDragCss = "drag";
-      this.section.disable();
-      this.drag = true;
+      const currentMouseY = Math.round(
+        event.targetTouches ? event.targetTouches[0].clientY : event.y
+      );
+      if (currentMouseY === this.startMouseY) {
+        event.stopPropagation();
+        event.preventDefault();
+        this.mouseY = Math.round(
+          event.targetTouches ? event.targetTouches[0].clientY : event.y
+        );
+        this.linkDragCss = "drag";
+        this.section.disable();
+        this.drag = true;
+      }
     }
   }
 
@@ -53,10 +65,17 @@ export default class SectionLink {
 
   @bind
   dragMove(event) {
+    this.startMouseY = Math.round(
+      event.targetTouches ? event.targetTouches[0].clientY : event.y
+    );
     if (!this.drag) {
       return;
     }
-    const currentMouseY = event.y;
+    event.stopPropagation();
+    event.preventDefault();
+    const currentMouseY = Math.round(
+      event.targetTouches ? event.targetTouches[0].clientY : event.y
+    );
     const distance = currentMouseY - this.mouseY;
     if (!this.linkHeight) {
       this.linkHeight = document.getElementsByClassName(

--- a/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
+++ b/app/assets/javascripts/discourse/app/components/topic-timeline/container.js
@@ -287,8 +287,10 @@ export default class TopicTimelineScrollArea extends Component {
   }
 
   @bind
-  dragMove(e) {
-    this.updatePercentage(e);
+  dragMove(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    this.updatePercentage(event);
   }
 
   @bind

--- a/app/assets/javascripts/discourse/app/modifiers/draggable.js
+++ b/app/assets/javascripts/discourse/app/modifiers/draggable.js
@@ -29,8 +29,6 @@ export default class DraggableModifier extends Modifier {
 
   @bind
   dragMove(e) {
-    e.stopPropagation();
-    e.preventDefault();
     if (!this.hasStarted) {
       this.hasStarted = true;
 

--- a/app/assets/stylesheets/common/base/sidebar-custom-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-custom-section.scss
@@ -18,6 +18,15 @@
     cursor: move;
   }
 
+  a {
+    -webkit-touch-callout: none !important;
+    -webkit-user-select: none !important;
+    -moz-user-select: none !important;
+    -ms-user-select: none !important;
+    -o-user-select: none !important;
+    user-select: none;
+  }
+
   .sidebar-section-wrapper.disabled {
     a {
       pointer-events: none;
@@ -35,6 +44,13 @@
           color: var(--primary-high);
         }
       }
+    }
+  }
+}
+.discourse-touch {
+  .sidebar-custom-sections {
+    a:hover {
+      background: none !important;
     }
   }
 }


### PR DESCRIPTION
Previously, reorder on touch screens was disabled https://github.com/discourse/discourse/pull/20769.

This PR enables it again. However, link has to be hold for 300 ms to enable drag&drop. Otherwise, normal scroll is performed.

https://user-images.githubusercontent.com/72780/228128980-5726b094-f510-4e57-a2b2-1b8df86108cb.mp4


