### PR TITLE
FIX: Handle deleted original message for thread index

### DIFF
--- a/plugins/chat/app/serializers/chat/thread_serializer.rb
+++ b/plugins/chat/app/serializers/chat/thread_serializer.rb
@@ -10,7 +10,9 @@ module Chat
     def initialize(object, opts)
       super(object, opts)
       @opts = opts
-      original_message.thread = object
+
+      # Avoids an N1 to re-load the thread in the serializer for original_message.
+      object.original_message.thread = object
     end
 
     def meta

--- a/plugins/chat/app/services/chat/lookup_channel_threads.rb
+++ b/plugins/chat/app/services/chat/lookup_channel_threads.rb
@@ -64,7 +64,9 @@ module Chat
         )
         .where("chat_messages.user_id = ? OR chat_messages.user_id IS NULL", guardian.user.id)
         .where(channel_id: channel.id)
-        .where("original_messages.deleted_at IS NULL AND chat_messages.deleted_at IS NULL")
+        .where(
+          "original_messages.deleted_at IS NULL AND chat_messages.deleted_at IS NULL AND original_messages.id IS NOT NULL",
+        )
         .group("chat_threads.id")
         .order("last_posted_at DESC NULLS LAST")
         .limit(50)

--- a/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
+++ b/plugins/chat/spec/services/chat/lookup_channel_threads_spec.rb
@@ -59,8 +59,13 @@ RSpec.describe Chat::LookupChannelThreads do
           expect(result.threads.map(&:id)).to eq([thread_3.id, thread_1.id, thread_2.id])
         end
 
-        it "does not return threads where the original message is deleted" do
+        it "does not return threads where the original message is trashed" do
           thread_1.original_message.trash!
+          expect(result.threads.map(&:id)).to eq([thread_3.id, thread_2.id])
+        end
+
+        it "does not return threads where the original message is deleted" do
+          thread_1.original_message.destroy
           expect(result.threads.map(&:id)).to eq([thread_3.id, thread_2.id])
         end
 


### PR DESCRIPTION
Since we have channel message retention which deletes
messages, we can end up with cases where the thread
is still around but the message is deleted. We will
handle the cascade delete in a different commit --
for now we will ensure the thread list lookup handles
this case and doesn't error.
