### PR TITLE
FIX: Ensure order when moving chat messages to another channel

### DIFF
--- a/plugins/chat/lib/chat/message_mover.rb
+++ b/plugins/chat/lib/chat/message_mover.rb
@@ -111,6 +111,7 @@ module Chat
         message_ids: @ordered_source_message_ids,
         destination_channel_id: destination_channel.id,
       }
+
       moved_message_ids = DB.query_single(<<~SQL, query_args)
       INSERT INTO chat_messages(
         chat_channel_id, user_id, last_editor_id, message, cooked, cooked_version, created_at, updated_at
@@ -125,6 +126,7 @@ module Chat
              CLOCK_TIMESTAMP()
       FROM chat_messages
       WHERE id IN (:message_ids)
+      ORDER BY created_at ASC, id ASC
       RETURNING id
     SQL
 


### PR DESCRIPTION
What is the problem?

Previously, this was the query used to move change messages into another
channel.

```
INSERT INTO chat_messages(
  chat_channel_id, user_id, last_editor_id, message, cooked, cooked_version, created_at, updated_at
)
SELECT :destination_channel_id,
        user_id,
        last_editor_id,
        message,
        cooked,
        cooked_version,
        CLOCK_TIMESTAMP(),
        CLOCK_TIMESTAMP()
FROM chat_messages
WHERE id IN (:message_ids)
RETURNING id
```

The problem is that this incorrectly assumes that the insertion will be based on the order of `message_ids`. However, that
is not the case as PostgreSQL provides no such guarantee. Instead we need to explicitly order the messages to ensure
the right order of insertion.

This problem was discovered by a flaky test which exposed the non-guarantee order of insertion.

```
1) Chat::MessageMover#move_to_channel preserves the order of the messages in the destination channel
     Failure/Error:
       expect(moved_messages.map(&:message)).to eq(
         ["the first to be moved", "message deux @testmovechat", "the third message"],
       )

       expected: ["the first to be moved", "message deux @testmovechat", "the third message"]
            got: ["message deux @testmovechat", "the third message", "the first to be moved"]

       (compared using ==)
     # ./plugins/chat/spec/lib/chat/message_mover_spec.rb:108:in `block (3 levels) in <main>'
     # ./spec/rails_helper.rb:358:in `block (2 levels) in <top (required)>'
```