### PR TITLE
UX: prevents long press on reaction to open actions

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.hbs
@@ -1,6 +1,7 @@
 {{#if (and @reaction this.emojiUrl)}}
   <button
     type="button"
+    {{on "touchstart" this.handleTouchStart}}
     {{on "click" this.handleClick}}
     tabindex="0"
     class={{concat-class

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.js
@@ -46,6 +46,11 @@ export default class ChatMessageReaction extends Component {
   }
 
   @action
+  handleTouchStart(event) {
+    event.stopPropagation();
+  }
+
+  @action
   handleClick() {
     this.args.react?.(
       this.args.reaction.emoji,


### PR DESCRIPTION
This is super hard to write a test as a combination of: long press, mobile and popup.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
