### PR TITLE
DEV: allow API for list_suggested_for to exclude random

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -205,6 +205,8 @@ class TopicQuery
 
   # Return a list of suggested topics for a topic
   def list_suggested_for(topic, pm_params: nil, include_random: true)
+    # The include_random param was added so plugins can generate a suggested topics list without the random topics
+
     # Don't suggest messages unless we have a user, and private messages are
     # enabled.
     if topic.private_message? &&

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -204,9 +204,8 @@ class TopicQuery
   end
 
   # Return a list of suggested topics for a topic
+  # The include_random param was added so plugins can generate a suggested topics list without the random topics
   def list_suggested_for(topic, pm_params: nil, include_random: true)
-    # The include_random param was added so plugins can generate a suggested topics list without the random topics
-
     # Don't suggest messages unless we have a user, and private messages are
     # enabled.
     if topic.private_message? &&

--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -204,7 +204,7 @@ class TopicQuery
   end
 
   # Return a list of suggested topics for a topic
-  def list_suggested_for(topic, pm_params: nil)
+  def list_suggested_for(topic, pm_params: nil, include_random: true)
     # Don't suggest messages unless we have a user, and private messages are
     # enabled.
     if topic.private_message? &&
@@ -250,7 +250,7 @@ class TopicQuery
     end
 
     if !topic.private_message?
-      unless builder.full?
+      if include_random && !builder.full?
         builder.add_results(
           random_suggested(topic, builder.results_left, builder.excluded_topic_ids),
         )

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1379,6 +1379,11 @@ RSpec.describe TopicQuery do
       it "should return the new topic" do
         expect(TopicQuery.new.list_suggested_for(topic).topics).to eq([new_topic])
       end
+
+      it "should return the nothing when random topics excluded" do
+        # this API was added so plugins can generate a suggested topics list without the random topics
+        expect(TopicQuery.new.list_suggested_for(topic, include_random: false).topics).to eq([])
+      end
     end
 
     context "when anonymously browsing with invisible, closed and archived" do

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1381,7 +1381,6 @@ RSpec.describe TopicQuery do
       end
 
       it "should return the nothing when random topics excluded" do
-        # this API was added so plugins can generate a suggested topics list without the random topics
         expect(TopicQuery.new.list_suggested_for(topic, include_random: false).topics).to eq([])
       end
     end


### PR DESCRIPTION
This is needed so plugins can potentially create lists without random topics
