### PR TITLE
DEV: Update minimum Ruby version to 3.2

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.1.0")
-  STDERR.puts "Discourse requires Ruby 3.1 or above"
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2.0")
+  STDERR.puts "Discourse requires Ruby 3.2 or above"
   exit 1
 end
 


### PR DESCRIPTION
We are now using features like Regexp.timeout, which are only supported in Ruby 3.2

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
