### PR TITLE
UX: cook message before sending edit

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -591,6 +591,7 @@ export default class ChatLivePane extends Component {
   }
 
   #sendEditMessage(message) {
+    message.cook();
     this.chatChannelPane.sending = true;
 
     const data = {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -238,6 +238,7 @@ export default class ChatThreadPanel extends Component {
   }
 
   #sendEditMessage(message) {
+    message.cook();
     this.chatChannelThreadPane.sending = true;
 
     const data = {

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -138,6 +138,18 @@ RSpec.describe "Chat composer", type: :system, js: true do
       expect(find(".chat-composer__input").value).to eq(message_2.message)
     end
 
+    it "updates the message instantly" do
+      chat.visit_channel(channel_1)
+      page.driver.browser.network_conditions = { offline: true }
+
+      channel.edit_message(message_2)
+      find(".chat-composer__input").send_keys("instant")
+      channel.click_send_message
+
+      expect(channel).to have_message(text: message_2.message + "instant")
+      page.driver.browser.network_conditions = { offline: false }
+    end
+
     context "when pressing escape" do
       it "cancels editing" do
         chat.visit_channel(channel_1)


### PR DESCRIPTION
This allows for instant feedback in the UI without having to wait for the roundtrip from the server.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
