### PR TITLE
FIX: prevents exception if thread is not found

### DIFF
--- a/plugins/chat/app/serializers/chat/message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_serializer.rb
@@ -158,7 +158,7 @@ module Chat
     end
 
     def thread_reply_count
-      object.thread.replies_count
+      object.thread&.replies_count || 0
     end
   end
 end


### PR DESCRIPTION
It is yet to investigate the exact reasons leading to this, but probably due to some delete operation or migration, it seems possible to have a `message` with a `thread_id` leading to a non existing thread row. This is only a temporary solution to prevent the crash. We should also probably be more defensive here and not include any of this if threading is not enabled.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
