### PR TITLE
FIX: increase reorder sidebar delay for desktop

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/user/section-link.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/user/section-link.js
@@ -4,7 +4,7 @@ import RouteInfoHelper from "discourse/lib/sidebar/route-info-helper";
 import discourseLater from "discourse-common/lib/later";
 
 const TOUCH_SCREEN_DELAY = 300;
-const MOUSE_DELAY = 100;
+const MOUSE_DELAY = 250;
 
 export default class SectionLink {
   @tracked linkDragCss;


### PR DESCRIPTION
100ms as a single click was too fast, because average single click is closer to 250ms.

Previous PR: https://github.com/discourse/discourse/pull/21098
