### PR TITLE
DEV: Add plugin modifier to alter in memory value of site setting

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -300,7 +300,6 @@ module SiteSettingExtension
       shadowed_settings.each { |ss| new_hash[ss] = GlobalSetting.public_send(ss) }
 
       changes, deletions = diff_hash(new_hash, current)
-
       changes.each { |name, val| current[name] = val }
       deletions.each { |name, _| current[name] = defaults_view[name] }
       uploads.clear
@@ -544,11 +543,11 @@ module SiteSettingExtension
       end
     else
       define_singleton_method clean_name do
-        if (c = current[name]).nil?
+        if (current_value = current[name]).nil?
           refresh!
           current[name]
         else
-          c
+          DiscoursePluginRegistry.apply_modifier(:site_setting, current_value, name)
         end
       end
     end

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -885,4 +885,29 @@ RSpec.describe SiteSettingExtension do
       expect(SiteSetting.exclude_rel_nofollow_domains_map).to eq([])
     end
   end
+
+  describe "plugin modifier for site setting value" do
+    class TestFilterPlugInstance < Plugin::Instance
+    end
+
+    let(:plugin_instance) { TestFilterPlugInstance.new }
+
+    it "can temporarily alter the value of a site setting" do
+      settings.setting(:test_setting, 123)
+
+      begin
+        plugin_instance.register_modifier(:site_setting) do |value, name|
+          456 if name == :test_setting && value == 567
+        end
+
+        expect(settings.test_setting).to eq(123)
+
+        settings.test_setting = 567
+
+        expect(settings.test_setting).to eq(456)
+      ensure
+        DiscoursePluginRegistry.clear_modifiers!
+      end
+    end
+  end
 end


### PR DESCRIPTION
This modifier is added such that plugins are able to temporarily alter
the in memory value of the site setting when ensuring the origin value
of the site setting in the database is untouched.