### PR TITLE
DEV: Warn when trying to track user status for user models without ID

### DIFF
--- a/app/assets/javascripts/discourse/app/models/user.js
+++ b/app/assets/javascripts/discourse/app/models/user.js
@@ -1401,6 +1401,13 @@ User.reopen(Evented, {
 
   // always call stopTrackingStatus() when done with a user
   trackStatus() {
+    if (!this.id) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "It's impossible to track user status on a user model that doesn't have id. This user model won't be receiving live user status updates."
+      );
+    }
+
     if (this._subscribersCount === 0) {
       this.addObserver("status", this, "_statusChanged");
 


### PR DESCRIPTION
User status updates come from the server in a map where keys are user IDs. If `user.trackStatus()` is called for a user model without an ID, the model cannot identify its status updates and silently misses them. It's quite hard to notice that a user rendered in the UI doesn't receive live status updates. Also, it's not immediately obvious what's the reason of the problem. A warning will be very helpful here.
