### PR TITLE
FIX: Ensure search input isn't cleared on clicking suggested term

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
+++ b/app/assets/javascripts/discourse/app/widgets/search-menu-results.js
@@ -772,10 +772,18 @@ createWidget("search-menu-assistant-item", {
 
   click(e) {
     const searchInput = document.querySelector("#search-term");
-    searchInput.value = this.attrs.slug;
+    const searchTerms = searchInput.value.trim().split(" ");
+
+    if (searchTerms.length > 1) {
+      searchTerms.pop();
+      searchInput.value = [...searchTerms, this.attrs.slug].join(" ");
+    } else {
+      searchInput.value = this.attrs.slug;
+    }
+
     searchInput.focus();
     this.sendWidgetAction("triggerAutocomplete", {
-      value: this.attrs.slug,
+      value: searchInput.value,
       searchTopics: true,
       setTopicContext: this.attrs.setTopicContext,
     });


### PR DESCRIPTION
If searching with multiple categories/tags, clicking each autocomplete suggested term clears the search input.

This fix only replaces the term currently being autocompleted

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
