### PR TITLE
UX: fix anchor z-index

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -107,6 +107,7 @@
         margin-left: -20px;
         padding-right: 4px;
         position: absolute;
+        z-index: 2;
       }
     }
 


### PR DESCRIPTION
Anchors clickable area is hidden behind floating avatars.

Here's a video that demonstrates the effect, with added borders for the purpose of showing the issue better:

https://user-images.githubusercontent.com/5654300/230346621-86c3acc5-b684-4902-8f57-33f41d8f107e.mp4

I set a z-index of 2 on the anchor icon. It's the same value as the floating avatar and will make the anchor icon kept in front of it since it's deeper in the DOM.
