### PR TITLE
DEV: Properly support composing multiple category filters on `/filter`

### DIFF
--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -138,6 +138,37 @@ RSpec.describe TopicsFilter do
         end
       end
 
+      describe "when query string is `category:category category:category2`" do
+        it "should return topics from any of the specified categories and its subcategories" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("category:category category:category2")
+              .pluck(:id),
+          ).to contain_exactly(
+            topic_in_category.id,
+            topic_in_category_subcategory.id,
+            topic_in_category2.id,
+            topic_in_category2_subcategory.id,
+          )
+        end
+      end
+
+      describe "when query string is `category:category =category:category2`" do
+        it "should return topics and subcategory topics from category but only topics from category2" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("category:category =category:category2")
+              .pluck(:id),
+          ).to contain_exactly(
+            topic_in_category.id,
+            topic_in_category_subcategory.id,
+            topic_in_category2.id,
+          )
+        end
+      end
+
       describe "when query string is `=category:category`" do
         it "should not return topics from subcategories`" do
           expect(


### PR DESCRIPTION
Before this commit, composing multiple category filters with a query such as `category:category1 and category:category2` would not return any results. This is because we were filtering for topics that belonged to both `category1` and `category2`, which is impossible since a topic can only belong to a single category.

With this commit, specifying a query like `category:category1 category:category2` will now translate to filtering for topics that belong to either the `category1` or `category2` category.