### PR TITLE
Change `virtual-dom` shim to be embroider-compatible

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
+++ b/app/assets/javascripts/discourse-common/addon/lib/icon-library.js
@@ -1,6 +1,6 @@
 import I18n from "I18n";
 import attributeHook from "discourse-common/lib/attribute-hook";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { isDevelopment } from "discourse-common/config/environment";
 import escape from "discourse-common/lib/escape";
 import deprecated from "discourse-common/lib/deprecated";

--- a/app/assets/javascripts/discourse-common/package.json
+++ b/app/assets/javascripts/discourse-common/package.json
@@ -15,6 +15,7 @@
     "start": "ember serve"
   },
   "dependencies": {
+    "@discourse/virtual-dom": "^2.1.2-0",
     "@uppy/aws-s3": "^3.0.5",
     "@uppy/aws-s3-multipart": "^3.1.2",
     "@uppy/core": "^3.0.4",

--- a/app/assets/javascripts/discourse/app/app.js
+++ b/app/assets/javascripts/discourse/app/app.js
@@ -1,3 +1,5 @@
+import "./global-compat";
+
 import Application from "@ember/application";
 import { buildResolver } from "discourse-common/resolver";
 import { isTesting } from "discourse-common/config/environment";

--- a/app/assets/javascripts/discourse/app/components/json-editor.js
+++ b/app/assets/javascripts/discourse/app/components/json-editor.js
@@ -1,6 +1,6 @@
 import { action } from "@ember/object";
 import Component from "@ember/component";
-import { create } from "virtual-dom";
+import { create } from "@discourse/virtual-dom";
 import discourseComputed from "discourse-common/utils/decorators";
 import { iconNode } from "discourse-common/lib/icon-library";
 import loadScript from "discourse/lib/load-script";

--- a/app/assets/javascripts/discourse/app/components/mount-widget.js
+++ b/app/assets/javascripts/discourse/app/components/mount-widget.js
@@ -1,5 +1,5 @@
 import { cancel, scheduleOnce } from "@ember/runloop";
-import { diff, patch } from "virtual-dom";
+import { diff, patch } from "@discourse/virtual-dom";
 import { queryRegistry, traverseCustomWidgets } from "discourse/widgets/widget";
 import Component from "@ember/component";
 import DirtyKeys from "discourse/lib/dirty-keys";

--- a/app/assets/javascripts/discourse/app/global-compat.js
+++ b/app/assets/javascripts/discourse/app/global-compat.js
@@ -1,4 +1,4 @@
-import virtualDom from "virtual-dom";
+import virtualDom from "@discourse/virtual-dom";
 import widgetHelpers from "discourse-widget-hbs/helpers";
 
 window.__widget_helpers = widgetHelpers;

--- a/app/assets/javascripts/discourse/app/global-compat.js
+++ b/app/assets/javascripts/discourse/app/global-compat.js
@@ -1,0 +1,7 @@
+import virtualDom from "virtual-dom";
+import widgetHelpers from "discourse-widget-hbs/helpers";
+
+window.__widget_helpers = widgetHelpers;
+
+// TODO: Eliminate this global
+window.virtualDom = virtualDom;

--- a/app/assets/javascripts/discourse/app/helpers/node.js
+++ b/app/assets/javascripts/discourse/app/helpers/node.js
@@ -1,5 +1,5 @@
 import { longDate, number, relativeAge } from "discourse/lib/formatter";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 
 export function dateNode(dt) {
   if (typeof dt === "string") {

--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -7,7 +7,7 @@ import { iconHTML, iconNode } from "discourse-common/lib/icon-library";
 import { setTextDirections } from "discourse/lib/text-direction";
 import { nativeLazyLoading } from "discourse/lib/lazy-load-images";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { create } from "virtual-dom";
+import { create } from "@discourse/virtual-dom";
 import showModal from "discourse/lib/show-modal";
 
 export default {

--- a/app/assets/javascripts/discourse/app/lib/plugin-api.js
+++ b/app/assets/javascripts/discourse/app/lib/plugin-api.js
@@ -77,7 +77,7 @@ import deprecated from "discourse-common/lib/deprecated";
 import { disableNameSuppression } from "discourse/widgets/poster-name";
 import { extraConnectorClass } from "discourse/lib/plugin-connectors";
 import { getOwner } from "discourse-common/lib/get-owner";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { includeAttributes } from "discourse/lib/transform-post";
 import { modifySelectKit } from "select-kit/mixins/plugin-api";
 import { on } from "@ember/object/evented";

--- a/app/assets/javascripts/discourse/app/lib/render-topic-featured-link.js
+++ b/app/assets/javascripts/discourse/app/lib/render-topic-featured-link.js
@@ -1,5 +1,5 @@
 import User from "discourse/models/user";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { renderIcon } from "discourse-common/lib/icon-library";
 
 const _decorators = [];

--- a/app/assets/javascripts/discourse/app/widgets/actions-summary.js
+++ b/app/assets/javascripts/discourse/app/widgets/actions-summary.js
@@ -2,7 +2,7 @@ import I18n from "I18n";
 import { avatarFor } from "discourse/widgets/post";
 import { createWidget } from "discourse/widgets/widget";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import hbs from "discourse/widgets/hbs-compiler";
 import { userPath } from "discourse/lib/url";
 

--- a/app/assets/javascripts/discourse/app/widgets/button.js
+++ b/app/assets/javascripts/discourse/app/widgets/button.js
@@ -1,7 +1,7 @@
 import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 
 export const ButtonClass = {

--- a/app/assets/javascripts/discourse/app/widgets/decorator-helper.js
+++ b/app/assets/javascripts/discourse/app/widgets/decorator-helper.js
@@ -1,7 +1,7 @@
 import Connector from "discourse/widgets/connector";
 import PostCooked from "discourse/widgets/post-cooked";
 import RawHtml from "discourse/widgets/raw-html";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import RenderGlimmer from "discourse/widgets/render-glimmer";
 
 class DecoratorHelper {

--- a/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
@@ -10,7 +10,7 @@ import RawHtml from "discourse/widgets/raw-html";
 import { createWidget } from "discourse/widgets/widget";
 import { emojiUnescape } from "discourse/lib/text";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { isEmpty } from "@ember/utils";
 import { wantsNewWindow } from "discourse/lib/intercept-click";

--- a/app/assets/javascripts/discourse/app/widgets/do-not-disturb.js
+++ b/app/assets/javascripts/discourse/app/widgets/do-not-disturb.js
@@ -1,7 +1,7 @@
 import I18n from "I18n";
 import { createWidget } from "discourse/widgets/widget";
 import { dateNode } from "discourse/helpers/node";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import showModal from "discourse/lib/show-modal";
 import DoNotDisturb from "discourse/lib/do-not-disturb";

--- a/app/assets/javascripts/discourse/app/widgets/embedded-post.js
+++ b/app/assets/javascripts/discourse/app/widgets/embedded-post.js
@@ -1,7 +1,7 @@
 import DecoratorHelper from "discourse/widgets/decorator-helper";
 import PostCooked from "discourse/widgets/post-cooked";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import hbs from "discourse/widgets/hbs-compiler";
 
 createWidget("post-link-arrow", {

--- a/app/assets/javascripts/discourse/app/widgets/glue.js
+++ b/app/assets/javascripts/discourse/app/widgets/glue.js
@@ -1,5 +1,5 @@
 import { cancel, scheduleOnce } from "@ember/runloop";
-import { diff, patch } from "virtual-dom";
+import { diff, patch } from "@discourse/virtual-dom";
 import { queryRegistry, traverseCustomWidgets } from "discourse/widgets/widget";
 import DirtyKeys from "discourse/lib/dirty-keys";
 import { isTesting } from "discourse-common/config/environment";

--- a/app/assets/javascripts/discourse/app/widgets/hamburger-categories.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-categories.js
@@ -2,7 +2,7 @@ import Category from "discourse/models/category";
 import I18n from "I18n";
 import { createWidget } from "discourse/widgets/widget";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { number } from "discourse/lib/formatter";
 
 createWidget("hamburger-category", {

--- a/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/hamburger-menu.js
@@ -4,7 +4,7 @@ import I18n from "I18n";
 import { NotificationLevels } from "discourse/lib/notification-levels";
 import { ajax } from "discourse/lib/ajax";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import discourseLater from "discourse-common/lib/later";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 

--- a/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-topic-info.js
@@ -4,7 +4,7 @@ import I18n from "I18n";
 import RawHtml from "discourse/widgets/raw-html";
 import { avatarImg } from "discourse/widgets/post";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import renderTags from "discourse/lib/render-tags";
 import { topicFeaturedLinkNode } from "discourse/lib/render-topic-featured-link";

--- a/app/assets/javascripts/discourse/app/widgets/header.js
+++ b/app/assets/javascripts/discourse/app/widgets/header.js
@@ -4,7 +4,7 @@ import { addExtraUserClasses } from "discourse/helpers/user-avatar";
 import { avatarImg } from "discourse/widgets/post";
 import { createWidget } from "discourse/widgets/widget";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { schedule } from "@ember/runloop";
 import { scrollTop } from "discourse/mixins/scroll-top";

--- a/app/assets/javascripts/discourse/app/widgets/home-logo.js
+++ b/app/assets/javascripts/discourse/app/widgets/home-logo.js
@@ -2,7 +2,7 @@ import DiscourseURL from "discourse/lib/url";
 import Session from "discourse/models/session";
 import { createWidget } from "discourse/widgets/widget";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 

--- a/app/assets/javascripts/discourse/app/widgets/link.js
+++ b/app/assets/javascripts/discourse/app/widgets/link.js
@@ -2,7 +2,7 @@ import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 import { createWidget } from "discourse/widgets/widget";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 

--- a/app/assets/javascripts/discourse/app/widgets/menu-panel.js
+++ b/app/assets/javascripts/discourse/app/widgets/menu-panel.js
@@ -1,5 +1,5 @@
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import hbs from "discourse/widgets/hbs-compiler";
 
 createWidget("menu-links", {

--- a/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js
@@ -1,6 +1,6 @@
 import { ButtonClass } from "discourse/widgets/button";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 
 createWidget(
   "post-admin-menu-button",

--- a/app/assets/javascripts/discourse/app/widgets/post-links.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-links.js
@@ -1,5 +1,5 @@
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { replaceEmoji } from "discourse/widgets/emoji";
 

--- a/app/assets/javascripts/discourse/app/widgets/post-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-menu.js
@@ -3,7 +3,7 @@ import { next } from "@ember/runloop";
 import discourseLater from "discourse-common/lib/later";
 import { Promise } from "rsvp";
 import { formattedReminderTime } from "discourse/lib/bookmark";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import showModal from "discourse/lib/show-modal";
 import { smallUserAtts } from "discourse/widgets/actions-summary";
 import I18n from "I18n";

--- a/app/assets/javascripts/discourse/app/widgets/post-small-action.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-small-action.js
@@ -4,7 +4,7 @@ import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 import { avatarFor } from "discourse/widgets/post";
 import { computed } from "@ember/object";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { userPath } from "discourse/lib/url";
 import { htmlSafe } from "@ember/template";

--- a/app/assets/javascripts/discourse/app/widgets/post-stream.js
+++ b/app/assets/javascripts/discourse/app/widgets/post-stream.js
@@ -5,7 +5,7 @@ import { addWidgetCleanCallback } from "discourse/components/mount-widget";
 import { avatarFor } from "discourse/widgets/post";
 import { createWidget } from "discourse/widgets/widget";
 import discourseDebounce from "discourse-common/lib/debounce";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import transformPost from "discourse/lib/transform-post";
 

--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -12,7 +12,7 @@ import PostCooked from "discourse/widgets/post-cooked";
 import { Promise } from "rsvp";
 import RawHtml from "discourse/widgets/raw-html";
 import { dateNode } from "discourse/helpers/node";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import hbs from "discourse/widgets/hbs-compiler";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { postTransformCallbacks } from "discourse/widgets/post-stream";

--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -2,7 +2,7 @@ import { applyDecorators, createWidget } from "discourse/widgets/widget";
 import I18n from "I18n";
 import { formatUsername } from "discourse/lib/utilities";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 

--- a/app/assets/javascripts/discourse/app/widgets/private-message-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/private-message-map.js
@@ -2,7 +2,7 @@ import { avatarFor, avatarImg } from "discourse/widgets/post";
 import I18n from "I18n";
 import { createWidget } from "discourse/widgets/widget";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import hbs from "discourse/widgets/hbs-compiler";
 import { makeArray } from "discourse-common/lib/helpers";
 

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-bookmarks.js
@@ -7,7 +7,7 @@ import { iconHTML } from "discourse-common/lib/icon-library";
 import QuickAccessPanel from "discourse/widgets/quick-access-panel";
 import { ajax } from "discourse/lib/ajax";
 import { createWidget, createWidgetFrom } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { postUrl } from "discourse/lib/utilities";
 import I18n from "I18n";
 import { htmlSafe } from "@ember/template";

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-item.js
@@ -2,7 +2,7 @@ import RawHtml from "discourse/widgets/raw-html";
 import { createWidget } from "discourse/widgets/widget";
 import { emojiUnescape } from "discourse/lib/text";
 import { escapeExpression } from "discourse/lib/utilities";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 
 /**

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-messages.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-messages.js
@@ -1,6 +1,6 @@
 import RawHtml from "discourse/widgets/raw-html";
 import { iconHTML } from "discourse-common/lib/icon-library";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import QuickAccessPanel from "discourse/widgets/quick-access-panel";
 import { createWidget, createWidgetFrom } from "discourse/widgets/widget";
 import { postUrl } from "discourse/lib/utilities";

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-notifications.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-notifications.js
@@ -4,7 +4,7 @@ import getURL from "discourse-common/lib/get-url";
 import QuickAccessPanel from "discourse/widgets/quick-access-panel";
 import { ajax } from "discourse/lib/ajax";
 import { createWidget, createWidgetFrom } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import I18n from "I18n";
 import { dasherize } from "@ember/string";
 import { htmlSafe } from "@ember/template";

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-panel.js
@@ -2,7 +2,7 @@ import I18n from "I18n";
 import { Promise } from "rsvp";
 import Session from "discourse/models/session";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { postRNWebviewMessage } from "discourse/lib/utilities";
 
 /**

--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -7,7 +7,7 @@ import { createWidget } from "discourse/widgets/widget";
 import { dateNode } from "discourse/helpers/node";
 import { emojiUnescape } from "discourse/lib/text";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import hbs from "discourse/widgets/hbs-compiler";
 import highlightSearch from "discourse/lib/highlight-search";
 import { iconNode } from "discourse-common/lib/icon-library";

--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -7,7 +7,7 @@ import DiscourseURL from "discourse/lib/url";
 import { createWidget } from "discourse/widgets/widget";
 import discourseDebounce from "discourse-common/lib/debounce";
 import getURL from "discourse-common/lib/get-url";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { isiPad, translateModKey } from "discourse/lib/utilities";
 import { popupAjaxError } from "discourse/lib/ajax-error";

--- a/app/assets/javascripts/discourse/app/widgets/time-gap.js
+++ b/app/assets/javascripts/discourse/app/widgets/time-gap.js
@@ -1,6 +1,6 @@
 import I18n from "I18n";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 
 function description(attrs) {
   const daysSince = attrs.daysSince;

--- a/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-admin-menu.js
@@ -1,5 +1,5 @@
 import { applyDecorators, createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 
 createWidget("admin-menu-button", {
   tagName: "li",

--- a/app/assets/javascripts/discourse/app/widgets/topic-map.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-map.js
@@ -2,7 +2,7 @@ import { avatarFor, avatarImg } from "discourse/widgets/post";
 import { dateNode, numberNode } from "discourse/helpers/node";
 import I18n from "I18n";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { replaceEmoji } from "discourse/widgets/emoji";
 import autoGroupFlairForUser from "discourse/lib/avatar-flair";
 import { userPath } from "discourse/lib/url";

--- a/app/assets/javascripts/discourse/app/widgets/topic-post-visited-line.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-post-visited-line.js
@@ -1,6 +1,6 @@
 import I18n from "I18n";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 
 export default createWidget("topic-post-visited-line", {
   tagName: "div.small-action.topic-post-visited",

--- a/app/assets/javascripts/discourse/app/widgets/topic-status.js
+++ b/app/assets/javascripts/discourse/app/widgets/topic-status.js
@@ -2,7 +2,7 @@ import I18n from "I18n";
 import TopicStatusIcons from "discourse/helpers/topic-status-icons";
 import { createWidget } from "discourse/widgets/widget";
 import { escapeExpression } from "discourse/lib/utilities";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 
 export default createWidget("topic-status", {

--- a/app/assets/javascripts/discourse/app/widgets/user-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-menu.js
@@ -1,6 +1,6 @@
 import discourseLater from "discourse-common/lib/later";
 import { createWidget } from "discourse/widgets/widget";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import showModal from "discourse/lib/show-modal";
 import I18n from "I18n";
 

--- a/app/assets/javascripts/discourse/app/widgets/user-notifications-large.js
+++ b/app/assets/javascripts/discourse/app/widgets/user-notifications-large.js
@@ -1,6 +1,6 @@
 import { createWidget } from "discourse/widgets/widget";
 import { dateNode } from "discourse/helpers/node";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { dasherize } from "@ember/string";
 
 createWidget("large-notification-item", {

--- a/app/assets/javascripts/discourse/app/widgets/widget.js
+++ b/app/assets/javascripts/discourse/app/widgets/widget.js
@@ -21,7 +21,7 @@ import I18n from "I18n";
 import { Promise } from "rsvp";
 import { deepMerge } from "discourse-common/lib/object";
 import { get } from "@ember/object";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 import { isProduction } from "discourse-common/config/environment";
 
 const _registry = {};

--- a/app/assets/javascripts/discourse/ember-cli-build.js
+++ b/app/assets/javascripts/discourse/ember-cli-build.js
@@ -48,6 +48,15 @@ module.exports = function (defaults) {
           moduleIds: "size", // Consistent module references https://github.com/ef4/ember-auto-import/issues/478#issuecomment-1000526638
         },
         resolve: {
+          alias: {
+            /**
+             * This doesn't actually alias the code, but allows webpack to think virtual-dom exists.
+             * We've defined an AMD/requirejs entrypoint that defines virtual-dom, and points at @discourse/virtual-dom
+             *
+             * (important for embroider compatibility)
+             */
+            "virtual-dom": "@discourse/virtual-dom",
+          },
           fallback: {
             // Sinon needs a `util` polyfill
             util: require.resolve("util/"),

--- a/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/discourse-boot.js
@@ -10,11 +10,6 @@
   // https://github.com/emberjs/ember.js/blob/0c5518ea7b/packages/%40ember/-internals/glimmer/lib/helper.ts#L134-L138
   require("ember");
 
-  window.__widget_helpers = require("discourse-widget-hbs/helpers").default;
-
-  // TODO: Eliminate this global
-  window.virtualDom = require("virtual-dom");
-
   let element = document.querySelector(
     `meta[name="discourse/config/environment"]`
   );

--- a/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
+++ b/app/assets/javascripts/discourse/public/assets/scripts/module-shims.js
@@ -46,3 +46,20 @@ if (glimmerTracking.cached) {
     get: () => require("ember-cached-decorator-polyfill").cached,
   });
 }
+
+/**
+ * Provide AMD/requirejs entrypoint for the custom virtual-dom fork.
+ *
+ * In order for this to work, the app/app.js must be evaluated before any other
+ * modules try to reach for 'virtual-dom'.
+ *
+ * And note that app/app.js uses the real module name, `@discourse/virtual-dom`.
+ */
+define("virtual-dom", ["exports"], function (exports) {
+  "use strict";
+
+  return {
+    default: window.virtualDom,
+    __esModule: true,
+  };
+});

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/widget-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/widget-test.js
@@ -9,7 +9,7 @@ import { Promise } from "rsvp";
 import { createWidget } from "discourse/widgets/widget";
 import { next } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { h } from "virtual-dom";
+import { h } from "@discourse/virtual-dom";
 
 module("Integration | Component | Widget | base", function (hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
On the embroider branch with _all the changes_ on it, I was running in to issues with trying to remap `virtual-dom` from `@discourse/virtual-dom` -- the only way I was able to get a successful polyfill, via minimal changes to code, was to patch-package the package.json of `@discourse/virtual-dom`. 
`resolutions` were ineffective, because embroider/webpack took issue with the folder-name / package.json#name mismatch.

I had put WIP on this because something went wrong with my branch that pulls everything altogether, so.. while things _work fine_ locally without the package rename, it's not a useful change if it's still not embroider-compatible.

---------------------

This PR builds on top of https://github.com/discourse/discourse/pull/20901 and will have a smaller diff once https://github.com/discourse/discourse/pull/20901 is merged.

Why is this needed?
(To be determined!)

Webpack, and other packagers, don't use AMD/requirejs. So we build on top of the `global-compat` code from #20901, and make a AMD/requirejs shim for code that still needs those shims (plugins, code built out-of-band from ember-cli, etc)

If plugins are compiled to AMD/requirejs, then the virtual-dom shim will be needed.
If ember-cli is building the plugins, then we don't need the shim, and instead we can use a babel transform to bring all the older plugins forward.