### PR TITLE
UX: admin barchart fixed colours

### DIFF
--- a/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
+++ b/app/assets/javascripts/admin/addon/components/admin-report-stacked-chart.js
@@ -54,6 +54,8 @@ export default class AdminReportStackedChart extends Component {
 
     const context = chartCanvas.getContext("2d");
 
+    const colours = ["#1EB8D1", "#9BC53D", "#721D8D", "#E84A5F", "#8A6916"];
+
     const chartData = makeArray(model.chartData || model.data).map((cd) => {
       return {
         label: cd.label,
@@ -64,15 +66,31 @@ export default class AdminReportStackedChart extends Component {
 
     const data = {
       labels: chartData[0].data.mapBy("x"),
-      datasets: chartData.map((cd) => {
+      datasets: chartData.map((cd, index) => {
         return {
           label: cd.label,
           stack: "pageviews-stack",
           data: cd.data,
-          backgroundColor: cd.color,
+          backgroundColor: colours[index % colours.length],
         };
       }),
     };
+
+    if (chartData.length > colours.length) {
+      const fallbackColors = chartData.slice(colours.length).map(() => {
+        return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+      });
+
+      data.datasets = data.datasets.map((ds, index) => {
+        return {
+          ...ds,
+          backgroundColor:
+            index < colours.length
+              ? colours[index % colours.length]
+              : fallbackColors[index - colours.length],
+        };
+      });
+    }
 
     loadScript("/javascripts/Chart.min.js").then(() => {
       this._resetChart();


### PR DESCRIPTION
The colours for the admin dashboard chart were based on tertiary and quaternary, which is often set as the same or very similar and lead to little to no differentiation
![image](https://user-images.githubusercontent.com/101828855/235901098-cb356711-6c9a-4bfb-8b32-39165c68f46a.png)

Therefore we're replacing this with hardcoded values that work in both light and dark schemes.

Added in a fallback in the case there's more than 5 colours needed (shouldn't be but one never knows).

