### PR TITLE
UX: ensures cursor is pointer over custom sections

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-custom-section.scss
+++ b/app/assets/stylesheets/common/base/sidebar-custom-section.scss
@@ -21,6 +21,7 @@
   a {
     -webkit-touch-callout: none !important;
     @include unselectable;
+    cursor: pointer;
   }
 
   .sidebar-section-wrapper.disabled {


### PR DESCRIPTION
Due to `@include unselectable;` the cursor was `default` instead of the expected `cursor` on a link.