### PR TITLE
DEV: Remove currentUser lookup in PrettyText

### DIFF
--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -215,16 +215,7 @@ module PrettyText
         buffer << "__optInput.forceQuoteLink = #{opts[:force_quote_link]};\n"
       end
 
-      if opts[:user_id]
-        buffer << "__optInput.userId = #{opts[:user_id].to_i};\n"
-
-        # NOTE: If using this for server-side cooking you will end up
-        # with a Hash once it is passed to a PrettyText::Helper. If
-        # you use that hash to instanciate a User model, you will want to do
-        # user.reload before accessing data on this parsed User, otherwise
-        # AR relations will not be loaded.
-        buffer << "__optInput.currentUser = #{User.find(opts[:user_id]).to_json}\n"
-      end
+      buffer << "__optInput.userId = #{opts[:user_id].to_i};\n" if opts[:user_id]
 
       opts[:hashtag_context] = opts[:hashtag_context] || "topic-composer"
       hashtag_types_as_js =


### PR DESCRIPTION
This was added in d3f02a127065aae65fc5933951acae98a95d014a
for hashtags but later removed usage in
b2acc416e7cdd502e2f394f1e6014210e6212b50. It was removed because
serializing the user does not include things like their
secure_categories.

It is not used by any other plugins or themes, and can cause
issues where it will error when operating on a null user. Better
to just pass in the user_id and use it to look up a user
directly in a PrettyText::Helper
