### PR TITLE
FEATURE: filter API for plugins

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -246,28 +246,28 @@ class DiscoursePluginRegistry
     asset
   end
 
-  def self.clear_filters!
-    @filters = nil
+  def self.clear_modifiers!
+    @modifiers = nil
   end
 
-  def self.register_filter(plugin_instance, name, &blk)
-    @filters ||= {}
-    filters = @filters[name] ||= []
-    filters << [plugin_instance, blk]
+  def self.register_modifier(plugin_instance, name, &blk)
+    @modifiers ||= {}
+    modifiers = @modifiers[name] ||= []
+    modifiers << [plugin_instance, blk]
   end
 
-  def self.apply_filter(name, arg, *more_args)
-    return arg if !@filters
+  def self.apply_modifier(name, arg, *more_args)
+    return arg if !@modifiers
 
-    registered_filters = @filters[name]
-    return arg if !registered_filters
+    registered_modifiers = @modifiers[name]
+    return arg if !registered_modifiers
 
     # iterate as fast as possible to minimize cost (avoiding each)
     # also erases one stack frame
-    length = registered_filters.length
+    length = registered_modifiers.length
     index = 0
     while index < length
-      plugin_instance, block = registered_filters[index]
+      plugin_instance, block = registered_modifiers[index]
       arg = block.call(arg, *more_args) if plugin_instance.enabled?
 
       index += 1
@@ -278,7 +278,7 @@ class DiscoursePluginRegistry
 
   def self.reset!
     @@register_names.each { |name| instance_variable_set(:"@#{name}", nil) }
-    clear_filters!
+    clear_modifiers!
   end
 
   def self.reset_register!(register_name)

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -259,15 +259,15 @@ class DiscoursePluginRegistry
   def self.apply_filter(name, arg, *more_args)
     return arg if !@filters
 
-    filters = @filters[name]
-    return arg if !filters
+    registered_filters = @filters[name]
+    return arg if !registered_filters
 
     # iterate as fast as possible to minimize cost (avoiding each)
     # also erases one stack frame
-    length = filters.length
+    length = registered_filters.length
     index = 0
     while index < length
-      plugin_instance, block = filters[index]
+      plugin_instance, block = registered_filters[index]
       arg = block.call(arg, *more_args) if plugin_instance.enabled?
 
       index += 1

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -134,6 +134,10 @@ class Plugin::Instance
     end
   end
 
+  def register_filter(filter_name, &blk)
+    DiscoursePluginRegistry.register_filter(self, filter_name, &blk)
+  end
+
   # Applies to all sites in a multisite environment. Ignores plugin.enabled?
   def add_report(name, &block)
     reloadable_patch { |plugin| Report.add_report(name, &block) }

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -134,8 +134,8 @@ class Plugin::Instance
     end
   end
 
-  def register_filter(filter_name, &blk)
-    DiscoursePluginRegistry.register_filter(self, filter_name, &blk)
+  def register_modifier(modifier_name, &blk)
+    DiscoursePluginRegistry.register_modifier(self, modifier_name, &blk)
   end
 
   # Applies to all sites in a multisite environment. Ignores plugin.enabled?

--- a/spec/lib/discourse_plugin_registry_spec.rb
+++ b/spec/lib/discourse_plugin_registry_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe DiscoursePluginRegistry do
   end
 
   context "with filters" do
-    after { DiscoursePluginRegistry.clear_filters! }
+    after { DiscoursePluginRegistry.clear_modifiers! }
 
     class TestFilterPlugInstance < Plugin::Instance
       def enabled?
@@ -275,33 +275,37 @@ RSpec.describe DiscoursePluginRegistry do
     let(:plugin_instance) { TestFilterPlugInstance.new }
     let(:plugin_instance2) { TestFilterPlugInstance.new }
 
-    it "handles filters with multiple parameters" do
-      DiscoursePluginRegistry.register_filter(plugin_instance, :magic_sum_filter) { |a, b| a + b }
+    it "handles modifiers with multiple parameters" do
+      DiscoursePluginRegistry.register_modifier(plugin_instance, :magic_sum_modifier) do |a, b|
+        a + b
+      end
 
-      sum = DiscoursePluginRegistry.apply_filter(:magic_sum_filter, 1, 2)
+      sum = DiscoursePluginRegistry.apply_modifier(:magic_sum_modifier, 1, 2)
       expect(sum).to eq(3)
     end
 
-    it "handles filter stacking" do
+    it "handles modifier stacking" do
       # first in, first called
-      DiscoursePluginRegistry.register_filter(plugin_instance, :stacking) { |x| x == 1 ? 2 : 1 }
-      DiscoursePluginRegistry.register_filter(plugin_instance2, :stacking) { |x| x + 1 }
+      DiscoursePluginRegistry.register_modifier(plugin_instance, :stacking) { |x| x == 1 ? 2 : 1 }
+      DiscoursePluginRegistry.register_modifier(plugin_instance2, :stacking) { |x| x + 1 }
 
-      expect(DiscoursePluginRegistry.apply_filter(:stacking, 1)).to eq(3)
+      expect(DiscoursePluginRegistry.apply_modifier(:stacking, 1)).to eq(3)
     end
 
     it "handles disabled plugins" do
       plugin_instance.enabled = false
-      DiscoursePluginRegistry.register_filter(plugin_instance, :magic_sum_filter) { |a, b| a + b }
+      DiscoursePluginRegistry.register_modifier(plugin_instance, :magic_sum_modifier) do |a, b|
+        a + b
+      end
 
-      sum = DiscoursePluginRegistry.apply_filter(:magic_sum_filter, 1, 2)
+      sum = DiscoursePluginRegistry.apply_modifier(:magic_sum_modifier, 1, 2)
       expect(sum).to eq(1)
     end
 
     it "can handle arity mismatch" do
-      DiscoursePluginRegistry.register_filter(plugin_instance, :magic_sum_filter) { 42 }
+      DiscoursePluginRegistry.register_modifier(plugin_instance, :magic_sum_modifier) { 42 }
 
-      sum = DiscoursePluginRegistry.apply_filter(:magic_sum_filter, 1, 2)
+      sum = DiscoursePluginRegistry.apply_modifier(:magic_sum_modifier, 1, 2)
       expect(sum).to eq(42)
     end
   end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -828,15 +828,15 @@ RSpec.describe Plugin::Instance do
     end
   end
 
-  describe "#register_filter" do
+  describe "#register_modifier" do
     let(:plugin) { Plugin::Instance.new }
 
-    after { DiscoursePluginRegistry.clear_filters! }
+    after { DiscoursePluginRegistry.clear_modifiers! }
 
-    it "allows filter registration" do
-      plugin.register_filter(:magic_sum_filter) { |a, b| a + b }
+    it "allows modifier registration" do
+      plugin.register_modifier(:magic_sum_modifier) { |a, b| a + b }
 
-      sum = DiscoursePluginRegistry.apply_filter(:magic_sum_filter, 1, 2)
+      sum = DiscoursePluginRegistry.apply_modifier(:magic_sum_modifier, 1, 2)
       expect(sum).to eq(3)
     end
   end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -827,4 +827,17 @@ RSpec.describe Plugin::Instance do
       expect(callback_called).to eq(false)
     end
   end
+
+  describe "#register_filter" do
+    let(:plugin) { Plugin::Instance.new }
+
+    after { DiscoursePluginRegistry.clear_filters! }
+
+    it "allows filter registration" do
+      plugin.register_filter(:magic_sum_filter) { |a, b| a + b }
+
+      sum = DiscoursePluginRegistry.apply_filter(:magic_sum_filter, 1, 2)
+      expect(sum).to eq(3)
+    end
+  end
 end


### PR DESCRIPTION
This new API can be thought of as a "plugin aware" version of DiscourseEvent

When plugins register a filter it will be called automatically if plugin
is enabled and core will "filter" a parameter is sent to it using the block
the plugin registered:


```
DiscoursePluginRegistry.register_filter(plugin_instance, :magic_sum_filter) { |a, b| a + b }
sum = DiscoursePluginRegistry.apply_filter(:magic_sum_filter, 1, 2)
expect(sum).to eq(3)
```

These filters stack (first in first called)
These filters auto disable when plugin is disabled
These filters will pass the stacked result of all the block invocations to caller
