### PR TITLE
DEV: Yarn install to avoid error during initial migration seed

### DIFF
--- a/bin/docker/boot_dev
+++ b/bin/docker/boot_dev
@@ -110,6 +110,9 @@ if [ "${initialize}" = "initialize" ]; then
     echo "Installing gems..."
     "${SCRIPTPATH}/bundle" install
 
+    echo "Yarn install..."
+    "${SCRIPTPATH}/exec" yarn install --cwd app/assets/javascripts/discourse
+
     echo "Migrating database..."
     "${SCRIPTPATH}/rake" db:migrate
     RAILS_ENV=test "${SCRIPTPATH}/rake" db:migrate


### PR DESCRIPTION
On a fresh attempt to initialize the dev environment, the migration seeding users errors due to missing files when it attempts to "cook" the user_profile. This change runs yarn install before to avoid this error.

See error in discussion here: https://meta.discourse.org/t/install-discourse-for-development-using-docker/102009/231