### PR TITLE
FIX: Multiple channels marked active in sidebar

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -9,7 +9,6 @@ import { emojiUnescape } from "discourse/lib/text";
 import { decorateUsername } from "discourse/helpers/decorate-username-selector";
 import { until } from "discourse/lib/formatter";
 import { inject as service } from "@ember/service";
-import { computed } from "@ember/object";
 
 export default {
   name: "chat-sidebar",
@@ -196,7 +195,6 @@ export default {
               return this.channel.slugifiedTitle;
             }
 
-            @computed("chatService.activeChannel")
             get classNames() {
               const classes = [];
 

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -242,11 +242,28 @@ RSpec.describe "Navigation", type: :system, js: true do
     end
 
     context "when opening a channel in full page" do
+      fab!(:other_user) { Fabricate(:user) }
+      fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [user, other_user]) }
+
       it "activates the channel in the sidebar" do
         visit("/chat/c/#{category_channel.slug}/#{category_channel.id}")
         expect(page).to have_css(
           ".sidebar-section-link-#{category_channel.slug}.sidebar-section-link--active",
         )
+      end
+
+      it "does not have multiple channels marked active in the sidebar" do
+        chat_page.visit_channel(dm_channel)
+        expect(page).to have_css(
+          ".sidebar-section-link-#{other_user.username}.sidebar-section-link--active",
+        )
+
+        page.find(".sidebar-section-link-#{category_channel.slug}").click
+        expect(page).to have_css(
+          ".sidebar-section-link-#{category_channel.slug}.sidebar-section-link--active",
+        )
+
+        expect(page).to have_css(".sidebar-section-link--active", count: 1)
       end
     end
 


### PR DESCRIPTION
Followup to c1dc6a2db4d9e98caa62ba51beba3a16adf495a8,
this commit just missed removing one of the @computed
decorators which was causing multiple active channels
to show in the sidebar. Fix the issue and introduce a
system spec to catch this.
