### PR TITLE
DEV: Remove hardcoded user_id in spec

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2135,17 +2135,11 @@ RSpec.describe User do
       expect(CategoryUser.lookup(user, :regular).pluck(:category_id)).to eq([category4.id])
     end
 
-    it "does not update category preferences if already set by group" do
-      user_id = 123
-
-      CategoryUser.create!(
-        user_id: user_id,
-        category_id: category2.id,
-        notification_level: CategoryUser.notification_levels[:normal],
-      )
-      user = Fabricate(:user, id: user_id, trust_level: 1)
-
-      expect(CategoryUser.lookup(user, :normal).pluck(:category_id)).to include(category2.id)
+    it "does not error on duplicate categories for set_default_categories_preferences" do
+      SiteSetting.default_categories_normal = category4.id.to_s + "|" + category4.id.to_s
+      user = nil
+      expect { user = Fabricate(:user, trust_level: 1) }.not_to raise_error
+      expect(CategoryUser.lookup(user, :normal).pluck(:category_id)).to include(category4.id)
     end
 
     it "does not set category preferences for staged users" do


### PR DESCRIPTION
Followup to 08ff6eebad83d921ad0d175aa02332fb04333ff7,
we can just test this using the original problem in
https://meta.discourse.org/t/-/172572, which is that
SiteSetting.default_categories_normal had duplicate
IDs.
