### PR TITLE
DEV: Uncomment chat upload system specs

### DIFF
--- a/plugins/chat/spec/system/channel_message_upload_spec.rb
+++ b/plugins/chat/spec/system/channel_message_upload_spec.rb
@@ -1,39 +1,39 @@
 # frozen_string_literal: true
 
-# RSpec.describe "Channel message selection", type: :system, js: true do
-#   fab!(:current_user) { Fabricate(:user) }
-#   fab!(:channel_1) { Fabricate(:chat_channel) }
-#   fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+RSpec.describe "Channel message selection", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:channel_1) { Fabricate(:chat_channel) }
+  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
 
-#   let(:chat) { PageObjects::Pages::Chat.new }
-#   let(:channel) { PageObjects::Pages::ChatChannel.new }
-#   let(:image) do
-#     Fabricate(
-#       :upload,
-#       original_filename: "test_image.jpg",
-#       width: 400,
-#       height: 300,
-#       extension: "jpg",
-#     )
-#   end
+  let(:chat) { PageObjects::Pages::Chat.new }
+  let(:channel) { PageObjects::Pages::ChatChannel.new }
+  let(:image) do
+    Fabricate(
+      :upload,
+      original_filename: "test_image.jpg",
+      width: 400,
+      height: 300,
+      extension: "jpg",
+    )
+  end
 
-#   before do
-#     chat_system_bootstrap
-#     channel_1.add(current_user)
-#     sign_in(current_user)
-#     message_1.attach_uploads([image])
-#   end
+  before do
+    chat_system_bootstrap
+    channel_1.add(current_user)
+    sign_in(current_user)
+    message_1.attach_uploads([image])
+  end
 
-#   it "can collapse/expand an image and still have lightbox working" do
-#     chat.visit_channel(channel_1)
+  it "can collapse/expand an image and still have lightbox working" do
+    chat.visit_channel(channel_1)
 
-#     find(".chat-message-collapser-button").click
-#     expect(page).to have_css(".chat-message-collapser-body.hidden", visible: :false)
-#     find(".chat-message-collapser-button").click
-#     expect(page).to have_no_css(".chat-message-collapser-body.hidden")
-#     find(".chat-img-upload").click
+    find(".chat-message-collapser-button").click
+    expect(page).to have_css(".chat-message-collapser-body.hidden", visible: :false)
+    find(".chat-message-collapser-button").click
+    expect(page).to have_no_css(".chat-message-collapser-body.hidden")
+    find(".chat-img-upload").click
 
-#     # visible false is because the upload doesn’t exist but it's enough to know lightbox is working
-#     expect(page).to have_css(".mfp-image-holder img[src*='#{image.url}']", visible: false)
-#   end
-# end
+    # visible false is because the upload doesn’t exist but it's enough to know lightbox is working
+    expect(page).to have_css(".mfp-image-holder img[src*='#{image.url}']", visible: false)
+  end
+end

--- a/plugins/chat/spec/system/uploads_spec.rb
+++ b/plugins/chat/spec/system/uploads_spec.rb
@@ -79,54 +79,54 @@ describe "Uploading files in chat messages", type: :system, js: true do
     end
   end
 
-  # context "when editing a message with uploads" do
-  #   fab!(:message_2) { Fabricate(:chat_message, user: current_user, chat_channel: channel_1) }
-  #   fab!(:upload_reference) do
-  #     Fabricate(
-  #       :upload_reference,
-  #       target: message_2,
-  #       upload: Fabricate(:upload, user: current_user),
-  #     )
-  #   end
+  context "when editing a message with uploads" do
+    fab!(:message_2) { Fabricate(:chat_message, user: current_user, chat_channel: channel_1) }
+    fab!(:upload_reference) do
+      Fabricate(
+        :upload_reference,
+        target: message_2,
+        upload: Fabricate(:upload, user: current_user),
+      )
+    end
 
-  #   before do
-  #     channel_1.add(current_user)
-  #     sign_in(current_user)
+    before do
+      channel_1.add(current_user)
+      sign_in(current_user)
 
-  #     file = file_from_fixtures("logo-dev.png", "images")
-  #     url = Discourse.store.store_upload(file, upload_reference.upload)
-  #     upload_reference.upload.update!(url: url, sha1: Upload.generate_digest(file))
-  #   end
+      file = file_from_fixtures("logo-dev.png", "images")
+      url = Discourse.store.store_upload(file, upload_reference.upload)
+      upload_reference.upload.update!(url: url, sha1: Upload.generate_digest(file))
+    end
 
-  #   it "allows deleting uploads" do
-  #     chat.visit_channel(channel_1)
-  #     channel.open_edit_message(message_2)
-  #     find(".chat-composer-upload").find(".remove-upload").click
-  #     channel.click_send_message
-  #     expect(channel.message_by_id(message_2.id)).not_to have_css(".chat-uploads")
-  #     expect(message_2.reload.uploads).to be_empty
-  #   end
+    it "allows deleting uploads" do
+      chat.visit_channel(channel_1)
+      channel.open_edit_message(message_2)
+      find(".chat-composer-upload").find(".remove-upload").click
+      channel.click_send_message
+      expect(channel.message_by_id(message_2.id)).not_to have_css(".chat-uploads")
+      expect(message_2.reload.uploads).to be_empty
+    end
 
-  #   it "allows adding more uploads" do
-  #     chat.visit_channel(channel_1)
-  #     channel.open_edit_message(message_2)
+    it "allows adding more uploads" do
+      chat.visit_channel(channel_1)
+      channel.open_edit_message(message_2)
 
-  #     file_path = file_from_fixtures("logo.png", "images").path
-  #     attach_file(file_path) do
-  #       channel.open_action_menu
-  #       channel.click_action_button("chat-upload-btn")
-  #     end
+      file_path = file_from_fixtures("logo.png", "images").path
+      attach_file(file_path) do
+        channel.open_action_menu
+        channel.click_action_button("chat-upload-btn")
+      end
 
-  #     expect(page).to have_css(".chat-composer-upload .preview .preview-img", count: 2)
-  #     expect(page).to have_content(File.basename(file_path))
+      expect(page).to have_css(".chat-composer-upload .preview .preview-img", count: 2)
+      expect(page).to have_content(File.basename(file_path))
 
-  #     channel.click_send_message
+      channel.click_send_message
 
-  #     expect(page).not_to have_css(".chat-composer-upload")
-  #     expect(page).to have_css(".chat-img-upload", count: 2)
-  #     expect(message_2.reload.uploads.count).to eq(2)
-  #   end
-  # end
+      expect(page).not_to have_css(".chat-composer-upload")
+      expect(page).to have_css(".chat-img-upload", count: 2)
+      expect(message_2.reload.uploads.count).to eq(2)
+    end
+  end
 
   context "when uploads are not allowed" do
     fab!(:user_2) { Fabricate(:user) }


### PR DESCRIPTION
These were commented in  daaa41ae0760c863c91bfcda659a4f966ea7545c,
doesn't seem to have made an observable difference, uncommenting
these now to see if chat system specs still pass.
