### PR TITLE
DEV: Introduce `in:pinned` filter for experimental `/filter` route

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -14,6 +14,8 @@ class TopicsFilter
       /(?<key_prefix>[-=])?(?<key>\w+):(?<value>[^\s]+)/,
     ) do |key_prefix, key, value|
       case key
+      when "in"
+        @scope = filter_state(state: value)
       when "status"
         @scope = filter_status(status: value)
       when "tags"
@@ -83,6 +85,18 @@ class TopicsFilter
   end
 
   private
+
+  def filter_state(state:)
+    case state
+    when "pinned"
+      @scope.where(
+        "topics.pinned_at IS NOT NULL AND topics.pinned_until > topics.pinned_at AND ? < topics.pinned_until",
+        Time.zone.now,
+      )
+    else
+      @scope
+    end
+  end
 
   def filter_categories(category_slugs:, exclude_subcategories: false, or_clause: false)
     category_ids = Category.ids_from_slugs(category_slugs)


### PR DESCRIPTION
This commit adds support for the `in:pinned` filter to the topics filtering
query language. When the filter is present, it will filter for topics
where `Topic#pinned_until` is greater than `Topic#pinned_at`.