### PR TITLE
FIX: Include group flair in homepage category topic lists

### DIFF
--- a/app/serializers/concerns/user_primary_group_mixin.rb
+++ b/app/serializers/concerns/user_primary_group_mixin.rb
@@ -7,6 +7,7 @@ module UserPrimaryGroupMixin
                      :flair_url,
                      :flair_bg_color,
                      :flair_color,
+                     :flair_group_id,
                      :admin,
                      :moderator,
                      :trust_level
@@ -24,7 +25,7 @@ module UserPrimaryGroupMixin
     object&.flair_group&.name
   end
 
-  def include_flair_group_name?
+  def include_flair_name?
     object&.flair_group.present?
   end
 
@@ -42,6 +43,14 @@ module UserPrimaryGroupMixin
 
   def include_flair_bg_color?
     object&.flair_group&.flair_bg_color.present?
+  end
+
+  def flair_group_id
+    object&.flair_group_id
+  end
+
+  def include_flair_group_id?
+    object&.flair_group_id.present?
   end
 
   def flair_color

--- a/spec/serializers/poster_serializer_spec.rb
+++ b/spec/serializers/poster_serializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe PosterSerializer do
+  let(:poster) { Fabricate(:user, admin: false, moderator: false) }
+
+  it "serializes the correct attributes" do
+    expect(PosterSerializer.new(poster).attributes.keys).to contain_exactly(
+      :trust_level,
+      :avatar_template,
+      :id,
+      :name,
+      :username,
+    )
+  end
+
+  it "includes group flair attributes when appropriate" do
+    group =
+      Fabricate(
+        :group,
+        name: "Groupster",
+        flair_bg_color: "#111111",
+        flair_color: "#999999",
+        flair_icon: "icon",
+      )
+    groupie = Fabricate(:user, flair_group: group)
+
+    expect(PosterSerializer.new(groupie).attributes.keys).to contain_exactly(
+      :trust_level,
+      :avatar_template,
+      :id,
+      :name,
+      :username,
+      :flair_bg_color,
+      :flair_color,
+      :flair_group_id,
+      :flair_name,
+      :flair_url,
+    )
+  end
+end


### PR DESCRIPTION
Followup to c03f83bbea558caee8090dfc43fb4c817028c464.

The `flair_group_id` parameter is now required to show the flair, and this serializer was missing that detail. 

This also fixes a typo in the `include_flair_group_name?` method. 