### PR TITLE
UX: fix kbd tag text color in the composer full screen prompt

### DIFF
--- a/app/assets/stylesheets/desktop/compose.scss
+++ b/app/assets/stylesheets/desktop/compose.scss
@@ -304,4 +304,7 @@ a.toggle-preview {
   padding: 0.5em 0.75em;
   pointer-events: none;
   border-radius: 2px;
+  kbd {
+    background: none;
+  }
 }


### PR DESCRIPTION
Because the composer fullscreen prompt has a dark background on a light theme and vice-versa, it leads to a `<kbd>` tag having text roughly the same color as the tag background, making it unreadable.

It seems to be the only occurrence in Discourse where the `<kbd>` tag is used in such a context.

Before:
![image](https://user-images.githubusercontent.com/5654300/233094470-8ad238f4-1429-4a92-974d-f59695e4b164.png)
![image](https://user-images.githubusercontent.com/5654300/233094717-5e547a1b-b7ac-42b7-88eb-816c8ee554b0.png)

After:
![image](https://user-images.githubusercontent.com/5654300/233095173-b613a774-7fe3-4cfc-8716-671d5eb49bce.png)
![image](https://user-images.githubusercontent.com/5654300/233094915-b924a35c-2d9d-4dd4-ae2d-8aaa176d6822.png)
