### PR TITLE
DEV: Delete old personal message settings

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -831,10 +831,6 @@ posting:
       ja: 4
       zh_CN: 4
       zh_TW: 4
-  enable_personal_messages:
-    default: true
-    client: true
-    hidden: true
   enable_system_message_replies:
     default: true
   personal_message_enabled_groups:
@@ -1592,10 +1588,6 @@ trust:
   min_trust_to_allow_self_wiki:
     default: 3
     enum: "TrustLevelSetting"
-  min_trust_to_send_messages:
-    default: 1
-    enum: "TrustLevelSetting"
-    hidden: true
   min_trust_to_send_email_messages:
     default: "4"
     enum: "TrustLevelAndStaffSetting"

--- a/db/migrate/20230523073109_delete_old_personal_message_settings.rb
+++ b/db/migrate/20230523073109_delete_old_personal_message_settings.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class DeleteOldPersonalMessageSettings < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      DELETE FROM site_settings WHERE name = 'enable_personal_messages'
+    SQL
+
+    execute <<~SQL
+      DELETE FROM site_settings WHERE name = 'min_trust_to_send_messages'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -8,8 +8,6 @@ module SiteSettings::DeprecatedSettings
     # [<old setting>, <new_setting>, <override>, <version to drop>]
     ["search_tokenize_chinese_japanese_korean", "search_tokenize_chinese", true, "2.9"],
     ["default_categories_regular", "default_categories_normal", true, "3.0"],
-    ["min_trust_to_send_messages", "personal_message_enabled_groups", false, "3.0"],
-    ["enable_personal_messages", "personal_message_enabled_groups", false, "3.0"],
   ]
 
   def setup_deprecated_methods


### PR DESCRIPTION
Followup to e62e93f83a77adfa80b38fbfecf82bbee14e12fe

Both enable_personal_messages and min_trust_to_send_messages
have been deprecated for a long time now, they can be deleted.
