### PR TITLE
FIX: Dismiss modal when "Keep Editing" is used

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/composer.js
+++ b/app/assets/javascripts/discourse/app/controllers/composer.js
@@ -1468,8 +1468,6 @@ export default class ComposerController extends Controller {
             this.appEvents.trigger("composer:cancelled");
             return resolve();
           },
-          // needed to resume saving drafts if composer stays open
-          onDismissModal: () => resolve(),
         });
       } else {
         // it is possible there is some sort of crazy draft with no body ... just give up on it

--- a/app/assets/javascripts/discourse/app/controllers/discard-draft.js
+++ b/app/assets/javascripts/discourse/app/controllers/discard-draft.js
@@ -13,7 +13,7 @@ export default Controller.extend(ModalFunctionality, {
       this.send("closeModal");
     },
 
-   dismissModal() {
+    dismissModal() {
       this.send("closeModal");
     },
   },

--- a/app/assets/javascripts/discourse/app/controllers/discard-draft.js
+++ b/app/assets/javascripts/discourse/app/controllers/discard-draft.js
@@ -13,7 +13,7 @@ export default Controller.extend(ModalFunctionality, {
       this.send("closeModal");
     },
 
-    async dismissModal() {
+   dismissModal() {
       this.send("closeModal");
     },
   },

--- a/app/assets/javascripts/discourse/app/controllers/discard-draft.js
+++ b/app/assets/javascripts/discourse/app/controllers/discard-draft.js
@@ -14,7 +14,6 @@ export default Controller.extend(ModalFunctionality, {
     },
 
     async dismissModal() {
-      await this.onDismissModal();
       this.send("closeModal");
     },
   },

--- a/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/composer-test.js
@@ -370,6 +370,26 @@ acceptance("Composer", function (needs) {
     );
   });
 
+  test("Can Keep Editing when replying on a different topic", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    await click("#topic-footer-buttons .create");
+    await fillIn(".d-editor-input", "this is the content of my reply");
+
+    await visit("/t/this-is-a-test-topic/9");
+    await click("#topic-footer-buttons .create");
+    assert.ok(visible(".discard-draft-modal.modal"));
+
+    await click(".modal-footer button.keep-editing");
+    assert.ok(invisible(".discard-draft-modal.modal"));
+
+    assert.strictEqual(
+      query(".d-editor-input").value,
+      "this is the content of my reply",
+      "composer does not switch when using Keep Editing button"
+    );
+  });
+
   test("Posting on a different topic", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click("#topic-footer-buttons .btn.create");


### PR DESCRIPTION
In some cases, this button was doing nothing.