### PR TITLE
FIX: Push notification delay should not be longer than specified

### DIFF
--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -55,12 +55,9 @@ class PostAlerter
 
     if user.push_subscriptions.exists?
       if user.seen_since?(SiteSetting.push_notification_time_window_mins.minutes.ago)
-        Jobs.enqueue_in(
-          SiteSetting.push_notification_time_window_mins.minutes,
-          :send_push_notification,
-          user_id: user.id,
-          payload: payload,
-        )
+        delay =
+          (SiteSetting.push_notification_time_window_mins - (Time.now - user.last_seen_at) / 60)
+        Jobs.enqueue_in(delay.minutes, :send_push_notification, user_id: user.id, payload: payload)
       else
         Jobs.enqueue(:send_push_notification, user_id: user.id, payload: payload)
       end

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -1238,6 +1238,18 @@ RSpec.describe PostAlerter do
         expect(Jobs::SendPushNotification.jobs[0]["at"]).not_to be_nil
       end
 
+      it "delays sending push notification for active online user for the correct delay ammount" do
+        evil_trout.update!(last_seen_at: 5.minutes.ago)
+
+        # SiteSetting.push_notification_time_window_mins is 10
+        # last_seen_at is 5 minutes ago
+        # 10 minutes from now - 5 minutes ago = 5 minutes
+        delay = 5.minutes.from_now.to_f
+
+        expect { mention_post }.to change { Jobs::SendPushNotification.jobs.count }
+        expect(Jobs::SendPushNotification.jobs[0]["at"]).to be_within(30.second).of(delay)
+      end
+
       it "does not delay push notification for inactive offline user" do
         evil_trout.update!(last_seen_at: 40.minutes.ago)
 


### PR DESCRIPTION
When user.last_seen was less than push_notification_time_window_mins we
where delaying the notification for the whole
push_notification_time_window_mins PLUS the time the user was away from.

Originally reported in https://meta.discourse.org/t/-/259688
