### PR TITLE
DEV: stop getting topic.url in specs

### DIFF
--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -4544,7 +4544,7 @@ RSpec.describe TopicsController do
   describe "crawler" do
     context "when not a crawler" do
       it "renders with the application layout" do
-        get topic.url
+        get topic.relative_url
 
         body = response.body
 
@@ -4577,7 +4577,7 @@ RSpec.describe TopicsController do
 
         user_agent = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 
-        get topic.url, env: { "HTTP_USER_AGENT" => user_agent }
+        get topic.relative_url, env: { "HTTP_USER_AGENT" => user_agent }
 
         body = response.body
 
@@ -4590,7 +4590,7 @@ RSpec.describe TopicsController do
 
         expect(response.headers["Last-Modified"]).to eq(page1_time.httpdate)
 
-        get topic.url + "?page=2", env: { "HTTP_USER_AGENT" => user_agent }
+        get topic.relative_url + "?page=2", env: { "HTTP_USER_AGENT" => user_agent }
         body = response.body
 
         expect(response.headers["Last-Modified"]).to eq(page2_time.httpdate)
@@ -4601,7 +4601,7 @@ RSpec.describe TopicsController do
         expect(body).to include('<link rel="prev" href="' + topic.relative_url)
         expect(body).to include('<link rel="next" href="' + topic.relative_url + "?page=3")
 
-        get topic.url + "?page=3", env: { "HTTP_USER_AGENT" => user_agent }
+        get topic.relative_url + "?page=3", env: { "HTTP_USER_AGENT" => user_agent }
         body = response.body
 
         expect(response.headers["Last-Modified"]).to eq(page3_time.httpdate)
@@ -4628,7 +4628,7 @@ RSpec.describe TopicsController do
 
       context "with wayback machine" do
         it "renders crawler layout" do
-          get topic.url,
+          get topic.relative_url,
               env: {
                 "HTTP_USER_AGENT" =>
                   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",


### PR DESCRIPTION
topic.url is a dangerous method to use, it is incompatible with our `sign_in`
helper.

This removes a bunch of places this was erroneously used and helps to avoid
future cargo culting.
