### PR TITLE
DEV: Introduce `Migration::Helpers` for new-site detection

### DIFF
--- a/db/migrate/20210527114834_set_tagging_enabled.rb
+++ b/db/migrate/20210527114834_set_tagging_enabled.rb
@@ -2,15 +2,8 @@
 
 class SetTaggingEnabled < ActiveRecord::Migration[6.1]
   def up
-    result = execute <<~SQL
-      SELECT created_at
-      FROM schema_migration_details
-      ORDER BY created_at
-      LIMIT 1
-    SQL
-
     # keep tagging disabled for existing sites
-    execute <<~SQL if result.first["created_at"].to_datetime < 1.hour.ago
+    execute <<~SQL if Migration::Helpers.existing_site?
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
         VALUES('tagging_enabled', 5, 'f', NOW(), NOW())
         ON CONFLICT (name) DO NOTHING

--- a/db/migrate/20220130192155_set_use_email_for_username_and_name_suggestions_on_existing_sites.rb
+++ b/db/migrate/20220130192155_set_use_email_for_username_and_name_suggestions_on_existing_sites.rb
@@ -2,15 +2,8 @@
 
 class SetUseEmailForUsernameAndNameSuggestionsOnExistingSites < ActiveRecord::Migration[6.1]
   def up
-    result = execute <<~SQL
-      SELECT created_at
-      FROM schema_migration_details
-      ORDER BY created_at
-      LIMIT 1
-    SQL
-
     # make setting enabled for existing sites
-    execute <<~SQL if result.first["created_at"].to_datetime < 1.hour.ago
+    execute <<~SQL if Migration::Helpers.existing_site?
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
         VALUES('use_email_for_username_and_name_suggestions', 5, 't', NOW(), NOW())
         ON CONFLICT (name) DO NOTHING

--- a/db/migrate/20221212225921_enable_sidebar_and_chat.rb
+++ b/db/migrate/20221212225921_enable_sidebar_and_chat.rb
@@ -2,15 +2,8 @@
 
 class EnableSidebarAndChat < ActiveRecord::Migration[7.0]
   def up
-    result = execute <<~SQL
-      SELECT created_at
-      FROM schema_migration_details
-      ORDER BY created_at
-      LIMIT 1
-    SQL
-
-    # keep sidebar legacy and chat disabled for for existing sites
-    if result.first["created_at"].to_datetime < 1.hour.ago
+    # keep sidebar legacy and chat disabled for existing sites
+    if Migration::Helpers.existing_site?
       execute <<~SQL
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
         VALUES('chat_enabled', 5, 'f', NOW(), NOW())

--- a/lib/migration/helpers.rb
+++ b/lib/migration/helpers.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Migration
+  module Helpers
+    def self.site_created_at
+      result = DB.query_single <<~SQL
+        SELECT created_at
+        FROM schema_migration_details
+        ORDER BY created_at
+        LIMIT 1
+      SQL
+      result.first
+    end
+
+    def self.existing_site?
+      site_created_at < 1.hour.ago
+    end
+
+    def self.new_site?
+      !old_site?
+    end
+  end
+end


### PR DESCRIPTION
We use schema_migration_details to determine the age of a site in multiple migrations. This commit moves the logic into a dedicated `Migration::Helpers` module so that it doesn't need to be re-implemented every time.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
