### PR TITLE
UX: onebox site icon needs a right margin

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -753,16 +753,10 @@ aside.onebox.xkcd .onebox-body img {
 }
 
 .onebox {
-  &.allowlistedgeneric,
-  &.whitelistedgeneric,
-  &.discoursetopic,
-  &.gfycat,
-  &.githubfolder {
-    .site-icon {
-      width: 16px;
-      height: 16px;
-      margin-right: 0.5em;
-    }
+  .site-icon {
+    width: 16px;
+    height: 16px;
+    margin-right: 0.5em;
   }
   &.category-onebox {
     border: 1px solid var(--primary-low);


### PR DESCRIPTION
I think we might have been too careful here, there are multiple oneboxes without site-icon space:


Before:
![Screenshot 2023-03-30 at 3 44 59 PM](https://user-images.githubusercontent.com/1681963/228951376-469d563a-fec1-4c37-9a41-0da5500207aa.png)
![Screenshot 2023-03-30 at 3 45 01 PM](https://user-images.githubusercontent.com/1681963/228951377-8606eeb4-0616-43c3-bcdb-4dfd89022934.png)
![Screenshot 2023-03-30 at 3 45 05 PM](https://user-images.githubusercontent.com/1681963/228951379-f8cb5ef6-7ac9-403c-b793-59b2d5667179.png)

After:
![Screenshot 2023-03-30 at 3 45 21 PM](https://user-images.githubusercontent.com/1681963/228951433-a6c70426-0349-4342-8839-1d54cd2c424b.png)
![Screenshot 2023-03-30 at 3 45 16 PM](https://user-images.githubusercontent.com/1681963/228951431-95fb2b4c-9012-43ad-911f-ffc998515619.png)
![Screenshot 2023-03-30 at 3 45 24 PM](https://user-images.githubusercontent.com/1681963/228951436-de1fd07d-4a3f-4b22-b7d8-327522055d2f.png)

