### PR TITLE
FIX: Don't render error for bad-sequence

### DIFF
--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -100,8 +100,9 @@ class DraftsController < ApplicationController
 
     begin
       Draft.clear(user, params[:id], params[:sequence].to_i)
-    rescue Draft::OutOfSequence => e
-      return render json: failed_json.merge(errors: e), status: 404
+    rescue Draft::OutOfSequence
+      # nothing really we can do here, if try clearing a draft that is not ours, just skip it.
+      # rendering an error causes issues in the composer
     rescue StandardError => e
       return render json: failed_json.merge(errors: e), status: 401
     end

--- a/spec/requests/drafts_controller_spec.rb
+++ b/spec/requests/drafts_controller_spec.rb
@@ -248,14 +248,6 @@ RSpec.describe DraftsController do
       expect(Draft.get(user, "xxx", 0)).to be_present
     end
 
-    it "raises bad sequence" do
-      user = sign_in(Fabricate(:user))
-      delete "/drafts/xxx.json", params: { sequence: 1 }
-
-      expect(response.status).to eq(404)
-      expect(response.parsed_body["errors"]).to eq("bad draft sequence")
-    end
-
     shared_examples "for a passed user" do
       it "deletes draft" do
         api_key = Fabricate(:api_key).key


### PR DESCRIPTION
We are seeing issues with the composer not being able to close due to the addition of a error message when rescuing from `Draft::OutOfSequence`. This PR will revert to the original solution implemented prior to https://github.com/discourse/discourse/pull/21148 that just silently rescues from `Draft::OutOfSequence`
