### PR TITLE
FIX: more resilient dates separators computation

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.js
@@ -8,7 +8,7 @@ import { action } from "@ember/object";
 import { handleStagedMessage } from "discourse/plugins/chat/discourse/services/chat-pane-base-subscriptions-manager";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { cancel, schedule, throttle } from "@ember/runloop";
+import { cancel, later, schedule } from "@ember/runloop";
 import discourseLater from "discourse-common/lib/later";
 import { inject as service } from "@ember/service";
 import { Promise } from "rsvp";
@@ -86,6 +86,7 @@ export default class ChatLivePane extends Component {
     removeOnPresenceChange(this.onPresenceChangeCallback);
     this._unsubscribeToUpdates(this._loadedChannelId);
     this.requestedTargetMessageId = null;
+    cancel(this._laterComputeHandler);
   }
 
   @action
@@ -862,7 +863,9 @@ export default class ChatLivePane extends Component {
 
   @action
   computeDatesSeparators() {
-    throttle(this, this._computeDatesSeparators, 50, true);
+    cancel(this._laterComputeHandler);
+    this._computeDatesSeparators();
+    this._laterComputeHandler = later(this, this.computeDatesSeparators, 100);
   }
 
   // A more consistent way to scroll to the bottom when we are sure this is our goal


### PR DESCRIPTION
In the past this was happening on scroll so we needed to be very conservative here. Also, if we wait too much theres a visible element flashing so this PR attempts to compute right away, and a second time 100ms later in case the first one happened too early.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
