### PR TITLE
DEV: Improve `add_to_serializer` `include_*` options

### DIFF
--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -109,7 +109,27 @@ class Plugin::Instance
 
   delegate :name, to: :metadata
 
-  def add_to_serializer(serializer, attr, define_include_method = true, &block)
+  def add_to_serializer(
+    serializer,
+    attr,
+    deprecated_respect_plugin_enabled = nil,
+    respect_plugin_enabled: true,
+    include_condition: nil,
+    &block
+  )
+    if !deprecated_respect_plugin_enabled.nil?
+      Discourse.deprecate(
+        "add_to_serializer's respect_plugin_enabled argument should be passed as a keyword argument",
+      )
+      respect_plugin_enabled = deprecated_respect_plugin_enabled
+    end
+
+    if attr.to_s.starts_with?("include_")
+      Discourse.deprecate(
+        "add_to_serializer should not be used to directly override include_*? methods. Use the include_condition keyword argument instead",
+      )
+    end
+
     reloadable_patch do |plugin|
       base =
         begin
@@ -123,9 +143,13 @@ class Plugin::Instance
         unless attr.to_s.start_with?("include_")
           klass.attributes(attr)
 
-          if define_include_method
+          if respect_plugin_enabled || include_condition
             # Don't include serialized methods if the plugin is disabled
-            klass.public_send(:define_method, "include_#{attr}?") { plugin.enabled? }
+            klass.public_send(:define_method, "include_#{attr}?") do
+              next false if respect_plugin_enabled && !plugin.enabled?
+              next instance_exec(&include_condition) if include_condition
+              true
+            end
           end
         end
 

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -195,7 +195,7 @@ after_initialize do
       end
   end
 
-  add_to_serializer(:post, :preloaded_polls, false) do
+  add_to_class(PostSerializer, :preloaded_polls) do
     @preloaded_polls ||=
       if @topic_view.present?
         @topic_view.polls[object.id]
@@ -204,15 +204,18 @@ after_initialize do
       end
   end
 
-  add_to_serializer(:post, :include_preloaded_polls?) { false }
-
-  add_to_serializer(:post, :polls, false) do
+  add_to_serializer(:post, :polls, include_condition: -> { preloaded_polls.present? }) do
     preloaded_polls.map { |p| PollSerializer.new(p, root: false, scope: self.scope) }
   end
 
-  add_to_serializer(:post, :include_polls?) { SiteSetting.poll_enabled && preloaded_polls.present? }
-
-  add_to_serializer(:post, :polls_votes, false) do
+  add_to_serializer(
+    :post,
+    :polls_votes,
+    include_condition: -> do
+      scope.user&.id.present? && preloaded_polls.present? &&
+        preloaded_polls.any? { |p| p.has_voted?(scope.user) }
+    end,
+  ) do
     preloaded_polls
       .map do |poll|
         user_poll_votes =
@@ -225,11 +228,6 @@ after_initialize do
         [poll.name, user_poll_votes]
       end
       .to_h
-  end
-
-  add_to_serializer(:post, :include_polls_votes?) do
-    SiteSetting.poll_enabled && scope.user&.id.present? && preloaded_polls.present? &&
-      preloaded_polls.any? { |p| p.has_voted?(scope.user) }
   end
 
   register_search_advanced_filter(/in:polls/) do |posts, match|

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe Plugin::Instance do
 
         # Serializer
         @plugin.add_to_serializer(:trout, :scales) { 1024 }
+        @plugin.add_to_serializer(:trout, :unconditional_scales, respect_plugin_enabled: false) do
+          2048
+        end
+        @plugin.add_to_serializer(
+          :trout,
+          :conditional_scales,
+          include_condition: -> { !!object.data&.[](:has_scales) },
+        ) { 4096 }
 
         @serializer = TroutSerializer.new(@trout)
         @child_serializer = TroutJuniorSerializer.new(@trout)
@@ -100,11 +108,31 @@ RSpec.describe Plugin::Instance do
         expect(@hello_count).to eq(1)
         expect(@serializer.scales).to eq(1024)
         expect(@serializer.include_scales?).to eq(false)
+        expect(@serializer.include_unconditional_scales?).to eq(true)
         expect(@serializer.name).to eq("a trout")
 
         expect(@child_serializer.scales).to eq(1024)
         expect(@child_serializer.include_scales?).to eq(false)
         expect(@child_serializer.name).to eq("a trout jr")
+      end
+
+      it "can control the include_* implementation" do
+        @plugin.enabled = true
+
+        expect(@serializer.scales).to eq(1024)
+        expect(@serializer.include_scales?).to eq(true)
+
+        expect(@serializer.unconditional_scales).to eq(2048)
+        expect(@serializer.include_unconditional_scales?).to eq(true)
+
+        expect(@serializer.include_conditional_scales?).to eq(false)
+        @trout.data = { has_scales: true }
+        expect(@serializer.include_conditional_scales?).to eq(true)
+
+        @plugin.enabled = false
+        expect(@serializer.include_scales?).to eq(false)
+        expect(@serializer.include_unconditional_scales?).to eq(true)
+        expect(@serializer.include_conditional_scales?).to eq(false)
       end
 
       it "only returns HTML if enabled" do


### PR DESCRIPTION
- Move the old '`define_include_method`' arg to a `respect_plugin_enabled` kwarg

- Introduce an `include_condition` kwarg which can be passed a lambda with inclusion logic. Lambda will be run via `instance_exec` in the context of the serializer instance

This is backwards compatible - old-style invocations will trigger a deprecation message