### PR TITLE
DEV: Revert buildjet

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     if: "!(github.event_name == 'push' && github.repository == 'discourse/discourse-private-mirror')"
     name: ${{ matrix.target }} ${{ matrix.build_type }} ${{ matrix.ruby }}
-    runs-on: ${{ (matrix.build_type == 'annotations') && 'ubuntu-latest' || (matrix.target == 'plugins') && (matrix.build_type == 'system') && 'buildjet-16vcpu-ubuntu-2204' || 'buildjet-8vcpu-ubuntu-2204' }}
+    runs-on: ${{ (matrix.build_type == 'annotations') && 'ubuntu-latest' || 'ubuntu-20.04-8core' }}
     container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}${{ (matrix.ruby == '3.1') && '-ruby-3.1.0' || '' }}
     timeout-minutes: 20
 
@@ -184,7 +184,7 @@ jobs:
 
       - name: Plugin QUnit
         if: matrix.build_type == 'frontend' && matrix.target == 'plugins'
-        run: QUNIT_PARALLEL=4 bin/rake plugin:qunit['*','1200000']
+        run: QUNIT_PARALLEL=3 bin/rake plugin:qunit['*','1200000']
         timeout-minutes: 30
 
       - name: Ember Build for System Tests
@@ -201,7 +201,7 @@ jobs:
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
-        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=8 bin/turbo_rspec --verbose plugins/*/spec/system
+        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=4 bin/turbo_rspec --verbose plugins/*/spec/system
         timeout-minutes: 30
 
       - name: Upload failed system test screenshots
@@ -231,7 +231,7 @@ jobs:
   core_frontend_tests:
     if: "!(github.event_name == 'push' && github.repository == 'discourse/discourse-private-mirror')"
     name: core frontend (${{ matrix.browser }})
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-20.04-8core
     container:
       image: discourse/discourse_test:slim-browsers
       options: --user discourse
@@ -282,7 +282,7 @@ jobs:
 
       - name: Core QUnit
         working-directory: ./app/assets/javascripts/discourse
-        run: yarn ember exam --path /tmp/emberbuild --load-balance --parallel=3 --launch "${{ env.TESTEM_BROWSER }}" --write-execution-file --random
+        run: yarn ember exam --path /tmp/emberbuild --load-balance --parallel=5  --launch "${{ env.TESTEM_BROWSER }}" --write-execution-file --random
         timeout-minutes: 15
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system' && matrix.target == 'plugins'
-        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=7 bin/turbo_rspec --verbose plugins/*/spec/system
+        run: LOAD_PLUGINS=1 PARALLEL_TEST_PROCESSORS=8 bin/turbo_rspec --verbose plugins/*/spec/system
         timeout-minutes: 30
 
       - name: Upload failed system test screenshots


### PR DESCRIPTION
We are seeing jobs waiting a very long time (more than 30 mins) for runners to become available. Reverting to GitHub actions

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
