### PR TITLE
UX: Update guidance for target DAU/MAU

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1194,7 +1194,7 @@ en:
       title: "DAU/MAU"
       xaxis: "Day"
       yaxis: "DAU/MAU"
-      description: "Number of members that logged in in the last day divided by number of members that logged in in the last month – returns a % which indicates community 'stickiness'. Aim for >30%."
+      description: "Number of members that logged in in the last day divided by number of members that logged in in the last month – returns a % which indicates community 'stickiness'. Aim for >20%."
     daily_engaged_users:
       title: "Daily Engaged Users"
       xaxis: "Day"


### PR DESCRIPTION
This goal may vary for different types of communities, but 20% is a more reasonable target as a default for the ratio of daily active users / monthly active users (DAU/MAU).
