### PR TITLE
FIX: Ensure expand table works regardless of click event target

### DIFF
--- a/app/assets/javascripts/discourse/app/initializers/post-decorations.js
+++ b/app/assets/javascripts/discourse/app/initializers/post-decorations.js
@@ -158,7 +158,7 @@ export default {
       }
 
       function generateModal(event) {
-        const table = event.target.parentElement.nextElementSibling;
+        const table = event.currentTarget.parentElement.nextElementSibling;
         const tempTable = table.cloneNode(true);
 
         showModal("fullscreen-table").set("tableHtml", tempTable);

--- a/app/assets/javascripts/discourse/tests/acceptance/post-table-wrapper-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/post-table-wrapper-test.js
@@ -37,6 +37,7 @@ acceptance("Post Table Wrapper Test", function () {
     await click(
       `${postWithLargeTable} .fullscreen-table-wrapper .btn-expand-table`
     );
+
     assert.ok(
       exists(".fullscreen-table-modal"),
       "The fullscreen table modal appears"
@@ -44,6 +45,16 @@ acceptance("Post Table Wrapper Test", function () {
     assert.ok(
       exists(".fullscreen-table-modal table"),
       "The table is present inside the modal"
+    );
+
+    await click(".fullscreen-table-modal .modal-close.close");
+    await click(
+      `${postWithLargeTable} .fullscreen-table-wrapper .btn-expand-table svg`
+    );
+
+    assert.ok(
+      exists(".fullscreen-table-modal"),
+      "Fullscreen table modal appears on clicking svg icon"
     );
   });
 });


### PR DESCRIPTION
In the expand table event handler, we currently rely on `event.target` to select the table being expanded. Sometimes, the target is the svg icon wrapped inside the button instead of the button itself. This throws things off.

This change uses `currentTarget` which refers to the button element even if the event originated from svg icon.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
