### PR TITLE
FIX: prevents fast channel switching to cause an error

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.js
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-replying-indicator.js
@@ -22,7 +22,7 @@ export default class ChatReplyingIndicator extends Component {
   async subscribe() {
     this.presenceChannel = this.presence.getChannel(this.channelName);
     await this.presenceChannel.subscribe();
-    this.users = this.presenceChannel.users;
+    this.users = this.presenceChannel.users || [];
     this.presenceChannel.on("change", this.handlePresenceChange);
   }
 


### PR DESCRIPTION
`this.users` would end up being nil and `this.users.filter` would generate an exception.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
