### PR TITLE
FIX: correct border color of message actions

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-message-actions.scss
@@ -63,7 +63,7 @@
     }
 
     &:first-child:not(:hover) {
-      border-color: var(--primary-low);
+      border-color: var(--primary-300);
       border-right-color: transparent;
     }
 
@@ -79,7 +79,7 @@
   .more-buttons.dropdown-select-box {
     .select-kit-header {
       background: none;
-      border: 1px solid var(--primary-low);
+      border: 1px solid var(--primary-300);
       border-left-color: transparent;
       border-radius: 0 0.25em 0.25em 0;
       padding: 0.5em 0;
@@ -87,7 +87,7 @@
       transition: background 0.2s, border-color 0.2s;
 
       &:focus {
-        border-color: var(--primary-low);
+        border-color: var(--primary-300);
         border-left-color: transparent;
 
         .select-kit-header-wrapper .d-icon {
@@ -119,7 +119,7 @@
     .select-kit-body {
       padding: 0.5rem;
       box-shadow: shadow("card");
-      border: 1px solid var(--primary-low);
+      border: 1px solid var(--primary-300);
     }
 
     .select-kit-row {
@@ -155,7 +155,7 @@
 
     &:first-child {
       border-bottom-left-radius: 0.25em;
-      border-left-color: var(--primary-low);
+      border-left-color: var(--primary-300);
       border-top-left-radius: 0.25em;
     }
 

--- a/plugins/chat/assets/stylesheets/desktop/chat-message.scss
+++ b/plugins/chat/assets/stylesheets/desktop/chat-message.scss
@@ -4,9 +4,9 @@
   .chat-message-thread-btn,
   .bookmark-btn {
     border: 1px solid transparent;
-    border-bottom-color: var(--primary-low);
+    border-bottom-color: var(--primary-300);
     border-radius: 0;
-    border-top-color: var(--primary-low);
+    border-top-color: var(--primary-300);
 
     &:hover {
       background: var(--primary-low);


### PR DESCRIPTION
This is a followup of https://github.com/discourse/discourse/commit/1372c5c43504dde7da19b08612afda23bce61e35

Before:

<img width="137" alt="Screenshot 2023-04-26 at 18 54 25" src="https://user-images.githubusercontent.com/339945/234648008-ea7dc012-67f3-45bd-8733-d94542a01867.png">

After:

<img width="285" alt="Screenshot 2023-04-26 at 18 54 46" src="https://user-images.githubusercontent.com/339945/234648016-650d3b6b-b0f1-478b-bf67-707c79285506.png">

