### PR TITLE
FIX: send notifications after a chat message was updated with new mentions

### DIFF
--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -97,19 +97,10 @@ module Chat
       already_notified_user_ids = existing_notifications.map(&:user_id)
 
       to_notify = list_users_to_notify
-      mentioned_user_ids = to_notify.extract!(:all_mentioned_user_ids)[:all_mentioned_user_ids]
-
-      needs_deletion = already_notified_user_ids - mentioned_user_ids
-      needs_deletion.each do |user_id|
-        chat_mention = existing_notifications.detect { |n| n.user_id == user_id }
-        chat_mention.notification.destroy! if chat_mention.notification.present?
-      end
-
-      needs_notification_ids = mentioned_user_ids - already_notified_user_ids
+      needs_notification_ids = to_notify[:all_mentioned_user_ids] - already_notified_user_ids
       return if needs_notification_ids.blank?
 
       notify_creator_of_inaccessible_mentions(to_notify)
-
       notify_mentioned_users(to_notify, already_notified_user_ids: already_notified_user_ids)
 
       to_notify

--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -90,7 +90,10 @@ module Chat
       @chat_message.update_mentions(@mentions.all_mentioned_users_ids)
 
       existing_notifications =
-        Chat::Mention.includes(:user, :notification).where(chat_message: @chat_message)
+        Chat::Mention
+          .includes(:user, :notification)
+          .where(chat_message: @chat_message)
+          .where.not(notification: nil)
       already_notified_user_ids = existing_notifications.map(&:user_id)
 
       to_notify = list_users_to_notify

--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -89,12 +89,11 @@ module Chat
     def notify_edit
       @chat_message.update_mentions(@mentions.all_mentioned_users_ids)
 
-      existing_notifications =
+      already_notified_user_ids =
         Chat::Mention
-          .includes(:user, :notification)
           .where(chat_message: @chat_message)
           .where.not(notification: nil)
-      already_notified_user_ids = existing_notifications.map(&:user_id)
+          .pluck(:user_id)
 
       to_notify = list_users_to_notify
       needs_notification_ids = to_notify[:all_mentioned_user_ids] - already_notified_user_ids


### PR DESCRIPTION
Steps to reproduce the bug:
1. Send a chat message
2. Edit the message and add a mention to it
3. The mentioned user won't receive a notification

This PR fixes the problem.

Also:
1. There's no need anymore to have a code for removing notifications in the `notify_edit` method, because a call to `@chat_message.update_mentions` in the first line of the `notify_edit` method does that job:
    https://github.com/discourse/discourse/blob/ff56f403a2e54db124a70cdcda5a9c1ca27f3535/plugins/chat/lib/chat/notifier.rb#L90

2. There's no need to load mention records from database, it's enough to pluck user ids
