### PR TITLE
UX: in sidebar dropdown mode expose 'more' items

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/common/community-section.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/community-section.hbs
@@ -33,8 +33,17 @@
     />
   {{/each}}
 
-  <Sidebar::MoreSectionLinks
-    @sectionLinks={{this.moreSectionLinks}}
-    @secondarySectionLinks={{this.moreSecondarySectionLinks}}
-  />
+  {{#if this.isDesktopDropdownMode}}
+    {{#each this.moreSectionLinks as |sectionLink|}}
+      <Sidebar::MoreSectionLink @sectionLink={{sectionLink}} />
+    {{/each}}
+    {{#each this.moreSecondarySectionLinks as |sectionLink|}}
+      <Sidebar::MoreSectionLink @sectionLink={{sectionLink}} />
+    {{/each}}
+  {{else}}
+    <Sidebar::MoreSectionLinks
+      @sectionLinks={{this.moreSectionLinks}}
+      @secondarySectionLinks={{this.moreSecondarySectionLinks}}
+    />
+  {{/if}}
 </Sidebar::Section>

--- a/app/assets/javascripts/discourse/app/components/sidebar/common/community-section.js
+++ b/app/assets/javascripts/discourse/app/components/sidebar/common/community-section.js
@@ -12,6 +12,7 @@ export default class SidebarCommunitySection extends Component {
   @service topicTrackingState;
   @service currentUser;
   @service appEvents;
+  @service site;
   @service siteSettings;
 
   @tracked sectionLinks;
@@ -75,6 +76,13 @@ export default class SidebarCommunitySection extends Component {
   // Override in child
   get defaultMoreSecondarySectionLinks() {
     return [];
+  }
+
+  get isDesktopDropdownMode() {
+    const headerDropdownMode =
+      this.siteSettings.navigation_menu === "header dropdown";
+
+    return !this.site.mobileView && headerDropdownMode;
   }
 
   #initializeSectionLinks(sectionLinkClasses, { inMoreDrawer } = {}) {

--- a/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/sidebar-user-test.js
@@ -51,6 +51,21 @@ acceptance(
         "hides the sidebar dropdown"
       );
     });
+
+    test("'more' dropdown should display as regular list items in header dropdown mode", async function (assert) {
+      await visit("/");
+      await click(".hamburger-dropdown");
+
+      assert.ok(
+        exists("[data-link-name='admin']"),
+        "the admin link is not within the 'more' dropdown"
+      );
+
+      assert.notOk(
+        exists(".sidebar-more-section-links-details-summary"),
+        "the 'more' dropdown should not be present in header dropdown mode"
+      );
+    });
   }
 );
 


### PR DESCRIPTION
this exposes the "more" menu items when the sidebar is in dropdown mode, which is closer to the legacy menu and avoids a dropdown within a dropdown

Before:
![Screenshot 2023-05-03 at 5 44 29 PM](https://user-images.githubusercontent.com/1681963/236056787-22c4710f-3702-45fd-ae09-37ec40ba47db.png)


After:
![Screenshot 2023-05-03 at 5 44 15 PM](https://user-images.githubusercontent.com/1681963/236056805-6ad41f88-b8a3-49f2-8096-e9366b7e3790.png)
