### PR TITLE
FIX: correct backdrop on mobile for the emoji picker

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-emoji-picker.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-emoji-picker.scss
@@ -18,8 +18,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      background: var(--primary);
-      opacity: 0.8;
+      background: rgba(var(--always-black-rgb), 0.75);
       z-index: z("header") + 1;
     }
   }


### PR DESCRIPTION
Before:

![Screenshot 2023-04-06 at 15 46 27](https://user-images.githubusercontent.com/339945/230397994-4ddc2548-441e-4c80-be8e-0637dad6b3a6.png)


After:
![Screenshot 2023-04-06 at 15 48 34](https://user-images.githubusercontent.com/339945/230398048-49a55941-2ee3-4031-9ab8-eb4f33a1fb65.png)
![Screenshot 2023-04-06 at 15 48 12](https://user-images.githubusercontent.com/339945/230398054-b361a384-3b90-4653-920a-fb40a00baef1.png)

