### PR TITLE
UX: Vertical alignment issues on mobile

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1166,7 +1166,7 @@ blockquote > *:last-child {
 
     p {
       margin: 0;
-      padding-right: 0.5em;
+      padding: 0.15em 0.5em 0 0;
     }
   }
 

--- a/plugins/poll/assets/stylesheets/mobile/poll.scss
+++ b/plugins/poll/assets/stylesheets/mobile/poll.scss
@@ -7,6 +7,10 @@ div.poll {
     button {
       margin: 0 0.5em 0.5em 0;
     }
+
+    button + .info-text {
+      margin: 0.4em 0 0 0.5em;
+    }
   }
 
   .poll-info {


### PR DESCRIPTION
Vertical alignment fixes for topic closed small message and poll info.

Before:

![before-1](https://user-images.githubusercontent.com/11170663/232557745-b0062788-0414-4521-879e-093d9168fabf.jpeg)

![before-2](https://user-images.githubusercontent.com/11170663/232557760-2264c422-fd5c-4405-a38c-1137b542a308.jpeg)

After:

<img width="293" alt="Screenshot 2023-04-17 at 10 29 40 PM" src="https://user-images.githubusercontent.com/11170663/232557794-aff7c219-9709-4d68-b668-a2374167aa14.png">

<img width="244" alt="Screenshot 2023-04-17 at 10 30 42 PM" src="https://user-images.githubusercontent.com/11170663/232557801-6ff76771-3f4c-4892-8027-a004223c7714.png">
