### PR TITLE
UX: Add a warning that updating min_trust_level_for_user_api_key will disable users from using DiscourseHub

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2346,7 +2346,9 @@ en:
 
     allow_user_api_keys: "Allow generation of user API keys"
     allow_user_api_key_scopes: "List of scopes allowed for user API keys"
-    min_trust_level_for_user_api_key: "Trust level required for generation of user API keys"
+    min_trust_level_for_user_api_key: |
+      Trust level required for generation of user API keys.<br>
+      <b>WARNING</b>: Changing the trust level will prevent users with a lower trust level from logging in via Discourse Hub
     allowed_user_api_auth_redirects: "Allowed URL for authentication redirect for user API keys. Wildcard symbol * can be used to match any part of it (e.g. www.example.com/*)."
     allowed_user_api_push_urls: "Allowed URLs for server push to user API"
     expire_user_api_keys_days: "Number of days before a user API key automatically expires (0 for never)"


### PR DESCRIPTION
We are using user_api_key to log users in via DiscourseHub. When an admin sets the value to > 0, new users will not be able to log in and see this error when redirected back:

![IMG_5154](https://user-images.githubusercontent.com/1555215/235059944-e9020678-9c7d-47e8-ba0d-42780499a293.jpeg)

_______________________


The setting description will now look like this:

<img width="622" alt="Screenshot 2023-04-28 at 1 12 44 PM" src="https://user-images.githubusercontent.com/1555215/235059765-7f4ffdbf-d3c3-4ad9-af72-dff5ae2245b8.png">
