### PR TITLE
FIX: Quoted images should be lightboxed

### DIFF
--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -209,7 +209,7 @@ class CookedPostProcessor
 
       return if upload.animated?
 
-      if img.ancestors(".onebox, .onebox-body, .quote").blank? && !img.classes.include?("onebox")
+      if img.ancestors(".onebox, .onebox-body").blank? && !img.classes.include?("onebox")
         add_lightbox!(img, original_width, original_height, upload, cropped: crop)
       end
 

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -1012,7 +1012,7 @@ RSpec.describe CookedPostProcessor do
       end
     end
 
-    it "optimizes images in quotes" do
+    it "optimizes and wraps images in quotes with lightbox wrapper" do
       post = Fabricate(:post, raw: <<~MD)
         [quote]
         ![image|1024x768, 50%](#{large_image_upload.short_url})
@@ -1023,7 +1023,7 @@ RSpec.describe CookedPostProcessor do
       cpp.post_process
 
       doc = Nokogiri::HTML5.fragment(cpp.html)
-      expect(doc.css(".lightbox-wrapper").size).to eq(0)
+      expect(doc.css(".lightbox-wrapper").size).to eq(1)
       expect(doc.css("img").first["srcset"]).to_not eq(nil)
     end
 


### PR DESCRIPTION
An older change about optimising images caused the selector that adds lightboxing not to apply on quoted images. This fixes that. The selector is now not applicable as optimisation occurs in a separate place.

This change allows quoted images to be opened in a lightbox.

<img width="485" alt="Screenshot 2023-05-02 at 4 40 58 PM" src="https://user-images.githubusercontent.com/1555215/235619978-917eb68c-6016-4cfa-928d-2de7accbddb4.png">
