### PR TITLE
DEV: Show select-kit deprecations in non-dev envs

### DIFF
--- a/app/assets/javascripts/select-kit/addon/components/select-kit.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit.js
@@ -1083,17 +1083,11 @@ export default Component.extend(
     },
 
     _deprecated(text) {
-      const discourseSetup = document.getElementById("data-discourse-setup");
-      if (
-        discourseSetup &&
-        discourseSetup.getAttribute("data-environment") === "development"
-      ) {
-        deprecated(text, {
-          since: "v2.4.0",
-          dropFrom: "2.9.0.beta1",
-          id: "discourse.select-kit",
-        });
-      }
+      deprecated(text, {
+        since: "v2.4.0",
+        dropFrom: "2.9.0.beta1",
+        id: "discourse.select-kit",
+      });
     },
 
     _deprecateValueAttribute() {


### PR DESCRIPTION
We should have them in CI ;)

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
