### PR TITLE
FIX: accounts for `hide_profile_and_presence` core user option

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -17,14 +17,17 @@ const CHAT_ONLINE_OPTIONS = {
 
 export default class Chat extends Service {
   @service appEvents;
+  @service currentUser;
   @service chatNotificationManager;
   @service chatSubscriptionsManager;
   @service chatStateManager;
   @service presence;
   @service router;
   @service site;
+
   @service chatChannelsManager;
   @tracked activeChannel = null;
+
   cook = null;
   presenceChannel = null;
   sidebarActive = false;
@@ -111,6 +114,10 @@ export default class Chat extends Service {
   updatePresence() {
     next(() => {
       if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+
+      if (this.currentUser.user_option?.hide_profile_and_presence) {
         return;
       }
 

--- a/plugins/chat/spec/system/user_presence.rb
+++ b/plugins/chat/spec/system/user_presence.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe "User presence", type: :system, js: true do
+  fab!(:channel_1) { Fabricate(:chat_channel) }
+  fab!(:current_user) { Fabricate(:user) }
+
+  let(:channel) { PageObjects::Pages::ChatChannel.new }
+
+  before do
+    chat_system_bootstrap
+    channel_1.add(current_user)
+  end
+
+  it "shows presence indicator" do
+    sign_in(current_user)
+    chat.visit_channel(channel_1)
+    channel.send_message("Am I present?")
+
+    expect(page).to have_selector(".chat-user-avatar.is-online")
+  end
+
+  context "when user hides presence" do
+    it "hides the presence indicator" do
+      current_user.user_option.update!(hide_profile_and_presence: true)
+      sign_in(current_user)
+      chat.visit_channel(channel_1)
+      channel.send_message("Am I present?")
+
+      expect(page).to have_no_selector(".chat-user-avatar.is-online")
+    end
+  end
+end


### PR DESCRIPTION
Chat will now correctly use this core setting and will not show the presence of the user in this case.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
