### PR TITLE
FIX: properly respects chat_minimum_message_length

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.js
@@ -103,9 +103,9 @@ export default class ChatComposer extends Component {
   }
 
   get hasContent() {
-    const minLength = this.siteSettings.chat_minimum_message_length || 0;
+    const minLength = this.siteSettings.chat_minimum_message_length || 1;
     return (
-      this.currentMessage?.message?.length > minLength ||
+      this.currentMessage?.message?.length >= minLength ||
       (this.canAttachUploads && this.currentMessage?.uploads?.length > 0)
     );
   }

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -293,4 +293,35 @@ RSpec.describe "Chat composer", type: :system, js: true do
       expect(find(".chat-composer__input").value).to eq("[discourse](https://www.discourse.org)")
     end
   end
+
+  context "when posting a message with length equal to minimum length" do
+    before do
+      SiteSetting.chat_minimum_message_length = 1
+      channel_1.add(current_user)
+      sign_in(current_user)
+    end
+
+    it "works" do
+      chat.visit_channel(channel_1)
+      find("body").send_keys("1")
+      channel.click_send_message
+
+      expect(channel).to have_message(text: "1")
+    end
+  end
+
+  context "when posting a message with length superior to minimum length" do
+    before do
+      SiteSetting.chat_minimum_message_length = 2
+      channel_1.add(current_user)
+      sign_in(current_user)
+    end
+
+    it "doesn’t allow to send" do
+      chat.visit_channel(channel_1)
+      find("body").send_keys("1")
+
+      expect(page).to have_css(".chat-composer--send-disabled")
+    end
+  end
 end


### PR DESCRIPTION
Before this fix we were only considering `>` and not `>=`, this also adds two tests.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
