### PR TITLE
UX: scroll to bottom when message is staged

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.js
@@ -190,6 +190,8 @@ export default class ChatThreadPanel extends Component {
     this.resetComposer();
     this.thread.messagesManager.addMessages([stagedMessage]);
 
+    this.scrollToBottom();
+
     return this.chatApi
       .sendMessage(this.channel.id, {
         message: stagedMessage.message,
@@ -198,9 +200,6 @@ export default class ChatThreadPanel extends Component {
         upload_ids: stagedMessage.uploads.map((upload) => upload.id),
         thread_id: this.thread.staged ? null : stagedMessage.thread.id,
         staged_thread_id: this.thread.staged ? stagedMessage.thread.id : null,
-      })
-      .then(() => {
-        this.scrollToBottom();
       })
       .catch((error) => {
         this.#onSendError(stagedMessage.id, error);


### PR DESCRIPTION
Since our recent change of inverting thread scrolling direction it feels more responsive to scroll down in thread panel as soon as message is staged and not after it's actually persisted.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
