### PR TITLE
FEATURE: Add new don't feed the trolls feature

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -550,10 +550,14 @@ class Post < ActiveRecord::Base
   end
 
   def is_flagged?
+    flags.count != 0
+  end
+
+  def flags
     post_actions.where(
       post_action_type_id: PostActionType.flag_types_without_custom.values,
       deleted_at: nil,
-    ).count != 0
+    )
   end
 
   def reviewable_flag

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -555,6 +555,8 @@ en:
 
     get_a_room: You’ve replied to @%{reply_username} %{count} times, did you know you could send them a personal message instead?
 
+    dont_feed_the_trolls: This post has already been flagged for moderator attention. Are you sure you wish to reply to it? Replies to negative content tend to encourage more negative behavior.
+
     too_many_replies: |
       ### You have reached the reply limit for this topic
 
@@ -2178,6 +2180,8 @@ en:
     sequential_replies_threshold: "Number of posts a user has to make in a row in a topic before being reminded about too many sequential replies."
 
     get_a_room_threshold: "Number of posts a user has to make to the same person in the same topic before being warned."
+
+    dont_feed_the_trolls_threshold: "Number of flags from other users before being warned."
 
     enable_mobile_theme: "Mobile devices use a mobile-friendly theme, with the ability to switch to the full site. Disable this if you want to use a custom stylesheet that is fully responsive."
 

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2390,6 +2390,7 @@ uncategorized:
   educate_until_posts: 2
   sequential_replies_threshold: 2
   get_a_room_threshold: 3
+  dont_feed_the_trolls_threshold: 2
   dominating_topic_minimum_percent: 40
   disable_avatar_education_message: false
   pm_warn_user_last_seen_months_ago: 24

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -334,10 +334,11 @@ RSpec.describe ComposerMessagesFinder do
     fab!(:other_user) { Fabricate(:user) }
     fab!(:third_user) { Fabricate(:user) }
     fab!(:topic) { Fabricate(:topic, user: author) }
-    fab!(:unflagged_post) { Fabricate(:post, topic_id: topic.id, user: author) }
-    fab!(:self_flagged_post) { Fabricate(:post, topic_id: topic.id, user: author) }
-    fab!(:under_flagged_post) { Fabricate(:post, topic_id: topic.id, user: author) }
-    fab!(:over_flagged_post) { Fabricate(:post, topic_id: topic.id, user: author) }
+    fab!(:original_post) { Fabricate(:post, topic: topic, user: author) }
+    fab!(:unflagged_post) { Fabricate(:post, topic: topic, user: author) }
+    fab!(:self_flagged_post) { Fabricate(:post, topic: topic, user: author) }
+    fab!(:under_flagged_post) { Fabricate(:post, topic: topic, user: author) }
+    fab!(:over_flagged_post) { Fabricate(:post, topic: topic, user: author) }
 
     before { SiteSetting.dont_feed_the_trolls_threshold = 2 }
 
@@ -361,6 +362,12 @@ RSpec.describe ComposerMessagesFinder do
           topic_id: topic.id,
           post_id: self_flagged_post.id,
         )
+      expect(finder.check_dont_feed_the_trolls).to be_present
+    end
+
+    it "shows a message when replying to flagged topic (first post)" do
+      Fabricate(:flag, post: original_post, user: user)
+      finder = ComposerMessagesFinder.new(user, composer_action: "reply", topic_id: topic.id)
       expect(finder.check_dont_feed_the_trolls).to be_present
     end
 

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -328,6 +328,68 @@ RSpec.describe ComposerMessagesFinder do
     end
   end
 
+  describe ".dont_feed_the_trolls" do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:author) { Fabricate(:user) }
+    fab!(:other_user) { Fabricate(:user) }
+    fab!(:third_user) { Fabricate(:user) }
+    fab!(:topic) { Fabricate(:topic, user: author) }
+    fab!(:unflagged_post) { Fabricate(:post, topic_id: topic.id, user: author) }
+    fab!(:self_flagged_post) { Fabricate(:post, topic_id: topic.id, user: author) }
+    fab!(:under_flagged_post) { Fabricate(:post, topic_id: topic.id, user: author) }
+    fab!(:over_flagged_post) { Fabricate(:post, topic_id: topic.id, user: author) }
+
+    before { SiteSetting.dont_feed_the_trolls_threshold = 2 }
+
+    it "does not show a message for unflagged posts" do
+      finder =
+        ComposerMessagesFinder.new(
+          user,
+          composer_action: "reply",
+          topic_id: topic.id,
+          post_id: unflagged_post.id,
+        )
+      expect(finder.check_dont_feed_the_trolls).to be_blank
+    end
+
+    it "shows a message when the replier has already flagged the post" do
+      Fabricate(:flag, post: self_flagged_post, user: user)
+      finder =
+        ComposerMessagesFinder.new(
+          user,
+          composer_action: "reply",
+          topic_id: topic.id,
+          post_id: self_flagged_post.id,
+        )
+      expect(finder.check_dont_feed_the_trolls).to be_present
+    end
+
+    it "does not show a message when not enough others have flagged the post" do
+      Fabricate(:flag, post: under_flagged_post, user: other_user)
+      finder =
+        ComposerMessagesFinder.new(
+          user,
+          composer_action: "reply",
+          topic_id: topic.id,
+          post_id: under_flagged_post.id,
+        )
+      expect(finder.check_dont_feed_the_trolls).to be_blank
+    end
+
+    it "shows a message when enough others have already flagged the post" do
+      Fabricate(:flag, post: over_flagged_post, user: other_user)
+      Fabricate(:flag, post: over_flagged_post, user: third_user)
+      finder =
+        ComposerMessagesFinder.new(
+          user,
+          composer_action: "reply",
+          topic_id: topic.id,
+          post_id: over_flagged_post.id,
+        )
+      expect(finder.check_dont_feed_the_trolls).to be_present
+    end
+  end
+
   describe ".check_get_a_room" do
     fab!(:user) { Fabricate(:user) }
     fab!(:other_user) { Fabricate(:user) }

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe ComposerMessagesFinder do
     end
   end
 
-  describe ".dont_feed_the_trolls" do
+  describe "#dont_feed_the_trolls" do
     fab!(:user) { Fabricate(:user) }
     fab!(:author) { Fabricate(:user) }
     fab!(:other_user) { Fabricate(:user) }

--- a/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
+++ b/spec/system/composer/dont_feed_the_trolls_popup_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe "Composer don't feed the trolls popup", type: :system, js: true do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:troll) { Fabricate(:user) }
+  fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:post) { Fabricate(:post, user: user, topic: topic) }
+  fab!(:reply) { Fabricate(:post, user: troll, topic: topic) }
+  fab!(:flag) { Fabricate(:flag, post: reply, user: user) }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+
+  before { sign_in user }
+
+  it "shows a popup when about to reply to a troll" do
+    SiteSetting.educate_until_posts = 0
+
+    topic_page.visit_topic(topic)
+    topic_page.click_post_action_button(reply, :reply)
+
+    expect(topic_page).to have_composer_popup_content(I18n.t("education.dont_feed_the_trolls"))
+  end
+end

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -43,6 +43,10 @@ module PageObjects
         composer_input.value == content
       end
 
+      def has_popup_content?(content)
+        composer_popup.has_content?(content)
+      end
+
       def select_action(action)
         find(action(action)).click
         self
@@ -82,6 +86,10 @@ module PageObjects
 
       def composer_input
         find("#{COMPOSER_ID} .d-editor .d-editor-input")
+      end
+
+      def composer_popup
+        find("#{COMPOSER_ID} .composer-popup")
       end
     end
   end

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -71,6 +71,8 @@ module PageObjects
         case button
         when :bookmark
           post_by_number(post).find(".bookmark.with-reminder").click
+        when :reply
+          post_by_number(post).find(".post-controls .reply").click
         end
       end
 
@@ -109,6 +111,10 @@ module PageObjects
 
       def has_composer_content?(content)
         @composer_component.has_content?(content)
+      end
+
+      def has_composer_popup_content?(content)
+        @composer_component.has_popup_content?(content)
       end
 
       def send_reply


### PR DESCRIPTION
### What is this feature?

Responding to negative behaviour tends to solicit more of the same. Common wisdom states: "don't feed the trolls".

This change codifies that advice by introducing a new nudge when hitting the reply button on a flagged post. It will be shown if either the current user, or two other users (configurable via a site setting) have flagged the post.

It looks like this:

<img width="1003" alt="Screenshot 2023-04-10 at 10 49 08 AM" src="https://user-images.githubusercontent.com/5259935/230815616-836aaa01-a66a-4755-9aad-1d323f1c7e35.png">

### How does this affect performance?

We use a single query to check the flags. It is triggered once when hitting the reply button on a post and looks like this:

```sql
SELECT
  COUNT(*) AS "count_all",
  "post_actions"."user_id" AS "post_actions_user_id"
FROM
  "post_actions"
WHERE
  "post_actions"."post_id" = :post_id AND
  "post_actions"."post_action_type_id" IN (3, 4, 8) AND
  "post_actions"."deleted_at" IS NULL
GROUP BY
  "post_actions"."user_id"
```

and the query analyzer output:

```
GroupAggregate  (cost=8.41..8.43 rows=1 width=12) (actual time=0.025..0.025 rows=0 loops=1)
Group Key: user_id
->  Sort  (cost=8.41..8.42 rows=1 width=4) (actual time=0.024..0.024 rows=0 loops=1)
    Sort Key: user_id
    Sort Method: quicksort  Memory: 25kB
    ->  Index Scan using index_post_actions_on_post_id on post_actions  (cost=0.28..8.40 rows=1 width=4) (actual time=0.019..0.019 rows=0 loops=1)
        Index Cond: (post_id = 301)
        Filter: ((deleted_at IS NULL) AND (deleted_at IS NULL) AND (post_action_type_id = ANY ('{3,4,8}'::integer[])))"
        Rows Removed by Filter: 6
Planning Time: 0.209 ms
Execution Time: 0.055 ms
```

We are carried by the post id index on post actions here, which should be sufficient, since any one post will not have a significant number of actions.