### PR TITLE
UX: truncate admin theme tab text to avoid overflow

### DIFF
--- a/app/assets/stylesheets/common/admin/customize.scss
+++ b/app/assets/stylesheets/common/admin/customize.scss
@@ -196,6 +196,10 @@
         }
       }
     }
+
+    .d-button-label {
+      @include ellipsis;
+    }
   }
 
   .themes-list-container {


### PR DESCRIPTION
Minor fix to avoid this overflow issue:

![Screenshot 2023-04-07 at 1 27 06 PM](https://user-images.githubusercontent.com/1681963/230651390-390b4a23-01fc-40a6-98b4-34834cc184b4.png)

After:

![Screenshot 2023-04-07 at 1 25 52 PM](https://user-images.githubusercontent.com/1681963/230651401-157a9fbc-6f6a-4454-b131-039c982ee5e7.png)
