### PR TITLE
DEV: Speed up chat plugin system tests

### DIFF
--- a/plugins/chat/spec/system/create_channel_spec.rb
+++ b/plugins/chat/spec/system/create_channel_spec.rb
@@ -10,11 +10,12 @@ RSpec.describe "Create channel", type: :system, js: true do
 
   context "when user cannot create channel" do
     fab!(:current_user) { Fabricate(:user) }
+
     before { sign_in(current_user) }
 
     it "does not show the create channel button" do
       chat_page.visit_browse
-      expect(chat_page).not_to have_new_channel_button
+      expect(chat_page).to have_no_new_channel_button
     end
   end
 

--- a/plugins/chat/spec/system/message_thread_indicator_spec.rb
+++ b/plugins/chat/spec/system/message_thread_indicator_spec.rb
@@ -22,7 +22,7 @@ describe "Thread indicator for chat messages", type: :system, js: true do
     it "shows no thread indicators in the channel" do
       thread = chat_thread_chain_bootstrap(channel: channel, users: [current_user, other_user])
       chat_page.visit_channel(channel)
-      expect(channel_page).not_to have_thread_indicator(thread.original_message)
+      expect(channel_page).to have_no_thread_indicator(thread.original_message)
     end
   end
 
@@ -36,7 +36,7 @@ describe "Thread indicator for chat messages", type: :system, js: true do
     it "shows no thread inidcators in the channel" do
       thread = chat_thread_chain_bootstrap(channel: channel, users: [current_user, other_user])
       chat_page.visit_channel(channel)
-      expect(channel_page).not_to have_thread_indicator(thread.original_message)
+      expect(channel_page).to have_no_thread_indicator(thread.original_message)
     end
   end
 

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe "Navigation", type: :system, js: true do
         visit("/chat/c/#{category_channel.slug}/#{category_channel.id}")
         find("#site-logo").click
 
-        expect(sidebar_component).not_to have_section_link(category_channel.name, active: true)
+        expect(sidebar_component).to have_no_section_link(category_channel.name, active: true)
       end
     end
 
@@ -299,7 +299,7 @@ RSpec.describe "Navigation", type: :system, js: true do
         sidebar_component.click_link(category_channel.name)
         chat_drawer_page.close
 
-        expect(sidebar_component).not_to have_section_link(category_channel.name, active: true)
+        expect(sidebar_component).to have_no_section_link(category_channel.name, active: true)
       end
     end
   end

--- a/plugins/chat/spec/system/page_objects/chat/chat.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat.rb
@@ -57,12 +57,18 @@ module PageObjects
         container.has_content?(message.user.username)
       end
 
+      NEW_CHANNEL_BUTTON_SELECTOR = ".new-channel-btn"
+
       def new_channel_button
-        find(".new-channel-btn")
+        find(NEW_CHANNEL_BUTTON_SELECTOR)
       end
 
       def has_new_channel_button?
-        has_css?(".new-channel-btn")
+        has_css?(NEW_CHANNEL_BUTTON_SELECTOR)
+      end
+
+      def has_no_new_channel_button?
+        has_no_css?(NEW_CHANNEL_BUTTON_SELECTOR)
       end
     end
   end

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -174,11 +174,21 @@ module PageObjects
       end
 
       def has_thread_indicator?(message)
-        has_css?("#{message_by_id_selector(message.id)} .chat-message-thread-indicator")
+        has_css?(message_thread_indicator_selector(message))
+      end
+
+      def has_no_thread_indicator?(message)
+        has_no_css?(message_thread_indicator_selector(message))
       end
 
       def message_thread_indicator(message)
-        find("#{message_by_id_selector(message.id)} .chat-message-thread-indicator")
+        find(message_thread_indicator_selector(message))
+      end
+
+      private
+
+      def message_thread_indicator_selector(message)
+        "#{message_by_id_selector(message.id)} .chat-message-thread-indicator"
       end
     end
   end


### PR DESCRIPTION
See e323628d8a363ea29d1f341b95ffcdf8f3c09fca for more details.

This commit speeds up the tests by roughly 10 seconds locally where the
default wait time is 2 seconds. On CI, this speeds up the tests by 20
seconds where the default wait time is 4 seconds.