### PR TITLE
FIX: disable text select on sidebar

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -29,6 +29,13 @@
   position: sticky;
   top: var(--header-offset);
 
+  -webkit-touch-callout: none !important;
+  -webkit-user-select: none !important;
+  -moz-user-select: none !important;
+  -ms-user-select: none !important;
+  -o-user-select: none !important;
+  user-select: none;
+
   .footer-nav-ipad & {
     top: calc(var(--header-offset) + var(--footer-nav-height));
     height: calc(


### PR DESCRIPTION
To make drag&drop links reliable, we have to disable user-select option on whole sidebar.

https://developer.mozilla.org/en-US/docs/Web/CSS/user-select