### PR TITLE
UX: Use dvh for sidebar height

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -31,13 +31,19 @@
 
   @include unselectable;
 
+  // 100dvh with fallback for old browsers
+  --100dvh: 100vh;
+  @supports (height: 100dvh) {
+    --100dvh: 100dvh;
+  }
+
   .footer-nav-ipad & {
     top: calc(var(--header-offset) + var(--footer-nav-height));
     height: calc(
-      100vh - var(--header-offset, 0px) - var(--footer-nav-height, 0px)
+      var(--100dvh) - var(--header-offset, 0px) - var(--footer-nav-height, 0px)
     );
   }
-  height: calc(100vh - var(--header-offset, 0px));
+  height: calc(var(--100dvh) - var(--header-offset, 0px));
   align-self: start;
   overflow-y: auto;
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -37,13 +37,15 @@
     --100dvh: 100dvh;
   }
 
+  height: calc(var(--100dvh) - var(--header-offset, 0px));
+
   .footer-nav-ipad & {
     top: calc(var(--header-offset) + var(--footer-nav-height));
     height: calc(
       var(--100dvh) - var(--header-offset, 0px) - var(--footer-nav-height, 0px)
     );
   }
-  height: calc(var(--100dvh) - var(--header-offset, 0px));
+
   align-self: start;
   overflow-y: auto;
 


### PR DESCRIPTION
This will automatically adjust when browser UI is shown/hidden (e.g. when scrolling up/down on mobile Safari).

Similar approach to https://github.com/discourse/discourse/commit/c82094cd9dbd6160a2e611e6dde915ce4695b32f, which targeted the 'slide-in' version of menus.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
