### PR TITLE
UX: update ring animation to avoid scroll

### DIFF
--- a/app/assets/stylesheets/color_definitions.scss
+++ b/app/assets/stylesheets/color_definitions.scss
@@ -25,6 +25,7 @@
   --header_background-rgb: #{hexToRGB($header_background)};
   --tertiary-rgb: #{hexToRGB($tertiary)};
   --highlight-rgb: #{hexToRGB($highlight)};
+  --success-rgb: #{hexToRGB($success)};
 
   --primary-very-low: #{$primary-very-low};
   --primary-low: #{$primary-low};

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -5,13 +5,17 @@
 
 // Animation Keyframes
 @keyframes ping {
-  from {
-    transform: scale(0.25);
-    opacity: 1;
+  0% {
+    transform: scale(0.6);
+    box-shadow: 0 0 0 0 rgba(var(--success-rgb), 0.7);
   }
-  to {
-    transform: scale(2);
-    opacity: 0;
+  70% {
+    transform: scale(1);
+    box-shadow: 0 0 0 10px rgba(var(--success-rgb), 0);
+  }
+  100% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(var(--success-rgb), 0);
   }
 }
 

--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -210,10 +210,11 @@
     right: 23.5px;
     z-index: z("base");
     margin-left: 0;
-    background: radial-gradient(transparent, var(--success));
     border-radius: 100%;
     width: 20px;
     height: 20px;
+    box-shadow: 0 0 0 rgba(var(--success-rgb), 1);
+    transform: scale(1);
     transform-origin: center;
     animation-iteration-count: infinite;
     animation-duration: 3s;


### PR DESCRIPTION
At some narrow widths the animation on the first notification for new users can cause some horizontal overflow scroll. This is because we're animating the scale of a div with transform, and it overflows the viewport. 

Updating the animation to use box-shadow instead avoids this issue. 

Before (scrollbar at the bottom at the end of the clip):


https://user-images.githubusercontent.com/1681963/232917370-4aa8cd35-1e59-48f0-881b-6cde9a1a28e1.mp4



After:

https://user-images.githubusercontent.com/1681963/232916906-fa5cfa61-54fe-43bd-9f12-79591e5dc9f5.mp4

