### PR TITLE
FIX: Ensure group-filtered group user event webhooks fire

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -810,6 +810,7 @@ class Group < ActiveRecord::Base
       :user_removed_from_group,
       id: group_user.id,
       payload: payload,
+      group_ids: [self.id],
     )
   end
 

--- a/config/initializers/012-web_hook_events.rb
+++ b/config/initializers/012-web_hook_events.rb
@@ -100,6 +100,7 @@ DiscourseEvent.on(:user_added_to_group) do |user, group, options|
     group_user,
     :user_added_to_group,
     WebHookGroupUserSerializer,
+    group_ids: [group.id],
   )
 end
 

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -558,7 +558,10 @@ RSpec.describe WebHook do
 
       job_args = Jobs::EmitWebHookEvent.jobs.last["args"].first
       expect(job_args["event_name"]).to eq("user_added_to_group")
+      expect(job_args["group_ids"]).to contain_exactly(group.id)
+
       payload = JSON.parse(job_args["payload"])
+
       expect(payload["group_id"]).to eq(group.id)
       expect(payload["user_id"]).to eq(user.id)
       expect(payload["notification_level"]).to eq(group.default_notification_level)
@@ -577,7 +580,10 @@ RSpec.describe WebHook do
 
       job_args = Jobs::EmitWebHookEvent.jobs.last["args"].first
       expect(job_args["event_name"]).to eq("user_removed_from_group")
+      expect(job_args["group_ids"]).to contain_exactly(group.id)
+
       payload = JSON.parse(job_args["payload"])
+
       expect(payload["group_id"]).to eq(group.id)
       expect(payload["user_id"]).to eq(user.id)
     end


### PR DESCRIPTION
Group user event webhooks filtered by group fail silently because the `group_ids` job arg wasn't being passed into the job.

This change add's `group_ids` to the `EmitWebHookEvent` jobs queued for `user_added_to_group` and `user_removed_from_group` events.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
