### PR TITLE
FIX: jumpy more sidebar section

### DIFF
--- a/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.hbs
+++ b/app/assets/javascripts/discourse/app/components/sidebar/more-section-links.hbs
@@ -10,18 +10,21 @@
     @label="sidebar.more"
   />
 </li>
-{{#if this.open}}
-  <div
-    class="sidebar-more-section-links-details-content-wrapper"
-    {{did-insert this.registerClickListener}}
-    {{will-destroy this.unregisterClickListener}}
-  >
 
-    <div class="sidebar-more-section-links-details-content">
-      <div class="sidebar-more-section-links-details-content-main">
-        {{#each this.sectionLinks as |sectionLink|}}
-          <Sidebar::MoreSectionLink @sectionLink={{sectionLink}} />
-        {{/each}}
+{{#if this.open}}
+  <div class="sidebar-more-section-links-details">
+    <div
+      class="sidebar-more-section-links-details-content-wrapper"
+      {{did-insert this.registerClickListener}}
+      {{will-destroy this.unregisterClickListener}}
+    >
+
+      <div class="sidebar-more-section-links-details-content">
+        <div class="sidebar-more-section-links-details-content-main">
+          {{#each this.sectionLinks as |sectionLink|}}
+            <Sidebar::MoreSectionLink @sectionLink={{sectionLink}} />
+          {{/each}}
+        </div>
       </div>
     </div>
   </div>

--- a/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
+++ b/app/assets/stylesheets/common/base/sidebar-more-section-links.scss
@@ -35,9 +35,14 @@
     padding: 0.33rem calc(var(--d-sidebar-row-horizontal-padding) / 3);
   }
 }
+.sidebar-more-section-links-details-content-main {
+  position: sticky;
+}
 .sidebar-more-section-links-details-content-wrapper {
   position: absolute;
   width: 100%;
   z-index: z("modal", "content") + 1;
-  position: sticky;
+}
+.sidebar-more-section-links-details {
+  position: relative;
 }


### PR DESCRIPTION
Bug introduced in PR https://github.com/discourse/discourse/pull/21398

More section needs to be wrapped in div with position:relative to have sticky and absolute position.

Before:
https://user-images.githubusercontent.com/72780/236731254-7ed68600-0e13-4f7c-b5ba-02c0e1fac192.mov

After:
https://user-images.githubusercontent.com/72780/236731242-6a08ccb5-c05b-4ab9-8a22-328acf599d51.mov


