### PR TITLE
FEATURE: support for chronologically merging posts into existing topic

### DIFF
--- a/app/assets/javascripts/discourse/app/components/choose-message.js
+++ b/app/assets/javascripts/discourse/app/components/choose-message.js
@@ -59,7 +59,6 @@ export default Component.extend({
     event?.preventDefault();
     const messageId = get(message, "id");
     this.set("selectedTopicId", messageId);
-
     next(() => $(`#choose-message-${messageId}`).prop("checked", "true"));
   },
 });

--- a/app/assets/javascripts/discourse/app/components/choose-message.js
+++ b/app/assets/javascripts/discourse/app/components/choose-message.js
@@ -9,7 +9,6 @@ export default Component.extend({
   loading: null,
   noResults: null,
   messages: null,
-  topicChangedCallback: null,
 
   @observes("messageTitle")
   messageTitleChanged() {
@@ -60,10 +59,6 @@ export default Component.extend({
     event?.preventDefault();
     const messageId = get(message, "id");
     this.set("selectedTopicId", messageId);
-
-    if (this.topicChangedCallback) {
-      this.topicChangedCallback(message);
-    }
 
     next(() => $(`#choose-message-${messageId}`).prop("checked", "true"));
   },

--- a/app/assets/javascripts/discourse/app/components/choose-message.js
+++ b/app/assets/javascripts/discourse/app/components/choose-message.js
@@ -9,6 +9,7 @@ export default Component.extend({
   loading: null,
   noResults: null,
   messages: null,
+  topicChangedCallback: null,
 
   @observes("messageTitle")
   messageTitleChanged() {
@@ -59,6 +60,11 @@ export default Component.extend({
     event?.preventDefault();
     const messageId = get(message, "id");
     this.set("selectedTopicId", messageId);
+
+    if (this.topicChangedCallback) {
+      this.topicChangedCallback(message);
+    }
+
     next(() => $(`#choose-message-${messageId}`).prop("checked", "true"));
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/move-to-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/move-to-topic.js
@@ -8,10 +8,8 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { flashAjaxError } from "discourse/lib/ajax-error";
 import { isEmpty } from "@ember/utils";
 import { next } from "@ember/runloop";
-import { inject as service } from "@ember/service";
 
 export default Controller.extend(ModalFunctionality, {
-  dialog: service(),
   topicName: null,
   saving: false,
   categoryId: null,
@@ -24,7 +22,7 @@ export default Controller.extend(ModalFunctionality, {
   newMessage: equal("selection", "new_message"),
   existingMessage: equal("selection", "existing_message"),
   participants: null,
-  selectedTopic: null,
+  chronologicalOrder: false,
 
   init() {
     this._super(...arguments);
@@ -84,6 +82,7 @@ export default Controller.extend(ModalFunctionality, {
       topicName: "",
       tags: null,
       participants: [],
+      chronologicalOrder: false,
     });
 
     const isPrivateMessage = this.get("model.isPrivateMessage");
@@ -113,64 +112,6 @@ export default Controller.extend(ModalFunctionality, {
     return canSplitTopic && this.currentUser && this.currentUser.admin;
   },
 
-  confirmMergeTypeDialog(isMessage) {
-    return new Promise((resolve, reject) => {
-      const dialogMessage = isMessage
-        ? I18n.t("topic.merge_topic.merge_type.title", {
-            count: this.selectedPosts.length,
-          })
-        : I18n.t("topic.move_to_existing_message.merge_type.title", {
-            count: this.selectedPosts.length,
-          });
-
-      const sequentialLabel = isMessage
-        ? I18n.t("topic.move_to_existing_message.merge_type.sequential")
-        : I18n.t("topic.merge_topic.merge_type.sequential");
-
-      const chronologicalLabel = isMessage
-        ? I18n.t("topic.move_to_existing_message.merge_type.chronological")
-        : I18n.t("topic.merge_topic.merge_type.chronological");
-
-      this.dialog.alert({
-        message: dialogMessage,
-        buttons: [
-          {
-            label: sequentialLabel,
-            icon: "arrow-down",
-            action: () => resolve("sequential"),
-          },
-          {
-            label: chronologicalLabel,
-            icon: "far-clock",
-            action: () => resolve("chronological"),
-          },
-          {
-            label: I18n.t("cancel"),
-            class: "btn-flat",
-            action: reject,
-          },
-        ],
-        class: "merge-type-modal",
-      });
-    });
-  },
-
-  shouldConfirmMergeType(moveType) {
-    const isPostBeforeLastInTopic = (post) =>
-      moment(post.created_at).isBefore(
-        moment(this.selectedTopic.last_posted_at)
-      );
-
-    const isAnyPostBeforeLastInTopic = this.selectedPosts.some(
-      isPostBeforeLastInTopic
-    );
-
-    return (
-      ["existingTopic", "existingMessage"].includes(moveType) &&
-      isAnyPostBeforeLastInTopic
-    );
-  },
-
   actions: {
     performMove() {
       this.moveTypes.forEach((type) => {
@@ -180,20 +121,7 @@ export default Controller.extend(ModalFunctionality, {
       });
     },
 
-    async movePostsTo(type) {
-      let mergeType = "sequential";
-
-      if (this.shouldConfirmMergeType(type)) {
-        try {
-          mergeType = await this.confirmMergeTypeDialog(
-            type === "existingMessage"
-          );
-        } catch {
-          // the user canceled the dialog
-          return;
-        }
-      }
-
+    movePostsTo(type) {
       this.set("saving", true);
       const topicId = this.get("model.id");
       let mergeOptions, moveOptions;
@@ -201,7 +129,7 @@ export default Controller.extend(ModalFunctionality, {
       if (type === "existingTopic") {
         mergeOptions = {
           destination_topic_id: this.selectedTopicId,
-          merge_type: mergeType,
+          chronological_order: this.chronologicalOrder,
         };
         moveOptions = Object.assign(
           { post_ids: this.get("topicController.selectedPostIds") },
@@ -212,7 +140,7 @@ export default Controller.extend(ModalFunctionality, {
           destination_topic_id: this.selectedTopicId,
           participants: this.participants.join(","),
           archetype: "private_message",
-          merge_type: mergeType,
+          chronological_order: this.chronologicalOrder,
         };
         moveOptions = Object.assign(
           { post_ids: this.get("topicController.selectedPostIds") },
@@ -252,10 +180,6 @@ export default Controller.extend(ModalFunctionality, {
         });
 
       return false;
-    },
-
-    newTopicSelected(topic) {
-      this.set("selectedTopic", topic);
     },
   },
 });

--- a/app/assets/javascripts/discourse/app/controllers/move-to-topic.js
+++ b/app/assets/javascripts/discourse/app/controllers/move-to-topic.js
@@ -82,6 +82,7 @@ export default Controller.extend(ModalFunctionality, {
       topicName: "",
       tags: null,
       participants: [],
+      selectedTopicId: null,
       chronologicalOrder: false,
     });
 

--- a/app/assets/javascripts/discourse/app/templates/modal/move-to-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/move-to-topic.hbs
@@ -69,10 +69,17 @@
           @onChange={{action (mut this.participants)}}
         />
 
-        <label class="checkbox-label">
-          <Input @type="checkbox" @checked={{this.chronologicalOrder}} />
-          {{i18n "topic.merge_topic.chronological_order"}}
-        </label>
+        {{#if this.selectedTopicId}}
+          <hr />
+          <label for="chronological-order" class="checkbox-label">
+            <Input
+              id="chronological-order"
+              @type="checkbox"
+              @checked={{this.chronologicalOrder}}
+            />
+            {{i18n "topic.merge_topic.chronological_order"}}
+          </label>
+        {{/if}}
       </form>
     {{/if}}
 
@@ -124,10 +131,17 @@
           @selectedTopicId={{this.selectedTopicId}}
         />
 
-        <label class="checkbox-label">
-          <Input @type="checkbox" @checked={{this.chronologicalOrder}} />
-          {{i18n "topic.merge_topic.chronological_order"}}
-        </label>
+        {{#if this.selectedTopicId}}
+          <hr />
+          <label for="chronological-order" class="checkbox-label">
+            <Input
+              id="chronological-order"
+              @type="checkbox"
+              @checked={{this.chronologicalOrder}}
+            />
+            {{i18n "topic.merge_topic.chronological_order"}}
+          </label>
+        {{/if}}
       </form>
     {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/modal/move-to-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/move-to-topic.hbs
@@ -60,7 +60,6 @@
         <ChooseMessage
           @currentTopicId={{this.model.id}}
           @selectedTopicId={{this.selectedTopicId}}
-          @topicChangedCallback={{action "newTopicSelected"}}
         />
 
         <label>{{i18n "topic.move_to_new_message.participants"}}</label>
@@ -69,6 +68,11 @@
           @value={{this.participants}}
           @onChange={{action (mut this.participants)}}
         />
+
+        <label class="checkbox-label">
+          <Input @type="checkbox" @checked={{this.chronologicalOrder}} />
+          {{i18n "topic.merge_topic.chronological_order"}}
+        </label>
       </form>
     {{/if}}
 
@@ -118,8 +122,12 @@
         <ChooseTopic
           @currentTopicId={{this.model.id}}
           @selectedTopicId={{this.selectedTopicId}}
-          @topicChangedCallback={{action "newTopicSelected"}}
         />
+
+        <label class="checkbox-label">
+          <Input @type="checkbox" @checked={{this.chronologicalOrder}} />
+          {{i18n "topic.merge_topic.chronological_order"}}
+        </label>
       </form>
     {{/if}}
 

--- a/app/assets/javascripts/discourse/app/templates/modal/move-to-topic.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/move-to-topic.hbs
@@ -60,6 +60,7 @@
         <ChooseMessage
           @currentTopicId={{this.model.id}}
           @selectedTopicId={{this.selectedTopicId}}
+          @topicChangedCallback={{action "newTopicSelected"}}
         />
 
         <label>{{i18n "topic.move_to_new_message.participants"}}</label>
@@ -117,6 +118,7 @@
         <ChooseTopic
           @currentTopicId={{this.model.id}}
           @selectedTopicId={{this.selectedTopicId}}
+          @topicChangedCallback={{action "newTopicSelected"}}
         />
       </form>
     {{/if}}

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -1,10 +1,40 @@
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
-import { click, visit } from "@ember/test-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import I18n from "I18n";
 import { test } from "qunit";
+import searchFixtures from "discourse/tests/fixtures/search-fixtures";
+import { cloneJSON } from "discourse-common/lib/object";
+
+let hasCalledMovedPostsEndpoint;
 
 acceptance("Topic move posts", function (needs) {
   needs.user();
+
+  needs.hooks.beforeEach(() => {
+    hasCalledMovedPostsEndpoint = false;
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/search/query", (request) => {
+      const result = cloneJSON(searchFixtures["search/query"]);
+
+      if (request.queryParams.term.includes("Newer topic")) {
+        result.topics[0].last_posted_at = "2020-12-22T05:50:15.898Z";
+      } else if (request.queryParams.term.includes("Older topic")) {
+        result.topics[0].last_posted_at = "2012-02-07T17:46:57.262Z";
+      }
+
+      return helper.response(result);
+    });
+
+    const movePostsHandler = () => {
+      hasCalledMovedPostsEndpoint = true;
+      return helper.response({ success: true });
+    };
+
+    server.post("/t/12/move-posts", movePostsHandler);
+    server.post("/t/280/move-posts", movePostsHandler);
+  });
 
   test("default", async function (assert) {
     await visit("/t/internationalization-localization");
@@ -85,6 +115,66 @@ acceptance("Topic move posts", function (needs) {
     );
   });
 
+  test("moving earlier posts to existing topic", async function (assert) {
+    await visit("/t/internationalization-localization");
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-multi-select .btn");
+    await click("#post_1 .select-post");
+
+    await click(".selected-posts .move-to-topic");
+
+    assert.ok(
+      query(".choose-topic-modal .radios").innerHTML.includes(
+        I18n.t("topic.merge_topic.radio_label")
+      ),
+      "it shows an option to move to an existing topic"
+    );
+
+    await click(".choose-topic-modal .radios #move-to-existing-topic");
+
+    await fillIn(".choose-topic-modal #choose-topic-title", "Newer topic");
+
+    await click(".choose-topic-list .existing-topic:first-child input");
+
+    await click(".choose-topic-modal .modal-footer .btn");
+
+    assert.ok(
+      query(".merge-type-modal").innerHTML.includes(
+        I18n.t("topic.merge_topic.merge_type.sequential")
+      ),
+      "it shows an option to move posts sequentially"
+    );
+
+    assert.ok(
+      query(".merge-type-modal").innerHTML.includes(
+        I18n.t("topic.merge_topic.merge_type.chronological")
+      ),
+      "it shows an option to move posts chronologically"
+    );
+  });
+
+  test("moving posts to existing topic", async function (assert) {
+    await visit("/t/internationalization-localization");
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-multi-select .btn");
+    await click("#post_1 .select-post");
+
+    await click(".selected-posts .move-to-topic");
+
+    await click(".choose-topic-modal .radios #move-to-existing-topic");
+
+    await fillIn(".choose-topic-modal #choose-topic-title", "Older topic");
+
+    await click(".choose-topic-list .existing-topic:first-child input");
+
+    await click(".choose-topic-modal .modal-footer .btn");
+
+    assert.ok(
+      hasCalledMovedPostsEndpoint,
+      "it moves posts without showing the merge type modal"
+    );
+  });
+
   test("moving posts from personal message", async function (assert) {
     await visit("/t/pm-for-testing/12");
     await click(".toggle-admin-menu");
@@ -140,6 +230,66 @@ acceptance("Topic move posts", function (needs) {
         I18n.t("topic.move_to.title")
       ),
       "it opens move to modal"
+    );
+  });
+
+  test("moving earlier posts from personal message to existing message", async function (assert) {
+    await visit("/t/pm-for-testing/12");
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-multi-select .btn");
+    await click("#post_1 .select-post");
+
+    await click(".selected-posts .move-to-topic");
+
+    assert.ok(
+      query(".choose-topic-modal .radios").innerHTML.includes(
+        I18n.t("topic.move_to_existing_message.radio_label")
+      ),
+      "it shows an option to move to an existing message"
+    );
+
+    await click(".choose-topic-modal .radios #move-to-existing-message");
+
+    await fillIn(".choose-topic-modal #choose-message-title", "Newer topic");
+
+    await click(".choose-topic-modal .existing-message:first-of-type input");
+
+    await click(".choose-topic-modal .modal-footer .btn");
+
+    assert.ok(
+      query(".merge-type-modal").innerHTML.includes(
+        I18n.t("topic.move_to_existing_message.merge_type.sequential")
+      ),
+      "it shows an option to move posts sequentially"
+    );
+
+    assert.ok(
+      query(".merge-type-modal").innerHTML.includes(
+        I18n.t("topic.move_to_existing_message.merge_type.chronological")
+      ),
+      "it shows an option to move posts chronologically"
+    );
+  });
+
+  test("moving posts from personal message to existing message", async function (assert) {
+    await visit("/t/pm-for-testing/12");
+    await click(".toggle-admin-menu");
+    await click(".topic-admin-multi-select .btn");
+    await click("#post_1 .select-post");
+
+    await click(".selected-posts .move-to-topic");
+
+    await click(".choose-topic-modal .radios #move-to-existing-message");
+
+    await fillIn(".choose-topic-modal #choose-message-title", "Older topic");
+
+    await click(".choose-topic-modal .existing-message:first-of-type input");
+
+    await click(".choose-topic-modal .modal-footer .btn");
+
+    assert.ok(
+      hasCalledMovedPostsEndpoint,
+      "it moves posts without showing the merge type modal"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -1,40 +1,10 @@
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import I18n from "I18n";
 import { test } from "qunit";
-import searchFixtures from "discourse/tests/fixtures/search-fixtures";
-import { cloneJSON } from "discourse-common/lib/object";
-
-let hasCalledMovedPostsEndpoint;
 
 acceptance("Topic move posts", function (needs) {
   needs.user();
-
-  needs.hooks.beforeEach(() => {
-    hasCalledMovedPostsEndpoint = false;
-  });
-
-  needs.pretender((server, helper) => {
-    server.get("/search/query", (request) => {
-      const result = cloneJSON(searchFixtures["search/query"]);
-
-      if (request.queryParams.term.includes("Newer topic")) {
-        result.topics[0].last_posted_at = "2020-12-22T05:50:15.898Z";
-      } else if (request.queryParams.term.includes("Older topic")) {
-        result.topics[0].last_posted_at = "2012-02-07T17:46:57.262Z";
-      }
-
-      return helper.response(result);
-    });
-
-    const movePostsHandler = () => {
-      hasCalledMovedPostsEndpoint = true;
-      return helper.response({ success: true });
-    };
-
-    server.post("/t/12/move-posts", movePostsHandler);
-    server.post("/t/280/move-posts", movePostsHandler);
-  });
 
   test("default", async function (assert) {
     await visit("/t/internationalization-localization");
@@ -115,7 +85,7 @@ acceptance("Topic move posts", function (needs) {
     );
   });
 
-  test("moving earlier posts to existing topic", async function (assert) {
+  test("moving posts to existing topic", async function (assert) {
     await visit("/t/internationalization-localization");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");
@@ -132,46 +102,11 @@ acceptance("Topic move posts", function (needs) {
 
     await click(".choose-topic-modal .radios #move-to-existing-topic");
 
-    await fillIn(".choose-topic-modal #choose-topic-title", "Newer topic");
-
-    await click(".choose-topic-list .existing-topic:first-child input");
-
-    await click(".choose-topic-modal .modal-footer .btn");
-
     assert.ok(
-      query(".merge-type-modal").innerHTML.includes(
-        I18n.t("topic.merge_topic.merge_type.sequential")
+      query(".choose-topic-modal .checkbox-label").innerHTML.includes(
+        I18n.t("topic.merge_topic.chronological_order")
       ),
-      "it shows an option to move posts sequentially"
-    );
-
-    assert.ok(
-      query(".merge-type-modal").innerHTML.includes(
-        I18n.t("topic.merge_topic.merge_type.chronological")
-      ),
-      "it shows an option to move posts chronologically"
-    );
-  });
-
-  test("moving posts to existing topic", async function (assert) {
-    await visit("/t/internationalization-localization");
-    await click(".toggle-admin-menu");
-    await click(".topic-admin-multi-select .btn");
-    await click("#post_1 .select-post");
-
-    await click(".selected-posts .move-to-topic");
-
-    await click(".choose-topic-modal .radios #move-to-existing-topic");
-
-    await fillIn(".choose-topic-modal #choose-topic-title", "Older topic");
-
-    await click(".choose-topic-list .existing-topic:first-child input");
-
-    await click(".choose-topic-modal .modal-footer .btn");
-
-    assert.ok(
-      hasCalledMovedPostsEndpoint,
-      "it moves posts without showing the merge type modal"
+      "it shows a checkbox to merge posts in chronological order"
     );
   });
 
@@ -233,7 +168,7 @@ acceptance("Topic move posts", function (needs) {
     );
   });
 
-  test("moving earlier posts from personal message to existing message", async function (assert) {
+  test("moving posts from personal message to existing message", async function (assert) {
     await visit("/t/pm-for-testing/12");
     await click(".toggle-admin-menu");
     await click(".topic-admin-multi-select .btn");
@@ -250,46 +185,11 @@ acceptance("Topic move posts", function (needs) {
 
     await click(".choose-topic-modal .radios #move-to-existing-message");
 
-    await fillIn(".choose-topic-modal #choose-message-title", "Newer topic");
-
-    await click(".choose-topic-modal .existing-message:first-of-type input");
-
-    await click(".choose-topic-modal .modal-footer .btn");
-
     assert.ok(
-      query(".merge-type-modal").innerHTML.includes(
-        I18n.t("topic.move_to_existing_message.merge_type.sequential")
+      query(".choose-topic-modal .checkbox-label").innerHTML.includes(
+        I18n.t("topic.merge_topic.chronological_order")
       ),
-      "it shows an option to move posts sequentially"
-    );
-
-    assert.ok(
-      query(".merge-type-modal").innerHTML.includes(
-        I18n.t("topic.move_to_existing_message.merge_type.chronological")
-      ),
-      "it shows an option to move posts chronologically"
-    );
-  });
-
-  test("moving posts from personal message to existing message", async function (assert) {
-    await visit("/t/pm-for-testing/12");
-    await click(".toggle-admin-menu");
-    await click(".topic-admin-multi-select .btn");
-    await click("#post_1 .select-post");
-
-    await click(".selected-posts .move-to-topic");
-
-    await click(".choose-topic-modal .radios #move-to-existing-message");
-
-    await fillIn(".choose-topic-modal #choose-message-title", "Older topic");
-
-    await click(".choose-topic-modal .existing-message:first-of-type input");
-
-    await click(".choose-topic-modal .modal-footer .btn");
-
-    assert.ok(
-      hasCalledMovedPostsEndpoint,
-      "it moves posts without showing the merge type modal"
+      "it shows a checkbox to merge posts in chronological order"
     );
   });
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-move-posts-test.js
@@ -1,5 +1,9 @@
-import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
-import { click, visit } from "@ember/test-helpers";
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import { click, fillIn, visit } from "@ember/test-helpers";
 import I18n from "I18n";
 import { test } from "qunit";
 
@@ -102,6 +106,15 @@ acceptance("Topic move posts", function (needs) {
 
     await click(".choose-topic-modal .radios #move-to-existing-topic");
 
+    await fillIn(".choose-topic-modal #choose-topic-title", "Topic");
+
+    assert.notOk(
+      exists(".choose-topic-modal .checkbox-label"),
+      "there is no chronological order checkbox when no topic is selected"
+    );
+
+    await click(".choose-topic-list .existing-topic:first-child input");
+
     assert.ok(
       query(".choose-topic-modal .checkbox-label").innerHTML.includes(
         I18n.t("topic.merge_topic.chronological_order")
@@ -184,6 +197,15 @@ acceptance("Topic move posts", function (needs) {
     );
 
     await click(".choose-topic-modal .radios #move-to-existing-message");
+
+    await fillIn(".choose-topic-modal #choose-message-title", "Topic");
+
+    assert.notOk(
+      exists(".choose-topic-modal .checkbox-label"),
+      "there is no chronological order checkbox when no message is selected"
+    );
+
+    await click(".choose-topic-modal .existing-message:first-of-type input");
 
     assert.ok(
       query(".choose-topic-modal .checkbox-label").innerHTML.includes(

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -606,8 +606,8 @@
 
   #choosing-topic {
     form {
-      .participant-selector {
-        margin-bottom: 9px;
+      hr {
+        margin-bottom: 0.5em;
       }
     }
   }

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -372,23 +372,6 @@
   }
 }
 
-.merge-type-modal {
-  .dialog-content {
-    width: 100%;
-    min-width: unset;
-    max-width: 30em;
-  }
-
-  .btn {
-    display: block;
-    text-align: left;
-    margin-bottom: 0.75em;
-    margin-right: 0;
-    overflow: hidden;
-    width: 100%;
-  }
-}
-
 .admin-delete-user-posts-progress-modal {
   .progress-bar {
     height: 15px;
@@ -618,6 +601,14 @@
     }
     .topic-categories {
       width: 100%;
+    }
+  }
+
+  #choosing-topic {
+    form {
+      .participant-selector {
+        margin-bottom: 9px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -372,6 +372,23 @@
   }
 }
 
+.merge-type-modal {
+  .dialog-content {
+    width: 100%;
+    min-width: unset;
+    max-width: 30em;
+  }
+
+  .btn {
+    display: block;
+    text-align: left;
+    margin-bottom: 0.75em;
+    margin-right: 0;
+    overflow: hidden;
+    width: 100%;
+  }
+}
+
 .admin-delete-user-posts-progress-modal {
   .progress-bar {
     height: 15px;

--- a/app/assets/stylesheets/desktop/modal.scss
+++ b/app/assets/stylesheets/desktop/modal.scss
@@ -50,7 +50,7 @@
 .choose-topic-modal {
   .modal-body {
     position: relative;
-    height: 350px;
+    min-height: 350px;
   }
 
   #choosing-topic {

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -824,6 +824,7 @@ class TopicsController < ApplicationController
 
     args = {}
     args[:destination_topic_id] = destination_topic_id.to_i
+    args[:merge_type] = params[:merge_type] if params[:merge_type].present?
 
     if params[:archetype].present?
       args[:archetype] = params[:archetype]
@@ -1265,6 +1266,7 @@ class TopicsController < ApplicationController
       :destination_topic_id
     ].present?
     args[:tags] = params[:tags] if params[:tags].present?
+    args[:merge_type] = params[:merge_type] if params[:merge_type].present?
 
     if params[:archetype].present?
       args[:archetype] = params[:archetype]

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -812,6 +812,7 @@ class TopicsController < ApplicationController
     topic_id = params.require(:topic_id)
     destination_topic_id = params.require(:destination_topic_id)
     params.permit(:participants)
+    params.permit(:chronological_order)
     params.permit(:archetype)
 
     raise Discourse::InvalidAccess if params[:archetype] == "private_message" && !guardian.is_staff?
@@ -824,7 +825,7 @@ class TopicsController < ApplicationController
 
     args = {}
     args[:destination_topic_id] = destination_topic_id.to_i
-    args[:merge_type] = params[:merge_type] if params[:merge_type].present?
+    args[:chronological_order] = params[:chronological_order] == "true"
 
     if params[:archetype].present?
       args[:archetype] = params[:archetype]
@@ -842,6 +843,7 @@ class TopicsController < ApplicationController
     params.permit(:category_id)
     params.permit(:tags)
     params.permit(:participants)
+    params.permit(:chronological_order)
     params.permit(:archetype)
 
     raise Discourse::InvalidAccess if params[:archetype] == "private_message" && !guardian.is_staff?
@@ -1266,7 +1268,7 @@ class TopicsController < ApplicationController
       :destination_topic_id
     ].present?
     args[:tags] = params[:tags] if params[:tags].present?
-    args[:merge_type] = params[:merge_type] if params[:merge_type].present?
+    args[:chronological_order] = params[:chronological_order] == "true"
 
     if params[:archetype].present?
       args[:archetype] = params[:archetype]

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -424,7 +424,7 @@ class PostMover
     DB.exec <<~SQL
       CREATE TEMPORARY TABLE temp_post_timings ON COMMIT DROP
         AS (
-          SELECT pt.topic_id, mp.new_post_number, pt.user_id, pt.msecs
+          SELECT pt.topic_id, mp.new_post_number as post_number, pt.user_id, pt.msecs
           FROM post_timings pt
           JOIN moved_posts mp
             ON mp.old_topic_id = pt.topic_id
@@ -436,7 +436,8 @@ class PostMover
 
   def insert_from_temp_post_timings
     DB.exec <<~SQL
-      INSERT INTO post_timings SELECT * FROM temp_post_timings
+      INSERT INTO post_timings (topic_id, user_id, post_number, msecs)
+      SELECT topic_id, user_id, post_number, msecs FROM temp_post_timings
     SQL
   end
 

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -219,7 +219,7 @@ class PostMover
       next_post_number += 1
     end
 
-    moved_posts.reverse.each do |post|
+    moved_posts.reverse_each do |post|
       if post.topic_id == destination_topic.id
         metadata = movement_metadata(post, new_post_number: @shift_map[post.post_number])
         new_post = move_same_topic(post)
@@ -234,6 +234,9 @@ class PostMover
 
       store_movement(metadata, new_post)
     end
+
+    # change topic owner if there's a new first post
+    destination_topic.update_column(:user_id, posts.first.user_id) if initial_post_number == 1
   end
 
   def create_first_post(post)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1237,7 +1237,10 @@ class Topic < ActiveRecord::Base
 
     if opts[:destination_topic_id]
       topic =
-        post_mover.to_topic(opts[:destination_topic_id], **opts.slice(:participants, :merge_type))
+        post_mover.to_topic(
+          opts[:destination_topic_id],
+          **opts.slice(:participants, :chronological_order),
+        )
 
       DiscourseEvent.trigger(:topic_merged, post_mover.original_topic, post_mover.destination_topic)
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1236,7 +1236,8 @@ class Topic < ActiveRecord::Base
       )
 
     if opts[:destination_topic_id]
-      topic = post_mover.to_topic(opts[:destination_topic_id], participants: opts[:participants])
+      topic =
+        post_mover.to_topic(opts[:destination_topic_id], **opts.slice(:participants, :merge_type))
 
       DiscourseEvent.trigger(:topic_merged, post_mover.original_topic, post_mover.destination_topic)
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3304,12 +3304,7 @@ en:
         instructions:
           one: "Please choose the topic you'd like to move that post to."
           other: "Please choose the topic you'd like to move those <b>%{count}</b> posts to."
-        merge_type:
-          title:
-            one: "Merge this post..."
-            other: "Merge these %{count} posts..."
-          sequential: "as one sequential block at the bottom of the topic"
-          chronological: "in time order throughout the topic"
+        chronological_order: "preserve chronological order after merging"
 
       move_to_new_message:
         title: "Move to New Message"
@@ -3329,12 +3324,6 @@ en:
         instructions:
           one: "Please choose the message you'd like to move that post to."
           other: "Please choose the message you'd like to move those <b>%{count}</b> posts to."
-        merge_type:
-          title:
-            one: "Merge this post..."
-            other: "Merge these %{count} posts..."
-          sequential: "as one sequential block at the bottom of the message"
-          chronological: "in time order throughout the message"
 
       merge_posts:
         title: "Merge Selected Posts"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3304,6 +3304,12 @@ en:
         instructions:
           one: "Please choose the topic you'd like to move that post to."
           other: "Please choose the topic you'd like to move those <b>%{count}</b> posts to."
+        merge_type:
+          title:
+            one: "Merge this post..."
+            other: "Merge these %{count} posts..."
+          sequential: "as one sequential block at the bottom of the topic"
+          chronological: "in time order throughout the topic"
 
       move_to_new_message:
         title: "Move to New Message"
@@ -3323,6 +3329,12 @@ en:
         instructions:
           one: "Please choose the message you'd like to move that post to."
           other: "Please choose the message you'd like to move those <b>%{count}</b> posts to."
+        merge_type:
+          title:
+            one: "Merge this post..."
+            other: "Merge these %{count} posts..."
+          sequential: "as one sequential block at the bottom of the message"
+          chronological: "in time order throughout the message"
 
       merge_posts:
         title: "Merge Selected Posts"

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -1773,13 +1773,33 @@ RSpec.describe PostMover do
             end
 
             it "moves timings when post timing exists in destination topic" do
+              destination_p2 =
+                Fabricate(
+                  :post,
+                  topic: destination_topic,
+                  user: another_user,
+                  created_at: destination_op.created_at + 10.minutes,
+                  post_number: 2,
+                )
+              destination_p3 =
+                Fabricate(
+                  :post,
+                  topic: destination_topic,
+                  user: another_user,
+                  created_at: destination_op.created_at + 15.minutes,
+                  post_number: 3,
+                )
+              destination_topic.update!(highest_post_number: 3)
+
               PostTiming.create!(
                 topic_id: destination_topic.id,
                 user_id: some_user.id,
-                post_number: 2,
+                post_number: 4,
                 msecs: 800,
               )
               create_post_timing(destination_op, some_user, 1500)
+              create_post_timing(destination_p2, some_user, 2000)
+              create_post_timing(destination_p3, some_user, 1250)
               create_post_timing(p1, some_user, 500)
 
               moved_to =
@@ -1795,7 +1815,7 @@ RSpec.describe PostMover do
                   :post_number,
                   :msecs,
                 ),
-              ).to contain_exactly([1, 500], [2, 1500])
+              ).to contain_exactly([1, 500], [2, 1500], [3, 2000], [4, 1250])
             end
           end
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -18,20 +18,6 @@ RSpec.describe PostMover do
     end
   end
 
-  describe "#merge_types" do
-    context "when verifying enum sequence" do
-      before { @merge_types = PostMover.merge_types }
-
-      it "'sequential' should be at 1st position" do
-        expect(@merge_types[:sequential]).to eq(1)
-      end
-
-      it "'chronological' should be at 2nd position" do
-        expect(@merge_types[:chronological]).to eq(2)
-      end
-    end
-  end
-
   describe "move_posts" do
     context "with topics" do
       before { freeze_time }
@@ -1339,7 +1325,7 @@ RSpec.describe PostMover do
                 user,
                 [p2.id, p3.id, p4.id],
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             expect(moved_to).to eq(destination_topic)
 
@@ -1453,7 +1439,7 @@ RSpec.describe PostMover do
                 user,
                 [p3.id, p4.id],
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             expect(moved_to).to eq(destination_topic)
 
@@ -1541,7 +1527,7 @@ RSpec.describe PostMover do
                 user,
                 [p6.id],
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             }.to change { p6.reload.topic_id }.and change {
                     destination_p8.reload.post_number
@@ -1560,7 +1546,7 @@ RSpec.describe PostMover do
                 user,
                 posts_to_move,
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             expect(moved_to).to be_present
 
@@ -1576,7 +1562,7 @@ RSpec.describe PostMover do
                 user,
                 posts_to_move,
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             expect(moved_to).to be_present
 
@@ -1592,7 +1578,7 @@ RSpec.describe PostMover do
                 user,
                 posts_to_move,
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             expect(moved_to).to be_present
 
@@ -1611,7 +1597,7 @@ RSpec.describe PostMover do
                 user,
                 posts_to_move,
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             expect(moved_to).to be_present
 
@@ -1630,7 +1616,7 @@ RSpec.describe PostMover do
                 user,
                 posts_to_move,
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             expect(moved_to).to be_present
 
@@ -1648,7 +1634,7 @@ RSpec.describe PostMover do
                 user,
                 posts_to_move,
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
             expect(moved_to).to be_present
 
@@ -1665,7 +1651,7 @@ RSpec.describe PostMover do
               user,
               posts_to_move,
               destination_topic_id: destination_topic.id,
-              merge_type: "chronological",
+              chronological_order: true,
             )
 
             topic.reload
@@ -1685,7 +1671,7 @@ RSpec.describe PostMover do
                 user,
                 [p1.id, p2.id, p3.id, p4.id, small_action.id],
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
 
             moved_to.reload
@@ -1706,7 +1692,7 @@ RSpec.describe PostMover do
                 user,
                 [p2.id],
                 destination_topic_id: destination_topic.id,
-                merge_type: "chronological",
+                chronological_order: true,
               )
 
             n2 = Notification.find(n2.id)
@@ -1733,7 +1719,7 @@ RSpec.describe PostMover do
               user,
               [p3.id],
               destination_topic_id: destination_topic.id,
-              merge_type: "chronological",
+              chronological_order: true,
             )
 
             expect(Notification.exists?(user_notification.id)).to eq(false)
@@ -1754,7 +1740,7 @@ RSpec.describe PostMover do
                   user,
                   [p1.id, p4.id],
                   destination_topic_id: destination_topic.id,
-                  merge_type: "chronological",
+                  chronological_order: true,
                 )
 
               expect(
@@ -1807,7 +1793,7 @@ RSpec.describe PostMover do
                   user,
                   [p1.id],
                   destination_topic_id: destination_topic.id,
-                  merge_type: "chronological",
+                  chronological_order: true,
                 )
 
               expect(
@@ -1836,7 +1822,7 @@ RSpec.describe PostMover do
               user,
               [p3.id],
               destination_topic_id: destination_topic.id,
-              merge_type: "chronological",
+              chronological_order: true,
             )
 
             expect(TopicUser.find_by(topic: topic, user: user).liked).to eq(false)
@@ -1918,7 +1904,7 @@ RSpec.describe PostMover do
                   user,
                   [p1.id, p2.id],
                   destination_topic_id: destination_topic.id,
-                  merge_type: "chronological",
+                  chronological_order: true,
                 )
 
               expect(TopicUser.find_by(topic: moved_to_topic, user: user1)).to have_attributes(
@@ -1988,7 +1974,7 @@ RSpec.describe PostMover do
                   user,
                   [p1.id, p2.id],
                   destination_topic_id: destination_topic.id,
-                  merge_type: "chronological",
+                  chronological_order: true,
                 )
 
               expect(TopicUser.find_by(topic: new_topic, user: user)).to have_attributes(
@@ -2285,7 +2271,7 @@ RSpec.describe PostMover do
             [p2.id, p5.id],
             destination_topic_id: another_personal_message.id,
             archetype: "private_message",
-            merge_type: "chronological",
+            chronological_order: true,
           )
 
           p2.reload
@@ -2307,7 +2293,7 @@ RSpec.describe PostMover do
             destination_topic_id: another_personal_message.id,
             participants: [regular_user.username],
             archetype: "private_message",
-            merge_type: "chronological",
+            chronological_order: true,
           )
 
           another_personal_message.reload
@@ -2330,7 +2316,7 @@ RSpec.describe PostMover do
               admin,
               [p2.id, p5.id],
               destination_topic_id: topic.id,
-              merge_type: "chronological",
+              chronological_order: true,
             )
           }.to raise_error(Discourse::InvalidParameters)
         end
@@ -2342,7 +2328,7 @@ RSpec.describe PostMover do
               [p1.id, p2.id, p3.id, p4.id, p5.id],
               destination_topic_id: another_personal_message.id,
               archetype: "private_message",
-              merge_type: "chronological",
+              chronological_order: true,
             )
           expect(moved_to).to be_present
 
@@ -2358,7 +2344,7 @@ RSpec.describe PostMover do
               [p2.id],
               destination_topic_id: another_personal_message.id,
               archetype: "private_message",
-              merge_type: "chronological",
+              chronological_order: true,
             )
           post = Post.find_by(topic_id: personal_message.id, post_type: Post.types[:whisper])
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe PostMover do
     end
   end
 
+  describe "#merge_types" do
+    context "when verifying enum sequence" do
+      before { @merge_types = PostMover.merge_types }
+
+      it "'sequential' should be at 1st position" do
+        expect(@merge_types[:sequential]).to eq(1)
+      end
+
+      it "'chronological' should be at 2nd position" do
+        expect(@merge_types[:chronological]).to eq(2)
+      end
+    end
+  end
+
   describe "move_posts" do
     context "with topics" do
       before { freeze_time }
@@ -1286,6 +1300,699 @@ RSpec.describe PostMover do
           end
         end
 
+        context "when moving chronologically to an existing topic" do
+          fab!(:destination_topic) { Fabricate(:topic, user: another_user) }
+          fab!(:destination_op) do
+            Fabricate(
+              :post,
+              topic: destination_topic,
+              user: another_user,
+              created_at: p2.created_at + 30.minutes,
+            )
+          end
+
+          it "works correctly with post_number gap in destination" do
+            destination_p6 =
+              Fabricate(
+                :post,
+                topic: destination_topic,
+                user: another_user,
+                created_at: p3.created_at + 5.minutes,
+                post_number: 6,
+                reply_count: 1,
+              )
+            destination_p7 =
+              Fabricate(
+                :post,
+                topic: destination_topic,
+                user: another_user,
+                created_at: p3.created_at + 10.minutes,
+                reply_to_post_number: destination_p6.post_number,
+              )
+            destination_p6.replies << destination_p7
+
+            # after: p2(-2h) destination_op p3(-1h) destination_p6 destination_p7 p4(-45min)
+
+            topic.expects(:add_moderator_post).once
+            moved_to =
+              topic.move_posts(
+                user,
+                [p2.id, p3.id, p4.id],
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            expect(moved_to).to eq(destination_topic)
+
+            # Check out destination topic
+            moved_to.reload
+            expect(moved_to.posts_count).to eq(6)
+            expect(moved_to.highest_post_number).to eq(8)
+            expect(moved_to.user_id).to eq(destination_op.user_id)
+            expect(moved_to.like_count).to eq(1)
+            expect(moved_to.category_id).to eq(SiteSetting.uncategorized_category_id)
+            p4.reload
+            expect(moved_to.last_post_user_id).to eq(p4.user_id)
+            expect(moved_to.last_posted_at).to eq_time(p4.created_at)
+
+            # Posts should be re-ordered
+            p2.reload
+            expect(p2.sort_order).to eq(1)
+            expect(p2.post_number).to eq(1)
+            expect(p2.topic_id).to eq(moved_to.id)
+            expect(p2.reply_count).to eq(1)
+            expect(p2.reply_to_post_number).to eq(nil)
+
+            destination_op.reload
+            expect(destination_op.sort_order).to eq(2)
+            expect(destination_op.post_number).to eq(2)
+            expect(destination_op.reply_count).to eq(0)
+            expect(destination_op.reply_to_post_number).to eq(nil)
+
+            p3.reload
+            expect(p3.post_number).to eq(3)
+            expect(p3.sort_order).to eq(3)
+            expect(p3.topic_id).to eq(moved_to.id)
+            expect(p3.reply_count).to eq(0)
+            expect(p3.reply_to_post_number).to eq(nil)
+
+            destination_p6.reload
+            expect(destination_p6.post_number).to eq(6)
+            expect(destination_p6.sort_order).to eq(6)
+            expect(destination_p6.reply_count).to eq(1)
+            expect(destination_p6.reply_to_post_number).to eq(nil)
+
+            destination_p7.reload
+            expect(destination_p7.post_number).to eq(7)
+            expect(destination_p7.sort_order).to eq(7)
+            expect(destination_p7.reply_count).to eq(0)
+            expect(destination_p7.reply_to_post_number).to eq(6)
+
+            p4.reload
+            expect(p4.post_number).to eq(8)
+            expect(p4.sort_order).to eq(8)
+            expect(p4.topic_id).to eq(moved_to.id)
+            expect(p4.reply_count).to eq(0)
+            expect(p4.reply_to_post_number).to eq(1)
+
+            # Check out the original topic
+            topic.reload
+            expect(topic.posts_count).to eq(1)
+            expect(topic.featured_user1_id).to be_blank
+            expect(topic.like_count).to eq(0)
+            expect(topic.posts.by_post_number).to match_array([p1])
+            expect(topic.highest_post_number).to eq(p1.post_number)
+
+            # Should notify correctly
+            notification =
+              p2.user.notifications.where(notification_type: Notification.types[:moved_post]).first
+
+            expect(notification.topic_id).to eq(destination_topic.id)
+            expect(notification.post_number).to eq(p2.post_number)
+
+            # Should update last reads
+            expect(
+              TopicUser.find_by(user_id: user.id, topic_id: topic.id).last_read_post_number,
+            ).to eq(p1.post_number)
+          end
+
+          it "works correctly keeping replies in destination" do
+            destination_p2 =
+              Fabricate(
+                :post,
+                topic: destination_topic,
+                user: another_user,
+                created_at: p3.created_at - 10.minutes,
+                post_number: 2,
+                reply_count: 1,
+              )
+            destination_p3 =
+              Fabricate(
+                :post,
+                topic: destination_topic,
+                user: another_user,
+                created_at: p4.created_at + 5.minutes,
+                reply_to_post_number: destination_p2.post_number,
+                reply_count: 1,
+              )
+            destination_p4 =
+              Fabricate(
+                :post,
+                topic: destination_topic,
+                user: another_user,
+                created_at: p4.created_at + 10.minutes,
+                reply_to_post_number: destination_p3.post_number,
+              )
+            destination_p2.replies << destination_p3
+            destination_p3.replies << destination_p4
+
+            # after: destination_op destination_p2 p3(-1h) p4(-45min) destination_p3 destination_p4
+
+            topic.expects(:add_moderator_post).once
+            moved_to =
+              topic.move_posts(
+                user,
+                [p3.id, p4.id],
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            expect(moved_to).to eq(destination_topic)
+
+            # Check out destination topic
+            moved_to.reload
+            expect(moved_to.posts_count).to eq(6)
+            expect(moved_to.highest_post_number).to eq(6)
+            expect(moved_to.user_id).to eq(destination_op.user_id)
+            expect(moved_to.like_count).to eq(1)
+            expect(moved_to.category_id).to eq(SiteSetting.uncategorized_category_id)
+
+            # Posts should be re-ordered
+            destination_op.reload
+            expect(destination_op.sort_order).to eq(1)
+            expect(destination_op.post_number).to eq(1)
+
+            destination_p2.reload
+            expect(destination_p2.post_number).to eq(2)
+            expect(destination_p2.sort_order).to eq(2)
+            expect(destination_p2.reply_count).to eq(1)
+            expect(destination_p2.reply_to_post_number).to eq(nil)
+
+            p3.reload
+            expect(p3.post_number).to eq(3)
+            expect(p3.sort_order).to eq(3)
+            expect(p3.topic_id).to eq(moved_to.id)
+            expect(p3.reply_count).to eq(0)
+            expect(p3.reply_to_post_number).to eq(nil)
+
+            p4.reload
+            expect(p4.post_number).to eq(4)
+            expect(p4.sort_order).to eq(4)
+            expect(p4.topic_id).to eq(moved_to.id)
+            expect(p4.reply_count).to eq(0)
+            expect(p4.reply_to_post_number).to eq(nil)
+
+            destination_p3.reload
+            expect(destination_p3.post_number).to eq(5)
+            expect(destination_p3.sort_order).to eq(5)
+            expect(destination_p3.reply_count).to eq(1)
+            expect(destination_p3.reply_to_post_number).to eq(destination_p2.post_number)
+
+            destination_p4.reload
+            expect(destination_p4.post_number).to eq(6)
+            expect(destination_p4.sort_order).to eq(6)
+            expect(destination_p4.reply_count).to eq(0)
+            expect(destination_p4.reply_to_post_number).to eq(destination_p3.post_number)
+
+            # Check out the original topic
+            topic.reload
+            expect(topic.posts_count).to eq(2)
+            expect(topic.featured_user1_id).to eq(p2.user_id)
+            expect(topic.like_count).to eq(0)
+            expect(topic.posts.by_post_number).to match_array([p1, p2])
+            expect(topic.highest_post_number).to eq(p2.post_number)
+
+            # Should update last reads
+            expect(
+              TopicUser.find_by(user_id: user.id, topic_id: topic.id).last_read_post_number,
+            ).to eq(p2.post_number)
+          end
+
+          it "correctly remaps quotes for shifted posts on destination topic" do
+            destination_p8 =
+              Fabricate(
+                :post,
+                topic: destination_topic,
+                user: another_user,
+                created_at: p6.created_at + 10.minutes,
+              )
+
+            raw = <<~RAW
+            [quote="dan, post:#{destination_p8.post_number}, topic:#{destination_p8.topic_id}, full:true"]
+            some quote from the other post
+            [/quote]
+
+            the quote above should be updated with new post number and topic id
+            RAW
+
+            p3.update!(raw: raw)
+            p3.rebake!
+
+            expect {
+              topic.move_posts(
+                user,
+                [p6.id],
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            }.to change { p6.reload.topic_id }.and change {
+                    destination_p8.reload.post_number
+                  }.and change { p3.reload.raw }.and change { p3.baked_version }.to(nil)
+
+            expect(p3.raw).to include(
+              "post:#{destination_p8.post_number}, topic:#{destination_p8.topic_id}",
+            )
+          end
+
+          it "moving all posts will close the topic" do
+            topic.expects(:add_moderator_post).twice
+            posts_to_move = [p1.id, p2.id, p3.id, p4.id]
+            moved_to =
+              topic.move_posts(
+                user,
+                posts_to_move,
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            expect(moved_to).to be_present
+
+            topic.reload
+            expect(topic).to be_closed
+          end
+
+          it "doesn't close the topic when not all posts were moved" do
+            topic.expects(:add_moderator_post).once
+            posts_to_move = [p2.id, p3.id]
+            moved_to =
+              topic.move_posts(
+                user,
+                posts_to_move,
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            expect(moved_to).to be_present
+
+            topic.reload
+            expect(topic).to_not be_closed
+          end
+
+          it "doesn't close the topic when all posts except the first one were moved" do
+            topic.expects(:add_moderator_post).once
+            posts_to_move = [p2.id, p3.id, p4.id]
+            moved_to =
+              topic.move_posts(
+                user,
+                posts_to_move,
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            expect(moved_to).to be_present
+
+            topic.reload
+            expect(topic).to_not be_closed
+          end
+
+          it "schedules topic deleting when all posts were moved" do
+            SiteSetting.delete_merged_stub_topics_after_days = 7
+            freeze_time
+
+            topic.expects(:add_moderator_post).twice
+            posts_to_move = [p1.id, p2.id, p3.id, p4.id]
+            moved_to =
+              topic.move_posts(
+                user,
+                posts_to_move,
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            expect(moved_to).to be_present
+
+            timer = topic.topic_timers.find_by(status_type: TopicTimer.types[:delete])
+            expect(timer).to be_present
+            expect(timer.execute_at).to eq_time(7.days.from_now)
+          end
+
+          it "doesn't schedule topic deleting when not all posts were moved" do
+            SiteSetting.delete_merged_stub_topics_after_days = 7
+
+            topic.expects(:add_moderator_post).once
+            posts_to_move = [p1.id, p2.id, p3.id]
+            moved_to =
+              topic.move_posts(
+                user,
+                posts_to_move,
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            expect(moved_to).to be_present
+
+            timer = topic.topic_timers.find_by(status_type: TopicTimer.types[:delete])
+            expect(timer).to be_nil
+          end
+
+          it "doesn't schedule topic deleting when all posts were moved if it's disabled in settings" do
+            SiteSetting.delete_merged_stub_topics_after_days = 0
+
+            topic.expects(:add_moderator_post).twice
+            posts_to_move = [p1.id, p2.id, p3.id, p4.id]
+            moved_to =
+              topic.move_posts(
+                user,
+                posts_to_move,
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+            expect(moved_to).to be_present
+
+            timer = topic.topic_timers.find_by(status_type: TopicTimer.types[:delete])
+            expect(timer).to be_nil
+          end
+
+          it "ignores moderator posts and closes the topic if all regular posts were moved" do
+            add_moderator_post_to topic, Post.types[:moderator_action]
+            add_moderator_post_to topic, Post.types[:small_action]
+
+            posts_to_move = [p1.id, p2.id, p3.id, p4.id]
+            topic.move_posts(
+              user,
+              posts_to_move,
+              destination_topic_id: destination_topic.id,
+              merge_type: "chronological",
+            )
+
+            topic.reload
+            expect(topic).to be_closed
+          end
+
+          it "does not try to move small action posts" do
+            small_action =
+              Fabricate(
+                :post,
+                topic: topic,
+                raw: "A small action",
+                post_type: Post.types[:small_action],
+              )
+            moved_to =
+              topic.move_posts(
+                user,
+                [p1.id, p2.id, p3.id, p4.id, small_action.id],
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+
+            moved_to.reload
+            expect(moved_to.posts_count).to eq(5)
+            expect(small_action.topic_id).to eq(topic.id)
+
+            moderator_post = topic.posts.find_by(post_number: 2)
+            expect(moderator_post.raw).to include("4 posts were merged")
+          end
+
+          it "updates existing notifications" do
+            n2 = Fabricate(:mentioned_notification, post: p2, user: another_user)
+            n4 = Fabricate(:mentioned_notification, post: p4, user: another_user)
+            dest_nop = Fabricate(:mentioned_notification, post: destination_op, user: another_user)
+
+            moved_to =
+              topic.move_posts(
+                user,
+                [p2.id],
+                destination_topic_id: destination_topic.id,
+                merge_type: "chronological",
+              )
+
+            n2 = Notification.find(n2.id)
+            expect(n2.topic_id).to eq(moved_to.id)
+            expect(n2.post_number).to eq(1)
+            expect(n2.data_hash[:topic_title]).to eq(moved_to.title)
+
+            n4 = Notification.find(n4.id)
+            expect(n4.topic_id).to eq(topic.id)
+            expect(n4.post_number).to eq(4)
+
+            dest_nop = Notification.find(dest_nop.id)
+            expect(dest_nop.post_number).to eq(2)
+          end
+
+          it "deletes notifications for users not allowed to see the topic" do
+            another_admin = Fabricate(:admin)
+            staff_category = Fabricate(:private_category, group: Group[:staff])
+            user_notification = Fabricate(:mentioned_notification, post: p3, user: another_user)
+            admin_notification = Fabricate(:mentioned_notification, post: p3, user: another_admin)
+
+            destination_topic.update!(category_id: staff_category.id)
+            topic.move_posts(
+              user,
+              [p3.id],
+              destination_topic_id: destination_topic.id,
+              merge_type: "chronological",
+            )
+
+            expect(Notification.exists?(user_notification.id)).to eq(false)
+            expect(Notification.exists?(admin_notification.id)).to eq(true)
+          end
+
+          context "with post timings" do
+            fab!(:some_user) { Fabricate(:user) }
+
+            it "successfully moves timings" do
+              create_post_timing(p1, some_user, 500)
+              create_post_timing(p2, some_user, 1000)
+              create_post_timing(p3, some_user, 1500)
+              create_post_timing(p4, some_user, 750)
+
+              moved_to =
+                topic.move_posts(
+                  user,
+                  [p1.id, p4.id],
+                  destination_topic_id: destination_topic.id,
+                  merge_type: "chronological",
+                )
+
+              expect(
+                PostTiming.where(topic_id: topic.id, user_id: some_user.id).pluck(
+                  :post_number,
+                  :msecs,
+                ),
+              ).to contain_exactly([1, 500], [2, 1000], [3, 1500])
+
+              expect(
+                PostTiming.where(topic_id: moved_to.id, user_id: some_user.id).pluck(
+                  :post_number,
+                  :msecs,
+                ),
+              ).to contain_exactly([1, 500], [3, 750])
+            end
+
+            it "moves timings when post timing exists in destination topic" do
+              PostTiming.create!(
+                topic_id: destination_topic.id,
+                user_id: some_user.id,
+                post_number: 2,
+                msecs: 800,
+              )
+              create_post_timing(destination_op, some_user, 1500)
+              create_post_timing(p1, some_user, 500)
+
+              moved_to =
+                topic.move_posts(
+                  user,
+                  [p1.id],
+                  destination_topic_id: destination_topic.id,
+                  merge_type: "chronological",
+                )
+
+              expect(
+                PostTiming.where(topic_id: moved_to.id, user_id: some_user.id).pluck(
+                  :post_number,
+                  :msecs,
+                ),
+              ).to contain_exactly([1, 500], [2, 1500])
+            end
+          end
+
+          it "updates topic_user.liked values for both source and destination topics" do
+            expect(TopicUser.find_by(topic: topic, user: user).liked).to eq(false)
+
+            like =
+              Fabricate(
+                :post_action,
+                post: p3,
+                user: user,
+                post_action_type_id: PostActionType.types[:like],
+              )
+            expect(TopicUser.find_by(topic: topic, user: user).liked).to eq(true)
+
+            expect(TopicUser.find_by(topic: destination_topic, user: user)).to eq(nil)
+            topic.move_posts(
+              user,
+              [p3.id],
+              destination_topic_id: destination_topic.id,
+              merge_type: "chronological",
+            )
+
+            expect(TopicUser.find_by(topic: topic, user: user).liked).to eq(false)
+            expect(TopicUser.find_by(topic: destination_topic, user: user).liked).to eq(true)
+          end
+
+          context "with read state and other stats per user" do
+            def create_topic_user(user, topic, opts = {})
+              notification_level = opts.delete(:notification_level) || :regular
+
+              Fabricate(
+                :topic_user,
+                opts.merge(
+                  notification_level: TopicUser.notification_levels[notification_level],
+                  topic: topic,
+                  user: user,
+                ),
+              )
+            end
+
+            fab!(:user1) { Fabricate(:user) }
+            fab!(:user2) { Fabricate(:user) }
+            fab!(:user3) { Fabricate(:user) }
+            fab!(:admin1) { Fabricate(:admin) }
+            fab!(:admin2) { Fabricate(:admin) }
+
+            it "leaves post numbers unchanged when they were lower then the topic's highest post number" do
+              Fabricate(:post, topic: destination_topic)
+              Fabricate(:whisper, topic: destination_topic)
+
+              destination_topic.reload
+              expect(destination_topic.highest_post_number).to eq(2)
+              expect(destination_topic.highest_staff_post_number).to eq(3)
+
+              create_topic_user(user1, topic, last_read_post_number: 3, last_emailed_post_number: 3)
+              create_topic_user(
+                user1,
+                destination_topic,
+                last_read_post_number: 1,
+                last_emailed_post_number: 1,
+              )
+
+              create_topic_user(user2, topic, last_read_post_number: 3, last_emailed_post_number: 3)
+              create_topic_user(
+                user2,
+                destination_topic,
+                last_read_post_number: 2,
+                last_emailed_post_number: 2,
+              )
+
+              create_topic_user(
+                admin1,
+                topic,
+                last_read_post_number: 3,
+                last_emailed_post_number: 3,
+              )
+              create_topic_user(
+                admin1,
+                destination_topic,
+                last_read_post_number: 2,
+                last_emailed_post_number: 1,
+              )
+
+              create_topic_user(
+                admin2,
+                topic,
+                last_read_post_number: 3,
+                last_emailed_post_number: 3,
+              )
+              create_topic_user(
+                admin2,
+                destination_topic,
+                last_read_post_number: 3,
+                last_emailed_post_number: 3,
+              )
+
+              moved_to_topic =
+                topic.move_posts(
+                  user,
+                  [p1.id, p2.id],
+                  destination_topic_id: destination_topic.id,
+                  merge_type: "chronological",
+                )
+
+              expect(TopicUser.find_by(topic: moved_to_topic, user: user1)).to have_attributes(
+                last_read_post_number: 1,
+                last_emailed_post_number: 1,
+              )
+
+              expect(TopicUser.find_by(topic: moved_to_topic, user: user2)).to have_attributes(
+                last_read_post_number: 2,
+                last_emailed_post_number: 2,
+              )
+
+              expect(TopicUser.find_by(topic: moved_to_topic, user: admin1)).to have_attributes(
+                last_read_post_number: 2,
+                last_emailed_post_number: 1,
+              )
+
+              expect(TopicUser.find_by(topic: moved_to_topic, user: admin2)).to have_attributes(
+                last_read_post_number: 3,
+                last_emailed_post_number: 3,
+              )
+            end
+
+            it "correctly updates existing topic_user records" do
+              destination_topic.update!(created_at: 1.day.ago)
+
+              original_topic_user1 =
+                create_topic_user(
+                  user1,
+                  topic,
+                  last_read_post_number: 5,
+                  first_visited_at: 5.hours.ago,
+                  last_visited_at: 30.minutes.ago,
+                  notification_level: :tracking,
+                ).reload
+              destination_topic_user1 =
+                create_topic_user(
+                  user1,
+                  destination_topic,
+                  last_read_post_number: 5,
+                  first_visited_at: 7.hours.ago,
+                  last_visited_at: 2.hours.ago,
+                  notification_level: :watching,
+                ).reload
+
+              original_topic_user2 =
+                create_topic_user(
+                  user2,
+                  topic,
+                  last_read_post_number: 5,
+                  first_visited_at: 3.hours.ago,
+                  last_visited_at: 1.hour.ago,
+                  notification_level: :watching,
+                ).reload
+              destination_topic_user2 =
+                create_topic_user(
+                  user2,
+                  destination_topic,
+                  last_read_post_number: 5,
+                  first_visited_at: 2.hours.ago,
+                  last_visited_at: 1.hour.ago,
+                  notification_level: :tracking,
+                ).reload
+
+              new_topic =
+                topic.move_posts(
+                  user,
+                  [p1.id, p2.id],
+                  destination_topic_id: destination_topic.id,
+                  merge_type: "chronological",
+                )
+
+              expect(TopicUser.find_by(topic: new_topic, user: user)).to have_attributes(
+                notification_level: TopicUser.notification_levels[:tracking],
+                posted: true,
+              )
+
+              expect(TopicUser.find_by(topic: new_topic, user: user1)).to have_attributes(
+                first_visited_at: destination_topic_user1.first_visited_at,
+                last_visited_at: original_topic_user1.last_visited_at,
+                notification_level: destination_topic_user1.notification_level,
+                posted: false,
+              )
+
+              expect(TopicUser.find_by(topic: new_topic, user: user2)).to have_attributes(
+                first_visited_at: original_topic_user2.first_visited_at,
+                last_visited_at: destination_topic_user2.last_visited_at,
+                notification_level: destination_topic_user2.notification_level,
+                posted: false,
+              )
+            end
+          end
+        end
+
         it "skips validations when moving posts" do
           p1.update_attribute(:raw, "foo")
           p2.update_attribute(:raw, "bar")
@@ -1544,6 +2251,102 @@ RSpec.describe PostMover do
               "move_posts.existing_message_moderator_post",
               count: 1,
               topic_link: "[#{moved_to.title}](#{p2.reload.url})",
+              locale: :en,
+            )
+
+          expect(post.raw).to eq(expected_text)
+        end
+      end
+
+      context "when moving chronologically to existing message" do
+        it "adds post users as topic allowed users" do
+          personal_message.move_posts(
+            admin,
+            [p2.id, p5.id],
+            destination_topic_id: another_personal_message.id,
+            archetype: "private_message",
+            merge_type: "chronological",
+          )
+
+          p2.reload
+          expect(p2.topic_id).to eq(another_personal_message.id)
+
+          another_personal_message.reload
+          expect(
+            another_personal_message.topic_allowed_users.where(user_id: another_user.id).count,
+          ).to eq(1)
+          expect(
+            another_personal_message.topic_allowed_users.where(user_id: evil_trout.id).count,
+          ).to eq(1)
+        end
+
+        it "can add additional participants" do
+          personal_message.move_posts(
+            admin,
+            [p2.id, p5.id],
+            destination_topic_id: another_personal_message.id,
+            participants: [regular_user.username],
+            archetype: "private_message",
+            merge_type: "chronological",
+          )
+
+          another_personal_message.reload
+          expect(
+            another_personal_message.topic_allowed_users.where(user_id: another_user.id).count,
+          ).to eq(1)
+          expect(
+            another_personal_message.topic_allowed_users.where(user_id: evil_trout.id).count,
+          ).to eq(1)
+          expect(
+            another_personal_message.topic_allowed_users.where(user_id: regular_user.id).count,
+          ).to eq(1)
+        end
+
+        it "does not allow moving regular topic posts in personal message" do
+          topic = Fabricate(:topic, created_at: 4.hours.ago)
+
+          expect {
+            personal_message.move_posts(
+              admin,
+              [p2.id, p5.id],
+              destination_topic_id: topic.id,
+              merge_type: "chronological",
+            )
+          }.to raise_error(Discourse::InvalidParameters)
+        end
+
+        it "moving all posts will close the message" do
+          moved_to =
+            personal_message.move_posts(
+              admin,
+              [p1.id, p2.id, p3.id, p4.id, p5.id],
+              destination_topic_id: another_personal_message.id,
+              archetype: "private_message",
+              merge_type: "chronological",
+            )
+          expect(moved_to).to be_present
+
+          personal_message.reload
+          expect(personal_message.closed).to eq(true)
+          expect(moved_to.posts_count).to eq(6)
+        end
+
+        it "uses the correct small action post" do
+          moved_to =
+            personal_message.move_posts(
+              admin,
+              [p2.id],
+              destination_topic_id: another_personal_message.id,
+              archetype: "private_message",
+              merge_type: "chronological",
+            )
+          post = Post.find_by(topic_id: personal_message.id, post_type: Post.types[:whisper])
+
+          expected_text =
+            I18n.t(
+              "move_posts.existing_message_moderator_post",
+              count: 1,
+              topic_link: "[#{moved_to.title}](#{moved_to.relative_url})",
               locale: :en,
             )
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -358,6 +358,29 @@ RSpec.describe TopicsController do
       end
     end
 
+    describe "moving chronologically to an existing topic" do
+      before { sign_in(moderator) }
+
+      fab!(:p1) { Fabricate(:post, user: moderator, created_at: dest_topic.created_at - 1.hour) }
+      fab!(:topic) { p1.topic }
+
+      context "with success" do
+        it "returns success" do
+          post "/t/#{topic.id}/move-posts.json",
+               params: {
+                 post_ids: [p1.id],
+                 destination_topic_id: dest_topic.id,
+                 merge_type: "chronological",
+               }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["success"]).to eq(true)
+          expect(result["url"]).to be_present
+        end
+      end
+    end
+
     describe "moving to an existing topic as a group moderator" do
       fab!(:category) { Fabricate(:category, reviewable_by_group: group_user.group) }
       fab!(:topic) { Fabricate(:topic, category: category) }
@@ -406,6 +429,40 @@ RSpec.describe TopicsController do
              }
 
         expect(response).to be_forbidden
+      end
+    end
+
+    describe "moving chronologically to an existing topic as a group moderator" do
+      fab!(:category) { Fabricate(:category, reviewable_by_group: group_user.group) }
+      fab!(:topic) { Fabricate(:topic, category: category) }
+      fab!(:p1) do
+        Fabricate(
+          :post,
+          user: group_user.user,
+          topic: topic,
+          created_at: dest_topic.created_at - 1.hour,
+        )
+      end
+
+      let!(:user) { group_user.user }
+
+      before do
+        sign_in(user)
+        SiteSetting.enable_category_group_moderation = true
+      end
+
+      it "moves the posts" do
+        post "/t/#{topic.id}/move-posts.json",
+             params: {
+               post_ids: [p1.id],
+               destination_topic_id: dest_topic.id,
+               merge_type: "chronological",
+             }
+
+        expect(response.status).to eq(200)
+        result = response.parsed_body
+        expect(result["success"]).to eq(true)
+        expect(result["url"]).to be_present
       end
     end
 
@@ -551,6 +608,48 @@ RSpec.describe TopicsController do
         end
       end
     end
+
+    describe "moving chronologically to an existing message" do
+      before { sign_in(admin) }
+
+      fab!(:evil_trout) { Fabricate(:evil_trout) }
+      fab!(:message) { pm }
+
+      fab!(:dest_message) do
+        Fabricate(
+          :private_message_topic,
+          user: trust_level_4,
+          topic_allowed_users: [Fabricate.build(:topic_allowed_user, user: evil_trout)],
+        )
+      end
+
+      fab!(:p2) do
+        Fabricate(
+          :post,
+          user: evil_trout,
+          post_number: 2,
+          topic: message,
+          created_at: dest_message.created_at - 1.hour,
+        )
+      end
+
+      context "with success" do
+        it "returns success" do
+          post "/t/#{message.id}/move-posts.json",
+               params: {
+                 post_ids: [p2.id],
+                 destination_topic_id: dest_message.id,
+                 archetype: "private_message",
+                 merge_type: "chronological",
+               }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["success"]).to eq(true)
+          expect(result["url"]).to be_present
+        end
+      end
+    end
   end
 
   describe "#merge_topic" do
@@ -579,6 +678,27 @@ RSpec.describe TopicsController do
         it "returns success" do
           sign_in(moderator)
           post "/t/#{topic.id}/merge-topic.json", params: { destination_topic_id: dest_topic.id }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["success"]).to eq(true)
+          expect(result["url"]).to be_present
+        end
+      end
+    end
+
+    describe "merging chronologically into another topic" do
+      fab!(:p1) { Fabricate(:post, user: user, created_at: dest_topic.created_at - 1.hour) }
+      fab!(:topic) { p1.topic }
+
+      context "when moving all the posts to the destination topic" do
+        it "returns success" do
+          sign_in(moderator)
+          post "/t/#{topic.id}/merge-topic.json",
+               params: {
+                 destination_topic_id: dest_topic.id,
+                 merge_type: "chronological",
+               }
 
           expect(response.status).to eq(200)
           result = response.parsed_body
@@ -625,6 +745,47 @@ RSpec.describe TopicsController do
       end
     end
 
+    describe "merging chronologically into another topic as a group moderator" do
+      fab!(:category) { Fabricate(:category, reviewable_by_group: group_user.group) }
+      fab!(:topic) { Fabricate(:topic, category: category) }
+      fab!(:p1) do
+        Fabricate(
+          :post,
+          user: post_author1,
+          post_number: 1,
+          topic: topic,
+          created_at: dest_topic.created_at - 1.hour,
+        )
+      end
+      fab!(:p2) do
+        Fabricate(
+          :post,
+          user: post_author2,
+          post_number: 2,
+          topic: topic,
+          created_at: dest_topic.created_at - 30.minutes,
+        )
+      end
+
+      before do
+        sign_in(group_user.user)
+        SiteSetting.enable_category_group_moderation = true
+      end
+
+      it "moves the posts" do
+        post "/t/#{topic.id}/merge-topic.json",
+             params: {
+               destination_topic_id: dest_topic.id,
+               merge_type: "chronological",
+             }
+
+        expect(response.status).to eq(200)
+        result = response.parsed_body
+        expect(result["success"]).to eq(true)
+        expect(result["url"]).to be_present
+      end
+    end
+
     describe "merging into another message" do
       fab!(:message) { Fabricate(:private_message_topic, user: user) }
       fab!(:p1) { Fabricate(:post, topic: message, user: trust_level_4) }
@@ -663,6 +824,53 @@ RSpec.describe TopicsController do
                params: {
                  destination_topic_id: dest_message.id,
                  archetype: "private_message",
+               }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["success"]).to eq(true)
+          expect(result["url"]).to be_present
+        end
+      end
+    end
+
+    describe "merging chronologically into another message" do
+      fab!(:message) { Fabricate(:private_message_topic, user: user) }
+
+      fab!(:dest_message) do
+        Fabricate(
+          :private_message_topic,
+          user: trust_level_4,
+          topic_allowed_users: [Fabricate.build(:topic_allowed_user, user: moderator)],
+        )
+      end
+
+      fab!(:p1) do
+        Fabricate(
+          :post,
+          topic: message,
+          user: trust_level_4,
+          created_at: dest_message.created_at - 1.hour,
+        )
+      end
+      fab!(:p2) do
+        Fabricate(
+          :post,
+          topic: message,
+          reply_to_post_number: p1.post_number,
+          user: user,
+          created_at: dest_message.created_at - 30.minutes,
+        )
+      end
+
+      context "when moving all the posts to the destination message" do
+        it "returns success" do
+          sign_in(moderator)
+          post "/t/#{message.id}/merge-topic.json",
+               params: {
+                 destination_topic_id: dest_message.id,
+                 archetype: "private_message",
+                 merge_type: "chronological",
                }
 
           expect(response.status).to eq(200)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe TopicsController do
                params: {
                  post_ids: [p1.id],
                  destination_topic_id: dest_topic.id,
-                 merge_type: "chronological",
+                 chronological_order: "true",
                }
 
           expect(response.status).to eq(200)
@@ -456,7 +456,7 @@ RSpec.describe TopicsController do
              params: {
                post_ids: [p1.id],
                destination_topic_id: dest_topic.id,
-               merge_type: "chronological",
+               chronological_order: "true",
              }
 
         expect(response.status).to eq(200)
@@ -640,7 +640,7 @@ RSpec.describe TopicsController do
                  post_ids: [p2.id],
                  destination_topic_id: dest_message.id,
                  archetype: "private_message",
-                 merge_type: "chronological",
+                 chronological_order: "true",
                }
 
           expect(response.status).to eq(200)
@@ -697,7 +697,7 @@ RSpec.describe TopicsController do
           post "/t/#{topic.id}/merge-topic.json",
                params: {
                  destination_topic_id: dest_topic.id,
-                 merge_type: "chronological",
+                 chronological_order: "true",
                }
 
           expect(response.status).to eq(200)
@@ -776,7 +776,7 @@ RSpec.describe TopicsController do
         post "/t/#{topic.id}/merge-topic.json",
              params: {
                destination_topic_id: dest_topic.id,
-               merge_type: "chronological",
+               chronological_order: "true",
              }
 
         expect(response.status).to eq(200)
@@ -870,7 +870,7 @@ RSpec.describe TopicsController do
                params: {
                  destination_topic_id: dest_message.id,
                  archetype: "private_message",
-                 merge_type: "chronological",
+                 chronological_order: "true",
                }
 
           expect(response.status).to eq(200)


### PR DESCRIPTION
Hi,

This PR addresses this feature request: https://meta.discourse.org/t/moving-posts-into-an-existing-topic-doesnt-keep-chronology/21392

When a user chooses to move a topic/message to an existing topic/message and there's at least one post to be moved that was `created_at` before the destination topic `last_posted_at`, we show this dialog so the user can pick the desired merging strategy they prefer:

![moving to an existing topic](https://user-images.githubusercontent.com/3530/236060663-38da6b80-1b7a-41f6-864a-63bbd0bc87bb.png)

![moving to an existing message](https://user-images.githubusercontent.com/3530/236060892-261c81c4-71e3-4f78-b3b1-2b21472f53d2.png)

I've reused the `moved_posts` temporary table to leverage the existing `post_number` updates for this new "shifted posts" scenario, but I'm fine separating it if necessary.

On `create_first_post`, I'm updating `post_number` after post creation, but ideally we'd do it during the `INSERT`. I thought about adding `post_number` to `PostCreator` but was unsure if you'd agree.

`move_post_timings` was moved before `copy_first_post_timings` so it can finish the post shifting, leaving room for adding the post timing for the first post on the right position.

There were some other changes to accommodate this feature, like the way `@first_post_number_moved` was being set and the logic behind `delete_invalid_post_timings`.
