### PR TITLE
FIX: staff_counters should be pluralized strings

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -22,11 +22,15 @@
         {{#if this.showStaffCounters}}
           <div class="staff-counters">
             {{#if this.model.number_of_flags_given}}
-              <div><span
-                  class="helpful-flags"
-                >{{this.model.number_of_flags_given}}</span>{{i18n
-                  "user.staff_counters.flags_given"
-                }}</div>
+              <div>
+                {{html-safe
+                  (i18n
+                    "user.staff_counters.flags_given"
+                    className="helpful-flags"
+                    count=this.model.number_of_flags_given
+                  )
+                }}
+              </div>
             {{/if}}
             {{#if this.model.number_of_flagged_posts}}
               <div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1281,7 +1281,9 @@ en:
       staged: "Staged"
 
       staff_counters:
-        flags_given: "helpful flags"
+        flags_given:
+          one: '<span class="%{className}">%{count}</span> helpful flag'
+          other: '<span class="%{className}">%{count}</span> helpful flags'
         flagged_posts: "flagged posts"
         deleted_posts: "deleted posts"
         suspensions: "suspensions"


### PR DESCRIPTION
Small change to format the staff counter template to apply the correct pluralization for flagged posts/topics.

I don't think we need tests for this small markup/locale modification.

/t/95500