### PR TITLE
FIX: scroll when clicking first emoji of section

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-emoji-picker.js
@@ -390,7 +390,7 @@ export default class ChatEmojiPicker extends Component {
         .scrollIntoView({
           behavior: "auto",
           block: "start",
-          inline: "nearest",
+          inline: "start",
         });
 
       later(() => {


### PR DESCRIPTION
This scroll on the body of the page was closing the picker and preventing the reaction.

This bug was also happening when tabbing through sections

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
