### PR TITLE
DEV: Only allow expanding hidden posts for author and staff

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -495,7 +495,10 @@ createWidget("post-contents", {
 
     result = result.concat(applyDecorators(this, "after-cooked", attrs, state));
 
-    if (attrs.cooked_hidden) {
+    if (
+      attrs.cooked_hidden &&
+      (this.currentUser?.isLeader || attrs.user_id === this.currentUser?.id)
+    ) {
       result.push(this.attach("expand-hidden", attrs));
     }
 

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -269,7 +269,10 @@ module PostGuardian
       return false
     end
     return true if is_moderator? || is_category_group_moderator?(post.topic.category)
-    return true if !post.trashed? || can_see_deleted_post?(post)
+    if (!post.trashed? || can_see_deleted_post?(post)) &&
+         (!post.hidden? || can_see_hidden_post?(post))
+      return true
+    end
     false
   end
 
@@ -278,6 +281,11 @@ module PostGuardian
     return false if @user.anonymous?
     return true if is_staff?
     post.deleted_by_id == @user.id && @user.has_trust_level?(TrustLevel[4])
+  end
+
+  def can_see_hidden_post?(post)
+    return false if anonymous?
+    post.user_id == @user.id || @user.has_trust_level_or_staff?(TrustLevel[4])
   end
 
   def can_view_edit_history?(post)

--- a/spec/lib/guardian/post_guardian_spec.rb
+++ b/spec/lib/guardian/post_guardian_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe PostGuardian do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:anon) { Fabricate(:anonymous) }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:tl3_user) { Fabricate(:trust_level_3) }
+  fab!(:tl4_user) { Fabricate(:trust_level_4) }
+  fab!(:moderator) { Fabricate(:moderator) }
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:hidden_post) { Fabricate(:post, topic: topic, hidden: true) }
+
+  describe "#can_see_hidden_post?" do
+    it "returns false for anonymous users" do
+      expect(Guardian.new(anon).can_see_hidden_post?(hidden_post)).to eq(false)
+    end
+
+    it "returns false for TL3 users" do
+      expect(Guardian.new(tl3_user).can_see_hidden_post?(hidden_post)).to eq(false)
+    end
+
+    it "returns true for TL4 users" do
+      expect(Guardian.new(tl4_user).can_see_hidden_post?(hidden_post)).to eq(true)
+    end
+
+    it "returns true for staff users" do
+      expect(Guardian.new(moderator).can_see_hidden_post?(hidden_post)).to eq(true)
+      expect(Guardian.new(admin).can_see_hidden_post?(hidden_post)).to eq(true)
+    end
+  end
+end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1992,7 +1992,7 @@ RSpec.describe PostsController do
       it "throws an exception for users" do
         sign_in(user)
         get "/posts/#{post.id}/revisions/#{post_revision.number}.json"
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
 
       it "works for admins" do


### PR DESCRIPTION
### Background

> We want to limit who can see posts when they are temporarily hidden by flags to further discourage others from engaging with posts in that state.

### What is this change?

After this is merged, only the author, staff, and TL4 users can reveal posts temporarily hidden by flags.

### Show me!

#### Changed behaviour

When signed in as John Doe:

<img width="767" alt="Screenshot 2023-04-22 at 3 24 31 PM" src="https://user-images.githubusercontent.com/5259935/233770477-acd9d2fc-03a8-482a-9684-6b3ae297bc83.png">

_Note: no option to expand content._

#### Unchanged behaviour

When signed in as author:

<img width="762" alt="Screenshot 2023-04-22 at 3 40 24 PM" src="https://user-images.githubusercontent.com/5259935/233770400-b6aec6e4-0320-4a3b-b2ad-c5e8286536e0.png">

When signed in as TL4 user:

<img width="774" alt="Screenshot 2023-04-22 at 3 37 52 PM" src="https://user-images.githubusercontent.com/5259935/233770430-4e3f2889-65c9-4ecc-b0ba-e259ef8a62d9.png">

When signed in as staff user:

<img width="776" alt="Screenshot 2023-04-22 at 3 33 05 PM" src="https://user-images.githubusercontent.com/5259935/233770437-f01c8418-e775-4107-ae1e-e29ce795d9a4.png">
