### PR TITLE
FIX: Do not log 'personal message view' when sending webhook

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -68,7 +68,7 @@ class WebHook < ActiveRecord::Base
     if active_web_hooks("topic").exists? && topic.present?
       payload ||=
         begin
-          topic_view = TopicView.new(topic.id, Discourse.system_user)
+          topic_view = TopicView.new(topic.id, Discourse.system_user, skip_staff_action: true)
           WebHook.generate_payload(:topic, topic_view, WebHookTopicViewSerializer)
         end
 

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -219,6 +219,29 @@ RSpec.describe WebHook do
       expect(payload["tags"]).to contain_exactly(tag.name)
     end
 
+    it "should not log a personal message view when processing new topic" do
+      SiteSetting.log_personal_messages_views = true
+      Fabricate(:topic_web_hook)
+
+      post =
+        PostCreator.create!(
+          user,
+          raw: "raw",
+          title: "title",
+          skip_validations: true,
+          archetype: Archetype.private_message,
+          target_usernames: user.username,
+        )
+      topic_id = post.topic.id
+      job_args = Jobs::EmitWebHookEvent.jobs.last["args"].first
+
+      expect(job_args["event_name"]).to eq("topic_created")
+      payload = JSON.parse(job_args["payload"])
+      expect(payload["id"]).to eq(topic_id)
+
+      expect(UserHistory.where(action: UserHistory.actions[:check_personal_message]).count).to eq(0)
+    end
+
     describe "when topic has been deleted" do
       it "should not enqueue a post/topic edited hooks" do
         topic.trash!


### PR DESCRIPTION
Similar to the issue resolved by 3b55de90e5

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
