### PR TITLE
UX: improve contrast of overridden setting indicator dot

### DIFF
--- a/app/assets/stylesheets/common/admin/settings.scss
+++ b/app/assets/stylesheets/common/admin/settings.scss
@@ -122,7 +122,7 @@
         width: 0.5rem;
         height: 0.5rem;
         border-radius: 100%;
-        background-color: var(--primary-low);
+        background-color: var(--quaternary-low);
       }
     }
   }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/101828855/232662352-f9cf6cee-11ab-47ec-8872-03f0d988453e.png)

After:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/101828855/232662370-26086744-dfb9-4040-95d6-614ea009044a.png">

