### PR TITLE
FIX: do not display the message content when it errors

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -764,7 +764,7 @@ export default class ChatLivePane extends Component {
 
     const stagedMessage = ChatMessage.createStagedMessage(this.args.channel, {
       message,
-      created_at: new Date(),
+      created_at: moment.utc().format(),
       uploads: cloneJSON(uploads),
       user: this.currentUser,
     });
@@ -790,6 +790,7 @@ export default class ChatLivePane extends Component {
       })
       .catch((error) => {
         this._onSendError(stagedMessage.id, error);
+        this.scrollToBottom();
       })
       .finally(() => {
         if (this._selfDeleted) {
@@ -827,6 +828,9 @@ export default class ChatLivePane extends Component {
       this.args.channel.messagesManager.findStagedMessage(id);
     if (stagedMessage) {
       if (error.jqXHR?.responseJSON?.errors?.length) {
+        // only network errors are retryable
+        stagedMessage.message = "";
+        stagedMessage.cooked = "";
         stagedMessage.error = error.jqXHR.responseJSON.errors[0];
       } else {
         this.chat.markNetworkAsUnreliable();

--- a/plugins/chat/spec/system/message_errors_spec.rb
+++ b/plugins/chat/spec/system/message_errors_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "Message errors", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:admin) }
+  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:channel_page) { PageObjects::Pages::ChatChannel.new }
+  let(:max_length) { SiteSetting.chat_maximum_message_length }
+
+  before { chat_system_bootstrap }
+
+  context "when message is too long" do
+    fab!(:channel) { Fabricate(:chat_channel) }
+
+    it "only shows the error, not the message" do
+      channel.add(current_user)
+      sign_in(current_user)
+      chat_page.visit_channel(channel)
+
+      channel_page.send_message("atoolongmessage" + "a" * max_length)
+
+      expect(page).to have_no_content("atoolongmessage")
+      expect(page).to have_content(I18n.t("chat.errors.message_too_long", count: max_length))
+    end
+  end
+end


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
