### PR TITLE
UX: Include subcategories in crawler view

### DIFF
--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -22,10 +22,7 @@
               <div itemprop='description'><%= c.description&.html_safe %></div>
               <div class='subcategories'>
                 <% c&.subcategory_list&.each_with_index do |sc, index| %>
-                  <a href='<%= sc.url %>'>
-                    <span itemprop='name'><%= sc.name %></span>
-                  </a>
-                  &nbsp;
+                  <a href='<%= sc.url %>'><%= sc.name %></a>&nbsp;
                 <% end %>
               </div>
             </div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -22,7 +22,7 @@
               <div itemprop='description'><%= c.description&.html_safe %></div>
               <% if c.subcategory_list.present? %>
                 <div class='subcategories'>
-                  <% c.subcategory_list&.each_with_index do |sc, index| %>
+                  <% c.subcategory_list.each_with_index do |sc, index| %>
                     <a href='<%= sc.url %>'><%= sc.name %></a>&nbsp;
                   <% end %>
                 </div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -20,11 +20,13 @@
                 </a>
               </h3>
               <div itemprop='description'><%= c.description&.html_safe %></div>
-              <div class='subcategories'>
-                <% c&.subcategory_list&.each_with_index do |sc, index| %>
-                  <a href='<%= sc.url %>'><%= sc.name %></a>&nbsp;
-                <% end %>
-              </div>
+              <% if c.subcategory_list.present? %>
+                <div class='subcategories'>
+                  <% c.subcategory_list&.each_with_index do |sc, index| %>
+                    <a href='<%= sc.url %>'><%= sc.name %></a>&nbsp;
+                  <% end %>
+                </div>
+              <% end %>
             </div>
           </td>
           <td class='topics'>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -20,6 +20,14 @@
                 </a>
               </h3>
               <div itemprop='description'><%= c.description&.html_safe %></div>
+              <div class='subcategories'>
+                <% c&.subcategory_list&.each_with_index do |sc, index| %>
+                  <a href='<%= sc.url %>'>
+                    <span itemprop='name'><%= sc.name %></span>
+                  </a>
+                  &nbsp;
+                <% end %>
+              </div>
             </div>
           </td>
           <td class='topics'>


### PR DESCRIPTION
Adds a bit more information to the categories view for crawlers, for better indexing of deep content. 

This only works when the "Subcategories with Featured Topics" is the selected layout for `desktop category page style` site setting (without that setting, the `subcategory_list` isn't available to the template).

Before: 

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/368961/234102376-df087f59-1def-4471-b78b-5a7cd8ab2d3c.png">

After: 

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/368961/234102455-9d755963-5a0b-4b64-8464-b81c208d54a3.png">
