### PR TITLE
A11Y: Use correct structure for badge headings

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/badges/index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/badges/index.hbs
@@ -10,7 +10,7 @@
       {{#each this.badgeGroups as |bg|}}
         <div class="badge-grouping">
           <div class="title">
-            <h3>{{bg.badgeGrouping.displayName}}</h3>
+            <h2>{{bg.badgeGrouping.displayName}}</h2>
           </div>
           <div class="badge-group-list">
             {{#each bg.badges as |b|}}


### PR DESCRIPTION
Annotated before/after screenshots: 

![image](https://user-images.githubusercontent.com/368961/234696454-61ae453a-5cbe-4cd8-94f6-14faced32c23.png)

![image](https://user-images.githubusercontent.com/368961/234696581-f0140ae6-b2b5-4727-b324-59c05dcaa7e7.png)
