### PR TITLE
FIX: more precise chat-replying-indicator

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.hbs
@@ -5,9 +5,8 @@
       (if this.presenceChannel.subscribed "is-subscribed")
     }}
     {{did-insert this.subscribe}}
-    {{did-update this.handleDraft @channel.isDraft}}
-    {{did-update this.subscribe this.channelName}}
-    {{will-destroy this.teardown}}
+    {{did-update this.updateSubscription @channel.id}}
+    {{will-destroy this.unsubscribe}}
   >
     {{#if this.shouldRender}}
       <span class="chat-replying-indicator__text">{{this.text}}</span>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.js
@@ -1,4 +1,4 @@
-import { isBlank, isPresent } from "@ember/utils";
+import { isPresent } from "@ember/utils";
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import I18n from "I18n";
@@ -13,37 +13,32 @@ export default class ChatReplyingIndicator extends Component {
   @tracked users = [];
 
   @action
-  async subscribe() {
-    this.presenceChannel = this.presence.getChannel(this.channelName);
-    this.presenceChannel.on("change", this.handlePresenceChange);
-    await this.presenceChannel.subscribe();
-  }
-
-  @action
-  async resubscribe() {
-    await this.teardown();
+  async updateSubscription() {
+    await this.unsubscribe();
     await this.subscribe();
   }
 
   @action
-  handlePresenceChange(presenceChannel) {
-    this.users = presenceChannel.users || [];
+  async subscribe() {
+    this.presenceChannel = this.presence.getChannel(this.channelName);
+    await this.presenceChannel.subscribe();
+    this.users = this.presenceChannel.users;
+    this.presenceChannel.on("change", this.handlePresenceChange);
   }
 
   @action
-  async handleDraft() {
-    if (this.args.channel.isDraft) {
-      await this.teardown();
-    } else {
-      await this.resubscribe();
-    }
-  }
+  async unsubscribe() {
+    this.users = [];
 
-  @action
-  async teardown() {
-    if (this.presenceChannel) {
+    if (this.presenceChannel.suscribed) {
+      this.presenceChannel.off("change", this.handlePresenceChange);
       await this.presenceChannel.unsubscribe();
     }
+  }
+
+  @action
+  handlePresenceChange(presenceChannel) {
+    this.users = presenceChannel.users;
   }
 
   get usernames() {
@@ -53,10 +48,6 @@ export default class ChatReplyingIndicator extends Component {
   }
 
   get text() {
-    if (isBlank(this.usernames)) {
-      return;
-    }
-
     if (this.usernames.length === 1) {
       return I18n.t("chat.replying_indicator.single_user", {
         username: this.usernames[0],

--- a/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.js
@@ -38,7 +38,7 @@ export default class ChatReplyingIndicator extends Component {
 
   @action
   handlePresenceChange(presenceChannel) {
-    this.users = presenceChannel.users;
+    this.users = presenceChannel.users || [];
   }
 
   get usernames() {


### PR DESCRIPTION
- correctly subscribe/unsubscribe channel
- instantly changes users list
- adds a test for testing channel change
- rewrites tests to be less verbose

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
