### PR TITLE
DEV: `tag:` filter on `/filter` only supported alphabets and numbers

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -334,7 +334,7 @@ class TopicsFilter
       break if key_prefix && key_prefix != "-"
 
       value.scan(
-        /\A(?<tag_names>([a-zA-Z0-9\-]+)(?<delimiter>[,+])?([a-zA-Z0-9\-]+)?(\k<delimiter>[a-zA-Z0-9\-]+)*)\z/,
+        /\A(?<tag_names>([\p{N}\p{L}\-]+)(?<delimiter>[,+])?([\p{N}\p{L}\-]+)?(\k<delimiter>[\p{N}\p{L}\-]+)*)\z/,
       ) do |tag_names, delimiter|
         match_all =
           if delimiter == ","

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -814,6 +814,19 @@ RSpec.describe TopicsFilter do
             .pluck(:id),
         ).to contain_exactly(topic_without_tag.id, topic_with_group_only_tag.id)
       end
+
+      describe "when query string is tag:日べé1" do
+        before { tag.update!(name: "日べé1") }
+
+        it "should return topics that are tagged with the specified tag" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("tag:日べé1")
+              .pluck(:id),
+          ).to contain_exactly(topic_with_tag.id, topic_with_tag_and_tag2.id)
+        end
+      end
     end
 
     describe "when filtering by topic author" do


### PR DESCRIPTION
A tag's name can consist of any Unicode characters as well