### PR TITLE
UX: improve composer control spacing on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/composer.hbs
+++ b/app/assets/javascripts/discourse/app/templates/composer.hbs
@@ -272,45 +272,6 @@
               {{/if}}
             {{/if}}
 
-            {{#if (or this.isUploading this.isProcessingUpload)}}
-              <div id="file-uploading">
-                {{#if this.isProcessingUpload}}
-                  {{loading-spinner size="small"}}<span>{{i18n
-                      "upload_selector.processing"
-                    }}</span>
-                {{else}}
-                  {{loading-spinner size="small"}}<span>{{i18n
-                      "upload_selector.uploading"
-                    }}
-                    {{this.uploadProgress}}%</span>
-                {{/if}}
-
-                {{#if this.isCancellable}}
-                  <a
-                    href
-                    id="cancel-file-upload"
-                    {{on "click" this.cancelUpload}}
-                  >{{d-icon "times"}}</a>
-                {{/if}}
-              </div>
-            {{/if}}
-
-            <div class={{if this.isUploading "hidden"}} id="draft-status">
-              {{#if this.model.draftStatus}}
-                <span class="draft-error" title={{this.model.draftStatus}}>
-                  {{#if this.model.draftConflictUser}}
-                    {{avatar this.model.draftConflictUser imageSize="small"}}
-                    {{d-icon "user-edit"}}
-                  {{else}}
-                    {{d-icon "exclamation-triangle"}}
-                  {{/if}}
-                  {{#unless this.site.mobileView}}
-                    {{this.model.draftStatus}}
-                  {{/unless}}
-                </span>
-              {{/if}}
-            </div>
-
             <span>
               <PluginOutlet
                 @name="composer-after-save-or-cancel"
@@ -356,7 +317,48 @@
                 @icon="pencil-alt"
               />
             {{/if}}
-          {{else}}
+          {{/if}}
+
+          {{#if (or this.isUploading this.isProcessingUpload)}}
+            <div id="file-uploading">
+              {{#if this.isProcessingUpload}}
+                {{loading-spinner size="small"}}<span>{{i18n
+                    "upload_selector.processing"
+                  }}</span>
+              {{else}}
+                {{loading-spinner size="small"}}<span>{{i18n
+                    "upload_selector.uploading"
+                  }}
+                  {{this.uploadProgress}}%</span>
+              {{/if}}
+
+              {{#if this.isCancellable}}
+                <a
+                  href
+                  id="cancel-file-upload"
+                  {{on "click" this.cancelUpload}}
+                >{{d-icon "times"}}</a>
+              {{/if}}
+            </div>
+          {{/if}}
+
+          <div class={{if this.isUploading "hidden"}} id="draft-status">
+            {{#if this.model.draftStatus}}
+              <span class="draft-error" title={{this.model.draftStatus}}>
+                {{#if this.model.draftConflictUser}}
+                  {{avatar this.model.draftConflictUser imageSize="small"}}
+                  {{d-icon "user-edit"}}
+                {{else}}
+                  {{d-icon "exclamation-triangle"}}
+                {{/if}}
+                {{#unless this.site.mobileView}}
+                  {{this.model.draftStatus}}
+                {{/unless}}
+              </span>
+            {{/if}}
+          </div>
+
+          {{#unless this.site.mobileView}}
             <DButton
               @action={{action "togglePreview"}}
               @translatedTitle={{this.toggleText}}
@@ -366,7 +368,7 @@
                 (unless this.showPreview "active")
               }}
             />
-          {{/if}}
+          {{/unless}}
         </div>
       </div>
     {{else}}

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -337,7 +337,8 @@ html.composer-open {
   .save-or-cancel {
     align-items: center;
     display: flex;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
+    margin-right: 1em;
 
     .btn-primary {
       flex: 0 0 auto;
@@ -357,32 +358,30 @@ html.composer-open {
         color: var(--danger);
       }
     }
-
-    #draft-status,
-    #file-uploading {
-      margin-left: 25px;
-    }
-    #file-uploading {
-      display: flex;
-      align-items: center;
-      a {
-        margin-left: 5px;
-        color: var(--primary-high);
-      }
-      .spinner {
-        margin-right: 5px;
-      }
-    }
-    #draft-status .d-icon-user-edit {
-      color: var(--danger);
-      font-size: 20px;
-      vertical-align: -5.5px;
-    }
   }
 
   #draft-status,
   #file-uploading {
     color: var(--primary-high);
+    margin-right: 0.5em;
+  }
+
+  #file-uploading {
+    display: flex;
+    align-items: center;
+    a {
+      margin-left: 0.33em;
+      color: var(--primary-high);
+    }
+    .spinner {
+      margin-right: 0.33em;
+    }
+  }
+
+  #draft-status .d-icon-user-edit {
+    color: var(--danger);
+    font-size: 20px;
+    vertical-align: -5.5px;
   }
 
   #file-uploader {
@@ -595,7 +594,7 @@ body:not(.ios-safari-composer-hacks) {
 }
 
 .toggle-preview {
-  margin-left: 8px;
+  margin-left: auto;
   transition: all 0.33s ease-out;
 
   &.active {

--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -378,10 +378,16 @@ html.composer-open {
     }
   }
 
-  #draft-status .d-icon-user-edit {
-    color: var(--danger);
-    font-size: 20px;
-    vertical-align: -5.5px;
+  #draft-status {
+    margin-left: auto;
+    .d-icon-user-edit {
+      color: var(--danger);
+      font-size: 20px;
+      vertical-align: -5.5px;
+    }
+    + .btn-mini-toggle {
+      margin-left: 0;
+    }
   }
 
   #file-uploader {

--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -226,7 +226,6 @@ a.toggle-preview {
 
 #draft-status,
 #file-uploading {
-  flex-grow: 1;
   text-align: right;
 }
 

--- a/app/assets/stylesheets/mobile/compose.scss
+++ b/app/assets/stylesheets/mobile/compose.scss
@@ -101,8 +101,18 @@
 
   .submit-panel {
     margin-top: 6px;
+    flex-wrap: wrap;
+    gap: 0.25em 0;
+
+    .create {
+      max-width: 50vw;
+      span {
+        @include ellipsis;
+      }
+    }
 
     .save-or-cancel {
+      margin-right: 0.5em;
       flex: 1 1 auto;
 
       #draft-status,


### PR DESCRIPTION
Mobile composer controls and messaging can get in a fairly bad state if button text gets too long.

For example, overlapping:

![Screenshot 2023-04-07 at 12 05 34 PM](https://user-images.githubusercontent.com/1681963/230642315-498bca36-70e3-49bb-aaf4-7d822605ac56.png)

or when uploading: 

![Screenshot 2023-04-07 at 12 05 10 PM](https://user-images.githubusercontent.com/1681963/230642422-34430983-5b14-4662-a920-045fd0438ea7.png)

This PR restricts the maximum with of the submit button on mobile, and truncates the text otherwise. It also moves some elements like the uploading and draft status in the template, so in worst case situations they can wrap without changing the position of other buttons

![Screenshot 2023-04-07 at 1 08 45 PM](https://user-images.githubusercontent.com/1681963/230649086-36ea30c8-6c05-4bf5-8192-ac4d4e6f1dbf.png)


![Screenshot 2023-04-07 at 12 14 57 PM](https://user-images.githubusercontent.com/1681963/230642647-f57ab0ce-9110-4593-811b-6999226b91a0.png)




