### PR TITLE
PERF: optimise serialization for topic tracking state

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -653,8 +653,10 @@ class ApplicationController < ActionController::Base
     report = TopicTrackingState.report(current_user)
     serializer = TopicTrackingStateSerializer.new(report, scope: guardian, root: false)
 
-    store_preloaded("topicTrackingStates", MultiJson.dump(serializer.as_json[:data]))
-    store_preloaded("topicTrackingStateMeta", MultiJson.dump(serializer.as_json[:meta]))
+    hash = serializer.as_json
+
+    store_preloaded("topicTrackingStates", MultiJson.dump(hash[:data]))
+    store_preloaded("topicTrackingStateMeta", MultiJson.dump(hash[:meta]))
   end
 
   def custom_html_json

--- a/app/serializers/topic_tracking_state_item_serializer.rb
+++ b/app/serializers/topic_tracking_state_item_serializer.rb
@@ -28,4 +28,8 @@ class TopicTrackingStateItemSerializer < ApplicationSerializer
   def include_is_category_topic?
     object.respond_to?(:category_topic_id)
   end
+
+  def object=(value)
+    @object = value
+  end
 end

--- a/app/serializers/topic_tracking_state_serializer.rb
+++ b/app/serializers/topic_tracking_state_serializer.rb
@@ -4,8 +4,12 @@ class TopicTrackingStateSerializer < ApplicationSerializer
   attributes :data, :meta
 
   def data
+    serializer = TopicTrackingStateItemSerializer.new(nil, scope: scope, root: false)
+    # note we may have 1000 rows, avoiding serializer instansitation saves significant time
+    # for 1000 rows this takes it down from 10ms to 3ms on a reasonably fast machine
     object.map do |item|
-      TopicTrackingStateItemSerializer.new(item, scope: scope, root: false).as_json
+      serializer.object = item
+      serializer.as_json
     end
   end
 


### PR DESCRIPTION
This corrects two issues:

1. We were double serializing topic tracking state (as_json calls were not cached)
2. We were inefficiently serializing items by instantiating extra objects
