### PR TITLE
DEV: more resilient scroll to bottom spec

### DIFF
--- a/plugins/chat/spec/system/navigating_to_message_spec.rb
+++ b/plugins/chat/spec/system/navigating_to_message_spec.rb
@@ -62,7 +62,15 @@ RSpec.describe "Navigating to message", type: :system, js: true do
         chat_page.visit_channel(channel_1)
 
         click_link(link)
+
+        expect(page).to have_css(
+          ".chat-message-container.highlighted[data-id='#{first_message.id}']",
+        )
+
         click_button(class: "chat-scroll-to-bottom")
+
+        expect(page).to have_content(link)
+
         click_link(link)
 
         expect(page).to have_css(


### PR DESCRIPTION
The spec now checks we are in the state we expect to be before clicking bottom button. The bottom button could show while it's still loading and on slow systems cause failures.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
