### PR TITLE
FIX: ChatComposerMessageDetails icon was always edit

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.hbs
@@ -7,7 +7,7 @@
         this.currentMessage
         this.currentMessage.inReplyTo
       }}
-      @icon="pencil-alt"
+      @icon={{if this.currentMessage.editing "pencil-alt" "reply"}}
       @cancelAction={{this.onCancel}}
     />
   {{/if}}


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
