### PR TITLE
FIX: makes mouse events passive

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.hbs
@@ -14,9 +14,9 @@
     {{on "touchmove" this.handleTouchMove passive=true}}
     {{on "touchstart" this.handleTouchStart passive=true}}
     {{on "touchend" this.handleTouchEnd passive=true}}
-    {{on "mouseenter" this.onMouseEnter}}
-    {{on "mouseleave" this.onMouseLeave}}
-    {{on "mousemove" this.onMouseMove}}
+    {{on "mouseenter" this.onMouseEnter passive=true}}
+    {{on "mouseleave" this.onMouseLeave passive=true}}
+    {{on "mousemove" this.onMouseMove passive=true}}
     class={{concat-class
       "chat-message-container"
       (if this.pane.selectingMessages "selecting-messages")


### PR DESCRIPTION
This should prevent a violation warning in chrome and eventually improve performance.