### PR TITLE
FIX: shows a message as hovered when hovering actions

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -64,6 +64,7 @@
           (if this.hideUserInfo "user-info-hidden")
           (if @message.error "errored")
           (if @message.bookmark "chat-message-bookmarked")
+          (if (eq @message.id this.chat.activeMessage.model.id) "is-active")
         }}
       >
         {{#unless this.hideReplyToInfo}}

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -207,6 +207,7 @@
     }
 
     .no-touch & {
+      &.is-active,
       &:hover,
       &:active {
         background: var(--primary-very-low);
@@ -219,6 +220,7 @@
       }
 
       &.chat-message-bookmarked {
+        &.is-active,
         &:hover {
           background: var(--highlight-medium);
         }

--- a/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
+++ b/plugins/chat/assets/stylesheets/desktop/base-desktop.scss
@@ -90,16 +90,6 @@
     .chat-live-pane {
       border-radius: unset;
     }
-
-    .chat-live-pane,
-    .chat-messages-scroll,
-    .chat-message:not(.highlighted):not(.deleted):not(.chat-message-bookmarked) {
-      background-color: transparent;
-    }
-
-    .chat-message:not(.highlighted):not(.deleted):not(.chat-message-bookmarked):hover {
-      background-color: var(--primary-very-low);
-    }
   }
 
   @media screen and (max-width: var(--max-chat-width)) {
@@ -126,18 +116,8 @@
       border-radius: 0;
     }
 
-    .chat-live-pane,
-    .chat-messages-scroll,
-    .chat-message:not(.highlighted):not(.deleted):not(.chat-message-bookmarked) {
-      background: transparent;
-    }
-
     .chat-message {
       padding-left: 1em;
-
-      &:hover {
-        background-color: var(--primary-very-low);
-      }
     }
 
     .chat-messages-container .chat-message-deleted {

--- a/plugins/chat/spec/system/chat_message_spec.rb
+++ b/plugins/chat/spec/system/chat_message_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe "Chat message", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:user) }
+  fab!(:channel_1) { Fabricate(:chat_channel) }
+  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+
+  let(:chat) { PageObjects::Pages::Chat.new }
+  let(:channel) { PageObjects::Pages::ChatChannel.new }
+
+  before { chat_system_bootstrap }
+
+  context "when hovering a message" do
+    before do
+      channel_1.add(current_user)
+      sign_in(current_user)
+    end
+
+    it "adds an active class" do
+      chat.visit_channel(channel_1)
+      channel.hover_message(message_1)
+
+      expect(page).to have_css("[data-id='#{message_1.id}'] .chat-message.is-active")
+    end
+  end
+end


### PR DESCRIPTION
When hovering the chat message actions we are technically not hovering the message anymore, which was removing the background and is slightly unexpected. This commit ensures we keep this background until closing the message actions.

This commit also removes a bunch of CSS which shouldn't be needed anymore.

This is the result we will now have (in this screenshot the mouse is on the message actions and not directly the message):
![Screenshot 2023-04-07 at 20 06 21](https://user-images.githubusercontent.com/339945/230656812-dd838728-bb17-46af-9707-744822f75ff6.png)

Instead of the current situation:
![Screenshot 2023-04-07 at 20 11 17](https://user-images.githubusercontent.com/339945/230657063-784898f8-ce6a-4228-8db9-aabad1865e30.png)
