### PR TITLE
UX: chat thread hover

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-thread-indicator.scss
@@ -5,16 +5,12 @@
   display: flex;
   cursor: pointer;
   grid-area: threadindicator;
-  border: 1px solid transparent;
-  margin: 4px 0 -2px calc(var(--message-left-width) - 5px);
-  padding: 4px;
-
-  &:hover {
-    .chat-message:hover & {
-      border-color: var(--primary-low);
-      background-color: var(--secondary);
-    }
-  }
+  background-color: var(--primary-very-low);
+  margin: 4px 0 -2px calc(var(--message-left-width) - 0.25rem);
+  padding-block: 0.25rem;
+  padding-inline: 0.5rem;
+  max-width: 500px;
+  border-radius: 4px;
 
   &__replies-count {
     color: var(--primary-medium);

--- a/plugins/chat/assets/stylesheets/common/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message.scss
@@ -213,13 +213,13 @@
 
     .touch & {
       &:active {
-        background: var(--primary-very-low);
+        background: var(--d-hover);
         border-radius: 5px;
       }
 
       &.chat-message-bookmarked {
         &:active {
-          background: var(--highlight-medium);
+          background: var(--highlight-low);
         }
       }
     }
@@ -228,7 +228,7 @@
       &.is-active,
       &:hover,
       &:active {
-        background: var(--primary-very-low);
+        background: var(--d-hover);
       }
 
       &:hover {


### PR DESCRIPTION
Minor design tweaks:
* always visible background 
* max-width to keep it more concise
* changed default hover colour to new variables
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/101828855/233330085-0d6ca9bc-2309-4b3f-bef1-e62415b33173.png">

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/101828855/233398592-378b8b61-55be-40ba-be80-0fe590048ea2.png">

