### PR TITLE
FIX: Add thumbnails for Vimeo unlisted lazy videos

### DIFF
--- a/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_vimeo.rb
+++ b/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_vimeo.rb
@@ -19,7 +19,7 @@ class Onebox::Engine::VimeoOnebox
         iframe_id = iframe_src.sub("https://player.vimeo.com/video/", "")
       end
 
-      thumbnail_url = "https://vumbnail.com/#{oembed_data[:video_id]}.jpg"
+      thumbnail_url = get_opengraph.image
       escaped_title = ERB::Util.html_escape(og_data.title)
 
       <<~HTML

--- a/plugins/discourse-lazy-videos/spec/lib/lazy-videos/lazy_vimeo_spec.rb
+++ b/plugins/discourse-lazy-videos/spec/lib/lazy-videos/lazy_vimeo_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Onebox::Engine::VimeoOnebox do
         'data-video-id="786646692"',
       )
       expect(Onebox.preview("https://vimeo.com/786646692").to_s).to include(
-        'src="https://vumbnail.com/786646692.jpg"',
+        'src="https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F1582157011-37115b15c717a168bf86e2f2855b6bbc23b1cbcee54ff99c8d7b808b459365d6-d_1280x720&amp;src1=https%3A%2F%2Ff.vimeocdn.com%2Fimages_v6%2Fshare%2Fplay_icon_overlay.png"',
       )
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe Onebox::Engine::VimeoOnebox do
         'data-video-id="192207770?h=0faf1dd09d&amp;app_id=122963"',
       )
       expect(Onebox.preview("https://vimeo.com/192207770/0faf1dd09d").to_s).to include(
-        'src="https://vumbnail.com/192207770.jpg"',
+        'src="https://i.vimeocdn.com/filter/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F603496523-33935d2b2cbf32d39c4697fa5b03364507eb81dc03a0be84b9a9fe4ec7b89868-d_1280x544&amp;src1=https%3A%2F%2Ff.vimeocdn.com%2Fimages_v6%2Fshare%2Fplay_icon_overlay.png"',
       )
     end
   end


### PR DESCRIPTION
Previously, the image for the thumbnail was taken from the oembed endpoint. Since these images are not available for some unlisted videos, the thumbnails are now sourced from Open Graph instead.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
