### PR TITLE
FIX: `<QuoteButton/>` shifts when content is added to header

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -17,7 +17,7 @@ import KeyEnterEscape from "discourse/mixins/key-enter-escape";
 import Sharing from "discourse/lib/sharing";
 import { action } from "@ember/object";
 import { alias } from "@ember/object/computed";
-import discourseComputed from "discourse-common/utils/decorators";
+import discourseComputed, { bind } from "discourse-common/utils/decorators";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { getAbsoluteURL } from "discourse-common/lib/get-url";
 import { next, schedule } from "@ember/runloop";
@@ -236,22 +236,21 @@ export default Component.extend(KeyEnterEscape, {
     });
   },
 
+  @bind
+  _updateRect() {
+    this.textRange?.updateRect();
+  },
+
   _setupSelectionListeners() {
-    const updateRect = () => {
-      if (this.visible) {
-        this.textRange.updateRect();
-      }
-    };
-    document.body.addEventListener("mouseup", updateRect);
-    window.addEventListener("scroll", updateRect);
-    document.scrollingElement.addEventListener("scroll", updateRect);
+    document.body.addEventListener("mouseup", this._updateRect);
+    window.addEventListener("scroll", this._updateRect);
+    document.scrollingElement.addEventListener("scroll", this._updateRect);
   },
 
   _teardownSelectionListeners() {
-    const updateRect = () => this.textRange.updateRect();
-    document.body.removeEventListener("mouseup", updateRect);
-    window.removeEventListener("scroll", updateRect);
-    document.scrollingElement.removeEventListener("scroll", updateRect);
+    document.body.removeEventListener("mouseup", this._updateRect);
+    window.removeEventListener("scroll", this._updateRect);
+    document.scrollingElement.removeEventListener("scroll", this._updateRect);
   },
 
   didInsertElement() {

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -24,7 +24,7 @@ import { next, schedule } from "@ember/runloop";
 import toMarkdown from "discourse/lib/to-markdown";
 import escapeRegExp from "discourse-common/utils/escape-regexp";
 import { createPopper } from "@popperjs/core";
-import VirtualElementFromTextRange from "discourse/lib/virtual-element-from-text-range";
+import virtualElementFromTextRange from "discourse/lib/virtual-element-from-text-range";
 
 function getQuoteTitle(element) {
   const titleEl = element.querySelector(".title");
@@ -204,7 +204,7 @@ export default Component.extend(KeyEnterEscape, {
         return;
       }
 
-      this.textRange = new VirtualElementFromTextRange(".cooked");
+      this.textRange = virtualElementFromTextRange(".cooked");
 
       this._popper = createPopper(this.textRange, this.element, {
         placement: this.placement,

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -237,7 +237,11 @@ export default Component.extend(KeyEnterEscape, {
   },
 
   _setupSelectionListeners() {
-    const updateRect = () => this.textRange.updateRect();
+    const updateRect = () => {
+      if (this.visible) {
+        this.textRange.updateRect();
+      }
+    };
     document.body.addEventListener("mouseup", updateRect);
     window.addEventListener("scroll", updateRect);
     document.scrollingElement.addEventListener("scroll", updateRect);

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -279,7 +279,6 @@ export default Component.extend(KeyEnterEscape, {
   },
 
   willDestroyElement() {
-    this.rangeRef.clearListeners();
     $(document)
       .off("mousedown.quote-button")
       .off("mouseup.quote-button")

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -24,7 +24,7 @@ import { next, schedule } from "@ember/runloop";
 import toMarkdown from "discourse/lib/to-markdown";
 import escapeRegExp from "discourse-common/utils/escape-regexp";
 import { createPopper } from "@popperjs/core";
-import RangeRef from "discourse/lib/range-ref";
+import VirtualElementFromTextRange from "discourse/lib/virtual-element-from-text-range";
 
 function getQuoteTitle(element) {
   const titleEl = element.querySelector(".title");
@@ -204,9 +204,9 @@ export default Component.extend(KeyEnterEscape, {
         return;
       }
 
-      this.rangeRef = new RangeRef(".cooked");
+      this.textRange = new VirtualElementFromTextRange(".cooked");
 
-      this._popper = createPopper(this.rangeRef, this.element, {
+      this._popper = createPopper(this.textRange, this.element, {
         placement: this.placement,
         modifiers: [
           {

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -57,7 +57,7 @@ export default Component.extend(KeyEnterEscape, {
   animated: false,
   privateCategory: alias("topic.category.read_restricted"),
   editPost: null,
-  placement: "top-start",
+  popperPlacement: "top-start",
 
   _isFastEditable: false,
   _displayFastEditInput: false,
@@ -195,7 +195,7 @@ export default Component.extend(KeyEnterEscape, {
     const showAtEnd = isMobileDevice || isIOS || isAndroid || isOpera;
 
     if (showAtEnd) {
-      this.placement = "bottom-start";
+      this.popperPlacement = "bottom-start";
     }
 
     // change the position of the button
@@ -207,7 +207,7 @@ export default Component.extend(KeyEnterEscape, {
       this.textRange = virtualElementFromTextRange(".cooked");
 
       this._popper = createPopper(this.textRange, this.element, {
-        placement: this.placement,
+        placement: this.popperPlacement,
         modifiers: [
           {
             name: "computeStyles",

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -205,7 +205,8 @@ export default Component.extend(KeyEnterEscape, {
         return;
       }
 
-      this.textRange = virtualElementFromTextRange(".cooked");
+      this.textRange = virtualElementFromTextRange();
+      this._setupSelectionListeners();
 
       this._popper = createPopper(this.textRange, this.element, {
         placement: this.popperPlacement,
@@ -231,6 +232,22 @@ export default Component.extend(KeyEnterEscape, {
         next(() => this.set("animated", true));
       }
     });
+  },
+
+  _setupSelectionListeners() {
+    const updateRect = () => this.textRange.updateRect();
+    document.querySelector(".cooked").addEventListener("mouseup", updateRect);
+    window.addEventListener("scroll", updateRect);
+    document.scrollingElement.addEventListener("scroll", updateRect);
+  },
+
+  _teardownSelectionListeners() {
+    const updateRect = () => this.textRange.updateRect();
+    document
+      .querySelectorAll(".cooked")
+      .forEach((element) => element.removeEventListener("mouseup", updateRect));
+    window.removeEventListener("scroll", updateRect);
+    document.scrollingElement.removeEventListener("scroll", updateRect);
   },
 
   didInsertElement() {
@@ -287,6 +304,7 @@ export default Component.extend(KeyEnterEscape, {
       .off("selectionchange.quote-button");
     this.appEvents.off("quote-button:quote", this, "insertQuote");
     this.appEvents.off("quote-button:edit", this, "_toggleFastEditForm");
+    this._teardownSelectionListeners();
   },
 
   @discourseComputed("topic.{isPrivateMessage,invisible,category}")

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -200,6 +200,10 @@ export default Component.extend(KeyEnterEscape, {
 
     // change the position of the button
     schedule("afterRender", () => {
+      if (!this.element || this.isDestroying || this.isDestroyed) {
+        return;
+      }
+
       this.rangeRef = new RangeRef(".cooked");
 
       this._popper = createPopper(this.rangeRef, this.element, {
@@ -219,10 +223,6 @@ export default Component.extend(KeyEnterEscape, {
           },
         ],
       });
-
-      if (!this.element || this.isDestroying || this.isDestroyed) {
-        return;
-      }
 
       if (!this.animated) {
         // We only enable CSS transitions after the initial positioning

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -57,6 +57,7 @@ export default Component.extend(KeyEnterEscape, {
   animated: false,
   privateCategory: alias("topic.category.read_restricted"),
   editPost: null,
+  _popper: null,
   popperPlacement: "top-start",
 
   _isFastEditable: false,
@@ -279,6 +280,7 @@ export default Component.extend(KeyEnterEscape, {
   },
 
   willDestroyElement() {
+    this._popper?.destroy();
     $(document)
       .off("mousedown.quote-button")
       .off("mouseup.quote-button")

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -200,10 +200,9 @@ export default Component.extend(KeyEnterEscape, {
 
     // change the position of the button
     schedule("afterRender", () => {
-      const quoteButton = document.querySelector(".quote-button");
       this.rangeRef = new RangeRef(".cooked");
 
-      this._popper = createPopper(this.rangeRef, quoteButton, {
+      this._popper = createPopper(this.rangeRef, this.element, {
         placement: this.placement,
         modifiers: [
           {

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -279,6 +279,7 @@ export default Component.extend(KeyEnterEscape, {
   },
 
   willDestroyElement() {
+    this.rangeRef.clearListeners();
     $(document)
       .off("mousedown.quote-button")
       .off("mouseup.quote-button")

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -87,6 +87,7 @@ export default Component.extend(KeyEnterEscape, {
 
   _selectionChanged() {
     if (this._displayFastEditInput) {
+      this.textRange = virtualElementFromTextRange();
       return;
     }
 

--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -82,6 +82,7 @@ export default Component.extend(KeyEnterEscape, {
     this.set("_displayFastEditInput", false);
     this.set("_fastEditInitalSelection", null);
     this.set("_fastEditNewSelection", null);
+    this._teardownSelectionListeners();
   },
 
   _selectionChanged() {
@@ -236,16 +237,14 @@ export default Component.extend(KeyEnterEscape, {
 
   _setupSelectionListeners() {
     const updateRect = () => this.textRange.updateRect();
-    document.querySelector(".cooked").addEventListener("mouseup", updateRect);
+    document.body.addEventListener("mouseup", updateRect);
     window.addEventListener("scroll", updateRect);
     document.scrollingElement.addEventListener("scroll", updateRect);
   },
 
   _teardownSelectionListeners() {
     const updateRect = () => this.textRange.updateRect();
-    document
-      .querySelectorAll(".cooked")
-      .forEach((element) => element.removeEventListener("mouseup", updateRect));
+    document.body.removeEventListener("mouseup", updateRect);
     window.removeEventListener("scroll", updateRect);
     document.scrollingElement.removeEventListener("scroll", updateRect);
   },

--- a/app/assets/javascripts/discourse/app/lib/range-ref.js
+++ b/app/assets/javascripts/discourse/app/lib/range-ref.js
@@ -1,0 +1,42 @@
+export default class RangeRef {
+  constructor(selector) {
+    this.selector = selector;
+    this.#updateRect();
+    this.setupListeners(selector);
+  }
+
+  #updateRect() {
+    const selection = document.getSelection();
+    this.range = selection && selection.rangeCount && selection.getRangeAt(0);
+    this.rect = this.range.getBoundingClientRect();
+    return this.rect;
+  }
+
+  getBoundingClientRect() {
+    return this.rect;
+  }
+
+  setupListeners(selector) {
+    const update = () => this.#updateRect();
+    document.querySelector(selector).addEventListener("mouseup", update);
+    window.addEventListener("scroll", update);
+    document.scrollingElement.addEventListener("scroll", update);
+  }
+
+  clearListeners() {
+    const update = () => this.#updateRect();
+    document
+      .querySelector(this.selector)
+      .removeEventListener("mouseup", update);
+    window.removeEventListener("scroll", update);
+    document.scrollingElement.removeEventListener("scroll", update);
+  }
+
+  get clientWidth() {
+    return this.rect.width;
+  }
+
+  get clientHeight() {
+    return this.rect.height;
+  }
+}

--- a/app/assets/javascripts/discourse/app/lib/range-ref.js
+++ b/app/assets/javascripts/discourse/app/lib/range-ref.js
@@ -26,8 +26,8 @@ export default class RangeRef {
   clearListeners() {
     const update = () => this.#updateRect();
     document
-      .querySelector(this.selector)
-      .removeEventListener("mouseup", update);
+      .querySelectorAll(this.selector)
+      .forEach((element) => element.removeEventListener("mouseup", update));
     window.removeEventListener("scroll", update);
     document.scrollingElement.removeEventListener("scroll", update);
   }

--- a/app/assets/javascripts/discourse/app/lib/virtual-element-from-text-range.js
+++ b/app/assets/javascripts/discourse/app/lib/virtual-element-from-text-range.js
@@ -6,6 +6,11 @@ class VirtualElementFromTextRange {
   updateRect() {
     const selection = document.getSelection();
     this.range = selection && selection.rangeCount && selection.getRangeAt(0);
+
+    if (!this.range) {
+      return;
+    }
+
     this.rect = this.range.getBoundingClientRect();
     return this.rect;
   }

--- a/app/assets/javascripts/discourse/app/lib/virtual-element-from-text-range.js
+++ b/app/assets/javascripts/discourse/app/lib/virtual-element-from-text-range.js
@@ -1,11 +1,9 @@
 class VirtualElementFromTextRange {
-  constructor(selector) {
-    this.selector = selector;
-    this.#updateRect();
-    this.setupListeners(selector);
+  constructor() {
+    this.updateRect();
   }
 
-  #updateRect() {
+  updateRect() {
     const selection = document.getSelection();
     this.range = selection && selection.rangeCount && selection.getRangeAt(0);
     this.rect = this.range.getBoundingClientRect();
@@ -14,22 +12,6 @@ class VirtualElementFromTextRange {
 
   getBoundingClientRect() {
     return this.rect;
-  }
-
-  setupListeners(selector) {
-    const update = () => this.#updateRect();
-    document.querySelector(selector).addEventListener("mouseup", update);
-    window.addEventListener("scroll", update);
-    document.scrollingElement.addEventListener("scroll", update);
-  }
-
-  clearListeners() {
-    const update = () => this.#updateRect();
-    document
-      .querySelectorAll(this.selector)
-      .forEach((element) => element.removeEventListener("mouseup", update));
-    window.removeEventListener("scroll", update);
-    document.scrollingElement.removeEventListener("scroll", update);
   }
 
   get clientWidth() {
@@ -41,6 +23,6 @@ class VirtualElementFromTextRange {
   }
 }
 
-export default function virtualElementFromTextRange(selector) {
-  return new VirtualElementFromTextRange(selector);
+export default function virtualElementFromTextRange() {
+  return new VirtualElementFromTextRange();
 }

--- a/app/assets/javascripts/discourse/app/lib/virtual-element-from-text-range.js
+++ b/app/assets/javascripts/discourse/app/lib/virtual-element-from-text-range.js
@@ -1,4 +1,4 @@
-export default class VirtualElementFromTextRange {
+class VirtualElementFromTextRange {
   constructor(selector) {
     this.selector = selector;
     this.#updateRect();
@@ -39,4 +39,8 @@ export default class VirtualElementFromTextRange {
   get clientHeight() {
     return this.rect.height;
   }
+}
+
+export default function virtualElementFromTextRange(selector) {
+  return new VirtualElementFromTextRange(selector);
 }

--- a/app/assets/javascripts/discourse/app/lib/virtual-element-from-text-range.js
+++ b/app/assets/javascripts/discourse/app/lib/virtual-element-from-text-range.js
@@ -1,4 +1,4 @@
-export default class RangeRef {
+export default class VirtualElementFromTextRange {
   constructor(selector) {
     this.selector = selector;
     this.#updateRect();


### PR DESCRIPTION
**This PR** resolves an issue where the quote button shifts downward and is in the incorrect position when custom content is added to a forum's header.

The fix is done by using PopperJS to handle the positioning of the quote button rather than custom logic.

**Before** ❌
<img width="959" alt="Screenshot 2023-03-29 at 16 24 45" src="https://user-images.githubusercontent.com/30090424/228689855-82946176-70a6-498f-9547-5b3f9dc494ae.png">

<hr>

**After** ✅
<img width="959" alt="Screenshot 2023-03-29 at 16 20 54" src="https://user-images.githubusercontent.com/30090424/228689868-6daae345-747f-4b31-bae4-0cfe70b656f6.png">

**Mobile**

https://user-images.githubusercontent.com/30090424/228962483-8d0767d1-8c4c-4f42-a476-c83dcb996bec.MP4

