### PR TITLE
DEV: Reset capybara sessions and default driver after each test

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -421,6 +421,8 @@ RSpec.configure do |config|
       end
     end
 
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
     Discourse.redis.flushdb
   end
 


### PR DESCRIPTION
I don't think we're leaking state at the moment but the docs are
recommending that this two methods are called after each run.