### PR TITLE
Revert "DEV: Add `overflow-x: hidden` to chat message containers (#21030)"

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -152,7 +152,6 @@ $float-height: 530px;
     display: grid;
     will-change: transform;
     transform: translateZ(0);
-    overflow-x: hidden;
 
     &.selecting-messages {
       grid-template-columns: 1.5em 1fr;


### PR DESCRIPTION
This reverts commit 768851920e94d1bef7811ffec0977fcf2a30f05e.

This was causing issues with the local date popup, cutting off
the top of it, there is no way to overrule an overflow:hidden
on the parent. Not z-index related.
