### PR TITLE
DEV: Disable SearchIndexer after fabrication

### DIFF
--- a/spec/jobs/create_recent_post_search_indexes_spec.rb
+++ b/spec/jobs/create_recent_post_search_indexes_spec.rb
@@ -3,15 +3,8 @@
 RSpec.describe Jobs::CreateRecentPostSearchIndexes do
   subject { described_class.new }
 
-  fab!(:post) do
-    SearchIndexer.enable
-    Fabricate(:post)
-  end
-
-  fab!(:post_2) do
-    SearchIndexer.enable
-    Fabricate(:post)
-  end
+  fab!(:post) { with_search_indexer_enabled { Fabricate(:post) } }
+  fab!(:post_2) { with_search_indexer_enabled { Fabricate(:post) } }
 
   before { SearchIndexer.enable }
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -653,8 +653,9 @@ RSpec.describe Topic do
 
     context "with a similar topic" do
       fab!(:post) do
-        SearchIndexer.enable
-        create_post(title: "Evil trout is the dude who posted this topic")
+        with_search_indexer_enabled do
+          create_post(title: "Evil trout is the dude who posted this topic")
+        end
       end
 
       let(:topic) { post.topic }

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -10,20 +10,19 @@ RSpec.describe SearchController do
   end
 
   fab!(:awesome_post) do
-    SearchIndexer.enable
-    Fabricate(:post, topic: awesome_topic, raw: "this is my really awesome post")
+    with_search_indexer_enabled do
+      Fabricate(:post, topic: awesome_topic, raw: "this is my really awesome post")
+    end
   end
 
   fab!(:awesome_post_2) do
-    SearchIndexer.enable
-    Fabricate(:post, raw: "this is my really awesome post 2")
+    with_search_indexer_enabled { Fabricate(:post, raw: "this is my really awesome post 2") }
   end
 
-  fab!(:user) { Fabricate(:user) }
+  fab!(:user) { with_search_indexer_enabled { Fabricate(:user) } }
 
   fab!(:user_post) do
-    SearchIndexer.enable
-    Fabricate(:post, raw: "#{user.username} is a cool person")
+    with_search_indexer_enabled { Fabricate(:post, raw: "#{user.username} is a cool person") }
   end
 
   context "with integration" do
@@ -470,35 +469,37 @@ RSpec.describe SearchController do
     fab!(:very_high_priority_topic) { Fabricate(:topic, category: very_high_priority_category) }
 
     fab!(:very_low_priority_post) do
-      SearchIndexer.enable
-      Fabricate(:post, topic: very_low_priority_topic, raw: "This is a very Low Priority Post")
+      with_search_indexer_enabled do
+        Fabricate(:post, topic: very_low_priority_topic, raw: "This is a very Low Priority Post")
+      end
     end
 
     fab!(:low_priority_post) do
-      SearchIndexer.enable
-
-      Fabricate(
-        :post,
-        topic: low_priority_topic,
-        raw: "This is a Low Priority Post",
-        created_at: 1.day.ago,
-      )
+      with_search_indexer_enabled do
+        Fabricate(
+          :post,
+          topic: low_priority_topic,
+          raw: "This is a Low Priority Post",
+          created_at: 1.day.ago,
+        )
+      end
     end
 
     fab!(:high_priority_post) do
-      SearchIndexer.enable
-      Fabricate(:post, topic: high_priority_topic, raw: "This is a High Priority Post")
+      with_search_indexer_enabled do
+        Fabricate(:post, topic: high_priority_topic, raw: "This is a High Priority Post")
+      end
     end
 
     fab!(:very_high_priority_post) do
-      SearchIndexer.enable
-
-      Fabricate(
-        :post,
-        topic: very_high_priority_topic,
-        raw: "This is a Old but Very High Priority Post",
-        created_at: 2.days.ago,
-      )
+      with_search_indexer_enabled do
+        Fabricate(
+          :post,
+          topic: very_high_priority_topic,
+          raw: "This is a Old but Very High Priority Post",
+          created_at: 2.days.ago,
+        )
+      end
     end
 
     it "sort posts with search priority when search term is empty" do

--- a/spec/requests/similar_topics_controller_spec.rb
+++ b/spec/requests/similar_topics_controller_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe SimilarTopicsController do
     end
 
     def reindex_posts
-      SearchIndexer.enable
-      Jobs::ReindexSearch.new.rebuild_posts
+      with_search_indexer_enabled { Jobs::ReindexSearch.new.rebuild_posts }
     end
 
     it "requires a title param" do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -202,4 +202,11 @@ module Helpers
         ips.map { |ip| Addrinfo.new([IPAddr.new(ip).ipv6? ? "AF_INET6" : "AF_INET", 80, nil, ip]) },
       )
   end
+
+  def with_search_indexer_enabled
+    SearchIndexer.enable
+    yield
+  ensure
+    SearchIndexer.disable
+  end
 end

--- a/spec/system/user_selector_spec.rb
+++ b/spec/system/user_selector_spec.rb
@@ -4,11 +4,7 @@ describe "User selector", type: :system, js: true do
   fab!(:topic) { Fabricate(:topic) }
   fab!(:post) { Fabricate(:post, topic: topic) }
   fab!(:current_user) { Fabricate(:admin) }
-
-  fab!(:user) do
-    SearchIndexer.enable
-    Fabricate(:user, username: "someone")
-  end
+  fab!(:user) { with_search_indexer_enabled { Fabricate(:user, username: "someone") } }
 
   before do
     current_user.activate


### PR DESCRIPTION
SearchIndexer is only automatically disabled in `before_all` and `before` blocks which means at the start
of test runs. Enabling the SearchIndexer in one `fab!` block will affect
all other `fab!` blocks which is not ideal as we may be indexing stuff
for search when we don't need to.