### PR TITLE
FIX: Don’t assume post is available in UserEmail job

### DIFF
--- a/app/jobs/regular/user_email.rb
+++ b/app/jobs/regular/user_email.rb
@@ -113,7 +113,7 @@ module Jobs
       if user.suspended?
         if !type.in?(%w[user_private_message account_suspended])
           return skip_message(SkippedEmailLog.reason_types[:user_email_user_suspended_not_pm])
-        elsif post.topic.group_pm?
+        elsif post&.topic&.group_pm?
           return skip_message(SkippedEmailLog.reason_types[:user_email_user_suspended])
         end
       end

--- a/spec/jobs/user_email_spec.rb
+++ b/spec/jobs/user_email_spec.rb
@@ -930,5 +930,24 @@ RSpec.describe Jobs::UserEmail do
         end
       end
     end
+
+    context "without post" do
+      context "when user is suspended" do
+        subject(:send_email) do
+          described_class.new.execute(
+            type: :account_suspended,
+            user_id: suspended.id,
+            user_history_id: user_history.id,
+          )
+        end
+
+        let(:user_history) { Fabricate(:user_history, action: UserHistory.actions[:suspend_user]) }
+
+        it "does send an email" do
+          send_email
+          expect(ActionMailer::Base.deliveries.first.to).to contain_exactly(suspended.email)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, we’re performing a check when a user is suspended in the `UserEmail` job, and we’re assuming a `post` is always available, which is not the case. The code indeed breaks when the job is called with the `account_suspended` type option.

This PR fixes this issue by making the check use the safe navigation operator, thus making it work when `post` is not provided.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
