### PR TITLE
DEV: add class names to group directory table

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/group-index.hbs
+++ b/app/assets/javascripts/discourse/app/templates/group-index.hbs
@@ -86,17 +86,19 @@
             @asc={{this.asc}}
             @field="username_lower"
             @labelKey="username"
-            @class="username"
+            @class="directory-table__column-header--username username"
             @automatic={{true}}
             @colspan="2"
           />
 
           {{#if this.canManageGroup}}
-            <div class="directory-table__column-header"></div>
+            <div
+              class="directory-table__column-header directory-table__column-header--can-manage"
+            ></div>
           {{/if}}
 
           <TableHeaderToggle
-            @class="directory-table__column-header"
+            @class="directory-table__column-header--added"
             @order={{this.order}}
             @asc={{this.asc}}
             @field="added_at"
@@ -104,7 +106,7 @@
             @automatic={{true}}
           />
           <TableHeaderToggle
-            @class="directory-table__column-header"
+            @class="directory-table__column-header--last-posted"
             @order={{this.order}}
             @asc={{this.asc}}
             @field="last_posted_at"
@@ -112,7 +114,7 @@
             @automatic={{true}}
           />
           <TableHeaderToggle
-            @class="directory-table__column-header"
+            @class="directory-table__column-header--last-seen"
             @order={{this.order}}
             @asc={{this.asc}}
             @field="last_seen_at"
@@ -121,7 +123,9 @@
           />
 
           {{#if this.canManageGroup}}
-            <div class="directory-table__column-header"></div>
+            <div
+              class="directory-table__column-header directory-table__column-header--member-settings"
+            ></div>
           {{/if}}
         </:header>
 
@@ -129,7 +133,10 @@
           {{#each this.model.members as |m|}}
             <div class="directory-table__row">
 
-              <div class="directory-table__cell group-member" colspan="2">
+              <div
+                class="directory-table__cell directory-table__cell--username group-member"
+                colspan="2"
+              >
                 {{#if this.canManageGroup}}
                   {{#if this.isBulk}}
                     <Input
@@ -148,7 +155,9 @@
               </div>
 
               {{#if this.canManageGroup}}
-                <div class="directory-table__cell group-owner">
+                <div
+                  class="directory-table__cell directory-table__cell--can-manage group-owner"
+                >
                   {{#if (or m.owner m.primary)}}
                     <span class="directory-table__label">
                       <span>{{i18n "groups.members.status"}}</span>
@@ -166,7 +175,7 @@
 
                 </div>
               {{/if}}
-              <div class="directory-table__cell">
+              <div class="directory-table__cell directory-table__cell--added">
                 <span class="directory-table__label">
                   <span>{{i18n "groups.member_added"}}</span>
                 </span>
@@ -178,7 +187,8 @@
                 class="directory-table__cell{{unless
                     m.last_posted_at
                     '--empty'
-                  }}"
+                  }}
+                  directory-table__cell--last-posted"
               >
                 {{#if m.last_posted_at}}
                   <span class="directory-table__label">
@@ -190,7 +200,8 @@
                 </span>
               </div>
               <div
-                class="directory-table__cell{{unless m.last_seen_at '--empty'}}"
+                class="directory-table__cell{{unless m.last_seen_at '--empty'}}
+                  directory-table__cell--last-seen"
               >
                 {{#if m.last_seen_at}}
                   <span class="directory-table__label">
@@ -202,7 +213,9 @@
                 </span>
               </div>
               {{#if this.canManageGroup}}
-                <div class="directory-table__cell member-settings">
+                <div
+                  class="directory-table__cell directory-table__cell--member-settings member-settings"
+                >
                   <GroupMemberDropdown
                     @member={{m}}
                     @canAdminGroup={{this.model.can_admin_group}}


### PR DESCRIPTION
Hiding group directory table columns with CSS is a little fragile at the moment, this adds some more descriptive class names (without removing any existing classes) 