### PR TITLE
Extract global compat code so that it participates in the module-graph creation.

### DIFF
--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -1,3 +1,5 @@
+import "./global-compat";
+
 import Application from "@ember/application";
 import { buildResolver } from "discourse-common/resolver";
 import { isTesting } from "discourse-common/config/environment";

--- a/app/assets/javascripts/discourse/app/global-compat.js
+++ b/app/assets/javascripts/discourse/app/global-compat.js
@@ -1,0 +1,7 @@
+import virtualDom from "virtual-dom";
+import widgetHelpers from "discourse-widget-hbs/helpers";
+
+window.__widget_helpers = widgetHelpers;
+
+// TODO: Eliminate this global
+window.virtualDom = virtualDom;

--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
@@ -10,11 +10,6 @@
   // https://github.com/emberjs/ember.js/blob/0c5518ea7b/packages/%40ember/-internals/glimmer/lib/helper.ts#L134-L138
   require("ember");
 
-  window.__widget_helpers = require("discourse-widget-hbs/helpers").default;
-
-  // TODO: Eliminate this global
-  window.virtualDom = require("virtual-dom");
-
   let element = document.querySelector(
     `meta[name="discourse/config/environment"]`
   );


### PR DESCRIPTION
This is a small PR that moves a couple things from discourse-boot.js to a different JS file imported from app/app.js.

This is a forwards compatible technique to import and throw data on the `window`.

One thing to make note of, though, is that if the virtual-dom and discourse-widget-hbs/helpers were previously included in the build elsewhere, they will now become part of the app bundle.
Later, when using embroider, all bundles will be chunks, and webpack will optimize which chunk contains which modules appropriately. 

Next: https://github.com/discourse/discourse/pull/20903