### PR TITLE
FIX: attempts to reconciliate tracking state

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-channel.js
@@ -223,11 +223,15 @@ export default class ChatChannel extends RestModel {
 
   updateMembership(membership) {
     this.currentUserMembership.following = membership.following;
-    this.currentUserMembership.muted = membership.muted;
+    this.currentUserMembership.last_read_message_id =
+      membership.last_read_message_id;
     this.currentUserMembership.desktop_notification_level =
       membership.desktop_notification_level;
     this.currentUserMembership.mobile_notification_level =
       membership.mobile_notification_level;
+    this.currentUserMembership.unread_count = membership.unread_count;
+    this.currentUserMembership.unread_mentions = membership.unread_mentions;
+    this.currentUserMembership.muted = membership.muted;
   }
 
   updateLastReadMessage(messageId) {

--- a/plugins/chat/assets/javascripts/discourse/services/chat-api.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-api.js
@@ -218,11 +218,7 @@ export default class ChatApi extends Service {
    * @returns {Promise}
    */
   listCurrentUserChannels() {
-    return this.#getRequest("/channels/me").then((result) => {
-      return (result?.channels || []).map((channel) =>
-        this.chatChannelsManager.store(channel)
-      );
-    });
+    return this.#getRequest("/channels/me");
   }
 
   /**

--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -251,17 +251,11 @@ export default class ChatSubscriptionsManager extends Service {
   @bind
   _updateChannelTrackingData(channelId, trackingData) {
     this.chatChannelsManager.find(channelId).then((channel) => {
-      if (
-        !channel?.currentUserMembership?.last_read_message_id ||
-        parseInt(channel?.currentUserMembership?.last_read_message_id, 10) <=
-          trackingData.last_read_message_id
-      ) {
-        channel.currentUserMembership.last_read_message_id =
-          trackingData.last_read_message_id;
-        channel.currentUserMembership.unread_count = trackingData.unread_count;
-        channel.currentUserMembership.unread_mentions =
-          trackingData.mention_count;
-      }
+      channel.currentUserMembership.last_read_message_id =
+        trackingData.last_read_message_id;
+      channel.currentUserMembership.unread_count = trackingData.unread_count;
+      channel.currentUserMembership.unread_mentions =
+        trackingData.mention_count;
     });
   }
 


### PR DESCRIPTION
After a long time with no activity or hidden browser (2.5 minutes), the app will re-sync the chat user-tracking-state to ensure unreads are synced.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
