### PR TITLE
FIX: safeguard in case the message is active during transition

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -45,6 +45,10 @@ export default class ChatMessageActionsDesktop extends Component {
         this.context
       );
 
+      if (!messageContainer) {
+        return;
+      }
+
       this.popper = createPopper(messageContainer, element, {
         placement: "top-end",
         strategy: "fixed",


### PR DESCRIPTION
Prior to this fix, we could sometimes still have an active message while the DOM node was already removed.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
