### PR TITLE
FIX: Better detect text selection in search input

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu.js
@@ -348,10 +348,17 @@ export default createWidget("search-menu", {
     });
   },
 
+  mouseDown(e) {
+    if (e.target === document.querySelector("input#search-term")) {
+      this.state.inputSelectionEvent = true;
+    }
+  },
+
   clickOutside() {
-    if (this.key === "search-menu" && !window.getSelection().toString()) {
+    if (this.key === "search-menu" && !this.state.inputSelectionEvent) {
       this.sendWidgetAction("toggleSearchMenu");
     }
+    this.state.inputSelectionEvent = false;
   },
 
   clearTopicContext() {


### PR DESCRIPTION
Followup to 17ba00c3950eb0a78dd510f3618f8e7be2d448fc. Fix for https://meta.discourse.org/t/-/261917

This fixes a usability issue where the user couldn't switch to the user menu when the search menu was visible and the text in the input was selected.

Explanation: The `click` event is triggered both when clicking and when selecting text. This means that when selecting text in the search input, at the end of the selection event, a click event is triggered. And if that click event happens outside of the search menu (i.e. when you continue dragging outside the input), then the menu would be dismissed. 

Previously, we fixed this by checked for the presence of a current text selection. But that results in a small side-effect reported in the linked issue on meta. This PR sets a flag during `mouseDown` when starting a text selection in the input and then it uses that flag when evaluating whether to trigger `clickOutside` or not.
