### PR TITLE
FIX: correct link on original message

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-message-interactor.js
@@ -233,7 +233,7 @@ export default class ChatMessageInteractor {
     const threadId = this.message.thread?.id;
 
     let url;
-    if (threadId) {
+    if (this.context === MESSAGE_CONTEXT_THREAD && threadId) {
       url = getURL(`/chat/c/-/${channelId}/t/${threadId}`);
     } else {
       url = getURL(`/chat/c/-/${channelId}/${this.message.id}`);

--- a/plugins/chat/spec/system/chat_message/thread_spec.rb
+++ b/plugins/chat/spec/system/chat_message/thread_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "Chat message - thread", type: :system, js: true do
 
   let(:cdp) { PageObjects::CDP.new }
   let(:chat) { PageObjects::Pages::Chat.new }
-  let(:channel) { PageObjects::Pages::ChatChannel.new }
-  let(:thread) { PageObjects::Pages::ChatThread.new }
+  let(:thread_page) { PageObjects::Pages::ChatThread.new }
   let(:message_1) { thread_1.chat_messages.first }
 
   before do
@@ -28,7 +27,7 @@ RSpec.describe "Chat message - thread", type: :system, js: true do
       first_message = thread_1.chat_messages.first
       chat.visit_thread(thread_1)
 
-      thread.hover_message(first_message)
+      thread_page.hover_message(first_message)
 
       expect(page).to have_css(
         ".chat-thread[data-id='#{thread_1.id}'] [data-id='#{first_message.id}'] .chat-message.is-active",
@@ -42,7 +41,7 @@ RSpec.describe "Chat message - thread", type: :system, js: true do
     it "copies the link to the thread" do
       chat.visit_thread(thread_1)
 
-      channel.copy_link(message_1)
+      thread_page.copy_link(message_1)
 
       expect(cdp.read_clipboard).to include("/chat/c/-/#{channel_1.id}/t/#{thread_1.id}")
     end

--- a/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_thread.rb
@@ -66,6 +66,16 @@ module PageObjects
         end
       end
 
+      def copy_link(message)
+        hover_message(message)
+        click_more_button
+        find("[data-value='copyLink']").click
+      end
+
+      def click_more_button
+        find(".more-buttons").click
+      end
+
       def hover_message(message)
         message_by_id(message.id).hover
       end


### PR DESCRIPTION
Ensures  that using <kbd>copy link</kbd> on the the original message of a thread  in a channel, copies the link to the channel and not the thread.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
