### PR TITLE
SECURITY: Update URI gem to 0.12.1 to address CVE-2023-28755

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,7 +470,7 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     uniform_notifier (1.16.0)
-    uri (0.12.0)
+    uri (0.12.1)
     uri_template (0.7.0)
     version_gem (1.1.1)
     web-push (3.0.0)


### PR DESCRIPTION
See https://www.ruby-lang.org/en/news/2023/03/28/redos-in-uri-cve-2023-28755/

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
