### PR TITLE
Use composerEventPrefix consistently in the composer-editor

### DIFF
--- a/app/assets/javascripts/discourse/app/components/composer-editor.js
+++ b/app/assets/javascripts/discourse/app/components/composer-editor.js
@@ -249,7 +249,7 @@ export default Component.extend(
         this._bindMobileUploadButton();
       }
 
-      this.appEvents.trigger("composer:will-open");
+      this.appEvents.trigger(`${this.composerEventPrefix}:will-open`);
     },
 
     @discourseComputed(
@@ -603,7 +603,7 @@ export default Component.extend(
           );
 
           this.appEvents.trigger(
-            "composer:replace-text",
+            `${this.composerEventPrefix}:replace-text`,
             matchingPlaceholder[index],
             replacement,
             { regex: IMAGE_MARKDOWN_REGEX, index }
@@ -648,7 +648,11 @@ export default Component.extend(
         `![${input.value}|$2$3$4]($5)`
       );
 
-      this.appEvents.trigger("composer:replace-text", match, replacement);
+      this.appEvents.trigger(
+        `${this.composerEventPrefix}:replace-text`,
+        match,
+        replacement
+      );
 
       this.resetImageControls(buttonWrapper);
     },
@@ -731,7 +735,7 @@ export default Component.extend(
       const matchingPlaceholder =
         this.get("composer.reply").match(IMAGE_MARKDOWN_REGEX);
       this.appEvents.trigger(
-        "composer:replace-text",
+        `${this.composerEventPrefix}:replace-text`,
         matchingPlaceholder[index],
         "",
         { regex: IMAGE_MARKDOWN_REGEX, index }
@@ -749,11 +753,11 @@ export default Component.extend(
     @on("willDestroyElement")
     _composerClosed() {
       this._unbindMobileUploadButton();
-      this.appEvents.trigger("composer:will-close");
+      this.appEvents.trigger(`${this.composerEventPrefix}:will-close`);
       next(() => {
         // need to wait a bit for the "slide down" transition of the composer
         discourseLater(
-          () => this.appEvents.trigger("composer:closed"),
+          () => this.appEvents.trigger(`${this.composerEventPrefix}:closed`),
           isTesting() ? 0 : 400
         );
       });


### PR DESCRIPTION
This allows the composer-editor to be used in a more modular fashion. There are other instances of `composer` events in the code (composer controller/server, model and composer-body) however they are more specific to the main Discourse composer. This is targeted at use of the composer-editor in other contexts, and leverages the existing property in that component. There are no tests here, as there is no existing way to test this in the QUnit test suite, albeit all tests are passing.
