### PR TITLE
DEV: Update experimental `/filter` route with categories support

### DIFF
--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe TopicsFilter do
+  fab!(:user) { Fabricate(:user) }
   fab!(:admin) { Fabricate(:admin) }
   fab!(:group) { Fabricate(:group) }
 
@@ -20,6 +21,143 @@ RSpec.describe TopicsFilter do
             .filter_from_query_string("status:closed tags:tag1,tag2")
             .pluck(:id),
         ).to contain_exactly(closed_topic_with_tag.id, closed_topic_with_tag2.id)
+      end
+    end
+
+    describe "when filtering by categories" do
+      fab!(:category) { Fabricate(:category, name: "category") }
+
+      fab!(:category_subcategory) do
+        Fabricate(:category, parent_category: category, name: "category subcategory")
+      end
+
+      fab!(:category2) { Fabricate(:category, name: "category2") }
+
+      fab!(:category2_subcategory) do
+        Fabricate(:category, parent_category: category2, name: "category2 subcategory")
+      end
+
+      fab!(:private_category) do
+        Fabricate(:private_category, group: group, slug: "private-category")
+      end
+
+      fab!(:topic_in_category) { Fabricate(:topic, category: category) }
+      fab!(:topic_in_category_subcategory) { Fabricate(:topic, category: category_subcategory) }
+      fab!(:topic_in_category2) { Fabricate(:topic, category: category2) }
+      fab!(:topic_in_category2_subcategory) { Fabricate(:topic, category: category2_subcategory) }
+      fab!(:topic_in_private_category) { Fabricate(:topic, category: private_category) }
+
+      describe "when query string is `-category:category`" do
+        it "ignores the filter because the prefix is invalid" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("-category:category")
+              .pluck(:id),
+          ).to contain_exactly(
+            topic_in_category.id,
+            topic_in_category_subcategory.id,
+            topic_in_category2.id,
+            topic_in_category2_subcategory.id,
+            topic_in_private_category.id,
+          )
+        end
+      end
+
+      describe "when query string is `category:private-category`" do
+        it "should not return any topics when user does not have access to specified category" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("category:private-category")
+              .pluck(:id),
+          ).to eq([])
+        end
+
+        it "should return topics from specified category when user has access to specified category" do
+          group.add(user)
+
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new(user))
+              .filter_from_query_string("category:private-category")
+              .pluck(:id),
+          ).to contain_exactly(topic_in_private_category.id)
+        end
+      end
+
+      describe "when query string is `category:category`" do
+        it "should return topics from specified category and its subcategories" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("category:category")
+              .pluck(:id),
+          ).to contain_exactly(topic_in_category.id, topic_in_category_subcategory.id)
+        end
+
+        it "should return topics from specified category, its subcategories and sub-subcategories" do
+          SiteSetting.max_category_nesting = 3
+
+          category_subcategory_subcategory =
+            Fabricate(
+              :category,
+              parent_category: category_subcategory,
+              name: "category subcategory subcategory",
+            )
+
+          topic_in_category_subcategory_subcategory =
+            Fabricate(:topic, category: category_subcategory_subcategory)
+
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("category:category")
+              .pluck(:id),
+          ).to contain_exactly(
+            topic_in_category.id,
+            topic_in_category_subcategory.id,
+            topic_in_category_subcategory_subcategory.id,
+          )
+        end
+      end
+
+      describe "when query string is `category:category,category2`" do
+        it "should return topics from any of the specified categories and its subcategories" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("category:category,category2")
+              .pluck(:id),
+          ).to contain_exactly(
+            topic_in_category.id,
+            topic_in_category_subcategory.id,
+            topic_in_category2.id,
+            topic_in_category2_subcategory.id,
+          )
+        end
+      end
+
+      describe "when query string is `=category:category`" do
+        it "should not return topics from subcategories`" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("=category:category")
+              .pluck(:id),
+          ).to contain_exactly(topic_in_category.id)
+        end
+      end
+
+      describe "when query string is `=category:category,category2`" do
+        it "should not return topics from subcategories" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("=category:category,category2")
+              .pluck(:id),
+          ).to contain_exactly(topic_in_category.id, topic_in_category2.id)
+        end
       end
     end
 


### PR DESCRIPTION
On the `/filter` route, the categories filtering query language is now
supported in the input per the example provided below:

```
category:bug => topics in the bug category AND all subcategories
=category:bug => topics in the bug category excluding subcategories
category:bug,feature => allow for categories either in bug or feature
=category:bug,feature => allow for exact categories match excluding sub cats
categories: => alias for category
```

Currently composing multiple category filters is not supported as we
have yet to determine what behaviour it should result in. For example,
`category:bug category:feature` would now return topics that are in both
the `bug` and `feature` category but it is not possible for a topic to
belong to two categories.