### PR TITLE
DEV: Remove diffhtml_preview for video thumbnails

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1009,8 +1009,7 @@ class Post < ActiveRecord::Base
       upload ||= Upload.get_from_url(src)
 
       # Link any video thumbnails
-      if SiteSetting.enable_diffhtml_preview && upload.present? &&
-           (FileHelper.supported_video.include? upload.extension)
+      if upload.present? && (FileHelper.supported_video.include? upload.extension)
         # Video thumbnails have the filename of the video file sha1 with a .png or .jpg extension.
         # This is because at time of upload in the composer we don't know the topic/post id yet
         # and there is no thumbnail info added to the markdown to tie the thumbnail to the topic/post after

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1532,8 +1532,6 @@ RSpec.describe Post do
   end
 
   describe "video_thumbnails" do
-    before { SiteSetting.enable_diffhtml_preview = true }
-
     fab!(:video_upload) { Fabricate(:upload, extension: "mp4") }
     fab!(:image_upload) { Fabricate(:upload) }
     fab!(:image_upload_2) { Fabricate(:upload) }


### PR DESCRIPTION
Video thumbnail generation is no longer dependent on
`enable_diffhtml_preview` being enabled.
