### PR TITLE
UX: improve edit history display

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -27,9 +27,29 @@
     padding: 5px;
   }
 
-  #revisions .row:first-of-type {
-    margin-top: 10px;
+  #revisions {
+    .row:first-of-type {
+      margin-top: 10px;
+    }
+    table {
+      thead {
+        th {
+          text-align: left;
+          padding-bottom: 2px;
+          font-weight: bold;
+          color: var(--primary);
+        }
+      }
+
+      td {
+        padding: 3px 3px 3px 0.5em;
+        img {
+          max-width: none;
+        }
+      }
+    }
   }
+
   ins,
   .diff-ins {
     code,

--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -34,7 +34,6 @@
     table {
       thead {
         th {
-          text-align: left;
           padding-bottom: 2px;
           font-weight: bold;
           color: var(--primary);

--- a/app/assets/stylesheets/mobile/history.scss
+++ b/app/assets/stylesheets/mobile/history.scss
@@ -8,9 +8,6 @@
   .modal-inner-container {
     min-height: 400px;
   }
-  #revisions {
-    max-width: 90vw;
-  }
   #revision-numbers {
     line-height: var(--line-height-large);
   }


### PR DESCRIPTION
Adds the cooked/preview table styles for a better table appearance overall in the edit history.

Removed a max-width on mobile which didn't seem to bring any benefit in the edit history appearance, as it only made the modal less wide but aligned to the left, creating an unneeded margin-like space on the right.

**Desktop**
Before:
![image](https://github.com/discourse/discourse/assets/5654300/4060288c-9231-4846-b48d-f4d8775acdfa)

After:
![image](https://github.com/discourse/discourse/assets/5654300/1789f686-f93c-4e0a-87c0-35ec2fb56dcd)

**Mobile**
Before:
![image](https://github.com/discourse/discourse/assets/5654300/203ae91d-894e-44f5-ac8a-f7932698e68e)

After:
![image](https://github.com/discourse/discourse/assets/5654300/a97f6b5c-9b4c-4a89-aa28-23b3fa61016c)
