### PR TITLE
Revert "FIX: fast-edit should fall back to composer for non-ascii characters (#21453)"

### DIFF
--- a/app/assets/javascripts/discourse/app/components/quote-button.js
+++ b/app/assets/javascripts/discourse/app/components/quote-button.js
@@ -165,14 +165,12 @@ export default Component.extend(KeyEnterEscape, {
       if (this._canEditPost) {
         const regexp = new RegExp(escapeRegExp(quoteState.buffer), "gi");
         const matches = cooked.innerHTML.match(regexp);
-        const non_ascii_regex = /[^\x00-\x7F]/;
 
         if (
           quoteState.buffer.length < 1 ||
           quoteState.buffer.includes("|") || // tables are too complex
           quoteState.buffer.match(/\n/g) || // linebreaks are too complex
-          matches?.length > 1 || // duplicates are too complex
-          non_ascii_regex.test(quoteState.buffer) // non-ascii chars break fast-edit
+          matches?.length > 1 // duplicates are too complex
         ) {
           this.set("_isFastEditable", false);
           this.set("_fastEditInitialSelection", null);

--- a/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/fast-edit-test.js
@@ -73,17 +73,4 @@ acceptance("Fast Edit", function (needs) {
     assert.notOk(exists("#fast-edit-input"), "fast editor is not open");
     assert.ok(exists(".d-editor-input"), "the composer is open");
   });
-
-  test("Opens full composer when editing non-ascii characters", async function (assert) {
-    await visit("/t/internationalization-localization/280");
-
-    query("#post_2 .cooked").childNodes[0].innerHTML += `Don’t ”say doesn’t”`;
-    const textNode = query("#post_2 .cooked");
-
-    await selectText(textNode);
-    await click(".quote-button .quote-edit-label");
-
-    assert.notOk(exists("#fast-edit-input"), "fast editor is not open");
-    assert.ok(exists(".d-editor-input"), "the composer is open");
-  });
 });


### PR DESCRIPTION
This reverts commit 249f4296bfed7d7ef03cf826be90856a159ce392.
