### PR TITLE
FIX: Show correct status for user reviewables

### DIFF
--- a/app/assets/javascripts/discourse/app/helpers/reviewable-status.js
+++ b/app/assets/javascripts/discourse/app/helpers/reviewable-status.js
@@ -21,7 +21,7 @@ function dataFor(status, type) {
             name: "approved_post",
             cssClass: "approved",
           };
-        case "User":
+        case "ReviewableUser":
           return {
             icon: "check",
             name: "approved_user",
@@ -42,7 +42,7 @@ function dataFor(status, type) {
             name: "rejected_post",
             cssClass: "rejected",
           };
-        case "User":
+        case "ReviewableUser":
           return {
             icon: "times",
             name: "rejected_user",


### PR DESCRIPTION
The status should use the word "user" instead of "flag", for example "approved user" instead of "approved flag". The problem was caused by a mismatched type.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
