### PR TITLE
DEV: API on CategorySerializer to modify available_groups query

### DIFF
--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -49,6 +49,7 @@ class CategorySerializer < SiteCategorySerializer
     available_groups_query_modifiers.each do |query_modifier|
       query = query_modifier.call(query, object)
     end
+
     query
   end
 

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -112,5 +112,20 @@ RSpec.describe CategorySerializer do
       json = described_class.new(category, scope: Guardian.new(admin), root: false).as_json
       expect(json[:available_groups]).to eq(Group.order(:name).pluck(:name) - ["everyone"])
     end
+
+    describe "with query modifier" do
+      fab!(:other_group) { Fabricate(:group) }
+
+      it "Evaluates the added modifiers for an admin" do
+        CategorySerializer.add_available_groups_query_modifier(
+          Proc.new { |query, _| query.where(id: other_group.id) },
+        )
+
+        json = described_class.new(category, scope: Guardian.new(admin), root: false).as_json
+        expect(json[:available_groups]).to eq([other_group.name])
+
+        CategorySerializer.reset_available_groups_query_modifiers
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows plugins to modify the `available_groups` query with a clean API rather than using `add_to_serializer` to overwrite the core logic.