### PR TITLE
DEV: Do not include silenced Discourse deprecations in counter

### DIFF
--- a/app/assets/javascripts/discourse/tests/helpers/deprecation-counter.js
+++ b/app/assets/javascripts/discourse/tests/helpers/deprecation-counter.js
@@ -34,7 +34,11 @@ export default class DeprecationCounter {
     let { id } = options;
     id ||= "discourse.(unknown)";
 
-    this.incrementDeprecation(id);
+    const matchingConfig = this.#configById.get(id);
+
+    if (matchingConfig !== "silence") {
+      this.incrementDeprecation(id);
+    }
   }
 
   incrementDeprecation(id) {


### PR DESCRIPTION
Silenced Ember deprecations were already being excluded from the test output. This applies the same logic to Discourse deprecations.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
