### PR TITLE
FIX: error when quoting message into topic

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane.js
@@ -16,7 +16,7 @@ export default class ChatChannelPane extends Service {
   @tracked sendingLoading = false;
 
   get selectedMessageIds() {
-    return this.chat.activeChannel.selectedMessages.mapBy("id");
+    return this.chat.activeChannel?.selectedMessages?.mapBy("id") || [];
   }
 
   get composerService() {


### PR DESCRIPTION
This error was only happening on mobile, note we also already have a (mobile) test (plugins/chat/spec/system/transcript_spec.rb:184) for this which was passing as it's only happening at a specific speed. I don't want to complicate the test too much for this case, will reconsider if it regresses again.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
