### PR TITLE
FIX: Blank user messages inbox dropdown on subfolder setup.

### DIFF
--- a/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-private-messages.js
@@ -41,10 +41,12 @@ export default class extends Controller {
   get messagesDropdownValue() {
     let value;
 
+    const currentURL = this.router.currentURL.toLowerCase();
+
     for (let i = this.messagesDropdownContent.length - 1; i >= 0; i--) {
       const row = this.messagesDropdownContent[i];
 
-      if (this.router.currentURL.toLowerCase().includes(row.id)) {
+      if (currentURL.includes(row.id.replace(this.router.rootURL, "/"))) {
         value = row.id;
         break;
       }

--- a/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-private-messages-test.js
@@ -45,6 +45,27 @@ acceptance(
       );
     });
 
+    test("viewing group messages on subfolder setup", async function (assert) {
+      const router = this.container.lookup("router:main");
+      const originalRootURL = router.rootURL;
+
+      try {
+        router.set("rootURL", "/forum/");
+
+        await visit("/forum/u/eviltrout/messages");
+
+        const messagesDropdown = selectKit(".user-nav-messages-dropdown");
+
+        assert.strictEqual(
+          messagesDropdown.header().name(),
+          I18n.t("user.messages.inbox"),
+          "User personal inbox is selected in dropdown"
+        );
+      } finally {
+        router.set("rootURL", originalRootURL);
+      }
+    });
+
     test("viewing messages of another user", async function (assert) {
       updateCurrentUser({ id: 5, username: "charlie" });
 


### PR DESCRIPTION
This commit fixes a bug on subfolder setups where the user messages
inbox dropdown will always be blank. This is because we were comparing
URLs using values from `router.currentURL` and `router.urlFor` where
`router.currentURL` does not include `router.rootURL` while
`router.urlFor` does.