### PR TITLE
Fix Twitch onebox multisite issue

### DIFF
--- a/lib/onebox/mixins/twitch_onebox.rb
+++ b/lib/onebox/mixins/twitch_onebox.rb
@@ -25,7 +25,7 @@ module Onebox
 
         def to_html
           <<~HTML
-          <iframe src="https://#{base_url}#{query_params}&parent=#{options[:hostname]}&autoplay=false" width="620" height="378" frameborder="0" style="overflow: hidden;" scrolling="no" allowfullscreen="allowfullscreen"></iframe>
+          <iframe src="https://#{base_url}#{query_params}&parent=#{Discourse.current_hostname}&autoplay=false" width="620" height="378" frameborder="0" style="overflow: hidden;" scrolling="no" allowfullscreen="allowfullscreen"></iframe>
           HTML
         end
       end

--- a/spec/lib/onebox/engine/twitch_clips_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_clips_onebox_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Onebox::Engine::TwitchClipsOnebox do
-  let(:hostname) { "www.example.com" }
+  let(:hostname) { Discourse.current_hostname }
   let(:options) { { hostname: hostname } }
 
   it "has the iframe with the correct channel" do

--- a/spec/lib/onebox/engine/twitch_stream_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_stream_onebox_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Onebox::Engine::TwitchStreamOnebox do
-  let(:hostname) { "www.example.com" }
+  let(:hostname) { Discourse.current_hostname }
   let(:options) { { hostname: hostname } }
 
   it "has the iframe with the correct channel" do

--- a/spec/lib/onebox/engine/twitch_video_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_video_onebox_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Onebox::Engine::TwitchVideoOnebox do
-  let(:hostname) { "www.example.com" }
+  let(:hostname) { Discourse.current_hostname }
   let(:options) { { hostname: hostname } }
 
   it "has the iframe with the correct channel" do


### PR DESCRIPTION
Fix for the issue described here:
https://meta.discourse.org/t/bug-embedding-twitch-content-on-multisite/262869

The oneboxing code included the multisite master hostname instead of the actual forum hostname, causing an embedding error.