### PR TITLE
FIX: Disallow invisible Unicode characters in usernames

### DIFF
--- a/app/models/username_validator.rb
+++ b/app/models/username_validator.rb
@@ -44,7 +44,34 @@ class UsernameValidator
   MAX_CHARS ||= 60
 
   ASCII_INVALID_CHAR_PATTERN ||= /[^\w.-]/
-  UNICODE_INVALID_CHAR_PATTERN ||= /[^\p{Alnum}\p{M}._-]/
+  # All Unicode characters except for alphabetic and numeric character, marks and underscores are invalid.
+  # In addition to that, the following letters and nonspacing marks are invalid:
+  #   (U+034F) Combining Grapheme Joiner
+  #   (U+115F) Hangul Choseong Filler
+  #   (U+1160) Hangul Jungseong Filler
+  #   (U+17B4) Khmer Vowel Inherent Aq
+  #   (U+17B5) Khmer Vowel Inherent Aa
+  #   (U+180B - U+180D) Mongolian Free Variation Selectors
+  #   (U+3164) Hangul Filler
+  #   (U+FFA0) Halfwidth Hangul Filler
+  #   (U+FE00 - U+FE0F) "Variation Selectors" block
+  #   (U+E0100 - U+E01EF) "Variation Selectors Supplement" block
+  UNICODE_INVALID_CHAR_PATTERN ||=
+    /
+      [^\p{Alnum}\p{M}._-]|
+      [
+        \u{034F}
+        \u{115F}
+        \u{1160}
+        \u{17B4}
+        \u{17B5}
+        \u{180B}-\u{180D}
+        \u{3164}
+        \u{FFA0}
+        \p{In Variation Selectors}
+        \p{In Variation Selectors Supplement}
+      ]
+    /x
   INVALID_LEADING_CHAR_PATTERN ||= /\A[^\p{Alnum}\p{M}_]+/
   INVALID_TRAILING_CHAR_PATTERN ||= /[^\p{Alnum}\p{M}]+\z/
   REPEATED_SPECIAL_CHAR_PATTERN ||= /[-_.]{2,}/

--- a/spec/models/username_validator_spec.rb
+++ b/spec/models/username_validator_spec.rb
@@ -201,6 +201,26 @@ RSpec.describe UsernameValidator do
         )
       end
 
+      it "is invalid when the username contains invisible characters" do
+        expect_invalid(
+          "a\u{034F}b",
+          "a\u{115F}b",
+          "a\u{1160}b",
+          "a\u{17B4}b",
+          "a\u{17B5}b",
+          "a\u{180B}b",
+          "a\u{180C}b",
+          "a\u{180D}b",
+          "a\u{3164}b",
+          "a\u{FFA0}b",
+          "a\u{FE00}b",
+          "a\u{FE0F}b",
+          "a\u{E0100}b",
+          "a\u{E01EF}b",
+          error_message: I18n.t(:"user.username.characters"),
+        )
+      end
+
       it "is invalid when the username contains zero width join characters" do
         expect_invalid("ണ്‍", "র‌্যাম", error_message: I18n.t(:"user.username.characters"))
       end


### PR DESCRIPTION
The list of excluded characters is based on https://invisible-characters.com/ and the list of invisible characters used by Visual Studio Code (https://github.com/hediet/vscode-unicode-data)