### PR TITLE
UX: Improve error message when a topic cannot be moved due to category restrictions

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -361,7 +361,11 @@ class TopicsController < ApplicationController
         category = Category.find_by(id: params[:category_id])
 
         if category || (params[:category_id].to_i == 0)
-          guardian.ensure_can_move_topic_to_category!(category)
+          begin
+            guardian.ensure_can_move_topic_to_category!(category)
+          rescue Discourse::InvalidAccess
+            return render_json_error I18n.t("category.errors.move_topic_to_category_disallowed"), status: :forbidden
+          end
         else
           return render_json_error(I18n.t("category.errors.not_found"))
         end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -364,7 +364,10 @@ class TopicsController < ApplicationController
           begin
             guardian.ensure_can_move_topic_to_category!(category)
           rescue Discourse::InvalidAccess
-            return render_json_error I18n.t("category.errors.move_topic_to_category_disallowed"), status: :forbidden
+            return(
+              render_json_error I18n.t("category.errors.move_topic_to_category_disallowed"),
+                                status: :forbidden
+            )
           end
         else
           return render_json_error(I18n.t("category.errors.not_found"))

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -705,6 +705,7 @@ en:
       disallowed_tags_generic: "This topic has disallowed tags."
       slug_contains_non_ascii_chars: "contains non-ascii characters"
       is_already_in_use: "is already in use"
+      move_topic_to_category_disallowed: "You can't move this topic to a category you cannot create topics on."
     cannot_delete:
       uncategorized: "This category is special. It is intended as a holding area for topics that have no category; it cannot be deleted."
       has_subcategories: "Can't delete this category because it has sub-categories."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -705,7 +705,7 @@ en:
       disallowed_tags_generic: "This topic has disallowed tags."
       slug_contains_non_ascii_chars: "contains non-ascii characters"
       is_already_in_use: "is already in use"
-      move_topic_to_category_disallowed: "You can't move this topic to a category you cannot create topics in."
+      move_topic_to_category_disallowed: "You cannot move this topic to a category where you do not have permission to create new topics."
     cannot_delete:
       uncategorized: "This category is special. It is intended as a holding area for topics that have no category; it cannot be deleted."
       has_subcategories: "Can't delete this category because it has sub-categories."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -705,7 +705,7 @@ en:
       disallowed_tags_generic: "This topic has disallowed tags."
       slug_contains_non_ascii_chars: "contains non-ascii characters"
       is_already_in_use: "is already in use"
-      move_topic_to_category_disallowed: "You can't move this topic to a category you cannot create topics on."
+      move_topic_to_category_disallowed: "You can't move this topic to a category you cannot create topics in."
     cannot_delete:
       uncategorized: "This category is special. It is intended as a holding area for topics that have no category; it cannot be deleted."
       has_subcategories: "Can't delete this category because it has sub-categories."

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1391,6 +1391,9 @@ RSpec.describe TopicsController do
         put "/t/#{topic.id}.json", params: { category_id: category.id }
 
         expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"].first).to eq(
+          I18n.t("category.errors.move_topic_to_category_disallowed"),
+        )
         expect(topic.reload.category_id).not_to eq(category.id)
       end
 


### PR DESCRIPTION
We were using the generic error message "An error occurred: You are not permitted to view the requested resource." which isn't very useful to the user. This is marginally better (the screenshot)

<img width="770" alt="Screenshot 2023-03-31 at 1 44 22 AM" src="https://user-images.githubusercontent.com/1555215/228920459-58770656-d489-4833-aa72-2598d82927c2.png">
