### PR TITLE
Update default ga_version to v4 and add warning message for v3

### DIFF
--- a/app/models/admin_dashboard_data.rb
+++ b/app/models/admin_dashboard_data.rb
@@ -205,7 +205,8 @@ class AdminDashboardData
                       :email_polling_errored_recently,
                       :out_of_date_themes,
                       :unreachable_themes,
-                      :watched_words_check
+                      :watched_words_check,
+                      :google_analytics_version_check
 
     register_default_scheduled_problem_checks
 
@@ -378,6 +379,10 @@ class AdminDashboardData
 
   def subfolder_ends_in_slash_check
     I18n.t("dashboard.subfolder_ends_in_slash") if Discourse.base_path =~ %r{/\z}
+  end
+
+  def google_analytics_version_check
+    I18n.t("dashboard.v3_analytics_deprecated") if SiteSetting.ga_version == "v3_analytics"
   end
 
   def email_polling_errored_recently

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1475,6 +1475,7 @@ en:
     out_of_date_themes: "Updates are available for the following themes:"
     unreachable_themes: "We were unable to check for updates on the following themes:"
     watched_word_regexp_error: "The regular expression for '%{action}' watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
+    v3_analytics_deprecated: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
 
   site_settings:
     allow_bulk_invite: "Allow bulk invites by uploading a CSV file"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1475,7 +1475,7 @@ en:
     out_of_date_themes: "Updates are available for the following themes:"
     unreachable_themes: "We were unable to check for updates on the following themes:"
     watched_word_regexp_error: "The regular expression for '%{action}' watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
-    v3_analytics_deprecated: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
+    v3_analytics_deprecated: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/t/260498'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
 
   site_settings:
     allow_bulk_invite: "Allow bulk invites by uploading a CSV file"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -150,7 +150,7 @@ basic:
     max: 36500
   ga_version:
     type: enum
-    default: v3_analytics
+    default: v4_gtag
     choices:
       - v3_analytics
       - v4_gtag

--- a/db/migrate/20230403094936_change_google_analytics_default.rb
+++ b/db/migrate/20230403094936_change_google_analytics_default.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class ChangeGoogleAnalyticsDefault < ActiveRecord::Migration[7.0]
+  def up
+    should_persist_old_default =
+      Migration::Helpers.existing_site? && tracking_code && current_db_version != "v4_gtag"
+
+    return if !should_persist_old_default
+
+    execute <<~SQL
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      VALUES ('ga_version', 7, 'v3_analytics', now(), now())
+      ON CONFLICT DO NOTHING
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def tracking_code
+    DB.query_single("SELECT value FROM site_settings WHERE name='ga_universal_tracking_code'")[
+      0
+    ].presence
+  end
+
+  def current_db_version
+    DB.query_single("SELECT value FROM site_settings WHERE name='ga_version'")[0].presence
+  end
+end

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -85,6 +85,8 @@ RSpec.describe ContentSecurityPolicy do
       before { SiteSetting.ga_universal_tracking_code = "UA-12345678-9" }
 
       it "allowlists Google Analytics v3 when integrated" do
+        SiteSetting.ga_version = "v3_analytics"
+
         script_srcs = parse(policy)["script-src"]
         expect(script_srcs).to include("https://www.google-analytics.com/analytics.js")
         expect(script_srcs).not_to include("https://www.googletagmanager.com/gtag/js")


### PR DESCRIPTION
Requires #20934, and the translation string needs to be updated to point to a Meta topic