### PR TITLE
FEATURE: Detect current git "branch" even when a tag is checked out 

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -777,10 +777,8 @@ module Discourse
 
   def self.git_branch
     @git_branch ||=
-      begin
-        git_cmd = "git rev-parse --abbrev-ref HEAD"
-        self.try_git(git_cmd, "unknown")
-      end
+      self.try_git("git branch --show-current", nil) ||
+        self.try_git("git config user.discourse-version", "unknown")
   end
 
   def self.full_version

--- a/lib/discourse_hub.rb
+++ b/lib/discourse_hub.rb
@@ -5,7 +5,7 @@ module DiscourseHub
 
   def self.version_check_payload
     default_payload = { installed_version: Discourse::VERSION::STRING }.merge!(
-      Discourse.git_branch == "unknown" ? {} : { branch: Discourse.git_branch },
+      Discourse.git_branch == "unknown" && !Rails.env.test? ? {} : { branch: Discourse.git_branch },
     )
     default_payload.merge!(get_payload)
   end


### PR DESCRIPTION
It switches to a different command for detecting the current git branch because the old command always returned HEAD as branch when the git repository is on a detached head (e.g. tag). The new command doesn't return a branch when the repository is on a detached head, which allows us to fall back to the `version` variable that is stored in the git config since https://github.com/discourse/discourse_docker/pull/707. It contains the value of the `version` from `app.yml`.

It also includes a small change to specs, because our tests usually run on specific commits instead of a branch or tag, so `Discourse.git_branch` always returns "unknown". We can use the "unknown" branch for tests, so it makes sense to ignore it only in other envs.