### PR TITLE
UX: remove extra space from emoji in notifications

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -216,6 +216,12 @@
         margin: 0;
         padding: 0 0.5em;
       }
+      img.emoji {
+        height: 1em;
+        width: 1em;
+        padding-top: 0.2em;
+        margin-right: 0.5em;
+      }
       .d-icon {
         padding-top: 0;
       }
@@ -503,13 +509,6 @@
       align-self: flex-start;
       width: 100%;
       .d-icon {
-        padding-top: 0.2em;
-        margin-right: 0.5em;
-      }
-
-      img.emoji {
-        height: 1em;
-        width: 1em;
         padding-top: 0.2em;
         margin-right: 0.5em;
       }


### PR DESCRIPTION
This removes an errant space after emoji in notifications

![image](https://user-images.githubusercontent.com/1681963/230653527-e556513c-a846-49dc-b4b9-df9aeed36984.png)

This was intended to only impact user statuses in the user portion of the menu. 

I've relocated this emoji style so it only applies in the more limited scope:

Spaced:
![Screenshot 2023-04-07 at 1 42 40 PM](https://user-images.githubusercontent.com/1681963/230653627-f4e1d2bd-c42b-414b-9aea-71d2b586f41e.png)

Not spaced:
![Screenshot 2023-04-07 at 1 42 43 PM](https://user-images.githubusercontent.com/1681963/230653631-644267c1-2d58-4320-b31e-9f66ab7ba1c4.png)
