### PR TITLE
FIX: do not allow title stuffing to dominate search

### DIFF
--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -118,7 +118,9 @@ class SearchIndexer
             .each do |index|
               family = nil
               family = index[-1] if index[-1].match?(/[A-D]/)
-              if (family_counts[family] += 1) <= max_dupes
+              # title dupes can completely dominate the index
+              # so we limit them to 1
+              if (family_counts[family] += 1) <= (family == "A" ? 1 : max_dupes)
                 new_index_array << index
               end
             end


### PR DESCRIPTION
We were giving topics with repeated words extra weight in search index.
This meant that it was trivial to stuff words into title to dominate in search
given we search for exact title matches first.

The following tweak means that:

`invite invited invites`
and
`invite some stuff`

Both rank the same for title searching.

Titles are short and punchy, duplicating words should not give special
weight.

Requires a full reindex to take effect.
