### PR TITLE
FIX: Handle all UTF-8 characters

### DIFF
--- a/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
+++ b/app/assets/javascripts/discourse-common/addon/utils/watched-words.js
@@ -1,6 +1,6 @@
 export function createWatchedWordRegExp(word) {
   const caseFlag = word.case_sensitive ? "" : "i";
-  return new RegExp(word.regexp, `${caseFlag}g`);
+  return new RegExp(word.regexp, `${caseFlag}gu`);
 }
 
 export function toWatchedWord(regexp) {

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -206,7 +206,7 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def censored_regexp
-    WordWatcher.serializable_word_matcher_regexp(:censor)
+    WordWatcher.serializable_word_matcher_regexp(:censor, engine: :js)
   end
 
   def custom_emoji_translation
@@ -222,11 +222,11 @@ class SiteSerializer < ApplicationSerializer
   end
 
   def watched_words_replace
-    WordWatcher.word_matcher_regexps(:replace)
+    WordWatcher.word_matcher_regexps(:replace, engine: :js)
   end
 
   def watched_words_link
-    WordWatcher.word_matcher_regexps(:link)
+    WordWatcher.word_matcher_regexps(:link, engine: :js)
   end
 
   def categories

--- a/app/serializers/watched_word_serializer.rb
+++ b/app/serializers/watched_word_serializer.rb
@@ -4,7 +4,7 @@ class WatchedWordSerializer < ApplicationSerializer
   attributes :id, :word, :regexp, :replacement, :action, :case_sensitive
 
   def regexp
-    WordWatcher.word_to_regexp(word, whole: true)
+    WordWatcher.word_to_regexp(word)
   end
 
   def action

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -68,10 +68,7 @@ class WordWatcher
     regexps = grouped_words.select { |_, w| w.present? }.transform_values { |w| w.join("|") }
 
     if !SiteSetting.watched_words_regular_expressions?
-      regexps.transform_values! do |regexp|
-        regexp = "(#{regexp})"
-        "(?:\\W|^)#{regexp}(?=\\W|$)"
-      end
+      regexps.transform_values! { |regexp| "(?:[^[:word:]]|^)(#{regexp})(?=[^[:word:]]|$)" }
     end
 
     regexps.map { |c, regexp| Regexp.new(regexp, c == :case_sensitive ? nil : Regexp::IGNORECASE) }
@@ -97,7 +94,7 @@ class WordWatcher
     regexp = Regexp.escape(word).gsub("\\*", '\S*')
 
     if whole && !SiteSetting.watched_words_regular_expressions?
-      regexp = "(?:\\W|^)(#{regexp})(?=\\W|$)"
+      regexp = "(?:[^[:word:]]|^)(#{regexp})(?=[^[:word:]]|$)"
     end
 
     regexp

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -204,9 +204,9 @@ module PrettyText
         __optInput.emojiUnicodeReplacer = __emojiUnicodeReplacer;
         __optInput.emojiDenyList = #{Emoji.denied.to_json};
         __optInput.lookupUploadUrls = __lookupUploadUrls;
-        __optInput.censoredRegexp = #{WordWatcher.serializable_word_matcher_regexp(:censor).to_json};
-        __optInput.watchedWordsReplace = #{WordWatcher.word_matcher_regexps(:replace).to_json};
-        __optInput.watchedWordsLink = #{WordWatcher.word_matcher_regexps(:link).to_json};
+        __optInput.censoredRegexp = #{WordWatcher.serializable_word_matcher_regexp(:censor, engine: :js).to_json};
+        __optInput.watchedWordsReplace = #{WordWatcher.word_matcher_regexps(:replace, engine: :js).to_json};
+        __optInput.watchedWordsLink = #{WordWatcher.word_matcher_regexps(:link, engine: :js).to_json};
         __optInput.additionalOptions = #{Site.markdown_additional_options.to_json};
       JS
 

--- a/spec/integration/watched_words_spec.rb
+++ b/spec/integration/watched_words_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe WatchedWord do
       should_block_post(manager)
     end
 
+    it "look at title too" do
+      block_word = Fabricate(:watched_word, action: WatchedWord.actions[:block], word: "abc")
+      manager =
+        NewPostManager.new(tl2_user, title: "Hello world", raw: "abcódef", topic_id: topic.id)
+
+      expect(manager.perform).to be_success
+    end
+
     it "should block the post from admin" do
       manager =
         NewPostManager.new(

--- a/spec/integration/watched_words_spec.rb
+++ b/spec/integration/watched_words_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe WatchedWord do
       should_block_post(manager)
     end
 
-    it "look at title too" do
+    it "should handle UTF-8 characters" do
       block_word = Fabricate(:watched_word, action: WatchedWord.actions[:block], word: "abc")
       manager =
         NewPostManager.new(tl2_user, title: "Hello world", raw: "abcódef", topic_id: topic.id)

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe WordWatcher do
 
         expect(regexps).to be_an(Array)
         expect(regexps.map(&:inspect)).to contain_exactly(
-          "/(?:\\W|^)(#{word1}|#{word2})(?=\\W|$)/i",
-          "/(?:\\W|^)(#{word3}|#{word4})(?=\\W|$)/",
+          "/(?:[^[:word:]]|^)(#{word1}|#{word2})(?=[^[:word:]]|$)/i",
+          "/(?:[^[:word:]]|^)(#{word3}|#{word4})(?=[^[:word:]]|$)/",
         )
       end
 
@@ -411,7 +411,7 @@ RSpec.describe WordWatcher do
           SiteSetting.watched_words_regular_expressions = true
           Fabricate(
             :watched_word,
-            word: "\\Wplaceholder",
+            word: "[^[:word:]]placeholder",
             replacement: "replacement",
             action: WatchedWord.actions[:replace],
           )

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -411,7 +411,7 @@ RSpec.describe WordWatcher do
           SiteSetting.watched_words_regular_expressions = true
           Fabricate(
             :watched_word,
-            word: "[^[:word:]]placeholder",
+            word: "\\Wplaceholder",
             replacement: "replacement",
             action: WatchedWord.actions[:replace],
           )


### PR DESCRIPTION
Watched words were converted to regular expressions containing \W, which handled only ASCII characters. Using [^[:word]] instead ensures that UTF-8 characters are also handled correctly.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
