### PR TITLE
Revert "FEATURE: Allow drafts to be deleted via the API (#21148)"

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -87,25 +87,11 @@ class DraftsController < ApplicationController
   end
 
   def destroy
-    user =
-      if is_api?
-        if @guardian.is_admin?
-          fetch_user_from_params
-        else
-          raise Discourse::InvalidAccess
-        end
-      else
-        current_user
-      end
-
     begin
-      Draft.clear(user, params[:id], params[:sequence].to_i)
-    rescue Draft::OutOfSequence => e
-      return render json: failed_json.merge(errors: e), status: 404
-    rescue StandardError => e
-      return render json: failed_json.merge(errors: e), status: 401
+      Draft.clear(current_user, params[:id], params[:sequence].to_i)
+    rescue Draft::OutOfSequence
+      # nothing really we can do here, if try clearing a draft that is not ours, just skip it.
     end
-
     render json: success_json
   end
 end

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -134,14 +134,12 @@ class Draft < ActiveRecord::Base
   end
 
   def self.clear(user, key, sequence)
-    if !user || !user.id || !User.human_user_id?(user.id)
-      raise StandardError.new("user not present")
-    end
+    return if !user || !user.id || !User.human_user_id?(user.id)
 
     current_sequence = DraftSequence.current(user, key)
 
     # bad caller is a reason to complain
-    raise Draft::OutOfSequence.new("bad draft sequence") if sequence != current_sequence
+    raise Draft::OutOfSequence if sequence != current_sequence
 
     # corrupt data is not a reason not to leave data
     Draft.where(user_id: user.id, draft_key: key).destroy_all


### PR DESCRIPTION
This reverts commit a3693fec58372a40f90f650e2c7c90a5109b41b6.

We are seeing issues with the composer not being able to close due to the addition of `rescue Draft::OutOfSequence`. Reverting for now.