### PR TITLE
FIX: minor thread changes on mobile

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.hbs
@@ -14,7 +14,7 @@
   >
     {{yield}}
 
-    {{#if site.desktopView}}
+    {{#if this.site.desktopView}}
       <ChatSidePanelResizer />
     {{/if}}
   </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.hbs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-side-panel.hbs
@@ -13,6 +13,9 @@
     }}
   >
     {{yield}}
-    <ChatSidePanelResizer />
+
+    {{#if site.desktopView}}
+      <ChatSidePanelResizer />
+    {{/if}}
   </div>
 {{/if}}

--- a/plugins/chat/assets/stylesheets/common/chat-thread.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread.scss
@@ -29,6 +29,6 @@
   }
 
   .chat-composer__wrapper {
-    padding-bottom: 28px;
+    padding-bottom: 27px;
   }
 }


### PR DESCRIPTION
- do not render sidepanel resizer as it's not usable on mobile
- removes 1px to the bottom spacing, this spacing won't be necessary once we implement chat-replying-indicator for thread

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
