### PR TITLE
FIX: decrease reorder sidebar delay for desktop

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/section-link.js
@@ -3,6 +3,9 @@ import { bind } from "discourse-common/utils/decorators";
 import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
 import discourseLater from "discourse-common/lib/later";
 
+const TOUCH_SCREEN_DELAY = 300;
+const MOUSE_DELAY = 100;
+
 export default class SectionLink {
   @tracked linkDragCss;
 
@@ -28,9 +31,12 @@ export default class SectionLink {
     if (event.button === 0 || event.targetTouches) {
       this.startMouseY = this.#calcMouseY(event);
       this.willDrag = true;
-      discourseLater(() => {
-        this.delayedStart(event);
-      }, 300);
+      discourseLater(
+        () => {
+          this.delayedStart(event);
+        },
+        event.targetTouches ? TOUCH_SCREEN_DELAY : MOUSE_DELAY
+      );
     }
   }
   delayedStart(event) {


### PR DESCRIPTION
Delay to reorder links in custom sidebar section doesn't have to be that long for desktop compared to touch screen.

