### PR TITLE
FIX: Ensure skip-module JS is transpiled correctly

### DIFF
--- a/lib/discourse_js_processor.rb
+++ b/lib/discourse_js_processor.rb
@@ -293,7 +293,7 @@ class DiscourseJsProcessor
         "transpile",
         source,
         {
-          skip_module: @skip_module,
+          skipModule: @skip_module,
           moduleId: module_name(root_path, logical_path),
           filename: logical_path || "unknown",
           themeId: theme_id,

--- a/spec/lib/discourse_js_processor_spec.rb
+++ b/spec/lib/discourse_js_processor_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe DiscourseJsProcessor do
     it "returns false if the header is not present" do
       expect(DiscourseJsProcessor.skip_module?("// just some JS\nconsole.log()")).to eq(false)
     end
+
+    it "works end-to-end" do
+      source = <<~JS.chomp
+        // discourse-skip-module
+        console.log("hello world");
+      JS
+      expect(DiscourseJsProcessor.transpile(source, "test", "test")).to eq(source)
+    end
   end
 
   it "passes through modern JS syntaxes which are supported in our target browsers" do


### PR DESCRIPTION
This regressed in 7e74dd0afea996d272c391bff9b0a516e7e323db, and was causing issues with 2fa security keys on the email verification route

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
