### PR TITLE
FIX: Educational composer messages regressed in 788dc0a

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-messages.js
+++ b/app/assets/javascripts/discourse/app/components/composer-messages.js
@@ -272,13 +272,13 @@ export default class ComposerMessages extends Component {
 
     this.set("checkedMessages", true);
 
-    for (const msg of messages) {
+    messages.forEach((msg) => {
       if (msg.wait_for_typing) {
         this.queuedForTyping.addObject(msg);
       } else {
         this.popup(msg);
       }
-    }
+    });
   }
 
   @action


### PR DESCRIPTION
Tests coming in another PR

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
