### PR TITLE
PERF: Set default global regex timeout to 2 seconds

### DIFF
--- a/config/discourse_defaults.conf
+++ b/config/discourse_defaults.conf
@@ -373,7 +373,7 @@ pg_force_readonly_mode = false
 dns_query_timeout_secs =
 
 # Default global regex timeout
-regex_timeout_seconds =
+regex_timeout_seconds = 2
 
 # Allow impersonation function on the cluster to admins
 allow_impersonation = true


### PR DESCRIPTION
Followup to a0140f6f7542a901bc5a5ed5d7d710b792c83360

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
