### PR TITLE
UI: thread panel sizing/spacing on mobile

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-side-panel.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-side-panel.scss
@@ -1,0 +1,3 @@
+.chat-side-panel {
+  border-left: 0;
+}

--- a/plugins/chat/assets/stylesheets/mobile/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-thread.scss
@@ -1,0 +1,6 @@
+.chat-thread {
+  &__body {
+    margin: 0 1px 0 0;
+    padding: 0 10px;
+  }
+}

--- a/plugins/chat/assets/stylesheets/mobile/index.scss
+++ b/plugins/chat/assets/stylesheets/mobile/index.scss
@@ -7,3 +7,5 @@
 @import "chat-selection-manager";
 @import "chat-emoji-picker";
 @import "chat-composer-upload";
+@import "chat-side-panel";
+@import "chat-thread";


### PR DESCRIPTION
The side panel on mobile is full screen. As a result we need to tweak spacing and sizing to make it correctly full screen like the channel.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
