### PR TITLE
FIX: Correctly pre-select first option in bookmark notification drop-down

### DIFF
--- a/app/assets/javascripts/discourse/app/components/bookmark.js
+++ b/app/assets/javascripts/discourse/app/components/bookmark.js
@@ -61,7 +61,7 @@ export default Component.extend({
       showOptions: false,
       _itsatrap: new ItsATrap(),
       autoDeletePreference:
-        this.model.autoDeletePreference ||
+        this.model.autoDeletePreference ??
         AUTO_DELETE_PREFERENCES.CLEAR_REMINDER,
     });
 

--- a/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/bookmark-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { render } from "@ember/test-helpers";
 import { query } from "discourse/tests/helpers/qunit-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import I18n from "I18n";
 
 module("Integration | Component | bookmark", function (hooks) {
   setupRenderingTest(hooks);
@@ -21,7 +22,7 @@ module("Integration | Component | bookmark", function (hooks) {
   test("prefills the custom reminder type date and time", async function (assert) {
     let name = "test";
     let reminderAt = "2020-05-15T09:45:00";
-    this.model = { id: 1, name, reminderAt };
+    this.model = { id: 1, autoDeletePreference: 0, name, reminderAt };
 
     await render(hbs`
       <Bookmark
@@ -40,5 +41,9 @@ module("Integration | Component | bookmark", function (hooks) {
       "2020-05-15"
     );
     assert.strictEqual(query("#custom-time").value, "09:45");
+    assert.strictEqual(
+      query(".selected-name > .name").innerHTML.trim(),
+      I18n.t("bookmarks.auto_delete_preference.never")
+    );
   });
 });


### PR DESCRIPTION
### What is the issue?

When selecting the "Keep bookmark" in the user preference for what to do after a bookmark reminder is sent, it does not propagate to the drop-down in the "Create bookmark" modal. Instead it defaults to "Keep bookmark and clear reminder". 

<img width="315" alt="Screenshot 2023-04-05 at 2 34 45 PM" src="https://user-images.githubusercontent.com/5259935/229999953-e936ed4a-be8b-4df4-8547-6bd6e1cacd8e.png">

All other options work fine.

### What was causing this?

On these lines, we set a default ("Keep bookmark and clear reminder") if no user preference is found:

https://github.com/discourse/discourse/blob/80ec85387733973a847aa1e8b96cfa1bd5ee4ae5/app/assets/javascripts/discourse/app/components/bookmark.js#L63-L65

However, this uses the index of the option, and the index of the first option ("Keep bookmark") is 0, which is treated as falsey in JavaScript, thus causing the default to be selected.

### How does this fix it?

Switch from logical or conditional `||` operator to nullish coalescing `??` operator.

#### Is this well supported?

[Yes](https://caniuse.com/?search=nullish%20coalescing).