### PR TITLE
FIX: Add missing translations strings for lazy-videos

### DIFF
--- a/plugins/discourse-lazy-videos/config/locales/server.en.yml
+++ b/plugins/discourse-lazy-videos/config/locales/server.en.yml
@@ -1,3 +1,6 @@
 en:
   site_settings:
     lazy_videos_enabled: "Enable the Lazy Videos plugin"
+    lazy_youtube_enabled: "Enable lazy loading for YouTube embeds"
+    lazy_vimeo_enabled: "Enable lazy loading for Vimeo embeds"
+    lazy_tiktok_enabled: "Enable lazy loading for TikTok embeds (experimental)"


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
