### PR TITLE
FIX: Resetting user directory columns

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/edit-user-directory-columns.js
+++ b/app/assets/javascripts/discourse/app/controllers/edit-user-directory-columns.js
@@ -49,12 +49,16 @@ export default Controller.extend(ModalFunctionality, {
   resetToDefault() {
     let resetColumns = this.columns;
     resetColumns
-      .sort((a, b) =>
-        (a.automatic_position || a.user_field.position + 1000) >
-        (b.automatic_position || b.user_field.position + 1000)
-          ? 1
-          : -1
-      )
+      .sort((a, b) => {
+        const a1 = a.automatic_position || (a.user_field?.position || 0) + 1000;
+        const b1 = b.automatic_position || (b.user_field?.position || 0) + 1000;
+
+        if (a1 === b1) {
+          return a.name.localeCompare(b.name);
+        } else {
+          return a1 > b1 ? 1 : -1;
+        }
+      })
       .forEach((column, index) => {
         column.setProperties({
           position: column.automatic_position || index + 1,

--- a/app/assets/javascripts/discourse/tests/acceptance/users-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/users-test.js
@@ -84,7 +84,7 @@ acceptance("User directory - Editing columns", function (needs) {
     const columns = queryAll(
       ".edit-directory-columns-container .edit-directory-column"
     );
-    assert.strictEqual(columns.length, 8);
+    assert.strictEqual(columns.length, 9);
 
     const checked = queryAll(
       ".edit-directory-columns-container .edit-directory-column input[type='checkbox']:checked"
@@ -94,7 +94,7 @@ acceptance("User directory - Editing columns", function (needs) {
     const unchecked = queryAll(
       ".edit-directory-columns-container .edit-directory-column input[type='checkbox']:not(:checked)"
     );
-    assert.strictEqual(unchecked.length, 1);
+    assert.strictEqual(unchecked.length, 2);
   });
 
   const fetchColumns = function () {
@@ -134,6 +134,7 @@ acceptance("User directory - Editing columns", function (needs) {
     await click(moveUserFieldColumnUpBtn);
     await click(moveUserFieldColumnUpBtn);
     await click(moveUserFieldColumnUpBtn);
+    await click(moveUserFieldColumnUpBtn);
 
     columns = fetchColumns();
     assert.strictEqual(
@@ -160,6 +161,7 @@ acceptance("User directory - Editing columns", function (needs) {
       "Topics Viewed",
       "Posts Read",
       "Days Visited",
+      "[en.an_extra_field]",
       "Favorite Color",
     ]);
   });

--- a/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
+++ b/app/assets/javascripts/discourse/tests/helpers/create-pretender.js
@@ -1043,11 +1043,21 @@ export function applyDefaultHandlers(pretender) {
         },
         {
           id: 9,
+          name: "an_extra_field",
+          type: "plugin",
+          enabled: false,
+          automatic_position: null,
+          position: 8,
+          icon: null,
+          user_field: null,
+        },
+        {
+          id: 10,
           name: null,
           type: "user_field",
           enabled: false,
           automatic_position: null,
-          position: 8,
+          position: 9,
           icon: null,
           user_field: {
             id: 3,


### PR DESCRIPTION
Having any `plugin` type columns was breaking "Reset to default" functionality.

(note: `[en.an_extra_field]` is an example of how fields from previously-installed plugins show up in the UI. dunno if it's a problem in the wild 🤷)