### PR TITLE
FEATURE: Default to subcategory when parent category does not allow posting

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/open-composer.js
+++ b/app/assets/javascripts/discourse/app/mixins/open-composer.js
@@ -6,6 +6,14 @@ import { getOwner } from "discourse-common/lib/get-owner";
 export default Mixin.create({
   openComposer(controller) {
     let categoryId = controller.get("category.id");
+
+    if (
+      !controller.canCreateTopicOnCategory &&
+      this.siteSettings.default_subcategory_on_read_only_category
+    ) {
+      categoryId = controller.get("defaultSubcategory.id");
+    }
+
     if (
       categoryId &&
       controller.category.isUncategorizedCategory &&

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1554,6 +1554,7 @@ en:
 
     post_excerpt_maxlength: "Maximum length of a post excerpt / summary."
     topic_excerpt_maxlength: "Maximum length of a topic excerpt / summary, generated from the first post in a topic."
+    default_subcategory_on_read_only_category: "Enables 'New Topic' button and selects a default subcategory to post on categories where the user is not allowed to create a new topic."
     show_pinned_excerpt_mobile: "Show excerpt on pinned topics in mobile view."
     show_pinned_excerpt_desktop: "Show excerpt on pinned topics in desktop view."
     post_onebox_maxlength: "Maximum length of a oneboxed Discourse post in characters."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -958,6 +958,9 @@ posting:
       ja: 120
       zh_CN: 120
       zh_TW: 120
+  default_subcategory_on_read_only_category:
+    client: true
+    default: false
   show_pinned_excerpt_mobile:
     client: true
     default: true

--- a/spec/system/composer/default_to_subcategory_spec.rb
+++ b/spec/system/composer/default_to_subcategory_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe "Default to Subcategory when parent Category doesn't allow posting",
+         type: :system,
+         js: true do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:group) { Fabricate(:group) }
+  fab!(:group_user) { Fabricate(:group_user, user: user, group: group) }
+  fab!(:category) { Fabricate(:private_category, group: group, permission_type: 3) }
+  fab!(:subcategory) do
+    Fabricate(:private_category, parent_category_id: category.id, group: group, permission_type: 1)
+  end
+  let(:category_page) { PageObjects::Pages::Category.new }
+  before { sign_in(user) }
+
+  describe "Setting enabled and can't post on parent category" do
+    before { SiteSetting.default_subcategory_on_read_only_category = true }
+
+    it "should have 'New Topic' button enabled and default Subcategory set in the composer" do
+      category_page.visit(category)
+      expect(category_page).to have_button("New Topic", disabled: false)
+      category_page.new_topic_button.click
+      select_kit =
+        PageObjects::Components::SelectKit.new(page.find("#reply-control.open .category-chooser"))
+      expect(select_kit).to have_selected_value(subcategory.id)
+    end
+  end
+
+  describe "Setting disabled and can't post on parent category" do
+    before { SiteSetting.default_subcategory_on_read_only_category = false }
+
+    it "should have 'New Topic' button disabled" do
+      category_page.visit(category)
+      expect(category_page).to have_button("New Topic", disabled: true)
+    end
+  end
+end

--- a/spec/system/page_objects/pages/category.rb
+++ b/spec/system/page_objects/pages/category.rb
@@ -65,6 +65,10 @@ module PageObjects
         find(".select-category-template").click
       end
 
+      def new_topic_button
+        find("#create-topic")
+      end
+
       CATEGORY_NAVIGATION_NEW_NAV_ITEM_SELECTOR = ".category-navigation .nav-item_new"
 
       def has_no_new_topics?


### PR DESCRIPTION
**Context**
Currently, when a user doesn't have permission to create a Topic in a Category, the `New Topic` button is disabled. This PR changes this so that when a user can't create a Topic on a Category the code searches for a Subcategory, of the current Category, where the user can create a Topic and enables the `New Topic` button, and selects said Subcategory as a default when creating the Topic.

I haven't implemented tests yet, there seems to be a couple tests broken by this code, I will investigate and implement appropriate tests