### PR TITLE
UX: Fix space position in badge counts

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-badge.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-badge.hbs
@@ -1,7 +1,7 @@
 <a class="user-card-badge-link" href={{this.badgeUrl}}>
   <BadgeButton @badge={{@badge}}>
     {{#if this.showGrantCount}}
-      <span class="count">(&times;&nbsp;{{@count}})</span>
+      <span class="count">&nbsp;(&times;{{@count}})</span>
     {{/if}}
   </BadgeButton>
 </a>


### PR DESCRIPTION
A space was put in the wrong place in the badge count on the badges admin page from a user profile.
This PR fixes the space.

Before:
![image](https://user-images.githubusercontent.com/5654300/234406057-238931ca-0d30-4406-971a-f3730cbf746f.png)

After:
![image](https://user-images.githubusercontent.com/5654300/234406073-bbac8a94-babd-46c3-98aa-3183521bd0b0.png)
