### PR TITLE
DEV: potential flakey specs fixes

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -452,7 +452,10 @@ export default class ChatLivePane extends Component {
 
       // if the last visible message is not fully visible, we don't want to mark it as read
       // attempt to mark previous one as read
-      if (!this.#isBottomOfMessageVisible(element, this.scrollable)) {
+      if (
+        element &&
+        !this.#isBottomOfMessageVisible(element, this.scrollable)
+      ) {
         lastUnreadVisibleMessage = lastUnreadVisibleMessage.previousMessage;
 
         if (

--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.js
@@ -33,6 +33,10 @@ export default class ChatSidePanel extends Component {
 
   @action
   didResize(element, size) {
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+
     const parentWidth = element.parentElement.getBoundingClientRect().width;
     const mainPanelWidth = parentWidth - size.width;
 


### PR DESCRIPTION
Example log found in a CI run:

```
 http://localhost:31339/assets/plugins/chat.js 3655:25 Uncaught TypeError: Cannot read properties of null (reading 'getBoundingClientRect')
```

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
