### PR TITLE
DEV: Do not rerender widgets on mouseup/mousedown

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
+++ b/app/assets/javascripts/discourse/app/widgets/default-notification-item.js
@@ -192,6 +192,7 @@ export const DefaultNotificationItem = createWidget(
           method: "PUT",
           data: { id: this.attrs.id },
         });
+        this.scheduleRerender();
       }
     },
   }

--- a/app/assets/javascripts/discourse/app/widgets/hooks.js
+++ b/app/assets/javascripts/discourse/app/widgets/hooks.js
@@ -263,13 +263,20 @@ WidgetClickHook.setupDocumentCallback = function () {
   });
 
   $(document).on("mousedown.discourse-widget", (e) => {
-    nodeCallback(e.target, MOUSE_DOWN_ATTRIBUTE_NAME, (w) => {
-      w.mouseDown(e);
-    });
+    nodeCallback(
+      e.target,
+      MOUSE_DOWN_ATTRIBUTE_NAME,
+      (w) => {
+        w.mouseDown(e);
+      },
+      { rerender: false }
+    );
   });
 
   $(document).on("mouseup.discourse-widget", (e) => {
-    nodeCallback(e.target, MOUSE_UP_ATTRIBUTE_NAME, (w) => w.mouseUp(e));
+    nodeCallback(e.target, MOUSE_UP_ATTRIBUTE_NAME, (w) => w.mouseUp(e), {
+      rerender: false,
+    });
   });
 
   $(document).on("mousemove.discourse-widget", (e) => {

--- a/app/assets/javascripts/discourse/tests/integration/components/widgets/default-notification-item-test.js
+++ b/app/assets/javascripts/discourse/tests/integration/components/widgets/default-notification-item-test.js
@@ -55,7 +55,11 @@ module(
       assert.ok(!exists("li.read"));
 
       await triggerEvent("li", "mouseup", { button: 1, which: 2 });
-      assert.strictEqual(count("li.read"), 1);
+      assert.strictEqual(
+        count("li.read"),
+        1,
+        "only one item is marked as read"
+      );
       assert.strictEqual(requests, 1);
     });
   }


### PR DESCRIPTION
Ran into an issue with these hooks preventing clicks on anchors in widgets. See: https://github.com/discourse/discourse-header-search/pull/24 for an explanation of the specific use case. 

This change should have no effect on existing usage of these hooks, they're only used in three places (I reviewed our plugins/themes/core):

- legacy navigation (for middle clicking to mark an item as read)
- reactions plugin (should be a no-op)
- discourse-header-search (will fix the issue!)
