### PR TITLE
DEV: stop leaking data into tables during test

### DIFF
--- a/spec/lib/concern/cached_counting_spec.rb
+++ b/spec/lib/concern/cached_counting_spec.rb
@@ -80,15 +80,15 @@ RSpec.describe CachedCounting do
       freeze_time
       d1 = Time.now.utc.to_date
 
-      RailsCacheCounter.perform_increment!("a,a")
-      RailsCacheCounter.perform_increment!("b")
-      20.times { RailsCacheCounter.perform_increment!("a,a") }
+      RailsCacheCounter.perform_increment!("a,a", async: true)
+      RailsCacheCounter.perform_increment!("b", async: true)
+      20.times { RailsCacheCounter.perform_increment!("a,a", async: true) }
 
       freeze_time 2.days.from_now
       d2 = Time.now.utc.to_date
 
-      RailsCacheCounter.perform_increment!("a,a")
-      RailsCacheCounter.perform_increment!("d")
+      RailsCacheCounter.perform_increment!("a,a", async: true)
+      RailsCacheCounter.perform_increment!("d", async: true)
 
       CachedCounting.flush
 

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Middleware::RequestTracker do
   end
 
   after do
+    CachedCounting.reset
     ApplicationRequest.disable
     CachedCounting.disable
   end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1309,9 +1309,11 @@ RSpec.describe Report do
       end
 
       after do
+        CachedCounting.reset
         ApplicationRequest.disable
         CachedCounting.disable
       end
+
       it "works" do
         3.times { ApplicationRequest.increment!(:page_view_crawler) }
         2.times { ApplicationRequest.increment!(:page_view_logged_in) }

--- a/spec/models/web_crawler_request_spec.rb
+++ b/spec/models/web_crawler_request_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe WebCrawlerRequest do
     CachedCounting.enable
   end
 
-  after { CachedCounting.disable }
+  after do
+    CachedCounting.reset
+    CachedCounting.disable
+  end
 
   it "can log crawler requests" do
     freeze_time


### PR DESCRIPTION
This amends it so our cached counting reliant specs run in synchronize mode

When running async there are situations where data is left over in the table
after a transactional test. This means that repeat runs of the test suite
fail.
