### PR TITLE
DEV: Enable patch-package in production and in `javascripts/discourse`

### DIFF
--- a/app/assets/javascripts/discourse/package.json
+++ b/app/assets/javascripts/discourse/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember serve",
-    "test": "ember test"
+    "test": "ember test",
+    "postinstall": "yarn --silent --cwd .. patch-package"
   },
   "dependencies": {
     "@babel/core": "^7.21.4",

--- a/app/assets/javascripts/package.json
+++ b/app/assets/javascripts/package.json
@@ -22,9 +22,9 @@
   "resolutions": {
     "**/babel-plugin-debug-macros": "npm:@discourse/babel-plugin-debug-macros@0.4.0-pre1"
   },
-  "devDependencies": {
+  "devDependencies": {},
+  "dependencies": {
     "patch-package": "^6.5.1",
     "postinstall-postinstall": "^2.1.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lttf:ignore": "lint-to-the-future ignore",
     "lttf:output": "lint-to-the-future output -o ./lint-progress/",
     "lint-progress": "yarn lttf:output && npx html-pages ./lint-progress --no-cache",
-    "postinstall": "yarn --cwd app/assets/javascripts/discourse $(node -e 'if(JSON.parse(process.env.npm_config_argv).original.includes(`--frozen-lockfile`)){console.log(`--frozen-lockfile`)}')"
+    "postinstall": "yarn --cwd app/assets/javascripts $(node -e 'if(JSON.parse(process.env.npm_config_argv).original.includes(`--frozen-lockfile`)){console.log(`--frozen-lockfile`)}')"
   },
   "engines": {
     "node": "16.* || >= 18",


### PR DESCRIPTION
When running `yarn install` in a yarn workspace, the lifecycle hooks in the root package.json are not triggered. https://github.com/yarnpkg/yarn/issues/5790

As a workaround, we can additionally run `patch-package` from the `javascripts/discourse/package.json` `postinstall` hook. `patch-package` is idempotent, so it doesn't matter if it is triggered multiple times.

Longer term we intend to move to pnpm, which has built-in patch support.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
