### PR TITLE
FIX: Render links with subfolders properly in Discobot

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/new_user_narrative.rb
@@ -638,7 +638,10 @@ module DiscourseNarrativeBot
     end
 
     def url_helpers(url, opts = {})
-      Rails.application.routes.url_helpers.public_send(url, opts.merge(host: Discourse.base_url))
+      Rails.application.routes.url_helpers.public_send(
+        url,
+        opts.merge(host: Discourse.base_url_no_prefix),
+      )
     end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -153,6 +153,7 @@ module Helpers
     global_setting :relative_url_root, f
     old_root = ActionController::Base.config.relative_url_root
     ActionController::Base.config.relative_url_root = f
+    Rails.application.routes.stubs(:relative_url_root).returns(f)
 
     before_next_spec { ActionController::Base.config.relative_url_root = old_root }
   end


### PR DESCRIPTION
Currently, some links aren’t properly built in Discobot when Discourse is hosted in a subfolder. This is because we’re providing `Discourse.base_url` to the Rails helpers which contains the base URL *with* the prefix. But Rails helpers already handle this prefix so the resulting link gets the prefix twice.

The fix is quite simple: use `Discourse.base_url_no_prefix` instead of `Discourse.base_url`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
