### PR TITLE
FIX: ensures tag notification level is changed

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/tag-show.js
+++ b/app/assets/javascripts/discourse/app/controllers/tag-show.js
@@ -184,6 +184,8 @@ export default DiscoverySortableController.extend(
         .then((response) => {
           const payload = response.responseJson;
 
+          this.tagNotification.set("notification_level", notificationLevel);
+
           this.currentUser.setProperties({
             watched_tags: payload.watched_tags,
             watching_first_post_tags: payload.watching_first_post_tags,

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -37,6 +37,11 @@ module PageObjects
         expand
         element.find(".select-kit-row[data-value='#{value}']").click
       end
+
+      def select_row_by_name(name)
+        expand
+        element.find(".select-kit-row[data-name='#{name}']").click
+      end
     end
   end
 end

--- a/spec/system/tag_notification_level_spec.rb
+++ b/spec/system/tag_notification_level_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe "Tag notification level", type: :system, js: true do
+  let(:tags_page) { PageObjects::Pages::Tag.new }
+  let(:select_kit) do
+    PageObjects::Components::SelectKit.new(page.find(".tag-notifications-button"))
+  end
+
+  fab!(:tag_1) { Fabricate(:tag) }
+  fab!(:current_user) { Fabricate(:admin) }
+
+  before { sign_in(current_user) }
+
+  describe "when changing a tag's notification level" do
+    it "should change instantly" do
+      tags_page.visit_tag(tag_1)
+      expect(select_kit).to have_selected_name("regular")
+
+      select_kit.select_row_by_name("watching")
+
+      expect(select_kit).to have_selected_name("watching")
+    end
+  end
+end


### PR DESCRIPTION
Following a change in https://github.com/discourse/discourse/commit/e9f726281321b6779b2e27c7f9d2f4b4ca3012aa which prevents the notification level to be returned from the update endpoint, the model couldn't update itself. This commit makes the update manually and adds a test to prevent future regressions.

Note we could also change the backend endpoint, but this should work correctly with minimum risk.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
