### PR TITLE
PERF: Fix N+1 queries problem when listing topics list

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -721,7 +721,11 @@ class TopicQuery
       end
     end
 
-    result = filter_by_tags(result)
+    if SiteSetting.tagging_enabled
+      result = result.includes(:tags)
+      result = filter_by_tags(result)
+    end
+
     result = apply_ordering(result, options)
 
     all_listable_topics =
@@ -1151,8 +1155,6 @@ class TopicQuery
   end
 
   def filter_by_tags(result)
-    return result if !SiteSetting.tagging_enabled
-
     tags_arg = @options[:tags]
 
     if tags_arg && tags_arg.size > 0


### PR DESCRIPTION
This performance regression was introduced in
7c6a8f1c74ea7ea3e81d9ffa80ca2227ee36a006 where the preloading of tags in
`TopicQuery` was accidentally removed.