### PR TITLE
DEV: Add plugin hook for transforming site setting defaults

### DIFF
--- a/lib/site_settings/defaults_provider.rb
+++ b/lib/site_settings/defaults_provider.rb
@@ -31,18 +31,18 @@ class SiteSettings::DefaultsProvider
   end
 
   def all(locale = nil)
-    if locale
-      @defaults[DEFAULT_LOCALE.to_sym].merge(@defaults[locale.to_sym] || {})
-    else
-      @defaults[DEFAULT_LOCALE.to_sym].dup
-    end
+    result =
+      if locale
+        @defaults[DEFAULT_LOCALE.to_sym].merge(@defaults[locale.to_sym] || {})
+      else
+        @defaults[DEFAULT_LOCALE.to_sym].dup
+      end
+
+    DiscoursePluginRegistry.apply_modifier(:site_setting_defaults, result)
   end
 
   def get(name, locale = DEFAULT_LOCALE)
-    value = @defaults.dig(locale.to_sym, name.to_sym)
-    return value unless value.nil?
-
-    @defaults.dig(DEFAULT_LOCALE.to_sym, name.to_sym)
+    all(locale)[name.to_sym]
   end
   alias [] get
 

--- a/spec/lib/site_settings/defaults_provider_spec.rb
+++ b/spec/lib/site_settings/defaults_provider_spec.rb
@@ -128,4 +128,27 @@ RSpec.describe SiteSettings::DefaultsProvider do
       expect(settings.defaults.has_setting?("question")).to be_truthy
     end
   end
+
+  describe "plugin modifier" do
+    before { settings.setting(:my_setting, "defaultval") }
+
+    class TestFilterPlugInstance < Plugin::Instance
+    end
+
+    let(:plugin_instance) { TestFilterPlugInstance.new }
+
+    it "can change defaults" do
+      expect(settings.defaults.get(:my_setting)).to eq "defaultval"
+      expect(settings.defaults.all[:my_setting]).to eq "defaultval"
+
+      plugin_instance.register_modifier(:site_setting_defaults) do |defaults|
+        defaults.merge({ my_setting: "overridden default" })
+      end
+
+      expect(settings.defaults.get(:my_setting)).to eq "overridden default"
+      expect(settings.defaults.all[:my_setting]).to eq "overridden default"
+    ensure
+      DiscoursePluginRegistry.reset!
+    end
+  end
 end

--- a/spec/multisite/site_settings_spec.rb
+++ b/spec/multisite/site_settings_spec.rb
@@ -29,4 +29,37 @@ RSpec.describe "Multisite SiteSettings", type: :multisite do
       test_multisite_connection("second") { expect(SiteSetting.default_locale).to eq("zh_TW") }
     end
   end
+
+  describe "transforming defaults from plugin" do
+    class TestFilterPlugInstance < Plugin::Instance
+    end
+
+    let(:plugin_instance) { TestFilterPlugInstance.new }
+
+    it "can change defaults" do
+      test_multisite_connection("default") { expect(SiteSetting.title).to eq("Discourse") }
+
+      plugin_instance.register_modifier(:site_setting_defaults) do |defaults|
+        defaults.merge({ title: "title for #{RailsMultisite::ConnectionManagement.current_db}" })
+      end
+
+      test_multisite_connection("default") do
+        SiteSetting.refresh!
+        expect(SiteSetting.title).to eq("title for default")
+        SiteSetting.title = "overridden default title"
+        expect(SiteSetting.title).to eq("overridden default title")
+      end
+
+      test_multisite_connection("second") do
+        SiteSetting.refresh!
+        expect(SiteSetting.title).to eq("title for second")
+        SiteSetting.title = "overridden second title"
+        expect(SiteSetting.title).to eq("overridden second title")
+      end
+    ensure
+      DiscoursePluginRegistry.reset!
+      test_multisite_connection("default") { SiteSetting.refresh! }
+      test_multisite_connection("second") { SiteSetting.refresh! }
+    end
+  end
 end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
