### PR TITLE
DEV: Fix `order:` filter not working on `/filter` route

### DIFF
--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1308,6 +1308,36 @@ RSpec.describe ListController do
       end
     end
 
+    describe "when ordering using the `order:` filter" do
+      fab!(:topic2) { Fabricate(:topic, views: 2) }
+      fab!(:topic3) { Fabricate(:topic, views: 3) }
+      fab!(:topic4) { Fabricate(:topic, views: 1) }
+
+      it "return topics ordered by topic bumped at date in descending order when `q` query param is not present" do
+        sign_in(user)
+
+        get "/filter.json"
+
+        expect(response.status).to eq(200)
+
+        expect(response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] }).to eq(
+          [topic4.id, topic3.id, topic2.id, topic.id],
+        )
+      end
+
+      it "return topics ordered by views when `q` query param is `order:views`" do
+        sign_in(user)
+
+        get "/filter.json", params: { q: "order:views" }
+
+        expect(response.status).to eq(200)
+
+        expect(response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] }).to eq(
+          [topic3.id, topic2.id, topic4.id, topic.id],
+        )
+      end
+    end
+
     describe "when filtering by status" do
       fab!(:group) { Fabricate(:group) }
       fab!(:private_category) { Fabricate(:private_category, group: group) }


### PR DESCRIPTION
`TopicQuery#latest_results` which was being used by
`TopicQuery#list_filter` defaults to ordering by `Topic#bumped_at` in
descending order and that was taking precedent over the order scopes
being applied by `TopicsFilter`.