### PR TITLE
FIX: Change the limit on badges description

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -119,7 +119,7 @@ class Badge < ActiveRecord::Base
   validates :badge_type, presence: true
   validates :allow_title, inclusion: [true, false]
   validates :multiple_grant, inclusion: [true, false]
-  validates :description, length: { maximum: 250 }
+  validates :description, length: { maximum: 500 }
   validates :long_description, length: { maximum: 1000 }
 
   scope :enabled, -> { where(enabled: true) }

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Badge do
     subject(:badge) { Fabricate.build(:badge) }
 
     it { is_expected.to validate_length_of(:name).is_at_most(100) }
-    it { is_expected.to validate_length_of(:description).is_at_most(250) }
+    it { is_expected.to validate_length_of(:description).is_at_most(500) }
     it { is_expected.to validate_length_of(:long_description).is_at_most(1000) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:badge_type) }


### PR DESCRIPTION
The current limit (250 characters) is too low, as we have some translations used for our badge descriptions that result in a description length of 264 characters.

To be on the safe side, the limit is now set to 500 characters.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
