### PR TITLE
FIX: Remove double escaping for Vimeo titles

### DIFF
--- a/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_vimeo.rb
+++ b/plugins/discourse-lazy-videos/lib/lazy-videos/lazy_vimeo.rb
@@ -19,18 +19,15 @@ class Onebox::Engine::VimeoOnebox
         iframe_id = iframe_src.sub("https://player.vimeo.com/video/", "")
       end
 
-      thumbnail_url = get_opengraph.image
-      escaped_title = ERB::Util.html_escape(og_data.title)
-
       <<~HTML
         <div class="vimeo-onebox lazy-video-container"
           data-video-id="#{iframe_id}"
-          data-video-title="#{escaped_title}"
+          data-video-title="#{og_data.title}"
           data-provider-name="vimeo">
           <a href="https://vimeo.com/#{full_video_id}" target="_blank">
             <img class="vimeo-thumbnail"
-              src="#{thumbnail_url}"
-              title="#{escaped_title}">
+              src="#{og_data.image}"
+              title="#{og_data.title}">
           </a>
         </div>
       HTML


### PR DESCRIPTION
`og_data` is already escaped. I also did a tiny refactor.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
