### PR TITLE
FIX: correctly use types for reviewables type

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -60,7 +60,7 @@ class Reviewable < ActiveRecord::Base
   end
 
   def self.valid_type?(type)
-    return false unless type =~ /\AReviewable[A-Za-z]+\z/
+    return false unless Reviewable.types.include?(type)
     type.constantize <= Reviewable
   rescue NameError
     false
@@ -459,7 +459,8 @@ class Reviewable < ActiveRecord::Base
 
     result = by_status(result, status)
     result = result.where(id: ids) if ids
-    result = result.where("reviewables.type = ?", type) if type
+
+    result = result.where("reviewables.type = ?", Reviewable.sti_class_for(type).sti_name) if type
     result = result.where("reviewables.category_id = ?", category_id) if category_id
     result = result.where("reviewables.topic_id = ?", topic_id) if topic_id
     result = result.where("reviewables.created_at >= ?", from_date) if from_date

--- a/plugins/chat/spec/system/reviewables_spec.rb
+++ b/plugins/chat/spec/system/reviewables_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe "Reviewables", type: :system, js: true do
+  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:channel_1) { Fabricate(:chat_channel) }
+  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+
+  before do
+    chat_system_bootstrap(current_user)
+    channel_1.add(current_user)
+    sign_in(current_user)
+
+    Chat::ReviewQueue.new.flag_message(
+      message_1,
+      current_user.guardian,
+      ReviewableScore.types[:spam],
+    )
+  end
+
+  context "when visiting reviews for messages " do
+    it "lists the correct message" do
+      visit("/review?type=Chat%3A%3AReviewableMessage")
+
+      expect(page).to have_content(message_1.message)
+    end
+  end
+end


### PR DESCRIPTION
Before this fix if the underlying model of a reviewable was changed, the filter wouldn't work anymore as it was expecting a 1:1 relation between filter type and model name.

This commit also relies on the `Reviewable.types` array to check against valid types instead of a regex not checking much.

Finally this commit adds a spec to ensure chat reviewables are listable from the review index page.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
