### PR TITLE
DEV: Fix flaky emoji deny list system spec

### DIFF
--- a/spec/system/emojis/emoji_deny_list_spec.rb
+++ b/spec/system/emojis/emoji_deny_list_spec.rb
@@ -50,10 +50,10 @@ describe "Emoji deny list", type: :system, js: true do
       topic_page.visit_topic_and_open_composer(topic)
       expect(composer).to be_opened
 
-      composer.click_toolbar_button(10)
+      composer.click_toolbar_button("insert-emoji")
       expect(composer.emoji_picker).to be_visible
 
-      expect(emoji_picker.has_emoji?("fu")).to eq(false)
+      expect(emoji_picker).not_to have_emoji("fu")
     end
 
     it "should not show denied emojis and aliases in emoji autocomplete" do

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -15,8 +15,8 @@ module PageObjects
         self
       end
 
-      def click_toolbar_button(number)
-        find(".d-editor-button-bar button:nth-child(#{number})").click
+      def click_toolbar_button(button_class)
+        find(".d-editor-button-bar button.#{button_class}").click
         self
       end
 

--- a/spec/system/page_objects/components/emoji_picker.rb
+++ b/spec/system/page_objects/components/emoji_picker.rb
@@ -3,8 +3,12 @@
 module PageObjects
   module Components
     class EmojiPicker < PageObjects::Components::Base
+      def emoji_button_selector(emoji_name)
+        ".emoji-picker .emoji[title='#{emoji_name}']"
+      end
+
       def select_emoji(emoji_name)
-        find(".emoji-picker .emoji[title='#{emoji_name}']").click
+        find(emoji_button_selector(emoji_name)).click
       end
 
       def search_emoji(emoji_name)
@@ -12,7 +16,7 @@ module PageObjects
       end
 
       def has_emoji?(emoji_name)
-        page.has_css?(".emoji-picker .emoji[title='#{emoji_name}']")
+        page.has_css?(emoji_button_selector(emoji_name))
       end
     end
   end


### PR DESCRIPTION
This was failing quite often with the following error:

```
 1) Emoji deny list when using composer should remove denied emojis from emoji picker
     Failure/Error: find("#{COMPOSER_ID} .emoji-picker")

     Capybara::ElementNotFound:
       Unable to find css "#reply-control .emoji-picker"
```

This was because our `click_toolbar_button` call on the Composer
page object used a number for the position of the toolbar button,
which can be flaky since there are things that hide/show toolbar
buttons or change their position.

Each toolbar button in the composer has a CSS class, so it is
more reliable to use that instead. Also fixed an instance of
calling `has_X?` method directly instead of using the
`have_x` rspec matcher.
