### PR TITLE
DEV: Reduce plugin system test parallel processors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
-        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=8 bin/turbo_rspec --verbose plugins/*/spec/system
+        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=7 bin/turbo_rspec --verbose plugins/*/spec/system
         timeout-minutes: 30
 
       - name: Upload failed system test screenshots


### PR DESCRIPTION
Still noting runner timeouts for plugin system tests.