### PR TITLE
DEV: Add debug for ChatablesControllerSpec

### DIFF
--- a/plugins/chat/spec/requests/chat/api/chatables_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/chatables_controller_spec.rb
@@ -155,6 +155,10 @@ RSpec.describe Chat::Api::ChatablesController do
 
         GroupUser.create(user: other_user, group: group)
         get "/chat/api/chatables", params: { filter: "janemay" }
+        if response.status == 500
+          puts "ERROR in ChatablesController spec:\n"
+          puts response.body
+        end
         expect(response.status).to eq(200)
         expect(response.parsed_body["direct_message_channels"][0]["id"]).to eq(dm_chat_channel_2.id)
       end


### PR DESCRIPTION
We keep getting this failure on the spec but I
cannot reproduce locally, add this extra log line
to see if it helps:

```
>  Chat::Api::ChatablesController#index with chat permissions does not return DM channels for users who are not in the chat allowed group
>  Failure/Error: example.run
>
>    expected: 200
>         got: 500
>
>    (compared using ==)
>  # ./plugins/chat/spec/requests/chat/api/chatables_controller_spec.rb:158:in `block (4 levels) in <main>'
>  # ./spec/rails_helper.rb:358:in `block (2 levels) in <top (required)>'
>  # ./vendor/bundle/ruby/3.2.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
>  # ------------------
>  # --- Caused by: ---
>  #
>  #   expected: 200
>  #        got: 500
>  #
>  #   (compared using ==)
>  #   ./plugins/chat/spec/requests/chat/api/chatables_controller_spec.rb:158:in `block (4 levels) in <main>'

```