### PR TITLE
A11Y: increase contrast of elements in wcag scheme

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -147,6 +147,10 @@ html {
     color: var(--primary-high);
   }
 
+  .topic-list .posters a:first-child .avatar.latest:not(.single) {
+    box-shadow: 0 0 0 2px var(--tertiary);
+  }
+
   // Posts
 
   .discourse-no-touch .topic-body .actions .fade-out {
@@ -301,4 +305,24 @@ html {
   .d-editor-preview mark {
     background-color: yellow; // resets to browser default
   }
+}
+
+// chat
+
+.no-touch
+  .chat-messages-container
+  .chat-message:hover
+  .chat-message-react-btn:hover {
+  .d-icon {
+    color: var(--primary) !important;
+  }
+}
+
+// sidebar
+
+.sidebar-wrapper
+  .sidebar-sections
+  .sidebar-section-link-suffix.icon.unread
+  svg {
+  color: var(--tertiary);
 }


### PR DESCRIPTION
This improves the contrast of a few elements:

* The unread circle in the sidebar
  ![Screenshot 2023-04-07 at 2 04 12 PM](https://user-images.githubusercontent.com/1681963/230656330-6ef6491a-02c5-44e8-988b-c93130b2a9a0.png)

* The chat emoji button on hover
   ![Screenshot 2023-04-07 at 2 04 23 PM](https://user-images.githubusercontent.com/1681963/230656340-6f8340fd-acae-4fcd-bea5-3a0d2b52faf4.png)

* The "latest poster" avatar ring highlight 

  ![Screenshot 2023-04-07 at 1 53 27 PM](https://user-images.githubusercontent.com/1681963/230656320-26e11be4-513d-4ddc-b489-4e71fbf45440.png)
