### PR TITLE
FIX: attempts to make cooking less order dependent

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -77,7 +77,7 @@ export default class ChatMessage {
         ? ChatMessage.create(channel, args.in_reply_to || args.replyToMsg)
         : null);
     this.draft = args.draft;
-    this._message = args.message || "";
+    this.message = args.message || "";
     this._cooked = args.cooked || "";
     this.reactions = this.#initChatMessageReactionModel(
       args.id,

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -49,9 +49,9 @@ export default class ChatMessage {
   @tracked newest = false;
   @tracked highlighted = false;
   @tracked firstOfResults = false;
+  @tracked message;
 
   @tracked _cooked;
-  @tracked _message;
 
   constructor(channel, args = {}) {
     this.channel = channel;
@@ -86,14 +86,6 @@ export default class ChatMessage {
     this.uploads = new TrackedArray(args.uploads || []);
     this.user = this.#initUserModel(args.user);
     this.bookmark = args.bookmark ? Bookmark.create(args.bookmark) : null;
-  }
-
-  get message() {
-    return this._message;
-  }
-
-  set message(newMessage) {
-    this._message = newMessage;
   }
 
   get cooked() {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane-subscriptions-manager.js
@@ -20,12 +20,6 @@ export default class ChatChannelPaneSubscriptionsManager extends ChatPaneBaseSub
     return;
   }
 
-  // TODO (martin) Move scrolling functionality to pane from ChatLivePane?
-  afterProcessedMessage() {
-    // this.scrollToLatestMessage();
-    return;
-  }
-
   handleThreadCreated(data) {
     const message = this.messagesManager.findMessage(data.chat_message.id);
     if (message) {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-pane-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-thread-pane-subscriptions-manager.js
@@ -39,10 +39,4 @@ export default class ChatChannelThreadPaneSubscriptionsManager extends ChatPaneB
   handleThreadOriginalMessageUpdate() {
     return;
   }
-
-  // NOTE: noop for now, later we may want to do scrolling or something like
-  // we do in the channel pane.
-  afterProcessedMessage() {
-    return;
-  }
 }

--- a/plugins/chat/assets/javascripts/discourse/services/chat-pane-base-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-pane-base-subscriptions-manager.js
@@ -28,11 +28,7 @@ export function handleStagedMessage(messagesManager, data) {
     inReplyToMsg.threadId = data.chat_message.thread_id;
   }
 
-  // some markdown is cooked differently on the server-side, e.g.
-  // quotes, avatar images etc.
-  if (data.chat_message?.cooked !== stagedMessage.cooked) {
-    stagedMessage.cooked = data.chat_message.cooked;
-  }
+  stagedMessage.cooked = data.chat_message.cooked;
 
   return stagedMessage;
 }
@@ -142,13 +138,7 @@ export default class ChatPaneBaseSubscriptionsManager extends Service {
     const message = this.messagesManager.findMessage(data.chat_message.id);
     if (message) {
       message.cooked = data.chat_message.cooked;
-      message.incrementVersion();
-      this.afterProcessedMessage(message);
     }
-  }
-
-  afterProcessedMessage() {
-    throw "not implemented";
   }
 
   handleReactionMessage(data) {
@@ -166,7 +156,6 @@ export default class ChatPaneBaseSubscriptionsManager extends Service {
       message.excerpt = data.chat_message.excerpt;
       message.uploads = cloneJSON(data.chat_message.uploads || []);
       message.edited = true;
-      message.incrementVersion();
     }
   }
 

--- a/plugins/chat/spec/system/chat_message_onebox_spec.rb
+++ b/plugins/chat/spec/system/chat_message_onebox_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Chat message onebox", type: :system, js: true do
       chat_page.visit_channel(channel_1)
       channel_page.send_message("https://en.wikipedia.org/wiki/Hyperlink")
 
-      expect(page).to have_content("This is a test")
+      expect(page).to have_content("This is a test", wait: 20)
     end
   end
 end


### PR DESCRIPTION
It's very hard to repro but under specific circumstances I suspect it was possible for this sequence to happen:

- set message TEXT
- cooking starts
- set message COOKED through another mean (like a message bus)
- the cooking started sooner finished and erases the cooked set at the step before causing the message to have the incorrect cooked

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
