### PR TITLE
DEV: Patch Sprockets::DirectiveProcessor to avoid extra newline

### DIFF
--- a/lib/freedom_patches/sprockets_patches.rb
+++ b/lib/freedom_patches/sprockets_patches.rb
@@ -36,3 +36,16 @@ if Rails.env.development? || Rails.env.test?
     alias_method :public_compute_asset_path, :compute_asset_path
   end
 end
+
+# By default, the Sprockets DirectiveProcessor introduces a newline between possible 'header' comments
+# and the rest of the JS file. (https://github.com/rails/sprockets/blob/f4d3dae71e/lib/sprockets/directive_processor.rb#L121)
+# This causes sourcemaps to be offset by 1 line, and therefore breaks browser tooling.
+# We know that Ember-Cli assets do not use Sprockets directives, so we can totally bypass the DirectiveProcessor for those files.
+Sprockets::DirectiveProcessor.prepend(
+  Module.new do
+    def process_source(source)
+      return source, [] if EmberCli.is_ember_cli_asset?(File.basename(@filename))
+      super
+    end
+  end,
+)


### PR DESCRIPTION
By default, the Sprockets DirectiveProcessor introduces a newline between possible 'header' comments and the rest of the JS file. This causes sourcemaps to be offset by 1 line, and therefore breaks browser tooling. We know that Ember-Cli assets do not use Sprockets directives, so we can totally bypass the DirectiveProcessor for those files.

We're using v3 of Sprockets, which is no longer supported - upstreaming a fix will be difficult. Long term, we intend to move away from sprockets.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
