### PR TITLE
Revert "DEV: Support modifyClass for native class fields on EmberObjects (#20987)"

### DIFF
--- a/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
+++ b/app/assets/javascripts/discourse/tests/unit/lib/plugin-api-test.js
@@ -4,7 +4,6 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupTest } from "ember-qunit";
 import { getOwner } from "discourse-common/lib/get-owner";
-import Sinon from "sinon";
 
 module("Unit | Utility | plugin-api", function (hooks) {
   setupTest(hooks);
@@ -36,9 +35,6 @@ module("Unit | Utility | plugin-api", function (hooks) {
 
   test("modifyClass works with native class Ember objects", function (assert) {
     class NativeTestThingy extends EmberObject {
-      firstField = "firstFieldValue";
-      otherField = "otherFieldValue";
-
       @discourseComputed
       prop() {
         return "howdy";
@@ -51,8 +47,6 @@ module("Unit | Utility | plugin-api", function (hooks) {
       api.modifyClass("native-test-thingy:main", {
         pluginId: "plugin-api-test",
 
-        otherField: "new otherFieldValue",
-
         @discourseComputed
         prop() {
           return `${this._super(...arguments)} partner`;
@@ -62,15 +56,10 @@ module("Unit | Utility | plugin-api", function (hooks) {
 
     const thingy = getOwner(this).lookup("native-test-thingy:main");
     assert.strictEqual(thingy.prop, "howdy partner");
-    assert.strictEqual(thingy.firstField, "firstFieldValue");
-    assert.strictEqual(thingy.otherField, "new otherFieldValue");
   });
 
   test("modifyClass works with native classes", function (assert) {
     class ClassTestThingy {
-      firstField = "firstFieldValue";
-      otherField = "otherFieldValue";
-
       get keep() {
         return "hey!";
       }
@@ -80,42 +69,23 @@ module("Unit | Utility | plugin-api", function (hooks) {
       }
     }
 
-    getOwner(this).register("class-test-thingy:main", ClassTestThingy);
-
-    const warnStub = Sinon.stub(console, "warn");
+    getOwner(this).register("class-test-thingy:main", new ClassTestThingy(), {
+      instantiate: false,
+    });
 
     withPluginApi("1.1.0", (api) => {
       api.modifyClass("class-test-thingy:main", {
         pluginId: "plugin-api-test",
 
-        otherField: "new otherFieldValue",
         get prop() {
           return "g'day";
         },
       });
     });
 
-    assert.strictEqual(
-      warnStub.callCount,
-      1,
-      "fields warning was printed to console"
-    );
-    assert.true(warnStub.args[0][1].startsWith("Attempted to modify fields"));
-
-    const thingy = new ClassTestThingy();
-
-    assert.strictEqual(thingy.keep, "hey!", "maintains unchanged base getter");
-    assert.strictEqual(thingy.prop, "g'day", "can override getter");
-    assert.strictEqual(
-      thingy.firstField,
-      "firstFieldValue",
-      "maintains unchanged base field"
-    );
-    assert.strictEqual(
-      thingy.otherField,
-      "otherFieldValue",
-      "cannot override field"
-    );
+    const thingy = getOwner(this).lookup("class-test-thingy:main");
+    assert.strictEqual(thingy.keep, "hey!");
+    assert.strictEqual(thingy.prop, "g'day");
   });
 
   skip("modifyClass works with getters", function (assert) {
@@ -125,7 +95,9 @@ module("Unit | Utility | plugin-api", function (hooks) {
       },
     });
 
-    getOwner(this).register("test-class:main", Base);
+    getOwner(this).register("test-class:main", Base, {
+      instantiate: false,
+    });
 
     // Performing this lookup triggers `factory._onLookup`. In DEBUG builds, that invokes injectedPropertyAssertion()
     // https://github.com/emberjs/ember.js/blob/36505f1b42/packages/%40ember/-internals/runtime/lib/system/core_object.js#L1144-L1163


### PR DESCRIPTION
This reverts commit a19efc4304e38a9faeef040278752a5214809d4d.

This is causing issues in production - reverting while we investigate

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
