### PR TITLE
FIX: correctly homogenizes panels min width

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.js
@@ -4,7 +4,7 @@ import { action } from "@ember/object";
 import { htmlSafe } from "@ember/template";
 import { tracked } from "@glimmer/tracking";
 
-const MIN_CHAT_CHANNEL_WIDTH = 300;
+const MIN_CHAT_CHANNEL_WIDTH = 250;
 
 export default class ChatSidePanel extends Component {
   @service chatStateManager;

--- a/plugins/chat/assets/stylesheets/common/chat-channel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel.scss
@@ -6,7 +6,7 @@
   overflow: hidden;
   grid-area: main;
   width: 100%;
-  min-width: 300px;
+  min-width: 250px;
 
   .open-drawer-btn {
     color: var(--primary-low-mid);


### PR DESCRIPTION
`.chat-channel` had `300px` min width, when `.chat-drawer` was `250px`, resulting in overflowing channel when in drawer. This commits ensures the limits are always set at `250px`.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
