### PR TITLE
Revert "UX: Take sticky header into account when spacebar scrolling (…

### DIFF
--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -61,7 +61,6 @@
 // Base Elements
 html {
   height: 100%;
-  scroll-padding-top: calc(var(--header-offset, 4em) + 1em);
 }
 
 body {


### PR DESCRIPTION
…#20848)"

This reverts commit cb92ea3c2b1fad5cdc79196268f902cf3e2ee3c9.

Was causing unexpected scrolling when interacting with the header. Will investigate.
