### PR TITLE
DEV: Offset quote button on mobile devices

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -59,6 +59,7 @@ export default Component.extend(KeyEnterEscape, {
   editPost: null,
   _popper: null,
   popperPlacement: "top-start",
+  popperOffset: [0, 3],
 
   _isFastEditable: false,
   _displayFastEditInput: false,
@@ -199,6 +200,12 @@ export default Component.extend(KeyEnterEscape, {
 
     if (showAtEnd) {
       this.popperPlacement = "bottom-start";
+
+      if (isAndroid) {
+        this.popperOffset = [0, 25];
+      } else {
+        this.popperOffset = [0, 15];
+      }
     }
 
     // change the position of the button
@@ -222,7 +229,7 @@ export default Component.extend(KeyEnterEscape, {
           {
             name: "offset",
             options: {
-              offset: [0, 3],
+              offset: this.popperOffset,
             },
           },
         ],


### PR DESCRIPTION
This PR is a fix for a [report on Meta](https://meta.discourse.org/t/quoting-popup-positioning-on-mobile/261550) regarding the quote button positioning since its switch to using popper (https://github.com/discourse/discourse/pull/20878).

This PR applies an offset to the quote button positioning so that it does not get covered by the select text anchors on mobile. Since the Android anchor is larger, we set a larger offset for Android compared to other devices.

**Android:**
<img width="319" alt="Screenshot 2023-04-17 at 10 51 22" src="https://user-images.githubusercontent.com/30090424/232570307-694c8776-400a-47ea-897b-ab712c0b13ae.png">

**iOS:**
<img width="391" alt="Screenshot 2023-04-17 at 10 56 44" src="https://user-images.githubusercontent.com/30090424/232570494-7fff0e70-a359-4fcb-86e9-0c2a5816498b.png">

**Desktop:**
<img width="402" alt="Screenshot 2023-04-17 at 10 31 31" src="https://user-images.githubusercontent.com/30090424/232570638-661d3b1f-6c53-4103-96ea-689893210ec4.png">
