### PR TITLE
FIX: channel_message_bus_last_id was incorrect

### DIFF
--- a/plugins/chat/app/serializers/chat/channel_serializer.rb
+++ b/plugins/chat/app/serializers/chat/channel_serializer.rb
@@ -128,7 +128,8 @@ module Chat
     private
 
     def channel_message_bus_last_id
-      @opts[:channel_message_bus_last_id] || Chat::Publisher.root_message_bus_channel(object.id)
+      @opts[:channel_message_bus_last_id] ||
+        MessageBus.last_id(Chat::Publisher.root_message_bus_channel(object.id))
     end
 
     def new_messages_message_bus_id

--- a/plugins/chat/app/serializers/chat/view_serializer.rb
+++ b/plugins/chat/app/serializers/chat/view_serializer.rb
@@ -25,7 +25,7 @@ module Chat
         can_delete_self: scope.can_delete_own_chats?(object.chat_channel.chatable),
         can_delete_others: scope.can_delete_other_chats?(object.chat_channel.chatable),
         channel_message_bus_last_id:
-          Chat::Publisher.root_message_bus_channel(object.chat_channel.id),
+          MessageBus.last_id(Chat::Publisher.root_message_bus_channel(object.chat_channel.id)),
       }
       meta_hash[
         :can_load_more_past


### PR DESCRIPTION
Followup to 3ea8df4b06e2fa57cbb72d5ddf99cc10ba2b2148,

I forgot to wrap the call to Chat::Publisher.root_message_bus_channel(object.chat_channel.id)
in MessageBus.last_id, so the channel_message_bus_last_id key was
ending up as e.g. "/chat/58" instead of the last ID value.
