### PR TITLE
Update the x-robots-tag for embedding topics

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -37,7 +37,7 @@ class EmbedController < ApplicationController
       end
     end
 
-    response.headers["X-Robots-Tag"] = "noindex, indexifembedded"
+    response.headers['X-Robots-Tag'] = 'googlebot:noindex, indexifembedded'
 
     if params.has_key?(:template) && params[:template] == "complete"
       @template = "complete"

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -37,7 +37,7 @@ class EmbedController < ApplicationController
       end
     end
 
-    response.headers['X-Robots-Tag'] = "googlebot:noindex, indexifembedded"
+    response.headers["X-Robots-Tag"] = "googlebot:noindex, indexifembedded"
 
     if params.has_key?(:template) && params[:template] == "complete"
       @template = "complete"

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -37,7 +37,7 @@ class EmbedController < ApplicationController
       end
     end
 
-    response.headers['X-Robots-Tag'] = 'googlebot:noindex, indexifembedded'
+    response.headers['X-Robots-Tag'] = "googlebot:noindex, indexifembedded"
 
     if params.has_key?(:template) && params[:template] == "complete"
       @template = "complete"

--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -37,7 +37,7 @@ class EmbedController < ApplicationController
       end
     end
 
-    response.headers["X-Robots-Tag"] = "googlebot:noindex, indexifembedded"
+    response.headers["X-Robots-Tag"] = "googlebot:noindex,indexifembedded"
 
     if params.has_key?(:template) && params[:template] == "complete"
       @template = "complete"

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -146,15 +146,14 @@ RSpec.describe EmbedController do
         expect(response.body).to match("data-referer=\"\\*\"")
       end
 
-      it "disallows indexing the embed topic list" do
-        get "/embed/topics?discourse_embed_id=de-1234",
-            headers: {
-              "REFERER" => "https://example.com/evil-trout",
-            }
-
+      it "disallows indexing the embed topic list for Googlebot" do
+        topic = Fabricate(:topic)
+        get '/embed/topics?discourse_embed_id=de-1234', headers: {
+          'REFERER' => 'https://example.com/evil-trout'
+        }
         expect(response.status).to eq(200)
-        expect(response.headers["X-Robots-Tag"]).to match(/noindex/)
-      end
+        expect(response.headers['X-Robots-Tag']).to match(/googlebot:noindex/)
+      end      
     end
   end
 

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -148,11 +148,11 @@ RSpec.describe EmbedController do
 
       it "disallows indexing the embed topic list for Googlebot" do
         topic = Fabricate(:topic)
-        get '/embed/topics?discourse_embed_id=de-1234', headers: {
-          'REFERER' => 'https://example.com/evil-trout'
+        get "/embed/topics?discourse_embed_id=de-1234", headers: {
+          "REFERER' => "https://example.com/evil-trout"
         }
         expect(response.status).to eq(200)
-        expect(response.headers['X-Robots-Tag']).to match(/googlebot:noindex/)
+        expect(response.headers["X-Robots-Tag"]).to match(/googlebot:noindex/)
       end      
     end
   end

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe EmbedController do
         }
         expect(response.status).to eq(200)
         expect(response.headers["X-Robots-Tag"]).to match(/googlebot:noindex/)
-      end      
+      end
     end
   end
 


### PR DESCRIPTION
The "noindex, indexifembedded" x-robots-tag is only for googlebot. Without specifying googlebot other crawlers will pick up just the "noindex" value which may cause indexing issues.
