### PR TITLE
DEV: Support excluding categories with the `category:` filter

### DIFF
--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -198,8 +198,8 @@ class TopicsFilter
     }
 
     values.each do |key_prefix, value|
-      exclude_categories = key_prefix&.include?("-") || false
-      exclude_subcategories = key_prefix&.include?("=") || false
+      exclude_categories = key_prefix&.include?("-")
+      exclude_subcategories = key_prefix&.include?("=")
 
       value
         .scan(

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1130,10 +1130,10 @@ RSpec.describe ListController do
   end
 
   describe "#filter" do
-    fab!(:category) { Fabricate(:category) }
+    fab!(:category) { Fabricate(:category, slug: "category-slug") }
     fab!(:tag) { Fabricate(:tag, name: "tag1") }
     fab!(:group) { Fabricate(:group) }
-    fab!(:private_category) { Fabricate(:private_category, group: Fabricate(:group)) }
+    fab!(:private_category) { Fabricate(:private_category, group:, slug: "private-category-slug") }
     fab!(:private_message_topic) { Fabricate(:private_message_topic) }
     fab!(:topic_in_private_category) { Fabricate(:topic, category: private_category) }
 
@@ -1259,6 +1259,33 @@ RSpec.describe ListController do
         expect(
           response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] },
         ).to contain_exactly(topic.id, topic2.id)
+      end
+    end
+
+    describe "when filtering with the `category:<category_slug>` filter" do
+      fab!(:topic_in_category) { Fabricate(:topic, category:) }
+
+      it "does not return any topics when `q` query param is `category:private-category-slug` and user is not allowed to see category" do
+        sign_in(user)
+
+        get "/filter.json", params: { q: "category:private-category-slug" }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] }).to eq([])
+      end
+
+      it "returns only topics in the category when `q` query param is `category:private-category-slug` and user can see category" do
+        group.add(user)
+
+        sign_in(user)
+
+        get "/filter.json", params: { q: "category:private-category-slug" }
+
+        expect(response.status).to eq(200)
+
+        expect(
+          response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] },
+        ).to contain_exactly(topic_in_private_category.id)
       end
     end
 


### PR DESCRIPTION
This commit adds support for excluding categories when using the
`category:` filter with the `-` prefix. For example,
`-category:category-slug` will exclude all topics that belong to the
category with slug "category-slug" and all of its sub-categories.

To only exclude a particular category and not all of its sub-categories,
the `-` prefix can be used with the `=` prefix. For example,
`-=category:category-slug` will only exclude topics that belong to the
category with slug "category-slug". Topics in the sub-categories of
"category-slug" will still be included.