### PR TITLE
A11Y: select kit close on focus out

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/category-edit-test.js
@@ -113,10 +113,12 @@ acceptance("Category Edit", function (needs) {
     const allowedTagChooser = selectKit("#category-allowed-tags");
     await allowedTagChooser.expand();
     await allowedTagChooser.selectRowByValue("monkey");
+    await allowedTagChooser.collapse();
 
     const allowedTagGroupChooser = selectKit("#category-allowed-tag-groups");
     await allowedTagGroupChooser.expand();
     await allowedTagGroupChooser.selectRowByValue("TagGroup1");
+    await allowedTagGroupChooser.collapse();
 
     await click("#save-category");
 
@@ -129,6 +131,7 @@ acceptance("Category Edit", function (needs) {
 
     await allowedTagChooser.expand();
     await allowedTagChooser.deselectItemByValue("monkey");
+    await allowedTagChooser.collapse();
 
     await allowedTagGroupChooser.expand();
     await allowedTagGroupChooser.deselectItemByValue("TagGroup1");

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -121,6 +121,7 @@ acceptance("Managing Group Membership", function (needs) {
     );
     await associatedGroups.expand();
     await associatedGroups.selectRowByName("google_oauth2:test-group");
+    await associatedGroups.keyboard("enter");
 
     assert.equal(associatedGroups.header().name(), "google_oauth2:test-group");
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/group-manage-membership-test.js
@@ -121,7 +121,6 @@ acceptance("Managing Group Membership", function (needs) {
     );
     await associatedGroups.expand();
     await associatedGroups.selectRowByName("google_oauth2:test-group");
-    await associatedGroups.keyboard("enter");
 
     assert.equal(associatedGroups.header().name(), "google_oauth2:test-group");
   });

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-categories-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-categories-test.js
@@ -39,10 +39,16 @@ acceptance("User Preferences - Categories", function (needs) {
       ".tracking-controls__regular-categories .category-selector"
     );
 
+    await trackedCategoriesSelector.collapse();
+
     await regularCategoriesSelector.expand();
     await regularCategoriesSelector.deselectItemByValue("4");
+
+    await regularCategoriesSelector.collapse();
     await trackedCategoriesSelector.expand();
     await trackedCategoriesSelector.selectRowByValue("4");
+    await trackedCategoriesSelector.collapse();
+
     await click(".save-changes");
 
     assert.deepEqual(putRequestData, {
@@ -63,6 +69,7 @@ acceptance("User Preferences - Categories", function (needs) {
     await categorySelector.expand();
     // User has `regular_category_ids` set to [4] in fixtures
     await categorySelector.selectRowByValue(4);
+    await categorySelector.collapse();
     await click(".save-changes");
 
     assert.deepEqual(putRequestData, {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-tracking-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-tracking-test.js
@@ -176,11 +176,10 @@ acceptance("User Preferences - Tracking", function (needs) {
       "category that is set to regular is not available for selection under tracked"
     );
 
-    await trackedCategoriesSelector.collapse();
     const regularCategoriesSelector = selectKit(
       ".tracking-controls__regular-categories .category-selector"
     );
-
+    await trackedCategoriesSelector.collapse();
     await regularCategoriesSelector.expand();
     await regularCategoriesSelector.deselectItemByValue("4");
 
@@ -192,13 +191,7 @@ acceptance("User Preferences - Tracking", function (needs) {
     await regularCategoriesSelector.collapse();
     await trackedCategoriesSelector.expand();
     await trackedCategoriesSelector.selectRowByValue("4");
-
-    assert.deepEqual(
-      trackedCategoriesSelector.header().value(),
-      "4",
-      "category is now selected under tracked"
-    );
-
+    await trackedCategoriesSelector.collapse();
     await click(".save-changes");
 
     assert.deepEqual(putRequestData, {

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-tracking-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-tracking-test.js
@@ -173,17 +173,32 @@ acceptance("User Preferences - Tracking", function (needs) {
 
     assert.notOk(
       trackedCategoriesSelector.rowByValue("4").exists(),
-      "category that is set to regular is not available for selection"
+      "category that is set to regular is not available for selection under tracked"
     );
 
+    await trackedCategoriesSelector.collapse();
     const regularCategoriesSelector = selectKit(
       ".tracking-controls__regular-categories .category-selector"
     );
 
     await regularCategoriesSelector.expand();
     await regularCategoriesSelector.deselectItemByValue("4");
+
+    assert.ok(
+      regularCategoriesSelector.rowByValue("4").exists(),
+      "category is no longer selected under regular"
+    );
+
+    await regularCategoriesSelector.collapse();
     await trackedCategoriesSelector.expand();
     await trackedCategoriesSelector.selectRowByValue("4");
+
+    assert.deepEqual(
+      trackedCategoriesSelector.header().value(),
+      "4",
+      "category is now selected under tracked"
+    );
+
     await click(".save-changes");
 
     assert.deepEqual(putRequestData, {

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { render } from "@ember/test-helpers";
+import { render, settled } from "@ember/test-helpers";
 import { exists, query, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { hbs } from "ember-cli-htmlbars";
@@ -57,10 +57,10 @@ module(
       await this.subject.expand();
       await this.subject.fillInFilter("baz");
       await this.subject.selectRowByValue("monkey");
+      await settled();
 
-      const error = query(".select-kit-error").innerText;
       assert.strictEqual(
-        error,
+        query(".select-kit-error").innerText,
         I18n.t("select_kit.max_content_reached", {
           count: this.siteSettings.max_tags_per_topic,
         })
@@ -87,6 +87,7 @@ module(
       );
 
       await this.subject.selectRowByValue("monkey");
+      await settled();
 
       assert.strictEqual(
         query("input[name=filter-input-search]").placeholder,

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { render, settled } from "@ember/test-helpers";
+import { render } from "@ember/test-helpers";
 import { exists, query, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { hbs } from "ember-cli-htmlbars";
@@ -57,7 +57,6 @@ module(
       await this.subject.expand();
       await this.subject.fillInFilter("baz");
       await this.subject.selectRowByValue("monkey");
-      await settled();
 
       assert.strictEqual(
         query(".select-kit-error").innerText,
@@ -87,7 +86,6 @@ module(
       );
 
       await this.subject.selectRowByValue("monkey");
-      await settled();
 
       assert.strictEqual(
         query("input[name=filter-input-search]").placeholder,

--- a/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { render } from "@ember/test-helpers";
+import { render, settled } from "@ember/test-helpers";
 import { exists, query, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { hbs } from "ember-cli-htmlbars";
@@ -57,6 +57,7 @@ module(
       await this.subject.expand();
       await this.subject.fillInFilter("baz");
       await this.subject.selectRowByValue("monkey");
+      await settled();
 
       assert.strictEqual(
         query(".select-kit-error").innerText,
@@ -86,6 +87,7 @@ module(
       );
 
       await this.subject.selectRowByValue("monkey");
+      await settled();
 
       assert.strictEqual(
         query("input[name=filter-input-search]").placeholder,

--- a/app/assets/javascripts/select-kit/addon/components/multi-select.js
+++ b/app/assets/javascripts/select-kit/addon/components/multi-select.js
@@ -77,7 +77,7 @@ export default SelectKitComponent.extend({
   },
 
   select(value, item) {
-    this.selectKit.set("multiSelectRecentlyChanged", true);
+    this.selectKit.set("multiSelectInFocus", true);
     if (this.selectKit.hasSelection && this.selectKit.options.maximum === 1) {
       this.selectKit.deselectByValue(
         this.getValue(this.selectedContent.firstObject)

--- a/app/assets/javascripts/select-kit/addon/components/multi-select.js
+++ b/app/assets/javascripts/select-kit/addon/components/multi-select.js
@@ -77,6 +77,7 @@ export default SelectKitComponent.extend({
   },
 
   select(value, item) {
+    this.selectKit.set("multiSelectRecentlyChanged", true);
     if (this.selectKit.hasSelection && this.selectKit.options.maximum === 1) {
       this.selectKit.deselectByValue(
         this.getValue(this.selectedContent.firstObject)

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -94,7 +94,7 @@ export default Component.extend(
           noneItem: null,
           newItem: null,
           filter: null,
-          multiSelectRecentlyChanged: null,
+          multiSelectInFocus: null,
 
           modifyContent: bind(this, this._modifyContentWrapper),
           modifySelection: bind(this, this._modifySelectionWrapper),
@@ -442,7 +442,7 @@ export default Component.extend(
         items = makeArray(items);
 
         if (this.multiSelect) {
-          this.selectKit.set("multiSelectRecentlyChanged", true);
+          this.selectKit.set("multiSelectInFocus", true);
           items = items.filter(
             (i) =>
               i !== this.newItem &&

--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -94,6 +94,7 @@ export default Component.extend(
           noneItem: null,
           newItem: null,
           filter: null,
+          multiSelectRecentlyChanged: null,
 
           modifyContent: bind(this, this._modifyContentWrapper),
           modifySelection: bind(this, this._modifySelectionWrapper),
@@ -441,6 +442,7 @@ export default Component.extend(
         items = makeArray(items);
 
         if (this.multiSelect) {
+          this.selectKit.set("multiSelectRecentlyChanged", true);
           items = items.filter(
             (i) =>
               i !== this.newItem &&

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -12,37 +12,24 @@ export default Component.extend({
     return false;
   }),
 
-  rootEventType: "focusout",
-
   init() {
     this._super(...arguments);
 
-    this.handleRootFocusOutHandler = bind(this, this.handleRootFocusOut);
+    this.focusOutHandler = bind(this, this.handleFocusOut);
   },
 
   didInsertElement() {
     this._super(...arguments);
-
     this.element.style.position = "relative";
-
-    this.element.addEventListener(
-      this.rootEventType,
-      this.handleRootFocusOutHandler,
-      true
-    );
+    this.element.addEventListener("focusout", this.focusOutHandler, true);
   },
 
   willDestroyElement() {
     this._super(...arguments);
-
-    this.element.removeEventListener(
-      this.rootEventType,
-      this.handleRootFocusOutHandler,
-      true
-    );
+    this.element.removeEventListener("focusout", this.focusOutHandler, true);
   },
 
-  handleRootFocusOut(event) {
+  handleFocusOut(event) {
     if (!this.selectKit.isExpanded) {
       return;
     }
@@ -55,8 +42,22 @@ export default Component.extend({
       return;
     }
 
-    if (this.selectKit.mainElement()) {
-      this.selectKit.close(event);
+    // multi-selects need to keep the UI visible when adding/removing items
+    // for these cases, we can't rely on event.relatedTarget
+    // because the element may have already been removed from the DOM
+    // so we cannot check if the element is contained within the main element
+    if (this.selectKit.mainElement().classList.contains("multi-select")) {
+      const hasClass = [
+        "select-kit-row",
+        "selected-choice",
+        "filter-input",
+      ].some((className) => event.target.classList.contains(className));
+
+      if (hasClass) {
+        return;
+      }
     }
+
+    this.selectKit.close(event);
   },
 });

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -1,5 +1,5 @@
 import Component from "@ember/component";
-import { bind } from "@ember/runloop";
+import { bind } from "discourse-common/utils/decorators";
 import { computed } from "@ember/object";
 import layout from "select-kit/templates/components/select-kit/select-kit-body";
 
@@ -12,24 +12,19 @@ export default Component.extend({
     return false;
   }),
 
-  init() {
-    this._super(...arguments);
-
-    this.focusOutHandler = bind(this, this.handleFocusOut);
-  },
-
   didInsertElement() {
     this._super(...arguments);
     this.element.style.position = "relative";
-    this.element.addEventListener("focusout", this.focusOutHandler, true);
+    this.element.addEventListener("focusout", this._handleFocusOut, true);
   },
 
   willDestroyElement() {
     this._super(...arguments);
-    this.element.removeEventListener("focusout", this.focusOutHandler, true);
+    this.element.removeEventListener("focusout", this._handleFocusOut, true);
   },
 
-  handleFocusOut(event) {
+  @bind
+  _handleFocusOut(event) {
     if (!this.selectKit.isExpanded) {
       return;
     }

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -51,7 +51,7 @@ export default Component.extend({
       return;
     }
 
-    if (this.selectKit.mainElement().contains(event.relatedTarget)) {
+    if (this.selectKit.mainElement().contains(event.target)) {
       return;
     }
 

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -42,11 +42,13 @@ export default Component.extend({
       return;
     }
 
-    // multi-selects need to keep the UI visible when adding/removing items
-    // for these cases, we can't rely on event.relatedTarget
-    // because the element has already been removed from DOM
-    if (this.selectKit.multiSelectRecentlyChanged) {
-      this.selectKit.set("multiSelectRecentlyChanged", false);
+    // We have to use a custom flag for multi-selects to keep UI visible.
+    // We can't rely on event.relatedTarget for these cases because,
+    // when adding/removing items in a multi-select, the DOM element
+    // has already been removed by this point, and therefore
+    // event.relatedTarget is going to be null.
+    if (this.selectKit.multiSelectInFocus) {
+      this.selectKit.set("multiSelectInFocus", false);
       return;
     }
 

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -51,7 +51,7 @@ export default Component.extend({
       return;
     }
 
-    if (this.selectKit.mainElement().contains(event.target)) {
+    if (this.selectKit.mainElement().contains(event.relatedTarget)) {
       return;
     }
 

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -7,6 +7,7 @@ export default Component.extend({
   layout,
   classNames: ["select-kit-body"],
   classNameBindings: ["emptyBody:empty-body"],
+  focusInMultiSelect: false,
 
   emptyBody: computed("selectKit.{filter,hasNoContent}", function () {
     return false;
@@ -16,12 +17,14 @@ export default Component.extend({
     this._super(...arguments);
 
     this.focusOutHandler = bind(this, this.handleFocusOut);
+    this.focusInHandler = bind(this, this.handleFocusIn);
   },
 
   didInsertElement() {
     this._super(...arguments);
     this.element.style.position = "relative";
     this.element.addEventListener("focusout", this.focusOutHandler, true);
+    this.element.addEventListener("focusin", this.focusInHandler, true);
   },
 
   willDestroyElement() {
@@ -42,22 +45,24 @@ export default Component.extend({
       return;
     }
 
+    // TODO: FIX THIS
     // multi-selects need to keep the UI visible when adding/removing items
     // for these cases, we can't rely on event.relatedTarget
     // because the element may have already been removed from the DOM
     // so we cannot check if the element is contained within the main element
-    if (this.selectKit.mainElement().classList.contains("multi-select")) {
-      const hasClass = [
-        "select-kit-row",
-        "selected-choice",
-        "filter-input",
-      ].some((className) => event.target.classList.contains(className));
-
-      if (hasClass) {
-        return;
-      }
+    if (this.focusInMultiSelect) {
+      this.focusInMultiSelect = false;
+      return;
     }
 
     this.selectKit.close(event);
+  },
+
+  handleFocusIn(event) {
+    if (this.selectKit.mainElement().classList.contains("multi-select")) {
+      if (this.selectKit.mainElement().contains(event.relatedTarget)) {
+        this.focusInMultiSelect = true;
+      }
+    }
   },
 });

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -7,7 +7,6 @@ export default Component.extend({
   layout,
   classNames: ["select-kit-body"],
   classNameBindings: ["emptyBody:empty-body"],
-  focusInMultiSelect: false,
 
   emptyBody: computed("selectKit.{filter,hasNoContent}", function () {
     return false;
@@ -17,14 +16,12 @@ export default Component.extend({
     this._super(...arguments);
 
     this.focusOutHandler = bind(this, this.handleFocusOut);
-    this.focusInHandler = bind(this, this.handleFocusIn);
   },
 
   didInsertElement() {
     this._super(...arguments);
     this.element.style.position = "relative";
     this.element.addEventListener("focusout", this.focusOutHandler, true);
-    this.element.addEventListener("focusin", this.focusInHandler, true);
   },
 
   willDestroyElement() {
@@ -54,13 +51,5 @@ export default Component.extend({
     }
 
     this.selectKit.close(event);
-  },
-
-  handleFocusIn(event) {
-    if (this.selectKit.mainElement().classList.contains("multi-select")) {
-      if (this.selectKit.mainElement().contains(event.relatedTarget)) {
-        this.focusInMultiSelect = true;
-      }
-    }
   },
 });

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -45,13 +45,11 @@ export default Component.extend({
       return;
     }
 
-    // TODO: FIX THIS
     // multi-selects need to keep the UI visible when adding/removing items
     // for these cases, we can't rely on event.relatedTarget
-    // because the element may have already been removed from the DOM
-    // so we cannot check if the element is contained within the main element
-    if (this.focusInMultiSelect) {
-      this.focusInMultiSelect = false;
+    // because the element has already been removed from DOM
+    if (this.selectKit.multiSelectRecentlyChanged) {
+      this.selectKit.set("multiSelectRecentlyChanged", false);
       return;
     }
 

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -12,12 +12,12 @@ export default Component.extend({
     return false;
   }),
 
-  rootEventType: "click",
+  rootEventType: "focusout",
 
   init() {
     this._super(...arguments);
 
-    this.handleRootMouseDownHandler = bind(this, this.handleRootMouseDown);
+    this.handleRootFocusOutHandler = bind(this, this.handleRootFocusOut);
   },
 
   didInsertElement() {
@@ -25,9 +25,9 @@ export default Component.extend({
 
     this.element.style.position = "relative";
 
-    document.addEventListener(
+    this.element.addEventListener(
       this.rootEventType,
-      this.handleRootMouseDownHandler,
+      this.handleRootFocusOutHandler,
       true
     );
   },
@@ -35,27 +35,23 @@ export default Component.extend({
   willDestroyElement() {
     this._super(...arguments);
 
-    document.removeEventListener(
+    this.element.removeEventListener(
       this.rootEventType,
-      this.handleRootMouseDownHandler,
+      this.handleRootFocusOutHandler,
       true
     );
   },
 
-  handleRootMouseDown(event) {
+  handleRootFocusOut(event) {
     if (!this.selectKit.isExpanded) {
       return;
     }
 
-    const headerElement = document.querySelector(
-      `#${this.selectKit.uniqueID}-header`
-    );
-
-    if (headerElement && headerElement.contains(event.target)) {
+    if (!this.selectKit.mainElement()) {
       return;
     }
 
-    if (this.element.contains(event.target)) {
+    if (this.selectKit.mainElement().contains(event.relatedTarget)) {
       return;
     }
 

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-header.js
@@ -122,7 +122,10 @@ export default Component.extend(UtilsMixin, {
       event.stopPropagation();
       event.preventDefault(); // prevents the space to trigger a scroll page-next
       this.selectKit.open(event);
-    } else if (event.key === "Escape") {
+    } else if (
+      event.key === "Escape" ||
+      (event.shiftKey && event.key === "Tab")
+    ) {
       event.stopPropagation();
       if (this.selectKit.isExpanded) {
         this.selectKit.close(event);

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-row.js
@@ -41,7 +41,6 @@ export default Component.extend(UtilsMixin, {
     if (!this.site.mobileView) {
       this.element.addEventListener("mouseenter", this.handleMouseEnter);
       this.element.addEventListener("focus", this.handleMouseEnter);
-      this.element.addEventListener("blur", this.handleBlur);
     }
   },
 
@@ -49,9 +48,8 @@ export default Component.extend(UtilsMixin, {
     this._super(...arguments);
 
     if (!this.site.mobileView) {
-      this.element.removeEventListener("mouseenter", this.handleBlur);
+      this.element.removeEventListener("mouseenter", this.handleMouseEnter);
       this.element.removeEventListener("focus", this.handleMouseEnter);
-      this.element.removeEventListener("blur", this.handleMouseEnter);
     }
   },
 
@@ -130,20 +128,6 @@ export default Component.extend(UtilsMixin, {
   handleMouseEnter() {
     if (!this.isDestroying || !this.isDestroyed) {
       this.selectKit.onHover(this.rowValue, this.item);
-    }
-    return false;
-  },
-
-  @action
-  handleBlur(event) {
-    if (
-      (!this.isDestroying || !this.isDestroyed) &&
-      event.target &&
-      this.selectKit.mainElement()
-    ) {
-      if (!this.selectKit.mainElement().contains(event.target)) {
-        this.selectKit.close(event);
-      }
     }
     return false;
   },


### PR DESCRIPTION
When navigating with the keyboard, select-kit components will not close when focus has moved to an element outside of the SK component. For example, when navigating via Tab or Shift+Tab, once the end of the list of options is reached, focus may move out of the SK element, but the SK itself stays visible. Here is a screenshot of this happening: 

<img width="600" alt="image" src="https://user-images.githubusercontent.com/368961/235707581-07c4f09a-934a-4b6c-85a8-c3c1f9aa4726.png">

(The focused element there is the New menu tab, but the SK dropdown is still present.)

Switching from a click event to a focusout event solves the issue and covers both mouse and keyboard navigation.

This PR also switches the event listener registration from the document  to the element, which should have a smaller performance footprint. 