### PR TITLE
Revert "Build(deps): Bump pg from 1.4.6 to 1.5.1 (#21231)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
       parallel
     parser (3.2.2.0)
       ast (~> 2.4.1)
-    pg (1.5.1)
+    pg (1.4.6)
     prettier_print (1.2.1)
     progress (3.6.0)
     pry (0.14.2)


### PR DESCRIPTION
This reverts commit d32709a74f715d9339fde730aa07901821a31fb1.

It is printing deprecation message due to Rails usage of the PG gem. We
need to wait for a new release of Rails to be cut first.