### PR TITLE
SECURITY: strip `xlink:href` from uploaded SVGs

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -500,6 +500,7 @@ class UploadCreator
         if use_el.attr("href")
           use_el.remove_attribute("href") unless use_el.attr("href").starts_with?("#")
         end
+        use_el.remove_attribute("xlink:href")
       end
     File.write(@file.path, doc.to_s)
     @file.rewind

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -613,7 +613,7 @@ RSpec.describe UploadCreator do
           <g>
             <use id="valid-use" x="123" href="#pathdef" />
           </g>
-          <use id="invalid-use1" href="https://svg.example.com/evil.svg" />
+          <use id="invalid-use1" xlink:href="https://svg.example.com/evil.svg" />
           <use id="invalid-use2" href="data:image/svg+xml;base64,#{b64}" />
         </svg>
       XML


### PR DESCRIPTION
This was inadvertently removed in 4c46c7e. In very specific scenarios, this could be used execute arbitrary JavaScript.

Only affects instances where SVGs are allowed as uploads and CDN is not configured.
