### PR TITLE
FIX: Hashtag subcategory ref incorrect when not highest-ranked type

### DIFF
--- a/spec/services/hashtag_autocomplete_service_spec.rb
+++ b/spec/services/hashtag_autocomplete_service_spec.rb
@@ -140,6 +140,44 @@ RSpec.describe HashtagAutocompleteService do
       )
     end
 
+    it "does not add a type suffix where
+        1. a subcategory name conflicts with an existing tag name and
+        2. the category is not the top ranked type" do
+      parent = Fabricate(:category, name: "Hobbies", slug: "hobbies")
+      category1.update!(parent_category: parent)
+      Fabricate(:tag, name: "the-book-club")
+
+      Fabricate(:bookmark, user: user, name: "book club")
+      guardian.user.reload
+
+      DiscoursePluginRegistry.register_hashtag_autocomplete_data_source(
+        FakeBookmarkHashtagDataSource,
+        stub(enabled?: true),
+      )
+
+      expect(subject.search("book", %w[bookmark category tag]).map(&:ref)).to eq(
+        %w[book-club hobbies:the-book-club great-books the-book-club::tag],
+      )
+    end
+
+    it "handles the type suffix where the top ranked type conflicts with a subcategory" do
+      parent = Fabricate(:category, name: "Hobbies", slug: "hobbies")
+      category1.update!(parent_category: parent)
+      Fabricate(:tag, name: "the-book-club")
+
+      Fabricate(:bookmark, user: user, name: "the book club")
+      guardian.user.reload
+
+      DiscoursePluginRegistry.register_hashtag_autocomplete_data_source(
+        FakeBookmarkHashtagDataSource,
+        stub(enabled?: true),
+      )
+
+      expect(subject.search("book", %w[bookmark category tag]).map(&:ref)).to eq(
+        %w[the-book-club hobbies:the-book-club::category great-books the-book-club::tag],
+      )
+    end
+
     it "orders results by (with type ordering within each section):
         1. exact match on slug (ignoring parent/child distinction for categories)
         2. slugs that start with the term
@@ -336,6 +374,18 @@ RSpec.describe HashtagAutocompleteService do
       result = subject.lookup(%w[media:the-book-club], %w[category tag])
       expect(result[:category].map(&:slug)).to eq(["the-book-club"])
       expect(result[:category].map(&:ref)).to eq(["media:the-book-club"])
+      expect(result[:category].map(&:relative_url)).to eq(
+        ["/c/media/the-book-club/#{category1.id}"],
+      )
+      category1.update!(parent_category: nil)
+    end
+
+    it "handles parent:child category lookups with type suffix" do
+      parent_category = Fabricate(:category, name: "Media", slug: "media")
+      category1.update!(parent_category: parent_category)
+      result = subject.lookup(%w[media:the-book-club::category], %w[category tag])
+      expect(result[:category].map(&:slug)).to eq(["the-book-club"])
+      expect(result[:category].map(&:ref)).to eq(["media:the-book-club::category"])
       expect(result[:category].map(&:relative_url)).to eq(
         ["/c/media/the-book-club/#{category1.id}"],
       )


### PR DESCRIPTION
This commit fixes the following scenario:

1. The user is searching for hashtags in chat, where the subcategory
   type is not highest-ranked in priority order.
2. There can, but doesn't have to be, a higher-ranked matching chat
   channel that has the same slug as the subcategory.
3. Since it is not the highest-ranked type, the subcategory, which
   normally has a ref of parent:child, has its ref changed to
   child::category, which does not work

This was happening because whenever a hashtag type was not highest
ranked, if _any_ other hashtag results conflicted slugs, we would
append the ::type suffix. Now, we only append this suffix if a
higher-ranked type conflicts with the hashtag, and we use the current ref
to build the new typed ref to preserve this parent:child format as well,
it's more accurate.
