### PR TITLE
UX: use relative units to prevent timeline crop

### DIFF
--- a/app/assets/stylesheets/common/topic-timeline.scss
+++ b/app/assets/stylesheets/common/topic-timeline.scss
@@ -139,7 +139,7 @@
       .timeline-scrollarea-wrapper {
         display: table-cell;
         padding-right: 1.5em;
-        width: 100px;
+        width: 7em;
       }
       .timeline-scrollarea {
         border-right: 1px solid var(--tertiary-low-or-tertiary-high);
@@ -265,7 +265,7 @@
 
     .timeline-ago {
       color: var(--primary-med-or-secondary-med);
-      max-width: 70px;
+      max-width: 4.6em;
       overflow: hidden;
       text-overflow: ellipsis;
     }


### PR DESCRIPTION
The width here was constrained in `px`, which meant that larger font sizes would get more aggressive timeline count & date cropping. Using relative units means the space increases along with the font-size, so the date can still fit the space.

Before: 
![Screenshot 2023-04-03 at 5 16 08 PM](https://user-images.githubusercontent.com/1681963/229630055-e57f34e3-28ed-490c-b099-28daf63d9fb0.png)

After:
![Screenshot 2023-04-03 at 5 26 15 PM](https://user-images.githubusercontent.com/1681963/229631186-28c9c85c-592d-4d1f-9506-21dc4f08637a.png)

Reported here: https://meta.discourse.org/t/date-in-timeline-slider-sometimes-not-showing-in-mobile-layout/259646
