### PR TITLE
DEV: Remove unnecessary `getURL("/")`

### DIFF
--- a/app/assets/javascripts/discourse/app/adapters/topic-list.js
+++ b/app/assets/javascripts/discourse/app/adapters/topic-list.js
@@ -1,11 +1,10 @@
 import PreloadStore from "discourse/lib/preload-store";
 import RestAdapter from "discourse/adapters/rest";
 import { ajax } from "discourse/lib/ajax";
-import getURL from "discourse-common/lib/get-url";
 
 export function finderFor(filter, params) {
   return function () {
-    let url = getURL("/") + filter + ".json";
+    let url = `/${filter}.json`;
 
     if (params) {
       const urlSearchParams = new URLSearchParams();
@@ -22,6 +21,7 @@ export function finderFor(filter, params) {
         url += `?${queryString}`;
       }
     }
+
     return ajax(url);
   };
 }

--- a/app/assets/javascripts/discourse/app/models/topic-list.js
+++ b/app/assets/javascripts/discourse/app/models/topic-list.js
@@ -5,7 +5,6 @@ import Session from "discourse/models/session";
 import User from "discourse/models/user";
 import { ajax } from "discourse/lib/ajax";
 import { getOwner } from "discourse-common/lib/get-owner";
-import getURL from "discourse-common/lib/get-url";
 import { isEmpty } from "@ember/utils";
 import { notEmpty } from "@ember/object/computed";
 
@@ -123,9 +122,7 @@ const TopicList = RestModel.extend({
       this.topics.filter((topic) => topic_ids.includes(topic.id))
     );
 
-    const url = `${getURL("/")}${this.filter}.json?topic_ids=${topic_ids.join(
-      ","
-    )}`;
+    const url = `/${this.filter}.json?topic_ids=${topic_ids.join(",")}`;
 
     return ajax({ url, data: this.params }).then((result) => {
       let i = 0;

--- a/app/assets/javascripts/discourse/app/models/topic.js
+++ b/app/assets/javascripts/discourse/app/models/topic.js
@@ -26,7 +26,7 @@ import { applyModelTransformations } from "discourse/lib/model-transformers";
 
 export function loadTopicView(topic, args) {
   const data = deepMerge({}, args);
-  const url = `${getURL("/t/")}${topic.id}`;
+  const url = `/t/${topic.id}`;
   const jsonUrl = (data.nearPost ? `${url}/${data.nearPost}` : url) + ".json";
 
   delete data.nearPost;

--- a/app/assets/javascripts/discourse/app/routes/discovery-categories.js
+++ b/app/assets/javascripts/discourse/app/routes/discovery-categories.js
@@ -10,7 +10,6 @@ import { defaultHomepage } from "discourse/lib/utilities";
 import { hash } from "rsvp";
 import { next } from "@ember/runloop";
 import showModal from "discourse/lib/show-modal";
-import getURL from "discourse-common/lib/get-url";
 import Session from "discourse/models/session";
 
 const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
@@ -57,7 +56,7 @@ const DiscoveryCategoriesRoute = DiscourseRoute.extend(OpenComposer, {
         this.topics.filter((topic) => topic_ids.includes(topic.id))
       );
 
-      const url = `${getURL("/")}latest.json?topic_ids=${topic_ids.join(",")}`;
+      const url = `/latest.json?topic_ids=${topic_ids.join(",")}`;
 
       return ajax({ url, data: this.params }).then((result) => {
         const topicIds = new Set();


### PR DESCRIPTION
Our `ajax()` prepends the protocol/host/subfolder path.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
