### PR TITLE
DEV: Use Migration::Helpers.existing_site? for other migrations

### DIFF
--- a/db/migrate/20220927171707_disable_allow_uncategorized_new_sites.rb
+++ b/db/migrate/20220927171707_disable_allow_uncategorized_new_sites.rb
@@ -2,15 +2,8 @@
 
 class DisableAllowUncategorizedNewSites < ActiveRecord::Migration[7.0]
   def up
-    result = execute <<~SQL
-      SELECT created_at
-      FROM schema_migration_details
-      ORDER BY created_at
-      LIMIT 1
-    SQL
-
     # keep allow uncategorized for existing sites
-    execute <<~SQL if result.first["created_at"].to_datetime < 1.hour.ago
+    execute <<~SQL if Migration::Helpers.existing_site?
         INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
         VALUES('allow_uncategorized_topics', 5, 't', NOW(), NOW())
         ON CONFLICT (name) DO NOTHING

--- a/db/migrate/20230103004613_make_experimental_hashtag_feature_default_for_new_sites.rb
+++ b/db/migrate/20230103004613_make_experimental_hashtag_feature_default_for_new_sites.rb
@@ -2,13 +2,6 @@
 
 class MakeExperimentalHashtagFeatureDefaultForNewSites < ActiveRecord::Migration[7.0]
   def up
-    result = execute <<~SQL
-      SELECT created_at
-      FROM schema_migration_details
-      ORDER BY created_at
-      LIMIT 1
-    SQL
-
     settings_insert_query = <<~SQL
       INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
       VALUES ('enable_experimental_hashtag_autocomplete', 5, 'f', now(), now())
@@ -16,7 +9,7 @@ class MakeExperimentalHashtagFeatureDefaultForNewSites < ActiveRecord::Migration
     SQL
 
     # keep enable_experimental_hashtag_autocomplete disabled for for existing sites
-    execute settings_insert_query if result.first["created_at"].to_datetime < 1.hour.ago
+    execute settings_insert_query if Migration::Helpers.existing_site?
   end
 
   def down


### PR DESCRIPTION
Followup to f3402be262b3d893463ce16071f1d3ebb22ff508, adds
the new helper to two other core migrations that need it.
