### PR TITLE
DEV: Check if video thumbnails site setting is enabled

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1014,7 +1014,7 @@ class Post < ActiveRecord::Base
 
       # Link any video thumbnails
       if SiteSetting.video_thumbnails_enabled && upload.present? &&
-           (FileHelper.supported_video.include? upload.extension&.downcase)
+           FileHelper.supported_video.include?(upload.extension&.downcase)
         # Video thumbnails have the filename of the video file sha1 with a .png or .jpg extension.
         # This is because at time of upload in the composer we don't know the topic/post id yet
         # and there is no thumbnail info added to the markdown to tie the thumbnail to the topic/post after

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1013,7 +1013,8 @@ class Post < ActiveRecord::Base
       upload ||= Upload.get_from_url(src)
 
       # Link any video thumbnails
-      if upload.present? && (FileHelper.supported_video.include? upload.extension&.downcase)
+      if SiteSetting.video_thumbnails_enabled && upload.present? &&
+           (FileHelper.supported_video.include? upload.extension&.downcase)
         # Video thumbnails have the filename of the video file sha1 with a .png or .jpg extension.
         # This is because at time of upload in the composer we don't know the topic/post id yet
         # and there is no thumbnail info added to the markdown to tie the thumbnail to the topic/post after

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1547,6 +1547,8 @@ RSpec.describe Post do
 
     let(:post) { Fabricate(:post, raw: raw_video) }
 
+    before { SiteSetting.video_thumbnails_enabled = true }
+
     it "has a topic thumbnail" do
       # Thumbnails are tied to a specific video file by using the
       # video's sha1 as the image filename
@@ -1576,6 +1578,16 @@ RSpec.describe Post do
 
       post.topic.reload
       expect(post.topic.image_upload_id).to eq(image_upload_2.id)
+    end
+
+    it "does not create thumbnails when disabled" do
+      SiteSetting.video_thumbnails_enabled = false
+      image_upload.original_filename = "#{video_upload.sha1}.png"
+      image_upload.save!
+      post.link_post_uploads
+
+      post.topic.reload
+      expect(post.topic.topic_thumbnails.length).to eq(0)
     end
   end
 


### PR DESCRIPTION
There is already a check on the front end for the
`video_thumbnails_enabled` site setting. This adds a check for the
backend as well just in case.
