### PR TITLE
DEV: Support `created-by:<username>` filter on `/filter` route

### DIFF
--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe TopicsFilter do
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user) { Fabricate(:user, username: "username") }
   fab!(:admin) { Fabricate(:admin) }
   fab!(:group) { Fabricate(:group) }
 
@@ -735,6 +735,79 @@ RSpec.describe TopicsFilter do
             .filter_from_query_string("-tags:tag1,tag2")
             .pluck(:id),
         ).to contain_exactly(topic_without_tag.id, topic_with_group_only_tag.id)
+      end
+    end
+
+    describe "when filtering by topic author" do
+      fab!(:user2) { Fabricate(:user, username: "username2") }
+      fab!(:topic_by_user) { Fabricate(:topic, user: user) }
+      fab!(:topic2_by_user) { Fabricate(:topic, user: user) }
+      fab!(:topic_by_user2) { Fabricate(:topic, user: user2) }
+
+      describe "when query string is `created-by:username`" do
+        it "should return the topics created by the specified user" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("created-by:#{user.username}")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user.id, topic2_by_user.id)
+        end
+      end
+
+      describe "when query string is `created-by:username2`" do
+        it "should return the topics created by the specified user" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("created-by:#{user2.username}")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user2.id)
+        end
+      end
+
+      describe "when query string is `created-by:username created-by:username2`" do
+        it "should return the topics created by either of the specified users" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("created-by:#{user.username} created-by:#{user2.username}")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user.id, topic2_by_user.id, topic_by_user2.id)
+        end
+      end
+
+      describe "when query string is `created-by:username,invalid`" do
+        it "should only return the topics created by the user with the valid username" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("created-by:#{user.username},invalid")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user.id, topic2_by_user.id)
+        end
+      end
+
+      describe "when query string is `created-by:username,username2`" do
+        it "should return the topics created by either of the specified users" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("created-by:#{user.username},#{user2.username}")
+              .pluck(:id),
+          ).to contain_exactly(topic_by_user.id, topic2_by_user.id, topic_by_user2.id)
+        end
+      end
+
+      describe "when query string is `created-by:invalid`" do
+        it "should not return any topics" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("created-by:invalid")
+              .pluck(:id),
+          ).to eq([])
+        end
       end
     end
   end


### PR DESCRIPTION
This commit adds support for the `created-by:<username>` query filter
which will return topics created by the specified user. Multiple
usernames can be specified by comma seperating the usernames like so:
`created-by:username1,username2`. This will filter for topics created by
either of the specified users. Multiple `created-by:<username>` can also
be composed together. `created-by:username1 created-by:username2` is
equivalent to `created-by:username1,username2`.