### PR TITLE
DEV: Make postgres_readonly cache work like other caches

### DIFF
--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Discourse do
     describe ".received_postgres_readonly!" do
       it "sets the right time" do
         time = Discourse.received_postgres_readonly!
-        expect(Discourse.postgres_last_read_only["default"]).to eq(time)
+        expect(Discourse.redis.get(Discourse::LAST_POSTGRES_READONLY_KEY).to_i).to eq(time.to_i)
       end
     end
 
@@ -328,7 +328,7 @@ RSpec.describe Discourse do
         messages = []
 
         expect do messages = MessageBus.track_publish { Discourse.clear_readonly! } end.to change {
-          Discourse.postgres_last_read_only["default"]
+          Discourse.redis.get(Discourse::LAST_POSTGRES_READONLY_KEY)
         }.to(nil)
 
         expect(messages.any? { |m| m.channel == Site::SITE_JSON_CHANNEL }).to eq(true)


### PR DESCRIPTION
We didn't have an authoritative source for this data previously, so now it's stored in redis.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
