### PR TITLE
UX: Do not show bootstrap mode button on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -5,8 +5,7 @@ createWidget("header-contents", {
   tagName: "div.contents.clearfix",
   transform() {
     return {
-      showBootstrapMode:
-        this.get("currentUser.staff") && this.get("site.desktopView"),
+      showBootstrapMode: this.currentUser?.staff && this.site.desktopView,
     };
   },
   template: hbs`

--- a/app/assets/javascripts/discourse/app/widgets/header-contents.js
+++ b/app/assets/javascripts/discourse/app/widgets/header-contents.js
@@ -5,7 +5,8 @@ createWidget("header-contents", {
   tagName: "div.contents.clearfix",
   transform() {
     return {
-      staff: this.get("currentUser.staff"),
+      showBootstrapMode:
+        this.get("currentUser.staff") && this.get("site.desktopView"),
     };
   },
   template: hbs`
@@ -20,7 +21,7 @@ createWidget("header-contents", {
     {{#if attrs.topic}}
       {{header-topic-info attrs=attrs}}
     {{else if this.siteSettings.bootstrap_mode_enabled}}
-      {{#if transformed.staff}}
+      {{#if transformed.showBootstrapMode}}
         {{header-bootstrap-mode attrs=attrs}}
       {{/if}}
     {{/if}}


### PR DESCRIPTION
It took too much place in the header.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
