### PR TITLE
DEV: Reintroduce chat rake dev generate tasks

### DIFF
--- a/lib/discourse_dev/record.rb
+++ b/lib/discourse_dev/record.rb
@@ -37,7 +37,7 @@ module DiscourseDev
         raise 'To run this rake task in a production site, set the value of `ALLOW_DEV_POPULATE` environment variable to "1"'
       end
 
-      unless ignore_current_count
+      unless ignore_current_count || @ignore_current_count
         if current_count >= @count
           puts "Already have #{current_count} #{type} records"
 
@@ -68,8 +68,8 @@ module DiscourseDev
       model.count
     end
 
-    def self.populate!(*args)
-      self.new(*args).populate!
+    def self.populate!(**args)
+      self.new(**args).populate!
     end
 
     def self.random(model, use_existing_records: true)

--- a/plugins/chat/lib/discourse_dev/category_channel.rb
+++ b/plugins/chat/lib/discourse_dev/category_channel.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "discourse_dev/record"
+require "faker"
+
+module DiscourseDev
+  class CategoryChannel < Record
+    def initialize
+      super(::Chat::CategoryChannel, 5)
+    end
+
+    def data
+      chatable = Category.random
+
+      {
+        chatable: chatable,
+        description: Faker::Lorem.paragraph,
+        user_count: 1,
+        name: Faker::Company.name,
+        created_at: Faker::Time.between(from: DiscourseDev.config.start_date, to: DateTime.now),
+      }
+    end
+
+    def create!
+      users = []
+      super do |channel|
+        Faker::Number
+          .between(from: 5, to: 10)
+          .times do
+            if Faker::Boolean.boolean(true_ratio: 0.5)
+              admin_username =
+                begin
+                  DiscourseDev::Config.new.config[:admin][:username]
+                rescue StandardError
+                  nil
+                end
+              admin_user = ::User.find_by(username: admin_username) if admin_username
+            end
+
+            user = admin_user || User.new(username: Faker::Internet.username(specifier: 10)).create!
+            Chat::ChannelMembershipManager.new(channel).follow(user)
+            users << user
+          end
+
+        Faker::Number
+          .between(from: 20, to: 80)
+          .times do
+            Chat::MessageCreator.create(
+              { user: users.sample, chat_channel: channel, content: Faker::Lorem.paragraph },
+            )
+          end
+      end
+    end
+  end
+end

--- a/plugins/chat/lib/discourse_dev/message.rb
+++ b/plugins/chat/lib/discourse_dev/message.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "discourse_dev/record"
+require "faker"
+
+module DiscourseDev
+  class Message < Record
+    def initialize(channel_id: nil, count: nil, ignore_current_count: false)
+      @channel_id = channel_id
+      @ignore_current_count = ignore_current_count
+      super(::Chat::Message, count&.to_i || 200)
+    end
+
+    def data
+      if @channel_id
+        channel = ::Chat::Channel.find(@channel_id)
+      else
+        channel = ::Chat::Channel.where(chatable_type: "Category").order("RANDOM()").first
+      end
+
+      return if !channel
+
+      membership =
+        ::Chat::UserChatChannelMembership.where(chat_channel: channel).order("RANDOM()").first
+      user = membership.user
+
+      { user: user, content: Faker::Lorem.paragraph, chat_channel: channel }
+    end
+
+    def create!
+      Chat::MessageCreator.create(data)
+    end
+  end
+end

--- a/plugins/chat/lib/discourse_dev/thread.rb
+++ b/plugins/chat/lib/discourse_dev/thread.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "discourse_dev/record"
+require "faker"
+
+module DiscourseDev
+  class Thread < Record
+    def initialize(channel_id:, message_count: nil, ignore_current_count: false)
+      @channel_id = channel_id
+      @message_count = message_count&.to_i || 30
+      @ignore_current_count = ignore_current_count
+      super(::Chat::Thread, 1)
+    end
+
+    def data
+      if !SiteSetting.enable_experimental_chat_threaded_discussions
+        raise "You need to enable_experimental_chat_threaded_discussions to run this task"
+      end
+
+      channel = ::Chat::Channel.find(@channel_id)
+      return if !channel
+
+      if !channel.threading_enabled
+        puts "Enabling threads in channel #{channel.id}"
+        channel.update!(threading_enabled: true)
+      end
+
+      membership =
+        ::Chat::UserChatChannelMembership.where(chat_channel: channel).order("RANDOM()").first
+      user = membership.user
+
+      om =
+        Chat::MessageCreator.create(
+          user: user,
+          content: Faker::Lorem.paragraph,
+          chat_channel: channel,
+        ).chat_message
+
+      { original_message_user: user, original_message: om, channel: channel }
+    end
+
+    def create!
+      super do |thread|
+        thread.original_message.update!(thread: thread)
+        user =
+          ::Chat::UserChatChannelMembership
+            .where(chat_channel: thread.channel)
+            .order("RANDOM()")
+            .first
+            .user
+        @message_count.times do
+          Chat::MessageCreator.create(
+            {
+              user: user,
+              chat_channel: thread.channel,
+              content: Faker::Lorem.paragraph,
+              thread_id: thread.id,
+            },
+          )
+        end
+      end
+    end
+  end
+end

--- a/plugins/chat/lib/tasks/chat.rake
+++ b/plugins/chat/lib/tasks/chat.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+if Discourse.allow_dev_populate?
+  desc "Generates sample messages in channels"
+  task "chat:message:populate", %i[channel_id count] => ["db:load_config"] do |_, args|
+    DiscourseDev::Message.populate!(
+      ignore_current_count: true,
+      channel_id: args[:channel_id],
+      count: args[:count],
+    )
+  end
+
+  desc "Generates random channels from categories"
+  task "chat:category_channel:populate" => ["db:load_config"] do |_, args|
+    DiscourseDev::CategoryChannel.populate!(ignore_current_count: true)
+  end
+
+  desc "Creates a thread with sample messages in a channel"
+  task "chat:thread:populate", %i[channel_id message_count] => ["db:load_config"] do |_, args|
+    DiscourseDev::Thread.populate!(
+      ignore_current_count: true,
+      channel_id: args[:channel_id],
+      message_count: args[:message_count],
+    )
+  end
+end


### PR DESCRIPTION
This is to help generate random channels and chat
messages for local dev. This was removed in 12a18d4d553b6c11a7f45f686ab699aa72c3312f
presumably because it was not worth refactoring at the
time.

I've only added these tasks:

- `rake chat:message:populate\[113,20\]` (channel_id, count)
  - Generates the count of messages for a channel ID provided,
    otherwise uses a random channel and 200 count.
- `rake chat:category_channel:populate`
  - Creates a chat channel for a random category.
- `rake chat:thread:populate\[132,5\]` (channel_id, message_count)
  - Creates a thread with N messages in the specified channel,
    and enables threading in that channel if necessary
