### PR TITLE
DEV: add optional `displayName` parameter for `discourse-tag`

### DIFF
--- a/app/assets/javascripts/discourse/app/lib/render-tag.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tag.js
@@ -49,7 +49,7 @@ export function defaultRenderTag(tag, params) {
     " class='" +
     classes.join(" ") +
     "'>" +
-    visibleName +
+    (escape(params.displayName) || visibleName) +
     "</" +
     tagName +
     ">";

--- a/app/assets/javascripts/discourse/app/lib/render-tag.js
+++ b/app/assets/javascripts/discourse/app/lib/render-tag.js
@@ -49,7 +49,7 @@ export function defaultRenderTag(tag, params) {
     " class='" +
     classes.join(" ") +
     "'>" +
-    (escape(params.displayName) || visibleName) +
+    (params.displayName ? escape(params.displayName) : visibleName) +
     "</" +
     tagName +
     ">";


### PR DESCRIPTION
In the tag banner component (https://meta.discourse.org/t/tag-banners/124240), at some point based on user requests I added the ability to strip underscores and hyphens from tags so they look a little nicer in banners. 

In a recent refactor I started using `{{discourse-tag}}` so I can get the consistent tag structure and styles, but if hyphens and underscores are stripped from the tag name and passed to the component, it produces a broken link. 

This allows me to optionally pass in a `displayName` in addition to a tag, so I can do something like this:

`{{discourse-tag @tag.name displayName=@formattedTagName}}`


So now I can get a tag with whatever text formatting I want that links to the correct place:

![Screenshot 2023-05-04 at 5 42 02 PM](https://user-images.githubusercontent.com/1681963/236336180-a0f167e8-277d-47a2-9b0a-9a68950c1560.png)
