### PR TITLE
DEV: Set QUnit per-test timeout

### DIFF
--- a/app/assets/javascripts/discourse/tests/setup-tests.js
+++ b/app/assets/javascripts/discourse/tests/setup-tests.js
@@ -202,6 +202,7 @@ export default function setupTests(config) {
   setupDeprecationCounter(QUnit);
 
   QUnit.config.hidepassed = true;
+  QUnit.config.testTimeout = 60_000;
 
   sinon.config = {
     injectIntoThis: false,

--- a/test/run-qunit.js
+++ b/test/run-qunit.js
@@ -213,8 +213,6 @@ function logQUnit() {
 
   console.log("\nRunning: " + JSON.stringify(QUnit.urlParams) + "\n");
 
-  QUnit.config.testTimeout = 10000;
-
   let durations = {};
 
   let inTest = false;


### PR DESCRIPTION
60s is a lot, and I'd prefer 15s, but the first test in a suite can take up to 40s. 60s is still better than `Infinity` 😌

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
