### PR TITLE
FEATURE: Add new notification for admin problems

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/notification-types-manager.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types-manager.js
@@ -1,5 +1,6 @@
 import NotificationTypeBase from "discourse/lib/notification-types/base";
 
+import AdminProblems from "discourse/lib/notification-types/admin-problems";
 import BookmarkReminder from "discourse/lib/notification-types/bookmark-reminder";
 import Custom from "discourse/lib/notification-types/custom";
 import GrantedBadge from "discourse/lib/notification-types/granted-badge";
@@ -27,6 +28,7 @@ const CLASS_FOR_TYPE = {
   membership_request_consolidated: MembershipRequestConsolidated,
   moved_post: MovedPost,
   new_features: NewFeatures,
+  admin_problems: AdminProblems,
   watching_first_post: WatchingFirstPost,
 };
 

--- a/app/assets/javascripts/discourse/app/lib/notification-types/admin-problems.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/admin-problems.js
@@ -16,6 +16,6 @@ export default class extends NotificationTypeBase {
   }
 
   get icon() {
-    return "exclamation-triangle";
+    return "gift";
   }
 }

--- a/app/assets/javascripts/discourse/app/lib/notification-types/admin-problems.js
+++ b/app/assets/javascripts/discourse/app/lib/notification-types/admin-problems.js
@@ -1,0 +1,21 @@
+import NotificationTypeBase from "discourse/lib/notification-types/base";
+import getURL from "discourse-common/lib/get-url";
+import I18n from "I18n";
+
+export default class extends NotificationTypeBase {
+  get label() {
+    return null;
+  }
+
+  get description() {
+    return I18n.t("notifications.admin_problems");
+  }
+
+  get linkHref() {
+    return getURL("/admin");
+  }
+
+  get icon() {
+    return "exclamation-triangle";
+  }
+}

--- a/app/jobs/scheduled/admin_problems.rb
+++ b/app/jobs/scheduled/admin_problems.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class DashboardStats < ::Jobs::Scheduled
+  class AdminProblems < ::Jobs::Scheduled
     every 30.minutes
 
     def execute(args)

--- a/app/jobs/scheduled/dashboard_stats.rb
+++ b/app/jobs/scheduled/dashboard_stats.rb
@@ -5,14 +5,15 @@ module Jobs
     every 30.minutes
 
     def execute(args)
+      Notification.where(notification_type: Notification.types[:admin_problems]).destroy_all
+
       if persistent_problems?
-        # If there have been problems reported on the dashboard for a while,
-        # send a message to admins no more often than once per week.
-        group_message =
-          GroupMessage.new(Group[:admins].name, :dashboard_problems, limit_once_per: 7.days.to_i)
-        Topic.transaction do
-          group_message.delete_previous!
-          group_message.create
+        Group[:admins].users.each do |user|
+          Notification.create!(
+            notification_type: Notification.types[:admin_problems],
+            user_id: user.id,
+            data: "{}",
+          )
         end
       end
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -152,6 +152,7 @@ class Notification < ActiveRecord::Base
         question_answer_user_commented: 35, # Used by https://github.com/discourse/discourse-question-answer
         watching_category_or_tag: 36,
         new_features: 37,
+        admin_problems: 38,
         following: 800, # Used by https://github.com/discourse/discourse-follow
         following_created_topic: 801, # Used by https://github.com/discourse/discourse-follow
         following_replied: 802, # Used by https://github.com/discourse/discourse-follow

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2580,6 +2580,7 @@ en:
       reaction_2: "<span>%{username}, %{username2}</span> %{description}"
       votes_released: "%{description} - completed"
       new_features: "New features available!"
+      admin_problems: "New advice on your site dashboard"
       dismiss_confirmation:
         body:
           default:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3537,16 +3537,6 @@ en:
       subject_template: "Downloading remote images disabled"
       text_body_template: "The `download_remote_images_to_local` setting was disabled because the disk space limit at `download_remote_images_threshold` was reached."
 
-    dashboard_problems:
-      title: "Dashboard Problems"
-      subject_template: "New advice on your site dashboard"
-      text_body_template: |
-        We have some new advice and recommendations for you based on your current site settings.
-
-        [Visit your site dashboard](%{base_url}/admin) to see it.
-
-        If nothing is visible on your dashboard, another staff member may have already acted on this advice. A list of staff actions can be found in your [Staff Action Logs](%{base_url}/admin/logs/staff_action_logs).
-
     new_user_of_the_month:
       title: "You're a New User of the Month!"
       subject_template: "You're a New User of the Month!"

--- a/spec/jobs/admin_problems_spec.rb
+++ b/spec/jobs/admin_problems_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe ::Jobs::DashboardStats do
+RSpec.describe ::Jobs::AdminProblems do
   fab!(:admin) { Fabricate(:admin) }
 
-  it "creates group notification when problems are persistent for 2 days" do
+  it "creates notification when problems persist for at least 2 days" do
     Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, Time.zone.now.to_s)
     expect { described_class.new.execute({}) }.not_to change { Notification.count }
 

--- a/spec/jobs/dashboard_stats_spec.rb
+++ b/spec/jobs/dashboard_stats_spec.rb
@@ -1,60 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe ::Jobs::DashboardStats do
-  let(:group_message) do
-    GroupMessage.new(Group[:admins].name, :dashboard_problems, limit_once_per: 7.days.to_i)
-  end
+  fab!(:admin) { Fabricate(:admin) }
 
-  def clear_recently_sent!
-    # We won't immediately create new PMs due to the limit_once_per option, reset the value for testing purposes.
-    Discourse.redis.del(group_message.sent_recently_key)
-  end
-
-  after { clear_recently_sent! }
-
-  it "creates group message when problems are persistent for 2 days" do
+  it "creates group notification when problems are persistent for 2 days" do
     Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, Time.zone.now.to_s)
-    expect { described_class.new.execute({}) }.not_to change { Topic.count }
+    expect { described_class.new.execute({}) }.not_to change { Notification.count }
 
     Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
-    expect { described_class.new.execute({}) }.to change { Topic.count }.by(1)
+    expect { described_class.new.execute({}) }.to change { Notification.count }.by(1)
   end
 
-  it "replaces old message" do
+  it "replaces old notification" do
     Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
-    expect { described_class.new.execute({}) }.to change { Topic.count }.by(1)
-    old_topic = Topic.last
-    clear_recently_sent!
+    expect { described_class.new.execute({}) }.to change { Notification.count }.by(1)
+    old_notification = Notification.last
 
-    new_topic = described_class.new.execute({}).topic
-    expect(old_topic.reload.deleted_at.present?).to eq(true)
-    expect(new_topic.reload.deleted_at).to be_nil
-    expect(new_topic.title).to eq(old_topic.title)
-  end
+    described_class.new.execute({})
+    new_notification = Notification.last
 
-  it "respects the sent_recently? check when deleting previous message" do
-    Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
-    expect { described_class.new.execute({}) }.to change { Topic.count }.by(1)
-
-    expect { described_class.new.execute({}) }.not_to change { Topic.count }
-  end
-
-  it "duplicates message if previous one has replies" do
-    Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
-    expect { described_class.new.execute({}) }.to change { Topic.count }.by(1)
-    clear_recently_sent!
-
-    _reply_1 = Fabricate(:post, topic: Topic.last)
-    expect { described_class.new.execute({}) }.to change { Topic.count }.by(1)
-  end
-
-  it "duplicates message if previous was 3 months ago" do
-    freeze_time 3.months.ago do
-      Discourse.redis.setex(AdminDashboardData.problems_started_key, 14.days.to_i, 3.days.ago)
-      expect { described_class.new.execute({}) }.to change { Topic.count }.by(1)
-      clear_recently_sent!
-    end
-
-    expect { described_class.new.execute({}) }.to change { Topic.count }.by(1)
+    expect(old_notification.id).not_to equal(new_notification.id)
   end
 end

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -41,6 +41,9 @@
         "new_features": {
           "type": "integer"
         },
+        "admin_problems": {
+          "type": "integer"
+        },
         "moved_post": {
           "type": "integer"
         },


### PR DESCRIPTION
Before:

<img width="373" alt="Screenshot 2023-04-28 at 17 17 40" src="https://user-images.githubusercontent.com/23153890/235175618-20662bea-7908-40c9-a91f-74f286db918c.png">

<img width="1087" alt="Screenshot 2023-04-28 at 17 17 54" src="https://user-images.githubusercontent.com/23153890/235175625-6edae00c-894c-4728-9637-c483af1c6580.png">

<img width="781" alt="Screenshot 2023-04-28 at 17 18 02" src="https://user-images.githubusercontent.com/23153890/235175631-87186df6-a203-48aa-a07b-6cd0dcf3800e.png">

Clicking on the link finally takes you to admin panel.

After:

<img width="373" alt="Screenshot 2023-04-28 at 17 29 48" src="https://user-images.githubusercontent.com/23153890/235175643-7759e515-2d32-4da1-87d9-93e153c69869.png">

Clicking on the notification immediately takes you to admin panel.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
