### PR TITLE
FIX: ensure user admin button is present on mobile

### DIFF
--- a/app/assets/javascripts/discourse/app/components/user-nav.hbs
+++ b/app/assets/javascripts/discourse/app/components/user-nav.hbs
@@ -76,8 +76,7 @@
         <span>{{i18n "user.preferences"}}</span>
       </DNavigationItem>
     {{/if}}
-
-    {{#if (and this.site.mobileView this.currentUser.staff)}}
+    {{#if (and @isMobileView @isStaff)}}
       <li class="user-nav__admin">
         <a href={{@user.adminPath}}>
           {{d-icon "wrench"}}

--- a/app/assets/javascripts/discourse/app/templates/user.hbs
+++ b/app/assets/javascripts/discourse/app/templates/user.hbs
@@ -319,7 +319,7 @@
               {{#if this.displayTopLevelAdminButton}}
                 <li><a
                     href={{this.model.adminPath}}
-                    class="btn btn-default"
+                    class="btn btn-default user-admin"
                   >{{d-icon "wrench"}}<span class="d-button-label">{{i18n
                         "admin.user.show_admin_profile"
                       }}</span></a></li>
@@ -452,6 +452,8 @@
     <div class="new-user-wrapper">
       <UserNav
         @user={{this.model}}
+        @isStaff={{this.currentUser.staff}}
+        @isMobileView={{this.site.mobileView}}
         @showNotificationsTab={{this.showNotificationsTab}}
         @showPrivateMessages={{this.showPrivateMessages}}
         @canInviteToForum={{this.canInviteToForum}}

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-admin-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-admin-test.js
@@ -1,0 +1,25 @@
+import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+
+acceptance("User Preferences Admin", function (needs) {
+  needs.user({ admin: true });
+
+  test("User admin button", async function (assert) {
+    await visit("/u/eviltrout");
+    assert.ok(exists(".user-admin"), "desktop user admin nav button exists");
+  });
+});
+
+acceptance("User Preferences Admin - Mobile", function (needs) {
+  needs.user({ admin: true });
+  needs.mobileView();
+
+  test("User admin button", async function (assert) {
+    await visit("/u/eviltrout");
+    assert.ok(
+      exists(".user-nav__admin"),
+      "mobile user admin nav button exists"
+    );
+  });
+});

--- a/app/assets/javascripts/discourse/tests/acceptance/user-preferences-admin-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-preferences-admin-test.js
@@ -5,7 +5,7 @@ import { visit } from "@ember/test-helpers";
 acceptance("User Preferences Admin", function (needs) {
   needs.user({ admin: true });
 
-  test("User admin button", async function (assert) {
+  test("Desktop user admin button", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok(exists(".user-admin"), "desktop user admin nav button exists");
   });
@@ -15,7 +15,7 @@ acceptance("User Preferences Admin - Mobile", function (needs) {
   needs.user({ admin: true });
   needs.mobileView();
 
-  test("User admin button", async function (assert) {
+  test("Mobile user admin button", async function (assert) {
     await visit("/u/eviltrout");
     assert.ok(
       exists(".user-nav__admin"),


### PR DESCRIPTION
Follow-up to 8caa58a

I removed a little too much from that previous commit, so here I'm making sure `mobileView` and `isStaff` are passed to the component. I also added a test to make sure the admin button exists on both mobile and desktop. 


Before:
![Screenshot 2023-05-03 at 1 33 50 PM](https://user-images.githubusercontent.com/1681963/235998353-ba23fd17-d1ce-446d-a8be-89ac797f93bf.png)


After:
![Screenshot 2023-05-03 at 1 33 41 PM](https://user-images.githubusercontent.com/1681963/235998472-e6c6df48-0be1-4468-85f1-c64336c9ba09.png)


