### PR TITLE
FIX: apply clear-transition class to correct wrapper for chat drawer

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-drawer.js
@@ -122,7 +122,9 @@ export default Component.extend({
       return;
     }
 
-    document.querySelector(".chat-drawer").classList.add("clear-transitions");
+    document
+      .querySelector(".chat-drawer-outlet-container")
+      .classList.add("clear-transitions");
   },
 
   _clearDynamicCheckSize() {
@@ -131,7 +133,7 @@ export default Component.extend({
     }
 
     document
-      .querySelector(".chat-drawer")
+      .querySelector(".chat-drawer-outlet-container")
       .classList.remove("clear-transitions");
     this._checkSize();
   },


### PR DESCRIPTION
Class was being applied to the wrong html element