### PR TITLE
FIX: ensures page height is correct on ipad + hub

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -582,6 +582,15 @@ html.has-full-page-chat {
     height: 100%;
     width: 100%;
 
+    &.footer-nav-ipad {
+      #main-outlet-wrapper {
+        grid-template-rows: calc(
+          var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
+            var(--footer-nav-height, 0px)
+        );
+      }
+    }
+
     #main-outlet {
       display: flex;
       flex-direction: column;
@@ -617,13 +626,6 @@ html.has-full-page-chat {
       grid-template-rows: calc(
         var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px)
       );
-
-      .footer-nav-ipad & {
-        grid-template-rows: calc(
-          var(--chat-vh, 1vh) * 100 - var(--header-offset, 0px) -
-            var(--footer-nav-height, 0px)
-        );
-      }
 
       .sidebar-wrapper {
         // prevents sidebar from overflowing behind the virtual keyboard


### PR DESCRIPTION
The previous style was not being hit in each case, this should correctly fix it.

Before:
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-02 at 21 58 49](https://user-images.githubusercontent.com/339945/235772567-aa0a72bf-daa3-492a-a29a-38c959e53d1c.png)


After:
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-05-02 at 21 58 01](https://user-images.githubusercontent.com/339945/235772589-744046d7-bfc0-427b-86da-38bbbe33cb67.png)
