### PR TITLE
FIX: require date db_timestamps_mover script

### DIFF
--- a/script/db_timestamps_mover.rb
+++ b/script/db_timestamps_mover.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "pg"
+require "date"
 
 usage = <<-TEXT
 Commands:


### PR DESCRIPTION
Before `pg` gem version 1.4.6 was loading `date` as dependency.

Looks like version 1.5.1 is not doing that anymore. Update was done here: https://github.com/discourse/discourse/commit/d32709a74f715d9339fde730aa07901821a31fb1

Because of that, this line was crashing: https://github.com/discourse/discourse/blob/main/script/db_timestamps_mover.rb#L128

Therefore, we have to load `date` explicitly.