### PR TITLE
UX: Add show password on mobile login modal

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
@@ -42,7 +42,7 @@
             <Input
               @value={{this.loginPassword}}
               class={{value-entered this.loginPassword}}
-              @type="password"
+              @type={{if this.maskPassword "password" "text"}}
               id="login-account-password"
               maxlength="200"
               disabled={{this.showSecondFactor}}
@@ -50,11 +50,18 @@
             <label class="alt-placeholder" for="login-account-password">{{i18n
                 "login.password"
               }}</label>
-            <a
-              href
-              id="forgot-password-link"
-              {{on "click" this.handleForgotPassword}}
-            >{{i18n "forgot_password.action"}}</a>
+            <div class="login__password-links">
+              <a
+                href
+                id="forgot-password-link"
+                {{on "click" this.handleForgotPassword}}
+              >{{i18n "forgot_password.action"}}</a>
+              <TogglePasswordMask
+                @maskPassword={{this.maskPassword}}
+                @togglePasswordMask={{this.togglePasswordMask}}
+                tabindex="3"
+              />
+            </div>
           </div>
         </div>
         <SecondFactorForm

--- a/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/modal/login.hbs
@@ -59,7 +59,6 @@
               <TogglePasswordMask
                 @maskPassword={{this.maskPassword}}
                 @togglePasswordMask={{this.togglePasswordMask}}
-                tabindex="3"
               />
             </div>
           </div>


### PR DESCRIPTION
As requested here; https://meta.discourse.org/t/show-password-optional/74414/21?u=canapin

With the toggle added on mobile:
![toggle off](https://user-images.githubusercontent.com/5654300/230380413-01c4a173-dbac-4c2f-9ff4-31d735966beb.png) 
![toggle on](https://user-images.githubusercontent.com/5654300/230380428-d8b0e262-7c22-42ee-b5cb-c0fe8e609663.png)

