### PR TITLE
WIP: Reacting to MessageBus in chat thread panel

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -312,11 +312,11 @@ module Chat
     end
 
     def thread_reply?
-      in_thread? && !is_thread_om?
+      in_thread? && !thread_om?
     end
 
-    def is_thread_om?
-      self.thread.original_message_id == self.id
+    def thread_om?
+      in_thread? && self.thread.original_message_id == self.id
     end
 
     private

--- a/plugins/chat/app/serializers/chat/thread_serializer.rb
+++ b/plugins/chat/app/serializers/chat/thread_serializer.rb
@@ -5,6 +5,6 @@ module Chat
     has_one :original_message_user, serializer: BasicUserWithStatusSerializer, embed: :objects
     has_one :original_message, serializer: Chat::ThreadOriginalMessageSerializer, embed: :objects
 
-    attributes :id, :title, :status
+    attributes :id, :title, :status, :channel_id
   end
 end

--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -10,8 +10,25 @@ module Chat
       "/chat/#{chat_channel_id}"
     end
 
+    def self.thread_message_bus_channel(chat_channel_id, thread_id)
+      "#{root_message_bus_channel(chat_channel_id)}/thread/#{thread_id}"
+    end
+
+    def self.calculate_publish_targets(chat_channel, chat_message)
+      targets = []
+      if chat_message.thread_om?
+        targets << root_message_bus_channel(chat_channel.id)
+        targets << thread_message_bus_channel(chat_channel.id, chat_message.thread_id)
+      elsif chat_message.thread_reply?
+        targets << thread_message_bus_channel(chat_channel.id, chat_message.thread_id)
+      else
+        targets << root_message_bus_channel(chat_channel.id)
+      end
+      targets
+    end
+
     def self.publish_new!(chat_channel, chat_message, staged_id)
-      return if chat_message.thread_reply?
+      message_bus_targets = calculate_publish_targets(chat_channel, chat_message)
 
       content =
         Chat::MessageSerializer.new(
@@ -22,19 +39,38 @@ module Chat
       content[:staged_id] = staged_id
       permissions = permissions(chat_channel)
 
-      MessageBus.publish(root_message_bus_channel(chat_channel.id), content.as_json, permissions)
+      message_bus_targets.each do |message_bus_channel|
+        MessageBus.publish(message_bus_channel, content.as_json, permissions)
+      end
 
-      MessageBus.publish(
-        self.new_messages_message_bus_channel(chat_channel.id),
-        {
-          channel_id: chat_channel.id,
-          message_id: chat_message.id,
-          user_id: chat_message.user.id,
-          username: chat_message.user.username,
-          thread_id: chat_message.thread_id,
-        },
-        permissions,
-      )
+      if chat_message.thread_reply?
+        MessageBus.publish(
+          root_message_bus_channel(chat_channel.id),
+          {
+            type: :update_thread_indicator,
+            original_message_id: chat_message.thread.original_message_id,
+            action: :increment_reply_count,
+          }.as_json,
+          permissions,
+        )
+      end
+
+      # NOTE: This means that the read count is only updated in the client
+      # for new messages in the main channel stream, maybe in future we want to
+      # do this for thread messages as well?
+      if !chat_message.thread_reply?
+        MessageBus.publish(
+          self.new_messages_message_bus_channel(chat_channel.id),
+          {
+            channel_id: chat_channel.id,
+            message_id: chat_message.id,
+            user_id: chat_message.user.id,
+            username: chat_message.user.username,
+            thread_id: chat_message.thread_id,
+          },
+          permissions,
+        )
+      end
     end
 
     def self.publish_thread_created!(chat_channel, chat_message)
@@ -50,7 +86,7 @@ module Chat
     end
 
     def self.publish_processed!(chat_message)
-      return if chat_message.thread_reply?
+      message_bus_targets = calculate_publish_targets(chat_channel, chat_message)
 
       chat_channel = chat_message.chat_channel
       content = {
@@ -60,15 +96,14 @@ module Chat
           cooked: chat_message.cooked,
         },
       }
-      MessageBus.publish(
-        root_message_bus_channel(chat_channel.id),
-        content.as_json,
-        permissions(chat_channel),
-      )
+
+      message_bus_targets.each do |message_bus_channel|
+        MessageBus.publish(message_bus_channel, content.as_json, permissions(chat_channel))
+      end
     end
 
     def self.publish_edit!(chat_channel, chat_message)
-      return if chat_message.thread_reply?
+      message_bus_targets = calculate_publish_targets(chat_channel, chat_message)
 
       content =
         Chat::MessageSerializer.new(
@@ -76,15 +111,14 @@ module Chat
           { scope: anonymous_guardian, root: :chat_message },
         ).as_json
       content[:type] = :edit
-      MessageBus.publish(
-        root_message_bus_channel(chat_channel.id),
-        content.as_json,
-        permissions(chat_channel),
-      )
+
+      message_bus_targets.each do |message_bus_channel|
+        MessageBus.publish(message_bus_channel, content.as_json, permissions(chat_channel))
+      end
     end
 
     def self.publish_refresh!(chat_channel, chat_message)
-      return if chat_message.thread_reply?
+      message_bus_targets = calculate_publish_targets(chat_channel, chat_message)
 
       content =
         Chat::MessageSerializer.new(
@@ -92,15 +126,14 @@ module Chat
           { scope: anonymous_guardian, root: :chat_message },
         ).as_json
       content[:type] = :refresh
-      MessageBus.publish(
-        root_message_bus_channel(chat_channel.id),
-        content.as_json,
-        permissions(chat_channel),
-      )
+
+      message_bus_targets.each do |message_bus_channel|
+        MessageBus.publish(message_bus_channel, content.as_json, permissions(chat_channel))
+      end
     end
 
     def self.publish_reaction!(chat_channel, chat_message, action, user, emoji)
-      return if chat_message.thread_reply?
+      message_bus_targets = calculate_publish_targets(chat_channel, chat_message)
 
       content = {
         action: action,
@@ -109,11 +142,10 @@ module Chat
         type: :reaction,
         chat_message_id: chat_message.id,
       }
-      MessageBus.publish(
-        root_message_bus_channel(chat_channel.id),
-        content.as_json,
-        permissions(chat_channel),
-      )
+
+      message_bus_targets.each do |message_bus_channel|
+        MessageBus.publish(message_bus_channel, content.as_json, permissions(chat_channel))
+      end
     end
 
     def self.publish_presence!(chat_channel, user, typ)
@@ -121,25 +153,31 @@ module Chat
     end
 
     def self.publish_delete!(chat_channel, chat_message)
-      return if chat_message.thread_reply?
+      message_bus_targets = calculate_publish_targets(chat_channel, chat_message)
 
-      MessageBus.publish(
-        root_message_bus_channel(chat_channel.id),
-        { type: "delete", deleted_id: chat_message.id, deleted_at: chat_message.deleted_at },
-        permissions(chat_channel),
-      )
+      message_bus_targets.each do |message_bus_channel|
+        MessageBus.publish(
+          message_bus_channel,
+          { type: "delete", deleted_id: chat_message.id, deleted_at: chat_message.deleted_at },
+          permissions(chat_channel),
+        )
+      end
     end
 
     def self.publish_bulk_delete!(chat_channel, deleted_message_ids)
-      MessageBus.publish(
-        root_message_bus_channel(chat_channel.id),
-        { typ: "bulk_delete", deleted_ids: deleted_message_ids, deleted_at: Time.zone.now },
-        permissions(chat_channel),
-      )
+      message_bus_targets = calculate_publish_targets(chat_channel, chat_message)
+
+      message_bus_targets.each do |message_bus_channel|
+        MessageBus.publish(
+          message_bus_channel,
+          { typ: "bulk_delete", deleted_ids: deleted_message_ids, deleted_at: Time.zone.now },
+          permissions(chat_channel),
+        )
+      end
     end
 
     def self.publish_restore!(chat_channel, chat_message)
-      return if chat_message.thread_reply?
+      message_bus_targets = calculate_publish_targets(chat_channel, chat_message)
 
       content =
         Chat::MessageSerializer.new(
@@ -147,33 +185,36 @@ module Chat
           { scope: anonymous_guardian, root: :chat_message },
         ).as_json
       content[:type] = :restore
-      MessageBus.publish(
-        root_message_bus_channel(chat_channel.id),
-        content.as_json,
-        permissions(chat_channel),
-      )
+
+      message_bus_targets.each do |message_bus_channel|
+        MessageBus.publish(message_bus_channel, content.as_json, permissions(chat_channel))
+      end
     end
 
     def self.publish_flag!(chat_message, user, reviewable, score)
-      return if chat_message.thread_reply?
+      message_bus_targets = calculate_publish_targets(chat_message.chat_channel, chat_message)
 
-      # Publish to user who created flag
-      MessageBus.publish(
-        "/chat/#{chat_message.chat_channel_id}",
-        {
-          type: "self_flagged",
-          user_flag_status: score.status_for_database,
-          chat_message_id: chat_message.id,
-        }.as_json,
-        user_ids: [user.id],
-      )
+      message_bus_targets.each do |message_bus_channel|
+        # Publish to user who created flag
+        MessageBus.publish(
+          message_bus_channel,
+          {
+            type: "self_flagged",
+            user_flag_status: score.status_for_database,
+            chat_message_id: chat_message.id,
+          }.as_json,
+          user_ids: [user.id],
+        )
+      end
 
-      # Publish flag with link to reviewable to staff
-      MessageBus.publish(
-        "/chat/#{chat_message.chat_channel_id}",
-        { type: "flag", chat_message_id: chat_message.id, reviewable_id: reviewable.id }.as_json,
-        group_ids: [Group::AUTO_GROUPS[:staff]],
-      )
+      message_bus_targets.each do |message_bus_channel|
+        # Publish flag with link to reviewable to staff
+        MessageBus.publish(
+          message_bus_channel,
+          { type: "flag", chat_message_id: chat_message.id, reviewable_id: reviewable.id }.as_json,
+          group_ids: [Group::AUTO_GROUPS[:staff]],
+        )
+      end
     end
 
     def self.user_tracking_state_message_bus_channel(user_id)

--- a/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-live-pane.js
@@ -4,7 +4,8 @@ import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 import ChatMessageDraft from "discourse/plugins/chat/discourse/models/chat-message-draft";
 import Component from "@glimmer/component";
 import { bind, debounce } from "discourse-common/utils/decorators";
-import EmberObject, { action } from "@ember/object";
+import { action } from "@ember/object";
+import { handleStagedMessage } from "discourse/plugins/chat/discourse/lib/staged-message-handler";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { cancel, schedule, throttle } from "@ember/runloop";
@@ -34,6 +35,8 @@ export default class ChatLivePane extends Component {
   @service chatStateManager;
   @service chatChannelComposer;
   @service chatChannelPane;
+  @service chatChannelPaneSubscriptionsManager;
+  @service chatChannelThreadIndicatorSubscriptionsManager;
   @service chatApi;
   @service currentUser;
   @service appEvents;
@@ -108,7 +111,7 @@ export default class ChatLivePane extends Component {
     }
 
     this.loadMessages();
-    this._subscribeToUpdates(this.args.channel?.id);
+    this._subscribeToUpdates(this.args.channel);
   }
 
   @action
@@ -209,8 +212,8 @@ export default class ChatLivePane extends Component {
     const loadingMoreKey = `loadingMore${capitalize(direction)}`;
 
     const canLoadMore = loadingPast
-      ? this.args.channel.messagesManager.canLoadMorePast
-      : this.args.channel.messagesManager.canLoadMoreFuture;
+      ? this.#messagesManager.canLoadMorePast
+      : this.#messagesManager.canLoadMoreFuture;
 
     if (
       !canLoadMore ||
@@ -261,7 +264,7 @@ export default class ChatLivePane extends Component {
         }
 
         this.args.channel.details = meta;
-        this.args.channel.messagesManager.addMessages(messages);
+        this.#messagesManager.addMessages(messages);
 
         // Edge case for IOS to avoid blank screens
         // and/or scrolling to bottom losing track of scroll position
@@ -508,9 +511,9 @@ export default class ChatLivePane extends Component {
   }
 
   removeMessage(msgData) {
-    const message = this.args.channel.messagesManager.findMessage(msgData.id);
+    const message = this.#messagesManager.findMessage(msgData.id);
     if (message) {
-      this.args.channel.messagesManager.removeMessage(message);
+      this.#messagesManager.removeMessage(message);
     }
   }
 
@@ -520,72 +523,6 @@ export default class ChatLivePane extends Component {
       case "sent":
         this.handleSentMessage(data);
         break;
-      case "processed":
-        this.handleProcessedMessage(data);
-        break;
-      case "edit":
-        this.handleEditMessage(data);
-        break;
-      case "refresh":
-        this.handleRefreshMessage(data);
-        break;
-      case "delete":
-        this.handleDeleteMessage(data);
-        break;
-      case "bulk_delete":
-        this.handleBulkDeleteMessage(data);
-        break;
-      case "reaction":
-        this.handleReactionMessage(data);
-        break;
-      case "restore":
-        this.handleRestoreMessage(data);
-        break;
-      case "mention_warning":
-        this.handleMentionWarning(data);
-        break;
-      case "self_flagged":
-        this.handleSelfFlaggedMessage(data);
-        break;
-      case "flag":
-        this.handleFlaggedMessage(data);
-        break;
-      case "thread_created":
-        this.handleThreadCreated(data);
-        break;
-    }
-  }
-
-  handleThreadCreated(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message.id
-    );
-    if (message) {
-      message.threadId = data.chat_message.thread_id;
-      message.threadReplyCount = 1;
-    }
-  }
-
-  _handleStagedMessage(stagedMessage, data) {
-    stagedMessage.error = null;
-    stagedMessage.id = data.chat_message.id;
-    stagedMessage.staged = false;
-    stagedMessage.excerpt = data.chat_message.excerpt;
-    stagedMessage.threadId = data.chat_message.thread_id;
-    stagedMessage.channelId = data.chat_message.chat_channel_id;
-    stagedMessage.createdAt = data.chat_message.created_at;
-
-    const inReplyToMsg = this.args.channel.messagesManager.findMessage(
-      data.chat_message.in_reply_to?.id
-    );
-    if (inReplyToMsg && !inReplyToMsg.threadId) {
-      inReplyToMsg.threadId = data.chat_message.thread_id;
-    }
-
-    // some markdown is cooked differently on the server-side, e.g.
-    // quotes, avatar images etc.
-    if (data.chat_message?.cooked !== stagedMessage.cooked) {
-      stagedMessage.cooked = data.chat_message.cooked;
     }
   }
 
@@ -595,136 +532,24 @@ export default class ChatLivePane extends Component {
     }
 
     if (data.chat_message.user.id === this.currentUser.id && data.staged_id) {
-      const stagedMessage = this.args.channel.messagesManager.findStagedMessage(
-        data.staged_id
-      );
-      if (stagedMessage) {
-        return this._handleStagedMessage(stagedMessage, data);
-      }
+      return handleStagedMessage(this.#messagesManager, data);
     }
 
-    if (this.args.channel.messagesManager.canLoadMoreFuture) {
+    if (this.#messagesManager.canLoadMoreFuture) {
       // If we can load more messages, we just notice the user of new messages
       this.hasNewMessages = true;
     } else if (this.#isTowardsBottom()) {
       // If we are at the bottom, we append the message and scroll to it
       const message = ChatMessage.create(this.args.channel, data.chat_message);
 
-      this.args.channel.messagesManager.addMessages([message]);
+      this.#messagesManager.addMessages([message]);
       this.scrollToLatestMessage();
       this.updateLastReadMessage();
     } else {
       // If we are almost at the bottom, we append the message and notice the user
       const message = ChatMessage.create(this.args.channel, data.chat_message);
-      this.args.channel.messagesManager.addMessages([message]);
+      this.#messagesManager.addMessages([message]);
       this.hasNewMessages = true;
-    }
-  }
-
-  handleProcessedMessage(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message.id
-    );
-    if (message) {
-      message.cooked = data.chat_message.cooked;
-      this.scrollToLatestMessage();
-    }
-  }
-
-  handleRefreshMessage(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message.id
-    );
-    if (message) {
-      message.incrementVersion();
-    }
-  }
-
-  handleEditMessage(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message.id
-    );
-    if (message) {
-      message.message = data.chat_message.message;
-      message.cooked = data.chat_message.cooked;
-      message.excerpt = data.chat_message.excerpt;
-      message.uploads = cloneJSON(data.chat_message.uploads || []);
-      message.edited = true;
-      message.incrementVersion();
-    }
-  }
-
-  handleBulkDeleteMessage(data) {
-    data.deleted_ids.forEach((deletedId) => {
-      this.handleDeleteMessage({
-        deleted_id: deletedId,
-        deleted_at: data.deleted_at,
-      });
-    });
-  }
-
-  handleDeleteMessage(data) {
-    const deletedId = data.deleted_id;
-    const targetMsg = this.args.channel.messagesManager.findMessage(deletedId);
-
-    if (!targetMsg) {
-      return;
-    }
-
-    if (this.currentUser.staff || this.currentUser.id === targetMsg.user.id) {
-      targetMsg.deletedAt = data.deleted_at;
-      targetMsg.expanded = false;
-    } else {
-      this.args.channel.messagesManager.removeMessage(targetMsg);
-    }
-  }
-
-  handleReactionMessage(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message_id
-    );
-    if (message) {
-      message.react(data.emoji, data.action, data.user, this.currentUser.id);
-    }
-  }
-
-  handleRestoreMessage(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message.id
-    );
-    if (message) {
-      message.deletedAt = null;
-    } else {
-      this.args.channel.messagesManager.addMessages([
-        ChatMessage.create(this.args.channel, data.chat_message),
-      ]);
-    }
-  }
-
-  handleMentionWarning(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message_id
-    );
-    if (message) {
-      message.mentionWarning = EmberObject.create(data);
-    }
-  }
-
-  handleSelfFlaggedMessage(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message_id
-    );
-    if (message) {
-      message.userFlagStatus = data.user_flag_status;
-    }
-  }
-
-  handleFlaggedMessage(data) {
-    const message = this.args.channel.messagesManager.findMessage(
-      data.chat_message_id
-    );
-    if (message) {
-      message.reviewableId = data.reviewable_id;
     }
   }
 
@@ -788,13 +613,13 @@ export default class ChatLivePane extends Component {
 
     if (stagedMessage.inReplyTo) {
       if (!this.args.channel.threadingEnabled) {
-        this.args.channel.messagesManager.addMessages([stagedMessage]);
+        this.#messagesManager.addMessages([stagedMessage]);
       }
     } else {
-      this.args.channel.messagesManager.addMessages([stagedMessage]);
+      this.#messagesManager.addMessages([stagedMessage]);
     }
 
-    if (!this.args.channel.messagesManager.canLoadMoreFuture) {
+    if (!this.#messagesManager.canLoadMoreFuture) {
       this.scrollToLatestMessage();
     }
 
@@ -844,8 +669,7 @@ export default class ChatLivePane extends Component {
   }
 
   _onSendError(id, error) {
-    const stagedMessage =
-      this.args.channel.messagesManager.findStagedMessage(id);
+    const stagedMessage = this.#messagesManager.findStagedMessage(id);
     if (stagedMessage) {
       if (error.jqXHR?.responseJSON?.errors?.length) {
         // only network errors are retryable
@@ -910,20 +734,24 @@ export default class ChatLivePane extends Component {
       return;
     }
 
+    this.chatChannelPaneSubscriptionsManager.unsubscribe();
+    this.chatChannelThreadIndicatorSubscriptionsManager.unsubscribe();
     this.messageBus.unsubscribe(`/chat/${channelId}`, this.onMessage);
   }
 
-  _subscribeToUpdates(channelId) {
-    if (!channelId) {
+  _subscribeToUpdates(channel) {
+    if (!channel) {
       return;
     }
 
-    this._unsubscribeToUpdates(channelId);
+    this._unsubscribeToUpdates(channel.id);
     this.messageBus.subscribe(
-      `/chat/${channelId}`,
+      `/chat/${channel.id}`,
       this.onMessage,
-      this.args.channel.channelMessageBusLastId
+      channel.channelMessageBusLastId
     );
+    this.chatChannelPaneSubscriptionsManager.subscribe(channel);
+    this.chatChannelThreadIndicatorSubscriptionsManager.subscribe(channel);
   }
 
   @bind

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
@@ -1,8 +1,11 @@
 <div
   class={{concat-class "chat-thread" (if this.loading "loading")}}
   data-id={{this.thread.id}}
+  {{did-insert this.subscribeToUpdates}}
   {{did-insert this.loadMessages}}
+  {{did-update this.thread.id this.subscribeToUpdates}}
   {{did-update this.thread.id this.loadMessages}}
+  {{will-destroy this.unsubscribeFromUpdates}}
 >
   <div class="chat-thread__header">
     <span class="chat-thread__label">{{i18n "chat.thread.label"}}</span>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -21,6 +21,7 @@ export default class ChatThreadPanel extends Component {
   @service chatComposerPresenceManager;
   @service chatChannelThreadComposer;
   @service chatChannelThreadPane;
+  @service chatChannelThreadPaneSubscriptionsManager;
   @service appEvents;
   @service capabilities;
 
@@ -35,6 +36,16 @@ export default class ChatThreadPanel extends Component {
 
   get channel() {
     return this.chat.activeChannel;
+  }
+
+  @action
+  subscribeToUpdates() {
+    this.chatChannelThreadPaneSubscriptionsManager.subscribe(this.thread);
+  }
+
+  @action
+  unsubscribeFromUpdates() {
+    this.chatChannelThreadPaneSubscriptionsManager.unsubscribe();
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/lib/staged-message-handler.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/staged-message-handler.js
@@ -1,0 +1,28 @@
+export function handleStagedMessage(messagesManager, data) {
+  const stagedMessage = messagesManager.findStagedMessage(data.stagedId);
+
+  if (!stagedMessage) {
+    return;
+  }
+
+  stagedMessage.error = null;
+  stagedMessage.id = data.chat_message.id;
+  stagedMessage.staged = false;
+  stagedMessage.excerpt = data.chat_message.excerpt;
+  stagedMessage.threadId = data.chat_message.thread_id;
+  stagedMessage.channelId = data.chat_message.chat_channel_id;
+  stagedMessage.createdAt = data.chat_message.created_at;
+
+  const inReplyToMsg = messagesManager.findMessage(
+    data.chat_message.in_reply_to?.id
+  );
+  if (inReplyToMsg && !inReplyToMsg.threadId) {
+    inReplyToMsg.threadId = data.chat_message.thread_id;
+  }
+
+  // some markdown is cooked differently on the server-side, e.g.
+  // quotes, avatar images etc.
+  if (data.chat_message?.cooked !== stagedMessage.cooked) {
+    stagedMessage.cooked = data.chat_message.cooked;
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane-subscriptions-manager.js
@@ -1,0 +1,189 @@
+import Service, { inject as service } from "@ember/service";
+import EmberObject from "@ember/object";
+import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
+import { cloneJSON } from "discourse-common/lib/object";
+import { bind } from "discourse-common/utils/decorators";
+
+export default class ChatChannelPaneSubscriptionsManager extends Service {
+  @service chat;
+  @service currentUser;
+
+  get messageBusChannel() {
+    return `/chat/${this.model.id}`;
+  }
+
+  get messageBusLastId() {
+    return this.model.channelMessageBusLastId;
+  }
+
+  get messagesManager() {
+    return this.model.messagesManager;
+  }
+
+  subscribe(model) {
+    this.unsubscribe();
+    this.model = model;
+    this.messageBus.subscribe(
+      this.messageBusChannel,
+      this.onMessage,
+      this.messageBusLastId
+    );
+  }
+
+  unsubscribe() {
+    if (!this.model) {
+      return;
+    }
+    this.messageBus.unsubscribe(this.messageBusChannel, this.onMessage);
+    this.model = null;
+  }
+
+  @bind
+  onMessage(busData) {
+    switch (busData.type) {
+      case "sent":
+        this.handleSentMessage(busData);
+        break;
+      case "reaction":
+        this.handleReactionMessage(busData);
+        break;
+      case "processed":
+        this.handleProcessedMessage(busData);
+        break;
+      case "edit":
+        this.handleEditMessage(busData);
+        break;
+      case "refresh":
+        this.handleRefreshMessage(busData);
+        break;
+      case "delete":
+        this.handleDeleteMessage(busData);
+        break;
+      case "bulk_delete":
+        this.handleBulkDeleteMessage(busData);
+        break;
+      case "restore":
+        this.handleRestoreMessage(busData);
+        break;
+      case "mention_warning":
+        this.handleMentionWarning(busData);
+        break;
+      case "self_flagged":
+        this.handleSelfFlaggedMessage(busData);
+        break;
+      case "flag":
+        this.handleFlaggedMessage(busData);
+        break;
+      case "thread_created":
+        this.handleThreadCreated(busData);
+        break;
+    }
+  }
+
+  handleSentMessage() {
+    // TODO (martin) Implement this for the channel, since it involves a bunch
+    // of scrolling and pane-specific logic. Will leave the existing sub inside
+    // ChatLivePane for now.
+  }
+
+  handleReactionMessage(data) {
+    const message = this.messagesManager.findMessage(data.chat_message_id);
+    if (message) {
+      message.react(data.emoji, data.action, data.user, this.currentUser.id);
+    }
+  }
+
+  handleProcessedMessage(data) {
+    const message = this.messagesManager.findMessage(data.chat_message.id);
+    if (message) {
+      message.cooked = data.chat_message.cooked;
+
+      // TODO: Move scrolling functionality to pane?
+      // this.scrollToLatestMessage();
+    }
+  }
+
+  handleEditMessage(data) {
+    const message = this.messagesManager.findMessage(data.chat_message.id);
+    if (message) {
+      message.message = data.chat_message.message;
+      message.cooked = data.chat_message.cooked;
+      message.excerpt = data.chat_message.excerpt;
+      message.uploads = cloneJSON(data.chat_message.uploads || []);
+      message.edited = true;
+      message.incrementVersion();
+    }
+  }
+
+  handleRefreshMessage(data) {
+    const message = this.messagesManager.findMessage(data.chat_message.id);
+    if (message) {
+      message.incrementVersion();
+    }
+  }
+
+  handleBulkDeleteMessage(data) {
+    data.deleted_ids.forEach((deletedId) => {
+      this.handleDeleteMessage({
+        deleted_id: deletedId,
+        deleted_at: data.deleted_at,
+      });
+    });
+  }
+
+  handleDeleteMessage(data) {
+    const deletedId = data.deleted_id;
+    const targetMsg = this.messagesManager.findMessage(deletedId);
+
+    if (!targetMsg) {
+      return;
+    }
+
+    if (this.currentUser.staff || this.currentUser.id === targetMsg.user.id) {
+      targetMsg.deletedAt = data.deleted_at;
+      targetMsg.expanded = false;
+    } else {
+      this.messagesManager.removeMessage(targetMsg);
+    }
+  }
+
+  handleRestoreMessage(data) {
+    const message = this.messagesManager.findMessage(data.chat_message.id);
+    if (message) {
+      message.deletedAt = null;
+    } else {
+      this.messagesManager.addMessages([
+        ChatMessage.create(this.args.channel, data.chat_message),
+      ]);
+    }
+  }
+
+  handleMentionWarning(data) {
+    const message = this.messagesManager.findMessage(data.chat_message_id);
+    if (message) {
+      message.mentionWarning = EmberObject.create(data);
+    }
+  }
+
+  handleSelfFlaggedMessage(data) {
+    const message = this.messagesManager.findMessage(data.chat_message_id);
+    if (message) {
+      message.userFlagStatus = data.user_flag_status;
+    }
+  }
+
+  handleFlaggedMessage(data) {
+    const message = this.messagesManager.findMessage(data.chat_message_id);
+    if (message) {
+      message.reviewableId = data.reviewable_id;
+    }
+  }
+
+  handleThreadCreated(data) {
+    const message = this.messagesManager.findMessage(data.chat_message.id);
+    if (message) {
+      message.threadId = data.chat_message.thread_id;
+      message.threadReplyCount = 1;
+    }
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-composer.js
@@ -1,7 +1,7 @@
 import ChatChannelComposer from "./chat-channel-composer";
 
 export default class extends ChatChannelComposer {
-  get #model() {
+  get model() {
     return this.chat.activeChannel.activeThread;
   }
 

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-indicator-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-indicator-subscriptions-manager.js
@@ -1,0 +1,56 @@
+import Service, { inject as service } from "@ember/service";
+import { bind } from "discourse-common/utils/decorators";
+
+export default class ChatChannelThreadIndicatorSubscriptionsManager extends Service {
+  @service chat;
+  @service currentUser;
+
+  get messageBusChannel() {
+    return `/chat/${this.model.id}`;
+  }
+
+  get messageBusLastId() {
+    return this.model.channelMessageBusLastId;
+  }
+
+  get messagesManager() {
+    return this.model.messagesManager;
+  }
+
+  subscribe(model) {
+    this.unsubscribe();
+    this.model = model;
+    this.messageBus.subscribe(
+      this.messageBusChannel,
+      this.onMessage,
+      this.messageBusLastId
+    );
+  }
+
+  unsubscribe() {
+    if (!this.model) {
+      return;
+    }
+    this.messageBus.unsubscribe(this.messageBusChannel, this.onMessage);
+    this.model = null;
+  }
+
+  @bind
+  onMessage(busData) {
+    switch (busData.type) {
+      case "update_thread_indicator":
+        this.handleThreadIndicatorUpdate(busData);
+        break;
+    }
+  }
+
+  handleThreadIndicatorUpdate(data) {
+    const message = this.messagesManager.findMessage(data.original_message_id);
+    if (message) {
+      if (data.action === "increment_reply_count") {
+        // TODO (martin) In future we should use a replies_count delivered from the server.
+        message.threadReplyCount += 1;
+      }
+    }
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-pane-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-pane-subscriptions-manager.js
@@ -1,0 +1,33 @@
+import ChatChannelPaneSubscriptionsManager from "./chat-channel-pane-subscriptions-manager";
+import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
+import { handleStagedMessage } from "discourse/plugins/chat/discourse/lib/staged-message-handler";
+
+export default class ChatChannelThreadPaneSubscriptionsManager extends ChatChannelPaneSubscriptionsManager {
+  get messageBusChannel() {
+    return `/chat/${this.model.channelId}/thread/${this.model.id}`;
+  }
+
+  get messageBusLastId() {
+    return this.model.threadMessageBusLastId;
+  }
+
+  // NOTE: This is a noop, there is nothing to do when a thread is created
+  // inside the thread panel.
+  handleThreadCreated() {
+    return;
+  }
+
+  handleSentMessage(data) {
+    if (data.chat_message.user.id === this.currentUser.id && data.staged_id) {
+      return handleStagedMessage(this.messagesManager, data);
+    }
+
+    const message = ChatMessage.create(
+      this.chat.activeChannel,
+      data.chat_message
+    );
+    this.messagesManager.addMessages([message]);
+
+    // TODO (martin) All the scrolling and new message indicator shenanigans.
+  }
+}


### PR DESCRIPTION
This commit introduces a ChatChannelPaneSubscriptionsManager
and a ChatChannelThreadPaneSubscriptionsManager that inherits
from the first service that handle MessageBus subscriptions
for the main channel and the thread panel respectively.

This necessitated a change to Chat::Publisher to be able to
send MessageBus messages to multiple channels based on whether
a message was an OM for a thread, a thread reply, or a regular
channel message.

An initial change to update the thread indicator with new replies
has been done too, but that will be improved in future as we have
more data to update on the indicators.

Still remaining is to fully move over the handleSentMessage
functionality which includes scrolling and new message indicator
things.
