### PR TITLE
FEATURE: ensure plugins do not override existing core attributes

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -377,3 +377,5 @@ regex_timeout_seconds = 2
 
 # Allow impersonation function on the cluster to admins
 allow_impersonation = true
+
+deprecate_serializer_overrides = true

--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -378,4 +378,4 @@ regex_timeout_seconds = 2
 # Allow impersonation function on the cluster to admins
 allow_impersonation = true
 
-deprecate_serializer_overrides = true
+deprecate_serializer_overrides = false

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -121,18 +121,22 @@ class Plugin::Instance
       is_include_attr = attr.to_s.start_with?("include_")
       include_attr_method = is_include_attr ? attr : "include_#{attr}?"
 
-      if !is_include_attr && base.method_defined?(attr)
-        Discourse.deprecate(
-          "Overriding the #{attr} attribute in serializer #{base} from a plugin is no longer supported",
-          drop_from: "3.1",
-        )
-      end
+      if GlobalSetting.deprecate_serializer_overrides
+        if !is_include_attr && base.method_defined?(attr)
+          Discourse.deprecate(
+            "Overriding the #{attr} attribute in serializer #{base} from a plugin is no longer supported, please make a core PR to add modifiers instead (#{caller[2]})",
+            drop_from: "3.1",
+          )
+        end
 
-      if base.method_defined?(include_attr_method)
-        Discourse.deprecate(
-          "Overriding the #{include_attr_method} method in serializer #{base} from a plugin is no longer supported",
-          drop_from: "3.1",
-        )
+        if define_include_method
+          if base.method_defined?(include_attr_method)
+            Discourse.deprecate(
+              "Overriding the #{include_attr_method} method in serializer #{base} from a plugin is no longer supported, please make a core PR to add modifiers instead (#{caller[2]})",
+              drop_from: "3.1",
+            )
+          end
+        end
       end
 
       # we have to work through descendants cause serializers may already be baked and cached

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -118,14 +118,31 @@ class Plugin::Instance
           "#{serializer.to_s}Serializer".constantize
         end
 
+      is_include_attr = attr.to_s.start_with?("include_")
+      include_attr_method = is_include_attr ? attr : "include_#{attr}?"
+
+      if !is_include_attr && base.method_defined?(attr)
+        Discourse.deprecate(
+          "Overriding the #{attr} attribute in serializer #{base} from a plugin is no longer supported",
+          drop_from: "3.1",
+        )
+      end
+
+      if base.method_defined?(include_attr_method)
+        Discourse.deprecate(
+          "Overriding the #{include_attr_method} method in serializer #{base} from a plugin is no longer supported",
+          drop_from: "3.1",
+        )
+      end
+
       # we have to work through descendants cause serializers may already be baked and cached
       ([base] + base.descendants).each do |klass|
-        unless attr.to_s.start_with?("include_")
+        if !is_include_attr
           klass.attributes(attr)
 
           if define_include_method
             # Don't include serialized methods if the plugin is disabled
-            klass.public_send(:define_method, "include_#{attr}?") { plugin.enabled? }
+            klass.public_send(:define_method, include_attr_method) { plugin.enabled? }
           end
         end
 

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -181,31 +181,25 @@ after_initialize do
     scope.user.id != object.id && scope.can_chat? && Guardian.new(object).can_chat?
   end
 
-  add_to_serializer(:current_user, :can_chat) { true }
-
   add_to_serializer(:current_user, :include_can_chat?) do
     return @can_chat if defined?(@can_chat)
 
     @can_chat = SiteSetting.chat_enabled && scope.can_chat?
   end
 
-  add_to_serializer(:current_user, :has_chat_enabled) { true }
+  add_to_serializer(:current_user, :can_chat, false) { true }
 
   add_to_serializer(:current_user, :include_has_chat_enabled?) do
     return @has_chat_enabled if defined?(@has_chat_enabled)
 
     @has_chat_enabled = include_can_chat? && object.user_option.chat_enabled
   end
-
-  add_to_serializer(:current_user, :chat_sound) { object.user_option.chat_sound }
+  add_to_serializer(:current_user, :has_chat_enabled, false) { true }
 
   add_to_serializer(:current_user, :include_chat_sound?) do
     include_has_chat_enabled? && object.user_option.chat_sound
   end
-
-  add_to_serializer(:current_user, :needs_channel_retention_reminder) { true }
-
-  add_to_serializer(:current_user, :needs_dm_retention_reminder) { true }
+  add_to_serializer(:current_user, :chat_sound, false) { object.user_option.chat_sound }
 
   add_to_serializer(:current_user, :has_joinable_public_channels) do
     Chat::ChannelFetcher.secured_public_channel_search(
@@ -226,13 +220,16 @@ after_initialize do
       !object.user_option.dismissed_channel_retention_reminder &&
       !SiteSetting.chat_channel_retention_days.zero?
   end
+  add_to_serializer(:current_user, :needs_channel_retention_reminder, false) { true }
 
   add_to_serializer(:current_user, :include_needs_dm_retention_reminder?) do
     include_has_chat_enabled? && !object.user_option.dismissed_dm_retention_reminder &&
       !SiteSetting.chat_dm_retention_days.zero?
   end
+  add_to_serializer(:current_user, :needs_dm_retention_reminder, false) { true }
 
-  add_to_serializer(:current_user, :chat_drafts) do
+  add_to_serializer(:current_user, :include_chat_drafts?) { include_has_chat_enabled? }
+  add_to_serializer(:current_user, :chat_drafts, false) do
     Chat::Draft
       .where(user_id: object.id)
       .order(updated_at: :desc)
@@ -241,13 +238,10 @@ after_initialize do
       .map { |row| { channel_id: row[0], data: row[1] } }
   end
 
-  add_to_serializer(:current_user, :include_chat_drafts?) { include_has_chat_enabled? }
-
   add_to_serializer(:user_option, :chat_enabled) { object.chat_enabled }
 
-  add_to_serializer(:user_option, :chat_sound) { object.chat_sound }
-
   add_to_serializer(:user_option, :include_chat_sound?) { !object.chat_sound.blank? }
+  add_to_serializer(:user_option, :chat_sound, false) { object.chat_sound }
 
   add_to_serializer(:user_option, :only_chat_push_notifications) do
     object.only_chat_push_notifications

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Plugin::Instance do
       end
     end
 
+    before { global_setting :deprecate_serializer_overrides, true }
+
     class ApiSafetySerializer < ApplicationSerializer
       attribute :name
     end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -19,6 +19,39 @@ RSpec.describe Plugin::Instance do
     end
   end
 
+  describe "api safety" do
+    class ApiSafetyPlugin < Plugin::Instance
+      attr_accessor :enabled
+      def enabled?
+        @enabled
+      end
+    end
+
+    class ApiSafetySerializer < ApplicationSerializer
+      attribute :name
+    end
+
+    it "logs a deprecation when attempting to override a core attribute" do
+      Discourse.expects(:deprecate).with(
+        "Overriding the name attribute in serializer ApiSafetySerializer from a plugin is no longer supported",
+        drop_from: "3.1",
+      )
+      Discourse.expects(:deprecate).with(
+        "Overriding the include_name? method in serializer ApiSafetySerializer from a plugin is no longer supported",
+        drop_from: "3.1",
+      )
+      ApiSafetyPlugin.new.add_to_serializer(:api_safety, :name) { "new name" }
+    end
+
+    it "logs a deprecation when attempting to override a core include_attribute?" do
+      Discourse.expects(:deprecate).with(
+        "Overriding the include_name? method in serializer ApiSafetySerializer from a plugin is no longer supported",
+        drop_from: "3.1",
+      )
+      ApiSafetyPlugin.new.add_to_serializer(:api_safety, :include_name?) { true }
+    end
+  end
+
   describe "enabling/disabling" do
     it "is enabled by default" do
       expect(Plugin::Instance.new.enabled?).to eq(true)


### PR DESCRIPTION
This feature is fragile and can not easily be disabled, core interfaces
can change leading to fragile plugins.

Instead simply disallow any overrides of core serializers from the safe API
