### PR TITLE
FIX: overflow of channel title in preview card

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-title.scss
@@ -1,3 +1,4 @@
+//appears in: header of chat pane, channel info, preview card
 .chat-channel-title-wrapper {
   display: flex;
   align-items: center;
@@ -8,6 +9,10 @@
   display: flex;
   align-items: center;
   @include ellipsis;
+
+  .chat-channel-preview-card & {
+    max-width: 100%;
+  }
 
   &__user-info {
     overflow: hidden;


### PR DESCRIPTION
Fixing an overflow in the preview card for joining a channel:
![image](https://user-images.githubusercontent.com/101828855/232484499-5ac30276-e5ea-4315-8f1d-4d6e306d9d2e.png)

There is a comment in the file but I humbly request permission to keep it there as I would like to have a reminder for myself of where this chat-channel-title is used. The list is not exhaustive yet, but now I can add items when I find instances Ive missed.
