### PR TITLE
UX: prevent overflow in description

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -16,6 +16,8 @@
   &__description {
     color: var(--primary-600);
     text-align: center;
+    overflow-wrap: break-word;
+    max-width: 100%;
   }
 
   .chat-channel-title__name {


### PR DESCRIPTION
Preventing an edge case where a long url in the description causes an overflow

<img width="378" alt="image" src="https://user-images.githubusercontent.com/101828855/232642561-b7763bdf-e947-49fe-ae25-5c691e531a16.png">
