### PR TITLE
FIX: Do not delete old chat messages if chat disabled

### DIFF
--- a/plugins/chat/app/jobs/scheduled/chat/delete_old_messages.rb
+++ b/plugins/chat/app/jobs/scheduled/chat/delete_old_messages.rb
@@ -6,6 +6,8 @@ module Jobs
       daily at: 0.hours
 
       def execute(args = {})
+        return if !SiteSetting.chat_enabled
+
         delete_public_channel_messages
         delete_dm_channel_messages
       end

--- a/plugins/chat/spec/jobs/scheduled/delete_old_chat_messages_spec.rb
+++ b/plugins/chat/spec/jobs/scheduled/delete_old_chat_messages_spec.rb
@@ -79,7 +79,10 @@ describe Jobs::Chat::DeleteOldMessages do
     )
   end
 
-  before { freeze_time(base_date) }
+  before do
+    freeze_time(base_date)
+    SiteSetting.chat_enabled = true
+  end
 
   it "doesn't delete messages when settings are 0" do
     SiteSetting.chat_channel_retention_days = 0
@@ -109,6 +112,16 @@ describe Jobs::Chat::DeleteOldMessages do
       SiteSetting.chat_channel_retention_days = 800
       expect { described_class.new.execute }.not_to change { Chat::Message.in_public_channel.count }
     end
+
+    context "when chat is disabled" do
+      before { SiteSetting.chat_enabled = false }
+
+      it "does nothing" do
+        expect { described_class.new.execute }.not_to change {
+          Chat::Message.in_public_channel.count
+        }
+      end
+    end
   end
 
   describe "dm channels" do
@@ -131,6 +144,14 @@ describe Jobs::Chat::DeleteOldMessages do
     it "does nothing when no messages fall in the time range" do
       SiteSetting.chat_dm_retention_days = 800
       expect { described_class.new.execute }.not_to change { Chat::Message.in_dm_channel.count }
+    end
+
+    context "when chat is disabled" do
+      before { SiteSetting.chat_enabled = false }
+
+      it "does nothing" do
+        expect { described_class.new.execute }.not_to change { Chat::Message.in_dm_channel.count }
+      end
     end
   end
 end


### PR DESCRIPTION
Further followup to 24ec06ff85c7acbad9621092b5e50eec2ede7b83,
where I prevented other chat scheduled jobs from running if
chat was disabled. We should not be running any plugin scheduled
jobs if that plugin is disabled, it can cause unexpected
behaviour.
