### PR TITLE
FIX: no event when threading is disabled

### DIFF
--- a/plugins/chat/lib/chat/message_creator.rb
+++ b/plugins/chat/lib/chat/message_creator.rb
@@ -191,12 +191,14 @@ module Chat
         @chat_message.in_reply_to.thread_id = thread.id
       end
 
-      Chat::Publisher.publish_thread_created!(
-        @chat_message.chat_channel,
-        @chat_message.in_reply_to,
-        thread.id,
-        @staged_thread_id,
-      )
+      if @chat_message.chat_channel.threading_enabled
+        Chat::Publisher.publish_thread_created!(
+          @chat_message.chat_channel,
+          @chat_message.in_reply_to,
+          thread.id,
+          @staged_thread_id,
+        )
+      end
 
       @chat_message.thread_id = thread.id
 

--- a/plugins/chat/spec/components/chat/message_creator_spec.rb
+++ b/plugins/chat/spec/components/chat/message_creator_spec.rb
@@ -440,19 +440,42 @@ describe Chat::MessageCreator do
         expect(message.thread.original_message_user).to eq(reply_message.user)
       end
 
-      it "publishes the new thread" do
-        messages =
-          MessageBus.track_publish do
-            described_class.create(
-              chat_channel: public_chat_channel,
-              user: user1,
-              content: "this is a message",
-              in_reply_to_id: reply_message.id,
-            ).chat_message
-          end
+      context "when threading is enabled" do
+        it "publishes the new thread" do
+          public_chat_channel.update!(threading_enabled: true)
 
-        thread_created_message = messages.find { |m| m.data["type"] == "thread_created" }
-        expect(thread_created_message.channel).to eq("/chat/#{public_chat_channel.id}")
+          messages =
+            MessageBus.track_publish do
+              described_class.create(
+                chat_channel: public_chat_channel,
+                user: user1,
+                content: "this is a message",
+                in_reply_to_id: reply_message.id,
+              ).chat_message
+            end
+
+          thread_created_message = messages.find { |m| m.data["type"] == "thread_created" }
+          expect(thread_created_message.channel).to eq("/chat/#{public_chat_channel.id}")
+        end
+      end
+
+      context "when threading is disabled" do
+        it "doesn’t publish the new thread" do
+          public_chat_channel.update!(threading_enabled: false)
+
+          messages =
+            MessageBus.track_publish do
+              described_class.create(
+                chat_channel: public_chat_channel,
+                user: user1,
+                content: "this is a message",
+                in_reply_to_id: reply_message.id,
+              ).chat_message
+            end
+
+          thread_created_message = messages.find { |m| m.data["type"] == "thread_created" }
+          expect(thread_created_message).to be_nil
+        end
       end
 
       context "when a staged_thread_id is provided" do

--- a/plugins/chat/spec/components/chat/message_creator_spec.rb
+++ b/plugins/chat/spec/components/chat/message_creator_spec.rb
@@ -482,6 +482,8 @@ describe Chat::MessageCreator do
         fab!(:existing_thread) { Fabricate(:chat_thread, channel: public_chat_channel) }
 
         it "creates a thread and publishes with the staged id" do
+          public_chat_channel.update!(threading_enabled: true)
+
           messages =
             MessageBus.track_publish do
               described_class.create(

--- a/plugins/chat/spec/requests/chat_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat_controller_spec.rb
@@ -388,6 +388,7 @@ RSpec.describe Chat::ChatController do
         context "when sending a message in a staged thread" do
           it "creates the thread and publishes with the staged id" do
             sign_in(user)
+            chat_channel.update!(threading_enabled: true)
 
             messages =
               MessageBus.track_publish do


### PR DESCRIPTION
Every replies creates a thread, even when threading is disabled. This is how we ensure we can go back and forth. However, a message bus event should only be published when threading is enabled, otherwise frontend will attempt to display a thread which is not possible when disabled.

This fixes a silent background 404 when doing a reply in a direct message channel or a non threading enabled category channel.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
