### PR TITLE
FIX: Error when trying to bump a topic with no category

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -579,7 +579,9 @@ class TopicTrackingState
   def self.secure_category_group_ids(topic)
     category = topic.category
 
-    if category&.read_restricted
+    return [Group::AUTO_GROUPS[:admins]] if category.nil?
+
+    if category.read_restricted
       ids = [Group::AUTO_GROUPS[:admins]]
       ids.push(*category.secure_group_ids)
       ids.uniq

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -579,7 +579,7 @@ class TopicTrackingState
   def self.secure_category_group_ids(topic)
     category = topic.category
 
-    if category.read_restricted
+    if category&.read_restricted
       ids = [Group::AUTO_GROUPS[:admins]]
       ids.push(*category.secure_group_ids)
       ids.uniq

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe PostRevisor do
         }.to change { post.topic.bumped_at }
       end
 
-      it "does not bump topic when no topic category" do
+      it "should bump topic when no topic category" do
         topic_with_no_category = Fabricate(:topic, category_id: nil)
         post_from_topic_with_no_category = Fabricate(:post, topic: topic_with_no_category)
         expect {

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -422,6 +422,20 @@ RSpec.describe PostRevisor do
         }.to change { post.topic.bumped_at }
       end
 
+      it "does not bump topic when no topic category" do
+        topic_with_no_category = Fabricate(:topic, category_id: nil)
+        post_from_topic_with_no_category = Fabricate(:post, topic: topic_with_no_category)
+        expect {
+          result =
+            subject.revise!(
+              Fabricate(:admin),
+              raw: post_from_topic_with_no_category.raw,
+              tags: ["foo"],
+            )
+          expect(result).to eq(true)
+        }.to change { topic.reload.bumped_at }
+      end
+
       it "should send muted and latest message" do
         TopicUser.create!(topic: post.topic, user: post.user, notification_level: 0)
         messages =


### PR DESCRIPTION
When revising a post, if the topic that post belonged to did not have a category attached it would error with 

> NoMethodError (undefined method `read_restricted' for nil:NilClass)
