### PR TITLE
FIX: allows composer to expand

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-composer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-composer.scss
@@ -37,7 +37,7 @@
     border-radius: 5px;
     background-color: var(--secondary);
     padding-inline: 0.25rem;
-    height: 42px;
+    min-height: 42px;
 
     .chat-composer--focused & {
       border-color: var(--primary-medium);


### PR DESCRIPTION
The fixed height was preventing the underlying textarea to expand (up to 125px height) when adding new lines with shift + enter

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
