### PR TITLE
FIX: Include liked_consolidated and reaction types in the likes tab unread count

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-menu/menu.js
+++ b/app/assets/javascripts/discourse/app/components/user-menu/menu.js
@@ -63,7 +63,11 @@ const CORE_TOP_TABS = [
     }
 
     get count() {
-      return this.getUnreadCountForType("liked");
+      return (
+        this.getUnreadCountForType("liked") +
+        this.getUnreadCountForType("liked_consolidated") +
+        this.getUnreadCountForType("reaction")
+      );
     }
 
     // TODO(osama): reaction is a type used by the reactions plugin, but it's

--- a/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/user-menu/menu-test.js
@@ -303,4 +303,23 @@ module("Integration | Component | user-menu", function (hooks) {
     );
     assert.strictEqual(queryAll("#quick-access-review-queue ul li").length, 8);
   });
+
+  test("count on the likes tab", async function (assert) {
+    this.currentUser.set("grouped_unread_notifications", {
+      [NOTIFICATION_TYPES.liked]: 1,
+      [NOTIFICATION_TYPES.liked_consolidated]: 2,
+      [NOTIFICATION_TYPES.reaction]: 3,
+      [NOTIFICATION_TYPES.bookmark_reminder]: 10,
+    });
+    await render(template);
+
+    const likesCountBadge = query(
+      "#user-menu-button-likes .badge-notification"
+    );
+    assert.strictEqual(
+      likesCountBadge.textContent,
+      (1 + 2 + 3).toString(),
+      "combines unread counts for `liked`, `liked_consolidated` and `reaction` types"
+    );
+  });
 });


### PR DESCRIPTION
The likes tab of the user menu shows 3 types of notifications: `liked`, `liked_consolidated` and `reaction`. However, the unread badge of the tab currently only counts unread notifications of the `liked` type. This inconsistency causes confusion because the count shown on the tab may not always match the number of unread notifications inside the tab.

This PR makes the unread badge include all notification types that the likes tab shows (`liked`, `liked_consolidated` and `reaction`).

Internal topic: t/97526.