### PR TITLE
FIX: ensures message actions are bounded

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.hbs
@@ -24,7 +24,7 @@
   <ChatMentionWarnings />
 
   <div
-    class="chat-messages-scroll chat-messages-container"
+    class="chat-messages-scroll chat-messages-container popper-viewport"
     {{on "scroll" this.computeScrollState passive=true}}
     {{chat/on-scroll this.resetIdle (hash delay=500)}}
     {{chat/on-scroll this.computeArrow (hash delay=150)}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -40,22 +40,31 @@ export default class ChatMessageActionsDesktop extends Component {
     this.popper?.destroy();
 
     schedule("afterRender", () => {
-      this.popper = createPopper(
-        chatMessageContainer(this.message.id, this.context),
-        element,
-        {
-          placement: "top-end",
-          strategy: "fixed",
-          modifiers: [
-            { name: "hide", enabled: true },
-            { name: "eventListeners", options: { scroll: false } },
-            {
-              name: "offset",
-              options: { offset: [-2, MSG_ACTIONS_VERTICAL_PADDING] },
-            },
-          ],
-        }
+      const messageContainer = chatMessageContainer(
+        this.message.id,
+        this.context
       );
+
+      this.popper = createPopper(messageContainer, element, {
+        placement: "top-end",
+        strategy: "fixed",
+        modifiers: [
+          {
+            name: "flip",
+            enabled: true,
+            options: {
+              boundary: messageContainer.closest(".popper-viewport"),
+              fallbackPlacements: ["bottom-end"],
+            },
+          },
+          { name: "hide", enabled: true },
+          { name: "eventListeners", options: { scroll: false } },
+          {
+            name: "offset",
+            options: { offset: [-2, MSG_ACTIONS_VERTICAL_PADDING] },
+          },
+        ],
+      });
     });
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
@@ -15,7 +15,10 @@
     </LinkTo>
   </div>
 
-  <div class="chat-thread__body" {{did-insert this.setScrollable}}>
+  <div
+    class="chat-thread__body popper-viewport"
+    {{did-insert this.setScrollable}}
+  >
     <div
       class="chat-thread__messages chat-messages-container"
       {{chat/on-resize this.didResizePane (hash delay=10)}}


### PR DESCRIPTION
Prior to this fix they could show outside of the channel/thread container.

Before:

![Screenshot 2023-04-07 at 20 28 25](https://user-images.githubusercontent.com/339945/230659486-b4905360-297e-4d38-b8ec-b575f868cc84.png)

After:

![Screenshot 2023-04-07 at 20 28 36](https://user-images.githubusercontent.com/339945/230659495-deb09d6d-b0d0-47d0-93f8-7480661cd911.png)


