### PR TITLE
DEV: Use `\A` and `\z` instead of `^` and `$` in `TopicsFilter`

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -114,7 +114,7 @@ class TopicsFilter
   private
 
   YYYY_MM_DD_REGEXP =
-    /^(?<year>[12][0-9]{3})-(?<month>0?[1-9]|1[0-2])-(?<day>0?[1-9]|[12]\d|3[01])$/
+    /\A(?<year>[12][0-9]{3})-(?<month>0?[1-9]|1[0-2])-(?<day>0?[1-9]|[12]\d|3[01])\z/
   private_constant :YYYY_MM_DD_REGEXP
 
   def extract_and_validate_value_for(filter, values)
@@ -190,7 +190,7 @@ class TopicsFilter
 
       value
         .scan(
-          /^(?<category_slugs>([a-zA-Z0-9\-:]+)(?<delimiter>[,])?([a-zA-Z0-9\-:]+)?(\k<delimiter>[a-zA-Z0-9\-:]+)*)$/,
+          /\A(?<category_slugs>([a-zA-Z0-9\-:]+)(?<delimiter>[,])?([a-zA-Z0-9\-:]+)?(\k<delimiter>[a-zA-Z0-9\-:]+)*)\z/,
         )
         .each do |category_slugs, delimiter|
           (
@@ -329,7 +329,7 @@ class TopicsFilter
       break if key_prefix && key_prefix != "-"
 
       value.scan(
-        /^(?<tag_names>([a-zA-Z0-9\-]+)(?<delimiter>[,+])?([a-zA-Z0-9\-]+)?(\k<delimiter>[a-zA-Z0-9\-]+)*)$/,
+        /\A(?<tag_names>([a-zA-Z0-9\-]+)(?<delimiter>[,+])?([a-zA-Z0-9\-]+)?(\k<delimiter>[a-zA-Z0-9\-]+)*)\z/,
       ) do |tag_names, delimiter|
         match_all =
           if delimiter == ","
@@ -456,7 +456,7 @@ class TopicsFilter
   }
   private_constant :ORDER_BY_MAPPINGS
 
-  ORDER_BY_REGEXP = /^(?<order_by>#{ORDER_BY_MAPPINGS.keys.join("|")})(?<asc>-asc)?$/
+  ORDER_BY_REGEXP = /\A(?<order_by>#{ORDER_BY_MAPPINGS.keys.join("|")})(?<asc>-asc)?\z/
   private_constant :ORDER_BY_REGEXP
 
   def order_by(values:)


### PR DESCRIPTION
`^` and `$` matches per line which is technically not what we want.