### PR TITLE
FIX: Show large image placeholder for image onebox

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -385,6 +385,8 @@ class CookedPostProcessor
   end
 
   def process_hotlinked_image(img)
+    onebox = img.ancestors(".onebox, .onebox-body").first
+
     @hotlinked_map ||= @post.post_hotlinked_media.preload(:upload).map { |r| [r.url, r] }.to_h
     normalized_src =
       PostHotlinkedMedia.normalize_src(img["src"] || img[PrettyText::BLOCKED_HOTLINKED_SRC_ATTR])
@@ -393,7 +395,7 @@ class CookedPostProcessor
     still_an_image = true
 
     if info&.too_large?
-      if img.ancestors(".onebox, .onebox-body").blank?
+      if !onebox || onebox.element_children.size == 1
         add_large_image_placeholder!(img)
       else
         img.remove
@@ -401,7 +403,7 @@ class CookedPostProcessor
 
       still_an_image = false
     elsif info&.download_failed?
-      if img.ancestors(".onebox, .onebox-body").blank?
+      if !onebox || onebox.element_children.size == 1
         add_broken_image_placeholder!(img)
       else
         img.remove

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -1152,13 +1152,13 @@ RSpec.describe CookedPostProcessor do
 
     it "replaces large image placeholder" do
       SiteSetting.max_image_size_kb = 4096
-      url = "https://image.com/my-avatar"
-      image_url = "https://image.com/avatar.png"
+      url = "https://image.com/avatar.png"
 
-      Oneboxer
-        .stubs(:onebox)
-        .with(url, anything)
-        .returns("<img class='onebox' src='#{image_url}' />")
+      Oneboxer.stubs(:onebox).with(url, anything).returns <<~HTML
+          <a href="#{url}" target="_blank" rel="noopener" class="onebox">
+            <img class='onebox' src='#{url}' />
+          </a>
+        HTML
 
       post = Fabricate(:post, raw: url)
 


### PR DESCRIPTION
Large or broken images are removed from oneboxes, but sometimes images were removed when they were oneboxed too. The reason is that images can be oneboxed by the AllowlistedGenericOnebox or ImageOnebox and only AllowlistedGenericOnebox was handled correctly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
