### PR TITLE
DEV: Add plugin outlet to `<NavigationBar/>` component

### DIFF
--- a/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
+++ b/app/assets/javascripts/discourse/app/templates/mobile/components/navigation-bar.hbs
@@ -21,3 +21,9 @@
     />
   </ul>
 {{/if}}
+
+<PluginOutlet
+  @name="inline-extra-nav-item"
+  @connectorTagName="li"
+  @outletArgs={{hash category=this.category filterMode=this.filterMode}}
+/>


### PR DESCRIPTION
This PR adds a plugin outlet to the `<NavigationBar />`'s mobile component for easier customization. Adding the new outlet `inline-extra-nav-item` allows for adding custom code within the navigation bar but outside of the dropdown, thereby being inline with the actual nav bar rather than being nested inside the dropdown.