### PR TITLE
DEV: Support both `tag:` as an alias for `tags:` filter for `/filter`

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -9,7 +9,7 @@ class TopicsFilter
     @topic_notification_levels = Set.new
   end
 
-  FILTER_ALIASES = { "categories" => "category" }
+  FILTER_ALIASES = { "categories" => "category", "tags" => "tag" }
   private_constant :FILTER_ALIASES
 
   def filter_from_query_string(query_string)
@@ -74,7 +74,7 @@ class TopicsFilter
         filter_by_number_of_posters(max: filter_values)
       when "status"
         filter_values.each { |status| @scope = filter_status(status: status) }
-      when "tags"
+      when "tag"
         filter_tags(values: key_prefixes.zip(filter_values))
       when "views-min"
         filter_by_number_of_views(min: filter_values)

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -668,7 +668,7 @@ RSpec.describe TopicsFilter do
           expect(
             TopicsFilter
               .new(guardian: Guardian.new)
-              .filter_from_query_string("tags:#{tag.name}+#{tag2.name}")
+              .filter_from_query_string("tag:#{tag.name}+#{tag2.name}")
               .pluck(:id),
           ).to contain_exactly(topic_with_tag_and_tag2.id)
         end

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -663,6 +663,17 @@ RSpec.describe TopicsFilter do
         )
       end
 
+      describe "when query string is `tag:tag1+tag2`" do
+        it "should only return topics that are tagged with all of the specified tags" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("tags:#{tag.name}+#{tag2.name}")
+              .pluck(:id),
+          ).to contain_exactly(topic_with_tag_and_tag2.id)
+        end
+      end
+
       it "should only return topics that are tagged with all of the specified tags when query string is `tags:tag1+tag2`" do
         expect(
           TopicsFilter


### PR DESCRIPTION
We already support `category:` as an alias for `categories` so it makes
sense to support `tag:` as an alias for `tags:`.