### PR TITLE
DEV: Add auto _map extension for simple/compact list SiteSettings

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -558,6 +558,13 @@ module SiteSettingExtension
       end
     end
 
+    # Same logic as above for group_list settings, with the caveat that normal
+    # list settings are not necessarily integers, so we just want to handle the splitting.
+    if type_supervisor.get_type(name) == :list &&
+         %w[simple compact].include?(type_supervisor.get_list_type(name))
+      define_singleton_method("#{clean_name}_map") { self.public_send(clean_name).to_s.split("|") }
+    end
+
     define_singleton_method "#{clean_name}?" do
       self.public_send clean_name
     end

--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -195,6 +195,10 @@ class SiteSettings::TypeSupervisor
     self.class.types[@types[name.to_sym]]
   end
 
+  def get_list_type(name)
+    @list_type[name.to_sym]
+  end
+
   private
 
   def normalize_input(name, val)

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -853,4 +853,36 @@ RSpec.describe SiteSettingExtension do
       end
     end
   end
+
+  describe "_map extension for list settings" do
+    it "handles splitting group_list settings" do
+      SiteSetting.personal_message_enabled_groups = "1|2"
+      expect(SiteSetting.personal_message_enabled_groups_map).to eq([1, 2])
+    end
+
+    it "handles splitting compact list settings" do
+      SiteSetting.markdown_linkify_tlds = "com|net"
+      expect(SiteSetting.markdown_linkify_tlds_map).to eq(%w[com net])
+    end
+
+    it "handles splitting simple list settings" do
+      SiteSetting.ga_universal_auto_link_domains = "test.com|xy.com"
+      expect(SiteSetting.ga_universal_auto_link_domains_map).to eq(%w[test.com xy.com])
+    end
+
+    it "does not handle splitting secret list settings" do
+      SiteSetting.discourse_connect_provider_secrets = "test|secret1\ntest2|secret2"
+      expect(SiteSetting.respond_to?(:discourse_connect_provider_secrets_map)).to eq(false)
+    end
+
+    it "handles null values for settings" do
+      SiteSetting.ga_universal_auto_link_domains = nil
+      SiteSetting.pm_tags_allowed_for_groups = nil
+      SiteSetting.exclude_rel_nofollow_domains = nil
+
+      expect(SiteSetting.ga_universal_auto_link_domains_map).to eq([])
+      expect(SiteSetting.pm_tags_allowed_for_groups_map).to eq([])
+      expect(SiteSetting.exclude_rel_nofollow_domains_map).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
Similar to the _map added for group_list SiteSettings in
e62e93f83a77adfa80b38fbfecf82bbee14e12fe, this commit adds
the same extension for simple and compact `list` type SiteSettings,
so developers do not have to do the `.to_s.split("|")` dance
themselves all the time.

For example:

```
SiteSetting.markdown_linkify_tlds

=> "com|net|org|io|onion|co|tv|ru|cn|us|uk|me|de|fr|fi|gov|ddd"

SiteSetting.markdown_linkify_tlds_map

=> ["com", "net", "org", "io", "onion", "co", "tv", "ru", "cn", "us", "uk", "me", "de", "fr", "fi", "gov"]
```
