### PR TITLE
DEV: more resilient upload spec

### DIFF
--- a/plugins/chat/spec/system/uploads_spec.rb
+++ b/plugins/chat/spec/system/uploads_spec.rb
@@ -64,10 +64,7 @@ describe "Uploading files in chat messages", type: :system, js: true do
 
       # image processing clientside is slow! here we are waiting for processing
       # to complete then the upload to complete as well
-      using_wait_time(10) do
-        expect(find(".chat-composer-upload")).to have_content("Uploading")
-        expect(page).to have_css(".chat-composer-upload .preview .preview-img")
-      end
+      expect(page).to have_css(".chat-composer-upload .preview .preview-img", wait: 25)
 
       channel.send_message("upload testing")
 


### PR DESCRIPTION
Checking "uploading" string is tricky because it both takes time before showing, and when it will show it will show for a short period of time. I prefer to reduce the surface tested here while still getting some confidence out of it and making the test more reliable.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
