### PR TITLE
FIX: Do not serialize thread data if threading disabled

### DIFF
--- a/plugins/chat/app/serializers/chat/message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_serializer.rb
@@ -153,8 +153,16 @@ module Chat
       end
     end
 
+    def include_threading_data?
+      SiteSetting.enable_experimental_chat_threaded_discussions && channel.threading_enabled
+    end
+
+    def include_thread_id?
+      include_threading_data?
+    end
+
     def include_thread_reply_count?
-      object.thread_id.present?
+      include_threading_data? && object.thread_id.present?
     end
 
     def thread_reply_count

--- a/plugins/chat/spec/serializer/chat/chat_message_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chat_message_serializer_spec.rb
@@ -208,4 +208,44 @@ describe Chat::MessageSerializer do
       end
     end
   end
+
+  describe "threading data" do
+    before { message_1.update!(thread: Fabricate(:chat_thread, channel: chat_channel)) }
+
+    context "when enable_experimental_chat_threaded_discussions is disabled" do
+      before { SiteSetting.enable_experimental_chat_threaded_discussions = false }
+
+      it "does not include thread data" do
+        serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+        expect(serialized).not_to have_key(:thread_id)
+        expect(serialized).not_to have_key(:thread_reply_count)
+      end
+    end
+
+    context "when the channel has threading_enabled false" do
+      before do
+        SiteSetting.enable_experimental_chat_threaded_discussions = true
+        chat_channel.update!(threading_enabled: false)
+      end
+
+      it "does not include thread data" do
+        serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+        expect(serialized).not_to have_key(:thread_id)
+        expect(serialized).not_to have_key(:thread_reply_count)
+      end
+    end
+
+    context "when the channel has threading_enabled true and enable_experimental_chat_threaded_discussions is true" do
+      before do
+        SiteSetting.enable_experimental_chat_threaded_discussions = true
+        chat_channel.update!(threading_enabled: true)
+      end
+
+      it "does include thread data" do
+        serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+        expect(serialized).to have_key(:thread_id)
+        expect(serialized).to have_key(:thread_reply_count)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Followup to ba11cf47670891681a8cb579c3a4819421111345,
this commit makes it so that none of the chat message
thread data is serialized if threading_enabled is false
for the channel or if enable_experimental_chat_threaded_discussions
is false, there is no need to serialize the data in this
case.
