### PR TITLE
FIX: composer collapse position while uploading

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -369,6 +369,7 @@ html.composer-open {
   #file-uploading {
     display: flex;
     align-items: center;
+    margin-right: auto;
     a {
       margin-left: 0.33em;
       color: var(--primary-high);


### PR DESCRIPTION
Minor follow-up fix to ce601ac

When uploading an image the composer preview show/hide toggle would become misaligned, this ensures it stays on the far right. 