### PR TITLE
DEV: Use guards to make `can_delete_reviewable` guardian more readable

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -232,7 +232,11 @@ class Guardian
   end
 
   def can_delete_reviewable_queued_post?(reviewable)
-    reviewable.present? && authenticated? && (reviewable.created_by_id == @user.id || @user.admin?)
+    return false if reviewable.blank?
+    return false if !authenticated?
+    return true if @user.admin?
+
+    reviewable.created_by_id == @user.id
   end
 
   def can_see_group?(group)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
