### PR TITLE
FIX: Empty video thumbnails

### DIFF
--- a/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-upload-uppy.js
@@ -325,32 +325,28 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
 
         cacheShortUploadUrl(upload.short_url, upload);
 
-        // video/mp4, video/webm, video/quicktime, etc.
-        if (file.type.split("/")[0] === "video") {
-          this._generateVideoThumbnail(file, upload.url);
-        }
-
-        if (this.useUploadPlaceholders) {
+        this._generateVideoThumbnail(file, upload.url, () => {
+          if (this.useUploadPlaceholders) {
+            this.appEvents.trigger(
+              `${this.composerEventPrefix}:replace-text`,
+              this.placeholders[file.id].uploadPlaceholder.trim(),
+              markdown
+            );
+          }
+          this._resetUpload(file, { removePlaceholder: false });
           this.appEvents.trigger(
-            `${this.composerEventPrefix}:replace-text`,
-            this.placeholders[file.id].uploadPlaceholder.trim(),
-            markdown
+            `${this.composerEventPrefix}:upload-success`,
+            file.name,
+            upload
           );
-        }
 
-        this._resetUpload(file, { removePlaceholder: false });
-        this.appEvents.trigger(
-          `${this.composerEventPrefix}:upload-success`,
-          file.name,
-          upload
-        );
-
-        if (this.inProgressUploads.length === 0) {
-          this.appEvents.trigger(
-            `${this.composerEventPrefix}:all-uploads-complete`
-          );
-          this._reset();
-        }
+          if (this.inProgressUploads.length === 0) {
+            this.appEvents.trigger(
+              `${this.composerEventPrefix}:all-uploads-complete`
+            );
+            this._reset();
+          }
+        });
       });
     });
 

--- a/app/assets/javascripts/discourse/app/mixins/composer-video-thumbnail-uppy.js
+++ b/app/assets/javascripts/discourse/app/mixins/composer-video-thumbnail-uppy.js
@@ -17,9 +17,12 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
   useUploadPlaceholders: true,
 
   @bind
-  _generateVideoThumbnail(videoFile, uploadUrl) {
+  _generateVideoThumbnail(videoFile, uploadUrl, callback) {
     if (!this.siteSettings.video_thumbnails_enabled) {
-      return;
+      callback();
+    }
+    if (videoFile.type.split("/")[0] !== "video") {
+      callback();
     }
     let video = document.createElement("video");
     video.src = URL.createObjectURL(videoFile.data);
@@ -45,10 +48,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
       // A timeout is needed on mobile.
       setTimeout(() => {
         ctx.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
-      }, 100);
 
-      // A timeout is needed on mobile.
-      setTimeout(() => {
         // upload video thumbnail
         canvas.toBlob((blob) => {
           this._uppyInstance = new Uppy({
@@ -103,6 +103,7 @@ export default Mixin.create(ExtendableUploader, UppyS3Multipart, {
             });
           }
         });
+        callback();
       }, 100);
     };
   },


### PR DESCRIPTION
This fix ensures that topic video thumbnail generation is completed
before the composer is allowed to submit which should prevent some bugs
around missing thumbnails on video topics.
