### PR TITLE
FIX: Regression with clicks outside dropdowns

### DIFF
--- a/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-notifications-button-test.js
@@ -1,7 +1,7 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { test } from "qunit";
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 
 acceptance("Topic Notifications button", function (needs) {
   needs.user();
@@ -56,6 +56,21 @@ acceptance("Topic Notifications button", function (needs) {
       notificationOptions.header().label(),
       "Muted",
       "it should display the right notification level"
+    );
+
+    await timelineNotificationOptions.expand();
+
+    assert.ok(
+      timelineNotificationOptions.isExpanded(),
+      "it should be expanded"
+    );
+
+    // clicking any element outside select-kit
+    await click(".toggle-summary p");
+
+    assert.notOk(
+      timelineNotificationOptions.isExpanded(),
+      "it should no longer be expanded"
     );
   });
 });

--- a/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
+++ b/app/assets/javascripts/select-kit/addon/components/select-kit/select-kit-body.js
@@ -13,12 +13,16 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.element.style.position = "relative";
-    this.element.addEventListener("focusout", this._handleFocusOut, true);
+    this.selectKit
+      .mainElement()
+      .addEventListener("focusout", this._handleFocusOut, true);
   },
 
   willDestroyElement() {
     this._super(...arguments);
-    this.element.removeEventListener("focusout", this._handleFocusOut, true);
+    this.selectKit
+      .mainElement()
+      .removeEventListener("focusout", this._handleFocusOut, true);
   },
 
   @bind


### PR DESCRIPTION
Some select-kit dropdowns don't set focus to the body immediately when opened, and this meant that they wouldn't get the `focusout` event either (following a change in 1b2a1c9).

This commit changes the event listener to be on the main element of the select-kit component instead of the body, the main element should have focus every time SK is invoked.
