### PR TITLE
FIX: Ensure reviewable counts are updated correctly for new user menu

### DIFF
--- a/app/jobs/regular/notify_reviewable.rb
+++ b/app/jobs/regular/notify_reviewable.rb
@@ -35,7 +35,7 @@ class Jobs::NotifyReviewable < ::Jobs::Base
           counts[reviewable_by_group_id] += count if reviewable_by_group_id
         end
 
-      if SiteSetting.legacy_navigation_menu?
+      if legacy_user_menu?
         notify_legacy(
           User.real.admins.pluck(:id),
           count: counts[:admins],
@@ -46,7 +46,7 @@ class Jobs::NotifyReviewable < ::Jobs::Base
       end
 
       if reviewable.reviewable_by_moderator?
-        if SiteSetting.legacy_navigation_menu?
+        if legacy_user_menu?
           notify_legacy(
             User.real.moderators.where("id NOT IN (?)", @contacted).pluck(:id),
             count: counts[:moderators],
@@ -71,7 +71,7 @@ class Jobs::NotifyReviewable < ::Jobs::Base
             count += counts[gu.group_id]
           end
 
-          if SiteSetting.legacy_navigation_menu?
+          if legacy_user_menu?
             notify_legacy([user.id], count: count, updates: updates)
           else
             notify_user(user, updates)
@@ -102,5 +102,9 @@ class Jobs::NotifyReviewable < ::Jobs::Base
 
   def notify_user(user, updates)
     user.publish_reviewable_counts(updates.present? ? { updates: updates } : nil)
+  end
+
+  def legacy_user_menu?
+    SiteSetting.legacy_navigation_menu? && !SiteSetting.enable_new_notifications_menu
   end
 end

--- a/spec/jobs/notify_reviewable_spec.rb
+++ b/spec/jobs/notify_reviewable_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Jobs::NotifyReviewable do
 
     it "will notify users of new reviewable content for the old user menu" do
       SiteSetting.navigation_menu = "legacy"
+      SiteSetting.enable_new_notifications_menu = false
       SiteSetting.enable_category_group_moderation = true
 
       GroupUser.create!(group_id: group.id, user_id: moderator.id)
@@ -170,6 +171,7 @@ RSpec.describe Jobs::NotifyReviewable do
 
     it "respects priority" do
       SiteSetting.navigation_menu = "legacy"
+      SiteSetting.enable_new_notifications_menu = false
       SiteSetting.enable_category_group_moderation = true
       Reviewable.set_priorities(medium: 2.0)
       SiteSetting.reviewable_default_visibility = "medium"
@@ -224,6 +226,8 @@ RSpec.describe Jobs::NotifyReviewable do
   end
 
   it "skips sending notifications if user_ids is empty" do
+    SiteSetting.navigation_menu = "legacy"
+    SiteSetting.enable_new_notifications_menu = false
     reviewable = Fabricate(:reviewable, reviewable_by_moderator: true)
     regular_user = Fabricate(:user)
 


### PR DESCRIPTION
On the client-side, message-bus subscriptions and reviewable count UI is based on the 'redesigned_user_menu_enabled' boolean. We need to use the same logic on the server-side to ensure things work correctly when legacy navigation is used alongside the new user menu.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
