### PR TITLE
DEV: Remove noisy SiteSetting deprecations

### DIFF
--- a/lib/site_settings/deprecated_settings.rb
+++ b/lib/site_settings/deprecated_settings.rb
@@ -8,21 +8,6 @@ module SiteSettings::DeprecatedSettings
     # [<old setting>, <new_setting>, <override>, <version to drop>]
     ["search_tokenize_chinese_japanese_korean", "search_tokenize_chinese", true, "2.9"],
     ["default_categories_regular", "default_categories_normal", true, "3.0"],
-    ["min_trust_to_send_messages", "personal_message_enabled_groups", false, "3.0"],
-    ["enable_personal_messages", "personal_message_enabled_groups", false, "3.0"],
-    ["secure_media", "secure_uploads", true, "3.0"],
-    [
-      "secure_media_allow_embed_images_in_emails",
-      "secure_uploads_allow_embed_images_in_emails",
-      true,
-      "3.0",
-    ],
-    [
-      "secure_media_max_email_embed_image_size_kb",
-      "secure_uploads_max_email_embed_image_size_kb",
-      true,
-      "3.0",
-    ],
   ]
 
   def setup_deprecated_methods


### PR DESCRIPTION
We don't need these, they are causing a lot of
log noise on our servers, they have been removed
from the main branch from some time and it is
doubtful that anyone else needs to be told these
warnings on stable.

