### PR TITLE
FIX: 500 error when adding restricted category tags

### DIFF
--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -634,7 +634,10 @@ module DiscourseTagging
       taggable.tags = Tag.where_name(tag_names).all
       new_tag_names =
         taggable.tags.size < tag_names.size ? tag_names - taggable.tags.map(&:name) : []
-      taggable.tags << Tag.where(target_tag_id: taggable.tags.map(&:id)).all
+      taggable.tags << Tag
+        .where(target_tag_id: taggable.tags.map(&:id))
+        .where.not(id: taggable.tags.map(&:id))
+        .all
       new_tag_names.each { |name| taggable.tags << Tag.create(name: name) }
     end
   end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1425,4 +1425,28 @@ RSpec.describe Category do
       )
     end
   end
+
+  describe "allowed_tags=" do
+    let(:category) { Fabricate(:category) }
+    fab!(:tag) { Fabricate(:tag) }
+    fab!(:tag2) { Fabricate(:tag) }
+
+    before { SiteSetting.tagging_enabled = true }
+
+    it "can use existing tags for category tags" do
+      category.allowed_tags = [tag.name]
+      expect_same_tag_names(category.reload.tags, [tag])
+    end
+
+    context "with synonyms" do
+      fab!(:synonym) { Fabricate(:tag, name: "synonym", target_tag: tag) }
+
+      it "can use existing tags for category tags" do
+        category.allowed_tags = [tag.name, synonym.name]
+        category.reload
+        category.allowed_tags = [tag.name, synonym.name, tag2.name]
+        expect_same_tag_names(category.reload.tags, [tag.name, synonym.name, tag2.name])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes a 500 error that occurs when adding a tag to a category's
restricted tag list if the category's restricted tags already included a
synonym tag.
