### PR TITLE
DEV: Change the params for categoryNone redirect

### DIFF
--- a/app/assets/javascripts/discourse/app/routes/build-category-route.js
+++ b/app/assets/javascripts/discourse/app/routes/build-category-route.js
@@ -62,10 +62,10 @@ export default (filterArg, params) => {
       ) {
         // TODO: avoid throwing away preload data by redirecting on the server
         PreloadStore.getAndRemove("topic_list");
-        return this.replaceWith("discovery.categoryNone", {
-          category,
-          category_slug_path_with_id: modelParams.category_slug_path_with_id,
-        });
+        return this.replaceWith(
+          "discovery.categoryNone",
+          modelParams.category_slug_path_with_id
+        );
       }
 
       this._setupNavigation(category);


### PR DESCRIPTION
Makes the params (`router.currentRoute.params`) the same in this codepath as in the regular flow. (issue originally reported in: https://meta.discourse.org/t/category-banners/86241/174)

See also https://github.com/discourse/discourse-category-banners/pull/31 for the first stab at the bug.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
