### PR TITLE
DEV: Change `created-by` topics query filter to `created-by:@<username>`

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -132,6 +132,8 @@ class TopicsFilter
          "posters-min", "posters-max", "views-min", "views-max"
       value = values.last
       value if value =~ /\A\d+\z/
+    when "created-by"
+      values.flat_map { |value| value.split(",").map { |username| username.delete_prefix("@") } }
     else
       values
     end

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -780,67 +780,69 @@ RSpec.describe TopicsFilter do
       fab!(:topic2_by_user) { Fabricate(:topic, user: user) }
       fab!(:topic_by_user2) { Fabricate(:topic, user: user2) }
 
-      describe "when query string is `created-by:username`" do
+      describe "when query string is `created-by:@username`" do
         it "should return the topics created by the specified user" do
           expect(
             TopicsFilter
               .new(guardian: Guardian.new)
-              .filter_from_query_string("created-by:#{user.username}")
+              .filter_from_query_string("created-by:@#{user.username}")
               .pluck(:id),
           ).to contain_exactly(topic_by_user.id, topic2_by_user.id)
         end
       end
 
-      describe "when query string is `created-by:username2`" do
+      describe "when query string is `created-by:@username2`" do
         it "should return the topics created by the specified user" do
           expect(
             TopicsFilter
               .new(guardian: Guardian.new)
-              .filter_from_query_string("created-by:#{user2.username}")
+              .filter_from_query_string("created-by:@#{user2.username}")
               .pluck(:id),
           ).to contain_exactly(topic_by_user2.id)
         end
       end
 
-      describe "when query string is `created-by:username created-by:username2`" do
+      describe "when query string is `created-by:@username created-by:@username2`" do
         it "should return the topics created by either of the specified users" do
           expect(
             TopicsFilter
               .new(guardian: Guardian.new)
-              .filter_from_query_string("created-by:#{user.username} created-by:#{user2.username}")
+              .filter_from_query_string(
+                "created-by:@#{user.username} created-by:@#{user2.username}",
+              )
               .pluck(:id),
           ).to contain_exactly(topic_by_user.id, topic2_by_user.id, topic_by_user2.id)
         end
       end
 
-      describe "when query string is `created-by:username,invalid`" do
+      describe "when query string is `created-by:@username,invalid`" do
         it "should only return the topics created by the user with the valid username" do
           expect(
             TopicsFilter
               .new(guardian: Guardian.new)
-              .filter_from_query_string("created-by:#{user.username},invalid")
+              .filter_from_query_string("created-by:@#{user.username},invalid")
               .pluck(:id),
           ).to contain_exactly(topic_by_user.id, topic2_by_user.id)
         end
       end
 
-      describe "when query string is `created-by:username,username2`" do
+      describe "when query string is `created-by:@username,@username2`" do
         it "should return the topics created by either of the specified users" do
           expect(
             TopicsFilter
               .new(guardian: Guardian.new)
-              .filter_from_query_string("created-by:#{user.username},#{user2.username}")
+              .filter_from_query_string("created-by:@#{user.username},@#{user2.username}")
               .pluck(:id),
           ).to contain_exactly(topic_by_user.id, topic2_by_user.id, topic_by_user2.id)
         end
       end
 
-      describe "when query string is `created-by:invalid`" do
+      describe "when query string is `created-by:@invalid`" do
         it "should not return any topics" do
           expect(
             TopicsFilter
               .new(guardian: Guardian.new)
-              .filter_from_query_string("created-by:invalid")
+              .filter_from_query_string("created-by:@invalid")
               .pluck(:id),
           ).to eq([])
         end


### PR DESCRIPTION
We want each username to be prefixed with the `@` symbol.