### PR TITLE
UX: onebox/blockquote/chatreaction slight accent colour change

### DIFF
--- a/app/assets/stylesheets/common/foundation/mixins.scss
+++ b/app/assets/stylesheets/common/foundation/mixins.scss
@@ -126,7 +126,7 @@ $hpad: 0.65em;
 
 // Stuff we repeat
 @mixin post-aside {
-  border-left: 5px solid var(--primary-low);
+  border-left: 5px solid var(--primary-300);
   background-color: var(--blend-primary-secondary-5);
 }
 

--- a/plugins/chat/assets/stylesheets/mixins/chat-reaction.scss
+++ b/plugins/chat/assets/stylesheets/mixins/chat-reaction.scss
@@ -5,7 +5,7 @@
   margin: 1px 0.25em 1px 0;
   font-size: var(--font-down-2);
   border-radius: 4px;
-  border: 1px solid var(--primary-low);
+  border: 1px solid var(--primary-300);
   background: transparent;
   cursor: pointer;
   user-select: none;


### PR DESCRIPTION
Chat messages use the correct d-hover variable but this conflicts with onebox/quote border and emoji reaction border:

<img width="357" alt="image" src="https://user-images.githubusercontent.com/101828855/234564170-a91775c2-3eb6-4d7b-9395-46c13f272fde.png">

Slight variation in the colour variable for these cases should fix it, without the change being too noticeable:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/101828855/234564862-c6660382-6941-4ad8-864d-66ca31f544f8.png">


