### PR TITLE
FIX: Service worker should cache only 200 requests

### DIFF
--- a/app/assets/javascripts/service-worker.js.erb
+++ b/app/assets/javascripts/service-worker.js.erb
@@ -81,6 +81,9 @@ if (cdnUrls.length > 0) {
         credentials: 'omit'
       },
       plugins: [
+        new workbox.cacheableResponse.Plugin({
+          statuses: [200] // opaque responses will return status code '0'
+        }),
         new workbox.expiration.Plugin({
           maxAgeSeconds: 7* 24 * 60 * 60, // 7 days
           maxEntries: 250,


### PR DESCRIPTION
This can cause CORB issues when combining S3, secure uploads and service workers.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
