### PR TITLE
UX: remove an unneeded margin after emojis in the notifications menu

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -511,7 +511,6 @@
         height: 1em;
         width: 1em;
         padding-top: 0.2em;
-        margin-right: 0.5em;
       }
     }
     .is-warning {


### PR DESCRIPTION
A `margin-right` applied specifically on emojis in the notifications menu seems to serve no purpose and *might* be remain of older versions of the user menu 🤔 

Actual topic's title:
![image](https://user-images.githubusercontent.com/5654300/230495629-04d3289a-afe0-41d3-81c0-f72364235bab.png)

In the notifications menu:
![image](https://user-images.githubusercontent.com/5654300/230495602-7c08ba02-16d2-41d8-a010-e5d03493540f.png)
