### PR TITLE
FIX: excerpt overflow and children click events

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-thread-original-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-original-message.scss
@@ -8,6 +8,11 @@
 
   &__excerpt {
     padding-bottom: 0.25rem;
+    word-break: break-all;
+
+    > * {
+      pointer-events: none;
+    }
   }
 
   &__author {


### PR DESCRIPTION
This commit prevents long links to overflow the container and also prevents click on the thread to open a link displayed in the excerpt, we only want to open the thread.

Before:

<img width="281" alt="Screenshot 2023-05-10 at 14 43 04" src="https://github.com/discourse/discourse/assets/339945/e9ce2c5f-47af-4d70-be96-ecbf69107dfe">


After:

<img width="285" alt="Screenshot 2023-05-10 at 14 44 26" src="https://github.com/discourse/discourse/assets/339945/3884dfae-3cfe-4749-bb74-14490285c970">
