### PR TITLE
FIX: fast-edit should fall back to composer for non-ascii characters

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -165,12 +165,14 @@ export default Component.extend(KeyEnterEscape, {
       if (this._canEditPost) {
         const regexp = new RegExp(escapeRegExp(quoteState.buffer), "gi");
         const matches = cooked.innerHTML.match(regexp);
+        const non_ascii_regex = /[^\x00-\x7F]/;
 
         if (
           quoteState.buffer.length < 1 ||
           quoteState.buffer.includes("|") || // tables are too complex
           quoteState.buffer.match(/\n/g) || // linebreaks are too complex
-          matches?.length > 1 // duplicates are too complex
+          matches?.length > 1 || // duplicates are too complex
+          non_ascii_regex.test(quoteState.buffer) // non-ascii chars break fast-edit
         ) {
           this.set("_isFastEditable", false);
           this.set("_fastEditInitialSelection", null);

--- a/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
@@ -73,4 +73,17 @@ acceptance("Fast Edit", function (needs) {
     assert.notOk(exists("#fast-edit-input"), "fast editor is not open");
     assert.ok(exists(".d-editor-input"), "the composer is open");
   });
+
+  test("Opens full composer when editing non-ascii characters", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    query("#post_2 .cooked").childNodes[0].innerHTML += `Don’t ”say doesn’t”`;
+    const textNode = query("#post_2 .cooked");
+
+    await selectText(textNode);
+    await click(".quote-button .quote-edit-label");
+
+    assert.notOk(exists("#fast-edit-input"), "fast editor is not open");
+    assert.ok(exists(".d-editor-input"), "the composer is open");
+  });
 });


### PR DESCRIPTION
### The problem
When selecting text and clicking the "Edit" button that pops up, this opens up the Fast Edit dialog.

The fast edit feature doesn't work well with non standard characters (non-ascii). If the user selects a string of text that contains non-ascii characters, then the edit won't save. It is non-obvious to the user why this is happening. This issue occurs more frequently when editing content that is written in other languages, as fast-edit doesn't work well with non-ascii characters. We currently replace do a global replace on a couple of the obvious quotation marks when the fast edit dialog attempts to save, but there are too many edge cases for foreign language content.

### The solution
The best solution is to catch those non-ascii characters before the user clicks the edit button to bring up the fast edit dialog. Then we can fallback to the full composer to edit their text, which has much better support for non-ascii characters.

### What does this regex do?
The regex used to catch this is `[^\x00-\x7F]`, which matches any character that is not within the ASCII range of 0x00 to 0x7F, which includes all control characters and non-ASCII characters.

This regex pattern can be used to match any character that is not a standard ASCII character, such as accented characters, non-Latin characters, and special symbols.

https://meta.discourse.org/t/fast-edit-doesnt-work-on-content-with-certain-characters/223145