### PR TITLE
DEV: Add deprecation warning for user_badge_removed event

### DIFF
--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -49,7 +49,6 @@ class UserBadge < ActiveRecord::Base
     UserStat.update_distinct_badge_count self.user_id
     UserBadge.update_featured_ranks! self.user_id
 
-    # TODO: Follow up with a deprecation notice for `user_badge_removed`
     DiscourseEvent.trigger(:user_badge_removed, self.badge_id, self.user_id)
     DiscourseEvent.trigger(:user_badge_revoked, user_badge: self)
   end

--- a/lib/discourse_event.rb
+++ b/lib/discourse_event.rb
@@ -21,6 +21,16 @@ class DiscourseEvent
         raise_error: true,
       )
     end
+
+    if event_name == :user_badge_removed
+      Discourse.deprecate(
+        "The :user_badge_removed event is deprecated. Please use :user_badge_revoked instead",
+        since: "3.1.0.beta5",
+        drop_from: "3.2.0.beta1",
+        output_in_test: true,
+      )
+    end
+
     events[event_name] << block
   end
 


### PR DESCRIPTION
`user_badge_removed` event has been replaced with `user_badge_revoked`

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
