### PR TITLE
FIX: Quote button doesn't press on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -199,12 +199,7 @@ export default Component.extend(KeyEnterEscape, {
 
     if (showAtEnd) {
       this.popperPlacement = "bottom-start";
-
-      if (isAndroid) {
-        this.popperOffset = [0, 25];
-      } else {
-        this.popperOffset = [0, 15];
-      }
+      this.popperOffset = [0, 25];
     }
 
     // change the position of the button


### PR DESCRIPTION
This PR increases the mobile offset for the quote-button to be the same as Android (`[0, 25]`) which both:
- simplifies things so there is only one offset
- fixes an issue on mobile where the button to quote text doesn't work when pressed