### PR TITLE
FIX: Do not overwrite existing thumbnails

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1016,7 +1016,7 @@ class Post < ActiveRecord::Base
         # creation.
         thumbnail =
           Upload.where("original_filename like ?", "#{upload.sha1}.%").first if upload.sha1.present?
-        if thumbnail.present? && self.is_first_post? && !self.topic.image_upload_id #topic
+        if thumbnail.present? && self.is_first_post? && !self.topic.image_upload_id
           upload_ids << thumbnail.id
           self.topic.update_column(:image_upload_id, thumbnail.id)
           extra_sizes =

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1009,24 +1009,21 @@ class Post < ActiveRecord::Base
       upload ||= Upload.get_from_url(src)
 
       # Link any video thumbnails
-      if upload.present? && (FileHelper.supported_video.include? upload.extension)
+      if upload.present? && (FileHelper.supported_video.include? upload.extension&.downcase)
         # Video thumbnails have the filename of the video file sha1 with a .png or .jpg extension.
         # This is because at time of upload in the composer we don't know the topic/post id yet
         # and there is no thumbnail info added to the markdown to tie the thumbnail to the topic/post after
         # creation.
         thumbnail =
           Upload.where("original_filename like ?", "#{upload.sha1}.%").first if upload.sha1.present?
-        if thumbnail.present?
-          upload_ids << thumbnail.id if thumbnail.present?
-
-          if self.is_first_post? #topic
-            self.topic.update_column(:image_upload_id, thumbnail.id)
-            extra_sizes =
-              ThemeModifierHelper.new(
-                theme_ids: Theme.user_selectable.pluck(:id),
-              ).topic_thumbnail_sizes
-            self.topic.generate_thumbnails!(extra_sizes: extra_sizes)
-          end
+        if thumbnail.present? && self.is_first_post? && !self.topic.image_upload_id #topic
+          upload_ids << thumbnail.id
+          self.topic.update_column(:image_upload_id, thumbnail.id)
+          extra_sizes =
+            ThemeModifierHelper.new(
+              theme_ids: Theme.user_selectable.pluck(:id),
+            ).topic_thumbnail_sizes
+          self.topic.generate_thumbnails!(extra_sizes: extra_sizes)
         end
       end
       upload_ids << upload.id if upload.present?

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1566,6 +1566,17 @@ RSpec.describe Post do
       post.topic.reload
       expect(post.topic.topic_thumbnails.length).to eq(0)
     end
+
+    it "does not overwrite existing thumbnails" do
+      image_upload.original_filename = "#{video_upload.sha1}.png"
+      image_upload.save!
+      post.topic.image_upload_id = image_upload_2.id
+      post.topic.save!
+      post.link_post_uploads
+
+      post.topic.reload
+      expect(post.topic.image_upload_id).to eq(image_upload_2.id)
+    end
   end
 
   describe "uploads" do


### PR DESCRIPTION
When auto generating video thumbnails they should not overwrite any
existing topic thumbnails.

This also addresses an issue with capitalized file extensions like .MOV
that were being excluded.
