### PR TITLE
PERF: Use `OpenSSL::KDF` for Pbkdf2 implementation

### DIFF
--- a/lib/pbkdf2.rb
+++ b/lib/pbkdf2.rb
@@ -1,28 +1,13 @@
 # frozen_string_literal: true
 
-# Note: This logic was originally extracted from the Pbkdf2 gem to fix Ruby 2.0
-# issues, but that gem has gone stale so we won't be returning to it.
-
-require "openssl"
-require "xorcist"
-
 class Pbkdf2
-  def self.hash_password(password, salt, iterations, algorithm = "sha256")
-    h = OpenSSL::Digest.new(algorithm)
-
-    u = ret = prf(h, password, salt + [1].pack("N"))
-
-    2.upto(iterations) do
-      u = prf(h, password, u)
-      Xorcist.xor!(ret, u)
-    end
-
-    ret.bytes.map { |b| ("0" + b.to_s(16))[-2..-1] }.join("")
-  end
-
-  protected
-
-  def self.prf(hash_function, password, data)
-    OpenSSL::HMAC.digest(hash_function, password, data)
+  def self.hash_password(password, salt, iterations, algorithm = "sha256", length: 32)
+    OpenSSL::KDF.pbkdf2_hmac(
+      password,
+      salt: salt,
+      iterations: iterations,
+      length: length,
+      hash: algorithm,
+    ).unpack1("H*")
   end
 end


### PR DESCRIPTION
This was introduced to the standard library in Ruby 2.4. In my testing, it produces the same result, and is around 8x faster than our pure-ruby implementation

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
