### PR TITLE
UX: resets active message when scrolling

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -501,6 +501,8 @@ export default class ChatLivePane extends Component {
       return;
     }
 
+    this.chat.activeMessage = null;
+
     if (this.#isAtTop()) {
       this.fetchMoreMessages({ direction: PAST });
       this.onScrollEnded();

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.hbs
@@ -26,6 +26,7 @@
   <div
     class="chat-thread__body popper-viewport"
     {{did-insert this.setScrollable}}
+    {{on "scroll" this.resetActiveMessage passive=true}}
   >
     <div
       class="chat-thread__messages chat-messages-container"

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -193,6 +193,11 @@ export default class ChatThreadPanel extends Component {
     this.chatChannelThreadComposer.reset(this.channel);
   }
 
+  @action
+  resetActiveMessage() {
+    this.chat.activeMessage = null;
+  }
+
   #sendNewMessage(message) {
     // TODO (martin) For desktop notifications
     // resetIdle()

--- a/plugins/chat/spec/system/chat_channel_spec.rb
+++ b/plugins/chat/spec/system/chat_channel_spec.rb
@@ -250,4 +250,28 @@ RSpec.describe "Chat channel", type: :system, js: true do
       expect(page).to have_selector("code.lang-ruby")
     end
   end
+
+  context "when scrolling" do
+    before do
+      channel_1.add(current_user)
+      50.times { Fabricate(:chat_message, chat_channel: channel_1) }
+      sign_in(current_user)
+    end
+
+    it "resets the active message" do
+      chat.visit_channel(channel_1)
+      last_message = find(".chat-message-container:last-child")
+      last_message.hover
+
+      expect(page).to have_css(
+        ".chat-message-actions-container[data-id='#{last_message["data-id"]}']",
+      )
+
+      find(".chat-messages-scroll").scroll_to(0, -1000)
+
+      expect(page).to have_no_css(
+        ".chat-message-actions-container[data-id='#{last_message["data-id"]}']",
+      )
+    end
+  end
 end


### PR DESCRIPTION
This will avoid the messages actions floating around while scrolling. Note it's not testing the thread counterpart yet as I have a plan in mind to tests channels and threads in a clean way in the near future.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
