### PR TITLE
FIX: Drop internal URL validation for paths in sidebar 

### DIFF
--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -15,11 +15,8 @@ class SidebarUrl < ActiveRecord::Base
   before_validation :remove_internal_hostname, :set_external
 
   def path_validator
-    if external?
-      raise ActionController::RoutingError.new("Not Found") if value !~ Discourse::Utils::URI_REGEXP
-    else
-      Rails.application.routes.recognize_path(value)
-    end
+    return true if !external?
+    raise ActionController::RoutingError.new("Not Found") if value !~ Discourse::Utils::URI_REGEXP
   rescue ActionController::RoutingError
     errors.add(
       :value,

--- a/spec/models/sidebar_url_spec.rb
+++ b/spec/models/sidebar_url_spec.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SidebarUrl do
-  it "validates path" do
-    expect(SidebarUrl.new(icon: "link", name: "categories", value: "/categories").valid?).to eq(
-      true,
-    )
-    expect(SidebarUrl.new(icon: "link", name: "categories", value: "/invalid_path").valid?).to eq(
-      false,
-    )
+  it "validates external URLs" do
     expect(
       SidebarUrl.new(
         icon: "link",


### PR DESCRIPTION
`Rails.application.routes.recognize_path(value)` was not working for /admin paths because StaffConstraint.new requires user to check permission.

This validation is not bringing much value, and the easiest way is to drop it. In the worst case scenario, a user will have an incorrect link in their sidebar.

Bug reported: https://meta.discourse.org/t/custom-sidebar-sections-being-tested-on-meta/255303/66
