### PR TITLE
FIX: Vertically center youtube thumbnails in lazy-videos

### DIFF
--- a/plugins/discourse-lazy-videos/assets/stylesheets/lazy-videos.scss
+++ b/plugins/discourse-lazy-videos/assets/stylesheets/lazy-videos.scss
@@ -17,6 +17,11 @@
       object-fit: cover;
       width: 100%;
       pointer-events: none;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      max-height: 100%;
     }
 
     &:hover,


### PR DESCRIPTION
`hqdefault` youtube thumbnails usually have extra black bars on top and bottom


<div align="center">

<b>Before / After</b>

![youtube thumbnail](https://user-images.githubusercontent.com/66427541/229107534-1f430223-2fa2-4386-a524-17e7ff8bf0c9.png)
(maybe not the best example as this video already has black bars)

</div>

