### PR TITLE
DEV: Support `in:<notification level>` filter on `/filter` route

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -269,10 +269,14 @@ class TopicQuery
   end
 
   def list_filter
-    results =
-      TopicsFilter.new(guardian: @guardian, scope: latest_results).filter_from_query_string(
-        @options[:q],
-      )
+    topics_filter =
+      TopicsFilter.new(guardian: @guardian, scope: latest_results(include_muted: false))
+
+    results = topics_filter.filter_from_query_string(@options[:q])
+
+    if !topics_filter.topic_notification_levels.include?(NotificationLevels.all[:muted])
+      results = remove_muted_topics(results, @user)
+    end
 
     create_list(:filter, {}, results)
   end
@@ -846,7 +850,11 @@ class TopicQuery
   end
 
   def remove_muted(list, user, options)
-    list = remove_muted_topics(list, user) unless options && options[:state] == "muted"
+    if options && (options[:include_muted].nil? || options[:include_muted]) &&
+         options[:state] != "muted"
+      list = remove_muted_topics(list, user)
+    end
+
     list = remove_muted_categories(list, user, exclude: options[:category])
     TopicQuery.remove_muted_tags(list, user, options)
   end


### PR DESCRIPTION
This commit adds support for the `in:<topic notification level>` query
filter. As an example, `in:tracking` will filter for topics that the
user is watching. Filtering for multiple topic notification levels can
be done by comma separating the topic notification level keys. For
example, `in:muted,tracking` or `in:muted,tracking,watching`.
Alternatively, the user can also compose multiple filters with `in:muted
in:tracking` which translates to the same behaviour as
`in:muted,tracking`.