### PR TITLE
UX: fix time pickers input width on mobile

### DIFF
--- a/app/assets/stylesheets/common/components/time-shortcut-picker.scss
+++ b/app/assets/stylesheets/common/components/time-shortcut-picker.scss
@@ -38,9 +38,6 @@
   &.custom-relative-wrap {
     .relative-time-picker {
       display: flex;
-      .select-kit.combo-box {
-        width: 60px;
-      }
     }
   }
 }


### PR DESCRIPTION
On mobile view, relative time pickers have a narrow set width, trimming the content.
Removing this arbitrary 60x width fixes the issue while having no apparent adversarial effect on other select-kit elements.

Before:
![image](https://user-images.githubusercontent.com/5654300/233097763-6dbf1322-ed68-474e-b0d8-62c11eeafac1.png)

After:
![image](https://user-images.githubusercontent.com/5654300/233098174-b0edd68c-4d20-4b06-a256-da5f82684d5e.png)