### PR TITLE
UX: slight design changes to chat timestamp

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-separator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-separator.scss
@@ -65,8 +65,10 @@
       &.is-pinned,
       &.is-force-pinned {
         .chat-message-separator__text {
-          border: 1px solid var(--secondary-high);
-          border-radius: 3px;
+          border: 1px solid var(--primary-200);
+          border-radius: 4px;
+          color: var(--primary-800);
+          background: var(--primary-50);
         }
 
         .chat-message-separator__last-visit {


### PR DESCRIPTION
Making the timestamp stand out a bit less

From 
<img width="692" alt="image" src="https://user-images.githubusercontent.com/101828855/232769397-c84d211e-ad46-48c7-989d-ad4f0d21c521.png">

To
<img width="418" alt="image" src="https://user-images.githubusercontent.com/101828855/232769201-218bc972-5ee9-46a1-bfaf-2a7dffcdee2c.png">

