### PR TITLE
DEV: Support `posts-min:<count>` and `posts-max:<count>` on `/filter`

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -40,6 +40,10 @@ class TopicsFilter
         filter_created_by_user(usernames: values.flat_map { |value| value.split(",") })
       when "in"
         filter_in(values: values)
+      when "posts-min"
+        filter_by_number_of_posts(min: values.last)
+      when "posts-max"
+        filter_by_number_of_posts(max: values.last)
       when "status"
         values.each { |status| @scope = filter_status(status: status) }
       when "tags"
@@ -76,6 +80,13 @@ class TopicsFilter
   end
 
   private
+
+  def filter_by_number_of_posts(min: nil, max: nil)
+    { min => ">=", max => "<=" }.each do |value, operator|
+      next if !value || value !~ /^\d+$/
+      @scope = @scope.where("topics.posts_count #{operator} ?", value)
+    end
+  end
 
   def filter_categories(values:)
     exclude_subcategories_category_slugs = []


### PR DESCRIPTION
This commit adds support for the `posts-min:<count>` and
`posts-max:<count>` filters for the topics filtering query language.
`posts-min:1` will filter for topics with at least a one post while
`posts-max:3` will filter for topics with a maximum of 3 posts.

If the filter has an invalid value, i.e string that cannot be converted
into an integer, the filter will be ignored.

If either of each filter is specify multiple times, only the last
occurence of each filter will be taken into consideration.