### PR TITLE
FEATURE: SiteSetting to default user path to different routes

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/url-redirects.js
+++ b/app/assets/javascripts/discourse/app/initializers/url-redirects.js
@@ -26,11 +26,12 @@ export default {
     let siteSettings = container.lookup("service:site-settings");
     initializeDefaultHomepage(siteSettings);
 
-    const defaultUserRoute = `/u/$1/${
-      siteSettings.view_user_route || "summary"
-    }`;
+    let defaultUserRoute = siteSettings.view_user_route || "summary";
+    if (!container.lookup(`route:user.${defaultUserRoute}`)) {
+      defaultUserRoute = "summary";
+    }
 
-    DiscourseURL.rewrite(/^\/u\/([^\/]+)\/?$/, defaultUserRoute, {
+    DiscourseURL.rewrite(/^\/u\/([^\/]+)\/?$/, `/u/$1/${defaultUserRoute}`, {
       exceptions: [
         "/u/account-created",
         "/users/account-created",

--- a/app/assets/javascripts/discourse/app/initializers/url-redirects.js
+++ b/app/assets/javascripts/discourse/app/initializers/url-redirects.js
@@ -26,7 +26,11 @@ export default {
     let siteSettings = container.lookup("service:site-settings");
     initializeDefaultHomepage(siteSettings);
 
-    DiscourseURL.rewrite(/^\/u\/([^\/]+)\/?$/, "/u/$1/summary", {
+    const defaultUserRoute = `/u/$1/${
+      siteSettings.view_user_route || "summary"
+    }`;
+
+    DiscourseURL.rewrite(/^\/u\/([^\/]+)\/?$/, defaultUserRoute, {
       exceptions: [
         "/u/account-created",
         "/users/account-created",

--- a/app/assets/javascripts/discourse/tests/acceptance/user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-test.js
@@ -335,6 +335,30 @@ acceptance(
   }
 );
 
+acceptance("User - Invalid view_user_route setting", function (needs) {
+  needs.settings({
+    view_user_route: "X",
+  });
+
+  test("It defaults to summary", async function (assert) {
+    await visit("/u/eviltrout");
+
+    assert.strictEqual(currentRouteName(), "user.summary");
+  });
+});
+
+acceptance("User - Valid view_user_route setting", function (needs) {
+  needs.settings({
+    view_user_route: "activity",
+  });
+
+  test("It defaults to summary", async function (assert) {
+    await visit("/u/eviltrout");
+
+    assert.strictEqual(currentRouteName(), "userActivity.index");
+  });
+});
+
 acceptance("User - Logout", function (needs) {
   needs.user({ username: "eviltrout" });
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2466,6 +2466,11 @@ uncategorized:
     default: 0
     hidden: true
 
+  view_user_route:
+    default: "summary"
+    hidden: true
+    client: true
+
   tos_topic_id:
     default: -1
     hidden: true


### PR DESCRIPTION
This site setting is used to change the default user view path from `summary` to anything (in this case, someone wants it to be `activity`).

I chose to make this hidden because it's a very niche thing, and I don't think people really need to see the setting... I'm open to making it visible if others think it's a good idea