### PR TITLE
FIX: icon toggles search menu display on click

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -348,8 +348,10 @@ export default createWidget("search-menu", {
     });
   },
 
-  mouseDownOutside() {
-    this.sendWidgetAction("toggleSearchMenu");
+  clickOutside() {
+    if (this.key === "search-menu" && !window.getSelection().toString()) {
+      this.sendWidgetAction("toggleSearchMenu");
+    }
   },
 
   clearTopicContext() {

--- a/app/assets/javascripts/discourse/tests/acceptance/search-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/search-test.js
@@ -15,7 +15,7 @@ import {
 import I18n from "I18n";
 import searchFixtures from "discourse/tests/fixtures/search-fixtures";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { skip, test } from "qunit";
+import { test } from "qunit";
 import { DEFAULT_TYPE_FILTER } from "discourse/widgets/search-menu";
 
 acceptance("Search - Anonymous", function (needs) {
@@ -114,8 +114,7 @@ acceptance("Search - Anonymous", function (needs) {
     );
   });
 
-  // TODO: This feature doesn't work currently (/t/69760)
-  skip("search button toggles search menu", async function (assert) {
+  test("search button toggles search menu", async function (assert) {
     await visit("/");
 
     await click("#search-button");


### PR DESCRIPTION
Using the `mouseDownOutside` event was problematic here because two events were being triggered consecutively: `mouseDown` would toggle the menu off and `click` would then toggle it back on. This switches the logic to use `clickOutside` again, but with two changes:
- it limits the action to the `search-menu` key (so that theme component overrides can do their own handling)
- it does not trigger the event when there is an active text selection (this was the original reason for switching to `mouseDownOutside`, see https://github.com/discourse/discourse/pull/14788)

