### PR TITLE
FIX: Make emoji cache store marshalled objects

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -67,10 +67,14 @@ class Emoji
     [[global_emoji_cache, :standard], [site_emoji_cache, :custom]].each do |cache, list_key|
       found_emoji =
         cache.defer_get_set(normalized_name) do
-          Emoji
-            .public_send(list_key)
-            .detect { |e| e.name == normalized_name && (!is_toned || (is_toned && e.tonable)) }
-        end
+          [
+            Emoji
+              .public_send(list_key)
+              .detect { |e| e.name == normalized_name && (!is_toned || (is_toned && e.tonable)) },
+          ]
+        end[
+          0
+        ]
 
       break if found_emoji
     end


### PR DESCRIPTION
We only marshal arrays, hashes and sets, which meant that the emojis here were just getting `to_s`ed.

This is a hack.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
