### PR TITLE
DEV: Fix thread excerpt word break

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-thread-original-message.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-thread-original-message.scss
@@ -8,7 +8,7 @@
 
   &__excerpt {
     padding-bottom: 0.25rem;
-    word-break: break-all;
+    word-break: break-word;
 
     > * {
       pointer-events: none;


### PR DESCRIPTION
Changing from break-all to break-word because otherwise
longer words (not just links) are split into separ
ate lines.
