### PR TITLE
UX: two column dropdown sidebar layout

### DIFF
--- a/app/assets/stylesheets/common/base/menu-panel.scss
+++ b/app/assets/stylesheets/common/base/menu-panel.scss
@@ -711,6 +711,8 @@ body.footer-nav-ipad {
 .menu-panel.slide-in {
   top: var(--header-top);
   box-sizing: border-box;
+  // ensure there's always space to click outside on tiny devices
+  max-width: 90vw;
 
   --100dvh: 100%;
   @supports (height: 100dvh) {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -133,10 +133,18 @@
     }
   }
 
+  .sidebar-section-wrapper .sidebar-section-header-caret {
+    display: none;
+  }
+
+  .sidebar-section-header-collapsable {
+    pointer-events: none; // disabling collapsible sections
+  }
+
   .sidebar-custom-sections .d-icon-globe {
-    left: -0.6em;
-    top: 0.2em;
-    font-size: 0.9em;
+    left: -0.95em;
+    top: 0.35em;
+    font-size: 0.7em;
   }
 
   .sidebar-footer-wrapper .sidebar-footer-container {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -150,7 +150,7 @@
   .sidebar-footer-wrapper .sidebar-footer-container {
     border: none;
     &:before {
-      top: calc(-100% + 0.5em);
+      top: -1.5em;
     }
   }
 

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -115,67 +115,6 @@
   }
 }
 
-.sidebar-hamburger-dropdown {
-  .sidebar-section-wrapper.sidebar-section {
-    padding-top: 0.5em;
-    .sidebar-section-header-wrapper {
-      margin: 0 0 var(--d-sidebar-row-vertical-padding);
-      border-bottom: 1px solid var(--primary-low);
-    }
-
-    ul {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-
-      li {
-        min-width: 0;
-      }
-    }
-  }
-
-  .sidebar-section-wrapper .sidebar-section-header-caret {
-    display: none;
-  }
-
-  .sidebar-section-header-collapsable {
-    pointer-events: none; // disabling collapsible sections
-  }
-
-  .sidebar-custom-sections .d-icon-globe {
-    left: -0.95em;
-    top: 0.35em;
-    font-size: 0.7em;
-  }
-
-  .sidebar-footer-wrapper .sidebar-footer-container {
-    border: none;
-    &:before {
-      top: -1.5em;
-    }
-  }
-
-  .discourse-no-touch & {
-    .sidebar-section-wrapper .sidebar-section-header-wrapper:hover,
-    .sidebar-section-wrapper .sidebar-section-header-wrapper:focus-within {
-      background: transparent;
-    }
-  }
-
-  .sidebar-footer-wrapper {
-    margin-top: 1em;
-    .sidebar-footer-container {
-      background: var(--secondary);
-      &:before {
-        background: linear-gradient(
-          to bottom,
-          transparent,
-          rgba(var(--secondary-rgb), 1)
-        );
-      }
-    }
-  }
-}
-
 .sidebar-section-form-modal {
   .modal-inner-container {
     width: var(--modal-max-width);

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -116,6 +116,36 @@
 }
 
 .sidebar-hamburger-dropdown {
+  .sidebar-section-wrapper.sidebar-section {
+    padding-top: 0.5em;
+    .sidebar-section-header-wrapper {
+      margin: 0 0 var(--d-sidebar-row-vertical-padding);
+      border-bottom: 1px solid var(--primary-low);
+    }
+
+    ul {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+
+      li {
+        min-width: 0;
+      }
+    }
+  }
+
+  .sidebar-custom-sections .d-icon-globe {
+    left: -0.6em;
+    top: 0.2em;
+    font-size: 0.9em;
+  }
+
+  .sidebar-footer-wrapper .sidebar-footer-container {
+    border: none;
+    &:before {
+      top: calc(-100% + 0.5em);
+    }
+  }
+
   .discourse-no-touch & {
     .sidebar-section-wrapper .sidebar-section-header-wrapper:hover,
     .sidebar-section-wrapper .sidebar-section-header-wrapper:focus-within {

--- a/app/assets/stylesheets/desktop/menu-panel.scss
+++ b/app/assets/stylesheets/desktop/menu-panel.scss
@@ -49,9 +49,6 @@
     padding: 0;
     .sidebar-footer-container {
       padding: 0;
-      &:before {
-        top: calc(-100% + 2px);
-      }
     }
   }
 }

--- a/app/assets/stylesheets/desktop/menu-panel.scss
+++ b/app/assets/stylesheets/desktop/menu-panel.scss
@@ -37,6 +37,35 @@
     .sidebar-section-header-wrapper .select-kit .btn:hover {
       background: transparent;
     }
+
+    &.sidebar-section {
+      padding-top: 0.5em;
+      .sidebar-section-header-wrapper {
+        margin: 0 0 var(--d-sidebar-row-vertical-padding);
+        border-bottom: 1px solid var(--primary-low);
+      }
+      ul {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        li {
+          min-width: 0;
+        }
+      }
+    }
+  }
+
+  .sidebar-section-wrapper .sidebar-section-header-caret {
+    display: none;
+  }
+
+  .sidebar-section-header-collapsable {
+    pointer-events: none; // disabling collapsible sections
+  }
+
+  .sidebar-custom-sections .d-icon-globe {
+    left: -0.9em;
+    top: 0.35em;
+    font-size: 0.7em;
   }
 
   .sidebar-section-link-wrapper
@@ -47,8 +76,28 @@
 
   .sidebar-footer-wrapper {
     padding: 0;
+    margin-top: 1em;
     .sidebar-footer-container {
       padding: 0;
+      border: none;
+      background: var(--secondary);
+      &:before {
+        top: -1.5em;
+        background: linear-gradient(
+          to bottom,
+          transparent,
+          rgba(var(--secondary-rgb), 1)
+        );
+      }
+    }
+  }
+}
+
+.sidebar-hamburger-dropdown {
+  .discourse-no-touch & {
+    .sidebar-section-wrapper .sidebar-section-header-wrapper:hover,
+    .sidebar-section-wrapper .sidebar-section-header-wrapper:focus-within {
+      background: transparent;
     }
   }
 }


### PR DESCRIPTION
This switches the new sidebar dropdown menu to two-columns, which is a little closer to the legacy menu layout and saves some space.


Before:
![Screenshot 2023-04-27 at 5 58 05 PM](https://user-images.githubusercontent.com/1681963/235000229-f8f33ace-89d0-4733-94e3-0e3879f52df8.png)


After:

![Screenshot 2023-04-28 at 2 04 02 PM](https://user-images.githubusercontent.com/1681963/235221099-b8fb56f9-0535-4e12-bd8a-4f59ef4335d5.png)

