### PR TITLE
DEV: Fix test

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -89,16 +89,25 @@ class Search
       Regexp.compile("[-–—―.。・（）()［］｛｝{}【】⟨⟩、､,，،…‥〽「」『』〜~！!：:？?\"'|_＿“”‘’;/⁄／«»]")
   end
 
+  def self.clean_term(term)
+    term = term.to_s.dup
+
+    # Removes any zero-width characters from search terms
+    term.gsub!(/[\u200B-\u200D\uFEFF]/, "")
+
+    # Replace curly quotes to regular quotes
+    term.gsub!(/[\u201c\u201d]/, '"')
+
+    # Replace fancy apostophes to regular apostophes
+    term.gsub!(/[\u02b9\u02bb\u02bc\u02bd\u02c8\u2018\u2019\u201b\u2032\uff07]/, "'")
+
+    term
+  end
+
   def self.prepare_data(search_data, purpose = nil)
     data = search_data.dup
     data.force_encoding("UTF-8")
-
-    # Removes any zero-width characters from search terms
-    data.gsub!(/[\u200B-\u200D\uFEFF]/, "")
-    # Replace curly quotes to regular quotes
-    data.gsub!(/[\u201c\u201d]/, '"')
-    # Replace fancy apostophes to regular apostophes
-    data.gsub!(/[\u02b9\u02bb\u02bc\u02bd\u02c8\u2018\u2019\u201b\u2032\uff07]/, "'")
+    data = clean_term(data)
 
     if purpose != :topic
       if segment_chinese?
@@ -221,7 +230,7 @@ class Search
     @page = @opts[:page]
     @search_all_pms = false
 
-    term = term.to_s.dup
+    term = Search.clean_term(term)
 
     @clean_term = term
     @in_title = false

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -93,6 +93,13 @@ class Search
     data = search_data.dup
     data.force_encoding("UTF-8")
 
+    # Removes any zero-width characters from search terms
+    data.gsub!(/[\u200B-\u200D\uFEFF]/, "")
+    # Replace curly quotes to regular quotes
+    data.gsub!(/[\u201c\u201d]/, '"')
+    # Replace fancy apostophes to regular apostophes
+    data.gsub!(/[\u02b9\u02bb\u02bc\u02bd\u02c8\u2018\u2019\u201b\u2032\uff07]/, "'")
+
     if purpose != :topic
       if segment_chinese?
         require "cppjieba_rb" unless defined?(CppjiebaRb)
@@ -215,11 +222,6 @@ class Search
     @search_all_pms = false
 
     term = term.to_s.dup
-
-    # Removes any zero-width characters from search terms
-    term.gsub!(/[\u200B-\u200D\uFEFF]/, "")
-    # Replace curly quotes to regular quotes
-    term.gsub!(/[\u201c\u201d]/, '"')
 
     @clean_term = term
     @in_title = false
@@ -1276,12 +1278,6 @@ class Search
   end
 
   def self.escape_string(term)
-    # HACK: The ’ and other similar characters have to be "unaccented" before
-    # it is escaped or the resulting tsqueries will be invalid
-    if SiteSetting.search_ignore_accents
-      term = term.gsub(/[\u02b9\u02bb\u02bc\u02bd\u02c8\u2018\u2019\u201b\u2032\uff07]/, "'")
-    end
-
     PG::Connection.escape_string(term).gsub('\\', '\\\\\\')
   end
 

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -139,33 +139,6 @@ RSpec.describe Search do
     end
   end
 
-  context "with apostrophes" do
-    fab!(:post_1) { Fabricate(:post, raw: "searching for: John's") }
-    fab!(:post_2) { Fabricate(:post, raw: "searching for: Johns") }
-
-    before { SearchIndexer.enable }
-
-    after { SearchIndexer.disable }
-
-    it "returns correct results" do
-      SiteSetting.search_ignore_accents = false
-      [post_1, post_2].each { |post| SearchIndexer.index(post.topic, force: true) }
-
-      expect(Search.execute("John's").posts).to contain_exactly(post_1, post_2)
-      expect(Search.execute("John’s").posts).to contain_exactly(post_1, post_2)
-      expect(Search.execute("Johns").posts).to contain_exactly(post_1, post_2)
-    end
-
-    it "returns correct results with accents" do
-      SiteSetting.search_ignore_accents = true
-      [post_1, post_2].each { |post| SearchIndexer.index(post.topic, force: true) }
-
-      expect(Search.execute("John's").posts).to contain_exactly(post_1, post_2)
-      expect(Search.execute("John’s").posts).to contain_exactly(post_1, post_2)
-      expect(Search.execute("Johns").posts).to contain_exactly(post_1, post_2)
-    end
-  end
-
   describe "custom_eager_load" do
     fab!(:topic) { Fabricate(:topic) }
     fab!(:post) { Fabricate(:post, topic: topic) }
@@ -1359,7 +1332,10 @@ RSpec.describe Search do
       end
 
       context "with non staff logged in" do
-        it "shows doesn’t show group" do
+        fab!(:user) { Fabricate(:user) }
+
+        it "shows doesn't show group" do
+          expect(search(user).groups.map(&:name)).to eq([])
         end
       end
     end


### PR DESCRIPTION
Apostrophe-like characters (for example, ’ and ') should be transformed to the
ASCII apostrophe (') regardless of search_ignore_accents. The same should
happen with all search terms before being transformed to tsqueries.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
