### PR TITLE
DEV: Support `in:bookmarked` filter for the `/filter` route

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -93,6 +93,13 @@ class TopicsFilter
         "topics.pinned_at IS NOT NULL AND topics.pinned_until > topics.pinned_at AND ? < topics.pinned_until",
         Time.zone.now,
       )
+    when "bookmarked"
+      return @scope.none unless @guardian.user
+
+      @scope.joins(:topic_users).where(
+        "topic_users.bookmarked AND topic_users.user_id = ?",
+        @guardian.user.id,
+      )
     else
       @scope
     end

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -56,6 +56,40 @@ RSpec.describe TopicsFilter do
           end
         end
       end
+
+      describe "when query string is `in:bookmarked`" do
+        fab!(:bookmark) do
+          BookmarkManager.new(user).create_for(
+            bookmarkable_id: topic.id,
+            bookmarkable_type: "Topic",
+          )
+        end
+
+        fab!(:bookmark2) do
+          BookmarkManager.new(admin).create_for(
+            bookmarkable_id: topic.id,
+            bookmarkable_type: "Topic",
+          )
+        end
+
+        it "should not return any topics when user is anonymous" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("in:bookmarked")
+              .pluck(:id),
+          ).to eq([])
+        end
+
+        it "should return topics that are bookmarked" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new(user))
+              .filter_from_query_string("in:bookmarked")
+              .pluck(:id),
+          ).to contain_exactly(topic.id)
+        end
+      end
     end
 
     describe "when filtering by categories" do


### PR DESCRIPTION
This filters the topics list to the topics that the current user has bookmarks in.