### PR TITLE
FIX: Use correct translation key for reviewable types

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/review-index.js
+++ b/app/assets/javascripts/discourse/app/controllers/review-index.js
@@ -42,9 +42,11 @@ export default Controller.extend({
   @discourseComputed("reviewableTypes")
   allTypes() {
     return (this.reviewableTypes || []).map((type) => {
+      const translationKey = underscore(type).replace(/[^\w]+/g, "_");
+
       return {
         id: type,
-        name: I18n.t(`review.types.${underscore(type)}.title`),
+        name: I18n.t(`review.types.${translationKey}.title`),
       };
     });
   },

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -585,9 +585,8 @@ en:
       transcript:
         view: "View previous messages transcript"
       types:
-        reviewable_chat_message:
+        chat_reviewable_message:
           title: "Flagged Chat Message"
-          flagged_by: "Flagged By"
     keyboard_shortcuts_help:
       chat:
         title: "Chat"


### PR DESCRIPTION
The translation key is built using the name of the reviewable as it was defined in Ruby. The chat plugin uses the `Chat` namespace and defines `Chat::ReviewableMessage`. This was then transformed to `chat::reviewable_message`, but it should be `chat_reviewable_message` to resemble the other translation keys.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
