### PR TITLE
FIX: ensures removing a reaction doesn’t remove others

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -151,18 +151,23 @@ export default class ChatMessage {
         }
         existingReaction.users.pushObject(actor);
       } else {
-        existingReaction.count = existingReaction.count - 1;
+        const existingUserReaction = existingReaction.users.find(
+          (user) => user.id === actor.id
+        );
+
+        if (!existingUserReaction) {
+          return;
+        }
 
         if (selfReaction) {
           existingReaction.reacted = false;
         }
 
-        if (existingReaction.count === 0) {
+        if (existingReaction.count === 1) {
           this.reactions.removeObject(existingReaction);
         } else {
-          existingReaction.users.removeObject(
-            existingReaction.users.find((user) => user.id === actor.id)
-          );
+          existingReaction.count = existingReaction.count - 1;
+          existingReaction.users.removeObject(existingUserReaction);
         }
       }
     } else {

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -112,15 +112,13 @@ module PageObjects
         within(message_by_id(message.id)) { find(".chat-message-bookmarked") }
       end
 
-      def find_reaction(message, reaction)
-        within(message_reactions_list(message)) do
-          return find("[data-emoji-name=\"#{reaction.emoji}\"]")
-        end
+      def find_reaction(message, emoji)
+        within(message_reactions_list(message)) { return find("[data-emoji-name=\"#{emoji}\"]") }
       end
 
-      def has_reaction?(message, reaction, text = nil)
+      def has_reaction?(message, emoji, text = nil)
         within(message_reactions_list(message)) do
-          has_css?("[data-emoji-name=\"#{reaction.emoji}\"]", text: text)
+          has_css?("[data-emoji-name=\"#{emoji}\"]", text: text)
         end
       end
 
@@ -136,8 +134,8 @@ module PageObjects
         within(message_by_id(message.id)) { has_no_css?(".chat-message-reaction-list") }
       end
 
-      def click_reaction(message, reaction)
-        find_reaction(message, reaction).click
+      def click_reaction(message, emoji)
+        find_reaction(message, emoji).click
       end
 
       def open_action_menu


### PR DESCRIPTION
Before this fix if user A and user B had the same reaction on a message, when user A would remove its reaction, reaction B would also be removed. Only visually for user A, this change was not made in backend.

Also refactors reaction helper to take an emoji name as param instead of an emoji object.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
